### PR TITLE
[AMD] Fix stage-b-test-large-8-gpu-mi35x-disaggregation-amd

### DIFF
--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -218,7 +218,7 @@ else
 fi
 
 # CACHE_HOST=/home/runner/sgl-data
-CACHE_HOST=/home/runner/sglang-data
+CACHE_HOST=/home/runner/temp-sglang-data
 if [[ -d "$CACHE_HOST" ]]; then
     CACHE_VOLUME="-v $CACHE_HOST:/sgl-data"
 else


### PR DESCRIPTION
## Motivation

The AMD PR-test job `stage-a-test-1-gpu-small-amd` fails with exit code 255 because the persistent CI cache volume is full. `test_basic_sanity_eagle3.py` crashes during `setUpClass` when the scheduler tries to download model weights:

```
OSError: [Errno 28] No space left on device:
  '/sgl-data/hf-cache/hub/.sglang_locks/download_ad753ee3601c0a7f.lock'
[...] Received sigquit from a child process. It usually means the child failed.
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26742266535](https://github.com/sgl-project/sglang/actions/runs/26742266535)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26742266413](https://github.com/sgl-project/sglang/actions/runs/26742266413)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->