### PR TITLE
fix(state_capturer): include num_tokens in device buffer size to prev…

### DIFF
--- a/python/sglang/srt/state_capturer/routed_experts.py
+++ b/python/sglang/srt/state_capturer/routed_experts.py
@@ -67,7 +67,7 @@ class RoutedExpertsCapturer(BaseTopkCapturer):
         max_batch_size = max(
             server_args.chunked_prefill_size * server_args.dp_size,
             max_running_requests * server_args.dp_size,
-            num_tokens,
+            num_tokens * server_args.dp_size,
         )
 
         super().__init__(

--- a/python/sglang/srt/state_capturer/routed_experts.py
+++ b/python/sglang/srt/state_capturer/routed_experts.py
@@ -67,6 +67,7 @@ class RoutedExpertsCapturer(BaseTopkCapturer):
         max_batch_size = max(
             server_args.chunked_prefill_size * server_args.dp_size,
             max_running_requests * server_args.dp_size,
+            num_tokens,
         )
 
         super().__init__(


### PR DESCRIPTION
## Motivation

Fixes #26860

When using `return_routed_experts=True` with long unchunked prefill sequences on MoE models (e.g., Qwen3-30B-A3B), the device cache buffer allocated by `RoutedExpertsCapturer` can be smaller than the actual token count in a forward pass. This causes a tensor assignment crash in `BaseDeviceCache.capture()` with error "The expanded size of the tensor (2048) must match the existing size (8192)".

## Modifications

**`python/sglang/srt/state_capturer/routed_experts.py`**
- Added `num_tokens` as a third lower bound in the `max_batch_size` calculation, ensuring the device cache buffer is large enough to hold the full token sequence during unchunked prefill.

The fix is a single-line addition:
```python
max_batch_size = max(
    server_args.chunked_prefill_size * server_args.dp_size,
    max_running_requests * server_args.dp_size,
    num_tokens,  # NEW: covers long unchunked prefill sequences
)
```

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process
1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26744405841](https://github.com/sgl-project/sglang/actions/runs/26744405841)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26744405330](https://github.com/sgl-project/sglang/actions/runs/26744405330)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->