### PR TITLE
[Bench] fix mmmu multi image

### DIFF
--- a/benchmark/mmmu/bench_hf.py
+++ b/benchmark/mmmu/bench_hf.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 
 import PIL
 import torch
@@ -12,6 +13,32 @@ from eval_utils import (
 )
 from tqdm import tqdm
 from transformers import AutoModel, AutoProcessor, GenerationConfig
+
+_IMAGE_TAG_RE = re.compile(r"<image\s+(\d+)>")
+
+
+def _walk_prompt(prompt, image_paths):
+    """Yield ``("text", str)`` and ``("image", path)`` parts in order by
+    resolving each ``<image N>`` placeholder against ``image_paths``. If the
+    prompt has no placeholders, the first image is anchored at the front."""
+    parts = []
+    last = 0
+    used = 0
+    for m in _IMAGE_TAG_RE.finditer(prompt):
+        if m.start() > last:
+            parts.append(("text", prompt[last : m.start()]))
+        idx = int(m.group(1)) - 1
+        if 0 <= idx < len(image_paths):
+            parts.append(("image", image_paths[idx]))
+            used += 1
+        else:
+            parts.append(("text", m.group(0)))
+        last = m.end()
+    if last < len(prompt):
+        parts.append(("text", prompt[last:]))
+    if used == 0 and image_paths:
+        parts.insert(0, ("image", image_paths[0]))
+    return parts
 
 
 @torch.no_grad()
@@ -79,23 +106,21 @@ def eval_mmmu(args):
     answer_dict = {}
     for sample in tqdm(samples):
         prompt = sample["final_input_prompt"]
-        image = sample["image"]
-        prefix = prompt.split("<")[0]
-        suffix = prompt.split(">")[1]
-        assert image is not None
+        image_paths = sample.get("image_paths") or [sample["image_path"]]
+        assert image_paths and image_paths[0] is not None
+        parts = _walk_prompt(prompt, image_paths)
 
         if "InternVL" in args.model_path:
-            image = PIL.Image.open(sample["image_path"]).convert("RGB")
-            pixel_values = image_to_pixel_values(
-                image, input_size=448, max_num=12, use_thumbnail=True
+            images = [PIL.Image.open(p).convert("RGB") for p in image_paths]
+            pv = [
+                image_to_pixel_values(im, input_size=448, max_num=12, use_thumbnail=True)
+                for im in images
+            ]
+            pixel_values = torch.cat(pv, dim=0).to(device="cuda", dtype=torch.bfloat16)
+            contents = "".join(
+                "<image>\n" if kind == "image" else val
+                for kind, val in parts
             )
-            pixel_values = pixel_values.to(device="cuda", dtype=torch.bfloat16)
-            contents = ""
-            if prefix:
-                contents += prefix
-            contents += "<image>\n"
-            if suffix:
-                contents += suffix
             response = model.chat(
                 tokenizer, pixel_values, contents, generation_config_internvl
             )
@@ -103,17 +128,10 @@ def eval_mmmu(args):
             process_result(response, sample, answer_dict, out_samples)
             continue
 
-        contents = []
-        if prefix:
-            contents += [{"type": "text", "text": prefix}]
-        contents += [
-            {
-                "type": "image",
-                "image": sample["image_path"],
-            }
+        contents = [
+            {"type": "image", "image": val} if kind == "image" else {"type": "text", "text": val}
+            for kind, val in parts
         ]
-        if suffix:
-            contents += [{"type": "text", "text": suffix}]
         messages = [{"role": "user", "content": contents}]
         try:
             model_inputs = processor.tokenizer.apply_chat_template(
@@ -130,13 +148,10 @@ def eval_mmmu(args):
             generation = generation[0][input_len:]
             response = processor.decode(generation, skip_special_tokens=True)
         except:
-            contents = []
-            if prefix:
-                contents += [prefix]
-            image = PIL.Image.open(sample["image_path"])
-            contents += [image]
-            if suffix:
-                contents += [suffix]
+            contents = [
+                PIL.Image.open(val) if kind == "image" else val
+                for kind, val in parts
+            ]
             messages = [{"role": "user", "content": contents}]
             response = model.chat(
                 msgs=messages,

--- a/benchmark/mmmu/bench_hf.py
+++ b/benchmark/mmmu/bench_hf.py
@@ -113,13 +113,14 @@ def eval_mmmu(args):
         if "InternVL" in args.model_path:
             images = [PIL.Image.open(p).convert("RGB") for p in image_paths]
             pv = [
-                image_to_pixel_values(im, input_size=448, max_num=12, use_thumbnail=True)
+                image_to_pixel_values(
+                    im, input_size=448, max_num=12, use_thumbnail=True
+                )
                 for im in images
             ]
             pixel_values = torch.cat(pv, dim=0).to(device="cuda", dtype=torch.bfloat16)
             contents = "".join(
-                "<image>\n" if kind == "image" else val
-                for kind, val in parts
+                "<image>\n" if kind == "image" else val for kind, val in parts
             )
             response = model.chat(
                 tokenizer, pixel_values, contents, generation_config_internvl
@@ -129,7 +130,11 @@ def eval_mmmu(args):
             continue
 
         contents = [
-            {"type": "image", "image": val} if kind == "image" else {"type": "text", "text": val}
+            (
+                {"type": "image", "image": val}
+                if kind == "image"
+                else {"type": "text", "text": val}
+            )
             for kind, val in parts
         ]
         messages = [{"role": "user", "content": contents}]
@@ -149,8 +154,7 @@ def eval_mmmu(args):
             response = processor.decode(generation, skip_special_tokens=True)
         except:
             contents = [
-                PIL.Image.open(val) if kind == "image" else val
-                for kind, val in parts
+                PIL.Image.open(val) if kind == "image" else val for kind, val in parts
             ]
             messages = [{"role": "user", "content": contents}]
             response = model.chat(

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -69,11 +69,47 @@ async def async_request_profile(api_url: str) -> RequestFuncOutput:
     return output
 
 
-def _get_prefix_suffix(prompt: str) -> Tuple[str, str]:
-    """Split the prompt into prefix and suffix."""
-    prefix = prompt.split("<")[0]
-    suffix = prompt.split(">", 1)[1]
-    return prefix, suffix
+_IMAGE_TAG_RE = re.compile(r"<image\s+(\d+)>")
+
+
+def _path_to_image_url(path: str) -> str:
+    if path and not path.startswith(("http://", "https://", "data:")):
+        p = Path(path)
+        mime = mimetypes.guess_type(str(p))[0] or "image/png"
+        with open(p, "rb") as f:
+            b64 = base64.b64encode(f.read()).decode()
+        return f"data:{mime};base64,{b64}"
+    return path
+
+
+def _build_multimodal_content(prompt: str, image_paths: List[str]) -> list:
+    """Interleave text and images by replacing each ``<image N>`` placeholder
+    in the prompt with ``image_paths[N-1]``."""
+    parts = []
+    last = 0
+    used = 0
+    for m in _IMAGE_TAG_RE.finditer(prompt):
+        text_chunk = prompt[last : m.start()]
+        if text_chunk:
+            parts.append({"type": "text", "text": text_chunk})
+        idx = int(m.group(1)) - 1
+        if 0 <= idx < len(image_paths):
+            url = _path_to_image_url(image_paths[idx])
+            parts.append({"type": "image_url", "image_url": {"url": url}})
+            used += 1
+        else:
+            # Placeholder with no matching image — keep the literal token
+            # rather than silently dropping it from the question.
+            parts.append({"type": "text", "text": m.group(0)})
+        last = m.end()
+    tail = prompt[last:]
+    if tail:
+        parts.append({"type": "text", "text": tail})
+    # No `<image N>` placeholders in the prompt: anchor the image at the front.
+    if used == 0 and image_paths:
+        parts.insert(0, {"type": "image_url",
+                         "image_url": {"url": _path_to_image_url(image_paths[0])}})
+    return parts
 
 
 async def process_sample(
@@ -86,31 +122,13 @@ async def process_sample(
 ) -> Tuple[dict, str]:
     """Send a single sample to the LLM and return (sample, response)."""
     prompt = sample["final_input_prompt"]
-    prefix, suffix = _get_prefix_suffix(prompt)
-    image = sample["image"]
-    assert image is not None
-    image_path = sample["image_path"]
-    if image_path and not image_path.startswith(("http://", "https://", "data:")):
-        p = Path(image_path)
-        mime = mimetypes.guess_type(str(p))[0] or "image/png"
-        with open(p, "rb") as f:
-            b64 = base64.b64encode(f.read()).decode()
-        image_url = f"data:{mime};base64,{b64}"
-    else:
-        image_url = image_path
+    image_paths = sample.get("image_paths") or [sample["image_path"]]
+    assert image_paths and image_paths[0] is not None
+    content = _build_multimodal_content(prompt, image_paths)
     extra_body = {"lora_path": lora_path} if lora_path else None
     payload = {
         "model": model,
-        "messages": [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": prefix},
-                    {"type": "image_url", "image_url": {"url": image_url}},
-                    {"type": "text", "text": suffix},
-                ],
-            }
-        ],
+        "messages": [{"role": "user", "content": content}],
         "extra_body": extra_body,
         **sampling_params,
     }

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -107,8 +107,13 @@ def _build_multimodal_content(prompt: str, image_paths: List[str]) -> list:
         parts.append({"type": "text", "text": tail})
     # No `<image N>` placeholders in the prompt: anchor the image at the front.
     if used == 0 and image_paths:
-        parts.insert(0, {"type": "image_url",
-                         "image_url": {"url": _path_to_image_url(image_paths[0])}})
+        parts.insert(
+            0,
+            {
+                "type": "image_url",
+                "image_url": {"url": _path_to_image_url(image_paths[0])},
+            },
+        )
     return parts
 
 

--- a/benchmark/mmmu/data_utils.py
+++ b/benchmark/mmmu/data_utils.py
@@ -114,24 +114,23 @@ def process_single_sample(data):
         for img_path in current_o_imgs_paths:
             o_imgs_paths.append(img_path)
 
-    if len(o_imgs_paths) > 1:  # multiple images in options, used for random selection
-        return {
-            "id": data["id"],
-            "question": question,
-            "options": data["options"],
-            "answer": data["answer"],
-            "image": None,
-            "question_type": data["question_type"],
-        }
-    else:
-        return {
-            "id": data["id"],
-            "question": question,
-            "options": data["options"],
-            "answer": data["answer"],
-            "image": data["image_1"],
-            "question_type": data["question_type"],
-        }
+    # MMMU rows carry up to 7 images as image_1..image_7.
+    images = [data[f"image_{i}"] for i in range(1, 8) if data.get(f"image_{i}") is not None]
+
+    common = {
+        "id": data["id"],
+        "question": question,
+        "options": data["options"],
+        "answer": data["answer"],
+        "question_type": data["question_type"],
+        "image": images[0] if images else None,
+        "images": images,
+    }
+    if len(o_imgs_paths) > 1:
+        # `<img='...'>` inlined-path variant — skip rather than misalign images.
+        common["image"] = None
+        common["images"] = []
+    return common
 
 
 # DATA SAVING

--- a/benchmark/mmmu/data_utils.py
+++ b/benchmark/mmmu/data_utils.py
@@ -115,7 +115,9 @@ def process_single_sample(data):
             o_imgs_paths.append(img_path)
 
     # MMMU rows carry up to 7 images as image_1..image_7.
-    images = [data[f"image_{i}"] for i in range(1, 8) if data.get(f"image_{i}") is not None]
+    images = [
+        data[f"image_{i}"] for i in range(1, 8) if data.get(f"image_{i}") is not None
+    ]
 
     common = {
         "id": data["id"],

--- a/benchmark/mmmu/eval_utils.py
+++ b/benchmark/mmmu/eval_utils.py
@@ -217,15 +217,22 @@ def prepare_samples(eval_args: EvalArgs):
     def process_sample(i, sample):
         sample = process_single_sample(sample)
         sample = construct_prompt(sample, eval_args.config)
-        image = sample["image"]
-        width, height = image.size
-        if 0 < eval_args.image_pixels_limit <= width * height:
+        images = sample.get("images") or []
+        if not images:
             return None, True
-        # Use a unique identifier for the image path to avoid potential collisions if indices reset
-        image_path = f"{images_path}/image_{sample['id']}.png"
-        if not os.path.exists(image_path):
-            image.save(image_path)
-        sample["image_path"] = image_path
+        if eval_args.image_pixels_limit > 0:
+            for img in images:
+                if img.size[0] * img.size[1] >= eval_args.image_pixels_limit:
+                    return None, True
+        image_paths = []
+        for idx, img in enumerate(images, start=1):
+            suffix = "" if len(images) == 1 else f"_{idx}"
+            path = f"{images_path}/image_{sample['id']}{suffix}.png"
+            if not os.path.exists(path):
+                img.save(path)
+            image_paths.append(path)
+        sample["image_path"] = image_paths[0]
+        sample["image_paths"] = image_paths
         return sample, False
 
     print("Processing samples...")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

benchmark/mmmu/bench_sglang.py and bench_hf.py build the request by splitting the prompt at the first `<…>` and attaching one image:

```
  prefix = prompt.split("<")[0]
  suffix = prompt.split(">", 1)[1]
  # ... attach sample["image_1"] only
```

MMMU has 39 / 900 val questions whose prompts reference multiple images (typically one molecule / diagram / artwork per option, e.g. validation_Biology_29 lists <image 1> … <image 5>). On those questions the bench currently:

  - attaches only image_1 to the request
  - leaves <image 2> … <image N> as literal text in the prompt

The model never sees options B–E, so it answers ~25 % correct (≈ random for 4-way MC) on the affected subset.

## Modifications

<!-- Detail the changes made in this pull request. -->

Walk the prompt and interleave each <image N> placeholder with the matching image_N from the dataset row. Two-line change in spirit, three files in practice (data_utils.py collects every non-null image_1..image_7; eval_utils.py saves and tracks all paths; the bench scripts build a content list by walking the placeholders).

Single-image questions are unchanged (same prompt token count, same content shape).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34827938730](https://github.com/sgl-project/sglang/actions/runs/34827938730)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34827938070](https://github.com/sgl-project/sglang/actions/runs/34827938070)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->