### PR TITLE
sampling: speed up get_max_seq_length() (1.2x-9.3x on per-request stop_regex bound calc)

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -220,39 +220,57 @@ def get_max_seq_length(regex_str: str):
 
 MAX_LEN = 2**30
 
+# Hoist token-kind sets and other ``sre_parse`` constants out of the inner loop:
+# the original ``token in {sre_parse.LITERAL, ...}`` literal rebuilt the set on
+# every iteration because its members are attribute lookups, not compile-time
+# constants. Hoisting them makes the membership test a single C-level hash
+# lookup against a pre-built ``frozenset``.
+#
+# ``LITERAL``    -- ``value`` is any one character
+# ``IN``         -- Any character within ``value``
+# ``ANY``        -- "."
+_SINGLE_CHAR_TOKENS = frozenset({sre_parse.LITERAL, sre_parse.IN, sre_parse.ANY})
+_REPEAT_TOKENS = frozenset({sre_parse.MAX_REPEAT, sre_parse.MIN_REPEAT})
+_SUBPATTERN_TOKEN = sre_parse.SUBPATTERN
+_BRANCH_TOKEN = sre_parse.BRANCH
+_AT_TOKEN = sre_parse.AT
+_MAXREPEAT = sre_parse.MAXREPEAT
+
 
 def _max_length_from_subpattern(subpattern: sre_parse.SubPattern):
     total = 0
     for token, value in subpattern:
-        if token in {
-            sre_parse.LITERAL,  # `value` is any one character
-            sre_parse.IN,  # Any character within `value`
-            sre_parse.ANY,  # "."
-        }:
+        if token in _SINGLE_CHAR_TOKENS:
             total += 1
-        elif token == sre_parse.SUBPATTERN:
+        elif token == _SUBPATTERN_TOKEN:
             # EG: (a\d+) ->
             # [(SUBPATTERN,
             #   (1, 0, 0, [(LITERAL, 97),
             #              (MAX_REPEAT, (1, MAXREPEAT, [(IN, [(CATEGORY, CATEGORY_DIGIT)])]))]))]
             _, _, _, inner_subpattern = value
             total += _max_length_from_subpattern(inner_subpattern)
-        elif token == sre_parse.BRANCH:
+        elif token == _BRANCH_TOKEN:
             _, branches = value
             total += max(_max_length_from_subpattern(branch) for branch in branches)
-        elif token in {sre_parse.MAX_REPEAT, sre_parse.MIN_REPEAT}:
+        elif token in _REPEAT_TOKENS:
             _, max_num_repeat, inner_subpattern = value
-            if max_num_repeat == sre_parse.MAXREPEAT:
-                total += MAX_LEN
-            else:
-                total += max_num_repeat * _max_length_from_subpattern(inner_subpattern)
-        elif token == sre_parse.AT:
-            # These are zero-width assertions like ^, $, and \b that don't add to the max
-            # length
-            total += 0
+            if max_num_repeat == _MAXREPEAT:
+                # Unbounded repeat saturates the upper bound; nothing else in
+                # the pattern can lower it below ``MAX_LEN``.
+                return MAX_LEN
+            total += max_num_repeat * _max_length_from_subpattern(inner_subpattern)
+        elif token == _AT_TOKEN:
+            # Zero-width assertions like ^, $, and \b that don't add to the max
+            # length.
+            continue
         else:
             logger.warning(f"Got unhandled regex token: {token}")
+            return MAX_LEN
 
-            total += MAX_LEN
+        # Once the bound has saturated, further additions can't change the
+        # downstream behaviour (callers compare against ``MAX_LEN`` and use
+        # the result as a buffer size capped by ``len(output_ids)``).
+        if total >= MAX_LEN:
+            return MAX_LEN
 
     return total

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -407,6 +407,21 @@ class TestRegexMaxLength(CustomTestCase):
         result = get_max_seq_length("(?<=x)y")
         self.assertGreaterEqual(result, MAX_LEN)
 
+    def test_unbounded_repeat_short_circuits_at_max_len(self):
+        """Test that an unbounded repeat early-exits at MAX_LEN even when
+        followed by additional contributing terms (the saturated bound is the
+        only thing callers care about)."""
+        # 'a*b{5}' would have summed to ``MAX_LEN + 5`` with the previous
+        # implementation. Saturating at ``MAX_LEN`` is consistent with how the
+        # value is consumed downstream (see ``Req.get_tail_decoded_str``).
+        self.assertEqual(get_max_seq_length("a*b{5}"), MAX_LEN)
+
+    def test_long_literal_does_not_overflow(self):
+        """Test that a long literal sequence accumulates correctly without
+        triggering the saturation guard prematurely."""
+        # 1024 characters is well below ``MAX_LEN`` (=2**30).
+        self.assertEqual(get_max_seq_length("a" * 1024), 1024)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`SamplingParams.normalize` calls `get_max_seq_length(stop_regex)` once per `stop_regex` per request, so `_max_length_from_subpattern` sits on the per-request critical path of the tokenizer / scheduler hot loop. Three Python-level micro-pessimizations on that loop add up:

1. **The set literals were rebuilt every iteration.** `if token in {sre_parse.LITERAL, sre_parse.IN, sre_parse.ANY}` looks like a compile-time literal but isn't — its members are attribute lookups, not constants. CPython emits `LOAD_GLOBAL sre_parse` / `LOAD_ATTR LITERAL` / … / `BUILD_SET` on every iteration (verified by `dis`).
2. **`sre_parse.MAXREPEAT` was looked up by attribute access** every time we hit a `MAX_REPEAT` / `MIN_REPEAT` token.
3. **Saturated bounds kept walking the rest of the AST.** Once the upper bound hits `MAX_LEN` (e.g. an `a*` was seen), nothing else in the pattern can change downstream behavior — the only consumer is `Req.get_tail_decoded_str`, which clips the value with `min(max_len_tail_str, len(self.output_ids))`. Yet the loop continued.

This PR fixes all three.

## Modifications

`python/sglang/srt/sampling/sampling_params.py`:

- Hoist `{sre_parse.LITERAL, sre_parse.IN, sre_parse.ANY}` and `{sre_parse.MAX_REPEAT, sre_parse.MIN_REPEAT}` into module-level `frozenset`s, plus cache `sre_parse.MAXREPEAT/SUBPATTERN/BRANCH/AT` as module-level constants.
- Early-exit when `total >= MAX_LEN` (or when an unbounded repeat / unhandled token is hit) — the function's contract is a strict upper bound, and `MAX_LEN` saturation is observationally indistinguishable from any larger value at the only call site.
- Style-preserving: existing comments retained and refactored to point at the new structure; no new dependencies; behavior is preserved against all four existing tests that exercise the saturated path (they only assert `>= MAX_LEN`).

`test/registered/unit/sampling/test_sampling_params.py`:

- Add `test_unbounded_repeat_short_circuits_at_max_len` — pins down that saturated bounds equal `MAX_LEN` exactly.
- Add `test_long_literal_does_not_overflow` — guards against the saturation guard firing prematurely on long bounded patterns.

```
 python/sglang/srt/sampling/sampling_params.py        | 52 +++++++++++++++-------
 test/registered/unit/sampling/test_sampling_params.py | 15 +++++++
 2 files changed, 50 insertions(+), 17 deletions(-)
```

## Accuracy Tests

Not applicable — this PR does not touch model forward code, kernels, or any output-producing path. It only adjusts a CPU-side regex-AST upper-bound calculator. The function's return value enters generation only as a buffer-size cap that is itself further clipped by `len(output_ids)` at the call site (`Req.get_tail_decoded_str`); for any input where `_max_length_from_subpattern` previously returned a value `>= MAX_LEN`, the post-clip behavior is identical.

## Speed Tests and Profiling

Bench environment: Python 3.12 (uv-managed venv), macOS arm64, M-series CPU. The function is called from `SamplingParams.normalize`, which runs in pure Python — no GPU is involved.

Microbenchmark (100 000 calls each, `timeit`):

| Pattern                          | Old (s) | New (s) | Speedup |
|----------------------------------|---------|---------|---------|
| plain literal stop               | 0.188   | 0.156   | 1.20×   |
| chat-template stops (3 alts)     | 0.390   | 0.302   | 1.29×   |
| classes + groups                 | 0.325   | 0.195   | 1.66×   |
| 64-char literal                  | 0.619   | 0.450   | 1.38×   |
| `a*b{1000}c{1000}` (saturate)    | 0.137   | 0.015   | 9.27×   |

Bench script (reproducible):

```python
import timeit
import re._parser as sre_parse
from sglang.srt.sampling.sampling_params import _max_length_from_subpattern as new

# original implementation captured before this PR for comparison
MAX_LEN = 2**30
def old(sp):
    total = 0
    for token, value in sp:
        if token in {sre_parse.LITERAL, sre_parse.IN, sre_parse.ANY}:
            total += 1
        elif token == sre_parse.SUBPATTERN:
            _, _, _, inner = value
            total += old(inner)
        elif token == sre_parse.BRANCH:
            _, branches = value
            total += max(old(b) for b in branches)
        elif token in {sre_parse.MAX_REPEAT, sre_parse.MIN_REPEAT}:
            _, n, inner = value
            total += MAX_LEN if n == sre_parse.MAXREPEAT else n * old(inner)
        elif token == sre_parse.AT:
            total += 0
        else:
            total += MAX_LEN
    return total

for label, p in [
    ('plain literal stop', '<|im_end|>'),
    ('chat-template stops', r'<\|im_end\|>|<\|endoftext\|>|<\|eot_id\|>'),
    ('classes + groups', r'\b(?:end|stop|halt)\b\s*[.!?]?'),
    ('64-char literal', 'A' * 64),
    ('saturate', 'a*b{1000}c{1000}'),
]:
    parsed = sre_parse.parse(p)
    a = timeit.timeit(lambda: old(parsed), number=100_000)
    b = timeit.timeit(lambda: new(parsed), number=100_000)
    print(f'{label}: {a:.3f}s -> {b:.3f}s ({a/b:.2f}x)')
```

## Test results

```
$ source .venv/bin/activate
$ PYTHONPATH=python python -m pytest test/registered/unit/sampling/test_sampling_params.py -v
======================== 68 passed, 3 warnings in 9.81s ========================
```

68 tests pass — the original 66 plus the 2 new tests added here.

Style/lint (`pre-commit run --files <changed files>`): every content hook (`isort`, `ruff`, `black-jupyter`, `codespell`, `check-ast`, `check registered tests have CI registry`) passes.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation: docstring/comments updated in place; no user-facing behavior change.
- [x] Provide speed benchmark results (above). No accuracy benchmark needed (CPU bound calculator, not on the inference math path).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26738537497](https://github.com/sgl-project/sglang/actions/runs/26738537497)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26738537392](https://github.com/sgl-project/sglang/actions/runs/26738537392)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->