### PR TITLE
[AMD] ci: switch CACHE_HOST to a fresh path to fix "No space left on device"

### DIFF
--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -273,7 +273,7 @@ else
 fi
 
 # CACHE_HOST=/home/runner/sgl-data
-CACHE_HOST=/home/runner/sglang-data
+CACHE_HOST=/home/runner/temp-sglang-data
 if [[ -d "$CACHE_HOST" ]]; then
     CACHE_VOLUME="-v $CACHE_HOST:/sgl-data"
 else


### PR DESCRIPTION
## Motivation

The AMD PR-test job `stage-a-test-1-gpu-small-amd` fails with exit code 255 because the persistent CI cache volume is full. `test_basic_sanity_eagle3.py` crashes during `setUpClass` when the scheduler tries to download model weights:

```
OSError: [Errno 28] No space left on device:
  '/sgl-data/hf-cache/hub/.sglang_locks/download_ad753ee3601c0a7f.lock'
[...] Received sigquit from a child process. It usually means the child failed.
```

`scripts/ci/amd/amd_ci_start_container.sh` bind-mounts `CACHE_HOST=/home/runner/sglang-data` into the container at `/sgl-data` whenever that host directory exists. That persistent volume (shared across CI runs and holding HF model weights, pip/MIOpen/aiter caches) has filled up, so every weight download lock acquisition fails.

Failing run: https://github.com/sgl-project/sglang/actions/runs/26611381745/job/78417864501#step:6:395

## Modifications

Point `CACHE_HOST` at a fresh path, `/home/runner/temp-sglang-data`, which does not exist on the runners. The existing guard then skips the bind mount:

```bash
CACHE_HOST=/home/runner/temp-sglang-data
if [[ -d "$CACHE_HOST" ]]; then
    CACHE_VOLUME="-v $CACHE_HOST:/sgl-data"
else
    CACHE_VOLUME=""   # <- taken now: no mount
fi
```

With no bind mount, `/sgl-data` falls back to the container's own ephemeral overlay storage (ample free space) instead of the exhausted persistent volume. This is the fallback path the workflow already anticipates ("WARNING: /sgl-data is not a mount point - models will be cleaned up after each test"). Trade-off: model/cache reuse across runs is disabled until the runners' persistent volume is reclaimed, in exchange for unblocking CI.

## Checklist

- [ ] Re-run the AMD PR test to confirm the disk-space failure is resolved.

> Note: a separate, unrelated failure also appeared in this run — `test_wave_attention_kernels.py` fails with `ModuleNotFoundError: No module named 'unittest.mock'`. That is not addressed here.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26614512965](https://github.com/sgl-project/sglang/actions/runs/26614512965)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26614512917](https://github.com/sgl-project/sglang/actions/runs/26614512917)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->