### PR TITLE
Apply gemma's position offset out-of-place instead of in-place

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -199,6 +199,7 @@ class Envs:
     SGLANG_SORT_WEIGHT_FILES = EnvBool(False)
     SGLANG_DISABLED_MODEL_ARCHS = EnvTuple(tuple())
     SGLANG_PREFETCH_BLOCK_SIZE_MB = EnvInt(16)
+    SGLANG_GEMMA_OUT_OF_PLACE_POSITION_MUTATION = EnvBool(False)
 
     # Logging Options
     SGLANG_LOG_GC = EnvBool(False)

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -29,6 +29,7 @@ from transformers import (
 )
 
 from sglang.srt.distributed import get_pp_group
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
 from sglang.srt.layers.layernorm import Gemma4RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
@@ -595,7 +596,11 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                 "You must specify exactly one of input_ids or inputs_embeds"
             )
 
-        positions += 1
+        if envs.SGLANG_GEMMA_OUT_OF_PLACE_POSITION_MUTATION.get():
+            positions = positions + 1
+        else:
+            positions += 1
+
         per_layer_inputs = None
         # PLE table and the per-layer projection live on the first rank only,
         # so non-first ranks must skip this and pull per_layer_inputs from the


### PR DESCRIPTION
Gate the `positions` increment in `Gemma4ForConditionalGeneration` behind a
new `SGLANG_GEMMA_OUT_OF_PLACE_POSITION_MUTATION` env flag. When enabled, the
forward pass uses an out-of-place `positions = positions + 1` instead of the
default in-place `positions += 1`, avoiding mutation of a shared positions
tensor. Adds the env declaration in `environ.py` and the import of `envs` in
`gemma4_mm.py`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26700328363](https://github.com/sgl-project/sglang/actions/runs/26700328363)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26700328354](https://github.com/sgl-project/sglang/actions/runs/26700328354)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->