### PR TITLE
Make unified tree SWA hicache tests faithful to write-through backup

### DIFF
--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1200,9 +1200,7 @@ class UnifiedRadixCacheSuite:
         aux = aux_types[0]
 
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
-        # One page keeps the leaf within a single SWA window so the SWA
-        # leaf-cap split does not fire; this test is about aux-only tombstone
-        # on a Full-locked leaf, not multi-node topology.
+        # One page stays within a single SWA window (no leaf-cap split).
         seq = self._make_seq(1, 1)
         self._insert(tree, allocator, req_to_token_pool, seq)
 
@@ -1530,11 +1528,7 @@ class UnifiedRadixCacheSuite:
         return False
 
     def _simulate_backup(self, tree, node):
-        """Simulate D->H backup by setting host_value on each component, for
-        the whole root->node path (parent-first), mirroring write-through.
-        A single insert may span several tree nodes (e.g. SWA caps a long leaf
-        to one window), so backing up only `node` would leave an unbacked
-        ancestor."""
+        """Simulate D->H backup over the whole root->node path (parent-first)."""
         chain = []
         cur = node
         while cur is not tree.root_node:
@@ -1607,11 +1601,8 @@ class UnifiedRadixCacheSuite:
         return fixture
 
     def _backup_node(self, tree, node):
-        # Back up the whole root->node path, ancestors first. Mirrors real
-        # write-through parent-first backup: a single insert may span several
-        # tree nodes (e.g. SWA caps a long leaf to one window), so backing up
-        # only `node` would leave an unbacked ancestor that production never
-        # produces.
+        # Parent-first backup over the whole path: one insert can span several
+        # nodes, so a single-node backup would leave an unbacked ancestor.
         chain = []
         cur = node
         while cur is not tree.root_node:
@@ -1791,10 +1782,8 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(len(m.device_indices), 0)
         self.assertIs(m.last_device_node, tree.root_node)
 
-        # Under the SWA leaf-cap split a single insert spans several nodes, so
-        # locate the host prefix via the match result and reconstruct the
-        # prefix/suffix by concatenating keys along the path rather than
-        # assuming a fixed parent/child shape.
+        # Locate the host prefix via last_host_node and rebuild prefix/suffix
+        # from path keys (a leaf may span several nodes).
         if self.cfg.has_mamba:
             self.assertEqual(m.host_hit_length, 0)
             self.assertIs(m.last_host_node, tree.root_node)
@@ -1908,9 +1897,7 @@ class UnifiedRadixCacheSuite:
         self._load_back_node(tree, node)
         self.assertFalse(node.evicted)
         self.assertIsNotNone(node.component_data[ComponentType.FULL].value)
-        # A single insert may span multiple tree nodes (SWA caps a long leaf to
-        # one window), so gather the whole reloaded prefix via match rather than
-        # the leaf's value alone.
+        # Gather the whole reloaded prefix via match (a leaf may be split).
         loaded_indices = tree.match_prefix(
             MatchPrefixParams(key=RadixKey(array("q", base)))
         ).device_indices
@@ -1989,11 +1976,9 @@ class UnifiedRadixCacheSuite:
         tree.sanity_check()
 
     def test_swa_deep_tree_backup_evict_loadback_stress(self):
-        """Multi-node SWA tree under real write-through: long leaves cap-split,
-        varied swa_evicted_seqlen tombstones, and shared-prefix branches build
-        a deep/wide tree; then backup -> stepwise evict -> loadback, asserting
-        sanity throughout. Exercises the split topology far more than the 1-2
-        page micro-tests, where a single insert yields at most two nodes."""
+        """Deep multi-node SWA tree (long leaves, decode-evict tombstones,
+        shared-prefix branches) through write-through backup -> evict ->
+        loadback, asserting sanity throughout."""
         if not self.cfg.has_swa:
             self.skipTest("requires SWA")
         if self._skip_unsupported_hicache_test():
@@ -2004,8 +1989,7 @@ class UnifiedRadixCacheSuite:
         tree, allocator, req_to_token_pool = self._build_hicache_fixture()
         tree.write_through_threshold = 1  # real eager write-through auto-backup
         ps = self.cfg.page_size
-        # Window measured in pages; sizes scale with it so the SWA leaf-cap
-        # split fires across configs (window may be < page or many pages).
+        # Window in pages; sizes scale with it so the leaf-cap split fires.
         tail_size = ((self.cfg.sliding_window_size + ps - 1) // ps) * ps
         wp = max(1, tail_size // ps)
 
@@ -2024,20 +2008,15 @@ class UnifiedRadixCacheSuite:
             tree.sanity_check()
             return True
 
-        # (1) Long leaf -> SWA cap-split (prefix + one-window tail).
-        base = self._make_seq(1, wp + 2)
+        base = self._make_seq(1, wp + 2)  # long leaf -> cap-split
         if not insert_swa(base, 0):
             self.skipTest("kv pool too small for deep-tree stress")
-        # (2) Fresh decode-evicted sequence: one page evicted during decode ->
-        #     tombstone-prefix + cap-split stacked (the cache_finished shape).
+        # fresh decode-evicted seq: tombstone-prefix + cap-split stacked
         insert_swa(self._make_seq(20000, wp + 2), ps)
-        # (3) Depth: extend the base chain.
-        insert_swa(base + self._make_seq(70000, 2), 0)
-        # (4) Width: branches sharing the base prefix.
-        for i in range(2):
+        insert_swa(base + self._make_seq(70000, 2), 0)  # depth
+        for i in range(2):  # width: branches off the base prefix
             insert_swa(base[: 2 * ps] + self._make_seq(80000 + 1000 * i, 3), 0)
 
-        # The tree must actually be deep/wide, otherwise the stress is moot.
         self.assertGreaterEqual(len(tree._collect_all_nodes()), 5)
 
         # Stepwise eviction -> demote to host, sanity after each round.

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1200,7 +1200,10 @@ class UnifiedRadixCacheSuite:
         aux = aux_types[0]
 
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
-        seq = self._make_seq(1, 2)
+        # One page keeps the leaf within a single SWA window so the SWA
+        # leaf-cap split does not fire; this test is about aux-only tombstone
+        # on a Full-locked leaf, not multi-node topology.
+        seq = self._make_seq(1, 1)
         self._insert(tree, allocator, req_to_token_pool, seq)
 
         match = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
@@ -1527,13 +1530,23 @@ class UnifiedRadixCacheSuite:
         return False
 
     def _simulate_backup(self, tree, node):
-        """Simulate D->H backup by setting host_value on each component."""
-        for ct in (ComponentType.FULL, ComponentType.MAMBA, ComponentType.SWA):
-            if ct not in self.cfg.components:
-                continue
-            cd = node.component_data[ct]
-            if cd.value is not None and cd.host_value is None:
-                cd.host_value = cd.value.clone()
+        """Simulate D->H backup by setting host_value on each component, for
+        the whole root->node path (parent-first), mirroring write-through.
+        A single insert may span several tree nodes (e.g. SWA caps a long leaf
+        to one window), so backing up only `node` would leave an unbacked
+        ancestor."""
+        chain = []
+        cur = node
+        while cur is not tree.root_node:
+            chain.append(cur)
+            cur = cur.parent
+        for ancestor in reversed(chain):
+            for ct in (ComponentType.FULL, ComponentType.MAMBA, ComponentType.SWA):
+                if ct not in self.cfg.components:
+                    continue
+                cd = ancestor.component_data[ct]
+                if cd.value is not None and cd.host_value is None:
+                    cd.host_value = cd.value.clone()
 
     def _simulate_backup_tree(self, tree):
         """Backup all non-root nodes (simulates write-through)."""
@@ -1594,9 +1607,24 @@ class UnifiedRadixCacheSuite:
         return fixture
 
     def _backup_node(self, tree, node):
-        backed_up = tree.write_backup(node, write_back=True)
-        self.assertGreater(backed_up, 0)
+        # Back up the whole root->node path, ancestors first. Mirrors real
+        # write-through parent-first backup: a single insert may span several
+        # tree nodes (e.g. SWA caps a long leaf to one window), so backing up
+        # only `node` would leave an unbacked ancestor that production never
+        # produces.
+        chain = []
+        cur = node
+        while cur is not tree.root_node:
+            chain.append(cur)
+            cur = cur.parent
+        backed_up = 0
+        for ancestor in reversed(chain):
+            if ancestor.backuped:
+                continue
+            backed_up = tree.write_backup(ancestor, write_back=True)
+            self.assertGreater(backed_up, 0)
         tree.writing_check(write_back=True)
+        self.assertTrue(node.backuped)
         return backed_up
 
     def _backup_tree(self, tree):
@@ -1763,22 +1791,38 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(len(m.device_indices), 0)
         self.assertIs(m.last_device_node, tree.root_node)
 
-        split_parent = node.parent
-        self.assertIsNot(split_parent, tree.root_node)
-        self.assertTrue(split_parent.evicted)
-        self.assertTrue(split_parent.backuped)
-        self.assertEqual(list(split_parent.key.token_ids), expected_prefix)
-        self.assertEqual(list(node.key.token_ids), expected_suffix)
-
+        # Under the SWA leaf-cap split a single insert spans several nodes, so
+        # locate the host prefix via the match result and reconstruct the
+        # prefix/suffix by concatenating keys along the path rather than
+        # assuming a fixed parent/child shape.
         if self.cfg.has_mamba:
             self.assertEqual(m.host_hit_length, 0)
             self.assertIs(m.last_host_node, tree.root_node)
-            self.assertIsNone(
-                split_parent.component_data[ComponentType.MAMBA].host_value
-            )
         else:
             self.assertEqual(m.host_hit_length, len(expected_prefix))
-            self.assertIs(m.last_host_node, split_parent)
+            split_parent = m.last_host_node
+            self.assertIsNot(split_parent, tree.root_node)
+            self.assertTrue(split_parent.evicted)
+            self.assertTrue(split_parent.backuped)
+            # root -> split_parent keys reconstruct expected_prefix
+            prefix_tokens: list[int] = []
+            chain = []
+            cur = split_parent
+            while cur is not tree.root_node:
+                chain.append(cur)
+                cur = cur.parent
+            for n in reversed(chain):
+                prefix_tokens.extend(n.key.token_ids)
+            self.assertEqual(prefix_tokens, expected_prefix)
+            # the diverged suffix stays as evicted+backuped descendant(s)
+            suffix_tokens: list[int] = []
+            cur = split_parent
+            while cur.children:
+                self.assertEqual(len(cur.children), 1)
+                cur = next(iter(cur.children.values()))
+                suffix_tokens.extend(cur.key.token_ids)
+            self.assertEqual(suffix_tokens, expected_suffix)
+            self.assertTrue(cur.evicted and cur.backuped)
         tree.sanity_check()
 
     def test_hicache_d_leaf_h_leaf_mutual_exclusion(self):
@@ -1861,9 +1905,15 @@ class UnifiedRadixCacheSuite:
         if original_mamba_indices is not None:
             self._fill_mamba_state(req_to_token_pool, original_mamba_indices, marker=21)
 
-        loaded_indices = self._load_back_node(tree, node)
+        self._load_back_node(tree, node)
         self.assertFalse(node.evicted)
         self.assertIsNotNone(node.component_data[ComponentType.FULL].value)
+        # A single insert may span multiple tree nodes (SWA caps a long leaf to
+        # one window), so gather the whole reloaded prefix via match rather than
+        # the leaf's value alone.
+        loaded_indices = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", base)))
+        ).device_indices
         loaded_k, loaded_v = self._snapshot_full_kv(allocator, loaded_indices)
         self.assertTrue(torch.equal(loaded_k, expected_k))
         self.assertTrue(torch.equal(loaded_v, expected_v))
@@ -1936,6 +1986,83 @@ class UnifiedRadixCacheSuite:
         self.assertTrue(split_leaf.evicted)
         self.assertTrue(split_leaf.backuped)
         self.assertIn(split_leaf, tree.evictable_host_leaves)
+        tree.sanity_check()
+
+    def test_swa_deep_tree_backup_evict_loadback_stress(self):
+        """Multi-node SWA tree under real write-through: long leaves cap-split,
+        varied swa_evicted_seqlen tombstones, and shared-prefix branches build
+        a deep/wide tree; then backup -> stepwise evict -> loadback, asserting
+        sanity throughout. Exercises the split topology far more than the 1-2
+        page micro-tests, where a single insert yields at most two nodes."""
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA")
+        if self._skip_unsupported_hicache_test():
+            return
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only keeps the deep-tree topology precise")
+
+        tree, allocator, req_to_token_pool = self._build_hicache_fixture()
+        tree.write_through_threshold = 1  # real eager write-through auto-backup
+        ps = self.cfg.page_size
+        # Window measured in pages; sizes scale with it so the SWA leaf-cap
+        # split fires across configs (window may be < page or many pages).
+        tail_size = ((self.cfg.sliding_window_size + ps - 1) // ps) * ps
+        wp = max(1, tail_size // ps)
+
+        def insert_swa(tokens, swa_ev):
+            value = self._alloc(allocator, len(tokens))
+            if value is None:
+                return False
+            tree.insert(
+                InsertParams(
+                    key=RadixKey(array("q", tokens)),
+                    value=value,
+                    swa_evicted_seqlen=swa_ev,
+                )
+            )
+            tree.writing_check()
+            tree.sanity_check()
+            return True
+
+        # (1) Long leaf -> SWA cap-split (prefix + one-window tail).
+        base = self._make_seq(1, wp + 2)
+        if not insert_swa(base, 0):
+            self.skipTest("kv pool too small for deep-tree stress")
+        # (2) Fresh decode-evicted sequence: one page evicted during decode ->
+        #     tombstone-prefix + cap-split stacked (the cache_finished shape).
+        insert_swa(self._make_seq(20000, wp + 2), ps)
+        # (3) Depth: extend the base chain.
+        insert_swa(base + self._make_seq(70000, 2), 0)
+        # (4) Width: branches sharing the base prefix.
+        for i in range(2):
+            insert_swa(base[: 2 * ps] + self._make_seq(80000 + 1000 * i, 3), 0)
+
+        # The tree must actually be deep/wide, otherwise the stress is moot.
+        self.assertGreaterEqual(len(tree._collect_all_nodes()), 5)
+
+        # Stepwise eviction -> demote to host, sanity after each round.
+        for _ in range(4):
+            full_ev = tree.full_evictable_size()
+            if full_ev == 0:
+                break
+            tree.evict(
+                EvictParams(
+                    num_tokens=max(ps, full_ev // 2),
+                    swa_num_tokens=tree.swa_evictable_size(),
+                )
+            )
+            tree.sanity_check()
+
+        # Load evicted prefixes back from host, sanity after each.
+        for tokens in (base, base[: 2 * ps]):
+            m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens))))
+            anchor = m.best_match_node
+            if anchor is not tree.root_node and anchor.evicted:
+                if tree.load_back(anchor):
+                    self._finish_pending_loads(tree)
+                    self._release_ongoing_load_back_locks(tree)
+            tree.sanity_check()
+
         tree.sanity_check()
 
     def test_hicache_evict_to_host_updates_aux_lru(self):


### PR DESCRIPTION
## Motivation

The SWA HiCache unit tests backed up a single node (with auto-backup disabled) and asserted on a single-leaf tree shape, so they neither exercised the real parent-first write-through backup nor tolerated a sequence spanning multiple tree nodes. This backs up the full path and asserts topology-agnostically, plus adds a multi-node deep-tree stress test.

## Modifications

- `_backup_node` / `_simulate_backup`: back up the whole root→node path ancestors-first (real write-through order) instead of a single node.
- `test_aux_evict_full_locked_leaf_tombstones_aux_only`: insert one page so the leaf stays within one SWA window.
- `test_hicache_load_back_restores_data`: gather the reloaded prefix via `match_prefix`, not the leaf value alone.
- `test_hicache_partial_match_splits_evicted_backed_up_node`: locate the host prefix via `last_host_node` and rebuild prefix/suffix from path keys instead of a fixed parent/child shape.
- Add `test_swa_deep_tree_backup_evict_loadback_stress`: multi-node SWA tree through backup → eviction → loadback with `sanity_check`.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26731239394](https://github.com/sgl-project/sglang/actions/runs/26731239394)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26731239313](https://github.com/sgl-project/sglang/actions/runs/26731239313)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->