### PR TITLE
[BugFix] Fix KDAAttnBackend missing conv_states_shape initialization    

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -131,6 +131,9 @@ class KDAAttnBackend(MambaAttnBackendBase):
 
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
+        self.conv_states_shape = (
+            model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape
+        )
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()
         self.kernel_dispatcher = KDAKernelDispatcher(decode_backend, prefill_backend)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
KDAAttnBackend` (used by Kimi-Linear-48B) crashes on the first extend  
  request with:
                                                                          
  TypeError: 'NoneType' object is not subscriptable         
    File "hybrid_linear_attn_backend.py", line 273, in
  _init_track_conv_indices

  The parent class `MambaAttnBackendBase` initializes
  `self.conv_states_shape = None`. Other subclasses (e.g.,
  `Mamba2AttnBackend`) override this with the actual conv state shape from
   the mamba pool, but `KDAAttnBackend` was missing this initialization.
  When `_init_track_conv_indices` indexes `self.conv_states_shape[0]`
  during extend, it crashes.

## Modifications

Add `conv_states_shape` initialization in `KDAAttnBackend.__init__`:

  ```python
  self.conv_states_shape = (
      model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape
  )

  This is consistent with how Mamba2AttnBackend initializes the same
  field.

## Accuracy Tests

No model output changes — this is a missing initialization fix. The conv
   state tracking logic was already correct; it just couldn't be reached
  before due to the crash.

## Speed Tests and Profiling

N/A — no performance-impacting change. This fix only enables the
  existing code path to execute without crashing.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26575848036](https://github.com/sgl-project/sglang/actions/runs/26575848036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #26575847867](https://github.com/sgl-project/sglang/actions/runs/26575847867)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->