### PR TITLE
[Fix] Keep DP-sharded mrope vision tensors on the compute device

### DIFF
--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -514,6 +514,12 @@ def run_dp_sharded_mrope_vision_model(
     if tp_size == 1:
         return vision_model(pixel_values, grid_thw=torch.tensor(grid_thw_list))
 
+    # Some models (e.g. Qwen3-VL/Qwen3.5) skip the pre-embed H2D copy and rely
+    # on this path to place features on the compute device. Resolve the vision
+    # model's device so the local slice and every image-less-rank placeholder
+    # below land on it instead of CPU, which would crash HCCL all_gather.
+    vision_device = next(vision_model.parameters()).device
+
     # GPU_0 tp_rank_local = 0
     # GPU_1 tp_rank_local = 1
     tp_rank_local = get_attention_tp_rank()
@@ -541,19 +547,21 @@ def run_dp_sharded_mrope_vision_model(
         cum_gpu_sample_counts[tp_rank_local] : cum_gpu_sample_counts[tp_rank_local + 1]
     ]
 
-    # Get the pixel values for the local images based on the image_idxs_local
+    # Get the pixel values for the local images based on the image_idxs_local.
+    # Slice on CPU (cheap indexing), then move only this rank's slice to the
+    # vision device so each DP rank does a single H2D of just its own share.
     if len(image_idxs_local) > 0:
         pixel_values_local = torch.cat(
             [
                 pixel_values[cum_patches_per_image[i] : cum_patches_per_image[i + 1]]
                 for i in image_idxs_local
             ]
-        )
+        ).to(vision_device, non_blocking=True)
     else:
         # Handle case where this rank has no images
         pixel_values_local = torch.empty(
             (0, pixel_values.shape[1]),
-            device=pixel_values.device,
+            device=vision_device,
             dtype=pixel_values.dtype,
         )
     # embed_dim_reduction_factor = 2 * 2
@@ -585,7 +593,7 @@ def run_dp_sharded_mrope_vision_model(
             out_dim = getattr(vision_model.config, "hidden_size", None)
             image_embeds_local = torch.empty(
                 (0, embed_dim_reduction_factor, out_dim),
-                device=pixel_values.device,
+                device=vision_device,
                 dtype=pixel_values.dtype,
             )
     else:
@@ -598,7 +606,7 @@ def run_dp_sharded_mrope_vision_model(
             # Handle empty case
             image_embeds_local = torch.empty(
                 (0, vision_model.out_hidden_size),
-                device=pixel_values.device,
+                device=vision_device,
                 dtype=pixel_values.dtype,
             )
 


### PR DESCRIPTION
## Motivation

Multimodal serving for Qwen3-VL / Qwen3.5 crashes on Ascend NPU during the data-parallel vision encoder path:

```
RuntimeError: No backend type associated with device type cpu
  at get_attention_tp_group().all_gather(image_embeds_local_padded, dim=0)
```

Root cause: `_can_skip_pre_embed_feature_move` (added for the single-big-H2D optimization) intentionally skips the pre-embed host→device copy for the Qwen3-VL/Qwen3.5 family, leaving `pixel_values` on CPU. `run_dp_sharded_mrope_vision_model` then builds its local slice, the image-less-rank placeholders, and padding from `pixel_values.device` (CPU). On NPU the HCCL communicator has no CPU branch and aborts. On CUDA/AMD this only "works" because image-less ranks silently fall into the `is_cpu` `shm_allgather` path while image ranks use NCCL — a latent cross-rank collective mismatch.

## Modifications

- In `run_dp_sharded_mrope_vision_model` (`python/sglang/srt/multimodal/mm_utils.py`), resolve the vision model's device once via `next(vision_model.parameters()).device`.
- Move **only this rank's** sliced `pixel_values_local` to that device (`.to(vision_device, non_blocking=True)`), preserving the one-H2D-per-rank cost the prior in-`vision_model`-forward copy had — no full-tensor broadcast across ranks.
- Allocate the image-less-rank empty placeholders (`pixel_values_local`, both `image_embeds_local` branches) on `vision_device` instead of `pixel_values.device`, so every rank feeds the collective a device tensor and all ranks take the same NCCL/HCCL path.
- No behavior change for models that already pre-move features (`qwen2_5_vl`, `glm4v`, `kimi_k25`): `vision_device` equals the existing device, so the `.to()` is a no-op.

## Accuracy Tests

In progress — Qwen3-VL/Qwen3.5 multimodal accuracy run is ongoing and will be attached before final approval. The change is device-placement only; model output is unchanged (no compute/dtype change).
```plaintext
2026-05-30 05:15:14 - evalscope - INFO: Overall report table: 
+----------+-----------+----------+----------+-------+---------+---------+
| Model    | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+==========+===========+==========+==========+=======+=========+=========+
| untitled | gsm8k     | mean_acc | main     |  1319 |  0.9689 | default |
+----------+-----------+----------+----------+-------+---------+---------+
```

## Benchmarking and Profiling

Hardware: **Ascend 910C**. Workload: 1920×1080 image + text, 128 requests, concurrency 64. Baseline (main) cannot be benchmarked on this path — it crashes; this PR enables it (0 failed requests):

```
============ Serving Benchmark Result ============
Successful requests:        128        Failed requests:    0
Max concurrency:            64         Duration (s):       110.76
Request throughput (req/s): 1.16       Output tok/s:       295.84
Total token throughput:     330.51     Peak output tok/s:  700.00
Mean TTFT (ms):             31341.45   Median TTFT (ms):   30641.70   P99: 59113.99
Mean TPOT (ms):             63.85      Median TPOT (ms):   72.91      P99: 164.88
Mean ITL (ms):              168.18     Median ITL (ms):    74.63      P99: 2564.85
Mean E2EL (ms):             47622.13   Median E2EL (ms):   45323.24   P99: 90762.24
==================================================
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit) guide.
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests) guide.
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations) guide.
- [ ] Provide accuracy and speed benchmark results.
- [ ] Follow the SGLang code style guidance.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26675200322](https://github.com/sgl-project/sglang/actions/runs/26675200322)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26675200294](https://github.com/sgl-project/sglang/actions/runs/26675200294)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->