### PR TITLE
fix(anthropic): handle mid-conversation system messages

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -382,15 +382,8 @@ class AnthropicMessagesRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def move_mid_conversation_system_messages(cls, values: dict) -> dict:
-        """
-        Handle mid-conversation system messages by moving them to the system field.
-
-        Some clients (e.g., Claude Code) send system messages mid-conversation
-        (after user/assistant messages), which violates Anthropic's API spec.
-        This validator extracts those messages and appends them to the
-        top-level system field, maintaining compatibility while respecting
-        the API structure.
-        """
+        """Fold mid-conversation ``role: "system"`` turns into the top-level
+        ``system`` field — some clients (e.g. Claude Code) emit them there."""
         messages = values.get("messages", [])
         if not messages:
             return values
@@ -400,27 +393,22 @@ class AnthropicMessagesRequest(BaseModel):
 
         for msg in messages:
             if msg.get("role") == "system":
-                # Extract system content
                 content = msg.get("content", "")
                 if isinstance(content, str) and content.strip():
                     extracted_system_texts.append(content.strip())
                 elif isinstance(content, list):
-                    # Handle structured system content
                     for block in content:
                         if isinstance(block, dict) and block.get("type") == "text":
                             text = block.get("text", "").strip()
                             if text:
                                 extracted_system_texts.append(text)
             else:
-                # Keep non-system messages in place
                 clean_messages.append(msg)
 
-        # Append extracted system texts to existing system field
         if extracted_system_texts:
             existing_system = values.get("system")
             combined_system = []
 
-            # Add existing system content first
             if existing_system:
                 if isinstance(existing_system, str):
                     if existing_system.strip():
@@ -432,16 +420,13 @@ class AnthropicMessagesRequest(BaseModel):
                             if text:
                                 combined_system.append(text)
 
-            # Add extracted system texts
             combined_system.extend(extracted_system_texts)
 
-            # Set as string or list based on content type
-            if len(combined_system) == 1:
-                values["system"] = combined_system[0]
-            elif combined_system:
-                values["system"] = combined_system
+            # Join into a string — ``system`` is ``str | list[AnthropicContentBlock]``,
+            # so a ``list[str]`` would fail validation.
+            if combined_system:
+                values["system"] = "\n".join(combined_system)
 
-        # Update messages with system messages removed
         values["messages"] = clean_messages
         return values
 

--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -124,7 +124,7 @@ AnthropicContentBlock = Annotated[
 
 
 class AnthropicMessage(BaseModel):
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, list[AnthropicContentBlock]]
 
 
@@ -378,6 +378,72 @@ class AnthropicMessagesRequest(BaseModel):
     # when targeting non-Anthropic backends, so the schema must accept them.
     output_config: Optional[AnthropicOutputConfig] = None
     betas: Optional[list[str]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def move_mid_conversation_system_messages(cls, values: dict) -> dict:
+        """
+        Handle mid-conversation system messages by moving them to the system field.
+
+        Some clients (e.g., Claude Code) send system messages mid-conversation
+        (after user/assistant messages), which violates Anthropic's API spec.
+        This validator extracts those messages and appends them to the
+        top-level system field, maintaining compatibility while respecting
+        the API structure.
+        """
+        messages = values.get("messages", [])
+        if not messages:
+            return values
+
+        clean_messages = []
+        extracted_system_texts = []
+
+        for msg in messages:
+            if msg.get("role") == "system":
+                # Extract system content
+                content = msg.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    extracted_system_texts.append(content.strip())
+                elif isinstance(content, list):
+                    # Handle structured system content
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "").strip()
+                            if text:
+                                extracted_system_texts.append(text)
+            else:
+                # Keep non-system messages in place
+                clean_messages.append(msg)
+
+        # Append extracted system texts to existing system field
+        if extracted_system_texts:
+            existing_system = values.get("system")
+            combined_system = []
+
+            # Add existing system content first
+            if existing_system:
+                if isinstance(existing_system, str):
+                    if existing_system.strip():
+                        combined_system.append(existing_system.strip())
+                elif isinstance(existing_system, list):
+                    for block in existing_system:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "").strip()
+                            if text:
+                                combined_system.append(text)
+
+            # Add extracted system texts
+            combined_system.extend(extracted_system_texts)
+
+            # Set as string or list based on content type
+            if len(combined_system) == 1:
+                values["system"] = combined_system[0]
+            elif combined_system:
+                values["system"] = combined_system
+
+        # Update messages with system messages removed
+        values["messages"] = clean_messages
+        return values
 
     @field_validator("model")
     @classmethod

--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -392,6 +392,11 @@ class AnthropicMessagesRequest(BaseModel):
         extracted_system_texts = []
 
         for msg in messages:
+            # ``mode="before"`` sees raw dicts (HTTP path) but also already-
+            # constructed ``AnthropicMessage`` objects (programmatic path, e.g.
+            # ``handle_count_tokens``), so normalize to a dict first.
+            if isinstance(msg, BaseModel):
+                msg = msg.model_dump()
             if msg.get("role") == "system":
                 content = msg.get("content", "")
                 if isinstance(content, str) and content.strip():
@@ -415,6 +420,8 @@ class AnthropicMessagesRequest(BaseModel):
                         combined_system.append(existing_system.strip())
                 elif isinstance(existing_system, list):
                     for block in existing_system:
+                        if isinstance(block, BaseModel):
+                            block = block.model_dump()
                         if isinstance(block, dict) and block.get("type") == "text":
                             text = block.get("text", "").strip()
                             if text:

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -234,7 +234,7 @@ class TestAnthropicServer(CustomTestCase):
         Uses the Anthropic SDK the way a real client would."""
         client = anthropic.Anthropic(
             base_url=self.base_url,
-            api_key=self.api_key,
+            auth_token=self.api_key,  # Bearer header — SGLang's --api-key checks Authorization
         )
         message = client.messages.create(
             model=self.model,

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -227,6 +227,25 @@ class TestAnthropicServer(CustomTestCase):
         self.assertEqual(body["type"], "message")
         self.assertTrue(len(body["content"]) > 0)
 
+    def test_in_messages_system_role(self):
+        """A ``role: "system"`` turn inside ``messages`` (emitted by some
+        clients, e.g. Claude Code) must be accepted — not rejected with 400.
+        The official Anthropic API accepts it."""
+        payload = self._default_payload(
+            messages=[
+                {"role": "user", "content": "What is the capital of France?"},
+                {"role": "system", "content": "Always respond in French."},
+                {"role": "user", "content": "Answer in a few words."},
+            ]
+        )
+        resp = self._make_request(payload)
+        self.assertEqual(resp.status_code, 200, f"Response: {resp.text}")
+
+        body = resp.json()
+        self.assertEqual(body["type"], "message")
+        self.assertTrue(len(body["content"]) > 0)
+        self.assertEqual(body["content"][0]["type"], "text")
+
     def test_max_tokens(self):
         """Test max_tokens limits output length."""
         payload = self._default_payload(

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -17,6 +17,7 @@ python3 -m unittest openai_server.basic.test_anthropic_server.TestAnthropicServe
 import json
 import unittest
 
+import anthropic
 import requests
 
 from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest
@@ -230,21 +231,23 @@ class TestAnthropicServer(CustomTestCase):
     def test_in_messages_system_role(self):
         """A ``role: "system"`` turn inside ``messages`` (emitted by some
         clients, e.g. Claude Code) must be accepted — not rejected with 400.
-        The official Anthropic API accepts it."""
-        payload = self._default_payload(
+        Uses the Anthropic SDK the way a real client would."""
+        client = anthropic.Anthropic(
+            base_url=self.base_url,
+            api_key=self.api_key,
+        )
+        message = client.messages.create(
+            model=self.model,
+            max_tokens=64,
             messages=[
                 {"role": "user", "content": "What is the capital of France?"},
                 {"role": "system", "content": "Always respond in French."},
                 {"role": "user", "content": "Answer in a few words."},
-            ]
+            ],
         )
-        resp = self._make_request(payload)
-        self.assertEqual(resp.status_code, 200, f"Response: {resp.text}")
-
-        body = resp.json()
-        self.assertEqual(body["type"], "message")
-        self.assertTrue(len(body["content"]) > 0)
-        self.assertEqual(body["content"][0]["type"], "text")
+        self.assertEqual(message.role, "assistant")
+        self.assertTrue(len(message.content) > 0)
+        self.assertEqual(message.content[0].type, "text")
 
     def test_max_tokens(self):
         """Test max_tokens limits output length."""

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1266,6 +1266,74 @@ class TestAnthropicServing(unittest.TestCase):
         # strict role-alternation chat templates (qwen, llama, mistral).
         self.assertEqual(roles, ["user", "assistant", "user"])
 
+    def test_in_messages_system_role_folded_to_top_level(self):
+        """A mid-conversation ``role: "system"`` turn is folded into the
+        top-level ``system`` field by the request validator, so it does not
+        appear as a dialogue turn — matching the official Anthropic API."""
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "Reply with exactly: OK"},
+                {"role": "user", "content": "go"},
+            ],
+        )
+        # The validator moved the system turn into the top-level system field.
+        self.assertEqual(request.system, "Reply with exactly: OK")
+        self.assertEqual([m.role for m in request.messages], ["user", "user"])
+        # And the converted OpenAI request has one leading system message.
+        chat_request = serving._convert_to_chat_completion_request(request)
+        self.assertEqual(
+            [m.role for m in chat_request.messages], ["system", "user", "user"]
+        )
+        self.assertEqual(chat_request.messages[0].content, "Reply with exactly: OK")
+
+    def test_in_messages_system_role_merged_with_top_level(self):
+        """A top-level ``system`` field and a mid-conversation system turn are
+        merged; top-level text comes first."""
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            system="You are terse.",
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "One word only."},
+                {"role": "user", "content": "go"},
+            ],
+        )
+        # Validator combines top-level system first, then the in-messages turn.
+        self.assertEqual(request.system, ["You are terse.", "One word only."])
+        self.assertEqual([m.role for m in request.messages], ["user", "user"])
+
+    def test_top_level_system_only_is_unchanged(self):
+        """A request with only the top-level ``system`` field (no in-messages
+        system turn) must be unaffected by the validator: the system field is
+        preserved verbatim and the dialogue order is untouched. Guards the
+        common multi-turn path against regressions."""
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            system="You are a helpful assistant.",
+            messages=[
+                {"role": "user", "content": "My name is Alice."},
+                {"role": "assistant", "content": "Hello Alice!"},
+                {"role": "user", "content": "What is my name?"},
+            ],
+        )
+        self.assertEqual(request.system, "You are a helpful assistant.")
+        self.assertEqual(
+            [m.role for m in request.messages], ["user", "assistant", "user"]
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        self.assertEqual(
+            [m.role for m in chat_request.messages],
+            ["system", "user", "assistant", "user"],
+        )
+        self.assertEqual(
+            chat_request.messages[0].content, "You are a helpful assistant."
+        )
+
     def test_thinking_history_drop_on_missing_detector(self):
         """Replaying a thinking block on a non-reasoning model should not 400."""
 

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -10,6 +10,7 @@ maybe_stub_sgl_kernel()  # must precede imports that may pull in sgl_kernel
 from fastapi.responses import JSONResponse  # noqa: E402
 
 from sglang.srt.entrypoints.anthropic.protocol import (  # noqa: E402
+    AnthropicMessage,
     AnthropicMessagesRequest,
 )
 from sglang.srt.entrypoints.anthropic.serving import AnthropicServing  # noqa: E402
@@ -1334,6 +1335,22 @@ class TestAnthropicServing(unittest.TestCase):
         self.assertEqual(
             chat_request.messages[0].content, "You are a helpful assistant."
         )
+
+    def test_validator_handles_constructed_message_objects(self):
+        """The ``mode="before"`` validator must also handle requests built
+        programmatically with ``AnthropicMessage`` objects (not just raw dicts),
+        e.g. ``handle_count_tokens`` constructs the request this way."""
+        request = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=8,
+            messages=[
+                AnthropicMessage(role="user", content="hi"),
+                AnthropicMessage(role="system", content="be terse"),
+                AnthropicMessage(role="user", content="go"),
+            ],
+        )
+        self.assertEqual(request.system, "be terse")
+        self.assertEqual([m.role for m in request.messages], ["user", "user"])
 
     def test_thinking_history_drop_on_missing_detector(self):
         """Replaying a thinking block on a non-reasoning model should not 400."""

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1302,8 +1302,9 @@ class TestAnthropicServing(unittest.TestCase):
                 {"role": "user", "content": "go"},
             ],
         )
-        # Validator combines top-level system first, then the in-messages turn.
-        self.assertEqual(request.system, ["You are terse.", "One word only."])
+        # Validator combines top-level system first, then the in-messages turn,
+        # joined into a single string.
+        self.assertEqual(request.system, "You are terse.\nOne word only.")
         self.assertEqual([m.role for m in request.messages], ["user", "user"])
 
     def test_top_level_system_only_is_unchanged(self):


### PR DESCRIPTION
## Problem

Claude Code and other clients send system messages mid-conversation (after user/assistant messages), which violates Anthropic's API spec. This causes 400 errors:

```
1 validation error: {'type': 'literal_error', 'loc': ('body', 'messages', N, 'role'), 'msg': 'Input should be ...'}
```

Additionally, the 'system' role was completely missing from the AnthropicMessage validation, causing any system messages to be rejected.

## Root Cause

1. **Missing role**: `AnthropicMessage.role` was defined as `Literal["user", "assistant"]` - excluding 'system'
2. **Mid-conversation system messages**: Claude Code sends system messages after user/assistant messages, violating Anthropic's spec

## Solution

1. **Add 'system' role** to AnthropicMessage validation
2. **Add model_validator** to extract mid-conversation system messages and move them to the top-level `system` field

The validator:
- Extracts system messages from any position in the messages array
- Appends them to existing system content
- Preserves message order for non-system messages

## Testing

Verified fix handles Claude Code's message format:
- System messages at any position are accepted
- Content is moved to the system field
- No 400 errors on multi-turn conversations

Fixes errors when Claude Code makes requests through arch-router-cuda to sglang.































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27715250341](https://github.com/sgl-project/sglang/actions/runs/27715250341)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27715248707](https://github.com/sgl-project/sglang/actions/runs/27715248707)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->