### PR TITLE
[KDA] Support KDA packed decode

### DIFF
--- a/benchmark/bench_linear_attention/bench_kda_decode.py
+++ b/benchmark/bench_linear_attention/bench_kda_decode.py
@@ -19,10 +19,6 @@ Usage:
 """
 
 import argparse
-import os
-import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
 
 import torch
 
@@ -217,10 +213,11 @@ def bench_shape(B, H, HV, K, V, pool_size, device, dtype):
             use_qk_l2norm_in_kernel=True,
         )
 
-    # Wall-clock CUDA event timing. Decode is per-token-per-step in practice
-    # (no fusion across steps), so the CPU dispatch overhead that ``packed``
-    # eliminates is a real cost — ``triton.testing.do_bench`` amortizes that
-    # away and would under-report the win.
+    # Intentionally wall-clock CUDA-event timing, not the shared do_bench /
+    # do_bench_cudagraph util: ~2/3 of the packed win is eager CPU dispatch
+    # (split + 3x unflatten + extra launch), which graph capture / L2-flush
+    # harnesses amortize away. Decode runs these ops eagerly every step, so
+    # wall-clock is the production-relevant metric (~1.7x vs ~1.3x kernel-only).
     warmup, iters = 50, 200
     for _ in range(warmup):
         fn_baseline()
@@ -395,4 +392,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/benchmark/bench_linear_attention/bench_kda_decode.py
+++ b/benchmark/bench_linear_attention/bench_kda_decode.py
@@ -1,0 +1,398 @@
+"""
+Benchmark & Correctness: KDA Packed Decode vs Baseline Decode.
+
+Compares:
+  - Baseline: split(mixed_qkv) -> view -> fused_sigmoid_gating_delta_rule_update(is_kda=True)
+  - Packed:   fused_recurrent_kda_packed_decode (single fused kernel)
+
+Differences from the GDN packed decode benchmark:
+  - KDA gate ``a`` is per-K with shape ``[B, HV * K]`` (instead of ``[B, HV]``).
+  - KDA ``dt_bias`` is per-K with shape ``[HV * K]`` (instead of ``[HV]``).
+  - State decay in the kernel is a per-K vector ``exp(g)`` (instead of a scalar).
+
+Reports correctness (output & state matching) and performance (us, speedup).
+
+Usage:
+    python bench_kda_decode.py                        # default sweep
+    python bench_kda_decode.py --mode bench           # benchmark only
+    python bench_kda_decode.py --mode correctness     # correctness only
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+
+import torch
+
+from sglang.srt.layers.attention.fla.fused_recurrent import (
+    fused_recurrent_kda_packed_decode,
+)
+from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+    fused_sigmoid_gating_delta_rule_update,
+)
+
+
+def make_inputs(
+    B: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    pool_size: int,
+    device: str,
+    dtype: torch.dtype,
+    seed: int = 42,
+):
+    """Create all input tensors for a single benchmark / correctness run."""
+    torch.manual_seed(seed)
+
+    qkv_dim = 2 * H * K + HV * V
+    mixed_qkv = torch.randn(B, qkv_dim, device=device, dtype=dtype) * 0.1
+    # KDA per-K gate: a is [B, HV*K], dt_bias is [HV*K].
+    a = torch.randn(B, HV * K, device=device, dtype=dtype) * 0.5 - 1.0
+    b = torch.randn(B, HV, device=device, dtype=dtype) * 0.5
+    A_log = torch.randn(HV, device=device, dtype=torch.float32) * 0.2
+    dt_bias = torch.randn(HV * K, device=device, dtype=torch.float32) * 0.1
+
+    ssm_states = torch.randn(pool_size, HV, V, K, device=device, dtype=dtype) * 0.01
+    cache_indices = torch.arange(B, device=device, dtype=torch.int32)
+
+    cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.long)
+
+    return dict(
+        B=B,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        qkv_dim=qkv_dim,
+        pool_size=pool_size,
+        mixed_qkv=mixed_qkv.contiguous(),
+        a=a.contiguous(),
+        b=b.contiguous(),
+        A_log=A_log,
+        dt_bias=dt_bias,
+        ssm_states=ssm_states.contiguous(),
+        cache_indices=cache_indices,
+        cu_seqlens=cu_seqlens,
+    )
+
+
+def run_baseline(inp):
+    """Baseline path: split -> view -> fused_sigmoid_gating_delta_rule_update.
+
+    Mirrors the existing decode path in ``KDAAttnBackend.forward_decode``
+    (post conv1d, pre-packed-optimization).
+    """
+    B, H, HV, K, V = inp["B"], inp["H"], inp["HV"], inp["K"], inp["V"]
+    mixed_qkv = inp["mixed_qkv"]
+    ssm_states = inp["ssm_states"].clone()
+
+    q_flat, k_flat, v_flat = torch.split(mixed_qkv, [H * K, H * K, HV * V], dim=-1)
+    q = q_flat.view(1, B, H, K)
+    k = k_flat.view(1, B, H, K)
+    v = v_flat.view(1, B, HV, V)
+
+    o = fused_sigmoid_gating_delta_rule_update(
+        A_log=inp["A_log"],
+        dt_bias=inp["dt_bias"],
+        q=q,
+        k=k,
+        v=v,
+        a=inp["a"],
+        b=inp["b"],
+        initial_state_source=ssm_states,
+        initial_state_indices=inp["cache_indices"],
+        cu_seqlens=inp["cu_seqlens"],
+        use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        is_kda=True,
+    )
+    return o, ssm_states
+
+
+def run_packed(inp):
+    """Packed path: single fused kernel directly on mixed_qkv."""
+    B, HV, K, V = inp["B"], inp["HV"], inp["K"], inp["V"]
+    ssm_states = inp["ssm_states"].clone()
+    out = inp["mixed_qkv"].new_empty(B, 1, HV, V)
+
+    fused_recurrent_kda_packed_decode(
+        mixed_qkv=inp["mixed_qkv"],
+        a=inp["a"],
+        b=inp["b"],
+        A_log=inp["A_log"],
+        dt_bias=inp["dt_bias"],
+        scale=inp["K"] ** -0.5,
+        initial_state=ssm_states,
+        out=out,
+        ssm_state_indices=inp["cache_indices"],
+        use_qk_l2norm_in_kernel=True,
+    )
+    return out.transpose(0, 1), ssm_states
+
+
+def check_correctness(B, H, HV, K, V, pool_size, device, dtype, seed=42):
+    """Run correctness check for a single config. Returns True if PASS."""
+    tag = f"B={B:>4} H={H:>2} HV={HV:>2} K={K:>3} V={V:>3} pool={pool_size:>4}"
+
+    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, seed=seed)
+
+    o_baseline, state_baseline = run_baseline(inp)
+    o_packed, state_packed = run_packed(inp)
+
+    atol = 2e-2 if dtype != torch.float32 else 1e-4
+    rtol = 1e-2 if dtype != torch.float32 else 1e-4
+
+    out_diff = (o_packed.float() - o_baseline.float()).abs().max().item()
+    output_ok = out_diff <= max(atol, rtol * o_baseline.float().abs().max().item())
+
+    indices = inp["cache_indices"]
+    st_diff = (
+        (state_packed[indices].float() - state_baseline[indices].float())
+        .abs()
+        .max()
+        .item()
+    )
+    state_ok = st_diff <= max(
+        atol, rtol * state_baseline[indices].float().abs().max().item()
+    )
+
+    passed = output_ok and state_ok
+    if passed:
+        print(
+            f"  [PASS] {tag}  (out max_diff={out_diff:.2e}, state max_diff={st_diff:.2e})"
+        )
+    else:
+        print(
+            f"  [FAIL] {tag}  out max_diff={out_diff:.6f}, state max_diff={st_diff:.6f}"
+        )
+    return passed
+
+
+def bench_shape(B, H, HV, K, V, pool_size, device, dtype):
+    """Benchmark baseline vs packed for a single config."""
+    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype)
+
+    def fn_baseline():
+        q_flat, k_flat, v_flat = torch.split(
+            inp["mixed_qkv"], [H * K, H * K, HV * V], dim=-1
+        )
+        q = q_flat.view(1, B, H, K)
+        k = k_flat.view(1, B, H, K)
+        v = v_flat.view(1, B, HV, V)
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=inp["A_log"],
+            dt_bias=inp["dt_bias"],
+            q=q,
+            k=k,
+            v=v,
+            a=inp["a"],
+            b=inp["b"],
+            initial_state_source=inp["ssm_states"],
+            initial_state_indices=inp["cache_indices"],
+            cu_seqlens=inp["cu_seqlens"],
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            is_kda=True,
+        )
+
+    out_buf = inp["mixed_qkv"].new_empty(B, 1, HV, V)
+
+    def fn_packed():
+        fused_recurrent_kda_packed_decode(
+            mixed_qkv=inp["mixed_qkv"],
+            a=inp["a"],
+            b=inp["b"],
+            A_log=inp["A_log"],
+            dt_bias=inp["dt_bias"],
+            scale=K**-0.5,
+            initial_state=inp["ssm_states"],
+            out=out_buf,
+            ssm_state_indices=inp["cache_indices"],
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    # Wall-clock CUDA event timing. Decode is per-token-per-step in practice
+    # (no fusion across steps), so the CPU dispatch overhead that ``packed``
+    # eliminates is a real cost — ``triton.testing.do_bench`` amortizes that
+    # away and would under-report the win.
+    warmup, iters = 50, 200
+    for _ in range(warmup):
+        fn_baseline()
+        fn_packed()
+    torch.cuda.synchronize()
+
+    def _time(fn):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            fn()
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / iters  # ms
+
+    ms_baseline = _time(fn_baseline)
+    ms_packed = _time(fn_packed)
+
+    speedup = ms_baseline / ms_packed if ms_packed > 0 else float("inf")
+    saved_us = (ms_baseline - ms_packed) * 1000
+
+    print(
+        f"  {B:>5}  {H:>3}  {HV:>3}  {K:>3}  {V:>3} | "
+        f"{ms_baseline * 1000:>10.1f} | "
+        f"{ms_packed * 1000:>10.1f} | "
+        f"{speedup:>7.2f}x | "
+        f"{saved_us:>+9.1f}"
+    )
+
+
+def run_correctness(device, dtype):
+    print("=" * 80)
+    print("Correctness: Baseline KDA Decode vs Packed KDA Decode")
+    print("=" * 80)
+
+    shapes = [
+        # (B, H, HV, K, V, pool_size)
+        (1, 16, 16, 128, 128, 32),
+        (4, 16, 16, 128, 128, 32),
+        (16, 16, 16, 128, 128, 64),
+        (32, 16, 16, 128, 128, 128),
+        (64, 16, 16, 128, 128, 128),
+        (128, 16, 16, 128, 128, 256),
+        (256, 16, 16, 128, 128, 512),
+        # Asymmetric H vs HV
+        (1, 32, 32, 128, 128, 32),
+        (32, 32, 32, 128, 128, 128),
+        (64, 32, 32, 128, 128, 128),
+        # Edge case
+        (1, 16, 16, 128, 128, 32),
+        (2, 16, 16, 128, 128, 32),
+    ]
+
+    all_pass = True
+    for B, H, HV, K, V, pool_size in shapes:
+        if not check_correctness(B, H, HV, K, V, pool_size, device, dtype):
+            all_pass = False
+
+    # PAD_SLOT_ID test: some indices < 0 should output zeros and skip state update.
+    print("\n  PAD_SLOT_ID test (indices with -1):")
+    inp = make_inputs(32, 16, 16, 128, 128, 128, device, dtype)
+    pad_mask = torch.zeros(32, device=device, dtype=torch.bool)
+    pad_mask[::4] = True
+    inp["cache_indices"] = torch.where(
+        pad_mask,
+        torch.tensor(-1, device=device, dtype=torch.int32),
+        inp["cache_indices"],
+    )
+    o_baseline, _ = run_baseline(inp)
+    o_packed, _ = run_packed(inp)
+    try:
+        torch.testing.assert_close(o_packed, o_baseline, atol=2e-2, rtol=1e-2)
+        print("  [PASS] PAD_SLOT_ID=-1 handling")
+    except AssertionError as e:
+        print(f"  [FAIL] PAD_SLOT_ID=-1 handling: {e}")
+        all_pass = False
+
+    print()
+    print("ALL PASSED." if all_pass else "SOME FAILED.")
+    return all_pass
+
+
+def run_benchmark(device, dtype, args):
+    print()
+    print("=" * 85)
+    print("Benchmark: Baseline KDA Decode vs Packed KDA Decode")
+    print("=" * 85)
+
+    K = args.head_size_k
+    V = args.head_size_v
+    pool_size = args.pool_size
+
+    bench_configs = []
+    for B in args.batch_sizes:
+        for H in args.num_q_heads:
+            for HV in args.num_v_heads:
+                bench_configs.append((B, H, HV))
+
+    print(f"  Config: K={K}, V={V}, pool_size={pool_size}, dtype={dtype}")
+    print(
+        f"  {'B':>5}  {'H':>3}  {'HV':>3}  {'K':>3}  {'V':>3} | "
+        f"{'base (us)':>10} | "
+        f"{'packed (us)':>10} | "
+        f"{'speedup':>8} | "
+        f"{'saved (us)':>10}"
+    )
+    print("  " + "-" * 80)
+
+    for B, H, HV in bench_configs:
+        # Packed kernel requires HV % H == 0 (GVA / grouped query layout).
+        if HV % H != 0:
+            continue
+        actual_pool = max(pool_size, B + 16)
+        bench_shape(B, H, HV, K, V, actual_pool, device, dtype)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark & Correctness: KDA Packed Decode vs Baseline"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["all", "correctness", "bench"],
+        default="all",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["float16", "bfloat16", "float32"],
+        default="bfloat16",
+    )
+    parser.add_argument("--head-size-k", type=int, default=128)
+    parser.add_argument("--head-size-v", type=int, default=128)
+    parser.add_argument("--pool-size", type=int, default=512)
+    parser.add_argument(
+        "--batch-sizes",
+        type=int,
+        nargs="+",
+        default=[1, 4, 8, 16, 32, 64, 128, 256],
+    )
+    parser.add_argument(
+        "--num-q-heads",
+        type=int,
+        nargs="+",
+        default=[16, 32],
+    )
+    parser.add_argument(
+        "--num-v-heads",
+        type=int,
+        nargs="+",
+        default=[16, 32],
+    )
+    args = parser.parse_args()
+
+    device = "cuda"
+    dtype = getattr(torch, args.dtype)
+
+    cap = torch.cuda.get_device_capability()
+    dev_name = torch.cuda.get_device_name()
+    print(f"Device: {dev_name}  (SM {cap[0]}{cap[1]})")
+
+    if args.mode in ("all", "correctness"):
+        all_pass = run_correctness(device, dtype)
+        if not all_pass and args.mode == "all":
+            print("\nSkipping benchmark due to correctness failures.")
+            return 1
+
+    if args.mode in ("all", "bench"):
+        run_benchmark(device, dtype, args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/sglang/srt/layers/attention/fla/fused_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_recurrent.py
@@ -402,6 +402,265 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     return out, initial_state
 
 
+@triton.jit
+def fused_recurrent_kda_packed_decode_kernel(
+    mixed_qkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    o,
+    h0,
+    ht,
+    ssm_state_indices,
+    scale,
+    stride_mixed_qkv_tok: tl.constexpr,
+    stride_a_tok: tl.constexpr,
+    stride_b_tok: tl.constexpr,
+    stride_init_state_token: tl.constexpr,
+    stride_final_state_token: tl.constexpr,
+    stride_indices_seq: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    SOFTPLUS_THRESHOLD: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+):
+    """KDA packed decode: same shape as the GDN packed decode kernel, but
+    with a per-K gate (``a`` is ``[B, HV*K]`` and ``dt_bias`` is ``[HV*K]``),
+    so the state decay is a per-K vector ``exp(g)`` rather than a scalar."""
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_v[:, None] & mask_k[None, :]
+
+    state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq).to(tl.int64)
+    p_o = o + (i_n * HV + i_hv) * V + o_v
+
+    if state_idx < 0:
+        zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
+        tl.store(p_o, zero, mask=mask_v)
+        return
+
+    p_h0 = h0 + state_idx * stride_init_state_token
+    p_h0 = p_h0 + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+    b_h = tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+
+    p_mixed = mixed_qkv + i_n * stride_mixed_qkv_tok
+    q_off = i_h * K + o_k
+    k_off = (H * K) + i_h * K + o_k
+    v_off = (2 * H * K) + i_hv * V + o_v
+    b_q = tl.load(p_mixed + q_off, mask=mask_k, other=0).to(tl.float32)
+    b_k = tl.load(p_mixed + k_off, mask=mask_k, other=0).to(tl.float32)
+    b_v = tl.load(p_mixed + v_off, mask=mask_v, other=0).to(tl.float32)
+
+    if USE_QK_L2NORM_IN_KERNEL:
+        b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+        b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+    b_q = b_q * scale
+
+    # KDA per-K gate: load BK values of ``a`` and ``dt_bias`` for this head.
+    p_a = a + i_n * stride_a_tok + i_hv * K + o_k
+    p_dt = dt_bias + i_hv * K + o_k
+    b_a = tl.load(p_a, mask=mask_k, other=0).to(tl.float32)
+    b_dt = tl.load(p_dt, mask=mask_k, other=0).to(tl.float32)
+    A_log_val = tl.load(A_log + i_hv).to(tl.float32)
+
+    x = b_a + b_dt
+    softplus_x = tl.where(x <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x)), x)
+    b_g = -tl.exp(A_log_val) * softplus_x  # [BK]
+
+    b_val = tl.load(b + i_n * stride_b_tok + i_hv).to(tl.float32)
+    # Keep beta in fp32 (no bf16 round-trip) to match the generic decode
+    # kernel `fused_sigmoid_gating_delta_rule_update`, which is the reference
+    # validated against torch.
+    beta_val = tl.sigmoid(b_val).to(tl.float32)
+
+    # Per-K decay: each K-row of the [V, K] state decays by its own exp(g_k).
+    b_h *= exp(b_g)[None, :]
+    b_v -= tl.sum(b_h * b_k[None, :], 1)
+    b_v *= beta_val
+    b_h += b_v[:, None] * b_k[None, :]
+    b_o = tl.sum(b_h * b_q[None, :], 1)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+
+    p_ht = ht + state_idx * stride_final_state_token
+    p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+    tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+
+
+def fused_recurrent_kda_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """KDA T=1 decode fast path. Mirrors ``fused_recurrent_gated_delta_rule_packed_decode``
+    but the gate ``g`` is a per-K vector instead of a scalar.
+
+    Args:
+        mixed_qkv: ``[B, 2*H*K + HV*V]`` packed projection output after conv1d.
+            Requires ``num_q_heads == num_k_heads == H`` and ``head_q_dim == head_k_dim == K``.
+        a: ``[B, HV*K]`` per-K gate input (typically reshaped from ``[B, HV, K]``).
+        b: ``[B, HV]`` beta input (post-sigmoid scalar per head).
+        A_log: ``[HV]`` log-space decay parameter.
+        dt_bias: ``[HV*K]`` per-K time-step bias.
+        scale: attention scale factor (typically ``head_k_dim ** -0.5``).
+        initial_state: ``[num_slots, HV, V, K]`` full state pool, updated in place.
+        out: ``[B, 1, HV, V]`` contiguous output buffer.
+        ssm_state_indices: ``[B]`` per-request state slot indices (-1 = skip).
+        use_qk_l2norm_in_kernel: apply per-head L2 norm to Q/K inside the kernel.
+    """
+    if mixed_qkv.ndim != 2:
+        raise ValueError(
+            f"`mixed_qkv` must be a 2D tensor (got ndim={mixed_qkv.ndim})."
+        )
+    if mixed_qkv.stride(-1) != 1:
+        raise ValueError("`mixed_qkv` must be contiguous in the last dim.")
+    if a.ndim != 2 or b.ndim != 2:
+        raise ValueError(
+            f"`a` and `b` must be 2D tensors (got a.ndim={a.ndim}, b.ndim={b.ndim})."
+        )
+    if a.stride(-1) != 1 or b.stride(-1) != 1:
+        raise ValueError("`a`/`b` must be contiguous in the last dim.")
+    if A_log.ndim != 1 or dt_bias.ndim != 1:
+        raise ValueError("`A_log`/`dt_bias` must be 1D tensors.")
+    if A_log.stride(0) != 1 or dt_bias.stride(0) != 1:
+        raise ValueError("`A_log`/`dt_bias` must be contiguous.")
+    if ssm_state_indices.ndim != 1:
+        raise ValueError(
+            f"`ssm_state_indices` must be 1D for packed decode (got ndim={ssm_state_indices.ndim})."
+        )
+    if not out.is_contiguous():
+        raise ValueError("`out` must be contiguous.")
+
+    dev = mixed_qkv.device
+    if any(
+        t.device != dev
+        for t in (a, b, A_log, dt_bias, initial_state, out, ssm_state_indices)
+    ):
+        raise ValueError("All inputs must be on the same device.")
+
+    B = mixed_qkv.shape[0]
+    if a.shape[0] != B or b.shape[0] != B:
+        raise ValueError(
+            "Mismatched batch sizes: "
+            f"mixed_qkv.shape[0]={B}, a.shape[0]={a.shape[0]}, b.shape[0]={b.shape[0]}."
+        )
+    if ssm_state_indices.shape[0] != B:
+        raise ValueError(
+            f"`ssm_state_indices` must have shape [B] (got {tuple(ssm_state_indices.shape)}; expected ({B},))."
+        )
+
+    if initial_state.ndim != 4:
+        raise ValueError(
+            f"`initial_state` must be a 4D tensor (got ndim={initial_state.ndim})."
+        )
+    if initial_state.stride(-1) != 1:
+        raise ValueError("`initial_state` must be contiguous in the last dim.")
+    HV, V, K = initial_state.shape[-3:]
+    if a.shape[1] != HV * K:
+        raise ValueError(
+            f"`a` must have shape [B, HV*K] with HV={HV}, K={K} "
+            f"(got a.shape={tuple(a.shape)})."
+        )
+    if b.shape[1] != HV:
+        raise ValueError(
+            f"`b` must have shape [B, HV] with HV={HV} (got b.shape={tuple(b.shape)})."
+        )
+    if A_log.numel() != HV:
+        raise ValueError(f"`A_log` must have {HV} elements (got {A_log.numel()}).")
+    if dt_bias.numel() != HV * K:
+        raise ValueError(
+            f"`dt_bias` must have {HV * K} elements (got {dt_bias.numel()})."
+        )
+    if out.shape != (B, 1, HV, V):
+        raise ValueError(
+            f"`out` must have shape {(B, 1, HV, V)} (got out.shape={tuple(out.shape)})."
+        )
+
+    qkv_dim = mixed_qkv.shape[1]
+    qk_dim = qkv_dim - HV * V
+    if qk_dim <= 0 or qk_dim % 2 != 0:
+        raise ValueError(
+            f"Invalid packed `mixed_qkv` last dim={qkv_dim} for HV={HV}, V={V}."
+        )
+    q_dim = qk_dim // 2
+    if q_dim % K != 0:
+        raise ValueError(
+            f"Invalid packed Q size {q_dim}: must be divisible by K={K}. "
+            "KDA packed decode requires num_q_heads == num_k_heads and "
+            "head_q_dim == head_k_dim."
+        )
+    H = q_dim // K
+    if H <= 0 or HV % H != 0:
+        raise ValueError(
+            f"Invalid head config inferred from mixed_qkv: H={H}, HV={HV}."
+        )
+
+    BK = triton.next_power_of_2(K)
+    if triton.cdiv(K, BK) != 1:
+        raise ValueError(
+            f"Packed decode kernel only supports NK=1 (got K={K}, BK={BK})."
+        )
+    BV = min(triton.next_power_of_2(V), 32)
+    num_stages = 3
+    num_warps = 1
+
+    stride_mixed_qkv_tok = mixed_qkv.stride(0)
+    stride_a_tok = a.stride(0)
+    stride_b_tok = b.stride(0)
+    stride_init_state_token = initial_state.stride(0)
+    stride_final_state_token = initial_state.stride(0)
+    stride_indices_seq = ssm_state_indices.stride(0)
+
+    NV = triton.cdiv(V, BV)
+    grid = (NV, B * HV)
+    fused_recurrent_kda_packed_decode_kernel[grid](
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        o=out,
+        h0=initial_state,
+        ht=initial_state,
+        ssm_state_indices=ssm_state_indices,
+        scale=scale,
+        stride_mixed_qkv_tok=stride_mixed_qkv_tok,
+        stride_a_tok=stride_a_tok,
+        stride_b_tok=stride_b_tok,
+        stride_init_state_token=stride_init_state_token,
+        stride_final_state_token=stride_final_state_token,
+        stride_indices_seq=stride_indices_seq,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        SOFTPLUS_THRESHOLD=20.0,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return out, initial_state
+
+
 class FusedRecurrentFunction(torch.autograd.Function):
 
     @staticmethod

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -66,9 +66,47 @@ class KDAKernelDispatcher:
                 "KDA currently only supports 'triton'."
             )
 
+        self.supports_packed_decode = getattr(
+            self.decode_kernel, "supports_packed_decode", False
+        )
+
         rank0_log(
             f"KDA kernel dispatcher: decode={self.decode_kernel.__class__.__name__}, "
-            f"extend={self.extend_kernel.__class__.__name__}"
+            f"extend={self.extend_kernel.__class__.__name__} "
+            f"packed_decode={self.supports_packed_decode}"
+        )
+
+    def packed_decode(
+        self,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        scale: float,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        num_v_heads: int,
+        head_v_dim: int,
+        **kwargs,
+    ) -> Optional[torch.Tensor]:
+        """Attempt packed decode. Returns output tensor or None if the decode
+        kernel does not support packed decode."""
+        if not self.supports_packed_decode:
+            return None
+        return self.decode_kernel.packed_decode(
+            mixed_qkv,
+            a,
+            b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            ssm_states=ssm_states,
+            cache_indices=cache_indices,
+            num_v_heads=num_v_heads,
+            head_v_dim=head_v_dim,
+            **kwargs,
         )
 
     def decode(
@@ -157,6 +195,23 @@ class KDAAttnBackend(MambaAttnBackendBase):
             activation="silu",
             conv_state_indices=cache_indices,
         )
+
+        # Skip split + reshape by consuming the packed mixed_qkv directly in a
+        # single fused Triton kernel (KDA per-K gate variant of GDN PR #20627).
+        if self.kernel_dispatcher.supports_packed_decode:
+            return self.kernel_dispatcher.packed_decode(
+                mixed_qkv=qkv,
+                a=a,
+                b=b,
+                A_log=layer.A_log,
+                dt_bias=layer.dt_bias,
+                scale=layer.head_k_dim**-0.5,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
+                num_v_heads=layer.num_v_heads,
+                head_v_dim=layer.head_v_dim,
+            )
+
         q, k, v = qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
         k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)  # n (h d) -> 1 n h d

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -198,7 +198,19 @@ class KDAAttnBackend(MambaAttnBackendBase):
 
         # Skip split + reshape by consuming the packed mixed_qkv directly in a
         # single fused Triton kernel (KDA per-K gate variant of GDN PR #20627).
+        #
+        # The packed kernel hard-assumes one token per sequence (T=1): it has no
+        # query_start_loc / per-sequence loop. forward_decode is only entered in
+        # decode mode (see HybridLinearAttnBackend.forward dispatch), where each
+        # request contributes exactly one token, so #tokens == #requests. Multi-
+        # token-per-seq speculative paths (target_verify / draft_extend) go
+        # through forward_extend instead. Assert the invariant so a future
+        # routing change fails loudly rather than silently corrupting state.
         if self.kernel_dispatcher.supports_packed_decode:
+            assert qkv.shape[0] == cache_indices.shape[0], (
+                "KDA packed decode requires one token per sequence (T=1): "
+                f"got {qkv.shape[0]} tokens for {cache_indices.shape[0]} requests."
+            )
             return self.kernel_dispatcher.packed_decode(
                 mixed_qkv=qkv,
                 a=a,

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -5,9 +5,12 @@ import torch
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
 )
-from sglang.srt.utils import is_cpu
+from sglang.srt.utils import is_cpu, is_npu
 
 if not is_cpu():
+    from sglang.srt.layers.attention.fla.fused_recurrent import (
+        fused_recurrent_kda_packed_decode,
+    )
     from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
         fused_sigmoid_gating_delta_rule_update,
     )
@@ -16,6 +19,53 @@ if not is_cpu():
 
 class TritonKDAKernel(LinearAttnKernelBase):
     """Triton-based kernel for KDA (Kimi Delta Attention) linear attention."""
+
+    supports_packed_decode: bool = not is_cpu() and not is_npu()
+
+    def packed_decode(
+        self,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        scale: float,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        num_v_heads: int,
+        head_v_dim: int,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Packed decode fast path: feed the conv-1d output ``mixed_qkv``
+        straight into a single fused Triton kernel that does Q/K/V extraction,
+        gate/beta computation, l2-norm, and the recurrent state update.
+
+        Returns output tensor of shape [1, B, HV, V] to match the existing
+        decode kernel output layout.
+        """
+        B = mixed_qkv.shape[0]
+        # a may come in as [B, HV, K] (or [B, 1, HV*K]); b may come in as
+        # [B, 1, HV]. Flatten both to the 2D shapes the kernel expects.
+        if a.dim() != 2:
+            a = a.reshape(B, -1)
+        if b.dim() != 2:
+            b = b.reshape(B, -1)
+        out = mixed_qkv.new_empty(B, 1, num_v_heads, head_v_dim)
+        fused_recurrent_kda_packed_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log.reshape(-1),
+            dt_bias=dt_bias.reshape(-1),
+            scale=scale,
+            initial_state=ssm_states,
+            out=out,
+            ssm_state_indices=cache_indices,
+            use_qk_l2norm_in_kernel=True,
+        )
+        # [B, 1, HV, V] -> [1, B, HV, V] view to match existing decode layout.
+        return out.transpose(0, 1)
 
     def decode(
         self,

--- a/test/registered/attention/test_kda_kernels.py
+++ b/test/registered/attention/test_kda_kernels.py
@@ -3,6 +3,9 @@ import unittest
 import torch
 
 from sglang.srt.layers.attention.fla.cumsum import chunk_local_cumsum
+from sglang.srt.layers.attention.fla.fused_recurrent import (
+    fused_recurrent_kda_packed_decode,
+)
 from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
     fused_sigmoid_gating_delta_rule_update,
 )
@@ -238,6 +241,150 @@ class TestKDAGateChunkCumsum(unittest.TestCase):
         )
         self.assertLess(
             max_diff, 1e-3, f"max_diff={max_diff:.2e}, rel_diff={rel_diff:.2e}"
+        )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+class TestKDAPackedDecode(unittest.TestCase):
+    """Verify ``fused_recurrent_kda_packed_decode`` matches the existing decode
+    path (split + unflatten + ``fused_sigmoid_gating_delta_rule_update``)."""
+
+    @staticmethod
+    def _make_inputs(B, H, HV, K, V, pool_size, dtype, device, seed=42):
+        torch.manual_seed(seed)
+        qkv_dim = 2 * H * K + HV * V
+        mixed_qkv = (
+            torch.randn(B, qkv_dim, dtype=dtype, device=device) * 0.1
+        ).contiguous()
+        a = (
+            torch.randn(B, HV * K, dtype=dtype, device=device) * 0.5 - 1.0
+        ).contiguous()
+        b = (torch.randn(B, HV, dtype=dtype, device=device) * 0.5).contiguous()
+        A_log = torch.randn(HV, dtype=torch.float32, device=device) * 0.2
+        dt_bias = torch.randn(HV * K, dtype=torch.float32, device=device) * 0.1
+        ssm_states = (
+            torch.randn(pool_size, HV, V, K, dtype=dtype, device=device) * 0.01
+        ).contiguous()
+        cache_indices = torch.arange(B, device=device, dtype=torch.int32)
+        return mixed_qkv, a, b, A_log, dt_bias, ssm_states, cache_indices
+
+    @staticmethod
+    def _run_baseline(
+        mixed_qkv, a, b, A_log, dt_bias, ssm_states, cache_indices, H, HV, K, V
+    ):
+        B = mixed_qkv.shape[0]
+        q_flat, k_flat, v_flat = torch.split(mixed_qkv, [H * K, H * K, HV * V], dim=-1)
+        q = q_flat.view(1, B, H, K)
+        k = k_flat.view(1, B, H, K)
+        v = v_flat.view(1, B, HV, V)
+        # The real backend passes query_start_loc = [0, 1, ..., B] so that
+        # each of the B tokens becomes its own length-1 sequence with an
+        # independent state; without this the kernel would share state.
+        cu_seqlens = torch.arange(B + 1, device=mixed_qkv.device, dtype=torch.int32)
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            dt_bias=dt_bias,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            q=q,
+            k=k,
+            v=v,
+            a=a,
+            b=b,
+            initial_state_source=ssm_states,
+            initial_state_indices=cache_indices,
+            cu_seqlens=cu_seqlens,
+            scale=K**-0.5,
+            use_qk_l2norm_in_kernel=True,
+            is_kda=True,
+        )
+
+    @staticmethod
+    def _run_packed(
+        mixed_qkv, a, b, A_log, dt_bias, ssm_states, cache_indices, HV, K, V
+    ):
+        B = mixed_qkv.shape[0]
+        out = mixed_qkv.new_empty(B, 1, HV, V)
+        fused_recurrent_kda_packed_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=K**-0.5,
+            initial_state=ssm_states,
+            out=out,
+            ssm_state_indices=cache_indices,
+            use_qk_l2norm_in_kernel=True,
+        )
+        return out.transpose(0, 1)
+
+    def _check(self, B, H, HV, K, V):
+        device = get_device()
+        dtype = torch.bfloat16
+        pool_size = B + 4
+        mixed_qkv, a, b, A_log, dt_bias, ssm_states, cache_indices = self._make_inputs(
+            B, H, HV, K, V, pool_size, dtype, device
+        )
+        s_packed = ssm_states.clone()
+        s_baseline = ssm_states.clone()
+
+        o_packed = self._run_packed(
+            mixed_qkv, a, b, A_log, dt_bias, s_packed, cache_indices, HV, K, V
+        )
+        o_baseline = self._run_baseline(
+            mixed_qkv, a, b, A_log, dt_bias, s_baseline, cache_indices, H, HV, K, V
+        )
+
+        torch.testing.assert_close(
+            o_packed.float(), o_baseline.float(), atol=2e-2, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            s_packed[cache_indices].float(),
+            s_baseline[cache_indices].float(),
+            atol=2e-2,
+            rtol=1e-2,
+        )
+
+    def test_b1(self):
+        self._check(B=1, H=16, HV=16, K=128, V=128)
+
+    def test_b4(self):
+        self._check(B=4, H=16, HV=16, K=128, V=128)
+
+    def test_b32(self):
+        self._check(B=32, H=16, HV=16, K=128, V=128)
+
+    def test_b128(self):
+        self._check(B=128, H=16, HV=16, K=128, V=128)
+
+    def test_asymmetric_heads(self):
+        # Common KDA config with HV > H (grouped query).
+        self._check(B=8, H=8, HV=16, K=128, V=128)
+
+    def test_pad_slot(self):
+        """Entries with state_idx == -1 must produce zero output and skip state writeback."""
+        device = get_device()
+        dtype = torch.bfloat16
+        B, H, HV, K, V = 8, 16, 16, 128, 128
+        pool_size = B + 4
+        mixed_qkv, a, b, A_log, dt_bias, ssm_states, cache_indices = self._make_inputs(
+            B, H, HV, K, V, pool_size, dtype, device
+        )
+        # Mark every other request as padded.
+        cache_indices = cache_indices.clone()
+        cache_indices[::2] = -1
+
+        s_packed = ssm_states.clone()
+        s_baseline = ssm_states.clone()
+        o_packed = self._run_packed(
+            mixed_qkv, a, b, A_log, dt_bias, s_packed, cache_indices, HV, K, V
+        )
+        o_baseline = self._run_baseline(
+            mixed_qkv, a, b, A_log, dt_bias, s_baseline, cache_indices, H, HV, K, V
+        )
+        torch.testing.assert_close(
+            o_packed.float(), o_baseline.float(), atol=2e-2, rtol=1e-2
         )
 
 

--- a/test/registered/attention/test_kda_kernels.py
+++ b/test/registered/attention/test_kda_kernels.py
@@ -387,6 +387,66 @@ class TestKDAPackedDecode(unittest.TestCase):
             o_packed.float(), o_baseline.float(), atol=2e-2, rtol=1e-2
         )
 
+    def test_production_shapes_through_dispatcher(self):
+        """Go through ``TritonKDAKernel.packed_decode`` with the exact tensor
+        shapes the KimiDeltaAttention model produces at decode time, so the
+        a/b/A_log/dt_bias reshape-normalization is unit-tested (not only E2E).
+
+        Production decode shapes (see kimi_linear.py forward + __init__):
+          - a (forget_gate): [B, HV*K]   (2D, not unflattened in decode)
+          - b (beta):        [1, B, HV]  (unsqueeze(0), pre-sigmoid)
+          - A_log:           [1, 1, HV, 1]
+          - dt_bias:         [HV*K]
+        """
+        from sglang.srt.layers.attention.linear.kernels.kda_triton import (
+            TritonKDAKernel,
+        )
+
+        device = get_device()
+        dtype = torch.bfloat16
+        B, H, HV, K, V = 4, 16, 16, 128, 128
+        pool_size = B + 4
+        mixed_qkv, a, b, A_log, dt_bias, ssm_states, cache_indices = self._make_inputs(
+            B, H, HV, K, V, pool_size, dtype, device
+        )
+
+        # Reshape the flat reference tensors into the production layouts.
+        b_prod = b.unsqueeze(0)  # [B, HV] -> [1, B, HV]
+        A_log_prod = A_log.view(1, 1, HV, 1)  # [HV] -> [1, 1, HV, 1]
+
+        kernel = TritonKDAKernel()
+        self.assertTrue(kernel.supports_packed_decode)
+
+        s_packed = ssm_states.clone()
+        out = kernel.packed_decode(
+            mixed_qkv,
+            a,
+            b_prod,
+            A_log=A_log_prod,
+            dt_bias=dt_bias,
+            scale=K**-0.5,
+            ssm_states=s_packed,
+            cache_indices=cache_indices,
+            num_v_heads=HV,
+            head_v_dim=V,
+        )
+
+        s_baseline = ssm_states.clone()
+        o_baseline = self._run_baseline(
+            mixed_qkv, a, b, A_log, dt_bias, s_baseline, cache_indices, H, HV, K, V
+        )
+
+        # Dispatcher returns [1, B, HV, V], same layout as the baseline.
+        torch.testing.assert_close(
+            out.float(), o_baseline.float(), atol=2e-2, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            s_packed[cache_indices].float(),
+            s_baseline[cache_indices].float(),
+            atol=2e-2,
+            rtol=1e-2,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

KDA decode is **overhead-bound** at small batch. The existing flow inside `KDAAttnBackend.forward_decode` is:

```
causal_conv1d_update(mixed_qkv)
  → qkv.split([q_dim, k_dim, v_dim], dim=-1)
  → q.unflatten + q.unsqueeze
  → k.unflatten + k.unsqueeze
  → v.unflatten + v.unsqueeze
  → fused_sigmoid_gating_delta_rule_update(q, k, v, a, b, ..., is_kda=True)
```

For B=1, T=1 the actual math per layer is tiny (a few rank-1 state updates), but the wall-clock latency is dominated by:

1. **Python/PyTorch dispatch overhead** — `split` + 3× `unflatten` + 3× `unsqueeze` cost ~15-20µs of CPU per layer even though they only produce views.
2. **Kernel launch overhead** — one extra kernel launch.
3. **Generic kernel dead branches** — `fused_sigmoid_gating_delta_rule_update_kernel` carries `for T` loop, `IS_VARLEN`, `HAS_EAGLE_TREE_CUSTOM_ATTN_MASK`, `CACHE_INTERMEDIATE_STATES`, `DISABLE_STATE_UPDATE` — five compile-time flags whose dead/degenerate branches still occupy registers and hurt instruction scheduling for the T=1 decode case.

This is the same problem GDN solved in #20627 (GDN packed decode), with ~2.59× speedup at B=1. This PR ports that optimization to KDA, with adaptations for KDA's per-K gate.

## Modifications

Adds a fused single-kernel KDA decode fast path that:
- Takes the `[B, qkv_dim]` packed conv1d output directly, doing Q/K/V extraction via pointer arithmetic inside the kernel — no `split` / `unflatten` / `unsqueeze` on the Python side.
- Computes gate (`-exp(A_log) * softplus(a + dt_bias)`) and beta (`sigmoid(b)`) in registers.
- Does L2-norm on Q/K in registers.
- Performs the single-step gated delta-rule recurrent state update and writes back the output and updated state.
- Specialized for T=1, so it drops the `for T` loop, `IS_VARLEN`, tree-attention, and cache-buffer branches that the generic decode kernel carries.

The unpacked decode path is fully preserved as a fallback (used on CPU/NPU where `supports_packed_decode = False`).

### Differences from the GDN packed decode kernel

KDA's gate is per-K, not per-head scalar like GDN. Concretely:

| | GDN | KDA |
|---|---|---|
| `a` shape | `[B, HV]` | `[B, HV*K]` |
| `dt_bias` shape | `[HV]` | `[HV*K]` |
| Gate `g` | scalar per head | vector per (head, K) |
| State decay | `b_h *= exp(g_val)` (scalar) | `b_h *= exp(b_g)[None, :]` (per-K vector) |

Everything else (pointer-offset Q/K/V extraction, L2-norm, beta, single-step delta rule, in-place state writeback, PAD_SLOT_ID=-1 handling) mirrors GDN packed decode.

## Files changed

- `python/sglang/srt/layers/attention/fla/fused_recurrent.py` — new `fused_recurrent_kda_packed_decode_kernel` + Python wrapper `fused_recurrent_kda_packed_decode`.
- `python/sglang/srt/layers/attention/linear/kernels/kda_triton.py` — `TritonKDAKernel.supports_packed_decode = True` and `packed_decode(...)` method.
- `python/sglang/srt/layers/attention/linear/kda_backend.py` — `KDAKernelDispatcher` exposes `supports_packed_decode` and a `packed_decode(...)` method; `KDAAttnBackend.forward_decode` short-circuits the split/reshape chain after `causal_conv1d_update` when packed decode is supported.
- `test/registered/attention/test_kda_kernels.py` — new `TestKDAPackedDecode` test class (6 tests covering B ∈ {1, 4, 32, 128}, asymmetric heads, and PAD_SLOT_ID=-1).
- `benchmark/bench_linear_attention/bench_kda_decode.py` — new benchmark + correctness script mirroring the GDN PR's bench layout.

## Correctness

### Unit tests

`test/registered/attention/test_kda_kernels.py::TestKDAPackedDecode`:

```
test_b1                  ok
test_b4                  ok
test_b32                 ok
test_b128                ok
test_asymmetric_heads    ok  (H=8, HV=16)
test_pad_slot            ok  (cache_indices contains -1)
Ran 6 tests in 4.889s   OK
```

`out max|diff|` ≤ 3e-5, `state max|diff|` ≤ 5e-4 (bf16 cast noise).

### E2E accuracy

`moonshotai/Kimi-Linear-48B-A3B-Instruct`, TP=2 on H200, GSM8K (200 examples, completion API):

```
metrics={
  'score': 0.925,                  # 92.5% accuracy
  'score:std': 0.263,
  'latency': 10.74s,
  'output_throughput': 1782 tok/s,
}
PASS  score=0.9250  threshold=0.88
```


Well above the 0.88 threshold used by `test/registered/models_e2e/test_kimi_linear_models.py`. The packed_decode path is exercised end-to-end with `supports_packed_decode = True` in the dispatcher.

## Production shape compatibility

The unit-test wrapper passes tightly-shaped tensors (`a: [B, HV*K]`, `b: [B, HV]`, `A_log: [HV]`, `dt_bias: [HV*K]`), but in production the upstream model code passes:

- `b` as 3D `[B, 1, HV]` (unsqueeze-on-T artifact),
- `A_log` as multi-dim e.g. `[1, 1, HV, 1]`,
- `dt_bias` as 2D `[HV, K]`.

`TritonKDAKernel.packed_decode` therefore normalizes these with zero-copy `reshape(-1)` / `reshape(B, -1)` calls before invoking the kernel. No extra memory or compute, just metadata views — but worth noting because the unit tests alone wouldn't have caught these mismatches.

## Performance (H200, BF16, K=V=128, single layer decode, wall-clock CUDA events)
<img width="1584" height="944" alt="image" src="https://github.com/user-attachments/assets/99a7a27c-b631-4948-bfaf-2227d804f6f0" />

```
   B    H   HV |  base (μs) | packed (μs) | speedup
   1   16   16 |       43.4 |       25.1  |  1.73x
   1   32   32 |       42.9 |       25.4  |  1.69x
   4   32   32 |       43.8 |       25.1  |  1.74x
  16   32   32 |       43.6 |       25.3  |  1.73x
  32   32   32 |       43.0 |       25.2  |  1.70x
  64   16   16 |       43.3 |       25.3  |  1.72x
 128   16   32 |      118.0 |       83.0  |  1.42x
 128   32   32 |      118.1 |       83.0  |  1.42x
 256   32   32 |      228.7 |      156.6  |  1.46x
```

- **B ≤ 64, smaller heads**: stable **~1.7× speedup**. Both paths are floor-limited (launch + minimum work), and packed eliminates the CPU dispatch + one launch.
- **B ≥ 128**: **1.4-1.5× speedup**. Compute starts to dominate, but packed still wins from the specialized kernel.
- The Triton kernel timing dropped from ~58µs to ~25µs at B=1; under `triton.testing.do_bench` (which amortizes CPU overhead away) the kernel-only delta is smaller — wall-clock is the relevant metric for decode since decode is per-step synchronous.

The relative win is slightly less than GDN's 2.59× because KDA's per-K gate loads K-times more `a`/`dt_bias` per program, adding some work the GDN scalar gate doesn't have.

## Test Plan

- [x] `python -m unittest test_kda_kernels.TestKDAPackedDecode -v` (6 tests pass)
- [x] `python benchmark/bench_linear_attention/bench_kda_decode.py` (correctness + bench)
- [x] End-to-end Kimi-Linear-48B-A3B-Instruct on GSM8K → 0.925 (≥ 0.88 threshold)































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26714982414](https://github.com/sgl-project/sglang/actions/runs/26714982414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26714982364](https://github.com/sgl-project/sglang/actions/runs/26714982364)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->