### PR TITLE
[LoRA] Add sgl_flashinfer_trtllm MoE LoRA backend with two-stream overlap

### DIFF
--- a/benchmark/kernels/lora_csgmv/bench_shrink_splitk.py
+++ b/benchmark/kernels/lora_csgmv/bench_shrink_splitk.py
@@ -1,0 +1,259 @@
+"""Self-contained micro-benchmark for _moe_lora_shrink_splitk_kernel (LoRA-A shrink).
+
+Scoped to the qwen3.5-35b local-EP gate_up shrink: tp=4/ep=4 -> 64 local experts,
+hidden=2048, rank=16, top_k=8. Builds v1 routing and times the shrink kernel in
+isolation (CUDA-graph replay), with a correctness check and an eager mode for ncu.
+
+  python3 bench_shrink_splitk.py --mode bench
+  python3 bench_shrink_splitk.py --mode correctness   # sweeps block_m {16,32,64} x bs {16,64}
+  python3 bench_shrink_splitk.py --mode profile --iters 2   # eager, for ncu
+
+correctness mode also guards the routing/tiling block-size contract: the launcher must tile
+with the same block size the routing buffers were aligned with, else expert_ids overruns -> IMA.
+"""
+from __future__ import annotations
+
+import argparse
+
+import torch
+import triton
+import triton.testing
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.srt.lora.triton_ops.virtual_experts import (
+    _fused_virtual_topk_ids,
+    _invoke_moe_lora_shrink_splitk,
+    fused_sanitize_expert_ids,
+)
+
+
+def make_inputs(bs, num_experts, top_k, hidden, rank, dtype, device):
+    torch.manual_seed(0)
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:top_k] for _ in range(bs)]
+    ).to(torch.int32)
+    token_lora_mapping = torch.zeros(bs, device=device, dtype=torch.int32)
+    hidden_states = torch.randn(bs, hidden, device=device, dtype=dtype) * 0.1
+    lora_a = torch.randn(1, num_experts, rank, hidden, device=device, dtype=dtype) * 0.1
+    return topk_ids, token_lora_mapping, hidden_states, lora_a
+
+
+def build_v1_routing(topk_ids, token_lora_mapping, num_experts, block_m):
+    virtual_topk_ids, _, virtual_num_experts = _fused_virtual_topk_ids(
+        topk_ids, token_lora_mapping, num_experts, shared_outer=False, max_loras=1
+    )
+    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+        virtual_topk_ids, block_m, virtual_num_experts
+    )
+    num_tokens = topk_ids.numel()
+    max_nonempty = min(num_tokens, virtual_num_experts)
+    tight = triton.cdiv(num_tokens + max_nonempty * (block_m - 1), block_m) * block_m
+    return (
+        sorted_token_ids[:tight],
+        fused_sanitize_expert_ids(expert_ids[: tight // block_m], virtual_num_experts),
+        num_tokens_post_padded,
+    )
+
+
+def shrink(hidden_states, lora_a, topk_ids, routing, block_m, block_k,
+           num_warps=4, num_stages=4, force_split_k=None, swap_mn=False):
+    sorted_token_ids, expert_ids, num_tokens_post_padded = routing
+    lora_a_virtual = lora_a.reshape(lora_a.shape[0] * lora_a.shape[1], *lora_a.shape[2:])
+    rank = lora_a.shape[2]
+    top_k = topk_ids.shape[1]
+    # SPLIT_K > 1 atomic-adds, so the intermediate must be zeroed each call.
+    intermediate = torch.zeros(
+        topk_ids.numel(), rank, dtype=hidden_states.dtype, device=hidden_states.device
+    )
+    config = {
+        "BLOCK_SIZE_M": block_m,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": block_k,
+        "GROUP_SIZE_M": 1,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "SWAP_MN": swap_mn,
+    }
+    if force_split_k is not None:
+        config["FORCE_SPLIT_K"] = force_split_k
+    _invoke_moe_lora_shrink_splitk(
+        hidden_states,
+        lora_a_virtual,
+        intermediate,
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        top_k,
+        config,
+    )
+    return intermediate
+
+
+def ref_shrink(hidden_states, lora_a, topk_ids):
+    bs, top_k = topk_ids.shape
+    rank = lora_a.shape[2]
+    a = lora_a[0].float()
+    out = torch.zeros(bs * top_k, rank, device=hidden_states.device, dtype=torch.float32)
+    for m in range(bs):
+        for k in range(top_k):
+            e = int(topk_ids[m, k].item())
+            out[m * top_k + k] = hidden_states[m].float() @ a[e].t()
+    return out
+
+
+def bench_ms(fn, warmup=25, rep=100, cudagraph=True, inner=200):
+    """Per-call milliseconds.
+
+    With ``cudagraph``, capture ``inner`` back-to-back ``fn()`` calls in ONE graph
+    and divide the measured replay time by ``inner``. A single fn()-per-graph
+    ``do_bench(g.replay)`` floors at ~8-10us for ANY tiny op -- it measures the
+    fixed per-replay launch/dispatch overhead, not the kernel. Amortizing over
+    ``inner`` back-to-back calls drives that overhead to ~0 and exposes the true
+    device time. (Same technique as control_shrink_floor.py.)
+    """
+    torch.cuda.synchronize()
+    if cudagraph:
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                for _ in range(inner):
+                    fn()
+        torch.cuda.current_stream().wait_stream(s)
+        torch.cuda.synchronize()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            for _ in range(inner):
+                fn()
+        torch.cuda.synchronize()
+        ms = triton.testing.do_bench(g.replay, warmup=warmup, rep=rep) / inner
+    else:
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    torch.cuda.synchronize()
+    return float(ms)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["bench", "correctness", "profile", "sweep", "sweepk"], default="bench")
+    ap.add_argument("--bs", type=int, default=2)
+    ap.add_argument("--num-experts", type=int, default=64)
+    ap.add_argument("--top-k", type=int, default=8)
+    ap.add_argument("--hidden", type=int, default=2048)
+    ap.add_argument("--rank", type=int, default=16)
+    ap.add_argument("--block-m", type=int, default=16)
+    ap.add_argument("--block-k", type=int, default=256)
+    ap.add_argument("--iters", type=int, default=2)
+    ap.add_argument("--force-split-k", type=int, default=None)
+    ap.add_argument("--transpose", action="store_true",
+                    help="SWAP_MN: rank in MMA M-slot, tokens in N-slot")
+    ap.add_argument("--tol", type=float, default=5e-1)
+    args = ap.parse_args()
+
+    dev = "cuda"
+    if args.mode == "sweep":
+        for bs in [1, 2, 4, 8, 16, 32, 64]:
+            for rank in [16, 32, 64]:
+                for hidden in [512, 768, 2048, 7168]:
+                    topk_ids, tlm, hidden_states, lora_a = make_inputs(
+                        bs, args.num_experts, args.top_k, hidden, rank,
+                        torch.bfloat16, dev,
+                    )
+                    # print(f"Testing with bs={bs}, rank={rank}, hidden={hidden}")
+                    best = None
+                    for block_m in [8, 16, 32, 64]:
+                        routing_m = build_v1_routing(topk_ids, tlm, args.num_experts, block_m)
+                        for block_k in [128, 256, 512]:
+                            for nw in [2, 4]:
+                                for ns in [2, 3, 4]:
+                                    for sk in [1, 2, 3, 4, 5, 6, 7, 8]:
+                                        for swap_mn in [False, True]:
+                                            f = lambda bm=block_m, bk=block_k, w=nw, s=ns, r=routing_m: shrink(
+                                                hidden_states, lora_a, topk_ids, r, bm, bk, w, s,
+                                                swap_mn=swap_mn, force_split_k=sk)
+                                            try:
+                                                ms = bench_ms(f, warmup=15, rep=60)
+                                            except Exception as e:
+                                                # print(f"  ERROR: {e}")
+                                                continue
+                                            us = ms * 1000
+                                            tag = f"bm={block_m} bk={block_k} warps={nw} stages={ns} swap_mn={swap_mn}, force_split_k={sk}"
+                                            if best is None or us < best[0]:
+                                                best = (us, tag)
+                                            #     print(f"  * {us:7.2f} us  {tag}")
+                                            # else:
+                                            #     print(f"    {us:7.2f} us  {tag}")
+                    print(f"\nBEST bs={bs}, rank={rank}, hidden={hidden}: {best[0]:.2f} us  {best[1]}")
+        return
+
+    # Shared inputs for the non-sweep modes (sweep builds its own per iteration).
+    topk_ids, tlm, hidden_states, lora_a = make_inputs(
+        args.bs, args.num_experts, args.top_k, args.hidden, args.rank,
+        torch.bfloat16, dev,
+    )
+    routing = build_v1_routing(topk_ids, tlm, args.num_experts, args.block_m)
+
+    if args.mode == "sweepk":
+        for sk in [1, 2, 3, 4, 5, 6, 7, 8]:
+            f = lambda s=sk: shrink(hidden_states, lora_a, topk_ids, routing,
+                                    args.block_m, args.block_k, force_split_k=s,
+                                    swap_mn=args.transpose)
+            ms = bench_ms(f, warmup=20, rep=80)
+            print(f"  SPLIT_K={sk}: {ms * 1000:7.2f} us")
+        return
+
+    fn = lambda: shrink(hidden_states, lora_a, topk_ids, routing, args.block_m,
+                        args.block_k, force_split_k=args.force_split_k,
+                        swap_mn=args.transpose)
+
+    if args.mode == "correctness":
+        # Guard the routing/tiling block-size contract: _invoke_moe_lora_shrink_splitk must
+        # tile with the SAME block the routing buffers were aligned with (it reads
+        # config["BLOCK_SIZE_M"]; expert_ids has one entry per M-block). A launcher that
+        # hardcodes one block size while the routing uses another overruns expert_ids ->
+        # CUDA illegal memory access (the f2adddd "shrink" regression, which only bit the
+        # server because its tuned config used block_m=64 while the launcher hardcoded 16).
+        # Build routing AND config with the same block_m per iteration, but SWEEP block_m so
+        # any single hardcoded value diverges from the routing at the other block sizes. Sweep
+        # bs too: a larger grid makes the overrun deterministic enough to fault.
+        block_ms = sorted({args.block_m, 16, 32, 64})
+        batch_sizes = sorted({args.bs, 16, 64})
+        failures = 0
+        for bs in batch_sizes:
+            tk, tlm_b, hs, la = make_inputs(
+                bs, args.num_experts, args.top_k, args.hidden, args.rank,
+                torch.bfloat16, dev,
+            )
+            ref = ref_shrink(hs, la, tk)
+            for bm in block_ms:
+                routing_bm = build_v1_routing(tk, tlm_b, args.num_experts, bm)
+                out = shrink(
+                    hs, la, tk, routing_bm, bm, args.block_k,
+                    force_split_k=args.force_split_k, swap_mn=args.transpose,
+                ).float()
+                err = float((out - ref).abs().max().item())
+                ok = err <= args.tol
+                failures += int(not ok)
+                print(f"{'PASS' if ok else 'FAIL'} bs={bs:<3d} block_m={bm:<2d} "
+                      f"max_abs_err={err:.4e}")
+        if failures:
+            raise SystemExit(1)
+    elif args.mode == "profile":
+        for _ in range(5):
+            fn()
+        torch.cuda.synchronize()
+        for _ in range(args.iters):
+            fn()
+        torch.cuda.synchronize()
+    else:
+        ms = bench_ms(fn)
+        print(f"BENCH shrink_splitk gate_up bs={args.bs} r={args.rank} "
+              f"K={args.hidden} N={args.rank}: {ms * 1000:.2f} us "
+              f"(amortized true device time)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/lora_moe_expand/JOURNAL.md
+++ b/benchmark/kernels/lora_moe_expand/JOURNAL.md
@@ -1,0 +1,73 @@
+# Task: UT + micro-benchmark for `_moe_lora_expand_add_kernel` (down-proj GEMM)
+
+**[try bs 64 first, rank 16 only] [P0]**
+
+## Goal
+Mirror `bench_shrink_splitk.py` (which targets the LoRA-A shrink) with an equivalent
+self-contained testbed for the LoRA-B **expand-add** kernel
+(`_moe_lora_expand_add_kernel` in `python/sglang/srt/lora/trtllm_moe/specialized_expand.py`),
+scoped to the **down-proj** GEMM. Confirm correctness against a torch reference, then
+ship a registered UT PR with the script attached.
+
+## Scope / kernel contract (verified from source)
+- Down-proj expand-add caller (`lora_dispatch.py:207`, `moe_overlap.py`): uses
+  `mul_routed_weight=True`, `fuse_sum_all_reduce=True`, `use_direct_expand_add=(rank<=64)`.
+- Kernel signature: `a` = shrink intermediate `[num_tokens*top_k, R]`,
+  `b` = `lora_b_virtual [num_virtual_experts, N, R]`, `c` = output `[num_tokens, N]`.
+- `FUSE_SUM_ALL_REDUCE`: per-(token,expert) delta atomic-added into `c[token//top_k]`
+  → output MUST be zeroed each call. `MUL_ROUTED_WEIGHT`: scale by `topk_weights`.
+- `_invoke_moe_lora_expand_add` forces `BLOCK_SIZE_N = 128` when `N % 128 == 0`
+  (N=2048 → 128) and hardcodes `num_stages=1`. Tunable knobs: `BLOCK_SIZE_M`,
+  `GROUP_SIZE_M`, `num_warps`.
+- qwen3.5-35b local-EP scope: tp=4/ep=4 → 64 local experts, N (down hidden) = 2048,
+  rank = 16, top_k = 8.
+
+## Correctness contract guarded (same class of bug as the shrink f2adddd regression)
+The launcher tiles `expert_ids` with `config["BLOCK_SIZE_M"]`; routing buffers must be
+aligned with the SAME block. Correctness mode sweeps block_m {16,32,64} × bs {16,64},
+building routing per block_m, so a hardcoded mismatch overruns `expert_ids` → IMA.
+
+## Plan / steps
+1. [done] Sync `lora-opti-nvfp4` w/ `jybsuper/nvfp4-lora` (already up to date @ ac0fa6d3ee).
+2. [done] Worktree `sglang-lora-moe-expand-down-bench`, branch `lora-moe-expand-down-bench`.
+3. [in progress] Write standalone `bench_expand_add_down.py` + registered UT.
+4. Launch GPU node (id `yushengsu-<date>-<time>`), run correctness + bench.
+5. Open UT PR with the script and journal attached.
+
+## Runs
+
+### Node
+- Pod `sglang-lora-expand-ut-yushengsu-20260602-174942` (id `yushengsu-20260602-174942`),
+  1× **NVIDIA GB200**, image `lmsysorg/sglang:dev-cu13`. Overlaid branch
+  `lora-moe-expand-down-bench` python tree onto the editable install (no model weights
+  needed — pure triton kernel UT). Released after the runs.
+
+### Correctness (`--mode correctness`) — PASS
+Reference fp32 vs kernel (per-expert bf16 atomic-add accumulation), tol=5e-2 abs:
+```
+PASS bs=16  block_m=16 max_abs_err=3.00e-03 rel=8.6e-03
+PASS bs=16  block_m=32 max_abs_err=2.46e-03 rel=7.0e-03
+PASS bs=16  block_m=64 max_abs_err=2.57e-03 rel=7.4e-03
+PASS bs=64  block_m=16 max_abs_err=2.46e-03 rel=6.7e-03
+PASS bs=64  block_m=32 max_abs_err=3.01e-03 rel=8.2e-03
+PASS bs=64  block_m=64 max_abs_err=2.38e-03 rel=6.5e-03
+```
+Registered UT `test/registered/lora/test_moe_lora_expand_add.py`: **2 passed, 6 subtests passed** (11.7s).
+
+### Bench / sweep (bs=64, rank=16, N=2048, top_k=8, GB200, amortized device time)
+Production default (block_m=64): **11.83 µs**.
+Sweep over block_m × group_m × num_warps (BLOCK_SIZE_N forced to 128, num_stages=1):
+```
+block_m=16: 6.38–7.42 µs   <-- best
+block_m=32: 6.94–7.69 µs
+block_m=64: 10.98–11.78 µs
+BEST: 6.38 µs  block_m=16 group_m=8 warps=8
+```
+**Finding (P0):** the down-proj expand at bs=64/rank=16 is ~1.85× faster with
+`BLOCK_SIZE_M=16` than the current `_get_stage_config` fallback default of 64.
+group_m / num_warps are second-order at block_m=16 (6.38–6.49 µs across 1/4/8 × 2/4/8).
+
+## Next steps (beyond this UT PR)
+- This PR ships the UT + bench only (no kernel/config change). The block_m=16 win is a
+  follow-up tuning change to `_get_stage_config` / a generated config, to be validated by
+  the full regression + perf-benchmark flow (Qwen + Kimi) per skill.md.

--- a/benchmark/kernels/lora_moe_expand/bench_expand_add_down.py
+++ b/benchmark/kernels/lora_moe_expand/bench_expand_add_down.py
@@ -1,0 +1,389 @@
+"""Self-contained micro-benchmark + correctness check for _moe_lora_expand_add_kernel
+(LoRA-B expand-add, down-proj GEMM).
+
+Companion to ``bench_shrink_splitk.py`` (which covers the LoRA-A shrink). The down-proj
+expand uses the fused sum-all-reduce + routed-weight variant: each of a token's top_k
+per-expert deltas is scaled by its routing weight and atomic-added into the single
+per-token output row.
+
+Two model shapes via ``--model`` (per-flag overrides win):
+  * ``qwen35`` (default): qwen3.5-35b local-EP, tp=4/ep=4 -> 64 local experts, N (down
+    output hidden) = 2048, rank = 16, top_k = 8.
+  * ``kimi-k25``: Kimi-K2.5-NVFP4, TP8/no-EP -> 384 routed experts, N = 7168, rank = 16,
+    top_k = 8. (Shapes from the adapter + config: down-proj LoRA-B is [r=16 x out=7168],
+    384 routed experts.)
+
+P0 scope: bs=64, rank=16 first.
+
+  python3 bench_expand_add_down.py --mode bench   --model kimi-k25   # default: reproduces the
+                                                                     #   PRODUCTION config (e2e kernel)
+  python3 bench_expand_add_down.py --mode bench   --model kimi-k25 --config manual --block-m 16 --block-n 512
+  python3 bench_expand_add_down.py --mode correctness --model kimi-k25  # block_m {16,32,64} x bs {16,64}
+  python3 bench_expand_add_down.py --mode profile --iters 2   # eager, for ncu
+  python3 bench_expand_add_down.py --mode sweep   --model kimi-k25      # block_m x block_n x group_m x warps
+
+By default ``--mode bench``/``profile`` use ``--config production``: the BLOCK_SIZE_M/GROUP_SIZE_M/
+num_warps that ``_get_stage_config`` -> ``try_get_optimal_moe_config`` picks at runtime (BLOCK_SIZE_N
+left to the launcher), so the headline number matches the e2e kernel. ``--config manual`` uses the
+explicit ``--block-*`` / ``--group-m`` / ``--num-warps`` flags instead (for A/B and tuning).
+
+``--mode sweep`` also tunes BLOCK_SIZE_N (the launcher's production default forces 128 for
+N%128==0; the sweep passes ``force_block_size_n`` to explore other tiles — valid for the
+non-gated down-proj).
+
+correctness mode also guards the routing/tiling block-size contract: the launcher must
+tile ``expert_ids`` with the same block size the routing buffers were aligned with, else
+expert_ids overruns -> IMA (the same class of bug as the shrink f2adddd regression).
+"""
+from __future__ import annotations
+
+import argparse
+
+import torch
+import triton
+import triton.testing
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.srt.lora.triton_ops.virtual_experts import (
+    _fused_virtual_topk_ids,
+    fused_sanitize_expert_ids,
+)
+from sglang.srt.lora.trtllm_moe.specialized_expand import _invoke_moe_lora_expand_add
+
+
+def production_config(num_experts, n, rank, bs, dtype):
+    """The config production actually launches the expand with, so the default bench run
+    reproduces the e2e kernel (not a hand-picked one).
+
+    Mirrors ``_get_stage_config`` (virtual_experts.py): call
+    ``try_get_optimal_moe_config(lora_b_virtual.shape, .., stage_top_k=1, M=bs)`` and, if it
+    raises (e.g. no tuned JSON + server args unset), use the same fallback (BLOCK_SIZE_M=64).
+    BLOCK_SIZE_N is left to the launcher (forced to 128 when N % 128 == 0), so ``force_block_n``
+    stays None. Returns ``(block_m, group_m, num_warps)``.
+    """
+    import functools
+
+    try:
+        from sglang.srt.server_args import (
+            ServerArgs,
+            get_global_server_args,
+            set_global_server_args_for_scheduler,
+        )
+
+        try:
+            get_global_server_args()
+        except Exception:
+            set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+        from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config import (
+            get_config_dtype_str,
+            try_get_optimal_moe_config,
+        )
+
+        weight_shape = (num_experts, n, rank)
+        config_dtype = get_config_dtype_str(dtype=dtype)
+        cfg = functools.partial(
+            try_get_optimal_moe_config, weight_shape, weight_shape, 1, config_dtype
+        )(bs)
+        return cfg["BLOCK_SIZE_M"], cfg.get("GROUP_SIZE_M", 1), cfg.get("num_warps", 4)
+    except Exception:
+        # _get_stage_config's fallback when try_get_optimal_moe_config raises.
+        return 64, 1, 4
+
+
+def make_inputs(bs, num_experts, top_k, n, rank, dtype, device):
+    """Down-proj expand inputs.
+
+    ``intermediate`` is the LoRA-A shrink output [bs*top_k, rank]; ``lora_b`` is the
+    per-(lora, expert) down LoRA-B weight [1, num_experts, N, rank].
+    """
+    torch.manual_seed(0)
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:top_k] for _ in range(bs)]
+    ).to(torch.int32)
+    # Positive routing weights (down-proj scales each per-expert delta by these).
+    topk_weights = torch.rand(bs, top_k, device=device, dtype=torch.float32) * 0.9 + 0.1
+    token_lora_mapping = torch.zeros(bs, device=device, dtype=torch.int32)
+    intermediate = torch.randn(bs * top_k, rank, device=device, dtype=dtype) * 0.1
+    lora_b = torch.randn(1, num_experts, n, rank, device=device, dtype=dtype) * 0.1
+    return topk_ids, topk_weights, token_lora_mapping, intermediate, lora_b
+
+
+def build_v1_routing(topk_ids, token_lora_mapping, num_experts, block_m):
+    """Single-adapter (max_loras=1) virtual-expert routing, tiled at ``block_m``.
+
+    Mirrors ``_get_routing`` in virtual_experts.py: virtual topk ids -> align ->
+    tight trim -> sanitize. The trim+sanitize matter because the launcher reads one
+    ``expert_ids`` entry per M-block.
+    """
+    virtual_topk_ids, _, virtual_num_experts = _fused_virtual_topk_ids(
+        topk_ids, token_lora_mapping, num_experts, shared_outer=False, max_loras=1
+    )
+    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+        virtual_topk_ids, block_m, virtual_num_experts
+    )
+    num_tokens = topk_ids.numel()
+    max_nonempty = min(num_tokens, virtual_num_experts)
+    tight = triton.cdiv(num_tokens + max_nonempty * (block_m - 1), block_m) * block_m
+    return (
+        sorted_token_ids[:tight],
+        fused_sanitize_expert_ids(expert_ids[: tight // block_m], virtual_num_experts),
+        num_tokens_post_padded,
+    )
+
+
+def expand(
+    intermediate,
+    lora_b,
+    topk_ids,
+    topk_weights,
+    routing,
+    block_m,
+    block_n=64,
+    group_m=1,
+    num_warps=4,
+    mul_routed_weight=True,
+    fuse_sum_all_reduce=True,
+    force_block_n=None,
+):
+    sorted_token_ids, expert_ids, num_tokens_post_padded = routing
+    lora_b_virtual = lora_b.reshape(lora_b.shape[0] * lora_b.shape[1], *lora_b.shape[2:])
+    n = lora_b.shape[2]
+    bs, top_k = topk_ids.shape
+    # FUSE_SUM_ALL_REDUCE atomic-adds the top_k deltas into one row -> zero each call.
+    # (Without it, each (token,expert) slot is written once -> bs*top_k rows.)
+    out_rows = bs if fuse_sum_all_reduce else bs * top_k
+    output = torch.zeros(
+        out_rows, n, dtype=intermediate.dtype, device=intermediate.device
+    )
+    config = {
+        # BLOCK_SIZE_N here is only used when N % 128 != 0 AND force_block_n is None;
+        # otherwise the launcher picks 128 (default) or force_block_n (tuning).
+        "BLOCK_SIZE_M": block_m,
+        "BLOCK_SIZE_N": block_n,
+        "GROUP_SIZE_M": group_m,
+        "num_warps": num_warps,
+    }
+    _invoke_moe_lora_expand_add(
+        intermediate,
+        lora_b_virtual,
+        output,
+        # kernel indexes topk_weights flat by virtual-token id in [0, bs*top_k).
+        topk_weights.reshape(-1),
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        config,
+        mul_routed_weight,
+        fuse_sum_all_reduce,
+        force_block_size_n=force_block_n,
+    )
+    return output
+
+
+def ref_expand(
+    intermediate, lora_b, topk_ids, topk_weights,
+    mul_routed_weight=True, fuse_sum_all_reduce=True,
+):
+    bs, top_k = topk_ids.shape
+    n = lora_b.shape[2]
+    b = lora_b[0].float()  # [num_experts, N, R]
+    inter = intermediate.float()  # [bs*top_k, R]
+    rows = bs if fuse_sum_all_reduce else bs * top_k
+    out = torch.zeros(rows, n, device=intermediate.device, dtype=torch.float32)
+    for m in range(bs):
+        for k in range(top_k):
+            e = int(topk_ids[m, k].item())
+            vt = m * top_k + k
+            delta = inter[vt] @ b[e].t()  # [N]
+            if mul_routed_weight:
+                delta = delta * float(topk_weights[m, k].item())
+            if fuse_sum_all_reduce:
+                out[m] += delta
+            else:
+                out[vt] = delta
+    return out
+
+
+def bench_ms(fn, warmup=25, rep=100, cudagraph=True, inner=200):
+    """Per-call milliseconds.
+
+    With ``cudagraph``, capture ``inner`` back-to-back ``fn()`` calls in ONE graph and
+    divide the measured replay time by ``inner``. A single fn()-per-graph
+    ``do_bench(g.replay)`` floors at ~8-10us for ANY tiny op -- it measures the fixed
+    per-replay launch/dispatch overhead, not the kernel. Amortizing over ``inner``
+    back-to-back calls drives that overhead to ~0 and exposes the true device time.
+    (Same technique as bench_shrink_splitk.py.)
+    """
+    torch.cuda.synchronize()
+    if cudagraph:
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                for _ in range(inner):
+                    fn()
+        torch.cuda.current_stream().wait_stream(s)
+        torch.cuda.synchronize()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            for _ in range(inner):
+                fn()
+        torch.cuda.synchronize()
+        ms = triton.testing.do_bench(g.replay, warmup=warmup, rep=rep) / inner
+    else:
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    torch.cuda.synchronize()
+    return float(ms)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--mode",
+        choices=["bench", "correctness", "profile", "sweep"],
+        default="bench",
+    )
+    # Model presets set (num_experts, n, top_k); per-flag overrides below win.
+    ap.add_argument("--model", choices=["qwen35", "kimi-k25"], default="qwen35")
+    # bench/profile config source: "production" reproduces what _get_stage_config launches
+    # (the e2e kernel); "manual" uses the --block-m/--block-n/--group-m/--num-warps flags.
+    ap.add_argument("--config", choices=["production", "manual"], default="production")
+    ap.add_argument("--bs", type=int, default=64)
+    ap.add_argument("--num-experts", type=int, default=None)
+    ap.add_argument("--top-k", type=int, default=None)
+    ap.add_argument("--n", type=int, default=None, help="down-proj output hidden")
+    ap.add_argument("--rank", type=int, default=16)
+    ap.add_argument("--block-m", type=int, default=64)
+    ap.add_argument("--block-n", type=int, default=None,
+                    help="force BLOCK_SIZE_N (overrides the launcher's N%%128==0 -> 128 rule)")
+    ap.add_argument("--group-m", type=int, default=1)
+    ap.add_argument("--num-warps", type=int, default=4)
+    ap.add_argument("--iters", type=int, default=2)
+    ap.add_argument("--tol", type=float, default=5e-2)
+    args = ap.parse_args()
+
+    # qwen35: tp4/ep4 -> 64 local experts, N=2048. kimi-k25: TP8/no-EP -> 384 experts, N=7168.
+    preset = {
+        "qwen35": {"num_experts": 64, "n": 2048, "top_k": 8},
+        "kimi-k25": {"num_experts": 384, "n": 7168, "top_k": 8},
+    }[args.model]
+    if args.num_experts is None:
+        args.num_experts = preset["num_experts"]
+    if args.n is None:
+        args.n = preset["n"]
+    if args.top_k is None:
+        args.top_k = preset["top_k"]
+
+    dev = "cuda"
+
+    if args.mode == "sweep":
+        # P0: bs=64, rank=16. Tunable knobs: BLOCK_SIZE_M / BLOCK_SIZE_N / GROUP_SIZE_M /
+        # num_warps (num_stages is hardcoded to 1 in the launcher). BLOCK_SIZE_N is swept via
+        # force_block_size_n (the production path forces 128 for N%128==0); only divisors of N
+        # are tried so no tile is wasted.
+        topk_ids, tkw, tlm, inter, lora_b = make_inputs(
+            args.bs, args.num_experts, args.top_k, args.n, args.rank,
+            torch.bfloat16, dev,
+        )
+        block_ns = [bn for bn in [64, 128, 256, 512] if args.n % bn == 0]
+        best = None
+        for block_m in [16, 32, 64]:
+            routing = build_v1_routing(topk_ids, tlm, args.num_experts, block_m)
+            for block_n in block_ns:
+                for group_m in [1, 4, 8]:
+                    for nw in [2, 4, 8]:
+                        f = lambda bm=block_m, bn=block_n, gm=group_m, w=nw, r=routing: expand(
+                            inter, lora_b, topk_ids, tkw, r, bm,
+                            group_m=gm, num_warps=w, force_block_n=bn,
+                        )
+                        try:
+                            us = bench_ms(f, warmup=15, rep=60) * 1000
+                        except Exception:
+                            continue
+                        tag = f"block_m={block_m} block_n={block_n} group_m={group_m} warps={nw}"
+                        if best is None or us < best[0]:
+                            best = (us, tag)
+                        print(f"  {us:7.2f} us  {tag}")
+        print(f"\nBEST bs={args.bs} r={args.rank} N={args.n} experts={args.num_experts}: "
+              f"{best[0]:.2f} us  {best[1]}")
+        return
+
+    topk_ids, tkw, tlm, inter, lora_b = make_inputs(
+        args.bs, args.num_experts, args.top_k, args.n, args.rank,
+        torch.bfloat16, dev,
+    )
+    # bench/profile: by default reproduce the config production launches (so the headline
+    # number matches the e2e kernel); --config manual uses the explicit flags instead.
+    if args.config == "production":
+        eff_block_m, eff_group_m, eff_warps = production_config(
+            args.num_experts, args.n, args.rank, args.bs, torch.bfloat16
+        )
+        eff_force_block_n = None  # let the launcher force 128 (N % 128 == 0), as production does
+    else:
+        eff_block_m, eff_group_m, eff_warps = args.block_m, args.group_m, args.num_warps
+        eff_force_block_n = args.block_n
+    routing = build_v1_routing(topk_ids, tlm, args.num_experts, eff_block_m)
+    fn = lambda: expand(
+        inter, lora_b, topk_ids, tkw, routing, eff_block_m,
+        group_m=eff_group_m, num_warps=eff_warps, force_block_n=eff_force_block_n,
+    )
+
+    if args.mode == "correctness":
+        # Guard the routing/tiling block-size contract: _invoke_moe_lora_expand_add tiles
+        # expert_ids with config["BLOCK_SIZE_M"] (one entry per M-block); routing must be
+        # aligned with the SAME block. Build routing AND config with the same block_m per
+        # iteration, but SWEEP block_m so any hardcoded value diverges from the routing at
+        # the other block sizes; sweep bs too so the overrun is deterministic enough to
+        # fault. Reference accumulates in fp32, kernel accumulates per-expert bf16
+        # atomic-adds -> generous abs tol.
+        block_ms = sorted({args.block_m, 16, 32, 64})
+        batch_sizes = sorted({args.bs, 16, 64})
+        failures = 0
+        for bs in batch_sizes:
+            tk, tkw_b, tlm_b, inter_b, lb = make_inputs(
+                bs, args.num_experts, args.top_k, args.n, args.rank,
+                torch.bfloat16, dev,
+            )
+            ref = ref_expand(inter_b, lb, tk, tkw_b)
+            for bm in block_ms:
+                routing_bm = build_v1_routing(tk, tlm_b, args.num_experts, bm)
+                out = expand(
+                    inter_b, lb, tk, tkw_b, routing_bm, bm,
+                    group_m=args.group_m, num_warps=args.num_warps,
+                    force_block_n=args.block_n,
+                ).float()
+                err = float((out - ref).abs().max().item())
+                rel = err / float(ref.abs().max().item() + 1e-9)
+                ok = err <= args.tol
+                failures += int(not ok)
+                print(
+                    f"{'PASS' if ok else 'FAIL'} bs={bs:<3d} block_m={bm:<2d} "
+                    f"max_abs_err={err:.4e} rel={rel:.2e}"
+                )
+        if failures:
+            raise SystemExit(1)
+    elif args.mode == "profile":
+        for _ in range(5):
+            fn()
+        torch.cuda.synchronize()
+        for _ in range(args.iters):
+            fn()
+        torch.cuda.synchronize()
+    else:
+        ms = bench_ms(fn)
+        eff_block_n = eff_force_block_n if eff_force_block_n is not None else (
+            128 if args.n % 128 == 0 else args.block_n
+        )
+        print(
+            f"BENCH expand_add down model={args.model} config={args.config} bs={args.bs} "
+            f"r={args.rank} N={args.n} experts={args.num_experts} top_k={args.top_k} "
+            f"block_m={eff_block_m} block_n={eff_block_n} group_m={eff_group_m} "
+            f"warps={eff_warps}: {ms * 1000:.2f} us (amortized true device time)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/lora_moe_expand/journal_tom.md
+++ b/benchmark/kernels/lora_moe_expand/journal_tom.md
@@ -1,0 +1,155 @@
+# Task (tom): Kimi-K2.5 down-proj LoRA-B expand-add — shapes + BLOCK_SIZE_N tuning, e2e-validated
+
+> **This file is the single source of truth for the PR** (jybsuper/sglang **#12**,
+> `fzyzcjy:tom/lora-moe-expand-down-bench` → `nvfp4-lora`). The PR description is intentionally
+> empty — read this journal. The PR is **stacked on #11**: until #11 merges, the PR diff also
+> shows #11's `bench_expand_add_down.py` + UT + `JOURNAL.md`; the net-new commits are the three
+> listed under "What changed".
+
+Follow-up to PR #11 (`bench_expand_add_down.py`), which scoped the down-proj expand-add to
+**qwen3.5-35b** (64 local experts, N=2048). This:
+1. Adds the **Kimi-K2.5** shape (`--model kimi-k25`).
+2. Makes **BLOCK_SIZE_N** tunable and sweeps it.
+3. **Validates the micro-bench against an e2e decode trace** (the headline check: a tuning
+   number only counts if the micro-bench reproduces what production actually runs).
+
+GPU: 1× NVIDIA GB200 (leira / Crusoe, pod `sglang-lora-tom` on node `np-67167b3f-16`), image
+`lmsysorg/sglang:dev-cu13`, branch `tom/lora-moe-expand-down-bench` (on PR #11 head
+`a4a46f3de`). No model weights — pure triton kernel testbed.
+
+## What changed
+
+1. `python/.../lora/trtllm_moe/specialized_expand.py` — `_invoke_moe_lora_expand_add` gains an
+   opt-in `force_block_size_n: int | None = None`. Default `None` → byte-identical to before
+   (`128 if N % 128 == 0 else config["BLOCK_SIZE_N"]`). When set, it overrides that so a
+   tuner/bench can explore BLOCK_SIZE_N. Down-proj is non-gated (`gated_a_half = 0`), so any
+   divisor of N is valid; the gated gate_up split still asserts `N/2 % block_size_n == 0`.
+2. `benchmark/kernels/lora_moe_expand/bench_expand_add_down.py`
+   - `--model {qwen35, kimi-k25}` preset (per-flag overrides win).
+   - `--mode sweep` now also sweeps `BLOCK_SIZE_N ∈ {64,128,256,512}` (divisors of N) via
+     `force_block_size_n`; `--block-n` forces it in single-config modes.
+   - **`--config {production, manual}` (default `production`)**: by default `--mode bench`/
+     `profile` reproduce the config production launches — `production_config()` queries the same
+     `try_get_optimal_moe_config` path `_get_stage_config` uses (BLOCK_SIZE_N left to the
+     launcher). So **the default run matches the e2e kernel**, not a hand-picked config.
+     `--config manual` uses the explicit `--block-*` / `--group-m` / `--num-warps` flags (A/B,
+     tuning). Verified default numbers: **kimi-k25 → 27.3 µs** (block_m=16, block_n=128, warps=4;
+     ≈ e2e 25.1 µs); **qwen35 → 6.49 µs** (same config).
+
+## Are PR #11's shapes wrong for Kimi? — Yes, they were qwen's
+
+Kimi-K2.5 down-proj LoRA-B shape, from the adapter + config (local note
+`kimi-k25-shapes-roofline.md` §3 MoE + §4 LoRA):
+
+| dim | PR #11 (qwen3.5-35b) | Kimi-K2.5 |
+|-----|----------------------|-----------|
+| routed experts | 64 (tp4/ep4 local) | **384** (TP8, no-EP — all experts present per rank) |
+| N = down output hidden | 2048 | **7168** (= hidden H) |
+| rank | 16 | 16 |
+| top_k | 8 | 8 |
+
+Down-proj per-expert is `[2048×7168]`; the LoRA-B (expand) weight is `[r=16 × out=7168]`, so the
+expand-add kernel sees **N=7168, R=16, 384 experts, top_k=8**. PR #11's N=2048 / 64 experts are
+qwen's numbers, not Kimi's.
+
+## The production config — and reproducing the e2e trace
+
+**This is the part that makes the numbers count.** An e2e decode trace (graph step
+`step[DECODE bs=64]`) shows `_moe_lora_expand_add_kernel` at **25.1 µs**. The micro-bench must
+reproduce that with the *same config production picks*, otherwise tuning deltas are meaningless.
+
+The production config comes from `_get_stage_config` (`virtual_experts.py`) →
+`try_get_optimal_moe_config(lora_b_virtual.shape, …, stage_top_k=1, dtype=bf16, M=bs)`. Probed
+in the pod for the Kimi expand shape `[E=384, N=7168, R=16]`:
+
+```python
+# (server args must be set, else try_get_optimal_moe_config raises and _get_stage_config
+#  falls back to BLOCK_SIZE_M=64 — see the Correction note below)
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config import (
+    get_config_dtype_str, try_get_optimal_moe_config)
+import functools, torch
+w = (384, 7168, 16); dt = get_config_dtype_str(dtype=torch.bfloat16)
+f = functools.partial(try_get_optimal_moe_config, w, w, 1, dt)
+print(f(64))   # M=bs=64
+# -> {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 1}  (M=16/32/64 identical)
+```
+
+There is **no tuned JSON** for this shape (`E=384,N=16,...GB200.json` not found), so it returns
+the library default `BLOCK_SIZE_M=16, GROUP_SIZE_M=1` (no `num_warps` key → launcher uses
+`config.get("num_warps", 4) = 4`). The launcher then forces `BLOCK_SIZE_N=128` (7168 % 128 == 0).
+
+**So the real production config = `block_m=16, block_n=128, group_m=1, num_warps=4`.** Micro-bench:
+
+```
+block_m=16 block_n=128 group_m=1 warps=4  ->  27.13 µs   (production-equivalent)
+block_m=16 block_n=128 group_m=1 warps=2  ->  22.57 µs
+```
+
+The e2e **25.1 µs** sits between these and ~8% under the warps=4 number — well within
+micro-bench-vs-e2e noise (single trace sample, surrounding-kernel state, warmup). **The
+micro-bench reproduces the e2e production kernel.** ✓
+
+### Correction (supersedes an earlier draft of this file)
+An earlier draft claimed the production default was `block_m=64` → 114 µs → a "5.68× win". That
+was **wrong**: `block_m=64` is the `_get_stage_config` *fallback* used only when
+`try_get_optimal_moe_config` raises (e.g. no server args). In real serving the server args are
+set and it returns `block_m=16`, giving ~25–27 µs — matching the e2e trace. The corrected win
+from tuning is below.
+
+This also applies to #11's qwen claim: with `--config production`, qwen35 resolves to
+`block_m=16` too (no tuned JSON either) → **6.49 µs**, i.e. qwen production already runs the
+`block_m=16` #11 called "best", not the `block_m=64` it called the default. **For both models the
+real untuned lever is `BLOCK_SIZE_N` (forced 128), not `block_m`.**
+
+## Results (1× GB200, bs=64, r=16, amortized device time)
+
+### Correctness (`--mode correctness --model kimi-k25`) — 6/6 PASS
+fp32 ref vs per-expert bf16 atomic-add, tol 5e-2 abs; block_m {16,32,64} × bs {16,64}:
+`max_abs_err` 2.6e-3–3.2e-3 (rel 6.5e-3–8.3e-3).
+
+### Sweep (`--mode sweep --model kimi-k25`) — block_m × block_n × group_m × num_warps
+**BEST: 20.12 µs `block_m=16 block_n=512 group_m=1 warps=4`.**
+
+Min µs per (block_m, block_n) over group_m/num_warps:
+
+| block_m \ block_n | 64 | 128 | 256 | 512 |
+|---|---|---|---|---|
+| **16** | 32.4 | 22.5 | 21.4 | **20.1** |
+| 32 | 38.9 | 31.8 | 30.5 | 33.0 |
+| 64 | 57.5 | 65.6 | 64.6 | 88.8 |
+
+- `block_m=16` dominates (production already uses it — consistent with the e2e number).
+- At block_m=16, **larger block_n helps**: 64→512 takes 32.4→20.1 µs. The production-forced
+  `block_n=128` is *not* optimal here.
+
+### A/B vs the real production config
+
+| config | µs (bench) | note |
+|---|---|---|
+| **production** `block_m=16 block_n=128(forced) warps=4` | **27.1** | ≈ **25.1 µs e2e** |
+| **BEST** `block_m=16 block_n=512 warps=4` | **20.1** | force_block_size_n=512 |
+
+→ Tuning **BLOCK_SIZE_N 128 → 512** at the production `block_m=16` gives **~1.35× vs the
+micro-bench production (27.1→20.1 µs)**, or **~1.25× vs the e2e 25.1 µs**. Not the 5.68× of the
+earlier (wrong) draft — the real, e2e-anchored win is ~25%.
+
+### Finding (for a follow-up — NOT a kernel/config change here)
+The down-proj expand at the Kimi shape (bs=64, r=16, N=7168, 384 experts) is **~25% faster with
+`BLOCK_SIZE_N=512`** than the launcher's forced 128. Shipping it means letting the down-proj
+expand pick block_n=512 (a generated/tuned config or a down-proj branch in the launcher), then
+validating with the full Qwen+Kimi regression + perf-benchmark flow. This PR only adds the
+testbed + the `force_block_size_n` knob.
+
+## Reproduce
+
+```bash
+cd /root/sglang   # pod sglang-lora-tom, branch tom/lora-moe-expand-down-bench
+B=benchmark/kernels/lora_moe_expand/bench_expand_add_down.py
+python3 $B --mode correctness --model kimi-k25                       # 6/6 PASS
+python3 $B --mode sweep       --model kimi-k25                       # BEST bm16 bn512 ~20us
+python3 $B --mode bench       --model kimi-k25                       # default=production ~27us (=25.1 e2e)
+python3 $B --mode bench       --model kimi-k25 --config manual --block-m 16 --block-n 512   # BEST ~20us
+# production config probe: see the python snippet in "The production config" section above.
+```

--- a/benchmark/kernels/lora_moe_expand/theoretical_analysis.md
+++ b/benchmark/kernels/lora_moe_expand/theoretical_analysis.md
@@ -1,0 +1,113 @@
+# Theoretical analysis: is 20 µs reasonable for the Kimi-K2.5 down-proj expand-add?
+
+Companion to `journal_tom.md`. The sweep's best result for the Kimi-K2.5 down-proj
+LoRA-B expand-add is **20.12 µs** (`block_m=16 block_n=512 group_m=1 warps=4`, 1× GB200,
+bs=64, r=16). Judged as a GEMM by FLOPs that looks absurdly slow. This note works the
+roofline and concludes it is **reasonable**: the op is deeply memory-bound on weight
+streaming, and 20 µs is ~40% of HBM peak — roughly 2–2.5× off the theoretical floor,
+which is typical for a tiny-K grouped GEMM.
+
+## Problem shape
+
+This is not a dense GEMM. It is a grouped (MoE) GEMM with a tiny reduction dim, followed
+by a routed atomic-add reduction:
+
+| symbol | meaning | value |
+|---|---|---|
+| `M` | token-expert rows = `bs · top_k` | 64 · 8 = **512** |
+| `K` | reduction dim = LoRA rank `r` | **16** |
+| `N` | down-proj output hidden | **7168** |
+| `E` | routed experts (TP8, no-EP) | **384** |
+| `E_hit` | distinct experts actually touched | **~284** (see below) |
+| `out` | fused per-token output `[bs, N]` | `[64, 7168]` |
+
+`E_hit`: each token picks `top_k=8` distinct experts (`randperm`), so a given expert is
+missed by one token with prob `(1 - 8/384)`, and over 64 tokens
+`E_hit ≈ 384·(1 - (1 - 8/384)^64) ≈ 284`. The grouped GEMM iterates `expert_ids` and
+skips empty experts, so only ~284 of 384 weight matrices are ever read (seed-dependent;
+upper bound 384).
+
+## 1. Compute roofline — not the bound
+
+```
+FLOPs = 2 · M · K · N = 2 · 512 · 16 · 7168 ≈ 117.4 MFLOP
+20.12 µs → 117.4e6 / 20.12e-6 ≈ 5.84 TFLOP/s
+```
+
+B200 bf16 dense peak ≈ 2250 TFLOP/s → **0.26% utilization**. If you stopped here you'd
+call the kernel broken. But the FLOPs are irrelevant here — see the arithmetic intensity
+below.
+
+## 2. Memory roofline — the real bound
+
+The dominant traffic is streaming each hit expert's LoRA-B weight `[N, r]` bf16 exactly
+once. Padding on `M` (block_m=16 vs avg `M_e ≈ 1.8` rows/expert) wastes compute but reads
+no extra weight bytes: per `(expert, n_tile)` the B tile is read once regardless of valid
+M rows.
+
+```
+weight bytes  = E_hit · N · K · 2
+              = 284 · 7168 · 16 · 2 ≈ 65.1 MB   (≈ 62 MiB)
+output bytes  = memset [64,7168] bf16 (0.92 MB) + atomic writeback (~0.92 MB) ≈ 1.8 MB
+input bytes   = intermediate [512,16] bf16 ≈ 16 KB  (negligible)
+total         ≈ 67 MB,  ~97% of it weights
+```
+
+Arithmetic intensity:
+
+```
+AI = 117.4 MFLOP / 67 MB ≈ 1.75 FLOP/byte
+ridge point (B200) = 2250 TFLOP/s ÷ 8 TB/s ≈ 281 FLOP/byte
+```
+
+`AI ≈ 1.75 ≪ 281` → memory-bound by ~160×. This is a weight-streaming op, full stop.
+
+### Floor vs achieved
+
+| quantity | value |
+|---|---|
+| HBM bandwidth (B200, HBM3e) | ~8 TB/s |
+| roofline floor = 67 MB / 8 TB/s | **~8.4 µs** |
+| achieved | **20.12 µs** |
+| effective bandwidth = 67 MB / 20.12 µs | **~3.3 TB/s** |
+| % of HBM peak | **~42%** |
+
+So the kernel runs at ~42% of HBM peak, ~2.4× off the streaming floor.
+
+## 3. Why ~42% and not ~100%
+
+The weight read (65 MB) is already optimally amortized — each hit expert is read once,
+shared across its `M_e` tokens — so the gap is per-tile efficiency, not redundant traffic:
+
+- **K=16 is a single MMA step.** There is no K-loop to amortize the tile prologue/epilogue
+  over. Each `[block_m,16]·[16,block_n]` tile does minimal math between its load and its
+  atomic-add epilogue, so memory latency is poorly hidden.
+- **Atomic-add reduction contention.** With `fuse_sum_all_reduce` + `mul_routed_weight`,
+  all 512 per-expert deltas atomic-add into just 64 output rows. Many tiles contend on the
+  same `[N]` row → serialization in the epilogue.
+- **~3976 tiny tiles.** `E_hit · cdiv(N, block_n) = 284 · 14 ≈ 3976` blocks, each with
+  `M_e ≤ 8 < block_m=16` (≈9× row padding). Lots of small grids → launch/scheduling and
+  tail/wave-quantization overhead relative to the trivial per-tile work.
+
+These also explain the sweep: `block_m=16` wins because larger block_m is pure M-padding
+waste; `block_n=512` wins because a wider N tile amortizes the fixed per-tile overhead and
+improves coalescing of the long `N=7168` weight rows.
+
+## Conclusion
+
+**20 µs is reasonable and in the right order of magnitude.** The op is memory-bound on
+~65 MB of weight streaming with a hard floor of ~8 µs; at ~42% of HBM peak the kernel is
+~2.4× off that floor, which is normal for a grouped GEMM with `K=16` and ~2-row experts.
+
+There is plausibly ~1.5–2× headroom (toward ~10–13 µs) for a kernel that hides the K=16
+latency better and reduces atomic contention, but the FLOPs-based "0.26% of peak" framing
+is misleading — there is no compute headroom to chase, only bandwidth efficiency.
+
+### Caveats / sensitivities
+- HBM peak taken as ~8 TB/s for B200; the % numbers scale inversely if the true sustained
+  figure differs.
+- `E_hit ≈ 284` is the expected value for this routing; the actual seed (`manual_seed(0)`)
+  fixes it. If the kernel instead read all 384 experts the floor would be ~10.5 µs and the
+  achieved efficiency ~56% of peak.
+- Output atomic traffic is treated as ~2 MB (target `[64,7168]` largely L2-resident); only
+  weights set the floor.

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/SOURCE.md
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/SOURCE.md
@@ -1,0 +1,20 @@
+FlashInfer TRTLLM MoE Overlay
+=============================
+
+This directory contains only the editable overlay files used by SGLang's
+`sgl_flashinfer_trtllm` SM100 TRTLLM fused MoE backend. Unmodified FlashInfer
+and TRTLLM sources are compiled from the installed `flashinfer` package at JIT
+time.
+
+Local overlay source:
+
+- `data/csrc/trtllm_fused_moe_kernel_launcher.cu`
+- `data/csrc/trtllm_fused_moe_runner.cu`
+- `data/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu`
+- `data/include/flashinfer/trtllm/fused_moe/DevKernel.h`
+- `data/include/flashinfer/trtllm/fused_moe/runner.h`
+
+The backend still depends on the installed `flashinfer` and `flashinfer_cubin`
+packages for the rest of the FlashInfer/TRTLLM JIT source tree and TRTLLM-Gen
+BMM cubin artifacts. The local include directory is passed before FlashInfer's
+installed include directory so these overlay headers shadow the originals.

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/__init__.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/__init__.py
@@ -1,0 +1,13 @@
+from sglang.jit_kernel.flashinfer_trtllm_moe.core import (
+    trtllm_fp8_block_scale_moe_lora_finalize,
+    trtllm_fp8_block_scale_moe,
+    trtllm_fp8_block_scale_routed_moe,
+    trtllm_fp8_block_scale_routed_moe_lora,
+)
+
+__all__ = [
+    "trtllm_fp8_block_scale_moe_lora_finalize",
+    "trtllm_fp8_block_scale_moe",
+    "trtllm_fp8_block_scale_routed_moe",
+    "trtllm_fp8_block_scale_routed_moe_lora",
+]

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/__init__.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/__init__.py
@@ -1,4 +1,6 @@
 from sglang.jit_kernel.flashinfer_trtllm_moe.core import (
+    trtllm_fp4_block_scale_moe_lora_finalize,
+    trtllm_fp4_block_scale_routed_moe_lora,
     trtllm_fp8_block_scale_moe_lora_finalize,
     trtllm_fp8_block_scale_moe,
     trtllm_fp8_block_scale_routed_moe,
@@ -6,6 +8,8 @@ from sglang.jit_kernel.flashinfer_trtllm_moe.core import (
 )
 
 __all__ = [
+    "trtllm_fp4_block_scale_moe_lora_finalize",
+    "trtllm_fp4_block_scale_routed_moe_lora",
     "trtllm_fp8_block_scale_moe_lora_finalize",
     "trtllm_fp8_block_scale_moe",
     "trtllm_fp8_block_scale_routed_moe",

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
@@ -225,6 +225,7 @@ def trtllm_fp8_block_scale_routed_moe_lora(
     tune_max_num_tokens: int = 8192,
     fp8_quantization_type=None,
     activation_type: Optional[int] = None,
+    lora_ready_event: int = 0,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
     from flashinfer.fused_moe.core import ActivationType, Fp8QuantizationType
     from flashinfer.utils import device_support_pdl
@@ -278,6 +279,7 @@ def trtllm_fp8_block_scale_routed_moe_lora(
         None,
         gate_up_lora_delta,
         activation_lora_input,
+        lora_ready_event,
     )
 
     return output if do_finalize else result

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
@@ -1,0 +1,302 @@
+import functools
+from typing import List, Optional, Union
+
+import torch
+
+
+@functools.cache
+def get_sgl_trtllm_moe_sm100_module():
+    import flashinfer.fused_moe.core as fi_core
+
+    from sglang.jit_kernel.flashinfer_trtllm_moe.jit import (
+        gen_sgl_trtllm_gen_fused_moe_sm100_module,
+    )
+
+    original_gen = fi_core.gen_trtllm_gen_fused_moe_sm100_module
+    fi_core.gen_trtllm_gen_fused_moe_sm100_module = (
+        gen_sgl_trtllm_gen_fused_moe_sm100_module
+    )
+    try:
+        fi_core.get_trtllm_moe_sm100_module.cache_clear()
+        return fi_core.get_trtllm_moe_sm100_module()
+    finally:
+        fi_core.gen_trtllm_gen_fused_moe_sm100_module = original_gen
+        fi_core.get_trtllm_moe_sm100_module.cache_clear()
+
+
+@functools.cache
+def get_sgl_trtllm_moe_sm100_raw_module():
+    from flashinfer.fused_moe.core import setup_cubin_loader
+
+    from sglang.jit_kernel.flashinfer_trtllm_moe.jit import (
+        gen_sgl_trtllm_gen_fused_moe_sm100_module,
+    )
+
+    module = gen_sgl_trtllm_gen_fused_moe_sm100_module()
+    moe_op = module.build_and_load()
+    setup_cubin_loader(str(module.get_library_path()))
+    return moe_op
+
+
+def _validate_routing_replay_out(
+    routing_replay_out: Optional[torch.Tensor], top_k: int
+) -> None:
+    if routing_replay_out is None:
+        return
+    assert routing_replay_out.dim() == 2
+    assert routing_replay_out.shape[1] == top_k
+    assert routing_replay_out.dtype == torch.int16
+    assert routing_replay_out.is_cuda
+    assert routing_replay_out.is_contiguous()
+
+
+def trtllm_fp8_block_scale_moe(
+    routing_logits: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    n_group: Optional[int],
+    topk_group: Optional[int],
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    use_shuffled_weight: bool = False,
+    weight_layout: int = 0,
+    do_finalize: bool = True,
+    enable_pdl: Optional[bool] = None,
+    tune_max_num_tokens: int = 8192,
+    fp8_quantization_type=None,
+    activation_type: Optional[int] = None,
+    norm_topk_prob: bool = True,
+    routing_replay_out: Optional[torch.Tensor] = None,
+) -> Union[List[torch.Tensor], torch.Tensor]:
+    from flashinfer.fused_moe.core import ActivationType, Fp8QuantizationType
+
+    _validate_routing_replay_out(routing_replay_out, top_k)
+
+    if fp8_quantization_type is None:
+        fp8_quantization_type = Fp8QuantizationType.DeepSeekFp8
+    if activation_type is None:
+        activation_type = ActivationType.Swiglu.value
+
+    output = torch.empty(
+        hidden_states.shape, dtype=torch.bfloat16, device=hidden_states.device
+    )
+    result = get_sgl_trtllm_moe_sm100_module().trtllm_fp8_block_scale_moe(
+        routing_logits,
+        None,
+        None,
+        routing_bias,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        output,
+        num_experts,
+        top_k,
+        n_group,
+        topk_group,
+        intermediate_size,
+        local_expert_offset,
+        local_num_experts,
+        routed_scaling_factor,
+        routing_method_type,
+        use_shuffled_weight,
+        weight_layout,
+        do_finalize,
+        enable_pdl,
+        tune_max_num_tokens,
+        fp8_quantization_type,
+        activation_type,
+        norm_topk_prob,
+        routing_replay_out,
+    )
+
+    return result[0] if do_finalize else result
+
+
+def trtllm_fp8_block_scale_routed_moe(
+    topk_ids: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    n_group: Optional[int],
+    topk_group: Optional[int],
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    use_shuffled_weight: bool = False,
+    weight_layout: int = 0,
+    do_finalize: bool = True,
+    enable_pdl: Optional[bool] = None,
+    output: Optional[torch.Tensor] = None,
+    tune_max_num_tokens: int = 8192,
+    fp8_quantization_type=None,
+    activation_type: Optional[int] = None,
+) -> Union[List[torch.Tensor], torch.Tensor]:
+    from flashinfer.fused_moe.core import ActivationType, Fp8QuantizationType
+
+    if fp8_quantization_type is None:
+        fp8_quantization_type = Fp8QuantizationType.DeepSeekFp8
+    if activation_type is None:
+        activation_type = ActivationType.Swiglu.value
+    if output is None:
+        output = torch.empty(
+            hidden_states.shape, dtype=torch.bfloat16, device=hidden_states.device
+        )
+
+    result = get_sgl_trtllm_moe_sm100_module().trtllm_fp8_block_scale_moe(
+        None,
+        topk_ids,
+        None,
+        routing_bias,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        output,
+        num_experts,
+        top_k,
+        n_group,
+        topk_group,
+        intermediate_size,
+        local_expert_offset,
+        local_num_experts,
+        routed_scaling_factor,
+        routing_method_type,
+        use_shuffled_weight,
+        weight_layout,
+        do_finalize,
+        enable_pdl,
+        tune_max_num_tokens,
+        fp8_quantization_type,
+        activation_type,
+        True,
+    )
+
+    return result[0] if do_finalize else result
+
+
+def trtllm_fp8_block_scale_routed_moe_lora(
+    topk_ids: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    gate_up_lora_delta: torch.Tensor,
+    activation_lora_input: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    n_group: Optional[int],
+    topk_group: Optional[int],
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    use_shuffled_weight: bool = False,
+    weight_layout: int = 0,
+    do_finalize: bool = True,
+    enable_pdl: Optional[bool] = None,
+    output: Optional[torch.Tensor] = None,
+    tune_max_num_tokens: int = 8192,
+    fp8_quantization_type=None,
+    activation_type: Optional[int] = None,
+) -> Union[List[torch.Tensor], torch.Tensor]:
+    from flashinfer.fused_moe.core import ActivationType, Fp8QuantizationType
+    from flashinfer.utils import device_support_pdl
+
+    if fp8_quantization_type is None:
+        fp8_quantization_type = Fp8QuantizationType.DeepSeekFp8
+    if activation_type is None:
+        activation_type = ActivationType.Swiglu.value
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(hidden_states.device)
+    if output is None:
+        output = torch.empty(
+            hidden_states.shape, dtype=torch.bfloat16, device=hidden_states.device
+        )
+
+    assert gate_up_lora_delta.is_contiguous()
+    assert activation_lora_input.is_contiguous()
+    empty_expert_weights = torch.empty(
+        (0,), dtype=torch.bfloat16, device=hidden_states.device
+    )
+
+    result = get_sgl_trtllm_moe_sm100_raw_module().sgl_trtllm_fp8_block_scale_moe_lora(
+        None,
+        topk_ids,
+        empty_expert_weights,
+        routing_bias,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        output,
+        num_experts,
+        top_k,
+        n_group,
+        topk_group,
+        intermediate_size,
+        local_expert_offset,
+        local_num_experts,
+        routed_scaling_factor,
+        routing_method_type,
+        use_shuffled_weight,
+        weight_layout,
+        do_finalize,
+        enable_pdl,
+        [-1, -1],
+        fp8_quantization_type,
+        activation_type,
+        True,
+        None,
+        gate_up_lora_delta,
+        activation_lora_input,
+    )
+
+    return output if do_finalize else result
+
+
+def trtllm_fp8_block_scale_moe_lora_finalize(
+    gemm2_output: torch.Tensor,
+    expert_weights: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    down_lora_delta: torch.Tensor,
+    output: torch.Tensor,
+    routed_scaling_factor: Optional[float],
+) -> torch.Tensor:
+    get_sgl_trtllm_moe_sm100_raw_module().sgl_trtllm_fp8_block_scale_moe_lora_finalize(
+        gemm2_output,
+        expert_weights,
+        expanded_idx_to_permuted_idx,
+        down_lora_delta,
+        output,
+        routed_scaling_factor,
+    )
+    return output

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
@@ -302,3 +302,133 @@ def trtllm_fp8_block_scale_moe_lora_finalize(
         routed_scaling_factor,
     )
     return output
+
+
+def trtllm_fp4_block_scale_routed_moe_lora(
+    topk_ids: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: Optional[torch.Tensor],
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    output1_scales_scalar: torch.Tensor,
+    output1_scales_gate_scalar: torch.Tensor,
+    output2_scales_scalar: torch.Tensor,
+    gate_up_lora_delta: torch.Tensor,
+    activation_lora_input: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    do_finalize: bool = True,
+    enable_pdl: Optional[bool] = None,
+    output: Optional[torch.Tensor] = None,
+    act_type: Optional[int] = None,
+    norm_topk_prob: bool = True,
+) -> Union[List[torch.Tensor], torch.Tensor]:
+    """NVFP4 sibling of :func:`trtllm_fp8_block_scale_routed_moe_lora`.
+
+    Decomposed (unfused-activation) MoE-LoRA on the flashinfer-trtllm backend:
+    routing -> gather -> gate_up grouped GEMM (raw 2*inter) -> activation that
+    adds ``gate_up_lora_delta`` pre-SwiGLU and writes ``activation_lora_input``
+    -> NvFP4 quant -> down grouped GEMM -> finalize. The down-LoRA is merged into
+    the output afterwards by the dispatch (virtual-experts) or via the finalize.
+
+    ``hidden_states`` is bf16 ``[num_tokens, hidden]`` (path 3: the op permutes then
+    NvFP4-quantizes it internally, ``hidden_states_scale=None``) or, legacy, packed NvFP4
+    (uint8 ``[num_tokens, hidden//2]``) with ``hidden_states_scale`` the fp8-e4m3 block
+    scale ``[num_tokens, hidden//16]``.
+    """
+    from flashinfer.fused_moe.core import ActivationType
+    from flashinfer.utils import device_support_pdl
+
+    if act_type is None:
+        act_type = ActivationType.Swiglu.value
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(hidden_states.device)
+
+    num_tokens = hidden_states.shape[0]
+    hidden_size = (
+        hidden_states.shape[1] * 2
+        if hidden_states.dtype == torch.uint8
+        else hidden_states.shape[1]
+    )
+    if output is None:
+        output = torch.empty(
+            (num_tokens, hidden_size), dtype=torch.bfloat16, device=hidden_states.device
+        )
+
+    assert gate_up_lora_delta.is_contiguous()
+    assert activation_lora_input.is_contiguous()
+    empty_expert_weights = torch.empty(
+        (0,), dtype=torch.bfloat16, device=hidden_states.device
+    )
+
+    result = get_sgl_trtllm_moe_sm100_raw_module().sgl_trtllm_fp4_block_scale_moe_lora(
+        None,  # routing_logits (precomputed routing via packed topk_ids)
+        topk_ids,  # expert_indices (packed: (expert_id<<16)|weight_bf16.view(int16))
+        empty_expert_weights,
+        routing_bias,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        None,  # gemm1_bias
+        None,  # gemm1_alpha
+        None,  # gemm1_beta
+        None,  # gemm1_clamp_limit
+        gemm2_weights,
+        gemm2_weights_scale,
+        None,  # gemm2_bias
+        output1_scales_scalar,
+        output1_scales_gate_scalar,
+        output2_scales_scalar,
+        None,  # per_token_scales (the down-GEMM act scale is produced internally)
+        num_experts,
+        top_k,
+        None,  # n_group
+        None,  # topk_group
+        intermediate_size,
+        local_expert_offset,
+        local_num_experts,
+        routed_scaling_factor,
+        routing_method_type,
+        do_finalize,
+        enable_pdl,
+        act_type,
+        output,
+        [-1, -1],  # config_index (autotuner)
+        norm_topk_prob,
+        None,  # routing_replay_out
+        gate_up_lora_delta,
+        activation_lora_input,
+    )
+
+    return output if do_finalize else result
+
+
+def trtllm_fp4_block_scale_moe_lora_finalize(
+    gemm2_output: torch.Tensor,
+    expert_weights: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    down_lora_delta: torch.Tensor,
+    output: torch.Tensor,
+    routed_scaling_factor: Optional[float],
+) -> torch.Tensor:
+    """NvFP4 analog of :func:`trtllm_fp8_block_scale_moe_lora_finalize` — combines
+    the permuted (bf16) GEMM2 output by expert weight and merges the down-LoRA
+    delta into the per-token output (non-virtual-experts hook path)."""
+    get_sgl_trtllm_moe_sm100_raw_module().sgl_trtllm_fp4_block_scale_moe_lora_finalize(
+        gemm2_output,
+        expert_weights,
+        expanded_idx_to_permuted_idx,
+        down_lora_delta,
+        output,
+        routed_scaling_factor,
+    )
+    return output

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
@@ -330,6 +330,8 @@ def trtllm_fp4_block_scale_routed_moe_lora(
     output: Optional[torch.Tensor] = None,
     act_type: Optional[int] = None,
     norm_topk_prob: bool = True,
+    lora_ready_event: int = 0,
+    act_ready_event: int = 0,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
     """NVFP4 sibling of :func:`trtllm_fp8_block_scale_routed_moe_lora`.
 
@@ -407,6 +409,8 @@ def trtllm_fp4_block_scale_routed_moe_lora(
         None,  # routing_replay_out
         gate_up_lora_delta,
         activation_lora_input,
+        lora_ready_event,
+        act_ready_event,
     )
 
     return output if do_finalize else result

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/core.py
@@ -331,7 +331,6 @@ def trtllm_fp4_block_scale_routed_moe_lora(
     act_type: Optional[int] = None,
     norm_topk_prob: bool = True,
     lora_ready_event: int = 0,
-    act_ready_event: int = 0,
 ) -> Union[List[torch.Tensor], torch.Tensor]:
     """NVFP4 sibling of :func:`trtllm_fp8_block_scale_routed_moe_lora`.
 
@@ -410,7 +409,6 @@ def trtllm_fp4_block_scale_routed_moe_lora(
         gate_up_lora_delta,
         activation_lora_input,
         lora_ready_event,
-        act_ready_event,
     )
 
     return output if do_finalize else result

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
@@ -1,0 +1,1043 @@
+/*
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cutlass/array.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_conversion.h>
+#include <cutlass/numeric_types.h>
+
+#include <algorithm>
+#include <cub/cub.cuh>
+#include <cuda/functional>
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+
+#include "flashinfer/exception.h"
+#include "flashinfer/trtllm/fused_moe/DevKernel.h"
+#include "flashinfer/utils.cuh"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Helper function for array conversion
+template <class T, class U>
+__host__ __device__ constexpr static U arrayConvert(T const& input) {
+  cutlass::NumericArrayConverter<typename U::Element, typename T::Element, U::kElements> converter;
+  return converter(input);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace moe::dev {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace activation {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+inline __device__ float silu(float x) { return x / (1.0f + expf(-x)); }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void activationKernel(KernelParams params) {
+  using Type = typename KernelParams::Type;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // immediately trigger the secondary kernel when using PDL, then wait on primary
+  if constexpr (KernelParams::UsePdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  for (int tokenIdx = blockIdx.z; tokenIdx < params.numTokens; tokenIdx += gridDim.z) {
+    // Look over experts per token
+    for (int k = blockIdx.y; k < params.topK; k += gridDim.y) {
+      int const expandedIdx = tokenIdx * params.topK + k;
+      int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
+
+      // Loop over hidden dim
+      for (int hiddenIdx = threadIdx.x + blockDim.x * blockIdx.x; hiddenIdx < params.innerDim / 2;
+           hiddenIdx += blockDim.x * gridDim.x) {
+        if (permutedIdx == -1) {
+          if (params.activationLoraInputOutPtr != nullptr) {
+            int64_t const activationIdx =
+                (int64_t)expandedIdx * (params.innerDim / 2) + hiddenIdx;
+            params.activationLoraInputOutPtr[activationIdx] = cutlass::bfloat16_t(0.0f);
+          }
+          continue;
+        }
+
+        // Use int64_t to avoid overflow when permutedIdx * innerDim > INT32_MAX
+        int64_t const baseIdx = (int64_t)permutedIdx * params.innerDim + hiddenIdx;
+
+        float x1 = (float)params.inPtr[baseIdx];
+        float x2 = (float)params.inPtr[baseIdx + params.innerDim / 2];
+        if (params.gateUpLoraDeltaPtr != nullptr) {
+          int64_t const loraBaseIdx = (int64_t)expandedIdx * params.innerDim + hiddenIdx;
+          x1 += static_cast<float>(params.gateUpLoraDeltaPtr[loraBaseIdx + params.innerDim / 2]);
+          x2 += static_cast<float>(params.gateUpLoraDeltaPtr[loraBaseIdx]);
+        }
+
+        float act = silu(x2);
+        Type out = (Type)(act * x1);
+        if (params.activationLoraInputOutPtr != nullptr) {
+          int64_t const activationIdx =
+              (int64_t)expandedIdx * (params.innerDim / 2) + hiddenIdx;
+          params.activationLoraInputOutPtr[activationIdx] =
+              static_cast<cutlass::bfloat16_t>(act * x1);
+        }
+
+        int64_t const outIdx = (int64_t)permutedIdx * (params.innerDim / 2) + hiddenIdx;
+        params.outPtr[outIdx] = out;
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Float4Max {
+  __device__ __forceinline__ float4 operator()(float4 const& a, float4 const& b) const {
+    float4 result;
+    result.x = fmaxf(a.x, b.x);
+    result.y = fmaxf(a.y, b.y);
+    result.z = fmaxf(a.z, b.z);
+    result.w = fmaxf(a.w, b.w);
+    return result;
+  }
+};
+
+struct Float2Max {
+  __device__ __forceinline__ float2 operator()(float2 const& a, float2 const& b) const {
+    float2 result;
+    result.x = fmaxf(a.x, b.x);
+    result.y = fmaxf(a.y, b.y);
+    return result;
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename VecType, int size>
+__device__ __forceinline__ VecType packedTypeFromArray(float data[size]) {
+  return {};
+}
+
+template <>
+__device__ __forceinline__ float4 packedTypeFromArray<float4, 4>(float data[4]) {
+  float4 result;
+  result.x = data[0];
+  result.y = data[1];
+  result.z = data[2];
+  result.w = data[3];
+  return result;
+}
+
+template <>
+__device__ __forceinline__ float2 packedTypeFromArray<float2, 2>(float data[2]) {
+  float2 result;
+  result.x = data[0];
+  result.y = data[1];
+  return result;
+}
+
+template <>
+__device__ __forceinline__ float packedTypeFromArray<float, 1>(float data[1]) {
+  return data[0];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename PackedType, int size>
+__device__ __forceinline__ cutlass::Array<float, size> arrayFromPackedType(PackedType data) {
+  return cutlass::Array<float, size>{};
+}
+
+template <>
+__device__ __forceinline__ cutlass::Array<float, 4> arrayFromPackedType<float4, 4>(float4 data) {
+  return cutlass::Array<float, 4>{data.x, data.y, data.z, data.w};
+}
+
+template <>
+__device__ __forceinline__ cutlass::Array<float, 2> arrayFromPackedType<float2, 2>(float2 data) {
+  return cutlass::Array<float, 2>{data.x, data.y};
+}
+
+template <>
+__device__ __forceinline__ cutlass::Array<float, 1> arrayFromPackedType<float, 1>(float data) {
+  return cutlass::Array<float, 1>{data};
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int NUM_TOKENS_PER_CTA>
+struct KernelTraits;
+
+template <>
+struct KernelTraits<4> {
+  using MaxOp = Float4Max;
+  using PackedType = float4;
+};
+
+template <>
+struct KernelTraits<2> {
+  using MaxOp = Float2Max;
+  using PackedType = float2;
+};
+
+template <>
+struct KernelTraits<1> {
+  using MaxOp = cuda::maximum<>;
+  using PackedType = float;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+constexpr int DEEP_SEEK_ACTIVATION_NUM_THREADS_PER_CTA = 128;
+
+template <typename KernelParams>
+__global__ void activationDeepSeekKernel(KernelParams params) {
+  using Type = typename KernelParams::Type;
+  int32_t constexpr NumTokensPerCta = KernelParams::NumTokensPerCta;
+  using KernelTraits = KernelTraits<NumTokensPerCta>;
+  using MaxOp = typename KernelTraits::MaxOp;
+  using PackedType = typename KernelTraits::PackedType;
+  using BlockReduce = cub::BlockReduce<PackedType, DEEP_SEEK_ACTIVATION_NUM_THREADS_PER_CTA>;
+
+  __shared__ float s_scaleOutArr[NumTokensPerCta];
+  __shared__ typename BlockReduce::TempStorage tempStorage;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // immediately trigger the secondary kernel when using PDL, then wait on primary
+  if constexpr (KernelParams::UsePdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  // The largest (finite) value that can be represented using E4m3.
+  float constexpr E4m3MaxVal{448.f};
+
+  int const totalNumPaddedTokens = params.totalNumPaddedTokens[0];
+  // Loop over tokens
+  float scale1Arr[NumTokensPerCta];
+  float scale2Arr[NumTokensPerCta];
+  float dataX1Arr[NumTokensPerCta];
+  float dataX2Arr[NumTokensPerCta];
+  float outArr[NumTokensPerCta];
+  float absOutArr[NumTokensPerCta];
+  int permutedIdxArr[NumTokensPerCta];
+
+  // Loop over tokens
+  for (int k = blockIdx.z; k < params.topK; k += gridDim.z) {
+    for (int tokenCtaIdx = blockIdx.y * NumTokensPerCta; tokenCtaIdx < params.numTokens;
+         tokenCtaIdx += gridDim.y * NumTokensPerCta) {
+      for (int hiddenIdx = threadIdx.x + blockDim.x * blockIdx.x; hiddenIdx < params.innerDim / 2;
+           hiddenIdx += blockDim.x * gridDim.x) {
+#pragma unroll
+        for (int tokenInCtaIdx = 0; tokenInCtaIdx < NumTokensPerCta; tokenInCtaIdx++) {
+          scale1Arr[tokenInCtaIdx] = 0.0f;
+          scale2Arr[tokenInCtaIdx] = 0.0f;
+          dataX1Arr[tokenInCtaIdx] = 0.0f;
+          dataX2Arr[tokenInCtaIdx] = 0.0f;
+          outArr[tokenInCtaIdx] = 0.0f;
+          absOutArr[tokenInCtaIdx] = 0.0f;
+        }
+#pragma unroll
+        for (int tokenInCtaIdx = 0; tokenInCtaIdx < NumTokensPerCta; tokenInCtaIdx++) {
+          int const tokenIdx = tokenCtaIdx + tokenInCtaIdx;
+          if (tokenIdx >= params.numTokens) {
+            break;
+          }
+
+          int const expandedIdx = tokenIdx * params.topK + k;
+          int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
+          permutedIdxArr[tokenInCtaIdx] = permutedIdx;
+          if (permutedIdx == -1) {
+            continue;
+          }
+
+          // Process blocks for this CTA
+          // Use int64_t to avoid overflow when permutedIdx * innerDim > INT32_MAX
+          int64_t const baseIdx = (int64_t)permutedIdx * params.innerDim + hiddenIdx;
+
+          int64_t const scale1Idx =
+              (int64_t)permutedIdx + (int64_t)totalNumPaddedTokens * (hiddenIdx / 128);
+          int64_t const scale2Idx =
+              (int64_t)permutedIdx +
+              (int64_t)totalNumPaddedTokens * ((hiddenIdx / 128) + (params.innerDim / 2 / 128));
+
+          scale1Arr[tokenInCtaIdx] = params.inDqSfsPtr[scale1Idx];
+          scale2Arr[tokenInCtaIdx] = params.inDqSfsPtr[scale2Idx];
+          dataX1Arr[tokenInCtaIdx] = static_cast<float>(params.inPtr[baseIdx]);
+          dataX2Arr[tokenInCtaIdx] =
+              static_cast<float>(params.inPtr[baseIdx + params.innerDim / 2]);
+        }
+
+#pragma unroll
+        for (int tokenInCtaIdx = 0; tokenInCtaIdx < NumTokensPerCta; tokenInCtaIdx++) {
+          float x1 = scale1Arr[tokenInCtaIdx] * dataX1Arr[tokenInCtaIdx];
+          float x2 = scale2Arr[tokenInCtaIdx] * dataX2Arr[tokenInCtaIdx];
+          auto const tokenIdx = tokenCtaIdx + tokenInCtaIdx;
+          if (params.gateUpLoraDeltaPtr != nullptr && tokenIdx < params.numTokens) {
+            int const expandedIdx = tokenIdx * params.topK + k;
+            int64_t const loraBaseIdx = (int64_t)expandedIdx * params.innerDim + hiddenIdx;
+            x1 += static_cast<float>(
+                params.gateUpLoraDeltaPtr[loraBaseIdx + params.innerDim / 2]);
+            x2 += static_cast<float>(params.gateUpLoraDeltaPtr[loraBaseIdx]);
+          }
+          float act = silu(x2);
+          float out = act * x1;
+          outArr[tokenInCtaIdx] = out;
+          absOutArr[tokenInCtaIdx] = fabsf(out);
+        }
+
+        auto absOutPacked = packedTypeFromArray<PackedType, NumTokensPerCta>(absOutArr);
+        auto aMaxPacked = BlockReduce(tempStorage).Reduce(absOutPacked, MaxOp{});
+        auto aMaxArr = arrayFromPackedType<PackedType, NumTokensPerCta>(aMaxPacked);
+
+#pragma unroll
+        for (int tokenInCtaIdx = 0; tokenInCtaIdx < NumTokensPerCta; tokenInCtaIdx++) {
+          if (threadIdx.x == 0) {
+            auto const tokenIdx = tokenCtaIdx + tokenInCtaIdx;
+            if (tokenIdx >= params.numTokens) {
+              break;
+            }
+            int const permutedIdx = permutedIdxArr[tokenInCtaIdx];
+            if (permutedIdx == -1) {
+              continue;
+            }
+            // Make sure the scale is strictly positive to avoid division by zero in case the
+            // maximum is zero.
+            float scaleOut =
+                fmaxf(aMaxArr[tokenInCtaIdx] / E4m3MaxVal, std::numeric_limits<float>::min());
+            s_scaleOutArr[tokenInCtaIdx] = scaleOut;
+            int64_t const scaleOut_idx = (int64_t)permutedIdxArr[tokenInCtaIdx] +
+                                         (int64_t)totalNumPaddedTokens * (hiddenIdx / 128);
+            params.outDqSfsPtr[scaleOut_idx] = scaleOut;
+          }
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int tokenInCtaIdx = 0; tokenInCtaIdx < NumTokensPerCta; tokenInCtaIdx++) {
+          auto const tokenIdx = tokenCtaIdx + tokenInCtaIdx;
+          if (tokenIdx >= params.numTokens) {
+            break;
+          }
+          int const permutedIdx = permutedIdxArr[tokenInCtaIdx];
+          if (permutedIdx == -1) {
+            if (params.activationLoraInputOutPtr != nullptr) {
+              int const expandedIdx = tokenIdx * params.topK + k;
+              int64_t const activationIdx =
+                  (int64_t)expandedIdx * (params.innerDim / 2) + hiddenIdx;
+              params.activationLoraInputOutPtr[activationIdx] = cutlass::bfloat16_t(0.0f);
+            }
+            continue;
+          }
+          float const scaleOut = s_scaleOutArr[tokenInCtaIdx];
+          int64_t const outIdx = (int64_t)permutedIdx * (params.innerDim / 2) + hiddenIdx;
+          params.outPtr[outIdx] = static_cast<Type>(outArr[tokenInCtaIdx] / scaleOut);
+          if (params.activationLoraInputOutPtr != nullptr) {
+            int const expandedIdx = tokenIdx * params.topK + k;
+            int64_t const activationIdx =
+                (int64_t)expandedIdx * (params.innerDim / 2) + hiddenIdx;
+            params.activationLoraInputOutPtr[activationIdx] =
+                static_cast<cutlass::bfloat16_t>(outArr[tokenInCtaIdx]);
+          }
+        }
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void run(Data const& data, void* stream) {
+  if (data.mDtypeElt == tg::Dtype::E2m1) {
+    // Note: this should be unreachable because the options are checked beforehand.
+    // E2m1 requires using higher-precision intermediate data (bf16).
+    FLASHINFER_CHECK(false, "Activation with E2m1_t isn't supported.");
+    return;
+  }
+
+  if (data.mUseDeepSeekFp8) {
+    constexpr int NUM_ELTS_PER_LOAD = 1;
+    constexpr int NUM_ELTS_PER_SF = 128;
+
+    int device{-1};
+    cudaGetDevice(&device);
+    int numSms = 0;
+    cudaDeviceGetAttribute(&numSms, cudaDevAttrMultiProcessorCount, device);
+
+    // Output dimension is innerDim / 2, and each scale block is 128 elements
+    int const outputDim = data.innerDim / 2;
+    int const numScaleBlocks = (outputDim + NUM_ELTS_PER_SF - 1) / NUM_ELTS_PER_SF;
+    int const gridSizeX = (numScaleBlocks + NUM_ELTS_PER_LOAD - 1) / NUM_ELTS_PER_LOAD;
+
+    auto numCtas = gridSizeX * data.numTokens * data.topK;
+    // FIXME: This is heruistic based on very short benchmark.
+    int numTokensPerCta = 1;
+    if (numCtas > numSms * 32) {
+      numTokensPerCta = 4;
+    } else if (numCtas > numSms * 4) {
+      numTokensPerCta = 2;
+    } else {
+      numTokensPerCta = 1;
+    }
+
+    int const gridSizeY = std::min(8192, (data.numTokens + numTokensPerCta - 1) / numTokensPerCta);
+
+    const dim3 grid(gridSizeX, gridSizeY, data.topK);
+
+    LAUNCH_ACTIVATION(data, activationDeepSeekKernel, numTokensPerCta, grid,
+                      DEEP_SEEK_ACTIVATION_NUM_THREADS_PER_CTA, 0, stream);
+  } else {
+    int const numThreads = 256;
+    const dim3 grid(data.innerDim / 128, data.topK, std::min(8192, data.numTokens));
+
+    LAUNCH_ACTIVATION(data, activationKernel, 1, grid, numThreads, 0, stream);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace activation
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace convertsf {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+namespace dev {
+// Compute the offset that corresponds to (dataRowIdx, dataBlkColIdx) in the SF tensor where
+// dataRowIdx and dataBlkColIdx are the respective indices of the row and the block of 16 elts
+// from the K dim in the tensor of data.
+inline __device__ int64_t getSfOffset(int32_t dataRowIdx, int32_t dataBlkColIdx,
+                                      int32_t numDataBlksPerRow) {
+  // The number of rows of SF per block.
+  static int32_t constexpr NumRowsPerSfBlock = 128;
+  // The number of cols of SF per block.
+  static int32_t constexpr NumColsPerSfBlock = 4;
+  // The size of each SF block.
+  static int32_t constexpr NumBytesPerSfBlock = NumRowsPerSfBlock * NumColsPerSfBlock;
+
+  // The number of rows of data per SF block.
+  static int32_t constexpr NumDataRowsPerSfBlock = NumRowsPerSfBlock;
+  // The number of cols of blocks of data per SF block.
+  static int32_t constexpr NumDataBlkColsPerSfBlock = NumColsPerSfBlock;
+
+  // The row of the SF block in the SF tensor.
+  int sfBlkRowIdx = dataRowIdx / NumDataRowsPerSfBlock;
+  // The col of the SF block in the SF tensor.
+  int sfBlkColIdx = dataBlkColIdx / NumDataBlkColsPerSfBlock;
+  // The blocks are stored row-major in the tensor of scaling factors.
+  int sfBlkIdx = sfBlkRowIdx * numDataBlksPerRow / NumDataBlkColsPerSfBlock + sfBlkColIdx;
+
+  // Find the row in the SF block.
+  int sfRowIdx = (dataRowIdx % 32) * 4 + (dataRowIdx % NumDataRowsPerSfBlock) / 32;
+  // Find the col in the SF block.
+  int sfColIdx = (dataBlkColIdx % 4);
+
+  // Compute the offset in bytes.
+  return sfBlkIdx * NumBytesPerSfBlock + sfRowIdx * NumColsPerSfBlock + sfColIdx;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Given the GMEM address of an output element, compute the offset of the corresponding scaling
+// factor in the SF tensor. Optionally, a startTokenIndex can be provided if the first token is not
+// the start token in the SF tensor. This is useful when inflight batching is enabled in TRT-LLM,
+// where the context and generation output are stored as one output tensor. In this case, the
+// generation output may not start with zero offset in the SF output tensor.
+template <int32_t NumBitsPerElt>
+inline __device__ int64_t getSfOffset(int64_t gmemOffsetInBytes, int32_t hiddenDim,
+                                      int32_t startTokenIdx = 0) {
+  // The number of elements per sf.
+  int32_t constexpr NumEltsPerSf = 16;
+  // The GMEM offset of the output element.
+  int64_t gmemOffset = gmemOffsetInBytes * 8 /*bits*/ / NumBitsPerElt;
+  // The row/col indices of the corresponding SF element.
+  int32_t sfRowIdx = gmemOffset / hiddenDim + startTokenIdx;
+  int32_t sfColIdx = (gmemOffset % hiddenDim) / NumEltsPerSf;
+  // Compute the SF offset.
+  return getSfOffset(sfRowIdx, sfColIdx, hiddenDim / NumEltsPerSf);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// TODO(tizheng): Refactor to track gmem offset instead of doing pointer subtraction.
+template <int32_t NumBitsPerElt>
+inline __device__ int64_t getSfOffset(void const* gmemOutPtr, void const* gmemBasePtr,
+                                      int32_t hiddenDim, int32_t startTokenIdx = 0) {
+  return getSfOffset<NumBitsPerElt>(
+      reinterpret_cast<char const*>(gmemOutPtr) - reinterpret_cast<char const*>(gmemBasePtr),
+      hiddenDim, startTokenIdx);
+}
+
+}  // namespace dev
+
+// TODO: it would be nice to move some of that logic to Fp4Utils.h
+template <tg::SfLayout Layout>
+inline __device__ int32_t getSfOffset(int32_t dataRowIdx, int32_t dataBlkColIdx,
+                                      int32_t numDataBlksPerRow) {
+  if constexpr (Layout == tg::SfLayout::Linear) {
+    return numDataBlksPerRow * dataRowIdx + dataBlkColIdx;
+  } else if constexpr (Layout == tg::SfLayout::R128c4) {
+    return static_cast<int32_t>(dev::getSfOffset(dataRowIdx, dataBlkColIdx, numDataBlksPerRow));
+  } else if constexpr (Layout == tg::SfLayout::R8c4 || Layout == tg::SfLayout::R8c16) {
+    static int32_t constexpr NumRowsPerSfBlock = 8;
+    static int32_t constexpr NumColsPerSfBlock = (Layout == tg::SfLayout::R8c4) ? 4 : 16;
+    static int32_t constexpr NumBytesPerSfBlock = NumRowsPerSfBlock * NumColsPerSfBlock;
+    int sfBlkRowIdx = dataRowIdx / NumRowsPerSfBlock;
+    int sfBlkColIdx = dataBlkColIdx / NumColsPerSfBlock;
+    int sfBlkIdx = sfBlkRowIdx * numDataBlksPerRow / NumColsPerSfBlock + sfBlkColIdx;
+    int sfRowIdx = dataRowIdx % NumRowsPerSfBlock;
+    int sfColIdx = dataBlkColIdx % NumColsPerSfBlock;
+    return sfBlkIdx * NumBytesPerSfBlock + sfRowIdx * NumColsPerSfBlock + sfColIdx;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <tg::SfLayout LayoutSrc, tg::SfLayout LayoutDst, typename KernelParams>
+__device__ void convertSfCommon(KernelParams params) {
+  // Note: it's assumed that the number of scaling factors per row is a multiple of 4.
+  constexpr int VecSize = 4;
+  using VecType = uint32_t;
+  static_assert(sizeof(VecType) == VecSize);
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // Immediately trigger the secondary kernel when using PDL, then wait on primary.
+  if constexpr (KernelParams::UsePdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  // TODO: consider optimizing if used in production.
+  // This is a naive kernel. It's not doing coalesced loads.
+
+  int const numSfPerRow = params.hiddenDimSf;
+
+  for (int tokenIdx = blockIdx.y; tokenIdx < params.numTokens; tokenIdx += gridDim.y) {
+    for (int hiddenSfVecIdx = threadIdx.x + blockDim.x * blockIdx.x;
+         hiddenSfVecIdx < numSfPerRow / VecSize; hiddenSfVecIdx += blockDim.x * gridDim.x) {
+      // Index of the first SF in the vector.
+      int const hiddenSfIdx = VecSize * hiddenSfVecIdx;
+
+      // Load scale factors.
+      int sfIdxIn = getSfOffset<LayoutSrc>(tokenIdx, hiddenSfIdx, numSfPerRow);
+      const VecType sfVec = reinterpret_cast<VecType const*>(params.inSfPtr)[sfIdxIn / VecSize];
+
+      // Store scale factors.
+      int const sfIdxOut = getSfOffset<LayoutDst>(tokenIdx, hiddenSfIdx, numSfPerRow);
+      reinterpret_cast<VecType*>(params.outSfPtr)[sfIdxOut / VecSize] = sfVec;
+    }
+  }
+}
+
+#define CONVERT_FP4_SF_KERNEL(LayoutSrc, LayoutDst)                                  \
+  template <typename KernelParams>                                                   \
+  __global__ void convertSf##LayoutSrc##To##LayoutDst##Kernel(KernelParams params) { \
+    convertSfCommon<tg::SfLayout::LayoutSrc, tg::SfLayout::LayoutDst>(params);       \
+  }
+// We only need a conversion to the linear layout.
+CONVERT_FP4_SF_KERNEL(R128c4, Linear);
+CONVERT_FP4_SF_KERNEL(R8c4, Linear);
+CONVERT_FP4_SF_KERNEL(R8c16, Linear);
+#undef CONVERT_FP4_SF_KERNEL
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void run(Data const& data, void* stream) {
+  constexpr int VecSize = 4;
+  int const numThreads = 128;
+  int const numBlocksX = (data.hiddenDimSf / VecSize - 1 + numThreads) / numThreads;
+  int const numBlocksY = std::min(8192, data.numTokens);
+  dim3 numBlocks(numBlocksX, numBlocksY);
+#define CONVERT_FP4_SF_LAUNCH(LayoutSrc, LayoutDst)                                             \
+  if (data.sfLayoutSrc == tg::SfLayout::LayoutSrc &&                                            \
+      data.sfLayoutDst == tg::SfLayout::LayoutDst) {                                            \
+    LAUNCH_PDL(data, false, cutlass::float_e4m3_t, convertSf##LayoutSrc##To##LayoutDst##Kernel, \
+               numBlocks, numThreads, 0, stream);                                               \
+    return;                                                                                     \
+  }
+  CONVERT_FP4_SF_LAUNCH(R128c4, Linear);
+  CONVERT_FP4_SF_LAUNCH(R8c4, Linear);
+  CONVERT_FP4_SF_LAUNCH(R8c16, Linear);
+#undef CONVERT_FP4_SF_LAUNCH
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace convertsf
+
+namespace permute {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void permuteKernel(KernelParams params) {
+  using Type = typename KernelParams::Type;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // immediately trigger the secondary kernel when using PDL, then wait on primary
+  if constexpr (KernelParams::UsePdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  for (int tokenIdx = blockIdx.y; tokenIdx < params.numTokens; tokenIdx += gridDim.y) {
+    // Loop over hidden dim
+    for (int hiddenIdx = threadIdx.x + blockDim.x * blockIdx.x; hiddenIdx < params.hiddenDim;
+         hiddenIdx += blockDim.x * gridDim.x) {
+      // Load chunk of token into registers
+      const Type data = params.inPtr[tokenIdx * params.hiddenDim + hiddenIdx];
+
+      // Write to topK places
+      for (int k = 0; k < params.topK; k++) {
+        int const expandedIdx = tokenIdx * params.topK + k;
+        int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
+        params.outPtr[permutedIdx * params.hiddenDim + hiddenIdx] = data;
+      }
+    }
+    if (params.useDeepSeekFp8) {
+      for (int scaleIdx = threadIdx.x + blockDim.x * blockIdx.x; scaleIdx < params.hiddenDim / 128;
+           scaleIdx += blockDim.x * gridDim.x) {
+        for (int k = 0; k < params.topK; k++) {
+          int const expandedIdx = tokenIdx * params.topK + k;
+          int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
+
+          int const idx_in = tokenIdx + params.numTokens * scaleIdx;
+          int const idx_out = permutedIdx + params.totalNumPaddedTokens[0] * scaleIdx;
+
+          params.outDqSfsPtr[idx_out] = params.inDqSfsPtr[idx_in];
+        }
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void run(Data const& data, void* stream) {
+  int const numThreads = 256;
+  int const numBlocksX = (data.hiddenDim - 1 + numThreads) / numThreads;
+  int const numBlocksY = std::min(8192, data.numTokens);
+  dim3 numBlocks(numBlocksX, numBlocksY);
+
+  LAUNCH(data, permuteKernel, numBlocks, numThreads, 0, stream);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace permute
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace finalize {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void finalizeKernel(KernelParams params) {
+  using Type = typename KernelParams::Type;
+  using TypeExpW = typename KernelParams::TypeExpW;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // wait on primary kernel when using PDL
+  if constexpr (KernelParams::UsePdl) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  for (int tokenIdx = blockIdx.y; tokenIdx < params.numTokens; tokenIdx += gridDim.y) {
+    // Loop over hidden dim
+    for (int hiddenIdx = threadIdx.x + blockDim.x * blockIdx.x; hiddenIdx < params.hiddenDim;
+         hiddenIdx += blockDim.x * gridDim.x) {
+      // Accumulate chunk of token into registers
+      float data = 0.0F;
+
+      // Write to topK places
+      for (int k = 0; k < params.topK; k++) {
+        int const expandedIdx = tokenIdx * params.topK + k;
+        int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
+
+        if (permutedIdx == -1) {
+          continue;
+        }
+
+        if (params.expertWeightsPtr != nullptr) {
+          TypeExpW const scale = params.expertWeightsPtr[expandedIdx];
+          data +=
+              float{scale} * float{params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]};
+        } else {
+          data += float{params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]};
+        }
+      }
+
+      params.outPtr[tokenIdx * params.hiddenDim + hiddenIdx] = static_cast<Type>(data);
+    }
+  }
+}
+
+constexpr static int FINALIZE_THREADS_PER_BLOCK = 256;
+
+__device__ float4 vectorizedLoadPtx(float4 const* ptr) {
+  float4 ret;
+  asm volatile("ld.global.v4.f32 {%0, %1, %2, %3}, [%4];"
+               : "=f"(ret.x), "=f"(ret.y), "=f"(ret.z), "=f"(ret.w)
+               : "l"(ptr));
+  return ret;
+}
+
+// Final kernel to unpermute and scale
+// This kernel unpermutes the original data, does the k-way reduction and performs the final skip
+// connection.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+constexpr int MaxTopK = 64;
+
+typedef struct __CUDA_ALIGN__(4) {
+  cutlass::bfloat16_t array[2];
+} bfloat16_2;
+
+typedef struct __CUDA_ALIGN__(8) {
+  cutlass::bfloat16_t array[4];
+} bfloat16_4;
+
+typedef struct __CUDA_ALIGN__(8) {
+  half array[4];
+} half_4;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int UnrollFactor_, typename TypeExpW_>
+struct ScaleTraitsStruct;
+
+template <>
+struct ScaleTraitsStruct<1, cutlass::bfloat16_t> {
+  using PackedType = cutlass::bfloat16_t;
+  using ArrayType = cutlass::Array<cutlass::bfloat16_t, 1>;
+};
+
+template <>
+struct ScaleTraitsStruct<2, cutlass::bfloat16_t> {
+  using PackedType = bfloat16_2;
+  using ArrayType = cutlass::Array<cutlass::bfloat16_t, 2>;
+};
+
+template <>
+struct ScaleTraitsStruct<4, cutlass::bfloat16_t> {
+  using PackedType = bfloat16_4;
+  using ArrayType = cutlass::Array<cutlass::bfloat16_t, 4>;
+};
+
+template <>
+struct ScaleTraitsStruct<1, float> {
+  using PackedType = float;
+  using ArrayType = cutlass::Array<float, 1>;
+};
+
+template <>
+struct ScaleTraitsStruct<2, float> {
+  using PackedType = float2;
+  using ArrayType = cutlass::Array<float, 2>;
+};
+
+template <>
+struct ScaleTraitsStruct<4, float> {
+  using PackedType = float4;
+  using ArrayType = cutlass::Array<float, 4>;
+};
+
+template <>
+struct ScaleTraitsStruct<1, half> {
+  using PackedType = half;
+  using ArrayType = cutlass::Array<half, 1>;
+};
+
+template <>
+struct ScaleTraitsStruct<2, half> {
+  using PackedType = half2;
+  using ArrayType = cutlass::Array<half, 2>;
+};
+
+template <>
+struct ScaleTraitsStruct<4, half> {
+  using PackedType = half_4;
+  using ArrayType = cutlass::Array<half, 4>;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int UnrollFactor_, typename TypeExpW_>
+struct FinalizeTraits;
+
+template <typename TypeExpW_>
+struct FinalizeTraits<1, TypeExpW_> {
+  using IdxPackedType = int;
+  using IdxArrayType = cutlass::Array<int, 1>;
+  using ScaleTraits = ScaleTraitsStruct<1, TypeExpW_>;
+  using ScalePackedType = typename ScaleTraits::PackedType;
+  using ScaleArrayType = typename ScaleTraits::ArrayType;
+};
+
+template <typename TypeExpW_>
+struct FinalizeTraits<2, TypeExpW_> {
+  using IdxPackedType = int2;
+  using IdxArrayType = cutlass::Array<int, 2>;
+  using ScaleTraits = ScaleTraitsStruct<2, TypeExpW_>;
+  using ScalePackedType = typename ScaleTraits::PackedType;
+  using ScaleArrayType = typename ScaleTraits::ArrayType;
+};
+
+template <typename TypeExpW_>
+struct FinalizeTraits<4, TypeExpW_> {
+  using IdxPackedType = int4;
+  using IdxArrayType = cutlass::Array<int, 4>;
+  using ScaleTraits = ScaleTraitsStruct<4, TypeExpW_>;
+  using ScalePackedType = typename ScaleTraits::PackedType;
+  using ScaleArrayType = typename ScaleTraits::ArrayType;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void finalizeKernelVecLoad(KernelParams params) {
+  using Type = typename KernelParams::Type;
+  using TypeExpW = typename KernelParams::TypeExpW;
+  int constexpr TopKUnrollFactor = KernelParams::TopKUnrollFactor;
+
+  static_assert(TopKUnrollFactor == 1 || TopKUnrollFactor == 2 || TopKUnrollFactor == 4,
+                "TopKUnrollFactor must be 1, 2, or 4");
+  using FinalizeTraits = FinalizeTraits<TopKUnrollFactor, TypeExpW>;
+  using IdxPackedType = typename FinalizeTraits::IdxPackedType;
+  using IdxArrayType = typename FinalizeTraits::IdxArrayType;
+  using ScalePackedType = typename FinalizeTraits::ScalePackedType;
+  using ScaleArrayType = typename FinalizeTraits::ScaleArrayType;
+
+  int const hiddenDimPaddedBits = params.hiddenDimPadded * cutlass::sizeof_bits<Type>::value;
+  int const hiddenDimBits = params.hiddenDim * cutlass::sizeof_bits<Type>::value;
+  assert(hiddenDimPaddedBits % 128 == 0);
+  assert(hiddenDimBits % 128 == 0);
+
+  // Load 128-bits per thread, according to the smallest data type we read/write
+  constexpr int64_t FINALIZE_ELEM_PER_THREAD = 128 / cutlass::sizeof_bits<Type>::value;
+  using InputElem = cutlass::Array<Type, FINALIZE_ELEM_PER_THREAD>;
+  using OutputElem = cutlass::Array<Type, FINALIZE_ELEM_PER_THREAD>;
+  using ComputeElem = cutlass::Array<float, FINALIZE_ELEM_PER_THREAD>;
+
+  int64_t const tokenIdx = blockIdx.x;
+  int64_t const startOffset = threadIdx.x;
+  int64_t const stride = FINALIZE_THREADS_PER_BLOCK;
+  int64_t const numElemsInPaddedCol = params.hiddenDimPadded / FINALIZE_ELEM_PER_THREAD;
+  int64_t const numElemsInCol = params.hiddenDim / FINALIZE_ELEM_PER_THREAD;
+  bool const useScale = params.expertWeightsPtr != nullptr;
+
+  __shared__ ScalePackedType scaleArrSmem[MaxTopK / TopKUnrollFactor];
+  __shared__ IdxPackedType permutedIdxArrSmem[MaxTopK / TopKUnrollFactor];
+
+  for (int kChunkIdx = threadIdx.x; kChunkIdx < params.topK / TopKUnrollFactor;
+       kChunkIdx += blockDim.x) {
+    int const expandedIdx = tokenIdx * params.topK + kChunkIdx * TopKUnrollFactor;
+    auto permutedIdxPacked = reinterpret_cast<IdxPackedType const*>(
+        params.expandedIdxToPermutedIdx)[expandedIdx / TopKUnrollFactor];
+    auto scalePacked = useScale ? reinterpret_cast<ScalePackedType const*>(
+                                      params.expertWeightsPtr)[expandedIdx / TopKUnrollFactor]
+                                : ScalePackedType{TypeExpW(1.f)};
+
+    scaleArrSmem[kChunkIdx] = scalePacked;
+    permutedIdxArrSmem[kChunkIdx] = permutedIdxPacked;
+  }
+
+  auto const offset = tokenIdx * params.hiddenDim;
+  Type* outputPtr = params.outPtr + offset;
+  auto* outElemPtr = reinterpret_cast<OutputElem*>(outputPtr);
+  auto const* inElemPtr = reinterpret_cast<InputElem const*>(params.inPtr);
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // wait on primary kernel when using PDL
+  if constexpr (KernelParams::UsePdl) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+  __syncthreads();
+
+  for (int elemIndex = startOffset; elemIndex < numElemsInCol; elemIndex += stride) {
+    ComputeElem threadOutput;
+    threadOutput.fill(0);
+    for (int kChunkIdx = 0; kChunkIdx < params.topK / TopKUnrollFactor; kChunkIdx++) {
+      auto permutedIdxArr = *reinterpret_cast<IdxArrayType const*>(&permutedIdxArrSmem[kChunkIdx]);
+      InputElem inputElemArr[TopKUnrollFactor];
+#pragma unroll
+      for (int ki = 0; ki < TopKUnrollFactor; ++ki) {
+        auto const permutedIdx = permutedIdxArr[ki];
+        if (permutedIdx == -1) {
+          continue;
+        }
+
+        auto const* inputPermutedPtr = inElemPtr + permutedIdx * numElemsInPaddedCol;
+
+        float4 input =
+            vectorizedLoadPtx(reinterpret_cast<float4 const*>(&inputPermutedPtr[elemIndex]));
+        inputElemArr[ki] = *reinterpret_cast<InputElem const*>(&input);
+      }
+      auto scaleArr = *reinterpret_cast<ScaleArrayType const*>(&scaleArrSmem[kChunkIdx]);
+      auto const scaleFloatArr =
+          arrayConvert<ScaleArrayType, cutlass::Array<float, TopKUnrollFactor>>(scaleArr);
+
+#pragma unroll
+      for (int ki = 0; ki < TopKUnrollFactor; ++ki) {
+        auto const permutedIdx = permutedIdxArr[ki];
+        if (permutedIdx == -1) {
+          continue;
+        }
+        auto scale = useScale ? scaleFloatArr[ki] : 1.0f;
+        ComputeElem expertResult = arrayConvert<InputElem, ComputeElem>(inputElemArr[ki]);
+        threadOutput = threadOutput + scale * expertResult;
+      }
+    }
+    OutputElem outputElem = arrayConvert<ComputeElem, OutputElem>(threadOutput);
+    outElemPtr[elemIndex] = outputElem;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void finalizeDeepSeekKernel(KernelParams params) {
+  using Type = typename KernelParams::Type;
+  using BlockReduce = cub::BlockReduce<float, 128>;
+
+  __shared__ float s_scaleOut;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // wait on primary kernel when using PDL
+  if constexpr (KernelParams::UsePdl) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  for (int tokenIdx = blockIdx.y; tokenIdx < params.numTokens; tokenIdx += gridDim.y) {
+    // Loop over hidden dim
+    for (int hiddenIdx = threadIdx.x + blockDim.x * blockIdx.x; hiddenIdx < params.hiddenDim;
+         hiddenIdx += blockDim.x * gridDim.x) {
+      // Accumulate chunk of token into registers
+      float acc = 0.0f;
+
+      for (int k = 0; k < params.topK; k++) {
+        int const expandedIdx = tokenIdx * params.topK + k;
+        int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
+        if (permutedIdx == -1) {
+          continue;
+        }
+        int const totalNumPaddedTokens = params.totalNumPaddedTokens[0];
+        int const scaleIdx = permutedIdx + totalNumPaddedTokens * (hiddenIdx / 128);
+        float const blockScale = params.inDqSfsPtr ? params.inDqSfsPtr[scaleIdx] : 1;
+
+        float const expertProb = (float)params.expertWeightsPtr[tokenIdx * params.topK + k];
+
+        float const scale = expertProb * blockScale;
+        acc += scale *
+               static_cast<float>(params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]);
+      }
+
+      // The largest (finite) value that can be represented using E4m3.
+      float constexpr E4m3MaxVal{448.f};
+
+      // Compute the absolute max
+      float aMax = BlockReduce(temp_storage).Reduce(fabsf(acc), cuda::maximum<>{});
+
+      if (threadIdx.x == 0) {
+        if (params.outDqSfsPtr) {
+          s_scaleOut = aMax / E4m3MaxVal;
+          int const scaleOut_idx = tokenIdx + hiddenIdx / 128 * params.numTokens;
+          params.outDqSfsPtr[scaleOut_idx] = aMax / E4m3MaxVal;
+        } else {
+          s_scaleOut = 1.0f;
+        }
+      }
+      __syncthreads();
+      float const scaleOut = s_scaleOut;
+      __syncthreads();
+      params.outPtr[tokenIdx * params.hiddenDim + hiddenIdx] = (Type)(acc / scaleOut);
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+void run(Data const& data, void* stream) {
+  if (data.mUseDeepSeekFp8) {
+    int const numThreads = 128;
+    int const numBlocksX = (data.hiddenDim - 1 + numThreads) / numThreads;
+    // Capped at rather arbitrary 8192 to avoid gridDim exceeding 65535 specified by CUDA.
+    int const numBlocksY = std::min(8192, data.numTokens);
+    dim3 numBlocks(numBlocksX, numBlocksY);
+
+    LAUNCH_TOPK_EXPW(data, finalizeDeepSeekKernel, numBlocks, numThreads, 0, stream);
+  } else {
+    int const numThreads = 256;
+    int const numBlocksX = (data.hiddenDim - 1 + numThreads) / numThreads;
+    // Capped at rather arbitrary 8192 to avoid gridDim exceeding 65535 specified by CUDA.
+    int const numBlocksY = std::min(8192, data.numTokens);
+
+    if (numBlocksX * numBlocksY < 1184) {
+      // The number 1184 comes from 148 * 8, where 148 is the number of SMs (Streaming
+      // Multiprocessors) in the Blackwell architecture, and the value 8 means that each Streaming
+      // Multiprocessor (SM) can hold up to 8 blocks for this kernel. This limitation is intended to
+      // ensure that when the number of waves is greater than 1, we choose to use the kernel with
+      // vectorized loading.
+      dim3 numBlocks(numBlocksX, numBlocksY);
+      LAUNCH_TOPK_EXPW(data, finalizeKernel, numBlocks, numThreads, 0, stream);
+    } else {
+      FLASHINFER_CHECK(
+          data.topK <= MaxTopK,
+          "Finalize kernel with vectorized loading is not supported for this TopK value: %d",
+          data.topK);
+      LAUNCH_TOPK_EXPW(data, finalizeKernelVecLoad, /*numBlocks=*/data.numTokens,
+                       /*numThreads=*/FINALIZE_THREADS_PER_BLOCK, 0, stream);
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace finalize
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace moe::dev

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
@@ -87,10 +87,18 @@ __global__ void activationKernel(KernelParams params) {
         }
 
         // Use int64_t to avoid overflow when permutedIdx * innerDim > INT32_MAX
-        int64_t const baseIdx = (int64_t)permutedIdx * params.innerDim + hiddenIdx;
+        int64_t const permBase = (int64_t)permutedIdx * params.innerDim;
 
-        float x1 = (float)params.inPtr[baseIdx];
-        float x2 = (float)params.inPtr[baseIdx + params.innerDim / 2];
+        // Contiguous input: gate = col hiddenIdx, up = col innerDim/2 + hiddenIdx.
+        // Interleaved input (fused de-interleave): gate = col 2*hiddenIdx, up = col 2*hiddenIdx+1.
+        float x1, x2;
+        if (params.interleavedGateUpInput) {
+          x1 = (float)params.inPtr[permBase + 2 * hiddenIdx];
+          x2 = (float)params.inPtr[permBase + 2 * hiddenIdx + 1];
+        } else {
+          x1 = (float)params.inPtr[permBase + hiddenIdx];
+          x2 = (float)params.inPtr[permBase + hiddenIdx + params.innerDim / 2];
+        }
         if (params.gateUpLoraDeltaPtr != nullptr) {
           int64_t const loraBaseIdx = (int64_t)expandedIdx * params.innerDim + hiddenIdx;
           x1 += static_cast<float>(params.gateUpLoraDeltaPtr[loraBaseIdx + params.innerDim / 2]);

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -11,12 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cuda_bf16.h>
 #include <cuda_runtime.h>
 #include <flashinfer/exception.h>
 #include <nvrtc.h>
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
@@ -2411,6 +2413,523 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
   return selected_launcher->run(config, enable_pdl);
 }
 
+// ===========================================================================
+// NVFP4 MoE LoRA (decomposed / unfused-activation) — FP4 sibling of the FP8
+// trtllm-lora op. The standard NVFP4 path fuses SwiGLU into GEMM1, which leaves
+// no seam to inject the gate_up LoRA delta pre-activation. We therefore run the
+// MoE as a hand-wired pipeline that mirrors what MoE::Runner::run does for the
+// DeepSeek-FP8 + per-token-NvFP4 path, but with the gate_up projection executed
+// as a raw (no-activation) grouped GEMM via Gemm2::Runner so the standalone,
+// LoRA-aware activation kernel can run between the two GEMMs:
+//
+//   gather (permute bf16) -> NvFP4 quant -> gate_up GEMM (K=hidden, N=2*inter,
+//   raw bf16 out) -> activation (adds gate_up_lora_delta pre-SwiGLU, writes
+//   activation_lora_input) -> NvFP4 quant -> down GEMM (K=inter, N=hidden) ->
+//   finalize.
+//
+// The hidden states are supplied as bf16 (path 3: the dispatch feeds bf16 and this op permutes
+// then NvFP4-quantizes internally, with globalScaleInv = 1/448/6 + per-token scaling, matching
+// SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION). No fp4-input dequant round-trip.
+// ===========================================================================
+
+// De-interleave the gated gate_up GEMM output for the decomposed NvFP4 MoE-LoRA path.
+//
+// The deployed w13 weight is prepared in the trtllm GEMM1 "gated" layout, which applies
+// reorder_rows_for_gated_act_gemm: row 2k = half0[k], row 2k+1 = half1[k] (a pairwise interleave
+// of the two N/2 halves). A trtllm-gen GEMM emits output in LOGICAL row order, so feeding this
+// weight to our raw Gemm2::Runner produces gate_up columns interleaved as
+//   [h0_0, h1_0, h0_1, h1_1, ..., h0_{inter-1}, h1_{inter-1}].
+// The standalone activation kernel (and the contiguous gate_up_lora_delta from the
+// virtual-experts LoRA) expect the CONTIGUOUS [half0(0..inter-1); half1(0..inter-1)] layout (==
+// the non-gated w13 output). Reverse the pairwise interleave here -- cheap (O(rows*inter)),
+// avoids storing a second non-gated w13 copy (~tens of GB/rank) or a runtime weight re-shuffle.
+__global__ void sgl_fp4_lora_deinterleave_gate_up_kernel(cutlass::bfloat16_t const* __restrict__ in,
+                                                         cutlass::bfloat16_t* __restrict__ out,
+                                                         int64_t rows, int64_t inter) {
+  int64_t const two_inter = 2 * inter;
+  for (int64_t r = blockIdx.y; r < rows; r += gridDim.y) {
+    for (int64_t k = threadIdx.x + blockDim.x * blockIdx.x; k < inter; k += blockDim.x * gridDim.x) {
+      out[r * two_inter + k] = in[r * two_inter + 2 * k];              // half0[k] <- col 2k
+      out[r * two_inter + inter + k] = in[r * two_inter + 2 * k + 1];  // half1[k] <- col 2k+1
+    }
+  }
+}
+
+// Decomposed NvFP4 MoE-LoRA launcher. Reuses FusedMoeLauncher's routing-phase
+// workspace allocation/bookkeeping (via prepare_routing-style setup) but owns
+// the MoE compute pipeline.
+class FP4BlockScaleLoraLauncher {
+ public:
+  // Match the plain FP4 E2m1 path's tile ladder (FP4BlockScaleLauncher::getSupportedTileNums for
+  // non-bf16 act). Large prefills (high avg tokens/expert) need 128/256; capping at 64 makes
+  // selectDefaultTileN pick a tile too small for the Gemm2 cubin to have a valid config at that
+  // token count -> "Failed to initialize the TMA descriptor / illegal memory access".
+  static constexpr std::array<int32_t, 6> mBaseSupportedTileNums = {8, 16, 32, 64, 128, 256};
+
+  static std::vector<int32_t> getSupportedTileNums() {
+    return std::vector<int32_t>(mBaseSupportedTileNums.begin(), mBaseSupportedTileNums.end());
+  }
+
+  FP4BlockScaleLoraLauncher(TensorView const& expert_indices, TensorView const& expert_weights,
+                            Optional<TensorView> const& routing_bias,
+                            TensorView const& hidden_states,
+                            Optional<TensorView> const& hidden_states_scale,
+                            TensorView const& gemm1_weights, TensorView const& gemm1_weights_scale,
+                            TensorView const& gemm2_weights, TensorView const& gemm2_weights_scale,
+                            Optional<TensorView> const& output1_scales_scalar,
+                            Optional<TensorView> const& output1_scales_gate_scalar,
+                            Optional<TensorView> const& output2_scales_scalar,
+                            TensorView const& gate_up_lora_delta,
+                            TensorView const& activation_lora_input, TensorView const& output)
+      : expert_indices_(expert_indices),
+        expert_weights_(expert_weights),
+        routing_bias_(routing_bias),
+        hidden_states_(hidden_states),
+        hidden_states_scale_(hidden_states_scale),
+        gemm1_weights_(gemm1_weights),
+        gemm1_weights_scale_(gemm1_weights_scale),
+        gemm2_weights_(gemm2_weights),
+        gemm2_weights_scale_(gemm2_weights_scale),
+        output1_scales_scalar_(output1_scales_scalar),
+        output1_scales_gate_scalar_(output1_scales_gate_scalar),
+        output2_scales_scalar_(output2_scales_scalar),
+        gate_up_lora_delta_(gate_up_lora_delta),
+        activation_lora_input_(activation_lora_input),
+        output_(output) {}
+
+  // Returns {output} when do_finalize, else {gemm2_output, expert_weights,
+  // expanded_idx_to_permuted_idx} for a downstream finalize kernel.
+  Array<Tensor> run(int64_t num_experts, int64_t top_k, int64_t intermediate_size,
+                    int64_t local_expert_offset, int64_t local_num_experts,
+                    double routed_scaling_factor, int64_t routing_method_type,
+                    int64_t tile_tokens_dim, bool norm_topk_prob, bool do_finalize,
+                    bool enable_pdl) {
+    namespace moe_ns = tensorrt_llm::kernels::trtllmgen_moe;
+    auto device = hidden_states_.device();
+    int dev_id = device.device_id;
+    cudaStream_t stream = get_stream(device);
+
+    int64_t const num_tokens = hidden_states_.size(0);
+    int64_t const hidden_size =
+        hidden_states_.dtype() == dl_uint8 ? hidden_states_.size(1) * 2 : hidden_states_.size(1);
+    int64_t const inter = intermediate_size;
+    int64_t const gate_up_n = 2 * inter;  // gated SwiGLU
+
+    // ---- 1) routing (precomputed packed topk) ----
+    Tensor num_tokens_per_expert = alloc_tensor({num_experts}, dl_int32, device);
+    int32_t max_num_padded_tokens =
+        moe_ns::Routing::getMaxPermutedPaddedCount(num_tokens, top_k, num_experts, tile_tokens_dim);
+    Tensor total_num_padded_tokens = alloc_tensor({1}, dl_int32, device);
+    Tensor expanded_idx_to_permuted_idx =
+        alloc_tensor({num_tokens * top_k}, dl_int32, device);
+    Tensor permuted_idx_to_token_idx = alloc_tensor({max_num_padded_tokens}, dl_int32, device);
+    int64_t const hist_size = std::max<int64_t>(num_experts * 2, 256 * 2);
+    Tensor expert_count_histogram = alloc_tensor({hist_size}, dl_int32, device);
+    int32_t max_num_ctas =
+        moe_ns::Routing::getMaxNumCtasInBatchDim(num_tokens, top_k, num_experts, tile_tokens_dim);
+    Tensor cta_idx_xy_to_batch_idx = alloc_tensor({max_num_ctas}, dl_int32, device);
+    Tensor cta_idx_xy_to_mn_limit = alloc_tensor({max_num_ctas}, dl_int32, device);
+    Tensor num_non_exiting_ctas = alloc_tensor({1}, dl_int32, device);
+
+    auto routing_bias_dtype =
+        routing_bias_.has_value() ? routing_bias_.value().dtype() : dl_bfloat16;
+    btg::Dtype mRoutingBiasDtype =
+        routing_bias_dtype == dl_bfloat16 ? btg::Dtype::Bfloat16 : btg::Dtype::Fp32;
+
+    // The wrapper passes an empty placeholder for expert_weights; the routing runner
+    // writes the unpacked per-(token,k) weights here. Allocate it ourselves (mirrors
+    // Fp8BlockScaleLauncher::prepare_routing when has_precomputed_weights is false).
+    // If the caller did pass a real expert_weights tensor, copy it into the allocation
+    // afterwards is unnecessary; we just compute into our own buffer for a clean Tensor
+    // return type. The bf16 routing-weight values are identical either way.
+    auto ew_dtype = mRoutingBiasDtype == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+    Tensor expert_weights_alloc = alloc_tensor({num_tokens, top_k}, ew_dtype, device);
+    void* expert_weights_ptr = expert_weights_alloc.data_ptr();
+
+    moe_ns::Routing::Runner routing_runner(tile_tokens_dim);
+    routing_runner.run(
+        /*routing_logits=*/nullptr,
+        routing_bias_.has_value() ? routing_bias_.value().data_ptr() : nullptr, num_tokens,
+        num_experts, top_k, /*n_group=*/0, /*topk_group=*/0, local_expert_offset, local_num_experts,
+        routed_scaling_factor, static_cast<int*>(const_cast<void*>(expert_indices_.data_ptr())),
+        static_cast<int*>(expert_count_histogram.data_ptr()),
+        static_cast<int*>(total_num_padded_tokens.data_ptr()),
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
+        /*permuted_idx_to_expanded_idx=*/nullptr,
+        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), expert_weights_ptr,
+        static_cast<int*>(num_tokens_per_expert.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
+        static_cast<int*>(num_non_exiting_ctas.data_ptr()), btg::Dtype::Bfloat16, mRoutingBiasDtype,
+        /*useRoutingScalesOnInput=*/false, /*useDeepSeekFp8=*/false,
+        static_cast<RoutingMethodType>(routing_method_type), stream, btg::Dtype::Bfloat16,
+        norm_topk_prob, /*routing_replay_out=*/nullptr);
+
+    // ---- 2) hidden as bf16 (path 3: dispatch feeds bf16; the op quantizes internally) ----
+    TVM_FFI_ICHECK(hidden_states_.dtype() == dl_bfloat16)
+        << "fp4 LoRA (path 3) requires bf16 hidden_states; the dispatch feeds bf16 and the op "
+           "permutes+NvFP4-quantizes internally (no python pre-quant / dequant round-trip).";
+    void* hidden_bf16_ptr = hidden_states_.data_ptr();
+
+    int64_t const tile = tile_tokens_dim;
+    // gate_up GEMM act operand (permuted fp4 hidden + scales). Declared in run() scope because the
+    // gate_up GEMM (step 5) consumes them; the LARGE [max_padded, hidden] bf16 gather buffer
+    // (permuted_hidden_bf16, ~4 GB at a 32K-token prefill) lives only inside the block below, so it
+    // frees right after the quant -- before the equally-large [max_padded, hidden] gemm2_output is
+    // allocated (step 8), letting the caching allocator reuse its block (halves the op's peak).
+    auto gu_sfLayout = tile >= 128 ? tensorrt_llm::QuantizationSFLayout::SWIZZLED_128x4
+                                   : tensorrt_llm::QuantizationSFLayout::SWIZZLED_8x4;
+    int64_t const hidden_sf_size =
+        tensorrt_llm::computeSwizzledLayoutSFSize(max_num_padded_tokens, hidden_size / 16);
+    Tensor hidden_fp4 = alloc_tensor({max_num_padded_tokens, hidden_size / 2}, dl_uint8, device);
+    Tensor hidden_fp4_sf = alloc_tensor({hidden_sf_size}, dl_uint8, device);
+    Tensor hidden_per_token_sf = alloc_tensor({max_num_padded_tokens}, dl_float32, device);
+    {
+      // ---- 3) permute (gather) bf16 hidden -> [max_padded, hidden] (transient, freed at block end)
+      Tensor permuted_hidden_bf16 =
+          alloc_tensor({max_num_padded_tokens, hidden_size}, dl_bfloat16, device);
+      // Zero-init so padded (unused) rows are well-defined for the subsequent quant.
+      cudaMemsetAsync(permuted_hidden_bf16.data_ptr(), 0,
+                      (size_t)max_num_padded_tokens * hidden_size * sizeof(cutlass::bfloat16_t),
+                      stream);
+      {
+        moe::dev::permute::Data permData;
+        permData.mDtypeElt = btg::Dtype::Bfloat16;
+        permData.mUsePdl = false;
+        permData.mUseDeepSeekFp8 = false;
+        permData.inPtr = hidden_bf16_ptr;
+        permData.outPtr = permuted_hidden_bf16.data_ptr();
+        permData.inDqSfsPtr = nullptr;
+        permData.outDqSfsPtr = nullptr;
+        permData.expandedIdxToPermutedIdx =
+            static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr());
+        permData.hiddenDim = hidden_size;
+        permData.numTokens = num_tokens;
+        permData.topK = top_k;
+        permData.totalNumPaddedTokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
+        moe::dev::permute::run(permData, stream);
+      }
+
+      // ---- 4) NvFP4 quant of permuted bf16 hidden -> permuted fp4 + swizzled sf + per-token sf ----
+      float const gu_globalScaleInv = 1.f / 448.f / 6.f;
+      // input is already permuted, so map=nullptr and m=max_padded (process all rows; padding=0).
+      tensorrt_llm::kernels::invokeNvfp4QuantAndPerTokenScale<__nv_bfloat16>(
+          max_num_padded_tokens, hidden_size,
+          reinterpret_cast<__nv_bfloat16 const*>(permuted_hidden_bf16.data_ptr()), gu_globalScaleInv,
+          /*expanded_idx_to_permuted_idx=*/nullptr,
+          reinterpret_cast<uint8_t*>(hidden_fp4.data_ptr()),
+          reinterpret_cast<uint8_t*>(hidden_fp4_sf.data_ptr()),
+          reinterpret_cast<float*>(hidden_per_token_sf.data_ptr()), gu_sfLayout, stream);
+    }  // permuted_hidden_bf16 frees here -> its ~4 GB block is reused by gemm2_output (step 8).
+
+    // ---- 5) gate_up GEMM: raw Gemm2::Runner(E2m1,E2m1,bf16, K=hidden, N=2*inter). ----
+    // Per-token (hidden) scale on the act operand + output1_scales_gate_scalar (g1_alphas) on
+    // the result reconstructs the TRUE gate_up projection (no NvFP4 unfused-act GEMM1 cubin
+    // exists, so we cannot reuse the plain PermuteGemm1 path here). In per-token mode g1_alphas
+    // applied to BOTH halves == the plain fused path's gate(g1_alphas)/up(g1_scale_c=g1_alphas).
+    // Output columns are INTERLEAVED (the w13 is in the gated layout); de-interleaved in 5b.
+    Tensor gate_up_bf16 = alloc_tensor({max_num_padded_tokens, gate_up_n}, dl_bfloat16, device);
+    {
+      moe_ns::Gemm2::Runner gemm_gate_up(btg::Dtype::E2m1, btg::Dtype::E2m1, btg::Dtype::Bfloat16,
+                                         /*useDeepSeekFp8=*/false, (int)tile,
+                                         /*useShuffledMatrix=*/true,
+                                         batchedGemm::gemm::MatrixLayout::MajorK,
+                                         /*usePerTokenScaling=*/true,
+                                         /*usePerChannelScaling=*/false);
+      int64_t cfg = gemm_gate_up.getDefaultValidConfigIndex(top_k, hidden_size, gate_up_n,
+                                                            local_num_experts, num_tokens);
+      size_t ws = gemm_gate_up.getWorkspaceSizeInBytes(top_k, hidden_size, gate_up_n,
+                                                       local_num_experts, num_tokens, cfg);
+      Tensor gemm_ws = alloc_tensor({(int64_t)ws}, dl_int8, device);
+      // Gemm2::Runner semantics: hiddenSize is the OUTPUT N dim, intermediateSize is the K dim.
+      gemm_gate_up.run(
+          hidden_fp4.data_ptr(), hidden_fp4_sf.data_ptr(), gemm1_weights_.data_ptr(),
+          gemm1_weights_scale_.data_ptr(),
+          /*perTokenScales=*/hidden_per_token_sf.data_ptr(), /*perChannelScales=*/nullptr,
+          output1_scales_gate_scalar_.has_value()
+              ? static_cast<float*>(output1_scales_gate_scalar_.value().data_ptr())
+              : nullptr,
+          /*ptrBias=*/nullptr, gate_up_bf16.data_ptr(), /*outputScale=*/nullptr, top_k,
+          /*hiddenSize(N)=*/gate_up_n, /*intermediateSize(K)=*/hidden_size, local_num_experts,
+          num_tokens, static_cast<int*>(num_non_exiting_ctas.data_ptr()),
+          static_cast<int*>(total_num_padded_tokens.data_ptr()),
+          static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
+          static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()), gemm_ws.data_ptr(), dev_id, stream,
+          (int)cfg, enable_pdl);
+    }
+
+    // ---- 5b) de-interleave the gated gate_up columns -> contiguous [half0; half1] ----
+    // The activation kernel and gate_up_lora_delta both assume the contiguous layout; the gated
+    // w13 gives interleaved columns (see sgl_fp4_lora_deinterleave_gate_up_kernel). Process all
+    // max_padded rows (padding rows are ignored downstream via the permuted-idx map).
+    Tensor gate_up_contig = alloc_tensor({max_num_padded_tokens, gate_up_n}, dl_bfloat16, device);
+    {
+      int const nthreads = 256;
+      dim3 grid((int)((inter + nthreads - 1) / nthreads),
+                (unsigned)std::min<int64_t>(8192, max_num_padded_tokens));
+      sgl_fp4_lora_deinterleave_gate_up_kernel<<<grid, nthreads, 0, stream>>>(
+          static_cast<cutlass::bfloat16_t const*>(gate_up_bf16.data_ptr()),
+          static_cast<cutlass::bfloat16_t*>(gate_up_contig.data_ptr()), max_num_padded_tokens,
+          inter);
+    }
+
+    // ---- 6) activation (LoRA-aware): SwiGLU on raw gate_up + gate_up_lora_delta pre-act ----
+    Tensor activated_bf16 = alloc_tensor({max_num_padded_tokens, inter}, dl_bfloat16, device);
+    {
+      moe::dev::activation::Data actData;
+      actData.mDtypeElt = btg::Dtype::Bfloat16;
+      actData.mUsePdl = false;
+      actData.mUseDeepSeekFp8 = false;
+      actData.inPtr = gate_up_contig.data_ptr();
+      actData.outPtr = activated_bf16.data_ptr();
+      actData.inDqSfsPtr = nullptr;
+      actData.outDqSfsPtr = nullptr;
+      actData.gateUpLoraDeltaPtr =
+          static_cast<cutlass::bfloat16_t const*>(gate_up_lora_delta_.data_ptr());
+      actData.activationLoraInputOutPtr =
+          static_cast<cutlass::bfloat16_t*>(activation_lora_input_.data_ptr());
+      actData.innerDim = gate_up_n;
+      actData.numTokens = num_tokens;
+      actData.topK = top_k;
+      actData.expandedIdxToPermutedIdx =
+          static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr());
+      actData.totalNumPaddedTokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
+      moe::dev::activation::run(actData, stream);
+    }
+
+    // ---- 7) NvFP4 quant of activated bf16 (already permuted) -> permuted fp4 + sf + per-token ----
+    // Mirrors the plain fp4 path's down-GEMM input quant EXACTLY (runner.cu invokeNvfp4QuantAnd
+    // PerTokenScale): the FC1 (post-SwiGLU) activation is bf16, quantized with the generic
+    // 1/448/6 global + a per-token scale, then the down GEMM applies output2_scales_scalar
+    // (g2_alphas). We pass m = num_tokens*top_k + the expanded->permuted map so only the valid
+    // (non-padding) permuted rows are quantized — the activation kernel leaves padding rows of
+    // `activated_bf16` uninitialized, and the quant kernel uses the remapped idx for read+write.
+    auto sfLayout = tile >= 128 ? tensorrt_llm::QuantizationSFLayout::SWIZZLED_128x4
+                                : tensorrt_llm::QuantizationSFLayout::SWIZZLED_8x4;
+    float const globalScaleInv = 1.f / 448.f / 6.f;
+    int64_t const act_sf_size =
+        tensorrt_llm::computeSwizzledLayoutSFSize(max_num_padded_tokens, inter / 16);
+    Tensor act_fp4 = alloc_tensor({max_num_padded_tokens, inter / 2}, dl_uint8, device);
+    Tensor act_fp4_sf = alloc_tensor({act_sf_size}, dl_uint8, device);
+    Tensor act_per_token_sf = alloc_tensor({max_num_padded_tokens}, dl_float32, device);
+    tensorrt_llm::kernels::invokeNvfp4QuantAndPerTokenScale<__nv_bfloat16>(
+        num_tokens * top_k, inter,
+        reinterpret_cast<__nv_bfloat16 const*>(activated_bf16.data_ptr()), globalScaleInv,
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
+        reinterpret_cast<uint8_t*>(act_fp4.data_ptr()),
+        reinterpret_cast<uint8_t*>(act_fp4_sf.data_ptr()),
+        reinterpret_cast<float*>(act_per_token_sf.data_ptr()), sfLayout, stream);
+
+    // ---- 8) down GEMM: Gemm2::Runner(E2m1,E2m1,bf16, K=inter, N=hidden) ----
+    // We run in per-token-activation mode (SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION), where
+    // w13/w2 input_scale == 1 so g1_scale_c == g1_alphas and g2_alphas == w2_weight_scale_2.
+    // The gate_up GEMM (step 5) applied g1_alphas to BOTH gate and up halves, which — with
+    // input_scale==1 — equals the plain fused path's separate gate(g1_alphas)/up(g1_scale_c)
+    // scaling. The standalone SwiGLU therefore produces the TRUE silu(gate)*up (same space as
+    // the proven DeepSeek-FP8 unfused path), so the down GEMM applies output2_scales_scalar
+    // (g2_alphas) DIRECTLY — exactly like the plain path's GEMM2 (runner.cu mGemm2.run).
+    Tensor gemm2_output = alloc_tensor({max_num_padded_tokens, hidden_size}, dl_bfloat16, device);
+    {
+      moe_ns::Gemm2::Runner gemm_down(btg::Dtype::E2m1, btg::Dtype::E2m1, btg::Dtype::Bfloat16,
+                                      /*useDeepSeekFp8=*/false, (int)tile,
+                                      /*useShuffledMatrix=*/true,
+                                      batchedGemm::gemm::MatrixLayout::MajorK,
+                                      /*usePerTokenScaling=*/true, /*usePerChannelScaling=*/false);
+      int64_t cfg = gemm_down.getDefaultValidConfigIndex(top_k, hidden_size, inter,
+                                                        local_num_experts, num_tokens);
+      size_t ws = gemm_down.getWorkspaceSizeInBytes(top_k, hidden_size, inter, local_num_experts,
+                                                    num_tokens, cfg);
+      Tensor gemm_ws = alloc_tensor({(int64_t)ws}, dl_int8, device);
+      float* down_scale_ptr = output2_scales_scalar_.has_value()
+                                  ? static_cast<float*>(output2_scales_scalar_.value().data_ptr())
+                                  : nullptr;
+      gemm_down.run(
+          act_fp4.data_ptr(), act_fp4_sf.data_ptr(), gemm2_weights_.data_ptr(),
+          gemm2_weights_scale_.data_ptr(), /*perTokenScales=*/act_per_token_sf.data_ptr(),
+          /*perChannelScales=*/nullptr, down_scale_ptr,
+          /*ptrBias=*/nullptr, gemm2_output.data_ptr(), /*outputScale=*/nullptr, top_k,
+          /*hiddenSize(N)=*/hidden_size, /*intermediateSize(K)=*/inter, local_num_experts,
+          num_tokens, static_cast<int*>(num_non_exiting_ctas.data_ptr()),
+          static_cast<int*>(total_num_padded_tokens.data_ptr()),
+          static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
+          static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()), gemm_ws.data_ptr(), dev_id, stream,
+          (int)cfg, enable_pdl);
+    }
+
+    if (!do_finalize) {
+      return {gemm2_output, expert_weights_alloc, expanded_idx_to_permuted_idx};
+    }
+
+    // ---- 9) finalize (combine by expert weight) -> output [num_tokens, hidden] ----
+    {
+      moe::dev::finalize::Data finData;
+      finData.mDtypeElt = btg::Dtype::Bfloat16;
+      finData.mDtypeExpW = mRoutingBiasDtype;
+      finData.mUsePdl = false;
+      finData.mUseDeepSeekFp8 = false;
+      finData.inPtr = gemm2_output.data_ptr();
+      finData.outPtr = output_.data_ptr();
+      finData.inDqSfsPtr = nullptr;
+      finData.outDqSfsPtr = nullptr;
+      finData.expertWeightsPtr = expert_weights_ptr;
+      finData.expandedIdxToPermutedIdx =
+          static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr());
+      finData.numTokens = num_tokens;
+      finData.numExperts = num_experts;
+      finData.topK = top_k;
+      finData.hiddenDim = hidden_size;
+      finData.hiddenDimPadded = hidden_size;
+      finData.totalNumPaddedTokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
+      moe::dev::finalize::run(finData, stream);
+    }
+    sync_check_cuda_error(stream);
+    // do_finalize=True: result written into output_ (the wrapper returns output_
+    // directly and ignores this value).
+    return Array<Tensor>();
+  }
+
+ private:
+  TensorView expert_indices_;
+  TensorView expert_weights_;
+  Optional<TensorView> routing_bias_;
+  TensorView hidden_states_;
+  Optional<TensorView> hidden_states_scale_;
+  TensorView gemm1_weights_;
+  TensorView gemm1_weights_scale_;
+  TensorView gemm2_weights_;
+  TensorView gemm2_weights_scale_;
+  Optional<TensorView> output1_scales_scalar_;
+  Optional<TensorView> output1_scales_gate_scalar_;
+  Optional<TensorView> output2_scales_scalar_;
+  TensorView gate_up_lora_delta_;
+  TensorView activation_lora_input_;
+  TensorView output_;
+};
+
+Array<Tensor> sgl_trtllm_fp4_block_scale_moe_lora(
+    Optional<TensorView> routing_logits, TensorView expert_indices, TensorView expert_weights,
+    Optional<TensorView> routing_bias, TensorView hidden_states,
+    Optional<TensorView> hidden_states_scale, TensorView gemm1_weights,
+    TensorView gemm1_weights_scale, Optional<TensorView> gemm1_bias,
+    Optional<TensorView> gemm1_alpha, Optional<TensorView> gemm1_beta,
+    Optional<TensorView> gemm1_clamp_limit, TensorView gemm2_weights,
+    TensorView gemm2_weights_scale, Optional<TensorView> gemm2_bias,
+    Optional<TensorView> output1_scales_scalar, Optional<TensorView> output1_scales_gate_scalar,
+    Optional<TensorView> output2_scales_scalar, Optional<TensorView> per_token_scales,
+    int64_t num_experts, int64_t top_k, Optional<int64_t> n_group, Optional<int64_t> topk_group,
+    int64_t intermediate_size, int64_t local_expert_offset, int64_t local_num_experts,
+    Optional<double> routed_scaling_factor, int64_t routing_method_type, bool do_finalize,
+    bool enable_pdl, int64_t act_type, TensorView output, Array<int64_t> config_index,
+    bool norm_topk_prob, Optional<TensorView> routing_replay_out, TensorView gate_up_lora_delta,
+    TensorView activation_lora_input) {
+  auto activation_type = validateAndCastActivationType(act_type);
+  TVM_FFI_ICHECK(isGatedActivation(activation_type))
+      << "sgl_trtllm_fp4_block_scale_moe_lora currently supports gated (SwiGLU) activation only.";
+  (void)routing_logits;
+  (void)gemm1_bias;
+  (void)gemm1_alpha;
+  (void)gemm1_beta;
+  (void)gemm1_clamp_limit;
+  (void)gemm2_bias;
+  (void)per_token_scales;
+  (void)n_group;
+  (void)topk_group;
+  (void)routing_replay_out;
+
+  // Precomputed routing is required (packed topk_ids).
+  TVM_FFI_ICHECK(expert_indices.ndim() == 2 && expert_indices.size(0) == hidden_states.size(0))
+      << "fp4 LoRA requires precomputed packed expert_indices [num_tokens, top_k].";
+  TVM_FFI_ICHECK_EQ(expert_indices.dtype(), dl_int32) << "expert_indices must be int32.";
+  TVM_FFI_ICHECK(gemm1_weights.dtype() == dl_uint8 && gemm2_weights.dtype() == dl_uint8)
+      << "fp4 LoRA: weights must be packed fp4 uint8.";
+  TVM_FFI_ICHECK_EQ(gemm1_weights_scale.dtype(), dl_float8_e4m3fn)
+      << "fp4 LoRA: gemm1_weights_scale must be fp8 e4m3.";
+  TVM_FFI_ICHECK_EQ(gemm2_weights_scale.dtype(), dl_float8_e4m3fn)
+      << "fp4 LoRA: gemm2_weights_scale must be fp8 e4m3.";
+  TVM_FFI_ICHECK_EQ(gate_up_lora_delta.dtype(), dl_bfloat16)
+      << "gate_up_lora_delta must be bf16.";
+  TVM_FFI_ICHECK_EQ(gate_up_lora_delta.ndim(), 3)
+      << "gate_up_lora_delta must be [num_tokens, top_k, 2*intermediate_size].";
+  TVM_FFI_ICHECK_EQ(gate_up_lora_delta.size(2), 2 * intermediate_size);
+  TVM_FFI_ICHECK_EQ(activation_lora_input.dtype(), dl_bfloat16)
+      << "activation_lora_input must be bf16.";
+  TVM_FFI_ICHECK_EQ(activation_lora_input.ndim(), 3)
+      << "activation_lora_input must be [num_tokens, top_k, intermediate_size].";
+  TVM_FFI_ICHECK_EQ(activation_lora_input.size(2), intermediate_size);
+  TVM_FFI_ICHECK(gate_up_lora_delta.IsContiguous() && activation_lora_input.IsContiguous())
+      << "lora bridge buffers must be contiguous.";
+
+  int64_t const num_tokens = hidden_states.size(0);
+  int64_t const tile_tokens_dim =
+      selectDefaultTileN(FP4BlockScaleLoraLauncher::getSupportedTileNums(), num_tokens, top_k,
+                         local_num_experts);
+
+  FP4BlockScaleLoraLauncher launcher(
+      expert_indices, expert_weights, routing_bias, hidden_states, hidden_states_scale,
+      gemm1_weights, gemm1_weights_scale, gemm2_weights, gemm2_weights_scale, output1_scales_scalar,
+      output1_scales_gate_scalar, output2_scales_scalar, gate_up_lora_delta, activation_lora_input,
+      output);
+  return launcher.run(num_experts, top_k, intermediate_size, local_expert_offset, local_num_experts,
+                      routed_scaling_factor.value_or(1.0), routing_method_type, tile_tokens_dim,
+                      norm_topk_prob, do_finalize, enable_pdl);
+}
+
+// bf16 combine + down-lora-delta merge — NvFP4 analog of the FP8 finalize op.
+// Logic is dtype-agnostic bf16, so this mirrors
+// sgl_trtllm_fp8_block_scale_moe_lora_finalize verbatim.
+void sgl_trtllm_fp4_block_scale_moe_lora_finalize(
+    TensorView gemm2_output, TensorView expert_weights, TensorView expanded_idx_to_permuted_idx,
+    TensorView down_lora_delta, TensorView output, Optional<double> routed_scaling_factor) {
+  TVM_FFI_ICHECK_EQ(gemm2_output.dtype(), dl_bfloat16) << "gemm2_output must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(expert_weights.dtype(), dl_bfloat16) << "expert_weights must be bfloat16.";
+  TVM_FFI_ICHECK((expanded_idx_to_permuted_idx.dtype() == DLDataType{kDLInt, 32, 1}))
+      << "expanded_idx_to_permuted_idx must be int32.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.dtype(), dl_bfloat16) << "down_lora_delta must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(output.dtype(), dl_bfloat16) << "output must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(gemm2_output.ndim(), 2) << "gemm2_output must be 2D.";
+  TVM_FFI_ICHECK_EQ(expert_weights.ndim(), 2) << "expert_weights must be 2D.";
+  TVM_FFI_ICHECK_EQ(expanded_idx_to_permuted_idx.ndim(), 1)
+      << "expanded_idx_to_permuted_idx must be 1D.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.ndim(), 3) << "down_lora_delta must be 3D.";
+  TVM_FFI_ICHECK_EQ(output.ndim(), 2) << "output must be 2D.";
+  TVM_FFI_ICHECK(gemm2_output.IsContiguous()) << "gemm2_output must be contiguous.";
+  TVM_FFI_ICHECK(expert_weights.IsContiguous()) << "expert_weights must be contiguous.";
+  TVM_FFI_ICHECK(expanded_idx_to_permuted_idx.IsContiguous())
+      << "expanded_idx_to_permuted_idx must be contiguous.";
+  TVM_FFI_ICHECK(down_lora_delta.IsContiguous()) << "down_lora_delta must be contiguous.";
+  TVM_FFI_ICHECK(output.IsContiguous()) << "output must be contiguous.";
+
+  int64_t const num_tokens = output.size(0);
+  int64_t const hidden_size = output.size(1);
+  int64_t const top_k = down_lora_delta.size(1);
+  TVM_FFI_ICHECK_EQ(expert_weights.size(0), num_tokens)
+      << "expert_weights dim0 must equal num_tokens.";
+  TVM_FFI_ICHECK_EQ(expert_weights.size(1), top_k) << "expert_weights dim1 must equal top_k.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.size(0), num_tokens)
+      << "down_lora_delta dim0 must equal num_tokens.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.size(2), hidden_size)
+      << "down_lora_delta dim2 must equal hidden_size.";
+  TVM_FFI_ICHECK_EQ(expanded_idx_to_permuted_idx.size(0), num_tokens * top_k)
+      << "expanded_idx_to_permuted_idx size must equal num_tokens * top_k.";
+  TVM_FFI_ICHECK(gemm2_output.size(1) >= hidden_size)
+      << "gemm2_output hidden dimension is smaller than output hidden dimension.";
+
+  int const num_threads = 128;
+  int const num_blocks_x = (hidden_size + num_threads - 1) / num_threads;
+  int const num_blocks_y = std::min<int64_t>(8192, num_tokens);
+  dim3 grid(num_blocks_x, num_blocks_y);
+  cudaStream_t stream = get_stream(output.device());
+  sgl_trtllm_fp8_block_scale_moe_lora_finalize_kernel<<<grid, num_threads, 0, stream>>>(
+      static_cast<cutlass::bfloat16_t const*>(gemm2_output.data_ptr()),
+      static_cast<cutlass::bfloat16_t const*>(expert_weights.data_ptr()),
+      static_cast<int32_t const*>(expanded_idx_to_permuted_idx.data_ptr()),
+      static_cast<cutlass::bfloat16_t const*>(down_lora_delta.data_ptr()),
+      static_cast<cutlass::bfloat16_t*>(output.data_ptr()), num_tokens, top_k, hidden_size,
+      gemm2_output.size(1), static_cast<float>(routed_scaling_factor.value_or(1.0)));
+  auto err = cudaGetLastError();
+  FLASHINFER_CHECK(err == cudaSuccess, cudaGetErrorString(err));
+}
+
 Array<Tensor> trtllm_mxint4_block_scale_moe(
     TensorView routing_logits, Optional<TensorView> routing_bias, TensorView hidden_states,
     TensorView gemm1_weights, TensorView gemm1_weights_scale, Optional<TensorView> gemm1_alpha,
@@ -2561,6 +3080,78 @@ Array<Array<int64_t>> trtllm_get_valid_moe_configs(
   return Array<Array<int64_t>>();
 }
 
+// ---------------------------------------------------------------------------
+// FP4 LoRA cubin probe (de-risk gate). The FP8-like LoRA design needs the FP4 GEMM1
+// to run with fusedAct=false so the standalone activation kernel can inject the
+// gate_up LoRA delta pre-SwiGLU (DeepSeek-FP8 already unfuses; NvFP4 normally fuses).
+// This builds an E2m1/E2m1 NvFP4 MoE::Runner both fused and unfused and reports
+// getValidConfigIndices().size() for each. A non-negative unfused value means the
+// trtllm-gen cubin set includes a non-fused gated GEMM1 for NvFP4 (path is viable);
+// -1 means construction threw (no such cubin / unsupported combo).
+Array<int64_t> sgl_trtllm_fp4_probe_unfused(int64_t top_k, int64_t hidden_size,
+                                            int64_t intermediate_size, int64_t num_local_experts,
+                                            int64_t num_tokens, int64_t tile_n) {
+  using RunnerType = tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner;
+  using ActivationType = tensorrt_llm::kernels::trtllmgen_moe::MoE::ActivationType;
+  // Probe variants:
+  //   [0] Swiglu fused   (normal NvFP4 path, fusedAct=true)              -> sanity, expect >0
+  //   [1] Swiglu unfused (fusedAct=false gated GEMM1)                    -> known dead (-1)
+  //   [2] Identity non-gated (plain route-act GEMM1, raw 2*inter output) -> candidate for unfuse
+  //   [3] Relu2   non-gated                                              -> alt candidate
+  auto probe = [&](ActivationType act, bool unfuse) -> int64_t {
+    try {
+      RunnerType r(btg::Dtype::E2m1, btg::Dtype::E2m1, /*useDeepSeekFp8=*/false,
+                   static_cast<int>(tile_n), act, /*useShuffledMatrix=*/true,
+                   batchedGemm::gemm::MatrixLayout::MajorK, /*usePerTokenScalingGemm1=*/true,
+                   /*usePerTokenScalingGemm2=*/true, /*usePerChannelScalingGemm1=*/false,
+                   /*usePerChannelScalingGemm2=*/false, /*unfuseActForLora=*/unfuse);
+      auto cfgs = r.getValidConfigIndices(
+          static_cast<int32_t>(top_k), static_cast<int32_t>(hidden_size),
+          static_cast<int32_t>(intermediate_size), static_cast<int32_t>(num_local_experts),
+          static_cast<int32_t>(num_tokens));
+      return static_cast<int64_t>(cfgs.size());
+    } catch (...) {
+      return -1;
+    }
+  };
+  return {probe(ActivationType::Swiglu, false), probe(ActivationType::Swiglu, true),
+          probe(ActivationType::Identity, false), probe(ActivationType::Relu2, false)};
+}
+
+// Evaluate Solution 1: use the non-gated routeAct=false GEMM2-style batched GEMM as the gate_up
+// (GEMM1) projection. Returns [num_passing_cubins, num_valid_for_dims] for an E2m1->bf16 Gemm2
+// runner at the requested (output=out_dim, K=k_dim) shape. A positive valid count means the
+// existing GEMM2 cubin can compute the raw (un-activated) gate_up projection on permuted tokens.
+Array<int64_t> sgl_trtllm_fp4_probe_gemm2(int64_t out_dim, int64_t k_dim,
+                                          int64_t num_local_experts, int64_t num_tokens,
+                                          int64_t top_k, int64_t tile_n) {
+  using G2 = tensorrt_llm::kernels::trtllmgen_moe::Gemm2::Runner;
+  auto probe = [&](bool per_tok) -> Array<int64_t> {
+    try {
+      G2 r(btg::Dtype::E2m1, btg::Dtype::E2m1, btg::Dtype::Bfloat16, /*useDeepSeekFp8=*/false,
+           static_cast<int>(tile_n), /*useShuffledMatrix=*/true,
+           batchedGemm::gemm::MatrixLayout::MajorK, /*usePerTokenScaling=*/per_tok,
+           /*usePerChannelScaling=*/false);
+      auto passing = r.getPassingConfigIndices();
+      int64_t valid = 0;
+      for (auto idx : passing) {
+        if (r.isValidConfigIndex(static_cast<int32_t>(idx), static_cast<int32_t>(top_k),
+                                 static_cast<int32_t>(out_dim), static_cast<int32_t>(k_dim),
+                                 static_cast<int32_t>(num_local_experts),
+                                 static_cast<int32_t>(num_tokens))) {
+          valid++;
+        }
+      }
+      return {static_cast<int64_t>(passing.size()), valid};
+    } catch (...) {
+      return {-1, -1};
+    }
+  };
+  auto pt = probe(true);
+  auto npt = probe(false);
+  return {pt[0], pt[1], npt[0], npt[1]};
+}
+
 namespace trtllm_cubin_loader {
 #include <flashinfer/cubin_loader.h>
 }
@@ -2573,6 +3164,12 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp8_block_scale_moe_lora,
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp8_block_scale_moe_lora_finalize,
                               sgl_trtllm_fp8_block_scale_moe_lora_finalize);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_fp4_block_scale_moe, trtllm_fp4_block_scale_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp4_block_scale_moe_lora,
+                              sgl_trtllm_fp4_block_scale_moe_lora);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp4_block_scale_moe_lora_finalize,
+                              sgl_trtllm_fp4_block_scale_moe_lora_finalize);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp4_probe_unfused, sgl_trtllm_fp4_probe_unfused);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp4_probe_gemm2, sgl_trtllm_fp4_probe_gemm2);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_mxint4_block_scale_moe, trtllm_mxint4_block_scale_moe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_get_valid_moe_configs, trtllm_get_valid_moe_configs);
 

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2015,7 +2015,8 @@ Array<Tensor> trtllm_fp8_block_scale_moe_impl(
     int64_t routing_method_type, bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
     bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type,
     int64_t act_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out,
-    Optional<TensorView> gate_up_lora_delta, Optional<TensorView> activation_lora_input) {
+    Optional<TensorView> gate_up_lora_delta, Optional<TensorView> activation_lora_input,
+    int64_t lora_ready_event = 0) {
   auto activation_type = validateAndCastActivationType(act_type);
   // DeepSeekFp8 currently uses a TRTLLM runner that hardwires Swiglu activation semantics.
   // Fail for any other activation to avoid silently running incorrect activation behavior.
@@ -2105,6 +2106,9 @@ Array<Tensor> trtllm_fp8_block_scale_moe_impl(
     args->do_finalize = do_finalize;
     args->output = output.data_ptr();
     args->output_scale = nullptr;
+    // GEMM1-LoRA overlap: cudaEvent_t handle (recorded on the LoRA side stream) the runner
+    // waits on right before activation; 0 = no wait (serial path).
+    args->lora_ready_event = reinterpret_cast<void*>(lora_ready_event);
 
     // Create and initialize launcher for this tile size
     auto launcher = std::make_unique<Fp8BlockScaleLauncher>(
@@ -2162,7 +2166,7 @@ Array<Tensor> sgl_trtllm_fp8_block_scale_moe_lora(
     int64_t routing_method_type, bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
     bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type,
     int64_t act_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out,
-    TensorView gate_up_lora_delta, TensorView activation_lora_input) {
+    TensorView gate_up_lora_delta, TensorView activation_lora_input, int64_t lora_ready_event) {
   if (quantization_type != Fp8QuantizationType::DeepSeekFp8) {
     TVM_FFI_LOG_AND_THROW(NotImplementedError)
         << "sgl_trtllm_fp8_block_scale_moe_lora currently supports DeepSeekFp8 only.";
@@ -2174,7 +2178,7 @@ Array<Tensor> sgl_trtllm_fp8_block_scale_moe_lora(
       local_num_experts, routed_scaling_factor, routing_method_type, use_shuffled_weight,
       weight_layout, do_finalize, enable_pdl, config_index, quantization_type, act_type,
       norm_topk_prob, routing_replay_out, Optional<TensorView>(gate_up_lora_delta),
-      Optional<TensorView>(activation_lora_input));
+      Optional<TensorView>(activation_lora_input), lora_ready_event);
 }
 
 __global__ void sgl_trtllm_fp8_block_scale_moe_lora_finalize_kernel(

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1,0 +1,2575 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cuda_runtime.h>
+#include <flashinfer/exception.h>
+#include <nvrtc.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include "flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/GemmGatedActOptions.h"
+#include "flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/trtllm/gen/DtypeDecl.h"
+#include "flashinfer/trtllm/fused_moe/DevKernel.h"
+#include "flashinfer/trtllm/fused_moe/RoutingKernel.h"
+#include "flashinfer/trtllm/fused_moe/runner.h"
+#include "nv_internal/tensorrt_llm/kernels/quantization.h"
+#include "nv_internal/tensorrt_llm/thop/utils.h"
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer {
+
+namespace btg = batchedGemm::trtllm::gen;
+using tensorrt_llm::kernels::trtllmgen_moe::MoE::ActivationType;
+using tensorrt_llm::kernels::trtllmgen_moe::Routing::RoutingMethodType;
+using tvm::ffi::Array;
+using tvm::ffi::Optional;
+
+// Validate routing_replay_out tensor properties.
+// NOTE: dim0 >= num_tokens is intentionally NOT checked — with CUDA graphs the buffer
+// is pre-allocated at maximum batch size and reused across steps with varying num_tokens.
+static void validate_routing_replay_out(TensorView const& replay, TensorView const& hidden_states,
+                                        int64_t top_k) {
+  TVM_FFI_ICHECK(replay.device().device_type == kDLCUDA)
+      << "routing_replay_out must be a CUDA tensor";
+  TVM_FFI_ICHECK(replay.device().device_id == hidden_states.device().device_id)
+      << "routing_replay_out must be on the same device as hidden_states";
+  TVM_FFI_ICHECK(replay.ndim() == 2) << "routing_replay_out must be 2D [num_tokens, top_k]";
+  TVM_FFI_ICHECK(replay.size(1) == top_k) << "routing_replay_out dim1 must equal top_k";
+  TVM_FFI_ICHECK((replay.dtype() == DLDataType{kDLInt, 16, 1}))
+      << "routing_replay_out must be int16 dtype";
+  TVM_FFI_ICHECK(replay.IsContiguous())
+      << "routing_replay_out must be contiguous (packed row-major)";
+}
+
+enum class Fp8QuantizationType {
+  NoneFp8,
+  DeepSeekFp8,
+  MxFp8,
+  PerTensorFp8,
+};
+
+inline std::string fp8QuantizationTypeToString(Fp8QuantizationType quantization_type) {
+  switch (quantization_type) {
+    default:
+    case Fp8QuantizationType::NoneFp8:
+      return "NoneFp8";
+    case Fp8QuantizationType::DeepSeekFp8:
+      return "DeepSeekFp8";
+    case Fp8QuantizationType::MxFp8:
+      return "MxFp8";
+    case Fp8QuantizationType::PerTensorFp8:
+      return "PerTensorFp8";
+  }
+}
+
+inline ActivationType validateAndCastActivationType(int64_t act_type) {
+  TVM_FFI_ICHECK(act_type >= 0 && act_type < static_cast<int64_t>(ActivationType::InvalidType))
+      << "Invalid activation type: " << act_type;
+  return static_cast<ActivationType>(act_type);
+}
+
+// Utility function to compute the next power of two
+inline int32_t nextPowerOfTwo(float value) {
+  int32_t n = static_cast<int32_t>(std::ceil(value));
+  if (n <= 1) return 1;
+
+  // If n is already a power of 2, return it
+  if ((n & (n - 1)) == 0) return n;
+
+  // Find the next power of 2
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  n++;
+
+  return n;
+}
+
+std::set<int32_t> computeSelectedTileN(std::vector<int32_t> const& supported_tile_nums,
+                                       int64_t const num_tokens, int64_t const top_k,
+                                       int64_t const num_local_experts) {
+  TVM_FFI_ICHECK(!supported_tile_nums.empty()) << "supported_tile_nums must not be empty.";
+  float const avg_tokens_per_expert = static_cast<float>(num_tokens * top_k) / num_local_experts;
+  // NOTE: This differs from Python AutoTuner bucketing:
+  // - AutoTuner maps raw num_tokens with last_positive_power_of_2 (round-down).
+  // - Here we map derived avg_tokens_per_expert and use nextPowerOfTwo (round-up).
+  // Because they round different quantities in different directions, cache bucket and runtime
+  // tile candidates can diverge; launcher-side tactic resolution handles that mismatch.
+  // assume supported_tile_nums is sorted
+  int32_t tile_tokens_dim = std::clamp(nextPowerOfTwo(avg_tokens_per_expert),
+                                       supported_tile_nums.front(), supported_tile_nums.back());
+  auto it = std::find(supported_tile_nums.begin(), supported_tile_nums.end(), tile_tokens_dim);
+  FLASHINFER_CHECK(
+      it != supported_tile_nums.end(), "computeSelectedTileN expected exact tile ", tile_tokens_dim,
+      " in supported_tile_nums (size=", supported_tile_nums.size(),
+      "). Please keep supported_tile_nums as a dense power-of-2 ladder for this launcher.");
+
+  // Candidate tile set centered on the heuristic tile.
+  // This function returns nearby candidates (not a single final tile):
+  //   center, +1, +2, and -1 neighbors when available.
+  // Final tile choice is made later (autotuner-provided tile if valid, otherwise fallback policy).
+  std::set<int32_t> selected_tile_nums;
+  selected_tile_nums.insert(tile_tokens_dim);
+  if (std::next(it) != supported_tile_nums.end()) {
+    selected_tile_nums.insert(*std::next(it));
+    if (std::next(std::next(it)) != supported_tile_nums.end()) {
+      selected_tile_nums.insert(*std::next(std::next(it)));
+    }
+  }
+  if (it != supported_tile_nums.begin()) {
+    selected_tile_nums.insert(*std::prev(it));
+  }
+
+  return selected_tile_nums;
+}
+
+int64_t selectDefaultTileN(std::vector<int32_t> const& supported_tile_nums,
+                           int64_t const num_tokens, int64_t const top_k,
+                           int64_t const num_local_experts) {
+  auto selected = computeSelectedTileN(supported_tile_nums, num_tokens, top_k, num_local_experts);
+  TVM_FFI_ICHECK(!selected.empty()) << "No selected tile_N candidates for current MoE input.";
+  return *selected.begin();
+}
+
+// Resolve the (tile_N, config) pair passed from Python side, applying fallback logic
+// when tile_N is -1.
+std::pair<int64_t, int64_t> resolveMoeTileAndConfig(Array<int64_t> const& config_index,
+                                                    std::vector<int32_t> const& supported_tile_nums,
+                                                    int64_t const num_tokens, int64_t const top_k,
+                                                    int64_t const num_local_experts) {
+  // Python side convention: tactic is [tile_N, config]
+  TVM_FFI_ICHECK(config_index.size() == 2)
+      << "Invalid tactic, expected to be [tile_N, config], but got array of size "
+      << config_index.size();
+  const int64_t tile_N = config_index[0];
+  const int64_t config = config_index[1];
+
+  if (tile_N == -1 || config == -1) {
+    // Use fallback tactic
+    auto const default_tile_N =
+        selectDefaultTileN(supported_tile_nums, num_tokens, top_k, num_local_experts);
+    return {default_tile_N, -1};
+  }
+
+  return {tile_N, config};
+}
+
+class FusedMoeLauncher {
+ protected:
+  Optional<TensorView> routing_logits;
+  Optional<TensorView> routing_bias;
+  TensorView hidden_states;
+  TensorView gemm1_weights;
+  Optional<TensorView> output1_scales_scalar;
+  Optional<TensorView> output1_scales_gate_scalar;
+  TensorView gemm2_weights;
+  Optional<TensorView> output2_scales_scalar;
+  Optional<TensorView> per_token_scales;
+  Tensor per_token_scales_fc2;
+
+  int64_t tile_tokens_dim{};
+  int64_t routing_method_type{};
+  bool use_shuffled_weight{};
+  batchedGemm::gemm::MatrixLayout weight_layout{batchedGemm::gemm::MatrixLayout::MajorK};
+
+  std::tuple<int, int> device_version;
+  std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs> args;
+  tensorrt_llm::kernels::trtllmgen_moe::MoE::MoEWorkspace workspace;
+
+  btg::Dtype mDtypeAct{btg::Dtype::Bfloat16};
+  btg::Dtype mDtypeWeights{btg::Dtype::Bfloat16};
+  btg::Dtype mRoutingBiasDtype{
+      btg::Dtype::Bfloat16};  // Dtype for expert weights in routing, based on routing bias
+  btg::Dtype mRoutingLogitsDtype{btg::Dtype::Bfloat16};
+  bool norm_topk_prob{true};
+  ActivationType activation_type{ActivationType::Swiglu};
+  btg::Dtype mDtypeScore{btg::Dtype::Bfloat16};
+
+  // Optional routing replay output: [num_tokens, top_k] int16 tensor
+  Optional<TensorView> routing_replay_out;
+
+  int64_t intermediate_size_factor{2};
+
+ public:
+  // Constructor that initializes all TensorView members
+  FusedMoeLauncher(const Optional<TensorView>& routing_logits,
+                   const Optional<TensorView>& routing_bias, const TensorView& hidden_states,
+                   const TensorView& gemm1_weights,
+                   const Optional<TensorView>& output1_scales_scalar,
+                   const Optional<TensorView>& output1_scales_gate_scalar,
+                   const TensorView& gemm2_weights,
+                   const Optional<TensorView>& output2_scales_scalar,
+                   const Optional<TensorView>& per_token_scales)
+      : routing_logits(routing_logits),
+        routing_bias(routing_bias),
+        hidden_states(hidden_states),
+        gemm1_weights(gemm1_weights),
+        output1_scales_scalar(output1_scales_scalar),
+        output1_scales_gate_scalar(output1_scales_gate_scalar),
+        gemm2_weights(gemm2_weights),
+        output2_scales_scalar(output2_scales_scalar),
+        per_token_scales(per_token_scales),
+        tile_tokens_dim{},
+        routing_method_type{},
+        use_shuffled_weight{},
+        weight_layout{batchedGemm::gemm::MatrixLayout::MajorK},
+        mDtypeAct{btg::Dtype::Bfloat16},
+        mDtypeWeights{btg::Dtype::Bfloat16},
+        activation_type{ActivationType::Swiglu},
+        intermediate_size_factor{2} {}
+
+ public:
+  void set_routing_replay_out(const Optional<TensorView>& replay_out) {
+    routing_replay_out = replay_out;
+  }
+
+ protected:
+  // Initialize common data necessary for later.
+  // May throw exception from TVM_FFI_ICHECK.
+  void init_common(std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>&& args,
+                   int64_t tile_tokens_dim, int64_t routing_method_type, bool use_shuffled_weight,
+                   int64_t weight_layout, ActivationType activation_type,
+                   bool norm_topk_prob = true);
+
+  // Routing logits [num_tokens, num_experts]
+  void check_routing_logits() const {
+    if (routing_logits.has_value()) {
+      // Check shape
+      TVM_FFI_ICHECK_EQ(routing_logits.value().ndim(), 2) << "routing_logits must be 2D.";
+      TVM_FFI_ICHECK_EQ(routing_logits.value().size(0), hidden_states.size(0))
+          << "routing_logits and hidden_states must have the same number of tokens.";
+      TVM_FFI_ICHECK_EQ(routing_logits.value().size(1), args->num_experts)
+          << "routing_logits dim1 must match num_experts.";
+
+      // Check dtype
+      TVM_FFI_ICHECK(routing_logits.value().dtype() == dl_float32 ||
+                     routing_logits.value().dtype() == dl_bfloat16)
+          << "routing_logits must be float or bfloat16.";
+    }
+  }
+
+  // Routing bias [num_experts]
+  void check_routing_bias_shape() const {
+    if (routing_bias.has_value()) {
+      TVM_FFI_ICHECK_EQ(routing_bias.value().ndim(), 1) << "routing_bias must be 1D.";
+      TVM_FFI_ICHECK_EQ(routing_bias.value().size(0), args->num_experts)
+          << "routing_bias has incorrect shape.";
+    }
+  }
+
+  // Hidden states [num_tokens, hidden_size]
+  void check_hidden_states_shape() const {
+    TVM_FFI_ICHECK_EQ(hidden_states.ndim(), 2) << "hidden_states must be 2D.";
+    TVM_FFI_ICHECK_EQ(hidden_states.size(1), args->intermediate_size)
+        << "hidden_states has incorrect shape.";
+  }
+
+  // GEMM1 or GEMM2 weights [num_experts, M, K] or [num_experts, K/block_k, M, block_k]
+  void check_weights_shape(std::string which_weights) const {
+    TensorView weights = (which_weights == "gemm1") ? gemm1_weights : gemm2_weights;
+    if (which_weights != "gemm1" && which_weights != "gemm2") {
+      TVM_FFI_LOG_AND_THROW(InternalError) << "Internal error: which_weights = " << which_weights;
+    }
+
+    int64_t Mn = 0, K = 0;
+    if (weight_layout == batchedGemm::gemm::MatrixLayout::MajorK) {
+      // MajorK [num_experts, M, K]
+      Mn = weights.size(1);
+      K = weights.size(2);
+    } else if (weight_layout == batchedGemm::gemm::MatrixLayout::BlockMajorK) {
+      // BlockMajorK [num_experts, K/block_k, M, block_k]
+      Mn = weights.size(2);
+      int64_t block_k = weights.size(3);
+      K = weights.size(1) * block_k;
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError)
+          << "Unsupported weight_layout: " << (int)weight_layout;
+    }
+    if (which_weights == "gemm1") {
+      // Gated MoE activations (e.g. Swiglu/Geglu) pack gate+up projections in GEMM1,
+      // so Mn = 2 * intermediate_size and must be even.
+      if (intermediate_size_factor == 2) {
+        TVM_FFI_ICHECK_EQ(Mn % 2, 0) << which_weights << " weights Mn dimension must be even.";
+      }
+      // Non-gated activations (e.g. Relu2) use a single projection in GEMM1,
+      // so Mn = intermediate_size. This check covers both gated and non-gated cases.
+      TVM_FFI_ICHECK_EQ(args->intermediate_size * intermediate_size_factor, Mn)
+          << "intermediate_size has incorrect shape.";
+      TVM_FFI_ICHECK_EQ(K, hidden_states.size(1))
+          << which_weights << " weights K dimension must be equal to hidden_size.";
+    } else if (which_weights == "gemm2") {
+      // GEMM2 always consumes the post-activation hidden of size intermediate_size.
+      TVM_FFI_ICHECK_EQ(K, args->intermediate_size)
+          << which_weights << " weights K dimension must be equal to intermediate_size.";
+    }
+  }
+
+  void check_routing_common() const {
+    TVM_FFI_ICHECK(args->top_k > 0 && args->top_k <= args->num_experts)
+        << "top_k must be between 1 and num_experts";
+    TVM_FFI_ICHECK(args->local_num_experts > 0 && args->local_num_experts <= args->num_experts)
+        << "local_num_experts must be between 1 and num_experts";
+    TVM_FFI_ICHECK(args->local_expert_offset >= 0 &&
+                   args->local_expert_offset + args->local_num_experts <= args->num_experts)
+        << "expert offset and count must be within valid range";
+
+    check_routing_logits();
+
+    if (routing_bias.has_value()) {
+      check_routing_bias_shape();
+    }
+  }
+
+  // Routing phase workspace tensors (allocated in prepare_routing() or prepare_routing_common())
+  Tensor num_tokens_per_expert;
+  Tensor total_num_padded_tokens;
+  Tensor expanded_idx_to_permuted_idx;
+  Tensor permuted_idx_to_token_idx;
+  Tensor expert_weights;
+  Tensor expert_indexes;
+  Tensor expert_count_histogram;
+  Tensor cta_idx_xy_to_batch_idx;
+  Tensor cta_idx_xy_to_mn_limit;
+  Tensor num_non_exiting_ctas;
+
+  void prepare_routing_common() {
+    // Allocate routing phase workspace tensors
+    num_tokens_per_expert = alloc_tensor({args->num_experts}, dl_int32, hidden_states.device());
+    int32_t max_num_padded_tokens =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxPermutedPaddedCount(
+            args->num_tokens, args->top_k, args->num_experts, tile_tokens_dim);
+
+    total_num_padded_tokens = alloc_tensor({1}, dl_int32, hidden_states.device());
+
+    expanded_idx_to_permuted_idx =
+        alloc_tensor({args->num_tokens * args->top_k}, dl_int32, hidden_states.device());
+
+    permuted_idx_to_token_idx =
+        alloc_tensor({max_num_padded_tokens}, dl_int32, hidden_states.device());
+
+    expert_indexes =
+        alloc_tensor({args->num_tokens, args->top_k}, dl_int32, hidden_states.device());
+
+    // expert_weights allocation should be done by derived class since data type could vary
+
+    int64_t const size_of_expert_count_histogram = std::max(args->num_experts * 2, 256 * 2);
+    expert_count_histogram = alloc_tensor({size_of_expert_count_histogram},
+                                          dl_int32,  // 256 is the max number of threads per block
+                                                     // and max number of experts
+                                          hidden_states.device());
+
+    int32_t max_num_ctas = tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxNumCtasInBatchDim(
+        args->num_tokens, args->top_k, args->num_experts, tile_tokens_dim);
+
+    cta_idx_xy_to_batch_idx = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
+
+    cta_idx_xy_to_mn_limit = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
+
+    num_non_exiting_ctas = alloc_tensor({1}, dl_int32, hidden_states.device());
+
+    workspace.total_num_padded_tokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
+    workspace.total_max_padded_tokens = max_num_padded_tokens;
+    workspace.ProjUpTileN = tile_tokens_dim;
+    workspace.routing_expert_indexes = static_cast<int*>(expert_indexes.data_ptr());
+    workspace.permuted_idx_size = static_cast<int*>(total_num_padded_tokens.data_ptr());
+    workspace.expanded_idx_to_permuted_idx =
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr());
+    workspace.permuted_idx_to_token_idx = static_cast<int*>(permuted_idx_to_token_idx.data_ptr());
+    // workspace.expert_weights will be set by derived class after expert_weights allocation
+    workspace.cta_idx_xy_to_batch_idx = static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr());
+    workspace.cta_idx_xy_to_mn_limit = static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr());
+    workspace.num_non_exiting_ctas = static_cast<int*>(num_non_exiting_ctas.data_ptr());
+
+    // Set dtype of score based on actual routing_logits dtype
+    if (routing_logits.has_value()) {
+      if (routing_logits.value().dtype() == dl_float32) {
+        mDtypeScore = btg::Dtype::Fp32;
+      } else {
+        mDtypeScore = btg::Dtype::Bfloat16;
+      }
+    }
+  }
+
+  void check_moe_common() const {
+    // Hidden states [num_tokens, hidden_size]
+    TVM_FFI_ICHECK_EQ(hidden_states.ndim(), 2) << "hidden_states must be 2D.";
+  }
+
+  // MoE computation phase workspace tensors (allocated in prepare_moe() or prepare_moe_common())
+  Tensor gemm1_output;
+  Tensor activation_output;
+  Tensor gemm2_output;
+  Tensor workspace_fc1;
+  Tensor workspace_fc2;
+  Tensor output;
+  int64_t moe_tactic{-1};
+  std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner> moe_runner;
+
+  void prepare_moe_common(int64_t& moe_tactic) {
+    using RunnerType = tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner;
+    bool usePerTokenScalingGemm1 =
+        per_token_scales.has_value() ||
+        static_cast<RoutingMethodType>(this->routing_method_type) == RoutingMethodType::Llama4;
+    bool usePerTokenScalingGemm2 =
+        per_token_scales.has_value() && this->mDtypeAct != btg::Dtype::Bfloat16;
+    // For FP8 block-scale (E4m3 activations, E4m3 weights) with DeepSeek FP8, use the
+    // weights-only Runner constructor to match the original kernel path and numerics.
+    if (this->mDtypeAct == btg::Dtype::E4m3 && this->mDtypeWeights == btg::Dtype::E4m3 &&
+        args->mUseDeepSeekFp8) {
+      moe_runner = std::make_unique<RunnerType>(this->mDtypeWeights, args->mUseDeepSeekFp8,
+                                                (int32_t)tile_tokens_dim, this->use_shuffled_weight,
+                                                this->weight_layout, usePerTokenScalingGemm1,
+                                                usePerTokenScalingGemm2, false, false);
+    } else {
+      moe_runner = std::make_unique<RunnerType>(
+          this->mDtypeAct, this->mDtypeWeights, args->mUseDeepSeekFp8, (int32_t)tile_tokens_dim,
+          this->activation_type, this->use_shuffled_weight, this->weight_layout,
+          usePerTokenScalingGemm1, usePerTokenScalingGemm2);
+    }
+
+    if (moe_tactic == -1) {
+      moe_tactic = moe_runner->getDefaultValidConfigIndex(
+          args->top_k, args->hidden_size, args->intermediate_size, args->local_num_experts,
+          args->num_tokens);
+    }
+    auto valid_cfgs =
+        moe_runner->getValidConfigIndices(args->top_k, args->hidden_size, args->intermediate_size,
+                                          args->local_num_experts, args->num_tokens);
+    auto valid_it = std::find(valid_cfgs.begin(), valid_cfgs.end(), moe_tactic);
+    FLASHINFER_CHECK(valid_it != valid_cfgs.end(), "Invalid MoE tactic ", moe_tactic,
+                     " for tile_N=", tile_tokens_dim, ". Number of valid tactics for this tile is ",
+                     valid_cfgs.size(),
+                     ". This often indicates a stale or mismatched autotuner cache entry.");
+    this->moe_tactic = moe_tactic;
+
+    auto workspace_sizes = moe_runner->getWorkspaceSizeInBytes(*args, moe_tactic);
+    workspace_fc1 = alloc_tensor({std::get<0>(workspace_sizes)}, dl_int8, hidden_states.device());
+    workspace_fc2 = alloc_tensor({std::get<1>(workspace_sizes)}, dl_int8, hidden_states.device());
+    workspace.bmm1_workspace = workspace_fc1.data_ptr();
+    workspace.bmm2_workspace = workspace_fc2.data_ptr();
+  }
+
+ public:
+  virtual void check_routing() const = 0;
+  virtual void prepare_routing() = 0;
+  virtual void check_moe() const = 0;
+  virtual void prepare_moe(int64_t& moe_tactic) = 0;
+
+  // Main entry point for all the executions.
+  // Do initializations prior to calling this as the initializations are different for bf16, fp8 and
+  // fp4. The executions are non-blocking by default.
+  virtual Array<Tensor> run(int64_t moe_tactic, bool enable_pdl = true,
+                            bool use_routing_scales_on_input = false,
+                            bool use_deep_seek_fp8 = false) {
+    check_routing();
+    prepare_routing();
+
+    // Execute routing
+    tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
+    cudaStream_t routing_stream = get_stream(hidden_states.device());
+
+    int16_t* replay_ptr = nullptr;
+    if (routing_replay_out.has_value()) {
+      replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
+    }
+
+    routing_runner.run(
+        args->routing_logits, args->routing_bias, args->num_tokens, args->num_experts, args->top_k,
+        args->n_group, args->topk_group, args->local_expert_offset, args->local_num_experts,
+        args->routed_scaling_factor, workspace.routing_expert_indexes,
+        static_cast<int*>(expert_count_histogram.data_ptr()),
+        static_cast<int*>(total_num_padded_tokens.data_ptr()),
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
+        nullptr /*permuted_idx_to_expanded_idx.data_ptr()*/,
+        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), workspace.expert_weights,
+        static_cast<int*>(num_tokens_per_expert.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
+        static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
+        use_routing_scales_on_input, use_deep_seek_fp8,
+        static_cast<RoutingMethodType>(routing_method_type), routing_stream, mRoutingLogitsDtype,
+        norm_topk_prob, replay_ptr);
+
+    check_moe();
+    prepare_moe(moe_tactic);
+
+    cudaStream_t moe_stream = get_stream(hidden_states.device());
+    moe_runner->run(*args, workspace, hidden_states.device().device_id, moe_stream, moe_tactic,
+                    enable_pdl);
+
+    if (args->do_finalize) {
+      return {output};
+    }
+    return {gemm2_output, FusedMoeLauncher::expert_weights, expanded_idx_to_permuted_idx};
+  }
+};
+
+void FusedMoeLauncher::init_common(
+    std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>&& args,
+    int64_t tile_tokens_dim, int64_t routing_method_type, bool use_shuffled_weight,
+    int64_t weight_layout, ActivationType activation_type, bool norm_topk_prob) {
+  // Check devicearchitecture: Blackwell (SM 10.x) required
+  auto device = hidden_states.device().device_id;
+  int major = 0, minor = 0;
+  cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
+  cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device);
+  TVM_FFI_ICHECK(major == 10 || major == 12)
+      << "MoE kernel requires SM 10.x or SM 12.x architecture. Current device has SM " << major
+      << minor;
+  this->device_version = std::make_tuple(major, minor);
+
+  args->routing_logits = routing_logits.has_value() ? routing_logits.value().data_ptr() : nullptr;
+  args->routing_bias = routing_bias.has_value() ? routing_bias.value().data_ptr() : nullptr;
+  args->hidden_states = hidden_states.data_ptr();
+  args->gemm1_weights = gemm1_weights.data_ptr();
+  args->gemm2_weights = gemm2_weights.data_ptr();
+
+  this->args = std::move(args);
+  this->tile_tokens_dim = tile_tokens_dim;
+  this->routing_method_type = routing_method_type;
+  this->use_shuffled_weight = use_shuffled_weight;
+  TVM_FFI_ICHECK(0 <= weight_layout && weight_layout <= 2)
+      << "the value of weight_layout is not recognized";
+  this->weight_layout = static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout);
+  this->activation_type = activation_type;
+  this->intermediate_size_factor = isGatedActivation(activation_type) ? 2 : 1;
+  this->norm_topk_prob = norm_topk_prob;
+}
+
+class Bf16MoeLauncher : public FusedMoeLauncher {
+ public:
+  static constexpr std::array<int32_t, 5> mSupportedTileNums = {8, 16, 32, 64, 128};
+
+  Bf16MoeLauncher(Optional<TensorView> const& routing_logits,
+                  Optional<TensorView> const& routing_bias, TensorView const& expert_indices,
+                  TensorView const& expert_weights, TensorView const& hidden_states,
+                  TensorView const& gemm1_weights, TensorView const& gemm2_weights)
+      : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights,
+                         Optional<TensorView>(), Optional<TensorView>(), gemm2_weights,
+                         Optional<TensorView>(), Optional<TensorView>()),
+        expert_indices(expert_indices),
+        expert_weights(expert_weights) {}
+
+  void init(std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>&& args,
+            int64_t tile_tokens_dim, int64_t routing_method_type, bool use_shuffled_weight,
+            int64_t weight_layout, ActivationType activation_type, bool norm_topk_prob = true) {
+    // Do base class init and perform common checks
+    FusedMoeLauncher::init_common(std::move(args), tile_tokens_dim, routing_method_type,
+                                  use_shuffled_weight, weight_layout, activation_type,
+                                  norm_topk_prob);
+  }
+
+  void check_routing() const override {
+    FusedMoeLauncher::check_routing_common();
+    if (expert_indices.ndim() == 2 && expert_indices.size(0) > 0) {
+      // Pre-computed routing: expert_indices is a packed tensor
+      // Format: (expert_id << 16) | (weight_bf16.view(int16))
+      TVM_FFI_ICHECK_EQ(expert_indices.ndim(), 2) << "expert_indices must be 2D.";
+      TVM_FFI_ICHECK_EQ(expert_indices.size(0), hidden_states.size(0))
+          << "expert_indices and hidden_states must have same number of tokens.";
+      TVM_FFI_ICHECK_EQ(expert_indices.size(1), args->top_k)
+          << "expert_indices dim1 must match top_k.";
+      TVM_FFI_ICHECK_EQ(expert_indices.dtype(), dl_int32) << "expert_indices must be int32.";
+    }
+
+    // TODO n_group, topk_group validation?
+  }
+
+  void prepare_routing() override {
+    FusedMoeLauncher::prepare_routing_common();
+
+    args->mDtypeElt = btg::Dtype::Bfloat16;
+    args->mUseDeepSeekFp8 = false;
+
+    // Set expert weights dtype based on routing bias
+    auto const routing_bias_dtype =
+        routing_bias.has_value() ? routing_bias.value().dtype() : dl_bfloat16;
+    mRoutingBiasDtype = routing_bias_dtype == dl_bfloat16 ? btg::Dtype::Bfloat16 : btg::Dtype::Fp32;
+
+    auto const routing_logits_dtype =
+        routing_logits.has_value() ? routing_logits.value().dtype() : dl_bfloat16;
+    mRoutingLogitsDtype =
+        routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+
+    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
+    bool has_precomputed_indices = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
+    if (has_precomputed_indices) {
+      // Use expert_indices directly
+      workspace.routing_expert_indexes =
+          static_cast<int*>(const_cast<void*>(expert_indices.data_ptr()));
+    }
+    bool has_precomputed_weights = expert_weights.ndim() == 2 && expert_weights.size(0) > 0;
+    if (has_precomputed_weights) {
+      workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
+    } else {
+      auto ew_dtype = mDtypeScore == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+      FusedMoeLauncher::expert_weights =
+          alloc_tensor({args->num_tokens, args->top_k}, ew_dtype, hidden_states.device());
+      workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
+    }
+  }
+
+  void check_moe() const override {
+    FusedMoeLauncher::check_moe_common();
+
+    TVM_FFI_ICHECK(weight_layout == batchedGemm::gemm::MatrixLayout::BlockMajorK)
+        << "BF16 Moe: weight_layout must be BlockMajorK";
+    check_weights_shape("gemm1");
+    check_weights_shape("gemm2");
+
+    TVM_FFI_ICHECK_EQ(args->intermediate_size % 128, 0)
+        << "the second dimension of weights must be a multiple of 128.";
+  }
+
+  void prepare_moe(int64_t& moe_tactic) override {
+    FusedMoeLauncher::prepare_moe_common(moe_tactic);
+
+    int32_t max_num_padded_tokens = workspace.total_max_padded_tokens;
+    gemm1_output = alloc_tensor({max_num_padded_tokens, args->intermediate_size}, dl_bfloat16,
+                                hidden_states.device());
+    activation_output = alloc_tensor({max_num_padded_tokens, args->intermediate_size}, dl_bfloat16,
+                                     hidden_states.device());
+    gemm2_output = alloc_tensor({max_num_padded_tokens, args->hidden_size}, dl_bfloat16,
+                                hidden_states.device());
+
+    workspace.hidden_states_scale_linear = nullptr;
+    workspace.gemm1_output = gemm1_output.data_ptr();
+    workspace.gemm1_output_scale = nullptr;
+    workspace.activation_output = activation_output.data_ptr();
+    workspace.activation_output_scale = nullptr;
+    workspace.gemm2_output = gemm2_output.data_ptr();
+    workspace.gemm2_output_scale = nullptr;
+
+    if (args->output == nullptr) {
+      output =
+          alloc_tensor({args->num_tokens, args->hidden_size}, dl_bfloat16, hidden_states.device());
+      args->output = output.data_ptr();
+    }
+    args->output_scale = nullptr;
+  }
+
+  static Array<Array<int64_t>> getValidConfigs(int64_t top_k, int64_t hidden_size,
+                                               int64_t intermediate_size, int64_t num_local_experts,
+                                               int64_t num_tokens, int64_t act_type,
+                                               bool use_shuffled_weight, int64_t weight_layout) {
+    Array<Array<int64_t>> valid_configs;
+
+    std::vector<int32_t> supported_tile_nums(mSupportedTileNums.begin(), mSupportedTileNums.end());
+    std::set<int32_t> selected_tile_nums =
+        computeSelectedTileN(supported_tile_nums, num_tokens, top_k, num_local_experts);
+
+    for (int32_t tile_N : selected_tile_nums) {
+      auto moe_runner = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner>(
+          btg::Dtype::Bfloat16,  // dtype_act
+          btg::Dtype::Bfloat16,  // dtype_weights
+          false,                 // useDeepSeekFp8
+          tile_N, static_cast<ActivationType>(act_type), use_shuffled_weight,
+          static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout));
+
+      auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
+                                                    num_local_experts, num_tokens);
+
+      for (auto cfg : cfgs) {
+        valid_configs.push_back({tile_N, cfg});
+      }
+    }
+
+    return valid_configs;
+  }
+
+ private:
+  TensorView expert_weights;
+  TensorView expert_indices;
+};
+
+class Fp8PerTensorLauncher : public FusedMoeLauncher {
+ public:
+  static constexpr std::array<int32_t, 5> mSupportedTileNums = {8, 16, 32, 64, 128};
+
+  // Constructor that passes TensorView parameters to base constructor
+  Fp8PerTensorLauncher(TensorView const& routing_logits, Optional<TensorView> const& routing_bias,
+                       TensorView const& hidden_states, TensorView const& gemm1_weights,
+                       TensorView const& output1_scales_scalar,
+                       TensorView const& output1_scales_gate_scalar,
+                       TensorView const& gemm2_weights, TensorView const& output2_scales_scalar)
+      : FusedMoeLauncher(Optional<TensorView>(routing_logits), routing_bias, hidden_states,
+                         gemm1_weights, Optional<TensorView>(output1_scales_scalar),
+                         Optional<TensorView>(output1_scales_gate_scalar), gemm2_weights,
+                         Optional<TensorView>(output2_scales_scalar), Optional<TensorView>()),
+        use_routing_scales_on_input(false) {}
+
+  void init(std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>&& args,
+            int64_t tile_tokens_dim, int64_t routing_method_type, bool use_shuffled_weight,
+            int64_t weight_layout, bool use_routing_scales_on_input_param,
+            ActivationType activation_type, bool norm_topk_prob = true) {
+    this->use_routing_scales_on_input = use_routing_scales_on_input_param;
+
+    auto dtype = hidden_states.dtype();
+    if (dtype == dl_float16) {
+      mDtypeAct = btg::Dtype::Fp16;
+    } else if (dtype == dl_bfloat16) {
+      mDtypeAct = btg::Dtype::Bfloat16;
+    } else if (dtype == dl_float8_e4m3fn) {
+      mDtypeAct = btg::Dtype::E4m3;
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError) << "Unsupported input dtype for FP8 MoE.";
+    }
+    mDtypeWeights = btg::Dtype::E4m3;
+
+    FusedMoeLauncher::init_common(std::move(args), tile_tokens_dim, routing_method_type,
+                                  use_shuffled_weight, weight_layout, activation_type,
+                                  norm_topk_prob);
+  }
+
+  void check_routing() const override { FusedMoeLauncher::check_routing_common(); }
+
+  void prepare_routing() override {
+    FusedMoeLauncher::prepare_routing_common();
+
+    auto dtype = hidden_states.dtype();
+    if (dtype == dl_float16) {
+      args->mDtypeElt = btg::Dtype::Fp16;
+    } else if (dtype == dl_bfloat16) {
+      args->mDtypeElt = btg::Dtype::Bfloat16;
+    } else if (dtype == dl_float8_e4m3fn) {
+      args->mDtypeElt = btg::Dtype::E4m3;
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError) << "Unsupported input dtype for MoE.";
+    }
+
+    args->mDtypeOut = btg::Dtype::Bfloat16;
+    args->mUseDeepSeekFp8 = false;
+
+    auto const routing_bias_dtype =
+        routing_bias.has_value() ? routing_bias.value().dtype() : dl_bfloat16;
+    mRoutingBiasDtype = routing_bias_dtype == dl_bfloat16 ? btg::Dtype::Bfloat16 : btg::Dtype::Fp32;
+
+    auto const routing_logits_dtype =
+        routing_logits.has_value() ? routing_logits.value().dtype() : dl_bfloat16;
+    mRoutingLogitsDtype =
+        routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+
+    auto expert_weights_dtype = mRoutingLogitsDtype == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+    expert_weights =
+        alloc_tensor({args->num_tokens, args->top_k}, expert_weights_dtype, hidden_states.device());
+
+    workspace.expert_weights = expert_weights.data_ptr();
+    if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Llama4) {
+      workspace.token_scales = expert_weights.data_ptr();  // Consumed by permuteGemm1 kernel
+    }
+  }
+
+  void check_moe() const override {
+    FusedMoeLauncher::check_moe_common();
+
+    TVM_FFI_ICHECK(output1_scales_scalar.has_value())
+        << "output1_scales_scalar is required for FP8 MoE";
+    TVM_FFI_ICHECK_EQ(output1_scales_scalar.value().dtype(), dl_float32)
+        << "output1_scales_scalar must be float.";
+    TVM_FFI_ICHECK_EQ(output1_scales_scalar.value().ndim(), 1)
+        << "output1_scales_scalar must be 1D.";
+    TVM_FFI_ICHECK_EQ(output1_scales_scalar.value().size(0), args->local_num_experts)
+        << "output1_scales_scalar has incorrect dim 0.";
+
+    TVM_FFI_ICHECK(output1_scales_gate_scalar.has_value())
+        << "output1_scales_gate_scalar is required for FP8 MoE";
+    TVM_FFI_ICHECK_EQ(output1_scales_gate_scalar.value().dtype(), dl_float32)
+        << "output1_scales_gate_scalar must be float.";
+    TVM_FFI_ICHECK_EQ(output1_scales_gate_scalar.value().ndim(), 1)
+        << "output1_scales_gate_scalar must be 1D.";
+    TVM_FFI_ICHECK_EQ(output1_scales_gate_scalar.value().size(0), args->local_num_experts)
+        << "output1_scales_gate_scalar has incorrect dim 0.";
+
+    TVM_FFI_ICHECK(output2_scales_scalar.has_value())
+        << "output2_scales_scalar is required for FP8 MoE";
+    TVM_FFI_ICHECK_EQ(output2_scales_scalar.value().dtype(), dl_float32)
+        << "output2_scales_scalar must be float.";
+    TVM_FFI_ICHECK_EQ(output2_scales_scalar.value().ndim(), 1)
+        << "output2_scales_scalar must be 1D.";
+    TVM_FFI_ICHECK_EQ(output2_scales_scalar.value().size(0), args->local_num_experts)
+        << "output2_scales_scalar has incorrect dim 0.";
+
+    TVM_FFI_ICHECK(hidden_states.dtype() == dl_float8_e4m3fn ||
+                   hidden_states.dtype() == dl_float16 || hidden_states.dtype() == dl_bfloat16)
+        << "FP8 MoE: hidden_states must be float8_e4m3fn, float16, or bfloat16.";
+    TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_float8_e4m3fn)
+        << "FP8 MoE: gemm1_weights must be float8_e4m3fn.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_float8_e4m3fn)
+        << "FP8 MoE: gemm2_weights must be float8_e4m3fn.";
+  }
+
+  void prepare_moe(int64_t& moe_tactic) override {
+    FusedMoeLauncher::prepare_moe_common(moe_tactic);
+
+    int32_t max_num_padded_tokens_gemm1 = workspace.total_max_padded_tokens + args->num_experts;
+    int32_t max_num_padded_tokens_gemm2 = workspace.total_max_padded_tokens;
+
+    gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, 2 * args->intermediate_size},
+                                dl_uint8, hidden_states.device());
+    gemm1_output_scale =
+        alloc_tensor({2 * args->intermediate_size / 128, max_num_padded_tokens_gemm1}, dl_float32,
+                     hidden_states.device());
+
+    activation_output = alloc_tensor({max_num_padded_tokens_gemm1, args->intermediate_size},
+                                     dl_uint8, hidden_states.device());
+    activation_output_scale =
+        alloc_tensor({args->intermediate_size / 128, max_num_padded_tokens_gemm1}, dl_float32,
+                     hidden_states.device());
+
+    gemm2_output = alloc_tensor({max_num_padded_tokens_gemm2, args->hidden_size}, dl_bfloat16,
+                                hidden_states.device());
+
+    workspace.hidden_states_scale_linear = nullptr;
+    workspace.gemm1_output = gemm1_output.data_ptr();
+    workspace.gemm1_output_scale = static_cast<float*>(gemm1_output_scale.data_ptr());
+    workspace.activation_output = activation_output.data_ptr();
+    workspace.activation_output_scale = static_cast<float*>(activation_output_scale.data_ptr());
+    workspace.gemm2_output = gemm2_output.data_ptr();
+    workspace.gemm2_output_scale = nullptr;
+
+    if (args->output == nullptr) {
+      output =
+          alloc_tensor({args->num_tokens, args->hidden_size}, dl_bfloat16, hidden_states.device());
+      args->output = output.data_ptr();
+    }
+    args->output_scale = nullptr;
+
+    // Set scale pointers
+    TVM_FFI_ICHECK(output1_scales_scalar.has_value());
+    TVM_FFI_ICHECK(output1_scales_gate_scalar.has_value());
+    TVM_FFI_ICHECK(output2_scales_scalar.has_value());
+
+    args->output1_scales_scalar = static_cast<float*>(output1_scales_scalar.value().data_ptr());
+    args->output1_scales_gate_scalar =
+        static_cast<float*>(output1_scales_gate_scalar.value().data_ptr());
+    args->output2_scales_scalar = static_cast<float*>(output2_scales_scalar.value().data_ptr());
+  }
+
+ private:
+  bool use_routing_scales_on_input;
+  Tensor gemm1_output_scale;
+  Tensor activation_output_scale;
+
+ public:
+  static Array<Array<int64_t>> getValidConfigs(int64_t top_k, int64_t hidden_size,
+                                               int64_t intermediate_size, int64_t num_local_experts,
+                                               int64_t num_tokens, int64_t act_type,
+                                               bool use_shuffled_weight, int64_t weight_layout,
+                                               btg::Dtype dtype_act, btg::Dtype dtype_weights) {
+    Array<Array<int64_t>> valid_configs;
+
+    std::vector<int32_t> supported_tile_nums(mSupportedTileNums.begin(), mSupportedTileNums.end());
+    std::set<int32_t> selected_tile_nums =
+        computeSelectedTileN(supported_tile_nums, num_tokens, top_k, num_local_experts);
+
+    for (int32_t tile_N : selected_tile_nums) {
+      auto moe_runner = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner>(
+          dtype_act, dtype_weights,
+          false,  // useDeepSeekFp8
+          tile_N, static_cast<ActivationType>(act_type), use_shuffled_weight,
+          static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout),
+          true,  // usePerTokenScalingGemm1. always true for per-tensor fp8 due to llama4 routing
+          false, false, false);
+
+      auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
+                                                    num_local_experts, num_tokens);
+
+      for (auto cfg : cfgs) {
+        valid_configs.push_back({tile_N, cfg});
+      }
+    }
+
+    return valid_configs;
+  }
+};
+
+class Fp8BlockScaleLauncher : public FusedMoeLauncher {
+ public:
+  static constexpr std::array<int32_t, 5> mBaseSupportedTileNums = {8, 16, 32, 64, 128};
+
+  static std::vector<int32_t> getSupportedTileNums(Fp8QuantizationType quantization_type) {
+    std::vector<int32_t> tiles(mBaseSupportedTileNums.begin(), mBaseSupportedTileNums.end());
+    if (quantization_type == Fp8QuantizationType::MxFp8) {
+      tiles.push_back(256);
+    }
+    return tiles;
+  }
+
+  Fp8BlockScaleLauncher(Optional<TensorView> const& routing_logits,
+                        Optional<TensorView> const& routing_bias, TensorView const& hidden_states,
+                        TensorView const& hidden_states_scale, TensorView const& gemm1_weights,
+                        TensorView const& gemm1_weights_scale, TensorView const& gemm2_weights,
+                        TensorView const& gemm2_weights_scale, TensorView const& expert_indices,
+                        TensorView const& expert_weights, Fp8QuantizationType quantization_type,
+                        Optional<TensorView> const& gate_up_lora_delta = Optional<TensorView>(),
+                        Optional<TensorView> const& activation_lora_input = Optional<TensorView>())
+      : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights,
+                         Optional<TensorView>(), Optional<TensorView>(), gemm2_weights,
+                         Optional<TensorView>(), Optional<TensorView>()),
+        hidden_states_scale(hidden_states_scale),
+        gemm1_weights_scale(gemm1_weights_scale),
+        gemm2_weights_scale(gemm2_weights_scale),
+        expert_indices(expert_indices),
+        expert_weights(expert_weights),
+        gate_up_lora_delta(gate_up_lora_delta),
+        activation_lora_input(activation_lora_input),
+        quantization_type(quantization_type) {}
+
+  void init(std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>&& args,
+            int64_t tile_tokens_dim, int64_t routing_method_type, bool use_shuffled_weight,
+            int64_t weight_layout, ActivationType activation_type, bool norm_topk_prob = true) {
+    if (quantization_type == Fp8QuantizationType::MxFp8) {
+      mDtypeAct = btg::Dtype::MxE4m3;
+      mDtypeWeights = btg::Dtype::MxE4m3;
+    } else {
+      mDtypeAct = btg::Dtype::E4m3;
+      mDtypeWeights = btg::Dtype::E4m3;
+    }
+
+    auto dtype = hidden_states.dtype();
+    if (dtype == dl_float16) {
+      args->mDtypeElt = btg::Dtype::Fp16;
+    } else if (dtype == dl_bfloat16) {
+      args->mDtypeElt = btg::Dtype::Bfloat16;
+    } else if (dtype == dl_float8_e4m3fn) {
+      args->mDtypeElt = btg::Dtype::E4m3;
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError) << "Unsupported input dtype for MoE.";
+    }
+
+    // Output is always bfloat16 for FP8 block scale
+    args->mDtypeOut = btg::Dtype::Bfloat16;
+
+    FusedMoeLauncher::init_common(std::move(args), tile_tokens_dim, routing_method_type,
+                                  use_shuffled_weight, weight_layout, activation_type,
+                                  norm_topk_prob);
+  }
+
+  void check_routing() const override {
+    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
+    if (expert_indices.ndim() == 2 && expert_indices.size(0) > 0) {
+      // Pre-computed routing: expert_indices is a packed tensor
+      // Format: (expert_id << 16) | (weight_bf16.view(int16))
+      TVM_FFI_ICHECK_EQ(expert_indices.ndim(), 2) << "expert_indices must be 2D.";
+      TVM_FFI_ICHECK_EQ(expert_indices.size(0), hidden_states.size(0))
+          << "expert_indices and hidden_states must have same number of tokens.";
+      TVM_FFI_ICHECK_EQ(expert_indices.size(1), args->top_k)
+          << "expert_indices dim1 must match top_k.";
+      TVM_FFI_ICHECK_EQ(expert_indices.dtype(), dl_int32) << "expert_indices must be int32.";
+    }
+
+    FusedMoeLauncher::check_routing_common();
+
+    if (static_cast<RoutingMethodType>(routing_method_type) != RoutingMethodType::DeepSeekV3) {
+      TVM_FFI_ICHECK(args->n_group <= 1)
+          << "Current routing kernel (no groups) only supports n_group <= 1";
+      TVM_FFI_ICHECK(args->topk_group <= 1)
+          << "Current routing kernel (no groups) only supports topk_group <= 1";
+    }
+
+    if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3) {
+      TVM_FFI_ICHECK(args->n_group != 0) << "n_group should not be zero for DeepSeekV3 routing";
+      TVM_FFI_ICHECK(args->topk_group != 0) << "if n_group is given, topk_group must be given";
+      TVM_FFI_ICHECK_EQ(args->num_experts % args->n_group, 0)
+          << "num_experts must be divisible by n_group";
+      // DeepSeekV3 routing supports top_k up to:
+      // - 8  when num_experts <= 384 (NumKimiK2Experts)
+      // - 22 when num_experts > 384 (NumNemotronExperts path)
+      // Keep this in sync with LAUNCH_ROUTING_DEEPSEEK in trtllm_fused_moe_routing_deepseek.cu.
+      constexpr int32_t kNumKimiK2Experts = 384;  // same as in trtllm_fused_moe_routing_deepseek.cu
+      int32_t max_supported_top_k = args->num_experts <= kNumKimiK2Experts ? 8 : 22;
+      TVM_FFI_ICHECK(args->top_k <= max_supported_top_k && args->top_k > 0)
+          << "Current routing kernel (with groups) only supports top_k<=" << max_supported_top_k
+          << " && top_k>0 for num_experts=" << args->num_experts << ".";
+      TVM_FFI_ICHECK(args->topk_group <= 4 && args->topk_group > 0)
+          << "Current routing kernel only (with groups) supports topk_group<=4 && topk_group > 0.";
+      TVM_FFI_ICHECK_LE(args->topk_group, args->n_group)
+          << "n_group must not be smaller than topk_group.";
+      TVM_FFI_ICHECK_LT(args->top_k, (args->topk_group * args->num_experts / args->n_group))
+          << "top_k must be less than total number of experts in selected groups";
+    } else if (static_cast<RoutingMethodType>(routing_method_type) ==
+                   RoutingMethodType::Renormalize ||
+               static_cast<RoutingMethodType>(routing_method_type) ==
+                   RoutingMethodType::RenormalizeNaive ||
+               static_cast<RoutingMethodType>(routing_method_type) ==
+                   RoutingMethodType::SigmoidRenorm ||
+               static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Sigmoid) {
+      TVM_FFI_ICHECK(args->top_k <= 32 && args->top_k > 0)
+          << "Current routing kernel (no groups) only supports top_k<=32 && top_k>0.";
+    } else if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Llama4) {
+      TVM_FFI_ICHECK_EQ(args->top_k, 1)
+          << "Current routing kernel (no groups, Llama4) only supports top_k=1.";
+    }
+
+    TVM_FFI_ICHECK_EQ(args->num_experts % 4, 0)
+        << "Routing kernel expects that num_experts must be divisible by 4";
+    TVM_FFI_ICHECK_GT(args->num_experts, args->top_k) << "num_experts must be greater than top_k";
+    TVM_FFI_ICHECK_LE(args->local_num_experts + args->local_expert_offset, args->num_experts)
+        << "num_experts must be greater or equal to local_num_experts + local_expert_offset";
+  }
+
+  void prepare_routing() override {
+    FusedMoeLauncher::prepare_routing_common();
+
+    auto dtype = hidden_states.dtype();
+    if (dtype == dl_float16) {
+      args->mDtypeElt = btg::Dtype::Fp16;
+    } else if (dtype == dl_bfloat16) {
+      args->mDtypeElt = btg::Dtype::Bfloat16;
+    } else if (dtype == dl_float8_e4m3fn) {
+      args->mDtypeElt = btg::Dtype::E4m3;
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError) << "Unsupported input dtype for MoE.";
+    }
+
+    args->mUseDeepSeekFp8 = quantization_type == Fp8QuantizationType::DeepSeekFp8;
+    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
+    bool has_precomputed_indices = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
+    if (has_precomputed_indices) {
+      // Use expert_indices directly
+      workspace.routing_expert_indexes =
+          static_cast<int*>(const_cast<void*>(expert_indices.data_ptr()));
+    } else {
+      // Use routing_logits directly
+      args->routing_logits = static_cast<float*>(routing_logits.value().data_ptr());
+    }
+    // Set expert weights dtype based on routing bias
+    auto const routing_bias_dtype =
+        routing_bias.has_value() ? routing_bias.value().dtype() : dl_bfloat16;
+    mRoutingBiasDtype = routing_bias_dtype == dl_bfloat16 ? btg::Dtype::Bfloat16 : btg::Dtype::Fp32;
+
+    auto const routing_logits_dtype =
+        routing_logits.has_value() ? routing_logits.value().dtype() : dl_bfloat16;
+    mRoutingLogitsDtype =
+        routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+
+    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
+    bool has_precomputed_weights = expert_weights.ndim() == 2 && expert_weights.size(0) > 0;
+    if (!has_precomputed_weights) {
+      auto ew_dtype = mDtypeScore == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+      FusedMoeLauncher::expert_weights =
+          alloc_tensor({args->num_tokens, args->top_k}, ew_dtype, hidden_states.device());
+      workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
+    } else {
+      workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
+    }
+  }
+
+  void check_moe() const override {
+    FusedMoeLauncher::check_moe_common();
+
+    TVM_FFI_ICHECK_EQ(hidden_states.dtype(), dl_float8_e4m3fn) << "hidden_states must be fp8.";
+    if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+      TVM_FFI_ICHECK_EQ(hidden_states_scale.dtype(), dl_float32)
+          << "hidden_states_scale must be float.";
+      TVM_FFI_ICHECK_EQ(hidden_states_scale.ndim(), 2) << "hidden_states_scale must be 2D.";
+      TVM_FFI_ICHECK_EQ(hidden_states_scale.size(0), hidden_states.size(1) / 128)
+          << "hidden_states_scale dim0 must match hidden_states dim1 / 128.";
+      TVM_FFI_ICHECK_EQ(hidden_states_scale.size(1), args->num_tokens)
+          << "hidden_states_scale dim1 must match num_tokens.";
+    } else if (quantization_type == Fp8QuantizationType::MxFp8) {
+      TVM_FFI_CHECK(weight_layout == batchedGemm::gemm::MatrixLayout::MajorK,
+                    "weight_layout must be MajorK for MxFp8.");
+      TVM_FFI_ICHECK_EQ(hidden_states_scale.dtype(), dl_uint8);
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError)
+          << "trtllm_fp8_block_scale_moe only supports DeepSeekFp8 or MxFp8.";
+    }
+
+    TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_float8_e4m3fn) << "gemm1_weights must be fp8.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_float8_e4m3fn) << "gemm2_weights must be fp8.";
+
+    if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+      TVM_FFI_ICHECK_EQ(gemm1_weights_scale.dtype(), dl_float32)
+          << "gemm1_weights_scale must be float.";
+      TVM_FFI_ICHECK_EQ(gemm1_weights_scale.ndim(), 3) << "gemm1_weights_scale must be 3D.";
+      TVM_FFI_ICHECK_EQ(gemm1_weights_scale.size(0), args->local_num_experts)
+          << "gemm1_weights_scale has incorrect shape.";
+      TVM_FFI_ICHECK_EQ(args->intermediate_size % 128, 0)
+          << "intermediate_size must be a multiple of 128.";
+      TVM_FFI_ICHECK_EQ(gemm1_weights_scale.size(1),
+                        intermediate_size_factor * args->intermediate_size / 128)
+          << "gemm1_weights_scale has incorrect shape.";
+      TVM_FFI_ICHECK_EQ(gemm1_weights_scale.size(2), args->hidden_size / 128)
+          << "gemm1_weights_scale has incorrect shape.";
+    } else if (quantization_type == Fp8QuantizationType::MxFp8) {
+      TVM_FFI_ICHECK_EQ(gemm1_weights_scale.dtype(), dl_uint8)
+          << "gemm1_weights_scale must be uint8.";
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError)
+          << "trtllm_fp8_block_scale_moe only supports DeepSeekFp8 or MxFp8.";
+    }
+
+    if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+      TVM_FFI_ICHECK_EQ(gemm2_weights_scale.dtype(), dl_float32)
+          << "gemm2_weights_scale must be float.";
+      TVM_FFI_ICHECK_EQ(gemm2_weights_scale.ndim(), 3) << "gemm2_weights_scale must be 3D.";
+      TVM_FFI_ICHECK_EQ(gemm2_weights_scale.size(0), args->local_num_experts)
+          << "gemm2_weights_scale has incorrect shape.";
+      TVM_FFI_ICHECK_EQ(gemm2_weights_scale.size(1), args->hidden_size / 128)
+          << "gemm2_weights_scale has incorrect shape.";
+      TVM_FFI_ICHECK_EQ(gemm2_weights_scale.size(2), args->intermediate_size / 128)
+          << "gemm2_weights_scale has incorrect shape.";
+    } else if (quantization_type == Fp8QuantizationType::MxFp8) {
+      TVM_FFI_ICHECK_EQ(gemm2_weights_scale.dtype(), dl_uint8)
+          << "gemm2_weights_scale must be uint8.";
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError)
+          << "trtllm_fp8_block_scale_moe only supports DeepSeekFp8 or MxFp8.";
+    }
+
+    check_weights_shape("gemm1");
+    check_weights_shape("gemm2");
+
+    if (gate_up_lora_delta.has_value()) {
+      TVM_FFI_ICHECK_EQ(gate_up_lora_delta.value().dtype(), dl_bfloat16)
+          << "gate_up_lora_delta must be bf16.";
+      TVM_FFI_ICHECK_EQ(gate_up_lora_delta.value().ndim(), 3)
+          << "gate_up_lora_delta must be [num_tokens, top_k, 2 * intermediate_size].";
+      TVM_FFI_ICHECK_EQ(gate_up_lora_delta.value().size(0), args->num_tokens);
+      TVM_FFI_ICHECK_EQ(gate_up_lora_delta.value().size(1), args->top_k);
+      TVM_FFI_ICHECK_EQ(gate_up_lora_delta.value().size(2),
+                        args->intermediate_size * intermediate_size_factor);
+    }
+    if (activation_lora_input.has_value()) {
+      TVM_FFI_ICHECK_EQ(activation_lora_input.value().dtype(), dl_bfloat16)
+          << "activation_lora_input must be bf16.";
+      TVM_FFI_ICHECK_EQ(activation_lora_input.value().ndim(), 3)
+          << "activation_lora_input must be [num_tokens, top_k, intermediate_size].";
+      TVM_FFI_ICHECK_EQ(activation_lora_input.value().size(0), args->num_tokens);
+      TVM_FFI_ICHECK_EQ(activation_lora_input.value().size(1), args->top_k);
+      TVM_FFI_ICHECK_EQ(activation_lora_input.value().size(2), args->intermediate_size);
+    }
+
+    if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+      TVM_FFI_ICHECK_EQ(args->intermediate_size % 128, 0)
+          << "intermediate_size must be a multiple of 128.";
+    }
+  }
+
+  void prepare_moe(int64_t& moe_tactic) override {
+    FusedMoeLauncher::prepare_moe_common(moe_tactic);
+
+    // Calculate max_num_padded_tokens for gemm1 and gemm2 using maybeGetMinTokenCount
+    int32_t max_num_padded_tokens_gemm1 =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::maybeGetMinTokenCount(
+            workspace.total_max_padded_tokens, args->intermediate_size,
+            btg::dtypeGetNumBits(args->mDtypeElt));
+    int32_t max_num_padded_tokens_gemm2 =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::maybeGetMinTokenCount(
+            workspace.total_max_padded_tokens, args->hidden_size,
+            btg::dtypeGetNumBits(args->mDtypeOut));
+
+    gemm1_output = alloc_tensor(
+        {max_num_padded_tokens_gemm1, intermediate_size_factor * args->intermediate_size}, dl_uint8,
+        hidden_states.device());
+
+    if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+      gemm1_output_scale = alloc_tensor({intermediate_size_factor * args->intermediate_size / 128,
+                                         workspace.total_max_padded_tokens},
+                                        dl_float32, hidden_states.device());
+    } else if (quantization_type == Fp8QuantizationType::MxFp8) {
+      // MxFP8 fuses the activation so no need for intermediate_size_factor
+      int64_t sf_size = tensorrt_llm::computeSwizzledLayoutSFSize(max_num_padded_tokens_gemm1,
+                                                                  args->intermediate_size / 32);
+      gemm1_output_scale = alloc_tensor({sf_size}, dl_uint8, hidden_states.device());
+    }
+
+    if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+      activation_output = alloc_tensor({max_num_padded_tokens_gemm1, args->intermediate_size},
+                                       dl_uint8, hidden_states.device());
+      activation_output_scale =
+          alloc_tensor({args->intermediate_size / 128, max_num_padded_tokens_gemm1}, dl_float32,
+                       hidden_states.device());
+    }
+
+    gemm2_output = alloc_tensor({max_num_padded_tokens_gemm2, args->hidden_size}, dl_bfloat16,
+                                hidden_states.device());
+
+    workspace.hidden_states_scale_linear = nullptr;
+    workspace.gemm1_output = gemm1_output.data_ptr();
+    workspace.gemm1_output_scale = static_cast<float*>(gemm1_output_scale.data_ptr());
+    if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+      workspace.activation_output = activation_output.data_ptr();
+      workspace.activation_output_scale = static_cast<float*>(activation_output_scale.data_ptr());
+    }
+    workspace.gemm2_output = gemm2_output.data_ptr();
+    workspace.gemm2_output_scale = nullptr;
+
+    if (args->output == nullptr) {
+      output =
+          alloc_tensor({args->num_tokens, args->hidden_size}, dl_bfloat16, hidden_states.device());
+      args->output = output.data_ptr();
+    }
+    args->output_scale = nullptr;
+
+    args->hidden_states_scale = static_cast<float*>(hidden_states_scale.data_ptr());
+    args->gemm1_weights_scale = static_cast<float*>(gemm1_weights_scale.data_ptr());
+    args->gemm2_weights_scale = static_cast<float*>(gemm2_weights_scale.data_ptr());
+    args->gate_up_lora_delta =
+        gate_up_lora_delta.has_value() ? gate_up_lora_delta.value().data_ptr() : nullptr;
+    args->activation_lora_input =
+        activation_lora_input.has_value() ? activation_lora_input.value().data_ptr() : nullptr;
+  }
+
+ private:
+  TensorView hidden_states_scale;
+  TensorView gemm1_weights_scale;
+  TensorView gemm2_weights_scale;
+  Tensor gemm1_output_scale;
+  Tensor activation_output_scale;
+  TensorView expert_indices;
+  TensorView expert_weights;
+  Optional<TensorView> gate_up_lora_delta;
+  Optional<TensorView> activation_lora_input;
+  Fp8QuantizationType quantization_type;
+
+ public:
+  // Override to handle pre-computed routing
+  Array<Tensor> run(int64_t moe_tactic, bool enable_pdl = true,
+                    bool use_routing_scales_on_input = false,
+                    bool use_deep_seek_fp8 = false) override {
+    check_routing();
+    prepare_routing();
+
+    cudaStream_t routing_stream = get_stream(hidden_states.device());
+    tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
+
+    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
+    bool use_precomputed = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
+    // When using pre-computed routing, pass nullptr as routing_logits to tell the
+    // routing runner to use the pre-computed expert indices from workspace.routing_expert_indexes
+    int16_t* replay_ptr = nullptr;
+    if (routing_replay_out.has_value()) {
+      replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
+    }
+
+    routing_runner.run(
+        use_precomputed ? nullptr : args->routing_logits, args->routing_bias, args->num_tokens,
+        args->num_experts, args->top_k, args->n_group, args->topk_group, args->local_expert_offset,
+        args->local_num_experts, args->routed_scaling_factor, workspace.routing_expert_indexes,
+        static_cast<int*>(expert_count_histogram.data_ptr()),
+        static_cast<int*>(total_num_padded_tokens.data_ptr()),
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
+        nullptr /*permuted_idx_to_expanded_idx.data_ptr()*/,
+        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), workspace.expert_weights,
+        static_cast<int*>(num_tokens_per_expert.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
+        static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
+        use_routing_scales_on_input, use_deep_seek_fp8,
+        static_cast<RoutingMethodType>(routing_method_type), routing_stream, mRoutingLogitsDtype,
+        norm_topk_prob, replay_ptr);
+
+    check_moe();
+    prepare_moe(moe_tactic);
+
+    cudaStream_t moe_stream = get_stream(hidden_states.device());
+    moe_runner->run(*args, workspace, hidden_states.device().device_id, moe_stream, moe_tactic,
+                    enable_pdl);
+
+    if (args->do_finalize) {
+      return {output};
+    }
+    return {gemm2_output, FusedMoeLauncher::expert_weights, expanded_idx_to_permuted_idx};
+  }
+
+  static Array<Array<int64_t>> getValidConfigs(
+      int64_t top_k, int64_t hidden_size, int64_t intermediate_size, int64_t num_local_experts,
+      int64_t num_tokens, bool use_shuffled_weight, int64_t weight_layout, btg::Dtype dtype_act,
+      btg::Dtype dtype_weights, Fp8QuantizationType quantization_type, int64_t act_type) {
+    Array<Array<int64_t>> valid_configs;
+    auto activation_type = validateAndCastActivationType(act_type);
+
+    auto supported_tile_nums = getSupportedTileNums(quantization_type);
+    std::set<int32_t> selected_tile_nums =
+        computeSelectedTileN(supported_tile_nums, num_tokens, top_k, num_local_experts);
+
+    for (int32_t tile_N : selected_tile_nums) {
+      std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner> moe_runner;
+      // Keep getValidConfigs constructor path aligned with runtime prepare_moe_common().
+      // This branch is for DeepSeek FP8 (E4m3 activations + E4m3 weights).
+      if (quantization_type == Fp8QuantizationType::DeepSeekFp8 && dtype_act == btg::Dtype::E4m3 &&
+          dtype_weights == btg::Dtype::E4m3) {
+        TVM_FFI_ICHECK(static_cast<int>(activation_type) ==
+                       static_cast<int>(ActivationType::Swiglu))
+            << "DeepSeekFp8 only supports ActivationType::Swiglu, got "
+            << static_cast<int>(activation_type) << ".";
+        moe_runner = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner>(
+            dtype_weights, true /* useDeepSeekFp8 */, tile_N, use_shuffled_weight,
+            static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout));
+      } else {
+        // Under current trtllm_get_valid_moe_configs() dispatch rules, this else-path is
+        // reached only by FP8 block-scale MXFP8 (dtype_act=dtype_weights=MxE4m3).
+        moe_runner = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner>(
+            dtype_act,                                              // dtypeAct
+            dtype_weights,                                          // dtypeWeights
+            quantization_type == Fp8QuantizationType::DeepSeekFp8,  // useDeepSeekFp8
+            tile_N, activation_type, use_shuffled_weight,
+            static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout));
+      }
+
+      auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
+                                                    num_local_experts, num_tokens);
+
+      for (auto cfg : cfgs) {
+        valid_configs.push_back({tile_N, cfg});
+      }
+    }
+
+    return valid_configs;
+  }
+};
+
+class MxInt4BlockScaleLauncher : public FusedMoeLauncher {
+ public:
+  static constexpr std::array<int32_t, 5> mSupportedTileNums = {8, 16, 32, 64, 128};
+
+  MxInt4BlockScaleLauncher(TensorView const& routing_logits,
+                           Optional<TensorView> const& routing_bias,
+                           TensorView const& hidden_states, TensorView const& gemm1_weights,
+                           TensorView const& gemm1_weights_scale,
+                           Optional<TensorView> const& gemm1_alpha,
+                           Optional<TensorView> const& gemm1_beta,
+                           Optional<TensorView> const& gemm1_clamp_limit,
+                           TensorView const& gemm2_weights, TensorView const& gemm2_weights_scale)
+      : FusedMoeLauncher(Optional<TensorView>(routing_logits), routing_bias, hidden_states,
+                         gemm1_weights, Optional<TensorView>(), Optional<TensorView>(),
+                         gemm2_weights, Optional<TensorView>(), Optional<TensorView>()),
+        gemm1_weights_scale(gemm1_weights_scale),
+        gemm2_weights_scale(gemm2_weights_scale) {}
+
+  void init(std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>&& args,
+            int64_t tile_tokens_dim, int64_t routing_method_type, bool norm_topk_prob = true) {
+    // currently only support mxint4 x bf16
+    auto dtype = hidden_states.dtype();
+    if (dtype == dl_bfloat16) {
+      args->mDtypeElt = btg::Dtype::Bfloat16;
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError) << "Unsupported input dtype for MoE.";
+    }
+    args->mDtypeOut = btg::Dtype::Bfloat16;
+
+    mDtypeAct = btg::Dtype::Bfloat16;
+    mDtypeWeights = btg::Dtype::MxInt4;
+
+    FusedMoeLauncher::init_common(
+        std::move(args), tile_tokens_dim, routing_method_type,
+        /*use_shuffled_weight=*/true,
+        static_cast<int64_t>(batchedGemm::gemm::MatrixLayout::BlockMajorK), ActivationType::Swiglu,
+        norm_topk_prob);
+  }
+
+  void check_routing() const override { FusedMoeLauncher::check_routing_common(); }
+
+  void prepare_routing() override {
+    FusedMoeLauncher::prepare_routing_common();
+
+    args->mDtypeElt = mDtypeAct;
+    args->mUseDeepSeekFp8 = false;
+    // Set expert weights dtype based on routing bias
+    auto const routing_bias_dtype =
+        routing_bias.has_value() ? routing_bias.value().dtype() : dl_bfloat16;
+    mRoutingBiasDtype = routing_bias_dtype == dl_bfloat16 ? btg::Dtype::Bfloat16 : btg::Dtype::Fp32;
+
+    auto const routing_logits_dtype =
+        routing_logits.has_value() ? routing_logits.value().dtype() : dl_bfloat16;
+    mRoutingLogitsDtype =
+        routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+
+    auto expert_weights_dtype = mRoutingLogitsDtype == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+    expert_weights =
+        alloc_tensor({args->num_tokens, args->top_k}, expert_weights_dtype, hidden_states.device());
+
+    workspace.expert_weights = expert_weights.data_ptr();
+  }
+
+  void check_moe() const override {
+    TVM_FFI_ICHECK(mDtypeAct == btg::Dtype::Bfloat16)
+        << "Only Bfloat16 is supported by MxInt4 block scale MoE";
+
+    TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_uint8) << "gemm1_weights must be uint8.";
+    TVM_FFI_ICHECK_EQ(gemm1_weights_scale.dtype(), dl_bfloat16)
+        << "gemm1_weights_scale must be bf16.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_uint8) << "gemm2_weights must be uint8.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights_scale.dtype(), dl_bfloat16)
+        << "gemm2_weights_scale must be bf16.";
+  }
+
+  void prepare_moe(int64_t& moe_tactic) override {
+    args->hidden_states = hidden_states.data_ptr();
+    args->hidden_states_scale = nullptr;
+    args->gemm1_weights = gemm1_weights.data_ptr();
+    args->gemm1_weights_scale = gemm1_weights_scale.data_ptr();
+    args->gemm1_alpha =
+        gemm1_alpha.has_value() ? static_cast<float*>(gemm1_alpha.value().data_ptr()) : nullptr;
+    args->gemm1_beta =
+        gemm1_beta.has_value() ? static_cast<float*>(gemm1_beta.value().data_ptr()) : nullptr;
+    args->gemm1_clamp_limit = gemm1_clamp_limit.has_value()
+                                  ? static_cast<float*>(gemm1_clamp_limit.value().data_ptr())
+                                  : nullptr;
+    args->gemm2_weights = gemm2_weights.data_ptr();
+    args->gemm2_weights_scale = gemm2_weights_scale.data_ptr();
+    args->output1_scales_scalar = nullptr;
+    args->output1_scales_gate_scalar = nullptr;
+    args->output2_scales_scalar = nullptr;
+
+    FusedMoeLauncher::prepare_moe_common(moe_tactic);
+
+    max_num_padded_tokens_gemm1 =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::maybeGetMinTokenCount(
+            workspace.total_max_padded_tokens, args->intermediate_size,
+            btg::dtypeGetNumBits(mDtypeAct));
+    max_num_padded_tokens_gemm2 =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::maybeGetMinTokenCount(
+            workspace.total_max_padded_tokens, args->hidden_size,
+            btg::dtypeGetNumBits(btg::Dtype::Bfloat16));  // Output is always BF16
+
+    auto const gemm1_output_hidden = args->intermediate_size;
+    gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, gemm1_output_hidden}, dl_bfloat16,
+                                hidden_states.device());
+
+    // Allocate gemm2_output
+    gemm2_output = alloc_tensor({max_num_padded_tokens_gemm2, args->hidden_size}, dl_bfloat16,
+                                hidden_states.device());
+
+    // Setup workspace pointers
+    workspace.hidden_states_scale_linear = nullptr;  // MxInt4 doesn't use linear scale
+    workspace.gemm1_output = gemm1_output.data_ptr();
+    workspace.gemm1_output_scale = nullptr;
+    // Note: activation_output and activation_output_scale are set by the base class
+    // prepare_moe_common() when gated activation is used
+    workspace.gemm2_output = gemm2_output.data_ptr();
+    workspace.gemm2_output_scale = nullptr;
+  }
+
+ private:
+  TensorView gemm1_weights_scale;
+  Optional<TensorView> gemm1_alpha;
+  Optional<TensorView> gemm1_beta;
+  Optional<TensorView> gemm1_clamp_limit;
+  TensorView gemm2_weights_scale;
+  int32_t max_num_padded_tokens_gemm1{};
+  int32_t max_num_padded_tokens_gemm2{};
+
+ public:
+  static Array<Array<int64_t>> getValidConfigs(int64_t top_k, int64_t hidden_size,
+                                               int64_t intermediate_size, int64_t num_local_experts,
+                                               int64_t num_tokens) {
+    Array<Array<int64_t>> valid_configs;
+
+    std::vector<int32_t> tile_sizes(mSupportedTileNums.begin(), mSupportedTileNums.end());
+    std::set<int32_t> selected_tile_nums =
+        computeSelectedTileN(tile_sizes, num_tokens, top_k, num_local_experts);
+
+    for (int32_t tile_N : selected_tile_nums) {
+      auto moe_runner = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner>(
+          btg::Dtype::Bfloat16, btg::Dtype::MxInt4,
+          false,  // useDeepSeekFp8
+          tile_N, ActivationType::Swiglu,
+          /*useShuffledMatrix*/ true, batchedGemm::gemm::MatrixLayout::BlockMajorK);
+
+      auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
+                                                    num_local_experts, num_tokens);
+
+      for (auto cfg : cfgs) {
+        valid_configs.push_back({tile_N, cfg});
+      }
+    }
+
+    return valid_configs;
+  }
+};
+
+class FP4BlockScaleLauncher : public FusedMoeLauncher {
+ public:
+  static constexpr std::array<int32_t, 4> mBaseSupportedTileNums = {8, 16, 32, 64};
+
+  static std::vector<int32_t> getSupportedTileNums(btg::Dtype dtype_act) {
+    std::vector<int32_t> tiles(mBaseSupportedTileNums.begin(), mBaseSupportedTileNums.end());
+    if (dtype_act != btg::Dtype::Bfloat16) {
+      tiles.push_back(128);
+      tiles.push_back(256);
+    }
+    return tiles;
+  }
+
+  FP4BlockScaleLauncher(
+      Optional<TensorView> const& routing_logits, Optional<TensorView> const& routing_bias,
+      TensorView const& hidden_states, Optional<TensorView> const& hidden_states_scale,
+      TensorView const& gemm1_weights, TensorView const& gemm1_weights_scale,
+      Optional<TensorView> const& gemm1_bias, Optional<TensorView> const& gemm1_alpha,
+      Optional<TensorView> const& gemm1_beta, Optional<TensorView> const& gemm1_clamp_limit,
+      TensorView const& gemm2_weights, TensorView const& gemm2_weights_scale,
+      Optional<TensorView> const& gemm2_bias, Optional<TensorView> const& output1_scales_scalar,
+      Optional<TensorView> const& output1_scales_gate_scalar,
+      Optional<TensorView> const& output2_scales_scalar,
+      Optional<TensorView> const& per_token_scales, TensorView const& expert_indices,
+      TensorView const& expert_weights)
+      : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights,
+                         output1_scales_scalar, output1_scales_gate_scalar, gemm2_weights,
+                         output2_scales_scalar, per_token_scales),
+        hidden_states_scale(hidden_states_scale),
+        gemm1_weights_scale(gemm1_weights_scale),
+        gemm1_bias(gemm1_bias),
+        gemm1_alpha(gemm1_alpha),
+        gemm1_beta(gemm1_beta),
+        gemm1_clamp_limit(gemm1_clamp_limit),
+        gemm2_weights_scale(gemm2_weights_scale),
+        gemm2_bias(gemm2_bias),
+        expert_indices(expert_indices),
+        expert_weights(expert_weights) {}
+
+  void init(std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>&& args,
+            int64_t tile_tokens_dim, int64_t routing_method_type, bool use_shuffled_weight,
+            int64_t weight_layout, ActivationType activation_type, btg::Dtype dtype_act,
+            btg::Dtype dtype_weights, bool norm_topk_prob = true) {
+    // Set data types
+    args->mDtypeElt = dtype_act;
+    args->mDtypeOut = btg::Dtype::Bfloat16;  // Output is always BF16 for FP4
+    args->mUseDeepSeekFp8 = false;           // FP4 doesn't use DeepSeek FP8
+
+    mDtypeAct = dtype_act;
+    mDtypeWeights = dtype_weights;
+
+    FusedMoeLauncher::init_common(std::move(args), tile_tokens_dim, routing_method_type,
+                                  use_shuffled_weight, weight_layout, activation_type,
+                                  norm_topk_prob);
+  }
+
+  void check_routing() const override {
+    // First call base class common routing checks
+    FusedMoeLauncher::check_routing_common();
+  }
+
+  void prepare_routing() override {
+    num_tokens_per_expert = alloc_tensor({args->num_experts}, dl_int32, hidden_states.device());
+    int32_t max_num_padded_tokens =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxPermutedPaddedCount(
+            args->num_tokens, args->top_k, args->num_experts, tile_tokens_dim);
+
+    total_num_padded_tokens = alloc_tensor({1}, dl_int32, hidden_states.device());
+    expanded_idx_to_permuted_idx =
+        alloc_tensor({args->num_tokens * args->top_k}, dl_int32, hidden_states.device());
+    permuted_idx_to_token_idx =
+        alloc_tensor({max_num_padded_tokens}, dl_int32, hidden_states.device());
+
+    int64_t const size_of_expert_count_histogram = std::max(args->num_experts * 2, 256 * 2);
+    expert_count_histogram =
+        alloc_tensor({size_of_expert_count_histogram}, dl_int32, hidden_states.device());
+
+    int32_t max_num_ctas = tensorrt_llm::kernels::trtllmgen_moe::Routing::getMaxNumCtasInBatchDim(
+        args->num_tokens, args->top_k, args->num_experts, tile_tokens_dim);
+    cta_idx_xy_to_batch_idx = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
+    cta_idx_xy_to_mn_limit = alloc_tensor({max_num_ctas}, dl_int32, hidden_states.device());
+    num_non_exiting_ctas = alloc_tensor({1}, dl_int32, hidden_states.device());
+
+    workspace.total_num_padded_tokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
+    workspace.total_max_padded_tokens = max_num_padded_tokens;
+    workspace.ProjUpTileN = tile_tokens_dim;
+    workspace.routing_expert_indexes =
+        static_cast<int*>(const_cast<void*>(expert_indices.data_ptr()));
+    workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
+    workspace.permuted_idx_size = static_cast<int*>(total_num_padded_tokens.data_ptr());
+    workspace.expanded_idx_to_permuted_idx =
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr());
+    workspace.permuted_idx_to_token_idx = static_cast<int*>(permuted_idx_to_token_idx.data_ptr());
+    workspace.cta_idx_xy_to_batch_idx = static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr());
+    workspace.cta_idx_xy_to_mn_limit = static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr());
+    workspace.num_non_exiting_ctas = static_cast<int*>(num_non_exiting_ctas.data_ptr());
+
+    args->mDtypeElt = mDtypeAct;
+    auto routing_bias_dtype = routing_bias.has_value() ? routing_bias.value().dtype() : dl_bfloat16;
+    mRoutingBiasDtype = routing_bias_dtype == dl_bfloat16 ? btg::Dtype::Bfloat16 : btg::Dtype::Fp32;
+
+    auto const routing_logits_dtype =
+        routing_logits.has_value() ? routing_logits.value().dtype() : dl_bfloat16;
+    mRoutingLogitsDtype =
+        routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+  }
+
+  void check_moe() const override {
+    TVM_FFI_ICHECK(mDtypeAct == btg::Dtype::E2m1 || mDtypeAct == btg::Dtype::Bfloat16 ||
+                   mDtypeAct == btg::Dtype::E4m3 || mDtypeAct == btg::Dtype::MxE4m3)
+        << "Only E2m1, Bfloat16, MxE4m3 and E4m3 are supported by Fp4 block scale MoE";
+
+    if (mDtypeAct == btg::Dtype::E2m1) {
+      TVM_FFI_ICHECK(mDtypeWeights == btg::Dtype::E2m1)
+          << "Only E2m1 and MxE2m1 are supported by block scale MoE with E2m1 activation";
+      TVM_FFI_ICHECK(hidden_states_scale.has_value())
+          << "hidden_states_scale is required for E2m1 activation";
+      TVM_FFI_ICHECK(output1_scales_scalar.has_value())
+          << "output1_scales_scalar is required for E2m1 activation";
+      TVM_FFI_ICHECK(output1_scales_gate_scalar.has_value())
+          << "output1_scales_gate_scalar is required for E2m1 activation";
+      TVM_FFI_ICHECK(output2_scales_scalar.has_value())
+          << "output2_scales_scalar is required for E2m1 activation";
+    } else if (mDtypeAct == btg::Dtype::Bfloat16 || mDtypeAct == btg::Dtype::E4m3 ||
+               mDtypeAct == btg::Dtype::MxE4m3) {
+      TVM_FFI_ICHECK(mDtypeWeights == btg::Dtype::MxE2m1)
+          << "Only MxE2m1 weights are supported by block scale MoE with Bfloat16, E4m3 or "
+             "MxE4m3 activation";
+    }
+
+    if (mDtypeAct == btg::Dtype::E4m3) {
+      TVM_FFI_ICHECK(output1_scales_scalar.has_value())
+          << "output1_scales_scalar is required for E4m3 activation";
+      TVM_FFI_ICHECK(output1_scales_gate_scalar.has_value())
+          << "output1_scales_gate_scalar is required for E4m3 activation";
+      TVM_FFI_ICHECK(output2_scales_scalar.has_value())
+          << "output2_scales_scalar is required for E4m3 activation";
+    }
+
+    TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_uint8) << "gemm1_weights must be byte.";
+    TVM_FFI_ICHECK_EQ(gemm1_weights_scale.dtype(), dl_float8_e4m3fn)
+        << "gemm1_weights_scale must be fp8.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_uint8) << "gemm2_weights must be byte.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights_scale.dtype(), dl_float8_e4m3fn)
+        << "gemm2_weights_scale must be fp8.";
+  }
+
+  void prepare_moe(int64_t& moe_tactic) override {
+    args->hidden_states = hidden_states.data_ptr();
+    args->hidden_states_scale =
+        hidden_states_scale.has_value() ? hidden_states_scale.value().data_ptr() : nullptr;
+    args->gemm1_weights = gemm1_weights.data_ptr();
+    args->gemm1_weights_scale = gemm1_weights_scale.data_ptr();
+    args->gemm1_bias =
+        gemm1_bias.has_value() ? static_cast<float*>(gemm1_bias.value().data_ptr()) : nullptr;
+    args->gemm1_alpha =
+        gemm1_alpha.has_value() ? static_cast<float*>(gemm1_alpha.value().data_ptr()) : nullptr;
+    args->gemm1_beta =
+        gemm1_beta.has_value() ? static_cast<float*>(gemm1_beta.value().data_ptr()) : nullptr;
+    args->gemm1_clamp_limit = gemm1_clamp_limit.has_value()
+                                  ? static_cast<float*>(gemm1_clamp_limit.value().data_ptr())
+                                  : nullptr;
+    args->gemm2_weights = gemm2_weights.data_ptr();
+    args->gemm2_weights_scale = gemm2_weights_scale.data_ptr();
+    args->gemm2_bias =
+        gemm2_bias.has_value() ? static_cast<float*>(gemm2_bias.value().data_ptr()) : nullptr;
+    args->output1_scales_scalar =
+        output1_scales_scalar.has_value()
+            ? static_cast<float*>(output1_scales_scalar.value().data_ptr())
+            : nullptr;
+    args->output1_scales_gate_scalar =
+        output1_scales_gate_scalar.has_value()
+            ? static_cast<float*>(output1_scales_gate_scalar.value().data_ptr())
+            : nullptr;
+    args->output2_scales_scalar =
+        output2_scales_scalar.has_value()
+            ? static_cast<float*>(output2_scales_scalar.value().data_ptr())
+            : nullptr;
+
+    FusedMoeLauncher::prepare_moe_common(moe_tactic);
+
+    auto const sf_vec_size = mDtypeWeights == btg::Dtype::MxE2m1 ? 32 : 16;
+
+    max_num_padded_tokens_gemm1 =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::maybeGetMinTokenCount(
+            workspace.total_max_padded_tokens, args->intermediate_size,
+            btg::dtypeGetNumBits(mDtypeAct));
+    max_num_padded_tokens_gemm2 =
+        tensorrt_llm::kernels::trtllmgen_moe::Routing::maybeGetMinTokenCount(
+            workspace.total_max_padded_tokens, args->hidden_size,
+            btg::dtypeGetNumBits(btg::Dtype::Bfloat16));  // Output is always BF16
+
+    auto const gemm1_output_hidden =
+        mDtypeAct == btg::Dtype::E2m1 ? args->intermediate_size / 2 : args->intermediate_size;
+    if (mDtypeAct == btg::Dtype::E2m1 || mDtypeAct == btg::Dtype::MxE4m3) {
+      int64_t sf_size = tensorrt_llm::computeSwizzledLayoutSFSize(
+          max_num_padded_tokens_gemm1, args->intermediate_size / sf_vec_size);
+      gemm1_output_scale = alloc_tensor({sf_size}, dl_uint8, hidden_states.device());
+    }
+    if (!per_token_scales.has_value()) {
+      gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, gemm1_output_hidden},
+                                  mDtypeAct == btg::Dtype::Bfloat16 ? dl_bfloat16 : dl_uint8,
+                                  hidden_states.device());
+    } else {  // FC1 output is Bfloat16
+      TVM_FFI_ICHECK(mDtypeAct == btg::Dtype::E2m1)
+          << "NvFP4 MoE: currently only support NvFP4 x NvFP4 when using per-token scaling.";
+      // When per-token scales are used, the FC1 output is always BF16 and will be quantized
+      gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, args->intermediate_size},
+                                  dl_bfloat16, hidden_states.device());
+      activation_output = alloc_tensor({max_num_padded_tokens_gemm1, gemm1_output_hidden}, dl_uint8,
+                                       hidden_states.device());
+      per_token_scales_fc2 =
+          alloc_tensor({max_num_padded_tokens_gemm1}, dl_float32, hidden_states.device());
+    }
+
+    // Allocate gemm2_output
+    gemm2_output = alloc_tensor({max_num_padded_tokens_gemm2, args->hidden_size}, dl_bfloat16,
+                                hidden_states.device());
+
+    // Setup workspace pointers
+    workspace.hidden_states_scale_linear = nullptr;  // FP4 doesn't use linear scale
+    workspace.gemm1_output = gemm1_output.data_ptr();
+    workspace.gemm1_output_scale = gemm1_output_scale.has_value()
+                                       ? static_cast<float*>(gemm1_output_scale.value().data_ptr())
+                                       : nullptr;
+    if (per_token_scales.has_value()) {
+      workspace.token_scales = per_token_scales.value().data_ptr();
+      workspace.activation_output = activation_output.data_ptr();
+      workspace.activation_output_scale = workspace.gemm1_output_scale;
+      workspace.token_scales_fc2 = per_token_scales_fc2.data_ptr();
+    }
+    workspace.gemm2_output = gemm2_output.data_ptr();
+    workspace.gemm2_output_scale = nullptr;
+  }
+
+ private:
+  Optional<TensorView> hidden_states_scale;
+  TensorView gemm1_weights_scale;
+  Optional<TensorView> gemm1_bias;
+  Optional<TensorView> gemm1_alpha;
+  Optional<TensorView> gemm1_beta;
+  Optional<TensorView> gemm1_clamp_limit;
+  TensorView gemm2_weights_scale;
+  Optional<TensorView> gemm2_bias;
+  int32_t max_num_padded_tokens_gemm1{};
+  int32_t max_num_padded_tokens_gemm2{};
+  Optional<Tensor> gemm1_output_scale;
+  TensorView expert_indices;
+  TensorView expert_weights;
+
+ public:
+  Array<Tensor> run(int64_t moe_tactic, bool enable_pdl = true,
+                    bool use_routing_scales_on_input = false,
+                    bool use_deep_seek_fp8 = false) override {
+    check_routing();
+    prepare_routing();
+
+    // Execute routing
+    tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
+    cudaStream_t routing_stream = get_stream(hidden_states.device());
+
+    int16_t* replay_ptr = nullptr;
+    if (routing_replay_out.has_value()) {
+      replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
+    }
+
+    routing_runner.run(
+        args->routing_logits, args->routing_bias, args->num_tokens, args->num_experts, args->top_k,
+        args->n_group, args->topk_group, args->local_expert_offset, args->local_num_experts,
+        args->routed_scaling_factor, static_cast<int*>(expert_indices.data_ptr()),
+        static_cast<int*>(expert_count_histogram.data_ptr()),
+        static_cast<int*>(total_num_padded_tokens.data_ptr()),
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
+        nullptr /*permuted_idx_to_expanded_idx.data_ptr()*/,
+        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), expert_weights.data_ptr(),
+        static_cast<int*>(num_tokens_per_expert.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
+        static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
+        use_routing_scales_on_input, use_deep_seek_fp8,
+        static_cast<RoutingMethodType>(routing_method_type), routing_stream, mRoutingLogitsDtype,
+        norm_topk_prob, replay_ptr);
+
+    check_moe();
+    prepare_moe(moe_tactic);
+
+    cudaStream_t moe_stream = get_stream(hidden_states.device());
+    moe_runner->run(*args, workspace, hidden_states.device().device_id, moe_stream, moe_tactic,
+                    enable_pdl);
+
+    // Match original FP4 behavior for return values
+    if (args->do_finalize) {
+      return {output};
+    }
+    return {gemm2_output, FusedMoeLauncher::expert_weights, expanded_idx_to_permuted_idx};
+  }
+
+  static Array<Array<int64_t>> getValidConfigs(int64_t top_k, int64_t hidden_size,
+                                               int64_t intermediate_size, int64_t num_local_experts,
+                                               int64_t num_tokens, int64_t act_type,
+                                               btg::Dtype dtype_act, btg::Dtype dtype_weights,
+                                               bool use_per_token_scaling) {
+    Array<Array<int64_t>> valid_configs;
+
+    std::vector<int32_t> tile_sizes = getSupportedTileNums(dtype_act);
+    std::set<int32_t> selected_tile_nums =
+        computeSelectedTileN(tile_sizes, num_tokens, top_k, num_local_experts);
+
+    for (int32_t tile_N : selected_tile_nums) {
+      auto moe_runner = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner>(
+          dtype_act, dtype_weights,
+          false,  // useDeepSeekFp8
+          tile_N, static_cast<ActivationType>(act_type),
+          /*useShuffledMatrix*/ true,
+          /*weight_layout*/ batchedGemm::gemm::MatrixLayout::MajorK,
+          // NOTE(siyuan): currently FP4 MoE always apply per-token scaling to both FC1 and FC2.
+          /*usePerTokenScalingGemm1*/ use_per_token_scaling,
+          /*usePerTokenScalingGemm2*/ use_per_token_scaling, false, false);
+
+      auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
+                                                    num_local_experts, num_tokens);
+
+      for (auto cfg : cfgs) {
+        valid_configs.push_back({tile_N, cfg});
+      }
+    }
+
+    return valid_configs;
+  }
+};
+
+Array<Tensor> trtllm_bf16_moe(Optional<TensorView> const& routing_logits,
+                              Optional<TensorView> const& routing_bias,
+                              TensorView const& expert_indices, TensorView const& expert_weights,
+                              TensorView const& hidden_states, TensorView const& gemm1_weights,
+                              TensorView const& gemm2_weights, TensorView output,
+                              int64_t num_experts, int64_t top_k, Optional<int64_t> n_group,
+                              Optional<int64_t> topk_group, int64_t intermediate_size,
+                              int64_t local_expert_offset, int64_t local_num_experts,
+                              Optional<double> routed_scaling_factor, int64_t routing_method_type,
+                              bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
+                              bool enable_pdl, Array<int64_t> moe_tactic, int64_t activation_type,
+                              bool norm_topk_prob, Optional<TensorView> routing_replay_out) {
+  // Just some basic type validation first and leave more checks to the launcher
+  if (routing_logits.has_value()) {
+    TVM_FFI_ICHECK(routing_logits.value().dtype() == dl_float32 ||
+                   routing_logits.value().dtype() == dl_bfloat16)
+        << "BF16 MoE: routing_logits must be bfloat16 or float.";
+  }
+  TVM_FFI_ICHECK_EQ(hidden_states.dtype(), dl_bfloat16)
+      << "BF16 MoE: hidden_states must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_bfloat16)
+      << "BF16 MoE: gemm1_weights must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_bfloat16)
+      << "BF16 MoE: gemm2_weights must be bfloat16.";
+
+  if (routing_replay_out.has_value()) {
+    validate_routing_replay_out(routing_replay_out.value(), hidden_states, top_k);
+  }
+
+  auto const num_tokens = hidden_states.size(0);
+  auto const hidden_size = hidden_states.size(1);
+  auto const activation = validateAndCastActivationType(activation_type);
+
+  // Calculate supported tile sizes
+  std::vector<int32_t> mSupportedTileN(Bf16MoeLauncher::mSupportedTileNums.begin(),
+                                       Bf16MoeLauncher::mSupportedTileNums.end());
+  // Build launchers for ALL supported tiles (not just the computeSelectedTileN subset)
+  // so that autotuner-cached tactics always find their tile_N in the map.
+  // Launcher creation is cheap (no GPU allocation until run()), so this is safe.
+
+  // Create a map of launchers for each tile size
+  std::unordered_map<int32_t, std::unique_ptr<Bf16MoeLauncher>> launchers_map;
+
+  for (int32_t curr_tile_N : mSupportedTileN) {
+    // Create MoE arguments for this launcher
+    auto args = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>();
+    args->num_tokens = num_tokens;
+    args->num_experts = num_experts;
+    args->hidden_size = hidden_size;
+    args->hidden_size_output = args->hidden_size;
+    args->top_k = top_k;
+    args->n_group = n_group.value_or(0);
+    args->topk_group = topk_group.value_or(0);
+    args->routed_scaling_factor = routed_scaling_factor.value_or(1.0);
+    args->local_expert_offset = local_expert_offset;
+    args->local_num_experts = local_num_experts;
+    args->intermediate_size = intermediate_size;
+    args->do_finalize = do_finalize;
+    args->output = output.data_ptr();
+    args->output_scale = nullptr;
+
+    // Create and initialize launcher for this tile size
+    auto launcher = std::make_unique<Bf16MoeLauncher>(routing_logits, routing_bias, expert_indices,
+                                                      expert_weights, hidden_states, gemm1_weights,
+                                                      gemm2_weights);
+    launcher->init(std::move(args), curr_tile_N, routing_method_type, use_shuffled_weight,
+                   weight_layout, activation, norm_topk_prob);
+    launcher->set_routing_replay_out(routing_replay_out);
+
+    launchers_map[curr_tile_N] = std::move(launcher);
+  }
+
+  auto const [tile_N, config] =
+      resolveMoeTileAndConfig(moe_tactic, mSupportedTileN, num_tokens, top_k, local_num_experts);
+
+  // Get the launcher for the selected tile_N
+  auto launcher_it = launchers_map.find(static_cast<int32_t>(tile_N));
+  FLASHINFER_CHECK(launcher_it != launchers_map.end(),
+                   "Internal error: missing BF16 MoE launcher for tile_N=", tile_N);
+  auto& selected_launcher = launcher_it->second;
+
+  // Run the launcher - it will create its own runner internally
+  return selected_launcher->run(config, enable_pdl);
+}
+
+Array<Tensor> trtllm_fp8_per_tensor_scale_moe(
+    TensorView routing_logits, Optional<TensorView> routing_bias, TensorView hidden_states,
+    TensorView gemm1_weights, TensorView output1_scales_scalar,
+    TensorView output1_scales_gate_scalar, TensorView gemm2_weights,
+    TensorView output2_scales_scalar, TensorView output, int64_t num_experts, int64_t top_k,
+    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
+    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
+    bool use_routing_scales_on_input, int64_t routing_method_type, bool do_finalize,
+    bool enable_pdl, Array<int64_t> config_index, int64_t activation_type, bool norm_topk_prob,
+    Optional<TensorView> routing_replay_out) {
+  // Basic type validation
+  auto dtype = hidden_states.dtype();
+  auto activation = validateAndCastActivationType(activation_type);
+
+  TVM_FFI_ICHECK(dtype == dl_float8_e4m3fn || dtype == dl_float16 || dtype == dl_bfloat16)
+      << "FP8 MoE: hidden_states must be float8_e4m3fn, float16, or bfloat16.";
+  TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_float8_e4m3fn)
+      << "FP8 MoE: gemm1_weights must be float8_e4m3fn.";
+  TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_float8_e4m3fn)
+      << "FP8 MoE: gemm2_weights must be float8_e4m3fn.";
+  TVM_FFI_ICHECK_EQ(output1_scales_scalar.dtype(), dl_float32)
+      << "FP8 MoE: output1_scales_scalar must be float32.";
+  TVM_FFI_ICHECK_EQ(output1_scales_gate_scalar.dtype(), dl_float32)
+      << "FP8 MoE: output1_scales_gate_scalar must be float32.";
+  TVM_FFI_ICHECK_EQ(output2_scales_scalar.dtype(), dl_float32)
+      << "FP8 MoE: output2_scales_scalar must be float32.";
+
+  if (routing_replay_out.has_value()) {
+    validate_routing_replay_out(routing_replay_out.value(), hidden_states, top_k);
+  }
+
+  auto const num_tokens = hidden_states.size(0);
+  auto const hidden_size = hidden_states.size(1);
+
+  // Use default values that match the original function behavior
+  bool use_shuffled_weight = true;  // Original uses /*useShuffledMatrix*/ true
+  int64_t weight_layout = 0;        // Default to MajorK
+
+  // Calculate supported tile sizes
+  std::vector<int32_t> mSupportedTileN(Fp8PerTensorLauncher::mSupportedTileNums.begin(),
+                                       Fp8PerTensorLauncher::mSupportedTileNums.end());
+  // Build launchers for ALL supported tiles so autotuner-cached tactics always find their tile_N.
+
+  // Create a map of launchers for each tile size
+  std::unordered_map<int32_t, std::unique_ptr<Fp8PerTensorLauncher>> launchers_map;
+
+  for (int32_t curr_tile_N : mSupportedTileN) {
+    // Create MoE arguments for this launcher
+    auto args = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>();
+    args->num_tokens = num_tokens;
+    args->num_experts = num_experts;
+    args->hidden_size = hidden_size;
+    args->hidden_size_output = args->hidden_size;
+    args->top_k = top_k;
+    args->n_group = n_group.value_or(0);
+    args->topk_group = topk_group.value_or(0);
+    args->local_expert_offset = local_expert_offset;
+    args->local_num_experts = local_num_experts;
+    args->intermediate_size = intermediate_size;
+    args->routed_scaling_factor = routed_scaling_factor.value_or(1.0);
+    args->do_finalize = do_finalize;
+    args->output = output.data_ptr();
+    args->output_scale = nullptr;
+
+    // Create and initialize launcher for this tile size
+    auto launcher = std::make_unique<Fp8PerTensorLauncher>(
+        routing_logits, routing_bias, hidden_states, gemm1_weights, output1_scales_scalar,
+        output1_scales_gate_scalar, gemm2_weights, output2_scales_scalar);
+    launcher->init(std::move(args), curr_tile_N, routing_method_type, use_shuffled_weight,
+                   weight_layout, use_routing_scales_on_input, activation, norm_topk_prob);
+    launcher->set_routing_replay_out(routing_replay_out);
+
+    launchers_map[curr_tile_N] = std::move(launcher);
+  }
+
+  auto const [tile_N, config] =
+      resolveMoeTileAndConfig(config_index, mSupportedTileN, num_tokens, top_k, local_num_experts);
+
+  // Get the launcher for the selected tile_N
+  auto launcher_it = launchers_map.find(static_cast<int32_t>(tile_N));
+  FLASHINFER_CHECK(launcher_it != launchers_map.end(),
+                   "Internal error: missing FP8 per-tensor MoE launcher for tile_N=", tile_N);
+  auto& selected_launcher = launcher_it->second;
+
+  // Run the launcher - it will create its own runner internally
+  return selected_launcher->run(config, enable_pdl, use_routing_scales_on_input);
+}
+
+Array<Tensor> trtllm_fp8_block_scale_moe_impl(
+    Optional<TensorView> routing_logits, TensorView expert_indices, TensorView expert_weights,
+    Optional<TensorView> routing_bias, TensorView hidden_states, TensorView hidden_states_scale,
+    TensorView gemm1_weights, TensorView gemm1_weights_scale, TensorView gemm2_weights,
+    TensorView gemm2_weights_scale, TensorView output, int64_t num_experts, int64_t top_k,
+    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
+    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
+    int64_t routing_method_type, bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
+    bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type,
+    int64_t act_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out,
+    Optional<TensorView> gate_up_lora_delta, Optional<TensorView> activation_lora_input) {
+  auto activation_type = validateAndCastActivationType(act_type);
+  // DeepSeekFp8 currently uses a TRTLLM runner that hardwires Swiglu activation semantics.
+  // Fail for any other activation to avoid silently running incorrect activation behavior.
+  if (quantization_type == Fp8QuantizationType::DeepSeekFp8 &&
+      activation_type != ActivationType::Swiglu) {
+    TVM_FFI_LOG_AND_THROW(NotImplementedError)
+        << "DeepSeekFp8 only supports ActivationType::Swiglu in this runner path. "
+        << "Received activation_type=" << static_cast<int>(activation_type);
+  }
+
+  // Basic type validation
+  auto dtype = hidden_states.dtype();
+
+  // Either routing_logits or expert_indices must be provided
+  // expert_indices is a packed tensor: (expert_id << 16) | (weight_bf16.view(int16))
+  bool use_routing_logits = routing_logits.has_value();
+  // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
+  bool use_precomputed_routing = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
+
+  TVM_FFI_ICHECK(use_routing_logits || use_precomputed_routing)
+      << "Either routing_logits or expert_indices must be provided.";
+
+  (void)use_routing_logits;
+  TVM_FFI_ICHECK(dtype == dl_float16 || dtype == dl_bfloat16 || dtype == dl_float8_e4m3fn)
+      << "FP8 block scale MoE: hidden_states must be fp16, bf16, or fp8.";
+  if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+    TVM_FFI_ICHECK_EQ(hidden_states_scale.dtype(), dl_float32)
+        << "FP8 block scale MoE: hidden_states_scale must be float32.";
+  } else if (quantization_type == Fp8QuantizationType::MxFp8) {
+    TVM_FFI_ICHECK_EQ(hidden_states_scale.dtype(), dl_uint8)
+        << "FP8 block scale MoE: hidden_states_scale must be uint8.";
+  } else {
+    TVM_FFI_LOG_AND_THROW(NotImplementedError)
+        << "trtllm_fp8_block_scale_moe only supports DeepSeekFp8 or MxFp8.";
+  }
+  TVM_FFI_ICHECK_EQ(gemm1_weights.dtype(), dl_float8_e4m3fn)
+      << "FP8 block scale MoE: gemm1_weights must be fp8.";
+  TVM_FFI_ICHECK_EQ(gemm2_weights.dtype(), dl_float8_e4m3fn)
+      << "FP8 block scale MoE: gemm2_weights must be fp8.";
+  if (quantization_type == Fp8QuantizationType::DeepSeekFp8) {
+    TVM_FFI_ICHECK_EQ(gemm1_weights_scale.dtype(), dl_float32)
+        << "FP8 block scale MoE: gemm1_weights_scale must be float32.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights_scale.dtype(), dl_float32)
+        << "FP8 block scale MoE: gemm2_weights_scale must be float32.";
+  } else if (quantization_type == Fp8QuantizationType::MxFp8) {
+    TVM_FFI_ICHECK_EQ(gemm1_weights_scale.dtype(), dl_uint8)
+        << "FP8 block scale MoE: gemm1_weights_scale must be uint8.";
+    TVM_FFI_ICHECK_EQ(gemm2_weights_scale.dtype(), dl_uint8)
+        << "FP8 block scale MoE: gemm2_weights_scale must be uint8.";
+  } else {
+    TVM_FFI_LOG_AND_THROW(NotImplementedError)
+        << "trtllm_fp8_block_scale_moe only supports DeepSeekFp8 or MxFp8.";
+  }
+
+  if (quantization_type == Fp8QuantizationType::MxFp8) {
+    TVM_FFI_ICHECK(use_shuffled_weight) << "use_shuffled_weight must be true for MxFp8.";
+    TVM_FFI_ICHECK(weight_layout == 0) << "weight_layout must be 0 for MxFp8.";
+  }
+
+  if (routing_replay_out.has_value()) {
+    validate_routing_replay_out(routing_replay_out.value(), hidden_states, top_k);
+  }
+
+  auto const num_tokens = hidden_states.size(0);
+  auto const hidden_size = hidden_states.size(1);
+
+  auto supported_tile_nums = Fp8BlockScaleLauncher::getSupportedTileNums(quantization_type);
+  // Build launchers for ALL supported tiles so autotuner-cached tactics always find their tile_N.
+
+  // Create a map of launchers for each tile size
+  std::unordered_map<int32_t, std::unique_ptr<Fp8BlockScaleLauncher>> launchers_map;
+
+  for (int32_t curr_tile_N : supported_tile_nums) {
+    // Create MoE arguments for this launcher
+    auto args = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>();
+    args->num_tokens = num_tokens;
+    args->num_experts = num_experts;
+    args->hidden_size = hidden_size;
+    args->hidden_size_output = args->hidden_size;
+    args->top_k = top_k;
+    args->n_group = n_group.value_or(0);
+    args->topk_group = topk_group.value_or(0);
+    args->local_expert_offset = local_expert_offset;
+    args->local_num_experts = local_num_experts;
+    args->intermediate_size = intermediate_size;
+    args->routed_scaling_factor = routed_scaling_factor.value_or(1.0);
+    args->do_finalize = do_finalize;
+    args->output = output.data_ptr();
+    args->output_scale = nullptr;
+
+    // Create and initialize launcher for this tile size
+    auto launcher = std::make_unique<Fp8BlockScaleLauncher>(
+        routing_logits, routing_bias, hidden_states, hidden_states_scale, gemm1_weights,
+        gemm1_weights_scale, gemm2_weights, gemm2_weights_scale, expert_indices, expert_weights,
+        quantization_type, gate_up_lora_delta, activation_lora_input);
+    launcher->init(std::move(args), curr_tile_N, routing_method_type, use_shuffled_weight,
+                   weight_layout, activation_type, norm_topk_prob);
+    launcher->set_routing_replay_out(routing_replay_out);
+
+    launchers_map[curr_tile_N] = std::move(launcher);
+  }
+
+  auto const [tile_N, config] = resolveMoeTileAndConfig(config_index, supported_tile_nums,
+                                                        num_tokens, top_k, local_num_experts);
+
+  // Get the launcher for the selected tile_N
+  auto launcher_it = launchers_map.find(static_cast<int32_t>(tile_N));
+  FLASHINFER_CHECK(launcher_it != launchers_map.end(),
+                   "Internal error: missing FP8 block-scale MoE launcher for tile_N=", tile_N);
+  auto& selected_launcher = launcher_it->second;
+
+  // Run the launcher with DeepSeek FP8 enabled - it will create its own runner internally
+  return selected_launcher->run(
+      config, enable_pdl, false /* use_routing_scales_on_input */,
+      quantization_type == Fp8QuantizationType::DeepSeekFp8 /* use_deep_seek_fp8 */);
+}
+
+Array<Tensor> trtllm_fp8_block_scale_moe(
+    Optional<TensorView> routing_logits, TensorView expert_indices, TensorView expert_weights,
+    Optional<TensorView> routing_bias, TensorView hidden_states, TensorView hidden_states_scale,
+    TensorView gemm1_weights, TensorView gemm1_weights_scale, TensorView gemm2_weights,
+    TensorView gemm2_weights_scale, TensorView output, int64_t num_experts, int64_t top_k,
+    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
+    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
+    int64_t routing_method_type, bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
+    bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type,
+    int64_t act_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out) {
+  return trtllm_fp8_block_scale_moe_impl(
+      routing_logits, expert_indices, expert_weights, routing_bias, hidden_states,
+      hidden_states_scale, gemm1_weights, gemm1_weights_scale, gemm2_weights, gemm2_weights_scale,
+      output, num_experts, top_k, n_group, topk_group, intermediate_size, local_expert_offset,
+      local_num_experts, routed_scaling_factor, routing_method_type, use_shuffled_weight,
+      weight_layout, do_finalize, enable_pdl, config_index, quantization_type, act_type,
+      norm_topk_prob, routing_replay_out, Optional<TensorView>(), Optional<TensorView>());
+}
+
+Array<Tensor> sgl_trtllm_fp8_block_scale_moe_lora(
+    Optional<TensorView> routing_logits, TensorView expert_indices, TensorView expert_weights,
+    Optional<TensorView> routing_bias, TensorView hidden_states, TensorView hidden_states_scale,
+    TensorView gemm1_weights, TensorView gemm1_weights_scale, TensorView gemm2_weights,
+    TensorView gemm2_weights_scale, TensorView output, int64_t num_experts, int64_t top_k,
+    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
+    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
+    int64_t routing_method_type, bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
+    bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type,
+    int64_t act_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out,
+    TensorView gate_up_lora_delta, TensorView activation_lora_input) {
+  if (quantization_type != Fp8QuantizationType::DeepSeekFp8) {
+    TVM_FFI_LOG_AND_THROW(NotImplementedError)
+        << "sgl_trtllm_fp8_block_scale_moe_lora currently supports DeepSeekFp8 only.";
+  }
+  return trtllm_fp8_block_scale_moe_impl(
+      routing_logits, expert_indices, expert_weights, routing_bias, hidden_states,
+      hidden_states_scale, gemm1_weights, gemm1_weights_scale, gemm2_weights, gemm2_weights_scale,
+      output, num_experts, top_k, n_group, topk_group, intermediate_size, local_expert_offset,
+      local_num_experts, routed_scaling_factor, routing_method_type, use_shuffled_weight,
+      weight_layout, do_finalize, enable_pdl, config_index, quantization_type, act_type,
+      norm_topk_prob, routing_replay_out, Optional<TensorView>(gate_up_lora_delta),
+      Optional<TensorView>(activation_lora_input));
+}
+
+__global__ void sgl_trtllm_fp8_block_scale_moe_lora_finalize_kernel(
+    cutlass::bfloat16_t const* __restrict__ gemm2_output,
+    cutlass::bfloat16_t const* __restrict__ expert_weights,
+    int32_t const* __restrict__ expanded_idx_to_permuted_idx,
+    cutlass::bfloat16_t const* __restrict__ down_lora_delta,
+    cutlass::bfloat16_t* __restrict__ output, int64_t num_tokens, int64_t top_k,
+    int64_t hidden_size, int64_t hidden_size_padded, float routed_scaling_factor) {
+  for (int64_t token_idx = blockIdx.y; token_idx < num_tokens; token_idx += gridDim.y) {
+    for (int64_t hidden_idx = threadIdx.x + blockDim.x * blockIdx.x; hidden_idx < hidden_size;
+         hidden_idx += blockDim.x * gridDim.x) {
+      float acc = 0.0f;
+      float lora_acc = 0.0f;
+      for (int64_t k = 0; k < top_k; ++k) {
+        int64_t const expanded_idx = token_idx * top_k + k;
+        int32_t const permuted_idx = expanded_idx_to_permuted_idx[expanded_idx];
+        if (permuted_idx != -1) {
+          float const expert_prob =
+              static_cast<float>(expert_weights[token_idx * top_k + k]);
+          acc += expert_prob *
+                 static_cast<float>(gemm2_output[permuted_idx * hidden_size_padded + hidden_idx]);
+        }
+        lora_acc +=
+            static_cast<float>(down_lora_delta[expanded_idx * hidden_size + hidden_idx]);
+      }
+      output[token_idx * hidden_size + hidden_idx] =
+          static_cast<cutlass::bfloat16_t>(acc + routed_scaling_factor * lora_acc);
+    }
+  }
+}
+
+void sgl_trtllm_fp8_block_scale_moe_lora_finalize(
+    TensorView gemm2_output, TensorView expert_weights, TensorView expanded_idx_to_permuted_idx,
+    TensorView down_lora_delta, TensorView output, Optional<double> routed_scaling_factor) {
+  TVM_FFI_ICHECK_EQ(gemm2_output.dtype(), dl_bfloat16)
+      << "gemm2_output must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(expert_weights.dtype(), dl_bfloat16)
+      << "expert_weights must be bfloat16.";
+  TVM_FFI_ICHECK((expanded_idx_to_permuted_idx.dtype() == DLDataType{kDLInt, 32, 1}))
+      << "expanded_idx_to_permuted_idx must be int32.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.dtype(), dl_bfloat16)
+      << "down_lora_delta must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(output.dtype(), dl_bfloat16) << "output must be bfloat16.";
+  TVM_FFI_ICHECK_EQ(gemm2_output.ndim(), 2) << "gemm2_output must be 2D.";
+  TVM_FFI_ICHECK_EQ(expert_weights.ndim(), 2) << "expert_weights must be 2D.";
+  TVM_FFI_ICHECK_EQ(expanded_idx_to_permuted_idx.ndim(), 1)
+      << "expanded_idx_to_permuted_idx must be 1D.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.ndim(), 3) << "down_lora_delta must be 3D.";
+  TVM_FFI_ICHECK_EQ(output.ndim(), 2) << "output must be 2D.";
+  TVM_FFI_ICHECK(gemm2_output.IsContiguous()) << "gemm2_output must be contiguous.";
+  TVM_FFI_ICHECK(expert_weights.IsContiguous()) << "expert_weights must be contiguous.";
+  TVM_FFI_ICHECK(expanded_idx_to_permuted_idx.IsContiguous())
+      << "expanded_idx_to_permuted_idx must be contiguous.";
+  TVM_FFI_ICHECK(down_lora_delta.IsContiguous()) << "down_lora_delta must be contiguous.";
+  TVM_FFI_ICHECK(output.IsContiguous()) << "output must be contiguous.";
+
+  int64_t const num_tokens = output.size(0);
+  int64_t const hidden_size = output.size(1);
+  int64_t const top_k = down_lora_delta.size(1);
+  TVM_FFI_ICHECK_EQ(expert_weights.size(0), num_tokens)
+      << "expert_weights dim0 must equal num_tokens.";
+  TVM_FFI_ICHECK_EQ(expert_weights.size(1), top_k) << "expert_weights dim1 must equal top_k.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.size(0), num_tokens)
+      << "down_lora_delta dim0 must equal num_tokens.";
+  TVM_FFI_ICHECK_EQ(down_lora_delta.size(2), hidden_size)
+      << "down_lora_delta dim2 must equal hidden_size.";
+  TVM_FFI_ICHECK_EQ(expanded_idx_to_permuted_idx.size(0), num_tokens * top_k)
+      << "expanded_idx_to_permuted_idx size must equal num_tokens * top_k.";
+  TVM_FFI_ICHECK(gemm2_output.size(1) >= hidden_size)
+      << "gemm2_output hidden dimension is smaller than output hidden dimension.";
+
+  int const num_threads = 128;
+  int const num_blocks_x = (hidden_size + num_threads - 1) / num_threads;
+  int const num_blocks_y = std::min<int64_t>(8192, num_tokens);
+  dim3 grid(num_blocks_x, num_blocks_y);
+  cudaStream_t stream = get_stream(output.device());
+  sgl_trtllm_fp8_block_scale_moe_lora_finalize_kernel<<<grid, num_threads, 0, stream>>>(
+      static_cast<cutlass::bfloat16_t const*>(gemm2_output.data_ptr()),
+      static_cast<cutlass::bfloat16_t const*>(expert_weights.data_ptr()),
+      static_cast<int32_t const*>(expanded_idx_to_permuted_idx.data_ptr()),
+      static_cast<cutlass::bfloat16_t const*>(down_lora_delta.data_ptr()),
+      static_cast<cutlass::bfloat16_t*>(output.data_ptr()), num_tokens, top_k, hidden_size,
+      gemm2_output.size(1), static_cast<float>(routed_scaling_factor.value_or(1.0)));
+  auto err = cudaGetLastError();
+  FLASHINFER_CHECK(err == cudaSuccess, cudaGetErrorString(err));
+}
+
+Array<Tensor> trtllm_fp4_block_scale_moe(
+    Optional<TensorView> routing_logits, TensorView expert_indices, TensorView expert_weights,
+    Optional<TensorView> routing_bias, TensorView hidden_states,
+    Optional<TensorView> hidden_states_scale, TensorView gemm1_weights,
+    TensorView gemm1_weights_scale, Optional<TensorView> gemm1_bias,
+    Optional<TensorView> gemm1_alpha, Optional<TensorView> gemm1_beta,
+    Optional<TensorView> gemm1_clamp_limit, TensorView gemm2_weights,
+    TensorView gemm2_weights_scale, Optional<TensorView> gemm2_bias,
+    Optional<TensorView> output1_scales_scalar, Optional<TensorView> output1_scales_gate_scalar,
+    Optional<TensorView> output2_scales_scalar, Optional<TensorView> per_token_scales,
+    int64_t num_experts, int64_t top_k, Optional<int64_t> n_group, Optional<int64_t> topk_group,
+    int64_t intermediate_size, int64_t local_expert_offset, int64_t local_num_experts,
+    Optional<double> routed_scaling_factor, int64_t routing_method_type, bool do_finalize,
+    bool enable_pdl, int64_t act_type, TensorView output, Array<int64_t> config_index,
+    bool norm_topk_prob, Optional<TensorView> routing_replay_out) {
+  // Determine data types based on input format
+  int const num_tokens = hidden_states.size(0);
+  int hidden_size = hidden_states.size(1);
+  if (hidden_states.dtype() == dl_uint8) hidden_size *= 2;
+
+  int64_t hidden_states_scale_vec_size = -1;
+  if (hidden_states_scale.has_value()) {
+    hidden_states_scale_vec_size =
+        (static_cast<int64_t>(num_tokens) * hidden_size) / hidden_states_scale.value().numel();
+  }
+  int64_t intermediate_size_factor =
+      isGatedActivation(static_cast<ActivationType>(act_type)) ? 2 : 1;
+  int64_t logical_scale_count = static_cast<int64_t>(local_num_experts) * intermediate_size *
+                                intermediate_size_factor * hidden_size;
+  int64_t weight_scale_vec_size_raw = logical_scale_count / gemm1_weights_scale.numel();
+
+  // Snap to nearest valid sf_vec_size (16 or 32).
+  // The raw value may be slightly smaller than the true vec_size because
+  // block_scale_interleave pads scale columns to a multiple of 4, inflating numel().
+  int64_t weight_scale_vec_size = weight_scale_vec_size_raw > 16 ? 32 : 16;
+
+  // Round-trip validation: the unpadded scale count must not exceed actual numel
+  // (padding only adds elements, never removes them).
+  int64_t expected_unpadded = logical_scale_count / weight_scale_vec_size;
+  TVM_FFI_ICHECK(gemm1_weights_scale.numel() >= expected_unpadded)
+      << "weight scale tensor too small: numel=" << gemm1_weights_scale.numel()
+      << " but expected at least " << expected_unpadded
+      << " for sf_vec_size=" << weight_scale_vec_size;
+
+  auto mDtypeWeights = weight_scale_vec_size == 16 ? btg::Dtype::E2m1 : btg::Dtype::MxE2m1;
+
+  if (routing_bias.has_value()) {
+    TVM_FFI_ICHECK(routing_bias.value().dtype() == dl_bfloat16 ||
+                   routing_bias.value().dtype() == dl_float32)
+        << "routing_bias must be bfloat16 or float.";
+
+    TVM_FFI_ICHECK_EQ(routing_bias.value().ndim(), 1) << "routing_bias must be 1D.";
+    TVM_FFI_ICHECK_EQ(routing_bias.value().size(0), num_experts)
+        << "routing_bias has incorrect shape.";
+  }
+
+  if (routing_replay_out.has_value()) {
+    validate_routing_replay_out(routing_replay_out.value(), hidden_states, top_k);
+  }
+
+  // Determine activation type
+  TVM_FFI_ICHECK(gemm1_weights.dtype() == dl_uint8 && gemm2_weights.dtype() == dl_uint8)
+      << "weights must be fp4 packed in uint8.";
+  TVM_FFI_ICHECK(hidden_states.dtype() == dl_uint8 || hidden_states.dtype() == dl_bfloat16 ||
+                 hidden_states.dtype() == dl_float8_e4m3fn)
+      << "hidden_states must be bf16, fp8 or uint8 (packed fp4).";
+
+  auto mDtypeAct = btg::Dtype::Bfloat16;
+  if (hidden_states.dtype() == dl_uint8) {
+    TVM_FFI_ICHECK(hidden_states_scale.has_value() &&
+                   hidden_states_scale.value().dtype() == dl_float8_e4m3fn)
+        << "hidden_states_scale must be provided for fp4 activation.";
+    if (hidden_states_scale_vec_size == 16) {
+      mDtypeAct = btg::Dtype::E2m1;
+    } else if (hidden_states_scale_vec_size == 32) {
+      mDtypeAct = btg::Dtype::MxE2m1;
+    } else {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError) << "Unsupported hidden state scale shape.";
+    }
+  } else if (hidden_states.dtype() == dl_float8_e4m3fn) {
+    if (hidden_states_scale.has_value()) {
+      if (hidden_states_scale_vec_size == 32) {
+        mDtypeAct = btg::Dtype::MxE4m3;
+      } else {
+        TVM_FFI_LOG_AND_THROW(NotImplementedError) << "Unsupported hidden state scale shape.";
+      }
+    } else {
+      mDtypeAct = btg::Dtype::E4m3;
+    }
+  }
+
+  // Determine supported tile sizes
+  std::vector<int32_t> mSupportedTileN = FP4BlockScaleLauncher::getSupportedTileNums(mDtypeAct);
+  // Build launchers for ALL supported tiles so autotuner-cached tactics always find their tile_N.
+
+  // Create a map of launchers for each tile size
+  std::unordered_map<int32_t, std::unique_ptr<FP4BlockScaleLauncher>> launchers_map;
+
+  for (int32_t curr_tile_N : mSupportedTileN) {
+    // Create MoE arguments for this launcher
+    auto args = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>();
+    args->num_tokens = num_tokens;
+    args->num_experts = num_experts;
+    // For E2m1, hidden_size is already multiplied by 2 above, so use it directly
+    args->hidden_size = hidden_size;
+    args->hidden_size_output = output.size(1);
+    args->top_k = top_k;
+    args->n_group = n_group.value_or(0);
+    args->topk_group = topk_group.value_or(0);
+    args->local_expert_offset = local_expert_offset;
+    args->local_num_experts = local_num_experts;
+    args->intermediate_size = intermediate_size;
+    args->routed_scaling_factor = routed_scaling_factor.value_or(1.0);
+    args->do_finalize = do_finalize;
+    args->output = output.data_ptr();
+    args->output_scale = nullptr;
+
+    // Create and initialize launcher for this tile size
+    auto launcher = std::make_unique<FP4BlockScaleLauncher>(
+        routing_logits, routing_bias, hidden_states, hidden_states_scale, gemm1_weights,
+        gemm1_weights_scale, gemm1_bias, gemm1_alpha, gemm1_beta, gemm1_clamp_limit, gemm2_weights,
+        gemm2_weights_scale, gemm2_bias, output1_scales_scalar, output1_scales_gate_scalar,
+        output2_scales_scalar, per_token_scales, expert_indices, expert_weights);
+    launcher->init(std::move(args), curr_tile_N, routing_method_type, /*use_shuffled_weight=*/true,
+                   /*weight_layout=*/0, static_cast<ActivationType>(act_type), mDtypeAct,
+                   mDtypeWeights, norm_topk_prob);
+    launcher->set_routing_replay_out(routing_replay_out);
+
+    launchers_map[curr_tile_N] = std::move(launcher);
+  }
+
+  auto const [tile_N, config] =
+      resolveMoeTileAndConfig(config_index, mSupportedTileN, num_tokens, top_k, local_num_experts);
+
+  // Get the launcher for the selected tile_N
+  auto launcher_it = launchers_map.find(static_cast<int32_t>(tile_N));
+  FLASHINFER_CHECK(launcher_it != launchers_map.end(),
+                   "Internal error: missing FP4 block-scale MoE launcher for tile_N=", tile_N);
+  auto& selected_launcher = launcher_it->second;
+
+  // Run the launcher - it will create its own runner internally
+  return selected_launcher->run(config, enable_pdl);
+}
+
+Array<Tensor> trtllm_mxint4_block_scale_moe(
+    TensorView routing_logits, Optional<TensorView> routing_bias, TensorView hidden_states,
+    TensorView gemm1_weights, TensorView gemm1_weights_scale, Optional<TensorView> gemm1_alpha,
+    Optional<TensorView> gemm1_beta, Optional<TensorView> gemm1_clamp_limit,
+    TensorView gemm2_weights, TensorView gemm2_weights_scale, int64_t num_experts, int64_t top_k,
+    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
+    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
+    int64_t routing_method_type, bool do_finalize, bool enable_pdl, TensorView output,
+    Array<int64_t> config_index, bool norm_topk_prob, Optional<TensorView> routing_replay_out) {
+  // Determine data types based on input format
+  int const num_tokens = hidden_states.size(0);
+  int hidden_size = hidden_states.size(1);
+  // Just some basic type validation first and leave more checks to the launcher
+
+  int weight_scale_vec_size =
+      (local_num_experts * intermediate_size * 2 * hidden_size) / gemm1_weights_scale.numel();
+
+  TVM_FFI_ICHECK(weight_scale_vec_size == 32) << "unsupported weight_scale_vec_size.";
+
+  TVM_FFI_ICHECK(routing_logits.dtype() == dl_float32 || routing_logits.dtype() == dl_bfloat16)
+      << "routing_logits must be float or bfloat16.";
+  TVM_FFI_ICHECK_EQ(routing_logits.ndim(), 2) << "routing_logits must be 2D.";
+  TVM_FFI_ICHECK_EQ(routing_logits.size(1), num_experts) << "routing_logits has incorrect shape.";
+  if (routing_bias.has_value()) {
+    TVM_FFI_ICHECK(routing_bias.value().dtype() == dl_bfloat16) << "routing_bias must be bfloat16.";
+    TVM_FFI_ICHECK_EQ(routing_bias.value().ndim(), 1) << "routing_bias must be 1D.";
+    TVM_FFI_ICHECK_EQ(routing_bias.value().size(0), num_experts)
+        << "routing_bias has incorrect shape.";
+  }
+
+  if (routing_replay_out.has_value()) {
+    validate_routing_replay_out(routing_replay_out.value(), hidden_states, top_k);
+  }
+
+  // Determine activation type
+  TVM_FFI_ICHECK(gemm1_weights.dtype() == dl_uint8 && gemm2_weights.dtype() == dl_uint8)
+      << "weights must be int4 packed in uint8.";
+  TVM_FFI_ICHECK(hidden_states.dtype() == dl_bfloat16) << "hidden_states must be bf16.";
+
+  // Determine supported tile sizes
+  std::vector<int32_t> mSupportedTileN(MxInt4BlockScaleLauncher::mSupportedTileNums.begin(),
+                                       MxInt4BlockScaleLauncher::mSupportedTileNums.end());
+  // Build launchers for ALL supported tiles so autotuner-cached tactics always find their tile_N.
+
+  // Create a map of launchers for each tile size
+  std::unordered_map<int32_t, std::unique_ptr<MxInt4BlockScaleLauncher>> launchers_map;
+
+  for (int32_t curr_tile_N : mSupportedTileN) {
+    // Create MoE arguments for this launcher
+    auto args = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::MoERunnerArgs>();
+    args->num_tokens = num_tokens;
+    args->num_experts = num_experts;
+    // For E2m1, hidden_size is already multiplied by 2 above, so use it directly
+    args->hidden_size = hidden_size;
+    args->hidden_size_output = args->hidden_size;
+    args->top_k = top_k;
+    args->n_group = n_group.value_or(0);
+    args->topk_group = topk_group.value_or(0);
+    args->local_expert_offset = local_expert_offset;
+    args->local_num_experts = local_num_experts;
+    args->intermediate_size = intermediate_size;
+    args->routed_scaling_factor = routed_scaling_factor.value_or(1.0);
+    args->do_finalize = do_finalize;
+    args->output = output.data_ptr();
+    args->output_scale = nullptr;
+
+    // Create and initialize launcher for this tile size
+    auto launcher = std::make_unique<MxInt4BlockScaleLauncher>(
+        routing_logits, routing_bias, hidden_states, gemm1_weights, gemm1_weights_scale,
+        gemm1_alpha, gemm1_beta, gemm1_clamp_limit, gemm2_weights, gemm2_weights_scale);
+    launcher->init(std::move(args), curr_tile_N, routing_method_type, norm_topk_prob);
+    launcher->set_routing_replay_out(routing_replay_out);
+
+    launchers_map[curr_tile_N] = std::move(launcher);
+  }
+
+  auto const [tile_N, config] =
+      resolveMoeTileAndConfig(config_index, mSupportedTileN, num_tokens, top_k, local_num_experts);
+
+  // Get the launcher for the selected tile_N
+  auto launcher_it = launchers_map.find(static_cast<int32_t>(tile_N));
+  FLASHINFER_CHECK(launcher_it != launchers_map.end(),
+                   "Internal error: missing MXINT4 block-scale MoE launcher for tile_N=", tile_N);
+  auto& selected_launcher = launcher_it->second;
+
+  // Run the launcher - it will create its own runner internally
+  return selected_launcher->run(config, enable_pdl);
+}
+
+Array<Array<int64_t>> trtllm_get_valid_moe_configs(
+    int64_t const dtype_act_, int64_t const dtype_weights_,
+    Fp8QuantizationType fp8_quantization_type, int64_t const top_k, int64_t const hidden_size,
+    int64_t const intermediate_size, int64_t const num_local_experts, int64_t const act_type,
+    bool const use_shuffled_weight, int64_t const weight_layout, bool const use_per_token_scaling,
+    int64_t const num_tokens) {
+  auto activation_type = validateAndCastActivationType(act_type);
+  auto dtype_act = static_cast<btg::Dtype>(dtype_act_);
+  auto dtype_weights = static_cast<btg::Dtype>(dtype_weights_);
+
+  if (dtype_act == btg::Dtype::Bfloat16 && dtype_weights == btg::Dtype::MxInt4) {
+    // MxInt4 MoE
+    return MxInt4BlockScaleLauncher::getValidConfigs(top_k, hidden_size, intermediate_size,
+                                                     num_local_experts, num_tokens);
+  }
+  if (dtype_act == btg::Dtype::Bfloat16 && dtype_weights == btg::Dtype::Bfloat16) {
+    // BF16 MoE
+    return Bf16MoeLauncher::getValidConfigs(top_k, hidden_size, intermediate_size,
+                                            num_local_experts, num_tokens, act_type,
+                                            use_shuffled_weight, weight_layout);
+
+  } else if (fp8_quantization_type == Fp8QuantizationType::DeepSeekFp8 &&
+             dtype_act == btg::Dtype::E4m3 && dtype_weights == btg::Dtype::E4m3) {
+    if (activation_type != ActivationType::Swiglu) {
+      TVM_FFI_LOG_AND_THROW(NotImplementedError)
+          << "DeepSeekFp8 only supports ActivationType::Swiglu, "
+          << "got act_type=" << act_type << ".";
+    }
+    // FP8 block scale (DeepSeek)
+    return Fp8BlockScaleLauncher::getValidConfigs(
+        top_k, hidden_size, intermediate_size, num_local_experts, num_tokens, use_shuffled_weight,
+        weight_layout, dtype_act, dtype_weights, fp8_quantization_type, act_type);
+  } else if (fp8_quantization_type == Fp8QuantizationType::MxFp8 &&
+             dtype_act == btg::Dtype::MxE4m3 && dtype_weights == btg::Dtype::MxE4m3) {
+    // FP8 block scale (MxFp8)
+    return Fp8BlockScaleLauncher::getValidConfigs(
+        top_k, hidden_size, intermediate_size, num_local_experts, num_tokens, use_shuffled_weight,
+        weight_layout, dtype_act, dtype_weights, fp8_quantization_type, act_type);
+  } else if ((fp8_quantization_type == Fp8QuantizationType::PerTensorFp8 ||
+              fp8_quantization_type == Fp8QuantizationType::NoneFp8) &&
+             dtype_weights == btg::Dtype::E4m3) {
+    return Fp8PerTensorLauncher::getValidConfigs(
+        top_k, hidden_size, intermediate_size, num_local_experts, num_tokens, act_type,
+        use_shuffled_weight, weight_layout, dtype_act, dtype_weights);
+  } else if (dtype_weights == btg::Dtype::E2m1 || dtype_weights == btg::Dtype::MxE2m1) {
+    // FP4 block scale
+    return FP4BlockScaleLauncher::getValidConfigs(top_k, hidden_size, intermediate_size,
+                                                  num_local_experts, num_tokens, act_type,
+                                                  dtype_act, dtype_weights, use_per_token_scaling);
+  }
+
+  TVM_FFI_LOG_AND_THROW(NotImplementedError)
+      << "Unsupported data type combination for getValidConfigs: "
+      << "dtype_act=" << static_cast<int>(dtype_act)
+      << ", dtype_weights=" << static_cast<int>(dtype_weights)
+      << ", fp8_quantization_type=" << fp8QuantizationTypeToString(fp8_quantization_type);
+
+  // Unreachable code - added to suppress compiler warning
+  return Array<Array<int64_t>>();
+}
+
+namespace trtllm_cubin_loader {
+#include <flashinfer/cubin_loader.h>
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_bf16_moe, trtllm_bf16_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_fp8_per_tensor_scale_moe, trtllm_fp8_per_tensor_scale_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_fp8_block_scale_moe, trtllm_fp8_block_scale_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp8_block_scale_moe_lora,
+                              sgl_trtllm_fp8_block_scale_moe_lora);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_trtllm_fp8_block_scale_moe_lora_finalize,
+                              sgl_trtllm_fp8_block_scale_moe_lora_finalize);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_fp4_block_scale_moe, trtllm_fp4_block_scale_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_mxint4_block_scale_moe, trtllm_mxint4_block_scale_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_get_valid_moe_configs, trtllm_get_valid_moe_configs);
+
+}  // namespace flashinfer

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2480,7 +2480,8 @@ class FP4BlockScaleLoraLauncher {
                             Optional<TensorView> const& output1_scales_gate_scalar,
                             Optional<TensorView> const& output2_scales_scalar,
                             TensorView const& gate_up_lora_delta,
-                            TensorView const& activation_lora_input, TensorView const& output)
+                            TensorView const& activation_lora_input, TensorView const& output,
+                            int64_t lora_ready_event, int64_t act_ready_event)
       : expert_indices_(expert_indices),
         expert_weights_(expert_weights),
         routing_bias_(routing_bias),
@@ -2495,7 +2496,9 @@ class FP4BlockScaleLoraLauncher {
         output2_scales_scalar_(output2_scales_scalar),
         gate_up_lora_delta_(gate_up_lora_delta),
         activation_lora_input_(activation_lora_input),
-        output_(output) {}
+        output_(output),
+        lora_ready_event_(lora_ready_event),
+        act_ready_event_(act_ready_event) {}
 
   // Returns {output} when do_finalize, else {gemm2_output, expert_weights,
   // expanded_idx_to_permuted_idx} for a downstream finalize kernel.
@@ -2588,10 +2591,11 @@ class FP4BlockScaleLoraLauncher {
       // ---- 3) permute (gather) bf16 hidden -> [max_padded, hidden] (transient, freed at block end)
       Tensor permuted_hidden_bf16 =
           alloc_tensor({max_num_padded_tokens, hidden_size}, dl_bfloat16, device);
-      // Zero-init so padded (unused) rows are well-defined for the subsequent quant.
-      cudaMemsetAsync(permuted_hidden_bf16.data_ptr(), 0,
-                      (size_t)max_num_padded_tokens * hidden_size * sizeof(cutlass::bfloat16_t),
-                      stream);
+      // Padded (unused) rows of permuted_hidden_bf16 are intentionally left UNINITIALIZED: the prior
+      // DEFENSIVE zero-init memset is always skipped now (env gate removed — proven safe). Padding rows
+      // never reach a valid output (moe::dev::finalize gathers only real tokens via the index map and
+      // skips permutedIdx==-1; the NvFP4 per-token scale is strictly per-row; the grouped GEMMs are
+      // per-row), so skipping it reclaims the ~max_padded*hidden*2B memset (a prefill/TTFT win).
       {
         moe::dev::permute::Data permData;
         permData.mDtypeElt = btg::Dtype::Bfloat16;
@@ -2673,6 +2677,14 @@ class FP4BlockScaleLoraLauncher {
           inter);
     }
 
+    // GEMM1-LoRA overlap: wait the side-stream LoRA event that produced the
+    // gate_up_lora_delta consumed by the activation below, so the gate_up GEMM1 +
+    // de-interleave above overlap the side-stream LoRA shrink/expand. No-op (0)
+    // on the single-stream path.
+    if (lora_ready_event_ != 0) {
+      cudaStreamWaitEvent(stream, reinterpret_cast<cudaEvent_t>(lora_ready_event_), 0);
+    }
+
     // ---- 6) activation (LoRA-aware): SwiGLU on raw gate_up + gate_up_lora_delta pre-act ----
     Tensor activated_bf16 = alloc_tensor({max_num_padded_tokens, inter}, dl_bfloat16, device);
     {
@@ -2695,6 +2707,12 @@ class FP4BlockScaleLoraLauncher {
           static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr());
       actData.totalNumPaddedTokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
       moe::dev::activation::run(actData, stream);
+      // Two-stream down-LoRA overlap (SGLANG_LORA_OVERLAP_DOWN): signal that activation_lora_input is
+      // ready so the side stream can run the down shrink/expand concurrent with the requant + down
+      // GEMM below. No-op (handle 0) unless the two-stream dispatch passes an event.
+      if (act_ready_event_ != 0) {
+        cudaEventRecord(reinterpret_cast<cudaEvent_t>(act_ready_event_), stream);
+      }
     }
 
     // ---- 7) NvFP4 quant of activated bf16 (already permuted) -> permuted fp4 + sf + per-token ----
@@ -2804,6 +2822,8 @@ class FP4BlockScaleLoraLauncher {
   TensorView gate_up_lora_delta_;
   TensorView activation_lora_input_;
   TensorView output_;
+  int64_t lora_ready_event_ = 0;
+  int64_t act_ready_event_ = 0;
 };
 
 Array<Tensor> sgl_trtllm_fp4_block_scale_moe_lora(
@@ -2821,7 +2841,7 @@ Array<Tensor> sgl_trtllm_fp4_block_scale_moe_lora(
     Optional<double> routed_scaling_factor, int64_t routing_method_type, bool do_finalize,
     bool enable_pdl, int64_t act_type, TensorView output, Array<int64_t> config_index,
     bool norm_topk_prob, Optional<TensorView> routing_replay_out, TensorView gate_up_lora_delta,
-    TensorView activation_lora_input) {
+    TensorView activation_lora_input, int64_t lora_ready_event, int64_t act_ready_event) {
   auto activation_type = validateAndCastActivationType(act_type);
   TVM_FFI_ICHECK(isGatedActivation(activation_type))
       << "sgl_trtllm_fp4_block_scale_moe_lora currently supports gated (SwiGLU) activation only.";
@@ -2868,7 +2888,7 @@ Array<Tensor> sgl_trtllm_fp4_block_scale_moe_lora(
       expert_indices, expert_weights, routing_bias, hidden_states, hidden_states_scale,
       gemm1_weights, gemm1_weights_scale, gemm2_weights, gemm2_weights_scale, output1_scales_scalar,
       output1_scales_gate_scalar, output2_scales_scalar, gate_up_lora_delta, activation_lora_input,
-      output);
+      output, lora_ready_event, act_ready_event);
   return launcher.run(num_experts, top_k, intermediate_size, local_expert_offset, local_num_experts,
                       routed_scaling_factor.value_or(1.0), routing_method_type, tile_tokens_dim,
                       norm_topk_prob, do_finalize, enable_pdl);

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2481,7 +2481,7 @@ class FP4BlockScaleLoraLauncher {
                             Optional<TensorView> const& output2_scales_scalar,
                             TensorView const& gate_up_lora_delta,
                             TensorView const& activation_lora_input, TensorView const& output,
-                            int64_t lora_ready_event, int64_t act_ready_event)
+                            int64_t lora_ready_event)
       : expert_indices_(expert_indices),
         expert_weights_(expert_weights),
         routing_bias_(routing_bias),
@@ -2497,8 +2497,7 @@ class FP4BlockScaleLoraLauncher {
         gate_up_lora_delta_(gate_up_lora_delta),
         activation_lora_input_(activation_lora_input),
         output_(output),
-        lora_ready_event_(lora_ready_event),
-        act_ready_event_(act_ready_event) {}
+        lora_ready_event_(lora_ready_event) {}
 
   // Returns {output} when do_finalize, else {gemm2_output, expert_weights,
   // expanded_idx_to_permuted_idx} for a downstream finalize kernel.
@@ -2707,12 +2706,6 @@ class FP4BlockScaleLoraLauncher {
           static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr());
       actData.totalNumPaddedTokens = static_cast<int*>(total_num_padded_tokens.data_ptr());
       moe::dev::activation::run(actData, stream);
-      // Two-stream down-LoRA overlap (SGLANG_LORA_OVERLAP_DOWN): signal that activation_lora_input is
-      // ready so the side stream can run the down shrink/expand concurrent with the requant + down
-      // GEMM below. No-op (handle 0) unless the two-stream dispatch passes an event.
-      if (act_ready_event_ != 0) {
-        cudaEventRecord(reinterpret_cast<cudaEvent_t>(act_ready_event_), stream);
-      }
     }
 
     // ---- 7) NvFP4 quant of activated bf16 (already permuted) -> permuted fp4 + sf + per-token ----
@@ -2823,7 +2816,6 @@ class FP4BlockScaleLoraLauncher {
   TensorView activation_lora_input_;
   TensorView output_;
   int64_t lora_ready_event_ = 0;
-  int64_t act_ready_event_ = 0;
 };
 
 Array<Tensor> sgl_trtllm_fp4_block_scale_moe_lora(
@@ -2841,7 +2833,7 @@ Array<Tensor> sgl_trtllm_fp4_block_scale_moe_lora(
     Optional<double> routed_scaling_factor, int64_t routing_method_type, bool do_finalize,
     bool enable_pdl, int64_t act_type, TensorView output, Array<int64_t> config_index,
     bool norm_topk_prob, Optional<TensorView> routing_replay_out, TensorView gate_up_lora_delta,
-    TensorView activation_lora_input, int64_t lora_ready_event, int64_t act_ready_event) {
+    TensorView activation_lora_input, int64_t lora_ready_event) {
   auto activation_type = validateAndCastActivationType(act_type);
   TVM_FFI_ICHECK(isGatedActivation(activation_type))
       << "sgl_trtllm_fp4_block_scale_moe_lora currently supports gated (SwiGLU) activation only.";
@@ -2888,7 +2880,7 @@ Array<Tensor> sgl_trtllm_fp4_block_scale_moe_lora(
       expert_indices, expert_weights, routing_bias, hidden_states, hidden_states_scale,
       gemm1_weights, gemm1_weights_scale, gemm2_weights, gemm2_weights_scale, output1_scales_scalar,
       output1_scales_gate_scalar, output2_scales_scalar, gate_up_lora_delta, activation_lora_input,
-      output, lora_ready_event, act_ready_event);
+      output, lora_ready_event);
   return launcher.run(num_experts, top_k, intermediate_size, local_expert_offset, local_num_experts,
                       routed_scaling_factor.value_or(1.0), routing_method_type, tile_tokens_dim,
                       norm_topk_prob, do_finalize, enable_pdl);

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2432,29 +2432,6 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
 // SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION). No fp4-input dequant round-trip.
 // ===========================================================================
 
-// De-interleave the gated gate_up GEMM output for the decomposed NvFP4 MoE-LoRA path.
-//
-// The deployed w13 weight is prepared in the trtllm GEMM1 "gated" layout, which applies
-// reorder_rows_for_gated_act_gemm: row 2k = half0[k], row 2k+1 = half1[k] (a pairwise interleave
-// of the two N/2 halves). A trtllm-gen GEMM emits output in LOGICAL row order, so feeding this
-// weight to our raw Gemm2::Runner produces gate_up columns interleaved as
-//   [h0_0, h1_0, h0_1, h1_1, ..., h0_{inter-1}, h1_{inter-1}].
-// The standalone activation kernel (and the contiguous gate_up_lora_delta from the
-// virtual-experts LoRA) expect the CONTIGUOUS [half0(0..inter-1); half1(0..inter-1)] layout (==
-// the non-gated w13 output). Reverse the pairwise interleave here -- cheap (O(rows*inter)),
-// avoids storing a second non-gated w13 copy (~tens of GB/rank) or a runtime weight re-shuffle.
-__global__ void sgl_fp4_lora_deinterleave_gate_up_kernel(cutlass::bfloat16_t const* __restrict__ in,
-                                                         cutlass::bfloat16_t* __restrict__ out,
-                                                         int64_t rows, int64_t inter) {
-  int64_t const two_inter = 2 * inter;
-  for (int64_t r = blockIdx.y; r < rows; r += gridDim.y) {
-    for (int64_t k = threadIdx.x + blockDim.x * blockIdx.x; k < inter; k += blockDim.x * gridDim.x) {
-      out[r * two_inter + k] = in[r * two_inter + 2 * k];              // half0[k] <- col 2k
-      out[r * two_inter + inter + k] = in[r * two_inter + 2 * k + 1];  // half1[k] <- col 2k+1
-    }
-  }
-}
-
 // Decomposed NvFP4 MoE-LoRA launcher. Reuses FusedMoeLauncher's routing-phase
 // workspace allocation/bookkeeping (via prepare_routing-style setup) but owns
 // the MoE compute pipeline.
@@ -2661,24 +2638,15 @@ class FP4BlockScaleLoraLauncher {
           (int)cfg, enable_pdl);
     }
 
-    // ---- 5b) de-interleave the gated gate_up columns -> contiguous [half0; half1] ----
-    // The activation kernel and gate_up_lora_delta both assume the contiguous layout; the gated
-    // w13 gives interleaved columns (see sgl_fp4_lora_deinterleave_gate_up_kernel). Process all
-    // max_padded rows (padding rows are ignored downstream via the permuted-idx map).
-    Tensor gate_up_contig = alloc_tensor({max_num_padded_tokens, gate_up_n}, dl_bfloat16, device);
-    {
-      int const nthreads = 256;
-      dim3 grid((int)((inter + nthreads - 1) / nthreads),
-                (unsigned)std::min<int64_t>(8192, max_num_padded_tokens));
-      sgl_fp4_lora_deinterleave_gate_up_kernel<<<grid, nthreads, 0, stream>>>(
-          static_cast<cutlass::bfloat16_t const*>(gate_up_bf16.data_ptr()),
-          static_cast<cutlass::bfloat16_t*>(gate_up_contig.data_ptr()), max_num_padded_tokens,
-          inter);
-    }
+    // The gated w13 weight makes GEMM1 emit gate_up columns pairwise-interleaved as
+    // (g0,u0,g1,u1,...) instead of the contiguous [gate | up] layout. Rather than run a
+    // standalone de-interleave kernel into a [max_num_padded_tokens, gate_up_n] scratch
+    // buffer, the activation kernel below de-interleaves on read (interleavedGateUpInput),
+    // fusing away that kernel + its HBM round-trip + the scratch allocation.
 
     // GEMM1-LoRA overlap: wait the side-stream LoRA event that produced the
-    // gate_up_lora_delta consumed by the activation below, so the gate_up GEMM1 +
-    // de-interleave above overlap the side-stream LoRA shrink/expand. No-op (0)
+    // gate_up_lora_delta consumed by the activation below, so the gate_up GEMM1
+    // above overlaps the side-stream LoRA shrink/expand. No-op (0)
     // on the single-stream path.
     if (lora_ready_event_ != 0) {
       cudaStreamWaitEvent(stream, reinterpret_cast<cudaEvent_t>(lora_ready_event_), 0);
@@ -2691,7 +2659,8 @@ class FP4BlockScaleLoraLauncher {
       actData.mDtypeElt = btg::Dtype::Bfloat16;
       actData.mUsePdl = false;
       actData.mUseDeepSeekFp8 = false;
-      actData.inPtr = gate_up_contig.data_ptr();
+      actData.inPtr = gate_up_bf16.data_ptr();
+      actData.interleavedGateUpInput = true;
       actData.outPtr = activated_bf16.data_ptr();
       actData.inDqSfsPtr = nullptr;
       actData.outDqSfsPtr = nullptr;

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_runner.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_runner.cu
@@ -751,6 +751,12 @@ void Runner::run(MoERunnerArgs const& args, MoEWorkspace const& workspace, int d
   void* gemm2_input_scale = workspace.gemm1_output_scale;
   // We do activation only for DeepSeek FP8, as cubins do not have fused activation.
   if (args.mDtypeElt == btg::Dtype::E4m3 && args.mUseDeepSeekFp8) {
+    // GEMM1-LoRA overlap: activation consumes gate_up_lora_delta, so wait on the LoRA
+    // side-stream event HERE (not before the op) -- permute+GEMM1 above overlapped the
+    // side-stream LoRA shrink/expand. nullptr event = no wait (serial / non-overlap path).
+    if (args.lora_ready_event != nullptr) {
+      cudaStreamWaitEvent(stream, static_cast<cudaEvent_t>(args.lora_ready_event), 0);
+    }
     // Run activation
     moe::dev::activation::run(activationData, stream);
     gemm2_input = workspace.activation_output;

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_runner.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_runner.cu
@@ -1,0 +1,806 @@
+/*
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include "flashinfer/exception.h"
+#include "flashinfer/trtllm/batched_gemm/KernelRunner.h"
+#include "flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/trtllm/gen/DtypeDecl.h"
+#include "flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/trtllm/gen/SfLayoutDecl.h"
+#include "flashinfer/trtllm/fused_moe/DevKernel.h"
+#include "flashinfer/trtllm/fused_moe/RoutingKernel.h"
+#include "flashinfer/trtllm/fused_moe/runner.h"
+#include "tensorrt_llm/kernels/quantization.h"
+
+namespace tensorrt_llm {
+namespace kernels {
+namespace trtllmgen_moe {
+
+namespace btg = batchedGemm::trtllm::gen;
+
+namespace Routing {
+namespace {
+inline int32_t computeLog2(int32_t val, std::string const& name = "") {
+  int32_t n = val;
+  int32_t out = 0;
+  while (n >>= 1) {
+    ++out;
+  }
+  if ((1 << out) != val) {
+    out = -1;
+  }
+  return out;
+}
+}  // namespace
+
+Runner::Runner() {}
+
+Runner::Runner(int32_t tileTokensDim) : mTileTokensDim(tileTokensDim) {}
+
+void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts,
+                 int32_t topK, int32_t nGroup, int32_t topkGroup, int32_t localExpertOffset,
+                 int32_t localNumExperts, float routedScalingFactor, int32_t* routingExpertIndexes,
+                 int32_t* expertCountHistogram, int32_t* permutedIdxSize,
+                 int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx,
+                 int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* numTokensPerExpert,
+                 int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit,
+                 int32_t* numNonExitingCtas, btg::Dtype dtypeElt, btg::Dtype dtypeBias,
+                 bool useRoutingScalesOnInput, bool useDeepSeekFp8,
+                 RoutingMethodType routingMethodType, cudaStream_t stream, btg::Dtype dtypeLogits,
+                 bool normTopkProb, int16_t* routing_replay_out) {
+  if (routingMethodType == RoutingMethodType::DeepSeekV3 && nGroup <= 1) {
+    // DeepSeek no-groups case: use routingCustom with SigmoidBias preprocess
+    // and ScaledSumNormalize postprocess. This is more efficient than the full DeepSeek
+    // kernel because it uses the warp-level routingTopKExperts flow.
+    moe::dev::routing::routingCustom::Data routingData;
+
+    routingData.mDtypeOutput = btg::Dtype::Bfloat16;
+    routingData.mDtypeInput = dtypeLogits;
+    routingData.mUsePdl = true;
+    routingData.mPreprocessType = moe::dev::routing::RoutingPreprocessType::SigmoidBias;
+    routingData.mPostprocessType = moe::dev::routing::RoutingPostprocessType::ScaledSumNormalize;
+    routingData.mPtrRoutingBias = routingBias;
+    routingData.mDtypeBias = dtypeBias;
+    routingData.mRouteScale = routedScalingFactor;
+
+    routingData.mPtrScores = routingLogits;
+    routingData.mPtrTopKPacked = routingExpertIndexes;
+    routingData.mPtrExpertCounts = expertCountHistogram;
+    routingData.mPtrPermutedIdxSize = permutedIdxSize;
+    routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
+    routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
+    routingData.mPtrTopKWeights = expertWeights;
+
+    routingData.mPtrCtaIdxXyToBatchIdx = ctaIdxXyToBatchIdx;
+    routingData.mPtrCtaIdxXyToMnLimit = ctaIdxXyToMnLimit;
+    routingData.mPtrNumNonExitingCtas = numNonExitingCtas;
+
+    routingData.mNumTokens = numTokens;
+    routingData.mNumExperts = numExperts;
+    routingData.mTopK = topK;
+    routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
+    routingData.mTileTokensDim = mTileTokensDim;
+    routingData.mLocalExpertsStartIdx = localExpertOffset;
+    routingData.mLocalExpertsStrideLog2 = 0;
+    routingData.mNumLocalExperts = localNumExperts;
+    routingData.mPtrRoutingReplayOut = routing_replay_out;
+
+    moe::dev::routing::routingCustom::run(routingData, stream);
+  } else if (routingMethodType == RoutingMethodType::MiniMax2) {
+    // MiniMaxM2: sigmoid(logit) + bias → topK → renormalize un-biased sigmoid scores.
+    // Similar to DeepSeek no-groups but with routeScale = 1.0 and epsilon = 1e-20
+    // to match the Python reference: weight / (sum + 1e-20).
+    moe::dev::routing::routingCustom::Data routingData;
+
+    routingData.mDtypeOutput = btg::Dtype::Bfloat16;
+    routingData.mDtypeInput = dtypeLogits;
+    routingData.mUsePdl = true;
+    routingData.mPreprocessType = moe::dev::routing::RoutingPreprocessType::SigmoidBias;
+    routingData.mPostprocessType = moe::dev::routing::RoutingPostprocessType::ScaledSumNormalize;
+    routingData.mPtrRoutingBias = routingBias;
+    routingData.mDtypeBias = dtypeBias;
+    routingData.mRouteScale = 1.0f;
+    routingData.mSumEpsilon = 1e-20f;
+
+    routingData.mPtrScores = routingLogits;
+    routingData.mPtrTopKPacked = routingExpertIndexes;
+    routingData.mPtrExpertCounts = expertCountHistogram;
+    routingData.mPtrPermutedIdxSize = permutedIdxSize;
+    routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
+    routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
+    routingData.mPtrTopKWeights = expertWeights;
+
+    routingData.mPtrCtaIdxXyToBatchIdx = ctaIdxXyToBatchIdx;
+    routingData.mPtrCtaIdxXyToMnLimit = ctaIdxXyToMnLimit;
+    routingData.mPtrNumNonExitingCtas = numNonExitingCtas;
+
+    routingData.mNumTokens = numTokens;
+    routingData.mNumExperts = numExperts;
+    routingData.mTopK = topK;
+    routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
+    routingData.mTileTokensDim = mTileTokensDim;
+    routingData.mLocalExpertsStartIdx = localExpertOffset;
+    routingData.mLocalExpertsStrideLog2 = 0;
+    routingData.mNumLocalExperts = localNumExperts;
+    routingData.mPtrRoutingReplayOut = routing_replay_out;
+
+    moe::dev::routing::routingCustom::run(routingData, stream);
+  } else if (routingMethodType == RoutingMethodType::DeepSeekV3) {
+    FLASHINFER_CHECK(topK <= 22, "For DeepSeek routing method, must have topK <= 22");
+    FLASHINFER_CHECK(topkGroup <= 4, "For DeepSeek routing method, must have topkGroup <= 4");
+    moe::dev::routing::routingDeepSeek::Data routingData;
+    routingData.mDtypeOutput =
+        btg::Dtype::Bfloat16;               // for DeepSeek, the expW is currently always bfloat16
+    routingData.mDtypeInput = dtypeLogits;  // routing logits can be bfloat16 or fp32
+    routingData.mDtypeBias = dtypeBias;     // for DeepSeek, the bias can be bfloat16 or fp32
+    routingData.mUsePdl = true;
+
+    // output:
+    routingData.mPtrTopKPacked = routingExpertIndexes;
+    routingData.mPtrExpertCounts = expertCountHistogram;
+    routingData.mPtrPermutedIdxSize = permutedIdxSize;
+    routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
+    routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
+    routingData.mPtrTopKWeights = expertWeights;
+
+    routingData.mPtrCtaIdxXyToBatchIdx = ctaIdxXyToBatchIdx;
+    routingData.mPtrCtaIdxXyToMnLimit = ctaIdxXyToMnLimit;
+    routingData.mPtrNumNonExitingCtas = numNonExitingCtas;
+
+    // input:
+    routingData.mPtrRoutingBias = routingBias;
+    routingData.mPtrScores = routingLogits;  // type-erased; InputT selected by forceFloatInput
+    routingData.mNumTokens = numTokens;
+    routingData.mNumExperts = numExperts;
+    routingData.mNumExpertGroups = nGroup;
+    routingData.mNumLimitedGroups = topkGroup;
+    routingData.mTopK = topK;
+    routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
+    routingData.mTileTokensDim = mTileTokensDim;
+    routingData.mLocalExpertsStartIdx = localExpertOffset;
+    routingData.mLocalExpertsStrideLog2 = 0;
+    routingData.mNumLocalExperts = localNumExperts;
+    routingData.mRouteScale = routedScalingFactor;
+    routingData.mUseRoutingSoftmax = false;
+    routingData.mPtrRoutingReplayOut = routing_replay_out;
+    moe::dev::routing::routingDeepSeek::run(routingData, stream);
+  } else if (routingMethodType == RoutingMethodType::Llama4) {
+    FLASHINFER_CHECK(topK == 1, "For Llama routing method, must have topK == 1");
+    if (nGroup > 0 || topkGroup > 0) {
+      FLASHINFER_WARN("For Llama routing method, nGroup/topkGroup is ignored, got ", nGroup, "/",
+                      topkGroup);
+    }
+    moe::dev::routing::routingLlama4::Data routingData;
+    routingData.mDtypeOutput = btg::Dtype::Bfloat16;
+    routingData.mDtypeInput = dtypeLogits;  // routing logits can be bfloat16 or fp32
+    routingData.mUsePdl = true;
+
+    // output:
+    routingData.mPtrTopKPacked = routingExpertIndexes;
+    routingData.mPtrExpertCounts = expertCountHistogram;
+    routingData.mPtrPermutedIdxSize = permutedIdxSize;
+    routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
+    routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
+    routingData.mPtrTopKWeights = expertWeights;
+
+    routingData.mPtrCtaIdxXyToBatchIdx = ctaIdxXyToBatchIdx;
+    routingData.mPtrCtaIdxXyToMnLimit = ctaIdxXyToMnLimit;
+    routingData.mPtrNumNonExitingCtas = numNonExitingCtas;
+
+    // input:
+    routingData.mPtrScores = routingLogits;
+    routingData.mNumTokens = numTokens;
+    routingData.mNumExperts = numExperts;
+    routingData.mTopK = topK;
+    routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
+    routingData.mTileTokensDim = mTileTokensDim;
+    routingData.mLocalExpertsStartIdx = localExpertOffset;
+    routingData.mLocalExpertsStrideLog2 = 0;
+    routingData.mNumLocalExperts = localNumExperts;
+    routingData.mPtrRoutingReplayOut = routing_replay_out;
+    moe::dev::routing::routingLlama4::run(routingData, stream);
+  } else if (routingMethodType == RoutingMethodType::Default        /* Softmax -> TopK */
+             || routingMethodType == RoutingMethodType::Renormalize /* TopK -> Softmax */
+             || routingMethodType ==
+                    RoutingMethodType::RenormalizeNaive      /* Softmax -> TopK -> Renormalize */
+             || routingMethodType == RoutingMethodType::TopK /* TopK only (no softmax) */
+             || routingMethodType ==
+                    RoutingMethodType::SigmoidRenorm /* Sigmoid -> TopK -> Renormalize */
+             || routingMethodType == RoutingMethodType::Sigmoid /* Sigmoid -> TopK */) {
+    using namespace moe::dev::routing;
+    routingCustom::Data routingData;
+
+    //
+    // Config
+    //
+
+    routingData.mDtypeOutput = btg::Dtype::Bfloat16;
+    routingData.mDtypeInput = dtypeLogits;  // routing logits can be bfloat16 or fp32
+    routingData.mUsePdl = true;
+
+    // Map routing method types to policy-based routing:
+    // Note: RenormalizeNaive (Softmax → TopK → SumNormalize) is mathematically equivalent
+    // to Renormalize (TopK → Softmax), because taking softmax over all experts, selecting
+    // top-K, and dividing by their sum produces the same result as applying softmax only
+    // over the top-K values. We therefore use the same Renormalize implementation for both.
+    if (routingMethodType == RoutingMethodType::Default) {
+      // Softmax -> TopK (softmax on all scores, then select top-K)
+      routingData.mPreprocessType = RoutingPreprocessType::Softmax;
+      routingData.mPostprocessType = RoutingPostprocessType::None;
+    } else if (routingMethodType == RoutingMethodType::SigmoidRenorm) {
+      // Sigmoid -> TopK -> SumNormalize (renormalize)
+      routingData.mPreprocessType = RoutingPreprocessType::Sigmoid;
+      routingData.mPostprocessType = RoutingPostprocessType::SumNormalize;
+      routingData.mNormTopkProb = normTopkProb;
+    } else if (routingMethodType == RoutingMethodType::Sigmoid) {
+      // Sigmoid -> TopK (no renormalization)
+      routingData.mPreprocessType = RoutingPreprocessType::Sigmoid;
+      routingData.mPostprocessType = RoutingPostprocessType::SumNormalize;
+      routingData.mNormTopkProb = false;
+    } else if (routingMethodType == RoutingMethodType::Renormalize ||
+               routingMethodType == RoutingMethodType::RenormalizeNaive) {
+      // TopK -> Softmax (also used for RenormalizeNaive, see comment above)
+      routingData.mPreprocessType = RoutingPreprocessType::None;
+      routingData.mPostprocessType = RoutingPostprocessType::Softmax;
+    } else {
+      // TopK only (no softmax or renormalize)
+      routingData.mPreprocessType = RoutingPreprocessType::None;
+      routingData.mPostprocessType = RoutingPostprocessType::None;
+    }
+
+    routingData.mPtrScores = routingLogits;
+
+    //
+    // Outputs
+    //
+    routingData.mPtrTopKPacked = routingExpertIndexes;
+    routingData.mPtrExpertCounts = expertCountHistogram;
+    routingData.mPtrPermutedIdxSize = permutedIdxSize;
+    routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+    routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
+    routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
+    routingData.mPtrTopKWeights = expertWeights;
+
+    //
+    // Grouped Gemm Launch Config Buffers
+    //
+    routingData.mPtrCtaIdxXyToBatchIdx = ctaIdxXyToBatchIdx;
+    routingData.mPtrCtaIdxXyToMnLimit = ctaIdxXyToMnLimit;
+    routingData.mPtrNumNonExitingCtas = numNonExitingCtas;
+
+    //
+    // Inputs
+    //
+    routingData.mNumTokens = numTokens;
+    routingData.mNumExperts = numExperts;
+    routingData.mTopK = topK;
+    routingData.mPaddingLog2 = computeLog2(mTileTokensDim);
+    routingData.mTileTokensDim = mTileTokensDim;
+    routingData.mLocalExpertsStartIdx = localExpertOffset;
+    routingData.mLocalExpertsStrideLog2 = 0;
+    routingData.mNumLocalExperts = localNumExperts;
+    routingData.mPtrRoutingReplayOut = routing_replay_out;
+
+    routingCustom::run(routingData, stream);
+  } else {
+    FLASHINFER_CHECK(false, "Unimplemented routing method ",
+                     serializeMoeRoutingMethodType(routingMethodType), " of enum ",
+                     (int)routingMethodType);
+  }
+}
+}  // namespace Routing
+
+namespace PermuteGemm1 {
+
+using tensorrt_llm::kernels::trtllmgen_moe::MoE::ActivationType;
+using tensorrt_llm::kernels::trtllmgen_moe::MoE::isGatedActivation;
+using tensorrt_llm::kernels::trtllmgen_moe::MoE::serializeActivationType;
+
+static inline ActType activationTypeToGatedActType(ActivationType actType) {
+  switch (actType) {
+    case ActivationType::Swiglu:
+      return ActType::SwiGlu;
+    case ActivationType::Geglu:
+      return ActType::GeGlu;
+    default:
+      FLASHINFER_CHECK(false, "Unsupported gated activation type ",
+                       serializeActivationType(actType), " of enum ",
+                       static_cast<int64_t>(actType));
+  }
+  return ActType::SwiGlu;
+}
+
+static inline EltwiseActType activationTypeToEltwiseActType(ActivationType actType) {
+  switch (actType) {
+    case ActivationType::Relu2:
+      return EltwiseActType::Relu2;
+    case ActivationType::Identity:
+      return EltwiseActType::None;
+    default:
+      FLASHINFER_CHECK(false, "Unsupported eltwise activation type ",
+                       serializeActivationType(actType), " of enum ",
+                       static_cast<int64_t>(actType));
+  }
+  return EltwiseActType::None;
+}
+
+tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions getOptions(
+    btg::Dtype dtypeAct, btg::Dtype dtypeWeights, btg::Dtype dtypeOutput, int32_t tileTokensDim,
+    bool useDeepSeekFp8, ActivationType activationType, bool useShuffledMatrix,
+    batchedGemm::gemm::MatrixLayout weightLayout, bool usePerTokenScaling,
+    bool usePerChannelScaling) {
+  int64_t actTypeInt = static_cast<int64_t>(activationType);
+  FLASHINFER_CHECK(
+      0 <= actTypeInt && actTypeInt < static_cast<int64_t>(ActivationType::InvalidType),
+      "Unknown activation type", serializeActivationType(activationType), "of enum", actTypeInt);
+  bool isGatedAct = isGatedActivation(activationType);
+  if (isGatedAct) {
+    ActType actType = activationTypeToGatedActType(activationType);
+    tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions options = {
+        // Swap A and B dtypes because transposeMmaOutput is hardcoded to true
+        .dtypeA = dtypeWeights,
+        .dtypeB = dtypeAct,
+        .dtypeC = dtypeOutput,
+        .actType = actType,
+        .deepSeekFp8 = useDeepSeekFp8,
+        .fusedAct = !useDeepSeekFp8,
+        .routeAct = true,
+        .staticBatch = false,
+        .transposeMmaOutput = true,
+        .tileSize = tileTokensDim,
+        .epilogueTileM = useDeepSeekFp8 ? 64 : 128,
+        .useShuffledMatrix = useShuffledMatrix,
+        .weightLayout = weightLayout,
+        .usePerTokenScaling = usePerTokenScaling,
+        .usePerChannelScaling = usePerChannelScaling,
+    };
+    return options;
+  } else {
+    EltwiseActType actType = activationTypeToEltwiseActType(activationType);
+    tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions options = {
+        // Swap A and B dtypes because transposeMmaOutput is hardcoded to true
+        .dtypeA = dtypeWeights,
+        .dtypeB = dtypeAct,
+        .dtypeC = dtypeOutput,
+        .eltwiseActType = actType,
+        .deepSeekFp8 = useDeepSeekFp8,
+        .fusedAct = false,
+        .routeAct = true,
+        .staticBatch = false,
+        .transposeMmaOutput = true,
+        .tileSize = tileTokensDim,
+        .epilogueTileM = 128,
+        .useShuffledMatrix = useShuffledMatrix,
+        .weightLayout = weightLayout,
+        .usePerTokenScaling = usePerTokenScaling,
+        .usePerChannelScaling = usePerChannelScaling};
+    return options;
+  }
+}
+
+Runner::Runner(btg::Dtype dtypeAct, btg::Dtype dtypeWeights, btg::Dtype dtypeOutput,
+               bool useDeepSeekFp8, int tileTokensDim, ActivationType activationType,
+               bool useShuffledMatrix, batchedGemm::gemm::MatrixLayout weightLayout,
+               bool usePerTokenScaling, bool usePerChannelScaling)
+    : mDtypeAct(dtypeAct),
+      mDtypeWeights(dtypeWeights),
+      mDtypeOutput(dtypeOutput),
+      mTileTokensDim(tileTokensDim),
+      mRunner(tensorrt_llm::kernels::TrtllmGenBatchedGemmRunner(getOptions(
+          mDtypeAct, mDtypeWeights, mDtypeOutput, mTileTokensDim, useDeepSeekFp8, activationType,
+          useShuffledMatrix, weightLayout, usePerTokenScaling, usePerChannelScaling))),
+      mActType(activationType) {}
+
+void Runner::run(void* hiddenState, void* hiddenStateScale, void* weights, void* weightsScale,
+                 void* perTokenScales, void* perChannelScales, float* outputScalesScalar,
+                 float* outputScalesGateScalar, float* ptrBias, float* ptrAlpha, float* ptrBeta,
+                 float* ptrClampLimit, void* output, void* outputScale, int32_t topK,
+                 int32_t hiddenSize, int32_t intermediateSize, int32_t numExperts,
+                 int32_t numTokens, int32_t* permutedIdxToTokenIdx, int32_t* ptrNumNonExitingCtas,
+                 int32_t* ptrTotalNumPaddedTokens, int32_t* ptrCtaIdxXyToBatchIdx,
+                 int32_t* ptrCtaIdxXyToMnLimit, void* bmm1Workspace, bool useRoutingScalesOnInput,
+                 int device, cudaStream_t stream, int32_t configIndex, bool enable_pdl) {
+  auto maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+  int32_t intermediateSizeFactor = (isGatedActivation(mActType) ? 2 : 1);
+  mRunner.run(numTokens, intermediateSizeFactor * intermediateSize, hiddenSize, {}, numTokens,
+              numExperts, maxNumCtasInBatchDim, hiddenState, hiddenStateScale, weights,
+              weightsScale, perTokenScales, perChannelScales, outputScalesScalar,
+              outputScalesGateScalar, ptrBias, ptrAlpha, ptrBeta, ptrClampLimit, output,
+              outputScale, permutedIdxToTokenIdx, ptrTotalNumPaddedTokens, ptrCtaIdxXyToBatchIdx,
+              ptrCtaIdxXyToMnLimit, ptrNumNonExitingCtas, bmm1Workspace, stream, device,
+              configIndex, enable_pdl);
+}
+
+size_t Runner::getWorkspaceSizeInBytes(int32_t topK, int32_t hiddenSize, int32_t intermediateSize,
+                                       int32_t numExperts, int32_t numTokens,
+                                       int32_t configIndex) const {
+  auto maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+  int32_t intermediateSizeFactor = (isGatedActivation(mActType) ? 2 : 1);
+  return mRunner.getWorkspaceSizeInBytes(numTokens, intermediateSizeFactor * intermediateSize,
+                                         hiddenSize, {}, numTokens, numExperts,
+                                         maxNumCtasInBatchDim, configIndex);
+}
+
+int32_t Runner::getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
+                                           int32_t intermediateSize, int32_t numExperts,
+                                           int32_t numTokens) const {
+  auto maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+  int32_t intermediateSizeFactor = (isGatedActivation(mActType) ? 2 : 1);
+  return mRunner.getDefaultValidConfigIndex(numTokens, intermediateSizeFactor * intermediateSize,
+                                            hiddenSize, {}, numTokens, numExperts,
+                                            maxNumCtasInBatchDim);
+}
+
+bool Runner::isValidConfigIndex(int32_t configIndex, int32_t topK, int32_t hiddenSize,
+                                int32_t intermediateSize, int32_t numExperts,
+                                int32_t numTokens) const {
+  auto maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+
+  int32_t intermediateSizeFactor = (isGatedActivation(mActType) ? 2 : 1);
+  auto const isValid =
+      mRunner.isValidConfigIndex(configIndex, numTokens, intermediateSizeFactor * intermediateSize,
+                                 hiddenSize, {}, numTokens, numExperts, maxNumCtasInBatchDim);
+
+  return isValid;
+}
+
+std::vector<int64_t> Runner::getPassingConfigIndices() const {
+  return mRunner.getPassingConfigIndices();
+}
+}  // namespace PermuteGemm1
+
+namespace Gemm2 {
+tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions getOptions(
+    btg::Dtype dtypeAct, btg::Dtype dtypeWeights, btg::Dtype dtypeOut, int32_t tileTokensDim,
+    bool useDeepSeekFp8, bool useShuffledMatrix, batchedGemm::gemm::MatrixLayout weightLayout,
+    bool usePerTokenScaling, bool usePerChannelScaling) {
+  tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions options = {
+      // Swap A and B dtypes because transposeMmaOutput is hardcoded to true
+      .dtypeA = dtypeWeights,
+      .dtypeB = dtypeAct,
+      .dtypeC = dtypeOut,
+      .eltwiseActType = EltwiseActType::None,
+      .deepSeekFp8 = useDeepSeekFp8,
+      .fusedAct = false,
+      .routeAct = false,
+      .staticBatch = false,
+      .transposeMmaOutput = true,
+      .tileSize = tileTokensDim,
+      .epilogueTileM = useDeepSeekFp8 ? 64 : 128,
+      .useShuffledMatrix = useShuffledMatrix,
+      .weightLayout = weightLayout,
+      .usePerTokenScaling = usePerTokenScaling,
+      .usePerChannelScaling = usePerChannelScaling};
+  return options;
+}
+
+Runner::Runner(btg::Dtype dtypeAct, btg::Dtype dtypeWeights, btg::Dtype dtypeOut,
+               bool useDeepSeekFp8, int tileTokensDim, bool useShuffledMatrix,
+               batchedGemm::gemm::MatrixLayout weightLayout, bool usePerTokenScaling,
+               bool usePerChannelScaling)
+    : mDtypeAct(dtypeAct),
+      mDtypeWeights(dtypeWeights),
+      mDtypeOut(dtypeOut),
+      mTileTokensDim(tileTokensDim),
+      mRunner(tensorrt_llm::kernels::TrtllmGenBatchedGemmRunner(
+          getOptions(dtypeAct, dtypeWeights, dtypeOut, tileTokensDim, useDeepSeekFp8,
+                     useShuffledMatrix, weightLayout, usePerTokenScaling, usePerChannelScaling))) {}
+
+void Runner::run(void* permutedHiddenState, void* permutedHiddenStateScale, void* weights,
+                 void* weightsScale, void* perTokenScales, void* perChannelScales,
+                 float* outputScalesScalar, float* ptrBias, void* output, void* outputScale,
+                 int32_t topK, int32_t hiddenSize, int32_t intermediateSize, int32_t numExperts,
+                 int32_t numTokens, int32_t* ptrNumNonExitingCtas, int32_t* ptrTotalNumPaddedTokens,
+                 int32_t* ptrCtaIdxXyToBatchIdx, int32_t* ptrCtaIdxXyToMnLimit, void* bmm2Workspace,
+                 int device, cudaStream_t stream, int32_t configIndex, bool enable_pdl) {
+  auto maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+  mRunner.run(
+      numTokens, hiddenSize, intermediateSize, {}, numTokens, numExperts, maxNumCtasInBatchDim,
+      permutedHiddenState, permutedHiddenStateScale, weights, weightsScale,
+      /* perTokensSfA */ perTokenScales,
+      /* perTokensSfB */ perChannelScales, outputScalesScalar, /* outputScalesGateScalar */ nullptr,
+      ptrBias,
+      /* ptrAlpha */ nullptr, /* ptrBeta */ nullptr, /* clampLimit */ nullptr, output, outputScale,
+      /* permutedIdxToTokenIdx */ nullptr, ptrTotalNumPaddedTokens, ptrCtaIdxXyToBatchIdx,
+      ptrCtaIdxXyToMnLimit, ptrNumNonExitingCtas, bmm2Workspace, stream, device, configIndex,
+      enable_pdl);
+}
+
+size_t Runner::getWorkspaceSizeInBytes(int32_t topK, int32_t hiddenSize, int32_t intermediateSize,
+                                       int32_t numExperts, int32_t numTokens,
+                                       int32_t configIndex) const {
+  auto maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+  return mRunner.getWorkspaceSizeInBytes(numTokens, hiddenSize, intermediateSize, {}, numTokens,
+                                         numExperts, maxNumCtasInBatchDim, configIndex);
+}
+
+int32_t Runner::getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
+                                           int32_t intermediateSize, int32_t numExperts,
+                                           int32_t numTokens) const {
+  auto maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+  return mRunner.getDefaultValidConfigIndex(numTokens, hiddenSize, intermediateSize, {}, numTokens,
+                                            numExperts, maxNumCtasInBatchDim);
+}
+
+bool Runner::isValidConfigIndex(int32_t configIndex, int32_t topK, int32_t hiddenSize,
+                                int32_t intermediateSize, int32_t numExperts,
+                                int32_t numTokens) const {
+  auto const maxNumCtasInBatchDim =
+      Routing::getMaxNumCtasInBatchDim(numTokens, topK, numExperts, mTileTokensDim);
+
+  auto const isValid =
+      mRunner.isValidConfigIndex(configIndex, numTokens, hiddenSize, intermediateSize, {},
+                                 numTokens, numExperts, maxNumCtasInBatchDim);
+
+  return isValid;
+}
+
+std::vector<int64_t> Runner::getPassingConfigIndices() const {
+  return mRunner.getPassingConfigIndices();
+}
+}  // namespace Gemm2
+
+namespace MoE {
+Runner::Runner(btg::Dtype dtypeAct, btg::Dtype dtypeWeights, bool useDeepSeekFp8,
+               int32_t tileTokensDim, ActivationType activationType, bool useShuffledMatrix,
+               batchedGemm::gemm::MatrixLayout weightLayout, bool usePerTokenScalingGemm1,
+               bool usePerTokenScalingGemm2, bool usePerChannelScalingGemm1,
+               bool usePerChannelScalingGemm2)
+    : mUsePerTokenScalingGemm1(usePerTokenScalingGemm1),
+      mUsePerTokenScalingGemm2(usePerTokenScalingGemm2),
+      mUsePerChannelScalingGemm1(usePerChannelScalingGemm1),
+      mUsePerChannelScalingGemm2(usePerChannelScalingGemm2),
+      mPermuteGemm1(PermuteGemm1::Runner(
+          dtypeAct, dtypeWeights, usePerTokenScalingGemm2 ? btg::Dtype::Bfloat16 : dtypeAct,
+          useDeepSeekFp8, tileTokensDim, activationType, useShuffledMatrix, weightLayout,
+          usePerTokenScalingGemm1, usePerChannelScalingGemm1)),
+      mGemm2(Gemm2::Runner(dtypeAct, dtypeWeights, btg::Dtype::Bfloat16, useDeepSeekFp8,
+                           tileTokensDim, useShuffledMatrix, weightLayout, usePerTokenScalingGemm2,
+                           usePerChannelScalingGemm2)) {
+  auto const& gemm1PassingIndices = mPermuteGemm1.getPassingConfigIndices();
+  auto const& gemm2PassingIndices = mGemm2.getPassingConfigIndices();
+
+  auto const totalPassingIndices = gemm1PassingIndices.size() * gemm2PassingIndices.size();
+  mPassingConfigs.reserve(totalPassingIndices);
+
+  for (auto const& indexGemm1 : gemm1PassingIndices) {
+    for (auto const& indexGemm2 : gemm2PassingIndices) {
+      mPassingConfigs.push_back(MoEConfig{indexGemm1, indexGemm2});
+    }
+  }
+  FLASHINFER_CHECK(!mPassingConfigs.empty(),
+                   "No compatible configs found for the fp8 block scale MoE runner.");
+}
+
+Runner::Runner(btg::Dtype dtypeElt, bool useDeepSeekFp8, int32_t tileTokensDim,
+               bool useShuffledMatrix, batchedGemm::gemm::MatrixLayout weightLayout,
+               bool usePerTokenScalingGemm1, bool usePerTokenScalingGemm2,
+               bool usePerChannelScalingGemm1, bool usePerChannelScalingGemm2)
+    : Runner(dtypeElt, dtypeElt, useDeepSeekFp8, tileTokensDim, ActivationType::Swiglu,
+             useShuffledMatrix, weightLayout, usePerTokenScalingGemm1, usePerTokenScalingGemm2,
+             usePerChannelScalingGemm1, usePerChannelScalingGemm2) {}
+
+void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace,
+                        moe::dev::convertsf::Data& convertSfData,
+                        moe::dev::activation::Data& activationData,
+                        moe::dev::finalize::Data& finalizeData) {
+  // Setup sf conversion data if needed
+  convertSfData.inSfPtr = args.hidden_states_scale;
+  convertSfData.outSfPtr = workspace.hidden_states_scale_linear;
+  convertSfData.hiddenDimSf = args.hidden_size / 16;
+  convertSfData.numTokens = args.num_tokens;
+  convertSfData.sfLayoutSrc = btg::SfLayout::R128c4;
+  convertSfData.sfLayoutDst = btg::SfLayout::Linear;
+  convertSfData.mUsePdl = true;
+
+  // Setup activation data
+  activationData.mDtypeElt = args.mDtypeElt;
+  activationData.mUsePdl = true;
+  activationData.mUseDeepSeekFp8 = true;
+  activationData.inPtr = workspace.gemm1_output;
+  activationData.outPtr = workspace.activation_output;
+  activationData.inDqSfsPtr = workspace.gemm1_output_scale;
+  activationData.outDqSfsPtr = workspace.activation_output_scale;
+  activationData.gateUpLoraDeltaPtr =
+      reinterpret_cast<cutlass::bfloat16_t const*>(args.gate_up_lora_delta);
+  activationData.activationLoraInputOutPtr =
+      reinterpret_cast<cutlass::bfloat16_t*>(args.activation_lora_input);
+  activationData.innerDim =
+      args.intermediate_size * (isGatedActivation(args.activation_type) ? 2 : 1);
+  activationData.topK = args.top_k;
+  activationData.numTokens = args.num_tokens;
+  activationData.expandedIdxToPermutedIdx = workspace.expanded_idx_to_permuted_idx;
+
+  activationData.totalNumPaddedTokens = workspace.total_num_padded_tokens;
+
+  // Setup finalize data
+  if (args.do_finalize) {
+    // Setup finalize data
+    finalizeData.mDtypeElt = args.mDtypeOut;
+    finalizeData.mDtypeExpW = args.mDtypeExpW;
+    finalizeData.mUsePdl = true;
+    finalizeData.mUseDeepSeekFp8 = false;
+    finalizeData.inPtr = workspace.gemm2_output;
+    finalizeData.outPtr = args.output;
+    finalizeData.inDqSfsPtr = workspace.gemm2_output_scale;
+    finalizeData.outDqSfsPtr = args.output_scale;
+    if (args.mUseRoutingScalesOnInput) {
+      finalizeData.expertWeightsPtr = nullptr;
+    } else {
+      finalizeData.expertWeightsPtr = workspace.expert_weights;
+    }
+    finalizeData.expandedIdxToPermutedIdx = workspace.expanded_idx_to_permuted_idx;
+    finalizeData.numTokens = args.num_tokens;
+    finalizeData.numExperts = args.num_experts;
+    finalizeData.topK = args.top_k;
+    // We want to fuse unpadding into the finalize kernel, so we need to use the output hidden size.
+    finalizeData.hiddenDim = args.hidden_size_output.value_or(args.hidden_size);
+    finalizeData.hiddenDimPadded = args.hidden_size;
+    finalizeData.totalNumPaddedTokens = workspace.total_num_padded_tokens;
+  }
+}
+
+std::tuple<int32_t, int32_t> Runner::getWorkspaceSizeInBytes(MoERunnerArgs const& args,
+                                                             int64_t configIndex) const {
+  FLASHINFER_CHECK(configIndex >= 0 && configIndex < static_cast<int64_t>(mPassingConfigs.size()),
+                   "Invalid MoE config index ", configIndex, ", valid range is [0, ",
+                   static_cast<int64_t>(mPassingConfigs.size()) - 1, "].");
+  auto const& config = mPassingConfigs[configIndex];
+
+  auto workspace_size_fc1 = static_cast<int32_t>(mPermuteGemm1.getWorkspaceSizeInBytes(
+      args.top_k, args.hidden_size, args.intermediate_size, args.local_num_experts, args.num_tokens,
+      config.gemm1Config));
+  auto workspace_size_fc2 = static_cast<int32_t>(
+      mGemm2.getWorkspaceSizeInBytes(args.top_k, args.hidden_size, args.intermediate_size,
+                                     args.local_num_experts, args.num_tokens, config.gemm2Config));
+  return std::make_tuple(workspace_size_fc1, workspace_size_fc2);
+}
+
+std::vector<int64_t> Runner::getValidConfigIndices(int32_t topK, int32_t hiddenSize,
+                                                   int32_t intermediateSize,
+                                                   int32_t numLocalExperts,
+                                                   int32_t numTokens) const {
+  std::vector<int64_t> validIndices;
+
+  for (int i = 0; i < mPassingConfigs.size(); ++i) {
+    auto const& config = mPassingConfigs[i];
+
+    if (mPermuteGemm1.isValidConfigIndex(config.gemm1Config, topK, hiddenSize, intermediateSize,
+                                         numLocalExperts, numTokens) &&
+        mGemm2.isValidConfigIndex(config.gemm2Config, topK, hiddenSize, intermediateSize,
+                                  numLocalExperts, numTokens)) {
+      validIndices.push_back(i);
+    }
+  }
+
+  return validIndices;
+}
+
+int64_t Runner::getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
+                                           int32_t intermediateSize, int32_t numLocalExperts,
+                                           int32_t numTokens) const {
+  int32_t indexGemm1 = mPermuteGemm1.getDefaultValidConfigIndex(topK, hiddenSize, intermediateSize,
+                                                                numLocalExperts, numTokens);
+  int32_t indexGemm2 = mGemm2.getDefaultValidConfigIndex(topK, hiddenSize, intermediateSize,
+                                                         numLocalExperts, numTokens);
+
+  auto it = std::find_if(mPassingConfigs.begin(), mPassingConfigs.end(),
+                         [indexGemm1, indexGemm2](MoEConfig cfg) {
+                           return (cfg.gemm1Config == indexGemm1 && cfg.gemm2Config == indexGemm2);
+                         });
+  FLASHINFER_CHECK(it != mPassingConfigs.end(),
+                   "No compatible configs found for the block scale MoE runner.");
+  return std::distance(mPassingConfigs.begin(), it);
+}
+
+void Runner::run(MoERunnerArgs const& args, MoEWorkspace const& workspace, int device,
+                 cudaStream_t stream, int64_t configIndex, bool enable_pdl) {
+  FLASHINFER_CHECK(configIndex >= 0 && configIndex < static_cast<int64_t>(mPassingConfigs.size()),
+                   "Invalid MoE config index ", configIndex, ", valid range is [0, ",
+                   static_cast<int64_t>(mPassingConfigs.size()) - 1, "].");
+  FLASHINFER_CHECK(!mUsePerChannelScalingGemm1 && !mUsePerChannelScalingGemm2,
+                   "Per-channel scaling is currently not supported.");
+  // Setup all operation data
+  moe::dev::activation::Data activationData;
+  moe::dev::finalize::Data finalizeData;
+  moe::dev::convertsf::Data convertSfData;
+  sync_check_cuda_error(stream);
+  setOpsData(args, workspace, convertSfData, activationData, finalizeData);
+
+  void* hidden_states_scale_linear{args.hidden_states_scale};
+
+  auto const& config = mPassingConfigs[configIndex];
+
+  mPermuteGemm1.run(
+      args.hidden_states, hidden_states_scale_linear, args.gemm1_weights, args.gemm1_weights_scale,
+      workspace.token_scales, /*perChannelScales*/ nullptr, args.output1_scales_scalar,
+      args.output1_scales_gate_scalar, args.gemm1_bias, args.gemm1_alpha, args.gemm1_beta,
+      args.gemm1_clamp_limit, workspace.gemm1_output, workspace.gemm1_output_scale, args.top_k,
+      args.hidden_size, args.intermediate_size, args.local_num_experts, args.num_tokens,
+      workspace.permuted_idx_to_token_idx, workspace.num_non_exiting_ctas,
+      workspace.total_num_padded_tokens, workspace.cta_idx_xy_to_batch_idx,
+      workspace.cta_idx_xy_to_mn_limit, workspace.bmm1_workspace, args.mUseRoutingScalesOnInput,
+      device, stream, config.gemm1Config, enable_pdl);
+
+  // We do not fuse activation with FC1 for DeepSeek FP8 due to the weights shuffling constraint.
+  void* gemm2_input = workspace.gemm1_output;
+  void* gemm2_input_scale = workspace.gemm1_output_scale;
+  // We do activation only for DeepSeek FP8, as cubins do not have fused activation.
+  if (args.mDtypeElt == btg::Dtype::E4m3 && args.mUseDeepSeekFp8) {
+    // Run activation
+    moe::dev::activation::run(activationData, stream);
+    gemm2_input = workspace.activation_output;
+    gemm2_input_scale = workspace.activation_output_scale;
+  } else if (mUsePerTokenScalingGemm2) {
+    // TODO(siyuan): currently only support per-token nvfp4 quantization
+    FLASHINFER_CHECK(
+        mPermuteGemm1.mDtypeOutput == btg::Dtype::Bfloat16,
+        "When using explicit quantization, PermuteGemm1 output dtype must be Bfloat16.");
+    FLASHINFER_CHECK(mGemm2.mDtypeAct == btg::Dtype::E2m1,
+                     "Currently only support NvFP4 when using explicit quantization.");
+    FLASHINFER_CHECK(
+        workspace.token_scales_fc2 != nullptr,
+        "workspace.token_scales_fc2 must be provided When using explicit quantization.");
+    // FIXME(siyuan): Detect from the kernel config. Currently only tile size >= 128 will use R128c4
+    auto sfLayout = mGemm2.mTileTokensDim >= 128 ? QuantizationSFLayout::SWIZZLED_128x4
+                                                 : QuantizationSFLayout::SWIZZLED_8x4;
+
+    // TODO(siyuan): should this value be exposed?
+    float globalScaleInv = 1.f / 448.f / 6.f;
+    invokeNvfp4QuantAndPerTokenScale<__nv_bfloat16>(
+        args.num_tokens * args.top_k, args.intermediate_size,
+        reinterpret_cast<__nv_bfloat16 const*>(workspace.gemm1_output), globalScaleInv,
+        workspace.expanded_idx_to_permuted_idx,
+        reinterpret_cast<uint8_t*>(workspace.activation_output),
+        reinterpret_cast<uint8_t*>(workspace.activation_output_scale),
+        reinterpret_cast<float*>(workspace.token_scales_fc2), sfLayout, stream);
+
+    gemm2_input = workspace.activation_output;
+    gemm2_input_scale = workspace.activation_output_scale;
+  }
+
+  // Run gemm2
+  mGemm2.run(gemm2_input, gemm2_input_scale, args.gemm2_weights, args.gemm2_weights_scale,
+             workspace.token_scales_fc2, /*perChannelScales*/ nullptr, args.output2_scales_scalar,
+             args.gemm2_bias, workspace.gemm2_output, workspace.gemm2_output_scale, args.top_k,
+             args.hidden_size, args.intermediate_size, args.local_num_experts, args.num_tokens,
+             workspace.num_non_exiting_ctas, workspace.total_num_padded_tokens,
+             workspace.cta_idx_xy_to_batch_idx, workspace.cta_idx_xy_to_mn_limit,
+             workspace.bmm2_workspace, device, stream, config.gemm2Config, enable_pdl);
+
+  // Run finalize
+  if (args.do_finalize) {
+    // Run finalize
+    moe::dev::finalize::run(finalizeData, stream);
+    sync_check_cuda_error(stream);
+  }
+}
+}  // namespace MoE
+
+}  // namespace trtllmgen_moe
+}  // namespace kernels
+}  // namespace tensorrt_llm

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_runner.cu
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/csrc/trtllm_fused_moe_runner.cu
@@ -345,7 +345,7 @@ tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions getOptions(
     btg::Dtype dtypeAct, btg::Dtype dtypeWeights, btg::Dtype dtypeOutput, int32_t tileTokensDim,
     bool useDeepSeekFp8, ActivationType activationType, bool useShuffledMatrix,
     batchedGemm::gemm::MatrixLayout weightLayout, bool usePerTokenScaling,
-    bool usePerChannelScaling) {
+    bool usePerChannelScaling, bool forceUnfusedAct = false) {
   int64_t actTypeInt = static_cast<int64_t>(activationType);
   FLASHINFER_CHECK(
       0 <= actTypeInt && actTypeInt < static_cast<int64_t>(ActivationType::InvalidType),
@@ -360,7 +360,8 @@ tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions getOptions(
         .dtypeC = dtypeOutput,
         .actType = actType,
         .deepSeekFp8 = useDeepSeekFp8,
-        .fusedAct = !useDeepSeekFp8,
+        // FP4 LoRA forces unfused activation so the gate_up LoRA delta can be added pre-SwiGLU.
+        .fusedAct = !useDeepSeekFp8 && !forceUnfusedAct,
         .routeAct = true,
         .staticBatch = false,
         .transposeMmaOutput = true,
@@ -398,14 +399,15 @@ tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions getOptions(
 Runner::Runner(btg::Dtype dtypeAct, btg::Dtype dtypeWeights, btg::Dtype dtypeOutput,
                bool useDeepSeekFp8, int tileTokensDim, ActivationType activationType,
                bool useShuffledMatrix, batchedGemm::gemm::MatrixLayout weightLayout,
-               bool usePerTokenScaling, bool usePerChannelScaling)
+               bool usePerTokenScaling, bool usePerChannelScaling, bool forceUnfusedAct)
     : mDtypeAct(dtypeAct),
       mDtypeWeights(dtypeWeights),
       mDtypeOutput(dtypeOutput),
       mTileTokensDim(tileTokensDim),
       mRunner(tensorrt_llm::kernels::TrtllmGenBatchedGemmRunner(getOptions(
           mDtypeAct, mDtypeWeights, mDtypeOutput, mTileTokensDim, useDeepSeekFp8, activationType,
-          useShuffledMatrix, weightLayout, usePerTokenScaling, usePerChannelScaling))),
+          useShuffledMatrix, weightLayout, usePerTokenScaling, usePerChannelScaling,
+          forceUnfusedAct))),
       mActType(activationType) {}
 
 void Runner::run(void* hiddenState, void* hiddenStateScale, void* weights, void* weightsScale,
@@ -569,15 +571,16 @@ Runner::Runner(btg::Dtype dtypeAct, btg::Dtype dtypeWeights, bool useDeepSeekFp8
                int32_t tileTokensDim, ActivationType activationType, bool useShuffledMatrix,
                batchedGemm::gemm::MatrixLayout weightLayout, bool usePerTokenScalingGemm1,
                bool usePerTokenScalingGemm2, bool usePerChannelScalingGemm1,
-               bool usePerChannelScalingGemm2)
+               bool usePerChannelScalingGemm2, bool unfuseActForLora)
     : mUsePerTokenScalingGemm1(usePerTokenScalingGemm1),
       mUsePerTokenScalingGemm2(usePerTokenScalingGemm2),
       mUsePerChannelScalingGemm1(usePerChannelScalingGemm1),
       mUsePerChannelScalingGemm2(usePerChannelScalingGemm2),
+      mUnfuseActForLora(unfuseActForLora),
       mPermuteGemm1(PermuteGemm1::Runner(
           dtypeAct, dtypeWeights, usePerTokenScalingGemm2 ? btg::Dtype::Bfloat16 : dtypeAct,
           useDeepSeekFp8, tileTokensDim, activationType, useShuffledMatrix, weightLayout,
-          usePerTokenScalingGemm1, usePerChannelScalingGemm1)),
+          usePerTokenScalingGemm1, usePerChannelScalingGemm1, unfuseActForLora)),
       mGemm2(Gemm2::Runner(dtypeAct, dtypeWeights, btg::Dtype::Bfloat16, useDeepSeekFp8,
                            tileTokensDim, useShuffledMatrix, weightLayout, usePerTokenScalingGemm2,
                            usePerChannelScalingGemm2)) {

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/DevKernel.h
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/DevKernel.h
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda.h>
+
+#include <iostream>
+#include <string>
+
+#include "flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/trtllm/gen/DtypeDecl.h"
+#include "flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/trtllm/gen/SfLayoutDecl.h"
+// #include <cuda_runtime_api.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_size.h>
+#include <cutlass/numeric_types.h>
+
+#include "flashinfer/exception.h"
+// #include <tensorrt_llm/common/assert.h>
+#include "flashinfer/trtllm/common/cudaUtils.h"
+#include "tensorrt_llm/common/logger.h"
+
+namespace moe::dev {
+
+#define CHECK_CUDA_ERROR(cmd)                                                                \
+  do {                                                                                       \
+    cudaError_t e = cmd;                                                                     \
+    if (e != cudaSuccess) {                                                                  \
+      std::cout << "CUDA error in " << __FILE__ << ":" << __LINE__ << " executing '" << #cmd \
+                << "': " << cudaGetErrorString(e);                                           \
+    }                                                                                        \
+    FLASHINFER_CHECK(e == cudaSuccess, "Got CUDA error. See above for details.");            \
+  } while (0)
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define LAUNCH_ESC(...) __VA_ARGS__
+
+#define LAUNCH_PDL(data, coopLaunch, types, kernel, numBlocks, numThreads, smemSize, stream) \
+  cudaLaunchConfig_t config{};                                                               \
+  config.gridDim = numBlocks;                                                                \
+  config.blockDim = numThreads;                                                              \
+  config.dynamicSmemBytes = smemSize;                                                        \
+  config.stream = (cudaStream_t)stream;                                                      \
+                                                                                             \
+  cudaLaunchAttribute attributes[2] = {};                                                    \
+  attributes[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;                     \
+  attributes[0].val.programmaticStreamSerializationAllowed = int(data.mUsePdl);              \
+  attributes[1].id = cudaLaunchAttributeCooperative;                                         \
+  attributes[1].val.cooperative = int(coopLaunch);                                           \
+  config.attrs = attributes;                                                                 \
+  config.numAttrs = 2;                                                                       \
+  if (data.mUsePdl) {                                                                        \
+    auto params = KernelParams<types, true>::setKernelParams(data);                          \
+    auto kernelTyped = kernel<KernelParams<types, true>>;                                    \
+    if (smemSize > 48 * 1024)                                                                \
+      CHECK_CUDA_ERROR(cudaFuncSetAttribute(                                                 \
+          kernelTyped, cudaFuncAttributeMaxDynamicSharedMemorySize, smemSize));              \
+    CHECK_CUDA_ERROR(cudaLaunchKernelEx(&config, kernelTyped, params));                      \
+  } else {                                                                                   \
+    auto params = KernelParams<types, false>::setKernelParams(data);                         \
+    auto kernelTyped = kernel<KernelParams<types, false>>;                                   \
+    if (smemSize > 48 * 1024)                                                                \
+      CHECK_CUDA_ERROR(cudaFuncSetAttribute(                                                 \
+          kernelTyped, cudaFuncAttributeMaxDynamicSharedMemorySize, smemSize));              \
+    CHECK_CUDA_ERROR(cudaLaunchKernelEx(&config, kernelTyped, params));                      \
+  }
+
+#define LAUNCH(data, kernel, numBlocks, numThreads, smemSize, stream)                              \
+  if (data.mDtypeElt == tg::Dtype::Fp16) {                                                         \
+    LAUNCH_PDL(data, false, cutlass::half_t, kernel, numBlocks, numThreads, smemSize, stream);     \
+  } else if (data.mDtypeElt == tg::Dtype::E4m3) {                                                  \
+    LAUNCH_PDL(data, false, cutlass::float_e4m3_t, kernel, numBlocks, numThreads, smemSize,        \
+               stream);                                                                            \
+  } else if (data.mDtypeElt == tg::Dtype::Bfloat16) {                                              \
+    LAUNCH_PDL(data, false, cutlass::bfloat16_t, kernel, numBlocks, numThreads, smemSize, stream); \
+  } else {                                                                                         \
+    FLASHINFER_WARN("Unsupported dtypeElt");                                                       \
+  }
+
+#define LAUNCH_NUM_TOKENS_PER_CTA(data, type, numTokensPerCta, kernel, numBlocks, numThreads,      \
+                                  smemSize, stream)                                                \
+  if (numTokensPerCta == 4) {                                                                      \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(type, 4), kernel, numBlocks, numThreads, smemSize, stream); \
+  } else if (numTokensPerCta == 2) {                                                               \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(type, 2), kernel, numBlocks, numThreads, smemSize, stream); \
+  } else if (numTokensPerCta == 1) {                                                               \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(type, 1), kernel, numBlocks, numThreads, smemSize, stream); \
+  } else {                                                                                         \
+    FLASHINFER_WARN("Unsupported numTokensPerCta");                                                \
+  }
+
+#define LAUNCH_ACTIVATION(data, kernel, numTokensPerCta, numBlocks, numThreads, smemSize, stream) \
+  if (data.mDtypeElt == tg::Dtype::Fp16) {                                                        \
+    LAUNCH_NUM_TOKENS_PER_CTA(data, cutlass::half_t, numTokensPerCta, kernel, numBlocks,          \
+                              numThreads, smemSize, stream);                                      \
+  } else if (data.mDtypeElt == tg::Dtype::E4m3) {                                                 \
+    LAUNCH_NUM_TOKENS_PER_CTA(data, cutlass::float_e4m3_t, numTokensPerCta, kernel, numBlocks,    \
+                              numThreads, smemSize, stream);                                      \
+  } else if (data.mDtypeElt == tg::Dtype::Bfloat16) {                                             \
+    LAUNCH_NUM_TOKENS_PER_CTA(data, cutlass::bfloat16_t, numTokensPerCta, kernel, numBlocks,      \
+                              numThreads, smemSize, stream);                                      \
+  } else {                                                                                        \
+    FLASHINFER_WARN("Unsupported dtypeElt");                                                      \
+  }
+
+#define LAUNCH_EXPW(data, kernel, topK, numBlocks, numThreads, smemSize, stream)                  \
+  if (data.mDtypeElt == tg::Dtype::Fp16 && data.mDtypeExpW == tg::Dtype::Fp32) {                  \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(cutlass::half_t, float, topK), kernel, numBlocks,          \
+               numThreads, smemSize, stream);                                                     \
+  } else if (data.mDtypeElt == tg::Dtype::E4m3 && data.mDtypeExpW == tg::Dtype::Fp32) {           \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(cutlass::float_e4m3_t, float, topK), kernel, numBlocks,    \
+               numThreads, smemSize, stream);                                                     \
+  } else if (data.mDtypeElt == tg::Dtype::Bfloat16 && data.mDtypeExpW == tg::Dtype::Fp32) {       \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(cutlass::bfloat16_t, float, topK), kernel, numBlocks,      \
+               numThreads, smemSize, stream);                                                     \
+  } else if (data.mDtypeElt == tg::Dtype::Fp16 && data.mDtypeExpW == tg::Dtype::Bfloat16) {       \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(cutlass::half_t, cutlass::bfloat16_t, topK), kernel,       \
+               numBlocks, numThreads, smemSize, stream);                                          \
+  } else if (data.mDtypeElt == tg::Dtype::E4m3 && data.mDtypeExpW == tg::Dtype::Bfloat16) {       \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(cutlass::float_e4m3_t, cutlass::bfloat16_t, topK), kernel, \
+               numBlocks, numThreads, smemSize, stream);                                          \
+  } else if (data.mDtypeElt == tg::Dtype::Bfloat16 && data.mDtypeExpW == tg::Dtype::Bfloat16) {   \
+    LAUNCH_PDL(data, false, LAUNCH_ESC(cutlass::bfloat16_t, cutlass::bfloat16_t, topK), kernel,   \
+               numBlocks, numThreads, smemSize, stream);                                          \
+  } else {                                                                                        \
+    FLASHINFER_WARN("Unsupported pair");                                                          \
+  }
+
+#define LAUNCH_TOPK_EXPW(data, kernel, numBlocks, numThreads, smemSize, stream) \
+  if (data.topK % 4 == 0) {                                                     \
+    LAUNCH_EXPW(data, kernel, 4, numBlocks, numThreads, smemSize, stream);      \
+  } else if (data.topK % 2 == 0) {                                              \
+    LAUNCH_EXPW(data, kernel, 2, numBlocks, numThreads, smemSize, stream);      \
+  } else {                                                                      \
+    LAUNCH_EXPW(data, kernel, 1, numBlocks, numThreads, smemSize, stream);      \
+  }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// NOTE: Old routing-specific macros (LAUNCH_TILEN, LAUNCH_ROUTING_LLAMA4,
+// LAUNCH_ROUTING_DEEPSEEK_*, LAUNCH_ROUTING_WITH_NUM_EXPERTS) have been moved to
+// RoutingDevKernel.h which uses the new template signature with runtime isPow2/UsePdl.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace activation {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Data {
+  tg::Dtype mDtypeElt{tg::Dtype::Fp16};
+  bool mUsePdl{false};
+  bool mUseDeepSeekFp8{false};
+
+  void* inPtr;
+  void* outPtr;
+  float* inDqSfsPtr = nullptr;
+  float* outDqSfsPtr = nullptr;
+  cutlass::bfloat16_t const* gateUpLoraDeltaPtr = nullptr;
+  cutlass::bfloat16_t* activationLoraInputOutPtr = nullptr;
+
+  int32_t innerDim;
+  int32_t numTokens;
+  int32_t topK;
+  int32_t* expandedIdxToPermutedIdx;
+
+  int32_t const* totalNumPaddedTokens;
+};
+
+template <typename Type_, int32_t NumTokensPerCta_, bool UsePdl_>
+struct KernelParams {
+  using Type = Type_;
+  static constexpr int32_t NumTokensPerCta = NumTokensPerCta_;
+  static constexpr bool UsePdl = UsePdl_;
+
+  Type const* inPtr;
+  Type* outPtr;
+
+  float* inDqSfsPtr = nullptr;
+  float* outDqSfsPtr = nullptr;
+  cutlass::bfloat16_t const* gateUpLoraDeltaPtr = nullptr;
+  cutlass::bfloat16_t* activationLoraInputOutPtr = nullptr;
+
+  int32_t innerDim;
+  int32_t numTokens;
+  int32_t topK;
+  int32_t* expandedIdxToPermutedIdx;
+
+  int32_t const* totalNumPaddedTokens;
+
+  static KernelParams setKernelParams(Data const& data) {
+    KernelParams params;
+
+    params.inPtr = (Type*)data.inPtr;
+    params.outPtr = (Type*)data.outPtr;
+    params.inDqSfsPtr = data.inDqSfsPtr;
+    params.outDqSfsPtr = data.outDqSfsPtr;
+    params.gateUpLoraDeltaPtr = data.gateUpLoraDeltaPtr;
+    params.activationLoraInputOutPtr = data.activationLoraInputOutPtr;
+
+    params.expandedIdxToPermutedIdx = data.expandedIdxToPermutedIdx;
+
+    params.innerDim = data.innerDim;
+    params.numTokens = data.numTokens;
+    params.topK = data.topK;
+    params.totalNumPaddedTokens = data.totalNumPaddedTokens;
+
+    return params;
+  }
+};
+
+void run(Data const& data, void* stream);
+
+}  // namespace activation
+
+namespace convertsf {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Data {
+  bool mUsePdl{false};
+
+  void* inSfPtr = nullptr;
+  void* outSfPtr = nullptr;
+  int32_t hiddenDimSf;
+  int32_t numTokens;
+  tg::SfLayout sfLayoutSrc;
+  tg::SfLayout sfLayoutDst;
+};
+
+template <typename Type_, bool UsePdl_>
+struct KernelParams {
+  using Type = Type_;
+  static constexpr bool UsePdl = UsePdl_;
+
+  void const* inSfPtr = nullptr;
+  void* outSfPtr = nullptr;
+  int32_t hiddenDimSf;
+  int32_t numTokens;
+  tg::SfLayout sfLayoutSrc;
+  tg::SfLayout sfLayoutDst;
+
+  static KernelParams setKernelParams(Data const& data) {
+    KernelParams params;
+
+    params.inSfPtr = data.inSfPtr;
+    params.outSfPtr = data.outSfPtr;
+    params.hiddenDimSf = data.hiddenDimSf;
+    params.numTokens = data.numTokens;
+    params.sfLayoutSrc = data.sfLayoutSrc;
+    params.sfLayoutDst = data.sfLayoutDst;
+
+    return params;
+  }
+};
+
+void run(Data const& data, void* stream);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace convertsf
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace permute {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Data {
+  tg::Dtype mDtypeElt{tg::Dtype::Fp16};
+  bool mUsePdl{false};
+  bool mUseDeepSeekFp8{false};
+
+  void* inPtr;
+  void* outPtr;
+  float* inDqSfsPtr = nullptr;
+  float* outDqSfsPtr = nullptr;
+  int32_t* expandedIdxToPermutedIdx;
+  int32_t hiddenDim;
+  int32_t numTokens;
+  int32_t topK;
+  int32_t const* totalNumPaddedTokens;
+};
+
+template <typename Type_, bool UsePdl_>
+struct KernelParams {
+  using Type = Type_;
+  static constexpr bool UsePdl = UsePdl_;
+
+  Type const* inPtr;
+  Type* outPtr;
+  float const* inDqSfsPtr;
+  float* outDqSfsPtr;
+  int32_t* expandedIdxToPermutedIdx;
+  int32_t hiddenDim;
+  int32_t numTokens;
+  int32_t topK;
+  int32_t const* totalNumPaddedTokens;
+  bool useDeepSeekFp8;
+
+  static KernelParams setKernelParams(Data const& data) {
+    KernelParams params;
+
+    params.inPtr = (Type*)data.inPtr;
+    params.outPtr = (Type*)data.outPtr;
+    params.inDqSfsPtr = data.inDqSfsPtr;
+    params.outDqSfsPtr = data.outDqSfsPtr;
+    params.expandedIdxToPermutedIdx = data.expandedIdxToPermutedIdx;
+    params.hiddenDim = data.hiddenDim;
+    params.numTokens = data.numTokens;
+    params.topK = data.topK;
+    params.totalNumPaddedTokens = data.totalNumPaddedTokens;
+    params.useDeepSeekFp8 = data.mUseDeepSeekFp8;
+
+    return params;
+  }
+};
+
+void run(Data const& data, void* stream);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace permute
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace finalize {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Data {
+  tg::Dtype mDtypeElt{tg::Dtype::Fp16};
+  tg::Dtype mDtypeExpW{tg::Dtype::Bfloat16};
+  bool mUsePdl{false};
+  bool mUseDeepSeekFp8{false};
+
+  void* inPtr;
+  void* outPtr;
+  float* inDqSfsPtr = nullptr;
+  float* outDqSfsPtr = nullptr;
+
+  void* expertWeightsPtr;
+  int32_t* expandedIdxToPermutedIdx;
+
+  int32_t numTokens;
+  int32_t numExperts;
+  int32_t topK;
+  // Hidden dimension output of MoE block. It is not padded.
+  int32_t hiddenDim;
+  // Hidden dimension output of FC2. It might be padded.
+  int32_t hiddenDimPadded;
+  int32_t const* totalNumPaddedTokens;
+};
+
+template <typename Type_, typename TypeExpW_, int TopKUnrollFactor_, bool UsePdl_>
+struct KernelParams {
+  using Type = Type_;
+  using TypeExpW = TypeExpW_;
+  static constexpr int TopKUnrollFactor = TopKUnrollFactor_;
+  static constexpr bool UsePdl = UsePdl_;
+
+  Type const* inPtr;
+  TypeExpW const* expertWeightsPtr;
+  Type* outPtr;
+
+  float* inDqSfsPtr = nullptr;
+  float* outDqSfsPtr = nullptr;
+
+  int32_t* expandedIdxToPermutedIdx;
+
+  int32_t hiddenDim;
+  int32_t hiddenDimPadded;
+  int32_t numTokens;
+  int32_t numExperts;
+  int32_t topK;
+  int32_t const* totalNumPaddedTokens;
+
+  static KernelParams setKernelParams(Data const& data) {
+    KernelParams params;
+
+    params.inPtr = (Type*)data.inPtr;
+    params.expertWeightsPtr = (TypeExpW*)data.expertWeightsPtr;
+    params.outPtr = (Type*)data.outPtr;
+    params.inDqSfsPtr = data.inDqSfsPtr;
+    params.outDqSfsPtr = data.outDqSfsPtr;
+
+    params.expandedIdxToPermutedIdx = data.expandedIdxToPermutedIdx;
+
+    params.hiddenDim = data.hiddenDim;
+    params.hiddenDimPadded = data.hiddenDimPadded;
+    params.numTokens = data.numTokens;
+    params.numExperts = data.numExperts;
+    params.topK = data.topK;
+    params.totalNumPaddedTokens = data.totalNumPaddedTokens;
+
+    return params;
+  }
+};
+
+void run(Data const& data, void* stream);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace finalize
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace moe::dev

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/DevKernel.h
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/DevKernel.h
@@ -174,6 +174,13 @@ struct Data {
   cutlass::bfloat16_t const* gateUpLoraDeltaPtr = nullptr;
   cutlass::bfloat16_t* activationLoraInputOutPtr = nullptr;
 
+  // When true, inPtr holds the column-interleaved gate/up GEMM1 output
+  // (g0,u0,g1,u1,...) and the kernel de-interleaves on read (x1=col 2k, x2=col 2k+1);
+  // when false, inPtr is the contiguous [gate | up] layout. Default false keeps the
+  // FP8 / non-LoRA semantics; the FP4 LoRA path sets it true to fuse the standalone
+  // de-interleave kernel into this activation read.
+  bool interleavedGateUpInput = false;
+
   int32_t innerDim;
   int32_t numTokens;
   int32_t topK;
@@ -196,6 +203,8 @@ struct KernelParams {
   cutlass::bfloat16_t const* gateUpLoraDeltaPtr = nullptr;
   cutlass::bfloat16_t* activationLoraInputOutPtr = nullptr;
 
+  bool interleavedGateUpInput = false;
+
   int32_t innerDim;
   int32_t numTokens;
   int32_t topK;
@@ -212,6 +221,7 @@ struct KernelParams {
     params.outDqSfsPtr = data.outDqSfsPtr;
     params.gateUpLoraDeltaPtr = data.gateUpLoraDeltaPtr;
     params.activationLoraInputOutPtr = data.activationLoraInputOutPtr;
+    params.interleavedGateUpInput = data.interleavedGateUpInput;
 
     params.expandedIdxToPermutedIdx = data.expandedIdxToPermutedIdx;
 

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/runner.h
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "DevKernel.h"
+#include "flashinfer/trtllm/fused_moe/RoutingKernel.h"
+// #include "flashinfer/trtllm/common/cudaDriverWrapper.h"
+#include "flashinfer/trtllm/batched_gemm/KernelRunner.h"
+#include "flashinfer/trtllm/batched_gemm/trtllmGen_bmm_export/trtllm/gen/DtypeDecl.h"
+#include "flashinfer/trtllm/common/cudaUtils.h"
+
+namespace tensorrt_llm {
+namespace kernels {
+namespace trtllmgen_moe {
+
+namespace MoE {
+class Runner;
+}  // namespace MoE
+
+namespace Routing {
+
+// The type of method in top-K routing, for use in torch custom op
+// Please keep this in sync with the counterpart defined in
+// flashinfer/fused_moe/core.py
+enum class RoutingMethodType : int64_t {
+  // Default: Softmax -> TopK
+  Default = 0,
+  // Renormalize: TopK -> Softmax
+  Renormalize = 1,
+  // DeepSeekV3: Sigmoid -> RoutingBiasAdd -> Top2 in group -> Top4 groups -> Top8 experts from the
+  // Top4 groups
+  DeepSeekV3 = 2,
+  // Llama4: Top1 -> Sigmoid
+  Llama4 = 3,
+  // RenormalizeNaive: Softmax -> TopK -> Renormalize
+  RenormalizeNaive = 4,
+  // TopK only (no softmax)
+  TopK = 5,
+  // SigmoidRenorm: Sigmoid -> TopK -> Renormalize (divide by sum of top-K weights)
+  SigmoidRenorm = 6,
+  // MiniMax2: Sigmoid + Bias -> TopK -> ScaledSumNormalize (routeScale=1.0, epsilon=1e-20)
+  MiniMax2 = 7,
+  // Sigmoid: Sigmoid -> TopK (no renormalization)
+  Sigmoid = 8,
+  // Unspecified
+  Unspecified = 9,
+};
+
+inline int32_t maybeGetMinTokenCount(int32_t numPaddedTokens, int32_t hiddenSize,
+                                     int32_t dtypeSizeBits) {
+  // Pad so total size exceeds 128KiB for performance reasons
+  int32_t minNumTokensRequired = common::divUp(128 * 1024 * 8, hiddenSize * dtypeSizeBits);
+  return std::max(numPaddedTokens, minNumTokensRequired);
+}
+
+inline std::string serializeMoeRoutingMethodType(RoutingMethodType routingMethodType) {
+  switch (routingMethodType) {
+    case RoutingMethodType::Default:
+      return "Default";
+    case RoutingMethodType::Renormalize:
+      return "Renormalize";
+    case RoutingMethodType::DeepSeekV3:
+      return "DeepSeekV3";
+    case RoutingMethodType::Llama4:
+      return "Llama4";
+    case RoutingMethodType::RenormalizeNaive:
+      return "RenormalizeNaive";
+    case RoutingMethodType::TopK:
+      return "TopK";
+    case RoutingMethodType::SigmoidRenorm:
+      return "SigmoidRenorm";
+    case RoutingMethodType::MiniMax2:
+      return "MiniMax2";
+    case RoutingMethodType::Sigmoid:
+      return "Sigmoid";
+    default:
+      return "InvalidRountingMethod";  // TODO throw error
+  };
+}
+
+inline int32_t getMaxNumCtasInBatchDim(int32_t numTokens, int32_t topK, int32_t numExperts,
+                                       int32_t tileTokensDim) {
+  // For MoE, mNumTokens != 0 and the number of CTAs is known only at runtime.
+  // We launch maximally possible number of CTAs and use ptrNumNonExitingCtas to determine
+  // the actual number of CTAs to run.
+
+  // Initialize number of tokens with the number of expanded tokens after routing.
+  int32_t numRemainingTokens = numTokens * topK;
+  int32_t maxNumCtasInBatchDim = 0;
+  // First, distribute one token each expert until token depletion to maximize CTA tile count.
+  int32_t numExpertsFilled = std::min(numExperts, numRemainingTokens);
+  maxNumCtasInBatchDim += numExpertsFilled;
+  numRemainingTokens -= numExpertsFilled;
+  // Next, greedily pour all remaining tokens to one expert to maximize CTA tile count.
+  // E.g., at this point tokens over 4 experts are [1, 1, 1, 1], and we have 4 tokens left.
+  // If each CTA handles 4 tokens/expert, the greedy strategy is to pour all remaining tokens
+  // to any one expert to get to the 5th CTA tile. Otherwise, we can only get 4 tiles in total.
+  //
+  // Another way to reason about this is to pour the remaining tokens into buckets of some fixed
+  // capacity. These buckets, if full, can then be attributed to any expert; it does not have to
+  // belong to the same expert every time.
+  if (numRemainingTokens > 0) {
+    // For every tileTokenDim tokens, we add an extra CTA tile in the token dimension.
+    // The number of CTA tiles is given by divDown(numRemainingTokens, tokenTileDim).
+    maxNumCtasInBatchDim += (numRemainingTokens / tileTokensDim);
+  }
+  return maxNumCtasInBatchDim;
+}
+
+inline int32_t getMaxPermutedPaddedCount(int32_t numTokens, int32_t expertsPerToken,
+                                         int32_t numExperts, int32_t padding) {
+  int32_t maxCtas = getMaxNumCtasInBatchDim(numTokens, expertsPerToken, numExperts, padding);
+  return maxCtas * padding;
+}
+
+class Runner {
+ public:
+  explicit Runner();
+
+  explicit Runner(int32_t tileTokensDim);
+
+  void run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts,
+           int32_t topK, int32_t nGroups, int32_t topkGroups, int32_t localExpertOffset,
+           int32_t localNumExperts, float routedScalingFactor, int32_t* routingExpertIndexes,
+           int32_t* expertCountHistogram, int32_t* permutedIdxSize,
+           int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx,
+           int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* numTokensPerExpert,
+           int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas,
+           batchedGemm::trtllm::gen::Dtype dtypeElt, batchedGemm::trtllm::gen::Dtype dtypeBias,
+           bool useRoutingScalesOnInput, bool useDeepSeekFp8, RoutingMethodType routingMethodType,
+           cudaStream_t stream, batchedGemm::trtllm::gen::Dtype dtypeLogits,
+           bool normTopkProb = true, int16_t* routing_replay_out = nullptr);
+
+ private:
+  friend class MoE::Runner;
+  int32_t mTileTokensDim{8};
+};
+}  // namespace Routing
+
+namespace MoE {
+// The type of activation function
+// Please keep this in sync with the counterpart defined in flashinfer/flashinfer/fused_moe/core.py
+enum class ActivationType : int64_t {
+  Gelu = 0,
+  Relu = 1,
+  Silu = 2,
+  Swiglu = 3,
+  Geglu = 4,
+  SwigluBias = 5,
+  Relu2 = 6,
+  Identity = 7,
+  InvalidType = 8,  // Must be last
+};
+
+inline std::string serializeActivationType(ActivationType activationType) {
+  switch (activationType) {
+    case ActivationType::Gelu:
+      return "Gelu";
+    case ActivationType::Relu:
+      return "Relu";
+    case ActivationType::Silu:
+      return "Silu";
+    case ActivationType::Swiglu:
+      return "Swiglu";
+    case ActivationType::Geglu:
+      return "Geglu";
+    case ActivationType::SwigluBias:
+      return "SwigluBias";
+    case ActivationType::Relu2:
+      return "Relu2";
+    case ActivationType::Identity:
+      return "Identity";
+    default:
+      return "InvalidActivationType";  // TODO throw error
+  };
+}
+
+inline bool isGatedActivation(ActivationType activationType) {
+  return activationType == ActivationType::Swiglu || activationType == ActivationType::Geglu ||
+         activationType == ActivationType::SwigluBias;
+}
+
+}  // namespace MoE
+
+namespace PermuteGemm1 {
+class Runner {
+ public:
+  explicit Runner(batchedGemm::trtllm::gen::Dtype dtypeAct,
+                  batchedGemm::trtllm::gen::Dtype dtypeWeights,
+                  batchedGemm::trtllm::gen::Dtype dtypeOutput, bool useDeepSeekFp8,
+                  int tileTokensDim, MoE::ActivationType activationType, bool useShuffledMatrix,
+                  batchedGemm::gemm::MatrixLayout weight_layout, bool usePerTokenScaling,
+                  bool usePerChannelScaling);
+
+  size_t getWorkspaceSizeInBytes(int32_t topK, int32_t hiddenSize, int32_t intermediateSize,
+                                 int32_t numExperts, int32_t numTokens, int32_t configIndex) const;
+
+  [[nodiscard]] int32_t getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
+                                                   int32_t intermediateSize, int32_t numExperts,
+                                                   int32_t numTokens) const;
+
+  [[nodiscard]] bool isValidConfigIndex(int32_t configIndex, int32_t topK, int32_t hiddenSize,
+                                        int32_t intermediateSize, int32_t numExperts,
+                                        int32_t numTokens) const;
+
+  [[nodiscard]] std::vector<int64_t> getPassingConfigIndices() const;
+
+  void run(void* hiddenState, void* hiddenStateScale, void* weight, void* weightScale,
+           void* perTokenScales, void* perChannelScales, float* outputScalesScalar,
+           float* outputScalesGateScalar, float* ptrBias, float* ptrGatedActAlpha,
+           float* ptrGatedActBeta, float* ptrClampLimit, void* output, void* outputScale,
+           int32_t topK, int32_t hiddenSize, int32_t intermediateSize, int32_t numExperts,
+           int32_t numTokens, int32_t* permutedIdxToTokenIdx, int32_t* ptrNumNonExitingCtas,
+           int32_t* ptrTotalNumPaddedTokens, int32_t* ptrCtaIdxXyToBatchIdx,
+           int32_t* ptrCtaIdxXyToMnLimit, void* bmm1Workspace, bool useRoutingScalesOnInput,
+           int device, cudaStream_t stream, int32_t configIndex, bool enable_pdl);
+
+ private:
+  friend class MoE::Runner;
+  batchedGemm::trtllm::gen::Dtype mDtypeAct;
+  batchedGemm::trtllm::gen::Dtype mDtypeWeights;
+  batchedGemm::trtllm::gen::Dtype mDtypeOutput;
+  int32_t mTileTokensDim;
+  tensorrt_llm::kernels::TrtllmGenBatchedGemmRunner mRunner;
+  tensorrt_llm::kernels::trtllmgen_moe::MoE::ActivationType mActType;
+};
+}  // namespace PermuteGemm1
+
+namespace Gemm2 {
+class Runner {
+ public:
+  explicit Runner(batchedGemm::trtllm::gen::Dtype dtypeAct,
+                  batchedGemm::trtllm::gen::Dtype dtypeWeights,
+                  batchedGemm::trtllm::gen::Dtype outputDtype, bool useDeepSeekFp8,
+                  int tileTokensDim, bool useShuffledMatrix,
+                  batchedGemm::gemm::MatrixLayout weight_layout, bool usePerTokenScaling,
+                  bool usePerChannelScaling);
+
+  size_t getWorkspaceSizeInBytes(int32_t topK, int32_t hiddenSize, int32_t intermediateSize,
+                                 int32_t numExperts, int32_t numTokens, int32_t configIndex) const;
+
+  [[nodiscard]] int32_t getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
+                                                   int32_t intermediateSize, int32_t numExperts,
+                                                   int32_t numTokens) const;
+
+  [[nodiscard]] bool isValidConfigIndex(int32_t configIndex, int32_t topK, int32_t hiddenSize,
+                                        int32_t intermediateSize, int32_t numExperts,
+                                        int32_t numTokens) const;
+
+  [[nodiscard]] std::vector<int64_t> getPassingConfigIndices() const;
+
+  void run(void* permutedHiddenState, void* permutedHiddenStateScale, void* weight,
+           void* weightScale, void* perTokenScales, void* perChannelScales,
+           float* outputScalesScalar, float* ptrBias, void* output, void* outputScale, int32_t topK,
+           int32_t hiddenSize, int32_t intermediateSize, int32_t numExperts, int32_t numTokens,
+           int32_t* ptrNumNonExitingCtas, int32_t* ptrTotalNumPaddedTokens,
+           int32_t* ptrCtaIdxXyToBatchIdx, int32_t* ptrCtaIdxXyToMnLimit, void* bmm2Workspace,
+           int device, cudaStream_t stream, int32_t configIndex, bool enable_pdl);
+
+ private:
+  friend class MoE::Runner;
+  batchedGemm::trtllm::gen::Dtype mDtypeAct;
+  batchedGemm::trtllm::gen::Dtype mDtypeWeights;
+  batchedGemm::trtllm::gen::Dtype mDtypeOut;
+  int32_t mTileTokensDim;
+  tensorrt_llm::kernels::TrtllmGenBatchedGemmRunner mRunner;
+};
+}  // namespace Gemm2
+
+namespace MoE {
+namespace btg = batchedGemm::trtllm::gen;
+
+struct MoERunnerArgs {
+  void* routing_logits = nullptr;  // [num_tokens, num_experts] in float, generated after
+                                   // gemm(hidden_state, routing_weights)
+  void* routing_bias = nullptr;    // [num_experts] in bfloat16 for now = mDtypeExpW
+  void* hidden_states = nullptr;   // [num_tokens, hidden_size] in fp8 = mDtypeElt
+  // [hidden_size/128, num_tokens] in float for e4m3 DS recipe
+  // and [num_tokens, hidden_size/16] in float for e2m1
+  void* hidden_states_scale = nullptr;
+
+  // Gemm input:
+  void* gemm1_weights = nullptr;
+  void* gemm1_weights_scale = nullptr;
+  void* gemm2_weights = nullptr;
+  void* gemm2_weights_scale = nullptr;
+
+  float* gemm1_bias = nullptr;
+  float* gemm1_alpha = nullptr;
+  float* gemm1_beta = nullptr;
+  float* gemm1_clamp_limit = nullptr;
+  float* gemm2_bias = nullptr;
+
+  ActivationType activation_type = ActivationType::Swiglu;
+
+  int32_t num_tokens{0};
+  int32_t num_experts{0};
+  // Hidden dimension input of MoE block. It might be padded.
+  int32_t hidden_size{0};
+  // Hidden dimension output of MoE block. It is not padded.
+  // If not provided it is the same as hidden_size.
+  std::optional<int32_t> hidden_size_output;
+  // TODO: only compiled routing kernel supports top_k = 8
+  int32_t top_k{0};
+  int32_t n_group{0};
+  // TODO: only compiled routing kernel supports topk_group = 4
+  int32_t topk_group{0};
+  float routed_scaling_factor{0.0f};
+  int32_t intermediate_size{0};
+  int32_t local_expert_offset{0};
+  int32_t local_num_experts{0};
+  // TODO: support other types
+  btg::Dtype mDtypeElt{btg::Dtype::Void};
+  btg::Dtype mDtypeExpW{btg::Dtype::Bfloat16};
+  btg::Dtype mDtypeOut{btg::Dtype::Bfloat16};
+
+  // Apply routing scale factors to input activations
+  bool mUseRoutingScalesOnInput{false};
+  bool mUseDeepSeekFp8{false};
+  float* output1_scales_scalar = nullptr;
+  float* output1_scales_gate_scalar = nullptr;
+  float* output2_scales_scalar = nullptr;
+
+  // Optional LoRA bridge buffers used by the copied SGLang TRTLLM FP8 path.
+  // gate_up_lora_delta: [num_tokens * top_k, 2 * intermediate_size], bf16,
+  // in FlashInfer gate/up order (up first, gate second).
+  // activation_lora_input: [num_tokens * top_k, intermediate_size], bf16,
+  // populated with the post-activation intermediate for down-proj LoRA.
+  void* gate_up_lora_delta = nullptr;
+  void* activation_lora_input = nullptr;
+
+  // Output:
+  void* output = nullptr;
+  float* output_scale = nullptr;
+
+  // finalize
+  bool do_finalize{true};
+};
+
+struct MoEWorkspace {
+  // Routing intermediate outputs:
+  int32_t* routing_expert_indexes = nullptr;
+  int32_t* permuted_idx_size = nullptr;
+  int32_t* total_num_padded_tokens = nullptr;  // TODO: duplicate of permuted_idx_size
+  int32_t total_max_padded_tokens{0};
+
+  int32_t* expanded_idx_to_permuted_idx = nullptr;
+  int32_t* permuted_idx_to_expanded_idx = nullptr;
+  int32_t* permuted_idx_to_token_idx = nullptr;
+
+  // consumed by finalize kernel
+  void* expert_weights = nullptr;  // [num_tokens, top_k] in bfloat16 = mDtypeExpW
+  // consumed by permuteGemm1 kernel
+  void* token_scales = nullptr;
+  // consumed by Gemm2 kernel
+  void* token_scales_fc2 = nullptr;
+
+  int32_t* cta_idx_xy_to_batch_idx = nullptr;
+  int32_t* cta_idx_xy_to_mn_limit = nullptr;
+  int32_t* num_non_exiting_ctas = nullptr;
+
+  void* hidden_states_scale_linear = nullptr;
+
+  // Permute intermediate outputs:
+  void* permuted_hidden_states = nullptr;
+  float* permuted_hidden_states_scale = nullptr;
+
+  // Gemm1 intermediate outputs:
+  int32_t ProjUpTileN{0};
+  void* gemm1_output = nullptr;
+  float* gemm1_output_scale = nullptr;
+
+  // Activation intermediate outputs:
+  void* activation_output = nullptr;
+  float* activation_output_scale = nullptr;
+
+  // Gemm2 intermediate outputs:
+  void* gemm2_output = nullptr;
+  float* gemm2_output_scale = nullptr;
+
+  // Finalize intermediate outputs (placeholder not used)
+  void* finalize_output = nullptr;
+  float* finalize_output_scale = nullptr;
+
+  // FC1 workspace:
+  void* bmm1_workspace = nullptr;
+
+  // FC2 workspace:
+  void* bmm2_workspace = nullptr;
+};
+
+// Config indices to be used with Batched GEMM runners
+struct MoEConfig {
+  int64_t gemm1Config;
+  int64_t gemm2Config;
+};
+
+class Runner {
+ public:
+  // FIXME: tileTokensDim is hardcoded for now
+  Runner(batchedGemm::trtllm::gen::Dtype dtypeAct, batchedGemm::trtllm::gen::Dtype dtypeWeights,
+         bool useDeepSeekFp8, int tileTokensDim = 8,
+         ActivationType activationType = ActivationType::Swiglu, bool useShuffledMatrix = false,
+         batchedGemm::gemm::MatrixLayout weight_layout = batchedGemm::gemm::MatrixLayout::MajorK,
+         bool usePerTokenScalingGemm1 = false, bool usePerTokenScalingGemm2 = false,
+         bool usePerChannelScalingGemm1 = false, bool usePerChannelScalingGemm2 = false);
+  Runner(batchedGemm::trtllm::gen::Dtype dtypeElt, bool useDeepSeekFp8, int tileTokensDim = 8,
+         bool useShuffledMatrix = false,
+         batchedGemm::gemm::MatrixLayout weight_layout = batchedGemm::gemm::MatrixLayout::MajorK,
+         bool usePerTokenScalingGemm1 = false, bool usePerTokenScalingGemm2 = false,
+         bool usePerChannelScalingGemm1 = false, bool usePerChannelScalingGemm2 = false);
+
+  void run(MoERunnerArgs const& args, MoEWorkspace const& workspace, int device,
+           cudaStream_t stream, int64_t configIndex, bool enable_pdl);
+
+  [[nodiscard]] std::tuple<int32_t, int32_t> getWorkspaceSizeInBytes(MoERunnerArgs const& args,
+                                                                     int64_t configIndex) const;
+
+  [[nodiscard]] std::vector<int64_t> getValidConfigIndices(int32_t topK, int32_t hiddenSize,
+                                                           int32_t intermediateSize,
+                                                           int32_t numLocalExperts,
+                                                           int32_t numTokens) const;
+
+  [[nodiscard]] int64_t getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
+                                                   int32_t intermediateSize,
+                                                   int32_t numLocalExperts,
+                                                   int32_t numTokens) const;
+
+ private:
+  void setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace,
+                  moe::dev::convertsf::Data& convertSfData,
+                  moe::dev::activation::Data& activationData,
+                  moe::dev::finalize::Data& finalizeData);
+
+ private:
+  bool mUsePerTokenScalingGemm1;
+  bool mUsePerTokenScalingGemm2;
+  bool mUsePerChannelScalingGemm1;
+  bool mUsePerChannelScalingGemm2;
+  PermuteGemm1::Runner mPermuteGemm1;
+  Gemm2::Runner mGemm2;
+
+  // This will be the cartesian product of the passing configs for gemm1 and gemm2
+  // This allows us to autotune the MoE as one operation instead of tuning gemm1 and gemm2
+  // separately
+  std::vector<MoEConfig> mPassingConfigs;
+};
+}  // namespace MoE
+
+}  // namespace trtllmgen_moe
+}  // namespace kernels
+}  // namespace tensorrt_llm

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/runner.h
@@ -345,6 +345,12 @@ struct MoERunnerArgs {
   void* gate_up_lora_delta = nullptr;
   void* activation_lora_input = nullptr;
 
+  // Optional CUDA event (cudaEvent_t) recorded on the LoRA side stream. When set, the
+  // runner waits on it right before the activation kernel (which consumes
+  // gate_up_lora_delta), so permute+GEMM1 overlap the side-stream LoRA shrink/expand
+  // instead of joining before the whole MoE op. nullptr = no wait (serial behavior).
+  void* lora_ready_event = nullptr;
+
   // Output:
   void* output = nullptr;
   float* output_scale = nullptr;

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/data/include/flashinfer/trtllm/fused_moe/runner.h
@@ -206,7 +206,7 @@ class Runner {
                   batchedGemm::trtllm::gen::Dtype dtypeOutput, bool useDeepSeekFp8,
                   int tileTokensDim, MoE::ActivationType activationType, bool useShuffledMatrix,
                   batchedGemm::gemm::MatrixLayout weight_layout, bool usePerTokenScaling,
-                  bool usePerChannelScaling);
+                  bool usePerChannelScaling, bool forceUnfusedAct = false);
 
   size_t getWorkspaceSizeInBytes(int32_t topK, int32_t hiddenSize, int32_t intermediateSize,
                                  int32_t numExperts, int32_t numTokens, int32_t configIndex) const;
@@ -395,6 +395,9 @@ struct MoEWorkspace {
   // Activation intermediate outputs:
   void* activation_output = nullptr;
   float* activation_output_scale = nullptr;
+  // Unfused FP4 LoRA: bf16 [max_padded_tokens, intermediate_size] activation output written by the
+  // standalone activation kernel (gate_up LoRA added pre-SwiGLU), then NvFP4-quantized for GEMM2.
+  void* activated_lora_bf16 = nullptr;
 
   // Gemm2 intermediate outputs:
   void* gemm2_output = nullptr;
@@ -425,7 +428,8 @@ class Runner {
          ActivationType activationType = ActivationType::Swiglu, bool useShuffledMatrix = false,
          batchedGemm::gemm::MatrixLayout weight_layout = batchedGemm::gemm::MatrixLayout::MajorK,
          bool usePerTokenScalingGemm1 = false, bool usePerTokenScalingGemm2 = false,
-         bool usePerChannelScalingGemm1 = false, bool usePerChannelScalingGemm2 = false);
+         bool usePerChannelScalingGemm1 = false, bool usePerChannelScalingGemm2 = false,
+         bool unfuseActForLora = false);
   Runner(batchedGemm::trtllm::gen::Dtype dtypeElt, bool useDeepSeekFp8, int tileTokensDim = 8,
          bool useShuffledMatrix = false,
          batchedGemm::gemm::MatrixLayout weight_layout = batchedGemm::gemm::MatrixLayout::MajorK,
@@ -459,6 +463,10 @@ class Runner {
   bool mUsePerTokenScalingGemm2;
   bool mUsePerChannelScalingGemm1;
   bool mUsePerChannelScalingGemm2;
+  // When true (FP4 LoRA path), GEMM1 emits the raw gate_up projection (fusedAct=false) so the
+  // standalone activation kernel can inject the gate_up LoRA delta pre-SwiGLU and capture the
+  // post-activation input for the down LoRA — mirroring the DeepSeek-FP8 unfused activation.
+  bool mUnfuseActForLora;
   PermuteGemm1::Runner mPermuteGemm1;
   Gemm2::Runner mGemm2;
 

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/jit.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/jit.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+
+def _data_dir() -> Path:
+    return Path(__file__).resolve().parent / "data"
+
+
+def gen_sgl_trtllm_gen_fused_moe_sm100_module():
+    import flashinfer
+
+    from flashinfer.artifacts import ArtifactPath, CheckSumHash
+    from flashinfer.jit import env as jit_env
+    from flashinfer.jit.core import current_compilation_context, gen_jit_spec
+    from flashinfer.jit.cubin_loader import (
+        ensure_symlink,
+        get_artifact,
+        get_meta_hash,
+        verify_symlinked_headers,
+    )
+    from flashinfer.jit.fused_moe import BMM_EXPORT_HEADERS
+
+    overlay_data_dir = _data_dir()
+    overlay_csrc_dir = overlay_data_dir / "csrc"
+    overlay_include_dir = overlay_data_dir / "include"
+    flashinfer_data_dir = Path(flashinfer.__file__).resolve().parent / "data"
+    flashinfer_csrc_dir = flashinfer_data_dir / "csrc"
+    flashinfer_include_dir = flashinfer_data_dir / "include"
+
+    include_path = f"{ArtifactPath.TRTLLM_GEN_BMM}/include"
+    header_name = "flashinferMetaInfo"
+    checksum_path = f"{ArtifactPath.TRTLLM_GEN_BMM}/checksums.txt"
+    checksum = get_artifact(checksum_path, CheckSumHash.TRTLLM_GEN_BMM)
+    assert checksum, f"Failed to get checksums.txt from {checksum_path}"
+    meta_hash = get_meta_hash(checksum)
+
+    metainfo = get_artifact(f"{include_path}/{header_name}.h", meta_hash)
+    assert metainfo, f"{header_name}.h not found"
+
+    bmm_export_path = f"{include_path}/trtllmGen_bmm_export"
+    for header in BMM_EXPORT_HEADERS:
+        h = get_artifact(f"{bmm_export_path}/{header}", get_meta_hash(checksum, header))
+        assert h, f"{header} not found"
+
+    symlink_path = (
+        jit_env.FLASHINFER_CUBIN_DIR
+        / "flashinfer"
+        / "trtllm"
+        / "batched_gemm"
+        / "trtllmGen_bmm_export"
+    )
+    ensure_symlink(symlink_path, jit_env.FLASHINFER_CUBIN_DIR / bmm_export_path)
+    verify_symlinked_headers(symlink_path, BMM_EXPORT_HEADERS, checksum)
+
+    nvcc_flags = current_compilation_context.get_nvcc_flags_list(
+        supported_major_versions=[10, 12]
+    )
+
+    return gen_jit_spec(
+        "sgl_fused_moe_trtllm_sm100",
+        [
+            flashinfer_csrc_dir / "nv_internal/cpp/kernels/quantization.cu",
+            flashinfer_csrc_dir / "nv_internal/cpp/common/envUtils.cpp",
+            flashinfer_csrc_dir / "nv_internal/cpp/common/logger.cpp",
+            flashinfer_csrc_dir / "nv_internal/cpp/common/stringUtils.cpp",
+            flashinfer_csrc_dir / "nv_internal/cpp/common/tllmException.cpp",
+            flashinfer_csrc_dir / "nv_internal/cpp/common/memoryUtils.cu",
+            overlay_csrc_dir / "trtllm_fused_moe_kernel_launcher.cu",
+            overlay_csrc_dir / "trtllm_fused_moe_runner.cu",
+            flashinfer_csrc_dir
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu",
+            flashinfer_csrc_dir
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu",
+            flashinfer_csrc_dir
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu",
+            flashinfer_csrc_dir
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu",
+            overlay_csrc_dir
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu",
+            flashinfer_csrc_dir / "trtllm_batched_gemm_runner.cu",
+        ],
+        extra_cuda_cflags=[
+            "-DTLLM_GEN_EXPORT_INTERFACE",
+            "-DTLLM_GEN_EXPORT_FLASHINFER",
+            "-DTLLM_ENABLE_CUDA",
+            "-DENABLE_BF16",
+            "-DENABLE_FP8",
+            "-DENABLE_FP4",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+            f'-DTLLM_GEN_GEMM_CUBIN_PATH=\\"{ArtifactPath.TRTLLM_GEN_BMM}\\"',
+        ]
+        + nvcc_flags,
+        extra_include_paths=[
+            overlay_include_dir,
+            overlay_csrc_dir,
+            flashinfer_include_dir,
+            flashinfer_csrc_dir,
+            flashinfer_csrc_dir / "nv_internal",
+            flashinfer_csrc_dir / "nv_internal/include",
+            jit_env.FLASHINFER_CUBIN_DIR,
+            jit_env.FLASHINFER_CUBIN_DIR / include_path,
+        ],
+    )

--- a/python/sglang/jit_kernel/flashinfer_trtllm_moe/topk_pack.py
+++ b/python/sglang/jit_kernel/flashinfer_trtllm_moe/topk_pack.py
@@ -1,0 +1,51 @@
+"""Fused pack for the trtllm routed-MoE topk format.
+
+The trtllm routed MoE consumes top-k routing as a single int32 per (token, slot):
+``PackedScoreIdx`` = ``(expert_id << 16) | bf16_weight_bits`` (little-endian: low 16
+bits = bf16 weight, high 16 bits = int16 expert id).
+
+The torch reference builds this with a cluster of ~4 elementwise ops (cast, cast, view,
+bitshift, or). On the decode LoRA path these run on the main CUDA stream between
+``per_token_group_quant_fp8`` and the trtllm MoE op. This kernel collapses them into a
+single Triton launch. Bit-identical to the torch reference: weights are softmax/renormalized
+(>= 0 -> bf16 sign bit is 0, so the low 16 bits never collide with the id field and masking
+== torch's sign-extend-then-or); expert ids are small (< num_experts).
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _pack_topk_kernel(ids_ptr, w_ptr, out_ptr, numel, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < numel
+    ids = tl.load(ids_ptr + offs, mask=mask)  # int32
+    w = tl.load(w_ptr + offs, mask=mask)  # float32
+    wb = w.to(tl.bfloat16)
+    wbits = wb.to(tl.int16, bitcast=True).to(tl.int32) & 0xFFFF
+    packed = (ids << 16) | wbits
+    tl.store(out_ptr + offs, packed, mask=mask)
+
+
+def fused_pack_topk(topk_ids: torch.Tensor, topk_weights: torch.Tensor) -> torch.Tensor:
+    """Single-launch replacement for the elementwise routed-MoE topk pack.
+
+    Returns int32 ``[*, top_k]`` packed tensor, bit-identical to the torch reference.
+    """
+    if topk_ids.dtype != torch.int32:
+        topk_ids = topk_ids.to(torch.int32)
+    topk_ids = topk_ids.contiguous()
+    if topk_weights.dtype != torch.float32:
+        topk_weights = topk_weights.to(torch.float32)
+    topk_weights = topk_weights.contiguous()
+    out = torch.empty_like(topk_ids, dtype=torch.int32)
+    numel = out.numel()
+    if numel == 0:
+        return out
+    BLOCK = 1024
+    grid = (triton.cdiv(numel, BLOCK),)
+    _pack_topk_kernel[grid](topk_ids, topk_weights, out, numel, BLOCK=BLOCK)
+    return out

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -446,6 +446,10 @@ class Envs:
     # (their env gates were removed — proven useful). The down-proj overlap is DISABLED (load-triggered
     # cuda-graph/NCCL race → decode garbage; see moe_overlap.py `_overlap_down`).
     SGLANG_TWO_STREAM_MAX_TOKENS = EnvInt(256)
+    # WIP (unstaged, test-only): tuned triton a_stage_config for the MoE LoRA shrink GEMM. Default off.
+    # Correctness-neutral (acc at the atomic-add noise floor, coherent). On GB200 this hand-tune currently
+    # beats PR #26899's B200-tuned auto-configs; for the auto-tuned path, re-run that PR's tuner on GB200.
+    SGLANG_OPT_LORA_SHRINK_TUNE = EnvBool(False)
     # Skip-softmax threshold scale factor for TRT-LLM attention (prefill and decode separately).
     # None = standard attention. See https://arxiv.org/abs/2512.12087
     SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR = EnvFloat(None)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -446,6 +446,14 @@ class Envs:
     # (their env gates were removed — proven useful). The down-proj overlap is DISABLED (load-triggered
     # cuda-graph/NCCL race → decode garbage; see moe_overlap.py `_overlap_down`).
     SGLANG_TWO_STREAM_MAX_TOKENS = EnvInt(256)
+    # Allocate the two-stream LoRA-A shrink OUTPUT buffer on the MAIN (consumer) stream instead of
+    # inside the side-stream context. A buffer allocated under `with torch.cuda.stream(side)` is tagged
+    # to the side stream, so the caching allocator can free/reuse it on the side stream's schedule —
+    # before the MAIN stream's LoRA-B expand (the real last consumer) finishes. Under cuda-graph replay
+    # (record_stream is a no-op during capture) that's a premature-reuse WAR → qwen3.5 mamba decode
+    # garbage with a single shared side stream. Set =1 to allocate the output on the consumer stream
+    # (as the MoE O1 path already does for gate_up_delta), making a single shared side stream graph-safe.
+    SGLANG_OPT_LORA_OVERLAP_MAIN_ALLOC = EnvBool(False)
     # WIP (unstaged, test-only): tuned triton a_stage_config for the MoE LoRA shrink GEMM. Default off.
     # Correctness-neutral (acc at the atomic-add noise floor, coherent). On GB200 this hand-tune currently
     # beats PR #26899's B200-tuned auto-configs; for the auto-tuned path, re-run that PR's tuner on GB200.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -425,8 +425,18 @@ class Envs:
     SGLANG_FLASHINFER_USE_PAGED = EnvBool(False)
     # Default to the pick from flashinfer
     SGLANG_FLASHINFER_WORKSPACE_SIZE = EnvInt(384 * 1024 * 1024)
-    # Enable per-token NVFP4 activation scaling path for FlashInfer TRT-LLM MoE.
+    # NVFP4 per-token activation scaling for the flashinfer-trtllm MoE. Default OFF (per-tensor,
+    # faster — main's behavior). Set =1 when serving NVFP4 LoRA on the sgl_flashinfer_trtllm
+    # backend: the decomposed LoRA scale composition needs w13/w2 input_scale==1 (see
+    # lora/trtllm_moe/lora_dispatch.py path-3 comment). Leaving it OFF for no-lora avoids the
+    # ~9-13% per-token overhead on the no-lora base.
     SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION = EnvBool(False)
+    # Token-count ceiling for the trtllm-LoRA decode two-stream overlap (now ALWAYS-ON): decode batches
+    # with <= this many tokens run two-stream; larger batches run single-stream. NOTE: the LoRA
+    # two-stream (attention + gate_up) overlap and the permute-memset skip are now unconditional
+    # (their env gates were removed — proven useful). The down-proj overlap is DISABLED (load-triggered
+    # cuda-graph/NCCL race → decode garbage; see moe_overlap.py `_overlap_down`).
+    SGLANG_TWO_STREAM_MAX_TOKENS = EnvInt(256)
     # Skip-softmax threshold scale factor for TRT-LLM attention (prefill and decode separately).
     # None = standard attention. See https://arxiv.org/abs/2512.12087
     SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR = EnvFloat(None)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -402,6 +402,15 @@ class Envs:
     SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM = EnvBool(False)
     # Delay all-gather after qlora for better performance for Deepseek v3.2
     SGLANG_USE_AG_AFTER_QLORA = EnvBool(False)
+    # Split-K for the dense LoRA-A (shrink) GEMM. At decode the shrink grid is
+    # bs programs (one per sequence), far below the SM count, so the large-K
+    # reduction under-fills the GPU. Splitting K across SPLIT_K programs that
+    # accumulate via fp32 atomics recovers the idle SMs. fp32 (not bf16) atomics
+    # are mandatory here: bf16 atomic_add is an emulated CAS loop that contends
+    # and caps the win, while native fp32 atomics scale and are more accurate.
+    # Only helps at large K (>=~2-4K input dim) and low batch; the heuristic
+    # returns SPLIT_K=1 (original path) otherwise. Opt-in; default off is a no-op.
+    SGLANG_ENABLE_LORA_SHRINK_SPLIT_K = EnvBool(False)
     # Quantize x to int8 in the dispatch operator
     DEEP_NORMAL_MODE_USE_INT8_QUANT = EnvBool(False) # This argument is deprecated
     SGLANG_NPU_FUSED_MOE_MODE = EnvInt(1)

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -811,6 +811,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
 # Re-export so existing import sites continue to resolve; the body was
 # moved to keep this file focused on the non-LoRA trtllm paths.
 from sglang.srt.lora.trtllm_moe.lora_dispatch import (  # noqa: E402,F401
+    fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora,
     fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora,
 )
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -571,11 +571,15 @@ class FlashInferTrtllmFp8MoeQuantInfo(MoeQuantInfo):
 def _pack_topk_for_flashinfer_routed(
     topk_ids: torch.Tensor, topk_weights: torch.Tensor
 ) -> torch.Tensor:
-    """Pack routed top-k tensors into FlashInfer's int32 format."""
-    packed_ids = topk_ids.to(torch.int32)
-    packed_weights = topk_weights.to(torch.bfloat16)
-    packed = (packed_ids << 16) | packed_weights.view(torch.int16).to(torch.int32)
-    return packed
+    """Pack routed top-k tensors into FlashInfer's int32 format.
+
+    Single fused Triton launch (bit-identical to the prior elementwise
+    cast/shift/or cluster); collapses the per-MoE-layer pack kernels on the
+    decode critical path.
+    """
+    from sglang.jit_kernel.flashinfer_trtllm_moe.topk_pack import fused_pack_topk
+
+    return fused_pack_topk(topk_ids, topk_weights)
 
 
 def fused_experts_none_to_flashinfer_trtllm_fp8(

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -583,6 +583,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
     quant_info: FlashInferTrtllmFp8MoeQuantInfo,
     runner_config: MoeRunnerConfig,
     use_routed_topk: bool = False,
+    use_sgl_kernel: bool = False,
 ) -> StandardCombineInput:
     from flashinfer.fused_moe import Fp8QuantizationType
 
@@ -663,7 +664,14 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 topk_weights=topk_output.topk_weights,
             )
 
-            output = trtllm_fp8_block_scale_routed_moe_wrapper(
+            if use_sgl_kernel:
+                from sglang.srt.layers.moe.sgl_flashinfer_trtllm_moe import (
+                    sgl_trtllm_fp8_block_scale_routed_moe_wrapper as fp8_routed_moe,
+                )
+            else:
+                fp8_routed_moe = trtllm_fp8_block_scale_routed_moe_wrapper
+
+            output = fp8_routed_moe(
                 topk_ids=packed_topk_ids,
                 routing_bias=None,
                 hidden_states=a_q,
@@ -697,7 +705,14 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
         else:
             assert TopKOutputChecker.format_is_bypassed(topk_output)
 
-            output = trtllm_fp8_block_scale_moe_wrapper(
+            if use_sgl_kernel:
+                from sglang.srt.layers.moe.sgl_flashinfer_trtllm_moe import (
+                    sgl_trtllm_fp8_block_scale_moe_wrapper as fp8_moe,
+                )
+            else:
+                fp8_moe = trtllm_fp8_block_scale_moe_wrapper
+
+            output = fp8_moe(
                 routing_logits=router_logits,
                 routing_bias=correction_bias,
                 hidden_states=a_q,
@@ -786,6 +801,14 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
         output = symm_output
 
     return StandardCombineInput(hidden_states=output)
+
+
+# === sgl_flashinfer_trtllm LoRA dispatch lives in lora/trtllm_moe/ ===
+# Re-export so existing import sites continue to resolve; the body was
+# moved to keep this file focused on the non-LoRA trtllm paths.
+from sglang.srt.lora.trtllm_moe.lora_dispatch import (  # noqa: E402,F401
+    fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora,
+)
 
 
 @dataclass
@@ -1176,6 +1199,22 @@ def fused_experts_none_to_flashinfer_trtllm(
         )
     raise TypeError(
         f"Unexpected quant_info type for flashinfer_trtllm: {type(quant_info)}"
+    )
+
+
+@register_fused_func("none", "sgl_flashinfer_trtllm")
+def fused_experts_none_to_sgl_flashinfer_trtllm(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    if isinstance(quant_info, FlashInferTrtllmFp8MoeQuantInfo):
+        return fused_experts_none_to_flashinfer_trtllm_fp8(
+            dispatch_output, quant_info, runner_config, use_sgl_kernel=True
+        )
+    raise TypeError(
+        f"Unexpected quant_info type for sgl_flashinfer_trtllm: {type(quant_info)}. "
+        "The copied backend currently supports the FP8 Qwen path only."
     )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -900,7 +900,9 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
 
-    # Quantize hidden states to FP4
+    # Quantize hidden states to FP4. Per-token activation (env-gated, default off) is needed only
+    # for the NVFP4 LoRA decomposed-scale path (sgl_flashinfer_trtllm); no-lora keeps the cheaper
+    # per-tensor quant. Gate must match the input_scale==1 weight-prep in modelopt_quant.
     if envs.SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION.get():
         from flashinfer import SfLayout, nvfp4_quantize
 

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
@@ -379,6 +379,7 @@ def fused_moe_kernel(
     filter_expert: tl.constexpr,
     swap_ab: tl.constexpr,
     FUSE_ADD_TO_OUTPUT: tl.constexpr,
+    MASK_OUTPUT: tl.constexpr,
     FUSE_SUM_ALL_REDUCE: tl.constexpr,
     ROUTER_TOPK: tl.constexpr,
 ):
@@ -441,10 +442,9 @@ def fused_moe_kernel(
 
     if filter_expert and off_experts == -1:
         # -----------------------------------------------------------
-        # Write back zeros to the output when the expert is not
-        # in the current expert parallel rank.
-        if not FUSE_ADD_TO_OUTPUT:
-            # skip the zero-write to preserve existing values.
+        if not FUSE_ADD_TO_OUTPUT and not FUSE_SUM_ALL_REDUCE:
+            # Write zeros only when this kernel owns the full output buffer.
+            # Direct-add modes must preserve the base output from another kernel.
             write_zeros_to_output(
                 c_ptr,
                 stride_cm,
@@ -616,6 +616,16 @@ def fused_moe_kernel(
         c_mask = token_mask[:, None] & add_mask[:, None] & (offs_cn[None, :] < N)
         existing = tl.load(c_ptrs, mask=c_mask, other=0.0)
         tl.store(c_ptrs, existing + accumulator, mask=c_mask)
+    elif MASK_OUTPUT:
+        # Store a fresh output while zeroing rows whose request has no active LoRA.
+        offs_token_out = offs_token // ROUTER_TOPK
+        output_mask = tl.load(
+            add_mask_ptr + offs_token_out, mask=token_mask, other=False
+        )
+        c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+        accumulator = tl.where(output_mask[:, None], accumulator, 0.0)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
     elif FUSE_SUM_ALL_REDUCE:
         offs_token_out = offs_token // ROUTER_TOPK
         c_ptrs = (
@@ -731,6 +741,7 @@ def invoke_fused_moe_kernel(
     router_topk: int = 1,
     fuse_add_to_output: bool = False,
     add_output_mask: Optional[torch.Tensor] = None,
+    mask_output: bool = False,
 ) -> None:
     assert topk_weights.stride(1) == 1
     assert sorted_token_ids.stride(0) == 1
@@ -807,6 +818,14 @@ def invoke_fused_moe_kernel(
         assert (
             add_output_mask is not None
         ), "add_output_mask required when fuse_add_to_output=True"
+    if mask_output:
+        assert (
+            not fuse_add_to_output
+        ), "mask_output and fuse_add_to_output are mutually exclusive"
+        assert (
+            not fuse_sum_all_reduce
+        ), "mask_output and fuse_sum_all_reduce are mutually exclusive"
+        assert add_output_mask is not None, "add_output_mask required when mask_output=True"
 
     if (
         (use_int8_w8a16 or use_int4_w4a16)
@@ -924,6 +943,7 @@ def invoke_fused_moe_kernel(
             filter_expert=filter_expert,
             swap_ab=swap_ab,
             FUSE_ADD_TO_OUTPUT=fuse_add_to_output,
+            MASK_OUTPUT=mask_output,
             FUSE_SUM_ALL_REDUCE=fuse_sum_all_reduce,
             ROUTER_TOPK=router_topk,
             **config,

--- a/python/sglang/srt/layers/moe/sgl_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/moe/sgl_flashinfer_trtllm_moe.py
@@ -1,0 +1,203 @@
+from typing import Optional
+
+import torch
+
+from sglang.srt.utils.custom_op import register_custom_op
+
+
+def _fake_fp8_block_scale_moe(
+    routing_logits: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    n_group: Optional[int],
+    topk_group: Optional[int],
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    use_shuffled_weight: bool = False,
+    weight_layout: int = 0,
+    enable_pdl: Optional[bool] = None,
+    tune_max_num_tokens: int = 8192,
+    fp8_quantization_type: Optional[int] = None,
+    activation_type: Optional[int] = None,
+) -> torch.Tensor:
+    return torch.empty(
+        hidden_states.shape, dtype=torch.bfloat16, device=hidden_states.device
+    )
+
+
+@register_custom_op(fake_impl=_fake_fp8_block_scale_moe)
+def sgl_trtllm_fp8_block_scale_moe_wrapper(
+    routing_logits: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    n_group: Optional[int],
+    topk_group: Optional[int],
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    use_shuffled_weight: bool = False,
+    weight_layout: int = 0,
+    enable_pdl: Optional[bool] = None,
+    tune_max_num_tokens: int = 8192,
+    fp8_quantization_type: Optional[int] = None,
+    activation_type: Optional[int] = None,
+) -> torch.Tensor:
+    try:
+        from flashinfer.fused_moe import Fp8QuantizationType
+        from flashinfer.fused_moe.core import ActivationType
+    except ImportError as e:
+        raise ImportError(
+            "sgl_flashinfer_trtllm requires flashinfer-python to provide "
+            "TRTLLM enums and cubin-loader utilities."
+        ) from e
+
+    from sglang.jit_kernel.flashinfer_trtllm_moe import trtllm_fp8_block_scale_moe
+
+    kwargs = {
+        "routing_logits": routing_logits,
+        "routing_bias": routing_bias,
+        "hidden_states": hidden_states,
+        "hidden_states_scale": hidden_states_scale,
+        "gemm1_weights": gemm1_weights,
+        "gemm1_weights_scale": gemm1_weights_scale,
+        "gemm2_weights": gemm2_weights,
+        "gemm2_weights_scale": gemm2_weights_scale,
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "n_group": n_group,
+        "topk_group": topk_group,
+        "intermediate_size": intermediate_size,
+        "local_expert_offset": local_expert_offset,
+        "local_num_experts": local_num_experts,
+        "routed_scaling_factor": routed_scaling_factor,
+        "routing_method_type": routing_method_type,
+        "use_shuffled_weight": use_shuffled_weight,
+        "weight_layout": weight_layout,
+        "enable_pdl": enable_pdl,
+        "tune_max_num_tokens": tune_max_num_tokens,
+    }
+    if fp8_quantization_type is not None:
+        kwargs["fp8_quantization_type"] = Fp8QuantizationType(fp8_quantization_type)
+    if activation_type is not None:
+        kwargs["activation_type"] = ActivationType(activation_type)
+
+    return trtllm_fp8_block_scale_moe(**kwargs)
+
+
+def _fake_fp8_block_scale_routed_moe(
+    topk_ids: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    n_group: Optional[int],
+    topk_group: Optional[int],
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    use_shuffled_weight: bool = False,
+    weight_layout: int = 0,
+    enable_pdl: Optional[bool] = None,
+    tune_max_num_tokens: int = 8192,
+    fp8_quantization_type: Optional[int] = None,
+    activation_type: Optional[int] = None,
+) -> torch.Tensor:
+    return torch.empty(
+        hidden_states.shape, dtype=torch.bfloat16, device=hidden_states.device
+    )
+
+
+@register_custom_op(fake_impl=_fake_fp8_block_scale_routed_moe)
+def sgl_trtllm_fp8_block_scale_routed_moe_wrapper(
+    topk_ids: torch.Tensor,
+    routing_bias: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gemm1_weights: torch.Tensor,
+    gemm1_weights_scale: torch.Tensor,
+    gemm2_weights: torch.Tensor,
+    gemm2_weights_scale: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+    n_group: Optional[int],
+    topk_group: Optional[int],
+    intermediate_size: int,
+    local_expert_offset: int,
+    local_num_experts: int,
+    routed_scaling_factor: Optional[float],
+    routing_method_type: int = 0,
+    use_shuffled_weight: bool = False,
+    weight_layout: int = 0,
+    enable_pdl: Optional[bool] = None,
+    tune_max_num_tokens: int = 8192,
+    fp8_quantization_type: Optional[int] = None,
+    activation_type: Optional[int] = None,
+) -> torch.Tensor:
+    try:
+        from flashinfer.fused_moe import Fp8QuantizationType
+        from flashinfer.fused_moe.core import ActivationType
+    except ImportError as e:
+        raise ImportError(
+            "sgl_flashinfer_trtllm requires flashinfer-python to provide "
+            "TRTLLM enums and cubin-loader utilities."
+        ) from e
+
+    from sglang.jit_kernel.flashinfer_trtllm_moe import (
+        trtllm_fp8_block_scale_routed_moe,
+    )
+
+    kwargs = {
+        "topk_ids": topk_ids,
+        "routing_bias": routing_bias,
+        "hidden_states": hidden_states,
+        "hidden_states_scale": hidden_states_scale,
+        "gemm1_weights": gemm1_weights,
+        "gemm1_weights_scale": gemm1_weights_scale,
+        "gemm2_weights": gemm2_weights,
+        "gemm2_weights_scale": gemm2_weights_scale,
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "n_group": n_group,
+        "topk_group": topk_group,
+        "intermediate_size": intermediate_size,
+        "local_expert_offset": local_expert_offset,
+        "local_num_experts": local_num_experts,
+        "routed_scaling_factor": routed_scaling_factor,
+        "routing_method_type": routing_method_type,
+        "use_shuffled_weight": use_shuffled_weight,
+        "weight_layout": weight_layout,
+        "enable_pdl": enable_pdl,
+        "tune_max_num_tokens": tune_max_num_tokens,
+    }
+    if fp8_quantization_type is not None:
+        kwargs["fp8_quantization_type"] = Fp8QuantizationType(fp8_quantization_type)
+    if activation_type is not None:
+        kwargs["activation_type"] = ActivationType(activation_type)
+
+    return trtllm_fp8_block_scale_routed_moe(**kwargs)

--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -100,6 +100,7 @@ class StandardDispatcher(BaseDispatcher):
             backend.is_flashinfer_cutlass()
             or backend.is_flashinfer_cutedsl()
             or backend.is_flashinfer_trtllm()
+            or backend.is_sgl_flashinfer_trtllm()
             or backend.is_flashinfer_trtllm_routed()
             or self.enable_flashinfer_mxfp4_moe
         )

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1221,7 +1221,13 @@ def biased_grouped_topk_gpu(
         if _is_cuda and num_experts == 384 and num_expert_group == 1:
             return kimi_k2_moe_fused_gate(
                 gating_output.to(dtype=torch.float32),
-                correction_bias,
+                # kimi_k2_moe_fused_gate requires input and bias to share a dtype;
+                # gating_output is upcast to fp32 above, so match the bias too.
+                (
+                    correction_bias.to(dtype=torch.float32)
+                    if correction_bias is not None
+                    else correction_bias
+                ),
                 topk=topk,
                 renormalize=renormalize,
                 routed_scaling_factor=routed_scaling_factor,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -430,12 +430,25 @@ class TopK(MultiPlatformOp):
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     ) -> TopKOutput:
+        moe_runner_backend = get_moe_runner_backend()
         if self.topk_config.output_format is not None:
             output_format = self.topk_config.output_format
-        elif get_moe_runner_backend().is_triton_kernels():
+        elif moe_runner_backend.is_triton_kernels():
             output_format = TopKOutputFormat.TRITON_KERNEL
-        elif get_moe_runner_backend().is_flashinfer_trtllm() or (
-            get_moe_runner_backend().is_flashinfer_mxfp4() and not self.is_fp4_experts
+        elif moe_runner_backend.is_sgl_flashinfer_trtllm():
+            try:
+                from sglang.srt.server_args import get_global_server_args
+
+                use_standard_for_lora = bool(get_global_server_args().enable_lora)
+            except ValueError:
+                use_standard_for_lora = False
+            output_format = (
+                TopKOutputFormat.STANDARD
+                if use_standard_for_lora
+                else TopKOutputFormat.BYPASSED
+            )
+        elif moe_runner_backend.is_flashinfer_trtllm() or (
+            moe_runner_backend.is_flashinfer_mxfp4() and not self.is_fp4_experts
         ):
             output_format = TopKOutputFormat.BYPASSED
         else:

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -91,6 +91,7 @@ class MoeRunnerBackend(Enum):
     TRITON = "triton"
     TRITON_KERNELS = "triton_kernel"
     FLASHINFER_TRTLLM = "flashinfer_trtllm"
+    SGL_FLASHINFER_TRTLLM = "sgl_flashinfer_trtllm"
     FLASHINFER_TRTLLM_ROUTED = "flashinfer_trtllm_routed"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_MXFP4 = "flashinfer_mxfp4"
@@ -112,7 +113,18 @@ class MoeRunnerBackend(Enum):
         return self == MoeRunnerBackend.TRITON_KERNELS
 
     def is_flashinfer_trtllm(self):
-        return self == MoeRunnerBackend.FLASHINFER_TRTLLM
+        # sgl_flashinfer_trtllm runs the same TRT-LLM FP8 kernels with the same
+        # weight layout, so it must inherit all trtllm weight-prep and dispatch
+        # behavior here. The few sites where it diverges (topk output format,
+        # token dispatcher, LoRA mem pool, LoRA MoE dispatch) check
+        # is_sgl_flashinfer_trtllm() explicitly, ordered before this predicate.
+        return self in (
+            MoeRunnerBackend.FLASHINFER_TRTLLM,
+            MoeRunnerBackend.SGL_FLASHINFER_TRTLLM,
+        )
+
+    def is_sgl_flashinfer_trtllm(self):
+        return self == MoeRunnerBackend.SGL_FLASHINFER_TRTLLM
 
     def is_flashinfer_trtllm_routed(self):
         return self == MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1876,6 +1876,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             w13_input_scale = layer.w13_input_scale.max(dim=-1).values.to(torch.float32)
             w2_input_scale = layer.w2_input_scale
 
+        # Per-token NVFP4 activation scaling (env-gated, default off — per-tensor is faster).
+        # When on, force w13/w2 input_scale==1 so the decomposed LoRA scale composition matches the
+        # fused path. Required (=1) for NVFP4 LoRA on sgl_flashinfer_trtllm; off keeps no-lora fast.
         if (
             self.enable_flashinfer_trtllm_moe
             and envs.SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION.get()

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -60,11 +60,16 @@ class TritonLoRABackend(BaseLoRABackend):
         weights: torch.Tensor,
         pruned_batch_info: LoRABatchInfo = None,
         stack_num: int = 1,
+        out_alloc_stream=None,
         *args,
         **kwargs,
     ) -> torch.Tensor:
         return sgemm_lora_a_fwd(
-            x, weights, self._sgemm_info(pruned_batch_info), stack_num=stack_num
+            x,
+            weights,
+            self._sgemm_info(pruned_batch_info),
+            stack_num=stack_num,
+            out_alloc_stream=out_alloc_stream,
         )
 
     def run_lora_b_sgemm(

--- a/python/sglang/srt/lora/deepseek_mla_correction.py
+++ b/python/sglang/srt/lora/deepseek_mla_correction.py
@@ -115,3 +115,98 @@ def apply_v_correction(
         attn_module.v_head_dim,
     )
     return attn_bmm_flat
+
+
+# ---------------------------------------------------------------------------
+# Two-stream overlap (O12) for the absorbed kv_b correction.
+#
+# Each correction factors into an input-only A-step (reads q_nope / attn_output,
+# independent of the absorbed bmm output) and a B-step that adds into that bmm
+# output. ``*_prepare`` forks the A-step onto the shared LoRA side stream so it
+# overlaps the main-stream ``q_nope @ w_kc`` / ``attn_output @ w_vc`` bmm;
+# ``*_apply`` rejoins and runs the B-step.
+#
+# Gated by ``SGLANG_LORA_TWO_STREAM`` (decode batches only) via
+# ``is_two_stream_active``. When inactive, ``*_prepare`` returns None and
+# ``*_apply`` falls back to the serial ``apply_*_correction`` (or a no-op when no
+# kv_b adapter is wrapped), so the deepseek call sites stay byte-identical with
+# two-stream off. Same fork/join (``wait_stream``) idiom as the O7/O8 attention
+# overrides — cuda-graph-capture safe.
+# ---------------------------------------------------------------------------
+
+
+def _kv_b_two_stream_state(attn_module, x):
+    from sglang.srt.lora.trtllm_moe import get_lora_side_stream, is_two_stream_active
+
+    if not is_two_stream_active(x):
+        return None
+    state = _get_state(attn_module)
+    if state is None:
+        return None
+    A_buf, B_buf, batch_info = state
+    return A_buf, B_buf, batch_info, get_lora_side_stream()
+
+
+def kv_b_lora_q_prepare(attn_module, q_nope):
+    """Fork the q-correction A-step onto the side stream (``step_a_q`` reads only
+    ``q_nope``) so it overlaps the main-stream ``q_nope @ w_kc`` bmm. Returns a
+    handle for :func:`kv_b_lora_q_apply`, or None when two-stream is inactive."""
+    st = _kv_b_two_stream_state(attn_module, q_nope)
+    if st is None:
+        return None
+    A_buf, B_buf, batch_info, side_stream = st
+    full_K_per_head = attn_module.qk_nope_head_dim + attn_module.v_head_dim
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        q_lora_a = step_a_q_fwd(q_nope, B_buf, batch_info, full_K_per_head)
+    return q_lora_a, A_buf, batch_info, side_stream
+
+
+def kv_b_lora_q_apply(attn_module, q_nope, q_nope_out, handle):
+    """Finish the q-correction: two-stream (rejoin + B-step) when ``handle`` is
+    set, else the serial correction, else a no-op. Single call replacing the
+    ``if is_kv_b_lora_active: apply_q_correction`` at the call site."""
+    if handle is not None:
+        q_lora_a, A_buf, batch_info, side_stream = handle
+        torch.cuda.current_stream().wait_stream(side_stream)
+        return step_b_q_fwd(q_lora_a, A_buf, batch_info, q_nope_out)
+    if is_kv_b_lora_active(attn_module):
+        return apply_q_correction(attn_module, q_nope, q_nope_out)
+    return q_nope_out
+
+
+def kv_b_lora_v_prepare(attn_module, attn_output):
+    """Fork the v-correction A-step onto the side stream (``step_a_v`` reads only
+    ``attn_output``) so it overlaps the main-stream ``attn_output @ w_vc`` bmm.
+    Returns a handle for :func:`kv_b_lora_v_apply`, or None when inactive."""
+    st = _kv_b_two_stream_state(attn_module, attn_output)
+    if st is None:
+        return None
+    A_buf, B_buf, batch_info, side_stream = st
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        attn_lora_a = step_a_v_fwd(attn_output, A_buf, batch_info)
+    return attn_lora_a, B_buf, batch_info, side_stream
+
+
+def kv_b_lora_v_apply(attn_module, attn_output, attn_bmm_flat, handle):
+    """Finish the v-correction: two-stream (rejoin + B-step) when ``handle`` is
+    set, else the serial correction, else a no-op."""
+    if handle is not None:
+        attn_lora_a, B_buf, batch_info, side_stream = handle
+        torch.cuda.current_stream().wait_stream(side_stream)
+        base_view = attn_bmm_flat.view(
+            -1, attn_module.num_local_heads, attn_module.v_head_dim
+        )
+        step_b_v_fwd(
+            attn_lora_a,
+            B_buf,
+            batch_info,
+            base_view,
+            attn_module.qk_nope_head_dim,
+            attn_module.v_head_dim,
+        )
+        return attn_bmm_flat
+    if is_kv_b_lora_active(attn_module):
+        return apply_v_correction(attn_module, attn_output, attn_bmm_flat)
+    return attn_bmm_flat

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -909,13 +909,21 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         else:
             runner_backend = MoeRunnerBackend.TRITON
 
-        self._lora_runner = MoeRunner(
-            runner_backend,
-            base_layer.moe_runner_config,
-            lora_enabled=True,
-        )
+        self._lora_runner_backend = runner_backend
 
-        if runner_backend.is_marlin():
+        if runner_backend.is_sgl_flashinfer_trtllm():
+            # sgl_flashinfer_trtllm LoRA setup lives in lora/trtllm_moe/.
+            from sglang.srt.lora.trtllm_moe.lora_layer import (
+                init_sgl_flashinfer_trtllm_lora,
+            )
+
+            init_sgl_flashinfer_trtllm_lora(self, base_layer)
+        elif runner_backend.is_marlin():
+            self._lora_runner = MoeRunner(
+                runner_backend,
+                base_layer.moe_runner_config,
+                lora_enabled=True,
+            )
             from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
                 CompressedTensorsFusedMoEMethod,
             )
@@ -928,6 +936,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             )
             self._quant_info = base_layer.quant_method.get_marlin_quant_info(base_layer)
         elif runner_backend.is_triton():
+            self._lora_runner = MoeRunner(
+                runner_backend,
+                base_layer.moe_runner_config,
+                lora_enabled=True,
+            )
             assert base_layer.quant_method is not None, "Quant method must be set"
             self._quant_info = base_layer.quant_method.get_triton_quant_info(base_layer)
         else:
@@ -1022,10 +1035,18 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         # Use pre-computed quant info (doesn't change so not sure why we need to pass it in every time)
         quant_info = self._quant_info
 
-        # Run the only lora moe runner (Triton)
-        combine_input = self._lora_runner.run(
-            dispatch_output, quant_info, lora_info=lora_info
-        )
+        if self._lora_runner_backend.is_sgl_flashinfer_trtllm():
+            from sglang.srt.lora.trtllm_moe.lora_layer import (
+                dispatch_sgl_flashinfer_trtllm_lora,
+            )
+
+            combine_input = dispatch_sgl_flashinfer_trtllm_lora(
+                dispatch_output, quant_info, base_layer, lora_info
+            )
+        else:
+            combine_input = self._lora_runner.run(
+                dispatch_output, quant_info, lora_info=lora_info
+            )
 
         final_hidden_states = base_layer.dispatcher.combine(combine_input=combine_input)
 

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -868,6 +868,23 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
     rather than computed independently and added at the end.
     """
 
+    def __getattr__(self, name: str):
+        # Transparent-wrapper fallback: delegate any attribute not defined on this
+        # wrapper to the wrapped base ``FusedMoE`` so model code that treats
+        # ``experts`` as a plain FusedMoE works (e.g. DeepSeek-V2/V3 reads
+        # ``experts.moe_runner_config`` / ``.dispatcher``). The actual MoE compute
+        # still flows through this wrapper's ``forward``/``run`` (LoRA applied) —
+        # the model's standard paths call ``self.experts(...)``, not
+        # ``experts.run_moe_core`` directly (that is the DeepEP/TBO path).
+        # nn.Module.__getattr__ resolves registered params/buffers/submodules first.
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            modules = self.__dict__.get("_modules")
+            if modules is not None and "base_layer" in modules:
+                return getattr(modules["base_layer"], name)
+            raise
+
     def __init__(
         self,
         base_layer: FusedMoE,
@@ -974,6 +991,17 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         moe_lora_info = batch_info.moe_lora_info
         assert moe_lora_info is not None
 
+        # Disable rank-0 (dummy/inactive) adapters so the virtual-experts kernel
+        # adds no delta for them — critical during cuda-graph capture where no
+        # real adapter is active (otherwise a garbage gate_up_delta corrupts the
+        # captured decode). In-place on the stable per-batch buffer (cuda-graph
+        # safe; idempotent across layers). Matches the NVFP4 GB200 cookbook fix.
+        rank_enabled = (lora_ranks > 0).to(
+            device=moe_lora_info.adapter_enabled.device,
+            dtype=moe_lora_info.adapter_enabled.dtype,
+        )
+        moe_lora_info.adapter_enabled.mul_(rank_enabled)
+
         # Single source of truth: lora_manager precomputes this per-batch from
         # the Python weight_indices list, no GPU sync needed.
         has_active_lora = bool(getattr(batch_info, "has_active_lora", False))
@@ -989,7 +1017,14 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             adapter_enabled=moe_lora_info.adapter_enabled,
             token_lora_mapping=moe_lora_info.token_lora_mapping,
             max_lora_rank=max_lora_rank,
-            num_experts=self.base_layer.num_experts,
+            # Local (per-rank) expert count the LoRA buffers are indexed by — not
+            # the global num_experts — so virtual-experts indexing matches the
+            # buffers under EP. Matches the NVFP4 GB200 cookbook fix.
+            num_experts=(
+                self.down_lora_a_weights.shape[1]
+                if self.down_lora_a_weights is not None
+                else self.base_layer.num_local_experts
+            ),
             has_active_lora=has_active_lora,
             experts_shared_outer_loras=self.experts_shared_outer_loras,
             cg_buffers=cg_buffers,

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -991,16 +991,15 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         moe_lora_info = batch_info.moe_lora_info
         assert moe_lora_info is not None
 
-        # Disable rank-0 (dummy/inactive) adapters so the virtual-experts kernel
-        # adds no delta for them — critical during cuda-graph capture where no
-        # real adapter is active (otherwise a garbage gate_up_delta corrupts the
-        # captured decode). In-place on the stable per-batch buffer (cuda-graph
-        # safe; idempotent across layers). Matches the NVFP4 GB200 cookbook fix.
-        rank_enabled = (lora_ranks > 0).to(
-            device=moe_lora_info.adapter_enabled.device,
-            dtype=moe_lora_info.adapter_enabled.dtype,
-        )
-        moe_lora_info.adapter_enabled.mul_(rank_enabled)
+        # NOTE: rank-0 (dummy/inactive) adapters are already disabled at the single
+        # build site of moe_lora_info — _compute_moe_lora_info() zeroes adapter_enabled
+        # and only sets (rank > 0) entries (both the Triton kernel and the eager
+        # scatter path; see backend/base_backend.py). The per-batch buffer is rebuilt
+        # every prepare_lora_batch (including the persistent cuda-graph buffer), so no
+        # stale rank-0 "1" can survive into a captured decode. A per-layer
+        # adapter_enabled.mul_(rank > 0) here would therefore be a no-op repeated once
+        # per MoE layer (3 CUDA launches × N layers, also baked into the CUDA graph),
+        # so it is intentionally omitted.
 
         # Single source of truth: lora_manager precomputes this per-batch from
         # the Python weight_indices list, no GPU sync needed.

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -1178,3 +1178,12 @@ def get_lora_layer(
             ret = lora_layer_type(layer, lora_backend)
             return ret
     raise Exception(f"No corresponding LoRA layer supported for {type(layer)}.")
+
+
+# === Two-stream LoRA overlap (O1 + O7 + O8) — opt-in via SGLANG_LORA_TWO_STREAM=1 ===
+# All logic lives in `sglang/srt/lora/trtllm_moe/`. The call below is a no-op
+# when the env var is unset (existing single-stream behavior unchanged); when
+# set, it monkey-patches the LoRA forwards above + the trtllm MoE LoRA dispatch
+# to use side-stream overlapped versions defined in that package.
+from sglang.srt.lora.trtllm_moe import install_two_stream_overrides as _install_lora_two_stream  # noqa: E402
+_install_lora_two_stream()

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -121,6 +121,13 @@ class LoRAManager:
             num_tokens_per_bs=num_tokens_per_bs,
         )
 
+        # Pre-capture: create the LoRA two-stream side stream now (no-op unless
+        # SGLANG_LORA_TWO_STREAM=1) so the torch.cuda.Stream() driver call never
+        # lands inside a cuda-graph capture region.
+        from sglang.srt.lora.trtllm_moe import init_lora_two_stream_resources
+
+        init_lora_two_stream_resources(self.device)
+
     def init_cuda_graph_moe_buffers(
         self, max_bs: int, max_loras: int, compute_dtype, moe_layer
     ):

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -119,6 +119,7 @@ def _moe_runner_keeps_global_expert_ids() -> bool:
         return (
             b.is_flashinfer_cutlass()
             or b.is_flashinfer_cutedsl()
+            or b.is_sgl_flashinfer_trtllm()
             or b.is_flashinfer_trtllm_routed()
         )
     except Exception:  # pragma: no cover - backend not initialized

--- a/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
@@ -119,7 +119,7 @@ def _gate_up_lora_b_kernel(
             & (n_offset[None, :] < output_dim),
             other=0.0,
         )
-        partial_sum += tl.dot(x_tile, w_tile)
+        partial_sum += tl.dot(x_tile.to(w_tile.dtype), w_tile)  # cast fused: split-K returns fp32, plain path bf16 (no-op)
 
         x_ptrs += BLOCK_K * x_stride_1
         w_ptrs += BLOCK_K * w_stride_2

--- a/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
@@ -120,7 +120,7 @@ def _qkv_lora_b_kernel(
             mask=(k_offset[:, None] < K - k * BLOCK_K) & (n_offset[None, :] < n_size),
             other=0.0,
         )
-        partial_sum += tl.dot(x_tile, w_tile)
+        partial_sum += tl.dot(x_tile.to(w_tile.dtype), w_tile)  # cast fused: split-K returns fp32, plain path bf16 (no-op)
 
         x_ptrs += BLOCK_K * x_stride_1
         w_ptrs += BLOCK_K * w_stride_2

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -125,13 +125,16 @@ def sgemm_lora_a_fwd(
     weights: torch.Tensor,
     batch_info: LoRABatchInfo,
     stack_num: int = 1,
+    out_alloc_stream=None,
 ) -> torch.Tensor:
     # Opt-in fp32 split-K for the dense LoRA-A shrink (PR #26962): route to the gated implementation in
     # trtllm_moe/sgemm_lora_a_split_k.py. Default (env off) falls through to the original path below.
     if envs.SGLANG_ENABLE_LORA_SHRINK_SPLIT_K.get():
         from sglang.srt.lora.trtllm_moe.sgemm_lora_a_split_k import sgemm_lora_a_fwd_split_k
 
-        return sgemm_lora_a_fwd_split_k(x, weights, batch_info, stack_num)
+        return sgemm_lora_a_fwd_split_k(
+            x, weights, batch_info, stack_num, out_alloc_stream=out_alloc_stream
+        )
     # x: (s, input_dim)
     # weights: (num_lora, stack_num * r, input_dim)
     # output: (s, stack_num * r)
@@ -161,7 +164,14 @@ def sgemm_lora_a_fwd(
 
     sorted_by_adapter = batch_info.permutation is not None
 
-    output = torch.empty((S, R), device=x.device, dtype=x.dtype)
+    # Allocate the output on the MAIN (consumer) stream when requested, so the caching allocator frees/
+    # reuses it on the consumer's schedule, not the side stream's (cuda-graph WAR — see
+    # lora_overlap_alloc_stream / SGLANG_OPT_LORA_OVERLAP_MAIN_ALLOC).
+    if out_alloc_stream is not None:
+        with torch.cuda.stream(out_alloc_stream):
+            output = torch.empty((S, R), device=x.device, dtype=x.dtype)
+    else:
+        output = torch.empty((S, R), device=x.device, dtype=x.dtype)
     _sgemm_lora_a_kernel[grid](
         x,
         weights,

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
@@ -108,7 +108,7 @@ def _sgemm_lora_b_kernel(
             mask=(k_offset[:, None] < K - k * BLOCK_K) & n_mask,
             other=0.0,
         )
-        partial_sum += tl.dot(x_tile, w_tile)
+        partial_sum += tl.dot(x_tile.to(w_tile.dtype), w_tile)  # cast fused: split-K returns fp32, plain path bf16 (no-op)
 
         x_ptrs += BLOCK_K * x_stride_1
         w_ptrs += BLOCK_K * w_stride_2

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -54,6 +54,7 @@ def _fused_virtual_topk_ids_kernel(
     # loads in downstream LoRA kernels.
     shifted = base + safe_lora * num_experts_for_weight
     result = tl.where(base < 0, base, shifted)
+    result = tl.where(mask_val, result, -1)
     tl.store(virtual_topk_ids_ptr + offs, result, mask=valid)
 
     # Write mask once per row (at first k position)
@@ -267,8 +268,7 @@ def _invoke_moe_lora_shrink_splitk(
     num_m_blocks = triton.cdiv(sorted_token_ids.shape[0], BLOCK_SIZE_M)
     num_n_blocks = triton.cdiv(N, BLOCK_SIZE_N)
     base_grid = num_m_blocks * num_n_blocks
-    max_split_k = max(1, K // BLOCK_SIZE_K)
-    SPLIT_K = min(max_split_k, max(1, 128 // base_grid)) if base_grid < 128 else 1
+    SPLIT_K = _get_moe_lora_shrink_split_k(weight, sorted_token_ids, config)
 
     grid = (SPLIT_K * base_grid,)
 
@@ -298,6 +298,32 @@ def _invoke_moe_lora_shrink_splitk(
         num_warps=config.get("num_warps", 4),
         num_stages=config.get("num_stages", 4),
     )
+
+
+def _get_moe_lora_shrink_split_k(
+    weight: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    config: dict[str, Any],
+) -> int:
+    N = weight.shape[1]
+    K = weight.shape[2]
+    block_size_m = config["BLOCK_SIZE_M"]
+    block_size_n = min(config.get("BLOCK_SIZE_N", 64), max(16, N))
+    block_size_k = config.get("BLOCK_SIZE_K", 64)
+    num_m_blocks = triton.cdiv(sorted_token_ids.shape[0], block_size_m)
+    num_n_blocks = triton.cdiv(N, block_size_n)
+    base_grid = num_m_blocks * num_n_blocks
+    max_split_k = max(1, K // block_size_k)
+    return min(max_split_k, max(1, 128 // base_grid)) if base_grid < 128 else 1
+
+
+# Rank-specialized LoRA-B expand kernel lives in lora/trtllm_moe/.
+# Re-export so existing call sites (and any external imports) keep working.
+from sglang.srt.lora.trtllm_moe.specialized_expand import (  # noqa: E402,F401
+    _invoke_moe_lora_expand_add,
+    _moe_lora_expand_add_kernel,
+)
+
 
 
 def _align_block_size_jit(
@@ -523,6 +549,9 @@ def _merged_experts_fused_moe_lora_add_impl(
     experts_shared_outer_loras_a: bool,
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
+    fuse_add_to_output: bool = True,
+    fuse_sum_all_reduce: bool = False,
+    use_direct_expand_add: bool = False,
 ) -> None:
     """
     1. Prepare virtual expert routing metadata from topk_ids + token_lora_mapping * num_experts.
@@ -646,12 +675,6 @@ def _merged_experts_fused_moe_lora_add_impl(
     num_experts_a = lora_a.shape[1]
     num_experts_b = lora_b.shape[1]
 
-    intermediate = torch.zeros(
-        [token_lora_mapping.shape[0], topk_ids.shape[1], max_lora_rank],
-        dtype=hidden_states.dtype,
-        device=hidden_states.device,
-    )
-
     a_stage_config = _get_stage_config(lora_a_virtual, input_top_k)
     (
         sorted_token_ids,
@@ -664,6 +687,27 @@ def _merged_experts_fused_moe_lora_add_impl(
         num_experts_a,
         experts_shared_outer_loras_a,
         a_stage_config["BLOCK_SIZE_M"],
+    )
+    intermediate_shape = [
+        token_lora_mapping.shape[0],
+        topk_ids.shape[1],
+        max_lora_rank,
+    ]
+    intermediate_split_k = _get_moe_lora_shrink_split_k(
+        lora_a_virtual, sorted_token_ids, a_stage_config
+    )
+    intermediate = (
+        torch.zeros(
+            intermediate_shape,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        if intermediate_split_k > 1
+        else torch.empty(
+            intermediate_shape,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
     )
 
     _invoke_moe_lora_shrink_splitk(
@@ -692,33 +736,55 @@ def _merged_experts_fused_moe_lora_add_impl(
         b_stage_config["BLOCK_SIZE_M"],
     )
 
-    invoke_fused_moe_kernel(
-        intermediate.view(-1, max_lora_rank),
-        lora_b_virtual,
-        None,
-        output,
-        None,
-        None,
-        None,
-        topk_weights,
-        topk_ids,
-        sorted_token_ids,
-        expert_ids,
-        num_tokens_post_padded,
-        mul_routed_weight,
-        1,
-        b_stage_config,
-        tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
-        False,
-        False,
-        False,
-        False,
-        False,
-        None,
-        fuse_add_to_output=True,
-        add_output_mask=token_lora_mask,
-        router_topk=topk_ids.shape[1],
-    )
+    intermediate_flat = intermediate.view(-1, max_lora_rank)
+    # The rank-specialized direct expand-add doesn't support the shared-outer
+    # LoRA-B layout; fall back to the generic kernel for that case instead of
+    # asserting, so adapters with experts_shared_outer_loras still work.
+    if use_direct_expand_add and not experts_shared_outer_loras_b:
+        assert not fuse_add_to_output
+        _invoke_moe_lora_expand_add(
+            intermediate_flat,
+            lora_b_virtual,
+            output,
+            topk_weights,
+            topk_ids,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            b_stage_config,
+            mul_routed_weight,
+            fuse_sum_all_reduce,
+        )
+    else:
+        invoke_fused_moe_kernel(
+            intermediate_flat,
+            lora_b_virtual,
+            None,
+            output,
+            None,
+            None,
+            None,
+            topk_weights,
+            topk_ids,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            1,
+            b_stage_config,
+            tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
+            False,
+            False,
+            False,
+            False,
+            False,
+            None,
+            fuse_add_to_output=fuse_add_to_output,
+            fuse_sum_all_reduce=fuse_sum_all_reduce,
+            add_output_mask=token_lora_mask,
+            mask_output=not fuse_add_to_output and not fuse_sum_all_reduce,
+            router_topk=topk_ids.shape[1],
+        )
 
 
 def _merged_experts_fused_moe_lora_add_op(
@@ -769,6 +835,9 @@ def merged_experts_fused_moe_lora_add(
     experts_shared_outer_loras_a: bool,
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
+    fuse_add_to_output: bool = True,
+    fuse_sum_all_reduce: bool = False,
+    use_direct_expand_add: bool = False,
 ) -> None:
     """Public API: wraps the registered op with routing_cache support."""
     _merged_experts_fused_moe_lora_add_impl(
@@ -783,4 +852,7 @@ def merged_experts_fused_moe_lora_add(
         experts_shared_outer_loras_a,
         experts_shared_outer_loras_b,
         routing_cache,
+        fuse_add_to_output=fuse_add_to_output,
+        fuse_sum_all_reduce=fuse_sum_all_reduce,
+        use_direct_expand_add=use_direct_expand_add,
     )

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -653,7 +653,11 @@ def _merged_experts_fused_moe_lora_add_impl(
         )
         sorted_token_ids = sorted_token_ids[:tight_padded]
         expert_ids = expert_ids[: tight_padded // block_size]
-        expert_ids = fused_sanitize_expert_ids(expert_ids, virtual_num_experts)
+        # Single adapter (max_loras == 1): the per-adapter virtual-expert offset
+        # (safe_lora * num_experts) is always 0, so align never emits an id >=
+        # virtual_num_experts and fused_sanitize_expert_ids is an identity -> skip it.
+        if max_loras != 1:
+            expert_ids = fused_sanitize_expert_ids(expert_ids, virtual_num_experts)
         result = (
             sorted_token_ids,
             expert_ids,

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -22,6 +22,9 @@ def _fused_virtual_topk_ids_kernel(
     M,
     top_k: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    local_expert_offset: tl.constexpr,
+    local_num_experts: tl.constexpr,
+    EP_LOCAL: tl.constexpr,
 ):
     """
     Fuses _get_virtual_topk_ids: comparison + clamp + arithmetic into one kernel.
@@ -48,6 +51,15 @@ def _fused_virtual_topk_ids_kernel(
     safe_lora = tl.maximum(lora_id, 0)
 
     base = tl.load(topk_ids_ptr + offs, mask=valid, other=0)
+    if EP_LOCAL:
+        # EP: drop experts this rank does not own to the -1 sentinel (handled just
+        # below); owned experts keep their GLOBAL id so the global contiguous weight
+        # buffer indexes with a single stride and the merged-weight reshape stays a
+        # free view. Fused in here -> no separate where()/elementwise launch.
+        owned = (base >= local_expert_offset) & (
+            base < local_expert_offset + local_num_experts
+        )
+        base = tl.where(owned, base, -1)
     # Preserve negative sentinel topk_ids (e.g. -1 for non-local experts after
     # EP dispatch). Without this, `-1 + safe_lora * num_experts` would land on
     # a real virtual-expert slot belonging to another adapter and trigger OOB
@@ -69,9 +81,16 @@ def _fused_virtual_topk_ids(
     num_experts: int,
     shared_outer: bool,
     max_loras: int,
+    local_expert_offset: int = 0,
+    local_num_experts: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, int]:
     """
     Returns virtual topk_ids, token_lora_mask, and virtual_num_experts.
+
+    `local_num_experts` (< `num_experts`) enables the EP mask on the per-expert
+    path: non-owned `topk_ids` slots are dropped to the -1 sentinel in-kernel.
+    The shared-outer path routes by lora id, not expert, so it is never masked
+    (else non-owned-but-valid tokens would be dropped on ranks > 0).
     """
     M, top_k = topk_ids.shape
     device = topk_ids.device
@@ -81,9 +100,11 @@ def _fused_virtual_topk_ids(
         # For shared_outer, we need topk_ids to be zeros
         zero_topk = torch.zeros_like(topk_ids)
         input_topk = zero_topk
+        ep_local = False
     else:
         num_experts_for_weight = num_experts
         input_topk = topk_ids
+        ep_local = local_num_experts is not None and local_num_experts < num_experts
 
     virtual_topk_ids = torch.empty_like(topk_ids)
     token_lora_mask = torch.empty(M, dtype=torch.bool, device=device)
@@ -100,6 +121,9 @@ def _fused_virtual_topk_ids(
         M,
         top_k,
         BLOCK_SIZE,
+        local_expert_offset,
+        local_num_experts if local_num_experts is not None else 0,
+        ep_local,
     )
 
     virtual_num_experts = num_experts_for_weight * max_loras
@@ -552,14 +576,27 @@ def _merged_experts_fused_moe_lora_add_impl(
     fuse_add_to_output: bool = True,
     fuse_sum_all_reduce: bool = False,
     use_direct_expand_add: bool = False,
+    local_expert_offset: int = 0,
+    local_num_experts: int | None = None,
 ) -> None:
     """
     1. Prepare virtual expert routing metadata from topk_ids + token_lora_mapping * num_experts.
     2. Flatten LoRA weights from [max_loras, num_experts, ...] to [max_loras * num_experts, ...].
     3. Run regular SGLang fused-MoE kernels for LoRA A and LoRA B.
     4. Mask out tokens with token_lora_mapping == -1 on the add path.
+
+    EP: when `local_num_experts` (< global) is given, this rank only computes the
+    delta for the experts it owns. We keep the GLOBAL expert ids + global contiguous
+    weights (so the merged-weight reshape stays a free view) and mask non-owned
+    [token, k] slots to the -1 sentinel inside `_fused_virtual_topk_ids_kernel`; the
+    grid shrinks via the per-rank trim in `_get_routing`. Slicing the weight's expert
+    dim instead would force the reshape to copy every step (non-contiguous fold).
     """
     max_loras, _, max_lora_rank, _ = lora_a.shape
+    # Global per-expert dim of the LoRA weights. lora_a may be shared-outer (expert
+    # dim 1) while lora_b is per-expert, so take the max for the true global count.
+    per_expert_dim = max(lora_a.shape[1], lora_b.shape[1])
+    ep_local = local_num_experts is not None and local_num_experts < per_expert_dim
     input_top_k = 1 if hidden_states.shape[0] == topk_ids.numel() else topk_ids.shape[1]
 
     def _merge_lora_expert_weight(t: torch.Tensor) -> torch.Tensor:
@@ -635,7 +672,13 @@ def _merged_experts_fused_moe_lora_add_impl(
 
         virtual_topk_ids, token_lora_mask, virtual_num_experts = (
             _fused_virtual_topk_ids(
-                topk_ids, token_lora_mapping, num_experts, shared_outer, max_loras
+                topk_ids,
+                token_lora_mapping,
+                num_experts,
+                shared_outer,
+                max_loras,
+                local_expert_offset,
+                local_num_experts,
             )
         )
         sorted_token_ids, expert_ids, num_tokens_post_padded = _align_block_size(
@@ -644,9 +687,17 @@ def _merged_experts_fused_moe_lora_add_impl(
             num_experts=virtual_num_experts,
         )
         # _align_block_size uses a worst-case padded allocation. Trim the routing buffers
-        # to a tighter upper bound so we keep the real routed work but drop unused padding
+        # to a tighter upper bound so we keep the real routed work but drop unused padding.
+        # Under EP only this rank's experts are populated, so the per-expert stage bounds
+        # the non-empty buckets by `local_num_experts * max_loras` owned (expert, lora)
+        # combos + 1 sentinel bucket (all non-owned -> -1). The +1 matters: each non-empty
+        # bucket adds up to block-1 padding, so omitting it could truncate real tokens.
         num_tokens = topk_ids.numel()
-        max_nonempty = min(num_tokens, virtual_num_experts)
+        if ep_local and not shared_outer and local_num_experts < num_experts:
+            populated_buckets = local_num_experts * max_loras + 1
+        else:
+            populated_buckets = virtual_num_experts
+        max_nonempty = min(num_tokens, populated_buckets)
         tight_padded = (
             triton.cdiv(num_tokens + max_nonempty * (block_size - 1), block_size)
             * block_size
@@ -700,13 +751,20 @@ def _merged_experts_fused_moe_lora_add_impl(
     intermediate_split_k = _get_moe_lora_shrink_split_k(
         lora_a_virtual, sorted_token_ids, a_stage_config
     )
+    # EP leaves non-owned [token, k] shrink slots unwritten. A per-expert expand skips
+    # non-owned blocks (never reads them), but a shared-outer expand routes by lora id
+    # and would read them into the real (all-reduced) output -> must zero. split_k > 1
+    # also needs a zeroed buffer for its accumulation.
+    zero_intermediate = intermediate_split_k > 1 or (
+        ep_local and experts_shared_outer_loras_b
+    )
     intermediate = (
         torch.zeros(
             intermediate_shape,
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
-        if intermediate_split_k > 1
+        if zero_intermediate
         else torch.empty(
             intermediate_shape,
             dtype=hidden_states.dtype,
@@ -842,6 +900,8 @@ def merged_experts_fused_moe_lora_add(
     fuse_add_to_output: bool = True,
     fuse_sum_all_reduce: bool = False,
     use_direct_expand_add: bool = False,
+    local_expert_offset: int = 0,
+    local_num_experts: int | None = None,
 ) -> None:
     """Public API: wraps the registered op with routing_cache support."""
     _merged_experts_fused_moe_lora_add_impl(
@@ -859,4 +919,6 @@ def merged_experts_fused_moe_lora_add(
         fuse_add_to_output=fuse_add_to_output,
         fuse_sum_all_reduce=fuse_sum_all_reduce,
         use_direct_expand_add=use_direct_expand_add,
+        local_expert_offset=local_expert_offset,
+        local_num_experts=local_num_experts,
     )

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -10,6 +10,7 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.moe_align import moe_align_block_size as jit_moe_align_block_size
+from sglang.srt.environ import envs
 
 
 @triton.jit
@@ -731,6 +732,16 @@ def _merged_experts_fused_moe_lora_add_impl(
     num_experts_b = lora_b.shape[1]
 
     a_stage_config = _get_stage_config(lora_a_virtual, input_top_k)
+    if envs.SGLANG_OPT_LORA_SHRINK_TUNE.get():
+        # Tuned decode shrink config: skinny GEMM (M=tokens small, N=rank, K=in large).
+        a_stage_config = {
+            **a_stage_config,
+            "BLOCK_SIZE_M": 16,
+            "BLOCK_SIZE_N": max_lora_rank,
+            "BLOCK_SIZE_K": 256,
+            "num_warps": 4,
+            "num_stages": 4,
+        }
     (
         sorted_token_ids,
         expert_ids,

--- a/python/sglang/srt/lora/trtllm_moe/__init__.py
+++ b/python/sglang/srt/lora/trtllm_moe/__init__.py
@@ -1,15 +1,168 @@
-"""sgl_flashinfer_trtllm MoE LoRA support (package).
+"""Two-stream LoRA overlap (O1 + O7 + O8 + O9) — installed as a monkey-patch.
 
-Holds the LoRA-specific bits of the ``sgl_flashinfer_trtllm`` MoE backend so
-that the existing files ``layers/moe/moe_runner/flashinfer_trtllm.py`` and
-``lora/layers.py`` need only tiny injection points (re-exports or
-``if backend == sgl_flashinfer_trtllm: ...`` branches) for the new LoRA path.
+Activates when env ``SGLANG_LORA_TWO_STREAM=1``. Triggered exactly once via
+:func:`install_two_stream_overrides` (called at end of ``sglang/srt/lora/layers.py``).
 
-Submodules:
-  * :mod:`.lora_dispatch` — the ``fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora``
-    dispatch function moved out of ``flashinfer_trtllm.py``.
-  * :mod:`.lora_layer` — the ``FusedMoEWithLoRA`` init/dispatch helpers moved
-    out of ``lora/layers.py``.
-  * :mod:`.specialized_expand` — the rank-specialized LoRA-B expand kernel
-    moved out of ``lora/triton_ops/virtual_experts.py``.
+When enabled, these call sites are redirected to side-stream-overlapped versions
+defined entirely in this package:
+
+  * ``QKVParallelLinearWithLoRA.forward``  → :mod:`.attention.qkv_proj_lora_forward`
+  * ``RowParallelLinearWithLoRA.forward``  → :mod:`.attention.row_parallel_lora_forward`
+  * ``MergedColumnParallelLinearWithLoRA.forward`` → :mod:`.merged_column.merged_column_lora_forward`
+  * ``fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora`` →
+    :mod:`.moe_overlap.fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream`
+
+When disabled (env unset), ``install_two_stream_overrides`` is a no-op and all
+the original functions / methods in ``sglang/srt/lora/layers.py`` and
+``sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py`` run unchanged.
+
+Per-batch gating still happens inside the patched callables — they fall back
+to the saved-original implementation for non-decode batches (token count above
+``SGLANG_TWO_STREAM_MAX_TOKENS`` default 256), so prefill stays on the serial
+path even with the patch installed.
 """
+import os
+from typing import Callable, Optional
+
+import torch
+
+_ENV_KEY = "SGLANG_LORA_TWO_STREAM"
+_MAX_TOKENS_KEY = "SGLANG_TWO_STREAM_MAX_TOKENS"
+_MAX_TOKENS_DEFAULT = 256
+
+
+def is_two_stream_active(x: torch.Tensor) -> bool:
+    """Per-batch gate. True iff env is on AND batch is decode-shaped."""
+    if os.environ.get(_ENV_KEY) != "1":
+        return False
+    try:
+        max_tok = int(os.environ.get(_MAX_TOKENS_KEY, str(_MAX_TOKENS_DEFAULT)))
+    except ValueError:
+        max_tok = _MAX_TOKENS_DEFAULT
+    return x.shape[0] <= max_tok
+
+
+_LORA_SIDE_STREAM: Optional[torch.cuda.Stream] = None
+
+
+def get_lora_side_stream() -> torch.cuda.Stream:
+    """Lazily allocate a single shared LoRA side stream.
+
+    Within one decode layer the three sites (qkv → attn → o_proj → moe_gate_up)
+    run sequentially, so one stream suffices and avoids extra graph-capture
+    nodes from per-site streams.
+    """
+    global _LORA_SIDE_STREAM
+    if _LORA_SIDE_STREAM is None:
+        _LORA_SIDE_STREAM = torch.cuda.Stream()
+    return _LORA_SIDE_STREAM
+
+
+def init_lora_two_stream_resources(device: Optional[torch.device] = None) -> None:
+    """Eagerly create the side stream before cuda-graph capture begins.
+
+    ``torch.cuda.Stream()`` is a driver call that must not run inside a
+    cuda-graph capture region. Since :func:`get_lora_side_stream` is otherwise
+    lazy, the first eligible decode forward would create it — which can fall
+    inside capture if warmup didn't happen to exercise a two-stream batch.
+    Calling this from a pre-capture hook pins creation to init/warmup on the
+    correct device. No-op unless ``SGLANG_LORA_TWO_STREAM=1``.
+    """
+    if os.environ.get(_ENV_KEY) != "1":
+        return
+    if device is not None:
+        with torch.cuda.device(device):
+            get_lora_side_stream()
+    else:
+        get_lora_side_stream()
+
+
+# References to the original implementations, captured at install time so the
+# patched callables can defer to them for non-decode batches.
+_ORIGINAL_QKV_FORWARD: Optional[Callable] = None
+_ORIGINAL_ROW_FORWARD: Optional[Callable] = None
+_ORIGINAL_MERGED_FORWARD: Optional[Callable] = None
+_ORIGINAL_MOE_LORA_FUNC: Optional[Callable] = None
+_INSTALLED: bool = False
+
+
+def get_original_qkv_forward() -> Callable:
+    return _ORIGINAL_QKV_FORWARD
+
+
+def get_original_row_forward() -> Callable:
+    return _ORIGINAL_ROW_FORWARD
+
+
+def get_original_merged_column_forward() -> Callable:
+    return _ORIGINAL_MERGED_FORWARD
+
+
+def get_original_moe_lora_func() -> Callable:
+    return _ORIGINAL_MOE_LORA_FUNC
+
+
+def install_two_stream_overrides() -> None:
+    """Install the side-stream overlapped overrides if ``SGLANG_LORA_TWO_STREAM=1``.
+
+    Idempotent: subsequent calls are a no-op. Patches:
+
+      1. ``QKVParallelLinearWithLoRA.forward`` (O7 — qkv LoRA shrink overlap)
+      2. ``RowParallelLinearWithLoRA.forward`` (O8 — o_proj LoRA shrink overlap)
+      3. ``MergedColumnParallelLinearWithLoRA.forward`` (O9 — merged-column LoRA
+         shrink overlap: dense gate_up + mamba in_proj_qkvz)
+      4. ``flashinfer_trtllm.fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora``
+         (O1 — MoE gate_up LoRA overlap)
+
+    The saved originals are exposed via :func:`get_original_qkv_forward`,
+    :func:`get_original_row_forward`, :func:`get_original_moe_lora_func` so the
+    new versions can fall back when their per-batch gate says single-stream.
+    """
+    global _INSTALLED, _ORIGINAL_QKV_FORWARD, _ORIGINAL_ROW_FORWARD, _ORIGINAL_MERGED_FORWARD, _ORIGINAL_MOE_LORA_FUNC
+
+    if _INSTALLED:
+        return
+    if os.environ.get(_ENV_KEY) != "1":
+        return
+
+    from sglang.srt.lora.layers import (
+        MergedColumnParallelLinearWithLoRA,
+        QKVParallelLinearWithLoRA,
+        RowParallelLinearWithLoRA,
+    )
+    from sglang.srt.lora.trtllm_moe.attention import (
+        qkv_proj_lora_forward,
+        row_parallel_lora_forward,
+    )
+    from sglang.srt.lora.trtllm_moe.merged_column import merged_column_lora_forward
+
+    _ORIGINAL_QKV_FORWARD = QKVParallelLinearWithLoRA.forward
+    _ORIGINAL_ROW_FORWARD = RowParallelLinearWithLoRA.forward
+    _ORIGINAL_MERGED_FORWARD = MergedColumnParallelLinearWithLoRA.forward
+    QKVParallelLinearWithLoRA.forward = qkv_proj_lora_forward
+    RowParallelLinearWithLoRA.forward = row_parallel_lora_forward
+    MergedColumnParallelLinearWithLoRA.forward = merged_column_lora_forward
+
+    import sglang.srt.layers.moe.moe_runner.flashinfer_trtllm as ft
+    from sglang.srt.lora.trtllm_moe.moe_overlap import (
+        fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream,
+    )
+
+    _ORIGINAL_MOE_LORA_FUNC = ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora
+    ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora = (
+        fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream
+    )
+
+    _INSTALLED = True
+
+
+__all__ = [
+    "is_two_stream_active",
+    "get_lora_side_stream",
+    "init_lora_two_stream_resources",
+    "get_original_qkv_forward",
+    "get_original_row_forward",
+    "get_original_merged_column_forward",
+    "get_original_moe_lora_func",
+    "install_two_stream_overrides",
+]

--- a/python/sglang/srt/lora/trtllm_moe/__init__.py
+++ b/python/sglang/srt/lora/trtllm_moe/__init__.py
@@ -1,0 +1,15 @@
+"""sgl_flashinfer_trtllm MoE LoRA support (package).
+
+Holds the LoRA-specific bits of the ``sgl_flashinfer_trtllm`` MoE backend so
+that the existing files ``layers/moe/moe_runner/flashinfer_trtllm.py`` and
+``lora/layers.py`` need only tiny injection points (re-exports or
+``if backend == sgl_flashinfer_trtllm: ...`` branches) for the new LoRA path.
+
+Submodules:
+  * :mod:`.lora_dispatch` — the ``fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora``
+    dispatch function moved out of ``flashinfer_trtllm.py``.
+  * :mod:`.lora_layer` — the ``FusedMoEWithLoRA`` init/dispatch helpers moved
+    out of ``lora/layers.py``.
+  * :mod:`.specialized_expand` — the rank-specialized LoRA-B expand kernel
+    moved out of ``lora/triton_ops/virtual_experts.py``.
+"""

--- a/python/sglang/srt/lora/trtllm_moe/__init__.py
+++ b/python/sglang/srt/lora/trtllm_moe/__init__.py
@@ -21,25 +21,15 @@ to the saved-original implementation for non-decode batches (token count above
 ``SGLANG_TWO_STREAM_MAX_TOKENS`` default 256), so prefill stays on the serial
 path even with the patch installed.
 """
-import os
 from typing import Callable, Optional
 
 import torch
 
-_ENV_KEY = "SGLANG_LORA_TWO_STREAM"
-_MAX_TOKENS_KEY = "SGLANG_TWO_STREAM_MAX_TOKENS"
-_MAX_TOKENS_DEFAULT = 256
-
+from sglang.srt.environ import envs
 
 def is_two_stream_active(x: torch.Tensor) -> bool:
-    """Per-batch gate. True iff env is on AND batch is decode-shaped."""
-    if os.environ.get(_ENV_KEY) != "1":
-        return False
-    try:
-        max_tok = int(os.environ.get(_MAX_TOKENS_KEY, str(_MAX_TOKENS_DEFAULT)))
-    except ValueError:
-        max_tok = _MAX_TOKENS_DEFAULT
-    return x.shape[0] <= max_tok
+    """Per-batch gate (two-stream now always-on). True iff batch is decode-shaped (<= SGLANG_TWO_STREAM_MAX_TOKENS)."""
+    return x.shape[0] <= envs.SGLANG_TWO_STREAM_MAX_TOKENS.get()
 
 
 _LORA_SIDE_STREAM: Optional[torch.cuda.Stream] = None
@@ -66,10 +56,8 @@ def init_lora_two_stream_resources(device: Optional[torch.device] = None) -> Non
     lazy, the first eligible decode forward would create it — which can fall
     inside capture if warmup didn't happen to exercise a two-stream batch.
     Calling this from a pre-capture hook pins creation to init/warmup on the
-    correct device. No-op unless ``SGLANG_LORA_TWO_STREAM=1``.
+    correct device.
     """
-    if os.environ.get(_ENV_KEY) != "1":
-        return
     if device is not None:
         with torch.cuda.device(device):
             get_lora_side_stream()
@@ -82,7 +70,10 @@ def init_lora_two_stream_resources(device: Optional[torch.device] = None) -> Non
 _ORIGINAL_QKV_FORWARD: Optional[Callable] = None
 _ORIGINAL_ROW_FORWARD: Optional[Callable] = None
 _ORIGINAL_MERGED_FORWARD: Optional[Callable] = None
+_ORIGINAL_COLUMN_FORWARD: Optional[Callable] = None
+_ORIGINAL_REPLICATED_FORWARD: Optional[Callable] = None
 _ORIGINAL_MOE_LORA_FUNC: Optional[Callable] = None
+_ORIGINAL_FP4_MOE_LORA_FUNC: Optional[Callable] = None
 _INSTALLED: bool = False
 
 
@@ -98,8 +89,20 @@ def get_original_merged_column_forward() -> Callable:
     return _ORIGINAL_MERGED_FORWARD
 
 
+def get_original_column_forward() -> Callable:
+    return _ORIGINAL_COLUMN_FORWARD
+
+
+def get_original_replicated_forward() -> Callable:
+    return _ORIGINAL_REPLICATED_FORWARD
+
+
 def get_original_moe_lora_func() -> Callable:
     return _ORIGINAL_MOE_LORA_FUNC
+
+
+def get_original_fp4_moe_lora_func() -> Callable:
+    return _ORIGINAL_FP4_MOE_LORA_FUNC
 
 
 def install_two_stream_overrides() -> None:
@@ -118,39 +121,56 @@ def install_two_stream_overrides() -> None:
     :func:`get_original_row_forward`, :func:`get_original_moe_lora_func` so the
     new versions can fall back when their per-batch gate says single-stream.
     """
-    global _INSTALLED, _ORIGINAL_QKV_FORWARD, _ORIGINAL_ROW_FORWARD, _ORIGINAL_MERGED_FORWARD, _ORIGINAL_MOE_LORA_FUNC
+    global _INSTALLED, _ORIGINAL_QKV_FORWARD, _ORIGINAL_ROW_FORWARD, _ORIGINAL_MERGED_FORWARD, _ORIGINAL_COLUMN_FORWARD, _ORIGINAL_REPLICATED_FORWARD, _ORIGINAL_MOE_LORA_FUNC, _ORIGINAL_FP4_MOE_LORA_FUNC
 
     if _INSTALLED:
         return
-    if os.environ.get(_ENV_KEY) != "1":
-        return
 
     from sglang.srt.lora.layers import (
+        ColumnParallelLinearWithLoRA,
         MergedColumnParallelLinearWithLoRA,
         QKVParallelLinearWithLoRA,
+        ReplicatedLinearWithLoRA,
         RowParallelLinearWithLoRA,
     )
     from sglang.srt.lora.trtllm_moe.attention import (
+        column_parallel_lora_forward,
         qkv_proj_lora_forward,
+        replicated_lora_forward,
         row_parallel_lora_forward,
     )
     from sglang.srt.lora.trtllm_moe.merged_column import merged_column_lora_forward
 
+    # Capture all originals before patching: QKV / MergedColumn subclass
+    # ColumnParallel, so the plain-Column O10 patch must not clobber the
+    # subclasses' own (3-/2-slice) forwards captured here as their fallbacks.
     _ORIGINAL_QKV_FORWARD = QKVParallelLinearWithLoRA.forward
     _ORIGINAL_ROW_FORWARD = RowParallelLinearWithLoRA.forward
     _ORIGINAL_MERGED_FORWARD = MergedColumnParallelLinearWithLoRA.forward
+    _ORIGINAL_COLUMN_FORWARD = ColumnParallelLinearWithLoRA.forward
+    _ORIGINAL_REPLICATED_FORWARD = ReplicatedLinearWithLoRA.forward
     QKVParallelLinearWithLoRA.forward = qkv_proj_lora_forward
     RowParallelLinearWithLoRA.forward = row_parallel_lora_forward
     MergedColumnParallelLinearWithLoRA.forward = merged_column_lora_forward
+    # O10 (MLA q_b_proj / kv_b_proj) + O11 (MLA fused_qkv_a_proj_with_mqa).
+    ColumnParallelLinearWithLoRA.forward = column_parallel_lora_forward
+    ReplicatedLinearWithLoRA.forward = replicated_lora_forward
 
     import sglang.srt.layers.moe.moe_runner.flashinfer_trtllm as ft
     from sglang.srt.lora.trtllm_moe.moe_overlap import (
+        fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream,
         fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream,
     )
 
+    # O1 (FP8 Qwen) + O1-fp4 (NVFP4 Kimi): MoE gate_up LoRA overlap. Each patched
+    # fn falls back to its saved single-stream original for non-decode batches.
     _ORIGINAL_MOE_LORA_FUNC = ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora
+    _ORIGINAL_FP4_MOE_LORA_FUNC = ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora
     ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora = (
         fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream
+    )
+    ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora = (
+        fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream
     )
 
     _INSTALLED = True
@@ -163,6 +183,9 @@ __all__ = [
     "get_original_qkv_forward",
     "get_original_row_forward",
     "get_original_merged_column_forward",
+    "get_original_column_forward",
+    "get_original_replicated_forward",
     "get_original_moe_lora_func",
+    "get_original_fp4_moe_lora_func",
     "install_two_stream_overrides",
 ]

--- a/python/sglang/srt/lora/trtllm_moe/__init__.py
+++ b/python/sglang/srt/lora/trtllm_moe/__init__.py
@@ -65,6 +65,21 @@ def init_lora_two_stream_resources(device: Optional[torch.device] = None) -> Non
         get_lora_side_stream()
 
 
+def lora_overlap_alloc_stream() -> Optional[torch.cuda.Stream]:
+    """Stream to allocate side-stream LoRA-shrink OUTPUT buffers on, or None for default behavior.
+
+    A buffer allocated *inside* ``with torch.cuda.stream(side)`` is tagged to the side stream, so the
+    caching allocator may free/reuse it on the side stream's schedule — before the MAIN stream (the real
+    consumer, via the LoRA-B expand) is done. Under cuda-graph replay that's a premature-reuse WAR ->
+    qwen3.5 mamba decode garbage. With ``SGLANG_OPT_LORA_OVERLAP_MAIN_ALLOC`` this returns the MAIN
+    stream so the op allocates the output on the consumer stream (like the MoE O1 ``gate_up_delta``),
+    making a single shared side stream graph-safe. Call on the MAIN stream BEFORE forking to the side.
+    """
+    if envs.SGLANG_OPT_LORA_OVERLAP_MAIN_ALLOC.get():
+        return torch.cuda.current_stream()
+    return None
+
+
 # References to the original implementations, captured at install time so the
 # patched callables can defer to them for non-decode batches.
 _ORIGINAL_QKV_FORWARD: Optional[Callable] = None

--- a/python/sglang/srt/lora/trtllm_moe/attention.py
+++ b/python/sglang/srt/lora/trtllm_moe/attention.py
@@ -16,7 +16,9 @@ from sglang.srt.distributed import (
 )
 from sglang.srt.lora.trtllm_moe import (
     get_lora_side_stream,
+    get_original_column_forward,
     get_original_qkv_forward,
+    get_original_replicated_forward,
     get_original_row_forward,
     is_two_stream_active,
 )
@@ -146,3 +148,94 @@ def row_parallel_lora_forward(
 
     output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
     return output_, output_bias
+
+
+def column_parallel_lora_forward(self, input_: torch.Tensor):
+    """O10 — side-stream LoRA-A shrink ‖ base ColumnParallel GEMM.
+
+    Covers DeepSeek/Kimi MLA's ``q_b_proj`` / ``kv_b_proj`` (plain
+    :class:`ColumnParallelLinearWithLoRA` — the merged/QKV subclasses keep their
+    own O9/O7 overrides). The shrink reads ``input_`` (same as the base GEMM, no
+    write conflict); the expand needs the shrink intermediate AND base_output,
+    so it runs after the rejoin. Byte-identical to the saved-original forward
+    for non-decode batches or when LoRA isn't set on this layer.
+    """
+    if not self.set_lora or not is_two_stream_active(input_):
+        return get_original_column_forward()(self, input_)
+
+    bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
+    side_stream = get_lora_side_stream()
+
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        lora_a_output = self.lora_backend.run_lora_a_sgemm(input_, self.A_buffer)
+
+    # Base ColumnParallel GEMM on main, concurrent with the side-stream shrink.
+    output_parallel = self.base_layer.quant_method.apply(self.base_layer, input_, bias)
+
+    # Rejoin: expand reads both the side-produced shrink and base_output.
+    torch.cuda.current_stream().wait_stream(side_stream)
+    output_parallel = self.lora_backend.run_lora_b_sgemm(
+        x=lora_a_output,
+        weights=self.B_buffer,
+        output_offset=self.output_offset,
+        output_offset_cpu=self.output_offset_cpu,
+        base_output=output_parallel,
+    )
+
+    if self.base_layer.gather_output:
+        output = tensor_model_parallel_all_gather(output_parallel)
+    else:
+        output = output_parallel
+    output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
+    return output, output_bias
+
+
+def replicated_lora_forward(self, x: torch.Tensor):
+    """O11 — side-stream LoRA-A shrink ‖ base ReplicatedLinear GEMM.
+
+    Covers DeepSeek/Kimi MLA's ``fused_qkv_a_proj_with_mqa``
+    (:class:`ReplicatedLinearWithLoRA`, no TP sharding). Handles both the
+    single-projection (``first_output_dim == 0``) and the fused q_a+kv_a
+    (``> 0``, ``n_slices=2``) cases, splitting the same A-shrink / B-expand the
+    backend's ``run_qkv_lora`` composes internally — A on the side stream, B on
+    the main after the rejoin. Falls back to the saved-original otherwise.
+    """
+    if not self.set_lora or not is_two_stream_active(x):
+        return get_original_replicated_forward()(self, x)
+
+    bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
+    side_stream = get_lora_side_stream()
+    first_dim = self.first_output_dim
+
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        lora_a_output = self.lora_backend.run_lora_a_sgemm(
+            x, self.A_buffer, stack_num=(2 if first_dim > 0 else 1)
+        )
+
+    # Base ReplicatedLinear GEMM on main, concurrent with the side-stream shrink.
+    output = self.base_layer.quant_method.apply(self.base_layer, x, bias)
+
+    torch.cuda.current_stream().wait_stream(side_stream)
+    if first_dim == 0:
+        output = self.lora_backend.run_lora_b_sgemm(
+            x=lora_a_output,
+            weights=self.B_buffer,
+            output_offset=self._output_offset,
+            base_output=output,
+        )
+    else:
+        from sglang.srt.lora.triton_ops import qkv_lora_b_fwd
+
+        output = qkv_lora_b_fwd(
+            lora_a_output,
+            self.B_buffer,
+            self.lora_backend._sgemm_info(),
+            self._output_offset,
+            self._max_out_dim,
+            output,
+            n_slices=2,
+        )
+    output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
+    return output, output_bias

--- a/python/sglang/srt/lora/trtllm_moe/attention.py
+++ b/python/sglang/srt/lora/trtllm_moe/attention.py
@@ -1,0 +1,148 @@
+"""Two-stream attention LoRA forward implementations (O7 + O8).
+
+These are monkey-patched onto :class:`QKVParallelLinearWithLoRA` and
+:class:`RowParallelLinearWithLoRA` by
+:func:`sglang.srt.lora.trtllm_moe.install_two_stream_overrides` when
+``SGLANG_LORA_TWO_STREAM=1``. The saved-original forward methods are
+preserved and called for batches where two-stream isn't active.
+"""
+import torch
+
+from sglang.srt.distributed import (
+    get_tensor_model_parallel_rank,
+    split_tensor_along_last_dim,
+    tensor_model_parallel_all_gather,
+    tensor_model_parallel_all_reduce,
+)
+from sglang.srt.lora.trtllm_moe import (
+    get_lora_side_stream,
+    get_original_qkv_forward,
+    get_original_row_forward,
+    is_two_stream_active,
+)
+
+
+def qkv_proj_lora_forward(self, input_: torch.Tensor):
+    """O7 — side-stream LoRA-A shrink ‖ base qkv_proj GEMM.
+
+    The shrink reads ``input_`` and the LoRA-A weights — same input as the
+    base GEMM, no write conflict. The expand needs the shrink intermediate
+    AND base_output, so it runs after the rejoin on the main stream.
+    """
+    if not self.set_lora or not is_two_stream_active(input_):
+        return get_original_qkv_forward()(self, input_)
+
+    from sglang.srt.lora.triton_ops import qkv_lora_b_fwd, sgemm_lora_a_fwd
+
+    bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
+    side_stream = get_lora_side_stream()
+    # sgemm_info is host-side (LoRABatchInfo); compute once, share both calls.
+    sgemm_info = self.lora_backend._sgemm_info()
+
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        shrink_intermediate = sgemm_lora_a_fwd(
+            input_, self.A_buffer_qkv, sgemm_info, stack_num=3
+        )
+
+    # Base qkv_proj GEMM on main, concurrent with the side-stream shrink.
+    output_parallel = self.base_layer.quant_method.apply(
+        self.base_layer, input_, bias
+    )
+
+    # Rejoin: expand reads both side-produced shrink_intermediate and base_output.
+    torch.cuda.current_stream().wait_stream(side_stream)
+    output_parallel = qkv_lora_b_fwd(
+        shrink_intermediate,
+        self.B_buffer_qkv,
+        sgemm_info,
+        self.output_offset,
+        self.max_qkv_out_dim,
+        output_parallel,
+        n_slices=3,
+    )
+
+    if self.base_layer.gather_output:
+        output = tensor_model_parallel_all_gather(output_parallel)
+    else:
+        output = output_parallel
+    output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
+    return output, output_bias
+
+
+def row_parallel_lora_forward(
+    self, input_: torch.Tensor, skip_all_reduce: bool = False, forward_batch=None
+):
+    """O8 — side-stream LoRA-A shrink ‖ base row-parallel (o_proj) GEMM.
+
+    Mirrors O7 but the row-parallel context adds: input split per TP rank
+    (when not already parallel), bias on rank 0 only, optional cross-rank
+    all-reduce on both base output and lora_a intermediate when reducing.
+
+    Falls back to the saved-original :meth:`forward` for non-decode batches
+    or when LoRA isn't set on this layer.
+    """
+    # We need ``input_parallel`` to gate the per-batch decode check (its
+    # token-count drives the threshold, not the unsplit ``input_``).
+    if self.base_layer.input_is_parallel:
+        input_parallel = input_
+    else:
+        tp_rank = get_tensor_model_parallel_rank()
+        splitted_input = split_tensor_along_last_dim(
+            input_, num_partitions=self.base_layer.tp_size
+        )
+        input_parallel = splitted_input[tp_rank].contiguous()
+
+    if not self.set_lora or not is_two_stream_active(input_parallel):
+        return get_original_row_forward()(self, input_, skip_all_reduce, forward_batch)
+
+    bias_ = (
+        None
+        if (self.base_layer.tp_rank > 0 or self.base_layer.skip_bias_add)
+        else self.base_layer.bias
+    )
+
+    side_stream = get_lora_side_stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        lora_a_output = self.lora_backend.run_lora_a_sgemm(
+            input_parallel, self.A_buffer
+        )
+
+    # Base row-parallel GEMM on main, concurrent with the side-stream shrink.
+    output_parallel = self.base_layer.quant_method.apply(
+        self.base_layer, input_parallel, bias=bias_
+    )
+
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    should_reduce = (
+        self.base_layer.reduce_results
+        and self.base_layer.tp_size > 1
+        and not skip_all_reduce
+    )
+
+    if should_reduce:
+        output_ = tensor_model_parallel_all_reduce(output_parallel)
+        lora_a_output = tensor_model_parallel_all_reduce(lora_a_output)
+        output_ = self.lora_backend.run_lora_b_sgemm(
+            x=lora_a_output,
+            weights=self.B_buffer,
+            output_offset=self.output_offset,
+            output_offset_cpu=self.output_offset_cpu,
+            base_output=output_,
+        )
+    else:
+        # Two-stream already produced lora_a_output on the side stream; finish
+        # the LoRA with just the expand atomic-add against output_parallel.
+        output_parallel = self.lora_backend.run_lora_b_sgemm(
+            x=lora_a_output,
+            weights=self.B_buffer,
+            output_offset=self.output_offset,
+            output_offset_cpu=self.output_offset_cpu,
+            base_output=output_parallel,
+        )
+        output_ = output_parallel
+
+    output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
+    return output_, output_bias

--- a/python/sglang/srt/lora/trtllm_moe/attention.py
+++ b/python/sglang/srt/lora/trtllm_moe/attention.py
@@ -21,6 +21,7 @@ from sglang.srt.lora.trtllm_moe import (
     get_original_replicated_forward,
     get_original_row_forward,
     is_two_stream_active,
+    lora_overlap_alloc_stream,
 )
 
 
@@ -41,10 +42,11 @@ def qkv_proj_lora_forward(self, input_: torch.Tensor):
     # sgemm_info is host-side (LoRABatchInfo); compute once, share both calls.
     sgemm_info = self.lora_backend._sgemm_info()
 
+    _alloc = lora_overlap_alloc_stream()  # capture MAIN stream here (before the fork)
     side_stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side_stream):
         shrink_intermediate = sgemm_lora_a_fwd(
-            input_, self.A_buffer_qkv, sgemm_info, stack_num=3
+            input_, self.A_buffer_qkv, sgemm_info, stack_num=3, out_alloc_stream=_alloc
         )
 
     # Base qkv_proj GEMM on main, concurrent with the side-stream shrink.
@@ -105,10 +107,11 @@ def row_parallel_lora_forward(
     )
 
     side_stream = get_lora_side_stream()
+    _alloc = lora_overlap_alloc_stream()  # capture MAIN stream here (before the fork)
     side_stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side_stream):
         lora_a_output = self.lora_backend.run_lora_a_sgemm(
-            input_parallel, self.A_buffer
+            input_parallel, self.A_buffer, out_alloc_stream=_alloc
         )
 
     # Base row-parallel GEMM on main, concurrent with the side-stream shrink.
@@ -166,9 +169,12 @@ def column_parallel_lora_forward(self, input_: torch.Tensor):
     bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
     side_stream = get_lora_side_stream()
 
+    _alloc = lora_overlap_alloc_stream()  # capture MAIN stream here (before the fork)
     side_stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side_stream):
-        lora_a_output = self.lora_backend.run_lora_a_sgemm(input_, self.A_buffer)
+        lora_a_output = self.lora_backend.run_lora_a_sgemm(
+            input_, self.A_buffer, out_alloc_stream=_alloc
+        )
 
     # Base ColumnParallel GEMM on main, concurrent with the side-stream shrink.
     output_parallel = self.base_layer.quant_method.apply(self.base_layer, input_, bias)
@@ -208,10 +214,11 @@ def replicated_lora_forward(self, x: torch.Tensor):
     side_stream = get_lora_side_stream()
     first_dim = self.first_output_dim
 
+    _alloc = lora_overlap_alloc_stream()  # capture MAIN stream here (before the fork)
     side_stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side_stream):
         lora_a_output = self.lora_backend.run_lora_a_sgemm(
-            x, self.A_buffer, stack_num=(2 if first_dim > 0 else 1)
+            x, self.A_buffer, stack_num=(2 if first_dim > 0 else 1), out_alloc_stream=_alloc
         )
 
     # Base ReplicatedLinear GEMM on main, concurrent with the side-stream shrink.

--- a/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
+++ b/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
@@ -1,0 +1,269 @@
+"""sgl_flashinfer_trtllm MoE LoRA dispatch (original single-stream).
+
+This is the LoRA-enabled fused-experts path added by the trtllm-lora work — it
+was originally a function in ``layers/moe/moe_runner/flashinfer_trtllm.py`` and
+is now hosted here so that file holds only a re-export. The function name
+remains ``fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora`` for
+import-site stability.
+
+When ``SGLANG_LORA_TWO_STREAM=1`` is set, this is the function the
+``install_two_stream_overrides()`` monkey-patch swaps for the side-stream
+version in :mod:`sglang.srt.lora.trtllm_moe.moe_overlap`. Otherwise it runs as
+the active path.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    use_symmetric_memory,
+)
+from sglang.srt.layers.dp_attention import is_allocation_symmetric
+from sglang.srt.layers.quantization.fp8_kernel import per_token_group_quant_fp8
+from sglang.srt.utils.common import next_power_of_2
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        FlashInferTrtllmFp8MoeQuantInfo,
+    )
+    from sglang.srt.layers.moe.token_dispatcher import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
+    dispatch_output: "StandardDispatchOutput",
+    quant_info: "FlashInferTrtllmFp8MoeQuantInfo",
+    runner_config: "MoeRunnerConfig",
+    lora_info,
+) -> "StandardCombineInput":
+    from flashinfer.fused_moe import Fp8QuantizationType
+
+    from sglang.jit_kernel.flashinfer_trtllm_moe import (
+        trtllm_fp8_block_scale_moe_lora_finalize,
+        trtllm_fp8_block_scale_routed_moe_lora,
+    )
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        _pack_topk_for_flashinfer_routed,
+        fused_experts_none_to_flashinfer_trtllm_fp8,
+    )
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+    from sglang.srt.layers.moe.utils import RoutingMethodType
+    from sglang.srt.lora.lora_moe_runners import build_lora_hooks
+    from sglang.srt.lora.triton_ops import merged_experts_fused_moe_lora_add
+    from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
+    assert runner_config.activation == "silu" and runner_config.is_gated, (
+        "sgl_flashinfer_trtllm LoRA currently supports the gated SwiGLU FP8 "
+        "Qwen path only."
+    )
+    assert quant_info.block_quant and not quant_info.use_mxfp8, (
+        "sgl_flashinfer_trtllm LoRA currently supports DeepSeekFp8 block-quant "
+        "checkpoints only."
+    )
+    assert quant_info.weight_block_k is not None
+    assert quant_info.w13_weight_scale_inv is not None
+    assert quant_info.w2_weight_scale_inv is not None
+
+    hidden_states = dispatch_output.hidden_states
+    topk_output = dispatch_output.topk_output
+    assert TopKOutputChecker.format_is_standard(topk_output)
+    assert runner_config.top_k is not None
+
+    if not get_is_capture_mode() and not lora_info.has_active_lora:
+        return fused_experts_none_to_flashinfer_trtllm_fp8(
+            dispatch_output,
+            quant_info,
+            runner_config,
+            use_routed_topk=True,
+            use_sgl_kernel=True,
+        )
+
+    topk_ids = topk_output.topk_ids
+    topk_weights = topk_output.topk_weights
+    use_virtual_lora_store = bool(
+        lora_info.lora_use_virtual_experts and lora_info.max_lora_rank > 0
+    )
+    if use_virtual_lora_store:
+        hooks = None
+        token_lora_mapping = lora_info.token_lora_mapping
+        fused_lora_routing_cache: dict = {}
+    else:
+        hooks = build_lora_hooks(hidden_states, lora_info, topk_ids)
+        token_lora_mapping = None
+        fused_lora_routing_cache = {}
+
+    a_q, a_sf = per_token_group_quant_fp8(hidden_states, quant_info.weight_block_k)
+    a_sf_t = a_sf.t().contiguous()
+
+    gate_up_delta_shape = (
+        hidden_states.shape[0],
+        runner_config.top_k,
+        quant_info.w13_weight.shape[1],
+    )
+    gate_up_delta = (
+        hidden_states.new_empty(gate_up_delta_shape)
+        if use_virtual_lora_store
+        else hidden_states.new_zeros(gate_up_delta_shape)
+    )
+    if use_virtual_lora_store:
+        merged_experts_fused_moe_lora_add(
+            output=gate_up_delta,
+            hidden_states=hidden_states,
+            lora_a=lora_info.gate_up_lora_a_weights,
+            lora_b=lora_info.gate_up_lora_b_weights,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            token_lora_mapping=token_lora_mapping,
+            mul_routed_weight=False,
+            experts_shared_outer_loras_a=lora_info.experts_shared_outer_loras,
+            experts_shared_outer_loras_b=False,
+            routing_cache=fused_lora_routing_cache,
+            fuse_add_to_output=False,
+            use_direct_expand_add=lora_info.max_lora_rank <= 64,
+        )
+    elif hooks.after_gate_up is not None:
+        hooks.after_gate_up(hidden_states, gate_up_delta, topk_weights, topk_ids)
+
+    activation_lora_input = torch.empty(
+        (hidden_states.shape[0], runner_config.top_k, quant_info.intermediate_size),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    packed_topk_ids = _pack_topk_for_flashinfer_routed(
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+    )
+
+    direct_down_output = None
+    if use_virtual_lora_store:
+        with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+            direct_down_output = torch.empty(
+                hidden_states.shape[0],
+                hidden_states.shape[1],
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+
+    moe_result = trtllm_fp8_block_scale_routed_moe_lora(
+        topk_ids=packed_topk_ids,
+        routing_bias=None,
+        hidden_states=a_q,
+        hidden_states_scale=a_sf_t,
+        gemm1_weights=quant_info.w13_weight,
+        gemm1_weights_scale=quant_info.w13_weight_scale_inv,
+        gemm2_weights=quant_info.w2_weight,
+        gemm2_weights_scale=quant_info.w2_weight_scale_inv,
+        gate_up_lora_delta=gate_up_delta,
+        activation_lora_input=activation_lora_input,
+        num_experts=quant_info.global_num_experts,
+        top_k=runner_config.top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=quant_info.intermediate_size,
+        local_expert_offset=quant_info.local_expert_offset,
+        local_num_experts=quant_info.local_num_experts,
+        routed_scaling_factor=(
+            runner_config.routed_scaling_factor
+            if runner_config.routed_scaling_factor is not None
+            else 1.0
+        ),
+        routing_method_type=(
+            RoutingMethodType.TopK
+            if quant_info.routing_method_type == RoutingMethodType.DeepSeekV3
+            else quant_info.routing_method_type
+        ),
+        use_shuffled_weight=False,
+        do_finalize=use_virtual_lora_store,
+        output=(
+            direct_down_output
+            if direct_down_output is not None
+            else torch.empty_like(hidden_states)
+        ),
+        tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
+        fp8_quantization_type=Fp8QuantizationType.DeepSeekFp8,
+        activation_type=quant_info.activation_type,
+    )
+    if use_virtual_lora_store:
+        output = moe_result
+        merged_experts_fused_moe_lora_add(
+            output=output,
+            hidden_states=activation_lora_input.view(-1, quant_info.intermediate_size),
+            lora_a=lora_info.down_lora_a_weights,
+            lora_b=lora_info.down_lora_b_weights,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            token_lora_mapping=token_lora_mapping,
+            mul_routed_weight=True,
+            experts_shared_outer_loras_a=False,
+            experts_shared_outer_loras_b=lora_info.experts_shared_outer_loras,
+            routing_cache=fused_lora_routing_cache,
+            fuse_add_to_output=False,
+            fuse_sum_all_reduce=True,
+            use_direct_expand_add=lora_info.max_lora_rank <= 64,
+        )
+        return StandardCombineInput(hidden_states=output)
+
+    gemm2_output, expert_weights, expanded_idx_to_permuted_idx = moe_result
+
+    down_delta_shape = (
+        hidden_states.shape[0],
+        runner_config.top_k,
+        hidden_states.shape[1],
+    )
+    down_delta = (
+        hidden_states.new_empty(down_delta_shape)
+        if use_virtual_lora_store
+        else hidden_states.new_zeros(down_delta_shape)
+    )
+    if use_virtual_lora_store:
+        merged_experts_fused_moe_lora_add(
+            output=down_delta,
+            hidden_states=activation_lora_input.view(-1, quant_info.intermediate_size),
+            lora_a=lora_info.down_lora_a_weights,
+            lora_b=lora_info.down_lora_b_weights,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            token_lora_mapping=token_lora_mapping,
+            mul_routed_weight=True,
+            experts_shared_outer_loras_a=False,
+            experts_shared_outer_loras_b=lora_info.experts_shared_outer_loras,
+            routing_cache=fused_lora_routing_cache,
+            fuse_add_to_output=False,
+        )
+    elif hooks.after_down is not None:
+        hooks.after_down(
+            activation_lora_input.view(-1, quant_info.intermediate_size),
+            down_delta,
+            topk_weights,
+            topk_ids,
+        )
+
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        output = torch.empty(
+            hidden_states.shape[0],
+            hidden_states.shape[1],
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+    output = trtllm_fp8_block_scale_moe_lora_finalize(
+        gemm2_output=gemm2_output,
+        expert_weights=expert_weights,
+        expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
+        down_lora_delta=down_delta,
+        output=output,
+        routed_scaling_factor=(
+            runner_config.routed_scaling_factor
+            if runner_config.routed_scaling_factor is not None
+            else 1.0
+        ),
+    )
+
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
+++ b/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
@@ -106,6 +106,10 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
     )
     a_sf_t = a_sf.t()
 
+    # EP-aware LoRA: under MoE EP each rank computes the delta only for the experts it
+    # owns (passed via local_expert_offset/local_num_experts below). gate_up_delta stays
+    # new_empty even though non-owned [token, k] slots are then left unwritten -- the
+    # trtllm MoE is itself EP-aware, so those slots never feed the all-reduced output.
     gate_up_delta_shape = (
         hidden_states.shape[0],
         runner_config.top_k,
@@ -131,6 +135,8 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
             routing_cache=fused_lora_routing_cache,
             fuse_add_to_output=False,
             use_direct_expand_add=lora_info.max_lora_rank <= 64,
+            local_expert_offset=quant_info.local_expert_offset,
+            local_num_experts=quant_info.local_num_experts,
         )
     elif hooks.after_gate_up is not None:
         hooks.after_gate_up(hidden_states, gate_up_delta, topk_weights, topk_ids)
@@ -212,6 +218,8 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
             fuse_add_to_output=False,
             fuse_sum_all_reduce=True,
             use_direct_expand_add=lora_info.max_lora_rank <= 64,
+            local_expert_offset=quant_info.local_expert_offset,
+            local_num_experts=quant_info.local_num_experts,
         )
         return StandardCombineInput(hidden_states=output)
 

--- a/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
+++ b/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
@@ -99,8 +99,12 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
         token_lora_mapping = None
         fused_lora_routing_cache = {}
 
-    a_q, a_sf = per_token_group_quant_fp8(hidden_states, quant_info.weight_block_k)
-    a_sf_t = a_sf.t().contiguous()
+    # Fuse the per-token scale transpose into the quant kernel (column-major scales) so the
+    # `.t()` is a free view -> drops the standalone ~2us transpose+copy. Byte/shape-identical.
+    a_q, a_sf = per_token_group_quant_fp8(
+        hidden_states, quant_info.weight_block_k, column_major_scales=True
+    )
+    a_sf_t = a_sf.t()
 
     gate_up_delta_shape = (
         hidden_states.shape[0],

--- a/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
+++ b/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
@@ -312,15 +312,6 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora(
         "sgl_flashinfer_trtllm NVFP4 LoRA currently supports the gated SwiGLU path only."
     )
 
-    from sglang.srt.environ import envs
-
-    assert envs.SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION.get(), (
-        "NVFP4 trtllm MoE LoRA requires SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION=1: it "
-        "forces w13/w2 input_scale==1 so g1_scale_c==g1_alphas and g2_alphas==w2_weight_scale_2, "
-        "which is what makes the decomposed gate_up(g1_alphas)/SwiGLU/down(g2_alphas) scale "
-        "composition match the plain fused path. Relaunch with that env var set."
-    )
-
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
     assert TopKOutputChecker.format_is_standard(topk_output)

--- a/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
+++ b/python/sglang/srt/lora/trtllm_moe/lora_dispatch.py
@@ -28,6 +28,7 @@ from sglang.srt.utils.common import next_power_of_2
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
     from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        FlashInferTrtllmFp4MoeQuantInfo,
         FlashInferTrtllmFp8MoeQuantInfo,
     )
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -278,4 +279,174 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
         ),
     )
 
+    return StandardCombineInput(hidden_states=output)
+
+
+def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora(
+    dispatch_output: "StandardDispatchOutput",
+    quant_info: "FlashInferTrtllmFp4MoeQuantInfo",
+    runner_config: "MoeRunnerConfig",
+    lora_info,
+) -> "StandardCombineInput":
+    """NVFP4 sibling of ``fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora``.
+
+    Decomposed (unfused-activation) MoE-LoRA: routing -> gather -> gate_up grouped
+    GEMM (raw 2*inter) -> activation that adds ``gate_up_lora_delta`` pre-SwiGLU and
+    captures ``activation_lora_input`` -> NvFP4 quant -> down grouped GEMM -> finalize,
+    then the virtual-experts down-LoRA is merged into the output. Single-stream
+    version; ``moe_overlap.py`` provides the two-stream variant.
+    """
+    from sglang.jit_kernel.flashinfer_trtllm_moe import (
+        trtllm_fp4_block_scale_routed_moe_lora,
+    )
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        _pack_topk_for_flashinfer_routed,
+        fused_experts_none_to_flashinfer_trtllm_fp4,
+    )
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+    from sglang.srt.lora.triton_ops import merged_experts_fused_moe_lora_add
+    from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
+    assert runner_config.activation == "silu" and runner_config.is_gated, (
+        "sgl_flashinfer_trtllm NVFP4 LoRA currently supports the gated SwiGLU path only."
+    )
+
+    from sglang.srt.environ import envs
+
+    assert envs.SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION.get(), (
+        "NVFP4 trtllm MoE LoRA requires SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION=1: it "
+        "forces w13/w2 input_scale==1 so g1_scale_c==g1_alphas and g2_alphas==w2_weight_scale_2, "
+        "which is what makes the decomposed gate_up(g1_alphas)/SwiGLU/down(g2_alphas) scale "
+        "composition match the plain fused path. Relaunch with that env var set."
+    )
+
+    hidden_states = dispatch_output.hidden_states
+    topk_output = dispatch_output.topk_output
+    assert TopKOutputChecker.format_is_standard(topk_output)
+    assert runner_config.top_k is not None
+
+    # No active LoRA in a non-capture decode -> plain (fast) FP4 path.
+    if not get_is_capture_mode() and not lora_info.has_active_lora:
+        return fused_experts_none_to_flashinfer_trtllm_fp4(
+            dispatch_output, quant_info, runner_config, use_routed_topk=True
+        )
+
+    topk_ids = topk_output.topk_ids
+    topk_weights = topk_output.topk_weights
+    use_virtual_lora_store = bool(
+        lora_info.lora_use_virtual_experts and lora_info.max_lora_rank > 0
+    )
+    assert use_virtual_lora_store, "NVFP4 trtllm LoRA requires virtual-experts."
+    token_lora_mapping = lora_info.token_lora_mapping
+    fused_lora_routing_cache: dict = {}
+
+    inter = quant_info.intermediate_size_per_partition
+
+    # Path 3: feed bf16 hidden DIRECTLY to the op (no python pre-quant). The op permutes the
+    # bf16 hidden (moe::dev::permute, token->expert order) then NvFP4-quantizes ONCE with the
+    # 1/(448*6) global + per-token scale — eliminating the dequant->permute->requant round-trip
+    # (and its magnitude bug) that pre-quantized fp4 input forced. Requires the layer to be in
+    # per-token-activation mode (SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION=1) so that
+    # g1_scale_c == g1_alphas and g2_alphas == w2_weight_scale_2, making the decomposed
+    # gate_up(g1_alphas)/SwiGLU/down(g2_alphas) scale composition match the plain fused path.
+
+    gate_up_delta_shape = (
+        hidden_states.shape[0],
+        runner_config.top_k,
+        quant_info.w13_weight.shape[1],
+    )
+    # Gated gate_up LoRA delta: a single merged_experts call on the full stacked [gate_A; up_A]
+    # lora_a (rank 2r) and [gate_B; up_B] lora_b (rank r), via the rank-specialized direct expand
+    # (use_direct_expand_add, rank <= 64). EP args scope the delta to this rank's experts, matching
+    # the EP-aware trtllm MoE base.
+    gate_up_delta = hidden_states.new_empty(gate_up_delta_shape)
+    merged_experts_fused_moe_lora_add(
+        output=gate_up_delta,
+        hidden_states=hidden_states,
+        lora_a=lora_info.gate_up_lora_a_weights,
+        lora_b=lora_info.gate_up_lora_b_weights,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        token_lora_mapping=token_lora_mapping,
+        mul_routed_weight=False,
+        experts_shared_outer_loras_a=lora_info.experts_shared_outer_loras,
+        experts_shared_outer_loras_b=False,
+        routing_cache=fused_lora_routing_cache,
+        fuse_add_to_output=False,
+        use_direct_expand_add=lora_info.max_lora_rank <= 64,
+        local_expert_offset=quant_info.local_expert_offset,
+        local_num_experts=quant_info.local_num_experts,
+    )
+
+    activation_lora_input = torch.empty(
+        (hidden_states.shape[0], runner_config.top_k, inter),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    packed_topk_ids = _pack_topk_for_flashinfer_routed(
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+    )
+
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        direct_down_output = torch.empty(
+            hidden_states.shape[0],
+            hidden_states.shape[1],
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+    output = trtllm_fp4_block_scale_routed_moe_lora(
+        topk_ids=packed_topk_ids,
+        routing_bias=None,
+        hidden_states=hidden_states,
+        hidden_states_scale=None,
+        gemm1_weights=quant_info.w13_weight,
+        gemm1_weights_scale=quant_info.w13_weight_scale.view(torch.float8_e4m3fn),
+        gemm2_weights=quant_info.w2_weight,
+        gemm2_weights_scale=quant_info.w2_weight_scale.view(torch.float8_e4m3fn),
+        output1_scales_scalar=quant_info.g1_scale_c,
+        output1_scales_gate_scalar=quant_info.g1_alphas,
+        output2_scales_scalar=quant_info.g2_alphas,
+        gate_up_lora_delta=gate_up_delta,
+        activation_lora_input=activation_lora_input,
+        num_experts=quant_info.global_num_experts,
+        top_k=runner_config.top_k,
+        intermediate_size=inter,
+        local_expert_offset=quant_info.local_expert_offset,
+        local_num_experts=quant_info.local_num_experts,
+        routed_scaling_factor=(
+            runner_config.routed_scaling_factor
+            if runner_config.routed_scaling_factor is not None
+            else 1.0
+        ),
+        routing_method_type=quant_info.routing_method_type,
+        do_finalize=True,
+        output=direct_down_output,
+    )
+
+    merged_experts_fused_moe_lora_add(
+        output=output,
+        hidden_states=activation_lora_input.view(-1, inter),
+        lora_a=lora_info.down_lora_a_weights,
+        lora_b=lora_info.down_lora_b_weights,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        token_lora_mapping=token_lora_mapping,
+        mul_routed_weight=True,
+        experts_shared_outer_loras_a=False,
+        experts_shared_outer_loras_b=lora_info.experts_shared_outer_loras,
+        routing_cache=fused_lora_routing_cache,
+        fuse_add_to_output=False,
+        fuse_sum_all_reduce=True,
+        use_direct_expand_add=lora_info.max_lora_rank <= 64,
+        # EP-aware: scope the down delta to this rank's experts, matching the gate_up
+        # call above and the FP8 down call. Harmless at EP=1 (local==global, Kimi today);
+        # required for correctness if MoE-EP is turned on later (otherwise non-owned
+        # experts' deltas get over-counted by the fuse_sum_all_reduce).
+        local_expert_offset=quant_info.local_expert_offset,
+        local_num_experts=quant_info.local_num_experts,
+    )
     return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/lora/trtllm_moe/lora_layer.py
+++ b/python/sglang/srt/lora/trtllm_moe/lora_layer.py
@@ -1,0 +1,103 @@
+"""sgl_flashinfer_trtllm-specific bits of ``FusedMoEWithLoRA``.
+
+This file holds the two trtllm-specific code blocks that used to be inlined
+inside the ``FusedMoEWithLoRA`` class in ``lora/layers.py``:
+
+  - :func:`init_sgl_flashinfer_trtllm_lora` — builds the FP8 block-scale
+    ``FlashInferTrtllmFp8MoeQuantInfo`` and stores it on the layer instance.
+    Called from ``FusedMoEWithLoRA.__init__`` when the runner backend is the
+    sgl_flashinfer_trtllm MoE.
+  - :func:`dispatch_sgl_flashinfer_trtllm_lora` — dispatches the LoRA fused
+    experts call. Called from ``FusedMoEWithLoRA.run`` for the same backend.
+
+Keeping them here means ``lora/layers.py`` only has tiny ``if backend == ...:
+init(self, base_layer)`` / ``dispatch(...)`` injection points for the new
+trtllm path instead of ~70 lines of inlined logic.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+
+def init_sgl_flashinfer_trtllm_lora(layer, base_layer) -> None:
+    """Build and store the trtllm FP8 LoRA quant info on the layer.
+
+    Sets ``layer._lora_runner = None`` (trtllm path doesn't use ``MoeRunner``)
+    and ``layer._quant_info`` to a fully-populated
+    ``FlashInferTrtllmFp8MoeQuantInfo``.
+    """
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        FlashInferTrtllmFp8MoeQuantInfo,
+        get_activation_type,
+    )
+    from sglang.srt.layers.moe.utils import RoutingMethodType
+
+    quant_method = base_layer.quant_method
+    quant_config = getattr(quant_method, "quant_config", None)
+    weight_block_size = getattr(quant_config, "weight_block_size", None)
+    if weight_block_size is None:
+        weight_block_size = getattr(quant_method, "weight_block_size", None)
+    use_mxfp8 = bool(getattr(quant_config, "use_mxfp8", False))
+    assert getattr(quant_method, "block_quant", False), (
+        "sgl_flashinfer_trtllm LoRA currently requires FP8 block quant."
+    )
+    assert not use_mxfp8, (
+        "sgl_flashinfer_trtllm LoRA currently targets the non-MX FP8 Qwen path."
+    )
+    assert weight_block_size is not None, (
+        "sgl_flashinfer_trtllm LoRA needs the FP8 weight block size."
+    )
+    w13_weight_scale = getattr(base_layer, "w13_weight_scale_inv", None)
+    if w13_weight_scale is None:
+        w13_weight_scale = getattr(base_layer, "w13_weight_scale", None)
+    w2_weight_scale = getattr(base_layer, "w2_weight_scale_inv", None)
+    if w2_weight_scale is None:
+        w2_weight_scale = getattr(base_layer, "w2_weight_scale", None)
+    assert w13_weight_scale is not None and w2_weight_scale is not None
+
+    layer._lora_runner = None
+    layer._quant_info = FlashInferTrtllmFp8MoeQuantInfo(
+        w13_weight=base_layer.w13_weight,
+        w2_weight=base_layer.w2_weight,
+        global_num_experts=int(base_layer.num_experts),
+        local_expert_offset=int(base_layer.moe_ep_rank)
+        * int(base_layer.num_local_experts),
+        local_num_experts=int(base_layer.num_local_experts),
+        intermediate_size=base_layer.w2_weight.shape[2],
+        routing_method_type=int(
+            getattr(base_layer, "routing_method_type", None)
+            or RoutingMethodType.DeepSeekV3
+        ),
+        block_quant=True,
+        use_mxfp8=False,
+        weight_block_k=weight_block_size[1],
+        w13_weight_scale_inv=w13_weight_scale,
+        w2_weight_scale_inv=w2_weight_scale,
+        activation_type=get_activation_type(
+            base_layer.moe_runner_config.activation,
+            is_gated=base_layer.moe_runner_config.is_gated,
+        ),
+    )
+
+
+def dispatch_sgl_flashinfer_trtllm_lora(
+    dispatch_output, quant_info, base_layer, lora_info
+) -> "StandardCombineInput":
+    """Call the trtllm fused-experts LoRA function for a single layer.
+
+    Looked up at call time so the install-time monkey-patch in
+    :mod:`sglang.srt.lora.trtllm_moe` (the two-stream override) takes effect.
+    """
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora,
+    )
+
+    return fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
+        dispatch_output,
+        quant_info,
+        base_layer.moe_runner_config,
+        lora_info,
+    )

--- a/python/sglang/srt/lora/trtllm_moe/lora_layer.py
+++ b/python/sglang/srt/lora/trtllm_moe/lora_layer.py
@@ -27,13 +27,52 @@ def init_sgl_flashinfer_trtllm_lora(layer, base_layer) -> None:
 
     Sets ``layer._lora_runner = None`` (trtllm path doesn't use ``MoeRunner``)
     and ``layer._quant_info`` to a fully-populated
-    ``FlashInferTrtllmFp8MoeQuantInfo``.
+    ``FlashInferTrtllmFp8MoeQuantInfo`` (or ``FlashInferTrtllmFp4MoeQuantInfo`` for
+    NVFP4 / modelopt checkpoints like Kimi-K2.5-NVFP4).
     """
     from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
         FlashInferTrtllmFp8MoeQuantInfo,
         get_activation_type,
     )
     from sglang.srt.layers.moe.utils import RoutingMethodType
+
+    # ---- NVFP4 (modelopt) path ----
+    # The fp4 weight loader sets ``g1_scale_c`` on the FusedMoE layer (see
+    # ModelOptNvFp4FusedMoEMethod.apply). Mirror the non-LoRA construction in
+    # modelopt_quant.py (~L2099) so the fp4 LoRA dispatch gets the same payload.
+    # NOTE(w13 layout): the decomposed op runs the gate_up projection as a *non-gated*
+    # Gemm2-style GEMM and lets the activation kernel do the SwiGLU split (silu(first)*second),
+    # so w13 must be [Gate, Up] with shuffle_matrix_a but WITHOUT reorder_rows_for_gated_act_gemm.
+    # The TRTLLM fp4 path uses load_up_proj_weight_first=False (=> [Gate, Up]); verify the
+    # processed w13 layout against this at e2e (acc gate) and re-prep if mismatched.
+    if hasattr(base_layer, "g1_scale_c"):
+        from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            FlashInferTrtllmFp4MoeQuantInfo,
+        )
+
+        layer._lora_runner = None
+        layer._quant_info = FlashInferTrtllmFp4MoeQuantInfo(
+            w13_weight=base_layer.w13_weight.data,
+            w2_weight=base_layer.w2_weight.data,
+            w13_weight_scale=base_layer.w13_weight_scale.data,
+            w2_weight_scale=base_layer.w2_weight_scale.data,
+            g1_scale_c=base_layer.g1_scale_c.data,
+            g1_alphas=base_layer.g1_alphas.data,
+            g2_alphas=base_layer.g2_alphas.data,
+            w13_input_scale_quant=base_layer.w13_input_scale_quant,
+            global_num_experts=int(base_layer.num_experts),
+            local_expert_offset=int(base_layer.moe_ep_rank)
+            * int(base_layer.num_local_experts),
+            local_num_experts=int(base_layer.num_local_experts),
+            intermediate_size_per_partition=int(
+                base_layer.intermediate_size_per_partition
+            ),
+            routing_method_type=int(
+                getattr(base_layer, "routing_method_type", None)
+                or RoutingMethodType.DeepSeekV3
+            ),
+        )
+        return
 
     quant_method = base_layer.quant_method
     quant_config = getattr(quant_method, "quant_config", None)
@@ -91,11 +130,20 @@ def dispatch_sgl_flashinfer_trtllm_lora(
     Looked up at call time so the install-time monkey-patch in
     :mod:`sglang.srt.lora.trtllm_moe` (the two-stream override) takes effect.
     """
+    import sglang.srt.layers.moe.moe_runner.flashinfer_trtllm as ft
     from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
-        fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora,
+        FlashInferTrtllmFp4MoeQuantInfo,
     )
 
-    return fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora(
+    # Resolve the fused-experts fn on the module at CALL TIME so the install-time
+    # two-stream monkey-patch (sglang.srt.lora.trtllm_moe) takes effect. Route by
+    # quant dtype: NVFP4 -> fp4 LoRA op, else the FP8 path.
+    if isinstance(quant_info, FlashInferTrtllmFp4MoeQuantInfo):
+        fused_fn = ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora
+    else:
+        fused_fn = ft.fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora
+
+    return fused_fn(
         dispatch_output,
         quant_info,
         base_layer.moe_runner_config,

--- a/python/sglang/srt/lora/trtllm_moe/merged_column.py
+++ b/python/sglang/srt/lora/trtllm_moe/merged_column.py
@@ -1,0 +1,84 @@
+"""Two-stream MergedColumnParallelLinear LoRA forward (O9).
+
+Monkey-patched onto :class:`MergedColumnParallelLinearWithLoRA` by
+:func:`sglang.srt.lora.trtllm_moe.install_two_stream_overrides` when
+``SGLANG_LORA_TWO_STREAM=1``. Covers the merged-column LoRA modules not handled
+by O7 (QKV) / O8 (o_proj) / O1 (MoE experts):
+
+  * Qwen3.5 mamba ``in_proj_qkvz`` (a MergedColumnParallelLinear, every mamba layer)
+  * dense ``gate_up_proj`` MLP layers (e.g. Qwen3-VL non-expert MLP)
+
+Same shape as O7: the LoRA-A shrink reads ``input_`` (same input as the base
+GEMM, no write conflict) and runs on the side stream concurrent with the base
+merged-column GEMM on the main stream; the LoRA-B expand needs both the shrink
+output and base_output, so it runs after the rejoin on the main stream. The
+expand mirrors ``MergedColumnParallelLinearWithLoRA.apply_lora`` — gate_up vs
+general n-slice.
+"""
+import torch
+
+from sglang.srt.distributed import tensor_model_parallel_all_gather
+from sglang.srt.lora.trtllm_moe import (
+    get_lora_side_stream,
+    get_original_merged_column_forward,
+    is_two_stream_active,
+)
+
+
+def merged_column_lora_forward(self, input_: torch.Tensor):
+    """O9 — side-stream LoRA-A shrink ‖ base merged-column GEMM."""
+    if not self.set_lora or not is_two_stream_active(input_):
+        return get_original_merged_column_forward()(self, input_)
+
+    from sglang.srt.lora.triton_ops import (
+        gate_up_lora_b_fwd,
+        qkv_lora_b_fwd,
+        sgemm_lora_a_fwd,
+    )
+
+    bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
+    side_stream = get_lora_side_stream()
+    # sgemm_info is host-side (LoRABatchInfo); compute once, share both calls.
+    sgemm_info = self.lora_backend._sgemm_info()
+    lora_n_slices = self._get_lora_n_slices()
+    use_gate_up = lora_n_slices == 2 and self.use_gate_up_lora
+
+    # Shrink on side stream, concurrent with the base merged-column GEMM on main.
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        shrink_intermediate = sgemm_lora_a_fwd(
+            input_, self.A_buffer, sgemm_info, stack_num=lora_n_slices
+        )
+
+    output_parallel = self.base_layer.quant_method.apply(
+        self.base_layer, input_, bias
+    )
+
+    # Rejoin: expand reads both side-produced shrink_intermediate and base_output.
+    torch.cuda.current_stream().wait_stream(side_stream)
+    if use_gate_up:
+        output_dim = self.B_buffer.shape[-2] // 2
+        output_parallel = gate_up_lora_b_fwd(
+            shrink_intermediate,
+            self.B_buffer,
+            sgemm_info,
+            output_dim,
+            output_parallel,
+        )
+    else:
+        output_parallel = qkv_lora_b_fwd(
+            shrink_intermediate,
+            self.B_buffer,
+            sgemm_info,
+            self.output_offset,
+            self.max_out_dim,
+            output_parallel,
+            n_slices=lora_n_slices,
+        )
+
+    if self.base_layer.gather_output:
+        output = tensor_model_parallel_all_gather(output_parallel)
+    else:
+        output = output_parallel
+    output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
+    return output, output_bias

--- a/python/sglang/srt/lora/trtllm_moe/merged_column.py
+++ b/python/sglang/srt/lora/trtllm_moe/merged_column.py
@@ -22,6 +22,7 @@ from sglang.srt.lora.trtllm_moe import (
     get_lora_side_stream,
     get_original_merged_column_forward,
     is_two_stream_active,
+    lora_overlap_alloc_stream,
 )
 
 
@@ -44,10 +45,11 @@ def merged_column_lora_forward(self, input_: torch.Tensor):
     use_gate_up = lora_n_slices == 2 and self.use_gate_up_lora
 
     # Shrink on side stream, concurrent with the base merged-column GEMM on main.
+    _alloc = lora_overlap_alloc_stream()  # capture MAIN stream here (before the fork)
     side_stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side_stream):
         shrink_intermediate = sgemm_lora_a_fwd(
-            input_, self.A_buffer, sgemm_info, stack_num=lora_n_slices
+            input_, self.A_buffer, sgemm_info, stack_num=lora_n_slices, out_alloc_stream=_alloc
         )
 
     output_parallel = self.base_layer.quant_method.apply(

--- a/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
+++ b/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
@@ -1,0 +1,198 @@
+"""Two-stream MoE LoRA dispatch (O1).
+
+Monkey-patches ``fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora`` in
+``layers/moe/moe_runner/flashinfer_trtllm.py`` (when
+``SGLANG_LORA_TWO_STREAM=1``) so the gate_up LoRA shrink+expand runs on a
+side stream concurrent with the main-stream FP8 quant.
+
+Batches that don't qualify for two-stream (prefill / non-virtual-lora /
+batch without active LoRA) fall through to the saved-original function so
+their behavior is byte-identical to the unpatched code path.
+"""
+import torch
+
+from sglang.srt.lora.trtllm_moe import (
+    get_lora_side_stream,
+    get_original_moe_lora_func,
+    is_two_stream_active,
+)
+
+
+def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
+    dispatch_output,
+    quant_info,
+    runner_config,
+    lora_info,
+):
+    """Drop-in replacement for the like-named function in flashinfer_trtllm.py.
+
+    Two-stream fast path: only fires when the batch is decode-shaped AND uses
+    virtual-experts LoRA. Everything else delegates to the original function.
+    """
+    hidden_states = dispatch_output.hidden_states
+
+    use_virtual_lora_store = bool(
+        lora_info.lora_use_virtual_experts and lora_info.max_lora_rank > 0
+    )
+    # Two-stream requires virtual-experts LoRA AND a decode-shaped batch.
+    # Fall back to the original implementation for anything else (prefill,
+    # non-virtual LoRA, non-LoRA capture, etc.).
+    if not (use_virtual_lora_store and is_two_stream_active(hidden_states)):
+        return get_original_moe_lora_func()(
+            dispatch_output, quant_info, runner_config, lora_info
+        )
+
+    # ---- two-stream fast path ----
+    from flashinfer.fused_moe import Fp8QuantizationType
+
+    from sglang.jit_kernel.flashinfer_trtllm_moe import (
+        trtllm_fp8_block_scale_routed_moe_lora,
+    )
+    from sglang.srt.distributed import get_tp_group
+    from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+        use_symmetric_memory,
+    )
+    from sglang.srt.layers.dp_attention import is_allocation_symmetric
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        _pack_topk_for_flashinfer_routed,
+    )
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+    from sglang.srt.layers.moe.utils import RoutingMethodType
+    from sglang.srt.layers.quantization.fp8_kernel import per_token_group_quant_fp8
+    from sglang.srt.lora.triton_ops import merged_experts_fused_moe_lora_add
+    from sglang.srt.utils.common import next_power_of_2
+
+    assert runner_config.activation == "silu" and runner_config.is_gated, (
+        "sgl_flashinfer_trtllm LoRA currently supports the gated SwiGLU FP8 "
+        "Qwen path only."
+    )
+    assert quant_info.block_quant and not quant_info.use_mxfp8, (
+        "sgl_flashinfer_trtllm LoRA currently supports DeepSeekFp8 block-quant "
+        "checkpoints only."
+    )
+    assert quant_info.weight_block_k is not None
+    assert quant_info.w13_weight_scale_inv is not None
+    assert quant_info.w2_weight_scale_inv is not None
+
+    topk_output = dispatch_output.topk_output
+    assert TopKOutputChecker.format_is_standard(topk_output)
+    assert runner_config.top_k is not None
+
+    topk_ids = topk_output.topk_ids
+    topk_weights = topk_output.topk_weights
+    token_lora_mapping = lora_info.token_lora_mapping
+    fused_lora_routing_cache: dict = {}
+
+    side_stream = get_lora_side_stream()
+
+    gate_up_delta_shape = (
+        hidden_states.shape[0],
+        runner_config.top_k,
+        quant_info.w13_weight.shape[1],
+    )
+    gate_up_delta = hidden_states.new_empty(gate_up_delta_shape)
+
+    def _run_gate_up_lora():
+        merged_experts_fused_moe_lora_add(
+            output=gate_up_delta,
+            hidden_states=hidden_states,
+            lora_a=lora_info.gate_up_lora_a_weights,
+            lora_b=lora_info.gate_up_lora_b_weights,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            token_lora_mapping=token_lora_mapping,
+            mul_routed_weight=False,
+            experts_shared_outer_loras_a=lora_info.experts_shared_outer_loras,
+            experts_shared_outer_loras_b=False,
+            routing_cache=fused_lora_routing_cache,
+            fuse_add_to_output=False,
+            use_direct_expand_add=lora_info.max_lora_rank <= 64,
+        )
+
+    # O1 fork — gate_up shrink/expand on side stream concurrent with the
+    # main-stream per-token-group FP8 quant below. gate_up needs only
+    # hidden_states + token_lora_mapping, so no conflict with quant.
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        _run_gate_up_lora()
+
+    a_q, a_sf = per_token_group_quant_fp8(hidden_states, quant_info.weight_block_k)
+    a_sf_t = a_sf.t().contiguous()
+
+    activation_lora_input = torch.empty(
+        (hidden_states.shape[0], runner_config.top_k, quant_info.intermediate_size),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    packed_topk_ids = _pack_topk_for_flashinfer_routed(
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+    )
+
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        direct_down_output = torch.empty(
+            hidden_states.shape[0],
+            hidden_states.shape[1],
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+    # O1 join — trtllm's activation step consumes gate_up_delta produced on side.
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    moe_result = trtllm_fp8_block_scale_routed_moe_lora(
+        topk_ids=packed_topk_ids,
+        routing_bias=None,
+        hidden_states=a_q,
+        hidden_states_scale=a_sf_t,
+        gemm1_weights=quant_info.w13_weight,
+        gemm1_weights_scale=quant_info.w13_weight_scale_inv,
+        gemm2_weights=quant_info.w2_weight,
+        gemm2_weights_scale=quant_info.w2_weight_scale_inv,
+        gate_up_lora_delta=gate_up_delta,
+        activation_lora_input=activation_lora_input,
+        num_experts=quant_info.global_num_experts,
+        top_k=runner_config.top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=quant_info.intermediate_size,
+        local_expert_offset=quant_info.local_expert_offset,
+        local_num_experts=quant_info.local_num_experts,
+        routed_scaling_factor=(
+            runner_config.routed_scaling_factor
+            if runner_config.routed_scaling_factor is not None
+            else 1.0
+        ),
+        routing_method_type=(
+            RoutingMethodType.TopK
+            if quant_info.routing_method_type == RoutingMethodType.DeepSeekV3
+            else quant_info.routing_method_type
+        ),
+        use_shuffled_weight=False,
+        do_finalize=True,
+        output=direct_down_output,
+        tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
+        fp8_quantization_type=Fp8QuantizationType.DeepSeekFp8,
+        activation_type=quant_info.activation_type,
+    )
+
+    output = moe_result
+    merged_experts_fused_moe_lora_add(
+        output=output,
+        hidden_states=activation_lora_input.view(-1, quant_info.intermediate_size),
+        lora_a=lora_info.down_lora_a_weights,
+        lora_b=lora_info.down_lora_b_weights,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        token_lora_mapping=token_lora_mapping,
+        mul_routed_weight=True,
+        experts_shared_outer_loras_a=False,
+        experts_shared_outer_loras_b=lora_info.experts_shared_outer_loras,
+        routing_cache=fused_lora_routing_cache,
+        fuse_add_to_output=False,
+        fuse_sum_all_reduce=True,
+        use_direct_expand_add=lora_info.max_lora_rank <= 64,
+    )
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
+++ b/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
@@ -17,6 +17,12 @@ from sglang.srt.lora.trtllm_moe import (
     is_two_stream_active,
 )
 
+# GEMM1-LoRA overlap: keep LoRA-ready events recorded during cuda-graph capture alive so the
+# captured cross-stream wait (resolved inside the trtllm op before activation) isn't torn down
+# before graph instantiation. Only appended while capturing; eager runs rely on CUDA's
+# deferred cudaEventDestroy.
+_LORA_OVERLAP_EVENTS: list = []
+
 
 def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
     dispatch_output,
@@ -116,12 +122,18 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
             local_num_experts=quant_info.local_num_experts,
         )
 
-    # O1 fork — gate_up shrink/expand on side stream concurrent with the
-    # main-stream per-token-group FP8 quant below. gate_up needs only
-    # hidden_states + token_lora_mapping, so no conflict with quant.
+    # GEMM1-LoRA overlap: fire the gate_up LoRA on the side stream + record an event; the
+    # trtllm op waits on it right before activation (the only consumer of gate_up_delta), so
+    # permute+GEMM1 overlap the side-stream LoRA shrink/expand instead of joining before the
+    # whole op.
+    lora_event = torch.cuda.Event()
+
+    # O1 fork — gate_up shrink/expand on side stream concurrent with the main-stream
+    # per-token-group FP8 quant + the trtllm op's permute+GEMM1 below.
     side_stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side_stream):
         _run_gate_up_lora()
+        lora_event.record()
 
     # Fuse the per-token scale transpose into the quant kernel: column-major scales make
     # the `.t()` a free view, dropping the standalone ~2us transpose+copy. The trtllm MoE
@@ -151,8 +163,12 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
             device=hidden_states.device,
         )
 
-    # O1 join — trtllm's activation step consumes gate_up_delta produced on side.
-    torch.cuda.current_stream().wait_stream(side_stream)
+    # No pre-op join: the trtllm op waits on lora_event right before its activation kernel,
+    # so permute+GEMM1 run concurrent with the side-stream LoRA. Keep the event alive through
+    # cuda-graph capture so the captured cross-stream wait isn't torn down before instantiation.
+    if torch.cuda.is_current_stream_capturing():
+        _LORA_OVERLAP_EVENTS.append(lora_event)
+    lora_ready_handle = lora_event.cuda_event
 
     moe_result = trtllm_fp8_block_scale_routed_moe_lora(
         topk_ids=packed_topk_ids,
@@ -165,6 +181,7 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
         gemm2_weights_scale=quant_info.w2_weight_scale_inv,
         gate_up_lora_delta=gate_up_delta,
         activation_lora_input=activation_lora_input,
+        lora_ready_event=lora_ready_handle,
         num_experts=quant_info.global_num_experts,
         top_k=runner_config.top_k,
         n_group=None,

--- a/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
+++ b/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
@@ -86,6 +86,10 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
 
     side_stream = get_lora_side_stream()
 
+    # EP-aware LoRA: under MoE EP each rank computes the delta only for its owned experts
+    # (passed via local_expert_offset/local_num_experts below). gate_up_delta stays
+    # new_empty even though non-owned [token, k] slots are then left unwritten -- the
+    # trtllm MoE is itself EP-aware, so those slots never feed the all-reduced output.
     gate_up_delta_shape = (
         hidden_states.shape[0],
         runner_config.top_k,
@@ -108,6 +112,8 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
             routing_cache=fused_lora_routing_cache,
             fuse_add_to_output=False,
             use_direct_expand_add=lora_info.max_lora_rank <= 64,
+            local_expert_offset=quant_info.local_expert_offset,
+            local_num_experts=quant_info.local_num_experts,
         )
 
     # O1 fork — gate_up shrink/expand on side stream concurrent with the
@@ -200,5 +206,7 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
         fuse_add_to_output=False,
         fuse_sum_all_reduce=True,
         use_direct_expand_add=lora_info.max_lora_rank <= 64,
+        local_expert_offset=quant_info.local_expert_offset,
+        local_num_experts=quant_info.local_num_experts,
     )
     return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
+++ b/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
@@ -117,8 +117,14 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
     with torch.cuda.stream(side_stream):
         _run_gate_up_lora()
 
-    a_q, a_sf = per_token_group_quant_fp8(hidden_states, quant_info.weight_block_k)
-    a_sf_t = a_sf.t().contiguous()
+    # Fuse the per-token scale transpose into the quant kernel: column-major scales make
+    # the `.t()` a free view, dropping the standalone ~2us transpose+copy. The trtllm MoE
+    # kernel wants the [K, M]-contiguous scale, which `.t()` of the column-major buffer is
+    # exactly -- byte/shape-identical to the old `a_sf.t().contiguous()`.
+    a_q, a_sf = per_token_group_quant_fp8(
+        hidden_states, quant_info.weight_block_k, column_major_scales=True
+    )
+    a_sf_t = a_sf.t()
 
     activation_lora_input = torch.empty(
         (hidden_states.shape[0], runner_config.top_k, quant_info.intermediate_size),

--- a/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
+++ b/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
@@ -13,6 +13,7 @@ import torch
 
 from sglang.srt.lora.trtllm_moe import (
     get_lora_side_stream,
+    get_original_fp4_moe_lora_func,
     get_original_moe_lora_func,
     is_two_stream_active,
 )
@@ -226,4 +227,198 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp8_lora_two_stream(
         local_expert_offset=quant_info.local_expert_offset,
         local_num_experts=quant_info.local_num_experts,
     )
+    return StandardCombineInput(hidden_states=output)
+
+
+def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream(
+    dispatch_output,
+    quant_info,
+    runner_config,
+    lora_info,
+):
+    """Two-stream NVFP4 sibling of the FP8 two-stream MoE LoRA dispatch.
+
+    Fires only for virtual-experts LoRA + decode-shaped batches; everything else
+    delegates to the saved-original single-stream FP4 dispatch (byte-identical).
+    """
+    hidden_states = dispatch_output.hidden_states
+
+    use_virtual_lora_store = bool(
+        lora_info.lora_use_virtual_experts and lora_info.max_lora_rank > 0
+    )
+    if not (use_virtual_lora_store and is_two_stream_active(hidden_states)):
+        return get_original_fp4_moe_lora_func()(
+            dispatch_output, quant_info, runner_config, lora_info
+        )
+
+    # ---- two-stream fast path ----
+    from sglang.jit_kernel.flashinfer_trtllm_moe import (
+        trtllm_fp4_block_scale_routed_moe_lora,
+    )
+    from sglang.srt.distributed import get_tp_group
+    from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+        use_symmetric_memory,
+    )
+    from sglang.srt.layers.dp_attention import is_allocation_symmetric
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        _pack_topk_for_flashinfer_routed,
+    )
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+    from sglang.srt.lora.triton_ops import merged_experts_fused_moe_lora_add
+
+    assert runner_config.activation == "silu" and runner_config.is_gated, (
+        "sgl_flashinfer_trtllm NVFP4 LoRA currently supports the gated SwiGLU path only."
+    )
+    topk_output = dispatch_output.topk_output
+    assert TopKOutputChecker.format_is_standard(topk_output)
+    assert runner_config.top_k is not None
+
+    topk_ids = topk_output.topk_ids
+    topk_weights = topk_output.topk_weights
+    token_lora_mapping = lora_info.token_lora_mapping
+    fused_lora_routing_cache: dict = {}
+    # Down-proj LoRA overlap is DISABLED: its side-stream NCCL all-reduce + act_ready_event
+    # cross-stream sync corrupts decode state under sustained heavy LoRA load (cuda-graph replay) —
+    # the server produces persistent garbage ("The!!!!") after a heavy LoRA bench. The gate_up
+    # overlap above is unaffected (verified safe under the same load); only the down-overlap is buggy,
+    # so the down-proj LoRA runs serially on the main stream. This is a PRE-EXISTING race (present in
+    # the env-gated nvfp4-lora reference too); re-enable only once the side-stream collective under
+    # cuda-graph capture is made correct.
+    _overlap_down = False
+
+    inter = quant_info.intermediate_size_per_partition
+    side_stream = get_lora_side_stream()
+
+    gate_up_delta = hidden_states.new_empty(
+        (hidden_states.shape[0], runner_config.top_k, quant_info.w13_weight.shape[1])
+    )
+
+    def _run_gate_up_lora():
+        merged_experts_fused_moe_lora_add(
+            output=gate_up_delta,
+            hidden_states=hidden_states,
+            lora_a=lora_info.gate_up_lora_a_weights,
+            lora_b=lora_info.gate_up_lora_b_weights,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            token_lora_mapping=token_lora_mapping,
+            mul_routed_weight=False,
+            experts_shared_outer_loras_a=lora_info.experts_shared_outer_loras,
+            experts_shared_outer_loras_b=False,
+            routing_cache=fused_lora_routing_cache,
+            fuse_add_to_output=False,
+            use_direct_expand_add=lora_info.max_lora_rank <= 64,
+            local_expert_offset=quant_info.local_expert_offset,
+            local_num_experts=quant_info.local_num_experts,
+        )
+
+    # O1-fp4 fork: gate_up shrink/expand on the side stream, concurrent with the
+    # FP4 op's permute + gate_up GEMM1 below. The op waits on lora_event right
+    # before its activation kernel (the only consumer of gate_up_delta).
+    lora_event = torch.cuda.Event()
+    act_ready_event = torch.cuda.Event() if _overlap_down else None
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        _run_gate_up_lora()
+        lora_event.record()
+
+    activation_lora_input = torch.empty(
+        (hidden_states.shape[0], runner_config.top_k, inter),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    packed_topk_ids = _pack_topk_for_flashinfer_routed(
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+    )
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        direct_down_output = torch.empty(
+            hidden_states.shape[0],
+            hidden_states.shape[1],
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        # Down-LoRA overlap: allocate + zero the delta buffer (symm-mem, for its all-reduce) BEFORE
+        # the op, so the op's act_ready_event (recorded mid-op, after activation) sequences after this
+        # zero-init and the side stream can safely accumulate the all-reduced down delta into it.
+        down_delta = torch.zeros_like(direct_down_output) if _overlap_down else None
+
+    # Keep the event alive through cuda-graph capture so the captured wait inside
+    # the FP4 op isn't torn down before instantiation (eager relies on deferred destroy).
+    if torch.cuda.is_current_stream_capturing():
+        _LORA_OVERLAP_EVENTS.append(lora_event)
+        if act_ready_event is not None:
+            _LORA_OVERLAP_EVENTS.append(act_ready_event)
+    lora_ready_handle = lora_event.cuda_event
+    act_ready_handle = act_ready_event.cuda_event if act_ready_event is not None else 0
+
+    output = trtllm_fp4_block_scale_routed_moe_lora(
+        topk_ids=packed_topk_ids,
+        routing_bias=None,
+        hidden_states=hidden_states,
+        hidden_states_scale=None,
+        gemm1_weights=quant_info.w13_weight,
+        gemm1_weights_scale=quant_info.w13_weight_scale.view(torch.float8_e4m3fn),
+        gemm2_weights=quant_info.w2_weight,
+        gemm2_weights_scale=quant_info.w2_weight_scale.view(torch.float8_e4m3fn),
+        output1_scales_scalar=quant_info.g1_scale_c,
+        output1_scales_gate_scalar=quant_info.g1_alphas,
+        output2_scales_scalar=quant_info.g2_alphas,
+        gate_up_lora_delta=gate_up_delta,
+        activation_lora_input=activation_lora_input,
+        lora_ready_event=lora_ready_handle,
+        act_ready_event=act_ready_handle,
+        num_experts=quant_info.global_num_experts,
+        top_k=runner_config.top_k,
+        intermediate_size=inter,
+        local_expert_offset=quant_info.local_expert_offset,
+        local_num_experts=quant_info.local_num_experts,
+        routed_scaling_factor=(
+            runner_config.routed_scaling_factor
+            if runner_config.routed_scaling_factor is not None
+            else 1.0
+        ),
+        routing_method_type=quant_info.routing_method_type,
+        do_finalize=True,
+        output=direct_down_output,
+    )
+
+    def _run_down_lora(out):
+        merged_experts_fused_moe_lora_add(
+            output=out,
+            hidden_states=activation_lora_input.view(-1, inter),
+            lora_a=lora_info.down_lora_a_weights,
+            lora_b=lora_info.down_lora_b_weights,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            token_lora_mapping=token_lora_mapping,
+            mul_routed_weight=True,
+            experts_shared_outer_loras_a=False,
+            experts_shared_outer_loras_b=lora_info.experts_shared_outer_loras,
+            routing_cache=fused_lora_routing_cache,
+            fuse_add_to_output=False,
+            fuse_sum_all_reduce=True,
+            use_direct_expand_add=lora_info.max_lora_rank <= 64,
+            local_expert_offset=quant_info.local_expert_offset,
+            local_num_experts=quant_info.local_num_experts,
+        )
+
+    if _overlap_down:
+        # Step-1 down overlap (all-reduce structure UNCHANGED, byte-equivalent to the serial path
+        # below): the op recorded act_ready_event after its activation kernel, so the side stream runs
+        # the down shrink/expand/all-reduce concurrent with the op's requant + down-GEMM + finalize,
+        # into the pre-zeroed symm-mem `down_delta`; the main stream adds it to the op output after
+        # both join.  (Step 2 — folding the add into a single finalize/all-reduce — is a follow-up.)
+        down_event = torch.cuda.Event()
+        with torch.cuda.stream(side_stream):
+            side_stream.wait_event(act_ready_event)
+            _run_down_lora(down_delta)
+            down_event.record()
+        if torch.cuda.is_current_stream_capturing():
+            _LORA_OVERLAP_EVENTS.append(down_event)
+        torch.cuda.current_stream().wait_event(down_event)
+        output.add_(down_delta)
+    else:
+        _run_down_lora(output)
     return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
+++ b/python/sglang/srt/lora/trtllm_moe/moe_overlap.py
@@ -278,15 +278,12 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream(
     topk_weights = topk_output.topk_weights
     token_lora_mapping = lora_info.token_lora_mapping
     fused_lora_routing_cache: dict = {}
-    # Down-proj LoRA overlap is DISABLED: its side-stream NCCL all-reduce + act_ready_event
-    # cross-stream sync corrupts decode state under sustained heavy LoRA load (cuda-graph replay) —
-    # the server produces persistent garbage ("The!!!!") after a heavy LoRA bench. The gate_up
-    # overlap above is unaffected (verified safe under the same load); only the down-overlap is buggy,
-    # so the down-proj LoRA runs serially on the main stream. This is a PRE-EXISTING race (present in
-    # the env-gated nvfp4-lora reference too); re-enable only once the side-stream collective under
-    # cuda-graph capture is made correct.
-    _overlap_down = False
 
+    # Down-proj LoRA runs serially on the main stream (after the trtllm op). The side-stream
+    # down-overlap was removed: bench-verified net-neutral-to-negative (the extra side-stream
+    # all-reduce cancels any overlap gain), AND its act_ready_event cross-stream sync corrupted
+    # decode state under sustained heavy LoRA load (cuda-graph replay -> persistent garbage). Only
+    # the gate_up overlap (O1-fp4, below) is kept; it is bench-safe under the same load.
     inter = quant_info.intermediate_size_per_partition
     side_stream = get_lora_side_stream()
 
@@ -317,7 +314,6 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream(
     # FP4 op's permute + gate_up GEMM1 below. The op waits on lora_event right
     # before its activation kernel (the only consumer of gate_up_delta).
     lora_event = torch.cuda.Event()
-    act_ready_event = torch.cuda.Event() if _overlap_down else None
     side_stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side_stream):
         _run_gate_up_lora()
@@ -339,19 +335,12 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream(
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
-        # Down-LoRA overlap: allocate + zero the delta buffer (symm-mem, for its all-reduce) BEFORE
-        # the op, so the op's act_ready_event (recorded mid-op, after activation) sequences after this
-        # zero-init and the side stream can safely accumulate the all-reduced down delta into it.
-        down_delta = torch.zeros_like(direct_down_output) if _overlap_down else None
 
     # Keep the event alive through cuda-graph capture so the captured wait inside
     # the FP4 op isn't torn down before instantiation (eager relies on deferred destroy).
     if torch.cuda.is_current_stream_capturing():
         _LORA_OVERLAP_EVENTS.append(lora_event)
-        if act_ready_event is not None:
-            _LORA_OVERLAP_EVENTS.append(act_ready_event)
     lora_ready_handle = lora_event.cuda_event
-    act_ready_handle = act_ready_event.cuda_event if act_ready_event is not None else 0
 
     output = trtllm_fp4_block_scale_routed_moe_lora(
         topk_ids=packed_topk_ids,
@@ -368,7 +357,6 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream(
         gate_up_lora_delta=gate_up_delta,
         activation_lora_input=activation_lora_input,
         lora_ready_event=lora_ready_handle,
-        act_ready_event=act_ready_handle,
         num_experts=quant_info.global_num_experts,
         top_k=runner_config.top_k,
         intermediate_size=inter,
@@ -404,21 +392,5 @@ def fused_experts_none_to_sgl_flashinfer_trtllm_fp4_lora_two_stream(
             local_num_experts=quant_info.local_num_experts,
         )
 
-    if _overlap_down:
-        # Step-1 down overlap (all-reduce structure UNCHANGED, byte-equivalent to the serial path
-        # below): the op recorded act_ready_event after its activation kernel, so the side stream runs
-        # the down shrink/expand/all-reduce concurrent with the op's requant + down-GEMM + finalize,
-        # into the pre-zeroed symm-mem `down_delta`; the main stream adds it to the op output after
-        # both join.  (Step 2 — folding the add into a single finalize/all-reduce — is a follow-up.)
-        down_event = torch.cuda.Event()
-        with torch.cuda.stream(side_stream):
-            side_stream.wait_event(act_ready_event)
-            _run_down_lora(down_delta)
-            down_event.record()
-        if torch.cuda.is_current_stream_capturing():
-            _LORA_OVERLAP_EVENTS.append(down_event)
-        torch.cuda.current_stream().wait_event(down_event)
-        output.add_(down_delta)
-    else:
-        _run_down_lora(output)
+    _run_down_lora(output)
     return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/lora/trtllm_moe/sgemm_lora_a_split_k.py
+++ b/python/sglang/srt/lora/trtllm_moe/sgemm_lora_a_split_k.py
@@ -248,4 +248,6 @@ def sgemm_lora_a_fwd_split_k(
         BLOCK_K,
         split_k,
     )
-    return output.to(x.dtype) if split_k > 1 else output
+    # split_k>1 returns the fp32 accumulator directly; the LoRA-B expand casts x to the weight dtype
+    # on-load (fused), dropping the standalone fp32->bf16 copy kernel. split_k==1 already returns x.dtype.
+    return output

--- a/python/sglang/srt/lora/trtllm_moe/sgemm_lora_a_split_k.py
+++ b/python/sglang/srt/lora/trtllm_moe/sgemm_lora_a_split_k.py
@@ -1,3 +1,16 @@
+"""Opt-in fp32 split-K for the dense LoRA-A (shrink) GEMM.
+
+Vendored from sgl-project/sglang PR #26962 (https://github.com/sgl-project/sglang/pull/26962) so the
+split-K path lives in one file behind the ``SGLANG_ENABLE_LORA_SHRINK_SPLIT_K`` gate; the base
+``triton_ops/sgemm_lora_a.py`` routes here only when that env is set (default off → original kernel).
+
+At decode the shrink grid is ~bs programs (one N-block/seq; rank is tiny), far below the SM count, so the
+large-K reduction under-fills the GPU. This splits K across SPLIT_K programs that fp32-atomic-add into a
+pre-zeroed accumulator, then casts back to the activation dtype. SPLIT_K==1 (prefill / large batch / small
+K, or env off) is the original single-program path, bit-identical to the base kernel.
+"""
+import functools
+
 import torch
 import triton
 import triton.language as tl
@@ -36,6 +49,7 @@ def _sgemm_lora_a_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    SPLIT_K: tl.constexpr = 1,
 ):
     """
     Computes a segmented batched matrix multiplication for the LoRA A matrix.
@@ -44,6 +58,16 @@ def _sgemm_lora_a_kernel(
     stores the product of the input `x` and the LoRA weights for the corresponding
     sequence. This implies that when rank is 0, the kernel is essentially a no-op,
     as output[seg_start:seg_start + seg_len, :0] is trivially correct (empty).
+
+    SPLIT_K (constexpr, default 1) splits the K reduction across SPLIT_K programs
+    for the under-filled decode shape (the shrink grid is ~bs programs, far below
+    the SM count, so a large-K reduction leaves SMs idle). With SPLIT_K > 1 each
+    program walks a strided K-slice and atomic-adds its partial sum into `output`,
+    which MUST then be fp32 (and pre-zeroed): bf16 atomic_add is an emulated CAS
+    loop that contends and loses precision, whereas native fp32 atomics scale and
+    are exact -- the launcher casts the fp32 result back to the activation dtype.
+    SPLIT_K == 1 is the plain single-program store path (compile-time identical to
+    the non-split kernel; constexpr folds the split-only expressions away).
 
     Args:
         x (torch.Tensor): The input activations tensor of shape `(s, K)`, where `s`
@@ -64,6 +88,10 @@ def _sgemm_lora_a_kernel(
         return
 
     pid = tl.program_id(axis=0)
+    # Fold the split-K factor out of axis-0 (SPLIT_K == 1 -> pid_sk == 0, pid_tile == pid).
+    pid_sk = pid % SPLIT_K
+    pid_tile = pid // SPLIT_K
+
     seg_start = tl.load(seg_indptr + batch_id)
     seg_len = tl.load(seg_lens + batch_id)
     if seg_len == 0:
@@ -74,17 +102,18 @@ def _sgemm_lora_a_kernel(
 
     # The tile in output matrix will have (pid_s, pid_n) as id
     num_pid_n = tl.cdiv(N, BLOCK_N)
-    pid_s = pid // num_pid_n
-    pid_n = pid % num_pid_n
+    pid_s = pid_tile // num_pid_n
+    pid_n = pid_tile % num_pid_n
     if pid_s * BLOCK_S >= seg_len:
         return
 
     # Create pointers for the first block of x and weights[batch_id]
     # The pointers will be advanced as we move in the K direction
-    # and accumulate
+    # and accumulate. With SPLIT_K > 1 this program starts at K-tile pid_sk and
+    # strides by BLOCK_K * SPLIT_K; with SPLIT_K == 1 it walks all of K.
     s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
     n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
-    k_offset = tl.arange(0, BLOCK_K)
+    k_offset = pid_sk * BLOCK_K + tl.arange(0, BLOCK_K)
     s_physical = _resolve_token_positions(
         sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
     )
@@ -95,43 +124,46 @@ def _sgemm_lora_a_kernel(
 
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
+    for k in range(0, tl.cdiv(K, BLOCK_K * SPLIT_K)):
+        k_remaining = K - k * (BLOCK_K * SPLIT_K)
         x_tile = tl.load(
             x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
+            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < k_remaining),
             other=0.0,
         )
         w_tile = tl.load(
             w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & (n_offset[None, :] < N),
+            mask=(k_offset[:, None] < k_remaining) & (n_offset[None, :] < N),
             other=0.0,
         )
         partial_sum += tl.dot(x_tile, w_tile)
 
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
+        x_ptrs += BLOCK_K * SPLIT_K * x_stride_1
+        w_ptrs += BLOCK_K * SPLIT_K * w_stride_2
 
     # Store result to output matrix
-    partial_sum = partial_sum.to(x.dtype.element_ty)
     output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
     output_ptr = output + (
         s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
     )
-    tl.store(output_ptr, partial_sum, mask=output_mask)
+    if SPLIT_K == 1:
+        tl.store(output_ptr, partial_sum.to(output.dtype.element_ty), mask=output_mask)
+    else:
+        # fp32 accumulator, pre-zeroed; combine the K-splits with native fp32 atomics.
+        tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
 
 
-def sgemm_lora_a_fwd(
+@functools.lru_cache(maxsize=None)
+def _num_sms(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+def sgemm_lora_a_fwd_split_k(
     x: torch.Tensor,
     weights: torch.Tensor,
     batch_info: LoRABatchInfo,
     stack_num: int = 1,
 ) -> torch.Tensor:
-    # Opt-in fp32 split-K for the dense LoRA-A shrink (PR #26962): route to the gated implementation in
-    # trtllm_moe/sgemm_lora_a_split_k.py. Default (env off) falls through to the original path below.
-    if envs.SGLANG_ENABLE_LORA_SHRINK_SPLIT_K.get():
-        from sglang.srt.lora.trtllm_moe.sgemm_lora_a_split_k import sgemm_lora_a_fwd_split_k
-
-        return sgemm_lora_a_fwd_split_k(x, weights, batch_info, stack_num)
     # x: (s, input_dim)
     # weights: (num_lora, stack_num * r, input_dim)
     # output: (s, stack_num * r)
@@ -154,14 +186,37 @@ def sgemm_lora_a_fwd(
     BLOCK_K = 256
     BLOCK_R = 16
 
+    sorted_by_adapter = batch_info.permutation is not None
+
+    # Opt-in split-K for the under-filled decode shape: the shrink grid is ~bs
+    # programs, far below the SM count, so a large-K reduction leaves SMs idle.
+    # Target ~2x SM oversubscription, capped by the K-tile count and at 16 (the
+    # win plateaus by sk16-24). split_k stays 1 (the plain store path, compile-time
+    # identical to before) for prefill, large batch, or small K, and whenever the
+    # flag is off. See SGLANG_ENABLE_LORA_SHRINK_SPLIT_K.
+    split_k = 1
+    if envs.SGLANG_ENABLE_LORA_SHRINK_SPLIT_K.get() and x.is_cuda:
+        num_k_tiles = triton.cdiv(K, BLOCK_K)
+        base_grid = batch_info.bs * triton.cdiv(batch_info.max_len, BLOCK_S)
+        num_sms = _num_sms(x.device.index)
+        if base_grid < num_sms and num_k_tiles >= 8:
+            split_k = max(1, min(2 * num_sms // base_grid, num_k_tiles, 16))
+
+    if split_k > 1:
+        # Cover the whole rank in one N-block (BLOCK_N >= R => num_pid_n == 1) and
+        # accumulate in a pre-zeroed fp32 buffer; cast back to x.dtype afterwards so
+        # the LoRA-B expand consumer keeps its bf16 input contract unchanged.
+        BLOCK_N = triton.next_power_of_2(R)
+        output = torch.zeros((S, R), device=x.device, dtype=torch.float32)
+    else:
+        BLOCK_N = BLOCK_R
+        output = torch.empty((S, R), device=x.device, dtype=x.dtype)
+
     grid = (
-        triton.cdiv(batch_info.max_len, BLOCK_S) * triton.cdiv(R, BLOCK_R),
+        triton.cdiv(batch_info.max_len, BLOCK_S) * triton.cdiv(R, BLOCK_N) * split_k,
         batch_info.bs,
     )
 
-    sorted_by_adapter = batch_info.permutation is not None
-
-    output = torch.empty((S, R), device=x.device, dtype=x.dtype)
     _sgemm_lora_a_kernel[grid](
         x,
         weights,
@@ -183,7 +238,8 @@ def sgemm_lora_a_fwd(
         batch_info.permutation,
         sorted_by_adapter,
         BLOCK_S,
-        BLOCK_R,
+        BLOCK_N,
         BLOCK_K,
+        split_k,
     )
-    return output
+    return output.to(x.dtype) if split_k > 1 else output

--- a/python/sglang/srt/lora/trtllm_moe/sgemm_lora_a_split_k.py
+++ b/python/sglang/srt/lora/trtllm_moe/sgemm_lora_a_split_k.py
@@ -163,7 +163,13 @@ def sgemm_lora_a_fwd_split_k(
     weights: torch.Tensor,
     batch_info: LoRABatchInfo,
     stack_num: int = 1,
+    out_alloc_stream=None,
 ) -> torch.Tensor:
+    # out_alloc_stream: accepted for signature parity with sgemm_lora_a_fwd. Main-stream output
+    # allocation (SGLANG_OPT_LORA_OVERLAP_MAIN_ALLOC) is not wired into the split-K path — no current
+    # config exercises split-K together with the two-stream overlap on a mamba model (qwen3.5 leaves
+    # split-K off; kimi uses split-K but is coherent with a single stream — no mamba). Wire it here if
+    # that combination ever ships.
     # x: (s, input_dim)
     # weights: (num_lora, stack_num * r, input_dim)
     # output: (s, stack_num * r)

--- a/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
+++ b/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
@@ -1,0 +1,187 @@
+"""Rank-specialized LoRA-B expand for virtual-expert LoRA.
+
+The kernel here was originally a chunk in ``lora/triton_ops/virtual_experts.py``.
+It is rank-specialized: the ``R`` dimension (LoRA rank) is a triton
+``constexpr``, so each rank value used at runtime gets its own JIT-compiled
+specialization (R=16, R=32, R=64 are all supported up to the ``R <= 64`` assert,
+with no perf interaction between them — each gets its own kernel).
+
+Called from :mod:`sglang.srt.lora.triton_ops.virtual_experts` when
+``use_direct_expand_add=True`` (the trtllm-lora path uses this when
+``max_lora_rank <= 64``); the generic ``invoke_fused_moe_kernel`` is used
+when that flag is False (incl. ranks above 64).
+"""
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _moe_lora_expand_add_kernel(
+    # Pointers
+    a_ptr,  # [num_tokens * top_k, rank]
+    b_ptr,  # [num_virtual_experts, N, rank]
+    c_ptr,  # [num_tokens, N]
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Dimensions
+    N,
+    R: tl.constexpr,
+    num_valid_tokens,
+    # Strides
+    stride_am,
+    stride_ar,
+    stride_be,
+    stride_bn,
+    stride_br,
+    stride_cm,
+    stride_cn,
+    # Constexprs
+    router_topk: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    FUSE_SUM_ALL_REDUCE: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_R: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Rank-specialized LoRA-B expand for virtual-expert LoRA."""
+    pid = tl.program_id(0)
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+    num_pid_m = tl.cdiv(num_tokens_post_padded, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id).to(tl.int64)
+    token_mask = offs_token < num_valid_tokens
+
+    off_expert = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+    if off_expert == -1:
+        if not FUSE_SUM_ALL_REDUCE:
+            offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+            c_ptrs = (
+                c_ptr
+                + offs_token[:, None] * stride_cm
+                + offs_n[None, :] * stride_cn
+            )
+            c_mask = token_mask[:, None] & (offs_n[None, :] < N)
+            zeros = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=c_ptr.dtype.element_ty)
+            tl.store(c_ptrs, zeros, mask=c_mask)
+        return
+
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    offs_r = tl.arange(0, BLOCK_SIZE_R).to(tl.int64)
+    rank_mask = offs_r < R
+
+    a = tl.load(
+        a_ptr + offs_token[:, None] * stride_am + offs_r[None, :] * stride_ar,
+        mask=token_mask[:, None] & rank_mask[None, :],
+        other=0.0,
+    )
+    b = tl.load(
+        b_ptr
+        + off_expert * stride_be
+        + offs_n[None, :] * stride_bn
+        + offs_r[:, None] * stride_br,
+        mask=(offs_n[None, :] < N) & rank_mask[:, None],
+        other=0.0,
+    )
+
+    accumulator = tl.dot(a, b, out_dtype=tl.float32)
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0.0)
+        accumulator *= moe_weight[:, None]
+
+    if FUSE_SUM_ALL_REDUCE:
+        offs_token_out = offs_token // router_topk
+    else:
+        offs_token_out = offs_token
+    c_ptrs = (
+        c_ptr
+        + offs_token_out[:, None] * stride_cm
+        + offs_n[None, :] * stride_cn
+    )
+    c_mask = token_mask[:, None] & (offs_n[None, :] < N)
+    if FUSE_SUM_ALL_REDUCE:
+        tl.atomic_add(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=c_mask)
+    else:
+        tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=c_mask)
+
+
+def _invoke_moe_lora_expand_add(
+    intermediate: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    config: "dict[str, Any]",
+    mul_routed_weight: bool,
+    fuse_sum_all_reduce: bool,
+) -> None:
+    """Launch the rank-specialized LoRA-B expand kernel.
+
+    ``R`` (= ``weight.shape[2]``) up to 64 is supported. ``BLOCK_SIZE_R`` is
+    set to ``next_power_of_2(R)`` so each rank value pairs with the smallest
+    tile that covers it (R=16 → BSR=16, R=32 → BSR=32, R=64 → BSR=64).
+    Triton compiles a separate specialization per (R, BLOCK_SIZE_R) combo
+    so different ranks don't interfere with each other's perf.
+    """
+    N = weight.shape[1]
+    R = weight.shape[2]
+    assert R <= 64, f"direct LoRA expand/add expects rank <= 64, got {R}"
+
+    block_size_m = config["BLOCK_SIZE_M"]
+    block_size_n = 128 if N % 128 == 0 else config["BLOCK_SIZE_N"]
+    group_size_m = config.get("GROUP_SIZE_M", 1)
+    block_size_r = triton.next_power_of_2(R)
+
+    grid = (
+        triton.cdiv(sorted_token_ids.shape[0], block_size_m)
+        * triton.cdiv(N, block_size_n),
+    )
+
+    _moe_lora_expand_add_kernel[grid](
+        intermediate,
+        weight,
+        output,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        N,
+        R,
+        topk_ids.numel(),
+        intermediate.stride(0),
+        intermediate.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        output.stride(-2),
+        output.stride(-1),
+        router_topk=topk_ids.shape[1],
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        FUSE_SUM_ALL_REDUCE=fuse_sum_all_reduce,
+        BLOCK_SIZE_M=block_size_m,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_R=block_size_r,
+        GROUP_SIZE_M=group_size_m,
+        num_warps=config.get("num_warps", 4),
+        num_stages=1,
+    )

--- a/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
+++ b/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
@@ -18,6 +18,7 @@ import triton
 import triton.language as tl
 
 
+
 @triton.jit
 def _moe_lora_expand_add_kernel(
     # Pointers
@@ -48,8 +49,18 @@ def _moe_lora_expand_add_kernel(
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_R: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
+    GATED_A_HALF: tl.constexpr,
 ):
-    """Rank-specialized LoRA-B expand for virtual-expert LoRA."""
+    """Rank-specialized LoRA-B expand for virtual-expert LoRA.
+
+    ``GATED_A_HALF`` > 0 enables the gate/up split for a gated (SwiGLU) gate_up
+    LoRA: the intermediate (A) has ``2*R`` columns (gate-shrink ``[0:R]`` then
+    up-shrink ``[R:2R]``) and the output has ``2*GATED_A_HALF`` columns (gate
+    then up). Output tiles in the up half (column >= ``GATED_A_HALF``) read the
+    up-shrink columns ``[R:2R]`` instead of ``[0:R]``. ``GATED_A_HALF`` must be
+    a multiple of ``BLOCK_SIZE_N`` so no tile straddles the gate/up boundary.
+    ``GATED_A_HALF == 0`` is the non-gated path (read ``[0:R]`` for all tiles).
+    """
     pid = tl.program_id(0)
     num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
     num_pid_m = tl.cdiv(num_tokens_post_padded, BLOCK_SIZE_M)
@@ -87,8 +98,14 @@ def _moe_lora_expand_add_kernel(
     offs_r = tl.arange(0, BLOCK_SIZE_R).to(tl.int64)
     rank_mask = offs_r < R
 
+    # Gated gate_up split: the up-half output tiles read up-shrink (A columns [R:2R]); gate-half
+    # tiles read gate-shrink (A columns [0:R]). GATED_A_HALF == 0 -> always read [0:R] (non-gated).
+    a_col = offs_r
+    if GATED_A_HALF > 0:
+        a_col = offs_r + tl.where(pid_n * BLOCK_SIZE_N >= GATED_A_HALF, R, 0)
+
     a = tl.load(
-        a_ptr + offs_token[:, None] * stride_am + offs_r[None, :] * stride_ar,
+        a_ptr + offs_token[:, None] * stride_am + a_col[None, :] * stride_ar,
         mask=token_mask[:, None] & rank_mask[None, :],
         other=0.0,
     )
@@ -152,6 +169,13 @@ def _invoke_moe_lora_expand_add(
     group_size_m = config.get("GROUP_SIZE_M", 1)
     block_size_r = triton.next_power_of_2(R)
 
+    # gate_up LoRA: the rank-specialized expand reads the intermediate's [0:R] shrink for both the gate
+    # and up output halves, which is correct for the supported adapters (kimi + qwen, verified vs
+    # cutlass/triton). A previous env-gated "gated split" (up reads up-shrink [R:2R]) assumed a
+    # [gate_A; up_A]-stacked layout that does NOT match these adapters — enabling it made kimi
+    # acc-vs-cutlass jump 0.36 -> 1.32 (wrong) — so the knob (SGLANG_ENABLE_LORA_GATED_SPLIT) was removed.
+    gated_a_half = 0
+
     grid = (
         triton.cdiv(sorted_token_ids.shape[0], block_size_m)
         * triton.cdiv(N, block_size_n),
@@ -182,6 +206,7 @@ def _invoke_moe_lora_expand_add(
         BLOCK_SIZE_N=block_size_n,
         BLOCK_SIZE_R=block_size_r,
         GROUP_SIZE_M=group_size_m,
+        GATED_A_HALF=gated_a_half,
         num_warps=config.get("num_warps", 4),
         num_stages=1,
     )

--- a/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
+++ b/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
@@ -151,6 +151,7 @@ def _invoke_moe_lora_expand_add(
     config: "dict[str, Any]",
     mul_routed_weight: bool,
     fuse_sum_all_reduce: bool,
+    force_block_size_n: "int | None" = None,
 ) -> None:
     """Launch the rank-specialized LoRA-B expand kernel.
 
@@ -165,7 +166,13 @@ def _invoke_moe_lora_expand_add(
     assert R <= 64, f"direct LoRA expand/add expects rank <= 64, got {R}"
 
     block_size_m = config["BLOCK_SIZE_M"]
-    block_size_n = 128 if N % 128 == 0 else config["BLOCK_SIZE_N"]
+    # BLOCK_SIZE_N defaults to 128 when N % 128 == 0 (a good N-divisible tile that also keeps
+    # the gated gate_up split aligned). ``force_block_size_n`` lets a tuner/bench override it;
+    # down-proj has no gate/up boundary, so any divisor of N is valid there.
+    if force_block_size_n is not None:
+        block_size_n = force_block_size_n
+    else:
+        block_size_n = 128 if N % 128 == 0 else config["BLOCK_SIZE_N"]
     group_size_m = config.get("GROUP_SIZE_M", 1)
     block_size_r = triton.next_power_of_2(R)
 

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -15,13 +15,10 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 )
 from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
 from sglang.srt.lora.deepseek_mla_correction import (
-    apply_q_correction as apply_kv_b_lora_q_correction,
-)
-from sglang.srt.lora.deepseek_mla_correction import (
-    apply_v_correction as apply_kv_b_lora_v_correction,
-)
-from sglang.srt.lora.deepseek_mla_correction import (
-    is_kv_b_lora_active,
+    kv_b_lora_q_apply,
+    kv_b_lora_q_prepare,
+    kv_b_lora_v_apply,
+    kv_b_lora_v_prepare,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import (
@@ -284,6 +281,10 @@ class DeepseekMLAForwardMixin:
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         k_pe = latent_cache[..., self.kv_lora_rank :].unsqueeze(1)
 
+        # O12-q: fork the kv_b q-correction A-step onto the LoRA side stream so it
+        # overlaps the q_nope @ w_kc bmm below. None (serial) when two-stream off.
+        _kvb_q = kv_b_lora_q_prepare(self, q_nope)
+
         if self.use_deep_gemm_bmm:
             (
                 q_nope_val,
@@ -367,8 +368,7 @@ class DeepseekMLAForwardMixin:
             q_nope_out = torch.bmm(q_nope.transpose(0, 1), self.w_kc)
 
         q_nope_out = q_nope_out.transpose(0, 1)
-        if is_kv_b_lora_active(self):
-            q_nope_out = apply_kv_b_lora_q_correction(self, q_nope, q_nope_out)
+        q_nope_out = kv_b_lora_q_apply(self, q_nope, q_nope_out, _kvb_q)
 
         skip_rope_for_dsa_tilelang_fused = self._skip_rope_for_dsa_tilelang_fused()
         skip_rope_for_aiter_fused_mla = self._skip_rope_for_aiter_fused_mla()
@@ -548,6 +548,10 @@ class DeepseekMLAForwardMixin:
             )
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
 
+        # O12-v: fork the kv_b v-correction A-step onto the LoRA side stream so it
+        # overlaps the attn_output @ w_vc bmm below. None (serial) when off.
+        _kvb_v = kv_b_lora_v_prepare(self, attn_output)
+
         if self.use_deep_gemm_bmm:
             (
                 attn_output_val,
@@ -686,10 +690,9 @@ class DeepseekMLAForwardMixin:
                         -1, self.num_local_heads, self.v_head_dim
                     ).transpose(0, 1),
                 )
-        if is_kv_b_lora_active(self):
-            attn_bmm_output = apply_kv_b_lora_v_correction(
-                self, attn_output, attn_bmm_output
-            )
+        attn_bmm_output = kv_b_lora_v_apply(
+            self, attn_output, attn_bmm_output, _kvb_v
+        )
         output, _ = self.o_proj(attn_bmm_output)
 
         if self.next_skip_topk is None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -215,6 +215,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "triton",
     "triton_kernel",
     "flashinfer_trtllm",
+    "sgl_flashinfer_trtllm",
     "flashinfer_trtllm_routed",
     "flashinfer_cutlass",
     "flashinfer_mxfp4",
@@ -3307,7 +3308,7 @@ class ServerArgs:
                 "FlashInfer CuteDSL MoE is enabled. --disable-shared-experts-fusion is automatically set."
             )
 
-        if self.moe_runner_backend == "flashinfer_trtllm":
+        if self.moe_runner_backend in ["flashinfer_trtllm", "sgl_flashinfer_trtllm"]:
             assert self.quantization in [
                 "modelopt_fp4",
                 "fp8",

--- a/test/registered/lora/test_moe_lora_expand_add.py
+++ b/test/registered/lora/test_moe_lora_expand_add.py
@@ -1,0 +1,156 @@
+"""Unit test for the rank-specialized LoRA-B expand-add kernel
+(`_moe_lora_expand_add_kernel` in
+`sglang/srt/lora/trtllm_moe/specialized_expand.py`), scoped to the **down-proj** GEMM.
+
+The down-proj caller (`lora_dispatch.py`, `moe_overlap.py`) drives this kernel with
+`mul_routed_weight=True` + `fuse_sum_all_reduce=True`: each of a token's `top_k`
+per-expert deltas is scaled by its routing weight and atomic-added into the single
+per-token output row. This test checks that fused variant against a torch reference for
+the qwen3.5-35b local-EP shape (64 experts, N=2048, rank=16, top_k=8).
+
+It also guards the routing/tiling block-size contract: `_invoke_moe_lora_expand_add`
+tiles `expert_ids` with `config["BLOCK_SIZE_M"]` (one entry per M-block), so the routing
+buffers MUST be aligned with the same block. The test sweeps block_m {16,32,64} so any
+hardcoded mismatch overruns `expert_ids` -> CUDA illegal memory access (the same class
+of bug as the shrink f2adddd regression).
+
+Companion micro-benchmark: `benchmark/kernels/lora_moe_expand/bench_expand_add_down.py`.
+
+Usage:
+    python -m pytest test/registered/lora/test_moe_lora_expand_add.py -v
+"""
+
+import unittest
+
+import torch
+import triton
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.srt.lora.triton_ops.virtual_experts import (
+    _fused_virtual_topk_ids,
+    fused_sanitize_expert_ids,
+)
+from sglang.srt.lora.trtllm_moe.specialized_expand import _invoke_moe_lora_expand_add
+
+
+def _make_inputs(bs, num_experts, top_k, n, rank, dtype, device):
+    torch.manual_seed(0)
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:top_k] for _ in range(bs)]
+    ).to(torch.int32)
+    topk_weights = torch.rand(bs, top_k, device=device, dtype=torch.float32) * 0.9 + 0.1
+    token_lora_mapping = torch.zeros(bs, device=device, dtype=torch.int32)
+    intermediate = torch.randn(bs * top_k, rank, device=device, dtype=dtype) * 0.1
+    lora_b = torch.randn(1, num_experts, n, rank, device=device, dtype=dtype) * 0.1
+    return topk_ids, topk_weights, token_lora_mapping, intermediate, lora_b
+
+
+def _build_routing(topk_ids, token_lora_mapping, num_experts, block_m):
+    """Single-adapter virtual-expert routing tiled at ``block_m`` (mirrors
+    `_get_routing` in virtual_experts.py: virtual ids -> align -> tight trim ->
+    sanitize)."""
+    virtual_topk_ids, _, virtual_num_experts = _fused_virtual_topk_ids(
+        topk_ids, token_lora_mapping, num_experts, shared_outer=False, max_loras=1
+    )
+    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+        virtual_topk_ids, block_m, virtual_num_experts
+    )
+    num_tokens = topk_ids.numel()
+    max_nonempty = min(num_tokens, virtual_num_experts)
+    tight = triton.cdiv(num_tokens + max_nonempty * (block_m - 1), block_m) * block_m
+    return (
+        sorted_token_ids[:tight],
+        fused_sanitize_expert_ids(expert_ids[: tight // block_m], virtual_num_experts),
+        num_tokens_post_padded,
+    )
+
+
+def _expand(intermediate, lora_b, topk_ids, topk_weights, routing, block_m):
+    sorted_token_ids, expert_ids, num_tokens_post_padded = routing
+    lora_b_virtual = lora_b.reshape(lora_b.shape[0] * lora_b.shape[1], *lora_b.shape[2:])
+    n = lora_b.shape[2]
+    bs = topk_ids.shape[0]
+    # fuse_sum_all_reduce atomic-adds the top_k deltas into one row -> zero each call.
+    output = torch.zeros(bs, n, dtype=intermediate.dtype, device=intermediate.device)
+    config = {"BLOCK_SIZE_M": block_m, "BLOCK_SIZE_N": 64, "GROUP_SIZE_M": 1, "num_warps": 4}
+    _invoke_moe_lora_expand_add(
+        intermediate,
+        lora_b_virtual,
+        output,
+        topk_weights.reshape(-1),
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        config,
+        mul_routed_weight=True,
+        fuse_sum_all_reduce=True,
+    )
+    return output
+
+
+def _ref_expand(intermediate, lora_b, topk_ids, topk_weights):
+    bs, top_k = topk_ids.shape
+    n = lora_b.shape[2]
+    b = lora_b[0].float()
+    inter = intermediate.float()
+    out = torch.zeros(bs, n, device=intermediate.device, dtype=torch.float32)
+    for m in range(bs):
+        for k in range(top_k):
+            e = int(topk_ids[m, k].item())
+            vt = m * top_k + k
+            out[m] += (inter[vt] @ b[e].t()) * float(topk_weights[m, k].item())
+    return out
+
+
+class TestMoeLoraExpandAddDown(CustomTestCase):
+    """Correctness of the fused (routed-weight + sum-all-reduce) down-proj expand-add."""
+
+    NUM_EXPERTS = 64
+    TOP_K = 8
+    N = 2048
+    RANK = 16
+    # fp32 reference vs per-expert bf16 atomic-add accumulation -> generous abs tol.
+    TOL = 5e-2
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA required")
+        cls.device = "cuda:0"
+
+    def _check(self, bs, block_m):
+        topk_ids, tkw, tlm, inter, lb = _make_inputs(
+            bs, self.NUM_EXPERTS, self.TOP_K, self.N, self.RANK,
+            torch.bfloat16, self.device,
+        )
+        routing = _build_routing(topk_ids, tlm, self.NUM_EXPERTS, block_m)
+        out = _expand(inter, lb, topk_ids, tkw, routing, block_m).float()
+        ref = _ref_expand(inter, lb, topk_ids, tkw)
+        err = float((out - ref).abs().max().item())
+        self.assertLessEqual(
+            err, self.TOL, f"bs={bs} block_m={block_m} max_abs_err={err:.4e}"
+        )
+
+    def test_p0_bs64_rank16(self):
+        """P0 scope: bs=64, rank=16, production-tuned block_m=64."""
+        self._check(bs=64, block_m=64)
+
+    def test_block_m_contract_sweep(self):
+        """Routing must be tiled with the same block the launcher uses. Sweeping block_m
+        catches any hardcoded-block mismatch (expert_ids overrun -> IMA)."""
+        for bs in (16, 64):
+            for block_m in (16, 32, 64):
+                with self.subTest(bs=bs, block_m=block_m):
+                    self._check(bs, block_m)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a LoRA-enabled trtllm-gen MoE backend for FP8 Qwen3 / Qwen3-VL serving plus a side-stream overlap optimization that pushes LoRA decode throughput from ~45% to ~74–85% of the no-LoRA ceiling.

What's in this PR:

- **`sgl_flashinfer_trtllm` MoE backend** — a LoRA-aware copy of the trtllm-gen FP8 block-scale MoE. The activation step consumes `gate_up_lora_delta` directly; the trtllm finalize writes per-rank output that the down LoRA atomic-adds into.
- **Virtual-experts LoRA path** — shrink + expand fused into one MoE-style triton kernel (one virtual expert per adapter), with a rank-specialized expand kernel (R ≤ 64) that falls back to the generic kernel above 64.
- **EP-aware virtual-experts LoRA** — under MoE expert parallelism each rank computes the LoRA delta only for the experts it owns; non-owned slots route to the `-1` sentinel and the global contiguous weights are kept (free reshape), removing the ~ep_size× redundant shrink/expand. Output-preserving; ~9–12% (qwen35) / ~3–4% (qwen3vl) decode e2e at ep4.
- **Two-stream side-stream overlap (decode-only, opt-in via `SGLANG_LORA_TWO_STREAM=1`)** — `--lora-use-virtual-experts` LoRA shrink/expand runs on a side CUDA stream concurrent with base GEMMs on the main stream. Four sites today:
    - **O1**: MoE gate_up LoRA shrink+expand ‖ FP8 quant + trtllm routing/GEMM1 (join is a CUDA event before the activation kernel)
    - **O7**: QKV LoRA shrink ‖ qkv_proj GEMM
    - **O8**: o_proj LoRA shrink ‖ o_proj GEMM
    - **O9**: merged-column LoRA shrink ‖ base GEMM — qwen3.5 mamba `in_proj_qkvz` (every mamba layer) + dense `gate_up_proj` MLP

## Perf (GB200, TP=4 EP=4, FP8, LoRA rank=16, input=output=2048, cuda-graph on)

Rebased onto latest `upstream/main` — the "Share MoE LoRA Info" change ([#24160](https://github.com/sgl-project/sglang/pull/24160)) is now native in main, so it is *not* a commit in this PR. Full branch (backend + O1/O7/O8/O9 two-stream + EP-aware + GEMM1-LoRA overlap), total request latency:

| Model | Cell | bs=16 | bs=32 | bs=64 |
|---|---|---:|---:|---:|
| Qwen3.5-35B-A3B-FP8 | no-LoRA (ceiling) | 9.46 s | 11.12 s | 12.92 s |
|  | stock LoRA (triton MoE) | 15.27 s | 17.71 s | 20.70 s |
|  | **this PR** | **11.42 s** | **13.11 s** | **15.56 s** |
|  | **% of ceiling** | **82.8%** | **84.8%** | **83.0%** |
|  | **vs stock** | **+34%** | **+35%** | **+33%** |
| Qwen3-VL-30B-A3B-Instruct-FP8 | no-LoRA (ceiling) | 9.90 s | 11.49 s | 13.23 s |
|  | stock LoRA (triton MoE) | 16.74 s | 19.26 s | 23.23 s |
|  | **this PR** | **13.10 s** | **15.60 s** | **17.89 s** |
|  | **% of ceiling** | **75.6%** | **73.7%** | **74.0%** |
|  | **vs stock** | **+28%** | **+23%** | **+30%** |

Acc (per-token logprob diff vs stock triton LoRA): p50 = 1.4e-4 (qwen35) / 4.5e-3 (qwen3vl) — within bf16 numerical noise.

Note vs. earlier numbers: upstream has since sped up the **stock triton MoE LoRA** baseline (qwen35 bs64 27.3→20.7 s, qwen3-VL 28.3→23.2 s), so this PR's **% of ceiling improved (~65→85%)** while the **margin vs stock narrowed** (+41–45% → +23–35%) — upstream closed part of the gap, but this backend is still the fastest LoRA path and sits closest to the no-LoRA ceiling. O9 (merged-column overlap) is included in these numbers.

## How the LoRA flow + two-stream overlap works (one decode layer)

```mermaid
sequenceDiagram
    autonumber
    participant M as Main CUDA stream
    participant S as LoRA side stream

    Note over M,S: --- Attention block ---
    par O7: shrink on side
        S->>S: sgemm_lora_a_fwd<br/>(qkv shrink)
    and base GEMM on main
        M->>M: qkv_proj quant_method.apply
    end
    S-->>M: join
    M->>M: qkv_lora_b_fwd (expand + atomic-add)
    M->>M: FlashAttention (fmha)
    par O8: shrink on side
        S->>S: sgemm_lora_a_fwd<br/>(o_proj shrink)
    and base GEMM on main
        M->>M: o_proj quant_method.apply
    end
    S-->>M: join
    M->>M: sgemm_lora_b_fwd (expand + atomic-add)
    M->>M: tensor_model_parallel_all_reduce

    Note over M,S: --- MoE block ---
    par O1: gate_up LoRA on side
        S->>S: merged_experts_fused_moe_lora_add<br/>(gate_up shrink + expand)<br/>→ gate_up_lora_delta
    and main: quant + trtllm routing/GEMM1
        M->>M: per_token_group_quant_fp8
        M->>M: trtllm op<br/>routing → permute → GEMM1
    end
    S-->>M: join (CUDA event) before activation
    M->>M: trtllm op (cont.)<br/>activation(+gate_up_lora_delta)<br/>→ GEMM2 → finalize → moe_result
    M->>M: merged_experts_fused_moe_lora_add<br/>(down LoRA shrink+expand, atomic-add to moe_result)
    M->>M: downstream all_reduce (in qwen3_moe)
```

The side stream is one shared `torch.cuda.Stream()`; within a layer the sites are sequential (qkv → attn → o_proj → moe_gate_up), so they reuse it without contention. O9 applies the identical shrink ‖ base pattern to mamba `in_proj_qkvz` (qwen3.5) and dense `gate_up_proj` MLP layers — not shown in the attention+MoE diagram above, which depicts a transformer layer. Decode-only gating (`hidden_states.shape[0] ≤ 256`) keeps prefill on the serial path.

## How to use

```
--moe-runner-backend sgl_flashinfer_trtllm \
--enable-lora --max-loras-per-batch 1 --max-lora-rank 16 --lora-backend triton \
--lora-use-virtual-experts \
--lora-paths alpha=<adapter>
```

Add `SGLANG_LORA_TWO_STREAM=1` to enable the side-stream overlap (decode-only, no-op for non-`virtual_experts` LoRA, prefill, or non-trtllm-MoE backends). Without the env var, all existing single-stream paths run unchanged.





































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26876076675](https://github.com/sgl-project/sglang/actions/runs/26876076675)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26876076186](https://github.com/sgl-project/sglang/actions/runs/26876076186)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->



