### PR TITLE
Change SGLANG_SORT_WEIGHT_FILES semantics, promote it to int, and default it to 0

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -163,7 +163,9 @@ class TextEncoderLoader(ComponentLoader):
                 f"Cannot find any model weights with `{model_name_or_path}`"
             )
 
-        if envs.SGLANG_SORT_WEIGHT_FILES.get():
+        # Sort weight files when SGLANG_SORT_WEIGHT_FILES >= 0 (default).
+        # Staggering is not applicable to text-encoder loading (no TP split).
+        if envs.SGLANG_SORT_WEIGHT_FILES.get() >= 0:
             hf_weights_files.sort()
 
         return hf_folder, hf_weights_files, use_safetensors

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -196,7 +196,14 @@ class Envs:
 
     # Model & File Download
     SGLANG_USE_MODELSCOPE = EnvBool(False)
-    SGLANG_SORT_WEIGHT_FILES = EnvBool(False)
+    # Controls weight-file ordering for load-time I/O optimization.
+    #   -1 : no sorting, no staggering; preserves original file order.
+    #    0 : sort files only; maximizes ordering but may reduce cross-rank I/O concurrency.
+    #   k>0: sort files and stagger per-rank order with factor k.
+    #        Files are processed in groups of (tp_size * k), and rank r starts each
+    #        group at offset (r * k), improving multi-rank I/O concurrency while
+    #        keeping access relatively ordered.
+    SGLANG_SORT_WEIGHT_FILES = EnvInt(0)
     SGLANG_DISABLED_MODEL_ARCHS = EnvTuple(tuple())
     SGLANG_PREFETCH_BLOCK_SIZE_MB = EnvInt(16)
     SGLANG_GEMMA_OUT_OF_PLACE_POSITION_MUTATION = EnvBool(False)

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -494,8 +494,24 @@ class DefaultModelLoader(BaseModelLoader):
                 f"Cannot find any model weights with `{model_name_or_path}`"
             )
 
-        if envs.SGLANG_SORT_WEIGHT_FILES.get():
+        # Sort and optionally stagger weight files (see SGLANG_SORT_WEIGHT_FILES).
+        # k=-1: no sort; k=0: sort only; k>0: sort + stagger by (tp_rank*k).
+        k = envs.SGLANG_SORT_WEIGHT_FILES.get()
+        if k >= 0:
             hf_weights_files.sort()
+            if k > 0:
+                tp_size = get_tensor_model_parallel_world_size()
+                if tp_size > 1:
+                    tp_rank = get_tensor_model_parallel_rank()
+                    group_size = tp_size * k
+                    staggered: List[str] = []
+                    for i in range(0, len(hf_weights_files), group_size):
+                        group = hf_weights_files[i : i + group_size]
+                        n = len(group)
+                        staggered.extend(
+                            group[(j + tp_rank * k) % n] for j in range(n)
+                        )
+                    hf_weights_files = staggered
 
         return hf_folder, hf_weights_files, use_safetensors
 

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -913,13 +913,11 @@ def safetensors_weights_iterator(
         not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
     )
 
-    sorted_files = sorted(hf_weights_files)
-
     if prefetch and not disable_mmap:
-        _prefetch_all_checkpoints(sorted_files, num_threads=prefetch_num_threads)
+        _prefetch_all_checkpoints(sorted(hf_weights_files), num_threads=prefetch_num_threads)
 
     for st_file in tqdm(
-        sorted_files,
+        hf_weights_files,
         desc="Loading safetensors checkpoint shards",
         disable=not enable_tqdm,
         bar_format=BAR_FORMAT,
@@ -1051,9 +1049,8 @@ def buffered_multi_thread_safetensors_weights_iterator(
     max_workers loading concurrently + 1 prefetched and ready to yield.
     Peak CPU RAM ≈ (max_workers + 2) × shard_file_size.
     """
-    sorted_files = sorted(hf_weights_files)
     if prefetch and not disable_mmap:
-        _prefetch_all_checkpoints(sorted_files, num_threads=prefetch_num_threads)
+        _prefetch_all_checkpoints(sorted(hf_weights_files), num_threads=prefetch_num_threads)
     enable_tqdm = (
         not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
     )
@@ -1071,7 +1068,7 @@ def buffered_multi_thread_safetensors_weights_iterator(
     buffer_size = max_workers + 1
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        file_iter = iter(sorted_files)
+        file_iter = iter(hf_weights_files)
         pending: collections.deque = collections.deque()
 
         # Seed the buffer.


### PR DESCRIPTION
SGLANG_SORT_WEIGHT_FILES was introduced in 18cfeab as a boolean env var to control weight-file sorting for more sequential I/O. This commit extends it to an integer-valued setting with optional stagger support.

Commit 04a53955 added _prefetch_all_checkpoints for page-cache warming, but also introduced unconditional sorted(hf_weights_files) calls inside both safetensors_weights_iterator and
buffered_multi_thread_safetensors_weights_iterator. Those internal sorts silently overrode any ordering, including any staggered ordering, already applied by SGLANG_SORT_WEIGHT_FILES.

This commit restores SGLANG_SORT_WEIGHT_FILES as the single, centralized mechanism that controls weight-file ordering.

SGLANG_SORT_WEIGHT_FILES semantics:
  -1 : no sorting, no staggering; preserves the original file order.
       This preserves the original filesystem / glob order, but can be
       overly unordered and may reduce sequential-read locality.

   0 (default):
       sort files only. This gives a fully deterministic and sequential
       order, but under TP>1 all ranks will read the same regions in the
       same order, which can limit effective I/O concurrency in some
       storage setups. This matches the strictly sorted order expected by
       _prefetch_all_checkpoints as introduced in 04a53955, so prefetch
       behavior is unchanged unless SGLANG_SORT_WEIGHT_FILES is explicitly
       set to a non-default value.

  k>0: sort files and stagger per-rank order with factor k.
       Files are processed in groups of (tp_size * k), and rank r starts
       each group at offset (r * k). This improves cross-rank I/O
       concurrency while keeping file access relatively ordered.

       For k>0, files are divided into blocks of (tp_size * k) consecutive
       files. Within each block, each TP rank performs a cyclic rotation
       by (tp_rank * k). As a result, every TP rank still reads all files,
       but each rank starts each block from a different region of the file
       list.

       Example (tp_size=4, 16 files, k=1):
         blocks: [f0 f1 f2 f3] [f4 f5 f6 f7] [f8 f9 f10 f11] [f12 f13 f14 f15]
         rank 0: f0 f1 f2 f3 | f4 f5 f6 f7 | f8 f9 f10 f11 | f12 f13 f14 f15
         rank 1: f1 f2 f3 f0 | f5 f6 f7 f4 | f9 f10 f11 f8 | f13 f14 f15 f12
         rank 2: f2 f3 f0 f1 | f6 f7 f4 f5 | f10 f11 f8 f9 | f14 f15 f12 f13
         rank 3: f3 f0 f1 f2 | f7 f4 f5 f6 | f11 f8 f9 f10 | f15 f12 f13 f14

       Example (tp_size=4, 16 files, k=2):
         blocks: [f0..f7] [f8..f15]
         rank 0: f0 f1 f2 f3 f4 f5 f6 f7 | f8 f9 f10 f11 f12 f13 f14 f15
         rank 1: f2 f3 f4 f5 f6 f7 f0 f1 | f10 f11 f12 f13 f14 f15 f8 f9
         rank 2: f4 f5 f6 f7 f0 f1 f2 f3 | f12 f13 f14 f15 f8 f9 f10 f11
         rank 3: f6 f7 f0 f1 f2 f3 f4 f5 | f14 f15 f8 f9 f10 f11 f12 f13

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

# Motivation

## Problem 1: Sorting behavior is hardcoded inside iterators

Commit 04a53955 added `sorted(hf_weights_files)` unconditionally inside
`safetensors_weights_iterator` and
`buffered_multi_thread_safetensors_weights_iterator`. This has two issues:

1. **Silent behavior change**: `SGLANG_SORT_WEIGHT_FILES` (introduced in 18cfeab)
   was already the designated mechanism to control weight-file ordering. The
   internal `sorted()` calls silently override whatever ordering the caller
   established, making the env var partially ineffective.

2. **Inconsistent coverage**: The `sorted()` calls were added to only 2 of the 6
   loading paths (safetensors, buffered-multi-thread-safetensors). The other
   paths (NPCACHE, FASTSAFETENSORS, PT, text-encoder) had no sorting at all,
   leading to inconsistent behavior across load formats.

## Problem 2: No way to adjust IO concurrency

Under TP>1, all ranks load the same set of weight files with zero concurrency. 

## What this commit does

1. **Centralizes sorting control**: Removes the hardcoded `sorted()` calls from
   the two iterators. Sorting (and staggering) is now applied once in
   `_prepare_weights()` (loader.py), which is the common path for all load
   formats. All loading paths inherit consistent behavior.

2. **Promotes `SGLANG_SORT_WEIGHT_FILES` to int**: Extends the boolean to an
   integer that supports -1 / 0 / k>0 semantics, where k>0 enables stagger.

3. **Defaults to 0**: The default (k=0, sort only) preserves existing behavior.
   `_prefetch_all_checkpoints` always receives `sorted(hf_weights_files)` to
   maintain consistent round-robin distribution across ranks, regardless of the
   stagger setting.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

# SGLANG_SORT_WEIGHT_FILES: weight-loading concurrency evaluation

## Test setup

- Scenario: a fresh deployment of 6 SGLang containers
- Model: Qwen/Qwen2.5-72B-Instruct (136 GB safetensors shards)
- TP size: 4
- Storage: a backend that supports prefetch / readahead
- Cache scenarios:
  - **cache-lack (30 GB)**: cache smaller than model weights; most reads go to network IO
  - **cache-enough (180 GB)**: cache can hold the full model; most reads are served from local cache

- `SGLANG_SORT_WEIGHT_FILES` values tested:
  - **k=-1**: no sort, no stagger
  - **k=0** (current default): sort files lexicographically; all ranks read in identical order
  - **k=1**: sort + stagger; each rank rotates file order within each block of `tp_size` files

## Results

| Scenario | k=-1 (random) | k=0 (sort only) | k=1 (sort+stagger) |
|----------|-------:|----------------:|-------------------:|
| cache-enough (180 GB) | 56.14 s | 155.17 s | 114.32 s |
| cache-lack (30 GB) | 240.19 s | 150.86 s | 125.07 s |

### Speedup vs k=0

| Scenario | k=-1 | k=1 |
|----------|-----:|-----:|
| cache-enough (180 GB) | **2.76x** | **1.36x** |
| cache-lack (30 GB) | 0.63x | **1.21x** |

## Analysis

### cache-enough: k=0 is the worst option

When cache can hold the full model, data is served from local cache rather than
network IO. The bottleneck shifts from device throughput to **lacking of 
concurrent**: all TP ranks under k=0 read the same file at the same moment.

k=-1 distributes ranks across different files, eliminating this contention
entirely (2.76x faster than k=0). k=1 provides a more structured alternative:
ranks are staggered so they rarely hit the same file simultaneously, achieving
1.36x over k=0 while preserving mostly-sequential access.

### cache-lack: k=-1 is worst, k=0 is decent, k=1 is better

When cache is far smaller than model weights, most reads must go to network IO.
Under k=-1, each rank shuffles files independently, so ranks read in completely
unrelated order. This causes **prefetch eviction / read amplification**: a page
fetched for one rank is evicted before another rank can use it (because that
other rank is reading a distant file), forcing the same data to be fetched again
from network IO. The result is significant redundant traffic (k=-1 is 1.59x
slower than k=0).

k=0 avoids this by keeping all ranks in identical sorted order — the storage
backend's prefetch / readahead is fully utilized, and fetched pages are shared
across ranks. However k=1 still outperforms k=0 by 1.21x: staggering spreads
IO across files within each small block, allowing the storage device to
interleave requests from different ranks without losing sequential locality,
and without causing the prefetch eviction problem that k=-1 suffers from.

### Why larger k helps: concurrency grows with k

The stagger mechanism divides files into blocks of `tp_size * k`. Within each
block, rank `r` starts reading at offset `r * k`. As k increases:

- Each rank starts further apart within its block → cross-rank IO concurrency
  increases, because ranks are less likely to hit the same file at the same time.
- Block size grows proportionally → each rank still reads files in sorted order
  within its local range, preserving sequential locality for the storage backend.

In the limit, when k is large enough, the per-rank staggering is so wide that
concurrency approaches the fully random (k=-1) case, while still retaining the
sorted foundation. Concretely, for some K, k >= K will match or even exceed
k=-1 performance, because unlike pure random it keeps each rank's access
sequential enough for the storage backend to prefetch effectively.

This is why the parameter is designed as an integer rather than a boolean:
k=0 → k=1 → k=2 → ... is a smooth knob from zero concurrency to maximum
concurrency, letting users tune for their specific storage and cache setup.

### Conclusion

k=0 (sort only) is a reasonable safe default. k=1 (sort + stagger) consistently outperforms k=0 — by 36% with
cache-enough and by 21% with cache-lack. Larger k values further increase
concurrency; for some K, k >= K can match or exceed k=-1 (random) while still
preserving sorted-order benefits. This makes stagger (k > 0) the preferred
choice for multi-rank loading on storage backends that support prefetch.


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26755789676](https://github.com/sgl-project/sglang/actions/runs/26755789676)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26755789390](https://github.com/sgl-project/sglang/actions/runs/26755789390)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->