### PR TITLE
Capture indexer top-k for rollout replay (DP-attention / cuda-graph safe)

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -467,7 +467,7 @@ class C4IndexerBackendMixin:
             compress_layer_id = token_to_kv_pool.layer_mapping[
                 c4_indexer.layer_id
             ].compress_layer_id
-            indexer_capturer.capture(compress_layer_id, raw_indices)
+            indexer_capturer.capture(compress_layer_id, raw_indices, forward_batch)
 
 
 class C4Indexer(nn.Module):

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -432,11 +432,13 @@ class Indexer(MultiPlatformOp):
             return
         dst.copy_(src)
 
-    def _capture_and_return(self, layer_id, topk_result, raw_result):
+    def _capture_and_return(self, layer_id, topk_result, raw_result, forward_batch):
         # capture sequence-relative indices for rollout replay; return the
         # transformed (paged/ragged) indices for the attention kernel
         maybe_capture_indexer_topk(
-            layer_id, raw_result if raw_result is not None else topk_result
+            layer_id,
+            raw_result if raw_result is not None else topk_result,
+            forward_batch,
         )
         return topk_result
 
@@ -1249,7 +1251,9 @@ class Indexer(MultiPlatformOp):
                 metadata,
                 return_indices,
             )
-            return self._capture_and_return(layer_id, topk_result, raw_result)
+            return self._capture_and_return(
+                layer_id, topk_result, raw_result, forward_batch
+            )
 
         if enable_dual_stream and forward_batch.forward_mode.is_decode_or_idle():
             current_stream = torch.cuda.current_stream()
@@ -1355,6 +1359,7 @@ class Indexer(MultiPlatformOp):
                         dtype=torch.int,
                         device=x_meta.device,
                     ),
+                    forward_batch,
                 )
 
             if (
@@ -1408,6 +1413,7 @@ class Indexer(MultiPlatformOp):
                         layer_id,
                         torch.cat([topk_result_prev, topk_result_next], dim=0),
                         torch.cat([raw_prev, raw_next], dim=0),
+                        forward_batch,
                     )
                 else:
                     topk_result, raw_result = self._get_topk_ragged(
@@ -1426,7 +1432,9 @@ class Indexer(MultiPlatformOp):
                 topk=self.index_topk,
                 layer_id=layer_id,
             )
-        return self._capture_and_return(layer_id, topk_result, raw_result)
+        return self._capture_and_return(
+            layer_id, topk_result, raw_result, forward_batch
+        )
 
     def forward_npu(
         self,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.layernorm import LayerNorm
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.state_capturer.indexer_topk import (
+    get_global_indexer_capturer,
     maybe_capture_indexer_topk,
 )
 from sglang.srt.utils import (
@@ -431,6 +432,14 @@ class Indexer(MultiPlatformOp):
             return
         dst.copy_(src)
 
+    def _capture_and_return(self, layer_id, topk_result, raw_result):
+        # capture sequence-relative indices for rollout replay; return the
+        # transformed (paged/ragged) indices for the attention kernel
+        maybe_capture_indexer_topk(
+            layer_id, raw_result if raw_result is not None else topk_result
+        )
+        return topk_result
+
     def _get_topk_paged(
         self,
         forward_batch: ForwardBatch,
@@ -538,8 +547,15 @@ class Indexer(MultiPlatformOp):
                 clean_logits=False,
             )
 
+        capture = get_global_indexer_capturer() is not None
         # NOTE(dark): logits should be cleaned in topk_transform
-        topk_result = metadata.topk_transform(logits, self.index_topk)
+        if capture:
+            topk_result, raw_result = metadata.topk_transform(
+                logits, self.index_topk, return_raw_indices=True
+            )
+        else:
+            topk_result = metadata.topk_transform(logits, self.index_topk)
+            raw_result = None
         # Restore possible padding exist in the hidden states.
         if not _is_hip and q_offset < q_fp8.shape[0]:
             pad_len = q_fp8.shape[0] - q_offset
@@ -550,7 +566,9 @@ class Indexer(MultiPlatformOp):
                 device=topk_result.device,
             )
             topk_result = torch.cat([topk_result, padding], dim=0)
-        return topk_result
+            if raw_result is not None:
+                raw_result = torch.cat([raw_result, padding], dim=0)
+        return topk_result, raw_result
 
     def _should_chunk_mqa_logits(
         self, num_q: int, num_k: int, device: torch.device
@@ -622,8 +640,10 @@ class Indexer(MultiPlatformOp):
         topk_result = torch.full(
             (token_nums, self.index_topk), -1, device=device, dtype=torch.int32
         )
+        capture = get_global_indexer_capturer() is not None
+        raw_result = torch.full_like(topk_result, -1) if capture else None
         if batch_size == 0:
-            return topk_result
+            return topk_result, raw_result
 
         ks, ke = metadata.get_indexer_kvcache_range()
 
@@ -674,9 +694,17 @@ class Indexer(MultiPlatformOp):
             assert logits.shape[0] == len(seq_lens_expanded)
             assert logits.shape[1] == k_offset
 
-            raw_topk_result = metadata.topk_transform(logits, self.index_topk, ks=ks)
-            topk_result[:q_offset] = raw_topk_result
-            return topk_result
+            if capture:
+                transformed, raw = metadata.topk_transform(
+                    logits, self.index_topk, ks=ks, return_raw_indices=True
+                )
+                topk_result[:q_offset] = transformed
+                raw_result[:q_offset] = raw
+            else:
+                topk_result[:q_offset] = metadata.topk_transform(
+                    logits, self.index_topk, ks=ks
+                )
+            return topk_result, raw_result
 
         # Chunk path
         bytes_per_elem = 4  # float32
@@ -739,19 +767,32 @@ class Indexer(MultiPlatformOp):
                 )
                 batch_idx_chunk = token_to_batch_idx[start:end]
 
-            raw_topk_chunk = metadata.topk_transform(
-                logits_chunk,
-                self.index_topk,
-                ks=ks[start:end],
-                cu_seqlens_q=cu_seqlens_q_chunk,
-                ke_offset=lengths_chunk,
-                batch_idx_list=batch_idx_chunk,
-                topk_indices_offset_override=topk_offset_chunk,
-            )
-            topk_result[start:end] = raw_topk_chunk
+            if capture:
+                transformed, raw = metadata.topk_transform(
+                    logits_chunk,
+                    self.index_topk,
+                    ks=ks[start:end],
+                    cu_seqlens_q=cu_seqlens_q_chunk,
+                    ke_offset=lengths_chunk,
+                    batch_idx_list=batch_idx_chunk,
+                    topk_indices_offset_override=topk_offset_chunk,
+                    return_raw_indices=True,
+                )
+                topk_result[start:end] = transformed
+                raw_result[start:end] = raw
+            else:
+                topk_result[start:end] = metadata.topk_transform(
+                    logits_chunk,
+                    self.index_topk,
+                    ks=ks[start:end],
+                    cu_seqlens_q=cu_seqlens_q_chunk,
+                    ke_offset=lengths_chunk,
+                    batch_idx_list=batch_idx_chunk,
+                    topk_indices_offset_override=topk_offset_chunk,
+                )
             start = end
 
-        return topk_result
+        return topk_result, raw_result
 
     def _forward_cuda_k_only(
         self,
@@ -782,7 +823,7 @@ class Indexer(MultiPlatformOp):
 
         # MHA doesn't need topk_indices
         if not return_indices:
-            return None
+            return None, None
 
         # MLA: use dummy logits with topk kernel's fast path to generate indices
         # When length <= 2048, naive_topk_cuda directly generates [0,1,...,length-1,-1,...]
@@ -793,7 +834,19 @@ class Indexer(MultiPlatformOp):
             dtype=torch.float32,
             device=x_meta.device,
         )
-        return metadata.topk_transform(dummy_logits, self.index_topk)
+        topk_result = metadata.topk_transform(dummy_logits, self.index_topk)
+        raw_result = None
+        if get_global_indexer_capturer() is not None:
+            # fast path selects all keys (seq_len <= index_topk); sequence-relative
+            # selection is [0..len-1] per token. fast_topk_v2 cannot reproduce this
+            # from the dummy logits (no naive_topk_cuda special case), so build it.
+            ar = torch.arange(self.index_topk, device=x_meta.device, dtype=torch.int32)
+            raw_result = torch.where(
+                ar.unsqueeze(0) < seq_lens_expanded.to(ar.device).unsqueeze(1),
+                ar.unsqueeze(0),
+                torch.full_like(ar, -1).unsqueeze(0),
+            )
+        return topk_result, raw_result
 
     def _get_topk_ragged_with_cp(
         self,
@@ -813,6 +866,7 @@ class Indexer(MultiPlatformOp):
         assert page_size == 64, "only support page size 64"
         assert len(weights.shape) == 3
         weights = weights.squeeze(-1)
+        capture = get_global_indexer_capturer() is not None
         k_fp8_list = []
         k_scale_list = []
         ks_list = []
@@ -885,14 +939,26 @@ class Indexer(MultiPlatformOp):
                     ke,
                     clean_logits=False,
                 )
-            topk_result = metadata.topk_transform(
-                logits,
-                self.index_topk,
-                ks=ks,
-                cu_seqlens_q=actual_seq_q,
-                ke_offset=ke_offset,
-                batch_idx_list=batch_idx_list,
-            )
+            if capture:
+                topk_result, raw_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                    batch_idx_list=batch_idx_list,
+                    return_raw_indices=True,
+                )
+            else:
+                topk_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                    batch_idx_list=batch_idx_list,
+                )
+                raw_result = None
         else:
             kv_len = (
                 forward_batch.seq_lens_cpu[0].item()
@@ -934,15 +1000,26 @@ class Indexer(MultiPlatformOp):
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )
-            topk_result = metadata.topk_transform(
-                logits,
-                self.index_topk,
-                ks=ks,
-                cu_seqlens_q=actual_seq_q,
-                ke_offset=ke_offset,
-            )
+            if capture:
+                topk_result, raw_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                    return_raw_indices=True,
+                )
+            else:
+                topk_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                )
+                raw_result = None
 
-        return topk_result
+        return topk_result, raw_result
 
     def forward_indexer(
         self,
@@ -1162,19 +1239,17 @@ class Indexer(MultiPlatformOp):
 
         # Optimization: fast path when skipping topk computation
         if skip_logits_computation and (not self.nsa_enable_prefill_cp):
-            return maybe_capture_indexer_topk(
+            topk_result, raw_result = self._forward_cuda_k_only(
+                x,
+                positions,
+                forward_batch,
                 layer_id,
-                self._forward_cuda_k_only(
-                    x,
-                    positions,
-                    forward_batch,
-                    layer_id,
-                    act_quant,
-                    enable_dual_stream,
-                    metadata,
-                    return_indices,
-                ),
+                act_quant,
+                enable_dual_stream,
+                metadata,
+                return_indices,
             )
+            return self._capture_and_return(layer_id, topk_result, raw_result)
 
         if enable_dual_stream and forward_batch.forward_mode.is_decode_or_idle():
             current_stream = torch.cuda.current_stream()
@@ -1263,6 +1338,7 @@ class Indexer(MultiPlatformOp):
 
             weights = self._get_logits_head_gate(x_for_gate, q_scale)
 
+        raw_result = None
         if _is_cuda or _is_hip:
             assert forward_batch.seq_lens_cpu is not None
             if len(forward_batch.seq_lens_cpu) == 0:
@@ -1286,7 +1362,7 @@ class Indexer(MultiPlatformOp):
                 or forward_batch.forward_mode.is_target_verify()
                 or forward_batch.forward_mode.is_draft_extend(include_v2=True)
             ):
-                topk_result = self._get_topk_paged(
+                topk_result, raw_result = self._get_topk_paged(
                     forward_batch, layer_id, q_fp8, weights, metadata
                 )
             else:
@@ -1309,7 +1385,7 @@ class Indexer(MultiPlatformOp):
                     weights_prev, weights_next = torch.split(
                         weights, (weights.shape[0] + 1) // 2, dim=0
                     )
-                    topk_result_prev = self._get_topk_ragged_with_cp(
+                    topk_result_prev, raw_prev = self._get_topk_ragged_with_cp(
                         forward_batch,
                         layer_id,
                         q_fp8_prev,
@@ -1319,7 +1395,7 @@ class Indexer(MultiPlatformOp):
                         actual_seq_q_prev,
                     )
 
-                    topk_result_next = self._get_topk_ragged_with_cp(
+                    topk_result_next, raw_next = self._get_topk_ragged_with_cp(
                         forward_batch,
                         layer_id,
                         q_fp8_next,
@@ -1328,12 +1404,13 @@ class Indexer(MultiPlatformOp):
                         kv_len_next,
                         actual_seq_q_next,
                     )
-                    return maybe_capture_indexer_topk(
+                    return self._capture_and_return(
                         layer_id,
                         torch.cat([topk_result_prev, topk_result_next], dim=0),
+                        torch.cat([raw_prev, raw_next], dim=0),
                     )
                 else:
-                    topk_result = self._get_topk_ragged(
+                    topk_result, raw_result = self._get_topk_ragged(
                         enable_dual_stream,
                         forward_batch,
                         layer_id,
@@ -1349,7 +1426,7 @@ class Indexer(MultiPlatformOp):
                 topk=self.index_topk,
                 layer_id=layer_id,
             )
-        return maybe_capture_indexer_topk(layer_id, topk_result)
+        return self._capture_and_return(layer_id, topk_result, raw_result)
 
     def forward_npu(
         self,

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -232,6 +232,7 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
         ke_offset: torch.Tensor = None,
         batch_idx_list: List[int] = None,
         topk_indices_offset_override: Optional[torch.Tensor] = None,
+        return_raw_indices: bool = False,
     ) -> torch.Tensor:
         from sgl_kernel import (
             fast_topk_transform_fused,
@@ -262,10 +263,18 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
             page_table_size_1 = self.attn_metadata.page_table_1
 
         if not envs.SGLANG_NSA_FUSE_TOPK.get() or self.force_unfused_topk:
-            return fast_topk_v2(logits, seq_lens_topk, topk, row_starts=ks)
-        elif self.topk_transform_method == TopkTransformMethod.PAGED:
-            # NOTE(dark): if fused, we return a transformed page table directly
-            return fast_topk_transform_fused(
+            result = fast_topk_v2(logits, seq_lens_topk, topk, row_starts=ks)
+            return (result, result) if return_raw_indices else result
+
+        # sequence-relative selection, before the kv-cache coordinate remap
+        raw_indices = (
+            fast_topk_v2(logits, seq_lens_topk, topk, row_starts=ks)
+            if return_raw_indices
+            else None
+        )
+
+        if self.topk_transform_method == TopkTransformMethod.PAGED:
+            result = fast_topk_transform_fused(
                 score=logits,
                 lengths=seq_lens_topk,
                 page_table_size_1=page_table_size_1,
@@ -279,7 +288,7 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
                     "RAGGED topk_transform requires topk_indices_offset; "
                     "expected extend-without-speculative metadata."
                 )
-            return fast_topk_transform_ragged_fused(
+            result = fast_topk_transform_ragged_fused(
                 score=logits,
                 lengths=seq_lens_topk,
                 topk_indices_offset=cu_topk_indices_offset,
@@ -288,6 +297,8 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
             )
         else:
             assert False, f"Unsupported {self.topk_transform_method = }"
+
+        return (result, raw_indices) if return_raw_indices else result
 
 
 _NSA_IMPL_T: TypeAlias = Literal[

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -384,6 +384,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             output_hidden_states=recv_obj.output_hidden_states,
             routed_experts=routed_experts,
             indexer_topk=indexer_topk,
+            indexer_topk_num_layers=recv_obj.indexer_topk_num_layers,
             customized_info=recv_obj.customized_info,
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1143,6 +1143,9 @@ class BatchTokenIDOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
     # For observability
     time_stats: Optional[List[SchedulerReqTimeStats]] = None
 
+    # Number of indexer layers, set when indexer_topk is non-empty
+    indexer_topk_num_layers: Optional[int] = None
+
 
 @dataclass
 class BatchStrOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
@@ -1208,6 +1211,9 @@ class BatchStrOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
 
     # For observability
     time_stats: Optional[List[SchedulerReqTimeStats]] = None
+
+    # Number of indexer layers, set when indexer_topk is non-empty
+    indexer_topk_num_layers: Optional[int] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -208,6 +208,7 @@ def _handle_output_by_index(output, i):
             indexer_topk=_extract_field_by_index(
                 output, "indexer_topk", i, check_length=False
             ),
+            indexer_topk_num_layers=getattr(output, "indexer_topk_num_layers", None),
             retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
@@ -295,6 +296,7 @@ def _handle_output_by_index(output, i):
             indexer_topk=_extract_field_by_index(
                 output, "indexer_topk", i, check_length=False
             ),
+            indexer_topk_num_layers=getattr(output, "indexer_topk_num_layers", None),
             customized_info=_extract_field_by_index(
                 output, "customized_info", i, check_length=False
             ),

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -1263,6 +1263,13 @@ class SchedulerOutputProcessorMixin:
 
         dp_ranks = [self.dp_rank] * len(rids) if rids else None
 
+        indexer_topk_num_layers = None
+        if (
+            indexer_topk is not None
+            and (cap := get_global_indexer_capturer()) is not None
+        ):
+            indexer_topk_num_layers = cap.num_layers
+
         # Send to detokenizer
         if reqs or is_idle_batch:
             if getattr(self.model_config, "is_multimodal_gen", False):
@@ -1304,6 +1311,7 @@ class SchedulerOutputProcessorMixin:
                     output_hidden_states=output_hidden_states,
                     routed_experts=routed_experts,
                     indexer_topk=indexer_topk,
+                    indexer_topk_num_layers=indexer_topk_num_layers,
                     customized_info=customized_info,
                     placeholder_tokens_idx=None,
                     placeholder_tokens_val=None,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1754,6 +1754,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     if isinstance(val, torch.Tensor):
                         val = pybase64.b64encode(val.numpy().tobytes()).decode("utf-8")
                     meta_info["indexer_topk"] = val
+                    if (
+                        n := getattr(recv_obj, "indexer_topk_num_layers", None)
+                    ) is not None:
+                        meta_info["indexer_topk_num_layers"] = n
             if getattr(recv_obj, "customized_info", None):
                 for k, v in recv_obj.customized_info.items():
                     meta_info[k] = v[i]

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -145,13 +145,19 @@ class DeepseekMHAForwardMixin:
                     q = self.q_b_proj(q_lora)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
                     )
+                from sglang.srt.state_capturer.indexer_topk import (
+                    get_global_indexer_capturer,
+                )
+
+                # dense MHA ignores topk_indices, but capture the prefill
+                # select-all selection for rollout replay when a capturer is set
                 _ = self.indexer(
                     x=hidden_states,
                     q_lora=q_lora,
                     positions=positions,
                     forward_batch=forward_batch,
                     layer_id=self.layer_id,
-                    return_indices=False,
+                    return_indices=get_global_indexer_capturer() is not None,
                 )
             elif _use_aiter_gfx95 and self.q_b_proj.weight.dtype == torch.uint8:
                 # MXFP4: fused RMSNorm + quant

--- a/python/sglang/srt/state_capturer/indexer_topk.py
+++ b/python/sglang/srt/state_capturer/indexer_topk.py
@@ -5,7 +5,13 @@ import numpy as np
 import pybase64
 import torch
 
-from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.layers.dp_attention import (
+    get_attention_dp_rank,
+    get_attention_tp_size,
+    get_dp_local_slice_cpu,
+    is_dp_attention_enabled,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.state_capturer.base import BaseTopkCapturer
 
 logger = logging.getLogger(__name__)
@@ -28,10 +34,13 @@ class IndexerTopkCapturer(BaseTopkCapturer):
         attn_tp_size = get_attention_tp_size()
         assert attn_tp_size == 1, "IndexerTopkCapturer now only supports DP attention"
 
-        # DP-attention capture is per-rank-local: each rank writes [:local_batch, ...]
-        # to its own device_cache, so the buffer only needs to fit one rank's batch.
+        # device_cache holds the global DP-rank-padded batch; each rank's slice is
+        # read back via _get_local_slice (see RoutedExpertsCapturer for the same pattern)
         server_args = get_global_server_args()
-        max_batch_size = max(server_args.chunked_prefill_size, max_running_requests)
+        max_batch_size = max(
+            server_args.chunked_prefill_size * server_args.dp_size,
+            max_running_requests,
+        )
 
         super().__init__(
             num_tokens=num_tokens,
@@ -41,6 +50,48 @@ class IndexerTopkCapturer(BaseTopkCapturer):
             device=device,
             name="indexer_topk",
         )
+
+    def capture(self, layer_id: int, topk_indices: torch.Tensor, forward_batch=None):
+        # Each DP rank only computes its own tokens' topk; write them at this
+        # rank's offset in the shared rank-padded buffer (writing the head would
+        # clobber across ranks). The offset matches _get_local_slice's read.
+        if forward_batch is not None and is_dp_attention_enabled():
+            gnt = forward_batch.global_num_tokens_cpu
+            dp_rank = get_attention_dp_rank()
+            batch = topk_indices.shape[0]
+            # gnt is None during cuda-graph capture (uniform dummy batch); the
+            # per-rank stride is then the captured batch size itself.
+            start = (
+                dp_rank * batch if gnt is None else sum(int(n) for n in gnt[:dp_rank])
+            )
+            self.device_cache.buffer[start : start + batch, layer_id, :] = topk_indices
+        else:
+            super().capture(layer_id, topk_indices)
+
+    def _get_local_slice(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: Optional[int],
+    ) -> torch.Tensor:
+        # Under DP attention the device buffer is rank-padded; read this rank's
+        # slice (handles eager, cuda-graph-replay, and cuda-graph-capture layouts)
+        # instead of the head, which would only be correct for DP rank 0.
+        if not is_dp_attention_enabled():
+            num = forward_batch.out_cache_loc.shape[0]
+            return self.device_cache.buffer[:num, :, : self.topk_size]
+        gnt = forward_batch.global_num_tokens_cpu
+        if gnt is None:
+            # cuda-graph capture: gnt not populated, uniform dummy batch.
+            num = forward_batch.out_cache_loc.shape[0]
+            start = get_attention_dp_rank() * (
+                cuda_graph_batch if cuda_graph_batch is not None else num
+            )
+        else:
+            start, num = get_dp_local_slice_cpu(
+                forward_batch, can_run_graph, cuda_graph_batch
+            )
+        return self.device_cache.buffer[start : start + num, :, : self.topk_size]
 
 
 _global_indexer_capturer: Optional[IndexerTopkCapturer] = None
@@ -56,7 +107,7 @@ def set_global_indexer_capturer(capturer: Optional[IndexerTopkCapturer]):
 
 
 def maybe_capture_indexer_topk(
-    layer_id: int, topk_indices: Optional[torch.Tensor]
+    layer_id: int, topk_indices: Optional[torch.Tensor], forward_batch=None
 ) -> Optional[torch.Tensor]:
     """Capture topk for layer_id if a capturer is set; pass through unchanged.
 
@@ -66,7 +117,9 @@ def maybe_capture_indexer_topk(
     if topk_indices is None:
         return None
     if (cap := get_global_indexer_capturer()) is not None:
-        cap.capture(layer_id=layer_id, topk_indices=topk_indices)
+        cap.capture(
+            layer_id=layer_id, topk_indices=topk_indices, forward_batch=forward_batch
+        )
     return topk_indices
 
 


### PR DESCRIPTION
## What

Capture the NSA / DSV4 indexer's per-query top-k selection during rollout so RL training can **replay** it instead of recomputing, for GLM-5 / DeepSeek-V4 sparse (compressed) attention.

Three commits:

1. **Return indexer_topk num_layers in meta_info** — plumb the indexer top-k layer count through the response pipeline (mirrors the existing `routed_experts` return path).
2. **Capture sequence-relative indexer top-k for rollout replay** — record the unfused `fast_topk_v2` selection (request-local sequence positions) rather than the post-`topk_transform` paged/ragged KV-cache coordinates; the attention kernel still consumes the transformed indices. The dense-MHA prefill path also captures its select-all selection when a capturer is set.
3. **Make indexer top-k capture DP-attention / cuda-graph safe** — under DP attention the device buffer is a shared, rank-padded global buffer, but each DP rank only computes its own tokens' top-k. Write/read at the per-DP-rank offset (mirroring `RoutedExpertsCapturer`) instead of the buffer head, and handle the `global_num_tokens_cpu is None` cuda-graph-capture batch.

## Why

Training-side replay needs request-local sequence positions. The earlier capture recorded paged coordinates and, under DP attention, only DP rank 0 was correct (ranks 1+ clobbered/read the buffer head) — training then attended to out-of-window keys (`-inf` indexer logits) and produced NaN in the backward pass.

Validated end-to-end on the GLM-5 4-layer indexer-replay e2e test: replay mismatch = 0 and finite train grad-norm across training steps.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->