### PR TITLE
[Bug] ngram verify: keep `batch.seq_lens_sum` in sync after accept

### DIFF
--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -465,6 +465,8 @@ class NgramVerifyInput(SpecInput):
 
         batch.seq_lens.add_(self.num_accept_tokens)
         batch.seq_lens_cpu.add_(num_accept_tokens_cpu)
+        # Keep seq_lens_sum in sync; attn backends size kv_indices from it.
+        batch.seq_lens_sum += int(num_accept_tokens_cpu.sum())
 
         return logits_output, self.accept_tokens, num_correct_drafts
 


### PR DESCRIPTION
After ngram verify accepts tokens, `batch.seq_lens` / `batch.seq_lens_cpu` are bumped but `batch.seq_lens_sum` is left stale. The Triton attention backend's eager target_verify path (taken when batch size exceeds `cuda-graph-max-bs`) sizes `kv_indices` directly from `forward_batch.seq_lens_sum`, so the next verify under-allocates and `create_flashinfer_kv_indices_triton` writes OOB. Surfaces as `CUDA error: illegal memory access` at the next D2H sync.

This matches the pattern `dflash_info.py` already maintains ("Keep seq_lens_sum in sync; flashinfer indices updaters rely on this for buffer sizing").











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26669800116](https://github.com/sgl-project/sglang/actions/runs/26669800116)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #26669800003](https://github.com/sgl-project/sglang/actions/runs/26669800003)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->