### PR TITLE
[BugFix] Fix PP mode HiCache layer_id offset in hybrid_pool_assembler

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -378,7 +378,7 @@ def build_deepseek_v4_hicache_stack(
         c4_state_host_pool = DeepSeekV4StateHostPool(
             pool_name=str(PoolName.DEEPSEEK_V4_C4_STATE),
             state_pools=[
-                kvcache.compress_state_pools[layer_id]
+                kvcache.compress_state_pools[kvcache.start_layer + layer_id]
                 for layer_id in c4_state_global_layers
             ],
             num_host_pages=swa_num_host_pages,
@@ -389,7 +389,7 @@ def build_deepseek_v4_hicache_stack(
         c4_indexer_state_host_pool = DeepSeekV4StateHostPool(
             pool_name=str(PoolName.DEEPSEEK_V4_C4_INDEXER_STATE),
             state_pools=[
-                kvcache.indexer_compress_state_pools[layer_id]
+                kvcache.indexer_compress_state_pools[kvcache.start_layer + layer_id]
                 for layer_id in c4_state_global_layers
             ],
             num_host_pages=swa_num_host_pages,
@@ -443,7 +443,7 @@ def build_deepseek_v4_hicache_stack(
         c128_state_host_pool = DeepSeekV4StateHostPool(
             pool_name=str(PoolName.DEEPSEEK_V4_C128_STATE),
             state_pools=[
-                kvcache.compress_state_pools[layer_id]
+                kvcache.compress_state_pools[kvcache.start_layer + layer_id]
                 for layer_id in c128_state_global_layers
             ],
             num_host_pages=swa_num_host_pages,


### PR DESCRIPTION
## Summary

Fix PP mode HiCache crash: `c4_state_global_layers` / `c128_state_global_layers` store local layer IDs from `enumerate()` but `compress_state_pools` and `indexer_compress_state_pools` are indexed by global layer ID.

## Root Cause

`layer_mapping` and `compress_state_pools` are parallel arrays of length 61 (full model), both indexed by global layer ID. In `hybrid_pool_assembler.py`, `c4_state_global_layers` stores the local enumerate index (0..30), but when used to index `compress_state_pools`, it accesses the wrong position for PP rank > 0 where `start_layer` > 0.

PP rank 0 works by coincidence because `start_layer=0`.

## Changes

3 occurrences in `hybrid_pool_assembler.py`: add `kvcache.start_layer` offset:
- `compress_state_pools[layer_id]` → `compress_state_pools[kvcache.start_layer + layer_id]`
- `indexer_compress_state_pools[layer_id]` → `indexer_compress_state_pools[kvcache.start_layer + layer_id]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26630962526](https://github.com/sgl-project/sglang/actions/runs/26630962526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26630962382](https://github.com/sgl-project/sglang/actions/runs/26630962382)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->