### PR TITLE
[AMD] Pin compressed-tensors==0.15.0 to fix ROCm nightly build

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -96,13 +96,10 @@ srt_hip = [
   "torch",
   "petit_kernel==0.0.2",
   "wave-lang==3.8.2",
-  # HOTFIX (2026-05-28): compressed-tensors 0.16.0 added `torch>=2.10.0`,
-  # which forces pip off the ROCm wheel (torch 2.9.1+rocm7.2) and silently
-  # swaps it for the PyPI default `torch 2.12.0+cu130`, breaking the
-  # downstream HIP build of fast-hadamard-transform with a NameError on
-  # `bare_metal_version`. Pin below 0.16.0 until the ROCm base ships
-  # torch>=2.10.
-  "compressed-tensors<0.16.0",
+  # Pin to 0.15.0: 0.16.0 needs torch>=2.10 (incompatible with ROCm torch
+  # 2.9.1). An open-ended `<0.16.0` made pip backtrack into an unbuildable
+  # ancient setuptools sdist; an exact pin keeps the resolver converging.
+  "compressed-tensors==0.15.0",
 ]
 
 diffusion_hip = [


### PR DESCRIPTION
## Problem

The nightly **Release Docker Images Nightly ROCm7.0 (AMD)** workflow has been failing every night since 2026-05-29 (last green: 2026-05-28).

Root cause: `compressed-tensors 0.16.0` was published 2026-05-28 14:31 UTC and requires `torch>=2.10.0`, which is incompatible with the ROCm base image torch (`2.9.1+rocm7.2`).

The existing hotfix (#26591) capped it with an **open-ended** `compressed-tensors<0.16.0`. With no lower bound and a hard upper conflict, pip's resolver could not converge: it backtracked `compressed-tensors` down to 0.3.0 **and** backtracked the unbounded `setuptools` pulled by `imageio-ffmpeg==0.5.1` all the way to the 2014 sdist `4.0.1`, whose build crashes with:

```
error: invalid command 'dist_info'
× Encountered error while generating package metadata.
```

so the docker build exits 1. (The downstream `push_local_registry` "artifact not found" errors are just a knock-on of the failed `publish` job.)

Failing run: https://github.com/sgl-project/sglang/actions/runs/26712841066

## Fix

Pin to the exact compatible version `compressed-tensors==0.15.0` (`torch<2.11`, `transformers>=4.45.0`) so the resolver has a single candidate and converges instead of sinking into an unbuildable ancient setuptools sdist.

## Verification

Dispatched both AMD nightly docker builds on this branch:

- **ROCm 7.0** (`release-docker-amd-nightly.yml`): https://github.com/sgl-project/sglang/actions/runs/26733316417 — ✅ success
- **ROCm 7.2** (`release-docker-amd-rocm720-nightly.yml`): https://github.com/sgl-project/sglang/actions/runs/26739421087

Both base images ship torch < 2.10 (rocm7.0 ~2.8.x, rocm7.2 2.9.1), so `compressed-tensors==0.15.0` (`torch<2.11`) is compatible with both. Lift the pin once a ROCm base ships torch>=2.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
