### PR TITLE
Skip flaky mamba extra_buffer disagg test

### DIFF
--- a/test/registered/disaggregation/test_disaggregation_hybrid_attention.py
+++ b/test/registered/disaggregation/test_disaggregation_hybrid_attention.py
@@ -316,6 +316,7 @@ class TestDisaggregationHybridAttentionMamba(PDDisaggregationServerBase):
         self.assertGreater(metrics["score"], 0.87)
 
 
+@unittest.skipIf(is_in_ci(), "Temporarily disable the flaky test.")
 class TestDisaggregationHybridAttentionMambaExtraBuffer(PDDisaggregationServerBase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Motivation

`TestDisaggregationHybridAttentionMambaExtraBuffer.test_gsm8k` is flaky and blocks unrelated PRs. The regression is upstream and tracked at https://github.com/sgl-project/sglang/pull/15829#issuecomment-4586094495 (repro shows score collapses to 0.82 → 0.70 on retry when the test runs after another class in the same Python process; isolated runs pass at 0.90+).

Apply the same `@unittest.skipIf(is_in_ci(), ...)` guard already in place for `TestDisaggregationHybridAttentionGDN` so CI stops tripping on this until the underlying fix lands.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26707097285](https://github.com/sgl-project/sglang/actions/runs/26707097285)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26707097270](https://github.com/sgl-project/sglang/actions/runs/26707097270)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->