### PR TITLE
Send auth headers from the hicache cache-hit benchmarks

### DIFF
--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -11,7 +11,7 @@ import numpy as np
 import requests
 from tqdm.asyncio import tqdm
 
-from sglang.bench_serving import RequestFuncOutput
+from sglang.bench_serving import RequestFuncOutput, get_auth_headers
 from sglang.benchmark.datasets.random import sample_random_requests
 from sglang.benchmark.utils import get_tokenizer
 from sglang.test.kits.cache_hit_kit import (
@@ -548,7 +548,9 @@ class WorkloadGenerator:
         heartbeat_input = [1] * input_len
         payload = gen_payload(heartbeat_input, output_len, self.lora_path)
         try:
-            requests.post(self.url, json=payload, timeout=30)
+            requests.post(
+                self.url, json=payload, headers=get_auth_headers(), timeout=30
+            )
         except Exception as e:
             print(f"Heartbeat request failed: {e}")
 
@@ -749,7 +751,7 @@ if __name__ == "__main__":
 
     for rate in request_rates:
         args.request_rate = rate
-        requests.post(flush_cache_url)
+        requests.post(flush_cache_url, headers=get_auth_headers())
         time.sleep(1)
         performance_data = WorkloadGenerator(args).run()
         log_to_jsonl_file(performance_data, args.log_file, tag=args.tag)

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -5,7 +5,7 @@ import time
 import aiohttp
 import requests
 
-from sglang.bench_serving import RequestFuncOutput
+from sglang.bench_serving import RequestFuncOutput, get_auth_headers
 from sglang.benchmark.datasets.random import sample_random_requests
 from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
@@ -22,7 +22,7 @@ async def async_request_sglang_generate(
     Returns a RequestFuncOutput with additional cached_tokens and output_ids attributes.
     """
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
-        headers = {}
+        headers = get_auth_headers()
         generated_text = ""
         all_output_ids = []
         ttft = 0.0
@@ -108,7 +108,9 @@ async def async_request_openai_chat_completions(
         output = RequestFuncOutput()
 
         try:
-            async with session.post(url=url, json=payload) as response:
+            async with session.post(
+                url=url, json=payload, headers=get_auth_headers()
+            ) as response:
                 if response.status == 200:
                     prompt_tokens = 0
                     cached_tokens = 0
@@ -221,7 +223,9 @@ async def _send_round(
 def _get_page_size(base_url: str) -> int:
     """Query server for page_size used by radix cache."""
     try:
-        resp = requests.get(f"{base_url}/server_info", timeout=10)
+        resp = requests.get(
+            f"{base_url}/server_info", headers=get_auth_headers(), timeout=10
+        )
         resp.raise_for_status()
         info = resp.json()
         return info.get("page_size", 1)
@@ -266,7 +270,7 @@ def run_multiturn_cache_hit_test(
     page_size = _get_page_size(base_url)
 
     # Flush cache for clean state
-    requests.post(f"{base_url}/flush_cache")
+    requests.post(f"{base_url}/flush_cache", headers=get_auth_headers())
     time.sleep(1)
 
     # Resolve sub-question length (0 means same as request_length)


### PR DESCRIPTION
## Motivation

Fixes #26630.

The multi-turn cache-hit benchmark (`benchmark/hicache/bench_multiturn.py`) and its shared request helpers sent requests with empty/no headers. A server launched with `--api-key` therefore rejected every request with `401 Unauthorized`, even when `OPENAI_API_KEY` was set and `--api-format openai` was used.

## Modifications

Attach `get_auth_headers()` — the same `OPENAI_API_KEY`/`API_KEY` helper already used throughout `python/sglang/bench_serving.py` — to every request the benchmark issues:

- `python/sglang/test/kits/cache_hit_kit.py`: the streaming `async_request_sglang_generate` and `async_request_openai_chat_completions` request functions, plus the `server_info` and `flush_cache` control calls.
- `benchmark/hicache/bench_multiturn.py`: the heartbeat request and the per-rate `flush_cache` call.

No new dependency or flag — it reuses the existing env-var convention.

## Accuracy Tests

N/A (benchmark tooling, no model-output changes).

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

---

Verified locally: the real `cache_hit_kit` request functions and control calls now attach `get_auth_headers()`, which returns a `Bearer` header when `OPENAI_API_KEY` is set and `{}` otherwise (preserving non-`--api-key` servers).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26866494552](https://github.com/sgl-project/sglang/actions/runs/26866494552)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26866494450](https://github.com/sgl-project/sglang/actions/runs/26866494450)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->