### PR TITLE
[fix] Triton: size kv_indices from actual cumsum, not forward_batch.seq_lens_sum

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 import triton
@@ -292,10 +292,30 @@ class TritonAttnBackend(AttentionBackend):
         bs: int,
         seq_lens: torch.Tensor,
         req_pool_indices: torch.Tensor,
-        kv_indices: torch.Tensor,
-    ) -> torch.Tensor:
+        kv_indices: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Build ``kv_indptr`` from cumsum(seq_lens) and fill ``kv_indices``.
+
+        If ``kv_indices`` is ``None`` (the eager path with no pre-allocated
+        buffer), allocate it sized to ``int(kv_indptr[-1])`` — the exact
+        total derived from this call's cumsum. Do **not** rely on
+        ``forward_batch.seq_lens_sum`` to size the buffer here: that cached
+        value can be stale relative to the GPU ``seq_lens`` (e.g. when a
+        spec-decode worker bumps ``seq_lens`` for the verify batch and the
+        cached sum was set on the pre-bump value, or when ``needs_cpu_seq_lens
+        = False`` leaves the sum unset). A stale sum produces an undersized
+        ``kv_indices`` and ``create_flashinfer_kv_indices_triton`` writes
+        OOB, corrupting whatever lives next to the allocation; later the
+        Triton extend kernel reads garbage indices and faults with
+        ``WARP_OUT_OF_RANGE_ADDRESS`` — that's the failure reported by
+        ``test_spec_ngram_extra.py`` on main post-#26665.
+        """
         kv_indptr = self.kv_indptr[: bs + 1]
         kv_indptr[1:] = torch.cumsum(seq_lens, dim=0)
+        if kv_indices is None:
+            kv_indices = torch.empty(
+                int(kv_indptr[-1]), dtype=torch.int64, device=self.device
+            )
         create_flashinfer_kv_indices_triton[(bs,)](
             self.req_to_token,
             req_pool_indices,
@@ -305,7 +325,7 @@ class TritonAttnBackend(AttentionBackend):
             kv_indices,
             self.req_to_token.stride(0),
         )
-        return kv_indptr
+        return kv_indptr, kv_indices
 
     def _update_decode_kv_buffers(
         self,
@@ -320,7 +340,7 @@ class TritonAttnBackend(AttentionBackend):
         """
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
-        kv_indptr = self._fill_kv_indptr_and_indices(
+        kv_indptr, _ = self._fill_kv_indptr_and_indices(
             bs, seq_lens, req_pool_indices, self.cuda_graph_kv_indices
         )
         window_kv_indptr = self.window_kv_indptr
@@ -359,7 +379,7 @@ class TritonAttnBackend(AttentionBackend):
             dtype=torch.int32,
             device=self.device,
         )
-        kv_indptr = self._fill_kv_indptr_and_indices(
+        kv_indptr, _ = self._fill_kv_indptr_and_indices(
             bs, seq_lens, req_pool_indices, self.cuda_graph_kv_indices
         )
         window_kv_indptr = self.window_kv_indptr
@@ -451,7 +471,7 @@ class TritonAttnBackend(AttentionBackend):
         else:
             # DRAFT_EXTEND_V1: seq_lens = prefix only.
             kv_lens = seq_lens
-        kv_indptr = self._fill_kv_indptr_and_indices(
+        kv_indptr, _ = self._fill_kv_indptr_and_indices(
             bs, kv_lens, req_pool_indices, self.cuda_graph_kv_indices
         )
         return qo_indptr, kv_indptr, num_tokens_per_bs
@@ -469,14 +489,17 @@ class TritonAttnBackend(AttentionBackend):
 
         if forward_batch.forward_mode.is_decode_or_idle():
             if spec_info is None:
-                kv_indices = torch.empty(
-                    forward_batch.seq_lens_sum, dtype=torch.int64, device=self.device
-                )
-                kv_indptr = self._fill_kv_indptr_and_indices(
+                # Eager path: let `_fill_kv_indptr_and_indices` size
+                # `kv_indices` from the actual cumsum total (`int(kv_indptr[-1])`).
+                # Sizing here off `forward_batch.seq_lens_sum` is unsafe — it
+                # can be stale or None (e.g. when Triton's
+                # `needs_cpu_seq_lens=False` skips computing it) and that
+                # leads to OOB writes from `create_flashinfer_kv_indices_triton`.
+                kv_indptr, kv_indices = self._fill_kv_indptr_and_indices(
                     bs,
                     forward_batch.seq_lens,
                     forward_batch.req_pool_indices,
-                    kv_indices,
+                    None,
                 )
                 # Sliding window
                 if (
@@ -537,15 +560,15 @@ class TritonAttnBackend(AttentionBackend):
                 dtype=torch.int32,
                 device=self.device,
             )
-            # Different with flashinfer kv_indptr and kv_indices construction
-            kv_indices = torch.empty(
-                forward_batch.seq_lens_sum, dtype=torch.int64, device=self.device
-            )
-            kv_indptr = self._fill_kv_indptr_and_indices(
+            # Different with flashinfer kv_indptr and kv_indices construction.
+            # Size `kv_indices` from the actual cumsum total — see the
+            # decode_or_idle branch above for why `forward_batch.seq_lens_sum`
+            # is unsafe to use here (stale / None under various spec workflows).
+            kv_indptr, kv_indices = self._fill_kv_indptr_and_indices(
                 bs,
                 forward_batch.seq_lens,
                 forward_batch.req_pool_indices,
-                kv_indices,
+                None,
             )
 
             if self.sliding_window_size is not None and self.sliding_window_size > 0:
@@ -605,16 +628,16 @@ class TritonAttnBackend(AttentionBackend):
             attn_logits = None
             attn_lse = None
         else:
-            kv_indices = torch.empty(
-                sum(forward_batch.extend_prefix_lens_cpu),
-                dtype=torch.int64,
-                device=self.device,
-            )
-            kv_indptr = self._fill_kv_indptr_and_indices(
+            # Size `kv_indices` from the actual cumsum total (the helper
+            # allocates it internally) — `sum(extend_prefix_lens_cpu)` can
+            # be stale relative to the GPU `extend_prefix_lens` tensor and
+            # would mis-size the buffer the same way the spec_v2 sum issue
+            # bit decode/target_verify (see _fill_kv_indptr_and_indices).
+            kv_indptr, kv_indices = self._fill_kv_indptr_and_indices(
                 bs,
                 forward_batch.extend_prefix_lens,
                 forward_batch.req_pool_indices,
-                kv_indices,
+                None,
             )
             # Sliding window
             if self.sliding_window_size is not None and self.sliding_window_size > 0:

--- a/test/registered/attention/unittests/dense/test_triton_seq_lens_sum_robust.py
+++ b/test/registered/attention/unittests/dense/test_triton_seq_lens_sum_robust.py
@@ -1,0 +1,177 @@
+"""Regression test: Triton ``init_forward_metadata`` must size ``kv_indices``
+from the actual GPU cumsum, not from a possibly-stale
+``forward_batch.seq_lens_sum``.
+
+Pre-#26665 Triton sized ``kv_indices`` as ``torch.empty(kv_indptr[-1], …)``
+(the exact total derived from this call's cumsum). #26665's refactor switched
+to ``torch.empty(forward_batch.seq_lens_sum, …)``, which is unsafe in three
+scenarios:
+
+1. ``needs_cpu_seq_lens=False`` (introduced by #26128): the scheduler may
+   skip computing ``seq_lens_sum``, leaving it as ``None``. ``torch.empty(None
+   …)`` raises ``TypeError`` and the request faults.
+2. Stale cached value: spec-decode workers bump ``forward_batch.seq_lens``
+   for a verify batch but don't always refresh ``seq_lens_sum``; the cached
+   value reflects the pre-bump state and is smaller than the actual cumsum
+   total.
+3. Test/utility scaffolding that sets ``seq_lens`` directly without
+   propagating to ``seq_lens_sum``.
+
+When ``seq_lens_sum < sum(seq_lens)``, the allocated ``kv_indices`` buffer
+is undersized; ``create_flashinfer_kv_indices_triton`` writes OOB, corrupts
+neighboring memory, and a later ``_fwd_kernel`` invocation reads garbage
+indices and faults with ``CUDBG_EXCEPTION_WARP_OUT_OF_RANGE_ADDRESS``.
+
+That's the exact failure pattern hit by ``test_spec_ngram_extra.py`` on
+``main`` post-#26665 — a GPU-only e2e failure that takes minutes to surface
+and produces a coredump with only ``_fwd_kernel`` on the stack, with no
+indication of which init wrote the bad metadata.
+
+These tests pin the contract at the init layer (≈seconds) so the same
+regression class can't sneak through the e2e gate next time.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.test_utils import CustomTestCase
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.attention_unittest.attention_methods.dense_attention import (
+    DenseAttentionCase,
+    build_dense_attention_fixture,
+)
+
+register_cuda_ci(est_time=10, stage="base-a", runner_config="1-gpu-small")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestTritonSeqLensSumRobust(CustomTestCase):
+
+    def _build(self, *, forward_mode: ForwardMode, prefix_lens, extend_lens=None):
+        case = DenseAttentionCase(
+            name=f"seq_lens_sum_robust_{forward_mode.name}",
+            backend="triton",
+            forward_mode=forward_mode,
+            num_heads=4,
+            num_kv_heads=4,
+            page_size=16,
+            prefix_lens=prefix_lens,
+            extend_lens=extend_lens,
+        )
+        try:
+            return build_dense_attention_fixture(self, case)
+        except (AssertionError, ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"triton backend unavailable: {exc}")
+
+    # ----- positive: init must produce a kv_indices view consistent with kv_indptr -----
+
+    def _assert_kv_indices_consistent_with_indptr(self, fixture):
+        """``kv_indices.numel() >= kv_indptr[-1]`` post-init.
+
+        ``create_flashinfer_kv_indices_triton`` writes ``[kv_indptr[i],
+        kv_indptr[i+1])`` per sequence, so the kv_indices buffer must cover
+        ``kv_indptr[-1]``. Pinning this catches the family of bugs where
+        ``kv_indices`` is sized off a stale CPU sum.
+        """
+        fixture.backend.init_forward_metadata(fixture.forward_batch)
+        meta = fixture.backend.forward_metadata
+        self.assertIsNotNone(meta)
+        kv_indptr = meta.kv_indptr
+        kv_indices = meta.kv_indices
+        self.assertIsNotNone(kv_indptr, "kv_indptr must be set after init")
+        self.assertIsNotNone(kv_indices, "kv_indices must be set after init")
+        total_from_indptr = int(kv_indptr[-1].item())
+        self.assertGreaterEqual(
+            kv_indices.numel(),
+            total_from_indptr,
+            f"kv_indices undersized: numel={kv_indices.numel()} but "
+            f"kv_indptr[-1]={total_from_indptr}. "
+            "create_flashinfer_kv_indices_triton would write OOB.",
+        )
+
+    def test_decode_consistent(self):
+        fixture = self._build(forward_mode=ForwardMode.DECODE, prefix_lens=(7, 11, 13))
+        self._assert_kv_indices_consistent_with_indptr(fixture)
+
+    def test_extend_consistent(self):
+        fixture = self._build(
+            forward_mode=ForwardMode.EXTEND,
+            prefix_lens=(0, 8, 16),
+            extend_lens=(15, 8, 1),
+        )
+        self._assert_kv_indices_consistent_with_indptr(fixture)
+
+    # ----- negative: init must not depend on forward_batch.seq_lens_sum being accurate -----
+
+    def _force_stale_seq_lens_sum(self, forward_batch, stale_value):
+        """Simulate the spec-v2 / spec-decode pattern where the cached sum is
+        stale relative to the GPU ``seq_lens`` tensor (or unset entirely).
+        """
+        forward_batch.seq_lens_sum = stale_value
+
+    def test_decode_robust_to_none_seq_lens_sum(self):
+        """``forward_batch.seq_lens_sum = None`` (the ``needs_cpu_seq_lens=False``
+        path from #26128) must not break ``init_forward_metadata`` —
+        ``torch.empty(None, …)`` raises ``TypeError`` if a caller is naively
+        relying on the cached sum to size buffers.
+        """
+        fixture = self._build(forward_mode=ForwardMode.DECODE, prefix_lens=(7, 11, 13))
+        self._force_stale_seq_lens_sum(fixture.forward_batch, None)
+        # Should not raise; kv_indices must be sized off the GPU cumsum total.
+        fixture.backend.init_forward_metadata(fixture.forward_batch)
+        self._assert_kv_indices_consistent_with_indptr_post_init(fixture)
+
+    def test_decode_robust_to_understated_seq_lens_sum(self):
+        """Caller cached ``seq_lens_sum`` before bumping ``seq_lens`` (the
+        spec verify pattern). The init must size ``kv_indices`` off the GPU
+        cumsum, not the stale cached value, otherwise OOB writes corrupt
+        memory and a later kernel reads garbage indices."""
+        fixture = self._build(forward_mode=ForwardMode.DECODE, prefix_lens=(7, 11, 13))
+        # Pretend the cached sum reflects a smaller pre-bump state.
+        actual_sum = int(fixture.forward_batch.seq_lens.sum().item())
+        self._force_stale_seq_lens_sum(fixture.forward_batch, actual_sum // 2)
+        fixture.backend.init_forward_metadata(fixture.forward_batch)
+        self._assert_kv_indices_consistent_with_indptr_post_init(fixture)
+
+    def test_extend_robust_to_stale_extend_prefix_lens_cpu(self):
+        """For EXTEND mode, ``init_forward_metadata`` similarly used
+        ``sum(extend_prefix_lens_cpu)`` to size ``kv_indices``. The fix sizes
+        from the actual GPU cumsum total via the helper; this test pins the
+        contract.
+        """
+        fixture = self._build(
+            forward_mode=ForwardMode.EXTEND,
+            prefix_lens=(0, 8, 16),
+            extend_lens=(15, 8, 1),
+        )
+        # Corrupt the cached CPU list to simulate it being stale.
+        fixture.forward_batch.extend_prefix_lens_cpu = [0, 0, 0]
+        fixture.backend.init_forward_metadata(fixture.forward_batch)
+        self._assert_kv_indices_consistent_with_indptr_post_init(fixture)
+
+    def _assert_kv_indices_consistent_with_indptr_post_init(self, fixture):
+        # Same as the helper above but expects init has already been called.
+        meta = fixture.backend.forward_metadata
+        self.assertIsNotNone(meta)
+        kv_indptr = meta.kv_indptr
+        kv_indices = meta.kv_indices
+        self.assertIsNotNone(kv_indptr)
+        self.assertIsNotNone(kv_indices)
+        total_from_indptr = int(kv_indptr[-1].item())
+        self.assertGreaterEqual(
+            kv_indices.numel(),
+            total_from_indptr,
+            f"kv_indices undersized: numel={kv_indices.numel()} but "
+            f"kv_indptr[-1]={total_from_indptr}.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

PR #26665 broke ``test_spec_ngram_extra.py`` on ``main``. The failure surfaces as a GPU coredump with only ``_fwd_kernel`` on the stack:

```
[12:02:47] Prefill batch, #new-seq: 3, #new-token: 203, #cached-token: 2374, … cuda graph: True
[12:02:50] coredump: CUDBG_EXCEPTION_WARP_OUT_OF_RANGE_ADDRESS
[12:02:50] coredump:   #0  _fwd_kernel
```
([failing run](https://github.com/sgl-project/sglang/actions/runs/26632345407/job/78484177972))

Root cause: pre-#26665 sized ``kv_indices`` as ``torch.empty(kv_indptr[-1], …)`` — the exact total derived from this call's cumsum. The refactor centralized the fill into ``_fill_kv_indptr_and_indices`` and moved the size source to ``forward_batch.seq_lens_sum`` (and ``sum(extend_prefix_lens_cpu)`` on the prefill branch). Both are unsafe:

1. **``needs_cpu_seq_lens=False``** (set on Triton by #26128 to skip the D2H on the CG-replay path) leaves ``forward_batch.seq_lens_sum`` as ``None``. ``torch.empty(None, …)`` raises ``TypeError``.
2. **Spec-decode verify**: workers bump ``forward_batch.seq_lens`` for a verify batch but the cached ``seq_lens_sum`` from ``ScheduleBatch`` construction reflects the pre-bump state. Undersized ``kv_indices`` → ``create_flashinfer_kv_indices_triton`` writes OOB → corrupted neighbor memory → a later ``_fwd_kernel`` launch reads garbage indices and faults.

The coredump only shows the kernel that read the bad indices, with no indication that the bad metadata was set by a much earlier ``init_forward_metadata`` call — nasty to debug at e2e.

## Modifications

**Fix** (``triton_backend.py``):
- ``_fill_kv_indptr_and_indices`` now allocates ``kv_indices`` internally from ``int(kv_indptr[-1])`` when callers pass ``None``. Matches pre-#26665 sizing exactly.
- Three eager callers (``decode_or_idle`` no-spec, ``target_verify``, ``extend``) switch to pass ``None`` and rely on the helper.
- CG-replay callers (which pass a pre-allocated ``self.cuda_graph_kv_indices``) are unchanged.

**Unit test** (``test_triton_seq_lens_sum_robust.py``, ≈10s on 1-gpu-small, registered to ``base-a/1-gpu-small``):

- _positive_: ``kv_indices.numel() >= kv_indptr[-1]`` after init for ``decode`` and ``extend`` modes
- _negative_: ``forward_batch.seq_lens_sum = None`` (``needs_cpu_seq_lens=False`` case) does not break init
- _negative_: stale (under-stated) ``forward_batch.seq_lens_sum`` still produces a correctly-sized ``kv_indices`` (spec-verify-bump pattern)
- _negative_: stale ``forward_batch.extend_prefix_lens_cpu`` still produces a correctly-sized ``kv_indices`` (EXTEND branch)

Verified the new tests fail on pre-fix Triton and pass on fixed Triton.

## Accuracy Tests

- [x] ``test/registered/attention/unittests/``: **180 passed, 21 skipped, 548 subtests** (Triton unit suite + new regression test)
- [ ] ``test/registered/spec/test_spec_ngram_extra.py``: should now pass on cluster (was the failing test on ``main``)
- [ ] GSM8K accuracy on ngram + Triton — delta < 0.5%

## Speed Tests and Profiling

- The fix moves the ``kv_indices`` allocation from before the cumsum to after — same number of allocations, same final size. No measurable overhead.
- ``int(kv_indptr[-1])`` adds one tiny D2H sync per init call (already implicit pre-#26665 via ``kv_indptr[-1]`` Python conversion in ``torch.empty``).

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [ ] Update documentation
- [ ] Provide accuracy/speed benchmarks
- [x] SGLang code style guidance

## Review and Merge Process

1. Ping Merge Oncalls.
2. Get approvals from CODEOWNERS and other reviewers.
3. Trigger CI tests with ``/tag-and-rerun-ci``.
4. Merge after green CI and required approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26669460509](https://github.com/sgl-project/sglang/actions/runs/26669460509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26669460474](https://github.com/sgl-project/sglang/actions/runs/26669460474)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->