### PR TITLE
[refactor] Drop redundant no-op init_forward_metadata override in TorchNativeAttnBackend

### DIFF
--- a/python/sglang/srt/layers/attention/torch_native_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_backend.py
@@ -39,10 +39,6 @@ class TorchNativeAttnBackend(AttentionBackend):
         k_pos = torch.arange(kv_len, device=device).unsqueeze(0)
         return (k_pos <= q_pos) & (k_pos >= q_pos - sliding_window_size)
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init the metadata for a forward pass."""
-        pass
-
     def _run_sdpa_forward_extend(
         self,
         query: torch.Tensor,


### PR DESCRIPTION
## Motivation

`TorchNativeAttnBackend` carried its own `init_forward_metadata` override whose body was just `pass`. The `AttentionBackend` ABC default `init_forward_metadata` already drives the standard `init_forward_metadata_out_graph` + `init_forward_metadata_in_graph` chain; this backend overrides neither helper, so both default to no-ops and the ABC default is already exactly the no-op the local override hand-rolled. Keeping the override adds nothing and risks diverging from the base contract.

## Modifications

- Remove the `init_forward_metadata` override (docstring + `pass`) from `TorchNativeAttnBackend` so it inherits the ABC default. No other changes; the inherited init path is a complete no-op for this backend, identical to before.

## Accuracy Tests

Pure no-op refactor; the compute path and model outputs are unaffected.

## Speed Tests and Profiling

Negligible — removes one trivial Python method from the MRO (invoked once per forward init).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26838069486](https://github.com/sgl-project/sglang/actions/runs/26838069486)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26838071380](https://github.com/sgl-project/sglang/actions/runs/26838071380)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
