### PR TITLE
Add GDN target verify intermediate state indexing contract

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1078,6 +1078,20 @@ class HybridLinearAttnBackend(AttentionBackend):
         intermediate_state_cache = mamba_caches.intermediate_ssm
         intermediate_conv_window_cache = mamba_caches.intermediate_conv_window[0]
 
+        verify_kernel = self.linear_attn_backend.kernel_dispatcher.verify_kernel
+        intermediate_state_indexing = (
+            verify_kernel.target_verify_intermediate_state_indexing
+        )
+        if intermediate_state_indexing == "batch":
+            intermediate_state_src_indices = None
+        elif intermediate_state_indexing == "cache":
+            intermediate_state_src_indices = state_indices_tensor
+        else:
+            raise RuntimeError(
+                "Unsupported target verify intermediate state indexing: "
+                f"{intermediate_state_indexing}"
+            )
+
         # Use fully fused kernel that handles masking internally
         # This avoids separate nonzero() and index_select() calls
         fused_mamba_state_scatter_with_mask(
@@ -1085,6 +1099,7 @@ class HybridLinearAttnBackend(AttentionBackend):
             intermediate_state_cache,
             state_indices_tensor,
             last_correct_step_indices,
+            src_indices_raw=intermediate_state_src_indices,
         )
         fused_mamba_state_scatter_with_mask(
             conv_states,
@@ -1102,6 +1117,7 @@ class HybridLinearAttnBackend(AttentionBackend):
                 intermediate_state_cache,
                 mamba_track_indices,
                 mamba_steps_to_track,
+                src_indices_raw=intermediate_state_src_indices,
             )
             fused_mamba_state_scatter_with_mask(
                 conv_states,

--- a/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
@@ -10,6 +10,11 @@ class LinearAttnKernelBase(ABC):
     and provides decode/extend/target_verify methods with a unified interface.
     """
 
+    # How target_verify lays out cached intermediate states:
+    # "batch" -> intermediate_state[batch_idx, step]
+    # "cache" -> intermediate_state[cache_indices[batch_idx], step]
+    target_verify_intermediate_state_indexing: str = "batch"
+
     @abstractmethod
     def decode(
         self,

--- a/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
@@ -6,6 +6,8 @@ This kernel replaces the expensive advanced indexing operations in
 avoiding multiple `index_elementwise_kernel` launches.
 """
 
+from typing import Optional
+
 import torch
 import triton
 import triton.language as tl
@@ -18,6 +20,7 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     # Raw index arrays (before index_select)
     dst_indices_raw_ptr,  # [total_requests] - state_indices_tensor
     step_indices_raw_ptr,  # [total_requests] - last_correct_step_indices or mamba_steps_to_track
+    src_indices_raw_ptr,  # optional [total_requests] - source request/cache indices
     elem_per_entry: tl.constexpr,
     src_layer_stride,
     src_req_stride,
@@ -27,6 +30,7 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     src_req_size,
     src_step_size,
     dst_req_size,
+    HAS_SRC_INDICES: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     """
@@ -36,7 +40,8 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     1. Iterating over all requests (pid_req from 0 to total_requests-1)
     2. Checking if step_indices_raw[pid_req] >= 0 (valid mask)
     3. If valid, performing the scatter:
-       dst[l, dst_indices_raw[pid_req], :] = src[l, pid_req, step_indices_raw[pid_req], :]
+       dst[l, dst_indices_raw[pid_req], :] = src[l, src_idx, step_indices_raw[pid_req], :]
+       where src_idx is either pid_req or src_indices_raw[pid_req].
 
     Grid: (total_requests, num_layers, ceil(elem_per_entry / BLOCK_SIZE))
     """
@@ -54,8 +59,10 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     # Load destination index
     dst_idx = tl.load(dst_indices_raw_ptr + pid_req).to(tl.int64)
 
-    # Source index is just the request index itself
-    src_idx = pid_req
+    if HAS_SRC_INDICES:
+        src_idx = tl.load(src_indices_raw_ptr + pid_req).to(tl.int64)
+    else:
+        src_idx = pid_req
 
     # Bounds check to avoid illegal memory access
     if not (
@@ -90,6 +97,7 @@ def fused_mamba_state_scatter_with_mask(
     src: torch.Tensor,  # [num_layers, spec_size, draft_tokens, *state_shape]
     dst_indices_raw: torch.Tensor,  # [total_requests] - raw indices (e.g., state_indices_tensor)
     step_indices_raw: torch.Tensor,  # [total_requests] - raw step indices (step >= 0 means valid)
+    src_indices_raw: Optional[torch.Tensor] = None,
 ):
     """
     Fully fused gather-scatter with built-in masking for mamba state updates.
@@ -99,13 +107,17 @@ def fused_mamba_state_scatter_with_mask(
     2. valid_indices = valid_mask.nonzero()
     3. dst_indices = dst_indices_raw[valid_indices]  (index_select)
     4. step_indices = step_indices_raw[valid_indices]  (index_select)
-    5. for each valid i: dst[:, dst_indices[i], :] = src[:, i, step_indices[i], :]
+    5. for each valid i: dst[:, dst_indices[i], :] = src[:, src_idx[i], step_indices[i], :]
+
+    By default `src_idx[i] == i`. If `src_indices_raw` is provided,
+    `src_idx[i] == src_indices_raw[i]`.
 
     Args:
         dst: Destination tensor [num_layers, cache_size, *state_shape]
         src: Source tensor [num_layers, spec_size, draft_tokens, *state_shape]
         dst_indices_raw: Raw destination indices for all requests [total_requests]
         step_indices_raw: Raw step indices; entry >= 0 means valid [total_requests]
+        src_indices_raw: Optional source indices for all requests [total_requests]
     """
     total_requests = step_indices_raw.shape[0]
     if total_requests == 0:
@@ -129,13 +141,31 @@ def fused_mamba_state_scatter_with_mask(
         raise ValueError(
             f"Trailing dims mismatch: {dst.shape[2:]=} vs {src.shape[3:]=}"
         )
-    if dst_indices_raw.ndim != 1 or step_indices_raw.ndim != 1:
+    if src_indices_raw is None:
+        src_indices_arg = dst_indices_raw
+        has_src_indices = False
+    else:
+        src_indices_arg = src_indices_raw
+        has_src_indices = True
+
+    if (
+        dst_indices_raw.ndim != 1
+        or step_indices_raw.ndim != 1
+        or src_indices_arg.ndim != 1
+    ):
         raise ValueError(
-            f"indices must be 1D: {dst_indices_raw.shape=} {step_indices_raw.shape=}"
+            "indices must be 1D: "
+            f"{dst_indices_raw.shape=} {step_indices_raw.shape=} {src_indices_arg.shape=}"
         )
-    if dst_indices_raw.shape[0] != step_indices_raw.shape[0]:
+    if not (
+        dst_indices_raw.shape[0]
+        == step_indices_raw.shape[0]
+        == src_indices_arg.shape[0]
+    ):
         raise ValueError(
-            f"indices length mismatch: {dst_indices_raw.shape[0]=} vs {step_indices_raw.shape[0]=}"
+            "indices length mismatch: "
+            f"{dst_indices_raw.shape[0]=} {step_indices_raw.shape[0]=} "
+            f"{src_indices_arg.shape[0]=}"
         )
 
     num_layers = dst.shape[0]
@@ -156,6 +186,7 @@ def fused_mamba_state_scatter_with_mask(
     # Ensure indices are int32 and contiguous
     dst_indices_raw = dst_indices_raw.to(torch.int32).contiguous()
     step_indices_raw = step_indices_raw.to(torch.int32).contiguous()
+    src_indices_arg = src_indices_arg.to(torch.int32).contiguous()
 
     # Ensure tensors are contiguous
     if not dst.is_contiguous():
@@ -174,6 +205,7 @@ def fused_mamba_state_scatter_with_mask(
         dst,
         dst_indices_raw,
         step_indices_raw,
+        src_indices_arg,
         elem_per_entry,
         src_layer_stride,
         src_req_stride,
@@ -183,5 +215,6 @@ def fused_mamba_state_scatter_with_mask(
         src_req_size,
         src_step_size,
         dst_req_size,
+        HAS_SRC_INDICES=has_src_indices,
         BLOCK_SIZE=BLOCK_SIZE,
     )


### PR DESCRIPTION
## Motivation

The existing upstream target-verify kernels keep the default batch-indexed intermediate-state contract:
- `TritonGDNKernel.target_verify`
- `FlashInferGDNKernel` on SM90/fp32, which uses FlashInfer's fp32 MTP wrapper

The follow-up SM100 bf16 FlashInfer MTP path can differ by FlashInfer runtime:
- Older bf16 MTP runtimes used a KV-cache/pool-indexed contract: `intermediate_ssm[cache_indices[batch_idx], step]`.
- Newer bf16 MTP APIs document a batch-indexed contract: `intermediate_ssm[batch_idx, step]`.

This PR adds an explicit kernel contract so the full-cache commit path reads the accepted final state from the layout declared by the verify kernel. The default remains `"batch"`, so existing Triton and SM90/fp32 FlashInfer verify paths are unchanged.

## Modifications

- Add `target_verify_intermediate_state_indexing`, defaulting to `"batch"`, to the linear attention kernel backend.
- Let the fused Mamba state scatter kernel optionally gather source rows from explicit indices.
- Teach the hybrid linear attention backend to use the verify kernel's declared intermediate-state layout when committing accepted GDN state.

## Accuracy Tests

Full deterministic GSM8K, Qwen3.5-397B-A17B-FP8, 8-shot, `temperature=0.0`, `top_p=1.0`, `max_tokens=14000`, `top_k=20`, `num_threads=256`, 1319 examples:

Full GSM8K1319 rerun results. Any smaller smoke run is intentionally not used as PR evidence.

| Variant | Verify kernel | Score |
|---|---|---:|
| upstream main | Triton | 0.977879 (job 1965971) |
| this PR | Triton | 0.977879 (job 1965972) |

GSM8K repro command:

```bash
export MODEL_PATH=/path/to/Qwen3.5-397B-A17B-FP8

python3 -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --served-model-name Qwen/Qwen3.5-397B-A17B-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --attention-backend trtllm_mha \
  --chunked-prefill-size 16384 \
  --context-length 16384 \
  --cuda-graph-max-bs 256 \
  --decode-log-interval 10 \
  --disable-radix-cache \
  --expert-parallel-size 1 \
  --kv-cache-dtype fp8_e4m3 \
  --linear-attn-decode-backend flashinfer \
  --mamba-scheduler-strategy no_buffer \
  --mamba-ssm-dtype bfloat16 \
  --max-prefill-tokens 16384 \
  --max-running-requests 256 \
  --mem-fraction-static 0.8 \
  --moe-runner-backend flashinfer_trtllm \
  --quantization fp8 \
  --random-seed 0 \
  --reasoning-parser qwen3 \
  --speculative-algorithm NEXTN \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --speculative-num-steps 3 \
  --stream-interval 50 \
  --tensor-parallel-size 4 \
  --trust-remote-code

python3 -m sglang.test.run_eval \
  --host 127.0.0.1 \
  --port 30000 \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --eval-name gsm8k \
  --num-examples 1319 \
  --num-threads 256 \
  --num-shots 8 \
  --max-tokens 14000 \
  --temperature 0.0 \
  --top-p 1.0 \
  --top-k 20 \
  --thinking-mode qwen-3
```

## Speed Tests and Profiling

SA-Bench c=256, ISL/OSL=1000/1000, Qwen3.5-397B-A17B-FP8:

| Variant | Verify kernel | Output tok/s | Median TPOT |
|---|---|---:|---:|
| upstream main | Triton | 10790.028 | 19.499 ms |
| this PR | Triton | 10894.487 | 19.346 ms |

Perf repro command:

```bash
export MODEL_PATH=/path/to/Qwen3.5-397B-A17B-FP8

python3 -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --served-model-name Qwen/Qwen3.5-397B-A17B-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --attention-backend trtllm_mha \
  --chunked-prefill-size 16384 \
  --context-length 4096 \
  --cuda-graph-max-bs 256 \
  --decode-log-interval 10 \
  --disable-radix-cache \
  --expert-parallel-size 1 \
  --kv-cache-dtype fp8_e4m3 \
  --linear-attn-decode-backend flashinfer \
  --mamba-scheduler-strategy no_buffer \
  --mamba-ssm-dtype bfloat16 \
  --max-prefill-tokens 16384 \
  --max-running-requests 256 \
  --mem-fraction-static 0.8 \
  --moe-runner-backend flashinfer_trtllm \
  --quantization fp8 \
  --random-seed 0 \
  --speculative-algorithm NEXTN \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --speculative-num-steps 3 \
  --stream-interval 50 \
  --tensor-parallel-size 4 \
  --trust-remote-code

python3 -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 \
  --port 30000 \
  --dataset-name random \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --random-input-len 1000 \
  --random-output-len 1000 \
  --random-range-ratio 1.0 \
  --num-prompts 512 \
  --max-concurrency 256 \
  --request-rate inf \
  --seed 0
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide full accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26719141948](https://github.com/sgl-project/sglang/actions/runs/26719141948)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #26737253686](https://github.com/sgl-project/sglang/actions/runs/26737253686)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->




