### PR TITLE
[P/D disagg] Add HiRadixCache (hierarchical KV cache) for decode disaggregation

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -51,6 +51,25 @@ def handle_pd_disaggregation(server_args: "ServerArgs") -> None:
                 )
             server_args.disable_radix_cache = False
             logger.warning("EXPERIMENTAL: Radix cache is enabled for decode server")
+
+            if server_args.disaggregation_decode_enable_hicache:
+                server_args.enable_hierarchical_cache = True
+                if server_args.disaggregation_decode_hicache_size > 0:
+                    server_args.hicache_size = (
+                        server_args.disaggregation_decode_hicache_size
+                    )
+                else:
+                    server_args.hicache_ratio = (
+                        server_args.disaggregation_decode_hicache_ratio
+                    )
+                server_args.hicache_write_policy = (
+                    server_args.disaggregation_decode_hicache_write_policy
+                )
+                logger.warning(
+                    "EXPERIMENTAL: HiRadixCache is enabled for decode server "
+                    f"(ratio={server_args.hicache_ratio}, "
+                    f"write_policy={server_args.hicache_write_policy})"
+                )
         else:
             server_args.disable_radix_cache = True
             logger.warning("KV cache is forced as chunk cache for decode server")

--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -71,6 +71,11 @@ def handle_pd_disaggregation(server_args: "ServerArgs") -> None:
                     f"write_policy={server_args.hicache_write_policy})"
                 )
         else:
+            if server_args.disaggregation_decode_enable_hicache:
+                raise ValueError(
+                    "--disaggregation-decode-enable-hicache requires "
+                    "--disaggregation-decode-enable-radix-cache to be enabled."
+                )
             server_args.disable_radix_cache = True
             logger.warning("KV cache is forced as chunk cache for decode server")
             if server_args.enable_mamba_extra_buffer():

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -56,7 +56,7 @@ from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
+from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams, InitLoadBackParams
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     page_align_floor,
@@ -240,6 +240,8 @@ class DecodeRequest:
     kv_receiver: CommonKVReceiver
     waiting_for_input: bool = False
     metadata_buffer_index: int = -1
+    waiting_for_prefetch: bool = False
+    prefetch_triggered_time: float = 0.0
 
     @property
     def seqlen(self) -> int:
@@ -250,10 +252,30 @@ class DecodeRequest:
         return self.req.priority
 
 
+@dataclass
+class _PlannedPrealloc:
+    decode_req: DecodeRequest
+    prefix_indices: Optional[torch.Tensor]
+    prefix_len: int
+    required_alloc_tokens: int
+    origin_input_len: int
+
+
+def _cleanup_hicache_aborted_request(
+    tree_cache: BasePrefixCache, enable_hicache: bool, req: Req
+) -> None:
+    """Clean up HiRadixCache state for an aborted request."""
+    if not enable_hicache:
+        return
+    tree_cache.release_aborted_request(req.rid)
+
+
 class DecodePreallocQueue:
     """
     Store the requests that are preallocating.
     """
+
+    _PREFETCH_WAIT_TIMEOUT: float = 5.0
 
     def __init__(
         self,
@@ -310,6 +332,7 @@ class DecodePreallocQueue:
                 "SGLANG_DISAGG_STAGING_BUFFER is designed for non-MLA models "
                 "(e.g. GQA, MHA). MLA models should not set this flag."
             )
+        self.enable_hicache = hasattr(tree_cache, "ongoing_prefetch")
         self.kv_manager = self._init_kv_manager()
         if self.enable_staging:
             self.transfer_queue._init_staging_handler(self.kv_manager)
@@ -477,6 +500,134 @@ class DecodePreallocQueue:
 
         return prefix_indices, len(prefix_indices)
 
+    def _match_prefix(self, req: Req):
+        """Match prefix against radix cache (read-only, no GPU allocation, no lock)."""
+        return match_prefix_for_req(
+            self.tree_cache,
+            req,
+            req.origin_input_ids,
+            cow_mamba=self.tree_cache.supports_mamba(),
+            include_req=True,
+        )
+
+    def _load_back_and_lock(
+        self,
+        req: Req,
+        match_result,
+        extra_load_back_budget_consumed: int = 0,
+        skip_load_back: bool = False,
+    ) -> Tuple[torch.Tensor, int, int, int]:
+        """
+        Optionally load matched host-cache prefix to GPU, then lock the
+        matched prefix node.
+
+        When *skip_load_back* is True the L2->L1 transfer is skipped (e.g.
+        because a budget pre-check already determined the request cannot
+        fit), avoiding wasteful GPU-pool allocation and DMA.
+
+        Returns:
+            (prefix_indices, prefix_len, load_back_tokens, lock_delta)
+        """
+        prefix_indices = match_result.device_indices
+        last_device_node = match_result.last_device_node
+        last_host_node = match_result.last_host_node
+        host_hit_length = match_result.host_hit_length
+        load_back_tokens = 0
+
+        logger.debug(
+            "[HiCache][match_prefix] req=%s total_input=%d L1_gpu_hit=%d L2_host_hit=%d",
+            req.rid,
+            len(req.origin_input_ids),
+            len(prefix_indices),
+            host_hit_length,
+        )
+
+        if (
+            not skip_load_back
+            and host_hit_length > 0
+            and self.enable_hicache
+        ):
+            mem_quota = (
+                self._allocatable_token_budgets(count_retracted=False)
+                - extra_load_back_budget_consumed
+            )
+            load_result, new_last_node = self.tree_cache.init_load_back(
+                InitLoadBackParams(
+                    best_match_node=last_host_node,
+                    host_hit_length=host_hit_length,
+                    mem_quota=mem_quota,
+                )
+            )
+            if len(load_result) > 0:
+                load_back_tokens = len(load_result)
+                prefix_indices = torch.cat([prefix_indices, load_result])
+                last_device_node = new_last_node
+                req.last_node = new_last_node
+
+                self.tree_cache.ready_to_load_host_cache()
+
+        lock_delta = 0
+        if len(prefix_indices) > 0:
+            lock_result = self.tree_cache.inc_lock_ref(last_device_node)
+            lock_delta = lock_result.delta
+
+        return prefix_indices, len(prefix_indices), load_back_tokens, lock_delta
+
+    def _unlock_prefix(self, req: Req, prefix_len: int) -> None:
+        """Undo inc_lock_ref from _load_back_and_lock when aborting or deferring."""
+        if prefix_len > 0:
+            self.tree_cache.dec_lock_ref(req.last_node)
+
+    def _trigger_prefetch_if_needed(
+        self, req: Req, last_host_node, prefix_len: int = 0
+    ) -> None:
+        """Trigger prefetch from storage if HiRadixCache is enabled and storage backend is available."""
+        if not self.enable_hicache:
+            return
+        if not self.tree_cache.enable_storage:
+            return
+
+        matched_len = prefix_len
+        total_len = len(req.origin_input_ids)
+
+        if matched_len >= total_len:
+            return
+
+        suffix_tokens = req.origin_input_ids[matched_len:]
+
+        if len(suffix_tokens) < self.tree_cache.prefetch_threshold:
+            return
+
+        last_hash = None
+        prefix_keys = None
+        if last_host_node is not None:
+            last_hash = last_host_node.get_last_hash_value()
+            if self.tree_cache.hicache_storage_pass_prefix_keys:
+                prefix_keys = last_host_node.get_prefix_hash_values(
+                    last_host_node.parent
+                )
+
+        self.tree_cache.prefetch_from_storage(
+            req_id=req.rid,
+            last_host_node=last_host_node,
+            new_input_tokens=suffix_tokens,
+            last_hash=last_hash,
+            prefix_keys=prefix_keys,
+        )
+
+    def _check_prefetch_progress(
+        self, rids_to_check: Optional[List[str]] = None
+    ) -> None:
+        """Check prefetch progress for ongoing prefetches and complete them."""
+        if not self.enable_hicache:
+            return
+
+        ongoing_prefetch_rids = list(self.tree_cache.ongoing_prefetch.keys())
+        for rid in ongoing_prefetch_rids:
+            if rids_to_check is not None and rid not in rids_to_check:
+                continue
+            self.tree_cache.check_prefetch_progress(rid)
+
     def _resolve_prefill_dp_rank(self, req: Req) -> Optional[int]:
         prefill_info = self.kv_manager.prefill_info_table.get(_bootstrap_addr(req))
         # If None, it will go to the slow path and resolve prefill_info by _ensure_prefill_info then cache it
@@ -520,6 +671,7 @@ class DecodePreallocQueue:
             message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} > {self.max_total_num_tokens}"
             logger.error(message)
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
+            _cleanup_hicache_aborted_request(self.tree_cache, self.enable_hicache, req)
             self.scheduler.output_streamer.stream_output([req], req.return_logprob)
             return True
         if self._uses_swa_tail_prealloc():
@@ -629,6 +781,7 @@ class DecodePreallocQueue:
                     error_message,
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
+                _cleanup_hicache_aborted_request(self.tree_cache, self.enable_hicache, decode_req.req)
                 if self.scheduler.metrics_reporter.enable_metrics:
                     self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
             else:
@@ -727,8 +880,16 @@ class DecodePreallocQueue:
         self._resolve_pending_reqs()
         self._update_handshake_waiters(rids_to_check)
 
+        # Check HiRadixCache events (write completion, load completion, prefetch progress)
+        if self.enable_hicache:
+            self.tree_cache.check_hicache_events()
+
+        # Check prefetch progress for ongoing prefetches
+        self._check_prefetch_progress(rids_to_check)
+
         failed_reqs = []
         preallocated_reqs = []
+        planned_preallocs: List[_PlannedPrealloc] = []
         indices_to_remove = set()
 
         # We need to make sure that the sum of inflight tokens and allocatable tokens is greater than maximum input+output length of each inflight request
@@ -770,6 +931,7 @@ class DecodePreallocQueue:
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
             if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                _cleanup_hicache_aborted_request(self.tree_cache, self.enable_hicache, decode_req.req)
                 self.scheduler.output_streamer.stream_output(
                     [decode_req.req],
                     decode_req.req.return_logprob,
@@ -793,6 +955,7 @@ class DecodePreallocQueue:
             )
 
         # Then, preallocate the remaining requests if possible
+        cumulative_load_back_tokens = 0
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
@@ -802,6 +965,19 @@ class DecodePreallocQueue:
 
             if not decode_req.waiting_for_input:
                 continue
+
+            # Two-phase prefetch: check if request is waiting for L3->L2 prefetch
+            if decode_req.waiting_for_prefetch:
+                rid = decode_req.req.rid
+                prefetch_done = rid not in self.tree_cache.ongoing_prefetch
+                timed_out = (
+                    time.monotonic() - decode_req.prefetch_triggered_time
+                    > self._PREFETCH_WAIT_TIMEOUT
+                )
+                if prefetch_done or timed_out:
+                    decode_req.waiting_for_prefetch = False
+                else:
+                    continue
 
             if self.req_to_token_pool.available_size() <= 0:
                 break
@@ -816,55 +992,154 @@ class DecodePreallocQueue:
             # TODO: add new_token ratio
             origin_input_len = len(decode_req.req.origin_input_ids)
             if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
-                # Match prefix against decode's radix cache.
-                prefix_indices, prefix_len = self._match_prefix_and_lock(decode_req.req)
-                # Align prefix_len down to page boundary so both prefill and
-                # decode agree on the page-aligned split point for KV transfer.
                 page_size = self.token_to_kv_pool_allocator.page_size
-                if page_size > 1 and prefix_len % page_size != 0:
-                    prefix_len = page_align_floor(prefix_len, page_size)
-                    prefix_indices = prefix_indices[:prefix_len]
+                fill_len = origin_input_len + max(
+                    len(decode_req.req.output_ids) - 1, 0
+                )
 
-                fill_len = origin_input_len + max(len(decode_req.req.output_ids) - 1, 0)
-                required_alloc_tokens = self._required_alloc_tokens(
-                    fill_len=fill_len, prefix_len=prefix_len
-                )
-                # Matching may lock previously-evictable radix pages, so refresh
-                # the admission budget against the post-lock pool state before we
-                # decide whether this request still fits.
-                full_allocatable_tokens = self._allocatable_token_budgets(
-                    retractable_tokens=retractable_tokens,
-                    count_retracted=True,
-                    extra_reserved_reqs=len(preallocated_reqs),
-                )
+                if self.enable_hicache:
+                    # Phase 1: Match prefix (read-only, no GPU allocation)
+                    match_result = self._match_prefix(decode_req.req)
+
+                    # Pre-check: skip load_back if request can't fit with L1-only prefix
+                    skip_load_back = False
+                    if match_result.host_hit_length > 0:
+                        l1_prefix_len = len(match_result.device_indices)
+                        if page_size > 1 and l1_prefix_len % page_size != 0:
+                            l1_prefix_len = page_align_floor(l1_prefix_len, page_size)
+                        conservative_alloc = self._required_alloc_tokens(
+                            fill_len=fill_len, prefix_len=l1_prefix_len
+                        )
+                        conservative_required = (
+                            conservative_alloc + self.num_reserved_decode_tokens
+                        )
+                        conservative_projected = (
+                            origin_input_len
+                            - l1_prefix_len
+                            + min(
+                                decode_req.req.sampling_params.max_new_tokens,
+                                CLIP_MAX_NEW_TOKEN,
+                            )
+                            - retractable_tokens
+                        )
+                        if (
+                            max(conservative_required, conservative_projected)
+                            > full_allocatable_tokens
+                        ):
+                            skip_load_back = True
+
+                    # Phase 2: Load back (if not skipped) + lock
+                    prefix_indices, prefix_len, load_back_tokens, lock_delta = (
+                        self._load_back_and_lock(
+                            decode_req.req,
+                            match_result,
+                            extra_load_back_budget_consumed=cumulative_load_back_tokens,
+                            skip_load_back=skip_load_back,
+                        )
+                    )
+                    full_allocatable_tokens += lock_delta
+
+                    # Align prefix_len down to page boundary
+                    if page_size > 1 and prefix_len % page_size != 0:
+                        prefix_len = page_align_floor(prefix_len, page_size)
+                        prefix_indices = prefix_indices[:prefix_len]
+
+                    # Two-phase prefetch: trigger L3->L2 and defer prealloc if started
+                    if decode_req.prefetch_triggered_time == 0.0:
+                        self._trigger_prefetch_if_needed(
+                            decode_req.req, decode_req.req.last_host_node, prefix_len
+                        )
+                        if decode_req.req.rid in self.tree_cache.ongoing_prefetch:
+                            self._unlock_prefix(decode_req.req, prefix_len)
+                            full_allocatable_tokens -= lock_delta
+                            decode_req.waiting_for_prefetch = True
+                            decode_req.prefetch_triggered_time = time.monotonic()
+                            continue
+                        else:
+                            decode_req.prefetch_triggered_time = time.monotonic()
+
+                    required_alloc_tokens = self._required_alloc_tokens(
+                        fill_len=fill_len, prefix_len=prefix_len
+                    )
+                else:
+                    # Non-HiCache radix cache path: use simple match_prefix_and_lock
+                    prefix_indices, prefix_len = self._match_prefix_and_lock(
+                        decode_req.req
+                    )
+                    lock_delta = 0
+                    load_back_tokens = 0
+                    if page_size > 1 and prefix_len % page_size != 0:
+                        prefix_len = page_align_floor(prefix_len, page_size)
+                        prefix_indices = prefix_indices[:prefix_len]
+                    required_alloc_tokens = self._required_alloc_tokens(
+                        fill_len=fill_len, prefix_len=prefix_len
+                    )
+                    full_allocatable_tokens = self._allocatable_token_budgets(
+                        retractable_tokens=retractable_tokens,
+                        count_retracted=True,
+                        extra_reserved_reqs=len(preallocated_reqs),
+                    )
             else:
                 prefix_indices = None
                 prefix_len = 0
+                lock_delta = 0
+                load_back_tokens = 0
                 required_alloc_tokens = origin_input_len
 
             required_tokens_for_request = (
                 required_alloc_tokens + self.num_reserved_decode_tokens
             )
 
-            if (
-                max(
-                    required_tokens_for_request,
-                    origin_input_len
-                    - prefix_len
-                    + min(
-                        decode_req.req.sampling_params.max_new_tokens,
-                        CLIP_MAX_NEW_TOKEN,
-                    )
-                    - retractable_tokens,
+            projected_tokens = (
+                origin_input_len
+                - prefix_len
+                + min(
+                    decode_req.req.sampling_params.max_new_tokens,
+                    CLIP_MAX_NEW_TOKEN,
                 )
+                - retractable_tokens
+            )
+            if (
+                max(required_tokens_for_request, projected_tokens)
                 > full_allocatable_tokens
             ):
-                if prefix_len > 0:
-                    self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                # Abort if permanently stuck
+                if (
+                    len(self.scheduler.running_batch.reqs) == 0
+                    and len(self.transfer_queue.queue) == 0
+                    and projected_tokens > full_allocatable_tokens
+                ):
+                    self._unlock_prefix(decode_req.req, prefix_len)
+                    full_allocatable_tokens -= lock_delta
+                    decode_req.req.finished_reason = FINISH_ABORT(
+                        f"Insufficient memory: projected need "
+                        f"~{projected_tokens} tokens but only "
+                        f"{full_allocatable_tokens} allocatable."
+                    )
+                    _cleanup_hicache_aborted_request(
+                        self.tree_cache, self.enable_hicache, decode_req.req
+                    )
+                    self.scheduler.output_streamer.stream_output(
+                        [decode_req.req], decode_req.req.return_logprob
+                    )
+                    failed_reqs.append(decode_req)
+                    indices_to_remove.add(i)
+                    continue
+
+                if self.enable_hicache:
+                    self._unlock_prefix(decode_req.req, prefix_len)
+                    full_allocatable_tokens -= lock_delta
+                else:
+                    if prefix_len > 0:
+                        self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
             if required_tokens_for_request > full_allocatable_tokens:
-                if prefix_len > 0:
-                    self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                if self.enable_hicache:
+                    self._unlock_prefix(decode_req.req, prefix_len)
+                    full_allocatable_tokens -= lock_delta
+                else:
+                    if prefix_len > 0:
+                        self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
 
             if uses_swa_tail_prealloc:
@@ -881,22 +1156,53 @@ class DecodePreallocQueue:
                     )
                     > swa_allocatable_tokens
                 ):
-                    if prefix_len > 0:
-                        self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                    if self.enable_hicache:
+                        self._unlock_prefix(decode_req.req, prefix_len)
+                        full_allocatable_tokens -= lock_delta
+                    else:
+                        if prefix_len > 0:
+                            self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                     break
 
-            dst_kv_indices = self._pre_alloc(decode_req.req, prefix_indices, prefix_len)
-            hisparse_req_budget -= 1
-            # Recompute from actual pool state for the next queue entry.
-            # This accounts for page rounding and newly locked evictable cache.
-            full_allocatable_tokens = self._allocatable_token_budgets(
-                retractable_tokens=retractable_tokens,
-                count_retracted=True,
-                extra_reserved_reqs=len(preallocated_reqs) + 1,
+            full_allocatable_tokens -= required_tokens_for_request
+            if load_back_tokens > 0:
+                cumulative_load_back_tokens += load_back_tokens
+            planned_preallocs.append(
+                _PlannedPrealloc(
+                    decode_req=decode_req,
+                    prefix_indices=prefix_indices,
+                    prefix_len=prefix_len,
+                    required_alloc_tokens=required_alloc_tokens,
+                    origin_input_len=origin_input_len,
+                )
             )
+            indices_to_remove.add(i)
+
+        # --- Batch eviction then allocate ---
+        self._batch_evict_for_prealloc(planned_preallocs)
+
+        for planned in planned_preallocs:
+            decode_req = planned.decode_req
+            prefix_indices = planned.prefix_indices
+            prefix_len = planned.prefix_len
+            origin_input_len = planned.origin_input_len
+
+            dst_kv_indices = self._pre_alloc(
+                decode_req.req,
+                prefix_indices=prefix_indices,
+                prefix_len=prefix_len,
+                allow_evict=not self.enable_hicache,
+            )
+            hisparse_req_budget -= 1
+
+            if not self.enable_hicache:
+                full_allocatable_tokens = self._allocatable_token_budgets(
+                    retractable_tokens=retractable_tokens,
+                    count_retracted=True,
+                    extra_reserved_reqs=len(preallocated_reqs) + 1,
+                )
             if uses_swa_tail_prealloc:
-                # SWA budget uses simple decrement (no radix cache eviction in
-                # the SWA pool, so page-rounding drift is negligible).
+                _, swa_required = self._prealloc_required_tokens(decode_req.req)
                 swa_allocatable_tokens -= swa_required
             decode_req.req.cache_protected_len = prefix_len
 
@@ -1184,11 +1490,49 @@ class DecodePreallocQueue:
         )
         return num_new_pages * page_size
 
+    def _evict_for_prealloc(
+        self,
+        required_alloc_tokens: int,
+        *,
+        req: Optional[Req] = None,
+        fill_len: Optional[int] = None,
+        prefix_len: Optional[int] = None,
+        delta_len: Optional[int] = None,
+    ) -> None:
+        if not self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
+            return
+
+        available_size = self.token_to_kv_pool_allocator.available_size()
+        if available_size >= required_alloc_tokens:
+            return
+
+        num_to_evict = required_alloc_tokens - available_size
+        result = self.tree_cache.evict(EvictParams(num_tokens=num_to_evict))
+        available_after = self.token_to_kv_pool_allocator.available_size()
+        if available_after >= required_alloc_tokens:
+            return
+
+        if req is None:
+            return
+
+    def _batch_evict_for_prealloc(
+        self, planned_preallocs: List[_PlannedPrealloc]
+    ) -> None:
+        if not planned_preallocs:
+            return
+
+        total_required_alloc_tokens = sum(
+            planned.required_alloc_tokens for planned in planned_preallocs
+        )
+        self._evict_for_prealloc(total_required_alloc_tokens)
+
     def _pre_alloc(
         self,
         req: Req,
         prefix_indices: Optional[torch.Tensor] = None,
         prefix_len: Optional[int] = None,
+        *,
+        allow_evict: bool = True,
     ) -> torch.Tensor:
         """Pre-allocate the memory for req_to_token and token_kv_pool"""
         if prefix_len is None:
@@ -1219,7 +1563,8 @@ class DecodePreallocQueue:
 
         # Evict cached entries if the pool doesn't have enough free pages.
         if (
-            self.scheduler.server_args.disaggregation_decode_enable_radix_cache
+            allow_evict
+            and self.scheduler.server_args.disaggregation_decode_enable_radix_cache
             and self.token_to_kv_pool_allocator.available_size() < required_alloc_tokens
         ):
             num_to_evict = (

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -737,6 +737,9 @@ class DecodePreallocQueue:
             resumed_reqs.append(req)
             indices_to_remove.add(i)
             req.is_retracted = False
+            if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
+                req.last_node = self.tree_cache.root_node
+                self.tree_cache.inc_lock_ref(self.tree_cache.root_node)
             self._pre_alloc(req)
             full_allocatable_tokens -= full_required
             if uses_swa_tail_prealloc:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -566,6 +566,16 @@ class DecodePreallocQueue:
 
                 self.tree_cache.ready_to_load_host_cache()
 
+        logger.debug(
+            "[HiCache][load_back_and_lock] req=%s L1_gpu_hit=%d "
+            "L2_host_hit=%d L2_load_back=%d total_prefix=%d",
+            req.rid,
+            len(match_result.device_indices),
+            host_hit_length,
+            load_back_tokens,
+            len(prefix_indices),
+        )
+
         lock_delta = 0
         if len(prefix_indices) > 0:
             lock_result = self.tree_cache.inc_lock_ref(last_device_node)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1060,7 +1060,7 @@ class DecodePreallocQueue:
                     # Two-phase prefetch: trigger L3->L2 and defer prealloc if started
                     if decode_req.prefetch_triggered_time == 0.0:
                         self._trigger_prefetch_if_needed(
-                            decode_req.req, decode_req.req.last_host_node, prefix_len
+                            decode_req.req, match_result.last_host_node, prefix_len
                         )
                         if decode_req.req.rid in self.tree_cache.ongoing_prefetch:
                             self._unlock_prefix(decode_req.req, prefix_len)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -451,6 +451,24 @@ class Scheduler(
         self.disable_radix_cache = result.disable_radix_cache
         self.tree_cache = result.tree_cache
 
+        # Decode radix cache is unsupported with hybrid SWA/SSM models —
+        # these use specialized memory pools incompatible with the
+        # prefix-match-and-lock allocation path.
+        if (
+            server_args.disaggregation_decode_enable_radix_cache
+            and server_args.disaggregation_mode == "decode"
+        ):
+            if self.is_hybrid_swa:
+                raise ValueError(
+                    "--disaggregation-decode-enable-radix-cache is incompatible "
+                    "with sliding window attention (SWA) models"
+                )
+            if self.is_hybrid_ssm:
+                raise ValueError(
+                    "--disaggregation-decode-enable-radix-cache is incompatible "
+                    "with Mamba/SSM models"
+                )
+
         if self.enable_hisparse:
             # Coordinator was created inside ModelRunner.initialize() before CUDA graph capture
             self.hisparse_coordinator = self.tp_worker.model_runner.hisparse_coordinator

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1449,7 +1449,6 @@ class HiRadixCache(RadixCache):
                     if node.backuped:
                         self.cache_controller.mem_pool_host.free(node.host_value)
                         node.host_value = None
-                        node.backuped = False
                     self.evictable_size_ += len(node.value)
                     self._update_leaf_status(node)
                     self._update_host_leaf_status(node)
@@ -1467,7 +1466,6 @@ class HiRadixCache(RadixCache):
                     if new_node.backuped:
                         self.cache_controller.mem_pool_host.free(new_node.host_value)
                         new_node.host_value = None
-                        new_node.backuped = False
                     self.evictable_size_ += len(new_node.value)
                     self._update_leaf_status(new_node)
                     self._update_host_leaf_status(new_node)

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1446,9 +1446,6 @@ class HiRadixCache(RadixCache):
             if prefix_len == len(node.key):
                 if node.evicted:
                     node.value = value[:prefix_len].clone()
-                    if node.backuped:
-                        self.cache_controller.mem_pool_host.free(node.host_value)
-                        node.host_value = None
                     self.evictable_size_ += len(node.value)
                     self._update_leaf_status(node)
                     self._update_host_leaf_status(node)
@@ -1463,9 +1460,6 @@ class HiRadixCache(RadixCache):
                 new_node.priority = max(new_node.priority, priority)
                 if new_node.evicted:
                     new_node.value = value[:prefix_len].clone()
-                    if new_node.backuped:
-                        self.cache_controller.mem_pool_host.free(new_node.host_value)
-                        new_node.host_value = None
                     self.evictable_size_ += len(new_node.value)
                     self._update_leaf_status(new_node)
                     self._update_host_leaf_status(new_node)

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1057,9 +1057,6 @@ class HiRadixCache(RadixCache):
         if last_node.evicted:
             loading_values = self.load_back(last_node, mem_quota)
             if loading_values is not None:
-                logger.debug(
-                    f"loading back {len(loading_values)} tokens for node {last_node.id}"
-                )
                 return loading_values, last_node
 
             while last_node.evicted:
@@ -1177,7 +1174,6 @@ class HiRadixCache(RadixCache):
         completed_tokens, hash_value = self.cache_controller.terminate_prefetch(
             operation
         )
-        logger.debug(f"Prefetch {req_id} completed with {completed_tokens} tokens")
 
         min_completed_tokens = completed_tokens
         # Synchronize workers before mutating host cache tree state.
@@ -1379,6 +1375,11 @@ class HiRadixCache(RadixCache):
             else:
                 if not child.evicted:
                     value.append(child.value)
+                else:
+                    # Stop at evicted boundary — continuing would create
+                    # a gap in device_indices if a descendant was re-filled.
+                    node = child
+                    break
                 node = child
                 key = key[prefix_len:]
 
@@ -1444,13 +1445,14 @@ class HiRadixCache(RadixCache):
 
             if prefix_len == len(node.key):
                 if node.evicted:
-                    # change the reference if the node is evicted
-                    # this often happens in the case of KV cache recomputation
                     node.value = value[:prefix_len].clone()
+                    if node.backuped:
+                        self.cache_controller.mem_pool_host.free(node.host_value)
+                        node.host_value = None
+                        node.backuped = False
                     self.evictable_size_ += len(node.value)
                     self._update_leaf_status(node)
                     self._update_host_leaf_status(node)
-                    # update parent status as a new leaf is added into device
                     self._update_leaf_status(node.parent)
                 else:
                     self._inc_hit_count(node, chunked)
@@ -1462,10 +1464,13 @@ class HiRadixCache(RadixCache):
                 new_node.priority = max(new_node.priority, priority)
                 if new_node.evicted:
                     new_node.value = value[:prefix_len].clone()
+                    if new_node.backuped:
+                        self.cache_controller.mem_pool_host.free(new_node.host_value)
+                        new_node.host_value = None
+                        new_node.backuped = False
                     self.evictable_size_ += len(new_node.value)
                     self._update_leaf_status(new_node)
                     self._update_host_leaf_status(new_node)
-                    # update parent status as a new leaf is added into device
                     self._update_leaf_status(new_node.parent)
                 else:
                     self._inc_hit_count(new_node, chunked)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -993,9 +993,6 @@ class ServerArgs:
         # Handle model loading format.
         self._handle_load_format()
 
-        # Handle PD disaggregation.
-        self._handle_pd_disaggregation()
-
         # Handle Encoder disaggregation.
         self._handle_encoder_disaggregation()
 
@@ -3833,82 +3830,6 @@ class ServerArgs:
             )
         except Exception:
             return False
-
-    def _handle_pd_disaggregation(self):
-        if self.disaggregation_mode == "decode":
-            if self.disaggregation_decode_enable_radix_cache:
-                if self.enable_hisparse:
-                    raise ValueError(
-                        "--disaggregation-decode-enable-radix-cache is incompatible "
-                        "with --enable-hisparse"
-                    )
-                if self.disaggregation_transfer_backend not in ("nixl", "mooncake"):
-                    raise ValueError(
-                        "--disaggregation-decode-enable-radix-cache currently "
-                        "requires --disaggregation-transfer-backend in "
-                        "('nixl', 'mooncake'), but got "
-                        f"{self.disaggregation_transfer_backend!r}"
-                    )
-                if self.speculative_algorithm is not None:
-                    raise ValueError(
-                        "--disaggregation-decode-enable-radix-cache is incompatible "
-                        "with speculative decoding "
-                        f"(--speculative-algorithm {self.speculative_algorithm})"
-                    )
-                if self.enable_dp_attention:
-                    logger.warning(
-                        "EXPERIMENTAL: Decode radix cache with DP attention. "
-                        "Requires prefix-aware DP rank routing for optimal cache hits."
-                    )
-                self.disable_radix_cache = False
-                logger.warning("EXPERIMENTAL: Radix cache is enabled for decode server")
-
-                if self.disaggregation_decode_enable_hicache:
-                    self.enable_hierarchical_cache = True
-                    if self.disaggregation_decode_hicache_size > 0:
-                        self.hicache_size = self.disaggregation_decode_hicache_size
-                    else:
-                        self.hicache_ratio = self.disaggregation_decode_hicache_ratio
-                    self.hicache_write_policy = (
-                        self.disaggregation_decode_hicache_write_policy
-                    )
-                    logger.warning(
-                        "EXPERIMENTAL: HiRadixCache is enabled for decode server "
-                        f"(ratio={self.hicache_ratio}, "
-                        f"write_policy={self.hicache_write_policy})"
-                    )
-            else:
-                self.disable_radix_cache = True
-                logger.warning("KV cache is forced as chunk cache for decode server")
-                if self.enable_mamba_extra_buffer():
-                    logger.warning(
-                        "Mamba extra_buffer is disabled because decode disaggregation "
-                        "currently forces chunk cache. Falling back to no_buffer."
-                    )
-                    self.mamba_scheduler_strategy = "no_buffer"
-
-        elif self.disaggregation_mode == "prefill":
-            assert (
-                self.disaggregation_transfer_backend != "fake"
-            ), "Prefill server does not support 'fake' as the transfer backend"
-
-            if self.disable_piecewise_cuda_graph:
-                self.disable_cuda_graph = True
-                logger.warning(
-                    "Cuda graph is disabled for prefill server when piecewise cuda graph is not enabled."
-                )
-
-        if self.disaggregation_mode in ("prefill", "decode"):
-            if (
-                envs.SGLANG_DISAGG_STAGING_BUFFER.get()
-                and self.disaggregation_transfer_backend not in ("mooncake", "nixl")
-            ):
-                raise ValueError(
-                    f"SGLANG_DISAGG_STAGING_BUFFER requires "
-                    f"disaggregation_transfer_backend='mooncake' or 'nixl', "
-                    f"got '{self.disaggregation_transfer_backend}'."
-                )
-
     def _handle_encoder_disaggregation(self):
         if self.enable_prefix_mm_cache and not self.encoder_only:
             raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -802,6 +802,10 @@ class ServerArgs:
     disaggregation_bootstrap_port: int = 8998
     disaggregation_ib_device: Optional[str] = None
     disaggregation_decode_enable_radix_cache: bool = False
+    disaggregation_decode_enable_hicache: bool = False
+    disaggregation_decode_hicache_ratio: float = 1.0
+    disaggregation_decode_hicache_size: int = 0
+    disaggregation_decode_hicache_write_policy: str = "write_through"
     disaggregation_decode_enable_offload_kvcache: bool = False
     num_reserved_decode_tokens: int = 512  # used for decode kv cache offload in PD
     # FIXME: hack to reduce ITL when decode bs is small
@@ -988,6 +992,9 @@ class ServerArgs:
 
         # Handle model loading format.
         self._handle_load_format()
+
+        # Handle PD disaggregation.
+        self._handle_pd_disaggregation()
 
         # Handle Encoder disaggregation.
         self._handle_encoder_disaggregation()
@@ -3826,6 +3833,81 @@ class ServerArgs:
             )
         except Exception:
             return False
+
+    def _handle_pd_disaggregation(self):
+        if self.disaggregation_mode == "decode":
+            if self.disaggregation_decode_enable_radix_cache:
+                if self.enable_hisparse:
+                    raise ValueError(
+                        "--disaggregation-decode-enable-radix-cache is incompatible "
+                        "with --enable-hisparse"
+                    )
+                if self.disaggregation_transfer_backend not in ("nixl", "mooncake"):
+                    raise ValueError(
+                        "--disaggregation-decode-enable-radix-cache currently "
+                        "requires --disaggregation-transfer-backend in "
+                        "('nixl', 'mooncake'), but got "
+                        f"{self.disaggregation_transfer_backend!r}"
+                    )
+                if self.speculative_algorithm is not None:
+                    raise ValueError(
+                        "--disaggregation-decode-enable-radix-cache is incompatible "
+                        "with speculative decoding "
+                        f"(--speculative-algorithm {self.speculative_algorithm})"
+                    )
+                if self.enable_dp_attention:
+                    logger.warning(
+                        "EXPERIMENTAL: Decode radix cache with DP attention. "
+                        "Requires prefix-aware DP rank routing for optimal cache hits."
+                    )
+                self.disable_radix_cache = False
+                logger.warning("EXPERIMENTAL: Radix cache is enabled for decode server")
+
+                if self.disaggregation_decode_enable_hicache:
+                    self.enable_hierarchical_cache = True
+                    if self.disaggregation_decode_hicache_size > 0:
+                        self.hicache_size = self.disaggregation_decode_hicache_size
+                    else:
+                        self.hicache_ratio = self.disaggregation_decode_hicache_ratio
+                    self.hicache_write_policy = (
+                        self.disaggregation_decode_hicache_write_policy
+                    )
+                    logger.warning(
+                        "EXPERIMENTAL: HiRadixCache is enabled for decode server "
+                        f"(ratio={self.hicache_ratio}, "
+                        f"write_policy={self.hicache_write_policy})"
+                    )
+            else:
+                self.disable_radix_cache = True
+                logger.warning("KV cache is forced as chunk cache for decode server")
+                if self.enable_mamba_extra_buffer():
+                    logger.warning(
+                        "Mamba extra_buffer is disabled because decode disaggregation "
+                        "currently forces chunk cache. Falling back to no_buffer."
+                    )
+                    self.mamba_scheduler_strategy = "no_buffer"
+
+        elif self.disaggregation_mode == "prefill":
+            assert (
+                self.disaggregation_transfer_backend != "fake"
+            ), "Prefill server does not support 'fake' as the transfer backend"
+
+            if self.disable_piecewise_cuda_graph:
+                self.disable_cuda_graph = True
+                logger.warning(
+                    "Cuda graph is disabled for prefill server when piecewise cuda graph is not enabled."
+                )
+
+        if self.disaggregation_mode in ("prefill", "decode"):
+            if (
+                envs.SGLANG_DISAGG_STAGING_BUFFER.get()
+                and self.disaggregation_transfer_backend not in ("mooncake", "nixl")
+            ):
+                raise ValueError(
+                    f"SGLANG_DISAGG_STAGING_BUFFER requires "
+                    f"disaggregation_transfer_backend='mooncake' or 'nixl', "
+                    f"got '{self.disaggregation_transfer_backend}'."
+                )
 
     def _handle_encoder_disaggregation(self):
         if self.enable_prefix_mm_cache and not self.encoder_only:
@@ -6740,6 +6822,30 @@ class ServerArgs:
             "--disaggregation-decode-enable-radix-cache",
             action="store_true",
             help="Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Requires --disaggregation-transfer-backend nixl or mooncake and is incompatible with --enable-hisparse.",
+        )
+        parser.add_argument(
+            "--disaggregation-decode-enable-hicache",
+            action="store_true",
+            help="Enable hierarchical cache (HiRadixCache) on decode server (PD mode). Requires --disaggregation-decode-enable-radix-cache. Adds host (L2) and optional storage (L3) cache layers.",
+        )
+        parser.add_argument(
+            "--disaggregation-decode-hicache-ratio",
+            type=float,
+            default=ServerArgs.disaggregation_decode_hicache_ratio,
+            help="The ratio of host KV cache memory pool to device pool for decode server HiRadixCache.",
+        )
+        parser.add_argument(
+            "--disaggregation-decode-hicache-size",
+            type=int,
+            default=ServerArgs.disaggregation_decode_hicache_size,
+            help="The size of host KV cache memory pool in GB for decode server HiRadixCache. Overrides --disaggregation-decode-hicache-ratio if set.",
+        )
+        parser.add_argument(
+            "--disaggregation-decode-hicache-write-policy",
+            type=str,
+            choices=["write_back", "write_through", "write_through_selective"],
+            default=ServerArgs.disaggregation_decode_hicache_write_policy,
+            help="The write policy for decode server HiRadixCache.",
         )
         parser.add_argument(
             "--disaggregation-decode-enable-offload-kvcache",


### PR DESCRIPTION
## Summary

In PD disaggregation, the decode worker can now use a **hierarchical radix cache** (L1 GPU + L2 host memory + Optional L3) to cache and reuse shared prefixes across requests. When a request arrives, the decode server first checks L1 (GPU radix cache), then L2 (host memory), and only requests the delta KV from prefill on a full miss.

This extends the existing decode radix cache (`--disaggregation-decode-enable-radix-cache`, PR #19746) with a host-memory backing store that dramatically increases effective cache capacity.

Enabled with `--disaggregation-decode-enable-hicache` on the decode server (requires `--disaggregation-decode-enable-radix-cache`).

## Motivation

The GPU-only decode radix cache is limited by GPU memory capacity. In a TP4/DP4 decode setup with `mem-fraction-static=0.85`, each rank can hold ~162K tokens (~10 unique 16K-token prefixes). When the working set exceeds this (e.g., 50 distinct prefix groups), GPU cache hit rate drops below 20% and most of the benefit is lost.

HiCache solves this by spilling evicted KV entries to host memory (L2) and loading them back via PCIe DMA on demand, providing a much larger effective cache without requiring additional GPU memory.

## Main Changes

- **Decode preallocation queue** (`decode.py`)
  - Two-phase prefix matching: read-only match → L2→L1 load-back → lock
  - L2→L1 async prefetch with timeout-based wait
  - Batch eviction before allocation to avoid per-request eviction overhead
  - Budget pre-check to skip wasteful DMA when request cannot fit
  - Permanent stuck detection and abort for oversized requests
  - HiCache abort cleanup at all failure points
- **HiRadixCache bug fixes** (`hiradix_cache.py`)
  - `match_prefix_helper`: break at evicted node boundary to prevent gaps
  - `insert()`: free `host_value` when restoring evicted nodes to prevent leaks
- **Retracted request fix** (`decode.py`)
  - Restore `last_node` for retracted requests so cache tree structure is preserved
- **CLI flags** (`server_args.py`)
  - `--disaggregation-decode-enable-hicache`
  - `--disaggregation-decode-hicache-ratio` (L2/L1 size ratio, default 3.0)
  - `--disaggregation-decode-hicache-size` (explicit L2 size in GB)
  - `--disaggregation-decode-hicache-write-policy` (`write_through` or `write_back`)
  - SWA/SSM model incompatibility check

## Interface

Enable HiCache on the **decode** worker:

```bash
python3 -m sglang.launch_server \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-decode-enable-radix-cache \
  --disaggregation-decode-enable-hicache \
  --disaggregation-decode-hicache-ratio 5.0 \
  --disaggregation-decode-hicache-write-policy write_through
```

The `--disaggregation-decode-hicache-ratio` controls L2 host memory size as a multiple of GPU KV capacity. With ratio=5.0 and ~40GB GPU KV, each rank allocates ~200GB host memory. For multi-DP setups, total host memory = ratio × GPU_KV × num_DP_ranks.

## Benchmark

### Setup

- **Hardware**: 8× NVIDIA H100 80GB, single-node PD disaggregation via Mooncake RDMA
- **Model**: Qwen3-32B BF16, context 40960
- **Layout**: 1P4D — Prefill GPU 0-3 (TP4), Decode GPU 4-7 (TP4/DP4/EP4/DPA)
- **HiCache config**: ratio=5.0, write_through, ~212GB L2 host cache per rank
- **Workload**: `generated-shared-prefix`, 16K shared prefix + 4.5K suffix, 350 output tokens, concurrency 8，"10 groups × 50 prompts" means all 50 requests within each group share the same 16K-token prefix.    

### Results — W1: High prefix reuse (10 groups × 50 prompts)

| Metric | Baseline (no cache) | Radix Cache (GPU-only) | **HiCache** |
|--------|:---:|:---:|:---:|
| Output throughput (tok/s) | 338.9 | 415.4 | **437.6** |
| TTFT median (ms) | 2772 | 1099 | **653** |
| TTFT mean (ms) | 3089 | 1401 | **863** |
| E2E mean (ms) | 8220 | 6697 | **6342** |

**HiCache vs Radix-only: TTFT median -41%, throughput +5%**

### Results — W2: Low prefix reuse (50 groups × 10 prompts)

| Metric | Baseline (no cache) | Radix Cache (GPU-only) | **HiCache** |
|--------|:---:|:---:|:---:|
| Output throughput (tok/s) | 380.8 | 373.7 | **386.4** |
| TTFT median (ms) | 1917 | 2170 | **1613** |
| TTFT mean (ms) | 2128 | 2337 | **1748** |
| E2E mean (ms) | 7310 | 7449 | **7203** |

**HiCache vs Radix-only: TTFT median -26%, throughput +3%**

In the low-reuse scenario (50 prefix groups), GPU-only radix cache is worse than baseline because eviction churn dominates. HiCache's L2 host store absorbs the overflow and maintains a positive hit rate.


### Cross-node PD: where HiCache shines most

The benchmarks above are single-node (prefill and decode on the same machine, RDMA over local InfiniBand). In production cross-node PD deployments, the benefit of HiCache is expected to be **significantly larger** .

## Test Plan

- [x] Qwen3-32B 1P4D on H100 (results above)
- [x] Qwen3-32B 3P1D on H100 (baseline validation)
- [x] Retracted request correctness with radix cache
- [x] HiCache abort cleanup on transfer failure
- [ ] Multi-node cross-host testing





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->