### PR TITLE
[refactor] Add opt-in get_compressor_state helper + document forward(**kwargs) aux-data contract

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -133,7 +133,31 @@ class AttentionBackend(ABC):
         save_kv_cache: bool = True,
         **kwargs,
     ):
-        """Run forward on an attention layer."""
+        """Run forward on an attention layer.
+
+        All aux data is sourced from backend-internal channels, NOT
+        ``**kwargs``:
+
+          - ``forward_batch.spec_info`` (e.g. ``spec_info.custom_mask``)
+          - ``self.forward_metadata`` (set in
+            :py:meth:`init_forward_metadata_out_graph`)
+          - ``self.cuda_graph_*`` (backend-private buffers; set in
+            :py:meth:`init_cuda_graph_state`)
+          - :py:meth:`get_indexer_metadata` /
+            :py:meth:`get_compressor_state` (opt-in reverse-query helpers)
+
+        ``**kwargs`` is reserved for **layer-level extras** that the model
+        layer (RadixAttention / RadixLinearAttention) injects per-call —
+        e.g. ``q_rope`` / ``k_rope`` (MLA rotary), ``sinks`` (sink-token
+        attention), ``cos_sin_cache`` / ``is_neox`` / ``llama_4_scaling``
+        (rotary variants), ``topk_indices`` (DSA). It MUST NOT carry spec
+        / mask / page table / indexer / compressor data — those are aux
+        data with explicit channels above.
+
+        Step 08 follow-up: enumerate layer-level extras explicitly and
+        drop ``**kwargs`` catch-all once the backend signatures are
+        aligned (see ``attention/08-decouple-aux-data.md``).
+        """
         if forward_batch.forward_mode.is_idle():
             return q.new_empty(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
         elif forward_batch.forward_mode.is_decode():

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -10,6 +10,7 @@ from sglang.srt.utils.common import is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.dsa.dsa_indexer import BaseIndexerMetadata
+    from sglang.srt.layers.attention.dsv4.compressor import FusedCompressMetadata
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
     from sglang.srt.speculative.spec_info import SpecInput
@@ -214,4 +215,23 @@ class AttentionBackend(ABC):
         forward_batch: ForwardBatch,
     ) -> Optional[BaseIndexerMetadata]:
         """Get the indexer metadata. None means don't support indexer."""
+        return None
+
+    def get_compressor_state(
+        self,
+        layer_id: int,
+        forward_batch: ForwardBatch,
+    ) -> Optional[FusedCompressMetadata]:
+        """Get the per-layer compressor state (DSV4 mhc / hisparse).
+
+        Symmetric opt-in helper to :py:meth:`get_indexer_metadata`. Default
+        ``None`` means this backend does not produce compressor state; the
+        caller (Compressor / mHC layer) should fall back to its own path.
+
+        Backends override to return their per-iter compressor metadata
+        (e.g. ``FusedCompressMetadata`` for DSV4) computed in
+        :py:meth:`init_forward_metadata_out_graph`. This routes compressor
+        data via a backend-internal explicit API instead of leaking it
+        through ``forward(**kwargs)``.
+        """
         return None

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -154,9 +154,8 @@ class AttentionBackend(ABC):
         / mask / page table / indexer / compressor data — those are aux
         data with explicit channels above.
 
-        Step 08 follow-up: enumerate layer-level extras explicitly and
-        drop ``**kwargs`` catch-all once the backend signatures are
-        aligned (see ``attention/08-decouple-aux-data.md``).
+        TODO: enumerate the layer-level extras explicitly and drop the
+        ``**kwargs`` catch-all once the backend signatures are aligned.
         """
         if forward_batch.forward_mode.is_idle():
             return q.new_empty(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -139,6 +139,10 @@ class HybridAttnBackend(AttentionBackend):
         backend = self._select_backend(forward_batch.forward_mode)
         return backend.get_indexer_metadata(layer_id, forward_batch)
 
+    def get_compressor_state(self, layer_id: int, forward_batch: ForwardBatch):
+        backend = self._select_backend(forward_batch.forward_mode)
+        return backend.get_compressor_state(layer_id, forward_batch)
+
     def forward(
         self,
         q: torch.Tensor = None,

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -145,6 +145,9 @@ class TboAttnBackend(AttentionBackend):
     def get_indexer_metadata(self, layer_id: int, forward_batch: "ForwardBatch"):
         return self.primary.get_indexer_metadata(layer_id, forward_batch)
 
+    def get_compressor_state(self, layer_id: int, forward_batch: "ForwardBatch"):
+        return self.primary.get_compressor_state(layer_id, forward_batch)
+
 
 def _build_tbo_child_replay_fb_view(
     fb_view,


### PR DESCRIPTION
## Motivation

Attention backends already expose `get_indexer_metadata` as an opt-in, backend-internal channel for callers to pull per-layer metadata a backend computed, instead of threading it through `forward(**kwargs)`. There is no symmetric channel for compressor state (`FusedCompressMetadata`). This PR adds the missing helper and tightens the documented contract for `AttentionBackend.forward(**kwargs)` so it is clear which data flows through backend-internal channels versus the per-call `**kwargs` catch-all. Both changes are additive.

## Modifications

- `base_attn_backend.py`:
  - Add `get_compressor_state(layer_id, forward_batch) -> Optional[FusedCompressMetadata]`, a default-`None` opt-in helper mirroring `get_indexer_metadata`.
  - Add a `TYPE_CHECKING`-only import for the return annotation (no runtime import).
  - Expand the `forward(...)` docstring to state the aux-data contract: spec/mask via `forward_batch.spec_info`, per-iter metadata via `self.forward_metadata`, cuda-graph buffers via `self.cuda_graph_*`, indexer/compressor state via the opt-in helpers; `**kwargs` is reserved for layer-level extras (e.g. `q_rope`/`k_rope`, `sinks`, rotary variants, `topk_indices`).
- `hybrid_attn_backend.py` / `tbo_backend.py`: override `get_compressor_state` to delegate (to the mode-selected sub-backend / to `self.primary`), matching the existing `get_indexer_metadata` delegation.

No concrete backend overrides the new helper and nothing calls it yet, so the runtime is unchanged: the base returns `None` and the wrappers only forward.

## Accuracy Tests

Not applicable — pure additive API. The only executable additions are a default-`None` method and two one-line delegations; the `forward` change is documentation only. No model output is affected.

## Speed Tests and Profiling

Not applicable — no perf-sensitive path is modified; the added import is `TYPE_CHECKING`-only.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26838930661](https://github.com/sgl-project/sglang/actions/runs/26838930661)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26838931564](https://github.com/sgl-project/sglang/actions/runs/26838931564)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
