### PR TITLE
feat(cache-dit): add MindIE-SD compile and attention backend support

### DIFF
--- a/docs_new/docs/sglang-diffusion/cache_dit.mdx
+++ b/docs_new/docs/sglang-diffusion/cache_dit.mdx
@@ -571,6 +571,24 @@ SGLang Diffusion x Cache-DiT supports almost all models originally supported in 
 For models with < 8 inference steps (e.g., DMD distilled models), SCM will be automatically disabled. DBCache
 acceleration still works.
 
+## Ascend NPU Compile Backend
+
+On Ascend NPU, the default `torchair` compile backend cannot compile DiT models due to missing
+custom operator converters. You can use the `MindieSDBackend` from MindIE-SD instead:
+
+```bash
+export SGLANG_CACHE_DIT_MINDIESD_COMPILE="true"
+export SGLANG_ENABLE_TORCH_COMPILE="true"
+```
+
+MindieSDBackend enables operator fusion patterns (FastGelu, AdaLayerNorm) and provides
+approximately 4-5% speedup at 768+ resolutions compared to the default NPU compile path.
+
+<Note>
+Requires the `mindiesd` package (version 3.0.0 or later) installed on Ascend NPU.
+The default `torchair` compile backend is not supported for DiT inference.
+</Note>
+
 ## References
 
 - [Cache-DiT](https://github.com/vipshop/cache-dit)

--- a/docs_new/docs/sglang-diffusion/environment_variables.mdx
+++ b/docs_new/docs/sglang-diffusion/environment_variables.mdx
@@ -238,6 +238,16 @@ See [cache-dit documentation](./cache_dit) for detailed configuration.
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>not set</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Custom SCM cache bins</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_CACHE_DIT_ATTN_BACKEND</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>not set</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Pass attention backend to cache-dit (e.g. <code>_mindiesd_laser</code> for Ascend NPU)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_CACHE_DIT_MINDIESD_COMPILE</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>false</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Use <code>MindieSDBackend</code> for torch.compile on Ascend NPU. Requires <code>SGLANG_ENABLE_TORCH_COMPILE=true</code> and the <code>mindiesd</code> package.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
     SGLANG_CACHE_DIT_SCM_COMPUTE_BINS: str | None = None
     SGLANG_CACHE_DIT_SCM_CACHE_BINS: str | None = None
     SGLANG_CACHE_DIT_SCM_POLICY: str = "dynamic"
+    SGLANG_CACHE_DIT_ATTN_BACKEND: str | None = None
+    SGLANG_CACHE_DIT_MINDIESD_COMPILE: bool = False
     # cache-dit env vars (secondary transformer, e.g., Wan2.2 low-noise expert)
     SGLANG_CACHE_DIT_SECONDARY_FN: int = 1
     SGLANG_CACHE_DIT_SECONDARY_BN: int = 0
@@ -284,6 +286,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "SGLANG_CACHE_DIT_SCM_CACHE_BINS": _lazy_str("SGLANG_CACHE_DIT_SCM_CACHE_BINS"),
     # SCM policy: dynamic or static
     "SGLANG_CACHE_DIT_SCM_POLICY": _lazy_str("SGLANG_CACHE_DIT_SCM_POLICY", "dynamic"),
+    # cache-dit attention backend (e.g., "_mindiesd_laser")
+    "SGLANG_CACHE_DIT_ATTN_BACKEND": _lazy_str("SGLANG_CACHE_DIT_ATTN_BACKEND"),
+    # Enable MindieSDBackend compile (replaces torchair on NPU)
+    "SGLANG_CACHE_DIT_MINDIESD_COMPILE": _lazy_bool(
+        "SGLANG_CACHE_DIT_MINDIESD_COMPILE", "false"
+    ),
     # model loading
     "SGLANG_USE_RUNAI_MODEL_STREAMER": _lazy_bool(
         "SGLANG_USE_RUNAI_MODEL_STREAMER", "true"

--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 import torch
 import torch.distributed as dist
 
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_ring_parallel_world_size,
     get_tp_world_size,
@@ -312,11 +313,18 @@ def enable_cache_on_transformer(
 
     _mark_transformer_parallelized(transformer, parallelism_config, sp_group, tp_group)
 
+    extra_kwargs = {}
+    attention_backend = envs.SGLANG_CACHE_DIT_ATTN_BACKEND
+    if attention_backend:
+        logger.info("cache-dit attention backend: %s", attention_backend)
+        extra_kwargs["attention_backend"] = attention_backend
+
     cache_dit.enable_cache(
         transformer,
         cache_config=cache_config,
         calibrator_config=calibrator_config,
         parallelism_config=None,
+        **extra_kwargs,
     )
 
     if parallelism_config is not None:
@@ -492,6 +500,11 @@ def enable_cache_on_dual_transformer(
         # Use Pattern_2 for Wan2.2 dual-transformer. We should check `model_name`
         # to ensure we only apply this for supported models. Different models
         # may require different ForwardPattern.
+        extra_kwargs = {}
+        attention_backend = envs.SGLANG_CACHE_DIT_ATTN_BACKEND
+        if attention_backend:
+            logger.info("cache-dit attention backend: %s", attention_backend)
+            extra_kwargs["attention_backend"] = attention_backend
         cache_dit.enable_cache(
             BlockAdapter(
                 transformer=[transformer, transformer_2],
@@ -501,6 +514,7 @@ def enable_cache_on_dual_transformer(
                 has_separate_cfg=True,
             ),
             parallelism_config=None,
+            **extra_kwargs,
         )
     else:
         raise ValueError(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -299,10 +299,17 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         compile_kwargs: dict[str, Any] = {"fullgraph": False, "dynamic": None}
 
         if current_platform.is_npu():
-            backend = get_compiler_backend()
-            compile_kwargs["backend"] = backend
-            compile_kwargs["dynamic"] = False
-            logger.info("Compiling transformer with torchair backend on NPU")
+            if envs.SGLANG_CACHE_DIT_MINDIESD_COMPILE:
+                from mindiesd.compilation import MindieSDBackend
+
+                compile_kwargs["backend"] = MindieSDBackend()
+                compile_kwargs["dynamic"] = True
+                logger.info("Compiling transformer with MindieSDBackend on NPU")
+            else:
+                backend = get_compiler_backend()
+                compile_kwargs["backend"] = backend
+                compile_kwargs["dynamic"] = False
+                logger.info("Compiling transformer with torchair backend on NPU")
         else:
             try:
                 import torch._inductor.config as _inductor_cfg

--- a/python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.util
+import os
 import sys
 import types
 import unittest
@@ -8,6 +9,10 @@ from unittest.mock import patch
 
 
 class _FakeDBCacheConfig:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
     def reset(self, **kwargs):
         return kwargs
 
@@ -16,6 +21,7 @@ def _install_cache_dit_stub():
     cache_dit = types.ModuleType("cache_dit")
     cache_dit.refresh_calls = []
     cache_dit.steps_mask_calls = []
+    cache_dit.enable_cache_calls = []
 
     def refresh_context(transformer, cache_config, verbose=False):
         cache_dit.refresh_calls.append(
@@ -32,8 +38,28 @@ def _install_cache_dit_stub():
         )
         return [1] * total_steps
 
+    def enable_cache(
+        transformer,
+        cache_config=None,
+        calibrator_config=None,
+        parallelism_config=None,
+        attention_backend=None,
+        **kwargs,
+    ):
+        cache_dit.enable_cache_calls.append(
+            {
+                "transformer": transformer,
+                "cache_config": cache_config,
+                "calibrator_config": calibrator_config,
+                "parallelism_config": parallelism_config,
+                "attention_backend": attention_backend,
+                "kwargs": kwargs,
+            }
+        )
+
     cache_dit.refresh_context = refresh_context
     cache_dit.steps_mask = steps_mask
+    cache_dit.enable_cache = enable_cache
     cache_dit.BlockAdapter = object
     cache_dit.DBCacheConfig = _FakeDBCacheConfig
     cache_dit.ForwardPattern = object
@@ -63,6 +89,7 @@ def _install_cache_dit_stub():
 def _install_sglang_dependency_stubs():
     sglang = types.ModuleType("sglang")
     multimodal_gen = types.ModuleType("sglang.multimodal_gen")
+    envs = types.ModuleType("sglang.multimodal_gen.envs")
     runtime = types.ModuleType("sglang.multimodal_gen.runtime")
     distributed = types.ModuleType("sglang.multimodal_gen.runtime.distributed")
     parallel_state = types.ModuleType(
@@ -78,6 +105,11 @@ def _install_sglang_dependency_stubs():
     parallel_state.get_ulysses_parallel_world_size = lambda: 1
     parallel_state.get_dit_group = lambda: None
 
+    envs.SGLANG_CACHE_DIT_ATTN_BACKEND = os.environ.get("SGLANG_CACHE_DIT_ATTN_BACKEND")
+    envs.SGLANG_CACHE_DIT_MINDIESD_COMPILE = (
+        os.environ.get("SGLANG_CACHE_DIT_MINDIESD_COMPILE", "").lower() == "true"
+    )
+
     class _FakeLogger:
         def debug(self, *_args, **_kwargs):
             pass
@@ -90,6 +122,7 @@ def _install_sglang_dependency_stubs():
     return {
         "sglang": sglang,
         "sglang.multimodal_gen": multimodal_gen,
+        "sglang.multimodal_gen.envs": envs,
         "sglang.multimodal_gen.runtime": runtime,
         "sglang.multimodal_gen.runtime.distributed": distributed,
         "sglang.multimodal_gen.runtime.distributed.parallel_state": parallel_state,
@@ -214,6 +247,79 @@ class TestCacheDitRefreshContext(unittest.TestCase):
                 "steps_computation_policy": None,
             },
         )
+
+    def _import_with_attn_env(self, attn_backend):
+        saved = os.environ.get("SGLANG_CACHE_DIT_ATTN_BACKEND")
+        if attn_backend is not None:
+            os.environ["SGLANG_CACHE_DIT_ATTN_BACKEND"] = attn_backend
+        else:
+            os.environ.pop("SGLANG_CACHE_DIT_ATTN_BACKEND", None)
+        try:
+            stub_modules = _install_cache_dit_stub()
+            stub_modules.update(_install_sglang_dependency_stubs())
+            stub_modules.update(_install_torch_stub())
+            module_path = (
+                Path(__file__).resolve().parents[2]
+                / "runtime"
+                / "cache"
+                / "cache_dit_integration.py"
+            )
+            with patch.dict(sys.modules, stub_modules):
+                spec = importlib.util.spec_from_file_location(
+                    "test_cache_dit_integration_target", module_path
+                )
+                module = importlib.util.module_from_spec(spec)
+                assert spec.loader is not None
+                spec.loader.exec_module(module)
+            return module
+        finally:
+            if saved is not None:
+                os.environ["SGLANG_CACHE_DIT_ATTN_BACKEND"] = saved
+            else:
+                os.environ.pop("SGLANG_CACHE_DIT_ATTN_BACKEND", None)
+
+    def test_enable_cache_passes_attention_backend_when_env_set(self):
+        module = self._import_with_attn_env("_mindiesd_laser")
+        transformer = type(
+            "FakeTransformer",
+            (),
+            {"__class__": type("FakeCls", (), {"__name__": "FluxTransformer2DModel"})},
+        )()
+        module.enable_cache_on_transformer(
+            transformer=transformer,
+            config=module.CacheDitConfig(
+                enabled=True,
+                num_inference_steps=20,
+            ),
+            model_name="transformer",
+            sp_group=None,
+            tp_group=None,
+        )
+        self.assertEqual(len(module.cache_dit.enable_cache_calls), 1)
+        self.assertEqual(
+            module.cache_dit.enable_cache_calls[0]["attention_backend"],
+            "_mindiesd_laser",
+        )
+
+    def test_enable_cache_skips_attention_backend_when_env_unset(self):
+        module = self._import_with_attn_env(None)
+        transformer = type(
+            "FakeTransformer",
+            (),
+            {"__class__": type("FakeCls", (), {"__name__": "FluxTransformer2DModel"})},
+        )()
+        module.enable_cache_on_transformer(
+            transformer=transformer,
+            config=module.CacheDitConfig(
+                enabled=True,
+                num_inference_steps=20,
+            ),
+            model_name="transformer",
+            sp_group=None,
+            tp_group=None,
+        )
+        self.assertEqual(len(module.cache_dit.enable_cache_calls), 1)
+        self.assertIsNone(module.cache_dit.enable_cache_calls[0]["attention_backend"])
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_envs.py
+++ b/python/sglang/multimodal_gen/test/unit/test_envs.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import types
+import unittest
+from importlib import util
+from unittest.mock import patch
+
+
+def _get_bool_env_var(key, default="false"):
+    return os.environ.get(key, str(default)).lower() == "true"
+
+
+class TestCacheDitEnvVars(unittest.TestCase):
+    def setUp(self):
+        self._saved_attn = os.environ.pop("SGLANG_CACHE_DIT_ATTN_BACKEND", None)
+        self._saved_compile = os.environ.pop("SGLANG_CACHE_DIT_MINDIESD_COMPILE", None)
+
+    def tearDown(self):
+        os.environ.pop("SGLANG_CACHE_DIT_ATTN_BACKEND", None)
+        os.environ.pop("SGLANG_CACHE_DIT_MINDIESD_COMPILE", None)
+        if self._saved_attn is not None:
+            os.environ["SGLANG_CACHE_DIT_ATTN_BACKEND"] = self._saved_attn
+        if self._saved_compile is not None:
+            os.environ["SGLANG_CACHE_DIT_MINDIESD_COMPILE"] = self._saved_compile
+
+    def _import_envs(self):
+        stub_utils = types.ModuleType("sglang.multimodal_gen.runtime.utils.common")
+        stub_utils.get_bool_env_var = _get_bool_env_var
+
+        stubs = {
+            "sglang": types.ModuleType("sglang"),
+            "sglang.multimodal_gen": types.ModuleType("sglang.multimodal_gen"),
+            "sglang.multimodal_gen.runtime": types.ModuleType(
+                "sglang.multimodal_gen.runtime"
+            ),
+            "sglang.multimodal_gen.runtime.utils": types.ModuleType(
+                "sglang.multimodal_gen.runtime.utils"
+            ),
+            "sglang.multimodal_gen.runtime.utils.common": stub_utils,
+        }
+
+        module_path = os.path.join(os.path.dirname(__file__), "..", "..", "envs.py")
+        with patch.dict(sys.modules, stubs):
+            spec = util.spec_from_file_location("envs_test_target", module_path)
+            module = util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        return module
+
+    def test_attn_backend_set_reads_correctly(self):
+        os.environ["SGLANG_CACHE_DIT_ATTN_BACKEND"] = "_mindiesd_laser"
+        module = self._import_envs()
+        self.assertEqual(module.SGLANG_CACHE_DIT_ATTN_BACKEND, "_mindiesd_laser")
+
+    def test_attn_backend_unset_defaults_none(self):
+        module = self._import_envs()
+        val = module.SGLANG_CACHE_DIT_ATTN_BACKEND
+        self.assertTrue(val is None or val == "")
+
+    def test_mindiesd_compile_default_false(self):
+        module = self._import_envs()
+        self.assertFalse(module.SGLANG_CACHE_DIT_MINDIESD_COMPILE)
+
+    def test_mindiesd_compile_set_true(self):
+        os.environ["SGLANG_CACHE_DIT_MINDIESD_COMPILE"] = "true"
+        module = self._import_envs()
+        self.assertTrue(module.SGLANG_CACHE_DIT_MINDIESD_COMPILE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
depend on: 
1. https://github.com/vipshop/cache-dit/pull/1004
2. pip install mindiesd （comming soon，approximately half a month），https://gitcode.com/Ascend/MindIE-SD
## Motivation

Enable MindIE-SD acceleration in SGLang Diffusion via the cache-dit backend.
On Ascend NPU, the default `torchair` compile backend cannot handle DiT inference
(missing custom operator converters). `MindieSDBackend` provides working DiT
compilation with 4-5% wall-clock speedup at 768+ resolutions.

## Modifications

- **`envs.py`** — 2 new env vars: `SGLANG_CACHE_DIT_ATTN_BACKEND` (string), `SGLANG_CACHE_DIT_MINDIESD_COMPILE` (bool)
- **`cache_dit_integration.py`** — pass `attention_backend` to `cache_dit.enable_cache()` in both single and dual-transformer paths
- **`denoising.py`** — NPU compile branch uses `MindieSDBackend()` when env var is set, fallback to `torchair` via `get_compiler_backend()`
- **`test_envs.py`** — new: 4 unit tests for env var read/unset/default behaviour (stub-based)
- **`test_cache_dit_integration.py`** — extended: 2 unit tests for attention_backend pass-through
- **`environment_variables.mdx`** — document 2 new env vars in Caching Acceleration table
- **`cache_dit.mdx`** — add `## Ascend NPU Compile Backend` section with usage example

## Accuracy Tests

Generated on Ascend 910B with FLUX.1-dev at 1024×1024, 28 denoising steps,
same seed (42) and 3 prompts, comparing `_native_npu` baseline vs
`_native_npu` + `MindieSDBackend` compile.

| Prompt | PSNR | pixels with diff >1 | file size change |
|--------|------|---------------------|------------------|
| cat on table | 23.0 dB | 85.3% | 898 → 819 KB (-9%) |
| futuristic city | 24.2 dB | 84.3% | 1054 → 907 KB (-14%) |
| fruit bowl | 19.5 dB | 93.5% | 920 → 833 KB (-9%) |

PSNR range 19.5–24.2 dB indicates visible differences. Caused by MindieSDBackend
kernel fusion (FastGelu replaces Gelu, AdaLayerNorm replaces LayerNorm) which
changes floating-point computation order. These numerical differences are amplified
over 28 diffusion steps. Visual inspection recommended before production deployment.

## Speed Tests and Profiling

Hardware: Ascend 910B (8 cards, single-card test).  
Model: FLUX.1-dev, bf16, cache-dit enabled, 10 warmup + 10 timed steps.

| Resolution | native_npu (baseline) | native + MindieSDBackend | speedup |
|------------|----------------------|-------------------------|---------|
| 512×512 | 305 ms | 304 ms | +0.3% |
| 768×768 | 457 ms | 435 ms | **+5.0%** |
| 1024×1024 | 726 ms | 697 ms | **+3.9%** |

Profiling analysis (1024×1024, 5-step avg, torch_npu profiler level L1):

| Metric | native_npu | native + compile | delta |
|--------|-----------|-----------------|-------|
| Kernel count | 33,810 | 25,560 | **-24.4%** |
| Computing total | 3141 ms | 2988 ms | **-4.9%** |
| ElementWise operators | 383 ms (12.2%) | 251 ms (8.4%) | **-34%** |
| GELU → FastGelu | 71 ms | 47 ms | **-34%** |
| LayerNorm → AdaLayerNorm | 64 ms | 98 ms | fused rewrite |
| Cast | 75 ms | 44 ms | **-41%** |

## Usage

```bash
# Enable cache-dit acceleration
export SGLANG_CACHE_DIT_ENABLED="true"

# Enable MindieSDBackend compile on Ascend NPU
export SGLANG_CACHE_DIT_MINDIESD_COMPILE="true"
export SGLANG_ENABLE_TORCH_COMPILE="true"

# Optional: override attention backend
export SGLANG_CACHE_DIT_ATTN_BACKEND="_native_npu"
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — isort, black, ruff, codespell all passed
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) — 9 tests (4 env var + 5 cache_dit integration), all passing
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — `environment_variables.mdx` and `cache_dit.mdx` updated
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) — see sections above
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance) — pre-commit hooks enforce compliance

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26580769198](https://github.com/sgl-project/sglang/actions/runs/26580769198)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26580767278](https://github.com/sgl-project/sglang/actions/runs/26580767278)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->