### PR TITLE
[mem_cache][1/N] refactor: split allocator.py into allocator/ subpackage

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/__init__.py
+++ b/python/sglang/srt/mem_cache/allocator/__init__.py
@@ -1,0 +1,15 @@
+"""Token-to-KV-slot allocators. One file per allocation strategy."""
+
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.paged import (
+    PagedTokenToKVPoolAllocator,
+    alloc_extend_naive,
+)
+from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
+
+__all__ = [
+    "BaseTokenToKVPoolAllocator",
+    "PagedTokenToKVPoolAllocator",
+    "TokenToKVPoolAllocator",
+    "alloc_extend_naive",
+]

--- a/python/sglang/srt/mem_cache/allocator/base.py
+++ b/python/sglang/srt/mem_cache/allocator/base.py
@@ -1,0 +1,110 @@
+"""
+Copyright 2025 SGLang Team
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+class BaseTokenToKVPoolAllocator(abc.ABC):
+    @abc.abstractmethod
+    def __init__(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        device: str,
+        kvcache: KVCache,
+        need_sort: bool,
+    ):
+        self.size = size
+        self.page_size = page_size
+        self.dtype = dtype
+        self.device = device
+        self._kvcache = kvcache
+        self.need_sort = need_sort
+
+        self.free_pages = None
+        self.release_pages = None
+        self.is_not_in_free_group = True
+        self.free_group = []
+
+    @property
+    def size_full(self):
+        return self.size
+
+    def debug_print(self) -> str:
+        return ""
+
+    def available_size(self):
+        return (len(self.free_pages) + len(self.release_pages)) * self.page_size
+
+    def get_kvcache(self):
+        return self._kvcache
+
+    def restore_state(self, state):
+        self.free_pages, self.release_pages = state
+
+    def backup_state(self):
+        return (self.free_pages, self.release_pages)
+
+    def free_group_begin(self):
+        self.is_not_in_free_group = False
+        self.free_group = []
+
+    def free_group_end(self):
+        self.is_not_in_free_group = True
+        if self.free_group:
+            self.free(torch.cat(self.free_group))
+
+    def merge_and_sort_free(self):
+        if len(self.release_pages) > 0:
+            self.free_pages = torch.cat((self.free_pages, self.release_pages))
+            self.free_pages, _ = torch.sort(self.free_pages)
+            self.release_pages = torch.empty(
+                (0,), dtype=self.release_pages.dtype, device=self.device
+            )
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        # FIXME: reuse the get_cpu_copy after paged allocator is implemented
+        raise NotImplementedError()
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        # FIXME: reuse the load_cpu_copy after paged allocator is implemented
+        raise NotImplementedError()
+
+    def alloc_extend(self, *args, **kwargs):
+        raise NotImplementedError("alloc_extend is only for paged allocator")
+
+    def alloc_decode(self, *args, **kwargs):
+        raise NotImplementedError("alloc_decode is only for paged allocator")
+
+    @abc.abstractmethod
+    def clear(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def alloc(self, need_size: int):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def free(self, free_index: torch.Tensor):
+        raise NotImplementedError()

--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """
 Copyright 2025 SGLang Team
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,166 +13,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from __future__ import annotations
+
 """
 Page-aligned memory pool.
 """
 
-import abc
 from typing import TYPE_CHECKING
 
 import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
 from sglang.srt.utils import get_bool_env_var, get_num_new_pages, next_power_of_2
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
-
-
-class BaseTokenToKVPoolAllocator(abc.ABC):
-    @abc.abstractmethod
-    def __init__(
-        self,
-        size: int,
-        page_size: int,
-        dtype: torch.dtype,
-        device: str,
-        kvcache: KVCache,
-        need_sort: bool,
-    ):
-        self.size = size
-        self.page_size = page_size
-        self.dtype = dtype
-        self.device = device
-        self._kvcache = kvcache
-        self.need_sort = need_sort
-
-        self.free_pages = None
-        self.release_pages = None
-        self.is_not_in_free_group = True
-        self.free_group = []
-
-    @property
-    def size_full(self):
-        return self.size
-
-    def debug_print(self) -> str:
-        return ""
-
-    def available_size(self):
-        return (len(self.free_pages) + len(self.release_pages)) * self.page_size
-
-    def get_kvcache(self):
-        return self._kvcache
-
-    def restore_state(self, state):
-        self.free_pages, self.release_pages = state
-
-    def backup_state(self):
-        return (self.free_pages, self.release_pages)
-
-    def free_group_begin(self):
-        self.is_not_in_free_group = False
-        self.free_group = []
-
-    def free_group_end(self):
-        self.is_not_in_free_group = True
-        if self.free_group:
-            self.free(torch.cat(self.free_group))
-
-    def merge_and_sort_free(self):
-        if len(self.release_pages) > 0:
-            self.free_pages = torch.cat((self.free_pages, self.release_pages))
-            self.free_pages, _ = torch.sort(self.free_pages)
-            self.release_pages = torch.empty(
-                (0,), dtype=self.release_pages.dtype, device=self.device
-            )
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        # FIXME: reuse the get_cpu_copy after paged allocator is implemented
-        raise NotImplementedError()
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        # FIXME: reuse the load_cpu_copy after paged allocator is implemented
-        raise NotImplementedError()
-
-    def alloc_extend(self, *args, **kwargs):
-        raise NotImplementedError("alloc_extend is only for paged allocator")
-
-    def alloc_decode(self, *args, **kwargs):
-        raise NotImplementedError("alloc_decode is only for paged allocator")
-
-    @abc.abstractmethod
-    def clear(self):
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def alloc(self, need_size: int):
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def free(self, free_index: torch.Tensor):
-        raise NotImplementedError()
-
-
-class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
-    """An allocator managing the indices to kv cache data."""
-
-    def __init__(
-        self,
-        size: int,
-        dtype: torch.dtype,
-        device: str,
-        kvcache: KVCache,
-        need_sort: bool,
-    ):
-        super().__init__(size, 1, dtype, device, kvcache, need_sort)
-        self.clear()
-
-    def clear(self):
-        # The padded slot 0 is used for writing dummy outputs from padded tokens.
-        self.free_pages = torch.arange(
-            1, self.size + 1, dtype=torch.int64, device=self.device
-        )
-        self.is_not_in_free_group = True
-        self.free_group = []
-        self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
-
-    def available_size(self):
-        # To avoid minor "len(free_pages) * 1" overhead
-        return len(self.free_pages) + len(self.release_pages)
-
-    def alloc(self, need_size: int):
-        if self.need_sort and need_size > len(self.free_pages):
-            self.merge_and_sort_free()
-
-        if need_size > len(self.free_pages):
-            return None
-
-        select_index = self.free_pages[:need_size]
-        self.free_pages = self.free_pages[need_size:]
-        return select_index
-
-    def free(self, free_index: torch.Tensor):
-        if free_index.numel() == 0:
-            return
-
-        if self.is_not_in_free_group:
-            if self.need_sort:
-                self.release_pages = torch.cat((self.release_pages, free_index))
-            else:
-                self.free_pages = torch.cat((self.free_pages, free_index))
-        else:
-            self.free_group.append(free_index)
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        return self._kvcache.load_cpu_copy(
-            kv_cache_cpu, indices, mamba_indices=mamba_indices
-        )
 
 
 def alloc_extend_naive(

--- a/python/sglang/srt/mem_cache/allocator/token.py
+++ b/python/sglang/srt/mem_cache/allocator/token.py
@@ -1,0 +1,84 @@
+"""
+Copyright 2025 SGLang Team
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
+    """An allocator managing the indices to kv cache data."""
+
+    def __init__(
+        self,
+        size: int,
+        dtype: torch.dtype,
+        device: str,
+        kvcache: KVCache,
+        need_sort: bool,
+    ):
+        super().__init__(size, 1, dtype, device, kvcache, need_sort)
+        self.clear()
+
+    def clear(self):
+        # The padded slot 0 is used for writing dummy outputs from padded tokens.
+        self.free_pages = torch.arange(
+            1, self.size + 1, dtype=torch.int64, device=self.device
+        )
+        self.is_not_in_free_group = True
+        self.free_group = []
+        self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
+
+    def available_size(self):
+        # To avoid minor "len(free_pages) * 1" overhead
+        return len(self.free_pages) + len(self.release_pages)
+
+    def alloc(self, need_size: int):
+        if self.need_sort and need_size > len(self.free_pages):
+            self.merge_and_sort_free()
+
+        if need_size > len(self.free_pages):
+            return None
+
+        select_index = self.free_pages[:need_size]
+        self.free_pages = self.free_pages[need_size:]
+        return select_index
+
+    def free(self, free_index: torch.Tensor):
+        if free_index.numel() == 0:
+            return
+
+        if self.is_not_in_free_group:
+            if self.need_sort:
+                self.release_pages = torch.cat((self.release_pages, free_index))
+            else:
+                self.free_pages = torch.cat((self.free_pages, free_index))
+        else:
+            self.free_group.append(free_index)
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        return self._kvcache.load_cpu_copy(
+            kv_cache_cpu, indices, mamba_indices=mamba_indices
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

First PR of the issue #25371 (parent: #24335) allocator-promotion series. Splits `allocator.py` into a dedicated `allocator/` subpackage with one file per family, per the parent issue's design rule.

Follow-up PRs in this series will move `SWATokenToKVPoolAllocator`/HiSparse allocator/mamba allocator into the same package.

## Modifications

Pure mechanical relocation. Class bodies are unchanged.

| Class / member | From | To |
|---|---|---|
| `BaseTokenToKVPoolAllocator` (abc) | `allocator.py` | `allocator/base.py` |
| `TokenToKVPoolAllocator` (page_size=1) | `allocator.py` | `allocator/token.py` |
| `PagedTokenToKVPoolAllocator` + `alloc_extend_naive` / `alloc_extend_kernel` / `alloc_decode_kernel` helpers | `allocator.py` | `allocator/paged.py` |

The three `alloc_extend_*` / `alloc_decode_*` helpers stay with `PagedTokenToKVPoolAllocator` because they are only used by that class (verified by grep: calls at lines 434 and 475 of the original `allocator.py`, both inside `PagedTokenToKVPoolAllocator` method bodies).

`allocator/__init__.py` re-exports all 3 classes plus `alloc_extend_naive` (the only helper used outside the package — by `hardware_backend/npu/allocator_npu.py`), so existing callers using `from sglang.srt.mem_cache.allocator import X` keep working with zero changes.

Caller-site impact: **0 changes**. All 28 existing import sites continue working via the `__init__.py` re-exports.

### Git blame preservation

- `git mv allocator.py → allocator/paged.py` is detected as **R073 rename** (above the 50% threshold), so `git blame` and `git log --follow` on `allocator/paged.py` trace **natively without `-C` flags** back through `allocator.py` (2025-06-22, R077 from `paged_allocator.py`) to `paged_allocator.py` (2025-03-12, PR #4356 "Support page size > 1"). `PagedTokenToKVPoolAllocator`'s 20-commit history is fully visible in the GitHub UI.
- For `allocator/base.py` and `allocator/token.py`, `git blame -C -C -C` recovers the full pre-refactor ancestry: **100% line coverage on `base.py`** (110/110 lines trace to original commits) and **94% on `token.py`** (79/84 — the 5 untraced lines are the new `from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator` import and surrounding blank lines).

### Mechanical Move

Transform script: https://gist.github.com/alphabetc1/c0560dd11919ef1fb83625dd3ba3c3d3

One-click verification:

```bash
python3 <(curl -sL https://gist.githubusercontent.com/alphabetc1/c0560dd11919ef1fb83625dd3ba3c3d3/raw/transform_allocator_promote.py) --stage 1
```

Expected output: `PASS stage 1: transform reproduces the commit exactly.`

## Accuracy Tests
### Unit tests
Relevant mem-cache/allocator tests:

```bash
python -m pytest -q \
  test/registered/unit/mem_cache/test_radix_cache_slru_accuracy.py \
  test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py \
  test/registered/unit/mem_cache/test_mamba_unittest.py \
  test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
```

Result:

```text
934 passed, 455 skipped, 21 warnings, 24 subtests passed in 316.31s (0:05:16)
```

### gsm8k
Before, original/base `36d0a6e08`:

```text
100%|██████████| 200/200 [04:50<00:00,  1.45s/it]
Accuracy: 0.515
Invalid: 0.000
Latency: 290.693 s
Output throughput: 92.847 token/s
```

After, PR `dd6588833`:

```text
100%|██████████| 200/200 [04:58<00:00,  1.49s/it]
Accuracy: 0.515
Invalid: 0.000
Latency: 298.833 s
Output throughput: 90.703 token/s
```

## Speed Tests and Profiling
```text
100%|██████████| 200/200 [00:13<00:00, 14.69it/s]
Accuracy: 0.555
Invalid: 0.000
Latency: 13.623 s
Output throughput: 2031.619 token/s
```

After, PR `dd6588833`:

```text
100%|██████████| 200/200 [00:13<00:00, 14.77it/s]
Accuracy: 0.520
Invalid: 0.000
Latency: 13.541 s
Output throughput: 2059.497 token/s
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26693193084](https://github.com/sgl-project/sglang/actions/runs/26693193084)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26693193050](https://github.com/sgl-project/sglang/actions/runs/26693193050)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->