### PR TITLE
pin kernels<0.15

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "watchfiles",
   "xgrammar==0.2.1",
   "smg-grpc-servicer>=0.5.0",
-  "kernels",
+  "kernels<0.15",
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
## Summary
`kernels==0.15.1` (released 2026-05-29 08:04 UTC) made `revision` / `version` mandatory on `LayerRepository`, breaking the call site in `transformers==5.8.1` at `transformers/integrations/hub_kernels.py:89`.

Result: any fresh CI install pulls `kernels` 0.15.1 → `from transformers.models.llama import modeling_llama` raises `ValueError: Either a revision or a version must be specified.` → all CPU jobs fail at sglang import time (via `_apply_hf_patches`).

## Fix
Pin `kernels<0.15` until either:
- `transformers` ships a release that passes `revision`/`version`, or
- we patch the import path ourselves.

## Test plan
- [ ] CPU CI passes on this branch

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26626947529](https://github.com/sgl-project/sglang/actions/runs/26626947529)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26626947386](https://github.com/sgl-project/sglang/actions/runs/26626947386)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->