### PR TITLE
fix(bench): send OpenAI API key in multiturn benchmark

### DIFF
--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import time
 
 import aiohttp
@@ -10,6 +11,11 @@ from sglang.benchmark.datasets.random import sample_random_requests
 from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=20 * 60 * 60)
+
+
+def _openai_auth_headers():
+    api_key = os.environ.get("OPENAI_API_KEY")
+    return {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
 
 async def async_request_sglang_generate(
@@ -108,7 +114,9 @@ async def async_request_openai_chat_completions(
         output = RequestFuncOutput()
 
         try:
-            async with session.post(url=url, json=payload) as response:
+            async with session.post(
+                url=url, json=payload, headers=_openai_auth_headers()
+            ) as response:
                 if response.status == 200:
                     prompt_tokens = 0
                     cached_tokens = 0

--- a/test/registered/unit/test_cache_hit_kit.py
+++ b/test/registered/unit/test_cache_hit_kit.py
@@ -1,0 +1,91 @@
+import asyncio
+import json
+import os
+import socket
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.kits.cache_hit_kit import (
+    async_request_openai_chat_completions,
+    gen_payload_openai,
+)
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class _ChatCompletionHandler(BaseHTTPRequestHandler):
+    auth_headers = []
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        self.auth_headers.append(self.headers.get("Authorization"))
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+
+        chunks = [
+            {"choices": [{"delta": {"content": "ok"}}], "usage": None},
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "prompt_tokens_details": {"cached_tokens": 0},
+                },
+            },
+        ]
+        for chunk in chunks:
+            self.wfile.write(b"data: " + json.dumps(chunk).encode() + b"\n\n")
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def log_message(self, fmt, *args):
+        return
+
+
+class TestOpenAIChatCompletionHeaders(CustomTestCase):
+    def test_openai_api_key_is_sent_for_openai_benchmark_requests(self):
+        _ChatCompletionHandler.auth_headers = []
+        server = HTTPServer(("127.0.0.1", _free_port()), _ChatCompletionHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        url = f"http://127.0.0.1:{server.server_port}/v1/chat/completions"
+        payload = gen_payload_openai(
+            [{"role": "user", "content": "hello"}],
+            output_len=1,
+            model="test-model",
+        )
+
+        try:
+            with patch.dict(os.environ, {"OPENAI_API_KEY": "unit-test-token"}):
+                output = asyncio.run(
+                    async_request_openai_chat_completions(payload, url)
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+        self.assertTrue(output.success)
+        self.assertEqual(
+            _ChatCompletionHandler.auth_headers, ["Bearer unit-test-token"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- send `OPENAI_API_KEY` as a bearer token for the OpenAI-compatible multi-turn cache benchmark request path
- keep unauthenticated behavior unchanged when the environment variable is not set
- add a lightweight local HTTP-server regression test for the header propagation

Fixes #26630.

## To verify
- `python -m py_compile python\sglang\test\kits\cache_hit_kit.py test\registered\unit\test_cache_hit_kit.py`
- `python -m ruff check python\sglang\test\kits\cache_hit_kit.py test\registered\unit\test_cache_hit_kit.py`
- `git diff --check`

I also tried `PYTHONPATH=python python -m pytest test/registered/unit/test_cache_hit_kit.py -q` locally, but this Windows checkout fails during collection before the test runs because importing `sglang` reaches the POSIX-only `resource` module. The neighboring existing `test_bench_long_context.py` fails the same way on this machine.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26702208992](https://github.com/sgl-project/sglang/actions/runs/26702208992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26702208954](https://github.com/sgl-project/sglang/actions/runs/26702208954)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->