### PR TITLE
[AMD] ci: fix stdlib 'unittest' shadowing breaking registered attention tests

### DIFF
--- a/test/registered/attention/unittest/__init__.py
+++ b/test/registered/attention/unittest/__init__.py
@@ -1,1 +1,0 @@
-"""Manual attention backend unit tests."""


### PR DESCRIPTION
## Motivation

In the AMD PR-test job `stage-a-test-1-gpu-small-amd`, `test_wave_attention_kernels.py` fails at import time:

```
import torch
  ...
  File ".../torch/_guards.py", line 11, in <module>
    import unittest.mock
ModuleNotFoundError: No module named 'unittest.mock'
```

Failing run: https://github.com/sgl-project/sglang/actions/runs/26611381745/job/78417864501#step:6:395

### Root cause

The registered-test runner (`python/sglang/test/ci/ci_utils.py`) runs each test as `python3 <file> -f`, so Python prepends the **test file's own directory** to `sys.path[0]`. For tests located directly under `test/registered/attention/`, that directory contains a `unittest/` subpackage (`test/registered/attention/unittest/`).

Because `test/registered/attention/unittest/__init__.py` existed — added by #26517 (`f66f56c6b`, cc @ch-wan) — that directory was a **regular package** and shadowed the standard-library `unittest`. `import unittest` then resolved to the local package (which has no `mock` submodule), so any sibling test that imports `torch` — which internally does `import unittest.mock` — crashed with `ModuleNotFoundError: No module named 'unittest.mock'`.

Reproduction (independent of torch):

```
$ cd test/registered/attention && python3 -c "import unittest; print(unittest.__file__); import unittest.mock"
.../attention/unittest/__init__.py
ModuleNotFoundError: No module named 'unittest.mock'
```

## Modifications

Remove `test/registered/attention/unittest/__init__.py` so the directory becomes a **namespace package** instead of a regular package. A regular package/module on a later `sys.path` entry (the stdlib) outranks a namespace portion on an earlier entry, so `import unittest` now resolves to the stdlib and `unittest.mock` imports correctly:

```
$ cd test/registered/attention && python3 -c "import unittest; print(unittest.__file__); import unittest.mock; print('ok')"
/usr/lib/python3.10/unittest/__init__.py
ok
```

This also matches the existing `unittest/conftest.py`, which deliberately adds the directory to `sys.path` so its subpackages (`dense/`, `mla/`, ...) import as top-level modules — behavior that only works when the directory is not itself a package. The `unittest/` subtests (registered via `register_cuda_ci`) use absolute `sglang.*` imports and add their own dir to `sys.path`, so they are unaffected.

## Notes

- Builds on #26642 (already merged), which fixed the other failure in the same run ("No space left on device" on the persistent cache volume). With both changes on `main`, this PR's AMD CI run validates the full job end-to-end.

## Checklist

- [ ] Confirm `stage-a-test-1-gpu-small-amd` passes `test_wave_attention_kernels.py` in AMD CI.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26615551287](https://github.com/sgl-project/sglang/actions/runs/26615551287)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26615711023](https://github.com/sgl-project/sglang/actions/runs/26615711023)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

