### PR TITLE
[BugFix] preserve cached token details in multi-tokenizer output

### DIFF
--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -246,6 +246,9 @@ def _handle_output_by_index(output, i):
             completion_tokens=_extract_field_by_index(output, "completion_tokens", i),
             reasoning_tokens=_extract_field_by_index(output, "reasoning_tokens", i),
             cached_tokens=_extract_field_by_index(output, "cached_tokens", i),
+            cached_tokens_details=_extract_field_by_index(
+                output, "cached_tokens_details", i
+            ),
             input_token_logprobs_val=_extract_field_by_index(
                 output, "input_token_logprobs_val", i, check_length=False
             ),

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -1,0 +1,68 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import BatchStrOutput
+from sglang.srt.managers.multi_tokenizer_mixin import _handle_output_by_index
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_batch_str_output() -> BatchStrOutput:
+    return BatchStrOutput(
+        rids=["rid-0", "rid-1"],
+        spec_verify_ct=[0, 0],
+        spec_num_correct_drafts=[0, 0],
+        spec_correct_drafts_histogram=[[], []],
+        finished_reasons=[None, {"type": "length"}],
+        output_strs=["first", "second"],
+        output_ids=[[1], [2]],
+        prompt_tokens=[10, 20],
+        completion_tokens=[1, 2],
+        reasoning_tokens=[0, 0],
+        cached_tokens=[3, 4],
+        cached_tokens_details=[
+            {"device": 3, "host": 0},
+            {"device": 1, "host": 3},
+        ],
+        input_token_logprobs_val=[[], []],
+        input_token_logprobs_idx=[[], []],
+        output_token_logprobs_val=[[], []],
+        output_token_logprobs_idx=[[], []],
+        input_top_logprobs_val=[[], []],
+        input_top_logprobs_idx=[[], []],
+        output_top_logprobs_val=[[], []],
+        output_top_logprobs_idx=[[], []],
+        input_token_ids_logprobs_val=[[], []],
+        input_token_ids_logprobs_idx=[[], []],
+        output_token_ids_logprobs_val=[[], []],
+        output_token_ids_logprobs_idx=[[], []],
+        output_token_entropy_val=[0.0, 0.0],
+        output_hidden_states=[None, None],
+        routed_experts=[None, None],
+        indexer_topk=[None, None],
+        placeholder_tokens_idx=[None, None],
+        placeholder_tokens_val=[None, None],
+        retraction_counts=[0, 0],
+    )
+
+
+class TestMultiTokenizerMixin(unittest.TestCase):
+    def test_batch_str_output_preserves_cached_tokens_details(self):
+        output = _make_batch_str_output()
+
+        single_output = _handle_output_by_index(output, 1)
+
+        self.assertEqual(single_output.rids, ["rid-1"])
+        self.assertEqual(single_output.cached_tokens, [4])
+        self.assertEqual(
+            single_output.cached_tokens_details,
+            [{"device": 1, "host": 3}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Current behavior: when launching the server with HiCache, metrics enabled, and `--tokenizer-worker-num > 1`, `cached_tokens_details` is computed by the scheduler but dropped in the multi-tokenizer `BatchStrOutput` split path. As a result, the metrics collector sees `cached_tokens > 0` with `cached_tokens_details=None` and emits only the fallback `sglang:cached_tokens_total{cache_source="total"}` series instead of the expected per-tier `cache_source="device"`, `"host"`, and `"storage_<backend>"` breakdown.

Verify fix works. Launch server with `--tokenizer-worker-num > 1`.

```
python3 -m sglang.launch_server --model-path=Qwen/Qwen3.5-397B-A17B-FP8 --host=0.0.0.0 --port=8888 --served-model-name Qwen/Qwen3.5-397B-A17B-FP8 --trust-remote-code --tensor-parallel-size=8 --data-parallel-size=1 --expert-parallel-size=8 --quantization fp8 --kv-cache-dtype fp8_e4m3 --mamba-ssm-dtype bfloat16 --attention-backend flashinfer --enable-flashinfer-allreduce-fusion --mem-fraction-static 0.75 --stream-interval 50 --scheduler-recv-interval 10 --tokenizer-worker-num 6 --tokenizer-path Qwen/Qwen3.5-397B-A17B-FP8 --enable-metrics --page-size 64 --enable-hierarchical-cache --hicache-size 93 --hicache-io-backend kernel --hicache-mem-layout page_first --hicache-write-policy write_through_selective
``` 
Poll `/metrics` and verify the per-tier cache metrics are available:
```
sa-shared@hpc-gpu-1-11:/tmp$ curl -s  http://localhost:8888/metrics | grep source
# HELP sglang:cached_tokens_total Number of cached prompt tokens by source (device/host/storage).
sglang:cached_tokens_total{cache_source="device",engine_type="unified",model_name="Qwen/Qwen3.5-397B-A17B-FP8"} 205236.0
sglang:cached_tokens_total{cache_source="host",engine_type="unified",model_name="Qwen/Qwen3.5-397B-A17B-FP8"} 1.7035148e+07
```

## Modifications

- Add the same `cached_tokens_details` forwarding logic used for `BatchTokenIDOutput` to the `BatchStrOutput` multi-tokenizer split path.
- Add a regression test covering per-request `BatchStrOutput` extraction with `cached_tokens_details`.

<!-- Detail the changes made in this pull request. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26588284115](https://github.com/sgl-project/sglang/actions/runs/26588284115)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26588283273](https://github.com/sgl-project/sglang/actions/runs/26588283273)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->