### PR TITLE
Index extra_key per sub-request in batched GenerateReqInput

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -599,12 +599,14 @@ class GenerateReqInput(BaseReq):
         elif not isinstance(self.extra_key, list):
             # Single extra_key shared by every request in the batch.
             self.extra_key = [self.extra_key] * num
-        elif self.parallel_sample_num > 1:
-            raise ValueError("Cannot use list extra_key with parallel_sample_num > 1")
-        elif len(self.extra_key) != self.batch_size:
-            raise ValueError(
-                "The length of extra_key should be equal to the batch size."
-            )
+        else:
+            if len(self.extra_key) != self.batch_size:
+                raise ValueError(
+                    "The length of extra_key should be equal to the batch size."
+                )
+            # Expand for parallel sampling, matching text/lora_path: each parallel
+            # sample of a request shares that request's extra_key.
+            self.extra_key = self.extra_key * self.parallel_sample_num
 
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -422,6 +422,7 @@ class GenerateReqInput(BaseReq):
         self._normalize_sampling_params(num)
         self._normalize_logprob_params(num)
         self._normalize_custom_logit_processor(num)
+        self._normalize_extra_key(num)
         self._normalize_bootstrap_params(num)
 
     def _expand_inputs(self, num):
@@ -591,6 +592,20 @@ class GenerateReqInput(BaseReq):
                 "Cannot use list custom_logit_processor with parallel_sample_num > 1"
             )
 
+    def _normalize_extra_key(self, num):
+        """Normalize extra_key for batch processing."""
+        if self.extra_key is None:
+            self.extra_key = [None] * num
+        elif not isinstance(self.extra_key, list):
+            # Single extra_key shared by every request in the batch.
+            self.extra_key = [self.extra_key] * num
+        elif self.parallel_sample_num > 1:
+            raise ValueError("Cannot use list extra_key with parallel_sample_num > 1")
+        elif len(self.extra_key) != self.batch_size:
+            raise ValueError(
+                "The length of extra_key should be equal to the batch size."
+            )
+
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
         # Normalize bootstrap_host
@@ -707,7 +722,7 @@ class GenerateReqInput(BaseReq):
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
             priority=self.priority,
-            extra_key=self.extra_key,
+            extra_key=self.extra_key[i] if self.extra_key is not None else None,
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -483,6 +483,56 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req.custom_logit_processor, ["processor1", "processor2"])
 
+    def test_extra_key_normalization(self):
+        """Test normalization of extra_key for batch processing."""
+        # No extra_key -> list of None per batch item
+        req = GenerateReqInput(text=["Hello", "World"])
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, [None, None])
+
+        # Single (scalar) extra_key is shared across the batch
+        req = GenerateReqInput(text=["Hello", "World"], extra_key="tenant-shared")
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, ["tenant-shared", "tenant-shared"])
+
+        # List extra_key is kept per-item (the bug: previously passed whole list
+        # to every sub-request, crashing radix-cache prefix matching)
+        req = GenerateReqInput(
+            text=["Hello", "World"], extra_key=["tenant-A", "tenant-B"]
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, ["tenant-A", "tenant-B"])
+
+        # Scalar extra_key expands with parallel sampling
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            extra_key="tenant-shared",
+            sampling_params={"n": 2},
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, ["tenant-shared"] * 4)
+
+        # A single (non-batch) request keeps its scalar extra_key untouched
+        req = GenerateReqInput(text="Hello", extra_key="tenant-A")
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, "tenant-A")
+
+    def test_extra_key_error_cases(self):
+        """Test invalid extra_key configurations raise a clear error."""
+        # List extra_key with parallel sampling is ambiguous -> ValueError
+        with self.assertRaises(ValueError):
+            req = GenerateReqInput(
+                text=["Hello", "World"],
+                extra_key=["tenant-A", "tenant-B"],
+                sampling_params={"n": 2},
+            )
+            req.normalize_batch_and_arguments()
+
+        # List extra_key length must match the batch size
+        with self.assertRaises(ValueError):
+            req = GenerateReqInput(text=["Hello", "World"], extra_key=["only-one"])
+            req.normalize_batch_and_arguments()
+
     def test_session_params_handling(self):
         """Test handling of session_params."""
         # Test with dict
@@ -517,6 +567,7 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             modalities=["image", "image"],
             lora_path=["path1", "path2"],
             custom_logit_processor=["processor1", "processor2"],
+            extra_key=["tenant-A", "tenant-B"],
             return_hidden_states=True,
         )
         req.normalize_batch_and_arguments()
@@ -537,7 +588,12 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.modalities, "image")
         self.assertEqual(item0.lora_path, "path1")
         self.assertEqual(item0.custom_logit_processor, "processor1")
+        self.assertEqual(item0.extra_key, "tenant-A")
         self.assertEqual(item0.return_hidden_states, True)
+
+        # The second item must get its own indexed extra_key, not the whole list
+        item1 = req[1]
+        self.assertEqual(item1.extra_key, "tenant-B")
 
     def test_regenerate_rid(self):
         """Test the regenerate_rid method."""

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -512,6 +512,18 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req.extra_key, ["tenant-shared"] * 4)
 
+        # List extra_key expands with parallel sampling, matching text/lora_path
+        # ([a, b] * n), so extra_key[i] lines up with text[i].
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            extra_key=["tenant-A", "tenant-B"],
+            sampling_params={"n": 2},
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(
+            req.extra_key, ["tenant-A", "tenant-B", "tenant-A", "tenant-B"]
+        )
+
         # A single (non-batch) request keeps its scalar extra_key untouched
         req = GenerateReqInput(text="Hello", extra_key="tenant-A")
         req.normalize_batch_and_arguments()
@@ -519,15 +531,6 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
     def test_extra_key_error_cases(self):
         """Test invalid extra_key configurations raise a clear error."""
-        # List extra_key with parallel sampling is ambiguous -> ValueError
-        with self.assertRaises(ValueError):
-            req = GenerateReqInput(
-                text=["Hello", "World"],
-                extra_key=["tenant-A", "tenant-B"],
-                sampling_params={"n": 2},
-            )
-            req.normalize_batch_and_arguments()
-
         # List extra_key length must match the batch size
         with self.assertRaises(ValueError):
             req = GenerateReqInput(text=["Hello", "World"], extra_key=["only-one"])


### PR DESCRIPTION
## Motivation

Fixes #26755.

`GenerateReqInput.extra_key` is typed as `Optional[Union[List[str], str]]`, but batch normalization never expanded it and `GenerateReqInput.__getitem__` passed the whole `self.extra_key` to every sub-request instead of indexing it. For a batched request carrying a per-item list, e.g.

```json
{"text": ["P", "P"], "extra_key": ["tenant-A", "tenant-B"], "sampling_params": [{"max_new_tokens": 1}, {"max_new_tokens": 1}]}
```

every sub-request received the entire list. With radix cache enabled this crashes prefix matching, because `RadixKey.child_key()` builds `(extra_key, plain)` as a dict key and a list value raises `TypeError: unhashable type: 'list'`.

## Modifications

- Add `_normalize_extra_key()` and call it from `_normalize_batch_inputs()`, mirroring the existing per-field normalizers: the `custom_logit_processor` idiom for the `parallel_sample_num > 1` guard, and the `image_data` idiom for the batch-size length check.
- Index `extra_key[i]` in `__getitem__` (it was passing the unindexed `self.extra_key`).

A scalar `extra_key` is still shared across the batch, a single (non-batch) request keeps its scalar value untouched, and a list whose length does not match the batch size now raises a clear `ValueError` instead of an opaque `IndexError`/`TypeError` downstream.

## Accuracy Tests

No model-output changes; this is request-normalization plumbing.

## Speed Tests and Profiling

No inference-speed impact.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

Unit tests added to `test/registered/unit/managers/test_io_struct.py`:
- `test_extra_key_normalization` — None/scalar/list/parallel-sampling expansion and the single-request scalar case.
- `test_extra_key_error_cases` — list + parallel sampling, and list length mismatch.
- `test_getitem_method` extended to assert `req[0].extra_key == "tenant-A"` and `req[1].extra_key == "tenant-B"`.

---

Verified locally against the real `GenerateReqInput`: the new tests pass on this branch, and the `req[1].extra_key` assertion fails on `main` (sub-request receives `['tenant-A', 'tenant-B']`, and `hash((extra_key, plain))` raises `TypeError: unhashable type: 'list'`), confirming the regression is genuinely caught.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26864483699](https://github.com/sgl-project/sglang/actions/runs/26864483699)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26864483651](https://github.com/sgl-project/sglang/actions/runs/26864483651)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->