### PR TITLE
Add NIXL disaggregation unit test coverage

### DIFF
--- a/test/registered/unit/disaggregation/test_nixl_node_failure.py
+++ b/test/registered/unit/disaggregation/test_nixl_node_failure.py
@@ -1,0 +1,81 @@
+"""Unit tests for NIXL prefill node failure handling."""
+
+import threading
+import unittest
+from collections import defaultdict
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager, TransferStatus
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestNixlNodeFailure(CustomTestCase):
+    def _make_manager(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.connection_lock = threading.Lock()
+        mgr.connection_pool = {
+            "10.0.0.1:8998_0_0_0": [{"rank_ip": "10.0.0.1"}],
+            "10.0.0.1:8998_0_0_1": [{"rank_ip": "10.0.0.1"}],
+            "10.0.0.2:8998_0_0_0": [{"rank_ip": "10.0.0.2"}],
+        }
+        mgr.prefill_info_table = {
+            "10.0.0.1:8998": object(),
+            "10.0.0.2:8998": object(),
+        }
+        mgr.addr_to_rooms_tracker = defaultdict(set)
+        mgr.addr_to_rooms_tracker["10.0.0.1:8998"] = {3, 4, 5}
+        mgr.transfer_statuses = {
+            3: TransferStatus(),
+            4: TransferStatus(),
+            5: TransferStatus(
+                received_aux=True,
+                num_pp_ranks_expected=1,
+                expected_kvs_per_pp={0: 0},
+            ),
+        }
+        mgr.request_status = {
+            3: KVPoll.WaitingForInput,
+            4: KVPoll.Transferring,
+            5: KVPoll.Success,
+        }
+        mgr.failure_records = {}
+        mgr.failure_lock = threading.Lock()
+        mgr.update_status = CommonKVManager.update_status.__get__(mgr, CommonKVManager)
+        mgr.check_status = CommonKVManager.check_status.__get__(mgr, CommonKVManager)
+        mgr.record_failure = CommonKVManager.record_failure.__get__(
+            mgr, CommonKVManager
+        )
+        return mgr
+
+    def test_handle_node_failure_removes_connections_and_marks_pending_rooms(self):
+        mgr = self._make_manager()
+
+        mgr._handle_node_failure("10.0.0.1:8998")
+
+        self.assertNotIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertNotIn("10.0.0.1:8998_0_0_1", mgr.connection_pool)
+        self.assertIn("10.0.0.2:8998_0_0_0", mgr.connection_pool)
+        self.assertNotIn("10.0.0.1:8998", mgr.prefill_info_table)
+        self.assertNotIn("10.0.0.1:8998", mgr.addr_to_rooms_tracker)
+        self.assertEqual(mgr.request_status[3], KVPoll.Failed)
+        self.assertEqual(mgr.request_status[4], KVPoll.Failed)
+        self.assertEqual(mgr.request_status[5], KVPoll.Success)
+        self.assertIn(3, mgr.failure_records)
+        self.assertIn(4, mgr.failure_records)
+        self.assertNotIn(5, mgr.failure_records)
+
+    def test_late_failed_update_does_not_resurrect_cleared_room(self):
+        mgr = object.__new__(CommonKVManager)
+        mgr.request_status = {}
+
+        CommonKVManager.update_status(mgr, 9, KVPoll.Failed)
+
+        self.assertNotIn(9, mgr.request_status)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_nixl_staging.py
+++ b/test/registered/unit/disaggregation/test_nixl_staging.py
@@ -1,0 +1,346 @@
+"""Unit tests for NIXL staging-buffer control paths."""
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
+from sglang.srt.disaggregation.nixl.conn import (
+    KVArgsRegisterInfo,
+    NixlKVManager,
+    TransferInfo,
+    TransferKVChunk,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class FakeAgent:
+    def __init__(self, register_result=None):
+        self.register_result = (
+            register_result if register_result is not None else ["desc"]
+        )
+        self.register_memory_calls = []
+        self.get_xfer_descs_calls = []
+        self.initialize_xfer_calls = []
+        self.transfer_calls = []
+
+    def register_memory(self, addrs, mem_type):
+        self.register_memory_calls.append((addrs, mem_type))
+        return self.register_result
+
+    def get_xfer_descs(self, reqs, mem_type):
+        self.get_xfer_descs_calls.append((reqs, mem_type))
+        return f"{mem_type}_{len(self.get_xfer_descs_calls)}"
+
+    def initialize_xfer(self, *args):
+        self.initialize_xfer_calls.append(args)
+        return "handle"
+
+    def transfer(self, handle):
+        self.transfer_calls.append(handle)
+        return "DONE"
+
+
+class FakeQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+class FakeTensor:
+    shape = (1, 1, 8)
+
+    def element_size(self):
+        return 2
+
+
+class FakeStagingBuffer:
+    def __init__(self, ptr=0x9000, size=1 << 20):
+        self.ptr = ptr
+        self.size = size
+
+    def fits(self, required_bytes):
+        return required_bytes <= self.size
+
+    def get_ptr(self):
+        return self.ptr
+
+
+class FakeStagingAllocator:
+    ALLOC_OVERSIZED = -2
+
+
+def _fake_staging_buffer_module(mock_gather=None):
+    module = types.ModuleType("sglang.srt.disaggregation.common.staging_buffer")
+    module.StagingAllocator = FakeStagingAllocator
+    module.compute_head_slice_params = lambda *args: (0, 1, 0, 1)
+    module.compute_staging_layout = lambda *args: (2, [256, 256], 512)
+    module.resolve_total_kv_heads = lambda kv_args, attn_tp_size: 2
+    module.gather_all_layers_to_staging = mock_gather or MagicMock()
+    return module
+
+
+class TestNixlStaging(CustomTestCase):
+    def _make_manager(self, agent=None):
+        mgr = object.__new__(NixlKVManager)
+        mgr.agent = agent or FakeAgent()
+        mgr.attn_tp_size = 2
+        mgr.is_mla_backend = False
+        mgr.kv_args = SimpleNamespace(
+            gpu_id=1,
+            engine_rank=1,
+            page_size=2,
+            total_kv_head_num=2,
+            kv_head_num=1,
+        )
+        mgr.server_args = SimpleNamespace(chunked_prefill_size=4)
+        return mgr
+
+    def test_register_staging_memory_uses_vram_and_fails_on_empty_descs(self):
+        agent = FakeAgent(register_result=["staging"])
+        mgr = self._make_manager(agent)
+
+        mgr._register_staging_memory(0x1000, 4096, 3)
+
+        self.assertEqual(
+            agent.register_memory_calls,
+            [([(0x1000, 4096, 3, "")], "VRAM")],
+        )
+
+        mgr = self._make_manager(FakeAgent(register_result=[]))
+        with self.assertRaisesRegex(RuntimeError, "staging buffer"):
+            mgr._register_staging_memory(0x1000, 4096, 3)
+
+    def test_prefetch_staging_reqs_noops_when_disabled_or_missing_kv_buffers(self):
+        mgr = self._make_manager()
+        mgr.enable_staging = False
+        mgr.kv_buffer_tensors = {"k_buffers": [], "v_buffers": [], "page_size": 1}
+
+        mgr._prefetch_staging_reqs(3)
+
+        mgr.enable_staging = True
+        mgr.kv_buffer_tensors = None
+        mgr._prefetch_staging_reqs(3)
+
+    def test_prefetch_staging_reqs_marks_room_when_no_peer_needs_staging(self):
+        mgr = self._make_manager()
+        mgr.enable_staging = True
+        mgr.kv_buffer_tensors = {"k_buffers": [], "v_buffers": [], "page_size": 1}
+        mgr._staging_ctx = PrefillStagingContext()
+        mgr.transfer_infos = {
+            3: {
+                "agent": TransferInfo(
+                    room=3,
+                    endpoint="127.0.0.1",
+                    dst_port=1000,
+                    agent_name="agent",
+                    dst_kv_indices=np.array([1], dtype=np.int32),
+                    dst_aux_index=0,
+                    required_dst_info_num=1,
+                    dst_state_indices=[],
+                )
+            }
+        }
+        mgr.decode_kv_args_table = {
+            "agent": SimpleNamespace(decode_tp_size=2),
+        }
+
+        mgr._prefetch_staging_reqs(3)
+
+        self.assertIn(3, mgr._staging_ctx.prefetched_rooms)
+
+    def test_do_staging_transfer_requeues_when_allocation_not_ready(self):
+        mgr = self._make_manager()
+        strategy = MagicMock()
+        strategy.check_ready.return_value = (False, 0, -1, 0, -1)
+        kv_chunk = TransferKVChunk(
+            room=3,
+            prefill_kv_indices=np.array([10, 11], dtype=np.int32),
+            index_slice=slice(0, 2),
+            is_last_chunk=False,
+            chunk_id=0,
+            prefill_aux_index=None,
+            state_indices=None,
+        )
+        req = SimpleNamespace(room=3, agent_name="decode_agent")
+        queue = FakeQueue()
+
+        handle, deferred = mgr._do_staging_transfer(
+            strategy, kv_chunk, req, SimpleNamespace(), queue
+        )
+
+        self.assertIsNone(handle)
+        self.assertTrue(deferred)
+        self.assertEqual(queue.items, [kv_chunk])
+
+    def test_do_staging_transfer_raises_for_oversized_allocation(self):
+        mgr = self._make_manager()
+        strategy = MagicMock()
+        strategy.check_ready.return_value = (
+            False,
+            0,
+            FakeStagingAllocator.ALLOC_OVERSIZED,
+            0,
+            -1,
+        )
+        kv_chunk = TransferKVChunk(
+            room=3,
+            prefill_kv_indices=np.array([10], dtype=np.int32),
+            index_slice=slice(0, 1),
+            is_last_chunk=False,
+            chunk_id=0,
+            prefill_aux_index=None,
+            state_indices=None,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "ring buffer total size"):
+            with patch.dict(
+                sys.modules,
+                {
+                    "sglang.srt.disaggregation.common.staging_buffer": _fake_staging_buffer_module()
+                },
+            ):
+                mgr._do_staging_transfer(
+                    strategy,
+                    kv_chunk,
+                    SimpleNamespace(room=3, agent_name="decode_agent"),
+                    SimpleNamespace(),
+                    FakeQueue(),
+                )
+
+    def test_do_staging_transfer_builds_staging_notification(self):
+        mgr = self._make_manager()
+        strategy = MagicMock()
+        strategy.check_ready.return_value = (True, 2, 128, 0, 512)
+        strategy.staging_buffer = FakeStagingBuffer()
+        kv_chunk = TransferKVChunk(
+            room=3,
+            prefill_kv_indices=np.array([10, 11], dtype=np.int32),
+            index_slice=slice(4, 6),
+            is_last_chunk=True,
+            chunk_id=7,
+            prefill_aux_index=0,
+            state_indices=None,
+        )
+        dst_info = KVArgsRegisterInfo(
+            room="None",
+            endpoint="127.0.0.1",
+            dst_port=1000,
+            agent_name="decode_agent",
+            agent_metadata=b"",
+            dst_kv_ptrs=[],
+            dst_aux_ptrs=[],
+            dst_state_data_ptrs=[],
+            gpu_id=5,
+            decode_tp_size=1,
+            decode_tp_rank=0,
+            dst_kv_item_len=128,
+            staging=SimpleNamespace(base_ptr=0x8000, total_size=4096),
+        )
+        calls = []
+        mgr.send_kvcache_staged = (
+            lambda *args, **kwargs: calls.append((args, kwargs)) or "handle"
+        )
+
+        handle, deferred = mgr._do_staging_transfer(
+            strategy,
+            kv_chunk,
+            SimpleNamespace(room=3, agent_name="decode_agent"),
+            dst_info,
+            FakeQueue(),
+        )
+
+        self.assertEqual(handle, "handle")
+        self.assertFalse(deferred)
+        self.assertEqual(calls[0][0][8], "3_stg_7_1_1_2_4_2_decode_agent")
+
+    def test_send_kvcache_staged_uses_one_bulk_vram_write(self):
+        mock_gather = MagicMock()
+        agent = FakeAgent()
+        mgr = self._make_manager(agent)
+        mgr.kv_buffer_tensors = {
+            "k_buffers": [FakeTensor(), FakeTensor()],
+            "v_buffers": [FakeTensor(), FakeTensor()],
+            "page_size": 2,
+        }
+
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.disaggregation.common.staging_buffer": _fake_staging_buffer_module(
+                    mock_gather
+                )
+            },
+        ):
+            handle = mgr.send_kvcache_staged(
+                "peer",
+                np.array([1, 2], dtype=np.int32),
+                dst_staging_ptr=0x100000,
+                dst_staging_size=1 << 20,
+                dst_gpu_id=4,
+                dst_tp_rank=0,
+                dst_attn_tp_size=1,
+                dst_kv_item_len=128,
+                notif="3_stg_0_1_1_0_0_2_decode_agent",
+                staging_buffer=FakeStagingBuffer(ptr=0x9000, size=1 << 20),
+            )
+
+        self.assertEqual(handle, "handle")
+        mock_gather.assert_called_once()
+        src_reqs, src_mem = agent.get_xfer_descs_calls[0]
+        dst_reqs, dst_mem = agent.get_xfer_descs_calls[1]
+        self.assertEqual(src_mem, "VRAM")
+        self.assertEqual(dst_mem, "VRAM")
+        self.assertEqual(src_reqs.shape, (1, 3))
+        self.assertEqual(dst_reqs.shape, (1, 3))
+        self.assertTrue(np.issubdtype(src_reqs.dtype, np.integer))
+        self.assertTrue(np.issubdtype(dst_reqs.dtype, np.integer))
+        self.assertEqual(int(src_reqs[0, 0]), 0x9000)
+        self.assertGreaterEqual(int(dst_reqs[0, 0]), 0x100000)
+        self.assertEqual(agent.initialize_xfer_calls[0][0], "WRITE")
+        self.assertEqual(
+            agent.initialize_xfer_calls[0][-1],
+            b"3_stg_0_1_1_0_0_2_decode_agent",
+        )
+
+    def test_send_kvcache_staged_falls_back_when_prefill_buffer_too_small(self):
+        mgr = self._make_manager()
+        mgr.kv_buffer_tensors = {
+            "k_buffers": [FakeTensor(), FakeTensor()],
+            "v_buffers": [FakeTensor(), FakeTensor()],
+            "page_size": 2,
+        }
+
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.disaggregation.common.staging_buffer": _fake_staging_buffer_module()
+            },
+        ):
+            handle = mgr.send_kvcache_staged(
+                "peer",
+                np.array([1, 2], dtype=np.int32),
+                dst_staging_ptr=0xA000,
+                dst_staging_size=1 << 20,
+                dst_gpu_id=4,
+                dst_tp_rank=0,
+                dst_attn_tp_size=1,
+                dst_kv_item_len=128,
+                notif="notif",
+                staging_buffer=FakeStagingBuffer(size=1),
+            )
+
+        self.assertIsNone(handle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add CPU unit coverage for NIXL disaggregation control paths.

### `test_nixl_node_failure.py`

Covers prefill-node failure cleanup in `NixlKVManager._handle_node_failure`.

The tests verify that failed bootstrap addresses are removed from connection and prefill-info caches, affected pending rooms are marked `KVPoll.Failed`, failure reasons are recorded, unrelated connections remain intact, and already-successful rooms are not changed.

It also covers the shared `CommonKVManager.update_status` guard that prevents late `KVPoll.Failed` updates from recreating already-cleared rooms.

### `test_nixl_staging.py`

Covers NIXL staging-buffer control paths without requiring NIXL, CUDA, or real manager initialization.

The tests verify staging memory registration as `VRAM`, failed registration handling, staging prefetch no-op paths, deferred requeue behavior when allocation/watermark is not ready, oversized allocation errors, staging notification tag construction, one bulk `VRAM` -> `VRAM` NIXL `WRITE`, and fallback when the prefill staging buffer is too small.

All tests use fake managers, fake NIXL agents, fake queues, and scoped module patching to stay CPU-only.

## Testing

- `python3 -m py_compile test/registered/unit/disaggregation/test_nixl_node_failure.py test/registered/unit/disaggregation/test_nixl_staging.py`
- local `.venv` run of both new unit files with repo Triton stub preload
  - `test_nixl_node_failure.py`: 2 passed
  - `test_nixl_staging.py`: 8 passed
- `.venv/bin/pre-commit run --all-files`
  - Python/style/test-registry hooks passed



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #26737617168](https://github.com/sgl-project/sglang/actions/runs/26737617168)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #26737617093](https://github.com/sgl-project/sglang/actions/runs/26737617093)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->