### PR TITLE
Fix multi-tokenizer batch request output routing (health stuck at 503)

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -562,11 +562,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
                 )
 
+        if self.server_args.tokenizer_worker_num > 1:
+            self._attach_multi_http_worker_info(obj)
         self._init_req_state(obj, request)
         if self.server_args.language_only:
             self._handle_epd_disaggregation_encode_request(obj)
-        if self.server_args.tokenizer_worker_num > 1:
-            self._attach_multi_http_worker_info(obj)
 
         # Log the request
         self.request_logger.log_received_request(obj, self.tokenizer, request)


### PR DESCRIPTION
In multi-http-worker mode (--tokenizer-worker-num > 1), generate_request called _init_req_state(obj) before _attach_multi_http_worker_info(obj).

For a batch request, _init_req_state accesses obj[i], and GenerateReqInput.__getitem__ builds and CACHES the per-index sub-objects (in _sub_obj_cache), copying the parent's http_worker_ipc at that moment. Since the attach step ran afterwards, the parent's http_worker_ipc was still None when the sub-objects were cached, so every cached sub-object kept http_worker_ipc=None. Attaching later only stamped the parent.

As a result the tokenized batch items carried http_worker_ipc=None, the scheduler built each Req with http_worker_ipc=None, and the streamed BatchStrOutput had http_worker_ipcs=[None, ...]. MultiTokenizerRouter then dropped those outputs ('IPC name is None ... skipping'), so the PD prefill warmup POST never received a response, server_status stayed at Starting, and /health returned 503 forever. Single-tokenizer mode and non-batch requests were unaffected.

Fix: attach the multi-http-worker info before _init_req_state so the parent's http_worker_ipc is set before sub-objects are built and cached.

CC @hnyls2002 







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26706200667](https://github.com/sgl-project/sglang/actions/runs/26706200667)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26706200629](https://github.com/sgl-project/sglang/actions/runs/26706200629)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->