### PR TITLE
Support FlashInfer SM100 GDN MTP verify

### DIFF
--- a/python/sglang/jit_kernel/tests/test_gdn_flashinfer_mtp_verify.py
+++ b/python/sglang/jit_kernel/tests/test_gdn_flashinfer_mtp_verify.py
@@ -1,0 +1,80 @@
+import torch
+
+from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
+    FlashInferGDNKernel,
+)
+
+
+def test_sm100_bf16_mtp_uses_cache_scoped_intermediate_buffer():
+    captured = _run_sm100_bf16_mtp_wrapper()
+
+    assert captured["intermediate_shape"] == (8, 3, 4, 8, 8)
+    assert captured["cache_indices"].tolist() == [4, 6]
+    assert captured["target_verify_intermediate_state_indexing"] == "cache"
+
+
+def _run_sm100_bf16_mtp_wrapper():
+    batch_size = 2
+    draft_token_num = 3
+    pool_size = 8
+    num_heads = 2
+    num_v_heads = 4
+    head_dim = 8
+
+    captured = {}
+
+    def fake_bf16_mtp_fn(**kwargs):
+        intermediate_states_buffer = kwargs["intermediate_states_buffer"]
+        captured["intermediate_shape"] = tuple(intermediate_states_buffer.shape)
+        captured["cache_indices"] = kwargs["initial_state_indices"].clone()
+        return torch.empty(
+            batch_size,
+            draft_token_num,
+            num_v_heads,
+            head_dim,
+            dtype=kwargs["v"].dtype,
+        )
+
+    kernel = object.__new__(FlashInferGDNKernel)
+    kernel.use_state_pool = True
+    kernel._bf16_mtp_fn = fake_bf16_mtp_fn
+    kernel.target_verify_intermediate_state_indexing = "cache"
+
+    seq_len = batch_size * draft_token_num
+    q = torch.randn(1, seq_len, num_heads, head_dim)
+    k = torch.randn(1, seq_len, num_heads, head_dim)
+    v = torch.randn(1, seq_len, num_v_heads, head_dim)
+    a = torch.randn(seq_len, num_v_heads)
+    b = torch.randn(seq_len, num_v_heads)
+    ssm_states = torch.randn(pool_size, num_v_heads, head_dim, head_dim)
+    cache_indices = torch.tensor([4, 6], dtype=torch.int32)
+    intermediate_states_buffer = torch.empty(
+        pool_size,
+        draft_token_num,
+        num_v_heads,
+        head_dim,
+        head_dim,
+    )
+
+    output = kernel.target_verify(
+        A_log=torch.randn(num_v_heads),
+        dt_bias=torch.randn(num_v_heads),
+        q=q,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        ssm_states=ssm_states,
+        cache_indices=cache_indices,
+        query_start_loc=torch.arange(0, seq_len + 1, draft_token_num),
+        intermediate_states_buffer=intermediate_states_buffer,
+        intermediate_state_indices=torch.arange(batch_size, dtype=torch.int32),
+        cache_steps=draft_token_num,
+        retrieve_parent_token=None,
+    )
+
+    assert output.shape == (1, seq_len, num_v_heads, head_dim)
+    captured["target_verify_intermediate_state_indexing"] = (
+        kernel.target_verify_intermediate_state_indexing
+    )
+    return captured

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1078,6 +1078,20 @@ class HybridLinearAttnBackend(AttentionBackend):
         intermediate_state_cache = mamba_caches.intermediate_ssm
         intermediate_conv_window_cache = mamba_caches.intermediate_conv_window[0]
 
+        verify_kernel = self.linear_attn_backend.kernel_dispatcher.verify_kernel
+        intermediate_state_indexing = (
+            verify_kernel.target_verify_intermediate_state_indexing
+        )
+        if intermediate_state_indexing == "batch":
+            intermediate_state_src_indices = None
+        elif intermediate_state_indexing == "cache":
+            intermediate_state_src_indices = state_indices_tensor
+        else:
+            raise RuntimeError(
+                "Unsupported target verify intermediate state indexing: "
+                f"{intermediate_state_indexing}"
+            )
+
         # Use fully fused kernel that handles masking internally
         # This avoids separate nonzero() and index_select() calls
         fused_mamba_state_scatter_with_mask(
@@ -1085,6 +1099,7 @@ class HybridLinearAttnBackend(AttentionBackend):
             intermediate_state_cache,
             state_indices_tensor,
             last_correct_step_indices,
+            src_indices_raw=intermediate_state_src_indices,
         )
         fused_mamba_state_scatter_with_mask(
             conv_states,
@@ -1102,6 +1117,7 @@ class HybridLinearAttnBackend(AttentionBackend):
                 intermediate_state_cache,
                 mamba_track_indices,
                 mamba_steps_to_track,
+                src_indices_raw=intermediate_state_src_indices,
             )
             fused_mamba_state_scatter_with_mask(
                 conv_states,

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -3,7 +3,8 @@
 Both SM90 and SM100+ use the same pool layout: [pool, HV, V, K] (K-last).
 
 SM90 (Hopper): full support — decode, prefill, MTP.  State dtype: fp32.
-SM100+ (Blackwell+): decode and prefill with bf16 state.  MTP verify on the way.
+SM100+ (Blackwell+): decode and prefill with bf16 state. MTP verify is enabled
+when FlashInfer provides the bf16-state MTP entry point.
 
 Requires flashinfer >= 0.6.4 (SM90) or >= 0.6.5 (SM100+).
 """
@@ -27,14 +28,17 @@ _flashinfer_gdn_available: Optional[bool] = None
 _flashinfer_chunk_gated_delta_rule = None
 _flashinfer_gated_delta_rule_mtp = None
 _flashinfer_gated_delta_rule_decode = None
+_flashinfer_bf16_mtp_fn = None
 
 
 def _get_flashinfer_gdn_kernels():
     """Lazy import for FlashInfer GDN prefill, decode and verify (MTP) kernels.
 
-    Returns (available, prefill_fn, mtp_fn, decode_fn).
+    Returns (available, prefill_fn, mtp_fn, decode_fn, bf16_mtp_fn).
     """
-    global _flashinfer_gdn_available, _flashinfer_chunk_gated_delta_rule, _flashinfer_gated_delta_rule_mtp, _flashinfer_gated_delta_rule_decode
+    global _flashinfer_gdn_available, _flashinfer_chunk_gated_delta_rule
+    global _flashinfer_gated_delta_rule_mtp, _flashinfer_gated_delta_rule_decode
+    global _flashinfer_bf16_mtp_fn
     if _flashinfer_gdn_available is None:
         try:
             os.environ.setdefault("FLASHINFER_DISABLE_VERSION_CHECK", "1")
@@ -48,6 +52,17 @@ def _get_flashinfer_gdn_kernels():
             _flashinfer_chunk_gated_delta_rule = chunk_gated_delta_rule
             _flashinfer_gated_delta_rule_mtp = gated_delta_rule_mtp
             _flashinfer_gated_delta_rule_decode = gated_delta_rule_decode_pretranspose
+            try:
+                from flashinfer.gdn_kernels.gdn_decode_bf16_state import (
+                    gated_delta_rule_mtp as bf16_mtp_fn,
+                )
+
+                _flashinfer_bf16_mtp_fn = bf16_mtp_fn
+            except (ImportError, RuntimeError, AttributeError) as e:
+                logger.debug(
+                    "FlashInfer GDN bf16-state MTP kernel not available: %s", e
+                )
+                _flashinfer_bf16_mtp_fn = None
             _flashinfer_gdn_available = (
                 torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
             )
@@ -62,6 +77,7 @@ def _get_flashinfer_gdn_kernels():
         _flashinfer_chunk_gated_delta_rule,
         _flashinfer_gated_delta_rule_mtp,
         _flashinfer_gated_delta_rule_decode,
+        _flashinfer_bf16_mtp_fn,
     )
 
 
@@ -74,7 +90,8 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
     """FlashInfer kernel for GDN with K-last SSM state layout.
 
     SM90 (Hopper): decode uses gather/scatter; prefill and MTP verify supported.
-    SM100+ (Blackwell+): decode and prefill supported; MTP verify not yet supported.
+    SM100+ (Blackwell+): decode and prefill supported; MTP verify is enabled
+    when the optional bf16-state MTP kernel is available.
 
     Requires flashinfer >= 0.6.4 (SM90) or >= 0.6.5 (SM100+).
     """
@@ -85,6 +102,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             self._prefill_fn,
             self._mtp_fn,
             self._decode_fn,
+            self._bf16_mtp_fn,
         ) = _get_flashinfer_gdn_kernels()
 
         if not available:
@@ -97,7 +115,10 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
 
         sm_major = torch.cuda.get_device_capability()[0]
         self.use_state_pool = sm_major >= 10
-        self.supports_target_verify = sm_major == 9
+        self.supports_target_verify = sm_major == 9 or (
+            self.use_state_pool and self._bf16_mtp_fn is not None
+        )
+        self.target_verify_intermediate_state_indexing = "cache"
 
         if sm_major == 9:
             if self._prefill_fn is None:
@@ -280,12 +301,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         retrieve_parent_token: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        if self.use_state_pool:
-            raise NotImplementedError(
-                "FlashInfer GDN MTP verify is not yet supported on SM100+."
-            )
-
-        # SM90: MTP verify using FlashInfer gated_delta_rule_mtp kernel.
         if retrieve_parent_token is not None:
             raise RuntimeError(
                 "FlashInfer GDN verify kernel only supports topk=1 "
@@ -313,21 +328,45 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         a_mtp = a.view(batch_size, draft_token_num, num_v_heads)
         b_mtp = b.view(batch_size, draft_token_num, num_v_heads)
 
-        output_fi, _ = self._mtp_fn(
-            q=query_mtp,
-            k=key_mtp,
-            v=value_mtp,
-            initial_state=ssm_states,
-            initial_state_indices=cache_indices,
-            A_log=A_log.detach(),
-            a=a_mtp,
-            dt_bias=dt_bias.detach(),
-            b=b_mtp,
-            scale=None,
-            output=None,
-            intermediate_states_buffer=intermediate_states_buffer,
-            disable_state_update=True,
-            use_qk_l2norm=True,
-        )
+        if self.use_state_pool:
+            if self._bf16_mtp_fn is None:
+                raise RuntimeError(
+                    "FlashInfer GDN bf16-state MTP kernel is unavailable."
+                )
+
+            output_fi = self._bf16_mtp_fn(
+                A_log=A_log.detach().float(),
+                a=a_mtp,
+                dt_bias=dt_bias.detach(),
+                softplus_beta=1.0,
+                softplus_threshold=20.0,
+                q=query_mtp,
+                k=key_mtp,
+                v=value_mtp,
+                b=b_mtp,
+                initial_state_source=ssm_states,
+                initial_state_indices=cache_indices,
+                intermediate_states_buffer=intermediate_states_buffer,
+                disable_state_update=True,
+                use_qk_l2norm_in_kernel=True,
+                scale=None,
+            )
+        else:
+            output_fi, _ = self._mtp_fn(
+                q=query_mtp,
+                k=key_mtp,
+                v=value_mtp,
+                initial_state=ssm_states,
+                initial_state_indices=cache_indices,
+                A_log=A_log.detach(),
+                a=a_mtp,
+                dt_bias=dt_bias.detach(),
+                b=b_mtp,
+                scale=None,
+                output=None,
+                intermediate_states_buffer=intermediate_states_buffer,
+                disable_state_update=True,
+                use_qk_l2norm=True,
+            )
 
         return output_fi.view(1, seq_len, num_v_heads, head_v_dim)

--- a/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
@@ -10,6 +10,11 @@ class LinearAttnKernelBase(ABC):
     and provides decode/extend/target_verify methods with a unified interface.
     """
 
+    # How target_verify lays out cached intermediate states:
+    # "batch" -> intermediate_state[batch_idx, step]
+    # "cache" -> intermediate_state[cache_indices[batch_idx], step]
+    target_verify_intermediate_state_indexing: str = "batch"
+
     @abstractmethod
     def decode(
         self,

--- a/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
@@ -6,6 +6,8 @@ This kernel replaces the expensive advanced indexing operations in
 avoiding multiple `index_elementwise_kernel` launches.
 """
 
+from typing import Optional
+
 import torch
 import triton
 import triton.language as tl
@@ -18,6 +20,7 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     # Raw index arrays (before index_select)
     dst_indices_raw_ptr,  # [total_requests] - state_indices_tensor
     step_indices_raw_ptr,  # [total_requests] - last_correct_step_indices or mamba_steps_to_track
+    src_indices_raw_ptr,  # optional [total_requests] - source request/cache indices
     elem_per_entry: tl.constexpr,
     src_layer_stride,
     src_req_stride,
@@ -27,6 +30,7 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     src_req_size,
     src_step_size,
     dst_req_size,
+    HAS_SRC_INDICES: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     """
@@ -36,7 +40,8 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     1. Iterating over all requests (pid_req from 0 to total_requests-1)
     2. Checking if step_indices_raw[pid_req] >= 0 (valid mask)
     3. If valid, performing the scatter:
-       dst[l, dst_indices_raw[pid_req], :] = src[l, pid_req, step_indices_raw[pid_req], :]
+       dst[l, dst_indices_raw[pid_req], :] = src[l, src_idx, step_indices_raw[pid_req], :]
+       where src_idx is either pid_req or src_indices_raw[pid_req].
 
     Grid: (total_requests, num_layers, ceil(elem_per_entry / BLOCK_SIZE))
     """
@@ -54,8 +59,10 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     # Load destination index
     dst_idx = tl.load(dst_indices_raw_ptr + pid_req).to(tl.int64)
 
-    # Source index is just the request index itself
-    src_idx = pid_req
+    if HAS_SRC_INDICES:
+        src_idx = tl.load(src_indices_raw_ptr + pid_req).to(tl.int64)
+    else:
+        src_idx = pid_req
 
     # Bounds check to avoid illegal memory access
     if not (
@@ -90,6 +97,7 @@ def fused_mamba_state_scatter_with_mask(
     src: torch.Tensor,  # [num_layers, spec_size, draft_tokens, *state_shape]
     dst_indices_raw: torch.Tensor,  # [total_requests] - raw indices (e.g., state_indices_tensor)
     step_indices_raw: torch.Tensor,  # [total_requests] - raw step indices (step >= 0 means valid)
+    src_indices_raw: Optional[torch.Tensor] = None,
 ):
     """
     Fully fused gather-scatter with built-in masking for mamba state updates.
@@ -99,13 +107,17 @@ def fused_mamba_state_scatter_with_mask(
     2. valid_indices = valid_mask.nonzero()
     3. dst_indices = dst_indices_raw[valid_indices]  (index_select)
     4. step_indices = step_indices_raw[valid_indices]  (index_select)
-    5. for each valid i: dst[:, dst_indices[i], :] = src[:, i, step_indices[i], :]
+    5. for each valid i: dst[:, dst_indices[i], :] = src[:, src_idx[i], step_indices[i], :]
+
+    By default `src_idx[i] == i`. If `src_indices_raw` is provided,
+    `src_idx[i] == src_indices_raw[i]`.
 
     Args:
         dst: Destination tensor [num_layers, cache_size, *state_shape]
         src: Source tensor [num_layers, spec_size, draft_tokens, *state_shape]
         dst_indices_raw: Raw destination indices for all requests [total_requests]
         step_indices_raw: Raw step indices; entry >= 0 means valid [total_requests]
+        src_indices_raw: Optional source indices for all requests [total_requests]
     """
     total_requests = step_indices_raw.shape[0]
     if total_requests == 0:
@@ -129,13 +141,31 @@ def fused_mamba_state_scatter_with_mask(
         raise ValueError(
             f"Trailing dims mismatch: {dst.shape[2:]=} vs {src.shape[3:]=}"
         )
-    if dst_indices_raw.ndim != 1 or step_indices_raw.ndim != 1:
+    if src_indices_raw is None:
+        src_indices_arg = dst_indices_raw
+        has_src_indices = False
+    else:
+        src_indices_arg = src_indices_raw
+        has_src_indices = True
+
+    if (
+        dst_indices_raw.ndim != 1
+        or step_indices_raw.ndim != 1
+        or src_indices_arg.ndim != 1
+    ):
         raise ValueError(
-            f"indices must be 1D: {dst_indices_raw.shape=} {step_indices_raw.shape=}"
+            "indices must be 1D: "
+            f"{dst_indices_raw.shape=} {step_indices_raw.shape=} {src_indices_arg.shape=}"
         )
-    if dst_indices_raw.shape[0] != step_indices_raw.shape[0]:
+    if not (
+        dst_indices_raw.shape[0]
+        == step_indices_raw.shape[0]
+        == src_indices_arg.shape[0]
+    ):
         raise ValueError(
-            f"indices length mismatch: {dst_indices_raw.shape[0]=} vs {step_indices_raw.shape[0]=}"
+            "indices length mismatch: "
+            f"{dst_indices_raw.shape[0]=} {step_indices_raw.shape[0]=} "
+            f"{src_indices_arg.shape[0]=}"
         )
 
     num_layers = dst.shape[0]
@@ -156,6 +186,7 @@ def fused_mamba_state_scatter_with_mask(
     # Ensure indices are int32 and contiguous
     dst_indices_raw = dst_indices_raw.to(torch.int32).contiguous()
     step_indices_raw = step_indices_raw.to(torch.int32).contiguous()
+    src_indices_arg = src_indices_arg.to(torch.int32).contiguous()
 
     # Ensure tensors are contiguous
     if not dst.is_contiguous():
@@ -174,6 +205,7 @@ def fused_mamba_state_scatter_with_mask(
         dst,
         dst_indices_raw,
         step_indices_raw,
+        src_indices_arg,
         elem_per_entry,
         src_layer_stride,
         src_req_stride,
@@ -183,5 +215,6 @@ def fused_mamba_state_scatter_with_mask(
         src_req_size,
         src_step_size,
         dst_req_size,
+        HAS_SRC_INDICES=has_src_indices,
         BLOCK_SIZE=BLOCK_SIZE,
     )


### PR DESCRIPTION
## Motivation

Merge after #26829.

This PR enables the FlashInfer GDN MTP target-verify kernel on SM100/B200 when the FlashInfer bf16-state MTP entry point is available.

The FlashInfer bf16 MTP path used by the current SM100 runtime writes intermediate states into the KV/cache pool, with shape `[pool_size, T, HV, V, K]`. The accepted-state commit path therefore marks this verify kernel as `"cache"` indexing, so SGLang gathers the accepted final state by `mamba_cache_indices`.

## Modifications

- Lazily import `flashinfer.gdn_kernels.gdn_decode_bf16_state.gated_delta_rule_mtp`.
- Enable `FlashInferGDNKernel.supports_target_verify` on SM100 when that kernel is present.
- Route SM100 target verify through the bf16-state MTP wrapper.
- Pass the full `intermediate_states_buffer` to match the cache/pool-scoped FlashInfer API.
- Set `target_verify_intermediate_state_indexing = "cache"` for this verify kernel.
- Add a regression test for the SM100 bf16 MTP wrapper buffer shape and indexing contract.

## Accuracy Tests

Full deterministic GSM8K, Qwen3.5-397B-A17B-FP8, 8-shot, `temperature=0.0`, `top_p=1.0`, `top_k=20`, `max_tokens=14000`, `num_threads=256`, 1319 examples:

| Variant | Verify kernel | Score |
|---|---|---:|
| upstream main | Triton | 0.977879 (job 1965971) |
| indexing contract | Triton | 0.977879 (job 1965972) |
| this PR | FlashInfer | 0.977879 (job 1966442) |

GSM8K repro command:

```bash
export MODEL_PATH=/path/to/Qwen3.5-397B-A17B-FP8

python3 -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --served-model-name Qwen/Qwen3.5-397B-A17B-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --attention-backend trtllm_mha \
  --chunked-prefill-size 16384 \
  --context-length 16384 \
  --cuda-graph-max-bs 256 \
  --decode-log-interval 10 \
  --disable-radix-cache \
  --expert-parallel-size 1 \
  --kv-cache-dtype fp8_e4m3 \
  --linear-attn-decode-backend flashinfer \
  --mamba-scheduler-strategy no_buffer \
  --mamba-ssm-dtype bfloat16 \
  --max-prefill-tokens 16384 \
  --max-running-requests 256 \
  --mem-fraction-static 0.8 \
  --moe-runner-backend flashinfer_trtllm \
  --quantization fp8 \
  --random-seed 0 \
  --reasoning-parser qwen3 \
  --speculative-algorithm NEXTN \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --speculative-num-steps 3 \
  --stream-interval 50 \
  --tensor-parallel-size 4 \
  --trust-remote-code

python3 -m sglang.test.run_eval \
  --host 127.0.0.1 \
  --port 30000 \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --eval-name gsm8k \
  --num-examples 1319 \
  --num-threads 256 \
  --num-shots 8 \
  --max-tokens 14000 \
  --temperature 0.0 \
  --top-p 1.0 \
  --top-k 20 \
  --thinking-mode qwen-3
```

## Speed Tests and Profiling

SA-Bench c=256, ISL/OSL=1000/1000, Qwen3.5-397B-A17B-FP8. Each run uses 1x concurrency warmup and 1x concurrency formal measurement; the table reports the formal run.

| Variant | Verify kernel | Output tok/s | Delta vs upstream | Delta vs indexing | Median TPOT | Formal accept len |
|---|---|---:|---:|---:|---:|---:|
| upstream main | Triton | 10790.028 | baseline | - | 19.499 ms | 2.94 |
| indexing contract | Triton | 10894.487 | +0.97% | baseline | 19.346 ms | 2.92 |
| this PR | FlashInfer | 11146.159 | +3.30% | +2.31% | 18.710 ms | 2.89 |

Perf repro command:

```bash
export MODEL_PATH=/path/to/Qwen3.5-397B-A17B-FP8

python3 -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --served-model-name Qwen/Qwen3.5-397B-A17B-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --attention-backend trtllm_mha \
  --chunked-prefill-size 16384 \
  --context-length 4096 \
  --cuda-graph-max-bs 256 \
  --decode-log-interval 10 \
  --disable-radix-cache \
  --expert-parallel-size 1 \
  --kv-cache-dtype fp8_e4m3 \
  --linear-attn-decode-backend flashinfer \
  --mamba-scheduler-strategy no_buffer \
  --mamba-ssm-dtype bfloat16 \
  --max-prefill-tokens 16384 \
  --max-running-requests 256 \
  --mem-fraction-static 0.8 \
  --moe-runner-backend flashinfer_trtllm \
  --quantization fp8 \
  --random-seed 0 \
  --speculative-algorithm NEXTN \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --speculative-num-steps 3 \
  --stream-interval 50 \
  --tensor-parallel-size 4 \
  --trust-remote-code

# Warmup: 1x concurrency.
python3 -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 \
  --port 30000 \
  --dataset-name random \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --random-input-len 1000 \
  --random-output-len 1000 \
  --random-range-ratio 1.0 \
  --num-prompts 256 \
  --max-concurrency 256 \
  --request-rate 250 \
  --seed 0

# Formal: 1x concurrency.
python3 -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 \
  --port 30000 \
  --dataset-name random \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --random-input-len 1000 \
  --random-output-len 1000 \
  --random-range-ratio 1.0 \
  --num-prompts 256 \
  --max-concurrency 256 \
  --request-rate inf \
  --seed 0
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide full accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26725936808](https://github.com/sgl-project/sglang/actions/runs/26725936808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #26737229618](https://github.com/sgl-project/sglang/actions/runs/26737229618)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
