### PR TITLE
perf: extend --prefill-only-disable-kv-cache to multi-item scoring

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -129,6 +129,18 @@ class FlashInferAttnBackend(AttentionBackend):
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.enable_mis = model_runner.server_args.enable_mis
+        # Skip per-layer KV pool reads/writes when --prefill-only-disable-kv-cache
+        # is on AND the structural preconditions for the ragged-MIS path hold.
+        # _handle_multi_item_scoring already enforces chunked_prefill_size=-1
+        # and disable_radix_cache for MIS, so the structural checks here are
+        # effectively redundant — they mirror FlashAttentionBackend.fa_skip_kv_cache
+        # for symmetry. The actual gate is enable_mis + prefill_only_disable_kv_cache.
+        self.fi_skip_kv_cache = (
+            model_runner.server_args.prefill_only_disable_kv_cache
+            and model_runner.server_args.enable_mis
+            and model_runner.server_args.chunked_prefill_size == -1
+            and model_runner.server_args.disable_radix_cache
+        )
 
         # FIXME: remove dllm workarounds from flashinfer
         self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
@@ -242,7 +254,11 @@ class FlashInferAttnBackend(AttentionBackend):
             ]
 
         fmha_backend = "auto"
-        if is_sm100_supported():
+        # Cutlass and cudnn FMHA paths in flashinfer drop the MIS attention
+        # params (prefix_len_ptr / token_pos_in_items_ptr / max_item_len_ptr)
+        # silently — see flashinfer/prefill.py:3082-3134. Force "auto" on MIS
+        # so the ragged-MIS path lands on FA2/FA3 where the params are honored.
+        if is_sm100_supported() and not self.enable_mis:
             if not model_runner.server_args.disable_piecewise_cuda_graph:
                 logger.info(
                     "CUTLASS backend is disabled when piecewise cuda graph is enabled "
@@ -478,16 +494,24 @@ class FlashInferAttnBackend(AttentionBackend):
         else:
             prefix_lens = forward_batch.extend_prefix_lens
 
-            # Disable ragged wrapper and ensure prefix handling for multimodal and multi-item scoring
-            if self.is_multimodal or self.enable_mis:
-                # use_ragged = False: Multi-item scoring requires the paged wrapper because:
-                # 1. Ragged wrapper doesn't support the specialized multi-item parameters
-                #    (prefix_len_ptr, token_pos_in_items_ptr, etc.)
-                # 2. Paged wrapper provides better control over attention masking needed
-                #    for respecting item boundaries in multi-item sequences
-                # 3. Custom masking logic conflicts with ragged wrapper's assumptions
+            # Multimodal still uses the paged wrapper.
+            if self.is_multimodal:
                 use_ragged = False
                 extend_no_prefix = False
+            elif self.enable_mis:
+                # MIS is prefill-only (max_new_tokens=0), and
+                # _handle_multi_item_scoring auto-enforces disable_radix_cache=True
+                # and chunked_prefill_size=-1. So there is no prefix to merge and
+                # K/V is transient per request — the ragged wrapper is the right
+                # tool. Flashinfer's ragged wrapper accepts prefix_len_ptr,
+                # token_pos_in_items_ptr, token_pos_in_items_len, and
+                # max_item_len_ptr natively (see flashinfer/prefill.py:2596-2630
+                # and the kernel call at 3174-3186), so MIS attention masks are
+                # honored end-to-end. Routing MIS through ragged also makes
+                # fi_skip_kv_cache work because the ragged path doesn't touch
+                # the paged KV pool — see forward_extend below.
+                use_ragged = True
+                extend_no_prefix = True
             else:
                 use_ragged = (
                     not self.enable_deterministic
@@ -800,7 +824,7 @@ class FlashInferAttnBackend(AttentionBackend):
         if not self.forward_metadata.use_ragged:
             if k is not None:
                 assert v is not None
-                if save_kv_cache:
+                if save_kv_cache and not self.fi_skip_kv_cache:
                     self.token_to_kv_pool.set_kv_buffer(
                         layer, cache_loc, k, v, layer.k_scale, layer.v_scale
                     )
@@ -892,7 +916,7 @@ class FlashInferAttnBackend(AttentionBackend):
 
                 o, _ = merge_state(o1, s1, o2, s2)
 
-            if save_kv_cache:
+            if save_kv_cache and not self.fi_skip_kv_cache:
                 self.token_to_kv_pool.set_kv_buffer(
                     layer, cache_loc, k, v, layer.k_scale, layer.v_scale
                 )
@@ -1516,27 +1540,11 @@ class FlashInferIndicesUpdaterPrefill:
                 )
             )
 
-        # extend part
-        if use_ragged:
-            wrapper_ragged.begin_forward(
-                qo_indptr,
-                qo_indptr,
-                self.num_qo_heads,
-                self.num_kv_heads,
-                self.head_dim,
-                q_data_type=self.q_data_type,
-            )
-
-        if use_sliding_window_kv_pool:
-            kv_last_index = kv_indptr[-1]
-            kv_indices[:kv_last_index] = (
-                self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
-                    kv_indices[:kv_last_index]
-                )
-            )
-
-        # cached part
-        # Conditionally set multi-item parameters
+        # Compute MIS params first so both ragged and paged begin_forward
+        # can consume them. Flashinfer's ragged wrapper accepts the full MIS
+        # parameter surface natively in current versions
+        # (flashinfer/prefill.py:2596-2630, kernel call at 3174-3186), which
+        # is what unblocks routing MIS through ragged.
         if multi_item_params is not None and multi_item_params.is_enabled():
             # Multi-item scoring is active - use specialized parameters and disable generic custom_mask
             use_custom_mask = None
@@ -1552,6 +1560,30 @@ class FlashInferIndicesUpdaterPrefill:
             token_pos_in_items_len = 0
             max_item_len_ptr = None
 
+        # extend part
+        if use_ragged:
+            wrapper_ragged.begin_forward(
+                qo_indptr,
+                qo_indptr,
+                self.num_qo_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                q_data_type=self.q_data_type,
+                prefix_len_ptr=prefix_len_ptr,
+                token_pos_in_items_ptr=token_pos_in_items_ptr,
+                token_pos_in_items_len=token_pos_in_items_len,
+                max_item_len_ptr=max_item_len_ptr,
+            )
+
+        if use_sliding_window_kv_pool:
+            kv_last_index = kv_indptr[-1]
+            kv_indices[:kv_last_index] = (
+                self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                    kv_indices[:kv_last_index]
+                )
+            )
+
+        # cached part — MIS params consumed above; just hand them to the paged wrapper.
         wrapper_paged.begin_forward(
             qo_indptr,
             kv_indptr,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3511,15 +3511,18 @@ class ServerArgs:
         if not self.prefill_only_disable_kv_cache:
             return
 
-        # This flag is intentionally scoped to embedding mode for now. Other
-        # prefill-only paths (for example scoring and MIS) can benefit from
-        # the same idea later, but some of them still stage K/V through the
-        # paged cache today.
-        if not self.is_embedding:
+        # The flag covers two prefill-only modes today:
+        #  - --is-embedding (FA fa_skip_kv_cache path)
+        #  - --enable-mis (flashinfer ragged-MIS path; see
+        #    FlashInferAttnBackend.fi_skip_kv_cache)
+        # Other prefill-only paths (e.g. CausalLM scoring with max_new_tokens=0)
+        # can be added once their attention paths stop touching the paged pool.
+        if not (self.is_embedding or self.enable_mis):
             raise ValueError(
-                "--prefill-only-disable-kv-cache currently requires --is-embedding. "
-                "Other prefill-only workloads may be supported in a future change once "
-                "their attention paths stop reading or writing the paged KV cache."
+                "--prefill-only-disable-kv-cache currently requires --is-embedding "
+                "or --enable-mis. Other prefill-only workloads may be supported in "
+                "a future change once their attention paths stop reading or writing "
+                "the paged KV cache."
             )
         if self.kv_cache_dtype == "fp4_e2m1":
             raise ValueError(
@@ -3589,11 +3592,20 @@ class ServerArgs:
         )
 
         prefill_backend, _ = self.get_attention_backends()
-        if prefill_backend not in ("fa3", "fa4"):
+        # FA fa_skip_kv_cache covers fa3/fa4 (--is-embedding path).
+        # Flashinfer fi_skip_kv_cache covers --enable-mis (see
+        # FlashInferAttnBackend.fi_skip_kv_cache). Other prefill-only workloads
+        # and backends may be supported in a future change.
+        if prefill_backend in ("fa3", "fa4"):
+            pass
+        elif prefill_backend == "flashinfer" and self.enable_mis:
+            pass
+        else:
             raise ValueError(
-                "--prefill-only-disable-kv-cache currently requires the FA prefill backend "
-                f"(fa3/fa4), but got prefill backend {prefill_backend!r}. Other prefill-only "
-                "workloads and backends may be supported in a future change."
+                "--prefill-only-disable-kv-cache currently supports prefill backends "
+                "fa3/fa4 (for --is-embedding) and flashinfer combined with --enable-mis. "
+                f"Got prefill backend {prefill_backend!r}; other backends and prefill-only "
+                "workloads may be supported in a future change."
             )
 
     def _handle_hicache(self):


### PR DESCRIPTION
# PR2 — sgl-project/sglang

**Title:** `perf: extend --prefill-only-disable-kv-cache to multi-item scoring`

**Branch:** `jiaguo/mis-skip-kv-cache`

---

> [!IMPORTANT]
> **This PR depends on flashinfer-ai/flashinfer#3434 ("fix(prefill): support multi-item scoring on BatchPrefillWithRaggedKVCacheWrapper").** Without that flashinfer fix, this PR ships a correctness regression: the ragged-MIS kernel produces wrong outputs because `MULTIITEMSCORING` is never threaded through the Hopper kernel dispatch chain, so `mask_mode=CAUSAL` is applied and per-item attention bounds are lost. Empirically, items collapse to bit-identical scores. **Please do not land this PR until the flashinfer fix is released and the sglang dependency on flashinfer is bumped to that version.**

## Summary

Extends #23675 (which enabled `--prefill-only-disable-kv-cache` for embedding-mode FA path via `fa_skip_kv_cache`) to **multi-item scoring (MIS) workloads** via a new `fi_skip_kv_cache` mirror on the flashinfer backend. After this PR + the dependency, a production MIS deployment can flip one engine arg and free its entire KV pool slab.

The optimization is the same as #23675's: replace `MHATokenToKVPool` with `NoOpMHATokenToKVPool` (already in tree) for prefill-only workloads, since no layer in the forward pass needs to read or write the paged pool. The new bit is making MIS one of those prefill-only workloads:

- MIS is already `max_new_tokens=0` (`tokenizer_manager_score_mixin.py:700`), so there's no decode step.
- `_handle_multi_item_scoring` already enforces `chunked_prefill_size=-1` and `disable_radix_cache=True` (`server_args.py:1351-1362`), so K/V is transient per request.
- Routing MIS through flashinfer's ragged wrapper (instead of the paged wrapper, which sglang has been doing) means the prefill attention reads K/V directly from the layer's projection output instead of through the pool. The ragged wrapper accepts the full MIS parameter surface (`prefix_len_ptr`, `token_pos_in_items_ptr`, `token_pos_in_items_len`, `max_item_len_ptr`) natively — see flashinfer/prefill.py:2596-2630 and the kernel call at 3174-3186. (Caveat: only correct once the flashinfer fix in this PR's dependency lands.)

This unlocks `--prefill-only-disable-kv-cache` for the flashinfer + MIS combination, freeing the full KV pool slab on MIS deployments.

## What this PR does

8 hunks across two files.

**`python/sglang/srt/layers/attention/flashinfer_backend.py`** (5 hunks):

1. `FlashInferAttnBackend.__init__` — add `self.fi_skip_kv_cache` as a mirror of `FlashAttentionBackend.fa_skip_kv_cache`:
   ```python
   self.fi_skip_kv_cache = (
       model_runner.server_args.prefill_only_disable_kv_cache
       and model_runner.server_args.enable_mis
       and model_runner.server_args.chunked_prefill_size == -1
       and model_runner.server_args.disable_radix_cache
   )
   ```
   The chunked_prefill / radix_cache structural checks are redundant (MIS auto-enforces both via `_handle_multi_item_scoring`) but match the symmetry of `fa_skip_kv_cache`.
2. `FlashInferAttnBackend.__init__` — pin `fmha_backend = "auto"` when `enable_mis` is on. Cutlass and cudnn FMHA paths in flashinfer drop the MIS attention params silently (`flashinfer/prefill.py:3082-3134`); without this guard, an SM100 deployment with MIS would land on cutlass and produce wrong outputs. This is independent of the rest of the PR but worth fixing together since SM100 + MIS is currently broken.
3. `init_forward_metadata_extend` — split multimodal vs MIS branches. MIS routes through `use_ragged=True, extend_no_prefix=True`. The stale comment claiming the ragged wrapper doesn't support MIS params is removed.
4. `FlashInferIndicesUpdaterPrefill.call_begin_forward` — lift the MIS-param block above the `use_ragged` branch and pass `prefix_len_ptr` / `token_pos_in_items_ptr` / `token_pos_in_items_len` / `max_item_len_ptr` to `wrapper_ragged.begin_forward`.
5. `forward_extend` — guard the two `set_kv_buffer` calls (paged branch line 805, ragged branch line 887) with `not self.fi_skip_kv_cache`. The `get_kv_buffer` read at line 815 lives in the paged branch, which the new MIS path skips by construction, so no read-side change is needed.

**`python/sglang/srt/server_args.py`** (3 hunks):

6. `_validate_prefill_only_disable_kv_cache_args` — relax the gate from `if not self.is_embedding` to `if not (self.is_embedding or self.enable_mis)`. The error message and comment block are updated accordingly.
7. `_handle_prefill_only_disable_kv_cache` — allow `flashinfer` backend when `enable_mis` is on, alongside the existing fa3/fa4 path for `is_embedding`.

No other code or tests are touched.

## Out of scope (deferred follow-ups)

- **CausalLM scoring with `max_new_tokens=0`** (the case called out as "doesn't cover yet" in #23675's body). Same `fi_skip_kv_cache` machinery would apply once the FA backend's `fa_skip_kv_cache` is extended to trigger for `max_new_tokens=0` in addition to `is_embedding`. Separate PR.
- **SM100 / Blackwell cutlass MIS support.** The PR pins `fmha_backend="auto"` under MIS to avoid silent correctness on cutlass — that's good enough for the Hopper-only MIS deployments today, but a full cutlass MIS port to flashinfer is a separate upstream effort.
- **MIS-aware K/V tile skip in the flashinfer ragged kernel.** The dependency PR makes ragged-MIS correct but doesn't yet do the K/V load-side optimization that paged-MIS has. Will be a follow-up flashinfer PR.

## Test plan

End-to-end tested on H200 + Qwen3-0.6B with the production sjs-ranking-2 overlay shape: `dtype=float16`, `attention_backend=flashinfer`, `enable_mis=True`, `mem_fraction_static=0.5`, `max_prefill_tokens=30000`, `chunked_prefill_size=-1`, `disable_radix_cache=True`, `disable_cuda_graph=True`.

Three variants:
- **A:** unpatched sglang + unpatched flashinfer (paged-MIS baseline, current production).
- **B:** this PR + flashinfer dependency, `prefill_only_disable_kv_cache=False` (ragged-MIS routing only, no skip-KV).
- **C:** this PR + flashinfer dependency, `prefill_only_disable_kv_cache=True` (the actual goal).

### Parity (per-item softmax scores; 3 distinct prompt sets)

`test_mis_basic` prompts ("Rate each option:" + "Option A/B/C"):

| | A | B | C |
|---|---|---|---|
| Option A | 0.3478 | 0.3469 | 0.3469 |
| Option B | 0.1993 | 0.1999 | 0.1999 |
| Option C | 0.1750 | 0.1738 | 0.1738 |

sjs-ranking-like 4-item:

| | A | B | C |
|---|---|---|---|
| item 0 | 0.9194 | 0.9198 | 0.9198 |
| item 1 | 0.6680 | 0.6715 | 0.6715 |
| item 2 | 0.9835 | 0.9835 | 0.9835 |
| item 3 | 0.7645 | 0.7631 | 0.7631 |

5 items of varied length (1 → 139 chars):

| | A | B | C |
|---|---|---|---|
| len=1 | 0.9478 | 0.9478 | 0.9478 |
| len=25 | 0.7909 | 0.7915 | 0.7915 |
| len=124 | 0.9297 | 0.9291 | 0.9291 |
| len=9 | 0.8650 | 0.8641 | 0.8641 |
| len=139 | 0.5660 | 0.5675 | 0.5675 |

A vs B max abs diff: 0.0035 (FP16 reduction-order noise across paged and ragged kernels — same math, slightly different reduction tree). B vs C: bit-identical (4/4 items in test 3; expected because `fi_skip_kv_cache` doesn't perturb compute, it just gates `set_kv_buffer` writes that go nowhere).

### Memory

KV pool reservation, same engine config:

| variant | GPU consumed at boot | avail mem after pool | log line |
|---|---|---|---|
| A | **71.5 GB** | 68.94 GB | `KV Cache is allocated. #tokens: 639895, K size: 34.17 GB, V size: 34.17 GB` |
| B | 71.5 GB | 68.94 GB | same |
| **C** | **3.1 GB** | **137.30 GB** | `KV Cache skipped (no-op pool). Logical #tokens: 639895, physical K/V size: ~112.0 KB placeholder` |

**Variant C frees 68 GB on H200 + Qwen3-0.6B at `mem_fraction_static=0.5`.** Proportional savings apply on H100 with smaller VRAM. The freed memory unlocks larger batch sizes, more replicas per pod, or both.

### Smoke

Variant C completes a 4-item MIS scoring request through the patched kernel path with no `NoOpMHATokenToKVPool.set_kv_buffer` raises and no scheduler exceptions. `set_kv_buffer` is correctly skipped at both call sites in `forward_extend`.

## Production target

LinkedIn's `llm-inference-sjs-ranking-2` (Qwen3-0.6B + flashinfer + `ENABLE_MIS=true` + `MEM_FRACTION_STATIC=0.5`) runs on H100 in three colos. Once the dependency lands and this PR is in a sglang release, the production rollout is one overlay flag: `sglang-engine-init.PREFILL_ONLY_DISABLE_KV_CACHE=true`. Expected to free a comparable proportion of the pool slab (the whole 50% mem_fraction_static).

## Notes for reviewers

- Patch is symmetric with #23675 — same `*_skip_kv_cache` field pattern, same validation-relaxation pattern, same `set_kv_buffer` gating pattern. Just one new backend (flashinfer-ragged) and one new mode (enable_mis) added to the matrix.
- `NoOpMHATokenToKVPool` is already in tree and pool-class-selection is already keyed on `prefill_only_disable_kv_cache` (not on `is_embedding`), so once validation passes, the no-op pool activates automatically. No memory_pool.py change needed.
- MIS auto-disables CUDA graph (`_handle_multi_item_scoring`), so there's no cudagraph re-capture concern.
- `_handle_multi_item_scoring` does NOT touch `is_embedding`; this PR is therefore the first place sglang allows `enable_mis + prefill_only_disable_kv_cache` together. Validation tests added to `test/registered/unit/server_args/test_server_args.py` cover the new path and confirm `is_embedding=False + enable_mis=False + prefill_only_disable_kv_cache=True` still fails with the original message.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26590650329](https://github.com/sgl-project/sglang/actions/runs/26590650329)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26590650147](https://github.com/sgl-project/sglang/actions/runs/26590650147)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->