### PR TITLE
dp-attention: add prefix_match load balance for in-instance cache-aware routing

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -14,6 +14,7 @@
 """A controller that dispatches requests to multiple data parallel workers."""
 
 import faulthandler
+import hashlib
 import logging
 import multiprocessing as mp
 import signal
@@ -76,6 +77,7 @@ class LoadBalanceMethod(Enum):
     FOLLOW_BOOTSTRAP_ROOM = auto()
     TOTAL_REQUESTS = auto()
     TOTAL_TOKENS = auto()
+    PREFIX_MATCH = auto()
 
     @classmethod
     def from_str(cls, method: str):
@@ -149,6 +151,7 @@ class DataParallelController:
             LoadBalanceMethod.FOLLOW_BOOTSTRAP_ROOM: self.follow_bootstrap_room_scheduler,
             LoadBalanceMethod.TOTAL_REQUESTS: self.total_requests_scheduler,
             LoadBalanceMethod.TOTAL_TOKENS: self.total_tokens_scheduler,
+            LoadBalanceMethod.PREFIX_MATCH: self.prefix_match_scheduler,
         }
         self.dispatching = dispatch_lookup[self.load_balance_method]
 
@@ -606,6 +609,33 @@ class DataParallelController:
             LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
         )
         self.workers[target_worker].send_pyobj(req)
+
+    def prefix_match_scheduler(self, req: Req):
+        """Route by stable hash of the first N input tokens.
+
+        Same prefix (e.g. shared system+tools) -> same DP rank -> radix cache
+        hit. Different prefixes spread evenly across ranks via stable hash.
+        No cross-rank state required; the decision is a pure function of the
+        request's leading tokens, so concurrent requests with the same prefix
+        all land on the same rank without coordination.
+        """
+        if self.maybe_external_dp_rank_routing(req):
+            return
+
+        dp_size = len(self.workers)
+        N = 4096
+        ids = getattr(req, "input_ids", None) or []
+        if len(ids) == 0:
+            target_rank = self.round_robin_counter % dp_size
+            self.round_robin_counter = (self.round_robin_counter + 1) % dp_size
+        else:
+            head = ids[:N]
+            h = hashlib.blake2b(
+                bytes(b & 0xFF for b in head[:256]) + len(head).to_bytes(4, "little"),
+                digest_size=8,
+            ).digest()
+            target_rank = int.from_bytes(h, "little") % dp_size
+        self.workers[target_rank].send_pyobj(req)
 
     def event_loop(self):
         while True:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5291,6 +5291,7 @@ class ServerArgs:
                 "follow_bootstrap_room",
                 "total_requests",
                 "total_tokens",
+                "prefix_match",
             ],
         )
         parser.add_argument(

--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -96,6 +96,46 @@ class TestDPAttentionMixedChunk(
         kill_process_tree(cls.process.pid)
 
 
+class TestDPAttentionPrefixMatchLoadBalance(
+    CustomTestCase,
+    GSM8KMixin,
+):
+    """Smoke test for --load-balance-method prefix_match.
+
+    The new method routes by a stable hash of the leading input tokens, so
+    requests sharing a prefix land on the same DP rank. This test only
+    asserts that the server boots with the option and that GSM8K accuracy
+    stays above the same threshold the other DP-attention configs use; the
+    routing decision is a pure function and does not affect inference output.
+    """
+
+    gsm8k_accuracy_thres = 0.6
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "2",
+                "--enable-dp-attention",
+                "--dp",
+                "2",
+                "--load-balance-method",
+                "prefix_match",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
 class TestDPRetract(
     CustomTestCase,
     JSONConstrainedMixin,

--- a/test/registered/unit/managers/test_prefix_match_scheduler.py
+++ b/test/registered/unit/managers/test_prefix_match_scheduler.py
@@ -1,0 +1,103 @@
+"""Unit tests for the prefix_match load balance method.
+
+The prefix_match scheduler routes requests by a stable hash of the leading
+input tokens, so requests sharing a prefix land on the same DP rank. These
+tests assert determinism (same prefix -> same rank), even spread across
+distinct prefixes, and the empty-input fallback path -- all without booting
+a real server.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.data_parallel_controller import (
+    DataParallelController,
+    LoadBalanceMethod,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_controller(dp_size: int = 8) -> DataParallelController:
+    """Construct a controller with just enough state to exercise the scheduler.
+
+    The real ``__init__`` spawns workers and binds ZMQ sockets, which we do
+    not need for a routing-only unit test. We bypass it and stitch in the
+    minimum attributes the scheduler reads.
+    """
+    ctrl = DataParallelController.__new__(DataParallelController)
+    ctrl.server_args = SimpleNamespace(dp_size=dp_size)
+    ctrl.workers = [MagicMock(name=f"worker-{i}") for i in range(dp_size)]
+    ctrl.round_robin_counter = 0
+    return ctrl
+
+
+def _make_req(input_ids, routed_dp_rank=None):
+    """Build a minimal req object recognised by the scheduler."""
+    return SimpleNamespace(input_ids=input_ids, routed_dp_rank=routed_dp_rank)
+
+
+class TestPrefixMatchScheduler(CustomTestCase):
+    def test_enum_registered(self):
+        self.assertIs(
+            LoadBalanceMethod.from_str("prefix_match"),
+            LoadBalanceMethod.PREFIX_MATCH,
+        )
+
+    def test_same_prefix_routes_to_same_rank(self):
+        ctrl = _make_controller(dp_size=16)
+        prefix = list(range(1, 4001))
+        req_a = _make_req(prefix + [9001, 9002])
+        req_b = _make_req(prefix + [7777])
+
+        ctrl.prefix_match_scheduler(req_a)
+        ctrl.prefix_match_scheduler(req_b)
+
+        sent_a = [i for i, w in enumerate(ctrl.workers) if w.send_pyobj.called]
+        called_on_b = [
+            i for i, w in enumerate(ctrl.workers) if w.send_pyobj.call_count >= 2
+        ]
+        self.assertEqual(len(sent_a), 1)
+        self.assertEqual(sent_a, called_on_b)
+
+    def test_distinct_prefixes_spread_across_ranks(self):
+        dp_size = 16
+        ctrl = _make_controller(dp_size=dp_size)
+        # 256 distinct prefixes -> we expect coverage of most ranks.
+        for seed in range(256):
+            req = _make_req([seed] * 4096)
+            ctrl.prefix_match_scheduler(req)
+
+        used = sum(1 for w in ctrl.workers if w.send_pyobj.called)
+        # With 256 prefixes uniformly hashed into 16 buckets the empty-bucket
+        # probability is vanishingly small; require at least 12/16 to allow
+        # generous slack while still catching a degenerate hash.
+        self.assertGreaterEqual(used, 12)
+
+    def test_empty_input_falls_back_to_round_robin(self):
+        dp_size = 4
+        ctrl = _make_controller(dp_size=dp_size)
+        for _ in range(dp_size):
+            ctrl.prefix_match_scheduler(_make_req([]))
+        for w in ctrl.workers:
+            self.assertEqual(w.send_pyobj.call_count, 1)
+
+    def test_external_routed_dp_rank_takes_precedence(self):
+        ctrl = _make_controller(dp_size=8)
+        req = _make_req([1, 2, 3, 4], routed_dp_rank=5)
+        ctrl.prefix_match_scheduler(req)
+        for i, w in enumerate(ctrl.workers):
+            if i == 5:
+                w.send_pyobj.assert_called_once_with(req)
+            else:
+                w.send_pyobj.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #26611.

## Motivation

The single-instance DP controller currently ships only `round_robin / follow_bootstrap_room / total_requests / total_tokens`. None of them route by request content, so when a single client sends many sequential turns over a shared system + tools prefix (agent serving), the radix cache on each DP rank gets a hit at best once every `dp_size` requests under `round_robin`.

Existing cache-aware routing work targets either the `sgl-router` Rust gateway (#2114, #6869) or P/D-disaggregated decode (#26046, #26561). Neither covers plain `--enable-dp-attention --dp-size N` serving with no gateway in front: the tokenizer manager dispatches directly to workers, and the only knob is `--load-balance-method`.

`total_tokens` accidentally approximates prefix locality only because the just-finished rank tends to be the lowest-loaded, and only for strictly sequential traffic. It degrades under concurrency.

## Modifications

- `python/sglang/srt/managers/data_parallel_controller.py`
  - Add `LoadBalanceMethod.PREFIX_MATCH` to the enum.
  - Register it in `dispatch_lookup`.
  - Add `DataParallelController.prefix_match_scheduler(req)`: hashes the first 4k input tokens via `blake2b` over a 256-token window and routes by `int.from_bytes(h) % dp_size`. Empty `input_ids` falls back to round-robin; the existing `routed_dp_rank` override is preserved (via `maybe_external_dp_rank_routing`).
  - Add `import hashlib`.
- `python/sglang/srt/server_args.py`
  - Add `"prefix_match"` to the `--load-balance-method` argparse `choices`.
- `test/registered/dp_attn/test_dp_attention.py`
  - New `TestDPAttentionPrefixMatchLoadBalance`: launches the standard MLA test model with `--enable-dp-attention --dp 2 --load-balance-method prefix_match` and asserts GSM8K accuracy stays above the same `0.6` threshold as the sibling DP-attention tests.
- `test/registered/unit/managers/test_prefix_match_scheduler.py`
  - New CPU-only unit test: same prefix -> same rank; distinct prefixes spread to >= 12/16 ranks across 256 prefixes; empty input falls back to round-robin; external `routed_dp_rank` takes precedence.

The decision is a pure function of `req.input_ids`, so concurrent requests with the same prefix all land on the same rank with no cross-rank coordination.

## Accuracy Tests

No inference output change; load balance method is a routing-only decision over which DP rank receives a request. The new registered DP-attention test (`TestDPAttentionPrefixMatchLoadBalance`) exercises GSM8K through the new code path with `--dp 2 --load-balance-method prefix_match` and asserts the same `gsm8k_accuracy_thres = 0.6` threshold as the existing `TestDPAttentionDP2TP2` / `TestDPAttentionMixedChunk` tests.

## Speed Tests

Measured on a Qwen3-class MoE checkpoint, `tp_size=16 dp_size=16 ep_size=16, moe_a2a_backend=deepep, attention_backend=fa3, mem_fraction_static=0.78, schedule_policy=lpm`. Workload: one client sending a 22,651-token shared prefix + a short user turn, `temperature=0`, `chat_template_kwargs.enable_thinking=false`.

| `load_balance_method` | First request TTFT (cold) | Subsequent same-prefix TTFT |
|---|---|---|
| `round_robin` | 7400 ms | 7400 ms every request -- each request lands on a different DP rank with a cold radix cache |
| `total_tokens` | 7400 ms | 2740 ms -- only holds for strictly sequential traffic |
| **`prefix_match` (this PR)** | 7400 ms | **1290 ms steady-state (p50 1292, p99 6012 from cold, 30 requests over 180 s, 0 errors)** |

That's **5.7x speedup vs `round_robin`** on the exact pattern that matters for agent serving. A 4-agent concurrent same-prefix bench (with `enable_mixed_chunk=true`) goes from c4 RPS 0.19 (`round_robin`) to 0.41 (`prefix_match`).

## Checklist

- [x] Format with `pre-commit run --files`
- [x] New tests added (registered DP-attention smoke + CPU unit)
- [x] No inference output change; routing-only







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26603772659](https://github.com/sgl-project/sglang/actions/runs/26603772659)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26603772607](https://github.com/sgl-project/sglang/actions/runs/26603772607)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->