### PR TITLE
Speed up DeepGEMM JIT warmup with per-PP-rank parallel compile

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -449,6 +449,7 @@ class Envs:
     SGLANG_DG_USE_NVRTC = EnvBool(False)
     SGLANG_USE_DEEPGEMM_BMM = EnvBool(False)
     SGLANG_DEEPGEMM_SANITY_CHECK = EnvBool(False)
+    SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP = EnvBool(False)
 
     # DeepSeek MHA Optimization
     SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD = EnvInt(8192)

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -450,3 +450,68 @@ def _deep_gemm_execution_hook(
     if m > 0:
         _maybe_compile_deep_gemm_one_type_all(kernel_type, n, k, num_groups)
     yield
+
+
+def pp_parallel_deep_gemm_warmup(model_runner) -> None:
+    """Run per-PP-rank dummy DECODE+EXTEND forwards so each rank's
+    DeepGEMM JIT compiles in parallel instead of serially via the warmup
+    /generate flowing through the pipeline. Opt-in via
+    SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP.
+    """
+    import time
+
+    from sglang.srt.model_executor.forward_batch_info import ForwardMode
+    from sglang.srt.utils import ceil_align
+
+    # n_splits ~= n_sms / ceil(bs/block_m) with block_m=64; sweep 5 bs to
+    # cover the brackets real /generate hits (smallest decode shape,
+    # mid-low, two mid, and n_splits=1 for ~5K+ token prefill). Ceil-align
+    # to attn_cp_size for DSA prefill CP's seq_len % cp_size == 0 assert.
+    n_sms = torch.cuda.get_device_properties(model_runner.device).multi_processor_count
+    block_m = 64
+    cp = max(model_runner.attn_cp_size, 1)
+    batch_sizes = sorted(
+        {
+            ceil_align(bs, cp)
+            for bs in (
+                1,
+                2 * block_m,
+                max(n_sms // 8, 2) * block_m,
+                max(n_sms // 4, 4) * block_m,
+                n_sms * block_m,
+            )
+        }
+    )
+
+    # In PD, prefill-only nodes never decode (indexer would OOM at large
+    # bs) and decode-only nodes never extend.
+    disagg_mode = model_runner.server_args.disaggregation_mode
+    run_decode = model_runner.is_generation and disagg_mode != "prefill"
+    run_extend = disagg_mode != "decode"
+
+    logger.info(
+        "PP-parallel DeepGEMM warmup start "
+        "(pp_rank=%d, tp_rank=%d, batch_sizes=%s, disagg=%s).",
+        model_runner.pp_rank,
+        model_runner.tp_rank,
+        batch_sizes,
+        disagg_mode,
+    )
+
+    t0 = time.perf_counter()
+    with torch.inference_mode():
+        for bs in batch_sizes:
+            if run_decode:
+                model_runner._dummy_run(
+                    batch_size=bs, forward_mode_override=ForwardMode.DECODE
+                )
+            if run_extend:
+                model_runner._dummy_run(
+                    batch_size=bs, forward_mode_override=ForwardMode.EXTEND
+                )
+
+    logger.info(
+        "PP-parallel DeepGEMM warmup done in %.2fs (pp_rank=%d).",
+        time.perf_counter() - t0,
+        model_runner.pp_rank,
+    )

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from contextlib import contextmanager, nullcontext
 from enum import IntEnum, auto
 from typing import Dict, List, Tuple
@@ -13,8 +14,9 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.deep_gemm_wrapper.configurer import ENABLE_JIT_DEEPGEMM
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import ceil_div, get_available_gpu_memory, is_musa
+from sglang.srt.utils import ceil_align, ceil_div, get_available_gpu_memory, is_musa
 
 logger = logging.getLogger(__name__)
 
@@ -458,11 +460,6 @@ def pp_parallel_deep_gemm_warmup(model_runner) -> None:
     /generate flowing through the pipeline. Opt-in via
     SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP.
     """
-    import time
-
-    from sglang.srt.model_executor.forward_batch_info import ForwardMode
-    from sglang.srt.utils import ceil_align
-
     # n_splits ~= n_sms / ceil(bs/block_m) with block_m=64; sweep 5 bs to
     # cover the brackets real /generate hits (smallest decode shape,
     # mid-low, two mid, and n_splits=1 for ~5K+ token prefill). Ceil-align

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2322,17 +2322,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         parallel across PP stages instead of serially via the warmup
         ``/generate`` request flowing through the pipeline.
         """
-        # Sweep representative batch sizes so kernels whose num_groups
-        # depends on num_tokens (e.g. TF32_HC_PRENORM_GEMM on DSv4) get
-        # compiled for both small-decode and large-prefill regimes.
-        batch_sizes = {1}
-        max_run = max(self.server_args.max_running_requests or 0, 1)
-        batch_sizes.add(max(max_run // max(self.pp_size, 1), 1))
-        chunked = self.server_args.chunked_prefill_size
-        if chunked and chunked > 0:
-            batch_sizes.add(chunked)
-        batch_sizes.add(1024)
-        batch_sizes = sorted(batch_sizes)
+        # n_splits ~= n_sms // ceil(bs/64); pick bs to cover 4 brackets.
+        n_sms = torch.cuda.get_device_properties(self.device).multi_processor_count
+        block_m = 64
+        batch_sizes = sorted(
+            {
+                1,
+                2 * block_m,
+                max(n_sms // 8, 2) * block_m,
+                max(n_sms // 4, 4) * block_m,
+            }
+        )
 
         logger.info(
             "PP-parallel DeepGEMM warmup start (pp_rank=%d, tp_rank=%d, batch_sizes=%s).",
@@ -2341,9 +2341,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             batch_sizes,
         )
         t0 = time.perf_counter()
-        try:
-            with torch.inference_mode():
-                for bs in batch_sizes:
+        for bs in batch_sizes:
+            try:
+                with torch.inference_mode():
                     if self.is_generation:
                         self._dummy_run(
                             batch_size=bs,
@@ -2353,9 +2353,21 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                         batch_size=bs,
                         forward_mode_override=ForwardMode.EXTEND,
                     )
-        except Exception as e:
-            logger.warning("PP-parallel DeepGEMM warmup skipped: %r", e)
-            return
+            except torch.cuda.OutOfMemoryError as e:
+                logger.warning(
+                    "PP-parallel DeepGEMM warmup OOM at batch_size=%d, stopping sweep: %r",
+                    bs,
+                    e,
+                )
+                torch.cuda.empty_cache()
+                break
+            except Exception as e:
+                logger.warning(
+                    "PP-parallel DeepGEMM warmup skipped at batch_size=%d: %r",
+                    bs,
+                    e,
+                )
+                break
 
         logger.info(
             "PP-parallel DeepGEMM warmup done in %.2fs (pp_rank=%d).",

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2303,15 +2303,54 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         return attn_backend_wrapper(self, full_attention_backend)
 
     def kernel_warmup(self):
-        """
-        Warmup and tune kernels before cuda graph capture.
-        Currently only doing FlashInfer autotune.
-        """
+        """Warmup and tune kernels before cuda graph capture."""
         if self.device != "cuda":
             return
 
         if self._should_run_flashinfer_autotune():
             self._flashinfer_autotune()
+
+        self._pp_parallel_deep_gemm_warmup()
+
+    def _pp_parallel_deep_gemm_warmup(self):
+        """Per-PP-rank local dummy forward so DeepGEMM JIT compiles in
+        parallel across PP stages instead of serially via the warmup
+        ``/generate`` request flowing through the pipeline.
+        """
+        if not deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
+            return
+        if self.pp_size <= 1:
+            return
+        # Speculative target-verify has its own metadata; rely on serving warmup.
+        if self.spec_algorithm.is_speculative():
+            return
+
+        logger.info(
+            "PP-parallel DeepGEMM warmup start (pp_rank=%d, tp_rank=%d).",
+            self.pp_rank,
+            self.tp_rank,
+        )
+        t0 = time.perf_counter()
+        try:
+            with torch.inference_mode():
+                if self.is_generation:
+                    self._dummy_run(
+                        batch_size=1,
+                        forward_mode_override=ForwardMode.DECODE,
+                    )
+                self._dummy_run(
+                    batch_size=1,
+                    forward_mode_override=ForwardMode.EXTEND,
+                )
+        except Exception as e:
+            logger.warning("PP-parallel DeepGEMM warmup skipped: %r", e)
+            return
+
+        logger.info(
+            "PP-parallel DeepGEMM warmup done in %.2fs (pp_rank=%d).",
+            time.perf_counter() - t0,
+            self.pp_rank,
+        )
 
     def _pre_initialize_flashinfer_allreduce_workspace(self):
         """Pre-initialize flashinfer allreduce fusion workspaces.
@@ -2440,9 +2479,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             / f"rank_tp{self.tp_rank}_pp{self.pp_rank}_dp{self.dp_rank or 0}.json"
         )
 
-    def _dummy_run(self, batch_size: int, run_ctx=None):
-        """Run a dummy forward pass for warmup/profiling."""
-        if self.is_generation:
+    def _dummy_run(
+        self,
+        batch_size: int,
+        run_ctx=None,
+        forward_mode_override: Optional[ForwardMode] = None,
+    ):
+        """Run a dummy forward pass for warmup/profiling.
+
+        ``forward_mode_override`` forces EXTEND/DECODE regardless of
+        ``is_generation`` (used by the PP-parallel DeepGEMM warmup).
+        """
+        if forward_mode_override is not None:
+            capture_forward_mode = forward_mode_override
+        elif self.is_generation:
             capture_forward_mode = ForwardMode.DECODE
         else:
             capture_forward_mode = ForwardMode.EXTEND
@@ -2517,7 +2567,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         buffers.num_token_non_padded[...] = num_tokens
 
         # For extend mode
-        if not self.is_generation:
+        if capture_forward_mode == ForwardMode.EXTEND:
             extend_prefix_lens_cpu = [0] * batch_size
             extend_seq_lens_cpu = [seq_len_fill_value] * batch_size
             extend_num_tokens = num_tokens

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2331,6 +2331,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 2 * block_m,
                 max(n_sms // 8, 2) * block_m,
                 max(n_sms // 4, 4) * block_m,
+                n_sms * block_m,
             }
         )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2341,33 +2341,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             batch_sizes,
         )
         t0 = time.perf_counter()
-        for bs in batch_sizes:
-            try:
-                with torch.inference_mode():
-                    if self.is_generation:
-                        self._dummy_run(
-                            batch_size=bs,
-                            forward_mode_override=ForwardMode.DECODE,
-                        )
+        with torch.inference_mode():
+            for bs in batch_sizes:
+                if self.is_generation:
                     self._dummy_run(
                         batch_size=bs,
-                        forward_mode_override=ForwardMode.EXTEND,
+                        forward_mode_override=ForwardMode.DECODE,
                     )
-            except torch.cuda.OutOfMemoryError as e:
-                logger.warning(
-                    "PP-parallel DeepGEMM warmup OOM at batch_size=%d, stopping sweep: %r",
-                    bs,
-                    e,
+                self._dummy_run(
+                    batch_size=bs,
+                    forward_mode_override=ForwardMode.EXTEND,
                 )
-                torch.cuda.empty_cache()
-                break
-            except Exception as e:
-                logger.warning(
-                    "PP-parallel DeepGEMM warmup skipped at batch_size=%d: %r",
-                    bs,
-                    e,
-                )
-                break
 
         logger.info(
             "PP-parallel DeepGEMM warmup done in %.2fs (pp_rank=%d).",

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2310,38 +2310,49 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self._should_run_flashinfer_autotune():
             self._flashinfer_autotune()
 
-        self._pp_parallel_deep_gemm_warmup()
+        if (
+            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            and self.pp_size > 1
+            and not self.spec_algorithm.is_speculative()
+        ):
+            self._pp_parallel_deep_gemm_warmup()
 
     def _pp_parallel_deep_gemm_warmup(self):
         """Per-PP-rank local dummy forward so DeepGEMM JIT compiles in
         parallel across PP stages instead of serially via the warmup
         ``/generate`` request flowing through the pipeline.
         """
-        if not deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
-            return
-        if self.pp_size <= 1:
-            return
-        # Speculative target-verify has its own metadata; rely on serving warmup.
-        if self.spec_algorithm.is_speculative():
-            return
+        # Sweep representative batch sizes so kernels whose num_groups
+        # depends on num_tokens (e.g. TF32_HC_PRENORM_GEMM on DSv4) get
+        # compiled for both small-decode and large-prefill regimes.
+        batch_sizes = {1}
+        max_run = max(self.server_args.max_running_requests or 0, 1)
+        batch_sizes.add(max(max_run // max(self.pp_size, 1), 1))
+        chunked = self.server_args.chunked_prefill_size
+        if chunked and chunked > 0:
+            batch_sizes.add(chunked)
+        batch_sizes.add(1024)
+        batch_sizes = sorted(batch_sizes)
 
         logger.info(
-            "PP-parallel DeepGEMM warmup start (pp_rank=%d, tp_rank=%d).",
+            "PP-parallel DeepGEMM warmup start (pp_rank=%d, tp_rank=%d, batch_sizes=%s).",
             self.pp_rank,
             self.tp_rank,
+            batch_sizes,
         )
         t0 = time.perf_counter()
         try:
             with torch.inference_mode():
-                if self.is_generation:
+                for bs in batch_sizes:
+                    if self.is_generation:
+                        self._dummy_run(
+                            batch_size=bs,
+                            forward_mode_override=ForwardMode.DECODE,
+                        )
                     self._dummy_run(
-                        batch_size=1,
-                        forward_mode_override=ForwardMode.DECODE,
+                        batch_size=bs,
+                        forward_mode_override=ForwardMode.EXTEND,
                     )
-                self._dummy_run(
-                    batch_size=1,
-                    forward_mode_override=ForwardMode.EXTEND,
-                )
         except Exception as e:
             logger.warning("PP-parallel DeepGEMM warmup skipped: %r", e)
             return

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2563,6 +2563,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             num_tokens_per_bs=num_tokens_per_bs,
             cache_loc_dtype=torch.int64,
             enable_mamba_track=False,
+            hc_hidden_size=getattr(self.model_config, "hc_hidden_size", None),
         )
         buffers.num_token_non_padded[...] = num_tokens
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2588,6 +2588,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
             )
             global_dp_buffer_len = num_tokens * self.server_args.dp_size
+            global_num_tokens_cpu = [num_tokens] * self.server_args.dp_size
         elif require_attn_tp_gather(self.server_args):
             buffers.global_num_tokens_gpu.copy_(
                 torch.tensor(
@@ -2604,8 +2605,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
             )
             global_dp_buffer_len = num_tokens
+            global_num_tokens_cpu = [num_tokens]
         else:
             global_dp_buffer_len = None
+            global_num_tokens_cpu = None
 
         def get_spec_info():
             spec_info = None
@@ -2694,6 +2697,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             extend_prefix_lens_cpu=extend_prefix_lens_cpu,
             extend_seq_lens_cpu=extend_seq_lens_cpu,
             global_num_tokens_gpu=buffers.global_num_tokens_gpu,
+            global_num_tokens_cpu=global_num_tokens_cpu,
             global_num_tokens_for_logprob_gpu=buffers.global_num_tokens_for_logprob_gpu,
             dp_padding_mode=DpPaddingMode.get_default_mode_in_cuda_graph(),
             global_dp_buffer_len=global_dp_buffer_len,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2322,16 +2322,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         parallel across PP stages instead of serially via the warmup
         ``/generate`` request flowing through the pipeline.
         """
-        # n_splits ~= n_sms // ceil(bs/64); pick bs to cover 4 brackets.
+        # n_splits ~= n_sms // ceil(bs/64); pick bs to cover 5 brackets.
         n_sms = torch.cuda.get_device_properties(self.device).multi_processor_count
         block_m = 64
+        cp = max(self.attn_cp_size, 1)
         batch_sizes = sorted(
             {
-                1,
-                2 * block_m,
-                max(n_sms // 8, 2) * block_m,
-                max(n_sms // 4, 4) * block_m,
-                n_sms * block_m,
+                ceil_align(bs, cp)
+                for bs in (
+                    1,
+                    2 * block_m,
+                    max(n_sms // 8, 2) * block_m,
+                    max(n_sms // 4, 4) * block_m,
+                    n_sms * block_m,
+                )
             }
         )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2339,24 +2339,35 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             }
         )
 
+        # Skip DECODE on prefill nodes (indexer would OOM) and EXTEND on decode nodes.
+        disagg_mode = self.server_args.disaggregation_mode
+        run_decode = self.is_generation and disagg_mode != "prefill"
+        run_extend = disagg_mode != "decode"
+
         logger.info(
-            "PP-parallel DeepGEMM warmup start (pp_rank=%d, tp_rank=%d, batch_sizes=%s).",
+            "PP-parallel DeepGEMM warmup start "
+            "(pp_rank=%d, tp_rank=%d, batch_sizes=%s, "
+            "disagg=%s, run_decode=%s, run_extend=%s).",
             self.pp_rank,
             self.tp_rank,
             batch_sizes,
+            disagg_mode,
+            run_decode,
+            run_extend,
         )
         t0 = time.perf_counter()
         with torch.inference_mode():
             for bs in batch_sizes:
-                if self.is_generation:
+                if run_decode:
                     self._dummy_run(
                         batch_size=bs,
                         forward_mode_override=ForwardMode.DECODE,
                     )
-                self._dummy_run(
-                    batch_size=bs,
-                    forward_mode_override=ForwardMode.EXTEND,
-                )
+                if run_extend:
+                    self._dummy_run(
+                        batch_size=bs,
+                        forward_mode_override=ForwardMode.EXTEND,
+                    )
 
         logger.info(
             "PP-parallel DeepGEMM warmup done in %.2fs (pp_rank=%d).",

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2602,8 +2602,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             extend_start_loc = None
 
         if self.server_args.pp_size > 1:
+            # DSA prefill CP: PP0 already cp-split hidden_states before send.
+            pp_hidden_tokens = num_tokens
+            if (
+                capture_forward_mode == ForwardMode.EXTEND
+                and self.pp_rank != 0
+                and self.attn_cp_size > 1
+                and is_dsa_enable_prefill_cp()
+            ):
+                pp_hidden_tokens = num_tokens // self.attn_cp_size
             pp_proxy_tensors = PPProxyTensors(
-                {k: v[:num_tokens] for k, v in buffers.pp_proxy_tensors.items()}
+                {k: v[:pp_hidden_tokens] for k, v in buffers.pp_proxy_tensors.items()}
             )
 
         if require_mlp_tp_gather_:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2311,69 +2311,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self._flashinfer_autotune()
 
         if (
-            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            envs.SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP.get()
+            and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             and self.pp_size > 1
             and not self.spec_algorithm.is_speculative()
         ):
-            self._pp_parallel_deep_gemm_warmup()
+            from sglang.srt.layers.deep_gemm_wrapper.compile_utils import (
+                pp_parallel_deep_gemm_warmup,
+            )
 
-    def _pp_parallel_deep_gemm_warmup(self):
-        """Per-PP-rank local dummy forward so DeepGEMM JIT compiles in
-        parallel across PP stages instead of serially via the warmup
-        ``/generate`` request flowing through the pipeline.
-        """
-        # n_splits ~= n_sms // ceil(bs/64); pick bs to cover 5 brackets.
-        n_sms = torch.cuda.get_device_properties(self.device).multi_processor_count
-        block_m = 64
-        cp = max(self.attn_cp_size, 1)
-        batch_sizes = sorted(
-            {
-                ceil_align(bs, cp)
-                for bs in (
-                    1,
-                    2 * block_m,
-                    max(n_sms // 8, 2) * block_m,
-                    max(n_sms // 4, 4) * block_m,
-                    n_sms * block_m,
-                )
-            }
-        )
-
-        # Skip DECODE on prefill nodes (indexer would OOM) and EXTEND on decode nodes.
-        disagg_mode = self.server_args.disaggregation_mode
-        run_decode = self.is_generation and disagg_mode != "prefill"
-        run_extend = disagg_mode != "decode"
-
-        logger.info(
-            "PP-parallel DeepGEMM warmup start "
-            "(pp_rank=%d, tp_rank=%d, batch_sizes=%s, "
-            "disagg=%s, run_decode=%s, run_extend=%s).",
-            self.pp_rank,
-            self.tp_rank,
-            batch_sizes,
-            disagg_mode,
-            run_decode,
-            run_extend,
-        )
-        t0 = time.perf_counter()
-        with torch.inference_mode():
-            for bs in batch_sizes:
-                if run_decode:
-                    self._dummy_run(
-                        batch_size=bs,
-                        forward_mode_override=ForwardMode.DECODE,
-                    )
-                if run_extend:
-                    self._dummy_run(
-                        batch_size=bs,
-                        forward_mode_override=ForwardMode.EXTEND,
-                    )
-
-        logger.info(
-            "PP-parallel DeepGEMM warmup done in %.2fs (pp_rank=%d).",
-            time.perf_counter() - t0,
-            self.pp_rank,
-        )
+            pp_parallel_deep_gemm_warmup(self)
 
     def _pre_initialize_flashinfer_allreduce_workspace(self):
         """Pre-initialize flashinfer allreduce fusion workspaces.
@@ -2613,13 +2560,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             extend_start_loc = None
 
         if self.server_args.pp_size > 1:
-            # DSA prefill CP: PP0 already cp-split hidden_states before send.
+            # PP0 already cp-split hidden_states before send.
             pp_hidden_tokens = num_tokens
             if (
                 capture_forward_mode == ForwardMode.EXTEND
                 and self.pp_rank != 0
                 and self.attn_cp_size > 1
-                and is_dsa_enable_prefill_cp()
             ):
                 pp_hidden_tokens = num_tokens // self.attn_cp_size
             pp_proxy_tensors = PPProxyTensors(


### PR DESCRIPTION
## Summary

Parallelize DeepGEMM JIT kernel compilation across PP ranks during startup warmup.

## Motivation

Today the startup warmup /generate request flows through PP stages serially: stage k can only start its DeepGEMM JIT compile after stage k-1 finishes. For large MoE models like DeepSeek-V4 this dominates startup time.

## Change

Add a per-PP-rank local dummy forward inside ModelRunner.kernel_warmup(). Each scheduler process is independent, so all PP ranks now trigger their layers' DeepGEMM JIT compile concurrently.

- New _pp_parallel_deep_gemm_warmup() runs _dummy_run(DECODE) + _dummy_run(EXTEND) with batch_size=1, gated on pp_size > 1, ENABLE_JIT_DEEPGEMM, non-speculative. Wrapped in try/except for graceful fallback.
- Extend _dummy_run with forward_mode_override so a generation model can also exercise EXTEND-mode shapes (CONTIG grouped GEMM); extend-buffer setup gate switched from not is_generation to capture_forward_mode == EXTEND, semantically equivalent for all existing callers.
- Pass hc_hidden_size to DecodeInputBuffers.create in _dummy_run so DSv4 mHC PP IPC buffer is allocated correctly (parity with cuda_graph_runner).

to enable this feauture:   set  `SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP=1`
## Result

On H20 with DeepSeek-V4-Pro --pp 4 --tp 8:

with prebuit cache:

| CP  | Enable SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP | startup time     | 
|-----|-----------------|--------------|
| OFF | OFF             | ~9 min      |
| OFF | ON              | ~3 min 40s   |
| ON  | OFF             | ~12 min      |
| ON  | ON              | ~4 min 4 s   |

CC  @ShangmingCai @Fridge003 






























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26715451885](https://github.com/sgl-project/sglang/actions/runs/26715451885)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26715451816](https://github.com/sgl-project/sglang/actions/runs/26715451816)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->