### PR TITLE
Add EAGLE3 + return_hidden_states regression test

### DIFF
--- a/test/registered/spec/eagle/test_eagle3_hidden_states.py
+++ b/test/registered/spec/eagle/test_eagle3_hidden_states.py
@@ -1,0 +1,88 @@
+"""Regression test for EAGLE3 speculative decoding + return_hidden_states.
+
+EAGLE3 lands in the same ``is_spec_v1`` branch as plain EAGLE in
+``batch_result_processor.process_batch_result_decode``, but returns
+*concatenated aux hidden_states* from multiple decoder layers — so
+``shape[-1]`` is wider than the model's hidden_dim, not equal to it. Plain
+EAGLE returns single-layer hidden_states.
+
+This test pins the per-request invariant ``len(hs) == completion_tokens`` on
+EAGLE3's wider aux layout so future refactors of ``_fill_requests`` /
+``accept_indices`` slicing don't silently break EAGLE3 (see issue #26163 and
+PR #26217 which generalizes the spec-V1 fix to EAGLE3 transitively).
+
+Verbatim-repeat prompts let the drafter land long accept streaks and actually
+exercise the multi-row slice that triggered the original bug.
+"""
+
+import unittest
+
+import sglang as sgl
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE3,
+    DEFAULT_TARGET_MODEL_EAGLE3,
+    CustomTestCase,
+)
+
+register_cuda_ci(est_time=120, stage="extra-a", runner_config="1-gpu-large")
+
+
+class TestEagle3ReturnHiddenStates(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        # speculative_eagle_topk=8 (>1) forces spec V1 in speculative_hook.py
+        # regardless of SGLANG_ENABLE_SPEC_V2 — no env-var management needed.
+        cls.engine = sgl.Engine(
+            model_path=DEFAULT_TARGET_MODEL_EAGLE3,
+            speculative_draft_model_path=DEFAULT_DRAFT_MODEL_EAGLE3,
+            speculative_algorithm="EAGLE3",
+            speculative_num_steps=5,
+            speculative_eagle_topk=8,
+            speculative_num_draft_tokens=64,
+            enable_return_hidden_states=True,
+            mem_fraction_static=0.7,
+            cuda_graph_max_bs=8,
+            dtype="float16",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.shutdown()
+
+    def test_eagle3_with_return_hidden_states(self):
+        prompts = [
+            "Repeat: the quick brown fox the quick brown fox the quick brown fox",
+            "Eeny meeny miny moe, eeny meeny miny moe, eeny meeny miny moe",
+        ]
+        outputs = self.engine.generate(
+            prompts,
+            sampling_params={"temperature": 0, "max_new_tokens": 32},
+            return_hidden_states=True,
+        )
+
+        for out in outputs:
+            hs = out["meta_info"]["hidden_states"]
+            ct = out["meta_info"]["completion_tokens"]
+            # Per-request invariant: one hidden_state row per emitted token.
+            # Before PR #26217 this asserted len(hs) ≈ num_verify_steps
+            # (e.g. 8 vs 32) because the spec-V1 path appended hidden_states[i]
+            # one row per verify step instead of extending by the per-req slice.
+            self.assertEqual(
+                len(hs),
+                ct,
+                f"EAGLE3 hidden_states truncation: len(hs)={len(hs)}, "
+                f"completion_tokens={ct} (see issue #26163)",
+            )
+            # EAGLE3 returns *concatenated* aux hidden_states; just sanity-check
+            # the row is non-empty. The exact shape[-1] depends on which layers
+            # the EAGLE3 draft was trained against.
+            self.assertGreater(
+                len(hs[0]),
+                0,
+                "EAGLE3 hidden_states row is empty; expected concatenated aux dim.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
EAGLE3 lands in the same is_spec_v1 branch as plain EAGLE in batch_result_processor.process_batch_result_decode but returns concatenated aux hidden_states from multiple decoder layers, so shape[-1] is wider than plain EAGLE's. PR #26217 generalizes the spec-V1 hidden_states slicing fix to EAGLE3 transitively, and explicitly defers EAGLE3 coverage to follow-ups (commit 50c9c28).

This test pins the per-request invariant len(hs) == completion_tokens on EAGLE3's wider aux layout so future refactors of _fill_requests / accept_indices slicing don't silently break EAGLE3.

Uses speculative_eagle_topk=8 (>1) to route through spec V1 via speculative_hook.py — no env-var management needed. Stage 'extra-a' + runner '1-gpu-large' matches existing EAGLE3 CI fixtures.

Refs #26163.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26616422567](https://github.com/sgl-project/sglang/actions/runs/26616422567)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26616422464](https://github.com/sgl-project/sglang/actions/runs/26616422464)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->