### PR TITLE
[DeepSeek-V4] Fuse UE8M0 scale rounding into FP8 group quantization

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -460,17 +460,28 @@ def create_per_token_group_quant_fp8_output_scale(
     scale_ue8m0: bool,
 ):
     if scale_ue8m0:
-        assert column_major_scales and scale_tma_aligned
-        *x_batch, x_q_mn, x_q_k = x_shape
-        x_s_mn, x_s_k = x_q_mn, x_q_k // 128
-        aligned_mn = ceil_align(x_s_mn, 4)
-        aligned_k = ceil_align(x_s_k, 4)
-        # TODO(FIXME): Fix cuda kernel and recover here to empty.
-        return torch.empty(
-            (*x_batch, aligned_k // 4, aligned_mn),
-            device=device,
-            dtype=torch.int,
-        ).transpose(-1, -2)[..., :x_s_mn, :]
+        if column_major_scales and scale_tma_aligned:
+            *x_batch, x_q_mn, x_q_k = x_shape
+            x_s_mn, x_s_k = x_q_mn, x_q_k // 128
+            aligned_mn = ceil_align(x_s_mn, 4)
+            aligned_k = ceil_align(x_s_k, 4)
+            # TODO(FIXME): Fix cuda kernel and recover here to empty.
+            return torch.empty(
+                (*x_batch, aligned_k // 4, aligned_mn),
+                device=device,
+                dtype=torch.int,
+            ).transpose(-1, -2)[..., :x_s_mn, :]
+        else:
+            assert not column_major_scales, (
+                "column_major_scales requires scale_tma_aligned=True "
+                "when scale_ue8m0 is enabled"
+            )
+            # Row-major float32 scale with power-of-2 values
+            return torch.empty(
+                x_shape[:-1] + (x_shape[-1] // group_size,),
+                device=device,
+                dtype=torch.float32,
+            )
     elif column_major_scales:
         if scale_tma_aligned:
             # TODO extract "align" function

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -896,8 +896,8 @@ class MQALayer(nn.Module):
             o_fp8, o_s = sglang_per_token_group_quant_fp8(
                 o.reshape(T * G, D).contiguous(),
                 group_size=128,
+                scale_ue8m0=True,
             )
-            o_s = deep_gemm.ceil_to_ue8m0(o_s)
             output = torch.empty(T, G, R, device=o.device, dtype=torch.bfloat16)
             deep_gemm.fp8_einsum(
                 "bhr,hdr->bhd",

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
@@ -255,7 +255,7 @@ template <
     bool IS_COLUMN_MAJOR = false,
     bool SCALE_UE8M0 = false,
     bool FUSE_SILU_AND_MUL = false,
-    typename scale_packed_t = std::conditional_t<SCALE_UE8M0, uint32_t, float>>
+    typename scale_packed_t = std::conditional_t<SCALE_UE8M0 && IS_COLUMN_MAJOR, uint32_t, float>>
 __global__ void per_token_group_quant_8bit_kernel(
     const T* __restrict__ input,
     DST_DTYPE* __restrict__ output_q,
@@ -268,7 +268,8 @@ __global__ void per_token_group_quant_8bit_kernel(
     const int scale_hidden_stride,
     const int num_tokens_per_expert) {
   using dst_dtype_info = DtypeInfo<DST_DTYPE>;
-  using scale_element_t = std::conditional_t<SCALE_UE8M0, uint8_t, float>;
+  // When row-major + SCALE_UE8M0, scale is still stored as float (value is power-of-2)
+  using scale_element_t = std::conditional_t<SCALE_UE8M0 && IS_COLUMN_MAJOR, uint8_t, float>;
   static_assert(sizeof(scale_packed_t) % sizeof(scale_element_t) == 0);
 
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
@@ -327,8 +328,8 @@ __global__ void per_token_group_quant_8bit_kernel(
                           hidden_idx_packed * scale_hidden_stride * num_elems_per_pack +
                           token_idx * scale_token_stride * num_elems_per_pack + pack_idx);
         } else {
-          static_assert(!SCALE_UE8M0);
-          scale_output = output_s + offset_num_groups;
+          static_assert(!SCALE_UE8M0 || std::is_same_v<scale_packed_t, float>);
+          scale_output = reinterpret_cast<scale_element_t*>(output_s) + offset_num_groups;
         }
 
         // can speed up if too slow
@@ -362,12 +363,25 @@ __global__ void per_token_group_quant_8bit_kernel(
         local_absmax = GroupReduceMax<THREADS_PER_SUBWARP>(local_absmax, lane_id);
 
         float y_scale, y_scale_inv;
-        calculate_fp8_scales<SCALE_UE8M0, dst_dtype_info>(local_absmax, y_scale, y_scale_inv);
-        float2 y_scale_repeated = {y_scale, y_scale};
-
-        if (lane_id == 0) {
-          *scale_output = extract_required_scale_format<SCALE_UE8M0>(y_scale_inv);
+        // For row-major + UE8M0: quantize with exact scale, but output rounded scale_inv
+        // This is equivalent to the original two-step approach (quant then ceil_to_ue8m0)
+        if constexpr (SCALE_UE8M0 && !IS_COLUMN_MAJOR) {
+          // Exact scale for quantization
+          constexpr float MAX_8BIT_INV = 1.0f / dst_dtype_info::MAX;
+          y_scale_inv = local_absmax * MAX_8BIT_INV;
+          y_scale = dst_dtype_info::MAX / local_absmax;
+          // Rounded scale_inv for output
+          float rounded_scale_inv = fast_pow2(fast_log2_ceil(y_scale_inv));
+          if (lane_id == 0) {
+            *scale_output = rounded_scale_inv;
+          }
+        } else {
+          calculate_fp8_scales<SCALE_UE8M0, dst_dtype_info>(local_absmax, y_scale, y_scale_inv);
+          if (lane_id == 0) {
+            *scale_output = extract_required_scale_format < SCALE_UE8M0 && IS_COLUMN_MAJOR > (y_scale_inv);
+          }
         }
+        float2 y_scale_repeated = {y_scale, y_scale};
 
         int4 output_buf;
         static_assert(sizeof(output_buf) == INPUT_PRIMARY_VEC_SIZE * sizeof(DST_DTYPE));
@@ -503,7 +517,11 @@ void sgl_per_token_group_quant_8bit_v2(
         LAUNCH_KERNEL_INNER(NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, float, true);            \
       }                                                                                                             \
     } else {                                                                                                        \
-      LAUNCH_KERNEL_INNER(NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, float, false);             \
+      if (scale_ue8m0) {                                                                                            \
+        LAUNCH_KERNEL_INNER(NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, float, false, true);     \
+      } else {                                                                                                      \
+        LAUNCH_KERNEL_INNER(NaiveScheduler, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, float, false);           \
+      }                                                                                                             \
     }                                                                                                               \
   } while (0)
 


### PR DESCRIPTION
# [DeepSeek-V4] Fuse UE8M0 scale rounding into FP8 group quantization

## Motivation

This PR optimizes the DeepSeek-V4 `wo_a` FP8 path by removing the separate `deep_gemm.ceil_to_ue8m0` call after activation quantization.

The original path launches quantization first, then rounds the generated FP8 scales to UE8M0/power-of-two format:

```text
sglang_per_token_group_quant_fp8 -> deep_gemm.ceil_to_ue8m0 -> deep_gemm.fp8_einsum
```

The optimized path emits the rounded power-of-two scale directly from the per-token group quantization kernel:

```text
sglang_per_token_group_quant_fp8(scale_ue8m0=True) -> deep_gemm.fp8_einsum
```

## Performance Test

DeepSeek-V4-Flash, TP=4, 32K input / 1K output, 128 requests, max concurrency 4.

Output token throughput increased by **7.8%**.
<img width="934" height="628" alt="image" src="https://github.com/user-attachments/assets/e26ce28d-729f-467c-98d9-137c3738c41c" />

The configuration of server is from cookbook but without MTP: https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
```bash
# launch server
  sglang serve \                                                                                                                                                                         
    --trust-remote-code \                                                                                                                                                                
    --model-path /xxx/DeepSeek-V4-Flash \                                                                                                                              
    --tp 4 \                                                                                                                                                                             
    --moe-runner-backend flashinfer_mxfp4 \                                                                                                                                              
    --chunked-prefill-size 4096 \
    --disable-flashinfer-autotune \
    --swa-full-tokens-ratio 0.1 \
    --host 0.0.0.0 \
    --port 30000

  # bench_serving：
  python3 -m sglang.bench_serving \
    --backend sglang \
    --host 127.0.0.1 \
    --port 30000 \
    --model /xxx/DeepSeek-V4-Flash \
    --dataset-name random-ids \
    --num-prompts 128 \
    --random-input-len 32000 \
    --random-output-len 1000 \
    --max-concurrency 4 \
    --request-rate inf \
    --tokenize-prompt
```

## Accuracy Tests

GSM8K score: **0.928**

## Modifications

### `sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu`

- Support row-major `scale_ue8m0=True` output.
- Keep exact raw scale for quantization.
- Store rounded power-of-two scale values for DeepGEMM consumption.
- Preserve the existing column-major packed UE8M0 behavior.

### `python/sglang/srt/models/deepseek_v4.py`

- Use `sglang_per_token_group_quant_fp8(..., scale_ue8m0=True)` in the DeepSeek-V4 `wo_a` FP8 path.
- Remove the separate `deep_gemm.ceil_to_ue8m0` call from this path.

## Checklist

- [x] Fused UE8M0 scale rounding into FP8 group quantization.
- [x] Preserved exact quantization behavior for row-major scale output.
- [x] Verified kernel-level scale equivalence.
- [x] Verified GSM8Kend-to-end accuracy.
- [x] Verified `bench_serving` performance improvement on DeepSeek-V4-Flash.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26643741620](https://github.com/sgl-project/sglang/actions/runs/26643741620)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26643741155](https://github.com/sgl-project/sglang/actions/runs/26643741155)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->