### PR TITLE
[Bug Fix] Gemma-4 mm: RGB-normalize GPU-decoded tensors + isolate mm encoder failures from the scheduler

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -31,6 +31,38 @@ from sglang.utils import logger
 
 _is_npu = is_npu()
 
+
+class MultimodalEmbeddingError(RuntimeError):
+    """A multimodal item failed to embed (vision/audio tower raised).
+
+    Raised by the embedding layer when a per-batch encoder call raises a
+    RuntimeError so the scheduler can catch and translate to per-request
+    aborts instead of letting the exception kill the scheduler subprocess
+    (and with it every unrelated in-flight request in the batch).
+
+    Attributes:
+        modality:        The modality whose embedder failed (e.g. IMAGE).
+        num_items:       Number of mm items in the failing batch (across all
+                         requests sharing this forward).
+        original_error:  The original RuntimeError raised by the encoder.
+    """
+
+    def __init__(
+        self,
+        modality: "Modality",
+        num_items: int,
+        original_error: BaseException,
+    ):
+        self.modality = modality
+        self.num_items = num_items
+        self.original_error = original_error
+        super().__init__(
+            f"Multimodal {modality.name.lower()} embedding failed "
+            f"({num_items} item(s) in batch): "
+            f"{type(original_error).__name__}: {original_error}"
+        )
+
+
 # NOTE: Using the shared logger from sglang.utils instead of creating a module-specific logger
 # to ensure consistent logging behavior across the codebase. This prevents issues with log
 # propagation that can cause some log messages (like 'server is fired up') to not appear
@@ -851,16 +883,43 @@ def embed_mm_inputs(
                     flatten_nested_list([item.offsets for item in mm_items])
                 )
 
-            embedding, mask, input_ids = get_embedding_and_mask(
-                data_embedding_func=embedder,
-                embedding_items=items,
-                placeholder_tensor=placeholder_tensor,
-                input_ids=input_ids,
-                items_size=items_size,
-                prefix_length=extend_prefix_lens,
-                extend_length=extend_seq_lens,
-                items_offset_list=items_offsets,
-            )
+            try:
+                embedding, mask, input_ids = get_embedding_and_mask(
+                    data_embedding_func=embedder,
+                    embedding_items=items,
+                    placeholder_tensor=placeholder_tensor,
+                    input_ids=input_ids,
+                    items_size=items_size,
+                    prefix_length=extend_prefix_lens,
+                    extend_length=extend_seq_lens,
+                    items_offset_list=items_offsets,
+                )
+            except MultimodalEmbeddingError:
+                # Already typed (e.g. raised by a nested mm encoder); propagate.
+                raise
+            except RuntimeError as e:
+                # A single malformed multimodal item (e.g. a non-RGB image
+                # that survives the loader, an oversize/short video frame,
+                # a bad audio sample rate, ...) would otherwise propagate up
+                # through forward_batch_generation -> run_batch -> the
+                # scheduler event loop, where the unhandled exception
+                # SIGQUITs the scheduler subprocess and takes every other
+                # in-flight request in the batch down with it. Re-raise as
+                # a typed error so the scheduler can catch it, abort the
+                # offending batch with an attributable finished_reason,
+                # and keep serving the next batch instead of restarting
+                # the pod.
+                logger.exception(
+                    "Multimodal %s embedding raised; "
+                    "translating to MultimodalEmbeddingError so the "
+                    "scheduler can isolate the failing batch.",
+                    modality.name.lower(),
+                )
+                raise MultimodalEmbeddingError(
+                    modality=modality,
+                    num_items=len(items),
+                    original_error=e,
+                ) from e
 
             if use_deepstack.get(modality, None) and embedding is not None:
                 embedding, deepstack_embedding = (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -146,6 +146,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
 )
 from sglang.srt.managers.load_snapshot import LoadSnapshot, create_load_snapshot_writer
+from sglang.srt.managers.mm_utils import MultimodalEmbeddingError
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.overlap_utils import decide_needs_cpu_seq_lens
 from sglang.srt.managers.prefill_delayer import (
@@ -1424,7 +1425,15 @@ class Scheduler(
 
             # Launch the current batch
             if batch:
-                result = self.run_batch(batch)
+                try:
+                    result = self.run_batch(batch)
+                except MultimodalEmbeddingError as e:
+                    # A multimodal item in this batch failed to embed.
+                    # Translate to per-batch aborts so the pod survives;
+                    # see _abort_batch_on_mm_error and embed_mm_inputs.
+                    self._abort_batch_on_mm_error(batch, e)
+                    self.last_batch = batch
+                    continue
                 self.process_batch_result(batch, result)
             else:
                 # When the server is idle, do self-check and re-init some states.
@@ -1470,7 +1479,17 @@ class Scheduler(
 
             # Launch the current batch
             if batch:
-                batch_result = self.run_batch(batch)
+                try:
+                    batch_result = self.run_batch(batch)
+                except MultimodalEmbeddingError as e:
+                    # See non-overlap loop for rationale. We must still
+                    # advance last_batch and skip the rest of this
+                    # iteration; the result_queue stays untouched so the
+                    # next iteration's pop_and_process sees the previous
+                    # (good) batch.
+                    self._abort_batch_on_mm_error(batch, e)
+                    self.last_batch = batch
+                    continue
                 self.result_queue.append((batch.copy(), batch_result))
             else:
                 batch_result = None
@@ -2943,6 +2962,51 @@ class Scheduler(
                     setattr(batch, name, value)
             else:
                 batch.sampling_info = sched_sampling_info
+
+    def _abort_batch_on_mm_error(
+        self, batch: ScheduleBatch, err: MultimodalEmbeddingError
+    ) -> None:
+        """Mark every request in ``batch`` as aborted due to a multimodal
+        embedding failure and log the original traceback.
+
+        This is the scheduler-side half of the multimodal blast-radius
+        isolation: ``embed_mm_inputs`` re-raises encoder RuntimeErrors as
+        ``MultimodalEmbeddingError`` so that we can catch them here, mark
+        the offending batch's requests as FINISH_ABORT, and keep the
+        scheduler event loop running instead of SIGQUIT-ing the pod.
+
+        NOTE: This currently aborts ALL requests in the failing batch
+        because the embed layer cannot yet attribute the failure to a
+        specific item / rid. Per-request attribution (retry items
+        one-by-one to identify the failing index, then abort only that
+        request and re-run the remainder) is the follow-up; see the
+        sketch in the linked issue.
+        """
+        logger.error(
+            "MultimodalEmbeddingError in batch (modality=%s, num_items=%d): %s. "
+            "Aborting %d request(s) in this batch; pod stays up.",
+            err.modality.name.lower(),
+            err.num_items,
+            err.original_error,
+            len(batch.reqs) if batch is not None else 0,
+        )
+        if batch is None:
+            return
+        message = (
+            f"Multimodal {err.modality.name.lower()} embedding failed for this "
+            f"batch: {type(err.original_error).__name__}: {err.original_error}. "
+            f"One of the multimodal items in the batch is malformed; per-request "
+            f"attribution is not yet wired up so all requests sharing this "
+            f"forward are aborted."
+        )
+        for req in batch.reqs:
+            if req.finished():
+                continue
+            req.to_finish = FINISH_ABORT(
+                message,
+                HTTPStatus.BAD_REQUEST,
+                err_type="MultimodalEmbeddingError",
+            )
 
     def run_batch(
         self,

--- a/python/sglang/srt/models/gemma4_vision.py
+++ b/python/sglang/srt/models/gemma4_vision.py
@@ -431,6 +431,22 @@ class Gemma4VisionPatchEmbedder(nn.Module):
             pixel_values: [batch, num_patches, patch_pixels] — already patchified
                           by the image processor, values in [0, 1].
         """
+        # Defensive: in_features assumes 3-channel RGB patches
+        # (3 * patch_size**2). A non-RGB image (e.g. a grayscale JPEG that
+        # slipped through GPU-decode without RGB conversion) produces patches
+        # of width patch_size**2 * channels for channels != 3, which would
+        # otherwise surface as a cryptic mat-mul shape mismatch and crash the
+        # scheduler. Surface a typed error here so the upstream isolation
+        # layer in mm_utils can attribute it to the failing request.
+        expected = self.input_proj.in_features
+        if pixel_values.dim() < 1 or pixel_values.shape[-1] != expected:
+            raise ValueError(
+                f"Gemma4VisionPatchEmbedder: pixel_values last dim "
+                f"{tuple(pixel_values.shape)[-1] if pixel_values.dim() else None} "
+                f"!= expected {expected} (= 3 * patch_size**2). "
+                f"This typically means a non-RGB image (1- or 4-channel) "
+                f"reached the vision tower without channel normalization."
+            )
         patches = 2 * (pixel_values - 0.5)
         return self.input_proj(patches.to(self.input_proj.weight.dtype))
 

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -535,13 +535,29 @@ class BaseMultimodalProcessor(ABC):
         try:
             if modality == Modality.IMAGE:
                 img, _ = load_image(data, cls.gpu_image_decode)
-                if (
-                    discard_alpha_channel
-                    and not isinstance(img, torch.Tensor)
-                    and img.mode != "RGB"
-                ):
-                    # Needed only when `img` is a PIL image
-                    img = img.convert("RGB")
+                if discard_alpha_channel:
+                    if isinstance(img, torch.Tensor):
+                        # GPU JPEG decode (nvJPEG) returns (C, H, W) preserving
+                        # the source channel count. Downstream HF image
+                        # processors (e.g. Gemma3/Gemma4) assume 3-channel RGB
+                        # and patchify with a fixed in_features=3*patch*patch;
+                        # a grayscale (C=1) image produces patches of the wrong
+                        # shape and crashes the patch-embedder linear layer.
+                        # Normalize to C=3 here so the tensor path matches the
+                        # PIL .convert("RGB") path below.
+                        if img.dim() == 3:
+                            c = img.shape[0]
+                            if c == 1:
+                                img = img.expand(3, -1, -1).contiguous()
+                            elif c == 2:
+                                # LA (luminance + alpha): drop alpha, expand L
+                                img = img[:1].expand(3, -1, -1).contiguous()
+                            elif c == 4:
+                                # RGBA: drop alpha
+                                img = img[:3].contiguous()
+                    elif img.mode != "RGB":
+                        # Needed only when `img` is a PIL image
+                        img = img.convert("RGB")
                 return img
             elif modality == Modality.VIDEO:
                 return load_video(data, frame_count_limit)

--- a/test/manual/vlm/test_gemma4_mm_channel_guard.py
+++ b/test/manual/vlm/test_gemma4_mm_channel_guard.py
@@ -1,0 +1,115 @@
+"""CPU-only regression tests for the Gemma-4 multimodal channel guard.
+
+Two bugs combined to make a single non-RGB image (e.g. a grayscale JPEG
+served by a public CDN) crash the entire Gemma-4 SGLang scheduler:
+
+  A. The GPU-decode path in base_processor._load_single_item only
+     applied RGB normalization to PIL images; torch.Tensor outputs
+     (nvJPEG) kept their source channel count, so a 1-channel image
+     reached the Gemma-4 patch embedder and produced patches of
+     width patch**2 * 1 instead of patch**2 * 3, crashing the linear
+     projection with `mat1 and mat2 shapes cannot be multiplied`.
+
+  B. That RuntimeError propagated unchecked through
+     embed_mm_inputs -> run_batch -> the scheduler event loop, where
+     the unhandled exception SIGQUIT'd the scheduler subprocess and
+     took every other unrelated in-flight request in the batch down
+     with it.
+
+These tests exercise both fixes without touching CUDA / the GPU.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.managers.mm_utils import MultimodalEmbeddingError, embed_mm_inputs
+from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+
+class TestChannelNormalizationTensorPath(unittest.TestCase):
+    """Fix A: GPU-decode (torch.Tensor) path normalizes non-3-channel images."""
+
+    def _load(self, tensor):
+        # Patch the I/O hook so we can supply a synthetic decoded tensor.
+        import sglang.srt.multimodal.processors.base_processor as base_mod
+
+        original = base_mod.load_image
+        try:
+            base_mod.load_image = lambda data, gpu: (tensor, None)
+            return BaseMultimodalProcessor._load_single_item(
+                data=b"unused",
+                modality=Modality.IMAGE,
+                discard_alpha_channel=True,
+            )
+        finally:
+            base_mod.load_image = original
+
+    def test_grayscale_tensor_expanded_to_rgb(self):
+        gray = torch.zeros((1, 8, 8), dtype=torch.uint8)
+        out = self._load(gray)
+        self.assertEqual(out.shape, (3, 8, 8))
+
+    def test_la_tensor_expanded_to_rgb_drops_alpha(self):
+        la = torch.zeros((2, 8, 8), dtype=torch.uint8)
+        out = self._load(la)
+        self.assertEqual(out.shape, (3, 8, 8))
+
+    def test_rgba_tensor_drops_alpha(self):
+        rgba = torch.zeros((4, 8, 8), dtype=torch.uint8)
+        out = self._load(rgba)
+        self.assertEqual(out.shape, (3, 8, 8))
+
+    def test_rgb_tensor_passthrough(self):
+        rgb = torch.zeros((3, 8, 8), dtype=torch.uint8)
+        out = self._load(rgb)
+        # Same object — no normalization needed.
+        self.assertEqual(out.shape, (3, 8, 8))
+
+
+class TestMultimodalEmbeddingErrorIsolation(unittest.TestCase):
+    """Fix B: embed_mm_inputs translates encoder RuntimeError to typed error."""
+
+    def test_runtime_error_is_translated(self):
+        # Simulate a mm-input list with one image item whose embedder raises.
+        mm_item = MagicMock()
+        mm_item.is_modality = lambda modality: modality == Modality.IMAGE
+        mm_item.pad_value = 0
+        mm_item.offsets = [(0, 1)]
+        mm_inputs = MagicMock()
+        mm_inputs.mm_items = [mm_item]
+
+        def boom(items):
+            raise RuntimeError(
+                "mat1 and mat2 shapes cannot be multiplied (2520x256 and 768x1152)"
+            )
+
+        multimodal_model = MagicMock()
+        # get_image_feature -> raises
+        multimodal_model.get_image_feature = boom
+        # No deepstack
+        del multimodal_model.deepstack_visual_indexes
+
+        input_ids = torch.zeros(8, dtype=torch.long)
+        input_embedding = torch.nn.Embedding(32, 16)
+
+        with self.assertRaises(MultimodalEmbeddingError) as ctx:
+            embed_mm_inputs(
+                mm_inputs_list=[mm_inputs],
+                extend_prefix_lens=[0],
+                extend_seq_lens=[1],
+                input_ids=input_ids,
+                input_embedding=input_embedding,
+                multimodal_model=multimodal_model,
+            )
+
+        self.assertEqual(ctx.exception.modality, Modality.IMAGE)
+        self.assertEqual(ctx.exception.num_items, 1)
+        self.assertIsInstance(ctx.exception.original_error, RuntimeError)
+        self.assertIn("mat1 and mat2", str(ctx.exception.original_error))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #26751.

## Motivation

Two stacked bugs combined to make a single non-RGB image (e.g. a grayscale JPEG served by an upstream CDN) crash the entire Gemma-4 SGLang scheduler and restart the pod, dropping every unrelated in-flight request in the batch.

- **Bug A (Gemma-4 mm channel guard):** `base_processor._load_single_item` only applied RGB normalization to PIL images, so the GPU JPEG decode path (nvJPEG returning a torch.Tensor) skipped it. A 1-channel image reached `Gemma4VisionPatchEmbedder.input_proj` as patches of width `patch**2 * 1 = 256` instead of `patch**2 * 3 = 768`, crashing the linear layer.
- **Bug B (scheduler blast-radius):** that RuntimeError propagated unchecked through `embed_mm_inputs` / `run_batch` into the scheduler event loop, where the uncaught exception SIGQUITed the scheduler subprocess and took every unrelated in-flight request in the batch down with it.

See #26751 for the full traceback, the decisive `256` vs `768` math, production-impact numbers, and a minimal repro snippet.

> Draft because we do not have a free GPU on this exact rev to verify the end-to-end Gemma-4 run; CPU-only unit tests are included.

## What this PR changes

### Fix A1: tensor-aware RGB normalization (root cause)

`python/sglang/srt/multimodal/processors/base_processor.py::_load_single_item` (~line 535)

Extend the existing `discard_alpha_channel` branch to also handle `torch.Tensor` images:
- `C=1` (grayscale) -> expand to `C=3`
- `C=2` (LA: luminance + alpha) -> drop alpha, expand L to `C=3`
- `C=4` (RGBA) -> drop alpha
- `C=3` (RGB) -> passthrough

The PIL path is unchanged. This fixes the root cause for any model that depends on the loader's RGB normalization with `gpu_image_decode=True` (Gemma-3, Gemma-4, and any future model that follows the same pattern).

### Fix A2: defensive guard at the crash site

`python/sglang/srt/models/gemma4_vision.py::Gemma4VisionPatchEmbedder._patch_projection`

Compare `pixel_values.shape[-1]` to `input_proj.in_features` and raise a typed `ValueError` with a clear actionable message. Replaces the cryptic mat-mul shape mismatch with something that points the operator at the channel-normalization root cause.

### Fix B v1: typed exception + scheduler-side abort (partial blast-radius fix)

`python/sglang/srt/managers/mm_utils.py`

- New typed exception class `MultimodalEmbeddingError` (subclasses `RuntimeError`).
- Wrap the per-modality encoder call inside `embed_mm_inputs` (the call to `get_embedding_and_mask`) in a try/except that re-raises any `RuntimeError` as a `MultimodalEmbeddingError` carrying the modality, the number of items in the batch, and the original error chained via `from e`.

`python/sglang/srt/managers/scheduler.py`

- New `Scheduler._abort_batch_on_mm_error` helper. Iterates the failing batch's requests and sets `req.to_finish = FINISH_ABORT(..., err_type=\"MultimodalEmbeddingError\")` so each request gets a clean error response.
- Both `event_loop` and `event_loop_overlap` now catch `MultimodalEmbeddingError` around `run_batch(batch)` and call the helper, then `continue` the loop. The pod stays up.

This is a half-fix for the blast-radius: damage is limited from \"pod-wide\" to \"batch-wide\". Unrelated requests in the same batch are still aborted (with a typed error response rather than a connection drop). True per-request isolation is sketched in the issue as Fix B v2; I'd appreciate maintainer input on the right shape before implementing.

## Alternatives considered

### Why fix Fix A in `base_processor` and not directly in the Gemma-4 processor?

The user-visible bug is Gemma-4-specific, but the same hole exists for any model that:
- inherits `gpu_image_decode = True` (the default), and
- relies on the loader's `discard_alpha_channel` normalization rather than doing its own.

Fixing it in the loader closes the hole for everyone in one place, matches the spirit of the existing PIL `.convert(\"RGB\")` step that is already there, and is the minimum-surface change.

I also considered setting `do_convert_rgb=True` on the HF `Gemma4ImageProcessor` from the SGLang processor layer. That would only fix Gemma-4 and would not help any other model. We can still do it on top of this PR as defense in depth if maintainers prefer.

### Why catch the typed error at the scheduler event loop and not deeper?

The right scope for Fix B v1 is the smallest place where we have batch-level context (to abort the right requests) and the event loop's flow control (to skip the rest of the iteration without poisoning state). `run_batch` itself is the wrong layer: by the time the error reaches it, the entire forward batch has been built and committed, and there is no way to map the failure back to a specific item without retrying. The deeper per-item retry is the Fix B v2 territory.

### Why subclass `RuntimeError`?

`MultimodalEmbeddingError` is a `RuntimeError` because it wraps `RuntimeError`s from the encoder. Subclassing keeps existing `except Exception` / `except RuntimeError` callers downstream working the same way. The except inside `embed_mm_inputs` explicitly re-raises `MultimodalEmbeddingError` first so a nested call cannot accidentally re-wrap an already-typed error.

## Test Plan

What I ran locally:
- `python3 -m ruff check --select=F401,F821 <changed files>` -> All checks passed.
- `python3 -m black --check <changed files>` -> 5 files would be left unchanged.
- `python3 -m isort --check --diff <changed files>` -> no diff.
- AST-parsed every touched file (`python3 -c \"import ast; ast.parse(...)\"`).

What I added but could not execute locally (no torch on this box):
- `test/manual/vlm/test_gemma4_mm_channel_guard.py`
  - `TestChannelNormalizationTensorPath` — 1ch / 2ch / 4ch / 3ch tensors through `_load_single_item` with `discard_alpha_channel=True`; checks output shape is `(3, H, W)`.
  - `TestMultimodalEmbeddingErrorIsolation` — mock `multimodal_model.get_image_feature` to raise `RuntimeError(\"mat1 ... 256 ... 768 ...\")`; assert `embed_mm_inputs` raises `MultimodalEmbeddingError` with `modality == Modality.IMAGE`, `num_items == 1`, and the original error chained.

What needs maintainer / GPU CI verification:
- The end-to-end Gemma-4 path on a real GPU: send a 1-channel JPEG to a running Gemma-4 SGLang server, observe a clean per-request abort instead of a pod restart. I can provide a runnable repro script (in #26751) but I do not have a free GPU to validate this rev on.
- The overlap event-loop path: I traced through `result_queue` / `last_batch` interactions and convinced myself the `continue` does not strand a previous good batch's result, but a code review of the overlap loop interaction is warranted.
- No regression on non-mm batches and on healthy mm batches.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26669879418](https://github.com/sgl-project/sglang/actions/runs/26669879418)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26669879335](https://github.com/sgl-project/sglang/actions/runs/26669879335)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->