### PR TITLE
fix(io_struct): index extra_key per sub-request in batched GenerateReqInput

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -422,6 +422,7 @@ class GenerateReqInput(BaseReq):
         self._normalize_sampling_params(num)
         self._normalize_logprob_params(num)
         self._normalize_custom_logit_processor(num)
+        self._normalize_extra_key(num)
         self._normalize_bootstrap_params(num)
 
     def _expand_inputs(self, num):
@@ -591,6 +592,21 @@ class GenerateReqInput(BaseReq):
                 "Cannot use list custom_logit_processor with parallel_sample_num > 1"
             )
 
+    def _normalize_extra_key(self, num):
+        """Normalize extra_key for batch processing."""
+        if self.extra_key is None:
+            return
+        if isinstance(self.extra_key, str):
+            self.extra_key = [self.extra_key] * num
+        elif isinstance(self.extra_key, list):
+            if len(self.extra_key) != self.batch_size:
+                raise ValueError(
+                    "The length of extra_key should be equal to the batch size."
+                )
+            self.extra_key = self.extra_key * self.parallel_sample_num
+        else:
+            raise ValueError("extra_key should be a list or a string.")
+
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
         # Normalize bootstrap_host
@@ -707,7 +723,7 @@ class GenerateReqInput(BaseReq):
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
             priority=self.priority,
-            extra_key=self.extra_key,
+            extra_key=self.extra_key[i] if self.extra_key is not None else None,
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -419,6 +419,57 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req.lora_path, expected_lora_paths)
 
+    def test_extra_key_normalization(self):
+        """Test normalization of extra_key."""
+        # Per-request list
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            extra_key=["tenant-A", "tenant-B"],
+            sampling_params=[{}, {}],
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, ["tenant-A", "tenant-B"])
+        self.assertEqual(req[0].extra_key, "tenant-A")
+        self.assertEqual(req[1].extra_key, "tenant-B")
+
+        # Scalar broadcast
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            extra_key="shared",
+            sampling_params=[{}, {}],
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, ["shared", "shared"])
+
+        # None stays None
+        req = GenerateReqInput(text=["Hello", "World"], sampling_params=[{}, {}])
+        req.normalize_batch_and_arguments()
+        self.assertIsNone(req.extra_key)
+        self.assertIsNone(req[0].extra_key)
+
+        # Parallel sampling expansion
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            extra_key=["tenant-A", "tenant-B"],
+            sampling_params={"n": 2},
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, ["tenant-A", "tenant-B"] * 2)
+
+        # Wrong-length list
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            extra_key=["only-one"],
+            sampling_params=[{}, {}],
+        )
+        with self.assertRaisesRegex(ValueError, "batch size"):
+            req.normalize_batch_and_arguments()
+
+        # Non-batched scalar unchanged
+        req = GenerateReqInput(text="Hello", extra_key="solo")
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.extra_key, "solo")
+
     def test_logprob_parameters_normalization(self):
         """Test normalization of logprob-related parameters."""
         # Test single example


### PR DESCRIPTION
## Motivation

`GenerateReqInput.extra_key` is typed `Optional[Union[List[str], str]]`, but batch normalization did not normalize/expand it and `__getitem__` passed `extra_key=self.extra_key` to every sub-request instead of indexing it (issue #26755).

A batched request with a per-request list crashes downstream prefix-cache matching:

```json
{"text": ["P", "P"], "extra_key": ["tenant-A", "tenant-B"], "sampling_params": [{"max_new_tokens": 1}, {"max_new_tokens": 1}]}
```

both sub-requests inherit `extra_key=["tenant-A", "tenant-B"]`, and `RadixKey.child_key()` produces `(['tenant-A', 'tenant-B'], 50)` which fails with `TypeError: unhashable type: 'list'`.

## Modifications

`python/sglang/srt/managers/io_struct.py`:

1. New `_normalize_extra_key(num)` wired into `_normalize_batch_inputs`, mirroring the existing `_normalize_custom_logit_processor` style:
   - `None` → unchanged
   - `str` → `[str] * num` (broadcast to every sub-request)
   - `list` of length `batch_size` → expanded by `parallel_sample_num`
   - `list` of mismatched length → `ValueError` with a clear message
   - Anything else → `ValueError`
2. `__getitem__` now reads `self.extra_key[i]` when non-None and `None` otherwise — matches the `custom_logit_processor` / `lora_path` pattern already used a few lines above in the same method.

After normalization the invariant becomes: `extra_key is None or len(extra_key) == batch_size * parallel_sample_num`, identical to the convention used by `lora_path` / `custom_logit_processor` / `logprob_params`.

## Tests

`test/registered/unit/managers/test_io_struct.py::TestGenerateReqInputNormalization::test_extra_key_normalization` covers:

- Per-request list → normalized list intact, `__getitem__` returns scalar per index (the bug fix).
- Scalar string → broadcast to a list, `__getitem__` returns the same string for every index.
- `None` → stays `None`, `__getitem__` broadcasts `None`.
- `parallel_sample_num=2` → list doubled by `parallel_sample_num`.
- Wrong-length list → `ValueError` with `batch size` in the message.
- Single (non-batched) request with scalar `extra_key` → unchanged.

Registered to `base-b-test-cpu` / `stage-b-test-1-gpu-small-amd` / cuda `base-b` `1-gpu-large` via the file's existing `register_*_ci(...)` block.

## Accuracy

**Not applicable.** No change to sampling, model forward, or scheduling. Only the routing of `extra_key` from the batched input to its sub-requests changes; downstream consumers (`RadixKey`, prefix cache) already expect a scalar per request.

## Speed Tests and Profiling

**Not applicable.** Normalization adds one Python list operation per batched request at admission time; negligible vs. tokenization and prefill.

## Checklist

- [x] Format your code according to pre-commit.
- [x] Add unit tests.
- [ ] Update documentation — N/A, no API change.
- [x] Provide accuracy and speed benchmark results — N/A, see sections above.

Closes #26755.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26981186663](https://github.com/sgl-project/sglang/actions/runs/26981186663)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26981186627](https://github.com/sgl-project/sglang/actions/runs/26981186627)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->