### PR TITLE
Enable SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT by default

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -672,7 +672,7 @@ class Envs:
     SGLANG_OPT_CACHE_SWA_TRANSLATION = EnvBool(True)
     # TODO(DSV4): @ispobock this has bug on main branch when retract
     SGLANG_OPT_SWA_RADIX_CACHE_COMPACT = EnvBool(False)
-    SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT = EnvBool(False)
+    SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT = EnvBool(True)
     SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW = EnvBool(False)
     SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN = EnvBool(False)
 


### PR DESCRIPTION
## Summary
- Enable `SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT` by default (`False` → `True`)

Without this flag, `inc_lock_ref` protects `len(leaf.value)` SWA tokens for the leaf even though SWA only needs the last `sliding_window_size` tokens. With chunked prefill, leaves can be thousands of tokens long, which inflates `swa_protected_size_` by ~`chunked_prefill_size / sliding_window_size` and causes premature SWA pool exhaustion and retract thrashing.

For example, with `--chunked-prefill-size 65536` and `sliding_window=128` (DeepSeek-V4), a single leaf could lock 65536 SWA slots instead of 128, a 512x over-protection.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26681168693](https://github.com/sgl-project/sglang/actions/runs/26681168693)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26681168651](https://github.com/sgl-project/sglang/actions/runs/26681168651)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->