### PR TITLE
[MUSA][Profiler] Support MUSA GPU events in torch profiler

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -89,6 +89,7 @@ from sglang.srt.utils import (
     suppress_other_loggers,
 )
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
+from sglang.srt.utils.profile_utils import get_torch_profiler_gpu_activities
 from sglang.srt.utils.tensor_bridge import use_mlx
 
 
@@ -123,7 +124,7 @@ def start_profile(
         if "CPU" in profile_activities:
             activities.append(torch.profiler.ProfilerActivity.CPU)
         if "GPU" in profile_activities:
-            activities.append(torch.profiler.ProfilerActivity.CUDA)
+            activities.extend(get_torch_profiler_gpu_activities())
         if "XPU" in profile_activities:
             activities.append(torch.profiler.ProfilerActivity.XPU)
         if activities:

--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -39,7 +39,10 @@ if _is_npu:
 logger = logging.getLogger(__name__)
 
 
-from sglang.srt.utils.profile_utils import ProfileManager
+from sglang.srt.utils.profile_utils import (
+    ProfileManager,
+    get_torch_profiler_gpu_activities,
+)
 
 
 @dataclass(kw_only=True)
@@ -163,14 +166,14 @@ class SchedulerProfilerManager:
         record_shapes = self.torch_profiler_record_shapes
 
         activity_map = {
-            "CPU": torch.profiler.ProfilerActivity.CPU,
-            "GPU": torch.profiler.ProfilerActivity.CUDA,
+            "CPU": [torch.profiler.ProfilerActivity.CPU],
+            "GPU": get_torch_profiler_gpu_activities(),
         }
         if hasattr(torch.profiler.ProfilerActivity, "XPU"):
-            activity_map["XPU"] = torch.profiler.ProfilerActivity.XPU
-        torchprof_activities = [
-            activity_map[a] for a in activities if a in activity_map
-        ]
+            activity_map["XPU"] = [torch.profiler.ProfilerActivity.XPU]
+        torchprof_activities = []
+        for activity in activities:
+            torchprof_activities.extend(activity_map.get(activity, []))
 
         if "RPD" in activities:  # for ROCM
             from rpdTracerControl import rpdTracerControl

--- a/python/sglang/srt/utils/profile_utils.py
+++ b/python/sglang/srt/utils/profile_utils.py
@@ -15,6 +15,7 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_npu
 
 _is_npu = is_npu()
+_is_musa = getattr(torch.version, "musa", None) is not None
 if _is_npu:
     import torch_npu
 
@@ -26,6 +27,25 @@ if _is_npu:
     torch_npu._apply_patches(patches)
 
 logger = logging.getLogger(__name__)
+
+
+def get_torch_profiler_gpu_activities():
+    """Return torch profiler activities that can carry accelerator events."""
+    if not _is_musa:
+        return [torch.profiler.ProfilerActivity.CUDA]
+
+    activities = []
+    for name in ("MUSA", "PrivateUse1"):
+        activity = getattr(torch.profiler.ProfilerActivity, name, None)
+        if activity is not None and activity not in activities:
+            activities.append(activity)
+    if not activities:
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+    if os.getenv("SGLANG_MUSA_PROFILER_INCLUDE_CUDA", "0") == "1":
+        activity = torch.profiler.ProfilerActivity.CUDA
+        if activity not in activities:
+            activities.append(activity)
+    return activities
 
 
 class ProfileManager:
@@ -263,12 +283,12 @@ class _ProfilerTorch(_ProfilerConcreteBase):
 
     def start(self):
         activity_map = {
-            "CPU": torch.profiler.ProfilerActivity.CPU,
-            "GPU": torch.profiler.ProfilerActivity.CUDA,
+            "CPU": [torch.profiler.ProfilerActivity.CPU],
+            "GPU": get_torch_profiler_gpu_activities(),
         }
-        torchprof_activities = [
-            activity_map[a] for a in self.activities if a in activity_map
-        ]
+        torchprof_activities = []
+        for activity in self.activities:
+            torchprof_activities.extend(activity_map.get(activity, []))
 
         self.torch_profiler = torch.profiler.profile(
             activities=torchprof_activities,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enable torch profiler GPU kernel events on MUSA. Currently, the generic GPU activity maps to `ProfilerActivity.CUDA`, which does not capture MUSA kernel events on torch-musa stacks.

## Modifications

- Add `get_torch_profiler_gpu_activities()` to select MUSA/PrivateUse1 profiler activity when running on MUSA.
- Use the selected GPU profiler activities in `bench_one_batch`, scheduler profiler, and profile v2.
- Keep CUDA/NPU/XPU behavior compatible with existing paths.

## Accuracy Tests

N/A. This change only affects profiling activity itself

## Speed Tests and Profiling
after patch,  showing musa gpu events properly
<img width="1180" height="411" alt="image" src="https://github.com/user-attachments/assets/a168d867-f67c-40c6-ae2b-f62d109acc29" />


## Checklist

- [x] Format/code style checked with `git diff --check`
- [x] Python files compile successfully
- [ ] CI

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26614399559](https://github.com/sgl-project/sglang/actions/runs/26614399559)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26614399506](https://github.com/sgl-project/sglang/actions/runs/26614399506)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->