### PR TITLE
Fix Mooncake HiCache registration for DeepSeek-V4 logical KV anchor

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1812,6 +1812,7 @@ class LogicalHostPool:
         self.start_layer = 0
         self.end_layer = 0
         self.kv_buffer = None
+        self.is_logical_anchor = True
         self.size_per_token = 0
         self.allocator = None
         self.lock = threading.RLock()
@@ -2600,6 +2601,10 @@ class HostPoolGroup:
     @property
     def kv_buffer(self):
         return self.anchor_entry.host_pool.kv_buffer
+
+    @property
+    def is_logical_anchor(self):
+        return getattr(self.anchor_entry.host_pool, "is_logical_anchor", False)
 
     @property
     def size_per_token(self):

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -533,6 +533,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             self.backup_pgs = []
             self.prefetch_bandwidth = []
             self.backup_bandwidth = []
+            self._logical_kv_anchor = False
 
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
@@ -613,9 +614,15 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
 
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
         super().register_mem_pool_host(mem_pool_host)
-        if getattr(self.mem_pool_host, "kv_buffer", None) is None:
-            # Hybrid logical anchors only own allocation indices. Their physical
-            # tensors are registered through register_mem_host_pool_v2().
+        self._logical_kv_anchor = getattr(
+            self.mem_pool_host, "is_logical_anchor", False
+        )
+        if self._logical_kv_anchor:
+            logger.info(
+                "Mooncake Store detected logical KV anchor; KV pages will be "
+                "tracked with marker keys and hybrid pools will be registered via v2."
+            )
+            self.gb_per_page = 0
             return
         try:
             for buffer in self._iter_host_pool_buffers(self.mem_pool_host):
@@ -626,6 +633,26 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
 
         bytes_per_page = mem_pool_host.get_ksize_per_token() * mem_pool_host.page_size
         self.gb_per_page = bytes_per_page / (1 << 30)
+
+    @staticmethod
+    def _logical_anchor_key(key: str) -> str:
+        return f"{key}_logical_kv"
+
+    def _batch_set_logical_anchor(self, keys: List[str]) -> List[bool]:
+        key_strs = [self._logical_anchor_key(key) for key in keys]
+        exist_result = self._batch_exist(key_strs)
+        results = [state == 1 for state in exist_result]
+        # Mooncake's put() path rejects zero-length payloads, so use one byte.
+        marker = b"1"
+        for i, key in enumerate(key_strs):
+            if results[i]:
+                continue
+            results[i] = self.store.put(key, marker) == 0
+        return results
+
+    def _batch_get_logical_anchor(self, keys: List[str]) -> List[bool]:
+        key_strs = [self._logical_anchor_key(key) for key in keys]
+        return [state == 1 for state in self._batch_exist(key_strs)]
 
     def register_mem_host_pool_v2(self, host_pool: HostKVCache, host_pool_name):
         # KV anchor memory is already registered via register_mem_pool_host().
@@ -654,7 +681,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
     def _get_hybrid_page_component_keys(
         self, page_keys: List[str], transfer: PoolTransfer
     ) -> Tuple[List[str], int]:
-        host_pool = getattr(self, "registered_pools", {}).get(transfer.name)
+        host_pool = self.registered_pools.get(transfer.name)
         if host_pool is None:
             raise ValueError(f"Unregistered Mooncake hybrid pool: {transfer.name}")
 
@@ -721,12 +748,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         pool_transfers: Optional[List[PoolTransfer]] = None,
         extra_info: Optional[HiCacheStorageExtraInfo] = None,
     ) -> PoolTransferResult:
-        if self.mem_pool_host.kv_buffer is None:
-            # Logical anchor: no physical KV object exists in Mooncake, so the
-            # usable prefix is determined entirely by required sidecar objects.
-            kv_pages = len(keys)
-        else:
-            kv_pages = self.batch_exists(keys, extra_info)
+        kv_pages = self.batch_exists(keys, extra_info)
 
         hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
         final_pages = kv_pages
@@ -775,7 +797,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         # storage objects per logical page, but API still reports page-level result.
         results: dict = {}
         for transfer in transfers:
-            host_pool = getattr(self, "registered_pools", {}).get(transfer.name)
+            host_pool = self.registered_pools.get(transfer.name)
             keys = transfer.keys
             page_size = getattr(host_pool, "page_size", 1) or 1
             host_indices = transfer.host_indices
@@ -936,12 +958,15 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         host_indices: torch.Tensor,
         extra_info: Optional[HiCacheStorageExtraInfo] = None,
     ) -> List[bool]:
-        if self.mem_pool_host.kv_buffer is None:
-            # DeepSeek V4's KV anchor is logical only; v2 side pools carry data.
+        if self.mem_pool_host.kv_buffer is None and not self._logical_kv_anchor:
+            # Non-KV logical anchors carry data through v2 side pools only.
             return [True] * len(keys)
 
         # Apply extra_backend_tag prefix if available
         keys = self._tag_keys(keys)
+
+        if self._logical_kv_anchor:
+            return self._batch_get_logical_anchor(keys)
 
         key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(keys, host_indices)
 
@@ -965,12 +990,15 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         host_indices: torch.Tensor,
         extra_info: Optional[HiCacheStorageExtraInfo] = None,
     ) -> List[bool]:
-        if self.mem_pool_host.kv_buffer is None:
-            # DeepSeek V4's KV anchor is logical only; v2 side pools carry data.
+        if self.mem_pool_host.kv_buffer is None and not self._logical_kv_anchor:
+            # Non-KV logical anchors carry data through v2 side pools only.
             return [True] * len(keys)
 
         # Apply extra_backend_tag prefix if available
         keys = self._tag_keys(keys)
+
+        if self._logical_kv_anchor:
+            return self._batch_set_logical_anchor(keys)
 
         key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(keys, host_indices)
         exist_result = self._batch_exist(key_strs)
@@ -1136,6 +1164,14 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
     ) -> int:
         # Apply extra_backend_tag prefix if available
         keys = self._tag_keys(keys)
+
+        if self._logical_kv_anchor:
+            query_keys = [self._logical_anchor_key(key) for key in keys]
+            exist_result = self._batch_exist(query_keys)
+            for i, state in enumerate(exist_result):
+                if state != 1:
+                    return i
+            return len(query_keys)
 
         if self.is_mla_backend:
             query_keys = [f"{key}_{self.mla_suffix}_k" for key in keys]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
DeepSeek-V4-Flash uses a hybrid HiCache layout with a logical KV anchor pool. The anchor pool owns page indices but does not own a real KV buffer; the actual data is stored in hybrid side pools such as SWA, compressed KV, indexer, and state pools.
When enabling Mooncake as the HiCache storage backend, Mooncake previously assumed the primary host pool always had a physical `kv_buffer` and a Mooncake-supported memory layout. For DeepSeek-V4, this caused startup to fail during host pool registration because the logical anchor has `kv_buffer=None` and `layout=layer_first`.

Verify fix works. Launch server as follows:
###  Example Commands
```bash
CUDA_VISIBLE_DEVICES="0,1,2,3" \
MOONCAKE_MASTER="0.0.0.0:50058" \
MOONCAKE_DEVICE="mlx5_0,mlx5_1,mlx5_2,mlx5_3" \
MOONCAKE_PROTOCOL="rdma" \
MOONCAKE_GLOBAL_SEGMENT_SIZE="0" \
SGLANG_ENABLE_UNIFIED_RADIX_TREE=1 \
python -m sglang.launch_server \
    --served-model-name deepseek-v4-flash \
    --model-path /mnt/models/deepseek-ai/DeepSeek-V4-Flash \
    --host 0.0.0.0 \
    --port 30000 \
    --page-size 64 \
    --enable-hierarchical-cache \
    --hicache-ratio 1.7 \
    --hicache-mem-layout page_first \
    --hicache-io-backend kernel \
    --hicache-storage-backend mooncake \
    --hicache-write-policy write_through \
    --hicache-storage-prefetch-policy wait_complete \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --mem-fraction-static 0.8 \
    --enable-metrics \
    --enable-cache-report \
    --moe-runner-backend marlin \
    --max-running-requests 100 \
    --dist-init-addr "0.0.0.0:29500"
```

This PR fixes Mooncake storage registration for DeepSeek-V4 hybrid HiCache. #26647

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Detect logical KV anchor pools during Mooncake host pool registration.
- Skip physical buffer registration and layout validation for logical KV anchors.
- Use lightweight marker keys to track logical KV page existence in Mooncake.
- Keep existing v2 registration and zero-copy I/O paths unchanged for real hybrid side pools.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
This change does not modify model forward logic, kernels, sampling, or numerical computation. No accuracy impact is expected.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
This change only affects Mooncake HiCache storage registration and logical KV page existence tracking for DeepSeek-V4 hybrid HiCache.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27398986088](https://github.com/sgl-project/sglang/actions/runs/27398986088)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27398985992](https://github.com/sgl-project/sglang/actions/runs/27398985992)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->