### PR TITLE
[core] Compute token_type_ids in ForwardBatch.init_new

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1537,7 +1537,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # Read by ForwardBatch ngram embedding init
     ne_token_table: torch.Tensor = None
 
-    token_type_ids: torch.Tensor = None  # shape: [b], int64
     req_pool_indices: torch.Tensor = None  # shape: [b], int64
     seq_lens: torch.Tensor = None  # shape: [b], int64
 
@@ -1809,10 +1808,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         prefix_lens = [len(r.prefix_indices) for r in reqs]
         extend_lens = [r.extend_input_len for r in reqs]
 
-        token_type_ids = [
-            r.token_type_ids for r in reqs if r.token_type_ids is not None
-        ]
-
         _pin = is_pin_memory_available(self.device)
         # Stay on pinned CPU; H2D is deferred to forward stream via
         # resolve_forward_inputs.
@@ -1824,12 +1819,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         orig_seq_lens_tensor = torch.tensor(
             orig_seq_lens, dtype=torch.int32, pin_memory=_pin
         ).to(self.device, non_blocking=True)
-
-        token_type_ids_tensor = None
-        if len(token_type_ids) > 0:
-            token_type_ids_tensor = torch.tensor(
-                sum(token_type_ids, []), dtype=torch.int64, pin_memory=_pin
-            ).to(self.device, non_blocking=True)
 
         # Set batch fields needed by alloc_for_extend
         self.prefix_lens = prefix_lens
@@ -2025,7 +2014,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     self.device, non_blocking=True
                 )
         self.multimodal_inputs = multimodal_inputs
-        self.token_type_ids = token_type_ids_tensor
         self.seq_lens_sum = sum(seq_lens)
 
         if self.return_logprob:

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -558,7 +558,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             spec_info=batch.spec_info,
         )
 
-        ret._maybe_init_embedding_mode_fields(batch)
+        ret._maybe_init_non_generation_fields(batch)
 
         device = model_runner.device
 
@@ -677,10 +677,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         return ret
 
-    def _maybe_init_embedding_mode_fields(self, batch: ScheduleBatch):
-        """Derive per-request fields for embedding-mode (max_new_tokens==0)
-        forwards from ``batch.reqs``. Two independent parts, each with its own
-        gate:
+    def _maybe_init_non_generation_fields(self, batch: ScheduleBatch):
+        """Derive per-request fields for non-generation (max_new_tokens==0)
+        forwards -- embedding / reward / scoring / cross-encoder -- from
+        ``batch.reqs``. Two independent parts, each with its own gate:
 
         - Pooling fields (dimensions / return_pooled_hidden_states / MIS
           delimiter indices): gated on ``is_prefill_only`` (the spec-disabled

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -678,18 +678,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         return ret
 
     def _maybe_init_non_generation_fields(self, batch: ScheduleBatch):
-        """Derive per-request fields for non-generation (max_new_tokens==0)
-        forwards -- embedding / reward / scoring / cross-encoder -- from
-        ``batch.reqs``. Two independent parts, each with its own gate:
+        """Derive non-generation (max_new_tokens==0) forward fields from reqs.
 
-        - Pooling fields (dimensions / return_pooled_hidden_states / MIS
-          delimiter indices): gated on ``is_prefill_only`` (the spec-disabled
-          subset of embedding mode); a missing value is a harmless default.
-        - Cross-encoder ``token_type_ids``: gated on presence in reqs, NOT on
-          ``is_prefill_only`` -- a missing tensor makes bert/roberta silently
-          fall back to zeros, so we key on the actual data. Built here (not in
-          ScheduleBatch) so SB carries no forward-only device tensor; consumed
-          by bert/roberta/transformers.
+        token_type_ids gates on presence, not is_prefill_only: a missing
+        tensor makes bert/roberta silently fall back to zeros.
         """
         if self.is_prefill_only:
             if batch.model_config.is_matryoshka and any(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -558,22 +558,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             spec_info=batch.spec_info,
         )
 
-        ret._maybe_init_prefill_only(batch)
+        ret._maybe_init_embedding_mode_fields(batch)
 
         device = model_runner.device
-
-        # Cross-encoder token_type_ids: gather from reqs and H2D on the forward
-        # stream. Built here (not in ScheduleBatch) so SB carries no
-        # forward-only device tensor; consumed by bert/roberta/transformers.
-        token_type_ids = [
-            r.token_type_ids for r in batch.reqs if r.token_type_ids is not None
-        ]
-        if token_type_ids:
-            ret.token_type_ids = torch.tensor(
-                sum(token_type_ids, []),
-                dtype=torch.int64,
-                pin_memory=is_pin_memory_available(device),
-            ).to(device, non_blocking=True)
 
         if batch.extend_input_logprob_token_ids is not None:
             ret.extend_input_logprob_token_ids_gpu = (
@@ -690,37 +677,56 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         return ret
 
-    def _maybe_init_prefill_only(self, batch: ScheduleBatch):
-        """Derive per-request fields from ``batch.reqs`` for non-generation
-        (embedding / reward / scoring) forwards; a no-op otherwise."""
-        if not self.is_prefill_only:
-            return
+    def _maybe_init_embedding_mode_fields(self, batch: ScheduleBatch):
+        """Derive per-request fields for embedding-mode (max_new_tokens==0)
+        forwards from ``batch.reqs``. Two independent parts, each with its own
+        gate:
 
-        if batch.model_config.is_matryoshka and any(
-            r.dimensions is not None for r in batch.reqs
-        ):
-            self.dimensions = [
-                r.dimensions if r.dimensions else batch.model_config.hidden_size
-                for r in batch.reqs
-            ]
+        - Pooling fields (dimensions / return_pooled_hidden_states / MIS
+          delimiter indices): gated on ``is_prefill_only`` (the spec-disabled
+          subset of embedding mode); a missing value is a harmless default.
+        - Cross-encoder ``token_type_ids``: gated on presence in reqs, NOT on
+          ``is_prefill_only`` -- a missing tensor makes bert/roberta silently
+          fall back to zeros, so we key on the actual data. Built here (not in
+          ScheduleBatch) so SB carries no forward-only device tensor; consumed
+          by bert/roberta/transformers.
+        """
+        if self.is_prefill_only:
+            if batch.model_config.is_matryoshka and any(
+                r.dimensions is not None for r in batch.reqs
+            ):
+                self.dimensions = [
+                    r.dimensions if r.dimensions else batch.model_config.hidden_size
+                    for r in batch.reqs
+                ]
 
-        self.return_pooled_hidden_states = any(
-            r.return_pooled_hidden_states for r in batch.reqs
-        )
+            self.return_pooled_hidden_states = any(
+                r.return_pooled_hidden_states for r in batch.reqs
+            )
 
-        # --enable-mis: every request must carry delimiter indices (the score
-        # endpoint always produces MIS-structured requests; consumers index
-        # without None-checking).
-        if get_global_server_args().enable_mis and any(
-            r.multi_item_delimiter_indices is not None for r in batch.reqs
-        ):
-            assert all(
+            # --enable-mis: every request must carry delimiter indices (the score
+            # endpoint always produces MIS-structured requests; consumers index
+            # without None-checking).
+            if get_global_server_args().enable_mis and any(
                 r.multi_item_delimiter_indices is not None for r in batch.reqs
-            ), "MIS batch must have delimiter indices on every request"
-            self.multi_item_delimiter_indices = [
-                torch.tensor(r.multi_item_delimiter_indices, dtype=torch.int64)
-                for r in batch.reqs
-            ]
+            ):
+                assert all(
+                    r.multi_item_delimiter_indices is not None for r in batch.reqs
+                ), "MIS batch must have delimiter indices on every request"
+                self.multi_item_delimiter_indices = [
+                    torch.tensor(r.multi_item_delimiter_indices, dtype=torch.int64)
+                    for r in batch.reqs
+                ]
+
+        token_type_ids = [
+            r.token_type_ids for r in batch.reqs if r.token_type_ids is not None
+        ]
+        if token_type_ids:
+            self.token_type_ids = torch.tensor(
+                sum(token_type_ids, []),
+                dtype=torch.int64,
+                pin_memory=is_pin_memory_available(batch.device),
+            ).to(batch.device, non_blocking=True)
 
     def adjust_num_token_non_padded_for_attn_tp(self, server_args) -> None:
         """Make num_token_non_padded local to this attention-TP rank."""

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -60,7 +60,7 @@ from sglang.srt.utils import (
     is_npu,
     support_triton,
 )
-from sglang.srt.utils.common import ceil_align
+from sglang.srt.utils.common import ceil_align, is_pin_memory_available
 
 if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsProcessorOutput
@@ -534,7 +534,6 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             input_embeds=batch.input_embeds,
             replace_embeds=batch.replace_embeds,
             replace_positions=batch.replace_positions,
-            token_type_ids=batch.token_type_ids,
             # Scalar config / flags
             return_logprob=batch.return_logprob,
             is_extend_in_batch=batch.is_extend_in_batch,
@@ -562,6 +561,19 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         ret._maybe_init_prefill_only(batch)
 
         device = model_runner.device
+
+        # Cross-encoder token_type_ids: gather from reqs and H2D on the forward
+        # stream. Built here (not in ScheduleBatch) so SB carries no
+        # forward-only device tensor; consumed by bert/roberta/transformers.
+        token_type_ids = [
+            r.token_type_ids for r in batch.reqs if r.token_type_ids is not None
+        ]
+        if token_type_ids:
+            ret.token_type_ids = torch.tensor(
+                sum(token_type_ids, []),
+                dtype=torch.int64,
+                pin_memory=is_pin_memory_available(device),
+            ).to(device, non_blocking=True)
 
         if batch.extend_input_logprob_token_ids is not None:
             ret.extend_input_logprob_token_ids_gpu = (


### PR DESCRIPTION
Move the cross-encoder `token_type_ids` device-tensor build out of `ScheduleBatch.prepare_for_extend` into `ForwardBatch.init_new`, so the H2D runs on the forward stream and SB no longer carries a forward-only field. Build expression is unchanged; same data-driven gate (`any(r.token_type_ids)`).



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26700102431](https://github.com/sgl-project/sglang/actions/runs/26700102431)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26700102395](https://github.com/sgl-project/sglang/actions/runs/26700102395)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->