### PR TITLE
fix mistral reasoning parser putting content into reasoning_content

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -517,7 +517,7 @@ class MistralDetector(BaseReasoningFormatDetector):
         super().__init__(
             "[THINK]",
             "[/THINK]",
-            force_reasoning=force_reasoning,
+            force_reasoning=False,
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
             previous_content=previous_content,


### PR DESCRIPTION
when `reasoning_effort` is set to anything other than `none`, `_get_reasoning_from_request` returns True for mistral, which makes `serving_chat.py` pass `force_reasoning=True` into the parser. that sets `_in_reasoning=True` from the start.

but the mistral format is `[THINK]...[/THINK]answer` — the model emits the opener itself. there's nothing to force. so on a turn where the model already thought once, called a tool, got the result, and then just answers without thinking again, the answer has no `[THINK]` tag and `detect_and_parse` falls into the "no end token, assume truncated reasoning" branch. the whole answer comes out as `reasoning_text` and `normal_text` is empty.

example chat-templated transcript where this happens:

```
[INST]what date is it?[/INST][THINK]The user is asking for the current date. I should use the get_current_date tool.[/THINK][TOOL_CALLS]get_current_date[ARGS]{}</s>[TOOL_RESULTS]2026-05-29[/TOOL_RESULTS]The current date is **29 May 2026**.</s>
```

the second model generation is just `The current date is **29 May 2026**.` — no `[THINK]` markers. with `force_reasoning=True` the parser returns `reasoning_text="The current date is **29 May 2026**."`, `normal_text=""`. the response body ends up with the answer in `reasoning_content` and empty `content`.

fix: hardcode `force_reasoning=False` in `MistralDetector` since priming makes no sense for this format. the parameter is left in the signature for call-site compatibility but is ignored.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26631856589](https://github.com/sgl-project/sglang/actions/runs/26631856589)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26631856426](https://github.com/sgl-project/sglang/actions/runs/26631856426)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->