### PR TITLE
fix(hicache): include extra_key in storage page hashes

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -98,7 +98,6 @@ class LayerDoneCounter:
 
 
 class CacheOperation:
-
     counter = 0
 
     def __init__(
@@ -193,6 +192,7 @@ class StorageOperation:
         last_hash: Optional[str] = None,
         hash_value: Optional[List[str]] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
     ):
         self.host_indices = host_indices
         self.token_ids = token_ids
@@ -200,6 +200,7 @@ class StorageOperation:
         self.completed_tokens = 0
         self.hash_value = hash_value if hash_value is not None else []
         self.prefix_keys = prefix_keys
+        self.extra_key = extra_key
 
         self.id = StorageOperation.counter
         StorageOperation.counter += 1
@@ -216,6 +217,7 @@ class PrefetchOperation(StorageOperation):
         token_ids: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
     ):
         self.request_id = request_id
 
@@ -223,7 +225,13 @@ class PrefetchOperation(StorageOperation):
         self._terminated_flag = False
         self.start_time = time.monotonic()
 
-        super().__init__(host_indices, token_ids, last_hash, prefix_keys=prefix_keys)
+        super().__init__(
+            host_indices,
+            token_ids,
+            last_hash,
+            prefix_keys=prefix_keys,
+            extra_key=extra_key,
+        )
 
     def increment(self, num_tokens: int):
         with self._lock:
@@ -241,7 +249,6 @@ class PrefetchOperation(StorageOperation):
 
 
 class HiCacheController:
-
     def __init__(
         self,
         token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
@@ -852,12 +859,18 @@ class HiCacheController:
         new_input_tokens: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
     ) -> PrefetchOperation:
         """
         Prefetch KV caches from storage backend to host memory.
         """
         operation = PrefetchOperation(
-            request_id, host_indices, new_input_tokens, last_hash, prefix_keys
+            request_id,
+            host_indices,
+            new_input_tokens,
+            last_hash,
+            prefix_keys,
+            extra_key,
         )
         self.prefetch_queue.put(operation)
         return operation
@@ -987,7 +1000,9 @@ class HiCacheController:
             batch_hashes = []
             for i in range(0, len(batch_tokens), self.page_size):
                 last_hash = self.get_hash_str(
-                    batch_tokens[i : i + self.page_size], last_hash
+                    batch_tokens[i : i + self.page_size],
+                    last_hash,
+                    extra_key=operation.extra_key,
                 )
                 batch_hashes.append(last_hash)
             extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -1757,6 +1757,7 @@ class HiMambaRadixCache(MambaRadixCache):
             new_input_tokens,
             last_hash,
             prefix_keys,
+            extra_key=last_host_node.key.extra_key if last_host_node.key else None,
             extra_pools=extra_pools,
         )
         self.ongoing_prefetch[req_id] = (

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1308,6 +1308,7 @@ class HiRadixCache(RadixCache):
             prefetch_key,
             last_hash,
             prefix_keys,
+            extra_key=prefetch_key.extra_key,
             **self._get_extra_pools(),
         )
         self.ongoing_prefetch[req_id] = (

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -108,9 +108,17 @@ class StorageOperation(BaseStorageOperation):
         last_hash: Optional[str] = None,
         hash_value: Optional[List[str]] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
         pool_transfers: Optional[list[PoolTransfer]] = None,
     ):
-        super().__init__(host_indices, token_ids, last_hash, hash_value, prefix_keys)
+        super().__init__(
+            host_indices,
+            token_ids,
+            last_hash,
+            hash_value,
+            prefix_keys,
+            extra_key,
+        )
         self.pool_transfers = pool_transfers
         self.pool_storage_result = PoolTransferResult.empty()
 
@@ -123,6 +131,7 @@ class PrefetchOperation(StorageOperation):
         token_ids: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
         pool_transfers: Optional[list[PoolTransfer]] = None,
     ):
         self.request_id = request_id
@@ -134,6 +143,7 @@ class PrefetchOperation(StorageOperation):
             token_ids,
             last_hash,
             prefix_keys=prefix_keys,
+            extra_key=extra_key,
             pool_transfers=pool_transfers,
         )
 
@@ -525,6 +535,7 @@ class HybridCacheController(BaseHiCacheController):
         new_input_tokens: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
         extra_pools: Optional[list[PoolTransfer]] = None,
     ) -> PrefetchOperation:
         operation = PrefetchOperation(
@@ -533,6 +544,7 @@ class HybridCacheController(BaseHiCacheController):
             new_input_tokens,
             last_hash,
             prefix_keys=prefix_keys,
+            extra_key=extra_key,
             pool_transfers=extra_pools,
         )
         self.prefetch_queue.put(operation)
@@ -561,7 +573,9 @@ class HybridCacheController(BaseHiCacheController):
         hash_value = []
         for start in range(0, len(operation.token_ids), self.page_size):
             last_hash = self.get_hash_str(
-                operation.token_ids[start : start + self.page_size], last_hash
+                operation.token_ids[start : start + self.page_size],
+                last_hash,
+                extra_key=operation.extra_key,
             )
             hash_value.append(last_hash)
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -47,7 +47,11 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchResult,
 )
 from sglang.srt.mem_cache.events import KVCacheEventMixin
-from sglang.srt.mem_cache.utils import get_eviction_strategy, split_node_hash_value
+from sglang.srt.mem_cache.utils import (
+    get_eviction_strategy,
+    split_node_hash_value,
+    update_hash_with_extra_key,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -184,6 +188,7 @@ class RadixKey:
         hasher = hashlib.sha256()
         if prior_hash:
             hasher.update(bytes.fromhex(prior_hash))
+        update_hash_with_extra_key(hasher, self.extra_key)
         t = self.token_ids
         if self.is_bigram:
             for j in range(start, end):

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1682,9 +1682,10 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         operation = self.cache_controller.prefetch(
             req_id,
             host_indices,
-            prefetch_key.token_ids,
+            prefetch_key,
             last_hash,
             prefix_keys,
+            extra_key=extra_key,
             extra_pools=aux_xfers or None,
         )
         self.ongoing_prefetch[req_id] = (

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -454,11 +454,25 @@ def maybe_init_custom_mem_pool(
         return False, None, None
 
 
-def get_hash_str(token_ids: List[int], prior_hash: Optional[str] = None) -> str:
+def update_hash_with_extra_key(hasher: Any, extra_key: Optional[str]) -> None:
+    if extra_key is None:
+        return
+    encoded = extra_key.encode("utf-8")
+    hasher.update(b"extra_key")
+    hasher.update(len(encoded).to_bytes(4, byteorder="little", signed=False))
+    hasher.update(encoded)
+
+
+def get_hash_str(
+    token_ids: List[int],
+    prior_hash: Optional[str] = None,
+    extra_key: Optional[str] = None,
+) -> str:
     hasher = hashlib.sha256()
 
     if prior_hash:
         hasher.update(bytes.fromhex(prior_hash))
+    update_hash_with_extra_key(hasher, extra_key)
 
     for t in token_ids:
         if isinstance(t, tuple):

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -41,6 +41,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+from sglang.srt.mem_cache.utils import get_hash_str
 
 # Test constants
 DEFAULT_PAGE_SIZE = 4
@@ -141,6 +142,57 @@ class TestRadixKey(unittest.TestCase):
         key = RadixKey(array("q", long_tokens))
         repr_str = repr(key)
         self.assertIn("...", repr_str)  # Should be truncated
+
+    def test_hash_page_uses_extra_key(self):
+        tokens = [11, 12, 13, 14, 15, 16, 17, 18]
+        page_size = 4
+        key_a = RadixKey(array("q", tokens), "tenant-A")
+        key_b = RadixKey(array("q", tokens), "tenant-B")
+        key_none = RadixKey(array("q", tokens))
+
+        hashes_a = []
+        hashes_b = []
+        hashes_none = []
+        last_a = last_b = last_none = None
+        for start in range(0, len(tokens), page_size):
+            end = start + page_size
+            last_a = key_a.hash_page(start, end, last_a)
+            last_b = key_b.hash_page(start, end, last_b)
+            last_none = key_none.hash_page(start, end, last_none)
+            hashes_a.append(last_a)
+            hashes_b.append(last_b)
+            hashes_none.append(last_none)
+
+        self.assertNotEqual(hashes_a, hashes_b)
+
+        prefetch_hashes = []
+        last = None
+        for start in range(0, len(tokens), page_size):
+            last = get_hash_str(
+                tokens[start : start + page_size],
+                last,
+                extra_key="tenant-A",
+            )
+            prefetch_hashes.append(last)
+        self.assertEqual(hashes_a, prefetch_hashes)
+
+        old_hashes = []
+        last = None
+        for start in range(0, len(tokens), page_size):
+            last = get_hash_str(tokens[start : start + page_size], last)
+            old_hashes.append(last)
+        self.assertEqual(hashes_none, old_hashes)
+
+    def test_prefetch_hash_slice_keeps_bigram_view(self):
+        tokens = [11, 12, 13, 14, 15, 16, 17]
+        key = RadixKey(array("q", tokens), "tenant-A", is_bigram=True)
+
+        page = key[:4]
+        expected = key.hash_page(0, 4)
+        self.assertEqual(get_hash_str(page, extra_key="tenant-A"), expected)
+
+        raw_hash = get_hash_str(page.token_ids[:4], extra_key="tenant-A")
+        self.assertNotEqual(raw_hash, expected)
 
 
 class TestTreeNode(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Fixes #26747.

HiCache storage page keys were still based on token ids and the prior page hash. The radix tree keeps different `extra_key` values apart, but storage prefetch recomputed page hashes without that namespace, so the same token pages could hit entries written for another `extra_key`.

## Modifications

- Include non-empty `extra_key` values in the storage page hash.
- Pass the request namespace through storage prefetch operations.
- Keep `extra_key=None` hashes unchanged.
- Add a unit test for namespaced page hashes and the prefetch hash path.

## Accuracy Tests

N/A. This only changes cache key construction.

## Speed Tests and Profiling

N/A. No hot-path data movement change.

## Checklist

- [x] Format your code according to the SGLang code style guidance.
- [x] Add unit tests according to the SGLang unit test guidance.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

Validation:

- `python -m py_compile python\sglang\srt\mem_cache\utils.py python\sglang\srt\mem_cache\radix_cache.py python\sglang\srt\managers\cache_controller.py python\sglang\srt\mem_cache\hybrid_cache\hybrid_cache_controller.py python\sglang\srt\mem_cache\hiradix_cache.py python\sglang\srt\mem_cache\unified_radix_cache.py python\sglang\srt\mem_cache\hi_mamba_radix_cache.py test\registered\unit\mem_cache\test_radix_cache_unit.py`
- `python -m ruff check --select=F401,F821 python\sglang\srt\mem_cache\utils.py python\sglang\srt\mem_cache\radix_cache.py python\sglang\srt\managers\cache_controller.py python\sglang\srt\mem_cache\hybrid_cache\hybrid_cache_controller.py python\sglang\srt\mem_cache\hiradix_cache.py python\sglang\srt\mem_cache\unified_radix_cache.py python\sglang\srt\mem_cache\hi_mamba_radix_cache.py test\registered\unit\mem_cache\test_radix_cache_unit.py`
- `python -m black --check python\sglang\srt\mem_cache\utils.py python\sglang\srt\mem_cache\radix_cache.py python\sglang\srt\managers\cache_controller.py python\sglang\srt\mem_cache\hybrid_cache\hybrid_cache_controller.py python\sglang\srt\mem_cache\hiradix_cache.py python\sglang\srt\mem_cache\unified_radix_cache.py python\sglang\srt\mem_cache\hi_mamba_radix_cache.py test\registered\unit\mem_cache\test_radix_cache_unit.py`















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26684760708](https://github.com/sgl-project/sglang/actions/runs/26684760708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26684760729](https://github.com/sgl-project/sglang/actions/runs/26684760729)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->