### PR TITLE
Fix non-determinism on Kimi-K2.5 MoE

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -219,6 +219,13 @@ def fused_marlin_moe(
         or torch.cuda.get_device_capability(hidden_states.device)[0] >= 9
     ) and (not is_mxfp4_marlin)
 
+    # Disable cross-block FP16 atomicAdd reduction under deterministic mode.
+    from sglang.srt.server_args import get_global_server_args
+
+    use_atomic_add = use_atomic_add and (
+        not get_global_server_args().enable_deterministic_inference
+    )
+
     intermediate_cache1 = moe_wna16_marlin_gemm(
         hidden_states,
         intermediate_cache1,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -853,6 +853,8 @@ class DeepseekV2MoE(nn.Module):
                     <= get_global_server_args().torch_compile_max_bs
                     * (get_global_server_args().speculative_num_draft_tokens or 1)
                 )
+                # Dual-stream MoE is non-deterministic under CUDA graph replay.
+                and not get_global_server_args().enable_deterministic_inference
             ):
                 return self.forward_normal_dual_stream(
                     hidden_states,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fixes https://github.com/sgl-project/sglang/issues/25912 : non-determinism in greedy generation on Kimi-K2.5 (and DeepSeek-V3-arch MoE models more broadly) when `--enable-deterministic-inference` is set.

## Modifications

Two source-level changes, both gated on the flag:
1. force `use_atomic_add=False` in `fused_marlin_moe` to eliminate FP16 cross-block atomicAdd noise in the Marlin INT4 MoE GEMM
2. bypass `DeepseekV2MoE.forward_normal_dual_stream` to avoid an inter-stream race under CUDA graph replay.

With both fixes Kimi-K2.5 at TP=8 + FA3 goes from 5 to 1 unique outputs across 20 runs.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->


### Summary

- **Steady-state ITL cost is small** and concentrated where there's the least batching to amortize it. At `conc=16` prefill the patches cost ~2% throughput; at `conc=1` decode they cost ~9%.
- **decode/c1 is the worst case**, **prefill/c16 is the best case**

### Slowdown of the two patches in deterministic mode

- decode: 1K/1K
- prefill: 8K/1K

| Workload | Conc | ΔOutTput | ΔITL (median) | ΔE2E (median) |
|---|---:|---:|---:|---:|
| decode  |  1 | **−9.3%** | +10.3% | +10.2% |
| decode  | 16 | **−3.5%** | +4.1%  | +4.0%  |
| prefill |  1 | **−5.4%** | +5.8%  | +5.7%  |
| prefill | 16 | **−1.8%** | +2.5%  | +1.9%  |

### Raw results

B: before this PR
A: after this PR

| Cfg | Workload | Conc | OutTput (tok/s) | InTput (tok/s) | Median TTFT (ms) | Median ITL (ms) | Median E2E (ms) | ReqTput (req/s) |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| B | decode  |  1 |  67.45 |  67.45 |  136.92 | 14.70 | 14823.94 | 0.07 |
| A | decode  |  1 |  61.19 |  61.19 |  137.03 | 16.22 | 16339.74 | 0.06 |
| B | decode  | 16 | 681.50 | 681.50 | 1237.38 | 22.12 | 23407.15 | 0.68 |
| A | decode  | 16 | 657.36 | 657.36 | 1236.11 | 23.02 | 24339.94 | 0.66 |
| B | prefill |  1 |  38.62 | 308.93 |  681.01 | 25.35 | 25971.35 | 0.04 |
| A | prefill |  1 |  36.54 | 292.35 |  682.74 | 26.81 | 27441.26 | 0.04 |
| B | prefill | 16 | 367.42 | 2939.39 | 6448.07 | 33.08 | 43012.09 | 0.37 |
| A | prefill | 16 | 360.79 | 2886.31 | 6439.60 | 33.91 | 43810.87 | 0.36 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27989144173](https://github.com/sgl-project/sglang/actions/runs/27989144173)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27989144002](https://github.com/sgl-project/sglang/actions/runs/27989144002)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->