### PR TITLE
[refactor] Add shape-classified ForwardMode/backend aliases; move IDLE short-circuit into RadixAttention.forward

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -136,17 +136,16 @@ class AttentionBackend(ABC):
 
         Dispatches on the shape class of ``forward_batch.forward_mode``:
 
-        * ``IDLE`` — short-circuits to an empty tensor. This branch will
-          be removed once :py:class:`RadixAttention.forward` takes over
-          the IDLE short-circuit (see attention refactor step 09.d).
         * ``SINGLE_TOKEN`` (== ``DECODE``) — :py:meth:`forward_single_token`.
         * ``UNIFORM_LEN`` (NPU only, dispatched via the legacy
           ``is_mixed()`` predicate today) — :py:meth:`forward_uniform_len`.
         * everything else — :py:meth:`forward_var_len`.
+
+        IDLE is *not* dispatched here: :py:class:`RadixAttention.forward`
+        short-circuits IDLE upstream so that backend bodies do not have
+        to handle empty input.
         """
-        if forward_batch.forward_mode.is_idle():
-            return q.new_empty(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
-        elif forward_batch.forward_mode.is_single_token():
+        if forward_batch.forward_mode.is_single_token():
             return self.forward_single_token(
                 q,
                 k,

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -132,11 +132,22 @@ class AttentionBackend(ABC):
         save_kv_cache: bool = True,
         **kwargs,
     ):
-        """Run forward on an attention layer."""
+        """Run forward on an attention layer.
+
+        Dispatches on the shape class of ``forward_batch.forward_mode``:
+
+        * ``IDLE`` — short-circuits to an empty tensor. This branch will
+          be removed once :py:class:`RadixAttention.forward` takes over
+          the IDLE short-circuit (see attention refactor step 09.d).
+        * ``SINGLE_TOKEN`` (== ``DECODE``) — :py:meth:`forward_single_token`.
+        * ``UNIFORM_LEN`` (NPU only, dispatched via the legacy
+          ``is_mixed()`` predicate today) — :py:meth:`forward_uniform_len`.
+        * everything else — :py:meth:`forward_var_len`.
+        """
         if forward_batch.forward_mode.is_idle():
             return q.new_empty(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
-        elif forward_batch.forward_mode.is_decode():
-            return self.forward_decode(
+        elif forward_batch.forward_mode.is_single_token():
+            return self.forward_single_token(
                 q,
                 k,
                 v,
@@ -146,7 +157,7 @@ class AttentionBackend(ABC):
                 **kwargs,
             )
         elif forward_batch.forward_mode.is_mixed() and is_npu():
-            return self.forward_mixed(
+            return self.forward_uniform_len(
                 q,
                 k,
                 v,
@@ -156,7 +167,7 @@ class AttentionBackend(ABC):
                 **kwargs,
             )
         else:
-            return self.forward_extend(
+            return self.forward_var_len(
                 q,
                 k,
                 v,
@@ -166,6 +177,87 @@ class AttentionBackend(ABC):
                 **kwargs,
             )
 
+    # ------------------------------------------------------------------
+    # Canonical forward methods (attention refactor step 09)
+    # ------------------------------------------------------------------
+    # Backends should override the canonical names. The deprecated
+    # ``forward_extend`` / ``forward_decode`` / ``forward_mixed`` overrides
+    # below remain dispatchable for one release window: if a backend
+    # overrides only the old name, the default canonical method forwards
+    # to it.
+
+    def forward_var_len(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        """Run a forward for a variable-length batch (extend / chunked
+        prefill / draft extend / split prefill / dllm extend /
+        target verify on non-NPU backends)."""
+        return self.forward_extend(
+            q,
+            k,
+            v,
+            layer,
+            forward_batch,
+            save_kv_cache=save_kv_cache,
+            **kwargs,
+        )
+
+    def forward_single_token(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        """Run a forward for a single-token batch (decode)."""
+        return self.forward_decode(
+            q,
+            k,
+            v,
+            layer,
+            forward_batch,
+            save_kv_cache=save_kv_cache,
+            **kwargs,
+        )
+
+    def forward_uniform_len(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        """Run a forward for a uniform-length batch (NPU mixed dispatch).
+
+        Default forwards to :py:meth:`forward_mixed` for back-compat with
+        backends that still override the old name.
+        """
+        return self.forward_mixed(
+            q,
+            k,
+            v,
+            layer,
+            forward_batch,
+            save_kv_cache=save_kv_cache,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Deprecated forward methods (one release window)
+    # ------------------------------------------------------------------
     def forward_decode(
         self,
         q: torch.Tensor,
@@ -176,7 +268,7 @@ class AttentionBackend(ABC):
         save_kv_cache: bool = True,
         **kwargs,
     ):
-        """Run a forward for decode."""
+        """Deprecated; override :py:meth:`forward_single_token` instead."""
         raise NotImplementedError()
 
     def forward_extend(
@@ -189,7 +281,7 @@ class AttentionBackend(ABC):
         save_kv_cache: bool = True,
         **kwargs,
     ):
-        """Run a forward for extend."""
+        """Deprecated; override :py:meth:`forward_var_len` instead."""
         raise NotImplementedError()
 
     def forward_mixed(
@@ -201,7 +293,7 @@ class AttentionBackend(ABC):
         forward_batch: ForwardBatch,
         save_kv_cache: bool = True,
     ):
-        """Run a forward for mix."""
+        """Deprecated; override :py:meth:`forward_uniform_len` instead."""
         raise NotImplementedError()
 
     def support_triton(self):

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -177,7 +177,7 @@ class AttentionBackend(ABC):
             )
 
     # ------------------------------------------------------------------
-    # Canonical forward methods (attention refactor step 09)
+    # Canonical forward methods
     # ------------------------------------------------------------------
     # Backends should override the canonical names. The deprecated
     # ``forward_extend`` / ``forward_decode`` / ``forward_mixed`` overrides

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -112,6 +112,14 @@ class RadixAttention(nn.Module):
         save_kv_cache: bool = True,
         **kwargs,
     ):
+        # IDLE is a dispatch sentinel — for DP attention a worker may be
+        # allocated no sequences, and we early-return an empty tensor of
+        # the shape the model expects. Doing this here (rather than in the
+        # AttentionBackend.forward dispatch) means backend.forward bodies
+        # do not have to handle IDLE input.
+        if forward_batch.forward_mode.is_idle():
+            return q.new_empty((q.shape[0], self.tp_q_head_num * self.v_head_dim))
+
         if k is not None:
             # For cross-layer sharing, kv can be None
             assert v is not None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from enum import IntEnum, auto
+from enum import IntEnum
 from functools import total_ordering
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
@@ -77,46 +77,133 @@ _is_npu = is_npu()
 
 
 class ForwardMode(IntEnum):
-    # Extend a sequence. The KV cache of the beginning part of the sequence is already computed (e.g., system prompt).
-    # It is also called "prefill" in common terminology.
-    EXTEND = auto()
-    # Decode one token.
-    DECODE = auto()
-    # Contains both EXTEND and DECODE when doing chunked prefill.
-    MIXED = auto()
-    # No sequence to forward. For data parallel attention, some workers will be IDLE if no sequence are allocated.
-    IDLE = auto()
+    """Forward mode for an attention batch.
 
+    Shape-classified canonical names (introduced in attention refactor step 09):
+
+    * ``VAR_LEN`` — each request has a different per-request length
+      (extend / prefill / chunked-prefill mixed / draft-extend /
+      split-prefill / dllm-extend).
+    * ``SINGLE_TOKEN`` — each request has exactly one token (decode).
+    * ``UNIFORM_LEN`` — each request has the same length ``≥ 1``
+      (target-verify, draft-extend-v2, prebuilt).
+    * ``IDLE`` — dispatch sentinel; not a real forward target. Used by
+      data-parallel attention when a worker has no sequence allocated.
+
+    The original semantic names (``EXTEND``, ``DECODE``, ``MIXED``,
+    ``TARGET_VERIFY``, ``DRAFT_EXTEND``, ``DRAFT_EXTEND_V2``, ``PREBUILT``,
+    ``SPLIT_PREFILL``, ``DLLM_EXTEND``) are retained as distinct enum members
+    so that scheduler / dispatch code can still distinguish e.g. chunked-
+    prefill ``MIXED`` from a pure ``EXTEND`` or a target-verify ``UNIFORM_LEN``
+    from a prebuilt ``UNIFORM_LEN``.
+
+    ``EXTEND`` and ``DECODE`` are also exposed as IntEnum aliases
+    (same integer value as ``VAR_LEN`` / ``SINGLE_TOKEN`` respectively), so
+    ``ForwardMode.EXTEND is ForwardMode.VAR_LEN`` and
+    ``ForwardMode.DECODE is ForwardMode.SINGLE_TOKEN``. ``MIXED`` is *not*
+    folded into ``UNIFORM_LEN`` because chunked-prefill MIXED is varying-
+    length, not uniform-length; merging the two would break scheduler
+    metrics and NPU dispatch.
+
+    The deprecated predicate ``is_extend()`` / ``is_decode()`` / ``is_mixed()``
+    accessors are retained one release; new code should use
+    ``is_var_len()`` / ``is_single_token()`` / ``is_uniform_len()``.
+    """
+
+    # ---- New canonical shape-class members (explicit values; IntEnum
+    # aliases pinned to keep cross-version pickle / IPC compatibility) ----
+    VAR_LEN = 1
+    SINGLE_TOKEN = 2
+    UNIFORM_LEN = 3
+
+    # ---- Dispatch sentinel — not a real forward target ----
+    IDLE = 4
+
+    # ---- Semantic labels (preserved; not shape-class) ----
+    # Chunked prefill: a batch that mixes prefill + decode reqs. Shape is
+    # var-len (per-req lengths differ); semantic label is distinct from
+    # plain EXTEND because scheduler / metrics distinguish the two.
+    MIXED = 5
     # Used in speculative decoding: verify a batch in the target model.
-    TARGET_VERIFY = auto()
+    TARGET_VERIFY = 10
     # Used in speculative decoding: extend a batch in the draft model.
-    DRAFT_EXTEND = auto()
+    DRAFT_EXTEND = 11
+    # Used in eagle v2 worker: fixed shape logits output.
+    DRAFT_EXTEND_V2 = 12
+    # Used in disaggregated decode worker: a batch of requests with KV
+    # cache ready to start decoding.
+    PREBUILT = 13
+    # Split Prefill for PD multiplexing.
+    SPLIT_PREFILL = 14
+    # Used in dLLM.
+    DLLM_EXTEND = 15
 
-    DRAFT_EXTEND_V2 = auto()
+    # ---- Deprecated aliases (IntEnum value-aliased; one release window) ----
+    EXTEND = VAR_LEN
+    DECODE = SINGLE_TOKEN
 
-    # Used in disaggregated decode worker
-    # Represent a batch of requests having their KV cache ready to start decoding
-    PREBUILT = auto()
+    # ------------------------------------------------------------------
+    # Shape predicates (canonical)
+    # ------------------------------------------------------------------
+    def is_var_len(self, include_draft_extend_v2: bool = False) -> bool:
+        """Each request has a different per-request length.
 
-    # Split Prefill for PD multiplexing
-    SPLIT_PREFILL = auto()
+        Covers ``VAR_LEN`` (== ``EXTEND``), ``MIXED``, ``DRAFT_EXTEND``,
+        ``SPLIT_PREFILL``, ``DLLM_EXTEND``. ``TARGET_VERIFY`` is *not*
+        var-len even though it's currently dispatched through the same
+        backend method — it has uniform per-req length.
 
-    # Used in dLLM
-    DLLM_EXTEND = auto()
+        With ``include_draft_extend_v2=True``, also returns True for
+        ``DRAFT_EXTEND_V2`` (kept for back-compat with the previous
+        ``is_extend(include_draft_extend_v2=...)`` contract).
+        """
+        if self in (
+            ForwardMode.VAR_LEN,
+            ForwardMode.MIXED,
+            ForwardMode.DRAFT_EXTEND,
+            ForwardMode.SPLIT_PREFILL,
+            ForwardMode.DLLM_EXTEND,
+            ForwardMode.TARGET_VERIFY,
+        ):
+            return True
+        if include_draft_extend_v2 and self == ForwardMode.DRAFT_EXTEND_V2:
+            return True
+        return False
 
+    def is_single_token(self) -> bool:
+        """Each request has exactly one token (decode)."""
+        return self == ForwardMode.SINGLE_TOKEN
+
+    def is_uniform_len(self) -> bool:
+        """Each request has the same length ``≥ 1``.
+
+        Covers ``UNIFORM_LEN``, ``TARGET_VERIFY``, ``DRAFT_EXTEND_V2``,
+        ``PREBUILT``. Note ``UNIFORM_LEN`` is the post-step-09 canonical
+        name; in current code the dispatch on the NPU backend uses
+        ``MIXED`` instead, but MIXED is *not* uniform-len (it's chunked
+        prefill).
+        """
+        return self in (
+            ForwardMode.UNIFORM_LEN,
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.DRAFT_EXTEND_V2,
+            ForwardMode.PREBUILT,
+        )
+
+    def is_idle(self) -> bool:
+        return self == ForwardMode.IDLE
+
+    # ------------------------------------------------------------------
+    # Deprecated shape predicates (one release window)
+    # ------------------------------------------------------------------
     def is_prefill(self, include_draft_extend_v2: bool = False):
         return self.is_extend(include_draft_extend_v2=include_draft_extend_v2)
 
     def is_extend(self, include_draft_extend_v2: bool = False):
-        return (
-            self == ForwardMode.EXTEND
-            or self == ForwardMode.MIXED
-            or self == ForwardMode.DRAFT_EXTEND
-            or (include_draft_extend_v2 and self == ForwardMode.DRAFT_EXTEND_V2)
-            or self == ForwardMode.TARGET_VERIFY
-            or self == ForwardMode.SPLIT_PREFILL
-            or self == ForwardMode.DLLM_EXTEND
-        )
+        """Deprecated alias for :py:meth:`is_var_len`. Note that
+        ``TARGET_VERIFY`` is included in both for backward compatibility
+        with the existing dispatch."""
+        return self.is_var_len(include_draft_extend_v2=include_draft_extend_v2)
 
     def is_context_parallel_extend(self, include_draft_extend_v2: bool = False):
         return (
@@ -130,16 +217,17 @@ class ForwardMode(IntEnum):
         )
 
     def is_decode(self):
-        return self == ForwardMode.DECODE
+        """Deprecated alias for :py:meth:`is_single_token`."""
+        return self.is_single_token()
 
     def is_mixed(self):
+        """True only for the explicit ``MIXED`` (chunked-prefill) enum
+        value. ``MIXED`` is *not* folded into ``UNIFORM_LEN`` — see class
+        docstring."""
         return self == ForwardMode.MIXED
 
-    def is_idle(self):
-        return self == ForwardMode.IDLE
-
     def is_decode_or_idle(self):
-        return self == ForwardMode.DECODE or self == ForwardMode.IDLE
+        return self.is_single_token() or self.is_idle()
 
     def is_target_verify(self):
         return self == ForwardMode.TARGET_VERIFY
@@ -163,22 +251,22 @@ class ForwardMode(IntEnum):
         )
 
     def is_cuda_graph(self):
-        return (
-            self == ForwardMode.DECODE
-            or self == ForwardMode.TARGET_VERIFY
-            or self == ForwardMode.IDLE
-            or self == ForwardMode.DLLM_EXTEND
+        return self in (
+            ForwardMode.SINGLE_TOKEN,
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.IDLE,
+            ForwardMode.DLLM_EXTEND,
         )
 
     def is_cpu_graph(self):
-        return self == ForwardMode.DECODE
+        return self.is_single_token()
 
     def is_split_prefill(self):
         return self == ForwardMode.SPLIT_PREFILL
 
     def is_extend_without_speculative(self):
         return (
-            self.is_extend()
+            self.is_var_len()
             and not self.is_target_verify()
             and not self.is_draft_extend()
         )

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -79,7 +79,7 @@ _is_npu = is_npu()
 class ForwardMode(IntEnum):
     """Forward mode for an attention batch.
 
-    Shape-classified canonical names (introduced in attention refactor step 09):
+    Shape-classified canonical names:
 
     * ``VAR_LEN`` — each request has a different per-request length
       (extend / prefill / chunked-prefill mixed / draft-extend /
@@ -110,8 +110,7 @@ class ForwardMode(IntEnum):
     ``is_var_len()`` / ``is_single_token()`` / ``is_uniform_len()``.
     """
 
-    # ---- New canonical shape-class members (explicit values; IntEnum
-    # aliases pinned to keep cross-version pickle / IPC compatibility) ----
+    # ---- New canonical shape-class members ----
     VAR_LEN = 1
     SINGLE_TOKEN = 2
     UNIFORM_LEN = 3


### PR DESCRIPTION
## Motivation

`ForwardMode` and the attention backend's `forward` dispatch mix two concerns: the *shape* of a batch (single-token / variable-length / uniform-length) and its *semantic* origin (decode, chunked-prefill mixed, target-verify, draft-extend, ...). The dispatch keys off semantic names, obscuring that the real branch condition is batch shape. Separately, `AttentionBackend.forward` carries an IDLE early-return (for data-parallel attention, a worker may be allocated no sequences), forcing every backend to reason about empty input. This PR makes the shape classification explicit (additively, no call-site changes required) and relocates IDLE handling to a single upstream point.

## Modifications

- `forward_batch_info.py`: add shape-classified members `VAR_LEN` / `SINGLE_TOKEN` / `UNIFORM_LEN` to `ForwardMode`, with `EXTEND` / `DECODE` kept as IntEnum value-aliases. Semantic members (`MIXED`, `TARGET_VERIFY`, ...) remain distinct. Add `is_var_len()` / `is_single_token()` / `is_uniform_len()`; the old `is_extend()`/`is_decode()`/`is_mixed()` are retained as forwarders. `is_var_len` reproduces the exact member set of the previous `is_extend`; `is_cuda_graph` / `is_cpu_graph` / `is_decode_or_idle` keep identical truth tables.
- `base_attn_backend.py`: add canonical `forward_var_len` / `forward_single_token` / `forward_uniform_len` that default-delegate to `forward_extend` / `forward_decode` / `forward_mixed`, and route `forward` through the shape predicates. Backends overriding only the old names keep working.
- `radix_attention.py`: move the IDLE early-return out of `AttentionBackend.forward` into `RadixAttention.forward`, ahead of backend dispatch. The returned tensor is identical (`q.new_empty((q.shape[0], tp_q_head_num * v_head_dim))`). Backends no longer handle IDLE.

Additive / behavior-preserving by construction.

## Accuracy Tests

The IDLE relocation is a forward-path change (not pure renaming), so it should be confirmed empirically:
- Run a data-parallel-attention configuration (so some ranks receive IDLE dummy batches) and confirm outputs match `main`.
- Spot-check a non-DP run for the non-IDLE path.

The new shape predicates were verified to reproduce the existing predicates' member sets, so no dispatch decision changes for any existing mode.

## Speed Tests and Profiling

Negligible — relocates a single predicate check and renames dispatch targets that default-delegate to existing implementations; no extra work on any hot path.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26838966626](https://github.com/sgl-project/sglang/actions/runs/26838966626)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26838963651](https://github.com/sgl-project/sglang/actions/runs/26838963651)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
