### PR TITLE
[NPU] D2H memory fix

### DIFF
--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -102,10 +102,13 @@ class GenerationBatchResult:
                     v.to("cpu", non_blocking=True) if torch.is_tensor(v) else v
                     for v in self.logits_output.next_token_token_ids_logprobs_val
                 ]
-        if return_hidden_states and self.logits_output.hidden_states is not None:
-            self.logits_output.hidden_states = self.logits_output.hidden_states.to(
-                "cpu", non_blocking=True
-            )
+        if self.logits_output.hidden_states is not None:
+            if return_hidden_states:
+                self.logits_output.hidden_states = self.logits_output.hidden_states.to(
+                    "cpu", non_blocking=True
+                )
+            else:
+                self.logits_output.hidden_states = None
         self.next_token_ids = self.next_token_ids.to("cpu", non_blocking=True)
 
         if self.accept_lens is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

PR #25155 avoids copying hidden states from device to CPU when `return_hidden_states=false`, but the device tensor reference is still kept in `logits_output.hidden_states`.

In overlap scheduling, `GenerationBatchResult` can be held in `result_queue` across the next forward iteration. If `hidden_states` remains a device tensor, the previous batch's hidden states stay alive while the next batch runs, increasing peak device memory usage. This is especially visible where hidden states may be captured internally even when they are not returned to the user.

## Modifications

When `logits_output.hidden_states` is present in `GenerationBatchResult.copy_to_cpu()`:

- Keep the existing behavior for `return_hidden_states=true`: copy hidden states to CPU for output processing.
- For `return_hidden_states=false`: set `logits_output.hidden_states = None` to drop the unused device tensor reference immediately.

This preserves the D2H optimization while avoiding unnecessary device memory retention.

## Accuracy Tests

<img width="985" height="168" alt="image" src="https://github.com/user-attachments/assets/35d8645f-bc63-4cb2-961e-af28d5b42ace" />

## Speed Tests and Profiling

<img width="400" height="573" alt="image" src="https://github.com/user-attachments/assets/6b0a5b18-fc60-4226-a864-a03a5af1ac27" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26669292093](https://github.com/sgl-project/sglang/actions/runs/26669292093)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26669292023](https://github.com/sgl-project/sglang/actions/runs/26669292023)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->