### PR TITLE
chore: add @pyc96 as codeowner for FrozenKVMTP module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,6 +90,6 @@
 /docs_new/src/snippets/autoregressive/gemma4-deployment.jsx @wisclmy0611 @zijiexia @Richardczl98 @kpham-sgl @pyc96
 /python/sglang/srt/speculative/ngram_*.py @hnyls2002 @Qiaolin-Yu @kpham-sgl
 /python/sglang/srt/speculative/cpp_ngram @hnyls2002 @Qiaolin-Yu @kpham-sgl
-/python/sglang/srt/speculative/frozen_kv_mtp_*.py @hnyls2002 @Qiaolin-Yu @kpham-sgl
+/python/sglang/srt/speculative/frozen_kv_mtp_*.py @hnyls2002 @Qiaolin-Yu @kpham-sgl @pyc96
 /python/sglang/jit_kernel/ngram_*.py @hnyls2002 @Qiaolin-Yu @kpham-sgl
 /python/sglang/jit_kernel/csrc/ngram_corpus @hnyls2002 @Qiaolin-Yu @kpham-sgl


### PR DESCRIPTION
## Motivation

Add [@pyc96](https://github.com/pyc96) as a codeowner for the FrozenKVMTP speculative-decoding module so they are auto-requested for review on changes to those files.

## Modifications

- `.github/CODEOWNERS`: add `@pyc96` to the `/python/sglang/srt/speculative/frozen_kv_mtp_*.py` rule (alongside the existing `@hnyls2002 @Qiaolin-Yu @kpham-sgl`).

The `frozen_kv_mtp_*.py` glob covers the module's files: `frozen_kv_mtp_worker.py`, `frozen_kv_mtp_worker_v2.py`, `frozen_kv_mtp_info.py`, `frozen_kv_mtp_utils.py`, `frozen_kv_mtp_cuda_graph_runner.py`.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26772571405](https://github.com/sgl-project/sglang/actions/runs/26772571405)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26772571027](https://github.com/sgl-project/sglang/actions/runs/26772571027)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->