### PR TITLE
[Quant] Plumb MXFP4 SwiGLU scalars from moe_runner_config

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -584,19 +584,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self._process_weights_for_sm90_cutlass(layer)
             return
         if self.use_flashinfer:
-            # TODO: these values are hardcoded for now, we need to get them from the model
-            layer.gemm1_alpha = Parameter(
-                torch.tensor([1.702] * self.num_experts, dtype=torch.float32).cuda(),
-                requires_grad=False,
-            )
-            layer.gemm1_beta = Parameter(
-                torch.tensor([1.0] * self.num_experts, dtype=torch.float32).cuda(),
-                requires_grad=False,
-            )
-            layer.gemm1_clamp_limit = Parameter(
-                torch.tensor([7.0] * self.num_experts, dtype=torch.float32).cuda(),
-                requires_grad=False,
-            )
             sf_block_size = 32  # mxfp4 block size
 
             assert (
@@ -990,20 +977,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_bias_padded = torch.zeros(E, K_pad, dtype=bias_dtype, device=device)
         w2_bias_padded[:, :K_un] = layer.w2_weight_bias.data
 
-        # ---- Per-expert SwiGLU scalars (GPT-OSS defaults) ------------------
-        layer.swiglu_alpha = Parameter(
-            torch.full((E,), 1.702, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-        layer.swiglu_beta = Parameter(
-            torch.full((E,), 1.0, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-        layer.swiglu_limit = Parameter(
-            torch.full((E,), 7.0, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-
         # ---- FlashInfer SM90 byte / scale interleave -----------------------
         # The padded buffers above are contiguous by construction (allocated
         # via torch.zeros + slice assignment), so we feed them straight in.
@@ -1032,10 +1005,65 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         torch.cuda.empty_cache()
 
+    def _init_flashinfer_swiglu_scalars(self, layer, moe_runner_config):
+        """Build per-expert SwiGLU scalar tensors for the FlashInfer trtllm-gen
+        and SM90 cutlass MXFP4 kernels from ``moe_runner_config``.
+
+        GPT-OSS (and any future MXFP4 model on these paths) plumbs the activation
+        scalars end-to-end: HF config (``hidden_act_alpha`` / ``swiglu_limit``) ->
+        models/gpt_oss.py -> FusedMoE -> MoeRunnerConfig (``gemm1_alpha`` /
+        ``gemm1_clamp_limit``). The limit always comes from ``gemm1_clamp_limit``
+        (``moe_runner_config.swiglu_limit`` is the DSv4 sibling field and is None
+        for GPT-OSS). ``beta`` has no config field -- it is a fixed 1.0 for this
+        SwiGLU kernel family. Fail loud if the model did not plumb the scalars,
+        instead of silently corrupting activations with GPT-OSS defaults.
+
+        Returns a (alpha, beta, limit) tuple of fp32 per-expert Parameters.
+        """
+        alpha = moe_runner_config.gemm1_alpha
+        limit = moe_runner_config.gemm1_clamp_limit
+        if alpha is None or limit is None:
+            raise ValueError(
+                "MXFP4 FlashInfer MoE requires SwiGLU activation scalars to be "
+                "plumbed via moe_runner_config, but got "
+                f"gemm1_alpha={alpha}, gemm1_clamp_limit={limit} "
+                f"(layer_id={moe_runner_config.layer_id}). The model definition "
+                "must set hidden_act_alpha and swiglu_limit (see "
+                "GptOssSparseMoeBlock in srt/models/gpt_oss.py)."
+            )
+        num_experts = self.num_experts
+        device = layer.w13_weight.device
+
+        def _per_expert(value):
+            return Parameter(
+                torch.full(
+                    (num_experts,), float(value), dtype=torch.float32, device=device
+                ),
+                requires_grad=False,
+            )
+
+        return _per_expert(alpha), _per_expert(1.0), _per_expert(limit)
+
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
+        # Per-expert SwiGLU scalars now come from the config (was hardcoded to
+        # GPT-OSS defaults). Built here because moe_runner_config is only passed
+        # to create_moe_runner, not to process_weights_after_loading (their old
+        # home). Mirror the path guards used there.
+        if self._fi_kernel == "cutlass_sm90":
+            (
+                layer.swiglu_alpha,
+                layer.swiglu_beta,
+                layer.swiglu_limit,
+            ) = self._init_flashinfer_swiglu_scalars(layer, moe_runner_config)
+        elif self.use_flashinfer:
+            (
+                layer.gemm1_alpha,
+                layer.gemm1_beta,
+                layer.gemm1_clamp_limit,
+            ) = self._init_flashinfer_swiglu_scalars(layer, moe_runner_config)
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto():
             # Must match apply() priority: _use_aiter before use_triton_kernels.

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm90_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm90_cutlass.py
@@ -265,20 +265,6 @@ def test_process_weights_matches_direct_interleave(num_experts, hidden, inter):
     assert torch.equal(layer.w13_weight_bias.data, ref_w13_b)
     assert torch.equal(layer.w2_weight_bias.data, ref_w2_b)
 
-    # SwiGLU per-expert scalars seeded with GPT-OSS defaults.
-    assert torch.allclose(
-        layer.swiglu_alpha,
-        torch.full((num_experts,), 1.702, dtype=torch.float32, device="cuda"),
-    )
-    assert torch.allclose(
-        layer.swiglu_beta,
-        torch.full((num_experts,), 1.0, dtype=torch.float32, device="cuda"),
-    )
-    assert torch.allclose(
-        layer.swiglu_limit,
-        torch.full((num_experts,), 7.0, dtype=torch.float32, device="cuda"),
-    )
-
 
 @pytest.mark.parametrize(
     "tokens,num_experts,hidden,inter,top_k",
@@ -319,6 +305,17 @@ def test_apply_sm90_cutlass_matches_flashinfer_direct(
     )
     method = _build_method(num_experts, hidden, inter)
     method._process_weights_for_sm90_cutlass(layer)
+
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+    _cfg = MoeRunnerConfig(
+        num_experts=num_experts, layer_id=0, gemm1_alpha=1.702, gemm1_clamp_limit=7.0
+    )
+    (
+        layer.swiglu_alpha,
+        layer.swiglu_beta,
+        layer.swiglu_limit,
+    ) = method._init_flashinfer_swiglu_scalars(layer, _cfg)
 
     out_sglang = method._apply_sm90_cutlass(
         layer, x.clone(), _MockTopKOutput(topk_w, topk_i)
@@ -536,6 +533,66 @@ class _MockDispatchOutput:
             topk_ids=topk_ids,
             router_logits=router_logits,
         )
+
+
+def test_swiglu_scalars_plumbed_from_config():
+    """The exact bug shape: per-expert SwiGLU scalars must come from
+    moe_runner_config, NOT the hardcoded GPT-OSS 1.702/7.0. We pass
+    deliberately non-GPT-OSS values and require them to flow through."""
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+    num_experts, hidden, inter = 4, 256, 256
+    w13, w2, w13_s, w2_s, w13_b, w2_b = _make_random_mxfp4(num_experts, hidden, inter)
+    layer = _build_mock_layer(
+        num_experts, hidden, inter, w13, w2, w13_s, w2_s, w13_b, w2_b
+    )
+    method = _build_method(num_experts, hidden, inter)
+
+    # NON-GPT-OSS values: a model whose true scalars differ from 1.702/7.0.
+    cfg = MoeRunnerConfig(
+        num_experts=num_experts,
+        layer_id=0,
+        gemm1_alpha=1.0,  # != 1.702
+        gemm1_clamp_limit=10.0,  # != 7.0
+    )
+    alpha, beta, limit = method._init_flashinfer_swiglu_scalars(layer, cfg)
+
+    assert torch.allclose(
+        alpha, torch.full((num_experts,), 1.0, dtype=torch.float32, device="cuda")
+    ), "alpha must come from moe_runner_config.gemm1_alpha, not hardcoded 1.702"
+    assert torch.allclose(
+        limit, torch.full((num_experts,), 10.0, dtype=torch.float32, device="cuda")
+    ), "limit must come from moe_runner_config.gemm1_clamp_limit, not hardcoded 7.0"
+    # beta has no config field -> constant 1.0 by design.
+    assert torch.allclose(
+        beta, torch.full((num_experts,), 1.0, dtype=torch.float32, device="cuda")
+    )
+    assert alpha.dtype == torch.float32 and alpha.device.type == "cuda"
+
+
+def test_swiglu_scalars_fail_loud_when_config_missing():
+    """Fail loud: if the model did not plumb the scalars (None on the
+    config), raise instead of silently using GPT-OSS defaults."""
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+    num_experts, hidden, inter = 4, 256, 256
+    w13, w2, w13_s, w2_s, w13_b, w2_b = _make_random_mxfp4(num_experts, hidden, inter)
+    layer = _build_mock_layer(
+        num_experts, hidden, inter, w13, w2, w13_s, w2_s, w13_b, w2_b
+    )
+    method = _build_method(num_experts, hidden, inter)
+
+    cfg_missing_alpha = MoeRunnerConfig(
+        num_experts=num_experts, layer_id=3, gemm1_alpha=None, gemm1_clamp_limit=7.0
+    )
+    with pytest.raises(ValueError, match="gemm1_alpha"):
+        method._init_flashinfer_swiglu_scalars(layer, cfg_missing_alpha)
+
+    cfg_missing_limit = MoeRunnerConfig(
+        num_experts=num_experts, layer_id=3, gemm1_alpha=1.702, gemm1_clamp_limit=None
+    )
+    with pytest.raises(ValueError, match="gemm1_clamp_limit"):
+        method._init_flashinfer_swiglu_scalars(layer, cfg_missing_limit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add config-driven SwiGLU scalar plumbing for the MXFP4 FlashInfer path with fail-loud unit tests, and update the SM90 tests accordingly.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The FlashInfer MXFP4 MoE weight-prep paths in `Mxfp4MoEMethod` hardcoded the per-expert SwiGLU activation scalars to GPT-OSS defaults (`alpha=1.702`, `beta=1.0`, `limit=7.0`): once in `process_weights_after_loading` for the trtllm-gen path (`gemm1_alpha` / `gemm1_beta` / `gemm1_clamp_limit`, behind a `# TODO: hardcoded ... get them from the model` note) and once in `_process_weights_for_sm90_cutlass` for the SM90 cutlass path (`swiglu_alpha` / `swiglu_beta` / `swiglu_limit`). The model already plumbs the real scalars end-to-end (`GptOssSparseMoeBlock` in `srt/models/gpt_oss.py` sets `hidden_act_alpha` / `swiglu_limit`, which reach `MoeRunnerConfig.gemm1_alpha` / `gemm1_clamp_limit`), but these two paths ignored the config and used the literals — so any MXFP4 model whose activation scalars differ from the GPT-OSS defaults would be silently run with the wrong SwiGLU activation, with no error.

## Modifications

- `python/sglang/srt/layers/quantization/mxfp4.py`
  - Add `_init_flashinfer_swiglu_scalars(layer, moe_runner_config)`: builds the per-expert fp32 `(alpha, beta, limit)` Parameters from `moe_runner_config.gemm1_alpha` and `gemm1_clamp_limit`. `beta` is a fixed `1.0` (it has no config field for this SwiGLU kernel family). If either `alpha` or `limit` is `None`, raise `ValueError` naming both fields, so a model that did not plumb the scalars fails loud instead of silently using GPT-OSS defaults.
  - Call the helper from `create_moe_runner` (the only site where `moe_runner_config` is available) for both FlashInfer paths: `swiglu_*` for the `cutlass_sm90` kernel, `gemm1_*` for the trtllm-gen path.
  - Remove both hardcoded scalar blocks and the stale `TODO`.
- `test/registered/unit/layers/quantization/test_mxfp4_sm90_cutlass.py`
  - Add `test_swiglu_scalars_plumbed_from_config`: passes deliberately non-GPT-OSS values (`alpha=1.0`, `limit=10.0`) and asserts they propagate, guarding against re-hardcoding.
  - Add `test_swiglu_scalars_fail_loud_when_config_missing`: `None` alpha or limit must raise `ValueError`.
  - Update the existing SM90 process/apply tests to seed the scalars through the new helper instead of asserting the old hardcoded constants.

## Accuracy Tests

For GPT-OSS (the only MXFP4 model on this path today) the change is a no-op: its config supplies exactly `gemm1_alpha=1.702` and `gemm1_clamp_limit=7.0`, identical to the removed literals, so the kernel receives bit-identical fp32 scalar tensors. Verified on the real model rather than by argument alone, with a before/after run:

- Model `openai/gpt-oss-20b` (native MXFP4), `--moe-runner-backend flashinfer_mxfp4` (SM90 cutlass path), 1x H100, greedy (`temperature=0`), `max_new_tokens=48`, `flashinfer-python` 0.6.11.
- OLD = `upstream/main` `ed85bcf8c` (hardcoded `1.702`/`1.0`/`7.0`); NEW = this branch (config-driven). Same server config, same prompts.

| Prompt | text identical | output token-ids identical | tokens |
| --- | --- | --- | --- |
| `The capital of France is` | yes | yes | 48 |
| `2+2 equals` | yes | yes | 48 |
| `Once upon a time, in a small village,` | yes | yes | 48 |
| `def fibonacci(n):` | yes | yes | 48 |
| `The three primary colors are` | yes | yes | 48 |
| `Explain quantum entanglement in one sentence:` | yes | yes | 48 |

All 6 prompts are token-identical between OLD and NEW (exact decoded text and exact output token-id sequences, 48 tokens each). Zero regression for GPT-OSS.

Unit tests: `14 passed` for `test/registered/unit/layers/quantization/test_mxfp4_sm90_cutlass.py` on 1x H100 (includes the two new plumbing / fail-loud tests above).

## Checklist

- [x] Format the code with pre-commit (isort / ruff / black / codespell pass on the changed files).
- [x] Add unit tests for the new behavior (config plumbing and fail-loud), and keep the existing SM90 suite green.
- [x] Provide accuracy results (before/after token-identical end-to-end run on gpt-oss-20b).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
## Modifications


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26668836257](https://github.com/sgl-project/sglang/actions/runs/26668836257)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26668836106](https://github.com/sgl-project/sglang/actions/runs/26668836106)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->