### PR TITLE
[Docs] Fix PD thread pool default

### DIFF
--- a/docs/advanced_features/pd_disaggregation.md
+++ b/docs/advanced_features/pd_disaggregation.md
@@ -145,7 +145,7 @@ The `SGLANG_MOONCAKE_CUSTOM_MEM_POOL` environment variable enables the custom me
 #### Prefill Server Configuration
 | Variable | Description | Default |
 |:--------:|:-----------:|:--------:
-| **`SGLANG_DISAGGREGATION_THREAD_POOL_SIZE`** | Controls the total number of worker threads for KVCache transfer operations per TP rank | A dynamic value calculated by `int(0.75 * os.cpu_count()) // 8)`, which is limited to be larger than 4 and less than 12 to ensure efficiency and prevent thread race conditions |
+| **`SGLANG_DISAGGREGATION_THREAD_POOL_SIZE`** | Controls the total number of worker threads for KVCache transfer operations per TP rank | A dynamic value calculated by `min(max(4, int(0.5 * os.cpu_count()) // 8), 12)`, which keeps the thread pool size between 4 and 12 inclusive to ensure efficiency and prevent thread race conditions |
 | **`SGLANG_DISAGGREGATION_QUEUE_SIZE`** | Sets the number of parallel transfer queues. KVCache transfer requests from multiple decode instances will be sharded into these queues so that they can share the threads and the transfer bandwidth at the same time. If it is set to `1`, then we transfer requests one by one according to fcfs strategy | `4` |
 | **`SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT`** | Timeout (seconds) for receiving destination KV indices during request initialization | `300` |
 | **`SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL`** | Interval (seconds) between cleanups of bootstrap entries | `120` |


### PR DESCRIPTION
## Motivation

The PD disaggregation documentation currently describes the default value of `SGLANG_DISAGGREGATION_THREAD_POOL_SIZE` as `int(0.75 * os.cpu_count()) // 8`, with bounds described as larger than 4 and less than 12.

However, the Mooncake backend computes the default as `min(max(4, int(0.5 * os.cpu_count()) // 8), 12)`, so the documentation is inconsistent with the implementation.

## Modifications

Update the PD disaggregation documentation to match the Mooncake backend's actual default thread pool size formula.

Also clarify that the effective default is bounded between 4 and 12 inclusive.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26758093780](https://github.com/sgl-project/sglang/actions/runs/26758093780)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26758093739](https://github.com/sgl-project/sglang/actions/runs/26758093739)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->