### PR TITLE
[CI] Bump xeon PR test unit tests timeout to 60 minutes

### DIFF
--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -132,7 +132,7 @@ jobs:
             bash -c "source /opt/.venv/bin/activate && python3 -c 'import torch; import sgl_kernel; assert torch._C._cpu._is_amx_tile_supported(); assert hasattr(torch.ops.sgl_kernel, \"convert_weight_packed\"); '"
 
       - name: Run unit tests
-        timeout-minutes: 36
+        timeout-minutes: 60
         run: |
           docker exec -w /sglang-checkout/ ci_sglang_${{ matrix.runner }} \
             bash -c "source /opt/.venv/bin/activate && cd ./test && python3 run_suite.py --hw cpu --suite ${{ matrix.suite }} ${{ matrix.partition_args }}"


### PR DESCRIPTION
The `Run unit tests` step in `pr-test-xeon.yml` occasionally hits the 36-minute step timeout on the `xeon-gnr` runner, causing spurious CI failures unrelated to test correctness. Bump the timeout to 60 minutes.


