### PR TITLE
[XPU] [DO NOT Merge] rotary_embedding: fp32 cos_sin_cache and fused RoPE+KV-cache dispatch

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -69,7 +69,7 @@ class RotaryEmbedding(MultiPlatformOp):
 
         cache = self._compute_cos_sin_cache()
         # NOTE(ByronHsu): cache needs to be in FP32 for numerical stability
-        if not _is_cuda:
+        if not _is_cuda and not _is_xpu:
             cache = cache.to(dtype)
 
         if (
@@ -414,17 +414,42 @@ class RotaryEmbedding(MultiPlatformOp):
         offsets: Optional[torch.Tensor] = None,
         fused_set_kv_buffer_arg: Optional[FusedSetKVBufferArg] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        assert (
-            fused_set_kv_buffer_arg is None
-        ), "fused_set_kv_buffer_arg is not supported for xpu implementation"
         positions = torch.add(positions, offsets) if offsets is not None else positions
 
+        if fused_set_kv_buffer_arg is not None:
+            try:
+                from sgl_kernel import apply_rope_inplace_with_kvcache_xpu
+            except ImportError:
+                pass
+            else:
+                nq_heads = query.shape[-1] // self.head_size
+                nkv_heads = key.shape[-1] // self.head_size
+                q3 = query.view(-1, nq_heads, self.head_size)
+                k3 = key.view(-1, nkv_heads, self.head_size)
+                v3 = fused_set_kv_buffer_arg.value.view(-1, nkv_heads, self.head_size)
+
+                apply_rope_inplace_with_kvcache_xpu(
+                    q3,
+                    k3,
+                    v3,
+                    k_cache=fused_set_kv_buffer_arg.k_buffer,
+                    v_cache=fused_set_kv_buffer_arg.v_buffer,
+                    cos_sin_cache=self.cos_sin_cache,
+                    positions=positions,
+                    out_loc=fused_set_kv_buffer_arg.cache_loc,
+                    is_neox=self.is_neox_style,
+                )
+                return query, key
+
+        # Unfused SYCL kernel expects cos_sin_cache in same dtype as query
+        if not hasattr(self, "_cos_sin_cache_bf16"):
+            self._cos_sin_cache_bf16 = self.cos_sin_cache.to(query.dtype)
         return torch.ops.sgl_kernel.rotary_embedding(
             positions,
             query,
             key,
             self.head_size,
-            self.cos_sin_cache,
+            self._cos_sin_cache_bf16,
             self.is_neox_style,
         )
 


### PR DESCRIPTION
## Summary

- Keep `cos_sin_cache` in fp32 on XPU (matching CUDA behavior) for numerical stability in RoPE computation.
- Cache a bf16 copy (`_cos_sin_cache_bf16`) for the unfused SYCL rotary_embedding kernel which expects same dtype as query.
- Wire `forward_xpu` to accept `fused_set_kv_buffer_arg` and dispatch to `apply_rope_inplace_with_kvcache_xpu` when available (ImportError-guarded for backwards compatibility).
- Remove the hard assert that rejected `fused_set_kv_buffer_arg` on XPU.

## Companion PR

The SYCL kernel (`apply_rope_inplace_with_kvcache_xpu`) will be added in a separate PR to [sgl-kernel-xpu](https://github.com/sgl-project/sgl-kernel-xpu). When not installed, the fused path is skipped and the unfused kernel runs.

## Test plan

- [x] E2B GSM8K 5-shot (N=200): 0.175 accuracy — no regression
- [x] Backwards compatible: works with and without sgl-kernel-xpu fused-rope-kvcache branch







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26592863221](https://github.com/sgl-project/sglang/actions/runs/26592863221)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26592863052](https://github.com/sgl-project/sglang/actions/runs/26592863052)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->