### PR TITLE
Make qwen3's set_embed_and_head idempotent

### DIFF
--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -674,8 +674,10 @@ class Qwen3ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()


### PR DESCRIPTION
Guard the weight deletions in `Qwen3ForCausalLM.set_embed_and_head` with
`hasattr` checks so the method is idempotent: calling it when
`embed_tokens.weight` / `lm_head.weight` have already been deleted (e.g. a
second invocation, or after a prior tie/share step) no longer raises
`AttributeError`.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26700294436](https://github.com/sgl-project/sglang/actions/runs/26700294436)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26700294381](https://github.com/sgl-project/sglang/actions/runs/26700294381)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->