### PR TITLE
Add HiCache host locks during load back

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1567,51 +1567,57 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         # Skip if there is nothing to load, or if the Full-KV transfer is too
         # small / exceeds memory quota. Aux transfers should still run even
         # when the Full-KV load is skipped by thresholding.
-        if (kv_tokens < self.load_back_threshold and not comp_xfers) or (
-            mem_quota is not None and kv_tokens > mem_quota + result.delta
-        ):
-            self.dec_lock_ref(best_match_node, ancestor_lock_params)
-            return False
-
-        if self.supports_swa():
-            avail = self.token_to_kv_pool_allocator.full_available_size()
-        else:
-            avail = self.token_to_kv_pool_allocator.available_size()
-        if avail < kv_tokens:
-            needed = kv_tokens - avail
-            result = self.evict(EvictParams(num_tokens=needed))
-            if result.num_tokens_evicted < needed:
-                self.dec_lock_ref(best_match_node, ancestor_lock_params)
+        host_lock_params: Optional[DecLockRefParams] = None
+        try:
+            if (kv_tokens < self.load_back_threshold and not comp_xfers) or (
+                mem_quota is not None and kv_tokens > mem_quota + result.delta
+            ):
                 return False
 
-        # Load H→D
-        aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
-        aux_xfers.extend(sidecar_xfers)
-        device_indices = self.cache_controller.load(
-            host_indices=kv_xfer.host_indices,
-            node_id=best_match_node.id,
-            extra_pools=aux_xfers or None,
-        )
+            host_lock_params = self.inc_host_lock_ref(best_match_node).to_dec_params()
 
-        self.dec_lock_ref(best_match_node, ancestor_lock_params)
-        if device_indices is None:
-            return False
+            if self.supports_swa():
+                avail = self.token_to_kv_pool_allocator.full_available_size()
+            else:
+                avail = self.token_to_kv_pool_allocator.available_size()
+            if avail < kv_tokens:
+                needed = kv_tokens - avail
+                result = self.evict(EvictParams(num_tokens=needed))
+                if result.num_tokens_evicted < needed:
+                    return False
 
-        # Commit: each component gets only its own transfers
-        kv_xfer.device_indices = device_indices
-        self.components[BASE_COMPONENT_TYPE].commit_hicache_transfer(
-            best_match_node,
-            CacheTransferPhase.LOAD_BACK,
-            [kv_xfer],
-        )
-        for node in kv_xfer.nodes_to_load or ():
-            self._record_store_event(node, medium=StorageMedium.GPU)
-        for ct, xfers in comp_xfers.items():
-            self.components[ct].commit_hicache_transfer(
+            # Load H→D
+            aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
+            aux_xfers.extend(sidecar_xfers)
+            device_indices = self.cache_controller.load(
+                host_indices=kv_xfer.host_indices,
+                node_id=best_match_node.id,
+                extra_pools=aux_xfers or None,
+            )
+
+            if device_indices is None:
+                return False
+
+            # Commit: each component gets only its own transfers
+            kv_xfer.device_indices = device_indices
+            self.components[BASE_COMPONENT_TYPE].commit_hicache_transfer(
                 best_match_node,
                 CacheTransferPhase.LOAD_BACK,
-                xfers,
+                [kv_xfer],
             )
+            for node in kv_xfer.nodes_to_load or ():
+                self._record_store_event(node, medium=StorageMedium.GPU)
+            for ct, xfers in comp_xfers.items():
+                self.components[ct].commit_hicache_transfer(
+                    best_match_node,
+                    CacheTransferPhase.LOAD_BACK,
+                    xfers,
+                )
+
+        finally:
+            self.dec_lock_ref(best_match_node, ancestor_lock_params)
+            if host_lock_params is not None:
+                self.dec_host_lock_ref(best_match_node, host_lock_params)
 
         self._update_evictable_leaf_sets(best_match_node)
         self.ongoing_load_back[best_match_node.id] = (

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2649,6 +2649,9 @@ class UnifiedRadixCacheSuite:
             MatchPrefixParams(key=RadixKey(array("q", seq)))
         ).last_device_node
 
+        # Full must stay host-resident for an SWA host tombstone to be valid:
+        # Full is the backbone, so aux host data requires Full host data.
+        self._simulate_backup(tree, node)
         self._set_aux_host_tombstone(tree, node, ComponentType.SWA)
         cd = node.component_data[ComponentType.SWA]
         host_lru = tree.host_lru_lists[ComponentType.SWA]
@@ -2678,18 +2681,22 @@ class UnifiedRadixCacheSuite:
             MatchPrefixParams(key=RadixKey(array("q", seq)))
         ).last_device_node
 
+        # Full must stay host-resident for an SWA host tombstone to be valid:
+        # Full is the backbone, so aux host data requires Full host data.
+        self._simulate_backup(tree, node)
         self._set_aux_host_tombstone(tree, node, ComponentType.SWA)
         cd = node.component_data[ComponentType.SWA]
         host_tokens = len(cd.host_value)
 
         # Lock as load_back does, then drive host eviction under heavy pressure.
-        # The locked tombstone must not be freed.
+        # The locked tombstone must not be freed. Do not sanity_check while the
+        # lock is held: a locked SWA tombstone is intentionally pulled out of
+        # the host LRU, which the host-LRU invariant does not model.
         lock_params = tree.inc_host_lock_ref(node).to_dec_params()
         freed = tree.evict_host(host_tokens * 100, component_type=ComponentType.SWA)
         self.assertEqual(freed, 0)
         self.assertIsNotNone(cd.host_value)
         self.assertEqual(cd.host_lock_ref, 1)
-        tree.sanity_check()
 
         # After release the tombstone is evictable again.
         tree.dec_host_lock_ref(node, lock_params)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2638,6 +2638,33 @@ class UnifiedRadixCacheSuite:
         tree.host_lru_lists[component_type].insert_mru(node)
         tree.component_evictable_size_[component_type] -= len(old_value)
 
+    def test_hicache_swa_host_lock_protects_host_tombstone(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires Full+SWA")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        node = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", seq)))
+        ).last_device_node
+
+        self._set_aux_host_tombstone(tree, node, ComponentType.SWA)
+        cd = node.component_data[ComponentType.SWA]
+        host_lru = tree.host_lru_lists[ComponentType.SWA]
+        self.assertIsNone(cd.value)
+        self.assertIsNotNone(cd.host_value)
+        self.assertTrue(host_lru.in_list(node))
+
+        lock_params = tree.inc_host_lock_ref(node).to_dec_params()
+        self.assertEqual(cd.host_lock_ref, 1)
+        self.assertFalse(host_lru.in_list(node))
+
+        tree.dec_host_lock_ref(node, lock_params)
+        self.assertEqual(cd.host_lock_ref, 0)
+        self.assertTrue(host_lru.in_list(node))
+        tree.sanity_check()
+
     def test_match_prefix_best_and_device_node_without_hicache(self):
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         ps = self.cfg.page_size

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2665,6 +2665,39 @@ class UnifiedRadixCacheSuite:
         self.assertTrue(host_lru.in_list(node))
         tree.sanity_check()
 
+    def test_hicache_swa_host_lock_blocks_host_eviction(self):
+        """A host-locked SWA tombstone survives host eviction pressure, and
+        becomes evictable again once the lock is released."""
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires Full+SWA")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        node = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", seq)))
+        ).last_device_node
+
+        self._set_aux_host_tombstone(tree, node, ComponentType.SWA)
+        cd = node.component_data[ComponentType.SWA]
+        host_tokens = len(cd.host_value)
+
+        # Lock as load_back does, then drive host eviction under heavy pressure.
+        # The locked tombstone must not be freed.
+        lock_params = tree.inc_host_lock_ref(node).to_dec_params()
+        freed = tree.evict_host(host_tokens * 100, component_type=ComponentType.SWA)
+        self.assertEqual(freed, 0)
+        self.assertIsNotNone(cd.host_value)
+        self.assertEqual(cd.host_lock_ref, 1)
+        tree.sanity_check()
+
+        # After release the tombstone is evictable again.
+        tree.dec_host_lock_ref(node, lock_params)
+        freed = tree.evict_host(host_tokens * 100, component_type=ComponentType.SWA)
+        self.assertEqual(freed, host_tokens)
+        self.assertIsNone(cd.host_value)
+        tree.sanity_check()
+
     def test_match_prefix_best_and_device_node_without_hicache(self):
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         ps = self.cfg.page_size


### PR DESCRIPTION
## Summary
- Protect HiCache H2D load-back with the existing component-aware host-lock API until component commit finishes.
- Keep the ancestor device lock held through load-back commit and release it from `finally`.
- Add UnifiedRadixCache regression tests for the Full+SWA host tombstone lock lifecycle.

## Rationale
HiCache load-back builds host index transfer lists before calling the cache controller. Under write-back memory pressure, device eviction or `cache_controller.load()` can trigger host eviction before component commit consumes those host-side indices.

This PR acquires `inc_host_lock_ref(best_match_node)` for the load-back lifetime and releases it in `finally`. The actual host-lock range is handled by the existing component implementations in main: Full protects the host leaf, SWA protects the relevant host window, and Mamba protects its host state. The ancestor device lock is also released from `finally` so exceptions and early returns cannot leak locks.

## Validation
- python3 -m py_compile python/sglang/srt/mem_cache/unified_radix_cache.py test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26935488323](https://github.com/sgl-project/sglang/actions/runs/26935488323)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26935488316](https://github.com/sgl-project/sglang/actions/runs/26935488316)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->