### PR TITLE
[XPU] Fix Ministral3 model loading and add XPU FP8 quantization fallbacks

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -40,6 +40,7 @@ from sglang.srt.utils import (
     is_musa,
     is_sm100_supported,
     is_sm120_supported,
+    is_xpu,
     log_info_on_rank0,
 )
 from sglang.srt.utils.custom_op import register_custom_op
@@ -49,6 +50,7 @@ _is_hip = is_hip()
 _is_cuda = is_cuda()
 _is_cpu = is_cpu()
 _is_musa = is_musa()
+_is_xpu = is_xpu()
 _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
@@ -76,6 +78,29 @@ if _is_cuda or _is_musa:
     from sglang.jit_kernel.per_token_group_quant_8bit_v2 import (
         per_token_group_quant_8bit_v2 as sgl_per_token_group_quant_8bit_jit_v2,
     )
+
+if _is_xpu:
+    # XPU fallbacks using pure PyTorch ops (no CUDA jit kernels available)
+    def sgl_per_token_quant_fp8(input, output, scale):
+        fp8_max_val = torch.finfo(output.dtype).max
+        eps = 1e-12
+        absmax = input.abs().max(dim=1, keepdim=True).values
+        absmax = torch.clamp(absmax, min=eps)
+        scale_val = absmax / fp8_max_val
+        scale.copy_(scale_val)
+        output.copy_(torch.clamp(input / scale_val, -fp8_max_val, fp8_max_val).to(output.dtype))
+
+    def sgl_per_tensor_quant_fp8(input, output, scale, is_static=False):
+        fp8_max_val = torch.finfo(output.dtype).max
+        if is_static:
+            output.copy_(torch.clamp(input / scale, -fp8_max_val, fp8_max_val).to(output.dtype))
+        else:
+            eps = 1e-12
+            absmax = input.abs().max()
+            absmax = torch.clamp(absmax, min=eps)
+            scale_val = absmax / fp8_max_val
+            scale.view(-1).copy_(scale_val.view(-1))
+            output.copy_(torch.clamp(input / scale_val, -fp8_max_val, fp8_max_val).to(output.dtype))
 
 if _is_hip:
     _has_vllm = False

--- a/python/sglang/srt/models/ministral3.py
+++ b/python/sglang/srt/models/ministral3.py
@@ -44,14 +44,14 @@ class Ministral3Attention(LlamaAttention):
             hidden_size,
             num_heads,
             num_kv_heads,
-            layer_id,
-            rope_theta,
-            rope_scaling,
-            rope_is_neox_style,
-            max_position_embeddings,
-            quant_config,
-            prefix,
-            bias,
+            layer_id=layer_id,
+            rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
+            rope_is_neox_style=rope_is_neox_style,
+            max_position_embeddings=max_position_embeddings,
+            quant_config=quant_config,
+            prefix=prefix,
+            bias=bias,
         )
         # Ministral3 specific: llama 4 style scaling beta
         self.llama_4_scaling_beta = config.rope_parameters.get("llama_4_scaling_beta")
@@ -96,7 +96,7 @@ class Ministral3Attention(LlamaAttention):
 
 class Ministral3DecoderLayer(LlamaDecoderLayer):
     def __init__(self, config, layer_id=0, quant_config=None, prefix=""):
-        super().__init__(config, layer_id, quant_config, prefix)
+        super().__init__(config, layer_id=layer_id, quant_config=quant_config, prefix=prefix)
         self.self_attn = Ministral3Attention(
             config=config,
             hidden_size=self.hidden_size,


### PR DESCRIPTION
# Fix Ministral3 model loading and add XPU FP8 quantization fallbacks

## Description

This PR fixes two issues that prevent Mistral/Devstral models (using `Ministral3` architecture) from loading on XPU:

### 1. Fix positional argument mismatch in `Ministral3` (`ministral3.py`)

`LlamaAttention.__init__` and `LlamaDecoderLayer.__init__` have a `start_layer` parameter between `layer_id` and subsequent arguments. `Ministral3Attention` and `Ministral3DecoderLayer` passed arguments positionally to `super().__init__()`, causing values to shift by one — `prefix` (a string) landed in the `quant_config` slot, triggering:

```
AttributeError: 'str' object has no attribute 'get_quant_method'
```

**Fix:** Switch to keyword arguments in both classes.

### 2. Add XPU fallbacks for FP8 per-tensor/per-token quantization (`fp8_kernel.py`)

`sgl_per_tensor_quant_fp8` and `sgl_per_token_quant_fp8` are only imported when `_is_cuda or _is_musa`, but the `else` branch `scaled_fp8_quant` calls them unconditionally. On XPU this results in:

```
NameError: name 'sgl_per_tensor_quant_fp8' is not defined
```

**Fix:** Add pure-PyTorch fallback implementations under `if _is_xpu:` that perform equivalent per-tensor and per-token FP8 quantization.

## Testing

Verified with `mistralai/Devstral-Small-2-24B-Instruct-2512` (FP8 checkpoint) on 4x Intel XPU with TP=4. Server starts successfully, loads weights, allocates KV cache, and serves inference requests.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27635968978](https://github.com/sgl-project/sglang/actions/runs/27635968978)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27635968844](https://github.com/sgl-project/sglang/actions/runs/27635968844)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->