### PR TITLE
[AMD] Pin compressed-tensors<0.16.0 for srt_hip (fixes ROCm 7.2 nightly build)

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -95,6 +95,13 @@ srt_hip = [
   "torch",
   "petit_kernel==0.0.2",
   "wave-lang==3.8.2",
+  # HOTFIX (2026-05-28): compressed-tensors 0.16.0 added `torch>=2.10.0`,
+  # which forces pip off the ROCm wheel (torch 2.9.1+rocm7.2) and silently
+  # swaps it for the PyPI default `torch 2.12.0+cu130`, breaking the
+  # downstream HIP build of fast-hadamard-transform with a NameError on
+  # `bare_metal_version`. Pin below 0.16.0 until the ROCm base ships
+  # torch>=2.10.
+  "compressed-tensors<0.16.0",
 ]
 
 diffusion_hip = [


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  - compressed-tensors 0.16.0 (released 2026-05-28T14:31:44Z on PyPI) bumped its torch
    requirement to >=2.10.0
  - On ROCm bases shipping torch 2.9.1+rocm7.2, pip resolves this by uninstalling the
    ROCm wheel and pulling PyPI's default torch 2.12.0+cu130
  - The CUDA-flavored torch then trips fast-hadamard-transform's setup.py at
    46efb7d, which dereferences `bare_metal_version` outside its `CUDA_HOME is not None`
    guard, breaking the AMD docker nightly
  - Scoped to srt_hip only so HPU / MUSA / MPS / NVIDIA / NPU / CPU / XPU remain
    unaffected

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26589332532](https://github.com/sgl-project/sglang/actions/runs/26589332532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26589332263](https://github.com/sgl-project/sglang/actions/runs/26589332263)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->