### PR TITLE
fix(processor): preserve fast TokenizersBackend when declared class would regress (#26650)

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -261,26 +261,41 @@ def get_processor(
     tokenizer = get_tokenizer_from_processor(processor)
 
     # AutoProcessor may internally create a TokenizersBackend tokenizer
-    # (same issue as get_tokenizer). Replace it with a properly loaded one.
+    # (same issue as get_tokenizer). Reload via get_tokenizer so the class
+    # declared in tokenizer_config.json is used -- but only when that reload
+    # is not a strict regression. For LLaVA-family models the
+    # TokenizersBackend produced by AutoProcessor is already a working fast
+    # Rust-backed tokenizer, while the declared class (e.g. Qwen2Tokenizer)
+    # is slow; swapping would regress tokenization throughput (issue #26650).
     if type(tokenizer).__name__ == _TOKENIZERS_BACKEND:
         from .tokenizer import get_tokenizer
 
-        logger.warning(
-            "Processor tokenizer for %s is TokenizersBackend, "
-            "reloading via get_tokenizer",
-            tokenizer_name,
-        )
-        tokenizer = get_tokenizer(
+        candidate = get_tokenizer(
             tokenizer_name,
             tokenizer_mode=tokenizer_mode,
             trust_remote_code=trust_remote_code,
             tokenizer_revision=revision,
             tokenizer_backend=tokenizer_backend,
         )
-        if isinstance(processor, PreTrainedTokenizerBase):
-            processor = tokenizer
+        if getattr(candidate, "is_fast", False) or not getattr(
+            tokenizer, "is_fast", False
+        ):
+            logger.warning(
+                "Processor tokenizer for %s is TokenizersBackend, "
+                "reloading via get_tokenizer",
+                tokenizer_name,
+            )
+            tokenizer = candidate
+            if isinstance(processor, PreTrainedTokenizerBase):
+                processor = tokenizer
+            else:
+                processor.tokenizer = tokenizer
         else:
-            processor.tokenizer = tokenizer
+            logger.debug(
+                "Keeping AutoProcessor's fast TokenizersBackend tokenizer for "
+                "%s (declared replacement class would regress to slow tokenizer)",
+                tokenizer_name,
+            )
 
     if tokenizer.chat_template is None:
         local_path = download_from_hf(


### PR DESCRIPTION
## Summary

Restores the LLaVA-OneVision tokenization fast path that regressed in commit `34fef07a` ("Upgrade transformers to 5.5.3 and refactor hf_transformers_utils into subpackage").

That commit added a post-processing branch in `get_processor()` that detects when the tokenizer produced by `AutoProcessor` is a generic `TokenizersBackend` and reloads it via `get_tokenizer()`. The intent (per `_load_tokenizer_by_declared_class`'s docstring) is to handle cases like `deepseek_vl_v2`, where `AutoTokenizer` returns a generic `TokenizersBackend` but `tokenizer_config.json` declares a richer class like `LlamaTokenizerFast`.

For LLaVA-family models (e.g. `lmms-lab/llava-onevision-qwen2-7b-ov`), `AutoProcessor` already returns a working fast Rust-backed `TokenizersBackend`, while `tokenizer_config.json` declares the **slow** `Qwen2Tokenizer`. The unconditional reload therefore swaps a working fast tokenizer for a slow one — exactly the regression reported in #26650.

## Fix

Only swap when the reload is not a strict regression: keep the existing tokenizer if it's already fast and the reload candidate would be slow. The `deepseek_vl_v2`-style case (existing TokenizersBackend → `LlamaTokenizerFast`) still triggers the swap as before, since the candidate is also fast.

Decision matrix after this patch:

| original `is_fast` | candidate `is_fast` | action            |
|--------------------|---------------------|-------------------|
| True               | True                | swap (unchanged)  |
| True               | False               | **keep original** |
| False              | True                | swap (unchanged)  |
| False              | False               | swap (unchanged)  |

The only changed cell is the second row — which is the LLaVA case.

## Test plan

- [ ] `pytest python/sglang/test/registered/vlm/test_vlm_input_format.py` (LLaVA path unchanged)
- [ ] Manual: serve `lmms-lab/llava-onevision-qwen2-7b-ov` and confirm `get_processor()` no longer emits the "Processor tokenizer for ... is TokenizersBackend, reloading via get_tokenizer" warning, and that tokenization is fast.
- [ ] Manual: serve a `deepseek_vl_v2` model and confirm the swap still happens (warning still emitted), since the declared `LlamaTokenizerFast` is fast.

Closes #26650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26624084150](https://github.com/sgl-project/sglang/actions/runs/26624084150)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26624084027](https://github.com/sgl-project/sglang/actions/runs/26624084027)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->