### PR TITLE
Honor --api-format in the long-context cache-hit benchmark

### DIFF
--- a/benchmark/hicache/bench_long_context.py
+++ b/benchmark/hicache/bench_long_context.py
@@ -12,14 +12,27 @@ from bench_multiturn import (
 )
 from tqdm.asyncio import tqdm
 
+from sglang.bench_serving import get_auth_headers
 from sglang.benchmark.utils import get_tokenizer
-from sglang.test.kits.cache_hit_kit import async_request_sglang_generate
+from sglang.test.kits.cache_hit_kit import (
+    async_request_openai_chat_completions,
+    async_request_sglang_generate,
+    gen_payload_openai,
+)
 
 
 class ContextWorkloadGenerator(WorkloadGenerator):
     def __init__(self, args):
-        self.url = f"http://{args.host}:{args.port}/generate"
-        self.request_func = async_request_sglang_generate
+        self.api_format = args.api_format
+        self.model_path = args.model_path
+
+        # Construct the base URL and select request/payload functions
+        if self.api_format == "openai":
+            self.url = f"http://{args.host}:{args.port}/v1/chat/completions"
+            self.request_func = async_request_openai_chat_completions
+        else:
+            self.url = f"http://{args.host}:{args.port}/generate"
+            self.request_func = async_request_sglang_generate
 
         self.tokenizer = get_tokenizer(args.model_path)
         self.distribution = args.distribution
@@ -41,13 +54,18 @@ class ContextWorkloadGenerator(WorkloadGenerator):
                 self.dataset["contexts"][context_id]
                 + self.dataset["queries"][i]["question"]
             )
-            input_ids = self.tokenizer.encode(prompt_text)
             output_len = len(
                 self.tokenizer(self.dataset["queries"][i]["reference_answer"])[
                     "input_ids"
                 ]
             )
-            init_requests.append((i, gen_payload(input_ids, output_len)))
+            if self.api_format == "openai":
+                messages = [{"role": "user", "content": prompt_text}]
+                payload = gen_payload_openai(messages, output_len, self.model_path)
+            else:
+                input_ids = self.tokenizer.encode(prompt_text)
+                payload = gen_payload(input_ids, output_len)
+            init_requests.append((i, payload))
         self.ready_queue = ReadyQueue(init_requests=init_requests)
 
         self.response_queue = queue.Queue()
@@ -94,7 +112,7 @@ if __name__ == "__main__":
 
     for request_rate in [24, 16, 12, 8, 4, 2, 1]:
         args.request_rate = request_rate
-        requests.post(flush_cache_url)
+        requests.post(flush_cache_url, headers=get_auth_headers())
         time.sleep(1)
         performance_data = ContextWorkloadGenerator(args).run()
         log_to_jsonl_file(performance_data, args.log_file, args.tag)

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -5,7 +5,7 @@ import time
 import aiohttp
 import requests
 
-from sglang.bench_serving import RequestFuncOutput
+from sglang.bench_serving import RequestFuncOutput, get_auth_headers
 from sglang.benchmark.datasets.random import sample_random_requests
 from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
@@ -22,7 +22,7 @@ async def async_request_sglang_generate(
     Returns a RequestFuncOutput with additional cached_tokens and output_ids attributes.
     """
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
-        headers = {}
+        headers = get_auth_headers()
         generated_text = ""
         all_output_ids = []
         ttft = 0.0
@@ -108,7 +108,9 @@ async def async_request_openai_chat_completions(
         output = RequestFuncOutput()
 
         try:
-            async with session.post(url=url, json=payload) as response:
+            async with session.post(
+                url=url, json=payload, headers=get_auth_headers()
+            ) as response:
                 if response.status == 200:
                     prompt_tokens = 0
                     cached_tokens = 0
@@ -221,7 +223,9 @@ async def _send_round(
 def _get_page_size(base_url: str) -> int:
     """Query server for page_size used by radix cache."""
     try:
-        resp = requests.get(f"{base_url}/server_info", timeout=10)
+        resp = requests.get(
+            f"{base_url}/server_info", headers=get_auth_headers(), timeout=10
+        )
         resp.raise_for_status()
         info = resp.json()
         return info.get("page_size", 1)
@@ -266,7 +270,7 @@ def run_multiturn_cache_hit_test(
     page_size = _get_page_size(base_url)
 
     # Flush cache for clean state
-    requests.post(f"{base_url}/flush_cache")
+    requests.post(f"{base_url}/flush_cache", headers=get_auth_headers())
     time.sleep(1)
 
     # Resolve sub-question length (0 means same as request_length)


### PR DESCRIPTION
## Motivation

Fixes #26632.

The long-context cache-hit benchmark (`benchmark/hicache/bench_long_context.py`) parses `--api-format` (inherited from `bench_multiturn.parse_args`), but `ContextWorkloadGenerator.__init__` hardcoded the native `/generate` endpoint and always built native payloads. So `--api-format openai` was silently ignored — requests never went to `/v1/chat/completions`.

## Modifications

- Select the endpoint, request function, and payload builder from `args.api_format` in `ContextWorkloadGenerator.__init__`, mirroring `WorkloadGenerator.__init__`:
  - `openai` → `/v1/chat/completions`, `async_request_openai_chat_completions`, and a chat `messages` payload via `gen_payload_openai`.
  - native (default) → `/generate`, `async_request_sglang_generate`, and the existing `input_ids` + `gen_payload` payload.
- `response_handler` only reads format-agnostic fields (`ttft`/`itl`/`latency`/`prompt_len`/`cached_tokens`/`generated_len`), so it is unchanged.
- Attach `get_auth_headers()` to the `flush_cache` call so the OpenAI path also works against a server launched with `--api-key`.

## Accuracy Tests

N/A (benchmark tooling, no model-output changes).

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

---

Verified locally by instantiating the real `ContextWorkloadGenerator`: with `--api-format openai` it selects `/v1/chat/completions` + `async_request_openai_chat_completions` + `gen_payload_openai`, and with the default it uses `/generate` + the native path.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26864485569](https://github.com/sgl-project/sglang/actions/runs/26864485569)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26864485512](https://github.com/sgl-project/sglang/actions/runs/26864485512)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->