### PR TITLE
fix: support DeepSeek-V4 PD disaggregation with hybrid SWA

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -134,11 +134,19 @@ class PrefillBootstrapQueue:
         self.kv_manager = self._init_kv_manager()
 
         if self.scheduler.tp_worker.is_hybrid_swa:
-            # FIXME: current SWA allocation allocate full kv cache size in prefill
-            self.max_total_num_tokens = min(
-                self.max_total_num_tokens,
-                self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
-            )
+            chunked_prefill_size = self.scheduler.chunked_prefill_size
+            if chunked_prefill_size is not None and chunked_prefill_size > 0:
+                self.max_total_num_tokens = min(
+                    self.max_total_num_tokens,
+                    self.scheduler.tp_worker.model_runner.full_max_total_num_tokens,
+                )
+            else:
+                # Without chunked prefill, SWA allocation still needs to cover
+                # the full prompt length on the prefill side.
+                self.max_total_num_tokens = min(
+                    self.max_total_num_tokens,
+                    self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
+                )
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -629,10 +629,29 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
     def free_swa(self, free_index: torch.Tensor):
         self._kvcache.invalidate_loc_cache()
+        free_index = free_index[free_index > 0]
+        if free_index.numel() == 0:
+            return
+
         swa_indices = self.full_to_swa_index_mapping[free_index]
         swa_indices = swa_indices[swa_indices > 0]
+        if swa_indices.numel() == 0:
+            self.full_to_swa_index_mapping[free_index] = 0
+            return
+
+        if self.page_size > 1:
+            full_pages = torch.unique(free_index // self.page_size)
+            full_page_indices = (
+                full_pages[:, None] * self.page_size
+                + torch.arange(self.page_size, device=self.device)
+            ).reshape(-1)
+            self.full_to_swa_index_mapping[full_page_indices] = 0
+            swa_indices = torch.unique(swa_indices // self.page_size) * self.page_size
+        else:
+            swa_indices = torch.unique(swa_indices)
+            self.full_to_swa_index_mapping[free_index] = 0
+
         self.swa_attn_allocator.free(swa_indices)
-        self.full_to_swa_index_mapping[free_index] = 0
 
     def backup_state(self):
         return [

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -245,6 +245,60 @@ class TestSWA(unittest.TestCase):
         result = alloc.translate_loc_from_full_to_swa(index)
         print(result)
 
+    def test_free_swa_clears_paged_mappings_by_page(self):
+        size = 16
+        size_swa = 16
+        page_size = 4
+        head_num = 8
+        head_dim = 128
+        num_layers = 48
+        global_interval = 4
+        dtype = torch.bfloat16
+        device = get_device()
+        full_attention_layer_ids = [i for i in range(0, num_layers, global_interval)]
+        full_attention_layer_ids_set = set(full_attention_layer_ids)
+        swa_attention_layer_ids = [
+            i for i in range(num_layers) if i not in full_attention_layer_ids_set
+        ]
+        pool = SWAKVPool(
+            size=size,
+            size_swa=size_swa,
+            page_size=page_size,
+            dtype=dtype,
+            head_num=head_num,
+            head_dim=head_dim,
+            swa_attention_layer_ids=swa_attention_layer_ids,
+            full_attention_layer_ids=full_attention_layer_ids,
+            enable_kvcache_transpose=False,
+            device=device,
+        )
+        alloc = SWATokenToKVPoolAllocator(
+            size=size,
+            size_swa=size_swa,
+            page_size=page_size,
+            dtype=dtype,
+            device=device,
+            kvcache=pool,
+            need_sort=False,
+        )
+
+        full_indices = alloc.full_attn_allocator.alloc(page_size)
+        swa_indices = alloc.swa_attn_allocator.alloc(page_size)
+        self.assertIsNotNone(full_indices)
+        self.assertIsNotNone(swa_indices)
+        alloc.full_to_swa_index_mapping[full_indices] = swa_indices
+
+        swa_available_before = alloc.swa_available_size()
+        alloc.free_swa(full_indices[:1])
+
+        self.assertEqual(alloc.swa_available_size(), swa_available_before + page_size)
+        self.assertTrue(
+            torch.all(alloc.full_to_swa_index_mapping[full_indices] == 0).item()
+        )
+
+        alloc.free_swa(full_indices[1:])
+        self.assertEqual(alloc.swa_available_size(), swa_available_before + page_size)
+
     def test_swa_radix_cache_1(self):
         # args
         req_size = 10


### PR DESCRIPTION
## Summary

This PR adds the minimal PD-disaggregation support needed for long-context DeepSeek-V4 / hybrid-SWA models.

It keeps the scope focused on the SWA constraints hit by PD disaggregation:

- allow the prefill bootstrap queue to admit long prompts when chunked prefill is enabled
- keep the previous conservative SWA cap for non-chunked prefill
- clear paged SWA full-to-SWA mappings at page granularity when SWA pages are freed
- add coverage for the paged SWA mapping cleanup path

## Motivation

DeepSeek-V4 uses hybrid full-attention + sliding-window attention KV pools. In PD disaggregation, the prefill side can process long prompts chunk by chunk, so it should not reject a request only because the full prompt length is larger than the SWA pool capacity. With chunked prefill, the prefill worker only needs SWA capacity for the active chunk, while the full-attention pool still tracks the full token budget.

Before this change, `PrefillBootstrapQueue` unconditionally clamped `max_total_num_tokens` to `swa_max_total_num_tokens` for hybrid-SWA models. That made valid long-context DeepSeek-V4 PD requests fail admission before chunked prefill could run.

The second part fixes a lifecycle issue in paged SWA mapping cleanup. Paged allocators free SWA capacity by page, but the mapping cleanup only cleared the exact token indices passed to `free_swa`. If a partial page was released, stale mappings could remain for other slots from the same page. Those stale entries can later point full KV indices at freed/reused SWA slots.

## Changes

### Prefill admission for hybrid SWA

For hybrid-SWA models:

- when `chunked_prefill_size > 0`, cap PD prefill admission by `full_max_total_num_tokens`
- when chunked prefill is disabled, preserve the existing `swa_max_total_num_tokens` cap

This keeps the old safe behavior for non-chunked prefill while allowing long-context PD prefill for DeepSeek-V4-style chunked execution.

### Paged SWA mapping cleanup

`SWATokenToKVPoolAllocator.free_swa()` now:

- ignores invalid / padded indices
- clears the whole full page from `full_to_swa_index_mapping` when `page_size > 1`
- frees unique SWA pages instead of only the token-level SWA indices
- keeps token-level cleanup for `page_size == 1`

## Test

- `python -m py_compile python/sglang/srt/disaggregation/prefill.py python/sglang/srt/mem_cache/swa_memory_pool.py test/registered/unit/mem_cache/test_swa_unittest.py`
- `python -m pytest test/registered/unit/mem_cache/test_swa_unittest.py -k free_swa -q`
  - `1 passed, 11 deselected`
- Local Mooncake PD smoke test with DeepSeek-V4-Pro dummy 1-layer model accepted long prompt requests at 131K, 262K, 524K, and 1M prompt tokens without the previous SWA admission failure.

## Scope

This PR intentionally only covers the DeepSeek-V4 PD/SWA compatibility fixes. Humming / DeepEP / MoE runner changes are not included here and should be reviewed separately.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26624684819](https://github.com/sgl-project/sglang/actions/runs/26624684819)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26624684623](https://github.com/sgl-project/sglang/actions/runs/26624684623)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->