### PR TITLE
Add Qwen3 + EAGLE3 offline batch inference example

### DIFF
--- a/examples/runtime/engine/offline_batch_inference_eagle3_qwen3.py
+++ b/examples/runtime/engine/offline_batch_inference_eagle3_qwen3.py
@@ -1,0 +1,59 @@
+"""Example: offline batch inference with EAGLE3 speculative decoding on Qwen3.
+
+Companion to ``offline_batch_inference_eagle.py`` (Llama-2 + EAGLE V1). This
+script targets Qwen3-1.7B paired with the community-maintained
+AngelSlim/Qwen3-1.7B_eagle3 draft. The same pattern works for the rest of
+the AngelSlim Qwen3 EAGLE3 family by swapping ``model_path`` and
+``speculative_draft_model_path`` (4B/8B/14B/32B/30B-A3B).
+
+Reference benchmark (AngelSlim, vLLM v0.11.2, single H20, tp=1, output_len=1024,
+num_speculative_tokens=2): Qwen3-1.7B vanilla 381 tok/s vs EAGLE3 643 tok/s
+(~1.69x, average accept length 2.17). See the model card for full numbers:
+https://huggingface.co/AngelSlim/Qwen3-1.7B_eagle3
+
+The defaults below follow AngelSlim's recommended SGLang configuration
+(speculative_num_steps=3, eagle_topk=1, num_draft_tokens=4). For short,
+template-heavy outputs (tool calling, structured JSON, code completion)
+these settings are typically a good starting point; for longer reasoning
+outputs you may want to raise ``speculative_num_draft_tokens`` after
+profiling acceptance length.
+"""
+
+import sglang as sgl
+
+
+def main():
+    # Sample prompts.
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    # Create a sampling params object.
+    sampling_params = {"temperature": 0, "max_new_tokens": 30}
+
+    # Create an LLM with EAGLE3 speculative decoding.
+    llm = sgl.Engine(
+        model_path="Qwen/Qwen3-1.7B",
+        speculative_algorithm="EAGLE3",
+        speculative_draft_model_path="AngelSlim/Qwen3-1.7B_eagle3",
+        speculative_num_steps=3,
+        speculative_eagle_topk=1,
+        speculative_num_draft_tokens=4,
+        cuda_graph_max_bs=8,
+    )
+
+    outputs = llm.generate(prompts, sampling_params)
+
+    # Print the outputs.
+    for prompt, output in zip(prompts, outputs):
+        print("===============================")
+        print(f"Prompt: {prompt}\nGenerated text: {output['text']}")
+
+
+# The __main__ condition is necessary here because we use "spawn" to create subprocesses
+# Spawn starts a fresh program every time, if there is no __main__, it will run into infinite loop to keep spawning processes from sgl.Engine
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This example serves as a companion to examples/runtime/engine/offline_batch_inference_eagle.py (which covers Llama-2 + EAGLE V1). It targets Qwen3-1.7B paired with the community-maintained AngelSlim/Qwen3-1.7B_eagle3 draft (42k+ HF downloads). The same pattern works for the rest of the AngelSlim Qwen3 EAGLE3 family (4B/8B/14B/32B/30B-A3B) by swapping the model paths.

Defaults follow AngelSlim's recommended SGLang configuration (num_steps=3, eagle_topk=1, num_draft_tokens=4). Reference benchmark (AngelSlim, vLLM v0.11.2, single H20, tp=1, num_speculative_tokens=2): Qwen3-1.7B vanilla 381 tok/s vs EAGLE3 643 tok/s, ~1.69× throughput, average accept length 2.17. Full numbers are available on the model card.

This work is motivated by the gap that none of the existing examples/runtime/engine/ scripts cover the Qwen3 + EAGLE3 combination, which is one of the most downloaded EAGLE3 draft families on Hugging Face.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`examples/runtime/engine/offline_batch_inference_eagle.py` only covers Llama-2 with EAGLE V1. Qwen3 is now widely used in production deployments (tool-calling agents, structured-output workloads, code completion), and the community-maintained [AngelSlim Qwen3 EAGLE3 family](https://huggingface.co/AngelSlim) provides drafts for 1.7B/4B/8B/14B/32B/30B-A3B (42k+ monthly downloads for the 1.7B draft alone).

This PR adds a counterpart example for `Qwen/Qwen3-1.7B` + `AngelSlim/Qwen3-1.7B_eagle3` so users can copy/paste a working EAGLE3 setup on Qwen3 without hunting through unit tests or benchmark scripts.

## Modifications

- Add `examples/runtime/engine/offline_batch_inference_eagle3_qwen3.py`.
- Defaults follow AngelSlim's recommended SGLang config:  
  `speculative_num_steps=3, speculative_eagle_topk=1, speculative_num_draft_tokens=4`.
- Header docstring explains how to swap in the larger AngelSlim drafts (4B/8B/14B/32B/30B-A3B) and points to the published benchmark numbers (vLLM v0.11.2, H20, tp=1, output_len=1024: 381 → 643 tok/s, ~1.69x, avg accept length 2.17).

No source code or APIs are modified.

## Verified output

Tested on a single H800 with SGLang 0.5.9 (`fa3` backend, bs=1, `max_new_tokens=30`, `temperature=0`):


===============================
Prompt: Hello, my name is
Generated text:  Lillian, and I'm a 12-year-old girl who loves to read, play with my dog, and watch movies. I also love
===============================
Prompt: The president of the United States is
Generated text:  elected by the Electoral College, which is a group of 538 electors. Each elector is assigned a certain number of electoral votes,
===============================
Prompt: The capital of France is
Generated text:  Paris. The capital of the United States is Washington, D.C. The capital of the United Kingdom is London. The capital of the Russian Federation is
===============================
Prompt: The future of AI is
Generated text:  not just about the technology itself, but also about the ethical implications and the societal impact of its development. As AI continues to evolve, it is essential
===============================

CUDA-graph capture succeeded for both target and draft (`bs=1..8`); no fallback path was hit.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci). *(N/A — example only, mirrors the layout of the existing `offline_batch_inference_eagle.py` which also has no dedicated test.)*
- [x] Update documentation / examples as described in [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide test results.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26808280934](https://github.com/sgl-project/sglang/actions/runs/26808280934)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26808280897](https://github.com/sgl-project/sglang/actions/runs/26808280897)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->