### PR TITLE
anthropic: translate `thinking` field into chat_template_kwargs

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -88,6 +88,14 @@ class AnthropicToolChoice(BaseModel):
     name: Optional[str] = None
 
 
+class AnthropicThinking(BaseModel):
+    """Anthropic extended-thinking configuration (Messages API)."""
+
+    type: Literal["enabled", "disabled", "adaptive"] = "disabled"
+    # Per Anthropic spec; ignored for templates with binary on/off support.
+    budget_tokens: Optional[int] = None
+
+
 class AnthropicCountTokensRequest(BaseModel):
     """Anthropic Count Tokens API request"""
 
@@ -116,6 +124,7 @@ class AnthropicMessagesRequest(BaseModel):
     system: Optional[str | list[AnthropicContentBlock]] = None
     temperature: Optional[float] = None
     tool_choice: Optional[AnthropicToolChoice] = None
+    thinking: Optional[AnthropicThinking] = None
     tools: Optional[list[AnthropicTool]] = None
     top_k: Optional[int] = None
     top_p: Optional[float] = None

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -276,6 +276,25 @@ class AnthropicServing:
         if anthropic_request.stream:
             request_data["stream_options"] = StreamOptions(include_usage=True)
 
+        # Translate Anthropic `thinking` into `chat_template_kwargs.enable_thinking`
+        # so reasoning-parser models (Qwen3 / DeepSeek-R1 / Hermes-3 / Phi-4 ...)
+        # honour the Anthropic Messages API spec: thinking is opt-in, not opt-out.
+        # Precedence: metadata override > thinking field > false default.
+        _ctk_override = (
+            (anthropic_request.metadata or {}).get("chat_template_kwargs")
+            if anthropic_request.metadata
+            else None
+        )
+        if _ctk_override and isinstance(_ctk_override, dict):
+            request_data["chat_template_kwargs"] = _ctk_override
+        elif anthropic_request.thinking is not None:
+            request_data["chat_template_kwargs"] = {
+                "enable_thinking": anthropic_request.thinking.type
+                in ("enabled", "adaptive"),
+            }
+        else:
+            request_data["chat_template_kwargs"] = {"enable_thinking": False}
+
         chat_request = ChatCompletionRequest(**request_data)
 
         # Convert tools. Deferred tools stay in the list with defer_loading=True;

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -147,6 +147,95 @@ class TestAnthropicServer(CustomTestCase):
             "data:image/png;base64,abcd",
         )
 
+    def test_thinking_field_roundtrip(self):
+        """Anthropic `thinking` field is parsed onto AnthropicMessagesRequest."""
+        # Default (no thinking field) parses to None.
+        req_default = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        self.assertIsNone(req_default.thinking)
+
+        # `thinking: {type: enabled}` round-trips.
+        req_enabled = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "enabled", "budget_tokens": 1024},
+        )
+        self.assertIsNotNone(req_enabled.thinking)
+        self.assertEqual(req_enabled.thinking.type, "enabled")
+        self.assertEqual(req_enabled.thinking.budget_tokens, 1024)
+
+        # `thinking: {type: disabled}` round-trips.
+        req_disabled = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "disabled"},
+        )
+        self.assertEqual(req_disabled.thinking.type, "disabled")
+
+        # `thinking: {type: adaptive}` round-trips.
+        req_adaptive = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive"},
+        )
+        self.assertEqual(req_adaptive.thinking.type, "adaptive")
+
+    def test_thinking_field_translation_to_chat_template_kwargs(self):
+        """`thinking` is translated to `chat_template_kwargs.enable_thinking`.
+
+        Precedence (matches the Anthropic Messages API default-off semantics):
+            metadata.chat_template_kwargs > thinking field > false default.
+        """
+        serving = AnthropicServing(openai_serving_chat=object())
+        base_kwargs = dict(
+            model=self.model,
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        # No `thinking` -> enable_thinking=False (Anthropic spec default).
+        req = AnthropicMessagesRequest(**base_kwargs)
+        chat_request = serving._convert_to_chat_completion_request(req)
+        self.assertEqual(chat_request.chat_template_kwargs, {"enable_thinking": False})
+
+        # `thinking: enabled` -> enable_thinking=True.
+        req = AnthropicMessagesRequest(**base_kwargs, thinking={"type": "enabled"})
+        chat_request = serving._convert_to_chat_completion_request(req)
+        self.assertEqual(chat_request.chat_template_kwargs, {"enable_thinking": True})
+
+        # `thinking: adaptive` -> enable_thinking=True (treated as opt-in).
+        req = AnthropicMessagesRequest(**base_kwargs, thinking={"type": "adaptive"})
+        chat_request = serving._convert_to_chat_completion_request(req)
+        self.assertEqual(chat_request.chat_template_kwargs, {"enable_thinking": True})
+
+        # `thinking: disabled` -> enable_thinking=False.
+        req = AnthropicMessagesRequest(**base_kwargs, thinking={"type": "disabled"})
+        chat_request = serving._convert_to_chat_completion_request(req)
+        self.assertEqual(chat_request.chat_template_kwargs, {"enable_thinking": False})
+
+        # `metadata.chat_template_kwargs` overrides the thinking field.
+        req = AnthropicMessagesRequest(
+            **base_kwargs,
+            thinking={"type": "disabled"},
+            metadata={
+                "chat_template_kwargs": {
+                    "enable_thinking": True,
+                    "custom_flag": "x",
+                }
+            },
+        )
+        chat_request = serving._convert_to_chat_completion_request(req)
+        self.assertEqual(
+            chat_request.chat_template_kwargs,
+            {"enable_thinking": True, "custom_flag": "x"},
+        )
+
     def test_simple_messages(self):
         """Test basic non-streaming message request."""
         payload = self._default_payload()


### PR DESCRIPTION
Fixes #26620

## Motivation

The Anthropic Messages API treats extended thinking as **opt-in**: thinking only runs when the client sends `thinking: {type: "enabled"|"adaptive"}`. The sglang adapter at `/v1/messages` was silently dropping the field because `AnthropicMessagesRequest` did not declare it. Concrete consequences:

- Clients explicitly sending `thinking: {type: "enabled"}` have no effect.
- Clients explicitly sending `thinking: {type: "disabled"}` have no effect.
- Models served with `--reasoning-parser` whose chat templates default `enable_thinking=True` (Qwen3 / Qwen3.5 / DeepSeek-R1 / Hermes-3 / Phi-4, ...) enter the long `<think>` phase on every request when served at `/v1/messages`, costing thousands of decode tokens and seconds-to-minutes of extra latency even for trivial prompts.
- Anthropic SDK clients (including Claude Code 2.1.154) rely on the default-off behavior. Today they get the opposite.

## Modifications

`python/sglang/srt/entrypoints/anthropic/protocol.py`

- New `AnthropicThinking` model with `type: Literal["enabled","disabled","adaptive"]` (defaults to `"disabled"`) and optional `budget_tokens`.
- New `thinking: Optional[AnthropicThinking] = None` field on `AnthropicMessagesRequest`.

`python/sglang/srt/entrypoints/anthropic/serving.py`

- In `_convert_to_chat_completion_request`, translate the field into `chat_template_kwargs.enable_thinking` for the inner `ChatCompletionRequest`. Precedence: `metadata.chat_template_kwargs` override > `thinking` field > `enable_thinking=False` default. The `False` default matches Anthropic's opt-in semantics regardless of what the model's chat template defaults to.

`test/registered/openai_server/basic/test_anthropic_server.py`

- `test_thinking_field_roundtrip`: asserts schema round-trip for default / enabled / disabled / adaptive (plus `budget_tokens` preserved).
- `test_thinking_field_translation_to_chat_template_kwargs`: asserts the precedence rules end-to-end on `_convert_to_chat_completion_request`.

## Accuracy Tests

No change to model output behavior unless the client explicitly opts in via `thinking`. The default change only stops `<think>` blocks from being emitted on requests that did not ask for them — exactly matching the Anthropic Messages API contract.

Server-side precedence (curl against `/v1/messages?beta=true`, reasoning-parser model):

| Anthropic body | result |
|---|---|
| no `thinking` field | 0 thinking_delta, content streams (matches spec) |
| `thinking.type=enabled` | thinking_delta streams |
| `thinking.type=disabled` | 0 thinking_delta, content streams |
| `thinking.type=adaptive` | thinking_delta streams |
| `metadata.chat_template_kwargs.enable_thinking=true` | thinking_delta streams (override path) |

Unit tests covering the same matrix are added in `test_anthropic_server.py`.

## Speed Tests

End-to-end with `claude --bare -p --output-format stream-json --include-partial-messages --verbose` (Claude Code 2.1.154) against an sglang server with this patch applied, reasoning-parser model served as `claude-sonnet-4-5-20250929` (the renaming is irrelevant to this PR; what matters is that Claude Code sends `thinking.type=adaptive` by default for Claude-named models):

| Client config | TTFT | thinking_delta events | text_delta events | total |
|---|---|---|---|---|
| `CLAUDE_CODE_DISABLE_THINKING=1` (sends `thinking.type=disabled`) | 439 ms | 0 | 3 | 720 ms |
| default (sends `thinking.type=adaptive`) | 779 ms | 21 | 4 | 1.73 s |

Without this PR the `CLAUDE_CODE_DISABLE_THINKING=1` row is indistinguishable from the default row because the `thinking` field is dropped at the pydantic boundary. With this PR the spec-mandated opt-in / opt-out semantics hold.

## Related PRs

Several open PRs touch adjacent concerns; none have shipped the input-side translation. This PR is intentionally narrow (two source files, ~25 lines + tests) so it can land independently of the broader scope work:

- #19334 Support thinking/reasoning tokens in /v1/messages (open, output-side)
- #21902 feat(anthropic): add thinking/reasoning support and cache token usage to /v1/messages (open, broader scope)
- #22135 [Anthropic] Support thinking/reasoning tokens in /v1/messages (open)
- #24294 fix(anthropic): track block type and surface reasoning_content as thinking (open, output-side correctness)
- #25271 feat(anthropic): support Claude 4.7 thinking/output_config and tool+t... (open, Claude-4.7-specific)
- #22061 [Anthropic] Add thinking support for /v1/messages (closed)

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add tests
- [x] Update documentation as needed (no public docs reference this adapter's request schema).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26608615478](https://github.com/sgl-project/sglang/actions/runs/26608615478)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26608615400](https://github.com/sgl-project/sglang/actions/runs/26608615400)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->