### PR TITLE
[Bugfix] Fix Ascend NPU CP attention for batch size > 1

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -825,10 +825,8 @@ class AscendAttnBackend(AttentionBackend):
         """
         cp_meta = forward_batch.attn_cp_metadata
 
-        # Split Q into prev/next halves per the zigzag layout. The local tokens
-        # are laid out [all_seqs_prev_blocks, all_seqs_next_blocks], so the split
-        # point is total_q_prev_tokens (sum of per-seq prev blocks), NOT the
-        # global midpoint -- torch.chunk(q, 2) is only correct when bs == 1.
+        # Local tokens are laid out [all_seqs_prev, all_seqs_next]; split at
+        # total_q_prev_tokens rather than the midpoint to support bs > 1.
         split = cp_meta.total_q_prev_tokens
         q_prev = (
             q[:split].contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
@@ -857,7 +855,7 @@ class AscendAttnBackend(AttentionBackend):
             sparse_mode=3,
             next_tokens=0,
             scale=layer.scaling,
-            actual_seq_lengths=np.cumsum(cp_meta.actual_seq_q_prev_list),
+            actual_seq_lengths=np.cumsum(cp_meta.actual_seq_q_prev_list).tolist(),
             actual_seq_lengths_kv=cp_meta.kv_len_prev_list,
         )
 
@@ -874,7 +872,7 @@ class AscendAttnBackend(AttentionBackend):
             sparse_mode=3,
             next_tokens=0,
             scale=layer.scaling,
-            actual_seq_lengths=np.cumsum(cp_meta.actual_seq_q_next_list),
+            actual_seq_lengths=np.cumsum(cp_meta.actual_seq_q_next_list).tolist(),
             actual_seq_lengths_kv=cp_meta.kv_len_next_list,
         )
 

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -825,12 +825,17 @@ class AscendAttnBackend(AttentionBackend):
         """
         cp_meta = forward_batch.attn_cp_metadata
 
-        # Split Q into prev/next halves per zigzag pattern.
-        # torch.chunk(q, 2) gives ceil(n/2) and floor(n/2), matching
-        # actual_seq_q_prev and actual_seq_q_next.
-        q_prev, q_next = torch.chunk(q, 2, dim=0)
-        q_prev = q_prev.contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
-        q_next = q_next.contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        # Split Q into prev/next halves per the zigzag layout. The local tokens
+        # are laid out [all_seqs_prev_blocks, all_seqs_next_blocks], so the split
+        # point is total_q_prev_tokens (sum of per-seq prev blocks), NOT the
+        # global midpoint -- torch.chunk(q, 2) is only correct when bs == 1.
+        split = cp_meta.total_q_prev_tokens
+        q_prev = (
+            q[:split].contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        )
+        q_next = (
+            q[split:].contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        )
 
         k_cache_paged = k_cache.view(
             -1, self.page_size, layer.tp_k_head_num * layer.qk_head_dim
@@ -852,8 +857,8 @@ class AscendAttnBackend(AttentionBackend):
             sparse_mode=3,
             next_tokens=0,
             scale=layer.scaling,
-            actual_seq_lengths=[cp_meta.actual_seq_q_prev],
-            actual_seq_lengths_kv=[cp_meta.kv_len_prev],
+            actual_seq_lengths=np.cumsum(cp_meta.actual_seq_q_prev_list),
+            actual_seq_lengths_kv=cp_meta.kv_len_prev_list,
         )
 
         attn_out_next, _ = torch.ops.npu.npu_fused_infer_attention_score(
@@ -869,8 +874,8 @@ class AscendAttnBackend(AttentionBackend):
             sparse_mode=3,
             next_tokens=0,
             scale=layer.scaling,
-            actual_seq_lengths=[cp_meta.actual_seq_q_next],
-            actual_seq_lengths_kv=[cp_meta.kv_len_next],
+            actual_seq_lengths=np.cumsum(cp_meta.actual_seq_q_next_list),
+            actual_seq_lengths_kv=cp_meta.kv_len_next_list,
         )
 
         attn_out = torch.cat([attn_out_prev, attn_out_next], dim=0)


### PR DESCRIPTION
## Motivation

#23269 generalized attention context-parallel (CP) prefill from `bs == 1` to `bs > 1` by reshaping `ContextParallelMetadata` from single scalars into per-sequence lists/tensors. That change updated the CUDA FlashAttention path and the DSA indexer, but **missed the Ascend NPU FIA CP path** in `do_cp_attn_fia`. As a result, on NPU the CP-extend (prefill) attention now:

1. **Raises `AttributeError`** — it still reads the removed scalar fields `cp_meta.actual_seq_q_prev / actual_seq_q_next / kv_len_prev / kv_len_next`, which no longer exist on the new `ContextParallelMetadata` (only `*_list` / `*_tensor` / `total_q_prev_tokens` remain). This breaks even `bs == 1` CP on NPU on current main.
2. **Splits Q incorrectly for `bs > 1`** — it uses `torch.chunk(q, 2)` (global midpoint), but under the zigzag layout the local tokens are `[all_seqs_prev_blocks | all_seqs_next_blocks]`, so the split point is `total_q_prev_tokens`, not `len(q) // 2`.

This PR restores the Ascend NPU CP attention path so Qwen3-MoE (and other non-MLA GQA models on the FIA path) work end-to-end with `--enable-prefill-context-parallel` for `bs > 1`, matching the community bs>1 design from #23269.

Affected path is reached only when `ASCEND_USE_FIA=1`, the attention backend is `ascend`, and a pure CP-extend prefill batch is scheduled. MLA and the DSA/NSA path (`do_cp_balance_attn`) are out of scope (the DSA CP path remains bs=1 in #23269) and are not touched.

## Modifications

`python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py`, method `do_cp_attn_fia`:

- Split Q at `cp_meta.total_q_prev_tokens` (`q[:split]` / `q[split:]`) instead of `torch.chunk(q, 2)`, so the prev/next halves match the per-sequence zigzag layout for `bs > 1`. (`torch.chunk` happened to be correct only for `bs == 1`.)
- Replace the removed scalar metadata fields in the two `npu_fused_infer_attention_score` calls with the per-sequence equivalents, aligned with the existing non-CP FIA convention in this file:
  - `actual_seq_lengths = np.cumsum(cp_meta.actual_seq_q_prev_list)` (cumulative q lengths), `actual_seq_lengths_kv = cp_meta.kv_len_prev_list` (per-seq kv lengths); analogous for the `_next` half.
- Fully backward compatible with `bs == 1`: `np.cumsum([x]) == [x]` and `total_q_prev_tokens == actual_seq_q_prev` in the single-sequence case.

## Accuracy Tests

Planned: GSM8K on Ascend 910C (A3), Qwen3-30B-A3B, `TP=4 / MOE_DP=2 / ATTN_CP=2`, `--enable-prefill-context-parallel` with `ASCEND_USE_FIA=1` (mirrors the registered test `test/registered/ascend/llm_models/test_npu_qwen3_30b_attn_cp.py`, target accuracy >= 0.92), compared against the TP-only / `bs == 1` baseline.

```plaintext
python test_gsm8k.py 
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 300/300 [01:46<00:00,  2.82it/s]
Questions:        300
Accuracy:         0.9367  (281/300)
Invalid parses:   0.0000
Latency:          106.52 s
Output tokens:    35844
Output throughput: 336.51 tok/s
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit) guideline.
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests) guideline.
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations) guideline.
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed) guideline.
- [ ] Follow the SGLang code style according to the [Code style](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style) guideline.

## Review Process

- After opening the PR, comment `/tag-run-ci-label` to trigger CI.
- Use `/rerun-failed-ci` to rerun only failed jobs, or `/tag-and-rerun-ci` to re-tag and rerun.
- Requires CODEOWNERS approval before merge.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26631281182](https://github.com/sgl-project/sglang/actions/runs/26631281182)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26631281067](https://github.com/sgl-project/sglang/actions/runs/26631281067)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->