### PR TITLE
Fix TokenizerManager crash on top_logprobs with tensor values

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2144,7 +2144,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # We should batch all top-k tokens in all positions.
         ret = []
         for i in range(len(token_logprobs_val)):
-            if token_logprobs_val[i]:
+            if token_logprobs_val[i] is not None:
                 ret.append(
                     self.detokenize_logprob_tokens(
                         token_logprobs_val[i], token_logprobs_idx[i], decode_to_text

--- a/test/registered/unit/managers/test_tokenizer_manager_top_logprobs_tensor.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_top_logprobs_tensor.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for TokenizerManager.detokenize_top_logprobs_tokens.
+
+Regression coverage for a crash where a per-position logprob value is a
+multi-element torch.Tensor instead of the annotated List[float]. The old
+truthiness check ``if token_logprobs_val[i]:`` raises::
+
+    RuntimeError: Boolean value of Tensor with more than one value is ambiguous.
+
+which propagates out of the detokenization handler, gets caught by
+print_exception_wrapper, and SIGKILLs the whole (prefill) process. The fix
+uses an explicit ``is not None`` test that matches the actual sentinel for
+skipped positions and works for both lists and tensors.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_tokenizer_manager() -> TokenizerManager:
+    """Create a bare TokenizerManager, bypassing __init__.
+
+    detokenize_top_logprobs_tokens / detokenize_logprob_tokens only touch
+    self.tokenizer when decode_to_text=True, so an uninitialised instance is
+    sufficient for the decode_to_text=False paths exercised here.
+    """
+    return TokenizerManager.__new__(TokenizerManager)
+
+
+class TestDetokenizeTopLogprobsTensor(CustomTestCase):
+    def test_multi_element_tensor_value_does_not_crash(self):
+        """A multi-element tensor position must be detokenized, not raise."""
+        tm = _make_tokenizer_manager()
+
+        val = [torch.tensor([-0.1, -0.2, -0.3])]
+        idx = [[10, 20, 30]]
+
+        ret = tm.detokenize_top_logprobs_tokens(val, idx, decode_to_text=False)
+
+        self.assertEqual(len(ret), 1)
+        self.assertEqual(
+            ret[0],
+            [(-0.1, 10, None), (-0.2, 20, None), (-0.3, 30, None)],
+        )
+
+    def test_none_position_yields_none(self):
+        """None is the sentinel for skipped positions and must stay None."""
+        tm = _make_tokenizer_manager()
+
+        val = [None, torch.tensor([-0.5, -0.6])]
+        idx = [None, [1, 2]]
+
+        ret = tm.detokenize_top_logprobs_tokens(val, idx, decode_to_text=False)
+
+        self.assertEqual(len(ret), 2)
+        self.assertIsNone(ret[0])
+        self.assertEqual(ret[1], [(-0.5, 1, None), (-0.6, 2, None)])
+
+    def test_plain_list_values_still_work(self):
+        """The ordinary List[float] path is unaffected by the fix."""
+        tm = _make_tokenizer_manager()
+
+        val = [[-0.1, -0.2]]
+        idx = [[7, 8]]
+
+        ret = tm.detokenize_top_logprobs_tokens(val, idx, decode_to_text=False)
+
+        self.assertEqual(ret, [[(-0.1, 7, None), (-0.2, 8, None)]])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

`detokenize_top_logprobs_tokens` checked `if token_logprobs_val[i]:` to skip
empty positions. When `token_logprobs_val[i]` is a multi-element `torch.Tensor`
(instead of the annotated `List[float]`), Python evaluates the truthiness of the
tensor and raises:

```
RuntimeError: Boolean value of Tensor with more than one value is ambiguous.
```

This propagates out of the detokenization handler and is caught by
`print_exception_wrapper`, which calls
`kill_process_tree(os.getpid(), include_parent=True)` and SIGKILLs the whole
prefill process (exit code -9). In disaggregated PD deployments this manifests
as a prefill restart storm whenever clients send requests with
`top_logprobs > 0`.

## Modifications

- Replace the truthiness check with an explicit `is not None` test in
  `detokenize_top_logprobs_tokens`. This matches the actual sentinel used to
  mark skipped positions and works for both lists and tensors.
- Add a CPU unit test
  (`test/registered/unit/managers/test_tokenizer_manager_top_logprobs_tensor.py`)
  that reproduces the crash with a multi-element tensor value and verifies the
  None-sentinel and plain-list paths.

## Accuracy Tests

N/A — this is an error-path correctness fix. It does not touch kernels or model
forward code and does not change model outputs.

## Speed Tests and Profiling

N/A — no impact on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26703224250](https://github.com/sgl-project/sglang/actions/runs/26703224250)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26703224130](https://github.com/sgl-project/sglang/actions/runs/26703224130)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->