### PR TITLE
Fix peak throughput undercount for OpenAI-compatible backends

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -962,6 +962,44 @@ async def get_request(
             await asyncio.sleep(interval)
 
 
+def _build_token_arrival_times(
+    output: RequestFuncOutput,
+    tokenizer: PreTrainedTokenizerBase,
+) -> List[float]:
+    """Build per-token arrival timestamps for peak throughput calculation.
+
+    OpenAI-compatible streaming backends may batch multiple tokens into one SSE
+    chunk while ``output_len`` reflects the true token count. Expand each chunk
+    interval across its tokens (same approach as ``async_request_sglang_generate``).
+    """
+    token_times = [output.start_time + output.ttft]
+    current_time = token_times[0]
+
+    if output.text_chunks:
+        for chunk_text, itl_value in zip(output.text_chunks, output.itl):
+            num_tokens = len(tokenizer.encode(chunk_text, add_special_tokens=False))
+            if num_tokens <= 0:
+                continue
+            adjust_itl = itl_value / num_tokens
+            for _ in range(num_tokens):
+                current_time += adjust_itl
+                token_times.append(current_time)
+    else:
+        for itl_value in output.itl:
+            current_time += itl_value
+            token_times.append(current_time)
+
+    if output.output_len > len(token_times):
+        remaining = output.output_len - len(token_times)
+        decode_duration = max(output.latency - output.ttft, 0.0)
+        avg_itl = decode_duration / max(output.output_len - 1, 1)
+        for _ in range(remaining):
+            current_time += avg_itl
+            token_times.append(current_time)
+
+    return token_times
+
+
 def calculate_metrics(
     input_requests: Optional[List[DatasetRow]],
     outputs: List[RequestFuncOutput],
@@ -1048,11 +1086,7 @@ def calculate_metrics(
             if not output.success:
                 continue
 
-            token_times = [output.start_time + output.ttft]
-            current_time = token_times[0]
-            for itl_value in output.itl:
-                current_time += itl_value
-                token_times.append(current_time)
+            token_times = _build_token_arrival_times(output, tokenizer)
 
             for token_time in token_times:
                 second_bucket = int(token_time - min_start_time)


### PR DESCRIPTION
## Motivation

When running `bench_serving` with OpenAI-compatible backends (e.g. `--backend sglang-oai`), **Peak output token throughput** can be lower than **Output token throughput**, which is counter-intuitive and makes benchmark results hard to interpret.

Root cause: average throughput uses `output_len` (actual generated token count), while peak throughput previously counted **one token per SSE chunk**. SGLang's OpenAI completions streaming can batch multiple tokens into a single chunk (see `serving_completions.py` delta generation), but `async_request_openai_completions` only records one ITL entry per chunk. The native `sglang` backend already expands ITL per token via `completion_tokens` deltas in `async_request_sglang_generate`.

This PR aligns peak-throughput token counting with average-throughput token counting for OpenAI-compatible streaming backends.

## Modifications

- Add `_build_token_arrival_times()` to expand each streaming chunk's ITL across its actual token count using `text_chunks` and the benchmark tokenizer.
- Use the expanded per-token timestamps when building the per-second peak throughput histogram in `calculate_metrics()`.
- Add a fallback that distributes any remaining tokens (when `output_len` still exceeds recorded timestamps) evenly across the decode phase.

Affected file: `python/sglang/bench_serving.py`.

No server/runtime behavior is changed; this only fixes benchmark metric reporting.

## Accuracy Tests

N/A. This change does not modify model forward code or generation outputs.

## Speed Tests and Profiling

N/A for server inference speed. This PR fixes benchmark **reporting**, not runtime performance.

Suggested verification with `bench_serving`:

```bash
python3 -m sglang.bench_serving \
  --backend sglang-oai \
  --base-url http://127.0.0.1:30000 \
  --model <model> \
  --dataset-name random \
  --num-prompts 100 \
  --random-input 512 \
  --random-output 128 \
  --request-rate inf

python3 -m sglang.bench_serving \
  --backend sglang \
  --base-url http://127.0.0.1:30000 \
  --model <model> \
  --dataset-name random \
  --num-prompts 100 \
  --random-input 512 \
  --random-output 128 \
  --request-rate inf











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26703600037](https://github.com/sgl-project/sglang/actions/runs/26703600037)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26703599988](https://github.com/sgl-project/sglang/actions/runs/26703599988)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->