### PR TITLE
[AMD] Reclaim orphaned HF-cache partial downloads to mitigate /sgl-data ENOSPC

### DIFF
--- a/python/sglang/srt/model_loader/ci_weight_validation.py
+++ b/python/sglang/srt/model_loader/ci_weight_validation.py
@@ -14,6 +14,7 @@ the overhead of validation and automatic cleanup. The CI-specific behavior is
 gated by is_in_ci() checks in weight_utils.py.
 """
 
+import errno
 import glob as glob_module
 import hashlib
 import json
@@ -1829,6 +1830,177 @@ def _cleanup_incomplete_blobs(model_name_or_path: str, cache_dir: Optional[str])
         return 0
 
 
+def _ci_cache_min_free_gb() -> float:
+    """Free-space threshold (GB) below which cache space is proactively reclaimed.
+
+    Overridable via the ``SGLANG_CI_CACHE_MIN_FREE_GB`` env var.
+    """
+    try:
+        return float(os.environ.get("SGLANG_CI_CACHE_MIN_FREE_GB", "50"))
+    except (TypeError, ValueError):
+        return 50.0
+
+
+def _ci_stale_incomplete_age_seconds() -> int:
+    """Minimum age (seconds) before an orphaned ``.incomplete`` partial download
+    is considered stale and safe to delete.
+
+    Defaults to 30 minutes and is overridable via
+    ``SGLANG_CI_STALE_INCOMPLETE_AGE_S``. An in-progress download continuously
+    updates its ``.incomplete`` file's mtime, so only files untouched for this
+    long (i.e. left behind by crashed/killed jobs) are removed.
+    """
+    try:
+        return int(os.environ.get("SGLANG_CI_STALE_INCOMPLETE_AGE_S", "1800"))
+    except (TypeError, ValueError):
+        return 1800
+
+
+def _effective_hf_cache_dir(cache_dir: Optional[str]) -> Optional[str]:
+    """Resolve the HF cache directory, returning None when it does not exist."""
+    effective = cache_dir
+    if effective is None:
+        try:
+            import huggingface_hub.constants
+
+            effective = huggingface_hub.constants.HF_HUB_CACHE
+        except Exception:
+            return None
+    return effective if effective and os.path.isdir(effective) else None
+
+
+def _cache_free_gb(path: str) -> Optional[float]:
+    """Return free space (GB) on the volume backing ``path``, or None on error."""
+    try:
+        return shutil.disk_usage(path).free / (1024**3)
+    except OSError:
+        return None
+
+
+def _reclaim_stale_incomplete_blobs(
+    cache_dir: Optional[str], min_age_seconds: int
+) -> Tuple[int, int]:
+    """Remove orphaned ``*.incomplete`` partial downloads across the *entire*
+    shared HF cache (not just one model).
+
+    On the shared CI cache, jobs that are SIGKILL'd mid-download leave behind
+    partial ``.incomplete`` blobs that are never reclaimed and slowly fill the
+    volume (eventually causing ``ENOSPC``). Unlike ``_cleanup_incomplete_blobs``
+    (single model, run under that model's lock), this scans all ``models--*``
+    repos and is therefore gated on file age: an in-progress download keeps its
+    ``.incomplete`` mtime fresh, so only files untouched for ``min_age_seconds``
+    are removed. Active downloads in other processes/containers are never
+    touched.
+
+    Returns:
+        Tuple of (files_removed, bytes_freed).
+    """
+    effective_cache_dir = _effective_hf_cache_dir(cache_dir)
+    if effective_cache_dir is None:
+        return (0, 0)
+
+    now = time.time()
+    files_removed = 0
+    bytes_freed = 0
+    pattern = os.path.join(effective_cache_dir, "models--*", "blobs", "*.incomplete")
+    for path in glob_module.glob(pattern):
+        try:
+            st = os.stat(path)
+        except OSError:
+            continue
+        if now - st.st_mtime < min_age_seconds:
+            # Possibly an active download in another process/container; skip.
+            continue
+        try:
+            os.remove(path)
+            files_removed += 1
+            bytes_freed += st.st_size
+        except OSError as e:
+            logger.debug("Failed to remove stale incomplete blob %s: %s", path, e)
+
+    if files_removed > 0:
+        logger.warning(
+            "[CI Download] Reclaimed %d stale .incomplete partial download(s) "
+            "(%.2f GB, older than %ds) from %s",
+            files_removed,
+            bytes_freed / (1024**3),
+            min_age_seconds,
+            effective_cache_dir,
+        )
+    return (files_removed, bytes_freed)
+
+
+def _preflight_reclaim_cache_space(
+    cache_dir: Optional[str], model_name_or_path: str
+) -> None:
+    """Reclaim orphaned partial-download space before taking the download lock.
+
+    Runs *before* lock acquisition because the lock file lives on the same
+    shared cache volume; when that volume is full, even creating the tiny lock
+    file fails with ``ENOSPC``. Only acts when free space is below the
+    configured threshold, so it is a no-op on healthy runners.
+    """
+    effective_cache_dir = _effective_hf_cache_dir(cache_dir)
+    if effective_cache_dir is None:
+        return
+
+    free_before = _cache_free_gb(effective_cache_dir)
+    min_free = _ci_cache_min_free_gb()
+    if free_before is not None and free_before >= min_free:
+        return
+
+    logger.warning(
+        "[CI Download] Low free space on cache volume %s "
+        "(%s GB free < %.1f GB threshold) before downloading %s; "
+        "reclaiming orphaned partial downloads.",
+        effective_cache_dir,
+        "unknown" if free_before is None else f"{free_before:.1f}",
+        min_free,
+        model_name_or_path,
+    )
+    _reclaim_stale_incomplete_blobs(cache_dir, _ci_stale_incomplete_age_seconds())
+    free_after = _cache_free_gb(effective_cache_dir)
+    if free_after is not None:
+        logger.warning(
+            "[CI Download] Cache volume %s free space after reclaim: %.1f GB",
+            effective_cache_dir,
+            free_after,
+        )
+
+
+def _ensure_lock_file_creatable(
+    lock_file_path: str, cache_dir: Optional[str], model_name_or_path: str
+) -> None:
+    """Fail fast with an actionable error when the cache volume is out of space.
+
+    Without this, a full volume surfaces as a cryptic
+    ``OSError: [Errno 28] No space left on device: '.../download_*.lock'`` from
+    deep inside ``filelock`` during lock acquisition, which looks like a locking
+    bug rather than a disk-capacity problem. We probe by creating the lock file
+    up front; on ``ENOSPC`` we raise a clear message instead. (Pre-creating the
+    file is harmless: ``filelock`` coordinates via ``flock`` on the fd, not file
+    existence.)
+    """
+    try:
+        fd = os.open(lock_file_path, os.O_CREAT | os.O_WRONLY, 0o666)
+        os.close(fd)
+    except OSError as e:
+        if getattr(e, "errno", None) != errno.ENOSPC:
+            # Unrelated (e.g. permissions): let filelock surface it normally.
+            return
+        effective_cache_dir = _effective_hf_cache_dir(cache_dir)
+        free = _cache_free_gb(effective_cache_dir) if effective_cache_dir else None
+        raise RuntimeError(
+            f"CI model cache volume is out of disk space (ENOSPC) while preparing "
+            f"to download '{model_name_or_path}'. "
+            f"Lock file: {lock_file_path}; cache dir: {effective_cache_dir} "
+            f"(free: {'unknown' if free is None else f'{free:.1f} GB'}). "
+            f"Reclaiming orphaned partial downloads did not free enough space; "
+            f"the shared HF cache needs an LRU prune or a capacity increase. "
+            f"Tunables: SGLANG_CI_CACHE_MIN_FREE_GB, SGLANG_CI_STALE_INCOMPLETE_AGE_S."
+        ) from e
+
+
 def ci_download_with_validation_and_retry(
     model_name_or_path: str,
     allow_patterns: List[str],
@@ -1893,6 +2065,13 @@ def ci_download_with_validation_and_retry(
         os.getpid(),
         model_name_or_path,
     )
+
+    # On the shared CI cache, reclaim orphaned partial-download space before
+    # taking the lock (the lock file lives on the same volume, so its creation
+    # fails with ENOSPC when the volume is full), then fail fast with a clear,
+    # actionable message if the volume is genuinely out of capacity.
+    _preflight_reclaim_cache_space(cache_dir, model_name_or_path)
+    _ensure_lock_file_creatable(lock_file_path, cache_dir, model_name_or_path)
 
     with lock:
         logger.info(

--- a/test/manual/test_weight_validation.py
+++ b/test/manual/test_weight_validation.py
@@ -5,14 +5,20 @@ Tests the fix for issue #14754 - ensuring that missing shards do not trigger
 entire cache deletion, which can cause race conditions in multi-process scenarios.
 """
 
+import errno
 import json
 import os
 import struct
 import tempfile
+import time
 import unittest
+from unittest import mock
 
 from sglang.srt.model_loader.ci_weight_validation import (
     _check_index_files_exist,
+    _ensure_lock_file_creatable,
+    _preflight_reclaim_cache_space,
+    _reclaim_stale_incomplete_blobs,
     _validate_sharded_model,
 )
 
@@ -180,6 +186,116 @@ class TestWeightValidation(unittest.TestCase):
             # The broken symlink should have been cleaned up
             self.assertFalse(os.path.exists(index_path))
             self.assertFalse(os.path.islink(index_path))
+
+
+class TestCacheSpaceReclaim(unittest.TestCase):
+    """Tests for the shared-CI-cache ENOSPC mitigation.
+
+    Covers age-gated reclaim of orphaned ``*.incomplete`` partial downloads and
+    the actionable out-of-space error raised when the lock file cannot be
+    created.
+    """
+
+    def _make_incomplete(self, cache_dir, repo, name, age_seconds, size=1024):
+        blobs = os.path.join(cache_dir, repo, "blobs")
+        os.makedirs(blobs, exist_ok=True)
+        path = os.path.join(blobs, name)
+        with open(path, "wb") as f:
+            f.write(b"x" * size)
+        mtime = time.time() - age_seconds
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def test_reclaim_removes_only_stale_incomplete(self):
+        """Stale partials (old mtime) are removed; active ones and real blobs stay."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale_a = self._make_incomplete(
+                tmpdir, "models--org--modelA", "aaa.incomplete", age_seconds=7200
+            )
+            stale_b = self._make_incomplete(
+                tmpdir, "models--org--modelB", "bbb.incomplete", age_seconds=7200
+            )
+            # Fresh partial == active download in another process/container.
+            fresh = self._make_incomplete(
+                tmpdir, "models--org--modelA", "ccc.incomplete", age_seconds=10
+            )
+            # A real (complete) blob must never be touched.
+            real_blob = os.path.join(tmpdir, "models--org--modelA", "blobs", "ddd")
+            with open(real_blob, "wb") as f:
+                f.write(b"y" * 2048)
+
+            removed, freed = _reclaim_stale_incomplete_blobs(
+                tmpdir, min_age_seconds=1800
+            )
+
+            self.assertEqual(removed, 2)
+            self.assertEqual(freed, 2048)  # 2 stale files * 1024 bytes
+            self.assertFalse(os.path.exists(stale_a))
+            self.assertFalse(os.path.exists(stale_b))
+            self.assertTrue(os.path.exists(fresh))
+            self.assertTrue(os.path.exists(real_blob))
+
+    def test_reclaim_noop_when_cache_dir_missing(self):
+        self.assertEqual(
+            _reclaim_stale_incomplete_blobs("/nonexistent/path/xyz", 0), (0, 0)
+        )
+
+    def test_preflight_noop_when_space_healthy(self):
+        """With a 0 GB threshold, free space is never 'low', so nothing is reclaimed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale = self._make_incomplete(
+                tmpdir, "models--org--modelA", "aaa.incomplete", age_seconds=7200
+            )
+            with mock.patch.dict(os.environ, {"SGLANG_CI_CACHE_MIN_FREE_GB": "0"}):
+                _preflight_reclaim_cache_space(tmpdir, "org/modelA")
+            self.assertTrue(os.path.exists(stale))
+
+    def test_preflight_reclaims_when_space_low(self):
+        """An unreachable free-space threshold forces a reclaim pass."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale = self._make_incomplete(
+                tmpdir, "models--org--modelA", "aaa.incomplete", age_seconds=7200
+            )
+            fresh = self._make_incomplete(
+                tmpdir, "models--org--modelA", "bbb.incomplete", age_seconds=10
+            )
+            with mock.patch.dict(
+                os.environ, {"SGLANG_CI_CACHE_MIN_FREE_GB": "100000000"}
+            ):
+                _preflight_reclaim_cache_space(tmpdir, "org/modelA")
+            self.assertFalse(os.path.exists(stale))
+            self.assertTrue(os.path.exists(fresh))
+
+    def test_ensure_lock_creatable_success(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = os.path.join(tmpdir, "download_test.lock")
+            _ensure_lock_file_creatable(lock_path, tmpdir, "org/modelA")
+            self.assertTrue(os.path.exists(lock_path))
+
+    def test_ensure_lock_creatable_enospc_raises_clear_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = os.path.join(tmpdir, "download_test.lock")
+
+            def fake_open(*args, **kwargs):
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            with mock.patch.object(os, "open", side_effect=fake_open):
+                with self.assertRaises(RuntimeError) as ctx:
+                    _ensure_lock_file_creatable(lock_path, tmpdir, "org/modelA")
+            self.assertIn("out of disk space", str(ctx.exception))
+            self.assertIn("org/modelA", str(ctx.exception))
+
+    def test_ensure_lock_creatable_ignores_non_enospc(self):
+        """Non-ENOSPC errors are swallowed so filelock can surface them normally."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = os.path.join(tmpdir, "download_test.lock")
+
+            def fake_open(*args, **kwargs):
+                raise OSError(errno.EACCES, "Permission denied")
+
+            with mock.patch.object(os, "open", side_effect=fake_open):
+                # Should not raise.
+                _ensure_lock_file_creatable(lock_path, tmpdir, "org/modelA")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The AMD CI runners share an NFS-mounted HuggingFace cache at `/sgl-data/hf-cache`. It has been filling up and causing `ENOSPC`, which is now escalating beyond the `amd-aiter-scout` nightly into the regular `pr-test-amd` matrix (e.g. `multimodal-gen-*` legs in run [26611381745](https://github.com/sgl-project/sglang/actions/runs/26611381745), and the EAGLE3 / HiCache server launches). The symptom is cryptic — the failure surfaces while creating the tiny per-model download lock file:

```
OSError: [Errno 28] No space left on device: '/sgl-data/hf-cache/hub/.sglang_locks/download_*.lock'
```

A major, reclaimable contributor is **orphaned `*.incomplete` partial downloads**: CI jobs frequently get SIGKILL'd (`-9`) mid-download (watchdog/OOM/timeout), leaving partial blobs that are never cleaned up and slowly fill the volume. The existing `_cleanup_incomplete_blobs` only runs *after* the lock is acquired and *only for the current model*, so it cannot help once the volume is already full (lock creation itself fails first).

## What this PR does

In the CI-only download path (`ci_download_with_validation_and_retry`), **before** acquiring the lock (the lock file lives on the same volume):

1. **Preflight reclaim (gated on low free space).** When free space on the cache volume is below a threshold, remove orphaned `*.incomplete` partials across the *entire* cache (`models--*/blobs/*.incomplete`). The reclaim is **age-gated** (default 30 min): an in-progress download continuously refreshes its `.incomplete` mtime, so only files left behind by dead jobs are removed — active downloads in other processes/containers are never touched. No-op on healthy runners.
2. **Actionable error on genuine exhaustion.** Probe lock-file creatability; if the volume is truly out of capacity, raise a clear `RuntimeError` (naming the cache dir + free space + remediation) instead of the opaque `ENOSPC` on a `.lock` path.

Tunables (env): `SGLANG_CI_CACHE_MIN_FREE_GB` (default `50`), `SGLANG_CI_STALE_INCOMPLETE_AGE_S` (default `1800`).

This is a safe, self-contained mitigation that reduces ENOSPC frequency and makes the remaining capacity failures obvious. It does **not** replace the infra-side fix — a genuinely-full volume (large complete model snapshots) still needs an LRU prune / capacity bump on the runners; reverting/clearing is out of scope here. No behavior change off the CI path.

## Test plan

- [x] New unit tests in `test/manual/test_weight_validation.py` (`TestCacheSpaceReclaim`) covering: age-gated reclaim (stale removed, active/real blobs kept, multi-repo), missing-cache no-op, low- vs healthy-space preflight, and the ENOSPC vs non-ENOSPC error paths. Verified passing against the real functions.
- [x] `black` / `isort` clean; diff is purely additive (existing logic untouched).
- [ ] Re-run a previously ENOSPC-affected AMD job (e.g. `multimodal-gen-test-*-amd`) on a runner near capacity to confirm orphaned partials are reclaimed and, if still full, the new actionable error appears.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26613673327](https://github.com/sgl-project/sglang/actions/runs/26613673327)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26613719746](https://github.com/sgl-project/sglang/actions/runs/26613719746)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->