### PR TITLE
[RL] Forward Kimi K2.5 weight hooks to language model

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -804,6 +804,24 @@ class KimiK25ForConditionalGeneration(nn.Module):
             for _ in stream_language_weights():
                 pass
 
+    def post_load_weights(self):
+        if self.language_model is not None:
+            self.language_model.post_load_weights()
+
+    @property
+    def stacked_params_mapping(self):
+        return getattr(self.language_model, "stacked_params_mapping", [])
+
+    @property
+    def expert_params_mapping(self):
+        return getattr(self.language_model, "expert_params_mapping", [])
+
+    def mutate_weight_preload(self, name):
+        return self.language_model.mutate_weight_preload(name)
+
+    def custom_scale_remap(self, name):
+        return self.language_model.custom_scale_remap(name)
+
     @classmethod
     def get_model_config_for_expert_location(cls, config: KimiK25Config):
         text_config = config.text_config


### PR DESCRIPTION
## Motivation

Kimi K2.5 needs these wrapper forwards for RL weight updates. RL weight sync code operates on the top-level model wrapper, but the actual language-model weight loading metadata lives on the inner language model. Without forwarding `stacked_params_mapping`, `expert_params_mapping`, `mutate_weight_preload()`, and `custom_scale_remap()`, fused and expert weights can fail to map through the wrapper during RL updates.

The wrapper also needs to forward `post_load_weights()` so the inner language model can run its post-load preparation after updated weights are applied. In particular, Kimi K2.5 uses MLA-related packed tensors that need to be prepared before execution/CUDA graph capture.

Related: #23339 handles a similar Kimi K2.5 checkpoint-engine update issue and also forwards `post_load_weights()` to the inner language model.

## Modifications

- Forward `post_load_weights()` from `KimiK25ForConditionalGeneration` to the inner language model.
- Expose the inner language model's weight mapping hooks through the Kimi K2.5 wrapper.

## Validation

- `git diff --check HEAD~1 HEAD`
- `python3 -m py_compile python/sglang/srt/models/kimi_k25.py`





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26663599671](https://github.com/sgl-project/sglang/actions/runs/26663599671)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26663599241](https://github.com/sgl-project/sglang/actions/runs/26663599241)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->