### PR TITLE
fix: split streaming reasoning/content logprobs per chunk (follow-up to #28601)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -359,7 +359,7 @@ class OpenAIServingChat(OpenAIServingBase):
         else:
             delta = content["text"][offset:]
             stream_offsets[index] = len(content["text"])
-
+        raw_delta = delta
         # Attach logprobs to the first chunk emitted this step (reasoning,
         # tool-call, or content) so they aren't dropped when a parser is active
         # nor duplicated across chunks; flush any leftover at the end.
@@ -370,6 +370,19 @@ class OpenAIServingChat(OpenAIServingBase):
             reasoning_text, delta = self._process_reasoning_stream(
                 index, delta, reasoning_parser_dict, content, request
             )
+            logprobs_handled, reasoning_logprobs, content_logprobs = (
+                self._split_streaming_logprobs_for_reasoning(
+                    choice_logprobs, raw_delta, reasoning_text, delta
+                )
+            )
+            # When the slice aligns to the parsed deltas, the reasoning chunk
+            # carries only its own tokens and the content tokens are routed to
+            # the content chunk below (swallowed parser markers are dropped).
+            # Fall back whenever the helper cannot assign token spans cleanly
+            # and unambiguously. Handled empty results mean "drop parser-only
+            # marker tokens".
+            if not logprobs_handled:
+                reasoning_logprobs = remaining_logprobs
             if reasoning_text:
                 usage = None
                 if continuous_usage_stats:
@@ -385,10 +398,15 @@ class OpenAIServingChat(OpenAIServingBase):
                     model=request.model,
                     index=index,
                     reasoning_content=reasoning_text,
-                    logprobs=remaining_logprobs,
+                    logprobs=reasoning_logprobs,
                     usage=usage,
                 )
-                remaining_logprobs = None
+                if logprobs_handled:
+                    remaining_logprobs = content_logprobs
+                else:
+                    remaining_logprobs = None
+            elif logprobs_handled:
+                remaining_logprobs = content_logprobs
 
         # Handle tool calls
         if request.tool_choice != "none" and request.tools and self.tool_call_parser:
@@ -1458,6 +1476,127 @@ class OpenAIServingChat(OpenAIServingBase):
 
         token_logprobs = self._process_logprobs_tokens(logprobs, use_token_index=True)
         return ChoiceLogprobs(content=token_logprobs)
+
+    @staticmethod
+    def _split_streaming_logprobs_for_reasoning(
+        choice_logprobs: Optional[Dict],
+        raw_delta: str,
+        reasoning_text: str,
+        content_text: str,
+    ) -> tuple[bool, Optional[Dict], Optional[Dict]]:
+        """Split one streaming logprob slice between reasoning and content deltas."""
+        if not choice_logprobs:
+            return True, None, None
+
+        logprob_content = choice_logprobs.get("content")
+        if not logprob_content:
+            return (
+                True,
+                choice_logprobs if reasoning_text else None,
+                (choice_logprobs if content_text else None),
+            )
+
+        if not reasoning_text and not content_text:
+            return True, None, None
+
+        def find_spans(text: str) -> list[tuple[int, int]]:
+            spans = []
+            start = raw_delta.find(text)
+            while start != -1:
+                end = start + len(text)
+                spans.append((start, end))
+                start = raw_delta.find(text, start + 1)
+            return spans
+
+        span_candidates = []
+        reasoning_spans = find_spans(reasoning_text) if reasoning_text else [None]
+        content_spans = find_spans(content_text) if content_text else [None]
+        for reasoning_span in reasoning_spans:
+            for content_span in content_spans:
+                candidate = []
+                if reasoning_span is not None:
+                    candidate.append(("reasoning", *reasoning_span))
+                if content_span is not None:
+                    candidate.append(("content", *content_span))
+                if (
+                    reasoning_span is not None
+                    and content_span is not None
+                    and reasoning_span[1] > content_span[0]
+                ):
+                    continue
+                span_candidates.append(candidate)
+
+        if not span_candidates:
+            logger.debug(
+                "Failed to locate parsed streaming reasoning deltas in the "
+                "raw delta; falling back to the unsplit logprobs for this chunk."
+            )
+            return False, None, None
+
+        token_text = "".join(entry.get("token", "") for entry in logprob_content)
+        if token_text != raw_delta:
+            if reasoning_text and not content_text and reasoning_text == raw_delta:
+                return True, choice_logprobs, None
+            if content_text and not reasoning_text and content_text == raw_delta:
+                return True, None, choice_logprobs
+            logger.debug(
+                "Failed to align streaming reasoning logprobs with parsed deltas; "
+                "falling back to the unsplit logprobs for this chunk."
+            )
+            return False, None, None
+
+        def assign_token_spans(
+            emitted_spans: list[tuple[str, int, int]],
+        ) -> Optional[tuple[tuple[int, ...], tuple[int, ...]]]:
+            reasoning_token_indices = []
+            content_token_indices = []
+            offset = 0
+            for token_index, token_logprob in enumerate(logprob_content):
+                token_text = token_logprob.get("token", "")
+                token_start = offset
+                offset += len(token_text)
+                token_end = offset
+                token_assigned = False
+                for target, span_start, span_end in emitted_spans:
+                    if span_start <= token_start and token_end <= span_end:
+                        if target == "reasoning":
+                            reasoning_token_indices.append(token_index)
+                        elif target == "content":
+                            content_token_indices.append(token_index)
+                        token_assigned = True
+                        break
+                if not token_assigned and any(
+                    token_start < span_end and span_start < token_end
+                    for _, span_start, span_end in emitted_spans
+                ):
+                    return None
+            return tuple(reasoning_token_indices), tuple(content_token_indices)
+
+        assignments = {
+            assignment
+            for candidate in span_candidates
+            if (assignment := assign_token_spans(candidate)) is not None
+        }
+        if len(assignments) != 1:
+            logger.debug(
+                "Failed to find a unique streaming reasoning logprob assignment; "
+                "falling back to the unsplit logprobs for this chunk."
+            )
+            return False, None, None
+
+        reasoning_indices, content_indices = next(iter(assignments))
+        reasoning_tokens = [logprob_content[index] for index in reasoning_indices]
+        content_tokens = [logprob_content[index] for index in content_indices]
+
+        reasoning_logprobs = (
+            {**choice_logprobs, "content": reasoning_tokens}
+            if reasoning_tokens
+            else None
+        )
+        content_logprobs = (
+            {**choice_logprobs, "content": content_tokens} if content_tokens else None
+        )
+        return True, reasoning_logprobs, content_logprobs
 
     def _process_tool_call_id(
         self,

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -117,6 +117,42 @@ class ServingChatTestCase(unittest.TestCase):
         self.fastapi_request = Mock(spec=Request)
         self.fastapi_request.headers = {}
 
+    def _collect_stream_content_chunks(
+        self,
+        *,
+        text: str,
+        request: ChatCompletionRequest,
+        choice_logprobs=None,
+    ):
+        async def collect_chunks():
+            gen = self.chat._generate_stream_content(
+                content={
+                    "text": text,
+                    "meta_info": {
+                        "id": "chatcmpl-test",
+                    },
+                },
+                index=0,
+                request=request,
+                stream_offsets={},
+                reasoning_parser_dict={},
+                parser_dict={},
+                has_tool_calls={},
+                choice_logprobs=choice_logprobs,
+                finish_reason_type=None,
+                continuous_usage_stats=False,
+                prompt_tokens={},
+                reasoning_tokens={},
+                completion_tokens={},
+            )
+            chunks = []
+            async for emitted in gen:
+                chunks.append(json.loads(emitted[len("data: ") :]))
+            return chunks
+
+        loop = get_or_create_event_loop()
+        return loop.run_until_complete(collect_chunks())
+
     # ------------- conversion tests -------------
     def test_convert_to_internal_request_single(self):
         with (
@@ -891,6 +927,318 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertIsNone(
             result, "Should return None when parser has no tool call data"
         )
+
+    def test_streaming_reasoning_chunk_includes_logprobs(self):
+        """Reasoning deltas should preserve the matching streaming logprobs."""
+        self.chat.reasoning_parser = "deepseek-r1"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+        choice_logprobs = {
+            "content": [
+                {
+                    "token": "reasoning",
+                    "bytes": list(b"reasoning"),
+                    "logprob": -0.25,
+                    "top_logprobs": [],
+                }
+            ]
+        }
+
+        chunks = self._collect_stream_content_chunks(
+            text="reasoning",
+            request=req,
+            choice_logprobs=choice_logprobs,
+        )
+
+        self.assertEqual(len(chunks), 1)
+        choice = chunks[0]["choices"][0]
+        self.assertEqual(choice["delta"]["reasoning_content"], "reasoning")
+        self.assertEqual(choice["logprobs"], choice_logprobs)
+
+    def test_streaming_reasoning_chunk_without_logprobs_is_unchanged(self):
+        """Reasoning deltas keep null logprobs when no logprobs were requested."""
+        self.chat.reasoning_parser = "deepseek-r1"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=False,
+            separate_reasoning=True,
+        )
+
+        chunks = self._collect_stream_content_chunks(text="reasoning", request=req)
+
+        self.assertEqual(len(chunks), 1)
+        choice = chunks[0]["choices"][0]
+        self.assertEqual(choice["delta"]["reasoning_content"], "reasoning")
+        self.assertIsNone(choice["logprobs"])
+
+    def test_streaming_reasoning_and_content_split_logprobs(self):
+        """Mixed reasoning/content deltas should not duplicate logprobs."""
+        self.chat.reasoning_parser = "deepseek-r1"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+        choice_logprobs = {
+            "content": [
+                {
+                    "token": "reasoning",
+                    "bytes": list(b"reasoning"),
+                    "logprob": -0.25,
+                    "top_logprobs": [],
+                },
+                {
+                    "token": "</think>",
+                    "bytes": list(b"</think>"),
+                    "logprob": -0.4,
+                    "top_logprobs": [],
+                },
+                {
+                    "token": "answer",
+                    "bytes": list(b"answer"),
+                    "logprob": -0.5,
+                    "top_logprobs": [],
+                },
+            ]
+        }
+
+        chunks = self._collect_stream_content_chunks(
+            text="reasoning</think>answer",
+            request=req,
+            choice_logprobs=choice_logprobs,
+        )
+
+        self.assertEqual(len(chunks), 2)
+        reasoning_choice = chunks[0]["choices"][0]
+        content_choice = chunks[1]["choices"][0]
+        self.assertEqual(reasoning_choice["delta"]["reasoning_content"], "reasoning")
+        self.assertEqual(content_choice["delta"]["content"], "answer")
+        self.assertEqual(
+            reasoning_choice["logprobs"]["content"],
+            [choice_logprobs["content"][0]],
+        )
+        self.assertEqual(
+            content_choice["logprobs"]["content"],
+            [choice_logprobs["content"][2]],
+        )
+
+    def test_streaming_reasoning_logprobs_drop_parser_markers(self):
+        """Parser-swallowed reasoning markers should not be exposed as logprobs."""
+        self.chat.reasoning_parser = "qwen3"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+        choice_logprobs = {
+            "content": [
+                {
+                    "token": "<think>",
+                    "bytes": list(b"<think>"),
+                    "logprob": -0.1,
+                    "top_logprobs": [],
+                },
+                {
+                    "token": "reasoning",
+                    "bytes": list(b"reasoning"),
+                    "logprob": -0.25,
+                    "top_logprobs": [],
+                },
+            ]
+        }
+
+        chunks = self._collect_stream_content_chunks(
+            text="<think>reasoning",
+            request=req,
+            choice_logprobs=choice_logprobs,
+        )
+
+        self.assertEqual(len(chunks), 1)
+        choice = chunks[0]["choices"][0]
+        self.assertEqual(choice["delta"]["reasoning_content"], "reasoning")
+        self.assertEqual(
+            choice["logprobs"]["content"],
+            [choice_logprobs["content"][1]],
+        )
+
+    def test_streaming_reasoning_marker_only_chunk_drops_logprobs(self):
+        """Parser-only marker chunks should not surface standalone logprobs."""
+        self.chat.reasoning_parser = "qwen3"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+
+        for parser_name, marker in (
+            ("qwen3", "<think>"),
+            ("qwen3", "<thi"),
+            ("deepseek-r1", "</think>"),
+        ):
+            with self.subTest(parser=parser_name, marker=marker):
+                self.chat.reasoning_parser = parser_name
+                choice_logprobs = {
+                    "content": [
+                        {
+                            "token": marker,
+                            "bytes": list(marker.encode("utf-8")),
+                            "logprob": -0.1,
+                            "top_logprobs": [],
+                        }
+                    ]
+                }
+
+                chunks = self._collect_stream_content_chunks(
+                    text=marker,
+                    request=req,
+                    choice_logprobs=choice_logprobs,
+                )
+
+                self.assertEqual(chunks, [])
+
+    def test_streaming_reasoning_boundary_spanning_token_falls_back(self):
+        """A token crossing a parser marker should preserve #28601 behavior."""
+        self.chat.reasoning_parser = "deepseek-r1"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+        choice_logprobs = {
+            "content": [
+                {
+                    "token": "</think>answer",
+                    "bytes": list(b"</think>answer"),
+                    "logprob": -0.5,
+                    "top_logprobs": [],
+                },
+            ]
+        }
+
+        chunks = self._collect_stream_content_chunks(
+            text="</think>answer",
+            request=req,
+            choice_logprobs=choice_logprobs,
+        )
+
+        self.assertEqual(len(chunks), 1)
+        choice = chunks[0]["choices"][0]
+        self.assertEqual(choice["delta"]["content"], "answer")
+        self.assertEqual(choice["logprobs"], choice_logprobs)
+
+    def test_streaming_reasoning_ambiguous_marker_match_falls_back(self):
+        """Content text repeated inside a swallowed marker must not be misassigned."""
+        self.chat.reasoning_parser = "deepseek-r1"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+        choice_logprobs = {
+            "content": [
+                {
+                    "token": "reasoning",
+                    "bytes": list(b"reasoning"),
+                    "logprob": -0.25,
+                    "top_logprobs": [],
+                },
+                {
+                    "token": "</",
+                    "bytes": list(b"</"),
+                    "logprob": -0.3,
+                    "top_logprobs": [],
+                },
+                {
+                    "token": "think",
+                    "bytes": list(b"think"),
+                    "logprob": -0.4,
+                    "top_logprobs": [],
+                },
+                {
+                    "token": ">",
+                    "bytes": list(b">"),
+                    "logprob": -0.45,
+                    "top_logprobs": [],
+                },
+                {
+                    "token": "think",
+                    "bytes": list(b"think"),
+                    "logprob": -0.5,
+                    "top_logprobs": [],
+                },
+            ]
+        }
+
+        chunks = self._collect_stream_content_chunks(
+            text="reasoning</think>think",
+            request=req,
+            choice_logprobs=choice_logprobs,
+        )
+
+        self.assertEqual(len(chunks), 2)
+        reasoning_choice = chunks[0]["choices"][0]
+        content_choice = chunks[1]["choices"][0]
+        self.assertEqual(reasoning_choice["delta"]["reasoning_content"], "reasoning")
+        self.assertEqual(content_choice["delta"]["content"], "think")
+        self.assertEqual(reasoning_choice["logprobs"], choice_logprobs)
+        self.assertIsNone(content_choice["logprobs"])
+
+    def test_streaming_content_chunk_keeps_logprobs_with_reasoning_parser(self):
+        """Normal content deltas should keep logprobs when no reasoning is emitted."""
+        self.chat.reasoning_parser = "qwen3"
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+        choice_logprobs = {
+            "content": [
+                {
+                    "token": "answer",
+                    "bytes": list(b"answer"),
+                    "logprob": -0.5,
+                    "top_logprobs": [],
+                },
+            ]
+        }
+
+        chunks = self._collect_stream_content_chunks(
+            text="answer",
+            request=req,
+            choice_logprobs=choice_logprobs,
+        )
+
+        self.assertEqual(len(chunks), 1)
+        choice = chunks[0]["choices"][0]
+        self.assertEqual(choice["delta"]["content"], "answer")
+        self.assertEqual(choice["logprobs"], choice_logprobs)
 
     # ------------- kimi_k2 tool_call_id formatting -------------
     def test_kimi_k2_non_streaming_tool_call_id_format(self):


### PR DESCRIPTION
## Motivation

I hit this doing online RL on reasoning models: the streamed logprobs are
consumed directly as the rollout (behavior-policy) logprobs in the training
step, so when `logprobs.content` doesn't line up with the reasoning/content
tokens that were actually surfaced, it shows up as a train–inference mismatch.

I reported it as #26778 and opened this PR before #28601 landed. #28601 has
since fixed the main problem — streaming logprobs dropped once a
`--reasoning-parser` / `--tool-call-parser` is active — by attaching the step's
logprobs to the first emitted chunk. I didn't realize it was already being
worked on; rather than duplicate it, I've rebased this PR on top and narrowed it
to the alignment follow-up #28601 left open.

#28601 calls out one deferred item under its own known limitations:

> logprobs are bundled per-step rather than split token-exactly across
> reasoning-vs-content boundaries ... Token-exact per-segment alignment would
> require threading the logprob cursor through the parsers — a larger change.

This PR takes a best-effort step toward that split. With a reasoning parser
active, when a step's tokens fall cleanly within the surfaced reasoning or
content text, each chunk's `logprobs.content` is restricted to its own tokens
and the logprobs of swallowed markers (`<think>` / `</think>`) are no longer
surfaced. It is not the full parser-cursor threading #28601 describes — see
Scope below. Same alignment concern as #25815.

It is a narrow refinement on top of #28601; if you would rather keep the simpler
per-step bundling, feel free to close.

## Modifications

`python/sglang/srt/entrypoints/openai/serving_chat.py`, `_generate_stream_content`:

- Add `_split_streaming_logprobs_for_reasoning`, which splits a step's
  `logprobs.content[]` slice between the surfaced reasoning and content text
  spans and drops tokens that fall outside either span (swallowed parser
  markers).
- Attach the reasoning slice to the reasoning chunk and route the content slice
  to the content chunk.
- When the slice cannot be aligned to the parsed deltas, fall back to #28601's
  behavior — whole slice on the first emitted chunk — so logprobs are never
  dropped while a parser is active.
- Drop logprobs for parser-only marker chunks. If a token or repeated text makes
  the reasoning/content split ambiguous, fall back to #28601's unsplit placement
  rather than misattributing marker logprobs to surfaced text.

No schema change is required — `build_sse_content` already supports `logprobs`.

## Behavior

For a step whose decode delta is `reasoning</think>answer` with per-token
logprobs `[reasoning, </think>, answer]`, reasoning parser active:

- before (on `main`): the reasoning chunk carries all three token logprobs; the
  content chunk (`delta.content="answer"`) carries `logprobs: null`.
- after: the reasoning chunk carries `[reasoning]`, the content chunk carries
  `[answer]`, and the `</think>` marker logprob is dropped.

## Scope / not covered

The split only happens when the step's tokens line up cleanly with the parsed
deltas; anything ambiguous falls back to #28601's behavior, so this is never
worse than #28601:

- A token that spans a reasoning↔content boundary, repeated text that makes the
  emitted span ambiguous, or a step whose tokens don't reconstruct the raw delta
  falls back to the unsplit slice on the first emitted chunk — not token-exact
  there, but logprobs are preserved, not dropped.
- Only swallowed parser markers (`<think>` / `</think>`) that sit cleanly
  between segments are dropped.
- Tool-call argument logprobs are unchanged — still #28601's standalone-chunk
  delivery.

## Accuracy Tests

N/A. This only changes how already-computed logprobs are projected onto OpenAI
streaming chunks; it does not touch model forward logic or the logprob values.

## Speed Tests and Profiling

N/A. The added work is per streamed chunk: a span lookup over the raw delta and a
small token-span assignment loop, negligible against decoding.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - `ruff --select=F401,F821,UP037`, `black --check`, and `isort --check-only` pass on the touched files.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - Per-chunk split, marker dropping, marker-only chunks, boundary-spanning tokens, ambiguous repeated text, reasoning-only and content-only cases, plus the existing #28601 streaming-logprobs tests.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Local Tests

```
TORCHDYNAMO_DISABLE=1 PYTHONPATH=python .venv/bin/python -m pytest \
  test/registered/unit/entrypoints/openai/test_serving_chat.py -q \
  -k "streaming and (logprobs or boundary or ambiguous)"
```





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28214515981](https://github.com/sgl-project/sglang/actions/runs/28214515981)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28214515908](https://github.com/sgl-project/sglang/actions/runs/28214515908)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->