### PR TITLE
[core] Make overlap-schedule WAR barrier CUDA-only

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1628,9 +1628,6 @@ class SchedulerDisaggregationDecodeMixin:
             if self._engine_paused:
                 continue
 
-            # WAR barrier: this iter's schedule writes to shared GPU buffers wait for prev forward's reads.
-            self.schedule_stream.wait_stream(self.forward_stream)
-
             # Get the next batch to run
             batch = self.get_next_disagg_decode_batch_to_run()
             self.cur_batch = batch

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1628,6 +1628,10 @@ class SchedulerDisaggregationDecodeMixin:
             if self._engine_paused:
                 continue
 
+            # WAR barrier: this iter's schedule writes to shared GPU buffers wait for prev forward's reads.
+            if self._war_barrier_enabled:
+                self.schedule_stream.wait_stream(self.forward_stream)
+
             # Get the next batch to run
             batch = self.get_next_disagg_decode_batch_to_run()
             self.cur_batch = batch

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -436,6 +436,10 @@ class SchedulerDisaggregationPrefillMixin:
             if self._engine_paused:
                 continue
 
+            # WAR barrier on shared GPU buffers (req_to_token_pool / SWA mapping).
+            if self._war_barrier_enabled:
+                self.schedule_stream.wait_stream(self.forward_stream)
+
             # Get the next batch to run
             batch = self.get_next_disagg_prefill_batch_to_run()
             self.cur_batch = batch

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -436,9 +436,6 @@ class SchedulerDisaggregationPrefillMixin:
             if self._engine_paused:
                 continue
 
-            # WAR barrier on shared GPU buffers (req_to_token_pool / SWA mapping).
-            self.schedule_stream.wait_stream(self.forward_stream)
-
             # Get the next batch to run
             batch = self.get_next_disagg_prefill_batch_to_run()
             self.cur_batch = batch

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -105,16 +105,6 @@ class FutureMap:
         self.new_seq_lens_buf = torch.empty(
             (self.req_pool_size,), dtype=torch.int64, device=self.device
         )
-        # Pinned host copy of new_seq_lens_buf + private stream for fwd-prepare
-        # D2H pulls (gated only on publish, off the schedule stream).
-        if _is_cuda or _is_hip:
-            self.new_seq_lens_cpu_pinned = torch.empty(
-                (self.req_pool_size,), dtype=torch.int64, pin_memory=True
-            )
-            self.fwd_prepare_d2h_stream = torch.get_device_module(self.device).Stream()
-        else:
-            self.new_seq_lens_cpu_pinned = None
-            self.fwd_prepare_d2h_stream = None
         if self.spec_algo.is_some():
             self._forward_buf_initialized = False
 
@@ -196,31 +186,17 @@ class FutureMap:
         batch.input_ids = -future_indices
 
     def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
-        # seq_lens_cpu may be needed on the host for kernel-launch prep (some backends).
-        # Run this D2H on a standalone stream to avoid chain-blocking forward_n ->
-        # prepare_{n+1}: a sync on the schedule stream would inherit its WAR barrier and
-        # stall the host until forward_n ends.
+        # Lazy pull from new_seq_lens_buf for spec_v2 (accept_lens not known to
+        # schedule). Write into both CPU and GPU so SB.seq_lens stays a faithful
+        # seq_lens_cpu mirror.
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
         if fi is None:
             return
         if self.publish_ready is not None:
             self.publish_ready.wait()
-        batch.seq_lens = self.new_seq_lens_buf[fi]
-
-        if self.fwd_prepare_d2h_stream is None or self.publish_ready is None:
-            batch.seq_lens_cpu = batch.seq_lens.cpu()  # bootstrap / non-CUDA
-            batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
-            return
-
-        # Mechanism: don't sync the schedule stream; gate a private stream on the
-        # publish event and copy into the static pinned buffer.
-        self.fwd_prepare_d2h_stream.wait_event(self.publish_ready)
-        with torch.get_device_module(self.device).stream(self.fwd_prepare_d2h_stream):
-            self.new_seq_lens_cpu_pinned.copy_(self.new_seq_lens_buf, non_blocking=True)
-        self.fwd_prepare_d2h_stream.synchronize()
-
-        # FIXME: fi == batch.req_pool_indices; unify future_indices and req_pool_indices.
-        batch.seq_lens_cpu = self.new_seq_lens_cpu_pinned[batch.req_pool_indices_cpu]
+        new_seq_lens = self.new_seq_lens_buf[fi]
+        batch.seq_lens = new_seq_lens
+        batch.seq_lens_cpu = new_seq_lens.cpu()
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
     def publish(self, future_indices: torch.Tensor, new_seq_lens: torch.Tensor) -> None:
@@ -228,7 +204,7 @@ class FutureMap:
         if indices.shape[0] == 0:
             return  # DP idle
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
-        # Only spec_v2 needs the event; it gates the seq_lens D2H on the private stream.
+        # Fast path: only spec_v2 needs the event (schedule-stream D2H sync).
         if self.spec_algo.is_some():
             if self.publish_ready is None:
                 self.publish_ready = torch.get_device_module(self.device).Event()

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -107,9 +107,8 @@ class FutureMap:
         )
         # Pinned host copy of new_seq_lens_buf + private stream for fwd-prepare
         # D2H pulls (gated only on publish, off the schedule stream). CUDA-only:
-        # this exists to recover occupancy lost to the WAR barrier, which is itself
-        # CUDA-only (HIP wait_stream serializes instead of overlapping). On AMD there
-        # is no barrier, so the plain .cpu() bootstrap path is used.
+        # recovers occupancy lost to the WAR barrier (also CUDA-only); AMD has no
+        # barrier and uses the plain .cpu() bootstrap path.
         if _is_cuda:
             self.new_seq_lens_cpu_pinned = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, pin_memory=True

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -107,8 +107,8 @@ class FutureMap:
         )
         # Pinned host copy of new_seq_lens_buf + private stream for fwd-prepare
         # D2H pulls (gated only on publish, off the schedule stream). CUDA-only:
-        # recovers occupancy lost to the WAR barrier (also CUDA-only); AMD has no
-        # barrier and uses the plain .cpu() bootstrap path.
+        # recovers occupancy lost to the WAR barrier (also CUDA-only); other
+        # platforms have no barrier and use the plain .cpu() bootstrap path.
         if _is_cuda:
             self.new_seq_lens_cpu_pinned = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, pin_memory=True

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -105,6 +105,19 @@ class FutureMap:
         self.new_seq_lens_buf = torch.empty(
             (self.req_pool_size,), dtype=torch.int64, device=self.device
         )
+        # Pinned host copy of new_seq_lens_buf + private stream for fwd-prepare
+        # D2H pulls (gated only on publish, off the schedule stream). CUDA-only:
+        # this exists to recover occupancy lost to the WAR barrier, which is itself
+        # CUDA-only (HIP wait_stream serializes instead of overlapping). On AMD there
+        # is no barrier, so the plain .cpu() bootstrap path is used.
+        if _is_cuda:
+            self.new_seq_lens_cpu_pinned = torch.empty(
+                (self.req_pool_size,), dtype=torch.int64, pin_memory=True
+            )
+            self.fwd_prepare_d2h_stream = torch.get_device_module(self.device).Stream()
+        else:
+            self.new_seq_lens_cpu_pinned = None
+            self.fwd_prepare_d2h_stream = None
         if self.spec_algo.is_some():
             self._forward_buf_initialized = False
 
@@ -186,17 +199,31 @@ class FutureMap:
         batch.input_ids = -future_indices
 
     def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
-        # Lazy pull from new_seq_lens_buf for spec_v2 (accept_lens not known to
-        # schedule). Write into both CPU and GPU so SB.seq_lens stays a faithful
-        # seq_lens_cpu mirror.
+        # seq_lens_cpu may be needed on the host for kernel-launch prep (some backends).
+        # Run this D2H on a standalone stream to avoid chain-blocking forward_n ->
+        # prepare_{n+1}: a sync on the schedule stream would inherit its WAR barrier and
+        # stall the host until forward_n ends.
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
         if fi is None:
             return
         if self.publish_ready is not None:
             self.publish_ready.wait()
-        new_seq_lens = self.new_seq_lens_buf[fi]
-        batch.seq_lens = new_seq_lens
-        batch.seq_lens_cpu = new_seq_lens.cpu()
+        batch.seq_lens = self.new_seq_lens_buf[fi]
+
+        if self.fwd_prepare_d2h_stream is None or self.publish_ready is None:
+            batch.seq_lens_cpu = batch.seq_lens.cpu()  # bootstrap / non-CUDA
+            batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
+            return
+
+        # Mechanism: don't sync the schedule stream; gate a private stream on the
+        # publish event and copy into the static pinned buffer.
+        self.fwd_prepare_d2h_stream.wait_event(self.publish_ready)
+        with torch.get_device_module(self.device).stream(self.fwd_prepare_d2h_stream):
+            self.new_seq_lens_cpu_pinned.copy_(self.new_seq_lens_buf, non_blocking=True)
+        self.fwd_prepare_d2h_stream.synchronize()
+
+        # FIXME: fi == batch.req_pool_indices; unify future_indices and req_pool_indices.
+        batch.seq_lens_cpu = self.new_seq_lens_cpu_pinned[batch.req_pool_indices_cpu]
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
     def publish(self, future_indices: torch.Tensor, new_seq_lens: torch.Tensor) -> None:
@@ -204,7 +231,7 @@ class FutureMap:
         if indices.shape[0] == 0:
             return  # DP idle
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
-        # Fast path: only spec_v2 needs the event (schedule-stream D2H sync).
+        # Only spec_v2 needs the event; it gates the seq_lens D2H on the private stream.
         if self.spec_algo.is_some():
             if self.publish_ready is None:
                 self.publish_ready = torch.get_device_module(self.device).Event()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1408,9 +1408,6 @@ class Scheduler(
             if self._engine_paused:
                 continue
 
-            # WAR barrier: this iter's schedule writes to shared GPU buffers wait for prev forward's reads.
-            self.schedule_stream.wait_stream(self.forward_stream)
-
             # Get the next batch to run
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -245,6 +245,7 @@ from sglang.srt.utils import (
     get_available_gpu_memory,
     get_bool_env_var,
     get_int_env_var,
+    is_cuda,
     is_mps,
     kill_itself_when_parent_died,
     require_mlp_sync,
@@ -1359,6 +1360,11 @@ class Scheduler(
         self.schedule_stream = self.device_module.Stream(priority=0)
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
+        # WAR barrier (schedule_stream.wait_stream(forward_stream)) is CUDA-only.
+        # On CUDA it is a free cross-stream dep -- schedule prep still overlaps the
+        # prev forward. On HIP/ROCm wait_stream serializes schedule behind forward,
+        # regressing AMD with no benefit, so AMD keeps the pre-barrier behavior.
+        self._war_barrier_enabled = is_cuda()
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)
 
@@ -1407,6 +1413,10 @@ class Scheduler(
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
+
+            # WAR barrier: this iter's schedule writes to shared GPU buffers wait for prev forward's reads.
+            if self._war_barrier_enabled:
+                self.schedule_stream.wait_stream(self.forward_stream)
 
             # Get the next batch to run
             batch = self.get_next_batch_to_run()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1360,10 +1360,9 @@ class Scheduler(
         self.schedule_stream = self.device_module.Stream(priority=0)
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
-        # WAR barrier (schedule_stream.wait_stream(forward_stream)) is CUDA-only.
-        # On CUDA it is a free cross-stream dep -- schedule prep still overlaps the
-        # prev forward. On HIP/ROCm wait_stream serializes schedule behind forward,
-        # regressing AMD with no benefit, so AMD keeps the pre-barrier behavior.
+        # WAR barrier is CUDA-only: verified to not affect CUDA throughput, but it
+        # caused scheduler hangs / regressions on AMD/HIP, so AMD keeps the
+        # pre-barrier behavior.
         self._war_barrier_enabled = is_cuda()
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1360,9 +1360,7 @@ class Scheduler(
         self.schedule_stream = self.device_module.Stream(priority=0)
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
-        # WAR barrier is CUDA-only: verified to not affect CUDA throughput, but it
-        # caused scheduler hangs / regressions on AMD/HIP, so AMD keeps the
-        # pre-barrier behavior.
+        # WAR barrier is CUDA-only; other platforms keep the pre-barrier behavior.
         self._war_barrier_enabled = is_cuda()
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -142,21 +142,23 @@ class EagleDraftInputV2Mixin:
         cur_kv_lens_cpu = torch.tensor(cur_kv_lens, dtype=torch.int32, device="cpu")
         nxt_kv_lens_cpu = torch.tensor(nxt_kv_lens, dtype=torch.int32, device="cpu")
 
+        # non_blocking H2D: a blocking .to() syncs the schedule stream, which the WAR
+        # barrier has chained to the prev forward -> host stalls a full forward.
+        cur_kv_lens_device = cur_kv_lens_cpu.to(device=batch.device, non_blocking=True)
+        nxt_kv_lens_device = nxt_kv_lens_cpu.to(device=batch.device, non_blocking=True)
         if page_size == 1:
             out_cache_loc = alloc_token_slots(batch.tree_cache, num_needed_tokens)
         else:
-            cur_kv_lens = cur_kv_lens_cpu.to(device=batch.device)
-            nxt_kv_lens = nxt_kv_lens_cpu.to(device=batch.device)
             last_loc = get_last_loc(
                 batch.req_to_token_pool.req_to_token,
                 batch.req_pool_indices,
-                cur_kv_lens,
+                cur_kv_lens_device,
             )
             out_cache_loc = alloc_paged_token_slots_extend(
                 batch.tree_cache,
-                cur_kv_lens,
+                cur_kv_lens_device,
                 cur_kv_lens_cpu,
-                nxt_kv_lens,
+                nxt_kv_lens_device,
                 nxt_kv_lens_cpu,
                 last_loc,
                 num_needed_tokens,
@@ -165,8 +167,8 @@ class EagleDraftInputV2Mixin:
         assign_req_to_token_pool_func(
             batch.req_pool_indices,
             batch.req_to_token_pool.req_to_token,
-            cur_kv_lens_cpu.to(device=batch.device),
-            nxt_kv_lens_cpu.to(device=batch.device),
+            cur_kv_lens_device,
+            nxt_kv_lens_device,
             out_cache_loc,
             bs,
         )

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -142,23 +142,21 @@ class EagleDraftInputV2Mixin:
         cur_kv_lens_cpu = torch.tensor(cur_kv_lens, dtype=torch.int32, device="cpu")
         nxt_kv_lens_cpu = torch.tensor(nxt_kv_lens, dtype=torch.int32, device="cpu")
 
-        # non_blocking H2D: a blocking .to() syncs the schedule stream, which the WAR
-        # barrier has chained to the prev forward -> host stalls a full forward.
-        cur_kv_lens_device = cur_kv_lens_cpu.to(device=batch.device, non_blocking=True)
-        nxt_kv_lens_device = nxt_kv_lens_cpu.to(device=batch.device, non_blocking=True)
         if page_size == 1:
             out_cache_loc = alloc_token_slots(batch.tree_cache, num_needed_tokens)
         else:
+            cur_kv_lens = cur_kv_lens_cpu.to(device=batch.device)
+            nxt_kv_lens = nxt_kv_lens_cpu.to(device=batch.device)
             last_loc = get_last_loc(
                 batch.req_to_token_pool.req_to_token,
                 batch.req_pool_indices,
-                cur_kv_lens_device,
+                cur_kv_lens,
             )
             out_cache_loc = alloc_paged_token_slots_extend(
                 batch.tree_cache,
-                cur_kv_lens_device,
+                cur_kv_lens,
                 cur_kv_lens_cpu,
-                nxt_kv_lens_device,
+                nxt_kv_lens,
                 nxt_kv_lens_cpu,
                 last_loc,
                 num_needed_tokens,
@@ -167,8 +165,8 @@ class EagleDraftInputV2Mixin:
         assign_req_to_token_pool_func(
             batch.req_pool_indices,
             batch.req_to_token_pool.req_to_token,
-            cur_kv_lens_device,
-            nxt_kv_lens_device,
+            cur_kv_lens_cpu.to(device=batch.device),
+            nxt_kv_lens_cpu.to(device=batch.device),
             out_cache_loc,
             bs,
         )


### PR DESCRIPTION
Started as a revert of #26380; instead this keeps #26380's data-race fix on CUDA and reverts it on other platforms, where the barrier caused regressions.

## Summary
- Gate the overlap-schedule WAR barrier (`schedule_stream.wait_stream(forward_stream)`) and its D2H-stream occupancy compensation behind `is_cuda()`. CUDA keeps #26380; other platforms (HIP / NPU / CPU) fall back to pre-#26380 behavior.

## Background
- #26380 added a global WAR barrier to fix an overlap-scheduling data race. It is free on CUDA but regressed AMD/HIP:
  - `test_deepseek_r1_mxfp4_8gpu` (MTP): all 8 TP ranks hit the scheduler watchdog timeout (hang).
  - `test_priority_scheduling`: `test_priority_scheduling_request_ordering_validation` assertion failure.
  - DSv4 non-MTP: ~20% throughput drop.
- CUDA shows no measurable throughput change across Llama-3 + EAGLE3 (MTP), DSv4 MTP, and DSv4 non-MTP — data in https://github.com/sgl-project/sglang/pull/26380#issuecomment-4571064550.

## Changes
- `scheduler.py` / `disaggregation/decode.py` / `disaggregation/prefill.py`: guard the three `schedule_stream.wait_stream(forward_stream)` barriers with `self._war_barrier_enabled = is_cuda()`.
- `managers/overlap_utils.py`: narrow the `fwd_prepare_d2h_stream` + pinned-buffer compensation from `_is_cuda or _is_hip` to `_is_cuda`.

Reference #26380.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26618967103](https://github.com/sgl-project/sglang/actions/runs/26618967103)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26618967022](https://github.com/sgl-project/sglang/actions/runs/26618967022)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
