### PR TITLE
fix(reasoning_parser): strip orphan closing think token instead of leaking it into content

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -64,7 +64,11 @@ class BaseReasoningFormatDetector:
         One-time parsing: Detects and parses reasoning sections in the provided text.
         Returns both reasoning content and normal text separately.
         """
-        in_reasoning = self._in_reasoning or self.think_start_token in text
+        in_reasoning = (
+            self._in_reasoning
+            or self.think_start_token in text
+            or self.think_end_token in text  # orphan close tag: open prefilled in prompt
+        )
 
         if not in_reasoning:
             return StreamingParseResult(normal_text=text)
@@ -133,6 +137,17 @@ class BaseReasoningFormatDetector:
             for token in tokens_to_check
         ):
             return StreamingParseResult()
+
+        # Orphan closing tag (open tag prefilled in the prompt, not generated):
+        # enter reasoning so the end tag is stripped instead of leaked as content.
+        if (
+            not self.stripped_think_start
+            and not self._in_reasoning
+            and self.think_end_token in current_text
+            and think_start_text not in current_text
+        ):
+            self._in_reasoning = True
+            self.stripped_think_start = True
 
         # Strip `<think>` token if present
         if not self.stripped_think_start and think_start_text in current_text:


### PR DESCRIPTION
## Problem

`BaseReasoningFormatDetector` can leak an **orphan closing think token** (e.g. `</think>`) into the normal/content output.

This happens when **both**:
- the detector is constructed with `force_reasoning=False`, and
- the model's chat template **prefills the opening think token**, so the *generated* text contains only the **closing** token (no opening token).

In that case `detect_and_parse` computes:

```python
in_reasoning = self._in_reasoning or self.think_start_token in text  # -> False
```

returns the whole text as `normal_text`, and the orphan closing token ends up in the user-visible `content`. `parse_streaming_increment` has the same gap (it only strips the closing token once `_in_reasoning` is set, which never happens without an opening token).

## Fix

Treat a bare closing token (closing token present, opening token absent, and not already in reasoning) as the end of an **empty** reasoning block, in both `detect_and_parse` (non-streaming) and `parse_streaming_increment` (streaming). The closing token is stripped; everything after it becomes normal content.

`force_reasoning` semantics are unchanged, so the thinking-disabled / no-tag path is untouched — a response containing **no** think tokens is still returned entirely as content.

## Verification

Checked against `BaseReasoningFormatDetector` (via a detector instance with the default `force_reasoning=False`), non-streaming and char-by-char streaming:

| input | content before | content after |
|---|---|---|
| `</think>answer` | `</think>answer` ❌ | `answer` ✅ (reasoning `""`) |
| `<think>r</think>answer` | `answer` | `answer` ✅ (reasoning `"r"`, unchanged) |
| `answer` (no tags) | `answer` | `answer` ✅ (unchanged) |

Found while serving a model whose chat template prefills the opening think token, where closing-only generations leaked the closing tag into `content`.

Draft for review — happy to adjust scope (e.g. gate behind a per-detector flag) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26732448057](https://github.com/sgl-project/sglang/actions/runs/26732448057)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26732447968](https://github.com/sgl-project/sglang/actions/runs/26732447968)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->