### PR TITLE
[Bugfix][ModelLoader] fastsafetensors: fix multinode device + add nogds opt-out

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -207,6 +207,10 @@ class Envs:
     SGLANG_DISABLED_MODEL_ARCHS = EnvTuple(tuple())
     SGLANG_PREFETCH_BLOCK_SIZE_MB = EnvInt(16)
     SGLANG_GEMMA_OUT_OF_PLACE_POSITION_MUTATION = EnvBool(False)
+    # Force fastsafetensors to skip GPU Direct Storage (cuFile) and use
+    # the CPU-staged fallback. Required when models live on storage
+    # backends without cuFile support (NFS, SMB, FUSE).
+    SGLANG_FASTSAFETENSORS_NOGDS = EnvBool(False)
 
     # Logging Options
     SGLANG_LOG_GC = EnvBool(False)

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -964,7 +964,19 @@ def fastsafetensors_weights_iterator(
     except Exception:
         rank = 0
 
-    device = torch.device(f"cuda:{rank}")
+    # Use the current device on this process, not the global TP rank. With
+    # one GPU per node (e.g. multi-node TP=2 over single-GPU hosts), the
+    # global rank can exceed the local GPU count and `cuda:{rank}` resolves
+    # to a nonexistent device on non-rank-0 nodes.
+    device = torch.device(f"cuda:{torch.cuda.current_device()}")
+
+    # Allow disabling GPU Direct Storage. fastsafetensors defaults to GDS,
+    # which requires cuFile support in the underlying storage. NFS, SMB,
+    # FUSE, and similar shared filesystems often lack cuFile and fail at
+    # loader.copy_files_to_device() time.
+    from sglang.srt.environ import envs
+
+    nogds = envs.SGLANG_FASTSAFETENSORS_NOGDS.get()
 
     weight_files_sub_lists = [
         hf_weights_files[i : i + pg.size()]
@@ -981,7 +993,7 @@ def fastsafetensors_weights_iterator(
         disable=False,
         bar_format=_BAR_FORMAT,
     ):
-        loader = SafeTensorsFileLoader(pg, device)
+        loader = SafeTensorsFileLoader(pg, device, nogds=nogds)
         rank_file_map = {i: [f] for i, f in enumerate(f_list)}
         loader.add_filenames(rank_file_map)
         try:


### PR DESCRIPTION
## Motivation

Two related bugs in `fastsafetensors_weights_iterator` prevent fastsafetensors-based model loading on multi-node TP setups with one GPU per node, and on installations where weights live on shared filesystems without cuFile support.

We have carried both fixes locally for several weeks on cross-node TP=2 NVIDIA DGX Spark / GB10 (1 GPU/node) with models on NFS-mounted storage. This PR upstreams them.

## Changes

### 1. Device fix — use local device, not global TP rank

`fastsafetensors_weights_iterator` builds the target device as `f"cuda:{rank}"` where `rank` is the global process-group rank. On a multi-node TP setup with one GPU per node, the global rank exceeds the local GPU count: rank-1 resolves to `cuda:1`, which does not exist on a single-GPU node. Loading then fails mid-weight-load with a CUDA device-not-found error that's hard to trace to this source.

Switching to `torch.cuda.current_device()` is correct in both single-node and multi-node settings — by the time we reach weight loading, the model runner has already set the correct CUDA device for this process.

```diff
-    device = torch.device(f"cuda:{rank}")
+    device = torch.device(f"cuda:{torch.cuda.current_device()}")
```

### 2. Expose `nogds` opt-out via env var

fastsafetensors defaults to GPU Direct Storage (cuFile), which requires cuFile support in the underlying filesystem. NFS, SMB, FUSE, and similar shared filesystems don't support cuFile; `loader.copy_files_to_device()` then fails at the GDS path.

The fastsafetensors library already exposes a `nogds=True` option to force the CPU-staged fallback (which works on any POSIX-readable backing). This PR exposes that via a new `SGLANG_FASTSAFETENSORS_NOGDS` env var, defined per the project's env-var-conventions guide in `Envs` and read with `envs.SGLANG_FASTSAFETENSORS_NOGDS.get()`.

Default behavior is unchanged (`nogds=False`); existing GDS-capable installs are unaffected. NFS/SMB/FUSE users can now set `SGLANG_FASTSAFETENSORS_NOGDS=1` instead of patching the file.

```diff
-        loader = SafeTensorsFileLoader(pg, device)
+        loader = SafeTensorsFileLoader(pg, device, nogds=nogds)
```

## Why one PR, not two

The two bugs surface together in the same function and the same deployment scenarios. Combining them keeps the touched-line count small (`+18/-2`) and the context easy to review in one pass.

## Test plan

- [x] Validated locally on cross-node TP=2 over NAS-mounted models on GB10 / DGX Spark (1 GPU/node) — both bugs previously blocked weight load; both fixes have been required in production for several weeks.
- [x] Default behavior preserved: `SGLANG_FASTSAFETENSORS_NOGDS` defaults to `False`, so existing single-GPU GDS-capable installs see no change.
- [x] Verified `env-var-conventions` skill compliance: env var declared in `Envs` class under "Model & File Download", accessed via `envs.SGLANG_FASTSAFETENSORS_NOGDS.get()`.

## AI assistance disclosure

Patch authored and tested by Umank Behera. Drafting assisted by Claude (Anthropic).



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27932120716](https://github.com/sgl-project/sglang/actions/runs/27932120716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27932120649](https://github.com/sgl-project/sglang/actions/runs/27932120649)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->