### PR TITLE
[XPU] Fix hybrid Mamba+Attention models (NemotronH) on Intel XPU

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -56,6 +56,16 @@ elif is_npu():
     from sgl_kernel_npu.mamba.causal_conv1d import (
         causal_conv1d_update_npu as causal_conv1d_update,
     )
+else:
+    # XPU and other devices: use triton implementations
+    from sglang.srt.layers.attention.mamba.causal_conv1d_triton import (
+        causal_conv1d_fn as causal_conv1d_fn_triton,
+    )
+    from sglang.srt.layers.attention.mamba.causal_conv1d_triton import (
+        causal_conv1d_update as causal_conv1d_update_triton,
+    )
+    causal_conv1d_fn = causal_conv1d_fn_triton
+    causal_conv1d_update = causal_conv1d_update_triton
 
 LoaderFunction = Callable[[torch.Tensor, torch.Tensor], None]
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -135,6 +135,7 @@ class TritonAttnBackend(AttentionBackend):
             model_runner.hybrid_gdn_config is not None
             or model_runner.kimi_linear_config is not None
             or model_runner.linear_attn_model_spec is not None
+            or hasattr(model_runner.token_to_kv_pool, 'get_v_head_dim')
         ):
             # For hybrid linear models, layer_id = 0 may not be full attention
             self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -627,6 +627,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         assert moe_runner_config.activation in [
             "silu",
             "gelu",
+            "relu2",
         ], f"activation = {moe_runner_config.activation} is not supported."
 
         backend = self.runner.runner_backend


### PR DESCRIPTION
## Motivation

Enable hybrid Mamba+Attention models (e.g., `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`) to run on Intel XPU. Currently, three separate issues prevent NemotronH from loading on XPU:

1. The triton attention backend crashes with `ValueError: layer_id=0 not in full attention layers` because NemotronH's hybrid architecture only has attention at layers [5, 12, 19, 26, 33, 42].
2. `causal_conv1d_fn_triton` and `causal_conv1d_update_triton` are undefined on XPU (only imported under `if is_cuda()`).
3. The XPU MoE forward path rejects `relu2` activation used by NemotronH's MoE layers.

## Modifications

1. **`srt/layers/attention/triton_backend.py`**: Added `hasattr(model_runner.token_to_kv_pool, 'get_v_head_dim')` duck-type check so that any `HybridLinearKVPool` (including NemotronH's) routes through `get_v_head_dim()` instead of `get_value_buffer(0)`.

2. **`srt/layers/attention/mamba/mamba.py`**: Added an `else` branch after the `is_npu()` check that imports triton-based `causal_conv1d_fn` and `causal_conv1d_update` for XPU and other non-CUDA/NPU devices.

3. **`srt/layers/quantization/unquant.py`**: Added `"relu2"` to the activation allowlist in `forward_xpu()`. The underlying `sgl_kernel.fused_experts` already supports it.


## Speed Tests and Profiling

Benchmark with `sglang.bench_serving` (20 prompts, 512 input / 128 output tokens, request_rate=4):

| Metric | Value |
|--------|-------|
| Total time | ~45s |
| Request throughput | 0.44 req/s |
| Output token throughput | 56.8 tok/s |
| Median TTFT | 2.84s |
| Median ITL | 89ms |

Server config: `--device xpu --tp 4 --context-length 2048 --mem-fraction-static 0.8 --dtype bfloat16`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26656191982](https://github.com/sgl-project/sglang/actions/runs/26656191982)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26656191201](https://github.com/sgl-project/sglang/actions/runs/26656191201)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->