### PR TITLE
Throttle the idle-time tree-cache sanity check

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/invariant_checker.py
+++ b/python/sglang/srt/managers/scheduler_components/invariant_checker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 import warnings
 from dataclasses import dataclass
 from typing import (
@@ -33,6 +34,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Minimum interval (seconds) between idle-time tree-cache sanity checks.
+# The check is a full recursive walk of the radix tree (O(N) over every
+# node, and more for hybrid SWA/SSM caches), so running it on every idle
+# tick can starve the scheduler under sustained load with a large cache.
+TREE_CACHE_SANITY_CHECK_INTERVAL_S = 30.0
+
 
 @dataclass(kw_only=True, slots=True)
 class SchedulerInvariantChecker:
@@ -52,6 +59,9 @@ class SchedulerInvariantChecker:
     get_running_batch: Callable
     count_req_pool_leak_warnings: int = 0
     count_memory_leak_warnings: int = 0
+    # Throttles the expensive idle-time tree-cache sanity check. 0.0 lets the
+    # first idle tick run the check, then it runs at most once per interval.
+    last_tree_cache_sanity_check_time: float = 0.0
 
     @staticmethod
     def _check_pool_invariant(
@@ -267,6 +277,16 @@ class SchedulerInvariantChecker:
         return has_leak, messages
 
     def _check_tree_cache(self):
+        # sanity_check is a full recursive tree walk; throttle it so a busy
+        # scheduler with a large cache does not spend every idle tick here.
+        now = time.perf_counter()
+        next_allowed = (
+            self.last_tree_cache_sanity_check_time + TREE_CACHE_SANITY_CHECK_INTERVAL_S
+        )
+        if now <= next_allowed:
+            return
+        self.last_tree_cache_sanity_check_time = now
+
         if (
             self.tree_cache.is_tree_cache()
             and (self.is_hybrid_swa and self.tree_cache.supports_swa())

--- a/python/sglang/srt/managers/scheduler_components/invariant_checker.py
+++ b/python/sglang/srt/managers/scheduler_components/invariant_checker.py
@@ -283,7 +283,10 @@ class SchedulerInvariantChecker:
         next_allowed = (
             self.last_tree_cache_sanity_check_time + TREE_CACHE_SANITY_CHECK_INTERVAL_S
         )
-        if now <= next_allowed:
+        # The 0.0 sentinel forces the first idle tick to run even when the
+        # process has been up for less than the interval (perf_counter() can be
+        # below the interval right after boot).
+        if self.last_tree_cache_sanity_check_time != 0.0 and now <= next_allowed:
             return
         self.last_tree_cache_sanity_check_time = now
 


### PR DESCRIPTION
## Motivation

Fixes #26796.

`SchedulerInvariantChecker._check_tree_cache()` runs `tree_cache.sanity_check()` on every scheduler idle tick (`Scheduler.on_idle()`). `sanity_check` is a full recursive walk of the radix tree — O(N) over every node, with extra per-node bookkeeping for hybrid SWA/SSM caches (`MambaRadixCache` / `SWARadixCache` traverse the tree multiple times and `heapify`). With a large grown cache (tens of thousands of tokens after many turns), a single walk is slow, so under sustained near-idle load the scheduler spends most of each idle tick re-walking the tree and effectively hangs at ~99% CPU with in-flight requests never returning.

## Modifications

Gate the check behind a time interval (30s, mirroring the existing `_maybe_log_idle_metrics` idle-metrics throttle in `metrics_reporter.py`) so invariants are still verified periodically without re-running every tick:

- Add a module constant `TREE_CACHE_SANITY_CHECK_INTERVAL_S = 30.0`.
- Add a `last_tree_cache_sanity_check_time` field to the slotted `SchedulerInvariantChecker` dataclass (default `0.0`, so the first idle tick still runs the check).
- Early-return from `_check_tree_cache()` when called again within the interval.

The cache geometry / eligibility condition that decides *whether* to run `sanity_check` is unchanged — this only changes *how often*.

## Accuracy Tests

N/A — `sanity_check` is a debug-only invariant verification; this does not change cache contents or model outputs.

## Speed Tests and Profiling

The fix removes a per-idle-tick O(N) tree walk for hybrid SWA/SSM caches. Before, each idle tick performed multiple full-tree traversals; after, at most one per 30s. This is the difference between a scheduler that spins at 99% CPU under sustained multi-stream load and one that stays responsive.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

---

Verified locally against the real `SchedulerInvariantChecker._check_tree_cache`: 1000 consecutive idle ticks invoke `tree_cache.sanity_check()` exactly **once** on this branch vs **1000** times on `main`, and the check correctly re-runs after the interval elapses.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26864486659](https://github.com/sgl-project/sglang/actions/runs/26864486659)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26864486514](https://github.com/sgl-project/sglang/actions/runs/26864486514)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->