### PR TITLE
fix(anthropic): emit thinking_delta events for reasoning_content in streaming

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -138,9 +138,12 @@ class AnthropicMessagesRequest(BaseModel):
 class AnthropicDelta(BaseModel):
     """Delta for streaming responses"""
 
-    type: Optional[Literal["text_delta", "input_json_delta"]] = None
+    type: Optional[
+        Literal["text_delta", "input_json_delta", "thinking_delta"]
+    ] = None
     text: Optional[str] = None
     partial_json: Optional[str] = None
+    thinking: Optional[str] = None
 
     # Message delta fields
     stop_reason: Optional[

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -439,6 +439,7 @@ class AnthropicServing:
         first_chunk = True
         content_block_index = 0
         content_block_open = False
+        current_block_type: Optional[str] = None  # "thinking" | "text" | "tool_use"
         finish_reason: Optional[str] = None
         usage_info: Optional[dict] = None
         message_id = f"msg_{uuid.uuid4().hex}"
@@ -587,6 +588,7 @@ class AnthropicServing:
                             "content_block_start",
                         )
                         content_block_open = True
+                        current_block_type = "tool_use"
 
                         # Stream initial arguments if present
                         if tc_func.arguments:
@@ -619,8 +621,69 @@ class AnthropicServing:
                         )
                 continue
 
+            # Handle reasoning_content (thinking) deltas
+            reasoning_text = getattr(delta, "reasoning_content", None)
+            if reasoning_text:
+                # Need a thinking block
+                if current_block_type != "thinking":
+                    # Close existing block if open
+                    if content_block_open:
+                        stop_event = AnthropicStreamEvent(
+                            type="content_block_stop",
+                            index=content_block_index,
+                        )
+                        yield _wrap_sse_event(
+                            stop_event.model_dump_json(exclude_none=True),
+                            "content_block_stop",
+                        )
+                        content_block_index += 1
+
+                    # Start thinking block
+                    start_event = AnthropicStreamEvent(
+                        type="content_block_start",
+                        index=content_block_index,
+                        content_block=AnthropicContentBlock(
+                            type="thinking", thinking=""
+                        ),
+                    )
+                    yield _wrap_sse_event(
+                        start_event.model_dump_json(exclude_none=True),
+                        "content_block_start",
+                    )
+                    content_block_open = True
+                    current_block_type = "thinking"
+
+                # Emit thinking delta
+                delta_event = AnthropicStreamEvent(
+                    type="content_block_delta",
+                    index=content_block_index,
+                    delta=AnthropicDelta(
+                        type="thinking_delta",
+                        thinking=reasoning_text,
+                    ),
+                )
+                yield _wrap_sse_event(
+                    delta_event.model_dump_json(exclude_none=True),
+                    "content_block_delta",
+                )
+                continue
+
             # Handle text content deltas
             if delta.content is not None and delta.content != "":
+                # Need a text block — close thinking block if open
+                if current_block_type != "text":
+                    if content_block_open:
+                        stop_event = AnthropicStreamEvent(
+                            type="content_block_stop",
+                            index=content_block_index,
+                        )
+                        yield _wrap_sse_event(
+                            stop_event.model_dump_json(exclude_none=True),
+                            "content_block_stop",
+                        )
+                        content_block_index += 1
+                        content_block_open = False
+
                 # Start a text content block if needed
                 if not content_block_open:
                     start_event = AnthropicStreamEvent(
@@ -633,6 +696,7 @@ class AnthropicServing:
                         "content_block_start",
                     )
                     content_block_open = True
+                    current_block_type = "text"
 
                 # Emit text delta
                 delta_event = AnthropicStreamEvent(
@@ -662,6 +726,15 @@ class AnthropicServing:
 
         choice = response.choices[0]
         content: list[AnthropicContentBlock] = []
+
+        # Add thinking content if present
+        if choice.message.reasoning_content:
+            content.append(
+                AnthropicContentBlock(
+                    type="thinking",
+                    thinking=choice.message.reasoning_content,
+                )
+            )
 
         # Add text content
         if choice.message.content:


### PR DESCRIPTION
## Motivation

Fixes #26795

The Anthropic `/v1/messages` streaming endpoint currently ignores `delta.reasoning_content` from the underlying OpenAI-format stream. This means reasoning output from models like Qwen3, DeepSeek-R1 is silently discarded — `thinking_delta` SSE events are never emitted to clients.

## Modifications

**`python/sglang/srt/entrypoints/anthropic/protocol.py`**
- Added `"thinking_delta"` to `AnthropicDelta.type` Literal union
- Added `thinking: Optional[str] = None` field to `AnthropicDelta`

**`python/sglang/srt/entrypoints/anthropic/serving.py`**
- Added `current_block_type` state variable to track active content block type (`"thinking"` / `"text"` / `"tool_use"`)
- Inserted reasoning_content handler before the text handler in `_generate_anthropic_stream()`: detects `delta.reasoning_content`, manages thinking block lifecycle (open/close), and emits `thinking_delta` events
- Added block transition logic: when switching from thinking to text, properly closes the thinking block before opening a text block
- Updated `_convert_response()` (non-streaming path) to include `thinking` content blocks when `choice.message.reasoning_content` is present

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26732856424](https://github.com/sgl-project/sglang/actions/runs/26732856424)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26732856346](https://github.com/sgl-project/sglang/actions/runs/26732856346)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->