### PR TITLE
[core] Compute dimensions/return_pooled_hidden_states in ForwardBatch.init_new

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1582,12 +1582,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # Speculative decoding
     spec_algorithm: SpeculativeAlgorithm = None
 
-    # For matryoshka embeddings
-    dimensions: Optional[list[int]] = None
-
-    # Whether to return pooled hidden states (pre-head transformer output)
-    return_pooled_hidden_states: bool = False
-
     # Whether to return hidden states
     return_hidden_states: bool = False
 
@@ -1817,21 +1811,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         orig_seq_lens = [max(len(r.fill_ids), len(r.origin_input_ids)) for r in reqs]
         prefix_lens = [len(r.prefix_indices) for r in reqs]
         extend_lens = [r.extend_input_len for r in reqs]
-
-        # For matryoshka embeddings
-        if self.model_config.is_matryoshka and any(
-            r.dimensions is not None for r in reqs
-        ):
-            self.dimensions = [
-                r.dimensions if r.dimensions else self.model_config.hidden_size
-                for r in reqs
-            ]
-
-        # OR across the batch so ForwardBatch matches a single fused forward; requests
-        # that did not ask for PHS still skip attaching it in the output processor.
-        self.return_pooled_hidden_states = any(
-            r.return_pooled_hidden_states for r in reqs
-        )
 
         token_type_ids = [
             r.token_type_ids for r in reqs if r.token_type_ids is not None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1609,9 +1609,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     encoder_cached: Optional[List[bool]] = None
     encoder_lens_cpu: Optional[List[int]] = None
 
-    # Multi-item scoring delimiter indices (set during prepare_for_extend)
-    multi_item_delimiter_indices: Optional[List[torch.Tensor]] = None
-
     # For extend and mixed chunekd prefill
     prefix_lens: List[int] = None
     extend_lens: List[int] = None
@@ -2030,23 +2027,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.multimodal_inputs = multimodal_inputs
         self.token_type_ids = token_type_ids_tensor
         self.seq_lens_sum = sum(seq_lens)
-
-        # Pre-compute delimiter indices as CPU tensors for MIS.
-        # When --enable-mis is on, every request in the batch is expected to
-        # carry delimiter indices (the score endpoint always produces MIS-structured
-        # requests). Consumers index this list without None-checking.
-        if get_global_server_args().enable_mis and any(
-            r.multi_item_delimiter_indices is not None for r in reqs
-        ):
-            assert all(
-                r.multi_item_delimiter_indices is not None for r in reqs
-            ), "MIS batch must have delimiter indices on every request"
-            self.multi_item_delimiter_indices = [
-                torch.tensor(r.multi_item_delimiter_indices, dtype=torch.int64)
-                for r in reqs
-            ]
-        else:
-            self.multi_item_delimiter_indices = None
 
         if self.return_logprob:
             self.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -559,7 +559,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             spec_info=batch.spec_info,
         )
 
-        ret._compute_derived_fields(batch)
+        ret._maybe_init_prefill_only(batch)
 
         device = model_runner.device
 
@@ -678,8 +678,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         return ret
 
-    def _compute_derived_fields(self, batch: ScheduleBatch):
-        """Derive per-request fields from ``batch.reqs`` (embedding / reward / scoring forwards)."""
+    def _maybe_init_prefill_only(self, batch: ScheduleBatch):
+        """Derive per-request fields from ``batch.reqs`` for non-generation
+        (embedding / reward / scoring) forwards; a no-op otherwise."""
+        if not self.is_prefill_only:
+            return
+
         if batch.model_config.is_matryoshka and any(
             r.dimensions is not None for r in batch.reqs
         ):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -544,8 +544,20 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             is_prefill_only=batch.is_prefill_only,
             spec_algorithm=batch.spec_algorithm,
             capture_hidden_mode=capture_hidden_mode,
-            dimensions=batch.dimensions,
-            return_pooled_hidden_states=batch.return_pooled_hidden_states,
+            dimensions=(
+                [
+                    r.dimensions if r.dimensions else batch.model_config.hidden_size
+                    for r in batch.reqs
+                ]
+                if batch.model_config.is_matryoshka
+                and any(r.dimensions is not None for r in batch.reqs)
+                else None
+            ),
+            # OR across the batch so a single fused forward matches; requests that
+            # did not ask for PHS still skip attaching it in the output processor.
+            return_pooled_hidden_states=any(
+                r.return_pooled_hidden_states for r in batch.reqs
+            ),
             return_hidden_states_before_norm=return_hidden_states_before_norm,
             tbo_split_seq_index=batch.tbo_split_seq_index,
             # Host-side metadata

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -511,6 +511,22 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if batch.seq_lens_sum is None and seq_lens_cpu is not None:
             batch.seq_lens_sum = int(seq_lens_cpu.sum())
 
+        # When --enable-mis is on, every request in the batch is expected to
+        # carry delimiter indices (the score endpoint always produces MIS-structured
+        # requests). Consumers index this list without None-checking.
+        if get_global_server_args().enable_mis and any(
+            r.multi_item_delimiter_indices is not None for r in batch.reqs
+        ):
+            assert all(
+                r.multi_item_delimiter_indices is not None for r in batch.reqs
+            ), "MIS batch must have delimiter indices on every request"
+            multi_item_delimiter_indices = [
+                torch.tensor(r.multi_item_delimiter_indices, dtype=torch.int64)
+                for r in batch.reqs
+            ]
+        else:
+            multi_item_delimiter_indices = None
+
         ret = cls(
             # Required core inputs
             forward_mode=batch.forward_mode,
@@ -566,7 +582,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             mm_inputs=batch.multimodal_inputs,
             encoder_cached=batch.encoder_cached,
             encoder_lens_cpu=batch.encoder_lens_cpu,
-            multi_item_delimiter_indices=batch.multi_item_delimiter_indices,
+            multi_item_delimiter_indices=multi_item_delimiter_indices,
             lora_ids=[req.lora_id for req in batch.reqs],
             rids=[req.rid for req in batch.reqs],
             # Compound (carry their own device tensors)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -679,14 +679,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         return ret
 
     def _compute_pooling_fields(self, batch: ScheduleBatch):
-        """Populate the pooling-family per-request fields from ``batch.reqs``.
-
-        These are only meaningful for embedding / reward / scoring (pooling)
-        forwards. They are recomputed fresh at every ForwardBatch construction
-        rather than stored on the cross-iter-reused ScheduleBatch.
-        """
-        # Matryoshka output dims, one per request (fall back to hidden_size for
-        # requests that did not ask for a custom dimension).
+        """Populate per-request fields for embedding / reward / scoring forwards."""
         if batch.model_config.is_matryoshka and any(
             r.dimensions is not None for r in batch.reqs
         ):
@@ -695,16 +688,13 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 for r in batch.reqs
             ]
 
-        # OR across the batch so a single fused forward matches; requests that
-        # did not ask for PHS still skip attaching it in the output processor.
         self.return_pooled_hidden_states = any(
             r.return_pooled_hidden_states for r in batch.reqs
         )
 
-        # When --enable-mis is on, every request in the batch is expected to
-        # carry delimiter indices (the score endpoint always produces
-        # MIS-structured requests). Consumers index this list without
-        # None-checking.
+        # --enable-mis: every request must carry delimiter indices (the score
+        # endpoint always produces MIS-structured requests; consumers index
+        # without None-checking).
         if get_global_server_args().enable_mis and any(
             r.multi_item_delimiter_indices is not None for r in batch.reqs
         ):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -559,7 +559,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             spec_info=batch.spec_info,
         )
 
-        ret._compute_pooling_fields(batch)
+        ret._compute_derived_fields(batch)
 
         device = model_runner.device
 
@@ -678,8 +678,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         return ret
 
-    def _compute_pooling_fields(self, batch: ScheduleBatch):
-        """Populate per-request fields for embedding / reward / scoring forwards."""
+    def _compute_derived_fields(self, batch: ScheduleBatch):
+        """Derive per-request fields from ``batch.reqs`` (embedding / reward / scoring forwards)."""
         if batch.model_config.is_matryoshka and any(
             r.dimensions is not None for r in batch.reqs
         ):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -511,22 +511,6 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if batch.seq_lens_sum is None and seq_lens_cpu is not None:
             batch.seq_lens_sum = int(seq_lens_cpu.sum())
 
-        # When --enable-mis is on, every request in the batch is expected to
-        # carry delimiter indices (the score endpoint always produces MIS-structured
-        # requests). Consumers index this list without None-checking.
-        if get_global_server_args().enable_mis and any(
-            r.multi_item_delimiter_indices is not None for r in batch.reqs
-        ):
-            assert all(
-                r.multi_item_delimiter_indices is not None for r in batch.reqs
-            ), "MIS batch must have delimiter indices on every request"
-            multi_item_delimiter_indices = [
-                torch.tensor(r.multi_item_delimiter_indices, dtype=torch.int64)
-                for r in batch.reqs
-            ]
-        else:
-            multi_item_delimiter_indices = None
-
         ret = cls(
             # Required core inputs
             forward_mode=batch.forward_mode,
@@ -560,20 +544,6 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             is_prefill_only=batch.is_prefill_only,
             spec_algorithm=batch.spec_algorithm,
             capture_hidden_mode=capture_hidden_mode,
-            dimensions=(
-                [
-                    r.dimensions if r.dimensions else batch.model_config.hidden_size
-                    for r in batch.reqs
-                ]
-                if batch.model_config.is_matryoshka
-                and any(r.dimensions is not None for r in batch.reqs)
-                else None
-            ),
-            # OR across the batch so a single fused forward matches; requests that
-            # did not ask for PHS still skip attaching it in the output processor.
-            return_pooled_hidden_states=any(
-                r.return_pooled_hidden_states for r in batch.reqs
-            ),
             return_hidden_states_before_norm=return_hidden_states_before_norm,
             tbo_split_seq_index=batch.tbo_split_seq_index,
             # Host-side metadata
@@ -582,13 +552,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             mm_inputs=batch.multimodal_inputs,
             encoder_cached=batch.encoder_cached,
             encoder_lens_cpu=batch.encoder_lens_cpu,
-            multi_item_delimiter_indices=multi_item_delimiter_indices,
             lora_ids=[req.lora_id for req in batch.reqs],
             rids=[req.rid for req in batch.reqs],
             # Compound (carry their own device tensors)
             sampling_info=batch.sampling_info,
             spec_info=batch.spec_info,
         )
+
+        ret._compute_pooling_fields(batch)
 
         device = model_runner.device
 
@@ -706,6 +677,44 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             model_runner.lora_manager.prepare_lora_batch(ret)
 
         return ret
+
+    def _compute_pooling_fields(self, batch: ScheduleBatch):
+        """Populate the pooling-family per-request fields from ``batch.reqs``.
+
+        These are only meaningful for embedding / reward / scoring (pooling)
+        forwards. They are recomputed fresh at every ForwardBatch construction
+        rather than stored on the cross-iter-reused ScheduleBatch.
+        """
+        # Matryoshka output dims, one per request (fall back to hidden_size for
+        # requests that did not ask for a custom dimension).
+        if batch.model_config.is_matryoshka and any(
+            r.dimensions is not None for r in batch.reqs
+        ):
+            self.dimensions = [
+                r.dimensions if r.dimensions else batch.model_config.hidden_size
+                for r in batch.reqs
+            ]
+
+        # OR across the batch so a single fused forward matches; requests that
+        # did not ask for PHS still skip attaching it in the output processor.
+        self.return_pooled_hidden_states = any(
+            r.return_pooled_hidden_states for r in batch.reqs
+        )
+
+        # When --enable-mis is on, every request in the batch is expected to
+        # carry delimiter indices (the score endpoint always produces
+        # MIS-structured requests). Consumers index this list without
+        # None-checking.
+        if get_global_server_args().enable_mis and any(
+            r.multi_item_delimiter_indices is not None for r in batch.reqs
+        ):
+            assert all(
+                r.multi_item_delimiter_indices is not None for r in batch.reqs
+            ), "MIS batch must have delimiter indices on every request"
+            self.multi_item_delimiter_indices = [
+                torch.tensor(r.multi_item_delimiter_indices, dtype=torch.int64)
+                for r in batch.reqs
+            ]
 
     def adjust_num_token_non_padded_for_attn_tp(self, server_args) -> None:
         """Make num_token_non_padded local to this attention-TP rank."""


### PR DESCRIPTION
These two `ScheduleBatch` fields are computed in `prepare_for_extend` and read only by `ForwardBatch` (no scheduler / filter / merge / SB-internal reader). Move the computation into `ForwardBatch.init_new` (over the same `batch.model_config` / `batch.reqs`) and drop the SB fields. Behavior-preserving; per-req `Req.dimensions` / `Req.return_pooled_hidden_states` unchanged.



































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26699077133](https://github.com/sgl-project/sglang/actions/runs/26699077133)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26699077068](https://github.com/sgl-project/sglang/actions/runs/26699077068)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->