### PR TITLE
fix: add Rust cargo bin to runtime stage PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -696,7 +696,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/
 
 # Add GKE default lib and bin locations + CUDA compiler paths for FlashInfer JIT
-ENV PATH="${PATH}:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/cuda/nvvm/bin" \
+ENV PATH="/root/.cargo/bin:${PATH}:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/cuda/nvvm/bin" \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
 
 # Install runtime dependencies (devel base provides gcc/g++/build tools)


### PR DESCRIPTION
## Summary
- Add `/root/.cargo/bin` to PATH in the runtime stage of the Dockerfile
- Rust is installed in the runtime image but its bin directory was missing from PATH, causing "rust compiler not found" errors







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26681807595](https://github.com/sgl-project/sglang/actions/runs/26681807595)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26681807555](https://github.com/sgl-project/sglang/actions/runs/26681807555)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->