### PR TITLE
fix: split batched extra_key values

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -414,6 +414,7 @@ class GenerateReqInput(BaseReq):
         self._normalize_logprob_params(num)
         self._normalize_custom_logit_processor(num)
         self._normalize_bootstrap_params(num)
+        self._normalize_extra_key(num)
 
     def _expand_inputs(self, num):
         """Expand the main inputs (text, input_ids, input_embeds) for parallel sampling."""
@@ -616,6 +617,15 @@ class GenerateReqInput(BaseReq):
         elif isinstance(self.bootstrap_pair_key, list):
             self.bootstrap_pair_key = self.bootstrap_pair_key * self.parallel_sample_num
 
+    def _normalize_extra_key(self, num):
+        if self.extra_key is None or isinstance(self.extra_key, str):
+            return
+        if len(self.extra_key) != self.batch_size:
+            raise ValueError(
+                "The length of extra_key should be equal to the batch size."
+            )
+        self.extra_key = self.extra_key * self.parallel_sample_num
+
     def _validate_session_params(self):
         """Validate that session parameters are properly formatted."""
         if self.session_params is not None:
@@ -698,7 +708,11 @@ class GenerateReqInput(BaseReq):
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
             priority=self.priority,
-            extra_key=self.extra_key,
+            extra_key=(
+                self.extra_key[i]
+                if isinstance(self.extra_key, list)
+                else self.extra_key
+            ),
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,
@@ -1384,9 +1398,7 @@ class PauseGenerationReqInput(BaseReq):
     def __post_init__(self):
         allowed = ["abort", "retract", "in_place"]
         if self.mode not in allowed:
-            raise ValueError(
-                f"Invalid mode: {self.mode!r}. " f"Expected one of {allowed}."
-            )
+            raise ValueError(f"Invalid mode: {self.mode!r}. Expected one of {allowed}.")
 
 
 @dataclass

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -363,7 +363,8 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         """Test that single input_embeds are properly converted to batch when using parallel sampling."""
         # Test the specific case that was fixed: single input_embeds with n > 1
         req = GenerateReqInput(
-            input_embeds=[[0.1, 0.2, 0.3]], sampling_params={"n": 2}  # Single embedding
+            input_embeds=[[0.1, 0.2, 0.3]],
+            sampling_params={"n": 2},  # Single embedding
         )
         req.normalize_batch_and_arguments()
 
@@ -418,6 +419,47 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
         req.normalize_batch_and_arguments()
         self.assertEqual(req.lora_path, expected_lora_paths)
+
+    def test_extra_key_list_normalization(self):
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            extra_key=["tenant-A", "tenant-B"],
+        )
+
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req.extra_key, ["tenant-A", "tenant-B"])
+        self.assertEqual(req[0].extra_key, "tenant-A")
+        self.assertEqual(req[1].extra_key, "tenant-B")
+
+    def test_extra_key_list_with_parallel_sampling(self):
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            extra_key=["tenant-A", "tenant-B"],
+            sampling_params={"n": 2},
+        )
+
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(
+            req.extra_key,
+            ["tenant-A", "tenant-B", "tenant-A", "tenant-B"],
+        )
+        self.assertEqual(req[0].extra_key, "tenant-A")
+        self.assertEqual(req[1].extra_key, "tenant-B")
+        self.assertEqual(req[2].extra_key, "tenant-A")
+        self.assertEqual(req[3].extra_key, "tenant-B")
+
+    def test_extra_key_list_length_mismatch(self):
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            extra_key=["tenant-A"],
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "length of extra_key should be equal to the batch size"
+        ):
+            req.normalize_batch_and_arguments()
 
     def test_logprob_parameters_normalization(self):
         """Test normalization of logprob-related parameters."""


### PR DESCRIPTION
## Motivation

Fixes #26755.

`GenerateReqInput.extra_key` can be passed as a list for batched requests, but the batch split path kept the whole list on each sub-request. That can leave a list in the radix cache key path instead of the per-request value.

## Modifications

- Normalize list-valued `extra_key` during batch setup.
- Split `extra_key` in `GenerateReqInput.__getitem__`.
- Add unit coverage for plain batches, parallel sampling, and length mismatch.

## Accuracy Tests

Not applicable; this only changes request normalization.

## Speed Tests and Profiling

Not applicable.

## Local Checks

- `python -m ruff check python/sglang/srt/managers/io_struct.py test/registered/unit/managers/test_io_struct.py`
- `python -m ruff format --check python/sglang/srt/managers/io_struct.py test/registered/unit/managers/test_io_struct.py`
- `python -m compileall -q python/sglang/srt/managers/io_struct.py test/registered/unit/managers/test_io_struct.py`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26676460970](https://github.com/sgl-project/sglang/actions/runs/26676460970)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26676460923](https://github.com/sgl-project/sglang/actions/runs/26676460923)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->