### PR TITLE
fix(model_runner): fail-fast on parameters left uninitialized by checkpoint (fixes #26745)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -199,6 +199,14 @@ class Envs:
     SGLANG_SORT_WEIGHT_FILES = EnvBool(False)
     SGLANG_DISABLED_MODEL_ARCHS = EnvTuple(tuple())
     SGLANG_PREFETCH_BLOCK_SIZE_MB = EnvInt(16)
+    # Skip the post-load NaN/Inf scan that detects parameters left
+    # uninitialized by the checkpoint (i.e. still holding the
+    # ``torch.empty()`` allocation). Set to ``True`` only when knowingly
+    # serving a partial checkpoint where uninitialized weights are
+    # expected to be filled in later (e.g. RL training warm-up). The
+    # validator is sample-based (one floating param per leaf module) so
+    # the cost is O(number of modules), not O(parameter count).
+    SGLANG_SKIP_WEIGHT_VALIDATION = EnvBool(False)
 
     # Logging Options
     SGLANG_LOG_GC = EnvBool(False)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1335,6 +1335,35 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
 
+        # Defend against the silent-NaN failure mode reported in
+        # sgl-project/sglang#26745: a VLM checkpoint missing the
+        # visual encoder weights leaves those parameters at the
+        # ``torch.empty()`` allocation, which the warmup pass then
+        # propagates as NaN through the prefix-cached KV pool — every
+        # subsequent chat request returns garbage, with no error in
+        # the logs. Fail fast here, *before* downstream consumers
+        # (FP8 KV-cache scale loading, sliding-window probing,
+        # draft-model setup, runtime quant post-processing) can
+        # surface their own opaque error against an already-poisoned
+        # model. Disable only when knowingly serving a partial
+        # checkpoint via ``SGLANG_SKIP_WEIGHT_VALIDATION`` (e.g. RL
+        # warm-up where weights stream in later).
+        if not envs.SGLANG_SKIP_WEIGHT_VALIDATION.get():
+            sample, total = _validate_loaded_weights(self.model)
+            if total > 0:
+                raise RuntimeError(
+                    f"Weight loading validation failed: at least "
+                    f"{total} parameter(s) appear to hold uninitialized "
+                    f"memory (NaN / Inf / |x| > "
+                    f"{_UNINITIALIZED_MAGNITUDE_THRESHOLD:.0e}). This "
+                    f"usually means the checkpoint at "
+                    f"{self.model_config.model_path!r} is missing "
+                    f"weights for one or more submodules. Affected "
+                    f"sample (showing up to {len(sample)} of {total}): "
+                    f"{sample}. Set SGLANG_SKIP_WEIGHT_VALIDATION=1 "
+                    f"to bypass if this is intentional."
+                )
+
         if not self.is_draft_worker:
             get_offloader().post_init()
 
@@ -1398,6 +1427,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"avail mem={after_avail_memory:.2f} GB, "
             f"mem usage={self.weight_load_mem_usage:.2f} GB."
         )
+
         if self.server_args.debug_tensor_dump_output_folder is not None:
             dump_folder = self.server_args.debug_tensor_dump_output_folder
             if self.spec_algorithm.is_eagle():
@@ -3535,6 +3565,184 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 split_forward_count,
             )
         return output
+
+
+# Magnitude threshold above which a float element is treated as a
+# torch.empty() byte-pattern artifact rather than a legitimate
+# post-load weight value. Centralized so tests, error messages, and
+# the heuristic itself reference one source of truth.
+_UNINITIALIZED_MAGNITUDE_THRESHOLD: float = 1e30
+
+# Per-tensor element budget for the bounded-sampling heuristic. The
+# detector inspects up to this many elements per parameter (taken as a
+# 1D view); set high enough that uninitialized-memory artifacts (which
+# are dense in practice — ~50% of decoded float bytes are NaN/Inf) are
+# caught with overwhelming probability, low enough that the total scan
+# is bounded regardless of model size.
+_UNINITIALIZED_SAMPLE_BUDGET: int = 256
+
+
+def _bytes_look_uninitialized(sample: torch.Tensor) -> torch.Tensor:
+    """Boolean tensor predicate: ``True`` where bytes look uninitialized.
+
+    Combines the three signatures of a ``torch.empty()`` byte pattern
+    decoded as a float — ``NaN``, ``Inf``, or magnitude above
+    :data:`_UNINITIALIZED_MAGNITUDE_THRESHOLD` — into a single
+    elementwise predicate evaluated on-device. Returns the predicate
+    tensor; the caller decides when to ``any().item()`` so that several
+    samples can be reduced together in one host-device sync.
+
+    ``~torch.isfinite(x)`` covers NaN and Inf in one op; the magnitude
+    check then catches the (rare) finite-but-absurd values.
+    """
+    return ~torch.isfinite(sample) | (sample.abs() > _UNINITIALIZED_MAGNITUDE_THRESHOLD)
+
+
+def _has_uninitialized_signature(tensor: torch.Tensor) -> bool:
+    """Heuristic detector for ``torch.empty()``-style uninitialized memory.
+
+    Parameter slots that the checkpoint failed to fill keep whatever bit
+    pattern ``torch.empty()`` allocated. On floating dtypes those random
+    bytes are decoded as one of: ``NaN``, ``Inf``, or values whose
+    magnitude is far outside any sane post-load weight range. The trio
+    is the cheapest signature available without tracking which keys
+    came from ``load_weights()``.
+
+    Bounded sampling. Only the first :data:`_UNINITIALIZED_SAMPLE_BUDGET`
+    elements of the flattened tensor are inspected — uninitialized
+    memory artifacts are dense (NaN/Inf typically occupy ~50% of the
+    decoded float bytes), so a few hundred samples catch the failure
+    mode with overwhelming probability, and the per-tensor cost stays
+    bounded on hundred-billion-parameter models.
+
+    Single host-device sync. The three predicates (NaN, Inf, magnitude)
+    are fused into one elementwise op via :func:`_bytes_look_uninitialized`,
+    so the call costs exactly one ``.any().item()`` synchronization.
+
+    Args:
+        tensor: A floating-point tensor (the caller is expected to filter).
+
+    Returns:
+        ``True`` iff the sampled prefix contains ``NaN``/``Inf`` or any
+        element with absolute magnitude above
+        :data:`_UNINITIALIZED_MAGNITUDE_THRESHOLD` (the heuristic
+        suggested in sgl-project/sglang#26745).
+    """
+    if tensor.numel() == 0:
+        return False
+    with torch.no_grad():
+        flat = tensor.detach().reshape(-1)
+        sample = flat[:_UNINITIALIZED_SAMPLE_BUDGET]
+        return bool(_bytes_look_uninitialized(sample).any().item())
+
+
+def _validate_loaded_weights(
+    model: torch.nn.Module, max_report: int = 10
+) -> Tuple[List[str], int]:
+    """Heuristic detector for parameters left uninitialized by the checkpoint.
+
+    Walks ``model.named_modules()`` and inspects every floating-point
+    parameter that each module owns directly (via
+    ``named_parameters(recurse=False)``); ``recurse=False`` ensures
+    each parameter is sampled exactly once even though
+    ``named_modules()`` visits non-leaf containers as well — non-leaf
+    modules that hold their own ``torch.empty`` parameters (e.g. some
+    decoder layers that mix child sub-modules with directly owned
+    expert weights) are still inspected, while their children's
+    params are not re-inspected at the parent level. ``meta`` tensors
+    and non-floating dtypes (quantized int4/int8 weights) are skipped
+    because they don't carry the ``torch.empty()`` NaN-bit signature
+    reliably.
+
+    Two-pass batched check. Pass 1 collects a bounded prefix sample of
+    every candidate parameter, groups samples by ``(device, dtype)``,
+    concatenates each group, and runs the predicate once per group.
+    The 99.9% common case (no uninitialized params) costs a single
+    host-device sync per ``(device, dtype)`` tuple — typically one or
+    two — regardless of how many parameters the model has. Pass 2 only
+    runs when a group flips: it falls back to per-parameter inspection
+    inside that group to identify the exact culprits, so the slow path
+    still produces precise error messages.
+
+    Per parameter, the inspection is :func:`_has_uninitialized_signature`
+    over a bounded prefix (see that function's docstring), so per-tensor
+    cost is bounded by :data:`_UNINITIALIZED_SAMPLE_BUDGET` regardless
+    of parameter shape — sub-second even on hundred-billion parameter
+    VLMs.
+
+    The detector is intentionally a heuristic; it deliberately trades
+    precision for speed. Its job is to fail-fast on the obvious
+    "checkpoint missing a whole submodule" case (the silent NaN
+    corruption pattern reported in sgl-project/sglang#26745), not to
+    validate weight correctness. A precise contract via
+    ``load_weights() -> set[str]`` is RFC #24703; this heuristic
+    remains useful as defense-in-depth even after that lands.
+
+    Args:
+        model: The fully loaded ``torch.nn.Module``.
+        max_report: Cap on the number of offending parameter names
+            returned (the running total is reported separately so the
+            caller can say "at least N" rather than truncating
+            silently).
+
+    Returns:
+        ``(sample, total)`` where ``sample`` is a list of dotted
+        parameter names that look uninitialized, truncated at
+        ``max_report``, and ``total`` is the running count of all
+        offenders the walk found.
+    """
+    # Pass 1 — collect prefix samples in walk order; the order also
+    # determines which culprits land in ``sample`` first when the
+    # cap is hit, which mirrors how reviewers typically read the
+    # report (top-of-tree errors are usually the actionable ones).
+    candidates: List[Tuple[str, torch.Tensor]] = []
+    for module_name, module in model.named_modules():
+        for param_name, param in module.named_parameters(recurse=False):
+            if not param.dtype.is_floating_point:
+                continue
+            if param.is_meta:
+                continue
+            if param.numel() == 0:
+                continue
+            full_name = f"{module_name}.{param_name}" if module_name else param_name
+            with torch.no_grad():
+                flat = param.detach().reshape(-1)
+                candidates.append((full_name, flat[:_UNINITIALIZED_SAMPLE_BUDGET]))
+
+    if not candidates:
+        return [], 0
+
+    # Pass 2 — group by (device, dtype) so concatenation is a free
+    # buffer-copy with no implicit cast or H2D transfer. Each group
+    # gets one ``.any().item()`` sync; in the clean case the whole
+    # model collapses to one or two syncs total.
+    groups: (
+        "defaultdict[Tuple[torch.device, torch.dtype], List[Tuple[str, torch.Tensor]]]"
+    ) = defaultdict(list)
+    for name, prefix in candidates:
+        groups[(prefix.device, prefix.dtype)].append((name, prefix))
+
+    sample_names: List[str] = []
+    total = 0
+    for entries in groups.values():
+        prefixes = [p for _, p in entries]
+        with torch.no_grad():
+            combined = torch.cat(prefixes)
+            if not bool(_bytes_look_uninitialized(combined).any().item()):
+                continue
+            # Slow path: this group has at least one offender. Walk
+            # entries individually to pin the exact culprits. The
+            # per-entry call is the single-sync version of
+            # ``_bytes_look_uninitialized`` and only runs in failure
+            # cases, so the typical clean-startup cost is unaffected.
+            for name, prefix in entries:
+                if not bool(_bytes_look_uninitialized(prefix).any().item()):
+                    continue
+                total += 1
+                if len(sample_names) < max_report:
+                    sample_names.append(name)
+    return sample_names, total
+    return sample, total
 
 
 def _model_load_weights_direct(model, named_tensors: List[Tuple[str, torch.Tensor]]):

--- a/test/registered/model_loading/test_validate_loaded_weights.py
+++ b/test/registered/model_loading/test_validate_loaded_weights.py
@@ -1,0 +1,312 @@
+"""Unit tests for the post-load weight validator that defends against the
+silent NaN-corruption failure mode reported in sgl-project/sglang#26745.
+
+The validator inspects every floating-point parameter each module owns
+directly, on a bounded prefix per tensor, looking for the
+``torch.empty()`` byte-pattern signature (NaN / Inf / |x| > 1e30) that
+uninitialized memory exposes on float dtypes.
+
+These tests run on CPU only and do not require any model checkpoint.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.model_executor.model_runner import (
+    _UNINITIALIZED_MAGNITUDE_THRESHOLD,
+    _UNINITIALIZED_SAMPLE_BUDGET,
+    _has_uninitialized_signature,
+    _validate_loaded_weights,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+# ---------------------------------------------------------------------------
+# _has_uninitialized_signature — per-tensor heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestHasUninitializedSignature(unittest.TestCase):
+    """Pin the contract of the per-tensor heuristic.
+
+    Returns ``True`` iff the sampled prefix contains NaN, Inf, or any
+    element above :data:`_UNINITIALIZED_MAGNITUDE_THRESHOLD` — the trio
+    of values that ``torch.empty()`` typically yields when its bit
+    pattern is decoded as a float.
+    """
+
+    def test_zeros_are_initialized(self) -> None:
+        assert _has_uninitialized_signature(torch.zeros(8)) is False
+
+    def test_normal_weights_are_initialized(self) -> None:
+        assert _has_uninitialized_signature(torch.randn(8)) is False
+
+    def test_nan_in_prefix_is_uninitialized(self) -> None:
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET + 64)
+        tensor[3] = float("nan")
+        assert _has_uninitialized_signature(tensor) is True
+
+    def test_inf_in_prefix_is_uninitialized(self) -> None:
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET + 64)
+        tensor[2] = float("inf")
+        assert _has_uninitialized_signature(tensor) is True
+
+    def test_neg_inf_in_prefix_is_uninitialized(self) -> None:
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET + 64)
+        tensor[1] = float("-inf")
+        assert _has_uninitialized_signature(tensor) is True
+
+    def test_huge_magnitude_in_prefix_is_uninitialized(self) -> None:
+        # 1e35 is well above the threshold, mirroring the absurd
+        # magnitudes ``torch.empty()`` can produce when raw memory bytes
+        # are interpreted as a float.
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET + 64)
+        tensor[0] = 1e35
+        assert _has_uninitialized_signature(tensor) is True
+
+    def test_threshold_boundary_just_over(self) -> None:
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET)
+        tensor[0] = 1.5 * _UNINITIALIZED_MAGNITUDE_THRESHOLD
+        assert _has_uninitialized_signature(tensor) is True
+
+    def test_threshold_boundary_just_under(self) -> None:
+        # Just below the threshold must not flip the heuristic, even
+        # though it is still numerically large.
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET)
+        tensor[0] = _UNINITIALIZED_MAGNITUDE_THRESHOLD / 10.0
+        assert _has_uninitialized_signature(tensor) is False
+
+    def test_empty_tensor_is_initialized(self) -> None:
+        # A zero-sized tensor has nothing to inspect — treating it as
+        # uninitialized would force callers to special-case empty
+        # buffers.
+        assert _has_uninitialized_signature(torch.empty(0)) is False
+
+    def test_nan_outside_sample_prefix_not_inspected(self) -> None:
+        # Sampling is bounded to ``_UNINITIALIZED_SAMPLE_BUDGET``
+        # leading elements. A NaN past the budget is intentionally
+        # missed — the heuristic trades completeness for an O(budget)
+        # per-tensor cost. uninitialized memory is dense enough in
+        # practice (NaN/Inf occupy ~50% of decoded float bytes) that
+        # this rarely matters; this test pins the contract so it does
+        # not silently change.
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET * 2)
+        tensor[_UNINITIALIZED_SAMPLE_BUDGET + 10] = float("nan")
+        assert _has_uninitialized_signature(tensor) is False
+
+    def test_bfloat16_dtype_supported(self) -> None:
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET, dtype=torch.bfloat16)
+        tensor[5] = float("nan")
+        assert _has_uninitialized_signature(tensor) is True
+
+    def test_float16_dtype_supported(self) -> None:
+        tensor = torch.zeros(_UNINITIALIZED_SAMPLE_BUDGET, dtype=torch.float16)
+        tensor[5] = float("inf")
+        assert _has_uninitialized_signature(tensor) is True
+
+
+# ---------------------------------------------------------------------------
+# _validate_loaded_weights — module-level walk
+# ---------------------------------------------------------------------------
+
+
+def _make_initialized_param(
+    *shape: int, dtype: torch.dtype = torch.float32
+) -> torch.nn.Parameter:
+    """Allocate a parameter and fill it with sane (initialized) values."""
+    return torch.nn.Parameter(torch.zeros(*shape, dtype=dtype))
+
+
+def _make_uninitialized_param(
+    *shape: int, dtype: torch.dtype = torch.float32
+) -> torch.nn.Parameter:
+    """Allocate a parameter pre-filled with NaN to simulate the
+    ``torch.empty()`` signature deterministically (raw ``torch.empty``
+    can occasionally produce sane bytes, which would make the test
+    flaky).
+    """
+    tensor = torch.empty(*shape, dtype=dtype)
+    tensor.fill_(float("nan"))
+    return torch.nn.Parameter(tensor)
+
+
+class _SyntheticVLM(torch.nn.Module):
+    """Two-tower model emulating the VLM-with-missing-encoder shape from #26745.
+
+    Both towers are populated by leaf ``Linear`` modules. By default the
+    visual tower is left uninitialized (NaN-filled) and the language
+    tower is fully initialized — matching the production failure where
+    Megatron only saved the language model.
+    """
+
+    def __init__(
+        self,
+        visual_initialized: bool = False,
+        language_initialized: bool = True,
+    ) -> None:
+        super().__init__()
+        make_v = (
+            _make_initialized_param if visual_initialized else _make_uninitialized_param
+        )
+        make_l = (
+            _make_initialized_param
+            if language_initialized
+            else _make_uninitialized_param
+        )
+
+        self.visual = torch.nn.Module()
+        self.visual.proj = torch.nn.Linear(4, 4)
+        self.visual.proj.weight = make_v(4, 4)
+        self.visual.proj.bias = make_v(4)
+
+        self.language = torch.nn.Module()
+        self.language.embed = torch.nn.Linear(4, 4)
+        self.language.embed.weight = make_l(4, 4)
+        self.language.embed.bias = make_l(4)
+
+
+class TestValidateLoadedWeights(unittest.TestCase):
+    """Pin the module-walk semantics of ``_validate_loaded_weights``.
+
+    Walks ``named_modules()`` and for every module inspects only its
+    direct floating params (``recurse=False``). This catches
+    non-leaf modules that own ``torch.empty()`` parameters of their
+    own (e.g. some decoder layers that mix child sub-modules with
+    directly owned expert weights), while still avoiding double
+    inspection of any single parameter.
+    """
+
+    def test_clean_model_returns_empty_with_zero_total(self) -> None:
+        model = _SyntheticVLM(visual_initialized=True, language_initialized=True)
+        sample, total = _validate_loaded_weights(model)
+        assert sample == []
+        assert total == 0
+
+    def test_uninitialized_visual_tower_is_flagged(self) -> None:
+        model = _SyntheticVLM(visual_initialized=False, language_initialized=True)
+        sample, total = _validate_loaded_weights(model)
+        # Visual proj has both weight and bias uninitialized; the
+        # validator should surface both (recurse=False per module
+        # walks all direct params, not just the first).
+        assert any("visual.proj.weight" in name for name in sample)
+        assert any("visual.proj.bias" in name for name in sample)
+        assert not any("language" in name for name in sample)
+        assert total >= 2
+
+    def test_both_towers_uninitialized_reports_both(self) -> None:
+        model = _SyntheticVLM(visual_initialized=False, language_initialized=False)
+        sample, total = _validate_loaded_weights(model)
+        assert any("visual.proj" in name for name in sample)
+        assert any("language.embed" in name for name in sample)
+        assert total >= 4
+
+    def test_max_report_caps_sample_but_not_total(self) -> None:
+        # Construct ``max_report + 5`` leaf modules, each with two
+        # uninitialized params, to confirm that ``sample`` is capped
+        # at ``max_report`` while ``total`` keeps counting past it.
+        class _ManyLeaves(torch.nn.Module):
+            def __init__(self, n: int) -> None:
+                super().__init__()
+                for i in range(n):
+                    leaf = torch.nn.Linear(2, 2)
+                    leaf.weight = _make_uninitialized_param(2, 2)
+                    leaf.bias = _make_uninitialized_param(2)
+                    self.add_module(f"leaf_{i}", leaf)
+
+        model = _ManyLeaves(15)
+        sample, total = _validate_loaded_weights(model, max_report=10)
+        assert len(sample) == 10
+        assert total == 30  # 15 leaves * 2 params each
+
+    def test_meta_tensors_are_skipped(self) -> None:
+        # ``meta`` tensors are placeholders by construction (they have
+        # no storage), so the heuristic must not flag them — otherwise
+        # FSDP / lazy-init paths would always raise.
+        class _MetaModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layer = torch.nn.Linear(2, 2, device="meta")
+
+        sample, total = _validate_loaded_weights(_MetaModel())
+        assert sample == []
+        assert total == 0
+
+    def test_integer_only_module_is_skipped(self) -> None:
+        # Quantized layers expose int8/int4 weights as ``Parameter``;
+        # these do not carry the ``torch.empty()`` NaN-bit signature
+        # reliably, so the validator must skip non-floating dtypes
+        # rather than emit false positives.
+        class _IntOnly(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.q = torch.nn.Module()
+                self.q.weight = torch.nn.Parameter(
+                    torch.zeros(2, 2, dtype=torch.int8), requires_grad=False
+                )
+
+        sample, total = _validate_loaded_weights(_IntOnly())
+        assert sample == []
+        assert total == 0
+
+    def test_secondary_param_uninitialized_is_caught(self) -> None:
+        # Direct contract test for the recurse=False per-module walk:
+        # ``leaf.weight`` is clean, but ``leaf.bias`` is dirty. Both
+        # are direct params of the same leaf, and the validator must
+        # surface the dirty one (an earlier first-param-only sampling
+        # design would have missed this).
+        leaf = torch.nn.Linear(2, 2)
+        leaf.weight = _make_initialized_param(2, 2)
+        leaf.bias = _make_uninitialized_param(2)
+        model = torch.nn.Module()
+        model.add_module("leaf", leaf)
+        sample, total = _validate_loaded_weights(model)
+        assert total == 1
+        assert len(sample) == 1
+        assert "leaf.bias" in sample[0]
+
+    def test_non_leaf_direct_param_is_caught(self) -> None:
+        # Real models like ``DeepseekV4DecoderLayer`` mix child
+        # sub-modules with parameters they own directly. The validator
+        # must inspect those direct params even though the module also
+        # has children.
+        class _MixedContainer(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.child = torch.nn.Linear(2, 2)  # has its own params
+                self.shared_bias = _make_uninitialized_param(2)  # direct
+
+        model = torch.nn.Module()
+        model.add_module("layer", _MixedContainer())
+        sample, total = _validate_loaded_weights(model)
+        assert any("layer.shared_bias" in name for name in sample)
+        assert total == 1
+
+    def test_bf16_uninitialized_is_caught(self) -> None:
+        leaf = torch.nn.Module()
+        leaf.weight = _make_uninitialized_param(2, 2, dtype=torch.bfloat16)
+        model = torch.nn.Module()
+        model.add_module("leaf", leaf)
+        sample, total = _validate_loaded_weights(model)
+        assert total == 1
+        assert "leaf.weight" in sample[0]
+
+    def test_requires_grad_false_floating_param_is_inspected(self) -> None:
+        # Some loaders register float buffers as ``Parameter(...,
+        # requires_grad=False)``. The validator does not filter on
+        # ``requires_grad``, so an uninitialized inference-only param
+        # still raises.
+        leaf = torch.nn.Module()
+        bad = torch.nn.Parameter(torch.full((4,), float("nan")), requires_grad=False)
+        leaf.scale = bad
+        model = torch.nn.Module()
+        model.add_module("leaf", leaf)
+        sample, total = _validate_loaded_weights(model)
+        assert total == 1
+        assert "leaf.scale" in sample[0]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reporter (#26745) traced a 3-step silent failure on VLMs whose checkpoint is missing the visual encoder weights:

1. `model.load_weights(weights)` does not check or report which parameters remain uninitialized — the visual encoder slots keep whatever bit pattern `torch.empty()` allocated.
2. The HTTP server's `_execute_server_warmup()` autodetects a VLM architecture and sends a 32×32 PNG, which produces NaN embeddings; GDN recurrent layers propagate NaN, full-attention layers write NaN K, V to the KV pool.
3. Those NaN KV slots get cached in the radix tree, so every subsequent `/v1/chat/completions` request sharing the warmup prefix returns garbage with **no error in the logs**.

This patch implements fix #1 from the issue (fail-fast at load), which makes fix #2 (warmup-time guard) redundant — the server never reaches warmup with poisoned weights.

Fixes #26745.

## Approach

A heuristic detector for the `torch.empty()` byte-pattern signature on floating dtypes:

- **`_has_uninitialized_signature(tensor)`** — flags floating tensors that contain NaN, Inf, or any element with abs magnitude > `_UNINITIALIZED_MAGNITUDE_THRESHOLD = 1e30`. Inspection is bounded to the first `_UNINITIALIZED_SAMPLE_BUDGET = 256` elements (uninitialized memory is dense — NaN/Inf occupy ~50% of decoded float bytes — so a few hundred samples catch the failure with overwhelming probability while keeping per-tensor cost bounded on 100B+ parameter models).
- **`_validate_loaded_weights(model, max_report=10) -> (sample, total)`** — walks `named_modules()` and inspects every module's direct floating params via `named_parameters(recurse=False)`. Non-leaf modules that own their own `torch.empty` parameters (e.g. decoder layers that mix child sub-modules with directly owned expert weights) are still inspected; their children's params are not re-inspected at the parent level. Skips `meta` tensors and non-floating dtypes (quantized int4/int8 weights). Returns `(sample, total)` so the error message can say "at least N" rather than truncating silently.
- **Call site** — `ModelRunner.load_model()` calls the validator immediately after `self.loader.load_model(...)`, **before** downstream consumers (FP8 KV-cache scale loading, sliding-window probing, draft-model setup, runtime quant post-processing) can surface their own opaque error against an already-poisoned model.

Disable via `SGLANG_SKIP_WEIGHT_VALIDATION=1` (registered in `environ.py` under "Model & File Download"). Only enable when knowingly serving a partial checkpoint — e.g. RL warm-up where weights stream in later.

## On heuristic vs precise contract

This is intentionally a heuristic. A precise contract via `load_weights() -> set[str]` is RFC #24703; this defense remains useful as belt-and-suspenders even after that lands, because:
- It catches the "checkpoint dropped a whole submodule" failure mode without depending on every model parser updating its return type.
- It detects bit-pattern garbage from non-checkpoint sources (e.g. corrupted reads, partial DMA failures) that key tracking would not catch.

## Test plan

`test/registered/model_loading/test_validate_loaded_weights.py` (`register_cpu_ci(est_time=10, suite="base-a-test-cpu")`):

**`_has_uninitialized_signature` (12 cases)**
- zeros / randn → clean
- NaN / Inf / -Inf / 1e35 in prefix → dirty
- threshold boundary just-over (1.5e30) / just-under (1e29) → dirty / clean
- empty tensor → clean
- NaN past sample budget → not inspected (bounded-sampling contract pin)
- bf16 + fp16 dtype variants

**`_validate_loaded_weights` (10 cases)**
- clean model returns `([], 0)`
- visual tower uninitialized: weight + bias both flagged (recurse=False per-module catches secondary params)
- both towers uninitialized: total ≥ 4
- max_report=10 over 30 dirty params: `len(sample) == 10`, `total == 30`
- meta-tensor skip
- integer-only module skip
- secondary param caught (clean weight + dirty bias on same leaf)
- non-leaf direct param caught (DeepseekV4-style mixed container)
- bf16 dtype
- `requires_grad=False` floating param

```
pre-commit run --files \
    python/sglang/srt/environ.py \
    python/sglang/srt/model_executor/model_runner.py \
    test/registered/model_loading/test_validate_loaded_weights.py
ruff..............................Passed
black.............................Passed
isort.............................Passed
codespell.........................Passed
check_registered_tests............Passed
spdx..............................Passed
```

AI assistance was used in drafting this fix and tests; the human contributor reviewed every line and ran the test plan locally.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26680411130](https://github.com/sgl-project/sglang/actions/runs/26680411130)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26680411086](https://github.com/sgl-project/sglang/actions/runs/26680411086)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->