### PR TITLE
Allow PR test and lint workflows to trigger on non-main bases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -15,7 +15,6 @@ name: PR Test Extra
 
 on:
   pull_request:
-    branches: [main]
     # `labeled` lets the workflow re-fire when `run-ci-extra` (or `run-ci`)
     # is added after the latest push — otherwise GHA leaves the stale
     # skipped run in place and there's no way to enable extra without

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,7 +11,6 @@ on:
   schedule:
     - cron: '0 11,23 * * *'  # Run 2x daily, 12h apart, off PR-push peaks
   pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       force_continue_on_error:


### PR DESCRIPTION










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26636756670](https://github.com/sgl-project/sglang/actions/runs/26636756670)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26636756500](https://github.com/sgl-project/sglang/actions/runs/26636756500)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->