### PR TITLE
perf: zero-copy RadixKey slicing

### DIFF
--- a/python/sglang/srt/mem_cache/events.py
+++ b/python/sglang/srt/mem_cache/events.py
@@ -62,10 +62,16 @@ class KVCacheEventMixin:
                 if end <= start:
                     continue
                 # Preserve historical event payload: bigram pages expose tuples.
+                # raw is a numpy int64 ndarray; tolist() converts to Python ints
+                # in a single vectorized step (msgspec requires plain int).
                 if is_bigram:
-                    page_tokens = [(raw[j], raw[j + 1]) for j in range(start, end)]
+                    raw_window = raw[start : end + 1].tolist()
+                    page_tokens = [
+                        (raw_window[j - start], raw_window[j + 1 - start])
+                        for j in range(start, end)
+                    ]
                 else:
-                    page_tokens = list(raw[start:end])
+                    page_tokens = raw[start:end].tolist()
 
                 block_hash = hash_str_to_int64(node.hash_value[page_index])
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -30,7 +30,10 @@ from array import array
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
+
+_EMPTY_INT64 = np.empty(0, dtype=np.int64)
 
 logger = logging.getLogger(__name__)
 
@@ -60,11 +63,15 @@ class RadixKey:
 
     def __init__(
         self,
-        token_ids: array[int],
+        token_ids,
         extra_key: Optional[str] = None,
         is_bigram: bool = False,
     ):
-        # token ids sequence (raw ints in both modes)
+        if isinstance(token_ids, np.ndarray):
+            if token_ids.dtype != np.int64:
+                token_ids = token_ids.astype(np.int64)
+        else:
+            token_ids = np.array(token_ids, dtype=np.int64)
         self.token_ids = token_ids
         # extra key (e.g. lora_id, cache_salt)
         self.extra_key = extra_key
@@ -101,7 +108,7 @@ class RadixKey:
         if self.is_bigram:
             # bigrams [start, stop) span raw tokens [start, stop + 1);
             # empty slice -> empty raw tokens (not a dangling boundary token).
-            raw = self.token_ids[start : stop + 1] if stop > start else array("q")
+            raw = self.token_ids[start : stop + 1] if stop > start else _EMPTY_INT64
             return RadixKey(raw, self.extra_key, is_bigram=True)
         return RadixKey(self.token_ids[start:stop], self.extra_key)
 
@@ -135,7 +142,6 @@ class RadixKey:
                 f"{self.extra_key=} != {other.extra_key=}"
             )
 
-    # TODO(Jialin): replace zip with numpy to skip per-element PyLong boxing
     def match(self, other: "RadixKey", page_size: int = 1) -> int:
         """Logical-unit prefix length shared with ``other``. Result is rounded down to ``page_size``."""
         self._check_compatible(other)
@@ -143,29 +149,32 @@ class RadixKey:
 
         if self.is_bigram:
             # Walk raw tokens; L matching tokens imply L-1 matching bigrams.
-            i = 0
-            for a, b in zip(t0, t1):
-                if a != b:
-                    break
-                i += 1
-            matched = max(0, min(i - 1, len(self), len(other)))
+            min_raw = min(len(t0), len(t1))
+            if min_raw == 0:
+                raw_match = 0
+            else:
+                diff = t0[:min_raw] != t1[:min_raw]
+                nz = np.flatnonzero(diff)
+                raw_match = int(nz[0]) if nz.size else min_raw
+            matched = max(0, min(raw_match - 1, len(self), len(other)))
             return (matched // page_size) * page_size if page_size > 1 else matched
 
-        if page_size == 1:
-            i = 0
-            for a, b in zip(t0, t1):
-                if a != b:
-                    break
-                i += 1
-            return i
+        min_len = min(len(t0), len(t1))
+        if min_len == 0:
+            return 0
+        if page_size > 1:
+            aligned = (min_len // page_size) * page_size
+            if aligned == 0:
+                return 0
+            diff = t0[:aligned] != t1[:aligned]
+            nz = np.flatnonzero(diff)
+            if nz.size == 0:
+                return aligned
+            return (int(nz[0]) // page_size) * page_size
 
-        min_len = min(len(self), len(other))
-        i = 0
-        while i < min_len:
-            if t0[i : i + page_size] != t1[i : i + page_size]:
-                break
-            i += page_size
-        return i
+        diff = t0[:min_len] != t1[:min_len]
+        nz = np.flatnonzero(diff)
+        return int(nz[0]) if nz.size else min_len
 
     def child_key(self, page_size: int = 1):
         """Hashable dict-key for the first ``page_size`` logical units, namespaced by ``extra_key``."""
@@ -187,12 +196,21 @@ class RadixKey:
         t = self.token_ids
         if self.is_bigram:
             for j in range(start, end):
-                hasher.update(t[j].to_bytes(4, byteorder="little", signed=False))
-                hasher.update(t[j + 1].to_bytes(4, byteorder="little", signed=False))
+                hasher.update(int(t[j]).to_bytes(4, byteorder="little", signed=False))
+                hasher.update(
+                    int(t[j + 1]).to_bytes(4, byteorder="little", signed=False)
+                )
         else:
             for j in range(start, end):
-                hasher.update(t[j].to_bytes(4, byteorder="little", signed=False))
+                hasher.update(int(t[j]).to_bytes(4, byteorder="little", signed=False))
         return hasher.hexdigest()
+
+    def _materialize(self) -> "RadixKey":
+        """Detach from any parent buffer so a tree node never pins a large
+        request-scoped backing array alive when it only references a window."""
+        if self.token_ids.base is None:
+            return self
+        return RadixKey(self.token_ids.copy(), self.extra_key, self.is_bigram)
 
 
 class TreeNode:
@@ -714,7 +732,8 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         if len(key):
             new_node = TreeNode(priority=priority)
             new_node.parent = node
-            new_node.key = key
+            # Materialize so the new leaf owns its buffer
+            new_node.key = key._materialize()
             new_node.value = value.clone()
             self._inc_hit_count(new_node, chunked)
             node.children[child_key] = new_node

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -24,6 +24,7 @@ import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
+import numpy as np
 import torch
 from numpy import float64
 
@@ -992,7 +993,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             # silently demotes EAGLE/MTP bigram keys → match() returns 0 →
             # _split_node assert.
             node.key = RadixKey(
-                node.key.token_ids + child.key.token_ids,
+                np.concatenate([node.key.token_ids, child.key.token_ids]),
                 node.key.extra_key,
                 is_bigram=node.key.is_bigram,
             )


### PR DESCRIPTION
## Motivation

During tests of chunked prefills of a long context (~1M tokens for DeepSeek-V4-Flash with Context Parallelism on Hopper), `stash_chunked_request` cost up to 50 ms for each chunk. When profiling five chunks towards the end of processing the 1M context, it was seen that up to 6% of the time was spent on cache related operations and up to 4% was spent on a `RadixKey.__get_item__`

Root cause: `token_ids` was stored as `array.array('q')`, where slicing is a full memcpy O(N). When walking the tree in `_insert_helper` / `_match_prefix_helper`, each iteration did `key = key[prefix_len:]`, copying the tail of hundreds of thousands of tokens. 

## Modifications

* `RadixKey.token_ids` now `np.ndarray[int64]`
* `RadixKey.__get_item__` now returns zero-copy view
* `match()` vectorized

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

Profile before:

<img width="1529" height="628" alt="before" src="https://github.com/user-attachments/assets/c7ec5592-5423-49d5-b3b4-f30df31178b5" />

Profile after:

<img width="1529" height="628" alt="after" src="https://github.com/user-attachments/assets/9e2f54eb-30c6-4635-ba24-f070aa51ca94" />

Test setup:

* DeepSeek-V4-Flash on Hopper
* Context Parallelism
* 1M tokens, 16k chunked prefill
* 5 forward steps near the ~950k tokens context

| 1M Prefill         | Before        | After         | delta % |
|--------------------|---------------|---------------|---------|
| Throughput (10x1M) | 24413 tok/sec | 24831 tok/sec | +1.7%   |
| TTFT               | 42795 ms.     | 40937 ms.     | -4.3%   |

Breakdown

| Metric (5 chunks sum)   | Before  | After   | delta % |
|-------------------------|---------|---------|---------|
| `RadixKey.__get_item__` | 208 ms  | 1.54 ms | -99%    |
| `match()`               | 38.6 ms | 16.2 ms | -58%    |
| Cache-related overhead  | ~6.0%   | ~1.5%   | -4.5pp  |

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26762068281](https://github.com/sgl-project/sglang/actions/runs/26762068281)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26762067827](https://github.com/sgl-project/sglang/actions/runs/26762067827)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->