### PR TITLE
fix: register gemma4_assistant model_type for speculative decoding draft model

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -138,6 +138,28 @@ try:
 except ImportError:
     pass
 
+# Gemma 4 assistant draft model for Frozen-KV MTP speculative decoding.
+# The draft checkpoint uses model_type "gemma4_assistant" which is not
+# registered in transformers, so AutoConfig.from_pretrained fails without
+# this shim. We subclass the nearest text config to inherit all field defs.
+try:
+    from transformers import Gemma4TextConfig as _Gemma4TextConfig
+
+    class _Gemma4AssistantConfig(_Gemma4TextConfig):
+        model_type = "gemma4_assistant"
+
+    _CONFIG_REGISTRY["gemma4_assistant"] = _Gemma4AssistantConfig
+except ImportError:
+    try:
+        from transformers import Gemma4Config as _Gemma4Config
+
+        class _Gemma4AssistantConfig(_Gemma4Config):
+            model_type = "gemma4_assistant"
+
+        _CONFIG_REGISTRY["gemma4_assistant"] = _Gemma4AssistantConfig
+    except ImportError:
+        pass
+
 for name, cls in _CONFIG_REGISTRY.items():
     try:
         AutoConfig.register(name, cls)


### PR DESCRIPTION
## Summary

The `gemma-4-31B-it-assistant` draft checkpoint uses `model_type: "gemma4_assistant"` which is not registered in HuggingFace transformers, causing `AutoConfig.from_pretrained` to fail with `ValueError` during speculative decoding initialization.

This PR adds a shim config class inheriting from `Gemma4TextConfig` (with fallback to `Gemma4Config`) and registers it in `_CONFIG_REGISTRY` so that `AutoConfig.from_pretrained` can recognize the model_type. This follows the same pattern as the existing DeepseekV3Config alias registration.

Fixes #26640.

## Motivation

When launching gemma4 with speculative decoding (`--speculative-algorithm NEXTN --speculative-draft-model-path google/gemma-4-31B-it-assistant`), the draft model config loading fails because transformers does not recognize `model_type: "gemma4_assistant"`. SGLang already has a config override mechanism (`config.py` L136) but it executes after `AutoConfig.from_pretrained`, which fails first.

## Modifications

- Added a `_Gemma4AssistantConfig` class that subclasses `Gemma4TextConfig` (or `Gemma4Config` as fallback) with `model_type = "gemma4_assistant"`
- Registered it in `_CONFIG_REGISTRY` so the existing `AutoConfig.register()` loop picks it up
- Wrapped in try/except ImportError for compatibility with older transformers versions

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26731281374](https://github.com/sgl-project/sglang/actions/runs/26731281374)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26731281338](https://github.com/sgl-project/sglang/actions/runs/26731281338)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->