### PR TITLE
Update Step-3.7-Flash Docker image tag

### DIFF
--- a/docs_new/cookbook/autoregressive/StepFun/Step-3.7-Flash.mdx
+++ b/docs_new/cookbook/autoregressive/StepFun/Step-3.7-Flash.mdx
@@ -19,14 +19,14 @@ Step-3.7-Flash is currently available in SGLang via Docker image install.
 ### Docker (NVIDIA)
 ```bash Command
 # Pull the docker image
-docker pull lmsysorg/sglang:dev-pr-18084
+docker pull lmsysorg/sglang:dev-step-3.7-flash
 
 # Launch the container
 docker run -it --gpus all \
   --shm-size=32g \
   --ipc=host \
   --network=host \
-  lmsysorg/sglang:dev-pr-18084 bash
+  lmsysorg/sglang:dev-step-3.7-flash bash
 ```
 
 ## 3. Model Deployment


### PR DESCRIPTION
Update the Docker image for Step-3.7-Flash cookbook from `lmsysorg/sglang:dev-pr-18084` to `lmsysorg/sglang:dev-step-3.7-flash`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26609827187](https://github.com/sgl-project/sglang/actions/runs/26609827187)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26609827053](https://github.com/sgl-project/sglang/actions/runs/26609827053)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->