### PR TITLE
feat(lora): opt-in fp32 split-K for the LoRA-A shrink GEMM

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -402,14 +402,7 @@ class Envs:
     SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM = EnvBool(False)
     # Delay all-gather after qlora for better performance for Deepseek v3.2
     SGLANG_USE_AG_AFTER_QLORA = EnvBool(False)
-    # Split-K for the dense LoRA-A (shrink) GEMM. At decode the shrink grid is
-    # bs programs (one per sequence), far below the SM count, so the large-K
-    # reduction under-fills the GPU. Splitting K across SPLIT_K programs that
-    # accumulate via fp32 atomics recovers the idle SMs. fp32 (not bf16) atomics
-    # are mandatory here: bf16 atomic_add is an emulated CAS loop that contends
-    # and caps the win, while native fp32 atomics scale and are more accurate.
-    # Only helps at large K (>=~2-4K input dim) and low batch; the heuristic
-    # returns SPLIT_K=1 (original path) otherwise. Opt-in; default off is a no-op.
+    # Split-K for the dense LoRA-A (shrink) GEMM.
     SGLANG_ENABLE_LORA_SHRINK_SPLIT_K = EnvBool(False)
     # Quantize x to int8 in the dispatch operator
     DEEP_NORMAL_MODE_USE_INT8_QUANT = EnvBool(False) # This argument is deprecated

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -402,6 +402,15 @@ class Envs:
     SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM = EnvBool(False)
     # Delay all-gather after qlora for better performance for Deepseek v3.2
     SGLANG_USE_AG_AFTER_QLORA = EnvBool(False)
+    # Split-K for the dense LoRA-A (shrink) GEMM. At decode the shrink grid is
+    # bs programs (one per sequence), far below the SM count, so the large-K
+    # reduction under-fills the GPU. Splitting K across SPLIT_K programs that
+    # accumulate via fp32 atomics recovers the idle SMs. fp32 (not bf16) atomics
+    # are mandatory here: bf16 atomic_add is an emulated CAS loop that contends
+    # and caps the win, while native fp32 atomics scale and are more accurate.
+    # Only helps at large K (>=~2-4K input dim) and low batch; the heuristic
+    # returns SPLIT_K=1 (original path) otherwise. Opt-in; default off is a no-op.
+    SGLANG_ENABLE_LORA_SHRINK_SPLIT_K = EnvBool(False)
     # Quantize x to int8 in the dispatch operator
     DEEP_NORMAL_MODE_USE_INT8_QUANT = EnvBool(False) # This argument is deprecated
     SGLANG_NPU_FUSED_MOE_MODE = EnvInt(1)

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -224,8 +224,6 @@ class TritonLoRABackend(BaseLoRABackend):
                 permutation=perm,
             )
 
-        # Carry the single-adapter flag onto the merged sgemm info so the dense
-        # cuBLAS fast path in sgemm_lora_a_fwd sees it for decode (eager).
         sgemm.single_adapter = bi.single_adapter
         self.sgemm_batch_info = sgemm
 
@@ -237,10 +235,6 @@ class TritonLoRABackend(BaseLoRABackend):
         scalings: list[float],
         use_cuda_graph: bool,
     ):
-        # Detect the single-adapter case from the host-side lists (no GPU sync):
-        # every request maps to the same buffer id with rank > 0. Stored on
-        # batch_info.single_adapter to enable the dense cuBLAS LoRA-A fast path
-        # in sgemm_lora_a_fwd (eager only).
         single_adapter = None
         if weight_indices and len(set(weight_indices)) == 1:
             idx = weight_indices[0]

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -29,6 +29,7 @@ class TritonLoRABackend(BaseLoRABackend):
         **kwargs,
     ):
         super().__init__(max_loras_per_batch, device)
+        self.max_lora_rank = kwargs.get("max_lora_rank")
 
     def run_lora_a_embedding(
         self,
@@ -183,6 +184,11 @@ class TritonLoRABackend(BaseLoRABackend):
                 permutation=torch.zeros(max_tokens, dtype=torch.int32),
             )
 
+            if mlpb == 1 and self.max_lora_rank:
+                forced = (0, self.max_lora_rank)
+                self.cuda_graph_batch_info.single_adapter = forced
+                self.cuda_graph_sgemm_batch_info.single_adapter = forced
+
     def compute_sgemm_routing(self, use_cuda_graph: bool):
         """Sort tokens by adapter and build merged segments for sgemm LoRA."""
         bi = self.batch_info
@@ -305,7 +311,8 @@ class TritonLoRABackend(BaseLoRABackend):
         batch_info.weight_indices[:bs].copy_(weight_indices_tensor, non_blocking=True)
 
         batch_info = self._add_moe_lora_info(forward_batch, batch_info)
-        batch_info.single_adapter = single_adapter
+        if not use_cuda_graph:
+            batch_info.single_adapter = single_adapter
         self.batch_info = batch_info
 
         # Biggest win is in decode.

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -224,6 +224,9 @@ class TritonLoRABackend(BaseLoRABackend):
                 permutation=perm,
             )
 
+        # Carry the single-adapter flag onto the merged sgemm info so the dense
+        # cuBLAS fast path in sgemm_lora_a_fwd sees it for decode (eager).
+        sgemm.single_adapter = bi.single_adapter
         self.sgemm_batch_info = sgemm
 
     def prepare_lora_batch(
@@ -234,6 +237,16 @@ class TritonLoRABackend(BaseLoRABackend):
         scalings: list[float],
         use_cuda_graph: bool,
     ):
+        # Detect the single-adapter case from the host-side lists (no GPU sync):
+        # every request maps to the same buffer id with rank > 0. Stored on
+        # batch_info.single_adapter to enable the dense cuBLAS LoRA-A fast path
+        # in sgemm_lora_a_fwd (eager only).
+        single_adapter = None
+        if weight_indices and len(set(weight_indices)) == 1:
+            idx = weight_indices[0]
+            if lora_ranks[idx] > 0:
+                single_adapter = (idx, lora_ranks[idx])
+
         # Use pinned memory to avoid synchronizations during host-to-device transfer
         weight_indices_tensor = torch.tensor(
             weight_indices, dtype=torch.int32, pin_memory=True, device="cpu"
@@ -298,6 +311,7 @@ class TritonLoRABackend(BaseLoRABackend):
         batch_info.weight_indices[:bs].copy_(weight_indices_tensor, non_blocking=True)
 
         batch_info = self._add_moe_lora_info(forward_batch, batch_info)
+        batch_info.single_adapter = single_adapter
         self.batch_info = batch_info
 
         # Biggest win is in decode.

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -106,6 +106,7 @@ class LoRAManager:
             target_modules=target_modules,
             lora_paths=lora_paths,
         )
+        self.lora_backend.max_lora_rank = self.max_lora_rank
 
     def init_cuda_graph_batch_info(
         self, max_bs_in_cuda_graph: int, num_tokens_per_bs: int

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -1,6 +1,7 @@
 import functools
 
 import torch
+import torch.nn.functional as F
 import triton
 import triton.language as tl
 
@@ -162,6 +163,22 @@ def sgemm_lora_a_fwd(
     R = weights.shape[-2]
     K = weights.shape[-1]
     assert x.shape[-1] == K
+
+    # Dense cuBLAS fast path for the single-adapter case: when every request
+    # uses the same adapter, the shrink is a plain GEMM out = x @ A.T, which
+    # cuBLAS does ~1.2-1.7x faster than the segmented split-K kernel on skinny
+    # rank decode shapes. Guards:
+    #  * eager only -- a captured CUDA graph cannot branch on per-replay adapter
+    #    membership, so under graph we stay on the data-driven Triton path.
+    #  * rank == max_r (= R // stack_num) only -- then F.linear's max_r-packed
+    #    output is bit-layout-identical to the kernel's rank-packed output for
+    #    every stack_num (see validate_cublas_stack.py). When rank < max_r the
+    #    layouts differ, so we fall through to the kernel.
+    single_adapter = getattr(batch_info, "single_adapter", None)
+    if single_adapter is not None and not batch_info.use_cuda_graph:
+        idx, rank = single_adapter
+        if rank == R // stack_num:
+            return F.linear(x, weights[idx])
 
     # Block shapes
     BLOCK_S = 16

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -164,8 +164,8 @@ def sgemm_lora_a_fwd(
     K = weights.shape[-1]
     assert x.shape[-1] == K
 
-    single_adapter = getattr(batch_info, "single_adapter", None)
-    if single_adapter is not None and not batch_info.use_cuda_graph:
+    single_adapter = batch_info.single_adapter
+    if single_adapter is not None:
         idx, rank = single_adapter
         if rank == R // stack_num:
             return F.linear(x, weights[idx])

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -164,16 +164,6 @@ def sgemm_lora_a_fwd(
     K = weights.shape[-1]
     assert x.shape[-1] == K
 
-    # Dense cuBLAS fast path for the single-adapter case: when every request
-    # uses the same adapter, the shrink is a plain GEMM out = x @ A.T, which
-    # cuBLAS does ~1.2-1.7x faster than the segmented split-K kernel on skinny
-    # rank decode shapes. Guards:
-    #  * eager only -- a captured CUDA graph cannot branch on per-replay adapter
-    #    membership, so under graph we stay on the data-driven Triton path.
-    #  * rank == max_r (= R // stack_num) only -- then F.linear's max_r-packed
-    #    output is bit-layout-identical to the kernel's rank-packed output for
-    #    every stack_num (see validate_cublas_stack.py). When rank < max_r the
-    #    layouts differ, so we fall through to the kernel.
     single_adapter = getattr(batch_info, "single_adapter", None)
     if single_adapter is not None and not batch_info.use_cuda_graph:
         idx, rank = single_adapter
@@ -193,9 +183,6 @@ def sgemm_lora_a_fwd(
         num_k_tiles = triton.cdiv(K, BLOCK_K)
         base_grid = batch_info.bs * num_s_tiles
         num_sms = _num_sms(x.device.index)
-        # Require K >= 4096 (>= 16 K-tiles): split-K has a ~5us floor (buffer
-        # zeroing + atomics + launch), so at K=2048 the non-split path is
-        # already below that floor and split-K regresses at higher batch.
         if base_grid < num_sms and num_k_tiles >= 16:
             split_k = max(1, min(2 * num_sms // base_grid, num_k_tiles, 16))
 

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -77,15 +77,6 @@ def _sgemm_lora_a_kernel(
         return
 
     # Adjust N (stack_num * max_rank) to this adapter's actual rank.
-    #
-    # Only clamp on the SPLIT_K == 1 path, for two reasons: (1) it keeps that
-    # path bit-identical to the original kernel; (2) on the split-K path a
-    # data-dependent N forces the bf16 store atomic into per-element scalar
-    # `atom...bf16`, whereas the unclamped (kernel-arg) N lets Triton emit the
-    # packed `atom...v2.bf16` (~3-4x fewer atomics under contention). The expand
-    # kernels read only the rank-packed [:rank*stack] region, so the extra
-    # columns the unclamped split-K path writes are never consumed
-    # (see validate_aclamp_layout.py).
     if SPLIT_K == 1:
         N = tl.minimum(N, rank * stack_num)
 
@@ -137,11 +128,6 @@ def _sgemm_lora_a_kernel(
     if SPLIT_K == 1:
         tl.store(output_ptr, partial_sum.to(output.dtype.element_ty), mask=output_mask)
     else:
-        # Pre-zeroed accumulator in x.dtype; combine the K-splits with native
-        # atomics. For bf16 x this is a packed `atom...v2.bf16` (unclamped N,
-        # see the SPLIT_K==1 clamp note above). Cross-split accumulation is in
-        # x.dtype, so bf16 trades some precision for skipping the fp32->bf16
-        # cast and halving the atomic count.
         tl.atomic_add(
             output_ptr,
             partial_sum.to(output.dtype.element_ty),
@@ -194,11 +180,23 @@ def sgemm_lora_a_fwd(
         if base_grid < num_sms and num_k_tiles >= 8:
             split_k = max(1, min(2 * num_sms // base_grid, num_k_tiles, 16))
 
+    # Launch-config tuning applies only to the split-K path; SPLIT_K == 1 keeps
+    # Triton's defaults so it stays byte-identical to the original kernel.
+    launch_kwargs = {}
     if split_k > 1:
         # Pre-zeroed accumulator in x.dtype: the K-splits atomic-add into it.
         # Keeping it in x.dtype (bf16) lets the bf16 atomic vectorize into a
         # packed .v2 store and avoids a trailing fp32->bf16 cast.
         output = torch.zeros((S, R), device=x.device, dtype=x.dtype)
+        # Tuned on B200 (sweep across K/bs): num_stages=3 is a free win (short
+        # K-loop, nothing to pipeline beyond ~3); the tiny 16xR tile over-fills
+        # at num_warps>=8, so use 2 warps at high batch (small split_k, device
+        # already fairly full) and 4 at low batch (needs more warps to hide
+        # latency). Best config is shape-dependent but these are near-optimal.
+        launch_kwargs = {
+            "num_warps": 2 if split_k <= 4 else 4,
+            "num_stages": 3,
+        }
     else:
         output = torch.empty((S, R), device=x.device, dtype=x.dtype)
 
@@ -231,5 +229,6 @@ def sgemm_lora_a_fwd(
         BLOCK_R,
         BLOCK_K,
         split_k,
+        **launch_kwargs,
     )
     return output.to(x.dtype)

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -176,7 +176,10 @@ def sgemm_lora_a_fwd(
         num_k_tiles = triton.cdiv(K, BLOCK_K)
         base_grid = batch_info.bs * num_s_tiles
         num_sms = _num_sms(x.device.index)
-        if base_grid < num_sms and num_k_tiles >= 8:
+        # Require K >= 4096 (>= 16 K-tiles): split-K has a ~5us floor (buffer
+        # zeroing + atomics + launch), so at K=2048 the non-split path is
+        # already below that floor and split-K regresses at higher batch.
+        if base_grid < num_sms and num_k_tiles >= 16:
             split_k = max(1, min(2 * num_sms // base_grid, num_k_tiles, 16))
 
     launch_kwargs = {}

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -77,8 +77,7 @@ def _sgemm_lora_a_kernel(
         return
 
     # Adjust N (stack_num * max_rank) to this adapter's actual rank.
-    if SPLIT_K == 1:
-        N = tl.minimum(N, rank * stack_num)
+    N = tl.minimum(N, rank * stack_num)
 
     # The tile in output matrix will have (pid_s, pid_n) as id
     num_pid_n = tl.cdiv(N, BLOCK_N)
@@ -180,19 +179,9 @@ def sgemm_lora_a_fwd(
         if base_grid < num_sms and num_k_tiles >= 8:
             split_k = max(1, min(2 * num_sms // base_grid, num_k_tiles, 16))
 
-    # Launch-config tuning applies only to the split-K path; SPLIT_K == 1 keeps
-    # Triton's defaults so it stays byte-identical to the original kernel.
     launch_kwargs = {}
     if split_k > 1:
-        # Pre-zeroed accumulator in x.dtype: the K-splits atomic-add into it.
-        # Keeping it in x.dtype (bf16) lets the bf16 atomic vectorize into a
-        # packed .v2 store and avoids a trailing fp32->bf16 cast.
-        output = torch.zeros((S, R), device=x.device, dtype=x.dtype)
-        # Tuned on B200 (sweep across K/bs): num_stages=3 is a free win (short
-        # K-loop, nothing to pipeline beyond ~3); the tiny 16xR tile over-fills
-        # at num_warps>=8, so use 2 warps at high batch (small split_k, device
-        # already fairly full) and 4 at low batch (needs more warps to hide
-        # latency). Best config is shape-dependent but these are near-optimal.
+        output = torch.zeros((S, R), device=x.device, dtype=torch.float32)
         launch_kwargs = {
             "num_warps": 2 if split_k <= 4 else 4,
             "num_stages": 3,

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -76,8 +76,18 @@ def _sgemm_lora_a_kernel(
     if seg_len == 0:
         return
 
-    # Adjust N (stack_num * max_rank) according to the specific LoRA adapter
-    N = tl.minimum(N, rank * stack_num)
+    # Adjust N (stack_num * max_rank) to this adapter's actual rank.
+    #
+    # Only clamp on the SPLIT_K == 1 path, for two reasons: (1) it keeps that
+    # path bit-identical to the original kernel; (2) on the split-K path a
+    # data-dependent N forces the bf16 store atomic into per-element scalar
+    # `atom...bf16`, whereas the unclamped (kernel-arg) N lets Triton emit the
+    # packed `atom...v2.bf16` (~3-4x fewer atomics under contention). The expand
+    # kernels read only the rank-packed [:rank*stack] region, so the extra
+    # columns the unclamped split-K path writes are never consumed
+    # (see validate_aclamp_layout.py).
+    if SPLIT_K == 1:
+        N = tl.minimum(N, rank * stack_num)
 
     # The tile in output matrix will have (pid_s, pid_n) as id
     num_pid_n = tl.cdiv(N, BLOCK_N)
@@ -88,8 +98,7 @@ def _sgemm_lora_a_kernel(
 
     # Create pointers for the first block of x and weights[batch_id]
     # The pointers will be advanced as we move in the K direction
-    # and accumulate. With SPLIT_K > 1 this program starts at K-tile pid_sk and
-    # strides by BLOCK_K * SPLIT_K; with SPLIT_K == 1 it walks all of K.
+    # and accumulate.
     s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
     n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
     k_offset = pid_sk * BLOCK_K + tl.arange(0, BLOCK_K)
@@ -128,8 +137,17 @@ def _sgemm_lora_a_kernel(
     if SPLIT_K == 1:
         tl.store(output_ptr, partial_sum.to(output.dtype.element_ty), mask=output_mask)
     else:
-        # fp32 accumulator, pre-zeroed; combine the K-splits with native fp32 atomics.
-        tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
+        # Pre-zeroed accumulator in x.dtype; combine the K-splits with native
+        # atomics. For bf16 x this is a packed `atom...v2.bf16` (unclamped N,
+        # see the SPLIT_K==1 clamp note above). Cross-split accumulation is in
+        # x.dtype, so bf16 trades some precision for skipping the fp32->bf16
+        # cast and halving the atomic count.
+        tl.atomic_add(
+            output_ptr,
+            partial_sum.to(output.dtype.element_ty),
+            mask=output_mask,
+            sem="relaxed",
+        )
 
 
 @functools.lru_cache(maxsize=None)
@@ -177,7 +195,10 @@ def sgemm_lora_a_fwd(
             split_k = max(1, min(2 * num_sms // base_grid, num_k_tiles, 16))
 
     if split_k > 1:
-        output = torch.zeros((S, R), device=x.device, dtype=torch.float32)
+        # Pre-zeroed accumulator in x.dtype: the K-splits atomic-add into it.
+        # Keeping it in x.dtype (bf16) lets the bf16 atomic vectorize into a
+        # packed .v2 store and avoids a trailing fp32->bf16 cast.
+        output = torch.zeros((S, R), device=x.device, dtype=x.dtype)
     else:
         output = torch.empty((S, R), device=x.device, dtype=x.dtype)
 

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -1,7 +1,10 @@
+import functools
+
 import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.environ import envs
 from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
 from sglang.srt.lora.utils import LoRABatchInfo
 
@@ -35,6 +38,7 @@ def _sgemm_lora_a_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    SPLIT_K: tl.constexpr = 1,
 ):
     """
     Computes a segmented batched matrix multiplication for the LoRA A matrix.
@@ -63,6 +67,10 @@ def _sgemm_lora_a_kernel(
         return
 
     pid = tl.program_id(axis=0)
+    # Fold the split-K factor out of axis-0 (SPLIT_K == 1 -> pid_sk == 0, pid_tile == pid).
+    pid_sk = pid % SPLIT_K
+    pid_tile = pid // SPLIT_K
+
     seg_start = tl.load(seg_indptr + batch_id)
     seg_len = tl.load(seg_lens + batch_id)
     if seg_len == 0:
@@ -73,17 +81,18 @@ def _sgemm_lora_a_kernel(
 
     # The tile in output matrix will have (pid_s, pid_n) as id
     num_pid_n = tl.cdiv(N, BLOCK_N)
-    pid_s = pid // num_pid_n
-    pid_n = pid % num_pid_n
+    pid_s = pid_tile // num_pid_n
+    pid_n = pid_tile % num_pid_n
     if pid_s * BLOCK_S >= seg_len:
         return
 
     # Create pointers for the first block of x and weights[batch_id]
     # The pointers will be advanced as we move in the K direction
-    # and accumulate
+    # and accumulate. With SPLIT_K > 1 this program starts at K-tile pid_sk and
+    # strides by BLOCK_K * SPLIT_K; with SPLIT_K == 1 it walks all of K.
     s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
     n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
-    k_offset = tl.arange(0, BLOCK_K)
+    k_offset = pid_sk * BLOCK_K + tl.arange(0, BLOCK_K)
     s_physical = _resolve_token_positions(
         sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
     )
@@ -94,29 +103,38 @@ def _sgemm_lora_a_kernel(
 
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
+    for k in range(0, tl.cdiv(K, BLOCK_K * SPLIT_K)):
+        k_remaining = K - k * (BLOCK_K * SPLIT_K)
         x_tile = tl.load(
             x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
+            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < k_remaining),
             other=0.0,
         )
         w_tile = tl.load(
             w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & (n_offset[None, :] < N),
+            mask=(k_offset[:, None] < k_remaining) & (n_offset[None, :] < N),
             other=0.0,
         )
         partial_sum += tl.dot(x_tile, w_tile)
 
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
+        x_ptrs += BLOCK_K * SPLIT_K * x_stride_1
+        w_ptrs += BLOCK_K * SPLIT_K * w_stride_2
 
     # Store result to output matrix
-    partial_sum = partial_sum.to(x.dtype.element_ty)
     output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
     output_ptr = output + (
         s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
     )
-    tl.store(output_ptr, partial_sum, mask=output_mask)
+    if SPLIT_K == 1:
+        tl.store(output_ptr, partial_sum.to(output.dtype.element_ty), mask=output_mask)
+    else:
+        # fp32 accumulator, pre-zeroed; combine the K-splits with native fp32 atomics.
+        tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
+
+
+@functools.lru_cache(maxsize=None)
+def _num_sms(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
 
 
 def sgemm_lora_a_fwd(
@@ -145,16 +163,29 @@ def sgemm_lora_a_fwd(
     # Block shapes
     BLOCK_S = 16
     BLOCK_K = 256
-    BLOCK_R = 16
-
-    grid = (
-        triton.cdiv(batch_info.max_len, BLOCK_S) * triton.cdiv(R, BLOCK_R),
-        batch_info.bs,
-    )
+    BLOCK_R = triton.next_power_of_2(R)
 
     sorted_by_adapter = batch_info.permutation is not None
 
-    output = torch.empty((S, R), device=x.device, dtype=x.dtype)
+    num_s_tiles = triton.cdiv(batch_info.max_len, BLOCK_S)
+    split_k = 1
+    if envs.SGLANG_ENABLE_LORA_SHRINK_SPLIT_K.get() and x.is_cuda:
+        num_k_tiles = triton.cdiv(K, BLOCK_K)
+        base_grid = batch_info.bs * num_s_tiles
+        num_sms = _num_sms(x.device.index)
+        if base_grid < num_sms and num_k_tiles >= 8:
+            split_k = max(1, min(2 * num_sms // base_grid, num_k_tiles, 16))
+
+    if split_k > 1:
+        output = torch.zeros((S, R), device=x.device, dtype=torch.float32)
+    else:
+        output = torch.empty((S, R), device=x.device, dtype=x.dtype)
+
+    grid = (
+        num_s_tiles * split_k,
+        batch_info.bs,
+    )
+
     _sgemm_lora_a_kernel[grid](
         x,
         weights,
@@ -178,5 +209,6 @@ def sgemm_lora_a_fwd(
         BLOCK_S,
         BLOCK_R,
         BLOCK_K,
+        split_k,
     )
-    return output
+    return output.to(x.dtype)

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -78,9 +78,7 @@ class LoRABatchInfo:
     moe_lora_info: Optional[MoELoRABatchInfo] = None
 
     # CPU-side (buffer_id, rank) when every request in the batch uses the same
-    # active adapter (rank > 0); None otherwise. Computed from Python lists in
-    # prepare_lora_batch (no GPU sync). Enables the dense cuBLAS LoRA-A fast path
-    # in sgemm_lora_a_fwd (eager only). See sgemm_lora_a.py.
+    # active adapter (rank > 0); None otherwise.
     single_adapter: Optional[Tuple[int, int]] = None
 
 

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -77,6 +77,12 @@ class LoRABatchInfo:
     # MoE LoRA batch info
     moe_lora_info: Optional[MoELoRABatchInfo] = None
 
+    # CPU-side (buffer_id, rank) when every request in the batch uses the same
+    # active adapter (rank > 0); None otherwise. Computed from Python lists in
+    # prepare_lora_batch (no GPU sync). Enables the dense cuBLAS LoRA-A fast path
+    # in sgemm_lora_a_fwd (eager only). See sgemm_lora_a.py.
+    single_adapter: Optional[Tuple[int, int]] = None
+
 
 class LoRAType(Enum):
     LORA_A = 0


### PR DESCRIPTION
## Motivation

At decode, the dense LoRA-A (shrink) GEMM `x(S,K) @ Wᵀ(K,N)` launches roughly `bs` programs (one N-block per sequence, since the rank `N` is tiny). On a large GPU that is far below the SM count, so the *large-K* reduction (e.g. K=7168/8192 for MLA q/kv/o projections) under-fills the device and leaves SMs idle.

## What this does

Adds an **opt-in** split-K path for `sgemm_lora_a_fwd`:

- Splits the K reduction across `SPLIT_K` programs that **fp32-atomic-add** their partial sums into a pre-zeroed fp32 accumulator, then casts back to the activation dtype (LoRA-B's bf16 input contract is unchanged). Accumulation is fp32 throughout, so precision tracks the non-split baseline.
- **Self-contained / non-invasive.** The split-K path covers the whole rank in a single N-block (`BLOCK_N = next_pow2(R)`). A heuristic picks
  `SPLIT_K = clamp(2 * NUM_SMS / base_grid, 1, min(num_k_tiles, 16))`,
  and engages **only when `base_grid < NUM_SMS` and `K >= 4096` (≥16 K-tiles)**; otherwise it returns `1` — the original kernel, **bit-identical** — for prefill, large batch, or small K.
- **Tuned launch config (split-K path only).** A B200 sweep over `num_warps × num_stages` picks `num_stages=3` and `num_warps = 2 if split_k<=4 else 4` (2 warps at high batch / small split_k where the device is fuller; 4 at low batch to hide latency). `num_warps=1/8` always lose. Applied only when `split_k>1`; the `SPLIT_K==1` path keeps Triton defaults and stays byte-identical.

Gated by **`SGLANG_ENABLE_LORA_SHRINK_SPLIT_K`** (default off → exact no-op).

### Why K >= 4096

Split-K has a ~5µs floor (buffer zeroing + atomics + launch). At K=2048 the non-split path is already ~5.8µs — below that floor — so split-K only adds atomic contention and *regresses* at higher batch (0.92–0.98× at bs 32/64). The `K >= 4096` gate engages only where the non-split path exceeds the floor. It gives up the marginal K=2048 low-batch wins (≤1.12×, latency regime) to avoid the throughput-batch regression.

### Why fp32 atomics

fp32 keeps the split-K accumulation at baseline precision (only rounding is the final `fp32→bf16` cast, same as the non-split store; measured `splk_err == base_err`). A bf16 accumulator is faster (packed `.v2.bf16` atomic + no cast, ~20–27% on the kernel) but accumulates across splits in bf16, raising max-abs error to ~3e-2–9e-2 at large K — not worth the accuracy risk here.

## Correctness

Validated on B200 across `K ∈ {512…18432}`, `rank ∈ {16,32}`, `stack ∈ {1,2,3}`, and prefill/decode shapes:
- when the heuristic returns `SPLIT_K=1` (incl. all K≤2048), output is **bit-identical** to the original path (`torch.equal`);
- with split-K on, output matches an fp32 reference within bf16 tolerance and is **never worse** than the flag-off baseline (`splk_err == base_err`);
- the heuristic correctly gates off in prefill and at small K.

## Performance

**vs `split_k==1` (= main), full forward incl. cast, B200 decode, rank 16, L2-cold:**

| K | off (main) | on (split-K) | bs=1 | bs=16 | bs=64 |
|------:|-----------:|-------------:|:----:|:-----:|:-----:|
| 2048  | ~5.8 µs | — | (gated off, 1.00×) | | |
| 4096  | ~9.2 µs | 5.1–7.5 µs | 1.77× | 1.59× | 1.25× |
| 7168  | ~14.5 µs | 5.6–9.1 µs | 2.55× | 2.25× | 1.60× |
| 8192  | ~16.1 µs | 5.6–9.6 µs | 2.85× | 2.49× | 1.69× |
| 18432 | ~33.5 µs | 7.1–14.9 µs | 4.68× | 4.01× | 2.25× |

The non-split path scales linearly with K (serial reduction); split-K stays flat (~5–15 µs). Largest wins at large-K / low-batch; still 2.25× at K=18432/bs64.

Raw numbers at **bs=64, r=16, B200, full-forward (incl. cast), L2-cold**:

| K | split_k | base (main) | split-K (on) | speedup |
|------:|--------:|------------:|-------------:|:-------:|
| 2048  | 1 |  5.84 µs |  5.85 µs | 1.00× (gated off) |
| 4096  | 4 |  9.37 µs |  7.47 µs | 1.25× |
| 7168  | 4 | 14.56 µs |  9.12 µs | 1.60× |
| 8192  | 4 | 16.26 µs |  9.61 µs | 1.69× |
| 18432 | 4 | 33.62 µs | 14.93 µs | 2.25× |

**Launch-config tuning** (`num_warps`/`num_stages`) of the split-K kernel, vs Triton's default (`num_warps=4, num_stages=2`), kernel-only B200 decode rank 16:

| K | bs | split_k | config | default | tuned | speedup |
|------:|---:|--------:|:------:|--------:|------:|:-------:|
| 18432 | 64 | 4  | w2,s3 | 17.30 µs | 13.59 µs | **1.27×** |
| 8192  | 64 | 4  | w2,s3 |  9.57 µs |  8.31 µs | 1.15× |
| 4096  | 64 | 4  | w2,s3 |  6.45 µs |  6.15 µs | 1.05× |
| 18432 | 16 | 16 | w4,s3 |  7.27 µs |  6.92 µs | 1.05× |
| 18432 |  1 | 16 | w4,s3 |  6.23 µs |  5.75 µs | 1.08× |
|  8192 |  1 | 16 | w4,s3 |  4.40 µs |  4.32 µs | 1.02× |

Largest gain at high batch (small `split_k`, where `num_warps=2` beats the default 4); near-neutral at bs=1. `num_warps=8` is up to ~25% slower (over-subscribed tile); `num_warps=1` also loses.

End-to-end on **Kimi-K2.5-NVFP4** (2-node TP8, trtllm MoE LoRA + two-stream): **+~11% decode throughput / −10% inter-token latency at bs64**, reproduced across multiple runs; accuracy within the run-to-run logprob noise floor. Smaller gains at low batch (where two-stream already overlaps the shrink); off by default so non-LoRA / non-decode paths are unaffected.

## Notes

- Opt-in and default-off; zero behavior change unless `SGLANG_ENABLE_LORA_SHRINK_SPLIT_K=1`.
- Only the dense LoRA-A (attention qkv/o, dense gate_up) shrink is affected; the MoE virtual-experts shrink is a separate kernel and untouched.

## Single-adapter cuBLAS fast path

When **every request in the batch uses the same adapter**, the LoRA-A shrink is mathematically a plain dense GEMM `x @ Aᵀ` (one weight for all rows), which cuBLAS runs faster than the segmented split-K Triton kernel on these skinny-rank shapes. `sgemm_lora_a_fwd` dispatches to `F.linear` when `LoRABatchInfo.single_adapter` is set.

- The single-adapter `(buffer_id, rank)` is detected **host-side** in `prepare_lora_batch` (no GPU sync) and carried on `LoRABatchInfo`, then propagated onto the merged decode info in `compute_sgemm_routing`.
- **Works under CUDA graph when `max_loras_per_batch == 1`** (single-adapter serving): the single resident adapter is an invariant across every replay, so `init_cuda_graph_batch_info` forces the flag and `F.linear` is the op captured into the graph. For `max_loras_per_batch > 1` a captured graph can't branch on per-replay adapter membership, so it stays on the data-driven Triton path. Eager (any batch) uses per-batch detection.
- **`rank == max_r` only**, so cuBLAS's `max_r`-packed output is bit-layout-identical to the kernel's rank-packed output for every `stack_num` (qkv/gate_up); `rank < max_r` falls back to the kernel.

Validated on B200 (`stack ∈ {1,2,3}`, decode/merged shapes): cuBLAS output matches the Triton kernel within bf16 tolerance; falls back for multi-adapter / `rank<max_r`; and under graph capture, `F.linear` is the captured op (and replay with updated weights matches eager) when forced, Triton otherwise.

**bs=64, B200, full-forward (incl. cast), L2-cold** (off = `single_adapter` unset → Triton merged split-K, the production decode path; on = cuBLAS fast path):

| r | K | triton (off) | cuBLAS (on) | speedup |
|--:|------:|------------:|------------:|:-------:|
| 16 | 2048  | 5.60 µs | 4.00 µs | 1.40× |
| 16 | 4096  | 5.34 µs | 4.03 µs | 1.33× |
| 16 | 7168  | 5.75 µs | 4.57 µs | 1.26× |
| 16 | 8192  | 5.76 µs | 4.90 µs | 1.18× |
| 16 | 18432 | 7.23 µs | 4.61 µs | 1.57× |
| 32 | 2048  | 6.85 µs | 4.02 µs | 1.70× |
| 32 | 4096  | 5.97 µs | 4.05 µs | 1.47× |
| 32 | 7168  | 6.43 µs | 4.58 µs | 1.40× |
| 32 | 8192  | 6.48 µs | 4.91 µs | 1.32× |
| 32 | 18432 | 8.10 µs | 4.62 µs | 1.75× |

cuBLAS stays ~flat at ~4.0–4.9 µs across both ranks (the small output's read of `x` dominates), while the Triton path grows with K *and* rank — so the win widens at higher rank (up to 1.75× at r=32, K=18432).

🤖 Generated with [Claude Code](https://claude.com/claude-code)








































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26929561800](https://github.com/sgl-project/sglang/actions/runs/26929561800)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26929561640](https://github.com/sgl-project/sglang/actions/runs/26929561640)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->










