### PR TITLE
[AMD] Fuse compress norm+rope+hadamard into single Triton kernel

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -100,6 +100,7 @@ class CompressorBackendMixin:
 
             from sglang.srt.layers.attention.dsv4.fused_compress_triton import (
                 hip_compress_forward,
+                hip_compress_fused_norm_rope_hadamard_inplace,
                 hip_compress_fused_norm_rope_inplace,
             )
 
@@ -116,14 +117,24 @@ class CompressorBackendMixin:
             norm_eps = (
                 norm.variance_epsilon if hasattr(norm, "variance_epsilon") else norm.eps
             )
-            hip_compress_fused_norm_rope_inplace(
-                kv_compressed,
-                norm.weight,
-                norm_eps,
-                freqs_cis_cache,
-                plan,
-            )
-            return rotate_activation(kv_compressed) if rotate else kv_compressed
+            if rotate:
+                hip_compress_fused_norm_rope_hadamard_inplace(
+                    kv_compressed,
+                    norm.weight,
+                    norm_eps,
+                    freqs_cis_cache,
+                    plan,
+                    head_dim,
+                )
+            else:
+                hip_compress_fused_norm_rope_inplace(
+                    kv_compressed,
+                    norm.weight,
+                    norm_eps,
+                    freqs_cis_cache,
+                    plan,
+                )
+            return kv_compressed
 
         kv_compressed = compress_forward(
             kv_score_buffer=kv_score_buffer,

--- a/python/sglang/srt/layers/attention/dsv4/fused_compress_triton.py
+++ b/python/sglang/srt/layers/attention/dsv4/fused_compress_triton.py
@@ -805,18 +805,21 @@ def _compress_norm_rope_hadamard_kernel(
     tl.store(kv_ptr + base + rope_start + 2 * pair_offs, out_real, mask=pair_mask)
     tl.store(kv_ptr + base + rope_start + 2 * pair_offs + 1, out_imag, mask=pair_mask)
 
-    # Walsh-Hadamard butterfly transform via store-reload through L1 cache
+    # Walsh-Hadamard butterfly transform via store-reload through L1 cache.
+    # Barriers are required because multiple warps share the same row in memory;
+    # without them a fast warp can overwrite a partner value before a slow warp reads it.
     for stage in tl.static_range(LOG2_HEAD_DIM):
         stride = 1 << stage
         is_even = ((offs >> stage) & 1) == 0
         partner = tl.where(is_even, offs + stride, offs - stride)
+        tl.debug_barrier()
         x_self = tl.load(kv_ptr + base + offs, mask=mask)
         x_partner = tl.load(kv_ptr + base + partner, mask=mask)
         result = tl.where(is_even, x_self + x_partner, x_partner - x_self)
+        if stage == LOG2_HEAD_DIM - 1:
+            result = result * hadamard_scale
+        tl.debug_barrier()
         tl.store(kv_ptr + base + offs, result, mask=mask)
-
-    x_final = tl.load(kv_ptr + base + offs, mask=mask) * hadamard_scale
-    tl.store(kv_ptr + base + offs, x_final, mask=mask)
 
 
 def _plan_as_i32(plan: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/layers/attention/dsv4/fused_compress_triton.py
+++ b/python/sglang/srt/layers/attention/dsv4/fused_compress_triton.py
@@ -723,6 +723,102 @@ def _compress_norm_rope_kernel(
     tl.store(kv_ptr + base + rope_start + 2 * pair_offs + 1, out_imag, mask=pair_mask)
 
 
+@triton.jit
+def _compress_norm_rope_hadamard_kernel(
+    kv_ptr,
+    weight_ptr,
+    freqs_ptr,
+    handle_ptr,
+    eps,
+    hadamard_scale,
+    kv_row_stride,
+    freqs_row_stride,
+    plan_row_stride,
+    HEAD_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    ROPE_PAIR_BLOCK: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    IS_DECODE: tl.constexpr,
+    LOG2_HEAD_DIM: tl.constexpr,
+):
+    work_id = tl.program_id(0)
+
+    if IS_DECODE:
+        row = work_id
+        seq_len = tl.load(handle_ptr + work_id).to(tl.int32)
+        position = ((seq_len - 1) // COMPRESS_RATIO) * COMPRESS_RATIO
+    else:
+        plan_base = handle_ptr + work_id * plan_row_stride
+        row = tl.load(plan_base + 0).to(tl.int32)
+        plan_position = tl.load(plan_base + 2).to(tl.int32)
+        if row < 0:
+            return
+        position = plan_position + 1 - COMPRESS_RATIO
+
+    base = row.to(tl.int64) * kv_row_stride
+    offs = tl.arange(0, HEAD_BLOCK)
+    mask = offs < HEAD_DIM
+    x = tl.load(kv_ptr + base + offs, mask=mask, other=0.0).to(tl.float32)
+    w = tl.load(weight_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    rms_inv = tl.rsqrt(tl.sum(x * x, axis=0) / HEAD_DIM + eps)
+    x_normed = x * rms_inv * w
+
+    rope_start: tl.constexpr = HEAD_DIM - ROPE_DIM
+    pair_offs = tl.arange(0, ROPE_PAIR_BLOCK)
+    pair_mask = pair_offs < (ROPE_DIM // 2)
+    x_real = tl.load(
+        kv_ptr + base + rope_start + 2 * pair_offs,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+    x_imag = tl.load(
+        kv_ptr + base + rope_start + 2 * pair_offs + 1,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+    w_real = tl.load(
+        weight_ptr + rope_start + 2 * pair_offs,
+        mask=pair_mask,
+        other=1.0,
+    ).to(tl.float32)
+    w_imag = tl.load(
+        weight_ptr + rope_start + 2 * pair_offs + 1,
+        mask=pair_mask,
+        other=1.0,
+    ).to(tl.float32)
+    x_real = x_real * rms_inv * w_real
+    x_imag = x_imag * rms_inv * w_imag
+
+    freq_base = position.to(tl.int64) * freqs_row_stride
+    f_real = tl.load(freqs_ptr + freq_base + 2 * pair_offs, mask=pair_mask, other=0.0)
+    f_imag = tl.load(
+        freqs_ptr + freq_base + 2 * pair_offs + 1,
+        mask=pair_mask,
+        other=0.0,
+    )
+    out_real = x_real * f_real - x_imag * f_imag
+    out_imag = x_real * f_imag + x_imag * f_real
+
+    # Store norm+rope result to kv_ptr (will be used for butterfly stages)
+    tl.store(kv_ptr + base + offs, x_normed, mask=mask & (offs < rope_start))
+    tl.store(kv_ptr + base + rope_start + 2 * pair_offs, out_real, mask=pair_mask)
+    tl.store(kv_ptr + base + rope_start + 2 * pair_offs + 1, out_imag, mask=pair_mask)
+
+    # Walsh-Hadamard butterfly transform via store-reload through L1 cache
+    for stage in tl.static_range(LOG2_HEAD_DIM):
+        stride = 1 << stage
+        is_even = ((offs >> stage) & 1) == 0
+        partner = tl.where(is_even, offs + stride, offs - stride)
+        x_self = tl.load(kv_ptr + base + offs, mask=mask)
+        x_partner = tl.load(kv_ptr + base + partner, mask=mask)
+        result = tl.where(is_even, x_self + x_partner, x_partner - x_self)
+        tl.store(kv_ptr + base + offs, result, mask=mask)
+
+    x_final = tl.load(kv_ptr + base + offs, mask=mask) * hadamard_scale
+    tl.store(kv_ptr + base + offs, x_final, mask=mask)
+
+
 def _plan_as_i32(plan: torch.Tensor) -> torch.Tensor:
     assert plan.dtype == torch.uint8 and plan.dim() == 2 and plan.shape[1] == 16
     return plan.view(torch.int32).view(-1, 4)
@@ -951,4 +1047,56 @@ def hip_compress_fused_norm_rope_inplace(
         ROPE_PAIR_BLOCK=ROPE_PAIR_BLOCK,
         COMPRESS_RATIO=plan.compress_ratio,
         IS_DECODE=is_decode,
+    )
+
+
+def hip_compress_fused_norm_rope_hadamard_inplace(
+    kv: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    freqs_cis: torch.Tensor,
+    plan: Union[CompressorDecodePlan, CompressorPrefillPlan],
+    head_dim: int,
+) -> None:
+    assert kv.dim() == 2 and kv.stride(-1) == 1
+    assert weight.shape == (kv.shape[1],)
+    assert kv.shape[1] == head_dim
+    freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
+    rope_dim = freqs_real.shape[-1]
+    assert head_dim >= rope_dim and rope_dim % 2 == 0
+    assert (head_dim & (head_dim - 1)) == 0, "head_dim must be power of 2"
+
+    is_decode = _is_decode_plan(plan)
+    if is_decode:
+        handle = plan.seq_lens
+    else:
+        handle = _plan_as_i32(plan.compress_plan)
+
+    if handle.numel() == 0:
+        return
+
+    import math
+
+    log2_head_dim = int(math.log2(head_dim))
+    hadamard_scale = head_dim**-0.5
+
+    HEAD_BLOCK = triton.next_power_of_2(head_dim)
+    ROPE_PAIR_BLOCK = max(triton.next_power_of_2(rope_dim // 2), 1)
+    _compress_norm_rope_hadamard_kernel[(handle.shape[0],)](
+        kv,
+        weight,
+        freqs_real,
+        handle,
+        eps,
+        hadamard_scale,
+        kv.stride(0),
+        freqs_real.stride(0),
+        handle.stride(0) if not is_decode else 0,
+        HEAD_DIM=head_dim,
+        ROPE_DIM=rope_dim,
+        HEAD_BLOCK=HEAD_BLOCK,
+        ROPE_PAIR_BLOCK=ROPE_PAIR_BLOCK,
+        COMPRESS_RATIO=plan.compress_ratio,
+        IS_DECODE=is_decode,
+        LOG2_HEAD_DIM=log2_head_dim,
     )


### PR DESCRIPTION
## Motivation

In the DSV4 compressor decode path on MI355, the post-compression pipeline runs two separate kernels back-to-back on the same `kv_compressed` tensor `[num_tokens, 512]`:

1. `_compress_norm_rope_kernel` (RMSNorm + RoPE) -- ~4.0 us
2. `fast_hadamard_transform_kernel` (Hadamard rotation) -- ~4.1 us

Since both operate on the same data and the full head_dim (512) fits in registers, fusing them eliminates one kernel launch and one global memory round-trip.

This fusion fires for every C4 compressor call with `rotate=True` (C-type layers have 2 such calls, A-type layers have 1). The C128 compressor has `rotate=False` and is unaffected.

## Modifications

- **`python/sglang/srt/layers/attention/compressed/fused_compress_triton.py`**:
  - Added `_compress_norm_rope_hadamard_kernel`: Triton kernel that performs RMSNorm + RoPE + Walsh-Hadamard butterfly transform (9 stages for dim=512) in a single kernel launch. The butterfly uses a store-reload pattern through L1 cache (2KB per row).
  - Added `hip_compress_fused_norm_rope_hadamard_inplace()`: Python wrapper that launches the fused kernel with the hadamard scale factor (`head_dim^-0.5`).

- **`python/sglang/srt/layers/attention/compressed/compressor.py`**:
  - When `rotate=True` (C4 compressor), dispatch to the new fused `hip_compress_fused_norm_rope_hadamard_inplace()` instead of separate `hip_compress_fused_norm_rope_inplace()` + `rotate_activation()`.
  - When `rotate=False` (C128 compressor), unchanged -- still uses `hip_compress_fused_norm_rope_inplace()`.

## Accuracy Tests

| Benchmark | Score | Threshold | Status |
|-----------|-------|-----------|--------|
| GSM8K (2000 questions, 5-shot, parallel=1000) | 0.950 | 0.94 | PASS |

## Benchmarking and Profiling

### Kernel Replacement (C-type layer, decode)

| Before | Time (us) | After | Time (us) |
|--------|-----------|-------|-----------|
| `_compress_norm_rope_kernel` (×2) | 8.3 | `_compress_norm_rope_hadamard_kernel` (×1) | 4.1 |
| `fast_hadamard_transform_kernel` (×2) | 8.3 | *(eliminated)* | -- |
| **Total** | **16.6** | `_compress_norm_rope_kernel` (×1, C128 rotate=False) | 4.0 |
| | | **Total** | **8.1** |

### Kernel-to-E2E Impact Analysis

| Layer Type | Layers/iter | Kernel Savings/Layer | Total Savings |
|------------|-------------|---------------------|---------------|
| C-type (MLA+Compressor+MoE) | 30 | 6.3 us | 189 us |
| A-type (MLA+Dense) | 61 | 0 us | 0 us |
| B-type (MoE) | 30 | 0 us | 0 us |
| **Total** | | | **189 us** |

Expected ITL improvement: 189 us / 20,570 us = **0.92%** (~0.19 ms). This is within typical run-to-run benchmark noise (1-2%), so the improvement is real at the kernel level but not distinguishable in e2e benchmarks at this precision.

TTFT impact: Negligible — prefill is dominated by large GEMMs; compressor norm+rope+hadamard is a tiny fraction.

### End-to-End Benchmark (il8k_ol1k, concurrency=4, 32 prompts)

| Metric | Baseline | After | Delta |
|--------|----------|-------|-------|
| Total throughput (tok/s) | 1,560.0 | 1,583.5 | +1.5% |
| Output throughput (tok/s) | 173.3 | 175.9 | +1.5% |
| Median E2E Latency (ms) | 23,080.4 | 23,078.8 | -0.0% |
| Median TTFT (ms) | 1,542.7 | 1,542.0 | -0.0% |
| Median ITL (ms) | 20.57 | 20.56 | -0.0% |
| Median TPOT (ms) | 21.51 | 21.10 | -1.9% |

### Configuration

- Model: DeepSeek-V4-Pro, TP=8, MI355
- Attention backend: compressed
- Page size: 256, chunked prefill: 8192

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.












































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26739113021](https://github.com/sgl-project/sglang/actions/runs/26739113021)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26739125967](https://github.com/sgl-project/sglang/actions/runs/26739125967)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->