### PR TITLE
Export cumulative prefix-cache hit rate as sglang:cache_hit_rate

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -140,6 +140,13 @@ class SchedulerMetricsReporter:
         self.spec_total_num_accept_tokens = 0  # lifetime
         self.spec_total_num_forward_ct = 0
 
+        # Lifetime prefix-cache token accumulators. The cache_hit_rate gauge is
+        # computed from these so it reflects a cumulative hit rate; otherwise a
+        # single zero-hit prefill batch (health probe, fresh prompt) would reset
+        # the last-batch-wins gauge to 0 and hide otherwise healthy caching.
+        self.total_cache_hit_tokens = 0
+        self.total_cache_input_tokens = 0
+
         # For PD disaggregation
         self.kv_transfer_speed_gb_s: float = 0.0
         self.kv_transfer_latency_ms: float = 0.0
@@ -491,6 +498,10 @@ class SchedulerMetricsReporter:
         self.spec_num_forward_ct = 0
         self.spec_total_num_accept_tokens = 0
         self.spec_total_num_forward_ct = 0
+        # Reset alongside the prefix cache (this runs on flush_cache), so the
+        # cumulative hit rate reflects only post-flush traffic.
+        self.total_cache_hit_tokens = 0
+        self.total_cache_input_tokens = 0
 
     def report_prefill_stats(
         self,
@@ -593,6 +604,13 @@ class SchedulerMetricsReporter:
             cache_hit_rate = (
                 effective_hit_tokens / total_tokens if total_tokens > 0 else 0.0
             )
+            # Also accumulate over the server lifetime for the cumulative gauge
+            # (see _cumulative_cache_hit_rate); the per-batch value above is
+            # still reported as stats.cache_hit_rate for the KV-events stream.
+            # Use the same effective (reprocessed-adjusted) counts as the
+            # per-batch rate so the cumulative ratio stays consistent.
+            self.total_cache_hit_tokens += effective_hit_tokens
+            self.total_cache_input_tokens += total_tokens
 
             # Basics
             self.stats.num_running_reqs = prefill_stats.num_running_reqs
@@ -601,6 +619,7 @@ class SchedulerMetricsReporter:
             )
             self.stats.num_grammar_queue_reqs = len(self.scheduler.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.cache_hit_rate_cumulative = self._cumulative_cache_hit_rate()
 
             # Memory pool usage ratios / Absolute token counts
             pool_stats.update_scheduler_stats(self.stats)
@@ -637,6 +656,12 @@ class SchedulerMetricsReporter:
             self.metrics_collector.log_stats(self.stats)
             self.scheduler.kv_events_publisher.emit_kv_metrics()
         self.scheduler.kv_events_publisher.publish_kv_events()
+
+    def _cumulative_cache_hit_rate(self) -> float:
+        """Server-lifetime prefix-cache hit rate (cached / total prefill tokens)."""
+        if self.total_cache_input_tokens > 0:
+            return self.total_cache_hit_tokens / self.total_cache_input_tokens
+        return 0.0
 
     def report_decode_stats(
         self,
@@ -730,6 +755,7 @@ class SchedulerMetricsReporter:
                 spec_num_steps = spec_snapshot["num_steps"]
                 spec_num_draft_tokens = spec_snapshot["num_draft_tokens"]
 
+        # Decode batches do no prefix matching, so the per-batch hit rate is 0.
         cache_hit_rate = 0.0
 
         if self.scheduler.disaggregation_mode == DisaggregationMode.DECODE:
@@ -787,6 +813,7 @@ class SchedulerMetricsReporter:
             self.stats.num_grammar_queue_reqs = len(self.scheduler.grammar_manager)
             self.stats.gen_throughput = self.last_gen_throughput
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.cache_hit_rate_cumulative = self._cumulative_cache_hit_rate()
             self.stats.decode_sum_seq_lens = _decode_total_seq_lens(batch)
 
             # Memory pool usage ratios / Absolute token counts

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -499,9 +499,13 @@ class SchedulerMetricsReporter:
         self.spec_total_num_accept_tokens = 0
         self.spec_total_num_forward_ct = 0
         # Reset alongside the prefix cache (this runs on flush_cache), so the
-        # cumulative hit rate reflects only post-flush traffic.
+        # cumulative hit rate reflects only post-flush traffic. Clear the
+        # exported stats too, so idle-time logging doesn't keep publishing the
+        # stale pre-flush rate until the next batch is processed.
         self.total_cache_hit_tokens = 0
         self.total_cache_input_tokens = 0
+        self.stats.cache_hit_rate = 0.0
+        self.stats.cache_hit_rate_cumulative = 0.0
 
     def report_prefill_stats(
         self,

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -68,7 +68,15 @@ class SchedulerStats:
     num_queue_reqs: QueueCount = field(default_factory=QueueCount)
     num_grammar_queue_reqs: int = 0
     gen_throughput: float = 0.0
+    # Per-batch prefix-cache hit rate (most recent prefill batch; 0 for decode).
+    # Kept per-batch because it is consumed by the KV-events stream
+    # (gpu_prefix_cache_hit_rate), which external KV-aware routers read as an
+    # instantaneous value.
     cache_hit_rate: float = 0.0
+    # Server-lifetime cumulative prefix-cache hit rate, exported as the
+    # sglang:cache_hit_rate Prometheus gauge so it is not clobbered to 0 by
+    # zero-hit prefill batches or decode-only intervals.
+    cache_hit_rate_cumulative: float = 0.0
     decode_sum_seq_lens: int = 0
 
     # Memory pool usage ratios (0.0–1.0).
@@ -1239,7 +1247,7 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         self._log_gauge_queue_count(self.num_queue_reqs, stats.num_queue_reqs)
         self._log_gauge(self.num_grammar_queue_reqs, stats.num_grammar_queue_reqs)
         self._log_gauge(self.gen_throughput, stats.gen_throughput)
-        self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate_cumulative)
         self._log_gauge(self.decode_sum_seq_lens, stats.decode_sum_seq_lens)
 
         # Memory pool usage ratios


### PR DESCRIPTION
## Motivation

Fixes #26608.

The `sglang:cache_hit_rate` Prometheus gauge was recomputed from a single batch: the prefill path set it to that batch's `log_hit / (log_input + log_hit)` ratio, and the decode path hardcoded it to `0.0`. Under mixed traffic the most-recent batch won, and because decode-stats logging runs far more often than prefill, the gauge sat at `0` almost permanently — any zero-hit prefill (health probe, fresh prompt) or any decode interval reset it. Dashboards and alerts that aggregate the gauge (`avg(sglang:cache_hit_rate)`, `sglang:cache_hit_rate < 0.1`) were effectively dead even when prefix caching was healthy.

## Modifications

- Accumulate hit tokens and total prefill tokens over the server lifetime (`total_cache_hit_tokens`, `total_cache_input_tokens`), following the existing lifetime-counter pattern in this reporter (`spec_total_num_*`).
- Add a `cache_hit_rate_cumulative` field to `SchedulerStats` and export **that** as the `sglang:cache_hit_rate` gauge (via `_cumulative_cache_hit_rate()`), so the gauge is a stable server-wide hit rate instead of a single batch's.
- Reset the accumulators in `reset_metrics()` (invoked on `flush_cache`), so after a cache flush the rate reflects only post-flush traffic, consistent with `tree_cache.reset()`.

**Deliberately scoped:** the existing per-batch `stats.cache_hit_rate` is left unchanged, because it is also consumed by the KV-events stream (`gpu_prefix_cache_hit_rate`), which external KV-aware routers read as an instantaneous value. Decoupling the new cumulative field means only the Prometheus gauge changes semantics; the KV-events contract is untouched.

## Accuracy Tests

N/A — observability-only change, no effect on model outputs.

## Speed Tests and Profiling

N/A — two integer adds and a divide per stats-log interval.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

---

Verified locally against the real reporter/collector: the `sglang:cache_hit_rate` gauge now reads `stats.cache_hit_rate_cumulative` and stays meaningful after a zero-hit batch (e.g. `900/1050`) instead of resetting to 0, while the KV-events `gpu_prefix_cache_hit_rate` still reads the unchanged per-batch `stats.cache_hit_rate`. `reset_metrics()` zeroes the accumulators on `flush_cache`.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26864487316](https://github.com/sgl-project/sglang/actions/runs/26864487316)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26864487274](https://github.com/sgl-project/sglang/actions/runs/26864487274)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->