### PR TITLE
[Qwen3.5][AMD] Fix shared-expert ×ep_size over-count under allreduce-EP

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -65,13 +65,13 @@ from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
     should_skip_post_experts_all_reduce,
 )
-from sglang.srt.layers.moe.utils import is_deepep_class_backend
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.moe.topk import StandardTopKOutput, TopK, TopKOutputChecker
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
+    is_deepep_class_backend,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -65,6 +65,7 @@ from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
     should_skip_post_experts_all_reduce,
 )
+from sglang.srt.layers.moe.utils import is_deepep_class_backend
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.moe.topk import StandardTopKOutput, TopK, TopKOutputChecker
@@ -343,7 +344,21 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             return None
         shared_out = self.shared_expert_gate(hidden_states)
         shared_logits = shared_out[0] if isinstance(shared_out, tuple) else shared_out
-        return F.sigmoid(shared_logits)
+        w = F.sigmoid(shared_logits)
+        # Allreduce-EP path: the fused shared expert occupies a single global
+        # slot loaded onto every EP rank (see FusedMoE.__init__: num_shared_slots
+        # == num_fused_shared_experts when not is_deepep_class_backend()). Every
+        # rank therefore computes the same full shared output, and the
+        # post-experts all_reduce sums it ep_size times. Pre-scale the per-token
+        # routing weight by 1/ep_size to cancel this, mirroring DeepSeek-V2's
+        # fused_shared_experts_scaling_factor pattern.
+        # DeepEP-class backends (DeepEP / Mooncake / Mori) are exempt: they
+        # allocate one shared slot per EP rank and dispatch each token's shared
+        # computation to its home rank only -- no over-count.
+        moe_ep_size = get_moe_expert_parallel_world_size()
+        if moe_ep_size > 1 and not is_deepep_class_backend():
+            w = w / float(moe_ep_size)
+        return w
 
     def _append_shared_to_topk_output(
         self,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -345,6 +345,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         shared_out = self.shared_expert_gate(hidden_states)
         shared_logits = shared_out[0] if isinstance(shared_out, tuple) else shared_out
         w = F.sigmoid(shared_logits)
+        # This block runs only on the AMD AITER shared_expert_fusion path
         # Allreduce-EP path: the fused shared expert occupies a single global
         # slot loaded onto every EP rank (see FusedMoE.__init__: num_shared_slots
         # == num_fused_shared_experts when not is_deepep_class_backend()). Every
@@ -352,9 +353,6 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         # post-experts all_reduce sums it ep_size times. Pre-scale the per-token
         # routing weight by 1/ep_size to cancel this, mirroring DeepSeek-V2's
         # fused_shared_experts_scaling_factor pattern.
-        # DeepEP-class backends (DeepEP / Mooncake / Mori) are exempt: they
-        # allocate one shared slot per EP rank and dispatch each token's shared
-        # computation to its home rank only -- no over-count.
         moe_ep_size = get_moe_expert_parallel_world_size()
         if moe_ep_size > 1 and not is_deepep_class_backend():
             w = w / float(moe_ep_size)


### PR DESCRIPTION
## Motivation

On the AMD/AITER path, fused shared expert was enabled for Qwen3.5 by #20736. When combined with allreduce-EP (`--expert-parallel-size > 1` and the default `--moe-a2a-backend none`), the shared-expert contribution is over-counted by exactly `ep_size`, which destroys generation quality.

Measured on **MI355X** with `Qwen3.5-397B-A17B-FP8`, sglang `b6f71d585`, container `rocm/sgl-dev:v0.5.12.post1-rocm720-mi35x-20260524`, GSM8K 5-shot, deterministic (temperature 0):

| Config | GSM8K Acc (1319q) | Invalid |
| --- | --- | --- |
| TP=4, no EP (reference) | 94.2% | 1.3% |
| TP=2, EP=2 (pristine main) | **10.8%** | 15.3% |
| TP=4, EP=4 (pristine main) | **0.9%** | 2.0% |

The deterministic 5-shot probe on GSM8K test-set question index 5 shows the model entering `<think>` and never closing it under EP, while the TP-only baseline closes immediately and answers correctly.

## Root cause

Under the standard (allreduce-EP) dispatcher, the fused shared expert is allocated as **one global slot** and loaded identically on every EP rank:

- `FusedMoE.__init__` (`fused_moe_triton/layer.py:204-207`): when `not is_deepep_class_backend()`, `num_shared_slots = num_fused_shared_experts` (single global slot, not per-rank).
- `FusedMoE._map_global_expert_id_to_local_expert_id` (`fused_moe_triton/layer.py:585-593`) maps that shared slot to a valid local id on every rank (only routed slots return `-1` on non-owning ranks). The weight loader therefore copies the shared expert weights into the same local slot on every rank.
- The standard dispatcher (`token_dispatcher/standard.py:185-194`) marks the shared slot as local on every rank for `expert_mask_gpu`. AITER `fused_moe` then computes the shared expert on every rank.
- With `moe_ep_size == tp_size` (e.g. TP=2 EP=2 or TP=4 EP=4), `moe_tp_size == 1`, so the intermediate dim is not sharded either. Each rank produces the **same, full** shared-expert contribution per token.
- `Qwen2MoeSparseMoeBlock.forward` does a single post-experts `tensor_model_parallel_all_reduce` over the global TP group (which coincides with the EP group when `moe_ep_size == tp_size`). That AR sums `ep_size` identical copies of the shared output ⇒ shared contribution multiplied by `ep_size`.

Routed experts are unaffected because each routed slot lives on exactly one EP rank.

| `moe_tp_size` | `moe_ep_size` | Shared output along EP | Shared AR factor |
| --- | --- | --- | --- |
| 4 | 1 | (n/a — pure TP, intermediate-sharded) | 1× ✓ |
| 1 | 2 | replicated | 2× ✗ |
| 1 | 4 | replicated | 4× ✗ |

## Fix

Pre-scale the per-token shared routing weight by `1/moe_ep_size` in `_get_shared_expert_weights`, so that after the post-experts all-reduce the shared contribution lands back at exactly `1×`.

This is the same correction DeepSeek-V2 already applies via `fused_shared_experts_scaling_factor` (`deepseek_v2.py:560-572`). The Qwen3.5 / Qwen2MoE path uses its own shared-expert append helper (`fused_append_shared_experts_with_weights`, which takes no `scale_factor` arg) and therefore never inherited that correction. This PR adds the equivalent scaling at the Python layer for that path.

**Guard scope:** the fix is gated on `not is_deepep_class_backend()`, which covers all backends that allocate a single global shared slot (the buggy allocation): the default `none` and any future non-a2a backends. The three DeepEP-class backends — **DeepEP, Mooncake, Mori** — are correctly exempt: they each allocate one shared slot per EP rank (`num_shared_slots = N * ep_size`) and dispatch each token's shared computation to its home rank only, so no all-reduce over-count is possible. This matches the gating logic DSv2 uses (`not _is_deepep_fusion`) and the existing `is_deepep_class_backend()` helper in `python/sglang/srt/layers/moe/utils.py`.

## Verification

Same MI355X setup, with this PR applied:

| Config | GSM8K Acc (200q) | Invalid |
| --- | --- | --- |
| TP=4, no EP, fusion on (reference) | 98.0% | 0.5% |
| TP=2, EP=2 + `--disable-shared-experts-fusion` (workaround) | 95.5% | 1.0% |
| **TP=2, EP=2, fusion on, with this PR** | **96.5%** | **0.0%** |

The deterministic 5-shot probe on GSM8K test-set question index 5 now produces output token-identical to the TP=4 baseline:

```
TP=4 baseline:                    '\n\n<think>\n\n</think>\n\nKylar buys 16 glasses...'
TP=2 EP=2 + this PR:              '\n\n<think>\n\n</think>\n\nKylar buys 16 glasses...'
TP=2 EP=2 pristine (buggy):       '\n\n<think>\nThe user wants me to solve...'   (never closes </think>)
```

Throughput is also slightly higher than the disable-fusion workaround (706 vs 656 tok/s on the 200q sweep) because the AITER kernel keeps handling shared in the same pass as routed.

## Reproduction

Launch the server (inside the AMD ROCm container, GPU 4,5 on a MI355X node):

```bash
docker run -d --name sglang-qwen-tp2-ep2 \
  --device=/dev/kfd --device=/dev/dri --group-add video \
  --security-opt seccomp=unconfined --ipc=host --shm-size 32G \
  -e HIP_VISIBLE_DEVICES=4,5 -v /models:/models:ro -p 31000:31000 \
  rocm/sgl-dev:v0.5.12.post1-rocm720-mi35x-20260524 \
  python3 -m sglang.launch_server \
    --model /models/Qwen3.5-397B-A17B-FP8 \
    --tp 2 --expert-parallel-size 2 \
    --host 0.0.0.0 --port 31000 --trust-remote-code
```

Run the deterministic GSM8K sweep (200 questions, ~50 s):

```bash
python3 -m sglang.test.few_shot_gsm8k \
  --host localhost --port 31000 \
  --num-shots 5 --num-questions 200 \
  --max-new-tokens 512 --parallel 32 \
  --temperature 0.0
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci) (existing Qwen3.5 GSM8K test in `test/registered/4-gpu-models/test_qwen35_models.py` and `test/registered/8-gpu-models/test_qwen35.py` covers EP combos)
- [x] Update documentation as needed (none required — internal correctness fix)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26867935154](https://github.com/sgl-project/sglang/actions/runs/26867935154)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26867935015](https://github.com/sgl-project/sglang/actions/runs/26867935015)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->