### PR TITLE
test: stabilize Gemma4 26B-A4B MTP GSM8K test with deterministic inference + tuned threshold

### DIFF
--- a/test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py
+++ b/test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py
@@ -31,10 +31,12 @@ GSM8K_NUM_THREADS = 128
 GSM8K_SCORE_MARGIN = 0.03
 SERVER_LAUNCH_TIMEOUT = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 3
 
-# Initial values are seeded from current Gemma4 GSM8K observations in the
-# cookbook. Replace each top-k entry with exact MTP first-200-sample scores as
-# CI calibration data becomes available.
-OBSERVED_GSM8K_SCORES = {1: 0.450, 3: 0.450}
+# Calibrated from deterministic-inference GSM8K runs (200 examples, 5-shot,
+# greedy, triton, TP=2). With --enable-deterministic-inference the per-topk
+# score is reproducible run-to-run (std=0 over N=20): topk=1 -> 0.445,
+# topk=3 -> 0.440. Without deterministic inference the same configs swing
+# ~0.33-0.50 due to batch-nondeterminism, which is why this test pins it.
+OBSERVED_GSM8K_SCORES = {1: 0.445, 3: 0.440}
 GSM8K_SCORE_THRESHOLD = min(OBSERVED_GSM8K_SCORES.values()) - GSM8K_SCORE_MARGIN
 ACCEPT_LENGTH_THRESHOLD = 1.5
 
@@ -84,6 +86,9 @@ class TestGemma4MTP26BA4B(CustomTestCase):
             "--max-total-tokens",
             "32768",
             "--skip-server-warmup",
+            # Batch-invariant kernels make the GSM8K score reproducible
+            # run-to-run; without this the topk=3 score swings ~0.33-0.50.
+            "--enable-deterministic-inference",
         ]
         if TENSOR_PARALLEL_SIZE > 1:
             args += ["--tp-size", str(TENSOR_PARALLEL_SIZE)]

--- a/test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py
+++ b/test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py
@@ -34,8 +34,7 @@ SERVER_LAUNCH_TIMEOUT = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 3
 # Calibrated from deterministic-inference GSM8K runs (200 examples, 5-shot,
 # greedy, triton, TP=2). With --enable-deterministic-inference the per-topk
 # score is reproducible run-to-run (std=0 over N=20): topk=1 -> 0.445,
-# topk=3 -> 0.440. Without deterministic inference the same configs swing
-# ~0.33-0.50 due to batch-nondeterminism, which is why this test pins it.
+# topk=3 -> 0.440.
 OBSERVED_GSM8K_SCORES = {1: 0.445, 3: 0.440}
 GSM8K_SCORE_THRESHOLD = min(OBSERVED_GSM8K_SCORES.values()) - GSM8K_SCORE_MARGIN
 ACCEPT_LENGTH_THRESHOLD = 1.5


### PR DESCRIPTION
## Summary

`test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py` fails on `main`. Two issues:

1. **Unreachable threshold.** `GSM8K_SCORE_THRESHOLD` (0.42) was derived from placeholder cookbook values (`OBSERVED_GSM8K_SCORES = {1: 0.45, 3: 0.45}`). Measured GSM8K (200 ex, 5-shot, greedy, triton, TP=2) centers around **0.36–0.39**, so the assertion never passes.
2. **High run-to-run variance.** Under the default (non-deterministic) path the `topk=3` config swings **~0.33–0.50** (std ≈ 0.06 over N=20) because batch-composition nondeterminism gets amplified through the speculative verify path. `topk=1` and baseline are more stable but still noisy (std ≈ 0.02).

This PR makes the test deterministic and recalibrates the threshold to the deterministic measurements.

### Changes
- Add `--enable-deterministic-inference` to the server args (batch-invariant kernels; triton is supported and keeps radix cache / CUDA graph).
- Recalibrate `OBSERVED_GSM8K_SCORES` to deterministic values `{1: 0.445, 3: 0.440}` → `GSM8K_SCORE_THRESHOLD = 0.440 - 0.03 = 0.41`.

### Evidence (N=20 each, 200 examples, 5-shot, greedy, triton, TP=2)

| config | non-deterministic mean ± std (range) | deterministic (std=0) |
|---|---|---|
| baseline (no MTP) | 0.378 ± 0.021 (0.335–0.435) | 0.470 |
| MTP topk=1 | 0.371 ± 0.017 (0.350–0.425) | **0.445** |
| MTP topk=3 | 0.409 ± 0.059 (0.335–0.500) | **0.440** |

With deterministic inference every one of the 20 runs/config produced an identical score (std = 0), and the `topk=3` bimodal swing disappears entirely — confirming it was nondeterminism, not a correctness bug. Acceptance lengths stay healthy (topk=1 ≈ 4.49, topk=3 ≈ 4.96; threshold 1.5).

## Test plan
- [ ] CI `extra-a` stage (`2-gpu-large`) runs `test_gsm8k_mtp` for topk ∈ {1, 3}; both should clear 0.41 with margin and std≈0.
- Note: deterministic mode is slightly slower per run (~40s vs ~35s here) and disables overlap scheduler / custom all-reduce.

## Follow-up (not in this PR)
The ~2.5–3 pt gap between baseline (0.470) and MTP (0.445/0.440) under greedy is small but nonzero; spec decoding should be near-lossless. Worth a separate investigation into the Frozen-KV MTP verify path. The non-deterministic topk=3 amplification is also worth understanding.

Made with [Cursor](https://cursor.com)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26616910613](https://github.com/sgl-project/sglang/actions/runs/26616910613)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26616910532](https://github.com/sgl-project/sglang/actions/runs/26616910532)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->