### PR TITLE
[AMD] Work around HIP TPOT regression from Event.wait() in MTP seq lens resolution

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -204,7 +204,11 @@ class FutureMap:
         if fi is None:
             return
         if self.publish_ready is not None:
-            self.publish_ready.wait()
+            if _is_hip:
+                # Temporary workaround: Event.wait() regresses TPOT on AMD MI355.
+                self.publish_ready.synchronize()
+            else:
+                self.publish_ready.wait()
         batch.seq_lens = self.new_seq_lens_buf[fi]
 
         if self.fwd_prepare_d2h_stream is None or self.publish_ready is None:


### PR DESCRIPTION
Use Event.synchronize() instead of Event.wait() for publish_ready on HIP,
avoiding the AMD MI355 TPOT regression while leaving other backends unchanged.

## Motivation

During MTP testing on AMD MI355, we found that using `Event.wait()` for
`publish_ready` in the `resolve_seq_lens_cpu` path caused a TPOT performance
regression. This issue was observed on the HIP backend, while other backends
should keep the existing synchronization behavior.

## Modifications

Replace `Event.wait()` with `Event.synchronize()` for `publish_ready` when
running on HIP in the `resolve_seq_lens_cpu` path. The change is scoped to
the HIP backend as a temporary workaround for the AMD MI355 TPOT regression,
and non-HIP backends continue to use the existing `Event.wait()` path.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26622697602](https://github.com/sgl-project/sglang/actions/runs/26622697602)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26622697453](https://github.com/sgl-project/sglang/actions/runs/26622697453)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->