### PR TITLE
feat(sampling): add MinerUNoRepeatNGramLogitProcessor (no_repeat_ngram_size for MinerU2.5)

### DIFF
--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -200,3 +200,94 @@ class DeepseekOCRNoRepeatNGramLogitProcessor(CustomLogitProcessor):
             logits[batch_idx, indices] = -float("inf")
 
         return logits
+
+
+# Port of mineru-vl-utils' MinerULogitsProcessor (HF-style ``no_repeat_ngram_size``):
+# https://github.com/opendatalab/mineru-vl-utils/blob/main/mineru_vl_utils/logits_processor/vllm_v1_no_repeat_ngram.py
+class MinerUNoRepeatNGramLogitProcessor(CustomLogitProcessor):
+    """Forbid repeating any ``ngram_size``-gram over the generated output.
+
+    This is the SGLang equivalent of ``mineru_vl_utils.MinerULogitsProcessor``,
+    the ``no_repeat_ngram_size`` guard the vLLM / Transformers paths apply for
+    MinerU2.5. A token is banned whenever emitting it would reproduce an
+    ``ngram_size``-token sequence that already appeared earlier in the output,
+    which breaks long verbatim repetition loops on degenerate documents while
+    leaving short legitimate repeats (e.g. table cells) untouched.
+
+    Custom params:
+        ngram_size (int): n-gram length to forbid repeating. Defaults to 100
+            (matching mineru-vl-utils) only when the key is absent; an explicit
+            value of ``0`` or less disables the processor. ``ngram_size=1`` bans
+            every token already seen in the scanned output.
+        window_size (int, optional): only scan the last ``window_size`` output
+            tokens for repeats. A positive value bounds the per-step cost; the
+            default (``None``, or any non-positive value) scans the full output
+            history, which is faithful to mineru-vl-utils but costs ``O(L)`` per
+            decode step (``O(L^2)`` over an ``L``-token generation). Set
+            ``window_size`` for long outputs.
+
+    Note: this rescans the output each step (like the sibling
+    ``DeepseekOCRNoRepeatNGramLogitProcessor``) rather than keeping a persistent
+    cross-step cache, since the processor instance is shared across requests and
+    the interface offers no per-request teardown hook.
+    """
+
+    DEFAULT_NGRAM_SIZE = 100
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        custom_param_list: Optional[List[Dict[str, Any]]] = None,
+    ) -> torch.Tensor:
+        if not custom_param_list:
+            return logits
+
+        for batch_idx, params in enumerate(custom_param_list):
+            if not params:
+                continue
+
+            req = params.get("__req__")
+            if req is None:
+                continue
+
+            try:
+                ngram_size = int(params.get("ngram_size", self.DEFAULT_NGRAM_SIZE))
+            except (TypeError, ValueError):
+                continue
+            if ngram_size <= 0:
+                continue
+
+            window = params.get("window_size")
+            try:
+                window_size = int(window) if window is not None else None
+            except (TypeError, ValueError):
+                window_size = None
+
+            # MinerU operates on the generated tokens only (not the prompt).
+            output_ids: List[int] = req.output_ids
+            if window_size is not None and window_size > 0:
+                output_ids = output_ids[-window_size:]
+            if len(output_ids) < ngram_size:
+                continue
+
+            # The trailing (ngram_size - 1)-gram that the next token would extend.
+            current_prefix = (
+                tuple(output_ids[-(ngram_size - 1) :]) if ngram_size > 1 else tuple()
+            )
+            # Cheap filter: only positions whose prefix ends in the same token as
+            # current_prefix can match, so we skip the tuple build/compare for the
+            # rest (keeps the common case ~O(L) instead of O(L * ngram_size)).
+            prefix_last = current_prefix[-1] if ngram_size > 1 else None
+
+            # Ban every token that already completed this same prefix earlier.
+            banned_tokens: Set[int] = set()
+            for idx in range(len(output_ids) - ngram_size + 1):
+                if ngram_size > 1 and output_ids[idx + ngram_size - 2] != prefix_last:
+                    continue
+                if tuple(output_ids[idx : idx + ngram_size - 1]) == current_prefix:
+                    banned_tokens.add(output_ids[idx + ngram_size - 1])
+
+            if banned_tokens:
+                logits[batch_idx, list(banned_tokens)] = -float("inf")
+
+        return logits

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -16,6 +16,7 @@ from sglang.srt.sampling.custom_logit_processor import (
     DeepseekOCRNoRepeatNGramLogitProcessor,
     DeepSeekR1ThinkingBudgetLogitProcessor,
     DisallowedTokensLogitsProcessor,
+    MinerUNoRepeatNGramLogitProcessor,
     Qwen3ThinkingBudgetLogitProcessor,
     _cache_from_str,
 )
@@ -440,6 +441,144 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         # Batch 1: prefix is (5), no matching prefix in window → no bans
         self.assertEqual(result[1, 3].item(), 0.0)
         self.assertEqual(result[1, 4].item(), 0.0)
+
+
+# MinerUNoRepeatNGramLogitProcessor
+class TestMinerUNoRepeatNGramLogitProcessor(CustomTestCase):
+    VOCAB = 100
+
+    def setUp(self):
+        self.processor = MinerUNoRepeatNGramLogitProcessor()
+
+    def _logits(self, batch_size=1):
+        return torch.zeros(batch_size, self.VOCAB)
+
+    def test_bans_repeated_bigram(self):
+        """Token that completes a previously seen bigram is banned."""
+        # output [1,2,3,1,2]: trailing prefix is (2), which was followed by 3.
+        req = _make_req(output_ids=[1, 2, 3, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2}]
+        result = self.processor(self._logits(), params)
+        self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
+
+    def test_non_repeated_token_unchanged(self):
+        """Tokens that do not complete a repeated ngram stay untouched."""
+        req = _make_req(output_ids=[1, 2, 3, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2}]
+        result = self.processor(self._logits(), params)
+        # Prefix (2) was only ever followed by 3, so token 1 is not banned.
+        self.assertEqual(result[0, 1].item(), 0.0)
+
+    def test_bans_repeated_trigram(self):
+        """ngram_size=3 bans the token completing a repeated trigram prefix."""
+        # output [1,2,3,4,1,2,3]: trailing prefix (2,3) was once followed by 4.
+        req = _make_req(output_ids=[1, 2, 3, 4, 1, 2, 3])
+        params = [{"__req__": req, "ngram_size": 3}]
+        result = self.processor(self._logits(), params)
+        self.assertTrue(torch.isinf(result[0, 4]) and result[0, 4] < 0)
+
+    def test_full_history_by_default(self):
+        """With no window_size, a far-back repeat is still blocked (MinerU semantics)."""
+        # The (2,3) bigram is 7 tokens back; trailing prefix is (2).
+        req = _make_req(output_ids=[2, 3, 9, 9, 9, 9, 9, 2])
+        params = [{"__req__": req, "ngram_size": 2}]
+        result = self.processor(self._logits(), params)
+        self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
+
+    def test_window_size_limits_search(self):
+        """window_size bounds the lookback; ngrams outside it are ignored."""
+        # Full history would ban 3 via (2,3); window of 3 covers only [5,1,2].
+        req = _make_req(output_ids=[1, 2, 3, 4, 5, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2, "window_size": 3}]
+        result = self.processor(self._logits(), params)
+        self.assertEqual(result[0, 3].item(), 0.0)
+
+    def test_default_ngram_size_is_100(self):
+        """Omitting ngram_size uses 100; short outputs are left unchanged."""
+        req = _make_req(output_ids=[7] * 50)
+        params = [{"__req__": req}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_ngram_size_zero_skips(self):
+        """ngram_size<=0 disables the processor."""
+        req = _make_req(output_ids=[1, 2, 1, 2])
+        params = [{"__req__": req, "ngram_size": 0}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_short_sequence_skips(self):
+        """Output shorter than ngram_size is skipped."""
+        req = _make_req(output_ids=[1, 2])
+        params = [{"__req__": req, "ngram_size": 3}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_none_req_skips(self):
+        """A batch item without __req__ is skipped."""
+        params = [{"ngram_size": 2}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_invalid_ngram_size_type_skips(self):
+        """Non-numeric ngram_size is handled gracefully."""
+        req = _make_req(output_ids=[1, 2, 1, 2])
+        params = [{"__req__": req, "ngram_size": "invalid"}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_empty_params_returns_unchanged(self):
+        """None param list returns logits unchanged (early return)."""
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, None)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_batch_processing(self):
+        """Batch items are processed independently."""
+        req1 = _make_req(output_ids=[1, 2, 3, 1, 2])  # prefix (2) → ban 3
+        req2 = _make_req(output_ids=[3, 4, 5])  # no repeat
+        params = [
+            {"__req__": req1, "ngram_size": 2},
+            {"__req__": req2, "ngram_size": 2},
+        ]
+        result = self.processor(self._logits(batch_size=2), params)
+        self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
+        self.assertEqual(result[1, 3].item(), 0.0)
+        self.assertEqual(result[1, 4].item(), 0.0)
+
+    def test_unigram_bans_all_seen_tokens(self):
+        """ngram_size=1 bans every token already present in the output."""
+        req = _make_req(output_ids=[5, 10, 15])
+        params = [{"__req__": req, "ngram_size": 1}]
+        result = self.processor(self._logits(), params)
+        for t in (5, 10, 15):
+            self.assertTrue(torch.isinf(result[0, t]) and result[0, t] < 0)
+        self.assertEqual(result[0, 0].item(), 0.0)
+
+    def test_window_size_zero_uses_full_history(self):
+        """window_size<=0 means 'no window' (full history), not 'disable'."""
+        # The (2,3) bigram is far back; with full history token 3 is still banned.
+        req = _make_req(output_ids=[2, 3, 9, 9, 9, 9, 9, 2])
+        params = [{"__req__": req, "ngram_size": 2, "window_size": 0}]
+        result = self.processor(self._logits(), params)
+        self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
+
+    def test_round_trip_serialization(self):
+        """The processor serializes and deserializes like its siblings."""
+        s = MinerUNoRepeatNGramLogitProcessor.to_str()
+        processor = CustomLogitProcessor.from_str(s)
+        self.assertIsInstance(processor, MinerUNoRepeatNGramLogitProcessor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

MinerU2.5 (`opendatalab/MinerU2.5-2509-1.2B`, a `Qwen2VLForConditionalGeneration` document-parsing model) runs on SGLang's standard Qwen2-VL path with no code changes. Its client library, `mineru-vl-utils`, applies an anti-repetition guard via `no_repeat_ngram_size` — on the vLLM/Transformers paths this is `MinerULogitsProcessor`. SGLang has no `no_repeat_ngram_size` sampling param, so when serving MinerU2.5 the `mineru-vl-utils` `http-client` backend sends that param inside `vllm_xargs` and the SGLang server silently ignores it. On clean documents this is fine, but on pathological inputs (dense repeated table cells, heavy noise) the model can fall into a verbatim repetition loop that the vLLM path would have broken.

This adds a faithful equivalent as a `CustomLogitProcessor`, parallel to the existing `DeepseekOCRNoRepeatNGramLogitProcessor` in the same file.

## What this does

`MinerUNoRepeatNGramLogitProcessor` bans a token whenever emitting it would reproduce an `ngram_size`-token sequence already present in the generated output — the classic HuggingFace `no_repeat_ngram_size` rule, matching `mineru-vl-utils`' implementation.

- `ngram_size` (default **100**, matching mineru-vl-utils) — applied only when the key is absent; `<= 0` disables.
- `window_size` (optional) — bounds the per-step scan; `None`/non-positive means full output history (faithful default). A cheap last-token filter keeps the common-case scan ~`O(L)`.

Usage:
```bash
python3 -m sglang.launch_server --model-path opendatalab/MinerU2.5-2509-1.2B \
  --host 0.0.0.0 --port 30000 --enable-custom-logit-processor
```
then per request: `custom_logit_processor=MinerUNoRepeatNGramLogitProcessor.to_str()` with `custom_params={"ngram_size": 100}`.

## Tests

- New CPU unit-test class `TestMinerUNoRepeatNGramLogitProcessor` (registered under the existing `register_cpu_ci` suite): bigram/trigram bans, full-history vs `window_size`, unigram mode, default-100 short-circuit, disable/skip paths, batch independence, serialization round-trip.
- Verified live end-to-end on a single H200: with `--enable-custom-logit-processor`, a greedy prompt that loops into `000…0` (77-token run) is broken to a coherent completion once the processor is attached; baseline vs processed outputs differ as expected.
- `pre-commit` (isort, ruff, black, codespell, python-ast, CI-registry check) passes on the changed files.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26623632960](https://github.com/sgl-project/sglang/actions/runs/26623632960)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26623632749](https://github.com/sgl-project/sglang/actions/runs/26623632749)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->