### PR TITLE
docs: clarify Apple Metal setup

### DIFF
--- a/docs_new/docs/hardware-platforms/apple_metal.mdx
+++ b/docs_new/docs/hardware-platforms/apple_metal.mdx
@@ -18,6 +18,9 @@ xcode-select --install
 
 If you have the full Xcode app installed, the Command Line Tools are already
 available. You can verify with `xcode-select -p && xcrun --find metal`.
+If `xcrun --find metal` fails, install the full Xcode app before compiling
+`sgl-kernel`. You can still run basic MLX serving and benchmarks without this
+optional native kernel build.
 
 ## Install SGLang
 
@@ -39,7 +42,7 @@ uv pip install --upgrade pip
 uv run sgl-kernel/setup_metal.py install
 
 # Install sglang python package along with diffusion support
-rm -f python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
+cp python/pyproject_other.toml python/pyproject.toml
 uv pip install -e "python[all_mps]"
 ```
 


### PR DESCRIPTION
## Motivation

Clarify the Apple Silicon / Metal setup instructions based on a fresh local setup.

The current docs mention verifying the Apple Metal compiler with `xcrun --find metal`, but do not say what to do if that check fails. On Apple Silicon, basic MLX serving and benchmarking can still work without compiling the optional native `sgl-kernel` Metal extension.

The install command also uses `mv` for `python/pyproject_other.toml`, which removes the template file from the working tree. Using `cp` keeps the setup behavior while preserving the template.

## Modifications

- Clarify that users should install the full Xcode app if `xcrun --find metal` fails before compiling `sgl-kernel`.
- Clarify that basic MLX serving and benchmarking can run without the optional native `sgl-kernel` build.
- Replace `mv python/pyproject_other.toml python/pyproject.toml` with `cp python/pyproject_other.toml python/pyproject.toml`.

## Accuracy Tests

Not applicable. This is a documentation-only change and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This is a documentation-only change and does not affect inference performance.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). N/A for docs-only change; ran an existing unit test.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A for docs-only change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Local validation:

- `sglang-metal/bin/pre-commit run --files docs_new/docs/hardware-platforms/apple_metal.mdx`
- `sglang-metal/bin/python -m pytest test/registered/unit/auto_benchmark/test_dataset_tools.py -q`















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26619965814](https://github.com/sgl-project/sglang/actions/runs/26619965814)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26619965746](https://github.com/sgl-project/sglang/actions/runs/26619965746)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->