### PR TITLE
fix(bench): honor --api-format in bench_long_context (fixes #26632)

### DIFF
--- a/benchmark/hicache/bench_long_context.py
+++ b/benchmark/hicache/bench_long_context.py
@@ -7,19 +7,34 @@ from bench_multiturn import (
     ReadyQueue,
     WorkloadGenerator,
     gen_payload,
+    gen_payload_openai,
     log_to_jsonl_file,
     parse_args,
 )
 from tqdm.asyncio import tqdm
 
 from sglang.benchmark.utils import get_tokenizer
-from sglang.test.kits.cache_hit_kit import async_request_sglang_generate
+from sglang.test.kits.cache_hit_kit import (
+    async_request_openai_chat_completions,
+    async_request_sglang_generate,
+)
 
 
 class ContextWorkloadGenerator(WorkloadGenerator):
     def __init__(self, args):
-        self.url = f"http://{args.host}:{args.port}/generate"
-        self.request_func = async_request_sglang_generate
+        # Honor --api-format the same way ``WorkloadGenerator.__init__``
+        # does; previously this subclass hard-coded the native
+        # ``/generate`` endpoint and silently ignored ``--api-format
+        # openai``, sending requests through the wrong API surface
+        # regardless of the user's choice.
+        self.api_format = args.api_format
+        self.model_path = args.model_path
+        if self.api_format == "openai":
+            self.url = f"http://{args.host}:{args.port}/v1/chat/completions"
+            self.request_func = async_request_openai_chat_completions
+        else:
+            self.url = f"http://{args.host}:{args.port}/generate"
+            self.request_func = async_request_sglang_generate
 
         self.tokenizer = get_tokenizer(args.model_path)
         self.distribution = args.distribution
@@ -47,7 +62,16 @@ class ContextWorkloadGenerator(WorkloadGenerator):
                     "input_ids"
                 ]
             )
-            init_requests.append((i, gen_payload(input_ids, output_len)))
+            # Match payload shape to the selected API: ``gen_payload``
+            # produces an ``input_ids`` / ``sampling_params`` body for
+            # ``/generate`` while ``gen_payload_openai`` produces a
+            # ``messages`` body for ``/v1/chat/completions``.
+            if self.api_format == "openai":
+                messages = [{"role": "user", "content": prompt_text}]
+                payload = gen_payload_openai(messages, output_len, self.model_path)
+            else:
+                payload = gen_payload(input_ids, output_len)
+            init_requests.append((i, payload))
         self.ready_queue = ReadyQueue(init_requests=init_requests)
 
         self.response_queue = queue.Queue()


### PR DESCRIPTION
## Summary

`benchmark/hicache/bench_long_context.py::ContextWorkloadGenerator.__init__` overrides `WorkloadGenerator.__init__` and unconditionally hard-codes the native sglang surface:

```python
self.url = f"http://{args.host}:{args.port}/generate"
self.request_func = async_request_sglang_generate
```

So `--api-format openai` is silently dropped on this benchmark — the script always hits `/generate` with `gen_payload(input_ids, ...)`, regardless of the user's choice. The parent class already dispatches correctly in `bench_multiturn.py`, and `--api-format` is exposed by the shared `parse_args()` this script imports.

Fixes #26632.

## Approach

Mirror the parent class dispatch in the subclass:

1. **Endpoint / request func dispatch** — set `self.url` and `self.request_func` based on `args.api_format`, matching the pattern at `bench_multiturn.py:213-222`.
2. **Payload shape dispatch** — `gen_payload(input_ids, output_len)` produces a native sglang body (`input_ids` / `sampling_params`) that `/v1/chat/completions` cannot consume; the OpenAI branch now decodes the prompt and calls `gen_payload_openai(messages, output_len, model_path)` (a `messages`-shaped body) instead.

`response_handler` is unchanged. The helpers in `sglang/test/kits/cache_hit_kit.py` already populate `ttft / itl / latency / prompt_len / cached_tokens / generated_len` on the response object for both formats, and the subclass's handler reads exactly those fields.

## Caveat — `cached_tokens` in OpenAI mode

`cached_tokens` reported via the OpenAI usage payload requires the server to be started with `--enable-cache-report`; without it the server returns `prompt_tokens_details=None` and the helper records `0`. The native `/generate` path is unaffected. Worth keeping in mind when comparing cache-hit metrics across the two formats.

## Test plan

- [x] `pre-commit run --files benchmark/hicache/bench_long_context.py` — clean (ruff / black / isort / codespell)
- [x] `python3 -c "import ast; ast.parse(open('benchmark/hicache/bench_long_context.py').read())"` — OK
- [ ] (Manual, requires GPU) Reproduce with `--api-format openai` per the steps in #26632 — confirmed to no longer hit `/generate` after this patch (verified by reading the dispatched URL/payload paths; HTTP-level repro requires the launch_server reproduction in the issue body)

The script is a benchmark utility, not production code, so this PR adds no automated regression test — happy to add one if maintainers prefer.

AI assistance was used in drafting this fix; the human contributor reviewed every line.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26618061837](https://github.com/sgl-project/sglang/actions/runs/26618061837)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26618061784](https://github.com/sgl-project/sglang/actions/runs/26618061784)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->