### PR TITLE
[CI] ci-coverage-overview: schedule + manual only, include XPU/MUSA/multimodal_gen

### DIFF
--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -71,6 +71,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain + protoc
+        # Editable install of sglang triggers `build_rust` for the bundled
+        # native gRPC extension (rust/sglang-grpc). The 1-gpu-h100 runner
+        # image has no Rust toolchain by default, which is why this job has
+        # been failing on every scheduled run. Use the same helper that
+        # ci_install_dependency.sh uses so the install path matches the
+        # rest of CI.
+        run: |
+          bash scripts/ci/utils/install_rust_protoc.sh
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+
       - name: Install dependencies
         timeout-minutes: 10
         run: |

--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -3,11 +3,6 @@ name: CI Coverage Overview
 on:
   schedule:
     - cron: '0 6 * * *'  # Daily at 6 AM UTC
-  pull_request:
-    paths:
-      - '.github/workflows/ci-coverage-overview.yml'
-      - 'scripts/ci/utils/ci_coverage_report.py'
-      - 'test/registered/**'
   workflow_dispatch:
     inputs:
       output_format:
@@ -70,7 +65,6 @@ jobs:
 
   unit-test-coverage:
     name: Unit Test Code Coverage
-    if: github.event_name != 'pull_request'
     runs-on: 1-gpu-h100
     timeout-minutes: 30
     steps:

--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -14,6 +14,7 @@ __all__ = [
     "register_amd_ci",
     "register_npu_ci",
     "register_xpu_ci",
+    "register_musa_ci",
     "ut_parse_one_file",
 ]
 
@@ -32,6 +33,7 @@ class HWBackend(Enum):
     AMD = auto()
     NPU = auto()
     XPU = auto()
+    MUSA = auto()
 
 
 @dataclass
@@ -119,12 +121,26 @@ def register_xpu_ci(
     return None
 
 
+def register_musa_ci(
+    est_time: float,
+    suite: Optional[str] = None,
+    nightly: bool = False,
+    disabled: Optional[str] = None,
+    *,
+    stage: Optional[str] = None,
+    runner_config: Optional[str] = None,
+):
+    """Marker for MUSA CI registration (parsed via AST; runtime no-op)."""
+    return None
+
+
 REGISTER_MAPPING = {
     "register_cpu_ci": HWBackend.CPU,
     "register_cuda_ci": HWBackend.CUDA,
     "register_amd_ci": HWBackend.AMD,
     "register_npu_ci": HWBackend.NPU,
     "register_xpu_ci": HWBackend.XPU,
+    "register_musa_ci": HWBackend.MUSA,
 }
 
 

--- a/scripts/ci/utils/ci_coverage_report.py
+++ b/scripts/ci/utils/ci_coverage_report.py
@@ -38,6 +38,52 @@ assert set(BACKEND_DISPLAY_ORDER) == {
     b.name for b in HWBackend
 }, "BACKEND_DISPLAY_ORDER is out of sync with HWBackend"
 
+# --------------------------------------------------------------------------- #
+# multimodal_gen test coverage
+#
+# multimodal_gen tests live under python/sglang/multimodal_gen/test/ and use
+# their own run_suite.py / partitioning framework, NOT the register_*_ci()
+# registry used under test/registered/. To surface them in the daily
+# overview we synthesize CIRegistry records from file paths + filename
+# tokens, using the rules below. These are heuristics derived from how the
+# multimodal_gen workflows (pr-test-{musa,npu,amd}.yml, pr-test-multimodal-
+# gen.yml) currently invoke each file -- they MAY drift if a workflow
+# stops/starts running a directory.
+# --------------------------------------------------------------------------- #
+MULTIMODAL_GEN_TEST_DIR = "python/sglang/multimodal_gen/test"
+
+# Subdirectory (relative to MULTIMODAL_GEN_TEST_DIR) -> backends those files
+# run on by default. Empty string is the top-level. Files whose tokenized
+# filename contains an explicit backend marker (see below) override this.
+_MM_GEN_SUBDIR_BACKENDS = {
+    # Top-level helper-style tests (e.g. test_consistency_metrics.py).
+    "": ("CUDA",),
+    # server/ top-level: pr-test-multimodal-gen.yml drives CUDA, pr-test-amd
+    # mirrors the same suite on AMD runners.
+    "server": ("CUDA", "AMD"),
+    "server/musa": ("MUSA",),
+    "server/ascend": ("NPU",),
+    "layers": ("CUDA",),
+    "unit": ("CUDA",),
+    "cli": ("CUDA",),
+    "manual": ("CUDA",),
+}
+
+# Filenames that match `test_*.py` by convention but contain no real tests
+# (utility / fixture modules). Skipped before classification.
+_MM_GEN_HELPER_FILENAMES = frozenset({"test_utils.py"})
+
+# Filename token -> backend override. Tokenization is `stem.split("_")`, so a
+# file like `test_server_1_gpu_musa.py` yields tokens
+# {test, server, 1, gpu, musa} and matches `musa`. This correctly catches
+# both `test_musa_*.py` (musa-named kernels) and `test_*_musa*.py` (musa
+# variants of generic server tests). `nightly` is detected the same way and
+# flips the nightly flag without changing the backend.
+_MM_GEN_FILENAME_BACKEND_TOKENS = {
+    "musa": ("MUSA",),
+    "npu": ("NPU",),
+}
+
 
 def collect_all_tests(registered_dir: str) -> list[CIRegistry]:
     """Collect all CI registrations from registered directory."""
@@ -54,10 +100,92 @@ def collect_all_tests(registered_dir: str) -> list[CIRegistry]:
     return all_tests
 
 
+def collect_multimodal_gen_tests(
+    mm_gen_dir: str = MULTIMODAL_GEN_TEST_DIR,
+) -> list[CIRegistry]:
+    """Synthesize CIRegistry records for multimodal_gen tests.
+
+    multimodal_gen doesn't use register_*_ci(); see the module-level comment
+    above MULTIMODAL_GEN_TEST_DIR for the rules. Returns one record per
+    (file, backend) pair, matching the convention used for registered tests
+    that target multiple backends.
+    """
+    mm_gen_path = Path(mm_gen_dir)
+    if not mm_gen_path.is_dir():
+        return []
+
+    # Discover test files: anything matching test_*.py anywhere under the
+    # tree. The csrc/ and apps/ subtrees aren't part of the test/ directory
+    # so we don't need to exclude them.
+    test_files = sorted(mm_gen_path.glob("**/test_*.py"))
+    records: list[CIRegistry] = []
+
+    for file in test_files:
+        rel = file.relative_to(mm_gen_path)
+        subdir = "/".join(rel.parts[:-1])  # "" for top-level
+        filename_only = rel.parts[-1]
+
+        if filename_only in _MM_GEN_HELPER_FILENAMES:
+            continue  # test_utils.py and similar -- helper modules, not tests
+
+        # Tokenize stem to look for explicit backend / nightly markers.
+        stem_tokens = set(filename_only[:-3].split("_"))
+        nightly = "nightly" in stem_tokens
+
+        backends: tuple[str, ...] = ()
+        for token, override in _MM_GEN_FILENAME_BACKEND_TOKENS.items():
+            if token in stem_tokens:
+                backends = override
+                break
+        if not backends:
+            backends = _MM_GEN_SUBDIR_BACKENDS.get(subdir, ())
+
+        if not backends:
+            print(
+                f"Warning: multimodal_gen file {file} matches no backend "
+                f"rule (subdir={subdir!r}, tokens={sorted(stem_tokens)}); "
+                f"add a rule to _MM_GEN_SUBDIR_BACKENDS.",
+                file=sys.stderr,
+            )
+            continue
+
+        for backend_name in backends:
+            records.append(
+                CIRegistry(
+                    backend=HWBackend[backend_name],
+                    filename=str(file),
+                    # mm_gen does its own per-case partitioning -- file-level
+                    # estimates aren't available. Surfaced as 0 in the
+                    # by-suite section, which is correct (we don't know).
+                    est_time=0.0,
+                    suite=f"mm-gen-{backend_name.lower()}",
+                    nightly=nightly,
+                    disabled=None,
+                )
+            )
+
+    return records
+
+
 def get_folder_name(filename: str) -> str:
-    """Extract folder name from test filename."""
-    # e.g., "registered/models/test_foo.py" -> "models"
+    """Extract folder name from test filename.
+
+    Registered tests use test/registered/<folder>/test_*.py and map to
+    <folder>. multimodal_gen tests live outside that tree and get a virtual
+    `mm_gen/<subdir>` folder so they show up as their own rows in the
+    Folder Summary table.
+    """
     parts = Path(filename).parts
+    if "multimodal_gen" in parts:
+        try:
+            mg_idx = parts.index("multimodal_gen")
+            test_idx = parts.index("test", mg_idx)
+            sub_parts = parts[test_idx + 1 : -1]  # strip 'test' anchor + file
+            if sub_parts:
+                return "mm_gen/" + "/".join(sub_parts)
+            return "mm_gen"
+        except ValueError:
+            pass  # fall through to default
     if "registered" in parts:
         idx = parts.index("registered")
         if idx + 1 < len(parts) - 1:  # Has subfolder
@@ -469,6 +597,14 @@ def main():
         default="test/registered",
         help="Path to registered test directory",
     )
+    parser.add_argument(
+        "--multimodal-gen-dir",
+        default=MULTIMODAL_GEN_TEST_DIR,
+        help=(
+            "Path to multimodal_gen test directory. Pass empty string to "
+            "skip multimodal_gen tests entirely."
+        ),
+    )
     args = parser.parse_args()
 
     # Change to repo root if needed
@@ -477,6 +613,8 @@ def main():
     os.chdir(repo_root)
 
     tests = collect_all_tests(args.registered_dir)
+    if args.multimodal_gen_dir:
+        tests.extend(collect_multimodal_gen_tests(args.multimodal_gen_dir))
 
     if args.output_format == "markdown":
         report = generate_markdown_report(tests, section=args.section)

--- a/scripts/ci/utils/ci_coverage_report.py
+++ b/scripts/ci/utils/ci_coverage_report.py
@@ -27,6 +27,17 @@ sys.path.insert(
 
 from ci_register import CIRegistry, HWBackend, ut_parse_one_file
 
+# Display order for backend tables / sections. The list is sourced from
+# HWBackend so a newly-added enum member can never be silently dropped from
+# the report -- if the assert below fires, add the new backend name here in
+# the right display slot. Order isn't alphabetical: CUDA/AMD/NPU/CPU lead
+# (highest test volume historically), then accelerators that have been
+# wired into the registry more recently (XPU, MUSA).
+BACKEND_DISPLAY_ORDER = ("CUDA", "AMD", "NPU", "CPU", "XPU", "MUSA")
+assert set(BACKEND_DISPLAY_ORDER) == {
+    b.name for b in HWBackend
+}, "BACKEND_DISPLAY_ORDER is out of sync with HWBackend"
+
 
 def collect_all_tests(registered_dir: str) -> list[CIRegistry]:
     """Collect all CI registrations from registered directory."""
@@ -113,7 +124,7 @@ def generate_summary_section(data: dict) -> str:
     lines.append("| Backend | Total | Enabled | Disabled | Per-Commit | Nightly |")
     lines.append("|---------|-------|---------|----------|------------|---------|")
 
-    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+    for backend in BACKEND_DISPLAY_ORDER:
         backend_tests = by_backend.get(backend, [])
         if not backend_tests:
             continue
@@ -128,21 +139,25 @@ def generate_summary_section(data: dict) -> str:
 
     lines.append("\n</details>\n")
 
-    # Folder summary (collapsible)
+    # Folder summary (collapsible). Only show columns for backends that
+    # have at least one registered test across the whole report -- otherwise
+    # adding scaffolding for an unused backend would widen every row with a
+    # column of zeros.
+    active_backends = [b for b in BACKEND_DISPLAY_ORDER if by_backend.get(b)]
     lines.append("<details>")
     lines.append("<summary><h2>Folder Summary</h2></summary>\n")
-    lines.append("| Folder | CUDA | AMD | NPU | CPU | Total |")
-    lines.append("|--------|------|-----|-----|-----|-------|")
+    header_cells = ["Folder", *active_backends, "Total"]
+    lines.append("| " + " | ".join(header_cells) + " |")
+    lines.append("|" + "|".join(["-" * max(len(c), 3) for c in header_cells]) + "|")
 
     for folder in sorted(by_folder.keys()):
         folder_tests = by_folder[folder]
-        cuda = sum(1 for t in folder_tests if t.backend == HWBackend.CUDA)
-        amd = sum(1 for t in folder_tests if t.backend == HWBackend.AMD)
-        npu = sum(1 for t in folder_tests if t.backend == HWBackend.NPU)
-        cpu = sum(1 for t in folder_tests if t.backend == HWBackend.CPU)
-        lines.append(
-            f"| {folder} | {cuda} | {amd} | {npu} | {cpu} | {len(folder_tests)} |"
-        )
+        backend_counts = {b.name: 0 for b in HWBackend}
+        for t in folder_tests:
+            backend_counts[t.backend.name] += 1
+        row = [folder] + [str(backend_counts[b]) for b in active_backends]
+        row.append(str(len(folder_tests)))
+        lines.append("| " + " | ".join(row) + " |")
 
     lines.append("\n</details>\n")
 
@@ -182,7 +197,7 @@ def generate_by_folder_section(data: dict) -> str:
         for t in folder_tests:
             folder_by_backend[t.backend.name].append(t)
 
-        for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+        for backend in BACKEND_DISPLAY_ORDER:
             backend_tests = folder_by_backend.get(backend, [])
             if not backend_tests:
                 continue
@@ -216,7 +231,7 @@ def generate_by_suite_section(data: dict) -> str:
 
     lines.append("# All Tests by Test Suite\n")
 
-    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+    for backend in BACKEND_DISPLAY_ORDER:
         backend_tests = by_backend.get(backend, [])
         if not backend_tests:
             continue
@@ -332,7 +347,7 @@ def generate_json_report(tests: list[CIRegistry]) -> str:
             "backends": {},
         }
 
-        for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+        for backend in BACKEND_DISPLAY_ORDER:
             backend_tests = folder_by_backend.get(backend, [])
             if backend_tests:
                 data["tests_by_folder"][folder]["backends"][backend] = [
@@ -350,7 +365,7 @@ def generate_json_report(tests: list[CIRegistry]) -> str:
                 ]
 
     # Section 2: Tests by Suite (Backend -> Suite)
-    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+    for backend in BACKEND_DISPLAY_ORDER:
         backend_tests = by_backend.get(backend, [])
         if not backend_tests:
             continue
@@ -393,7 +408,7 @@ def generate_json_report(tests: list[CIRegistry]) -> str:
             }
 
     # Backend summary
-    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+    for backend in BACKEND_DISPLAY_ORDER:
         backend_tests = by_backend.get(backend, [])
         if backend_tests:
             data["backend_summary"][backend] = {
@@ -408,14 +423,16 @@ def generate_json_report(tests: list[CIRegistry]) -> str:
                 ),
             }
 
-    # Folder summary
+    # Folder summary -- one count per backend in HWBackend, in display
+    # order, so every registered backend shows up regardless of whether
+    # this folder has tests for it.
     for folder in sorted(by_folder.keys()):
         folder_tests = by_folder[folder]
+        backend_counts = {b: 0 for b in BACKEND_DISPLAY_ORDER}
+        for t in folder_tests:
+            backend_counts[t.backend.name] += 1
         data["folder_summary"][folder] = {
-            "CUDA": sum(1 for t in folder_tests if t.backend == HWBackend.CUDA),
-            "AMD": sum(1 for t in folder_tests if t.backend == HWBackend.AMD),
-            "NPU": sum(1 for t in folder_tests if t.backend == HWBackend.NPU),
-            "CPU": sum(1 for t in folder_tests if t.backend == HWBackend.CPU),
+            **backend_counts,
             "total": len(folder_tests),
         }
 


### PR DESCRIPTION
Three related fixes to the daily CI coverage overview workflow.

(This replaces #26613, which was opened from a personal fork. Same commits.)

## 1. Trigger frequency

`ci-coverage-overview.yml` currently triggers on every PR that touches `.github/workflows/ci-coverage-overview.yml`, `scripts/ci/utils/ci_coverage_report.py`, or `test/registered/**`. With the recent tag-gated nightly migration (#24725) moving large numbers of test files under `test/registered/`, the third path matches a substantial fraction of in-flight PRs. The last 20 runs were essentially all `pull_request`-triggered for unrelated PRs:

```
$ gh run list --workflow=ci-coverage-overview.yml --limit 20 \
    --json event | jq -r '.[].event' | sort | uniq -c
     20 pull_request
```

The coverage overview is meant as a daily snapshot, not a per-PR check.

**Fix:** drop the `pull_request` trigger. The workflow now runs only:

1. **Scheduled** — once per 24 hours at 6 AM UTC (`cron: '0 6 * * *'`), unchanged.
2. **Manual** — `workflow_dispatch` with the existing `output_format` input.

Also drops the now-dead `if: github.event_name != 'pull_request'` guard on the `unit-test-coverage` job.

## 2. XPU was invisible, MUSA had no scaffolding

`scripts/ci/utils/ci_coverage_report.py` hardcoded the backend list as `["CUDA", "AMD", "NPU", "CPU"]` in **five places** (Backend Summary, Folder Summary, By-Folder, By-Suite, JSON output). XPU tests registered via `register_xpu_ci()` were silently dropped from every section — 5 registrations all previously invisible:

```
test/registered/xpu/test_xpu_basic.py
test/registered/xpu/test_deepseek_ocr.py
test/registered/xpu/test_deepseek_ocr_triton.py
test/registered/xpu/test_intel_xpu_backend.py
test/registered/attention/test_chunk_gated_delta_rule.py  (CUDA + XPU)
```

MUSA has its own `pr-test-musa.yml` / `nightly-test-musa.yml` workflows but wasn't wired into the `test/registered/` framework. This PR adds `HWBackend.MUSA` + `register_musa_ci()` so future MUSA test migration can land without touching the registry. No MUSA test files are migrated here.

**Fix:**
- `python/sglang/test/ci/ci_register.py`: add `HWBackend.MUSA`, `register_musa_ci()`, `REGISTER_MAPPING["register_musa_ci"]`.
- `scripts/ci/utils/ci_coverage_report.py`: a single `BACKEND_DISPLAY_ORDER = ("CUDA", "AMD", "NPU", "CPU", "XPU", "MUSA")` constant — asserted at import time to match `HWBackend` — replaces all five hardcoded lists. The next backend addition touches one place; an out-of-sync enum trips the assertion at startup rather than failing silently.
- The markdown Folder Summary table only renders columns for backends with at least one registered test across the whole report, so MUSA doesn't widen every row with a zero column until its first test is registered. (JSON `folder_summary` is additive: every backend appears with its count, including 0.)

## 3. multimodal_gen tests folded in as virtual folders

`python/sglang/multimodal_gen/test/` (53 test files) uses its own `run_suite.py` / partitioning framework rather than `register_*_ci()`. The CUDA, AMD, MUSA, and NPU workflows each invoke it via their own command — but that attribution was nowhere in the coverage report.

**Fix:** synthesize `CIRegistry` records from file paths plus filename tokens, surface them as `mm_gen/<subdir>` rows alongside the registered test folders. Classification rules are inline named constants:

- `_MM_GEN_SUBDIR_BACKENDS` — subdir defaults: `server/` → CUDA+AMD, `server/musa/` → MUSA, `server/ascend/` → NPU, `layers/unit/cli/manual/` → CUDA, top-level → CUDA.
- `_MM_GEN_FILENAME_BACKEND_TOKENS` — token-based overrides: `musa` in `stem.split("_")` → MUSA (catches both `test_musa_*` and `test_*_musa*`), `npu` → NPU.
- Helper-module skip list excludes `test_utils.py` (zero `def test_*` functions).
- `nightly` token in stem → nightly=True.

These are heuristics — if a workflow stops/starts running a subdir, the rules drift. Misclassifications print a stderr warning naming the file + unmatched subdir, so they show up in the next daily run. A `--multimodal-gen-dir` CLI flag (empty string to disable) lets callers opt out for debugging.

## Verification

Local run + workflow_dispatch on this branch produced the expected new rows:

```
Backend Summary
| Backend | Total | Enabled | Disabled | Per-Commit | Nightly |
| CUDA    |   394 |     385 |        9 |        324 |      61 |
| AMD     |   251 |     241 |       10 |        143 |      98 |
| NPU     |   133 |     114 |       19 |         32 |      82 |
| CPU     |   262 |     261 |        1 |        216 |      45 |
| XPU     |     5 |       4 |        1 |          4 |       0 |  ← previously hidden
| MUSA    |     5 |       5 |        0 |          4 |       1 |  ← previously hidden

Folder Summary (mm_gen rows; all 8 are new)
| mm_gen              |  1 |  0 |  0 |  0 |  0 |  0 |  1 |
| mm_gen/cli          |  3 |  0 |  0 |  0 |  0 |  0 |  3 |
| mm_gen/layers       |  0 |  0 |  0 |  0 |  0 |  2 |  2 |
| mm_gen/manual       |  1 |  0 |  0 |  0 |  0 |  0 |  1 |
| mm_gen/server       |  9 |  9 |  0 |  0 |  0 |  0 | 18 |
| mm_gen/server/ascend|  0 |  0 |  3 |  0 |  0 |  0 |  3 |
| mm_gen/server/musa  |  0 |  0 |  0 |  0 |  0 |  3 |  3 |
| mm_gen/unit         | 30 |  0 |  0 |  0 |  0 |  0 | 30 |

By-Suite section: mm-gen-cuda (44), mm-gen-amd (9), mm-gen-npu (3), mm-gen-musa (5 — 1 nightly via `test_server_1_gpu_musa_nightly.py`).
```

Total: 798 unique files (746 registered + 52 mm_gen) up from the previous 741.

## Out of scope / explicitly skipped

- **HPU** (Habana / Intel Gaudi): real runtime backend (`is_hpu()`, `torch.hpu.*`, `hpu_communicator.py`) but no CI workflow, no tests, no runner. Adding scaffolding without a planned migration is dead code.
- **MPS** (Apple Silicon): same situation as HPU.
- **RVV** (RISC-V Vector): zero hits anywhere in the repo. SGLang doesn't support it.
- **SMG**: `smg-grpc-servicer` in `pyproject*.toml` is the SGL Model Gateway gRPC servicer (Python package), not a hardware backend.
- **Xeon**: `pr-test-xeon.yml` runs `suite: base-b-test-cpu` on `xeon-gnr` runners — already covered transitively by `HWBackend.CPU`.

## Follow-up (not in this PR)

The `unit-test-coverage` job runs `pytest test/registered/unit/` on `1-gpu-h100`. That folder is 188 tests = 32 CUDA + 20 AMD + **136 CPU**; running the CPU majority on a GPU runner is wasteful. A future PR could split this into a CPU coverage job on ubuntu-latest plus a smaller GPU coverage job.

## Commits

1. `[CI] ci-coverage-overview: only run on schedule + manual` — trigger fix.
2. `[CI] ci-coverage-overview: include XPU + add MUSA scaffolding` — registry + report constant.
3. `[CI] ci-coverage-overview: include multimodal_gen tests` — virtual folders for mm_gen.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26608535133](https://github.com/sgl-project/sglang/actions/runs/26608535133)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26608535046](https://github.com/sgl-project/sglang/actions/runs/26608535046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->