### PR TITLE
Lazy Mamba extra-buffer allocation for radix cache

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -254,6 +254,9 @@ class Envs:
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY = EnvInt(0)
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE = EnvBool(True)
 
+    # Scheduler: mamba lazy extra buffer
+    SGLANG_MAMBA_LAZY_EXTRA_BUFFER = EnvBool(False)
+
     # Load snapshot backend
     SGLANG_LOAD_SNAPSHOT_USE_ZMQ = EnvBool(False)
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -254,9 +254,6 @@ class Envs:
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY = EnvInt(0)
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE = EnvBool(True)
 
-    # Scheduler: mamba lazy extra buffer
-    SGLANG_MAMBA_LAZY_EXTRA_BUFFER = EnvBool(False)
-
     # Load snapshot backend
     SGLANG_LOAD_SNAPSHOT_USE_ZMQ = EnvBool(False)
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2159,7 +2159,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # so we need to add 1 to the seqlen to retrieve the correct mamba state from h.
                 mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)
 
-            if not self.req_to_token_pool.enable_mamba_extra_buffer_lazy:
+            # In lazy mode, skip the swap — the second ping-pong slot is not
+            # allocated yet; it will be allocated on demand at the track boundary
+            # in mamba_lazy_prealloc_at_boundary during prepare_for_decode.
+            if not get_global_server_args().enable_mamba_extra_buffer_lazy():
                 req.mamba_next_track_idx = (
                     self.req_to_token_pool.get_mamba_ping_pong_other_idx(
                         req.mamba_next_track_idx
@@ -2416,25 +2419,26 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         assert not ret or self.spec_algorithm.supports_spec_v2()
         return ret
 
-    def _mamba_lazy_prealloc_at_boundary(self, mamba_track_interval: int):
+    def mamba_lazy_prealloc_at_boundary(self, mamba_track_interval: int):
         """Allocate a temporary second ping-pong slot for reqs at a track boundary.
 
         In lazy mode each request normally holds only 1 ping-pong slot.
         When seq_len hits a track interval boundary, we allocate the
         second slot so the forward pass can write the new tracked state
         there. The old slot is freed after the forward in
-        _mamba_lazy_post_decode_at_boundary.
+        mamba_lazy_post_decode_at_boundary.
         """
         pool = self.req_to_token_pool
         for i, req in enumerate(self.reqs):
             buf = req.mamba_ping_pong_track_buffer
-            if buf is None or self.seq_lens_cpu[i].item() % mamba_track_interval != 0:
+            assert buf is not None
+            # Skip reqs not at a track boundary
+            if self.seq_lens_cpu[i].item() % mamba_track_interval != 0:
                 continue
             other_idx = 1 - req.mamba_next_track_idx
-            if buf[other_idx].item() != -1:
-                continue
+            assert buf[other_idx].item() == -1
             new_slot = pool.mamba_pool.alloc(1)
-            if new_slot is None and self.tree_cache and self.tree_cache.supports_mamba():
+            if new_slot is None:
                 self.tree_cache.evict(EvictParams(num_tokens=0, mamba_num=1))
                 new_slot = pool.mamba_pool.alloc(1)
             if new_slot is not None:
@@ -2525,17 +2529,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if get_global_server_args().enable_mamba_extra_buffer():
             mamba_track_interval = get_global_server_args().mamba_track_interval
 
-            if (
-                self.req_to_token_pool.enable_mamba_extra_buffer_lazy
-                and len(self.reqs) > 0
-            ):
-                self._mamba_lazy_prealloc_at_boundary(mamba_track_interval)
-
             if len(self.reqs) == 0:
                 self.mamba_track_indices = torch.empty(
                     (0,), dtype=torch.int64, device=self.device
                 )
             else:
+                if get_global_server_args().enable_mamba_extra_buffer_lazy():
+                    self.mamba_lazy_prealloc_at_boundary(mamba_track_interval)
                 set_mamba_track_indices_from_reqs(self)
 
             # async H2D

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1556,6 +1556,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     mamba_track_indices: torch.Tensor = None  # shape: [b], int64
     mamba_track_mask: torch.Tensor = None  # shape: [b], bool
     mamba_track_seqlens: torch.Tensor = None  # shape: [b], int64
+    mamba_lazy_backup_mask_cpu: Optional[List[bool]] = None  # shape: [b]
     # Deferred mamba init ops: COW pairs and clear indices (performed on forward stream)
     mamba_cow_src_indices: torch.Tensor = None
     mamba_cow_dst_indices: torch.Tensor = None
@@ -2420,37 +2421,42 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         assert not ret or self.spec_algorithm.supports_spec_v2()
         return ret
 
-    def mamba_lazy_prealloc_at_boundary(self, mamba_track_interval: int):
-        """Allocate a temporary second ping-pong slot for reqs at a track boundary.
+    def mamba_lazy_backup_at_boundary(
+        self, should_backup_cpu: List[bool]
+    ) -> List[bool]:
+        """Copy the keep slot into a temporary backup for boundary forwards.
 
         In lazy mode each request normally holds only 1 ping-pong slot.
-        When seq_len hits a track interval boundary, we allocate the
-        second slot so the forward pass can write the new tracked state
-        there. The old slot is freed after the forward in
-        mamba_lazy_post_decode_at_boundary.
+        Boundary forwards still track into that normal slot; the backup keeps
+        the previous checkpoint cacheable while overlap may have a stale
+        boundary forward in flight.
         """
         pool = self.req_to_token_pool
-        for i, req in enumerate(self.reqs):
+        backup_mask_cpu = []
+        for req, should_backup in zip(self.reqs, should_backup_cpu):
             buf = req.mamba_ping_pong_track_buffer
             assert buf is not None
-            # Skip reqs not at a track boundary
-            if self.seq_lens_cpu[i].item() % mamba_track_interval != 0:
+            if not should_backup:
+                backup_mask_cpu.append(False)
                 continue
             other_idx = 1 - req.mamba_next_track_idx
-            assert buf[other_idx].item() == -1, (
-                f"Lazy ping-pong slot leak: buf={buf.tolist()}, "
-                f"next_track_idx={req.mamba_next_track_idx}, "
-                f"seq_len={self.seq_lens_cpu[i].item()}, "
-                f"forward_mode={self.forward_mode}, "
-                f"rid={req.rid}"
-            )
+            if buf[other_idx].item() != -1:
+                backup_mask_cpu.append(True)
+                continue
             new_slot = pool.mamba_pool.alloc(1)
             if new_slot is None:
                 self.tree_cache.evict(EvictParams(num_tokens=0, mamba_num=1))
                 new_slot = pool.mamba_pool.alloc(1)
             if new_slot is not None:
+                src_slot = buf[req.mamba_next_track_idx].unsqueeze(0)
+                pool.mamba_pool.copy_from(src_slot, new_slot)
                 pool.set_mamba_ping_pong_slot(req, other_idx, new_slot[0])
-                req.mamba_next_track_idx = other_idx
+                backup_mask_cpu.append(True)
+            else:
+                backup_mask_cpu.append(False)
+
+        self.mamba_lazy_backup_mask_cpu = backup_mask_cpu
+        return backup_mask_cpu
 
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
@@ -2542,7 +2548,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 )
             else:
                 if get_global_server_args().enable_mamba_extra_buffer_lazy():
-                    self.mamba_lazy_prealloc_at_boundary(mamba_track_interval)
+                    self.mamba_lazy_backup_at_boundary(
+                        (self.seq_lens_cpu % mamba_track_interval == 0).tolist()
+                    )
                 set_mamba_track_indices_from_reqs(self)
 
             # async H2D
@@ -2610,6 +2618,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.mamba_track_indices = None
         self.mamba_track_mask = None
         self.mamba_track_seqlens = None
+        self.mamba_lazy_backup_mask_cpu = None
         self.mamba_cow_src_indices = None
         self.mamba_cow_dst_indices = None
         self.mamba_clear_indices = None
@@ -2666,6 +2675,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.mamba_track_indices = None
         self.mamba_track_mask = None
         self.mamba_track_seqlens = None
+        self.mamba_lazy_backup_mask_cpu = None
         if self.return_logprob and other.return_logprob:
             self.top_logprobs_nums.extend(other.top_logprobs_nums)
             self.token_ids_logprobs.extend(other.token_ids_logprobs)
@@ -2712,6 +2722,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             mamba_track_indices=self.mamba_track_indices,
             mamba_track_mask=self.mamba_track_mask,
             mamba_track_seqlens=self.mamba_track_seqlens,
+            mamba_lazy_backup_mask_cpu=self.mamba_lazy_backup_mask_cpu,
             dp_cooperation_info=self.dp_cooperation_info,
             prefill_stats=self.prefill_stats,
             fpm_start_time=self.fpm_start_time,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2417,42 +2417,29 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         return ret
 
     def _mamba_lazy_prealloc_at_boundary(self, mamba_track_interval: int):
-        """Pre-allocate a mamba state for reqs at the track interval boundary.
+        """Allocate a temporary second ping-pong slot for reqs at a track boundary.
 
-        In lazy mode, each request normally holds only 1 ping-pong slot.
-        At the boundary, we allocate the second slot so the forward pass
-        can write the tracked state there.
+        In lazy mode each request normally holds only 1 ping-pong slot.
+        When seq_len hits a track interval boundary, we allocate the
+        second slot so the forward pass can write the new tracked state
+        there. The old slot is freed after the forward in
+        _mamba_lazy_post_decode_at_boundary.
         """
-        req_to_token_pool = self.req_to_token_pool
-        mamba_pool = req_to_token_pool.mamba_pool
-
+        pool = self.req_to_token_pool
         for i, req in enumerate(self.reqs):
-            if req.mamba_ping_pong_track_buffer is None:
+            buf = req.mamba_ping_pong_track_buffer
+            if buf is None or self.seq_lens_cpu[i].item() % mamba_track_interval != 0:
                 continue
-            if self.seq_lens_cpu[i].item() % mamba_track_interval != 0:
-                continue
-
             other_idx = 1 - req.mamba_next_track_idx
-            if req.mamba_ping_pong_track_buffer[other_idx].item() != -1:
+            if buf[other_idx].item() != -1:
                 continue
-
-            new_slot = mamba_pool.alloc(1)
-            if new_slot is None:
-                if (
-                    self.tree_cache is not None
-                    and self.tree_cache.supports_mamba()
-                ):
-                    self.tree_cache.evict(
-                        EvictParams(num_tokens=0, mamba_num=1)
-                    )
-                    new_slot = mamba_pool.alloc(1)
-
+            new_slot = pool.mamba_pool.alloc(1)
+            if new_slot is None and self.tree_cache and self.tree_cache.supports_mamba():
+                self.tree_cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+                new_slot = pool.mamba_pool.alloc(1)
             if new_slot is not None:
-                req.mamba_ping_pong_track_buffer[other_idx] = new_slot[0]
+                pool.set_mamba_ping_pong_slot(req, other_idx, new_slot[0])
                 req.mamba_next_track_idx = other_idx
-                req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
-                    req.req_pool_idx
-                ] = req.mamba_ping_pong_track_buffer
 
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -768,7 +768,8 @@ class Req(ReqDllmMixin):
         self.mamba_cow_src_index: Optional[torch.Tensor] = None
         # Deferred clear: newly allocated mamba slot needs zeroing on forward stream
         self.mamba_needs_clear: bool = False
-        # Lazy extra buffer: whether to insert into radix cache on finish
+        # Lazy extra buffer: skip radix cache insert when prealloc failed at
+        # boundary — the forward overwrites the only slot, corrupting the state.
         self.mamba_lazy_is_insert: bool = True
 
         # Check finish
@@ -2436,7 +2437,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             if self.seq_lens_cpu[i].item() % mamba_track_interval != 0:
                 continue
             other_idx = 1 - req.mamba_next_track_idx
-            assert buf[other_idx].item() == -1
+            assert buf[other_idx].item() == -1, (
+                f"Lazy ping-pong slot leak: buf={buf.tolist()}, "
+                f"next_track_idx={req.mamba_next_track_idx}, "
+                f"seq_len={self.seq_lens_cpu[i].item()}, "
+                f"forward_mode={self.forward_mode}, "
+                f"rid={req.rid}"
+            )
             new_slot = pool.mamba_pool.alloc(1)
             if new_slot is None:
                 self.tree_cache.evict(EvictParams(num_tokens=0, mamba_num=1))

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -75,6 +75,7 @@ from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
+    EvictParams,
     MatchPrefixParams,
     zero_match_result,
 )
@@ -2156,11 +2157,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # so we need to add 1 to the seqlen to retrieve the correct mamba state from h.
                 mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)
 
-            req.mamba_next_track_idx = (
-                self.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                    req.mamba_next_track_idx
+            if not self.req_to_token_pool._mamba_lazy_extra_buffer:
+                req.mamba_next_track_idx = (
+                    self.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                        req.mamba_next_track_idx
+                    )
                 )
-            )
             if req.mamba_branching_seqlen is not None:
                 # track branching point in this forward if the branching point
                 # is within the current extend batch.
@@ -2412,6 +2414,44 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         assert not ret or self.spec_algorithm.supports_spec_v2()
         return ret
 
+    def _mamba_lazy_prealloc_at_boundary(self, mamba_track_interval: int):
+        """Pre-allocate a mamba state for reqs at the track interval boundary.
+
+        In lazy mode, each request normally holds only 1 ping-pong slot.
+        At the boundary, we allocate the second slot so the forward pass
+        can write the tracked state there.
+        """
+        req_to_token_pool = self.req_to_token_pool
+        mamba_pool = req_to_token_pool.mamba_pool
+
+        for i, req in enumerate(self.reqs):
+            if req.mamba_ping_pong_track_buffer is None:
+                continue
+            if self.seq_lens_cpu[i].item() % mamba_track_interval != 0:
+                continue
+
+            other_idx = 1 - req.mamba_next_track_idx
+            if req.mamba_ping_pong_track_buffer[other_idx].item() != -1:
+                continue
+
+            new_slot = mamba_pool.alloc(1)
+            if new_slot is None:
+                if (
+                    self.tree_cache is not None
+                    and self.tree_cache.supports_mamba()
+                ):
+                    self.tree_cache.evict(
+                        EvictParams(num_tokens=0, mamba_num=1)
+                    )
+                    new_slot = mamba_pool.alloc(1)
+
+            if new_slot is not None:
+                req.mamba_ping_pong_track_buffer[other_idx] = new_slot[0]
+                req.mamba_next_track_idx = other_idx
+                req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
+                    req.req_pool_idx
+                ] = req.mamba_ping_pong_track_buffer
+
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
         bs = len(self.reqs)
@@ -2494,6 +2534,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
         if get_global_server_args().enable_mamba_extra_buffer():
+            mamba_track_interval = get_global_server_args().mamba_track_interval
+
+            if (
+                self.req_to_token_pool._mamba_lazy_extra_buffer
+                and len(self.reqs) > 0
+            ):
+                self._mamba_lazy_prealloc_at_boundary(mamba_track_interval)
+
             if len(self.reqs) == 0:
                 self.mamba_track_indices = torch.empty(
                     (0,), dtype=torch.int64, device=self.device
@@ -2503,7 +2551,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
             # async H2D
             self.mamba_track_mask = (
-                (self.seq_lens_cpu % get_global_server_args().mamba_track_interval == 0)
+                (self.seq_lens_cpu % mamba_track_interval == 0)
                 .pin_memory()
                 .to(device=self.device, non_blocking=True)
             )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -768,6 +768,8 @@ class Req(ReqDllmMixin):
         self.mamba_cow_src_index: Optional[torch.Tensor] = None
         # Deferred clear: newly allocated mamba slot needs zeroing on forward stream
         self.mamba_needs_clear: bool = False
+        # Lazy extra buffer: whether to insert into radix cache on finish
+        self.mamba_lazy_is_insert: bool = True
 
         # Check finish
         self.tokenizer = None
@@ -2157,7 +2159,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # so we need to add 1 to the seqlen to retrieve the correct mamba state from h.
                 mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)
 
-            if not self.req_to_token_pool._mamba_lazy_extra_buffer:
+            if not self.req_to_token_pool.enable_mamba_extra_buffer_lazy:
                 req.mamba_next_track_idx = (
                     self.req_to_token_pool.get_mamba_ping_pong_other_idx(
                         req.mamba_next_track_idx
@@ -2537,7 +2539,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             mamba_track_interval = get_global_server_args().mamba_track_interval
 
             if (
-                self.req_to_token_pool._mamba_lazy_extra_buffer
+                self.req_to_token_pool.enable_mamba_extra_buffer_lazy
                 and len(self.reqs) > 0
             ):
                 self._mamba_lazy_prealloc_at_boundary(mamba_track_interval)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -91,7 +91,6 @@ class SchedulerBatchResultProcessor:
                 req.time_stats.set_quick_finish_time()
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                self._mamba_lazy_swap_before_cache(req, batch)
                 release_kv_cache(req, self.tree_cache)
 
         # Note: Logprobs should be handled on the prefill engine.
@@ -233,7 +232,6 @@ class SchedulerBatchResultProcessor:
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
-                        self._mamba_lazy_swap_before_cache(req, batch)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
@@ -318,7 +316,6 @@ class SchedulerBatchResultProcessor:
                     req.update_finish_state()
 
                     if req.finished():
-                        self._mamba_lazy_swap_before_cache(req, batch)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     else:
@@ -853,16 +850,6 @@ class SchedulerBatchResultProcessor:
         if req.require_reasoning and think_end_id is not None:
             req.update_reasoning_tokens(next_token_id, think_end_id)
 
-    def _mamba_lazy_swap_before_cache(self, req: Req, batch: ScheduleBatch):
-        """Swap mamba_next_track_idx so the valid slot is at 'other' for cache_finished_req."""
-        if not batch.req_to_token_pool.enable_mamba_extra_buffer_lazy:
-            return
-        if req.mamba_ping_pong_track_buffer is None:
-            return
-        other_idx = 1 - req.mamba_next_track_idx
-        if req.mamba_ping_pong_track_buffer[other_idx].item() == -1:
-            req.mamba_next_track_idx = other_idx
-
     def _mamba_prefix_cache_update(
         self,
         req: Req,
@@ -877,52 +864,25 @@ class SchedulerBatchResultProcessor:
         mamba_track_interval = get_global_server_args().mamba_track_interval
         lazy = batch.req_to_token_pool.enable_mamba_extra_buffer_lazy
 
-        if lazy:
-            self._mamba_lazy_prefix_cache_update(
-                req, batch, result, i, seq_len, mamba_track_interval
-            )
-            return
-
-        if batch.spec_algorithm.is_none() and seq_len % mamba_track_interval == 0:
-            req.mamba_next_track_idx = (
-                batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                    req.mamba_next_track_idx
+        if batch.spec_algorithm.is_none():
+            if lazy:
+                at_boundary = (
+                    seq_len % mamba_track_interval == mamba_track_interval - 1
                 )
-            )
-            req.mamba_last_track_seqlen = seq_len
+            else:
+                at_boundary = seq_len % mamba_track_interval == 0
+            if at_boundary:
+                if not lazy:
+                    req.mamba_next_track_idx = (
+                        batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                            req.mamba_next_track_idx
+                        )
+                    )
+                req.mamba_last_track_seqlen = (seq_len + 1) if lazy else seq_len
         elif (
             not batch.spec_algorithm.is_none()
             and result.num_correct_drafts_per_req_cpu is not None
         ):
-            actual_seq_len = req.seqlen - 1
-            if (
-                actual_seq_len // mamba_track_interval
-                != (actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1)
-                // mamba_track_interval
-            ):
-                req.mamba_next_track_idx = (
-                    batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                        req.mamba_next_track_idx
-                    )
-                )
-                req.mamba_last_track_seqlen = (
-                    actual_seq_len // mamba_track_interval * mamba_track_interval
-                )
-
-    def _mamba_lazy_prefix_cache_update(
-        self,
-        req: Req,
-        batch: ScheduleBatch,
-        result: GenerationBatchResult,
-        i: int,
-        seq_len: int,
-        mamba_track_interval: int,
-    ) -> None:
-        """Lazy mode: set mamba_last_track_seqlen at boundary."""
-        if batch.spec_algorithm.is_none():
-            if seq_len % mamba_track_interval == mamba_track_interval - 1:
-                req.mamba_last_track_seqlen = seq_len + 1
-        elif result.num_correct_drafts_per_req_cpu is not None:
             actual_seq_len = req.seqlen - 1
             prev_seq_len = (
                 actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1
@@ -931,10 +891,14 @@ class SchedulerBatchResultProcessor:
                 actual_seq_len // mamba_track_interval
                 != prev_seq_len // mamba_track_interval
             ):
+                if not lazy:
+                    req.mamba_next_track_idx = (
+                        batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                            req.mamba_next_track_idx
+                        )
+                    )
                 req.mamba_last_track_seqlen = (
-                    actual_seq_len
-                    // mamba_track_interval
-                    * mamba_track_interval
+                    actual_seq_len // mamba_track_interval * mamba_track_interval
                 )
 
     def _mamba_lazy_post_decode(
@@ -944,53 +908,42 @@ class SchedulerBatchResultProcessor:
         result: GenerationBatchResult,
         i: int,
     ) -> None:
-        """Handle lazy-mode post-decode: free double->single for running reqs,
-        swap mamba_next_track_idx for finished reqs so cache_finished_req works."""
+        """Lazy-mode post-decode: free the temporary second slot for running reqs,
+        or mark is_insert=False for finished reqs when prealloc failed at boundary."""
+        if req.mamba_ping_pong_track_buffer is None:
+            return
+
         mamba_track_interval = get_global_server_args().mamba_track_interval
         seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
-        req_to_token_pool = batch.req_to_token_pool
 
         if batch.spec_algorithm.is_none():
             at_boundary = (
                 seq_len % mamba_track_interval == mamba_track_interval - 1
             )
+        elif result.num_correct_drafts_per_req_cpu is not None:
+            actual_seq_len = req.seqlen - 1
+            prev_seq_len = (
+                actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1
+            )
+            at_boundary = (
+                actual_seq_len // mamba_track_interval
+                != prev_seq_len // mamba_track_interval
+            )
         else:
-            if result.num_correct_drafts_per_req_cpu is not None:
-                actual_seq_len = req.seqlen - 1
-                prev_seq_len = (
-                    actual_seq_len
-                    - result.num_correct_drafts_per_req_cpu[i]
-                    - 1
-                )
-                at_boundary = (
-                    actual_seq_len // mamba_track_interval
-                    != prev_seq_len // mamba_track_interval
-                )
-            else:
-                at_boundary = False
+            at_boundary = False
 
+        if not at_boundary:
+            return
+
+        other_idx = 1 - req.mamba_next_track_idx
         if req.finished():
-            if at_boundary:
-                other_idx = 1 - req.mamba_next_track_idx
-                other_val = req.mamba_ping_pong_track_buffer[other_idx].item()
-                if other_val == -1:
-                    req.mamba_lazy_is_insert = False
-                else:
-                    req.mamba_lazy_is_insert = True
-                    req.mamba_next_track_idx = other_idx
-            else:
-                req.mamba_lazy_is_insert = True
-                other_idx = 1 - req.mamba_next_track_idx
-                other_val = req.mamba_ping_pong_track_buffer[other_idx].item()
-                if other_val == -1:
-                    req.mamba_next_track_idx = other_idx
+            if req.mamba_ping_pong_track_buffer[other_idx].item() == -1:
+                req.mamba_lazy_is_insert = False
         else:
-            if at_boundary:
-                other_idx = 1 - req.mamba_next_track_idx
-                old_val = req.mamba_ping_pong_track_buffer[other_idx]
-                if old_val.item() != -1:
-                    req_to_token_pool.mamba_pool.free(old_val.unsqueeze(0))
-                req.mamba_ping_pong_track_buffer[other_idx] = -1
-                req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
-                    req.req_pool_idx
-                ] = req.mamba_ping_pong_track_buffer
+            old_val = req.mamba_ping_pong_track_buffer[other_idx]
+            if old_val.item() != -1:
+                batch.req_to_token_pool.mamba_pool.free(old_val.unsqueeze(0))
+            req.mamba_ping_pong_track_buffer[other_idx] = -1
+            batch.req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
+                req.req_pool_idx
+            ] = req.mamba_ping_pong_track_buffer

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -644,7 +644,7 @@ class SchedulerBatchResultProcessor:
             if is_spec_v1:
                 self._mamba_prefix_cache_update(req, batch, result, i)
                 req.time_stats.set_last_decode_finish_time()
-                if getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False):
+                if batch.req_to_token_pool.enable_mamba_extra_buffer_lazy:
                     self._mamba_lazy_post_decode(req, batch, result, i)
                 self._handle_finished_req(req, i, logits_output)
                 if req.return_hidden_states and logits_output.hidden_states is not None:
@@ -671,7 +671,7 @@ class SchedulerBatchResultProcessor:
             req.time_stats.set_last_decode_finish_time()
             req.update_finish_state(new_accepted_len)
 
-            if getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False):
+            if batch.req_to_token_pool.enable_mamba_extra_buffer_lazy:
                 self._mamba_lazy_post_decode(req, batch, result, i)
 
             self._handle_finished_req(req, i, logits_output)
@@ -836,9 +836,8 @@ class SchedulerBatchResultProcessor:
             else:
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                lazy_is_insert = getattr(req, "_mamba_lazy_is_insert", True)
                 release_kv_cache(
-                    req, self.tree_cache, is_insert=lazy_is_insert
+                    req, self.tree_cache, is_insert=req.mamba_lazy_is_insert
                 )
 
             req.time_stats.set_completion_time()
@@ -856,7 +855,7 @@ class SchedulerBatchResultProcessor:
 
     def _mamba_lazy_swap_before_cache(self, req: Req, batch: ScheduleBatch):
         """Swap mamba_next_track_idx so the valid slot is at 'other' for cache_finished_req."""
-        if not getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False):
+        if not batch.req_to_token_pool.enable_mamba_extra_buffer_lazy:
             return
         if req.mamba_ping_pong_track_buffer is None:
             return
@@ -876,7 +875,7 @@ class SchedulerBatchResultProcessor:
             return
 
         mamba_track_interval = get_global_server_args().mamba_track_interval
-        lazy = getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False)
+        lazy = batch.req_to_token_pool.enable_mamba_extra_buffer_lazy
 
         if lazy:
             self._mamba_lazy_prefix_cache_update(
@@ -975,12 +974,12 @@ class SchedulerBatchResultProcessor:
                 other_idx = 1 - req.mamba_next_track_idx
                 other_val = req.mamba_ping_pong_track_buffer[other_idx].item()
                 if other_val == -1:
-                    req._mamba_lazy_is_insert = False
+                    req.mamba_lazy_is_insert = False
                 else:
-                    req._mamba_lazy_is_insert = True
+                    req.mamba_lazy_is_insert = True
                     req.mamba_next_track_idx = other_idx
             else:
-                req._mamba_lazy_is_insert = True
+                req.mamba_lazy_is_insert = True
                 other_idx = 1 - req.mamba_next_track_idx
                 other_val = req.mamba_ping_pong_track_buffer[other_idx].item()
                 if other_val == -1:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -856,7 +856,7 @@ class SchedulerBatchResultProcessor:
             return
 
         mamba_track_interval = get_global_server_args().mamba_track_interval
-        lazy = batch.req_to_token_pool.enable_mamba_extra_buffer_lazy
+        lazy = get_global_server_args().enable_mamba_extra_buffer_lazy()
         seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
         at_boundary = False
 
@@ -886,9 +886,9 @@ class SchedulerBatchResultProcessor:
                 )
             req.mamba_last_track_seqlen = track_seqlen
             if lazy:
-                self._mamba_lazy_post_decode_at_boundary(req, batch)
+                self.mamba_lazy_post_decode_at_boundary(req, batch)
 
-    def _mamba_lazy_post_decode_at_boundary(
+    def mamba_lazy_post_decode_at_boundary(
         self, req: Req, batch: ScheduleBatch
     ):
         """Post-decode cleanup at a lazy-mode track boundary.

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -641,8 +641,6 @@ class SchedulerBatchResultProcessor:
             if is_spec_v1:
                 self._mamba_prefix_cache_update(req, batch, result, i)
                 req.time_stats.set_last_decode_finish_time()
-                if batch.req_to_token_pool.enable_mamba_extra_buffer_lazy:
-                    self._mamba_lazy_post_decode(req, batch, result, i)
                 self._handle_finished_req(req, i, logits_output)
                 if req.return_hidden_states and logits_output.hidden_states is not None:
                     req.hidden_states.append(
@@ -663,13 +661,10 @@ class SchedulerBatchResultProcessor:
 
             self._maybe_update_reasoning_tokens(req, next_token_id)
 
-            # Update Mamba last track seqlen
-            self._mamba_prefix_cache_update(req, batch, result, i)
             req.time_stats.set_last_decode_finish_time()
             req.update_finish_state(new_accepted_len)
 
-            if batch.req_to_token_pool.enable_mamba_extra_buffer_lazy:
-                self._mamba_lazy_post_decode(req, batch, result, i)
+            self._mamba_prefix_cache_update(req, batch, result, i)
 
             self._handle_finished_req(req, i, logits_output)
 
@@ -857,84 +852,53 @@ class SchedulerBatchResultProcessor:
         result: GenerationBatchResult,
         i: int,
     ) -> None:
-        seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
         if req.mamba_ping_pong_track_buffer is None:
             return
 
         mamba_track_interval = get_global_server_args().mamba_track_interval
         lazy = batch.req_to_token_pool.enable_mamba_extra_buffer_lazy
+        seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
+        at_boundary = False
 
         if batch.spec_algorithm.is_none():
-            if lazy:
-                at_boundary = (
-                    seq_len % mamba_track_interval == mamba_track_interval - 1
-                )
-            else:
-                at_boundary = seq_len % mamba_track_interval == 0
+            check = (mamba_track_interval - 1) if lazy else 0
+            at_boundary = seq_len % mamba_track_interval == check
             if at_boundary:
-                if not lazy:
-                    req.mamba_next_track_idx = (
-                        batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                            req.mamba_next_track_idx
-                        )
-                    )
-                req.mamba_last_track_seqlen = (seq_len + 1) if lazy else seq_len
-        elif (
-            not batch.spec_algorithm.is_none()
-            and result.num_correct_drafts_per_req_cpu is not None
-        ):
+                track_seqlen = (seq_len + 1) if lazy else seq_len
+        elif result.num_correct_drafts_per_req_cpu is not None:
             actual_seq_len = req.seqlen - 1
-            prev_seq_len = (
-                actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1
-            )
-            if (
+            prev = actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1
+            at_boundary = (
                 actual_seq_len // mamba_track_interval
-                != prev_seq_len // mamba_track_interval
-            ):
-                if not lazy:
-                    req.mamba_next_track_idx = (
-                        batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                            req.mamba_next_track_idx
-                        )
-                    )
-                req.mamba_last_track_seqlen = (
+                != prev // mamba_track_interval
+            )
+            if at_boundary:
+                track_seqlen = (
                     actual_seq_len // mamba_track_interval * mamba_track_interval
                 )
 
-    def _mamba_lazy_post_decode(
-        self,
-        req: Req,
-        batch: ScheduleBatch,
-        result: GenerationBatchResult,
-        i: int,
-    ) -> None:
-        """Lazy-mode post-decode: free the temporary second slot for running reqs,
-        or mark is_insert=False for finished reqs when prealloc failed at boundary."""
-        if req.mamba_ping_pong_track_buffer is None:
-            return
+        if at_boundary:
+            if not lazy:
+                req.mamba_next_track_idx = (
+                    batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                        req.mamba_next_track_idx
+                    )
+                )
+            req.mamba_last_track_seqlen = track_seqlen
+            if lazy:
+                self._mamba_lazy_post_decode_at_boundary(req, batch)
 
-        mamba_track_interval = get_global_server_args().mamba_track_interval
-        seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
+    def _mamba_lazy_post_decode_at_boundary(
+        self, req: Req, batch: ScheduleBatch
+    ):
+        """Post-decode cleanup at a lazy-mode track boundary.
 
-        if batch.spec_algorithm.is_none():
-            at_boundary = (
-                seq_len % mamba_track_interval == mamba_track_interval - 1
-            )
-        elif result.num_correct_drafts_per_req_cpu is not None:
-            actual_seq_len = req.seqlen - 1
-            prev_seq_len = (
-                actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1
-            )
-            at_boundary = (
-                actual_seq_len // mamba_track_interval
-                != prev_seq_len // mamba_track_interval
-            )
-        else:
-            at_boundary = False
-
-        if not at_boundary:
-            return
-
+        For running reqs: free the old ping-pong slot so we go back to
+        holding only 1 slot until the next boundary.
+        For finished reqs: if the prealloc failed (other slot is -1),
+        mark is_insert=False so cache_finished_req skips the insert.
+        """
+        pool = batch.req_to_token_pool
         other_idx = 1 - req.mamba_next_track_idx
         if req.finished():
             if req.mamba_ping_pong_track_buffer[other_idx].item() == -1:
@@ -942,8 +906,5 @@ class SchedulerBatchResultProcessor:
         else:
             old_val = req.mamba_ping_pong_track_buffer[other_idx]
             if old_val.item() != -1:
-                batch.req_to_token_pool.mamba_pool.free(old_val.unsqueeze(0))
-            req.mamba_ping_pong_track_buffer[other_idx] = -1
-            batch.req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
-                req.req_pool_idx
-            ] = req.mamba_ping_pong_track_buffer
+                pool.mamba_pool.free(old_val.unsqueeze(0))
+            pool.set_mamba_ping_pong_slot(req, other_idx, -1)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -831,7 +831,7 @@ class SchedulerBatchResultProcessor:
             else:
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                is_insert = req.mamba_lazy_is_insert if self.server_args.enable_mamba_extra_buffer_lazy() else True
+                is_insert = req.mamba_lazy_is_insert if get_global_server_args().enable_mamba_extra_buffer_lazy() else True
                 release_kv_cache(req, self.tree_cache, is_insert=is_insert)
 
             req.time_stats.set_completion_time()
@@ -884,20 +884,17 @@ class SchedulerBatchResultProcessor:
     def _mamba_check_track_boundary(self, req, batch, result, i):
         """Check if this decode step crosses a mamba track interval boundary.
 
-        Returns (at_boundary, track_seqlen). In lazy mode the boundary is
-        detected one step early (interval-1) so the prealloc in
-        prepare_for_decode can allocate the second slot before the forward.
-        For spec decode, the boundary is detected by comparing the accepted
-        seq_len range against interval boundaries.
+        Returns (at_boundary, track_seqlen). Both lazy and non-lazy use the
+        same boundary condition (seq_len % interval == 0). For spec decode,
+        the boundary is detected by comparing the accepted seq_len range
+        against interval boundaries.
         """
         interval = get_global_server_args().mamba_track_interval
-        lazy = get_global_server_args().enable_mamba_extra_buffer_lazy()
 
         if batch.spec_algorithm.is_none():
             seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
-            check = (interval - 1) if lazy else 0
-            if seq_len % interval == check:
-                return True, (seq_len + 1) if lazy else seq_len
+            if seq_len % interval == 0:
+                return True, seq_len
         elif result.num_correct_drafts_per_req_cpu is not None:
             cur = req.seqlen - 1
             prev = cur - result.num_correct_drafts_per_req_cpu[i] - 1
@@ -913,16 +910,17 @@ class SchedulerBatchResultProcessor:
 
         For running reqs: free the old ping-pong slot so we go back to
         holding only 1 slot until the next boundary.
-        For finished reqs: if the prealloc failed (other slot is -1),
-        mark is_insert=False so cache_finished_req skips the insert.
+        For finished reqs: if prealloc failed (other slot is -1), the
+        forward overwrote the only slot with corrupted state — mark
+        is_insert=False so cache_finished_req skips the insert.
         """
-        pool = batch.req_to_token_pool
         other_idx = 1 - req.mamba_next_track_idx
         if req.finished():
             if req.mamba_ping_pong_track_buffer[other_idx].item() == -1:
                 req.mamba_lazy_is_insert = False
-        else:
-            old_val = req.mamba_ping_pong_track_buffer[other_idx]
-            if old_val.item() != -1:
-                pool.mamba_pool.free(old_val.unsqueeze(0))
-            pool.set_mamba_ping_pong_slot(req, other_idx, -1)
+            return
+        pool = batch.req_to_token_pool
+        old_val = req.mamba_ping_pong_track_buffer[other_idx]
+        if old_val.item() != -1:
+            pool.mamba_pool.free(old_val.unsqueeze(0))
+        pool.set_mamba_ping_pong_slot(req, other_idx, -1)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -639,9 +639,8 @@ class SchedulerBatchResultProcessor:
                 continue
 
             if is_spec_v1:
-                self._mamba_prefix_cache_update(req, batch, result, i)
                 req.time_stats.set_last_decode_finish_time()
-                self._handle_finished_req(req, i, logits_output)
+                self._handle_finish_state_updated_req(req, batch, result, i, logits_output)
                 if req.return_hidden_states and logits_output.hidden_states is not None:
                     req.hidden_states.append(
                         logits_output.hidden_states[i].cpu().clone().tolist()
@@ -664,9 +663,7 @@ class SchedulerBatchResultProcessor:
             req.time_stats.set_last_decode_finish_time()
             req.update_finish_state(new_accepted_len)
 
-            self._mamba_prefix_cache_update(req, batch, result, i)
-
-            self._handle_finished_req(req, i, logits_output)
+            self._handle_finish_state_updated_req(req, batch, result, i, logits_output)
 
             if req.return_logprob:
                 self._apply_decode_logprobs(
@@ -802,12 +799,18 @@ class SchedulerBatchResultProcessor:
             self.abort_request(AbortReq(rid=req.rid))
         req.grammar.finished = req.finished()
 
-    def _handle_finished_req(
+    def _handle_finish_state_updated_req(
         self,
         req: Req,
+        batch: ScheduleBatch,
+        result: GenerationBatchResult,
         i: int,
         logits_output: LogitsProcessorOutput,
     ):
+        # Called here (after update_finish_state) so req.finished() is valid
+        # for mamba_lazy_post_decode_at_boundary inside.
+        self._mamba_prefix_cache_update(req, batch, result, i)
+
         if (
             self.server_args.disaggregation_decode_enable_offload_kvcache
             and not req.finished()
@@ -828,9 +831,8 @@ class SchedulerBatchResultProcessor:
             else:
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                release_kv_cache(
-                    req, self.tree_cache, is_insert=req.mamba_lazy_is_insert
-                )
+                is_insert = req.mamba_lazy_is_insert if self.server_args.enable_mamba_extra_buffer_lazy() else True
+                release_kv_cache(req, self.tree_cache, is_insert=is_insert)
 
             req.time_stats.set_completion_time()
 
@@ -852,41 +854,57 @@ class SchedulerBatchResultProcessor:
         result: GenerationBatchResult,
         i: int,
     ) -> None:
+        """Update mamba track state at ping-pong boundaries.
+
+        Non-lazy: swap the ping-pong index so the next forward writes to
+        the alternate slot.
+        Lazy: keep the same index (prealloc handles the swap) and run
+        post-decode cleanup to free the temporary second slot.
+        """
         if req.mamba_ping_pong_track_buffer is None:
             return
 
-        mamba_track_interval = get_global_server_args().mamba_track_interval
+        at_boundary, track_seqlen = self._mamba_check_track_boundary(
+            req, batch, result, i
+        )
+        if not at_boundary:
+            return
+
         lazy = get_global_server_args().enable_mamba_extra_buffer_lazy()
-        seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
-        at_boundary = False
+        if not lazy:
+            req.mamba_next_track_idx = (
+                batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                    req.mamba_next_track_idx
+                )
+            )
+        req.mamba_last_track_seqlen = track_seqlen
+        if lazy:
+            self.mamba_lazy_post_decode_at_boundary(req, batch)
+
+    def _mamba_check_track_boundary(self, req, batch, result, i):
+        """Check if this decode step crosses a mamba track interval boundary.
+
+        Returns (at_boundary, track_seqlen). In lazy mode the boundary is
+        detected one step early (interval-1) so the prealloc in
+        prepare_for_decode can allocate the second slot before the forward.
+        For spec decode, the boundary is detected by comparing the accepted
+        seq_len range against interval boundaries.
+        """
+        interval = get_global_server_args().mamba_track_interval
+        lazy = get_global_server_args().enable_mamba_extra_buffer_lazy()
 
         if batch.spec_algorithm.is_none():
-            check = (mamba_track_interval - 1) if lazy else 0
-            at_boundary = seq_len % mamba_track_interval == check
-            if at_boundary:
-                track_seqlen = (seq_len + 1) if lazy else seq_len
+            seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
+            check = (interval - 1) if lazy else 0
+            if seq_len % interval == check:
+                return True, (seq_len + 1) if lazy else seq_len
         elif result.num_correct_drafts_per_req_cpu is not None:
-            actual_seq_len = req.seqlen - 1
-            prev = actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1
-            at_boundary = (
-                actual_seq_len // mamba_track_interval
-                != prev // mamba_track_interval
-            )
-            if at_boundary:
-                track_seqlen = (
-                    actual_seq_len // mamba_track_interval * mamba_track_interval
-                )
+            cur = req.seqlen - 1
+            prev = cur - result.num_correct_drafts_per_req_cpu[i] - 1
+            if cur // interval != prev // interval:
+                return True, cur // interval * interval
 
-        if at_boundary:
-            if not lazy:
-                req.mamba_next_track_idx = (
-                    batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                        req.mamba_next_track_idx
-                    )
-                )
-            req.mamba_last_track_seqlen = track_seqlen
-            if lazy:
-                self.mamba_lazy_post_decode_at_boundary(req, batch)
+        return False, 0
 
     def mamba_lazy_post_decode_at_boundary(
         self, req: Req, batch: ScheduleBatch

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -91,6 +91,7 @@ class SchedulerBatchResultProcessor:
                 req.time_stats.set_quick_finish_time()
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
+                self._mamba_lazy_swap_before_cache(req, batch)
                 release_kv_cache(req, self.tree_cache)
 
         # Note: Logprobs should be handled on the prefill engine.
@@ -232,6 +233,7 @@ class SchedulerBatchResultProcessor:
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
+                        self._mamba_lazy_swap_before_cache(req, batch)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
@@ -316,6 +318,7 @@ class SchedulerBatchResultProcessor:
                     req.update_finish_state()
 
                     if req.finished():
+                        self._mamba_lazy_swap_before_cache(req, batch)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     else:
@@ -641,6 +644,8 @@ class SchedulerBatchResultProcessor:
             if is_spec_v1:
                 self._mamba_prefix_cache_update(req, batch, result, i)
                 req.time_stats.set_last_decode_finish_time()
+                if getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False):
+                    self._mamba_lazy_post_decode(req, batch, result, i)
                 self._handle_finished_req(req, i, logits_output)
                 if req.return_hidden_states and logits_output.hidden_states is not None:
                     req.hidden_states.append(
@@ -665,6 +670,9 @@ class SchedulerBatchResultProcessor:
             self._mamba_prefix_cache_update(req, batch, result, i)
             req.time_stats.set_last_decode_finish_time()
             req.update_finish_state(new_accepted_len)
+
+            if getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False):
+                self._mamba_lazy_post_decode(req, batch, result, i)
 
             self._handle_finished_req(req, i, logits_output)
 
@@ -828,7 +836,10 @@ class SchedulerBatchResultProcessor:
             else:
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                release_kv_cache(req, self.tree_cache)
+                lazy_is_insert = getattr(req, "_mamba_lazy_is_insert", True)
+                release_kv_cache(
+                    req, self.tree_cache, is_insert=lazy_is_insert
+                )
 
             req.time_stats.set_completion_time()
 
@@ -843,6 +854,16 @@ class SchedulerBatchResultProcessor:
         if req.require_reasoning and think_end_id is not None:
             req.update_reasoning_tokens(next_token_id, think_end_id)
 
+    def _mamba_lazy_swap_before_cache(self, req: Req, batch: ScheduleBatch):
+        """Swap mamba_next_track_idx so the valid slot is at 'other' for cache_finished_req."""
+        if not getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False):
+            return
+        if req.mamba_ping_pong_track_buffer is None:
+            return
+        other_idx = 1 - req.mamba_next_track_idx
+        if req.mamba_ping_pong_track_buffer[other_idx].item() == -1:
+            req.mamba_next_track_idx = other_idx
+
     def _mamba_prefix_cache_update(
         self,
         req: Req,
@@ -851,32 +872,126 @@ class SchedulerBatchResultProcessor:
         i: int,
     ) -> None:
         seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
-        if req.mamba_ping_pong_track_buffer is not None:
-            mamba_track_interval = get_global_server_args().mamba_track_interval
-            if batch.spec_algorithm.is_none() and seq_len % mamba_track_interval == 0:
-                # for non-spec decode, we update mamba_last_track_seqlen at the end of each track interval
+        if req.mamba_ping_pong_track_buffer is None:
+            return
+
+        mamba_track_interval = get_global_server_args().mamba_track_interval
+        lazy = getattr(batch.req_to_token_pool, "_mamba_lazy_extra_buffer", False)
+
+        if lazy:
+            self._mamba_lazy_prefix_cache_update(
+                req, batch, result, i, seq_len, mamba_track_interval
+            )
+            return
+
+        if batch.spec_algorithm.is_none() and seq_len % mamba_track_interval == 0:
+            req.mamba_next_track_idx = (
+                batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                    req.mamba_next_track_idx
+                )
+            )
+            req.mamba_last_track_seqlen = seq_len
+        elif (
+            not batch.spec_algorithm.is_none()
+            and result.num_correct_drafts_per_req_cpu is not None
+        ):
+            actual_seq_len = req.seqlen - 1
+            if (
+                actual_seq_len // mamba_track_interval
+                != (actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1)
+                // mamba_track_interval
+            ):
                 req.mamba_next_track_idx = (
                     batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
                         req.mamba_next_track_idx
                     )
                 )
-                req.mamba_last_track_seqlen = seq_len
-            elif (
-                not batch.spec_algorithm.is_none()
-                and result.num_correct_drafts_per_req_cpu is not None
+                req.mamba_last_track_seqlen = (
+                    actual_seq_len // mamba_track_interval * mamba_track_interval
+                )
+
+    def _mamba_lazy_prefix_cache_update(
+        self,
+        req: Req,
+        batch: ScheduleBatch,
+        result: GenerationBatchResult,
+        i: int,
+        seq_len: int,
+        mamba_track_interval: int,
+    ) -> None:
+        """Lazy mode: set mamba_last_track_seqlen at boundary."""
+        if batch.spec_algorithm.is_none():
+            if seq_len % mamba_track_interval == mamba_track_interval - 1:
+                req.mamba_last_track_seqlen = seq_len + 1
+        elif result.num_correct_drafts_per_req_cpu is not None:
+            actual_seq_len = req.seqlen - 1
+            prev_seq_len = (
+                actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1
+            )
+            if (
+                actual_seq_len // mamba_track_interval
+                != prev_seq_len // mamba_track_interval
             ):
-                # for spec decode, update mamba_last_track_seqlen if this iteration crosses a track interval
-                actual_seq_len = req.seqlen - 1
-                if (
-                    actual_seq_len // mamba_track_interval
-                    != (actual_seq_len - result.num_correct_drafts_per_req_cpu[i] - 1)
+                req.mamba_last_track_seqlen = (
+                    actual_seq_len
                     // mamba_track_interval
-                ):
-                    req.mamba_next_track_idx = (
-                        batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                            req.mamba_next_track_idx
-                        )
-                    )
-                    req.mamba_last_track_seqlen = (
-                        actual_seq_len // mamba_track_interval * mamba_track_interval
-                    )
+                    * mamba_track_interval
+                )
+
+    def _mamba_lazy_post_decode(
+        self,
+        req: Req,
+        batch: ScheduleBatch,
+        result: GenerationBatchResult,
+        i: int,
+    ) -> None:
+        """Handle lazy-mode post-decode: free double->single for running reqs,
+        swap mamba_next_track_idx for finished reqs so cache_finished_req works."""
+        mamba_track_interval = get_global_server_args().mamba_track_interval
+        seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
+        req_to_token_pool = batch.req_to_token_pool
+
+        if batch.spec_algorithm.is_none():
+            at_boundary = (
+                seq_len % mamba_track_interval == mamba_track_interval - 1
+            )
+        else:
+            if result.num_correct_drafts_per_req_cpu is not None:
+                actual_seq_len = req.seqlen - 1
+                prev_seq_len = (
+                    actual_seq_len
+                    - result.num_correct_drafts_per_req_cpu[i]
+                    - 1
+                )
+                at_boundary = (
+                    actual_seq_len // mamba_track_interval
+                    != prev_seq_len // mamba_track_interval
+                )
+            else:
+                at_boundary = False
+
+        if req.finished():
+            if at_boundary:
+                other_idx = 1 - req.mamba_next_track_idx
+                other_val = req.mamba_ping_pong_track_buffer[other_idx].item()
+                if other_val == -1:
+                    req._mamba_lazy_is_insert = False
+                else:
+                    req._mamba_lazy_is_insert = True
+                    req.mamba_next_track_idx = other_idx
+            else:
+                req._mamba_lazy_is_insert = True
+                other_idx = 1 - req.mamba_next_track_idx
+                other_val = req.mamba_ping_pong_track_buffer[other_idx].item()
+                if other_val == -1:
+                    req.mamba_next_track_idx = other_idx
+        else:
+            if at_boundary:
+                other_idx = 1 - req.mamba_next_track_idx
+                old_val = req.mamba_ping_pong_track_buffer[other_idx]
+                if old_val.item() != -1:
+                    req_to_token_pool.mamba_pool.free(old_val.unsqueeze(0))
+                req.mamba_ping_pong_track_buffer[other_idx] = -1
+                req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
+                    req.req_pool_idx
+                ] = req.mamba_ping_pong_track_buffer

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -864,22 +864,37 @@ class SchedulerBatchResultProcessor:
         if req.mamba_ping_pong_track_buffer is None:
             return
 
+        lazy = get_global_server_args().enable_mamba_extra_buffer_lazy()
         at_boundary, track_seqlen = self._mamba_check_track_boundary(
             req, batch, result, i
         )
         if not at_boundary:
+            if (
+                lazy
+                and batch.mamba_lazy_backup_mask_cpu is not None
+                and i < len(batch.mamba_lazy_backup_mask_cpu)
+                and batch.mamba_lazy_backup_mask_cpu[i]
+            ):
+                self.mamba_lazy_post_decode_at_boundary(req, batch)
             return
 
-        lazy = get_global_server_args().enable_mamba_extra_buffer_lazy()
         if not lazy:
             req.mamba_next_track_idx = (
                 batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
                     req.mamba_next_track_idx
                 )
             )
-        req.mamba_last_track_seqlen = track_seqlen
-        if lazy:
+            req.mamba_last_track_seqlen = track_seqlen
+            return
+
+        if req.finished():
+            # Cache the backed-up previous checkpoint instead of the boundary
+            # slot that may have been overwritten by an overlapped stale forward.
             self.mamba_lazy_post_decode_at_boundary(req, batch)
+            return
+
+        req.mamba_last_track_seqlen = track_seqlen
+        self.mamba_lazy_post_decode_at_boundary(req, batch)
 
     def _mamba_check_track_boundary(self, req, batch, result, i):
         """Check if this decode step crosses a mamba track interval boundary.
@@ -908,11 +923,10 @@ class SchedulerBatchResultProcessor:
     ):
         """Post-decode cleanup at a lazy-mode track boundary.
 
-        For running reqs: free the old ping-pong slot so we go back to
-        holding only 1 slot until the next boundary.
-        For finished reqs: if prealloc failed (other slot is -1), the
-        forward overwrote the only slot with corrupted state — mark
-        is_insert=False so cache_finished_req skips the insert.
+        For running reqs: free the temporary backup so we go back to holding
+        only 1 slot until the next boundary.
+        For finished reqs: keep the backup for cache insertion; if no backup
+        exists, skip insertion because the only slot may have been overwritten.
         """
         other_idx = 1 - req.mamba_next_track_idx
         if req.finished():
@@ -920,7 +934,7 @@ class SchedulerBatchResultProcessor:
                 req.mamba_lazy_is_insert = False
             return
         pool = batch.req_to_token_pool
-        old_val = req.mamba_ping_pong_track_buffer[other_idx]
-        if old_val.item() != -1:
-            pool.mamba_pool.free(old_val.unsqueeze(0))
+        backup_val = req.mamba_ping_pong_track_buffer[other_idx]
+        if backup_val.item() != -1:
+            pool.mamba_pool.free(backup_val.unsqueeze(0))
         pool.set_mamba_ping_pong_slot(req, other_idx, -1)

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -29,6 +29,7 @@ class CacheInitParams:
     enable_kv_cache_events: bool = False
 
     enable_mamba_extra_buffer: bool = False
+    enable_mamba_extra_buffer_lazy: bool = False
 
     pp_rank: int = 0
     pp_size: int = 1

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -409,7 +409,7 @@ def alloc_req_slots(
         if tree_cache.supports_mamba():
             factor = (
                 MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY
-                if req_to_token_pool._mamba_lazy_extra_buffer
+                if req_to_token_pool.enable_mamba_extra_buffer_lazy
                 else MAMBA_STATE_PER_REQ_PREFIX_CACHE
             )
         else:

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 # Needs 2 + 1 slots for mamba request with prefix cache. 2 for ping pong cache, 1 for running mamba state.
 MAMBA_STATE_PER_REQ_PREFIX_CACHE = 3
+# Lazy mode: 1 + 1 slots (1 ping-pong + 1 running), second ping-pong allocated on demand at boundary.
+MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY = 2
 MAMBA_STATE_PER_REQ_NO_CACHE = 1
 
 logger = logging.getLogger(__name__)
@@ -404,11 +406,14 @@ def alloc_req_slots(
     num_reqs = len(reqs)
     if isinstance(req_to_token_pool, HybridReqToTokenPool):
         mamba_available_size = req_to_token_pool.mamba_pool.available_size()
-        factor = (
-            MAMBA_STATE_PER_REQ_PREFIX_CACHE
-            if tree_cache.supports_mamba()
-            else MAMBA_STATE_PER_REQ_NO_CACHE
-        )
+        if tree_cache.supports_mamba():
+            factor = (
+                MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY
+                if req_to_token_pool._mamba_lazy_extra_buffer
+                else MAMBA_STATE_PER_REQ_PREFIX_CACHE
+            )
+        else:
+            factor = MAMBA_STATE_PER_REQ_NO_CACHE
         mamba_state_needed = num_reqs * factor
         if mamba_available_size < mamba_state_needed:
             if tree_cache is not None and tree_cache.supports_mamba():

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -218,6 +218,7 @@ def build_kv_cache(
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,
         enable_mamba_extra_buffer=server_args.enable_mamba_extra_buffer(),
+        enable_mamba_extra_buffer_lazy=server_args.enable_mamba_extra_buffer_lazy(),
         pp_rank=ps.pp_rank,
         pp_size=ps.pp_size,
         chunked_prefill_size=effective_chunked_prefill_size,

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -559,14 +559,9 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             # Radix Cache takes one ref in memory pool
             # insert the token_ids and kv_indices into the radix tree
             if self.enable_mamba_extra_buffer:
-                if self.enable_mamba_extra_buffer_lazy:
-                    mamba_ping_pong_track_buffer_to_keep = req.mamba_next_track_idx
-                else:
-                    mamba_ping_pong_track_buffer_to_keep = (
-                        self.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                            req.mamba_next_track_idx
-                        )
-                    )
+                mamba_ping_pong_track_buffer_to_keep = (
+                    self.req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
+                )
                 mamba_value = (
                     req.mamba_ping_pong_track_buffer[
                         mamba_ping_pong_track_buffer_to_keep

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -558,11 +558,14 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             # Radix Cache takes one ref in memory pool
             # insert the token_ids and kv_indices into the radix tree
             if self.enable_mamba_extra_buffer:
-                mamba_ping_pong_track_buffer_to_keep = (
-                    self.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                        req.mamba_next_track_idx
+                if self.req_to_token_pool.enable_mamba_extra_buffer_lazy:
+                    mamba_ping_pong_track_buffer_to_keep = req.mamba_next_track_idx
+                else:
+                    mamba_ping_pong_track_buffer_to_keep = (
+                        self.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                            req.mamba_next_track_idx
+                        )
                     )
-                )
                 mamba_value = (
                     req.mamba_ping_pong_track_buffer[
                         mamba_ping_pong_track_buffer_to_keep

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -644,20 +644,21 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         # Donate the mamba index to the radix cache instead of copying.
         # This avoids a data copy that would race with the forward stream.
         if self.enable_mamba_extra_buffer:
-            mamba_ping_pong_track_buffer_to_keep = (
-                self.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                    req.mamba_next_track_idx
+            if self.req_to_token_pool._mamba_lazy_extra_buffer:
+                donate_idx = req.mamba_next_track_idx
+            else:
+                donate_idx = (
+                    self.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                        req.mamba_next_track_idx
+                    )
                 )
-            )
             mamba_value_donated = (
-                req.mamba_ping_pong_track_buffer[mamba_ping_pong_track_buffer_to_keep]
+                req.mamba_ping_pong_track_buffer[donate_idx]
                 .unsqueeze(-1)
                 .clone()
             )
             new_slot = self._alloc_mamba_slot()
-            req.mamba_ping_pong_track_buffer[mamba_ping_pong_track_buffer_to_keep] = (
-                new_slot[0]
-            )
+            req.mamba_ping_pong_track_buffer[donate_idx] = new_slot[0]
             self.req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
                 req.req_pool_idx
             ] = req.mamba_ping_pong_track_buffer

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -431,6 +431,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         self.disable = params.disable
         self.enable_kv_cache_events = params.enable_kv_cache_events
         self.enable_mamba_extra_buffer = params.enable_mamba_extra_buffer
+        self.enable_mamba_extra_buffer_lazy = params.enable_mamba_extra_buffer_lazy
         self.kv_event_queue = []
 
         if not self.enable_mamba_extra_buffer:
@@ -558,7 +559,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             # Radix Cache takes one ref in memory pool
             # insert the token_ids and kv_indices into the radix tree
             if self.enable_mamba_extra_buffer:
-                if self.req_to_token_pool.enable_mamba_extra_buffer_lazy:
+                if self.enable_mamba_extra_buffer_lazy:
                     mamba_ping_pong_track_buffer_to_keep = req.mamba_next_track_idx
                 else:
                     mamba_ping_pong_track_buffer_to_keep = (

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -644,24 +644,10 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         # Donate the mamba index to the radix cache instead of copying.
         # This avoids a data copy that would race with the forward stream.
         if self.enable_mamba_extra_buffer:
-            if self.req_to_token_pool._mamba_lazy_extra_buffer:
-                donate_idx = req.mamba_next_track_idx
-            else:
-                donate_idx = (
-                    self.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                        req.mamba_next_track_idx
-                    )
-                )
-            mamba_value_donated = (
-                req.mamba_ping_pong_track_buffer[donate_idx]
-                .unsqueeze(-1)
-                .clone()
-            )
             new_slot = self._alloc_mamba_slot()
-            req.mamba_ping_pong_track_buffer[donate_idx] = new_slot[0]
-            self.req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
-                req.req_pool_idx
-            ] = req.mamba_ping_pong_track_buffer
+            mamba_value_donated = self.req_to_token_pool.donate_mamba_ping_pong_slot(
+                req, new_slot
+            )
         else:
             mamba_value_donated = self._alloc_mamba_slot()
             self.req_to_token_pool.mamba_pool.copy_from(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -663,12 +663,27 @@ class HybridReqToTokenPool(ReqToTokenPool):
         else:
             return mamba_next_track_idx
 
+    def set_mamba_ping_pong_slot(self, req: "Req", idx: int, value):
+        """Update a ping-pong slot value and sync the device-side mapping.
+
+        The req holds the authoritative buffer; this keeps the
+        req_index_to_mamba_ping_pong_track_buffer_mapping in sync so that
+        set_mamba_track_indices_from_reqs reads correct slot indices.
+        """
+        req.mamba_ping_pong_track_buffer[idx] = value
+        self.req_index_to_mamba_ping_pong_track_buffer_mapping[
+            req.req_pool_idx
+        ] = req.mamba_ping_pong_track_buffer
+
     def donate_mamba_ping_pong_slot(
         self, req: "Req", new_slot: torch.Tensor
     ) -> torch.Tensor:
-        """Donate a ping-pong slot to the radix cache and replace it with new_slot.
+        """Donate the tracked-state ping-pong slot to the radix cache.
 
-        Returns the donated mamba value tensor (shape [1]) for insertion into the cache.
+        Returns the old slot index (shape [1]) for cache insertion and
+        replaces it with new_slot so the request can continue tracking.
+        In lazy mode the valid state is at next_track_idx; in normal mode
+        it is at the "other" index.
         """
         if self.enable_mamba_extra_buffer_lazy:
             donate_idx = req.mamba_next_track_idx
@@ -679,10 +694,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         mamba_value_donated = (
             req.mamba_ping_pong_track_buffer[donate_idx].unsqueeze(-1).clone()
         )
-        req.mamba_ping_pong_track_buffer[donate_idx] = new_slot[0]
-        self.req_index_to_mamba_ping_pong_track_buffer_mapping[
-            req.req_pool_idx
-        ] = req.mamba_ping_pong_track_buffer
+        self.set_mamba_ping_pong_slot(req, donate_idx, new_slot[0])
         return mamba_value_donated
 
     def free_mamba_cache(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -604,24 +604,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             mamba_indices.append(req.mamba_pool_idx)
             if self.enable_mamba_extra_buffer:
                 if req.mamba_ping_pong_track_buffer is None:
-                    if self.enable_mamba_extra_buffer_lazy:
-                        alloc_result = self.mamba_pool.alloc(1)
-                        assert (
-                            alloc_result is not None
-                        ), "Not enough space for mamba ping pong idx, try to increase --mamba-full-memory-ratio."
-                        req.mamba_ping_pong_track_buffer = torch.tensor(
-                            [alloc_result[0].item(), -1],
-                            dtype=torch.int64,
-                            device=self.device,
-                        )
-                    else:
-                        req.mamba_ping_pong_track_buffer = self.mamba_pool.alloc(
-                            self.mamba_ping_pong_track_buffer_size
-                        )
-                        assert (
-                            req.mamba_ping_pong_track_buffer is not None
-                        ), "Not enough space for mamba ping pong idx, try to increase --mamba-full-memory-ratio."
-                    req.mamba_next_track_idx = 0
+                    self._alloc_ping_pong_buffer(req)
                 mamba_ping_pong_track_buffers.append(req.mamba_ping_pong_track_buffer)
         assert len(select_index) == len(
             mamba_indices
@@ -662,6 +645,26 @@ class HybridReqToTokenPool(ReqToTokenPool):
             return 1 - mamba_next_track_idx
         else:
             return mamba_next_track_idx
+
+    def _alloc_ping_pong_buffer(self, req: "Req"):
+        """Allocate the ping-pong track buffer for a new request.
+
+        Lazy mode allocates 1 slot with the second set to -1 (allocated
+        on demand at track boundaries). Normal mode allocates all slots upfront.
+        """
+        n = 1 if self.enable_mamba_extra_buffer_lazy else self.mamba_ping_pong_track_buffer_size
+        slots = self.mamba_pool.alloc(n)
+        assert slots is not None, (
+            "Not enough space for mamba ping pong idx, "
+            "try to increase --mamba-full-memory-ratio."
+        )
+        if self.enable_mamba_extra_buffer_lazy:
+            req.mamba_ping_pong_track_buffer = torch.tensor(
+                [slots[0].item(), -1], dtype=slots.dtype, device=slots.device,
+            )
+        else:
+            req.mamba_ping_pong_track_buffer = slots
+        req.mamba_next_track_idx = 0
 
     def set_mamba_ping_pong_slot(self, req: "Req", idx: int, value):
         """Update a ping-pong slot value and sync the device-side mapping.

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -649,10 +649,14 @@ class HybridReqToTokenPool(ReqToTokenPool):
     def get_mamba_ping_pong_keep_idx(self, req: "Req") -> int:
         """Return the ping-pong index holding the most recent tracked state.
 
-        In lazy mode the valid state stays at next_track_idx (no eager swap).
+        In lazy mode the valid state normally stays at next_track_idx. A
+        short-lived backup in the other slot takes priority during overlap.
         In normal mode it is at the "other" index (swapped after each track).
         """
         if self.enable_mamba_extra_buffer_lazy:
+            backup_idx = self.get_mamba_ping_pong_other_idx(req.mamba_next_track_idx)
+            if req.mamba_ping_pong_track_buffer[backup_idx].item() != -1:
+                return backup_idx
             return req.mamba_next_track_idx
         return self.get_mamba_ping_pong_other_idx(req.mamba_next_track_idx)
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -668,12 +668,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
             "Not enough space for mamba ping pong idx, "
             "try to increase --mamba-full-memory-ratio."
         )
-        if self.enable_mamba_extra_buffer_lazy:
-            req.mamba_ping_pong_track_buffer = torch.tensor(
-                [slots[0].item(), -1], dtype=slots.dtype, device=slots.device,
-            )
-        else:
-            req.mamba_ping_pong_track_buffer = slots
+        buf = torch.full(
+            (self.mamba_ping_pong_track_buffer_size,), -1,
+            dtype=slots.dtype, device=slots.device,
+        )
+        buf[:n] = slots
+        req.mamba_ping_pong_track_buffer = buf
         req.mamba_next_track_idx = 0
 
     def set_mamba_ping_pong_slot(self, req: "Req", idx: int, value):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -525,6 +525,11 @@ class HybridReqToTokenPool(ReqToTokenPool):
 
         self.mamba_ping_pong_track_buffer_size = 2 if enable_overlap_schedule else 1
         self.enable_mamba_extra_buffer = enable_mamba_extra_buffer
+        from sglang.srt.environ import envs
+
+        self._mamba_lazy_extra_buffer = (
+            enable_mamba_extra_buffer and envs.SGLANG_MAMBA_LAZY_EXTRA_BUFFER.get()
+        )
         self.enable_memory_saver = enable_memory_saver
         self.start_layer = start_layer if start_layer is not None else 0
         self.layer_transfer_counter = None
@@ -600,12 +605,23 @@ class HybridReqToTokenPool(ReqToTokenPool):
             mamba_indices.append(req.mamba_pool_idx)
             if self.enable_mamba_extra_buffer:
                 if req.mamba_ping_pong_track_buffer is None:
-                    req.mamba_ping_pong_track_buffer = self.mamba_pool.alloc(
-                        self.mamba_ping_pong_track_buffer_size
-                    )
-                    assert (
-                        req.mamba_ping_pong_track_buffer is not None
-                    ), "Not enough space for mamba ping pong idx, try to increase --mamba-full-memory-ratio."
+                    if self._mamba_lazy_extra_buffer:
+                        alloc_result = self.mamba_pool.alloc(1)
+                        assert (
+                            alloc_result is not None
+                        ), "Not enough space for mamba ping pong idx, try to increase --mamba-full-memory-ratio."
+                        req.mamba_ping_pong_track_buffer = torch.tensor(
+                            [alloc_result[0].item(), -1],
+                            dtype=torch.int64,
+                            device=self.device,
+                        )
+                    else:
+                        req.mamba_ping_pong_track_buffer = self.mamba_pool.alloc(
+                            self.mamba_ping_pong_track_buffer_size
+                        )
+                        assert (
+                            req.mamba_ping_pong_track_buffer is not None
+                        ), "Not enough space for mamba ping pong idx, try to increase --mamba-full-memory-ratio."
                     req.mamba_next_track_idx = 0
                 mamba_ping_pong_track_buffers.append(req.mamba_ping_pong_track_buffer)
         assert len(select_index) == len(
@@ -687,6 +703,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
                     mamba_ping_pong_track_buffer_to_free = (
                         mamba_ping_pong_track_buffer_to_free[0:0]
                     )
+            if self._mamba_lazy_extra_buffer:
+                mamba_ping_pong_track_buffer_to_free = (
+                    mamba_ping_pong_track_buffer_to_free[
+                        mamba_ping_pong_track_buffer_to_free != -1
+                    ]
+                )
             self.mamba_pool.free(mamba_ping_pong_track_buffer_to_free)
 
     def clear(self):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -646,6 +646,16 @@ class HybridReqToTokenPool(ReqToTokenPool):
         else:
             return mamba_next_track_idx
 
+    def get_mamba_ping_pong_keep_idx(self, req: "Req") -> int:
+        """Return the ping-pong index holding the most recent tracked state.
+
+        In lazy mode the valid state stays at next_track_idx (no eager swap).
+        In normal mode it is at the "other" index (swapped after each track).
+        """
+        if self.enable_mamba_extra_buffer_lazy:
+            return req.mamba_next_track_idx
+        return self.get_mamba_ping_pong_other_idx(req.mamba_next_track_idx)
+
     def _alloc_ping_pong_buffer(self, req: "Req"):
         """Allocate the ping-pong track buffer for a new request.
 
@@ -688,12 +698,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         In lazy mode the valid state is at next_track_idx; in normal mode
         it is at the "other" index.
         """
-        if self.enable_mamba_extra_buffer_lazy:
-            donate_idx = req.mamba_next_track_idx
-        else:
-            donate_idx = self.get_mamba_ping_pong_other_idx(
-                req.mamba_next_track_idx
-            )
+        donate_idx = self.get_mamba_ping_pong_keep_idx(req)
         mamba_value_donated = (
             req.mamba_ping_pong_track_buffer[donate_idx].unsqueeze(-1).clone()
         )

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -139,6 +139,8 @@ def _set_kv_buffer_impl(
 class ReqToTokenPool:
     """A memory pool that maps a request to its token locations."""
 
+    enable_mamba_extra_buffer_lazy: bool = False
+
     def __init__(
         self,
         size: int,
@@ -512,6 +514,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         cache_params: BaseLinearStateParams,
         mamba_layer_ids: List[int],
         enable_mamba_extra_buffer: bool,
+        enable_mamba_extra_buffer_lazy: bool = False,
         speculative_num_draft_tokens: int = None,
         enable_overlap_schedule: bool = True,
         start_layer: Optional[int] = None,
@@ -525,11 +528,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
 
         self.mamba_ping_pong_track_buffer_size = 2 if enable_overlap_schedule else 1
         self.enable_mamba_extra_buffer = enable_mamba_extra_buffer
-        from sglang.srt.environ import envs
-
-        self._mamba_lazy_extra_buffer = (
-            enable_mamba_extra_buffer and envs.SGLANG_MAMBA_LAZY_EXTRA_BUFFER.get()
-        )
+        self.enable_mamba_extra_buffer_lazy = enable_mamba_extra_buffer_lazy
         self.enable_memory_saver = enable_memory_saver
         self.start_layer = start_layer if start_layer is not None else 0
         self.layer_transfer_counter = None
@@ -605,7 +604,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             mamba_indices.append(req.mamba_pool_idx)
             if self.enable_mamba_extra_buffer:
                 if req.mamba_ping_pong_track_buffer is None:
-                    if self._mamba_lazy_extra_buffer:
+                    if self.enable_mamba_extra_buffer_lazy:
                         alloc_result = self.mamba_pool.alloc(1)
                         assert (
                             alloc_result is not None
@@ -664,6 +663,28 @@ class HybridReqToTokenPool(ReqToTokenPool):
         else:
             return mamba_next_track_idx
 
+    def donate_mamba_ping_pong_slot(
+        self, req: "Req", new_slot: torch.Tensor
+    ) -> torch.Tensor:
+        """Donate a ping-pong slot to the radix cache and replace it with new_slot.
+
+        Returns the donated mamba value tensor (shape [1]) for insertion into the cache.
+        """
+        if self.enable_mamba_extra_buffer_lazy:
+            donate_idx = req.mamba_next_track_idx
+        else:
+            donate_idx = self.get_mamba_ping_pong_other_idx(
+                req.mamba_next_track_idx
+            )
+        mamba_value_donated = (
+            req.mamba_ping_pong_track_buffer[donate_idx].unsqueeze(-1).clone()
+        )
+        req.mamba_ping_pong_track_buffer[donate_idx] = new_slot[0]
+        self.req_index_to_mamba_ping_pong_track_buffer_mapping[
+            req.req_pool_idx
+        ] = req.mamba_ping_pong_track_buffer
+        return mamba_value_donated
+
     def free_mamba_cache(
         self, req: "Req", mamba_ping_pong_track_buffer_to_keep: Optional[int] = None
     ):
@@ -703,7 +724,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
                     mamba_ping_pong_track_buffer_to_free = (
                         mamba_ping_pong_track_buffer_to_free[0:0]
                     )
-            if self._mamba_lazy_extra_buffer:
+            if self.enable_mamba_extra_buffer_lazy:
                 mamba_ping_pong_track_buffer_to_free = (
                     mamba_ping_pong_track_buffer_to_free[
                         mamba_ping_pong_track_buffer_to_free != -1

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -312,13 +312,22 @@ class MambaComponent(TreeComponent):
                 return 0
             # Donate the mamba index to the radix cache instead of copying.
             if self.enable_mamba_extra_buffer:
-                keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                    req.mamba_next_track_idx
-                )
+                if self.cache.req_to_token_pool._mamba_lazy_extra_buffer:
+                    donate_idx = req.mamba_next_track_idx
+                else:
+                    donate_idx = (
+                        self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                            req.mamba_next_track_idx
+                        )
+                    )
                 mamba_value_donated = (
-                    req.mamba_ping_pong_track_buffer[keep_idx].unsqueeze(-1).clone()
+                    req.mamba_ping_pong_track_buffer[donate_idx]
+                    .unsqueeze(-1)
+                    .clone()
                 )
-                req.mamba_ping_pong_track_buffer[keep_idx] = self._alloc_mamba_slot()[0]
+                req.mamba_ping_pong_track_buffer[donate_idx] = (
+                    self._alloc_mamba_slot()[0]
+                )
                 self.cache.req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
                     req.req_pool_idx
                 ] = req.mamba_ping_pong_track_buffer

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -312,25 +312,12 @@ class MambaComponent(TreeComponent):
                 return 0
             # Donate the mamba index to the radix cache instead of copying.
             if self.enable_mamba_extra_buffer:
-                if self.cache.req_to_token_pool._mamba_lazy_extra_buffer:
-                    donate_idx = req.mamba_next_track_idx
-                else:
-                    donate_idx = (
-                        self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                            req.mamba_next_track_idx
-                        )
-                    )
+                new_slot = self._alloc_mamba_slot()
                 mamba_value_donated = (
-                    req.mamba_ping_pong_track_buffer[donate_idx]
-                    .unsqueeze(-1)
-                    .clone()
+                    self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
+                        req, new_slot
+                    )
                 )
-                req.mamba_ping_pong_track_buffer[donate_idx] = (
-                    self._alloc_mamba_slot()[0]
-                )
-                self.cache.req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
-                    req.req_pool_idx
-                ] = req.mamba_ping_pong_track_buffer
             else:
                 mamba_value_donated = self._alloc_mamba_slot()
                 self.cache.req_to_token_pool.mamba_pool.copy_from(

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -297,9 +297,12 @@ class MambaComponent(TreeComponent):
             if cache_len is None:
                 cache_len = 0
             if self.enable_mamba_extra_buffer:
-                keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                    req.mamba_next_track_idx
-                )
+                if self.cache.req_to_token_pool.enable_mamba_extra_buffer_lazy:
+                    keep_idx = req.mamba_next_track_idx
+                else:
+                    keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                        req.mamba_next_track_idx
+                    )
                 mamba_value = (
                     req.mamba_ping_pong_track_buffer[keep_idx].unsqueeze(-1).clone()
                 )
@@ -338,9 +341,12 @@ class MambaComponent(TreeComponent):
                 insert_result.mamba_exist if insert_result is not None else True
             )
             if self.enable_mamba_extra_buffer:
-                keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                    req.mamba_next_track_idx
-                )
+                if self.cache.req_to_token_pool.enable_mamba_extra_buffer_lazy:
+                    keep_idx = req.mamba_next_track_idx
+                else:
+                    keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
+                        req.mamba_next_track_idx
+                    )
             else:
                 keep_idx = None
             if mamba_exist:

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -47,6 +47,7 @@ class MambaComponent(TreeComponent):
             ), f"MambaComponent requires page_size=1 when mamba_extra_buffer is disabled, got {cache.page_size}"
         super().__init__(cache, params)
         self.enable_mamba_extra_buffer = params.enable_mamba_extra_buffer
+        self.enable_mamba_extra_buffer_lazy = params.enable_mamba_extra_buffer_lazy
         # HiCache state
         self._mamba_pool_host = None  # set to host mamba pool when HiCache enabled
 
@@ -297,7 +298,7 @@ class MambaComponent(TreeComponent):
             if cache_len is None:
                 cache_len = 0
             if self.enable_mamba_extra_buffer:
-                if self.cache.req_to_token_pool.enable_mamba_extra_buffer_lazy:
+                if self.enable_mamba_extra_buffer_lazy:
                     keep_idx = req.mamba_next_track_idx
                 else:
                     keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
@@ -341,7 +342,7 @@ class MambaComponent(TreeComponent):
                 insert_result.mamba_exist if insert_result is not None else True
             )
             if self.enable_mamba_extra_buffer:
-                if self.cache.req_to_token_pool.enable_mamba_extra_buffer_lazy:
+                if self.enable_mamba_extra_buffer_lazy:
                     keep_idx = req.mamba_next_track_idx
                 else:
                     keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -298,12 +298,7 @@ class MambaComponent(TreeComponent):
             if cache_len is None:
                 cache_len = 0
             if self.enable_mamba_extra_buffer:
-                if self.enable_mamba_extra_buffer_lazy:
-                    keep_idx = req.mamba_next_track_idx
-                else:
-                    keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                        req.mamba_next_track_idx
-                    )
+                keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
                 mamba_value = (
                     req.mamba_ping_pong_track_buffer[keep_idx].unsqueeze(-1).clone()
                 )
@@ -342,12 +337,7 @@ class MambaComponent(TreeComponent):
                 insert_result.mamba_exist if insert_result is not None else True
             )
             if self.enable_mamba_extra_buffer:
-                if self.enable_mamba_extra_buffer_lazy:
-                    keep_idx = req.mamba_next_track_idx
-                else:
-                    keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_other_idx(
-                        req.mamba_next_track_idx
-                    )
+                keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
             else:
                 keep_idx = None
             if mamba_exist:

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -238,6 +238,11 @@ class ModelRunnerKVCacheMixin:
             else:
                 additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP
 
+            from sglang.srt.environ import envs
+
+            if envs.SGLANG_MAMBA_LAZY_EXTRA_BUFFER.get():
+                additional_ratio = max(0, additional_ratio - 1)
+
         return MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO + additional_ratio
 
     def _validate_prefill_only_disable_kv_cache_pool_family(

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 # the ratio of mamba cache pool size to max_running_requests
 MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO = 3
 MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP = 2
+MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP_LAZY = 1
 MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP = 1
 
 logger = logging.getLogger(__name__)
@@ -233,13 +234,17 @@ class ModelRunnerKVCacheMixin:
         additional_ratio = 0
         if self.server_args.enable_mamba_extra_buffer():
             # ping-pong buffer size is 2 when overlap schedule is on, 1 otherwise.
+            # Lazy mode saves 1 slot (2 → 1) for overlap; non-overlap already uses 1.
             if not self.server_args.disable_overlap_schedule:
-                additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP
+                if self.server_args.enable_mamba_extra_buffer_lazy():
+                    additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP_LAZY
+                else:
+                    additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP
             else:
+                assert not self.server_args.enable_mamba_extra_buffer_lazy(), (
+                    "Lazy extra buffer requires overlap schedule (--disable-overlap-schedule is incompatible)"
+                )
                 additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP
-
-            if self.server_args.enable_mamba_extra_buffer_lazy():
-                additional_ratio = max(0, additional_ratio - 1)
 
         return MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO + additional_ratio
 

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -238,9 +238,7 @@ class ModelRunnerKVCacheMixin:
             else:
                 additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP
 
-            from sglang.srt.environ import envs
-
-            if envs.SGLANG_MAMBA_LAZY_EXTRA_BUFFER.get():
+            if self.server_args.enable_mamba_extra_buffer_lazy():
                 additional_ratio = max(0, additional_ratio - 1)
 
         return MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO + additional_ratio
@@ -357,6 +355,7 @@ class ModelRunnerKVCacheMixin:
                         ]
                     ),
                     enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+                    enable_mamba_extra_buffer_lazy=self.server_args.enable_mamba_extra_buffer_lazy(),
                     speculative_num_draft_tokens=max_spec_draft_tokens,
                     enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
                     start_layer=self.start_layer,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -280,7 +280,12 @@ NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
 DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
 
-MAMBA_SCHEDULER_STRATEGY_CHOICES = ["auto", "no_buffer", "extra_buffer"]
+MAMBA_SCHEDULER_STRATEGY_CHOICES = [
+    "auto",
+    "no_buffer",
+    "extra_buffer",
+    "extra_buffer_lazy",
+]
 
 MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
 
@@ -7102,7 +7107,10 @@ class ServerArgs:
         )
 
     def enable_mamba_extra_buffer(self) -> bool:
-        return self.mamba_scheduler_strategy == "extra_buffer"
+        return self.mamba_scheduler_strategy in ("extra_buffer", "extra_buffer_lazy")
+
+    def enable_mamba_extra_buffer_lazy(self) -> bool:
+        return self.mamba_scheduler_strategy == "extra_buffer_lazy"
 
     @cached_property
     def max_speculative_num_draft_tokens(self) -> Optional[int]:

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -16,7 +16,10 @@ from sglang.srt.layers.dp_attention import (
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.sampler import apply_custom_logit_processor
-from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.schedule_batch import (
+    ScheduleBatch,
+    set_mamba_track_indices_from_reqs,
+)
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
@@ -169,15 +172,23 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             bs,
         )
 
-        if get_global_server_args().enable_mamba_extra_buffer():
-            batch.mamba_track_indices = torch.tensor(
-                [
-                    req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx]
-                    for req in batch.reqs
-                ],
-                dtype=torch.int64,
-                device=batch.device,
-            )
+        server_args = get_global_server_args()
+        if server_args.enable_mamba_extra_buffer():
+            if server_args.enable_mamba_extra_buffer_lazy():
+                interval = server_args.mamba_track_interval
+                seq_lens_cpu = (
+                    batch.seq_lens_cpu.tolist()
+                    if batch.seq_lens_cpu is not None
+                    else [req.seqlen for req in batch.reqs]
+                )
+                batch.mamba_lazy_backup_at_boundary(
+                    [
+                        seq_len // interval
+                        != (seq_len + self.draft_token_num) // interval
+                        for seq_len in seq_lens_cpu
+                    ]
+                )
+            set_mamba_track_indices_from_reqs(batch)
             batch.mamba_track_mask = None
             batch.mamba_track_seqlens = None
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -301,7 +301,22 @@ class EagleVerifyInputV2Mixin:
                 device=device,
             )
 
-            if get_global_server_args().enable_mamba_extra_buffer():
+            server_args = get_global_server_args()
+            if server_args.enable_mamba_extra_buffer():
+                if server_args.enable_mamba_extra_buffer_lazy():
+                    interval = server_args.mamba_track_interval
+                    seq_lens_cpu = (
+                        batch.seq_lens_cpu.tolist()
+                        if batch.seq_lens_cpu is not None
+                        else [req.seqlen for req in batch.reqs]
+                    )
+                    batch.mamba_lazy_backup_at_boundary(
+                        [
+                            seq_len // interval
+                            != (seq_len + self.draft_token_num) // interval
+                            for seq_len in seq_lens_cpu
+                        ]
+                    )
                 set_mamba_track_indices_from_reqs(batch)
                 batch.mamba_track_mask = None
                 batch.mamba_track_seqlens = None

--- a/test/manual/4-gpu-models/test_qwen3_next_models.py
+++ b/test/manual/4-gpu-models/test_qwen3_next_models.py
@@ -1,9 +1,20 @@
+import os
+import time
 import unittest
 
+import requests
+
+from sglang.srt.utils import kill_process_tree
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
-from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase, openai_api_env
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
 
 QWEN3_NEXT_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 
@@ -19,12 +30,60 @@ class TestQwen3Next(
         "--tp-size",
         "4",
         "--chunked-prefill-size",
-        "2048",
+        "1024",
         "--mamba-scheduler-strategy",
         "extra_buffer",
         "--mamba-track-interval",
-        "128",
+        "64",
+        "--moe-runner-backend",
+        "triton",
     ]
+
+
+class TestQwen3NextLazyExtraBuffer(
+    GSM8KMixin, KLDivergenceMixin, PrefixCacheBranchingMixin, CustomTestCase
+):
+    model = QWEN3_NEXT_MODEL
+    cache_chunk_size = 64
+    base_url = DEFAULT_URL_FOR_TEST
+    timeout = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+    api_key = "sk-123456"
+    gsm8k_accuracy_thres = 0.93
+    kl_div_thres = 0.0025
+    other_args = [
+        "--tp-size",
+        "4",
+        "--chunked-prefill-size",
+        "1024",
+        "--mamba-scheduler-strategy",
+        "extra_buffer",
+        "--mamba-track-interval",
+        "64",
+        "--moe-runner-backend",
+        "triton",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        env = os.environ.copy()
+        env["SGLANG_MAMBA_LAZY_EXTRA_BUFFER"] = "true"
+        with openai_api_env(cls.api_key):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=cls.timeout,
+                other_args=cls.other_args,
+                env=env,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid, wait_timeout=60)
+        time.sleep(2)
+
+    @classmethod
+    def flush_cache(cls):
+        requests.post(cls.base_url + "/flush_cache")
 
 
 if __name__ == "__main__":

--- a/test/manual/4-gpu-models/test_qwen3_next_models.py
+++ b/test/manual/4-gpu-models/test_qwen3_next_models.py
@@ -1,20 +1,9 @@
-import os
-import time
 import unittest
 
-import requests
-
-from sglang.srt.utils import kill_process_tree
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
-from sglang.test.server_fixtures.default_fixture import DefaultServerBase, openai_api_env
-from sglang.test.test_utils import (
-    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-    DEFAULT_URL_FOR_TEST,
-    CustomTestCase,
-    popen_launch_server,
-)
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
 QWEN3_NEXT_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 
@@ -41,13 +30,10 @@ class TestQwen3Next(
 
 
 class TestQwen3NextLazyExtraBuffer(
-    GSM8KMixin, KLDivergenceMixin, PrefixCacheBranchingMixin, CustomTestCase
+    GSM8KMixin, KLDivergenceMixin, PrefixCacheBranchingMixin, DefaultServerBase
 ):
     model = QWEN3_NEXT_MODEL
     cache_chunk_size = 64
-    base_url = DEFAULT_URL_FOR_TEST
-    timeout = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
-    api_key = "sk-123456"
     gsm8k_accuracy_thres = 0.93
     kl_div_thres = 0.0025
     other_args = [
@@ -56,34 +42,12 @@ class TestQwen3NextLazyExtraBuffer(
         "--chunked-prefill-size",
         "1024",
         "--mamba-scheduler-strategy",
-        "extra_buffer",
+        "extra_buffer_lazy",
         "--mamba-track-interval",
         "64",
         "--moe-runner-backend",
         "triton",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        env = os.environ.copy()
-        env["SGLANG_MAMBA_LAZY_EXTRA_BUFFER"] = "true"
-        with openai_api_env(cls.api_key):
-            cls.process = popen_launch_server(
-                cls.model,
-                cls.base_url,
-                timeout=cls.timeout,
-                other_args=cls.other_args,
-                env=env,
-            )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid, wait_timeout=60)
-        time.sleep(2)
-
-    @classmethod
-    def flush_cache(cls):
-        requests.post(cls.base_url + "/flush_cache")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Co-authored-by: @hanming-lu

This PR implements lazy Mamba extra-buffer allocation for radix-cache tracking. It keeps the existing request-owned ping-pong buffer representation for backward compatibility, while reducing fixed extra-buffer allocation by materializing the second track slot only when a tracking boundary may need it.

The optimization is motivated by the memory-overhead reduction explored in #22542. This PR preserves that memory-saving goal, but keeps the existing ping-pong lifecycle instead of replacing it with a new pending-slot ownership model. This keeps the change local, additive, and closer to the current request-owned buffer semantics.

Concretely:

- Lazy mode allocates one Mamba ping-pong track slot at request allocation time and leaves the other entry as `-1`.
- At a Mamba track boundary, the missing target slot is allocated on demand.
- If the target slot already exists, it is reused. This matters for speculative decoding where the same boundary may be prepared before the final accept length is known.
- If target-slot allocation fails under pressure, this PR does not evict radix cache just to create a transient boundary slot. It falls back to a detached keep-slot track and skips unsafe finished-request Mamba insertion when needed.
- The non-lazy/full ping-pong path remains unchanged.

## Design Rationale

The design keeps the existing request-owned ping-pong buffer lifecycle for compatibility. That allows the memory optimization to be implemented as a local lazy-allocation change instead of a broader ownership rewrite.

The main semantic cleanup is that `mamba_next_track_idx` consistently means the next write target. In lazy mode, the request usually owns one valid keep slot and one missing target slot (`-1`); the missing target is materialized only near a track boundary.

## Validation

Unless otherwise noted:

- Model: `Qwen/Qwen3-Next-80B-A3B-Instruct`
- `N = max_running_requests = 32`
- `mamba_track_interval = 128`
- Radix cache enabled
- `5N` means `max_mamba_cache_size = 160`
- KL is computed only on rows that hit decode cache, which checks that a cache hit uses a valid Mamba radix state.

### Accuracy / KL

| Case | Job | Decode-cache hit | Cached tokens | Decode-cache KL | Result |
|---|---:|---:|---|---:|---|
| no-MTP, `N=32`, `5N` | `1961806` | `32/32` | all `896` | `0.0015160608971137046` | pass `< 0.008` |
| no-MTP stress, `64 req = 2N`, `5N` | `1961808` | `31/64` | `0` or `896` | `0.001059574473602977` | pass `< 0.008` on hit rows |
| MTP, `N=32`, `5N` | `1961809` | `32/32` | `896` or `1024` | `0.0008251577837979901` | pass `< 0.008` |
| MTP debug rerun, same config | `1961859` | `32/32` | `896` or `1024` | `0.0016668516675800381` | pass `< 0.008` |

### Cache-Hit Comparison

| Workload | Baseline old ping-pong | Pending-slot PR #22542 | This PR |
|---|---:|---:|---:|
| no-MTP, `N=32`, `5N` | `31/32` | `32/32` | `32/32` |
| MTP, `N=32`, `5N` | `31/32` | `32/32` | `32/32` |
| no-MTP stress, `64 req = 2N`, `5N` | `0/64` | `31/64` | `31/64` |

This PR recovers the cache opportunity of the pending-slot implementation while keeping the ping-pong buffer layout.

### Boundary / Pool-Pressure Debug Counters

Counters below are from runs with gated debug logging enabled.

| Event | no-MTP N32 `1961806` | no-MTP stress `1961808` | MTP debug `1961859` |
|---|---:|---:|---:|
| `target_alloc_failed` | `464` | `1504` | `0` |
| `fallback_detach_keep` | `464` | `1504` | `0` |
| `fallback_no_keep` | `0` | `0` | `0` |
| `target_alloc_success` | `560` | `544` | `1024` |
| `target_exists` | `0` | `0` | `756` |
| `cache_finished_skip_mamba` | `0` | `128` | `0` |
| `evict_begin` | `0` | `136` | `0` |
| `evict_node` | `0` | `428` | `0` |
| `cache_finished_insert` | `396` | `520` | `396` |
| `release_detached_track` | `0` | `128` | `0` |
| `restore_detached_track` | `464` | `1376` | `0` |

Key readout:

- In the no-MTP `N=32` run, boundary target allocation failed 464 times, but this PR used detached keep-slot fallback without any schedule-side radix eviction, and still achieved `32/32` hits.
- In the stress run, evictions still happen later due to radix insert pressure, but they are no longer caused by retrying target-slot allocation at the tracking boundary.
- In the MTP run, all target slots were either allocated or already present, and cache-hit/KL behavior was normal.

## Local Checks

- `python3 -m compileall -q` on changed Python files
- `pre-commit run --files` on changed Python files









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->