### PR TITLE
[diffusion] Speed up PNG image output saving

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, List, Optional, Sequence, Union
 import imageio
 import numpy as np
 import torch
+from PIL import Image
 
 try:
     import scipy.io.wavfile as scipy_wavfile
@@ -643,11 +644,30 @@ def post_process_sample(
                             indexed_path = f"{parts[0]}_{i}.{parts[1]}"
                         else:
                             indexed_path = f"{save_file_path}_{i}"
-                        imageio.imwrite(indexed_path, image, quality=quality)
+                        _save_image_frame(
+                            indexed_path, image, quality, output_compression
+                        )
                 else:
-                    imageio.imwrite(save_file_path, frames[0], quality=quality)
+                    _save_image_frame(
+                        save_file_path, frames[0], quality, output_compression
+                    )
             logger.info(f"Output saved to {CYAN}{save_file_path}{RESET}")
         else:
             logger.info(f"No output path provided, output not saved")
 
     return frames
+
+
+def _save_image_frame(
+    path: str, frame: np.ndarray, quality: int | None, output_compression: int | None
+) -> None:
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".png":
+        compress_level = 1
+        if output_compression is not None and output_compression != 75:
+            compress_level = max(0, min(9, round(output_compression / 100 * 9)))
+        if frame.ndim == 3 and frame.shape[-1] == 1:
+            frame = frame[..., 0]
+        Image.fromarray(frame).save(path, format="PNG", compress_level=compress_level)
+    else:
+        imageio.imwrite(path, frame, quality=quality)

--- a/python/sglang/multimodal_gen/test/unit/test_output_saving.py
+++ b/python/sglang/multimodal_gen/test/unit/test_output_saving.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+from PIL import Image
+
+import sglang.multimodal_gen.runtime.entrypoints.utils as output_utils
+from sglang.multimodal_gen.configs.sample.sampling_params import DataType
+from sglang.multimodal_gen.runtime.entrypoints.utils import post_process_sample
+
+
+def _rgb_frame() -> np.ndarray:
+    return np.array(
+        [
+            [[0, 32, 255], [64, 128, 192], [255, 224, 16]],
+            [[9, 17, 33], [127, 128, 129], [240, 12, 88]],
+        ],
+        dtype=np.uint8,
+    )
+
+
+@pytest.mark.parametrize("output_compression", [None, 0, 75])
+def test_png_output_saving_preserves_pixels(tmp_path, output_compression):
+    frame = _rgb_frame()
+    output_path = tmp_path / f"sample_{output_compression}.png"
+
+    frames = post_process_sample(
+        frame,
+        DataType.IMAGE,
+        fps=1,
+        save_file_path=str(output_path),
+        output_compression=output_compression,
+    )
+
+    assert output_path.exists()
+    np.testing.assert_array_equal(frames[0], frame)
+    np.testing.assert_array_equal(np.array(Image.open(output_path)), frame)
+
+
+@pytest.mark.parametrize(
+    ("output_compression", "expected_compress_level"), [(None, 1), (0, 0), (75, 1)]
+)
+def test_png_output_saving_uses_fast_pillow_path(
+    tmp_path, monkeypatch, output_compression, expected_compress_level
+):
+    frame = _rgb_frame()
+    output_path = tmp_path / f"sample_{output_compression}.png"
+
+    def fail_imageio_imwrite(*args, **kwargs):
+        raise AssertionError("PNG output should use Pillow's PNG fast path")
+
+    original_save = Image.Image.save
+    save_calls = []
+
+    def save_spy(self, fp, format=None, **params):
+        save_calls.append((format, params.get("compress_level")))
+        return original_save(self, fp, format=format, **params)
+
+    monkeypatch.setattr(output_utils.imageio, "imwrite", fail_imageio_imwrite)
+    monkeypatch.setattr(Image.Image, "save", save_spy)
+
+    post_process_sample(
+        frame,
+        DataType.IMAGE,
+        fps=1,
+        save_file_path=str(output_path),
+        output_compression=output_compression,
+    )
+
+    assert save_calls == [("PNG", expected_compress_level)]


### PR DESCRIPTION
## Summary
- use Pillow for PNG image output saving with a faster default compression level
- keep non-PNG image saving on the existing imageio path
- add a pixel-preservation unit test for PNG output, including default and explicit compression settings

## Why
For PNG image responses, the server currently spends a large part of request tail latency in imageio PNG encoding. PNG is lossless, so using a lower compression level changes encoded bytes and file size, but not decoded pixels.

Measured on H200 with a Cosmos3 Nano 720p T2I stack, torch compile off, cache off, guardrails off, `performance-mode speed`, PNG `b64_json`:

| Variant | Best client | Avg client | Best server inference | Avg client-inference tail |
| --- | ---: | ---: | ---: | ---: |
| baseline imageio PNG | 2.126s | 2.130s | 1.852s | 274ms |
| this PR default PNG | 1.933s | 1.940s | 1.852s | 81ms |
| this PR + `output_compression=0` | 1.912s | 1.918s | 1.851s | 60ms |

A direct 720p RGB PNG encode probe showed imageio/Pillow default compression at about 252ms, Pillow `compress_level=1` at about 59ms, and `compress_level=0` at about 31ms.

## Precision / correctness
- PNG remains lossless; this changes compression level, not pixel values.
- The new unit test writes a deterministic RGB frame through `post_process_sample`, reloads it with Pillow, and checks exact pixel equality.
- Existing consistency tests compare decoded images, so they guard model-output semantics rather than encoded PNG byte identity.

## Validation
- Remote H200: `python3 -m pytest -q python/sglang/multimodal_gen/test/unit/test_output_saving.py` -> `3 passed`

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26765072639](https://github.com/sgl-project/sglang/actions/runs/26765072639)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26765516643](https://github.com/sgl-project/sglang/actions/runs/26765516643)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->