### PR TITLE
fix(function-call): parse qwen xml tool calls

### DIFF
--- a/python/sglang/srt/function_call/qwen25_detector.py
+++ b/python/sglang/srt/function_call/qwen25_detector.py
@@ -41,10 +41,13 @@ class Qwen25Detector(BaseFormatDetector):
         self.tool_call_separator = "\n"
         self._normal_text_buffer = ""  # Buffer for handling partial end tokens
         self._xml_detector = Qwen3CoderDetector()
+        self._streaming_xml = False
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a Qwen 2.5 format tool call."""
-        return self.bot_token in text
+        return self.bot_token in text or (
+            "<function=" in text and self._xml_detector.has_tool_call(text)
+        )
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         """
@@ -54,12 +57,13 @@ class Qwen25Detector(BaseFormatDetector):
         :param tools: List of available tools.
         :return: ParseResult indicating success or failure, consumed text, leftover text, and parsed calls.
         """
+        if "<function=" in text and self._xml_detector.has_tool_call(text):
+            return self._xml_detector.detect_and_parse(text, tools)
+
         idx = text.find(self.bot_token)
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=normal_text, calls=[])
-        if "<function=" in text:
-            return self._xml_detector.detect_and_parse(text, tools)
 
         # Find all <tool_call>\n...\n</tool_call> blocks
         pattern = rf"{re.escape(self.bot_token)}(.*?){re.escape(self.eot_token)}"
@@ -83,6 +87,17 @@ class Qwen25Detector(BaseFormatDetector):
         Streaming incremental parsing for Qwen 2.5 tool calls.
         Uses base class implementation with buffering to handle partial end tokens.
         """
+        pending_text = self._buffer + new_text
+        if self._streaming_xml or (
+            "<function=" in pending_text
+            and self._xml_detector.has_tool_call(pending_text)
+        ):
+            self._streaming_xml = True
+            if self._buffer:
+                new_text = self._buffer + new_text
+                self._buffer = ""
+            return self._xml_detector.parse_streaming_increment(new_text, tools)
+
         result = super().parse_streaming_increment(new_text, tools)
 
         # Handle partial end tokens that are streamed character by character

--- a/python/sglang/srt/function_call/qwen25_detector.py
+++ b/python/sglang/srt/function_call/qwen25_detector.py
@@ -10,6 +10,7 @@ from sglang.srt.function_call.core_types import (
     StructureInfo,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ class Qwen25Detector(BaseFormatDetector):
         self.eot_token = "\n</tool_call>"
         self.tool_call_separator = "\n"
         self._normal_text_buffer = ""  # Buffer for handling partial end tokens
+        self._xml_detector = Qwen3CoderDetector()
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a Qwen 2.5 format tool call."""
@@ -56,6 +58,8 @@ class Qwen25Detector(BaseFormatDetector):
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=normal_text, calls=[])
+        if "<function=" in text:
+            return self._xml_detector.detect_and_parse(text, tools)
 
         # Find all <tool_call>\n...\n</tool_call> blocks
         pattern = rf"{re.escape(self.bot_token)}(.*?){re.escape(self.eot_token)}"

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -4885,6 +4885,36 @@ class TestQwen25Detector(unittest.TestCase):
         self.assertEqual(len(result.calls), 1)
         self.assertIn("let me check", result.normal_text)
 
+    def test_detect_and_parse_xml_style_tool_call(self):
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_current_weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                ),
+            )
+        ]
+        text = (
+            "Thinking Process:\n...</think>\n\n"
+            "<tool_call>\n"
+            "<function=get_current_weather>\n"
+            "<parameter=location>\nNew York\n</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_current_weather")
+        self.assertIn("Thinking Process", result.normal_text)
+        self.assertNotIn("<function=", result.normal_text)
+        self.assertEqual(
+            json.loads(result.calls[0].parameters), {"location": "New York"}
+        )
+
     # -- Streaming tests --
 
     def _collect_streaming_tool_calls(self, chunks):

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -4915,6 +4915,50 @@ class TestQwen25Detector(unittest.TestCase):
             json.loads(result.calls[0].parameters), {"location": "New York"}
         )
 
+    def test_streaming_xml_style_tool_call(self):
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_current_weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                ),
+            )
+        ]
+        chunks = [
+            "Thinking Process:\n",
+            "<tool_call>\n",
+            "<function=get_current_weather>\n",
+            "<parameter=location>\n",
+            "New York",
+            "\n</parameter>\n",
+            "</function>\n",
+            "</tool_call>",
+        ]
+        normal_text = ""
+        tool_calls = {}
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, tools)
+            normal_text += result.normal_text
+            for call in result.calls:
+                if call.tool_index is None:
+                    continue
+                tool_calls.setdefault(call.tool_index, {"name": "", "parameters": ""})
+                if call.name:
+                    tool_calls[call.tool_index]["name"] = call.name
+                if call.parameters:
+                    tool_calls[call.tool_index]["parameters"] += call.parameters
+
+        self.assertEqual(normal_text, "Thinking Process:\n")
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_current_weather")
+        self.assertEqual(
+            json.loads(tool_calls[0]["parameters"]), {"location": "New York"}
+        )
+
     # -- Streaming tests --
 
     def _collect_streaming_tool_calls(self, chunks):


### PR DESCRIPTION
﻿## Summary
- Fixes #26790
- Let the `qwen` / `qwen25` parser handle XML-style `<function=...>` tool calls as well as the existing JSON form
- Reuses the existing Qwen3 Coder XML parser path instead of duplicating XML parameter parsing logic
- Adds a non-streaming regression test for the reported OpenAI response shape

## To verify
- `python -m py_compile python\sglang\srt\function_call\qwen25_detector.py test\registered\unit\function_call\test_function_call_parser.py`
- `python -m ruff check --select=F401,F821 python\sglang\srt\function_call\qwen25_detector.py test\registered\unit\function_call\test_function_call_parser.py`
- `python -m black --check python\sglang\srt\function_call\qwen25_detector.py test\registered\unit\function_call\test_function_call_parser.py`
- `git diff --check`

I also ran a focused parser behavior check for the XML sample from the issue. Full pytest collection is blocked in my Windows checkout because importing `sglang` pulls POSIX/runtime dependencies (`resource`, then `triton`) that are not available in this environment.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26708916914](https://github.com/sgl-project/sglang/actions/runs/26708916914)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26708916904](https://github.com/sgl-project/sglang/actions/runs/26708916904)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->