### PR TITLE
[WIP] Fuse shared expert gate into a single Triton kernel for Qwen MoE

### DIFF
--- a/benchmark/kernels/bench_fused_gate_sigmoid_mul_add.py
+++ b/benchmark/kernels/bench_fused_gate_sigmoid_mul_add.py
@@ -1,0 +1,53 @@
+"""Benchmark fused_gate_sigmoid_mul_add: Triton kernel vs PyTorch eager.
+
+Compares the fused Triton kernel against a plain PyTorch implementation
+over a sweep of (num_tokens, hidden_dim) shapes typical for Qwen2 MoE.
+"""
+
+import torch
+import triton
+
+from sglang.srt.layers.elementwise import fused_gate_sigmoid_mul_add
+
+
+def _pytorch_reference(hidden_states, gate_weight, shared_output, final_hidden_states):
+    gate = hidden_states @ gate_weight
+    final_hidden_states += torch.sigmoid(gate).unsqueeze(1) * shared_output
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_tokens"],
+        x_vals=[1, 4, 16, 64, 128, 256, 512, 1024, 2048, 4096],
+        line_arg="impl",
+        line_vals=["triton", "pytorch"],
+        line_names=["Triton fused", "PyTorch eager"],
+        styles=[("blue", "-"), ("orange", "--")],
+        ylabel="us",
+        plot_name="fused_gate_sigmoid_mul_add",
+        args={},
+    )
+)
+def bench(num_tokens, impl, hidden_dim=3584, dtype=torch.bfloat16):
+    hidden_states = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+    gate_weight = torch.randn(hidden_dim, dtype=dtype, device="cuda")
+    shared_output = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+    final_hidden_states = torch.randn(
+        num_tokens, hidden_dim, dtype=dtype, device="cuda"
+    )
+
+    if impl == "triton":
+        fn = lambda: fused_gate_sigmoid_mul_add(
+            hidden_states, gate_weight, shared_output, final_hidden_states
+        )
+    else:
+        fn = lambda: _pytorch_reference(
+            hidden_states, gate_weight, shared_output, final_hidden_states
+        )
+
+    ms = triton.testing.do_bench(fn, warmup=100, rep=200)
+    return ms * 1000  # convert to us
+
+
+if __name__ == "__main__":
+    bench.run(print_data=True)

--- a/python/sglang/srt/layers/elementwise.py
+++ b/python/sglang/srt/layers/elementwise.py
@@ -589,3 +589,73 @@ def silu_and_mul_triton(
         return out_hidden_states, out_scales
     else:
         return out_hidden_states, None
+
+
+@triton.jit
+def _fused_gate_sigmoid_mul_add_kernel(
+    hidden_states_ptr,  # [num_tokens, hidden_dim]
+    gate_weight_ptr,  # [hidden_dim]
+    shared_output_ptr,  # [num_tokens, hidden_dim]
+    final_hidden_states_ptr,  # [num_tokens, hidden_dim]
+    hidden_dim: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0).to(tl.int64)
+    row_offset = pid * hidden_dim
+
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < hidden_dim
+
+    # Phase 1: dot product in fp32
+    h = tl.load(hidden_states_ptr + row_offset + offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    w = tl.load(gate_weight_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.sum(h * w, axis=0)
+
+    # Sigmoid in fp32
+    gate_val = tl.sigmoid(gate)
+
+    # Phase 2: final_hidden_states += gate_val * shared_output
+    s = tl.load(shared_output_ptr + row_offset + offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    f = tl.load(
+        final_hidden_states_ptr + row_offset + offsets, mask=mask, other=0.0
+    ).to(tl.float32)
+    result = f + gate_val * s
+
+    tl.store(final_hidden_states_ptr + row_offset + offsets, result, mask=mask)
+
+
+def fused_gate_sigmoid_mul_add(
+    hidden_states: torch.Tensor,
+    gate_weight: torch.Tensor,
+    shared_output: torch.Tensor,
+    final_hidden_states: torch.Tensor,
+) -> None:
+    """
+    Fused gate-sigmoid-mul-add for MoE shared expert gating.
+
+    Equivalent to:
+        gate = hidden_states @ gate_weight
+        final_hidden_states += sigmoid(gate).unsqueeze(1) * shared_output
+    """
+    num_tokens, hidden_dim = hidden_states.shape
+
+    max_warps = 16 if _is_hip else 32
+    config = {
+        "BLOCK_SIZE": triton.next_power_of_2(hidden_dim),
+        "num_warps": max(
+            min(triton.next_power_of_2(triton.cdiv(hidden_dim, 256)), max_warps), 4
+        ),
+    }
+
+    _fused_gate_sigmoid_mul_add_kernel[(num_tokens,)](
+        hidden_states,
+        gate_weight,
+        shared_output,
+        final_hidden_states,
+        hidden_dim=hidden_dim,
+        **config,
+    )

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -374,11 +374,13 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             router_logits=topk_output.router_logits,
         )
 
-    def _forward_shared_experts(self, hidden_states: torch.Tensor):
+    def _forward_shared_experts(
+        self, hidden_states: torch.Tensor, apply_gate: bool = True
+    ):
         shared_output = None
         if self.shared_expert is not None:
             shared_output = self.shared_expert(hidden_states)
-            if self.shared_expert_gate is not None:
+            if self.shared_expert_gate is not None and apply_gate:
                 if use_intel_amx_backend(self.shared_expert_gate):
                     shared_output = torch.ops.sgl_kernel.fused_linear_sigmoid_mul(
                         hidden_states,
@@ -450,10 +452,13 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
     def forward_normal_dual_stream(
         self,
         hidden_states: torch.Tensor,
+        use_fused_gate: bool = False,
     ) -> torch.Tensor:
         current_stream = torch.cuda.current_stream()
         self.alt_stream.wait_stream(current_stream)
-        shared_output = self._forward_shared_experts(hidden_states.clone())
+        shared_output = self._forward_shared_experts(
+            hidden_states.clone(), apply_gate=not use_fused_gate
+        )
 
         with torch.cuda.stream(self.alt_stream):
             router_output = self._forward_router_experts(hidden_states)
@@ -475,6 +480,11 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         if get_moe_a2a_backend().is_deepep():
             return self._forward_deepep(hidden_states, forward_batch)
 
+        use_fused_gate = (
+            self.shared_expert_gate is not None
+            and not use_intel_amx_backend(self.shared_expert_gate)
+        )
+
         if hidden_states.shape[0] == 0:
             # M=0 guard for idle DP ranks: skip shared_experts and gate
             # (which crash on empty tensors in FP4 GEMM), but still call
@@ -484,14 +494,28 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             final_hidden_states = self.experts(hidden_states, topk_output)
         elif self.alt_stream is not None and get_is_capture_mode():
             final_hidden_states, shared_output = self.forward_normal_dual_stream(
-                hidden_states
+                hidden_states, use_fused_gate=use_fused_gate
             )
         else:
-            shared_output = self._forward_shared_experts(hidden_states)
+            shared_output = self._forward_shared_experts(
+                hidden_states, apply_gate=not use_fused_gate
+            )
             final_hidden_states = self._forward_router_experts(hidden_states)
 
         if shared_output is not None:
-            final_hidden_states += shared_output
+            if use_fused_gate:
+                from sglang.srt.layers.elementwise import (
+                    fused_gate_sigmoid_mul_add,
+                )
+
+                fused_gate_sigmoid_mul_add(
+                    hidden_states,
+                    self.shared_expert_gate.weight.squeeze(),
+                    shared_output,
+                    final_hidden_states,
+                )
+            else:
+                final_hidden_states += shared_output
         if (
             self.tp_size > 1
             and not should_skip_post_experts_all_reduce(

--- a/test/registered/unit/layers/test_fused_gate_sigmoid_mul_add.py
+++ b/test/registered/unit/layers/test_fused_gate_sigmoid_mul_add.py
@@ -1,0 +1,78 @@
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.elementwise import fused_gate_sigmoid_mul_add
+
+
+def _reference(hidden_states, gate_weight, shared_output, final_hidden_states):
+    gate = hidden_states @ gate_weight
+    final_hidden_states += torch.sigmoid(gate).unsqueeze(1) * shared_output
+
+
+class TestFusedGateSigmoidMulAdd(unittest.TestCase):
+    DTYPES = [torch.float16, torch.bfloat16]
+    TOKEN_COUNTS = [1, 7, 32, 128, 1024]
+    HIDDEN_DIMS = [2048, 3072, 4096, 5120]
+
+    def _run_and_compare(self, num_tokens, hidden_dim, dtype, rtol=1e-2, atol=1e-2):
+        torch.manual_seed(42)
+        hidden_states = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+        gate_weight = torch.randn(hidden_dim, dtype=dtype, device="cuda")
+        shared_output = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+        final_ref = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+        final_test = final_ref.clone()
+
+        _reference(hidden_states, gate_weight, shared_output, final_ref)
+        fused_gate_sigmoid_mul_add(
+            hidden_states, gate_weight, shared_output, final_test
+        )
+
+        torch.testing.assert_close(final_test, final_ref, rtol=rtol, atol=atol)
+
+    def test_correctness_fp16(self):
+        for n in self.TOKEN_COUNTS:
+            for d in self.HIDDEN_DIMS:
+                with self.subTest(num_tokens=n, hidden_dim=d, dtype="fp16"):
+                    self._run_and_compare(n, d, torch.float16)
+
+    def test_correctness_bf16(self):
+        for n in self.TOKEN_COUNTS:
+            for d in self.HIDDEN_DIMS:
+                with self.subTest(num_tokens=n, hidden_dim=d, dtype="bf16"):
+                    self._run_and_compare(n, d, torch.bfloat16, rtol=2e-2, atol=2e-2)
+
+    def test_gate_near_zero(self):
+        for dtype in self.DTYPES:
+            with self.subTest(dtype=dtype):
+                num_tokens, hidden_dim = 16, 2048
+                hs = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+                gw = torch.zeros(hidden_dim, dtype=dtype, device="cuda")
+                so = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+                f_ref = torch.randn(num_tokens, hidden_dim, dtype=dtype, device="cuda")
+                f_test = f_ref.clone()
+
+                _reference(hs, gw, so, f_ref)
+                fused_gate_sigmoid_mul_add(hs, gw, so, f_test)
+
+                torch.testing.assert_close(f_test, f_ref, rtol=1e-2, atol=1e-2)
+
+    def test_inplace_semantics(self):
+        num_tokens, hidden_dim = 32, 2048
+        hs = torch.randn(num_tokens, hidden_dim, dtype=torch.float16, device="cuda")
+        gw = torch.randn(hidden_dim, dtype=torch.float16, device="cuda")
+        so = torch.randn(num_tokens, hidden_dim, dtype=torch.float16, device="cuda")
+        fhs = torch.randn(num_tokens, hidden_dim, dtype=torch.float16, device="cuda")
+        original_ptr = fhs.data_ptr()
+
+        fused_gate_sigmoid_mul_add(hs, gw, so, fhs)
+
+        self.assertEqual(fhs.data_ptr(), original_ptr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

# need a triton expert to review

## Motivation
### Before
<img width="704" height="896" alt="image" src="https://github.com/user-attachments/assets/ab825ee1-a3c5-4006-9c31-ab44b83ca2a2" />

<img width="1232" height="694" alt="image" src="https://github.com/user-attachments/assets/d941d4bf-c577-4a36-86b8-2ebed313ce23" />

### After

<img width="660" height="766" alt="image" src="https://github.com/user-attachments/assets/a6b5f28a-c9e1-4b2a-a68c-574f680b3fbf" />

<img width="1084" height="572" alt="image" src="https://github.com/user-attachments/assets/22c83e83-7d19-472c-8857-958ea946b621" />

  - Add a Triton kernel fused_gate_sigmoid_mul_add that fuses the shared expert gating operation (gate = hidden_states @ gate_weight; final_hidden_states += sigmoid(gate) * shared_output) into a single kernel, replacing 4 separate kernel launches (matmul + sigmoid + mul + add). 
  - Wire it into Qwen2MoeSparseMoeBlock.forward — the gate is deferred from _forward_shared_experts and applied as a fused op after router experts complete

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26640742815](https://github.com/sgl-project/sglang/actions/runs/26640742815)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26640742688](https://github.com/sgl-project/sglang/actions/runs/26640742688)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->