### PR TITLE
[P/D disagg] Add cache-aware DP routing for decode disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -615,6 +615,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             resumed_reqs.append(req)
             indices_to_remove.add(i)
             req.is_retracted = False
+            if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
+                req.last_node = self.tree_cache.root_node
+                self.tree_cache.inc_lock_ref(self.tree_cache.root_node)
             self._pre_alloc(req)
             full_allocatable_tokens -= full_required
             if uses_swa_tail_prealloc:

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -201,6 +201,11 @@ class DataParallelController:
         self.refresh_load_budget_on_dispatch = self.load_balance_method in (
             LoadBalanceMethod.TOTAL_REQUESTS,
             LoadBalanceMethod.TOTAL_TOKENS,
+            # cache_aware reads each rank's load AND cache digest from the
+            # snapshot on every dispatch; without refreshing here the budget
+            # (and cache_digests) stay empty and routing degrades to a static
+            # fallback.
+            LoadBalanceMethod.CACHE_AWARE,
         )
 
         # Load balance budget

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -786,6 +786,16 @@ class DataParallelController:
                 )
 
         self.dp_budget.total_requests[best_rank] += 1
+        logger.debug(
+            "[CacheAware] req=%s input_len=%d -> rank=%d match=%d "
+            "matches=%s reqs=%s",
+            getattr(req, "rid", "?"),
+            len(token_ids),
+            best_rank,
+            match_info.get(best_rank, 0),
+            match_info,
+            {r: self.dp_budget.total_requests[r] for r in active_ranks},
+        )
         self.workers[best_rank].send_pyobj(req)
 
     def event_loop(self):

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -79,7 +79,7 @@ def _fast_chain_hash(token_ids: List[int], start: int, end: int, prior: bytes) -
     h = hashlib.sha256()
     if prior:
         h.update(prior)
-    h.update(repr(token_ids[start:end]).encode())
+    h.update(repr(list(token_ids[start:end])).encode())
     return h.digest()
 
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -781,8 +781,20 @@ class DataParallelController:
                 and self._rank_available_tokens(r) >= input_len - match_info.get(r, 0)
             ]
             if viable:
-                best_rank = min(
-                    viable, key=lambda r: self.dp_budget.total_requests[r]
+                best_rank = min(viable, key=lambda r: self.dp_budget.total_requests[r])
+            else:
+                # No rank has enough capacity for this request.  Cache
+                # affinity is moot here, so fall back to the rank with the
+                # most free space (largest available - needed), breaking ties
+                # by fewest requests.  This keeps us from piling onto a rank
+                # we already know is over capacity.
+                best_rank = max(
+                    active_ranks,
+                    key=lambda r: (
+                        self._rank_available_tokens(r)
+                        - (input_len - match_info.get(r, 0)),
+                        -self.dp_budget.total_requests[r],
+                    ),
                 )
 
         self.dp_budget.total_requests[best_rank] += 1

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -14,13 +14,14 @@
 """A controller that dispatches requests to multiple data parallel workers."""
 
 import faulthandler
+import hashlib
 import logging
 import multiprocessing as mp
 import signal
 import threading
 import time
 from enum import Enum, auto
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import psutil
 import setproctitle
@@ -69,6 +70,41 @@ logger = logging.getLogger(__name__)
 SCHEDULER_PIDS_ARG = "scheduler_pids"
 
 
+def _fast_chain_hash(token_ids: List[int], start: int, end: int, prior: bytes) -> bytes:
+    """Deterministic chained hash: SHA256 on token repr bytes.
+
+    Unlike Python builtin hash(), SHA256 is consistent across processes.
+    Handles both int and tuple token IDs (e.g. EAGLE bigram mode).
+    """
+    h = hashlib.sha256()
+    if prior:
+        h.update(prior)
+    h.update(repr(token_ids[start:end]).encode())
+    return h.digest()
+
+
+def estimate_prefix_match(
+    token_ids: List[int],
+    digest_entries: Dict[bytes, int],
+    chunk_size: int,
+) -> int:
+    """Estimate prefix match length against a CacheDigest's prefix_entries.
+
+    Uses the same chained-hash scheme as RadixCache.build_cache_digest() so
+    the hashes are comparable.  Walks chunk-aligned boundaries until the
+    first miss.
+    """
+    matched_len = 0
+    chain_hash = b""
+    for end in range(chunk_size, len(token_ids) + 1, chunk_size):
+        chain_hash = _fast_chain_hash(token_ids, end - chunk_size, end, chain_hash)
+        if chain_hash in digest_entries:
+            matched_len = end
+        else:
+            break
+    return matched_len
+
+
 class LoadBalanceMethod(Enum):
     """Load balance method."""
 
@@ -76,6 +112,7 @@ class LoadBalanceMethod(Enum):
     FOLLOW_BOOTSTRAP_ROOM = auto()
     TOTAL_REQUESTS = auto()
     TOTAL_TOKENS = auto()
+    CACHE_AWARE = auto()
 
     @classmethod
     def from_str(cls, method: str):
@@ -92,6 +129,8 @@ class DPBudget:
         self.total_requests = [0] * dp_size
         self.total_tokens = [0] * dp_size
         self.last_timestamp = [0.0] * dp_size
+        self.max_total_tokens = [0] * dp_size
+        self.cache_digests: List[Optional[object]] = [None] * dp_size
 
     def update_budget(self, loads):
         """Update budget from shm snapshots, skipping stale reads."""
@@ -103,6 +142,9 @@ class DPBudget:
                 load.num_running_reqs + load.num_waiting_reqs
             )
             self.total_tokens[load.dp_rank] = load.num_total_tokens
+            self.max_total_tokens[load.dp_rank] = load.max_total_num_tokens
+            if hasattr(load, "cache_digest") and load.cache_digest is not None:
+                self.cache_digests[load.dp_rank] = load.cache_digest
 
     def dispatch(self, method: LoadBalanceMethod, estimated_tokens: int = 0):
         if method == LoadBalanceMethod.TOTAL_REQUESTS:
@@ -153,6 +195,7 @@ class DataParallelController:
             LoadBalanceMethod.FOLLOW_BOOTSTRAP_ROOM: self.follow_bootstrap_room_scheduler,
             LoadBalanceMethod.TOTAL_REQUESTS: self.total_requests_scheduler,
             LoadBalanceMethod.TOTAL_TOKENS: self.total_tokens_scheduler,
+            LoadBalanceMethod.CACHE_AWARE: self.cache_aware_scheduler,
         }
         self.dispatching = dispatch_lookup[self.load_balance_method]
         self.refresh_load_budget_on_dispatch = self.load_balance_method in (
@@ -168,6 +211,10 @@ class DataParallelController:
             caller="DataParallelController",
         )
         self._last_refresh_time = 0.0
+
+        # Cache-aware routing params
+        self.dp_routing_digest_chunk_size = server_args.dp_routing_digest_chunk_size
+        self.dp_routing_max_extra_reqs = server_args.dp_routing_max_extra_reqs
 
         # To protect changing env vars to set CUDA_VISIBLE_DEVICES.
         self.env_lock = threading.Lock()
@@ -642,6 +689,104 @@ class DataParallelController:
             LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
         )
         self.workers[target_worker].send_pyobj(req)
+
+    def _rank_available_tokens(self, rank: int) -> float:
+        max_tok = self.dp_budget.max_total_tokens[rank]
+        if max_tok <= 0:
+            return float("inf")
+        used = self.dp_budget.total_tokens[rank]
+        digest = self.dp_budget.cache_digests[rank]
+        evictable = digest.evictable_tokens if digest is not None else 0
+        return max_tok - used + evictable
+
+    def cache_aware_scheduler(self, req: Req):
+        """Dispatch considering both prefix cache affinity and request balance.
+
+        Logic:
+          1. Estimate cache match length on each active DP rank.
+          2. Pick the ranks with the longest match.
+          3. Among those, pick the one with fewest requests.
+          4. But if that rank already has more requests than the
+             least-loaded rank by >= max_extra_reqs, ignore cache
+             and pick the least-loaded rank instead.
+          5. If the chosen rank doesn't have enough capacity for the
+             request, pick the least-loaded rank that does.
+        """
+        if self.maybe_external_dp_rank_routing(req):
+            return
+
+        rid = getattr(req, "rid", "")
+        if isinstance(rid, str) and rid.startswith("HEALTH_CHECK_"):
+            self.round_robin_scheduler(req)
+            return
+
+        dp_size = len(self.workers)
+        chunk_size = self.dp_routing_digest_chunk_size
+        max_extra = self.dp_routing_max_extra_reqs
+
+        token_ids = getattr(req, "input_ids", None)
+        if token_ids is None:
+            token_ids = getattr(req, "origin_input_ids", None)
+
+        active_ranks = [i for i in range(dp_size) if self.status[i]]
+        if not active_ranks:
+            active_ranks = list(range(dp_size))
+
+        has_any_digest = any(
+            self.dp_budget.cache_digests[r] is not None for r in active_ranks
+        )
+        if not has_any_digest or not token_ids or len(token_ids) < chunk_size:
+            estimated_tokens = len(token_ids) if token_ids else 0
+            target = self.dp_budget.dispatch(
+                LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
+            )
+            if target is None:
+                target = active_ranks[self.round_robin_counter % len(active_ranks)]
+                self.round_robin_counter += 1
+            self.workers[target].send_pyobj(req)
+            return
+
+        match_info: Dict[int, int] = {}
+        for rank in active_ranks:
+            digest = self.dp_budget.cache_digests[rank]
+            if digest is not None and digest.prefix_entries:
+                match_info[rank] = estimate_prefix_match(
+                    token_ids, digest.prefix_entries, chunk_size
+                )
+            else:
+                match_info[rank] = 0
+
+        best_match = max(match_info.values())
+        if best_match > 0:
+            candidates = [r for r in active_ranks if match_info[r] == best_match]
+        else:
+            candidates = active_ranks
+
+        best_rank = min(candidates, key=lambda r: self.dp_budget.total_requests[r])
+
+        min_reqs = min(self.dp_budget.total_requests[r] for r in active_ranks)
+        if self.dp_budget.total_requests[best_rank] - min_reqs >= max_extra:
+            best_rank = min(
+                active_ranks, key=lambda r: self.dp_budget.total_requests[r]
+            )
+
+        input_len = len(token_ids)
+        needed = input_len - match_info.get(best_rank, 0)
+        available = self._rank_available_tokens(best_rank)
+        if needed > available:
+            viable = [
+                r
+                for r in active_ranks
+                if r != best_rank
+                and self._rank_available_tokens(r) >= input_len - match_info.get(r, 0)
+            ]
+            if viable:
+                best_rank = min(
+                    viable, key=lambda r: self.dp_budget.total_requests[r]
+                )
+
+        self.dp_budget.total_requests[best_rank] += 1
+        self.workers[best_rank].send_pyobj(req)
 
     def event_loop(self):
         while True:

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2104,6 +2104,16 @@ class GetLoadsReqInput(BaseReq):
 
 
 @dataclass
+class CacheDigest:
+    dp_rank: int
+    prefix_entries: Dict[bytes, int]
+    total_cached_tokens: int
+    evictable_tokens: int
+    protected_tokens: int
+    timestamp: float
+
+
+@dataclass
 class GetLoadsReqOutput(BaseReq):
     """Per-DP-rank load metrics for /v1/loads endpoint."""
 
@@ -2156,6 +2166,7 @@ class GetLoadsReqOutput(BaseReq):
     lora: Optional[LoRAMetrics] = None
     disaggregation: Optional[DisaggregationMetrics] = None
     queues: Optional[QueueMetrics] = None
+    cache_digest: Optional[CacheDigest] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -87,7 +87,10 @@ def should_use_zmq(server_args) -> bool:
     ) or envs.SGLANG_LOAD_SNAPSHOT_USE_ZMQ.get()
 
 
-_LOAD_AWARE_METHODS = frozenset({"total_requests", "total_tokens"})
+# Methods for which the DataParallelController reads load snapshots on every
+# dispatch (and thus owns the zmq PULL socket in multi-node mode).
+# cache_aware also consumes the per-rank cache digest carried in the snapshot.
+_LOAD_AWARE_METHODS = frozenset({"total_requests", "total_tokens", "cache_aware"})
 
 
 def _tokenizer_load_snapshot_owner_caller(server_args) -> str:
@@ -214,6 +217,21 @@ SECTION_FIELDS = (
 )
 
 
+class CacheDigestSnapshot(msgspec.Struct, omit_defaults=True):
+    """Serializable mirror of ``io_struct.CacheDigest`` for the SHM/zmq
+    transport.  Carries the chunk-aligned prefix hash digest a decode rank
+    publishes so the DP controller can do cache-aware routing.  ``bytes`` keys
+    round-trip cleanly through msgpack.
+    """
+
+    dp_rank: int = 0
+    prefix_entries: dict[bytes, int] = {}
+    total_cached_tokens: int = 0
+    evictable_tokens: int = 0
+    protected_tokens: int = 0
+    timestamp: float = 0.0
+
+
 class LoadSnapshot(msgspec.Struct, omit_defaults=True):
     timestamp: float = 0.0
     dp_rank: int = 0
@@ -260,6 +278,11 @@ class LoadSnapshot(msgspec.Struct, omit_defaults=True):
     queue_paused: int = 0
     queue_retracted: int = 0
 
+    # Cache-aware DP routing digest (decode ranks with radix cache only).
+    # None for prefill / non-cache-aware ranks; omit_defaults keeps the
+    # encoded payload tiny in that case.
+    cache_digest: Optional[CacheDigestSnapshot] = None
+
     @classmethod
     def from_get_loads_output(cls, output: GetLoadsReqOutput) -> LoadSnapshot:
         snapshot: dict = {}
@@ -282,6 +305,17 @@ class LoadSnapshot(msgspec.Struct, omit_defaults=True):
                 else:
                     value = _native(value)
                 snapshot[snapshot_attr] = value
+
+        digest = getattr(output, "cache_digest", None)
+        if digest is not None:
+            snapshot["cache_digest"] = CacheDigestSnapshot(
+                dp_rank=int(digest.dp_rank),
+                prefix_entries=digest.prefix_entries,
+                total_cached_tokens=int(digest.total_cached_tokens),
+                evictable_tokens=int(digest.evictable_tokens),
+                protected_tokens=int(digest.protected_tokens),
+                timestamp=_native(digest.timestamp),
+            )
 
         return cls(**snapshot)
 
@@ -343,10 +377,15 @@ snapshot_decoder = msgspec.msgpack.Decoder(LoadSnapshot)
 # ---------------------------------------------------------------------------
 
 MAGIC = b"SLNS"
-VERSION = 2
+VERSION = 3
 HEADER_STRUCT = struct.Struct("<4sHHI")
 SLOT_LEN_STRUCT = struct.Struct("<I")
-SLOT_SIZE = 16 * 1024
+# 128 KiB per slot: must hold a full cache-aware routing digest.  A digest of
+# the default max_entries=2048 chunk hashes (32-byte key + int) encodes to
+# ~76 KiB via msgpack; 16 KiB (the metrics-only size) overflows and the write
+# raises.  Readers negotiate the actual slot size from the SHM header, so
+# bumping this is backward-safe (VERSION bump invalidates stale files).
+SLOT_SIZE = 128 * 1024
 
 
 @contextmanager

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1811,6 +1811,7 @@ class Scheduler(
             get_disagg_decode_transfer_queue=lambda: self.disagg_decode_transfer_queue,
             get_spec_total_num_accept_tokens=lambda: self.metrics_reporter.spec_total_num_accept_tokens,
             get_spec_total_num_forward_ct=lambda: self.metrics_reporter.spec_total_num_forward_ct,
+            get_tree_cache=lambda: self.tree_cache,
         )
 
     def init_output_streamer(self) -> None:

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -222,20 +222,25 @@ class SchedulerLoadInquirer:
             tree_cache = self.get_tree_cache()
             if hasattr(tree_cache, "build_cache_digest"):
                 dirty = getattr(tree_cache, "_digest_dirty", True)
-                if dirty or not hasattr(tree_cache, "_cached_cache_digest"):
+                # Only the expensive prefix_entries (a full tree walk) is
+                # cached behind _digest_dirty.  The capacity scalars below are
+                # cheap O(1) reads and MUST be re-sampled every snapshot;
+                # otherwise the DP controller does capacity checks against a
+                # stale evictable_tokens and can over- or under-commit a rank.
+                if dirty or not hasattr(tree_cache, "_cached_prefix_entries"):
                     chunk_size = self.server_args.dp_routing_digest_chunk_size
                     digest_data = tree_cache.build_cache_digest(
                         chunk_size=chunk_size,
                     )
-                    tree_cache._cached_cache_digest = CacheDigest(
-                        dp_rank=self.ps.dp_rank,
-                        prefix_entries=digest_data["prefix_entries"],
-                        total_cached_tokens=digest_data["total_cached_tokens"],
-                        evictable_tokens=digest_data["evictable_tokens"],
-                        protected_tokens=digest_data["protected_tokens"],
-                        timestamp=time.time(),
-                    )
-                cache_digest = tree_cache._cached_cache_digest
+                    tree_cache._cached_prefix_entries = digest_data["prefix_entries"]
+                cache_digest = CacheDigest(
+                    dp_rank=self.ps.dp_rank,
+                    prefix_entries=tree_cache._cached_prefix_entries,
+                    total_cached_tokens=tree_cache.total_size(),
+                    evictable_tokens=tree_cache.evictable_size(),
+                    protected_tokens=tree_cache.protected_size(),
+                    timestamp=time.time(),
+                )
 
         return GetLoadsReqOutput(
             dp_rank=self.ps.dp_rank,

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import (
+    CacheDigest,
     DisaggregationMetrics,
     GetLoadsReqInput,
     GetLoadsReqOutput,
@@ -51,6 +52,7 @@ class SchedulerLoadInquirer:
     get_disagg_decode_transfer_queue: Callable
     get_spec_total_num_accept_tokens: Callable
     get_spec_total_num_forward_ct: Callable
+    get_tree_cache: Callable
 
     def _get_num_pending_tokens(self, chunk_deduct: int = 0) -> int:
         """Get the total number of tokens pending prefill.
@@ -212,6 +214,29 @@ class SchedulerLoadInquirer:
                 retracted=self.get_stats().num_retracted_reqs,
             )
 
+        cache_digest = None
+        if (
+            self.disaggregation_mode == DisaggregationMode.DECODE
+            and self.server_args.disaggregation_decode_enable_radix_cache
+        ):
+            tree_cache = self.get_tree_cache()
+            if hasattr(tree_cache, "build_cache_digest"):
+                dirty = getattr(tree_cache, "_digest_dirty", True)
+                if dirty or not hasattr(tree_cache, "_cached_cache_digest"):
+                    chunk_size = self.server_args.dp_routing_digest_chunk_size
+                    digest_data = tree_cache.build_cache_digest(
+                        chunk_size=chunk_size,
+                    )
+                    tree_cache._cached_cache_digest = CacheDigest(
+                        dp_rank=self.ps.dp_rank,
+                        prefix_entries=digest_data["prefix_entries"],
+                        total_cached_tokens=digest_data["total_cached_tokens"],
+                        evictable_tokens=digest_data["evictable_tokens"],
+                        protected_tokens=digest_data["protected_tokens"],
+                        timestamp=time.time(),
+                    )
+                cache_digest = tree_cache._cached_cache_digest
+
         return GetLoadsReqOutput(
             dp_rank=self.ps.dp_rank,
             timestamp=time.time(),
@@ -231,4 +256,5 @@ class SchedulerLoadInquirer:
             lora=lora,
             disaggregation=disaggregation,
             queues=queues,
+            cache_digest=cache_digest,
         )

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -977,6 +977,15 @@ class HiRadixCache(RadixCache):
     def evictable_size(self):
         return self.evictable_size_
 
+    def _skip_node_in_digest(self, node: TreeNode) -> bool:
+        # Include evicted nodes that have a host backup — they are recoverable
+        # via load_back() and should be visible to cache-aware DP routing.
+        return node.evicted and not node.backuped
+
+    def _to_radix_key(self, token_ids: List[int]) -> RadixKey:
+        """Convert raw token_ids to a RadixKey; must be list (not tuple) for paged match."""
+        return RadixKey(token_ids=list(token_ids))
+
     def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
         if self.disable:
             return IncLockRefResult(delta=0)
@@ -1076,6 +1085,8 @@ class HiRadixCache(RadixCache):
                 self._evict_backuped(node)
 
         self.update_eviction_metrics(num_evicted, start_time)
+        if num_evicted > 0:
+            self._digest_dirty = True
         return EvictResult(num_tokens_evicted=num_evicted)
 
     def _evict_backuped(self, node: TreeNode):
@@ -1201,6 +1212,7 @@ class HiRadixCache(RadixCache):
             self._record_store_event(node, medium=StorageMedium.GPU)
         self.evictable_size_ += len(device_indices)
         self.inc_lock_ref(last_hit_node)
+        self._digest_dirty = True
 
         if self.metrics_collector is not None:
             self.metrics_collector.observe_load_back_duration(
@@ -1709,6 +1721,7 @@ class HiRadixCache(RadixCache):
 
             if self.cache_controller.write_policy != "write_back":
                 self._inc_hit_count(new_node, chunked)
+        self._digest_dirty = True
         return InsertResult(prefix_len=total_prefix_length)
 
     def release_aborted_request(self, rid: str):

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -670,7 +670,10 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
                 if self._skip_node_in_digest(child):
                     continue
 
-                path_tokens = parent_tokens + child.key.token_ids
+                # child.key.token_ids may be an array.array; normalize to list
+                # so the concat works and repr(chunk) matches the list-based
+                # hashing in the DP controller's _fast_chain_hash.
+                path_tokens = parent_tokens + list(child.key.token_ids)
                 if len(path_tokens) > max_prefix_tokens:
                     path_tokens = path_tokens[:max_prefix_tokens]
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -658,11 +658,13 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
 
         Returns a dict ready to populate a CacheDigest dataclass.
         """
+        from collections import deque
+
         prefix_entries: dict = {}
 
-        stack: list = [(self.root_node, [], b"", 0)]
-        while stack:
-            node, parent_tokens, parent_chain_hash, parent_boundary = stack.pop()
+        queue = deque([(self.root_node, [], b"", 0)])
+        while queue:
+            node, parent_tokens, parent_chain_hash, parent_boundary = queue.popleft()
 
             for child in node.children.values():
                 if self._skip_node_in_digest(child):
@@ -695,9 +697,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
                     break
 
                 if len(path_tokens) < max_prefix_tokens and child.children:
-                    stack.append(
-                        (child, path_tokens, chain_hash, last_boundary)
-                    )
+                    queue.append((child, path_tokens, chain_hash, last_boundary))
 
             if len(prefix_entries) >= max_entries:
                 break

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -342,6 +342,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         self.root_node.hash_value = []
         self.evictable_size_ = 0
         self.protected_size_ = 0
+        self._digest_dirty = True
         self.evictable_leaves.clear()
         self._empty_match_result = MatchResult(
             device_indices=torch.empty(
@@ -433,6 +434,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             value = torch.tensor(key.token_ids[: len(key)], dtype=torch.int64)
 
         prefix_len = self._insert_helper(self.root_node, key, value, priority, chunked)
+        self._digest_dirty = True
         return InsertResult(prefix_len=prefix_len)
 
     def cache_finished_req(self, req: Req, is_insert: bool = True):
@@ -582,6 +584,8 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             self._record_remove_event(x)
 
         self.update_eviction_metrics(num_evicted, start_time)
+        if num_evicted > 0:
+            self._digest_dirty = True
         return EvictResult(num_tokens_evicted=num_evicted)
 
     def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
@@ -626,6 +630,86 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
     def protected_size(self):
         # protected size refers to the size of the cache that is locked
         return self.protected_size_
+
+    def _skip_node_in_digest(self, node: TreeNode) -> bool:
+        """Whether to skip *node* when building a cache digest.
+
+        RadixCache skips evicted nodes (GPU data gone, unrecoverable).
+        HiRadixCache overrides this to keep evicted nodes that still have
+        a host backup, since they can be recovered via load_back().
+        """
+        return node.evicted
+
+    def build_cache_digest(
+        self,
+        chunk_size: int = 256,
+        max_entries: int = 2048,
+        max_prefix_tokens: int = 8192,
+    ) -> dict:
+        """Build a compact digest of cached prefixes for cache-aware DP routing.
+
+        Traverses the radix tree and produces chunk-aligned prefix hashes.
+        Each entry maps hash(token_ids[:chunk_boundary]) -> cached_length,
+        allowing the DP controller to estimate prefix match length for incoming
+        requests without accessing the actual tree.
+
+        Uses a deterministic chained hash: SHA256 on repr-encoded token
+        bytes, matching the estimation function in the DP controller.
+
+        Returns a dict ready to populate a CacheDigest dataclass.
+        """
+        prefix_entries: dict = {}
+
+        stack: list = [(self.root_node, [], b"", 0)]
+        while stack:
+            node, parent_tokens, parent_chain_hash, parent_boundary = stack.pop()
+
+            for child in node.children.values():
+                if self._skip_node_in_digest(child):
+                    continue
+
+                path_tokens = parent_tokens + child.key.token_ids
+                if len(path_tokens) > max_prefix_tokens:
+                    path_tokens = path_tokens[:max_prefix_tokens]
+
+                chain_hash = parent_chain_hash
+                first_boundary = parent_boundary + chunk_size
+
+                last_boundary = parent_boundary
+                for boundary in range(first_boundary, len(path_tokens) + 1, chunk_size):
+                    h = hashlib.sha256()
+                    if chain_hash:
+                        h.update(chain_hash)
+                    chunk = path_tokens[boundary - chunk_size : boundary]
+                    h.update(repr(chunk).encode())
+                    chain_hash = h.digest()
+                    prefix_entries[chain_hash] = max(
+                        prefix_entries.get(chain_hash, 0), boundary
+                    )
+                    last_boundary = boundary
+
+                    if len(prefix_entries) >= max_entries:
+                        break
+
+                if len(prefix_entries) >= max_entries:
+                    break
+
+                if len(path_tokens) < max_prefix_tokens and child.children:
+                    stack.append(
+                        (child, path_tokens, chain_hash, last_boundary)
+                    )
+
+            if len(prefix_entries) >= max_entries:
+                break
+
+        total = self._total_size_helper()
+        self._digest_dirty = False
+        return {
+            "prefix_entries": prefix_entries,
+            "total_cached_tokens": total,
+            "evictable_tokens": self.evictable_size_,
+            "protected_tokens": self.protected_size_,
+        }
 
     def all_values_flatten(self):
         values = []

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -882,6 +882,7 @@ class ServerArgs:
                 "follow_bootstrap_room",
                 "total_requests",
                 "total_tokens",
+                "cache_aware",
             ],
         ),
     ] = "auto"
@@ -2254,6 +2255,17 @@ class ServerArgs:
         "Number of optimistic prefill retries that will skip the bootstrap wait. ",
     ] = 0
 
+    # Cache-aware DP routing (decode multi-DP)
+    dp_routing_digest_chunk_size: A[
+        int,
+        "Chunk size (in tokens) for CacheDigest prefix hashing. Default 256.",
+    ] = 256
+    dp_routing_max_extra_reqs: A[
+        int,
+        "Max extra requests a cache-preferred rank can have over the least-loaded "
+        "rank before falling back to load balance. Default 1.",
+    ] = 1
+
     # -------------------------------------------------------------------------
     # Encode prefill disaggregation
     # -------------------------------------------------------------------------
@@ -2627,12 +2639,18 @@ class ServerArgs:
             # Default behavior:
             # - non-PD: round_robin
             # - PD prefill: follow_bootstrap_room
-            # - PD decode: round_robin
-            self.load_balance_method = (
-                "follow_bootstrap_room"
-                if self.disaggregation_mode == "prefill"
-                else "round_robin"
-            )
+            # - PD decode + radix cache + dp > 1: cache_aware
+            # - PD decode (other): round_robin
+            if self.disaggregation_mode == "prefill":
+                self.load_balance_method = "follow_bootstrap_room"
+            elif (
+                self.disaggregation_mode == "decode"
+                and self.disaggregation_decode_enable_radix_cache
+                and self.dp_size > 1
+            ):
+                self.load_balance_method = "cache_aware"
+            else:
+                self.load_balance_method = "round_robin"
             return
 
     def _handle_ssl_validation(self):


### PR DESCRIPTION
## Summary

In PD disaggregation with DP attention, the decode workers can now use **cache-aware routing** to dispatch requests to the DP rank that has the best radix cache match for the request's prefix, instead of round-robin. This maximizes prefix reuse across DP ranks and dramatically reduces TTFT.

The DP controller periodically collects compact cache digests (chunk-aligned SHA256 hashes) from each worker, then routes each incoming request to the rank with the longest prefix match — with automatic fallback to the least-loaded rank when the preferred rank is overloaded or lacks capacity.

### Routing Decision Logic

1. **Find best cache match**: estimate prefix match length against each rank's cache digest, select the rank with the longest hit.
2. **Load balance check**: if the best-match rank's pending request count exceeds the least-loaded rank by more than `--dp-routing-max-extra-reqs`, fall back to the least-loaded rank (prevents hot-rank overload).
3. **Capacity check**: if the best-match rank's available KV cache cannot accommodate the request (prefix + suffix tokens), fall back to the least-loaded rank (avoids KV-full stalls).
4. **No match**: if no rank has a prefix hit, route to the least-loaded rank (equivalent to load-balanced round-robin).

Enabled with `--load-balance-method cache_aware` on the decode server (requires `--disaggregation-decode-enable-radix-cache` and DP > 1).

## Motivation

With round-robin routing in a DP4 decode setup, requests sharing the same prefix are scattered across all 4 ranks. Each rank independently caches a partial copy of the same prefix, wasting GPU KV capacity and reducing hit rates. In a 50-group workload, round-robin achieves only 12.7% hit rate per rank, which is actually *worse* than no cache at all (+13% TTFT regression).

Cache-aware routing solves this by concentrating same-prefix requests on the same rank, achieving 2x higher hit rates (27.4% vs 12.7%) in low-reuse scenarios and near-perfect reuse (88.5% vs 57.1%) in high-reuse scenarios.

## Main Changes

- **DP controller** (`data_parallel_controller.py`)
  - `CacheDigest` dataclass for compact prefix hash summaries
  - `cache_aware_scheduler()`: multi-criteria routing (cache affinity → request balance → capacity check)
  - `estimate_prefix_match()`: client-side hash matching against worker digests
  - Periodic digest collection from workers with dirty-flag optimization
- **RadixCache** (`radix_cache.py`)
  - `build_cache_digest()`: chunk-aligned SHA256 prefix hashing
  - Dirty-flag tracking to avoid unnecessary digest rebuilds
- **HiRadixCache** (`hiradix_cache.py`)
  - `_skip_node_in_digest()`: include host-backed evicted nodes in digests since they are recoverable via `load_back()`
- **Scheduler** (`scheduler.py`, `load_inquirer.py`)
  - Export cache digest and load info to DP controller
- **CLI flags** (`server_args.py`)
  - `--dp-routing-digest-chunk-size` (default 256 tokens)
  - `--dp-routing-max-extra-reqs` (default 1, overflow tolerance)

## Interface

Enable cache-aware routing on the **decode** worker with `--load-balance-method cache_aware`:

```bash
# Decode server
python3 -m sglang.launch_server \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-decode-enable-radix-cache \
  --load-balance-method cache_aware \
  --tp 4 --dp-size 4 --ep-size 4 --enable-dp-attention

# Router (decode-policy is overridden by cache-aware internally)
python -m sglang_router.launch_router \
  --pd-disaggregation \
  --prefill http://127.0.0.1:8001 8998 \
  --decode http://127.0.0.1:8000
```

Optional tuning:
- `--dp-routing-digest-chunk-size 256`: hash granularity (smaller = more precise, more memory)
- `--dp-routing-max-extra-reqs 2`: how many extra requests a cache-preferred rank can accept before fallback

## Benchmark

### Setup

- **Hardware**: 8× NVIDIA H100 80GB, single-node PD disaggregation via Mooncake RDMA
- **Model**: Qwen3-32B BF16, context 40960
- **Layout**: 1P4D — Prefill GPU 0-3 (TP4), Decode GPU 4-7 (TP4/DP4/EP4/DPA)
- **Workload**: `generated-shared-prefix`, 16K shared prefix + 4.5K suffix, 350 output tokens, concurrency 8，"10 groups × 50 prompts" means all 50 requests within each group share the same 16K-token prefix.    

### Results — W1: High prefix reuse (10 groups × 50 prompts)

| Metric | Baseline (no cache) | Radix + Round-Robin | **Radix + Cache-Aware** |
|--------|:---:|:---:|:---:|
| Output throughput (tok/s) | 338.9 | 415.4 | **433.6** |
| TTFT median (ms) | 2772 | 1099 | **584** |
| TTFT mean (ms) | 3089 | 1401 | **795** |
| E2E mean (ms) | 8220 | 6697 | **6424** |
| Cache hit rate (per rank) | — | 57.1% | **88.5%** |

**Cache-aware vs round-robin: TTFT median -47%, hit rate +55%**

### Results — W2: Low prefix reuse (50 groups × 10 prompts)

| Metric | Baseline (no cache) | Radix + Round-Robin | **Radix + Cache-Aware** |
|--------|:---:|:---:|:---:|
| Output throughput (tok/s) | 380.8 | 373.7 | **396.0** |
| TTFT median (ms) | 1917 | 2170 | **1356** |
| TTFT mean (ms) | 2128 | 2337 | **1454** |
| E2E mean (ms) | 7310 | 7449 | **7016** |
| Cache hit rate (per rank) | — | 12.7% | **27.4%** |

**Cache-aware vs round-robin: TTFT median -38%, hit rate +116%**

Note: Radix + round-robin actually **degrades** TTFT vs baseline in W2 (+13%) because random dispatch destroys prefix locality. Cache-aware routing is the only configuration that consistently beats baseline across both workloads.

### Cache Hit Rate Analysis

| Workload | Round-Robin Hit Rate | Cache-Aware Hit Rate | Improvement |
|----------|:---:|:---:|:---:|
| W1 (10g×50p) | 57.1% | **88.5%** | +55% |
| W2 (50g×10p) | 12.7% | **27.4%** | +116% |

## Test Plan

- [x] Qwen3-32B 1P4D on H100, W1 and W2 (results above)
- [x] Baseline / Radix+RR / Cache-Aware A/B/C comparison
- [x] Verify cache hit rate from decode logs
- [x] HiRadixCache digest compatibility (evicted nodes included)
- [ ] Multi-node cross-host testing
- [ ] Interaction with HiCache (PR1) — expected to be complementary













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->