### PR TITLE
Fix TRTLLM MHA draft decode cache seqlens replay

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -458,16 +458,19 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 # Draft Decode
                 # Here we only support topk = 1 for now.
                 metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
-                metadata.max_seq_len_k = max_len + self.speculative_step_id + 1
+                metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
+                    "cache_seqlens"
+                ][:bs]
+                metadata.cache_seqlens_int32.copy_(
+                    seq_lens + self.speculative_step_id + 1
+                )
+                metadata.max_seq_len_k = seq_lens.max().item() + (
+                    self.speculative_step_id + 1
+                )
 
                 max_seq_pages = (
                     metadata.max_seq_len_k + self.page_size - 1
                 ) // self.page_size
-
-                metadata.cache_seqlens_int32.copy_(
-                    seq_lens + self.speculative_step_id + 1
-                )
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]


### PR DESCRIPTION
Updates the TRTLLM MHA draft-decode CUDA graph replay path to rebind cache_seqlens_int32 to the active batch slice before copying updated sequence lengths.\n\nValidation:\n- python3 -m py_compile python/sglang/srt/layers/attention/trtllm_mha_backend.py\n- git diff --check HEAD~1..HEAD







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26617047442](https://github.com/sgl-project/sglang/actions/runs/26617047442)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26617047366](https://github.com/sgl-project/sglang/actions/runs/26617047366)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->