### PR TITLE
[KDA] Add target_verify support for speculative decoding

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -403,6 +403,11 @@ class KDAAttnBackend(MambaAttnBackendBase):
 
         ssm_states = mamba_cache_params.temporal
 
+        # Normal extend path
+        if forward_batch.extend_prefix_lens is None:
+            raise RuntimeError(
+                "extend_prefix_lens cannot be None in non-TARGET_VERIFY mode."
+            )
         has_initial_state = forward_batch.extend_prefix_lens > 0
 
         if self.forward_metadata.has_mamba_track_mask:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -381,6 +381,34 @@ class MambaPool:
         intermediate_ssm: Optional[torch.Tensor]
         intermediate_conv_window: List[torch.Tensor]
 
+    def _detect_conv_window_axis(
+        self, conv_state_shape: List[Tuple[int, int]], win_len: int
+    ) -> int:
+        """Prefer GDN's trailing axis when both match; mixed layer layouts cannot
+        share one overlapping conv-window buffer.
+        """
+        axis = None
+        for conv_shape in conv_state_shape:
+            if conv_shape[-1] == win_len:
+                shape_axis = len(conv_shape) - 1
+            elif conv_shape[0] == win_len:
+                shape_axis = 0
+            else:
+                raise ValueError(
+                    f"conv_state shape {conv_shape} has no axis of length "
+                    f"conv_kernel-1={win_len}; cannot build the deduplicated "
+                    "sliding-window conv-intermediate view."
+                )
+            if axis is None:
+                axis = shape_axis
+            elif axis != shape_axis:
+                raise ValueError(
+                    "inconsistent conv-window axis across conv shapes "
+                    f"{conv_state_shape}; a single conv_window_axis cannot serve "
+                    "mixed layouts."
+                )
+        return axis
+
     def _allocate_deduplicated_conv_window(
         self,
         *,
@@ -676,6 +704,22 @@ class MambaPool:
                 )
                 self._intermediate_conv_window_phys = []
                 if dedup_conv_window:
+                    # The sliding window is the (K-1)-wide axis; the other conv
+                    # axis is the independent channel axis. Different backends
+                    # order these two axes differently in their conv_state:
+                    #   GDN  -> (channel, K-1)  (channel-major)
+                    #   KDA  -> (K-1, channel)  (window-major, axes swapped in
+                    #           KimiLinearStateShape.create)
+                    # Detect the window axis by its length (conv_kernel - 1)
+                    # rather than assuming a fixed position, so the dedup view's
+                    # last two dims keep the SAME order as conv_state. That keeps
+                    # the shared sliding buffer built over the true K-1 window
+                    # axis (not the channel axis) for both layouts, and lets the
+                    # layout-agnostic scatter/commit read it through strides.
+                    win_len = cache_params.shape.conv_kernel - 1
+                    self.conv_window_axis = self._detect_conv_window_axis(
+                        conv_state_shape, win_len
+                    )
                     intermediate_conv_window_cache = []
                     for conv_shape in conv_state_shape:
                         phys, view = self._allocate_deduplicated_conv_window(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -704,18 +704,6 @@ class MambaPool:
                 )
                 self._intermediate_conv_window_phys = []
                 if dedup_conv_window:
-                    # The sliding window is the (K-1)-wide axis; the other conv
-                    # axis is the independent channel axis. Different backends
-                    # order these two axes differently in their conv_state:
-                    #   GDN  -> (channel, K-1)  (channel-major)
-                    #   KDA  -> (K-1, channel)  (window-major, axes swapped in
-                    #           KimiLinearStateShape.create)
-                    # Detect the window axis by its length (conv_kernel - 1)
-                    # rather than assuming a fixed position, so the dedup view's
-                    # last two dims keep the SAME order as conv_state. That keeps
-                    # the shared sliding buffer built over the true K-1 window
-                    # axis (not the channel axis) for both layouts, and lets the
-                    # layout-agnostic scatter/commit read it through strides.
                     win_len = cache_params.shape.conv_kernel - 1
                     self.conv_window_axis = self._detect_conv_window_axis(
                         conv_state_shape, win_len

--- a/python/sglang/srt/models/kimi_linear.py
+++ b/python/sglang/srt/models/kimi_linear.py
@@ -384,8 +384,12 @@ class KimiDeltaAttention(nn.Module):
 
         # For prefill: raw gate is passed to chunk_kda_fwd, which fuses gate
         # activation with chunk_local_cumsum (kda_gate_chunk_cumsum kernel).
-        # For decode: gate activation is handled inside fused_recurrent kernel.
-        if not forward_batch.forward_mode.is_decode():
+        # For decode and target_verify: gate activation is handled inside
+        # fused_recurrent / fused_sigmoid_gating_delta_rule_update kernel.
+        if (
+            not forward_batch.forward_mode.is_decode()
+            and not forward_batch.forward_mode.is_target_verify()
+        ):
             forget_gate = forget_gate.unflatten(
                 -1, (-1, self.head_dim)
             )  # [T, H*K] -> [T, H, K]

--- a/python/sglang/srt/models/kimi_linear.py
+++ b/python/sglang/srt/models/kimi_linear.py
@@ -382,10 +382,8 @@ class KimiDeltaAttention(nn.Module):
                 hidden_states
             )
 
-        # For prefill: raw gate is passed to chunk_kda_fwd, which fuses gate
-        # activation with chunk_local_cumsum (kda_gate_chunk_cumsum kernel).
-        # For decode and target_verify: gate activation is handled inside
-        # fused_recurrent / fused_sigmoid_gating_delta_rule_update kernel.
+        # Prefill passes raw gates to chunk KDA; decode and target-verify kernels
+        # apply the activation internally.
         if (
             not forward_batch.forward_mode.is_decode()
             and not forward_batch.forward_mode.is_target_verify()

--- a/test/manual/test_kda_spec_integration.py
+++ b/test/manual/test_kda_spec_integration.py
@@ -1,0 +1,92 @@
+"""Engine-level integration test for KDA speculative decoding path.
+
+Launches server with KDA model + extra_buffer, sends requests,
+and verifies the forward path works correctly. Without a draft model,
+this verifies no regression in normal decode/extend paths after adding
+target_verify code.
+
+Usage:
+    # Start server first:
+    python -m sglang.launch_server \
+        --model-path /path/to/Kimi-Linear-48B-A3B-Instruct \
+        --tp 2 --trust-remote-code \
+        --mamba-scheduler-strategy extra_buffer
+
+    # Then run this test:
+    python test/manual/test_kda_spec_integration.py
+"""
+
+import concurrent.futures
+import time
+
+import requests
+
+BASE_URL = "http://localhost:30000"
+SHARED_PREFIX = "You are a helpful assistant. " * 20
+
+
+def test_normal_inference_no_regression():
+    """Normal inference still works after code changes."""
+    resp = requests.post(
+        f"{BASE_URL}/generate",
+        json={
+            "text": "What is 2+2?",
+            "sampling_params": {"max_new_tokens": 32, "temperature": 0.0},
+        },
+    )
+    assert resp.status_code == 200, f"Status {resp.status_code}: {resp.text}"
+    data = resp.json()
+    print(f"Normal inference: {data['text'][:80]}")
+    assert len(data["text"]) > 0
+
+
+def test_prefix_caching_still_works():
+    """Prefix caching (radix cache) still works."""
+    resp1 = requests.post(
+        f"{BASE_URL}/generate",
+        json={
+            "text": SHARED_PREFIX + "What is 1+1?",
+            "sampling_params": {"max_new_tokens": 32, "temperature": 0.0},
+        },
+    )
+    time.sleep(0.5)
+    resp2 = requests.post(
+        f"{BASE_URL}/generate",
+        json={
+            "text": SHARED_PREFIX + "What is 3+3?",
+            "sampling_params": {"max_new_tokens": 32, "temperature": 0.0},
+        },
+    )
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    cached = resp2.json().get("meta_info", {}).get("cached_tokens", 0)
+    print(f"Cached tokens: {cached}")
+    assert cached > 0, "Prefix caching should work"
+
+
+def test_batch_inference():
+    """Multiple concurrent requests work."""
+    prompts = [f"Count from 1 to {i + 3}" for i in range(8)]
+
+    def send(p):
+        return requests.post(
+            f"{BASE_URL}/generate",
+            json={
+                "text": p,
+                "sampling_params": {"max_new_tokens": 64, "temperature": 0.0},
+            },
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(send, p) for p in prompts]
+        results = [f.result() for f in futures]
+    for r in results:
+        assert r.status_code == 200
+    print(f"Batch test passed: {len(results)} requests OK")
+
+
+if __name__ == "__main__":
+    test_normal_inference_no_regression()
+    test_prefix_caching_still_works()
+    test_batch_inference()
+    print("\nAll tests PASSED!")

--- a/test/manual/test_kda_spec_integration.py
+++ b/test/manual/test_kda_spec_integration.py
@@ -1,21 +1,3 @@
-"""Engine-level integration test for KDA speculative decoding path.
-
-Launches server with KDA model + extra_buffer, sends requests,
-and verifies the forward path works correctly. Without a draft model,
-this verifies no regression in normal decode/extend paths after adding
-target_verify code.
-
-Usage:
-    # Start server first:
-    python -m sglang.launch_server \
-        --model-path /path/to/Kimi-Linear-48B-A3B-Instruct \
-        --tp 2 --trust-remote-code \
-        --mamba-scheduler-strategy extra_buffer
-
-    # Then run this test:
-    python test/manual/test_kda_spec_integration.py
-"""
-
 import concurrent.futures
 import time
 
@@ -26,7 +8,6 @@ SHARED_PREFIX = "You are a helpful assistant. " * 20
 
 
 def test_normal_inference_no_regression():
-    """Normal inference still works after code changes."""
     resp = requests.post(
         f"{BASE_URL}/generate",
         json={
@@ -41,7 +22,6 @@ def test_normal_inference_no_regression():
 
 
 def test_prefix_caching_still_works():
-    """Prefix caching (radix cache) still works."""
     resp1 = requests.post(
         f"{BASE_URL}/generate",
         json={
@@ -65,7 +45,6 @@ def test_prefix_caching_still_works():
 
 
 def test_batch_inference():
-    """Multiple concurrent requests work."""
     prompts = [f"Count from 1 to {i + 3}" for i in range(8)]
 
     def send(p):

--- a/test/manual/test_kda_target_verify.py
+++ b/test/manual/test_kda_target_verify.py
@@ -15,7 +15,7 @@ import torch
 def test_kda_target_verify_equivalence():
     """Verify target_verify with linear chain (retrieve_parent_token=None)
     produces the same output as N sequential decode calls."""
-    from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+    from sglang.kernels.ops.attention.fla.fused_sigmoid_gating_recurrent import (
         fused_sigmoid_gating_delta_rule_update,
     )
 
@@ -149,7 +149,7 @@ def test_kda_target_verify_equivalence():
 
 def test_kda_target_verify_bf16():
     """Same test with bfloat16 to verify acceptable numerical tolerance."""
-    from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+    from sglang.kernels.ops.attention.fla.fused_sigmoid_gating_recurrent import (
         fused_sigmoid_gating_delta_rule_update,
     )
 

--- a/test/manual/test_kda_target_verify.py
+++ b/test/manual/test_kda_target_verify.py
@@ -1,56 +1,35 @@
-"""Kernel-level correctness test for KDA target_verify.
-
-Verifies that:
-1. target_verify output matches N sequential decode outputs (linear chain)
-2. intermediate SSM states match per-step decode SSM states
-3. SSM states are not modified in-place (disable_state_update=True)
-
-Usage:
-    python test/manual/test_kda_target_verify.py
-"""
-
 import torch
 
 
 def test_kda_target_verify_equivalence():
-    """Verify target_verify with linear chain (retrieve_parent_token=None)
-    produces the same output as N sequential decode calls."""
     from sglang.kernels.ops.attention.fla.fused_sigmoid_gating_recurrent import (
         fused_sigmoid_gating_delta_rule_update,
     )
 
     B, HV, K, V = 2, 4, 64, 64
-    N = 4  # draft tokens
+    N = 4
     device = "cuda"
     dtype = torch.float32
 
     torch.manual_seed(42)
-    # Input layout for target_verify: [req0_step0..stepN-1, req1_step0..stepN-1]
-    # shape (1, B*N, HV, K)
     q = torch.randn(1, B * N, HV, K, dtype=dtype, device=device)
     k = torch.randn(1, B * N, HV, K, dtype=dtype, device=device)
     v = torch.randn(1, B * N, HV, V, dtype=dtype, device=device)
-    # KDA a shape: (B*N, HV*K) — per-token, per-head-K gating
     a = torch.randn(B * N, HV * K, dtype=dtype, device=device)
-    # KDA b shape: (1, B*N, HV) — per-token, per-head scalar beta
-    # (from model: beta_proj output is (T, num_heads) then unsqueeze(0))
     b = torch.randn(1, B * N, HV, dtype=dtype, device=device)
     A_log = torch.randn(HV, dtype=torch.float32, device=device)
     dt_bias = torch.randn(HV, dtype=torch.float32, device=device)
 
-    num_slots = B + 2  # extra slots for padding
+    num_slots = B + 2
     ssm_states_base = torch.randn(num_slots, HV, K, V, dtype=dtype, device=device)
     cache_indices = torch.arange(B, dtype=torch.int32, device=device)
-    # cu_seqlens for target_verify: [0, N, 2N, ..., B*N]
     query_start_loc = torch.arange(0, B * N + 1, N, dtype=torch.int32, device=device)
 
-    # --- Path A: N sequential decode calls ---
     ssm_states_decode = ssm_states_base.clone()
     outputs_decode = []
     states_after_step = []
 
     for step in range(N):
-        # For req i, step j is at position i*N + j in the flat layout
         step_indices = [i * N + step for i in range(B)]
         step_q = q[:, step_indices].contiguous()
         step_k = k[:, step_indices].contiguous()
@@ -76,13 +55,9 @@ def test_kda_target_verify_equivalence():
             is_kda=True,
         )
         outputs_decode.append(out)
-        # Save per-request states after this step
         states_after_step.append(ssm_states_decode[cache_indices].clone())
 
-    # --- Path B: single target_verify call ---
     ssm_states_verify = ssm_states_base.clone()
-    # intermediate buffer shape: (num_slots, N, HV, K, V)
-    # This matches the actual per-layer shape from MambaPool.SpeculativeState
     intermediate_buffer = torch.zeros(
         num_slots, N, HV, K, V, dtype=dtype, device=device
     )
@@ -110,26 +85,22 @@ def test_kda_target_verify_equivalence():
         retrieve_parent_token=None,
     )
 
-    # --- Compare outputs ---
-    # Sequential decode outputs per step: (1, B, HV, V)
-    # Concatenate to (1, B*N, HV, V) matching target_verify layout
     out_decode_list = []
     for req_idx in range(B):
         for step in range(N):
             out_decode_list.append(outputs_decode[step][:, req_idx : req_idx + 1])
-    out_decode_cat = torch.cat(out_decode_list, dim=1)  # (1, B*N, HV, V)
+    out_decode_cat = torch.cat(out_decode_list, dim=1)
 
     max_diff = (out_verify - out_decode_cat).abs().max().item()
     mean_diff = (out_verify - out_decode_cat).abs().mean().item()
     print(f"Output max diff: {max_diff:.6e}, mean diff: {mean_diff:.6e}")
     assert max_diff < 1e-5, f"Output mismatch! max diff: {max_diff}"
 
-    # --- Compare intermediate SSM states ---
     print("Intermediate state comparison:")
     for step in range(N):
         for req_idx in range(B):
-            cached_state = intermediate_buffer[req_idx, step]  # (HV, K, V)
-            decode_state = states_after_step[step][req_idx]  # (HV, K, V)
+            cached_state = intermediate_buffer[req_idx, step]
+            decode_state = states_after_step[step][req_idx]
             state_diff = (cached_state - decode_state).abs().max().item()
             status = "OK" if state_diff < 1e-5 else "FAIL"
             print(f"  step={step} req={req_idx}: diff={state_diff:.6e} [{status}]")
@@ -137,7 +108,6 @@ def test_kda_target_verify_equivalence():
                 state_diff < 1e-5
             ), f"Intermediate state mismatch at step={step}, req={req_idx}: {state_diff}"
 
-    # --- Verify SSM states are NOT modified in-place ---
     ssm_unchanged_diff = (ssm_states_verify - ssm_states_base).abs().max().item()
     print(f"SSM state in-place change (should be 0): {ssm_unchanged_diff:.6e}")
     assert (
@@ -148,7 +118,6 @@ def test_kda_target_verify_equivalence():
 
 
 def test_kda_target_verify_bf16():
-    """Same test with bfloat16 to verify acceptable numerical tolerance."""
     from sglang.kernels.ops.attention.fla.fused_sigmoid_gating_recurrent import (
         fused_sigmoid_gating_delta_rule_update,
     )
@@ -163,7 +132,6 @@ def test_kda_target_verify_bf16():
     k = torch.randn(1, B * N, HV, K, dtype=dtype, device=device)
     v = torch.randn(1, B * N, HV, V, dtype=dtype, device=device)
     a = torch.randn(B * N, HV * K, dtype=dtype, device=device)
-    # KDA b shape: (1, B*N, HV)
     b = torch.randn(1, B * N, HV, dtype=dtype, device=device)
     A_log = torch.randn(HV, dtype=torch.float32, device=device)
     dt_bias = torch.randn(HV, dtype=torch.float32, device=device)
@@ -173,7 +141,6 @@ def test_kda_target_verify_bf16():
     cache_indices = torch.arange(B, dtype=torch.int32, device=device)
     query_start_loc = torch.arange(0, B * N + 1, N, dtype=torch.int32, device=device)
 
-    # Sequential decode
     ssm_states_decode = ssm_states_base.clone()
     outputs_decode = []
     for step in range(N):
@@ -202,7 +169,6 @@ def test_kda_target_verify_bf16():
         )
         outputs_decode.append(out)
 
-    # target_verify
     ssm_states_verify = ssm_states_base.clone()
     intermediate_buffer = torch.zeros(
         num_slots, N, HV, K, V, dtype=dtype, device=device
@@ -239,7 +205,7 @@ def test_kda_target_verify_bf16():
     max_diff = (out_verify - out_decode_cat).abs().max().item()
     mean_diff = (out_verify - out_decode_cat).abs().mean().item()
     print(f"\n[bf16] Output max diff: {max_diff:.6e}, mean diff: {mean_diff:.6e}")
-    # bf16 tolerance: kernel accumulates in fp32 internally, so diff should still be small
+    # FP32 accumulation keeps this close to the sequential bf16 path.
     assert max_diff < 1e-3, f"[bf16] Output mismatch! max diff: {max_diff}"
 
     print("PASSED: KDA target_verify bf16 test!")

--- a/test/manual/test_kda_target_verify.py
+++ b/test/manual/test_kda_target_verify.py
@@ -133,16 +133,16 @@ def test_kda_target_verify_equivalence():
             state_diff = (cached_state - decode_state).abs().max().item()
             status = "OK" if state_diff < 1e-5 else "FAIL"
             print(f"  step={step} req={req_idx}: diff={state_diff:.6e} [{status}]")
-            assert state_diff < 1e-5, (
-                f"Intermediate state mismatch at step={step}, req={req_idx}: {state_diff}"
-            )
+            assert (
+                state_diff < 1e-5
+            ), f"Intermediate state mismatch at step={step}, req={req_idx}: {state_diff}"
 
     # --- Verify SSM states are NOT modified in-place ---
     ssm_unchanged_diff = (ssm_states_verify - ssm_states_base).abs().max().item()
     print(f"SSM state in-place change (should be 0): {ssm_unchanged_diff:.6e}")
-    assert ssm_unchanged_diff == 0.0, (
-        f"target_verify modified ssm_states in-place! diff: {ssm_unchanged_diff}"
-    )
+    assert (
+        ssm_unchanged_diff == 0.0
+    ), f"target_verify modified ssm_states in-place! diff: {ssm_unchanged_diff}"
 
     print("\nPASSED: KDA target_verify matches sequential decode!")
 
@@ -185,10 +185,19 @@ def test_kda_target_verify_bf16():
         step_b = b[:, step_indices].contiguous()
         decode_qsl = torch.arange(0, B + 1, dtype=torch.int32, device=device)
         out = fused_sigmoid_gating_delta_rule_update(
-            A_log=A_log, dt_bias=dt_bias, q=step_q, k=step_k, v=step_v,
-            a=step_a, b=step_b, initial_state_source=ssm_states_decode,
-            initial_state_indices=cache_indices, cu_seqlens=decode_qsl,
-            use_qk_l2norm_in_kernel=True, softplus_beta=1.0, softplus_threshold=20.0,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            q=step_q,
+            k=step_k,
+            v=step_v,
+            a=step_a,
+            b=step_b,
+            initial_state_source=ssm_states_decode,
+            initial_state_indices=cache_indices,
+            cu_seqlens=decode_qsl,
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
             is_kda=True,
         )
         outputs_decode.append(out)
@@ -200,12 +209,24 @@ def test_kda_target_verify_bf16():
     )
     intermediate_indices = torch.arange(B, dtype=torch.int32, device=device)
     out_verify = fused_sigmoid_gating_delta_rule_update(
-        A_log=A_log, dt_bias=dt_bias, q=q, k=k, v=v, a=a, b=b,
-        initial_state_source=ssm_states_verify, initial_state_indices=cache_indices,
-        cu_seqlens=query_start_loc, use_qk_l2norm_in_kernel=True,
-        softplus_beta=1.0, softplus_threshold=20.0, is_kda=True,
-        disable_state_update=True, intermediate_states_buffer=intermediate_buffer,
-        intermediate_state_indices=intermediate_indices, cache_steps=N,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        initial_state_source=ssm_states_verify,
+        initial_state_indices=cache_indices,
+        cu_seqlens=query_start_loc,
+        use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        is_kda=True,
+        disable_state_update=True,
+        intermediate_states_buffer=intermediate_buffer,
+        intermediate_state_indices=intermediate_indices,
+        cache_steps=N,
         retrieve_parent_token=None,
     )
 

--- a/test/manual/test_kda_target_verify.py
+++ b/test/manual/test_kda_target_verify.py
@@ -1,0 +1,229 @@
+"""Kernel-level correctness test for KDA target_verify.
+
+Verifies that:
+1. target_verify output matches N sequential decode outputs (linear chain)
+2. intermediate SSM states match per-step decode SSM states
+3. SSM states are not modified in-place (disable_state_update=True)
+
+Usage:
+    python test/manual/test_kda_target_verify.py
+"""
+
+import torch
+
+
+def test_kda_target_verify_equivalence():
+    """Verify target_verify with linear chain (retrieve_parent_token=None)
+    produces the same output as N sequential decode calls."""
+    from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+        fused_sigmoid_gating_delta_rule_update,
+    )
+
+    B, HV, K, V = 2, 4, 64, 64
+    N = 4  # draft tokens
+    device = "cuda"
+    dtype = torch.float32
+
+    torch.manual_seed(42)
+    # Input layout for target_verify: [req0_step0..stepN-1, req1_step0..stepN-1]
+    # shape (1, B*N, HV, K)
+    q = torch.randn(1, B * N, HV, K, dtype=dtype, device=device)
+    k = torch.randn(1, B * N, HV, K, dtype=dtype, device=device)
+    v = torch.randn(1, B * N, HV, V, dtype=dtype, device=device)
+    # KDA a shape: (B*N, HV*K) — per-token, per-head-K gating
+    a = torch.randn(B * N, HV * K, dtype=dtype, device=device)
+    # KDA b shape: (1, B*N, HV) — per-token, per-head scalar beta
+    # (from model: beta_proj output is (T, num_heads) then unsqueeze(0))
+    b = torch.randn(1, B * N, HV, dtype=dtype, device=device)
+    A_log = torch.randn(HV, dtype=torch.float32, device=device)
+    dt_bias = torch.randn(HV, dtype=torch.float32, device=device)
+
+    num_slots = B + 2  # extra slots for padding
+    ssm_states_base = torch.randn(num_slots, HV, K, V, dtype=dtype, device=device)
+    cache_indices = torch.arange(B, dtype=torch.int32, device=device)
+    # cu_seqlens for target_verify: [0, N, 2N, ..., B*N]
+    query_start_loc = torch.arange(0, B * N + 1, N, dtype=torch.int32, device=device)
+
+    # --- Path A: N sequential decode calls ---
+    ssm_states_decode = ssm_states_base.clone()
+    outputs_decode = []
+    states_after_step = []
+
+    for step in range(N):
+        # For req i, step j is at position i*N + j in the flat layout
+        step_indices = [i * N + step for i in range(B)]
+        step_q = q[:, step_indices].contiguous()
+        step_k = k[:, step_indices].contiguous()
+        step_v = v[:, step_indices].contiguous()
+        step_a = a[step_indices].contiguous()
+        step_b = b[:, step_indices].contiguous()
+        decode_qsl = torch.arange(0, B + 1, dtype=torch.int32, device=device)
+
+        out = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            dt_bias=dt_bias,
+            q=step_q,
+            k=step_k,
+            v=step_v,
+            a=step_a,
+            b=step_b,
+            initial_state_source=ssm_states_decode,
+            initial_state_indices=cache_indices,
+            cu_seqlens=decode_qsl,
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            is_kda=True,
+        )
+        outputs_decode.append(out)
+        # Save per-request states after this step
+        states_after_step.append(ssm_states_decode[cache_indices].clone())
+
+    # --- Path B: single target_verify call ---
+    ssm_states_verify = ssm_states_base.clone()
+    # intermediate buffer shape: (num_slots, N, HV, K, V)
+    # This matches the actual per-layer shape from MambaPool.SpeculativeState
+    intermediate_buffer = torch.zeros(
+        num_slots, N, HV, K, V, dtype=dtype, device=device
+    )
+    intermediate_indices = torch.arange(B, dtype=torch.int32, device=device)
+
+    out_verify = fused_sigmoid_gating_delta_rule_update(
+        A_log=A_log,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        initial_state_source=ssm_states_verify,
+        initial_state_indices=cache_indices,
+        cu_seqlens=query_start_loc,
+        use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        is_kda=True,
+        disable_state_update=True,
+        intermediate_states_buffer=intermediate_buffer,
+        intermediate_state_indices=intermediate_indices,
+        cache_steps=N,
+        retrieve_parent_token=None,
+    )
+
+    # --- Compare outputs ---
+    # Sequential decode outputs per step: (1, B, HV, V)
+    # Concatenate to (1, B*N, HV, V) matching target_verify layout
+    out_decode_list = []
+    for req_idx in range(B):
+        for step in range(N):
+            out_decode_list.append(outputs_decode[step][:, req_idx : req_idx + 1])
+    out_decode_cat = torch.cat(out_decode_list, dim=1)  # (1, B*N, HV, V)
+
+    max_diff = (out_verify - out_decode_cat).abs().max().item()
+    mean_diff = (out_verify - out_decode_cat).abs().mean().item()
+    print(f"Output max diff: {max_diff:.6e}, mean diff: {mean_diff:.6e}")
+    assert max_diff < 1e-5, f"Output mismatch! max diff: {max_diff}"
+
+    # --- Compare intermediate SSM states ---
+    print("Intermediate state comparison:")
+    for step in range(N):
+        for req_idx in range(B):
+            cached_state = intermediate_buffer[req_idx, step]  # (HV, K, V)
+            decode_state = states_after_step[step][req_idx]  # (HV, K, V)
+            state_diff = (cached_state - decode_state).abs().max().item()
+            status = "OK" if state_diff < 1e-5 else "FAIL"
+            print(f"  step={step} req={req_idx}: diff={state_diff:.6e} [{status}]")
+            assert state_diff < 1e-5, (
+                f"Intermediate state mismatch at step={step}, req={req_idx}: {state_diff}"
+            )
+
+    # --- Verify SSM states are NOT modified in-place ---
+    ssm_unchanged_diff = (ssm_states_verify - ssm_states_base).abs().max().item()
+    print(f"SSM state in-place change (should be 0): {ssm_unchanged_diff:.6e}")
+    assert ssm_unchanged_diff == 0.0, (
+        f"target_verify modified ssm_states in-place! diff: {ssm_unchanged_diff}"
+    )
+
+    print("\nPASSED: KDA target_verify matches sequential decode!")
+
+
+def test_kda_target_verify_bf16():
+    """Same test with bfloat16 to verify acceptable numerical tolerance."""
+    from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+        fused_sigmoid_gating_delta_rule_update,
+    )
+
+    B, HV, K, V = 2, 4, 64, 64
+    N = 4
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    torch.manual_seed(42)
+    q = torch.randn(1, B * N, HV, K, dtype=dtype, device=device)
+    k = torch.randn(1, B * N, HV, K, dtype=dtype, device=device)
+    v = torch.randn(1, B * N, HV, V, dtype=dtype, device=device)
+    a = torch.randn(B * N, HV * K, dtype=dtype, device=device)
+    # KDA b shape: (1, B*N, HV)
+    b = torch.randn(1, B * N, HV, dtype=dtype, device=device)
+    A_log = torch.randn(HV, dtype=torch.float32, device=device)
+    dt_bias = torch.randn(HV, dtype=torch.float32, device=device)
+
+    num_slots = B + 2
+    ssm_states_base = torch.randn(num_slots, HV, K, V, dtype=dtype, device=device)
+    cache_indices = torch.arange(B, dtype=torch.int32, device=device)
+    query_start_loc = torch.arange(0, B * N + 1, N, dtype=torch.int32, device=device)
+
+    # Sequential decode
+    ssm_states_decode = ssm_states_base.clone()
+    outputs_decode = []
+    for step in range(N):
+        step_indices = [i * N + step for i in range(B)]
+        step_q = q[:, step_indices].contiguous()
+        step_k = k[:, step_indices].contiguous()
+        step_v = v[:, step_indices].contiguous()
+        step_a = a[step_indices].contiguous()
+        step_b = b[:, step_indices].contiguous()
+        decode_qsl = torch.arange(0, B + 1, dtype=torch.int32, device=device)
+        out = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log, dt_bias=dt_bias, q=step_q, k=step_k, v=step_v,
+            a=step_a, b=step_b, initial_state_source=ssm_states_decode,
+            initial_state_indices=cache_indices, cu_seqlens=decode_qsl,
+            use_qk_l2norm_in_kernel=True, softplus_beta=1.0, softplus_threshold=20.0,
+            is_kda=True,
+        )
+        outputs_decode.append(out)
+
+    # target_verify
+    ssm_states_verify = ssm_states_base.clone()
+    intermediate_buffer = torch.zeros(
+        num_slots, N, HV, K, V, dtype=dtype, device=device
+    )
+    intermediate_indices = torch.arange(B, dtype=torch.int32, device=device)
+    out_verify = fused_sigmoid_gating_delta_rule_update(
+        A_log=A_log, dt_bias=dt_bias, q=q, k=k, v=v, a=a, b=b,
+        initial_state_source=ssm_states_verify, initial_state_indices=cache_indices,
+        cu_seqlens=query_start_loc, use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0, softplus_threshold=20.0, is_kda=True,
+        disable_state_update=True, intermediate_states_buffer=intermediate_buffer,
+        intermediate_state_indices=intermediate_indices, cache_steps=N,
+        retrieve_parent_token=None,
+    )
+
+    out_decode_list = []
+    for req_idx in range(B):
+        for step in range(N):
+            out_decode_list.append(outputs_decode[step][:, req_idx : req_idx + 1])
+    out_decode_cat = torch.cat(out_decode_list, dim=1)
+
+    max_diff = (out_verify - out_decode_cat).abs().max().item()
+    mean_diff = (out_verify - out_decode_cat).abs().mean().item()
+    print(f"\n[bf16] Output max diff: {max_diff:.6e}, mean diff: {mean_diff:.6e}")
+    # bf16 tolerance: kernel accumulates in fp32 internally, so diff should still be small
+    assert max_diff < 1e-3, f"[bf16] Output mismatch! max diff: {max_diff}"
+
+    print("PASSED: KDA target_verify bf16 test!")
+
+
+if __name__ == "__main__":
+    test_kda_target_verify_equivalence()
+    test_kda_target_verify_bf16()

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -6,7 +6,7 @@ state commit helper updates hybrid linear-attention models.
 """
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -129,16 +129,12 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
 class TestNgramMambaVerifyUpdate(CustomTestCase):
     """Test that NGRAM verify commits mamba states through the shared helper."""
 
-    def _make_mock_target_worker(self, has_mambaish_config: bool):
+    def _make_mock_target_worker(self):
         """Create a mock target worker with necessary model runner attributes."""
         target_worker = MagicMock()
         target_worker.model_runner.model = MagicMock()
         target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify = (
             MagicMock()
-        )
-
-        target_worker.model_runner.mambaish_config = (
-            {"some": "config"} if has_mambaish_config else None
         )
         return target_worker
 
@@ -146,7 +142,7 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
         """commit_mamba_states_after_verify passes correct last_correct_step_indices."""
         from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
 
-        target_worker = self._make_mock_target_worker(has_mambaish_config=True)
+        target_worker = self._make_mock_target_worker()
         batch = MagicMock()
         batch.forward_mode.is_idle.return_value = False
         batch.mamba_track_indices = None
@@ -161,13 +157,17 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
             dtype=torch.int32,
         )
 
-        commit_mamba_states_after_verify(
-            target_worker,
-            batch,
-            accept_lens,
-            accept_index,
-            draft_token_num=5,
-        )
+        with patch(
+            "sglang.srt.speculative.spec_utils.mambaish_config",
+            return_value={"some": "config"},
+        ):
+            commit_mamba_states_after_verify(
+                target_worker,
+                batch,
+                accept_lens,
+                accept_index,
+                draft_token_num=5,
+            )
 
         update_call = (
             target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify
@@ -187,20 +187,24 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
         """Verify the commit helper is a no-op when mambaish_config is None."""
         from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
 
-        target_worker = self._make_mock_target_worker(has_mambaish_config=False)
+        target_worker = self._make_mock_target_worker()
         batch = MagicMock()
         batch.forward_mode.is_idle.return_value = False
         batch.mamba_track_indices = None
         accept_lens = torch.tensor([1], dtype=torch.int32)
         accept_index = torch.tensor([[0, -1, -1, -1, -1]], dtype=torch.int32)
 
-        commit_mamba_states_after_verify(
-            target_worker,
-            batch,
-            accept_lens,
-            accept_index,
-            draft_token_num=5,
-        )
+        with patch(
+            "sglang.srt.speculative.spec_utils.mambaish_config",
+            return_value=None,
+        ):
+            commit_mamba_states_after_verify(
+                target_worker,
+                batch,
+                accept_lens,
+                accept_index,
+                draft_token_num=5,
+            )
 
         update_call = (
             target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify
@@ -209,11 +213,9 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
 
     def test_mamba_verify_update_with_track_indices(self):
         """commit_mamba_states_after_verify computes mamba_steps_to_track."""
-        from unittest.mock import patch
-
         from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
 
-        target_worker = self._make_mock_target_worker(has_mambaish_config=True)
+        target_worker = self._make_mock_target_worker()
         batch = MagicMock()
         batch.forward_mode.is_idle.return_value = False
         batch.mamba_track_indices = torch.tensor([100, 200], dtype=torch.int64)
@@ -229,7 +231,10 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
         )
 
         with patch(
-            "sglang.srt.speculative.spec_utils.get_global_server_args",
+            "sglang.srt.speculative.spec_utils.mambaish_config",
+            return_value={"some": "config"},
+        ), patch(
+            "sglang.srt.speculative.spec_utils.get_server_args",
             return_value=MagicMock(mamba_track_interval=256),
         ):
             commit_mamba_states_after_verify(

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -1,0 +1,263 @@
+"""Unit tests for NGRAM speculative decoding mamba state rollback.
+
+Tests that `last_correct_step_indices` is correctly computed from
+`accept_index` and `accept_lens`, and that the shared post-verify mamba
+state commit helper updates hybrid linear-attention models.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestNgramLastCorrectStepIndices(CustomTestCase):
+    """Test the last_correct_step_indices computation logic."""
+
+    def _compute_last_correct_step_indices(
+        self,
+        accept_indices: torch.Tensor,
+        num_correct_drafts: torch.Tensor,
+        draft_token_num: int,
+    ) -> torch.Tensor:
+        """Replicate the computation from ngram_info.py verify()."""
+        bs = accept_indices.shape[0]
+        req_idx = torch.arange(bs, dtype=torch.int64, device=accept_indices.device)
+        accept_indices_offset = (req_idx * draft_token_num).to(accept_indices.dtype)
+        last_correct_step_indices = (
+            accept_indices[req_idx, num_correct_drafts.to(torch.int64)]
+            - accept_indices_offset
+        )
+        return last_correct_step_indices
+
+    def test_linear_chain_all_accepted(self):
+        """All draft tokens accepted in a linear chain (topk=1)."""
+        bs, draft_token_num = 3, 5
+        # Linear chain: accept_indices[i] = [i*5, i*5+1, ..., i*5+4]
+        accept_indices = torch.stack(
+            [
+                torch.arange(
+                    i * draft_token_num,
+                    i * draft_token_num + draft_token_num,
+                    dtype=torch.int32,
+                )
+                for i in range(bs)
+            ]
+        )
+        # All 5 drafts accepted (last accepted = index 4)
+        num_correct_drafts = torch.tensor([4, 4, 4], dtype=torch.int32)
+
+        result = self._compute_last_correct_step_indices(
+            accept_indices, num_correct_drafts, draft_token_num
+        )
+        # Last accepted step within each request's window should be 4
+        expected = torch.tensor([4, 4, 4], dtype=torch.int32)
+        self.assertTrue(torch.equal(result, expected))
+
+    def test_linear_chain_partial_accept(self):
+        """Partial acceptance in a linear chain with correct kernel output format.
+
+        verify_tree_greedy fills accept_indices with the accepted positions:
+        - num_correct_drafts[i] correct drafts + 1 bonus = num_accept_tokens
+        - The first (num_correct_drafts[i] + 1) entries are valid global indices
+        - The remaining entries are -1
+        """
+        bs, draft_token_num = 3, 5
+        # Request 0: 2 correct drafts + bonus = 3 accepted (steps 0,1,2 in window)
+        # Request 1: 0 correct drafts + bonus = 1 accepted (step 0 in window)
+        # Request 2: 4 correct drafts + bonus = 5 accepted (steps 0,1,2,3,4 in window)
+        accept_indices = torch.tensor(
+            [
+                [0, 1, 2, -1, -1],  # req 0: global indices 0,1,2 accepted
+                [5, -1, -1, -1, -1],  # req 1: global index 5 accepted (bonus only)
+                [10, 11, 12, 13, 14],  # req 2: all 5 accepted
+            ],
+            dtype=torch.int32,
+        )
+        num_correct_drafts = torch.tensor([2, 0, 4], dtype=torch.int32)
+
+        result = self._compute_last_correct_step_indices(
+            accept_indices, num_correct_drafts, draft_token_num
+        )
+        # Request 0: accept_indices[0, 2] = 2, offset = 0*5 = 0, step = 2-0 = 2
+        # Request 1: accept_indices[1, 0] = 5, offset = 1*5 = 5, step = 5-5 = 0
+        # Request 2: accept_indices[2, 4] = 14, offset = 2*5 = 10, step = 14-10 = 4
+        expected = torch.tensor([2, 0, 4], dtype=torch.int32)
+        self.assertTrue(torch.equal(result, expected))
+
+    def test_tree_structure_non_sequential(self):
+        """Tree structure (topk > 1) where accepted path is non-sequential."""
+        bs, draft_token_num = 2, 6
+        # Request 0: tree path goes through positions 0, 2, 5 (skipping linear chain)
+        # Request 1: tree path goes through positions 6, 7, 10
+        accept_indices = torch.tensor(
+            [
+                [0, 2, 5, -1, -1, -1],  # 2 correct drafts + bonus
+                [6, 7, 10, -1, -1, -1],  # 2 correct drafts + bonus
+            ],
+            dtype=torch.int32,
+        )
+        num_correct_drafts = torch.tensor([2, 2], dtype=torch.int32)
+
+        result = self._compute_last_correct_step_indices(
+            accept_indices, num_correct_drafts, draft_token_num
+        )
+        # Request 0: accept_indices[0, 2] = 5, offset = 0, step = 5
+        # Request 1: accept_indices[1, 2] = 10, offset = 6, step = 4
+        expected = torch.tensor([5, 4], dtype=torch.int32)
+        self.assertTrue(torch.equal(result, expected))
+
+    def test_single_request_zero_drafts(self):
+        """Edge case: zero correct drafts (only bonus token accepted)."""
+        bs, draft_token_num = 1, 4
+        accept_indices = torch.tensor([[0, -1, -1, -1]], dtype=torch.int32)
+        num_correct_drafts = torch.tensor([0], dtype=torch.int32)
+
+        result = self._compute_last_correct_step_indices(
+            accept_indices, num_correct_drafts, draft_token_num
+        )
+        # accept_indices[0, 0] = 0, offset = 0, step = 0
+        expected = torch.tensor([0], dtype=torch.int32)
+        self.assertTrue(torch.equal(result, expected))
+
+
+class TestNgramMambaVerifyUpdate(CustomTestCase):
+    """Test that NGRAM verify commits mamba states through the shared helper."""
+
+    def _make_mock_target_worker(self, has_mambaish_config: bool):
+        """Create a mock target worker with necessary model runner attributes."""
+        target_worker = MagicMock()
+        target_worker.model_runner.model = MagicMock()
+        target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify = (
+            MagicMock()
+        )
+
+        target_worker.model_runner.mambaish_config = (
+            {"some": "config"} if has_mambaish_config else None
+        )
+        return target_worker
+
+    def test_mamba_verify_update_called_with_correct_indices(self):
+        """commit_mamba_states_after_verify passes correct last_correct_step_indices."""
+        from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
+
+        target_worker = self._make_mock_target_worker(has_mambaish_config=True)
+        batch = MagicMock()
+        batch.forward_mode.is_idle.return_value = False
+        batch.mamba_track_indices = None
+        batch.seq_lens = torch.tensor([10, 20, 30], dtype=torch.int32)
+        accept_lens = torch.tensor([3, 1, 5], dtype=torch.int32)
+        accept_index = torch.tensor(
+            [
+                [0, 1, 2, -1, -1],
+                [5, -1, -1, -1, -1],
+                [10, 11, 12, 13, 14],
+            ],
+            dtype=torch.int32,
+        )
+
+        commit_mamba_states_after_verify(
+            target_worker,
+            batch,
+            accept_lens,
+            accept_index,
+            draft_token_num=5,
+        )
+
+        update_call = (
+            target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify
+        )
+        update_call.assert_called_once()
+        call_kwargs = update_call.call_args[1]
+        self.assertTrue(
+            torch.equal(
+                call_kwargs["last_correct_step_indices"],
+                torch.tensor([2, 0, 4], dtype=torch.int32),
+            )
+        )
+        self.assertIsNone(call_kwargs["mamba_track_indices"])
+        self.assertIsNone(call_kwargs["mamba_steps_to_track"])
+
+    def test_mamba_verify_update_not_called_for_non_mamba_model(self):
+        """Verify the commit helper is a no-op when mambaish_config is None."""
+        from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
+
+        target_worker = self._make_mock_target_worker(has_mambaish_config=False)
+        batch = MagicMock()
+        batch.forward_mode.is_idle.return_value = False
+        batch.mamba_track_indices = None
+        accept_lens = torch.tensor([1], dtype=torch.int32)
+        accept_index = torch.tensor([[0, -1, -1, -1, -1]], dtype=torch.int32)
+
+        commit_mamba_states_after_verify(
+            target_worker,
+            batch,
+            accept_lens,
+            accept_index,
+            draft_token_num=5,
+        )
+
+        update_call = (
+            target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify
+        )
+        update_call.assert_not_called()
+
+    def test_mamba_verify_update_with_track_indices(self):
+        """commit_mamba_states_after_verify computes mamba_steps_to_track."""
+        from unittest.mock import patch
+
+        from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
+
+        target_worker = self._make_mock_target_worker(has_mambaish_config=True)
+        batch = MagicMock()
+        batch.forward_mode.is_idle.return_value = False
+        batch.mamba_track_indices = torch.tensor([100, 200], dtype=torch.int64)
+        # seq_lens before verify; helper adds accept_lens to compute the post-verify lengths.
+        batch.seq_lens = torch.tensor([253, 128], dtype=torch.int32)
+        accept_lens = torch.tensor([4, 3], dtype=torch.int32)
+        accept_index = torch.tensor(
+            [
+                [0, 1, 2, 3, -1],
+                [5, 6, 7, -1, -1],
+            ],
+            dtype=torch.int32,
+        )
+
+        with patch(
+            "sglang.srt.speculative.spec_utils.get_global_server_args",
+            return_value=MagicMock(mamba_track_interval=256),
+        ):
+            commit_mamba_states_after_verify(
+                target_worker,
+                batch,
+                accept_lens,
+                accept_index,
+                draft_token_num=5,
+            )
+
+        update_call = (
+            target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify
+        )
+        update_call.assert_called_once()
+        call_kwargs = update_call.call_args[1]
+        self.assertTrue(
+            torch.equal(
+                call_kwargs["last_correct_step_indices"],
+                torch.tensor([3, 2], dtype=torch.int32),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                call_kwargs["mamba_steps_to_track"],
+                torch.tensor([2, -1], dtype=torch.int32),
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -259,5 +259,198 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
         )
 
 
+class TestConvWindowDedupLayout(CustomTestCase):
+    """Guard the deduplicated sliding-window conv-intermediate view layout.
+
+    Regression for the KDA aliasing bug: the dedup ``as_strided`` view in
+    ``MambaPool.__init__`` was built assuming GDN's ``(channel, K-1)`` conv
+    layout. KDA swaps its conv_state axes to ``(K-1, channel)``
+    (``KimiLinearStateShape.create``), so unpacking ``conv_dim, win = conv_shape``
+    aliased the draft-step axis onto the channel axis: per-step window writes
+    clobbered each other, and the post-verify commit restored channel-shifted
+    garbage into conv_states whenever acceptance was *partial* (full acceptance
+    was coincidentally correct, which is why equivalence tests passed). Only
+    triggers for chain EAGLE/MTP (topk<=1, where dedup is enabled).
+
+    These tests replicate the exact view construction from
+    ``MambaPool.__init__`` (device-independent, so they run on CPU CI) for both
+    layouts and assert the sliding-window semantics: step ``t``'s window is the
+    shared buffer slice ``[..., t:t+(K-1)]`` and the channel axis stays
+    independent.
+    """
+
+    @staticmethod
+    def _build_fixed_view(channel_dim, win_len, draft_tokens, window_major, device):
+        """Replicate the fixed dedup view construction from MambaPool.__init__.
+
+        phys keeps the channel axis independent and the shared sliding window on
+        its last axis; the logical view's last two dims follow conv_state's axis
+        order (channel-major for GDN, window-major for KDA).
+        """
+        shared_win = draft_tokens + win_len - 1
+        L, S = 1, 1
+        phys = torch.zeros(L, S, channel_dim, shared_win, device=device)
+        # Encode each physical cell as channel*1000 + shared_col so we can read
+        # back which (channel, window-column) each view element points to.
+        for c in range(channel_dim):
+            for w in range(shared_win):
+                phys[0, 0, c, w] = c * 1000 + w
+        if not window_major:
+            # GDN: view[l, s, step, d, w] = phys[l, s, d, step + w]
+            view = phys.as_strided(
+                (L, S, draft_tokens, channel_dim, win_len),
+                (
+                    phys.stride(0),
+                    phys.stride(1),
+                    phys.stride(3),  # step -> shared-win axis
+                    phys.stride(2),  # channel
+                    phys.stride(3),  # win -> shared-win axis
+                ),
+            )
+        else:
+            # KDA: view[l, s, step, w, d] = phys[l, s, d, step + w]
+            view = phys.as_strided(
+                (L, S, draft_tokens, win_len, channel_dim),
+                (
+                    phys.stride(0),
+                    phys.stride(1),
+                    phys.stride(3),  # step -> shared-win axis
+                    phys.stride(3),  # win -> shared-win axis
+                    phys.stride(2),  # channel
+                ),
+            )
+        return view, phys
+
+    @staticmethod
+    def _build_buggy_kda_view(channel_dim, win_len, draft_tokens, device):
+        """Replicate the ORIGINAL buggy construction for the KDA layout.
+
+        The old code did ``conv_dim, win = conv_shape`` on KDA's
+        ``(K-1, channel)`` shape, giving ``conv_dim = K-1`` and ``win = channel``,
+        so the shared window was built over the channel axis.
+        """
+        conv_shape = (win_len, channel_dim)  # KDA (K-1, channel)
+        conv_dim, win = conv_shape  # buggy unpack: conv_dim=K-1, win=channel
+        shared_win = draft_tokens + win - 1
+        L, S = 1, 1
+        phys = torch.zeros(L, S, conv_dim, shared_win, device=device)
+        for c in range(conv_dim):
+            for w in range(shared_win):
+                phys[0, 0, c, w] = c * 1000 + w
+        view = phys.as_strided(
+            (L, S, draft_tokens, conv_dim, win),
+            (
+                phys.stride(0),
+                phys.stride(1),
+                phys.stride(3),
+                phys.stride(2),
+                phys.stride(3),
+            ),
+        )
+        return view
+
+    def test_kda_window_major_sliding_window(self):
+        """Fixed KDA view: step t's window == phys[:, t:t+(K-1)], channel independent."""
+        channel_dim, win_len, draft_tokens = 5, 3, 4  # K=4 -> win=3
+        view, _ = self._build_fixed_view(
+            channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
+        )
+        # view[0,0,t,w,d] must equal phys code d*1000 + (t+w)
+        for t in range(draft_tokens):
+            for w in range(win_len):
+                for d in range(channel_dim):
+                    got = int(view[0, 0, t, w, d].item())
+                    self.assertEqual(
+                        got,
+                        d * 1000 + (t + w),
+                        msg=f"KDA view alias at step={t} w={w} d={d}",
+                    )
+
+    def test_kda_channel_axis_independent(self):
+        """Fixed KDA view: the channel (last) axis must carry the channel identity."""
+        channel_dim, win_len, draft_tokens = 5, 3, 4
+        view, _ = self._build_fixed_view(
+            channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
+        )
+        for t in range(draft_tokens):
+            for w in range(win_len):
+                for d in range(channel_dim):
+                    # channel identity == floor(code / 1000) must equal d
+                    self.assertEqual(int(view[0, 0, t, w, d].item()) // 1000, d)
+
+    def test_kda_window_shifts_by_one_per_step(self):
+        """Fixed KDA view: advancing the draft step slides the window by exactly 1."""
+        channel_dim, win_len, draft_tokens = 5, 3, 4
+        view, _ = self._build_fixed_view(
+            channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
+        )
+        fixed_channel = 2
+        for t in range(draft_tokens - 1):
+            a = view[0, 0, t, :, fixed_channel].tolist()
+            b = view[0, 0, t + 1, :, fixed_channel].tolist()
+            # b is a shifted left by one within the shared window
+            self.assertEqual(a[1:], b[:-1])
+
+    def test_gdn_channel_major_unchanged(self):
+        """Fixed GDN view keeps the legacy channel-major semantics."""
+        channel_dim, win_len, draft_tokens = 5, 3, 4
+        view, _ = self._build_fixed_view(
+            channel_dim, win_len, draft_tokens, window_major=False, device="cpu"
+        )
+        # view[0,0,t,d,w] must equal phys code d*1000 + (t+w)
+        for t in range(draft_tokens):
+            for d in range(channel_dim):
+                for w in range(win_len):
+                    self.assertEqual(
+                        int(view[0, 0, t, d, w].item()), d * 1000 + (t + w)
+                    )
+
+    def test_partial_accept_commit_reads_correct_window(self):
+        """Under partial acceptance, committing step n reads the right window.
+
+        Simulates the post-verify commit: for accepted step n, the conv_state to
+        restore is the window at draft step n. Assert the fixed KDA view exposes
+        that window intact (channel-independent, correctly shifted), which the
+        buggy view did not.
+        """
+        channel_dim, win_len, draft_tokens = 5, 3, 4
+        view, _ = self._build_fixed_view(
+            channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
+        )
+        # Partial accept: last correct step = 1 (not full acceptance)
+        n = 1
+        committed = view[0, 0, n]  # shape (win_len, channel_dim)
+        for w in range(win_len):
+            for d in range(channel_dim):
+                self.assertEqual(int(committed[w, d].item()), d * 1000 + (n + w))
+
+    def test_buggy_kda_view_aliases_step_onto_channel(self):
+        """Regression sentinel: the OLD construction DID alias step->channel.
+
+        This documents the bug and guards against silently reintroducing the
+        old unpack. In the buggy view, advancing the draft step changes the
+        (mislabeled) channel axis content, i.e. step contaminates channel.
+        """
+        channel_dim, win_len, draft_tokens = 5, 3, 4
+        buggy = self._build_buggy_kda_view(
+            channel_dim, win_len, draft_tokens, device="cpu"
+        )
+        # The buggy view's 4th axis has size K-1 (=win_len), NOT channel_dim,
+        # confirming the axes were swapped/mislabeled.
+        self.assertEqual(buggy.shape[3], win_len)
+        self.assertEqual(buggy.shape[4], channel_dim)
+        # Stepping t must change the mislabeled-channel slice -> aliasing present.
+        aliased = False
+        for c in range(buggy.shape[3]):
+            if buggy[0, 0, 0, c, :].tolist() != buggy[0, 0, 1, c, :].tolist():
+                aliased = True
+                break
+        self.assertTrue(
+            aliased,
+            "expected the buggy KDA view to alias the draft-step axis onto the "
+            "channel axis",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -1,10 +1,3 @@
-"""Unit tests for NGRAM speculative decoding mamba state rollback.
-
-Tests that `last_correct_step_indices` is correctly computed from
-`accept_index` and `accept_lens`, and that the shared post-verify mamba
-state commit helper updates hybrid linear-attention models.
-"""
-
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -17,15 +10,12 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestNgramLastCorrectStepIndices(CustomTestCase):
-    """Test the last_correct_step_indices computation logic."""
-
     def _compute_last_correct_step_indices(
         self,
         accept_indices: torch.Tensor,
         num_correct_drafts: torch.Tensor,
         draft_token_num: int,
     ) -> torch.Tensor:
-        """Replicate the computation from ngram_info.py verify()."""
         bs = accept_indices.shape[0]
         req_idx = torch.arange(bs, dtype=torch.int64, device=accept_indices.device)
         accept_indices_offset = (req_idx * draft_token_num).to(accept_indices.dtype)
@@ -36,9 +26,7 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         return last_correct_step_indices
 
     def test_linear_chain_all_accepted(self):
-        """All draft tokens accepted in a linear chain (topk=1)."""
         bs, draft_token_num = 3, 5
-        # Linear chain: accept_indices[i] = [i*5, i*5+1, ..., i*5+4]
         accept_indices = torch.stack(
             [
                 torch.arange(
@@ -49,33 +37,21 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
                 for i in range(bs)
             ]
         )
-        # All 5 drafts accepted (last accepted = index 4)
         num_correct_drafts = torch.tensor([4, 4, 4], dtype=torch.int32)
 
         result = self._compute_last_correct_step_indices(
             accept_indices, num_correct_drafts, draft_token_num
         )
-        # Last accepted step within each request's window should be 4
         expected = torch.tensor([4, 4, 4], dtype=torch.int32)
         self.assertTrue(torch.equal(result, expected))
 
     def test_linear_chain_partial_accept(self):
-        """Partial acceptance in a linear chain with correct kernel output format.
-
-        verify_tree_greedy fills accept_indices with the accepted positions:
-        - num_correct_drafts[i] correct drafts + 1 bonus = num_accept_tokens
-        - The first (num_correct_drafts[i] + 1) entries are valid global indices
-        - The remaining entries are -1
-        """
         bs, draft_token_num = 3, 5
-        # Request 0: 2 correct drafts + bonus = 3 accepted (steps 0,1,2 in window)
-        # Request 1: 0 correct drafts + bonus = 1 accepted (step 0 in window)
-        # Request 2: 4 correct drafts + bonus = 5 accepted (steps 0,1,2,3,4 in window)
         accept_indices = torch.tensor(
             [
-                [0, 1, 2, -1, -1],  # req 0: global indices 0,1,2 accepted
-                [5, -1, -1, -1, -1],  # req 1: global index 5 accepted (bonus only)
-                [10, 11, 12, 13, 14],  # req 2: all 5 accepted
+                [0, 1, 2, -1, -1],
+                [5, -1, -1, -1, -1],
+                [10, 11, 12, 13, 14],
             ],
             dtype=torch.int32,
         )
@@ -84,21 +60,15 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         result = self._compute_last_correct_step_indices(
             accept_indices, num_correct_drafts, draft_token_num
         )
-        # Request 0: accept_indices[0, 2] = 2, offset = 0*5 = 0, step = 2-0 = 2
-        # Request 1: accept_indices[1, 0] = 5, offset = 1*5 = 5, step = 5-5 = 0
-        # Request 2: accept_indices[2, 4] = 14, offset = 2*5 = 10, step = 14-10 = 4
         expected = torch.tensor([2, 0, 4], dtype=torch.int32)
         self.assertTrue(torch.equal(result, expected))
 
     def test_tree_structure_non_sequential(self):
-        """Tree structure (topk > 1) where accepted path is non-sequential."""
         bs, draft_token_num = 2, 6
-        # Request 0: tree path goes through positions 0, 2, 5 (skipping linear chain)
-        # Request 1: tree path goes through positions 6, 7, 10
         accept_indices = torch.tensor(
             [
-                [0, 2, 5, -1, -1, -1],  # 2 correct drafts + bonus
-                [6, 7, 10, -1, -1, -1],  # 2 correct drafts + bonus
+                [0, 2, 5, -1, -1, -1],
+                [6, 7, 10, -1, -1, -1],
             ],
             dtype=torch.int32,
         )
@@ -107,13 +77,10 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         result = self._compute_last_correct_step_indices(
             accept_indices, num_correct_drafts, draft_token_num
         )
-        # Request 0: accept_indices[0, 2] = 5, offset = 0, step = 5
-        # Request 1: accept_indices[1, 2] = 10, offset = 6, step = 4
         expected = torch.tensor([5, 4], dtype=torch.int32)
         self.assertTrue(torch.equal(result, expected))
 
     def test_single_request_zero_drafts(self):
-        """Edge case: zero correct drafts (only bonus token accepted)."""
         bs, draft_token_num = 1, 4
         accept_indices = torch.tensor([[0, -1, -1, -1]], dtype=torch.int32)
         num_correct_drafts = torch.tensor([0], dtype=torch.int32)
@@ -121,16 +88,12 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         result = self._compute_last_correct_step_indices(
             accept_indices, num_correct_drafts, draft_token_num
         )
-        # accept_indices[0, 0] = 0, offset = 0, step = 0
         expected = torch.tensor([0], dtype=torch.int32)
         self.assertTrue(torch.equal(result, expected))
 
 
 class TestNgramMambaVerifyUpdate(CustomTestCase):
-    """Test that NGRAM verify commits mamba states through the shared helper."""
-
     def _make_mock_target_worker(self):
-        """Create a mock target worker with necessary model runner attributes."""
         target_worker = MagicMock()
         target_worker.model_runner.model = MagicMock()
         target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify = (
@@ -139,7 +102,6 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
         return target_worker
 
     def test_mamba_verify_update_called_with_correct_indices(self):
-        """commit_mamba_states_after_verify passes correct last_correct_step_indices."""
         from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
 
         target_worker = self._make_mock_target_worker()
@@ -184,7 +146,6 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
         self.assertIsNone(call_kwargs["mamba_steps_to_track"])
 
     def test_mamba_verify_update_not_called_for_non_mamba_model(self):
-        """Verify the commit helper is a no-op when mambaish_config is None."""
         from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
 
         target_worker = self._make_mock_target_worker()
@@ -212,14 +173,13 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
         update_call.assert_not_called()
 
     def test_mamba_verify_update_with_track_indices(self):
-        """commit_mamba_states_after_verify computes mamba_steps_to_track."""
         from sglang.srt.speculative.spec_utils import commit_mamba_states_after_verify
 
         target_worker = self._make_mock_target_worker()
         batch = MagicMock()
         batch.forward_mode.is_idle.return_value = False
         batch.mamba_track_indices = torch.tensor([100, 200], dtype=torch.int64)
-        # seq_lens before verify; helper adds accept_lens to compute the post-verify lengths.
+        # Only the first request crosses the 256-token tracking boundary.
         batch.seq_lens = torch.tensor([253, 128], dtype=torch.int32)
         accept_lens = torch.tensor([4, 3], dtype=torch.int32)
         accept_index = torch.tensor(
@@ -265,38 +225,16 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
 
 
 class TestConvWindowDedupLayout(CustomTestCase):
-    """Guard the deduplicated sliding-window conv-intermediate view layout.
-
-    Regression for the KDA aliasing bug: the dedup ``as_strided`` view in
-    ``MambaPool.__init__`` was built assuming GDN's ``(channel, K-1)`` conv
-    layout. KDA swaps its conv_state axes to ``(K-1, channel)``
-    (``KimiLinearStateShape.create``), so unpacking ``conv_dim, win = conv_shape``
-    aliased the draft-step axis onto the channel axis: per-step window writes
-    clobbered each other, and the post-verify commit restored channel-shifted
-    garbage into conv_states whenever acceptance was *partial* (full acceptance
-    was coincidentally correct, which is why equivalence tests passed). Only
-    triggers for chain EAGLE/MTP (topk<=1, where dedup is enabled).
-
-    These tests replicate the exact view construction from
-    ``MambaPool.__init__`` (device-independent, so they run on CPU CI) for both
-    layouts and assert the sliding-window semantics: step ``t``'s window is the
-    shared buffer slice ``[..., t:t+(K-1)]`` and the channel axis stays
-    independent.
+    """KDA stores conv_state as (K-1, channel), unlike GDN; partial-accept
+    commits must preserve that layout in the overlapping view.
     """
 
     @staticmethod
     def _build_fixed_view(channel_dim, win_len, draft_tokens, window_major, device):
-        """Replicate the fixed dedup view construction from MambaPool.__init__.
-
-        phys keeps the channel axis independent and the shared sliding window on
-        its last axis; the logical view's last two dims follow conv_state's axis
-        order (channel-major for GDN, window-major for KDA).
-        """
         shared_win = draft_tokens + win_len - 1
         L, S = 1, 1
         phys = torch.zeros(L, S, channel_dim, shared_win, device=device)
-        # Encode each physical cell as channel*1000 + shared_col so we can read
-        # back which (channel, window-column) each view element points to.
+        # Encoding both coordinates makes axis aliasing observable.
         for c in range(channel_dim):
             for w in range(shared_win):
                 phys[0, 0, c, w] = c * 1000 + w
@@ -307,9 +245,9 @@ class TestConvWindowDedupLayout(CustomTestCase):
                 (
                     phys.stride(0),
                     phys.stride(1),
-                    phys.stride(3),  # step -> shared-win axis
-                    phys.stride(2),  # channel
-                    phys.stride(3),  # win -> shared-win axis
+                    phys.stride(3),
+                    phys.stride(2),
+                    phys.stride(3),
                 ),
             )
         else:
@@ -319,23 +257,20 @@ class TestConvWindowDedupLayout(CustomTestCase):
                 (
                     phys.stride(0),
                     phys.stride(1),
-                    phys.stride(3),  # step -> shared-win axis
-                    phys.stride(3),  # win -> shared-win axis
-                    phys.stride(2),  # channel
+                    phys.stride(3),
+                    phys.stride(3),
+                    phys.stride(2),
                 ),
             )
         return view, phys
 
     @staticmethod
     def _build_buggy_kda_view(channel_dim, win_len, draft_tokens, device):
-        """Replicate the ORIGINAL buggy construction for the KDA layout.
-
-        The old code did ``conv_dim, win = conv_shape`` on KDA's
-        ``(K-1, channel)`` shape, giving ``conv_dim = K-1`` and ``win = channel``,
-        so the shared window was built over the channel axis.
+        """Preserve the former axis swap so the regression test distinguishes
+        the corrected view from the broken one.
         """
-        conv_shape = (win_len, channel_dim)  # KDA (K-1, channel)
-        conv_dim, win = conv_shape  # buggy unpack: conv_dim=K-1, win=channel
+        conv_shape = (win_len, channel_dim)
+        conv_dim, win = conv_shape
         shared_win = draft_tokens + win - 1
         L, S = 1, 1
         phys = torch.zeros(L, S, conv_dim, shared_win, device=device)
@@ -355,12 +290,10 @@ class TestConvWindowDedupLayout(CustomTestCase):
         return view
 
     def test_kda_window_major_sliding_window(self):
-        """Fixed KDA view: step t's window == phys[:, t:t+(K-1)], channel independent."""
-        channel_dim, win_len, draft_tokens = 5, 3, 4  # K=4 -> win=3
+        channel_dim, win_len, draft_tokens = 5, 3, 4
         view, _ = self._build_fixed_view(
             channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
         )
-        # view[0,0,t,w,d] must equal phys code d*1000 + (t+w)
         for t in range(draft_tokens):
             for w in range(win_len):
                 for d in range(channel_dim):
@@ -372,7 +305,6 @@ class TestConvWindowDedupLayout(CustomTestCase):
                     )
 
     def test_kda_channel_axis_independent(self):
-        """Fixed KDA view: the channel (last) axis must carry the channel identity."""
         channel_dim, win_len, draft_tokens = 5, 3, 4
         view, _ = self._build_fixed_view(
             channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
@@ -380,11 +312,9 @@ class TestConvWindowDedupLayout(CustomTestCase):
         for t in range(draft_tokens):
             for w in range(win_len):
                 for d in range(channel_dim):
-                    # channel identity == floor(code / 1000) must equal d
                     self.assertEqual(int(view[0, 0, t, w, d].item()) // 1000, d)
 
     def test_kda_window_shifts_by_one_per_step(self):
-        """Fixed KDA view: advancing the draft step slides the window by exactly 1."""
         channel_dim, win_len, draft_tokens = 5, 3, 4
         view, _ = self._build_fixed_view(
             channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
@@ -393,16 +323,13 @@ class TestConvWindowDedupLayout(CustomTestCase):
         for t in range(draft_tokens - 1):
             a = view[0, 0, t, :, fixed_channel].tolist()
             b = view[0, 0, t + 1, :, fixed_channel].tolist()
-            # b is a shifted left by one within the shared window
             self.assertEqual(a[1:], b[:-1])
 
     def test_gdn_channel_major_unchanged(self):
-        """Fixed GDN view keeps the legacy channel-major semantics."""
         channel_dim, win_len, draft_tokens = 5, 3, 4
         view, _ = self._build_fixed_view(
             channel_dim, win_len, draft_tokens, window_major=False, device="cpu"
         )
-        # view[0,0,t,d,w] must equal phys code d*1000 + (t+w)
         for t in range(draft_tokens):
             for d in range(channel_dim):
                 for w in range(win_len):
@@ -411,40 +338,23 @@ class TestConvWindowDedupLayout(CustomTestCase):
                     )
 
     def test_partial_accept_commit_reads_correct_window(self):
-        """Under partial acceptance, committing step n reads the right window.
-
-        Simulates the post-verify commit: for accepted step n, the conv_state to
-        restore is the window at draft step n. Assert the fixed KDA view exposes
-        that window intact (channel-independent, correctly shifted), which the
-        buggy view did not.
-        """
         channel_dim, win_len, draft_tokens = 5, 3, 4
         view, _ = self._build_fixed_view(
             channel_dim, win_len, draft_tokens, window_major=True, device="cpu"
         )
-        # Partial accept: last correct step = 1 (not full acceptance)
         n = 1
-        committed = view[0, 0, n]  # shape (win_len, channel_dim)
+        committed = view[0, 0, n]
         for w in range(win_len):
             for d in range(channel_dim):
                 self.assertEqual(int(committed[w, d].item()), d * 1000 + (n + w))
 
     def test_buggy_kda_view_aliases_step_onto_channel(self):
-        """Regression sentinel: the OLD construction DID alias step->channel.
-
-        This documents the bug and guards against silently reintroducing the
-        old unpack. In the buggy view, advancing the draft step changes the
-        (mislabeled) channel axis content, i.e. step contaminates channel.
-        """
         channel_dim, win_len, draft_tokens = 5, 3, 4
         buggy = self._build_buggy_kda_view(
             channel_dim, win_len, draft_tokens, device="cpu"
         )
-        # The buggy view's 4th axis has size K-1 (=win_len), NOT channel_dim,
-        # confirming the axes were swapped/mislabeled.
         self.assertEqual(buggy.shape[3], win_len)
         self.assertEqual(buggy.shape[4], channel_dim)
-        # Stepping t must change the mislabeled-channel slice -> aliasing present.
         aliased = False
         for c in range(buggy.shape[3]):
             if buggy[0, 0, 0, c, :].tolist() != buggy[0, 0, 1, c, :].tolist():


### PR DESCRIPTION
## PR Summary

### New Features
- Added `target_verify` method to **KDA kernel** and **dispatcher**, enabling **EAGLE speculative decoding** for `KimiLinearForCausalLM`.
- Added `is_target_verify` branch in `KDAAttnBackend.forward_extend` with convolution state handling and intermediate SSM state caching.
- Registered **KDA (kimi_linear_config)** in **eagle worker mamba verify detection** across all three eagle worker variants.

### Motivation
- **GDN** (a sister linear attention backend) already supports full EAGLE speculative decoding.  
  This PR achieves feature parity for **KDA** with specific adaptations:
  - Added `is_kda=True` gating in fused sigmoid recurrent kernel.
  - Convolution state transpose: `(conv_width, qkv_dim) → (qkv_dim, conv_width)` for `causal_conv1d_update`.
  - Full convolution weights applied to combined `mixed_qkv` (matching KDA decode behavior).

---

## Test Plan

1. **Kernel-Level Equivalence**  
   - `target_verify` with N draft tokens == N sequential decode calls (fp32 exact match, bf16 error < 1e-3).

2. **Unit Tests**  
   - `test_runner_mode_eagle_verify_cases`: chain (topk=1), tree (topk=2), `frozen_kv_mtp`, `dflash`, `ngram` all pass.
   - CUDA graph verify: `test_runner_mode_eagle_verify_cuda_graph_cases` pass.
   - Draft extend: `test_runner_mode_eagle_draft_extend_cases` pass.
   - E2E server test with `Kimi-Linear-48B-A3B-Instruct`, TP=2, no_buffer — normal inference, prefix caching, batch inference all pass.

---

## Test Results

### Mock Fixture Unit Tests

| Test Case                                         | Result | Time   |
|---------------------------------------------------|--------|--------|
| test_projected_kda_attention_cases                | ✓      |        |
| test_layout_robustness_cases                      | ✓      |        |
| test_runner_mode_cuda_graph_decode_cases          | ✓      |        |
| test_runner_mode_eagle_verify_cases               | ✓      |        |
| test_runner_mode_eagle_verify_cuda_graph_cases    | ✓      |        |
| test_runner_mode_eagle_draft_extend_cases         | ✓      |        |
| test_runner_mode_split_op_extend_cases            | ✓      | 5.8s   |

---

### Kernel-Level Correctness

| Precision | Max Diff       | Mean Diff      | Status |
|-----------|---------------|---------------|--------|
| fp32      | 0.000000e+00  | 0.000000e+00  | PASS   |
| bf16      | 1.862645e-04  | 9.756498e-06  | PASS   |

**Intermediate State Comparison (fp32)**: All steps and requests match exactly.  
**SSM State In-Place Change**: `0.000000e+00` (PASS).

---

### E2E Server Test (Kimi-Linear-48B-A3B-Instruct, TP=2, extra_buffer)

| Test Type        | Result | Notes               |
|------------------|--------|---------------------|
| Normal inference | OK     | Correct generation  |
| Cached tokens    | 64     |                     |
| Batch test       | OK     | 8 requests passed   |




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30141026299](https://github.com/sgl-project/sglang/actions/runs/30141026299)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30141026082](https://github.com/sgl-project/sglang/actions/runs/30141026082)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->