### PR TITLE
[perf][Sampler] avoid fp32 intermediate in RL on-policy logprob

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -151,14 +151,13 @@ class Sampler(nn.Module):
             # In RL on-policy mode, we use log_softmax to compute logprobs to match the trainer.
             logprobs_via_logsoftmax_kernel = None
             if self.rl_on_policy_target is not None:
-                # TODO: use more inplace ops to save memory
-                logits_div_temperature = (
-                    logits.bfloat16().div(sampling_info.temperatures).bfloat16()
+                logprobs_via_logsoftmax_kernel = logits.to(torch.bfloat16, copy=True)
+                logprobs_via_logsoftmax_kernel.div_(sampling_info.temperatures)
+                torch.log_softmax(
+                    logprobs_via_logsoftmax_kernel,
+                    dim=-1,
+                    out=logprobs_via_logsoftmax_kernel,
                 )
-                logprobs_via_logsoftmax_kernel = torch.log_softmax(
-                    logits_div_temperature, dim=-1
-                )
-                del logits_div_temperature
 
             if self.use_ascend_backend:
                 # Ascend backend: sample from logits directly.


### PR DESCRIPTION
## Motivation

Resolves the TODO at `sampler.py:138` introduced in #18915.

> use more inplace ops to save memory

## Modifications

In `python/sglang/srt/layers/sampler.py`, replace the chained-cast form with inplace `.div_()` + `log_softmax(out=)` reusing a single bf16 buffer.

## Accuracy Tests

```python
import torch

def legacy(logits, T):
    return torch.log_softmax(logits.bfloat16().div(T).bfloat16(), dim=-1)

def new(logits, T):
    x = logits.to(torch.bfloat16, copy=True)
    x.div_(T)
    torch.log_softmax(x, dim=-1, out=x)
    return x

device = "cuda"
torch.manual_seed(0)

# baseline shape (large RL rollout vocab)
logits = torch.randn(256, 256_000, dtype=torch.float32, device=device)
T = torch.rand(256, 1, device=device) * 0.7 + 0.5
assert torch.equal(legacy(logits, T), new(logits, T))

# extreme temperatures (near-greedy and high-entropy)
for t_val in (0.01, 10.0):
    T_ext = torch.full((256, 1), t_val, device=device)
    assert torch.equal(legacy(logits, T_ext), new(logits, T_ext))

# extreme logit magnitude (near bf16 representable limit)
big = torch.randn(256, 256_000, device=device) * 200
T_one = torch.ones(256, 1, device=device)
assert torch.equal(legacy(big, T_one), new(big, T_one))

# logit-bias scenario: half vocab masked to -inf
masked = torch.randn(32, 1024, device=device)
masked[:, :512] = float("-inf")
T_mask = torch.ones(32, 1, device=device)
assert torch.equal(legacy(masked, T_mask), new(masked, T_mask))

# bf16 input — verifies `.to(copy=True)` keeps the input intact
bf16_in = torch.randn(32, 152_064, dtype=torch.bfloat16, device=device)
T_bf = torch.rand(32, 1, device=device) * 0.7 + 0.5
orig = bf16_in.clone()
_ = new(bf16_in, T_bf)
assert torch.equal(bf16_in, orig)

print("all passed")
```

Expected: `div_` computes at the promoted (fp32) precision and writes back at `self.dtype` (see PyTorch [test_type_promotion.py::test_inplace](https://github.com/pytorch/pytorch/blob/main/test/test_type_promotion.py)).
Since `.div_()` is in-place, `to(bfloat16, copy=True)` is used to guarantee fresh storage and never alias the `logits`.

Also verified bit-identical on MPS.

## Speed Tests and Profiling

H200. Isolated timing of the RL on-policy block (500 iters + 50 warmup):

| bs  | vocab   | OLD peak  | NEW peak  | save  | OLD time | NEW time | bit-equal |
|-----|---------|-----------|-----------|-------|----------|----------|-----------|
| 32  |  32 000 |   6.1 MB  |   2.0 MB  | -67%  | 0.023 ms | 0.020 ms | ✓         |
| 32  | 152 064 |  29.7 MB  |   9.7 MB  | -67%  | 0.067 ms | 0.057 ms | ✓         |
| 256 | 152 064 | 233.6 MB  |  77.9 MB  | -67%  | 0.372 ms | 0.322 ms | ✓         |
| 256 | 256 000 | 394.3 MB  | 131.1 MB  | -67%  | 0.613 ms | 0.530 ms | ✓         |

End-to-end `Sampler.forward` peak (bs=256, vocab=256K): Gumbel sampling allocates two fp64 [bs, vocab] tensors (~1 GB) that dominate `max_memory_allocated`, so this change does not move the peak;
`max_memory_reserved` drops ~262 MB because the fp32 intermediate is no longer held in the caching allocator.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- Add unit tests according to the Run and add unit tests.
      _No `test/registered/unit/layers/test_sampler.py` exists yet; the script above covers the change._
- Update documentation — N/A.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Follow-up

This PR intentionally keeps the scope limited to the RL logprob path. And the same pattern appears in gumbel noise generation (`hashed.to(torch.float64) / max_uint32`, line 587), this part dominates the peak above. So maybe we can create a follow-up PR to apply the same fix.

Note: under `torch.compile`, Inductor fuses this chain automatically.
The sampler's RL on-policy path is currently in eager mode, so the fix has to be in source.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30372642974](https://github.com/sgl-project/sglang/actions/runs/30372642974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30372642573](https://github.com/sgl-project/sglang/actions/runs/30372642573)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->