### PR TITLE
fix(cache_hit_kit): apply OPENAI_API_KEY/API_KEY auth header to bench requests (#26630)

### DIFF
--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -5,7 +5,7 @@ import time
 import aiohttp
 import requests
 
-from sglang.bench_serving import RequestFuncOutput
+from sglang.bench_serving import RequestFuncOutput, get_auth_headers
 from sglang.benchmark.datasets.random import sample_random_requests
 from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
@@ -22,7 +22,7 @@ async def async_request_sglang_generate(
     Returns a RequestFuncOutput with additional cached_tokens and output_ids attributes.
     """
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
-        headers = {}
+        headers = get_auth_headers()
         generated_text = ""
         all_output_ids = []
         ttft = 0.0
@@ -100,6 +100,7 @@ async def async_request_openai_chat_completions(
     async_request_sglang_generate (except output_ids, which is unavailable).
     """
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+        headers = get_auth_headers()
         generated_text = ""
         ttft = 0.0
         latency = 0.0
@@ -108,7 +109,7 @@ async def async_request_openai_chat_completions(
         output = RequestFuncOutput()
 
         try:
-            async with session.post(url=url, json=payload) as response:
+            async with session.post(url=url, json=payload, headers=headers) as response:
                 if response.status == 200:
                     prompt_tokens = 0
                     cached_tokens = 0


### PR DESCRIPTION
## What

`benchmark/hicache/bench_multiturn.py` re-imports `async_request_openai_chat_completions` and `async_request_sglang_generate` from `sglang.test.kits.cache_hit_kit` (not from `sglang.bench_serving`). Both of these copies were sending requests with no `Authorization` header — `async_request_sglang_generate` initialised `headers = {}`, and `async_request_openai_chat_completions` never set headers at all.

When the server is launched with `--api-key …`, the bench gets `401 Unauthorized` even though `OPENAI_API_KEY` (or `API_KEY`) is exported in the environment, because the env-derived auth header never reaches `session.post(...)`.

## Why this matters

Reported in [#26630](https://github.com/sgl-project/sglang/issues/26630). The companion functions in `sglang/bench_serving.py` already read `OPENAI_API_KEY`/`API_KEY` via `get_auth_headers()` and route them as `Authorization` — only this `test/kits` copy was missing that lookup.

## Fix

Reuse the existing `get_auth_headers()` helper from `sglang.bench_serving` instead of duplicating the env lookup:

- `async_request_sglang_generate`: `headers = {}` → `headers = get_auth_headers()`
- `async_request_openai_chat_completions`: add `headers = get_auth_headers()` and pass it to `session.post(...)`

`get_auth_headers()` is module-level in `bench_serving` and depends only on env vars (`OPENAI_API_KEY` → `Bearer ...`; else `API_KEY` → raw), so it works without `set_global_args` having run.

## Repro

```bash
# server (excerpt from #26630)
python3 -m sglang.launch_server --model openai/gpt-oss-120b ... --api-key sk-sg-api-key ...

# bench — used to return 401 for every request, now succeeds
OPENAI_API_KEY=sk-sg-api-key python3 benchmark/hicache/bench_multiturn.py \
    --model-path openai/gpt-oss-120b --port 30000 ... --api-format openai
```

Same path works for `--api-format generate` once the server is `--api-key`-protected.

Fixes #26630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26612364825](https://github.com/sgl-project/sglang/actions/runs/26612364825)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26612364757](https://github.com/sgl-project/sglang/actions/runs/26612364757)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->