### PR TITLE
[diffusion] reduce Cosmos3 denoise overhead

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -750,6 +750,32 @@ class USPAttention(nn.Module):
 
         return torch.cat([out_rep, out_shard], dim=1)
 
+    def forward_with_replicated_kv_prefix(
+        self,
+        q: torch.Tensor,
+        k_prefix: torch.Tensor,
+        v_prefix: torch.Tensor,
+        k_suffix: torch.Tensor,
+        v_suffix: torch.Tensor,
+    ) -> torch.Tensor:
+        """attention with replicated K/V prefix supplied separately"""
+        forward_context: ForwardContext = get_forward_context()
+        ctx_attn_metadata = forward_context.attn_metadata
+
+        if self.skip_sequence_parallel or get_sequence_parallel_world_size() == 1:
+            k = torch.cat([k_prefix, k_suffix], dim=1)
+            v = torch.cat([v_prefix, v_suffix], dim=1)
+            return self.attn_impl.forward(q, k, v, ctx_attn_metadata)
+
+        if get_ulysses_parallel_world_size() == 1:
+            k = torch.cat([k_prefix, k_suffix], dim=1)
+            v = torch.cat([v_prefix, v_suffix], dim=1)
+            return self(q, k, v)
+
+        return self._forward_with_replicated_kv_prefix_split(
+            q, k_prefix, v_prefix, k_suffix, v_suffix, ctx_attn_metadata
+        )
+
     def _forward_with_replicated_kv_prefix(
         self,
         q: torch.Tensor,
@@ -771,10 +797,24 @@ class USPAttention(nn.Module):
         3. Concatenate prefix + suffix on the sequence dim and attend.
         4. All-to-all the output back (head shard → seq shard).
         """
-        sp_rank = get_sp_parallel_rank()
-
         k_rep, k_shard = k[:, :num_rep], k[:, num_rep:]
         v_rep, v_shard = v[:, :num_rep], v[:, num_rep:]
+
+        return self._forward_with_replicated_kv_prefix_split(
+            q, k_rep, v_rep, k_shard, v_shard, ctx_attn_metadata
+        )
+
+    def _forward_with_replicated_kv_prefix_split(
+        self,
+        q: torch.Tensor,
+        k_rep: torch.Tensor,
+        v_rep: torch.Tensor,
+        k_shard: torch.Tensor,
+        v_shard: torch.Tensor,
+        ctx_attn_metadata,
+    ) -> torch.Tensor:
+        """split form avoids materializing full K/V before Ulysses all-to-all"""
+        sp_rank = get_sp_parallel_rank()
 
         q = _usp_input_all_to_all(q, head_dim=2)
         k_shard = _usp_input_all_to_all(k_shard, head_dim=2)

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -757,6 +757,7 @@ class USPAttention(nn.Module):
         v_prefix: torch.Tensor,
         k_suffix: torch.Tensor,
         v_suffix: torch.Tensor,
+        kv_prefix_head_sharded: bool = False,
     ) -> torch.Tensor:
         """attention with replicated K/V prefix supplied separately"""
         forward_context: ForwardContext = get_forward_context()
@@ -773,7 +774,13 @@ class USPAttention(nn.Module):
             return self(q, k, v)
 
         return self._forward_with_replicated_kv_prefix_split(
-            q, k_prefix, v_prefix, k_suffix, v_suffix, ctx_attn_metadata
+            q,
+            k_prefix,
+            v_prefix,
+            k_suffix,
+            v_suffix,
+            ctx_attn_metadata,
+            kv_prefix_head_sharded,
         )
 
     def _forward_with_replicated_kv_prefix(
@@ -812,6 +819,7 @@ class USPAttention(nn.Module):
         k_shard: torch.Tensor,
         v_shard: torch.Tensor,
         ctx_attn_metadata,
+        kv_prefix_head_sharded: bool = False,
     ) -> torch.Tensor:
         """split form avoids materializing full K/V before Ulysses all-to-all"""
         sp_rank = get_sp_parallel_rank()
@@ -820,11 +828,12 @@ class USPAttention(nn.Module):
         k_shard = _usp_input_all_to_all(k_shard, head_dim=2)
         v_shard = _usp_input_all_to_all(v_shard, head_dim=2)
 
-        h_kv_local = k_shard.shape[2]
-        h_start = sp_rank * h_kv_local
-        h_end = h_start + h_kv_local
-        k_rep = k_rep[:, :, h_start:h_end, :].contiguous()
-        v_rep = v_rep[:, :, h_start:h_end, :].contiguous()
+        if not kv_prefix_head_sharded:
+            h_kv_local = k_shard.shape[2]
+            h_start = sp_rank * h_kv_local
+            h_end = h_start + h_kv_local
+            k_rep = k_rep[:, :, h_start:h_end, :].contiguous()
+            v_rep = v_rep[:, :, h_start:h_end, :].contiguous()
 
         k = torch.cat([k_rep, k_shard], dim=1)
         v = torch.cat([v_rep, v_shard], dim=1)

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -757,7 +757,6 @@ class USPAttention(nn.Module):
         v_prefix: torch.Tensor,
         k_suffix: torch.Tensor,
         v_suffix: torch.Tensor,
-        kv_prefix_head_sharded: bool = False,
     ) -> torch.Tensor:
         """attention with replicated K/V prefix supplied separately"""
         forward_context: ForwardContext = get_forward_context()
@@ -774,13 +773,7 @@ class USPAttention(nn.Module):
             return self(q, k, v)
 
         return self._forward_with_replicated_kv_prefix_split(
-            q,
-            k_prefix,
-            v_prefix,
-            k_suffix,
-            v_suffix,
-            ctx_attn_metadata,
-            kv_prefix_head_sharded,
+            q, k_prefix, v_prefix, k_suffix, v_suffix, ctx_attn_metadata
         )
 
     def _forward_with_replicated_kv_prefix(
@@ -819,7 +812,6 @@ class USPAttention(nn.Module):
         k_shard: torch.Tensor,
         v_shard: torch.Tensor,
         ctx_attn_metadata,
-        kv_prefix_head_sharded: bool = False,
     ) -> torch.Tensor:
         """split form avoids materializing full K/V before Ulysses all-to-all"""
         sp_rank = get_sp_parallel_rank()
@@ -828,12 +820,11 @@ class USPAttention(nn.Module):
         k_shard = _usp_input_all_to_all(k_shard, head_dim=2)
         v_shard = _usp_input_all_to_all(v_shard, head_dim=2)
 
-        if not kv_prefix_head_sharded:
-            h_kv_local = k_shard.shape[2]
-            h_start = sp_rank * h_kv_local
-            h_end = h_start + h_kv_local
-            k_rep = k_rep[:, :, h_start:h_end, :].contiguous()
-            v_rep = v_rep[:, :, h_start:h_end, :].contiguous()
+        h_kv_local = k_shard.shape[2]
+        h_start = sp_rank * h_kv_local
+        h_end = h_start + h_kv_local
+        k_rep = k_rep[:, :, h_start:h_end, :].contiguous()
+        v_rep = v_rep[:, :, h_start:h_end, :].contiguous()
 
         k = torch.cat([k_rep, k_shard], dim=1)
         v = torch.cat([v_rep, v_shard], dim=1)

--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -1095,11 +1095,22 @@ class Cosmos3OmniTransformer(CachableDiT):
         # Check if sequence parallelism is enabled
         sequence_shard_enabled = self.sp_size > 1
 
-        # Patchify visual tokens. With Ulysses enabled, shard before proj_in
-        # because the projection is token-local and replicated on every rank.
-        hidden_gen = self.patchify(hidden_states, T, H, W)
+        # Patchify and project to hidden dim
+        hidden_gen, _ = self.proj_in(self.patchify(hidden_states, T, H, W))
         seq_len_orig = hidden_gen.shape[1]
         seq_shard_pad = 0
+
+        # Per-token noisy mask follows the same pad/shard as hidden_gen, so
+        # build it before the SP split.
+        token_noisy_mask: torch.Tensor | None = None
+        if noisy_frame_mask is not None:
+            token_noisy_mask = (
+                noisy_frame_mask[:, 0, :, 0, 0]
+                .unsqueeze(-1)
+                .expand(-1, -1, Hp * Wp)
+                .reshape(batch_size, -1, 1)
+                .to(hidden_gen.dtype)
+            )
 
         # Shard sequence across GPUs if SP enabled
         if sequence_shard_enabled:
@@ -1111,32 +1122,19 @@ class Cosmos3OmniTransformer(CachableDiT):
                     device=hidden_gen.device,
                 )
                 hidden_gen = torch.cat([hidden_gen, pad], dim=1)
+                if token_noisy_mask is not None:
+                    mask_pad = torch.zeros(
+                        (batch_size, seq_shard_pad, 1),
+                        dtype=token_noisy_mask.dtype,
+                        device=token_noisy_mask.device,
+                    )
+                    token_noisy_mask = torch.cat([token_noisy_mask, mask_pad], dim=1)
             local_seq_len = hidden_gen.shape[1] // self.sp_size
             hidden_gen = hidden_gen.view(
                 batch_size, self.sp_size, local_seq_len, hidden_gen.shape[2]
             )
             hidden_gen = hidden_gen[:, self.sp_rank, :, :]
-
-        hidden_gen, _ = self.proj_in(hidden_gen)
-
-        # Per-token noisy mask follows the same pad/shard as hidden_gen.
-        token_noisy_mask: torch.Tensor | None = None
-        if noisy_frame_mask is not None:
-            token_noisy_mask = (
-                noisy_frame_mask[:, 0, :, 0, 0]
-                .unsqueeze(-1)
-                .expand(-1, -1, Hp * Wp)
-                .reshape(batch_size, -1, 1)
-                .to(hidden_gen.dtype)
-            )
-            if sequence_shard_enabled and seq_shard_pad > 0:
-                mask_pad = torch.zeros(
-                    (batch_size, seq_shard_pad, 1),
-                    dtype=token_noisy_mask.dtype,
-                    device=token_noisy_mask.device,
-                )
-                token_noisy_mask = torch.cat([token_noisy_mask, mask_pad], dim=1)
-            if sequence_shard_enabled:
+            if token_noisy_mask is not None:
                 token_noisy_mask = token_noisy_mask.view(
                     batch_size, self.sp_size, local_seq_len, 1
                 )[:, self.sp_rank, :, :]

--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -1095,22 +1095,11 @@ class Cosmos3OmniTransformer(CachableDiT):
         # Check if sequence parallelism is enabled
         sequence_shard_enabled = self.sp_size > 1
 
-        # Patchify and project to hidden dim
-        hidden_gen, _ = self.proj_in(self.patchify(hidden_states, T, H, W))
+        # Patchify visual tokens. With Ulysses enabled, shard before proj_in
+        # because the projection is token-local and replicated on every rank.
+        hidden_gen = self.patchify(hidden_states, T, H, W)
         seq_len_orig = hidden_gen.shape[1]
         seq_shard_pad = 0
-
-        # Per-token noisy mask follows the same pad/shard as hidden_gen, so
-        # build it before the SP split.
-        token_noisy_mask: torch.Tensor | None = None
-        if noisy_frame_mask is not None:
-            token_noisy_mask = (
-                noisy_frame_mask[:, 0, :, 0, 0]
-                .unsqueeze(-1)
-                .expand(-1, -1, Hp * Wp)
-                .reshape(batch_size, -1, 1)
-                .to(hidden_gen.dtype)
-            )
 
         # Shard sequence across GPUs if SP enabled
         if sequence_shard_enabled:
@@ -1122,19 +1111,32 @@ class Cosmos3OmniTransformer(CachableDiT):
                     device=hidden_gen.device,
                 )
                 hidden_gen = torch.cat([hidden_gen, pad], dim=1)
-                if token_noisy_mask is not None:
-                    mask_pad = torch.zeros(
-                        (batch_size, seq_shard_pad, 1),
-                        dtype=token_noisy_mask.dtype,
-                        device=token_noisy_mask.device,
-                    )
-                    token_noisy_mask = torch.cat([token_noisy_mask, mask_pad], dim=1)
             local_seq_len = hidden_gen.shape[1] // self.sp_size
             hidden_gen = hidden_gen.view(
                 batch_size, self.sp_size, local_seq_len, hidden_gen.shape[2]
             )
             hidden_gen = hidden_gen[:, self.sp_rank, :, :]
-            if token_noisy_mask is not None:
+
+        hidden_gen, _ = self.proj_in(hidden_gen)
+
+        # Per-token noisy mask follows the same pad/shard as hidden_gen.
+        token_noisy_mask: torch.Tensor | None = None
+        if noisy_frame_mask is not None:
+            token_noisy_mask = (
+                noisy_frame_mask[:, 0, :, 0, 0]
+                .unsqueeze(-1)
+                .expand(-1, -1, Hp * Wp)
+                .reshape(batch_size, -1, 1)
+                .to(hidden_gen.dtype)
+            )
+            if sequence_shard_enabled and seq_shard_pad > 0:
+                mask_pad = torch.zeros(
+                    (batch_size, seq_shard_pad, 1),
+                    dtype=token_noisy_mask.dtype,
+                    device=token_noisy_mask.device,
+                )
+                token_noisy_mask = torch.cat([token_noisy_mask, mask_pad], dim=1)
+            if sequence_shard_enabled:
                 token_noisy_mask = token_noisy_mask.view(
                     batch_size, self.sp_size, local_seq_len, 1
                 )[:, self.sp_rank, :, :]

--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -1163,24 +1163,23 @@ class Cosmos3OmniTransformer(CachableDiT):
             self.cached_kv[cache_key] = self.language_model(
                 text_ids, text_mask, freqs_und[0], freqs_und[1]
             )
-            self.cached_freqs_gen[cache_key] = freqs_gen
+            cos_gen, sin_gen = freqs_gen
+            if sequence_shard_enabled:
+                if seq_shard_pad > 0:
+                    pad_cos = cos_gen[:, -1:].expand(-1, seq_shard_pad, -1)
+                    pad_sin = sin_gen[:, -1:].expand(-1, seq_shard_pad, -1)
+                    cos_gen = torch.cat([cos_gen, pad_cos], dim=1)
+                    sin_gen = torch.cat([sin_gen, pad_sin], dim=1)
+                cos_gen = cos_gen.view(batch_size, self.sp_size, local_seq_len, -1)
+                sin_gen = sin_gen.view(batch_size, self.sp_size, local_seq_len, -1)
+                cos_gen = cos_gen[:, self.sp_rank, :, :]
+                sin_gen = sin_gen[:, self.sp_rank, :, :]
+            cos_gen = cos_gen.unsqueeze(2)  # [B, S, 1, D]
+            sin_gen = sin_gen.unsqueeze(2)
+            self.cached_freqs_gen[cache_key] = (cos_gen, sin_gen)
 
         freqs_gen = self.cached_freqs_gen[cache_key]
         cos_gen, sin_gen = freqs_gen
-
-        if sequence_shard_enabled:
-            if seq_shard_pad > 0:
-                pad_cos = cos_gen[:, -1:].expand(-1, seq_shard_pad, -1)
-                pad_sin = sin_gen[:, -1:].expand(-1, seq_shard_pad, -1)
-                cos_gen = torch.cat([cos_gen, pad_cos], dim=1)
-                sin_gen = torch.cat([sin_gen, pad_sin], dim=1)
-            cos_gen = cos_gen.view(batch_size, self.sp_size, local_seq_len, -1)
-            sin_gen = sin_gen.view(batch_size, self.sp_size, local_seq_len, -1)
-            cos_gen = cos_gen[:, self.sp_rank, :, :]
-            sin_gen = sin_gen[:, self.sp_rank, :, :]
-
-        cos_gen = cos_gen.unsqueeze(2)  # [B, S, 1, D]
-        sin_gen = sin_gen.unsqueeze(2)
 
         # Run GEN layers. `residual` is threaded so each layer's
         # input_layernorm and post_attention_layernorm can use the

--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -526,13 +526,16 @@ class Cosmos3CrossAttention(nn.Module):
         v_und: torch.Tensor,
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
+        kv_prefix_head_sharded: bool = False,
     ) -> torch.Tensor:
         """Cross-attention from GEN to cached UND K/V.
 
         Args:
             hidden_states: [B, S_gen_local, hidden_size] visual tokens (may be sharded)
-            k_und: [B, S_und, H_kv, D] pre-computed UND keys (always full/replicated)
-            v_und: [B, S_und, H_kv, D] pre-computed UND values (always full/replicated)
+            k_und: [B, S_und, H_kv, D] pre-computed UND keys
+                (full/replicated unless ``kv_prefix_head_sharded`` is true)
+            v_und: [B, S_und, H_kv, D] pre-computed UND values
+                (full/replicated unless ``kv_prefix_head_sharded`` is true)
             freqs_cos: [B, S_gen_local, 1, D] cosine part of RoPE (for local shard)
             freqs_sin: [B, S_gen_local, 1, D] sine part of RoPE (for local shard)
         """
@@ -566,7 +569,14 @@ class Cosmos3CrossAttention(nn.Module):
         # K/V = [text (replicated full on every SP rank) | image (sharded same as Q)].
         # USPAttention routes through the registered attention backend (FA, sage,
         # …) and handles the Ulysses all-to-all when SP > 1.
-        out = self.attn.forward_with_replicated_kv_prefix(q, k_und, v_und, k, v)
+        out = self.attn.forward_with_replicated_kv_prefix(
+            q,
+            k_und,
+            v_und,
+            k,
+            v,
+            kv_prefix_head_sharded=kv_prefix_head_sharded,
+        )
         out = out.reshape(batch_size, seq_len_gen, -1)
         out, _ = self.to_out(out)
         return out
@@ -686,6 +696,7 @@ class Cosmos3GenDecoderLayer(nn.Module):
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
         residual: torch.Tensor | None = None,
+        kv_prefix_head_sharded: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Fused add+rmsnorm: each `(hidden_states, residual) = norm(...)`
         # collapses the residual add and RMSNorm into one kernel. The
@@ -698,7 +709,12 @@ class Cosmos3GenDecoderLayer(nn.Module):
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
         hidden_states = self.cross_attention(
-            hidden_states, k_und, v_und, freqs_cos, freqs_sin
+            hidden_states,
+            k_und,
+            v_und,
+            freqs_cos,
+            freqs_sin,
+            kv_prefix_head_sharded=kv_prefix_head_sharded,
         )
 
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
@@ -918,6 +934,9 @@ class Cosmos3OmniTransformer(CachableDiT):
         # This allows maintaining separate caches for conditional and unconditional
         # prompts, avoiding recomputation on every denoising step
         self.cached_kv: dict[str, list[tuple[torch.Tensor, torch.Tensor]]] = {}
+        self.cached_kv_head_sharded: dict[
+            str, list[tuple[torch.Tensor, torch.Tensor]]
+        ] = {}
         self.cached_freqs_gen: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
         self.__post_init__()
@@ -1029,11 +1048,14 @@ class Cosmos3OmniTransformer(CachableDiT):
         if cache_key is None:
             # Reset all caches
             self.cached_kv = {}
+            self.cached_kv_head_sharded = {}
             self.cached_freqs_gen = {}
         else:
             # Reset specific cache
             if cache_key in self.cached_kv:
                 del self.cached_kv[cache_key]
+            if cache_key in self.cached_kv_head_sharded:
+                del self.cached_kv_head_sharded[cache_key]
             if cache_key in self.cached_freqs_gen:
                 del self.cached_freqs_gen[cache_key]
 
@@ -1041,8 +1063,32 @@ class Cosmos3OmniTransformer(CachableDiT):
         """Ensure cache dictionaries exist (for backwards compatibility)."""
         if not isinstance(self.cached_kv, dict):
             self.cached_kv = {}
+        if not isinstance(self.cached_kv_head_sharded, dict):
+            self.cached_kv_head_sharded = {}
         if not isinstance(self.cached_freqs_gen, dict):
             self.cached_freqs_gen = {}
+
+    def _can_use_head_sharded_kv_cache(self) -> bool:
+        return (
+            self.sp_group is not None
+            and self.sp_group.ulysses_world_size > 1
+            and self.sp_group.ring_world_size == 1
+            and self.num_key_value_heads % self.sp_group.ulysses_world_size == 0
+        )
+
+    def _build_head_sharded_kv_cache(
+        self, cached_kv: list[tuple[torch.Tensor, torch.Tensor]]
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        h_kv_local = self.num_key_value_heads // self.sp_group.ulysses_world_size
+        h_start = self.sp_rank * h_kv_local
+        h_end = h_start + h_kv_local
+        return [
+            (
+                k[:, :, h_start:h_end, :].contiguous(),
+                v[:, :, h_start:h_end, :].contiguous(),
+            )
+            for k, v in cached_kv
+        ]
 
     def forward(
         self,
@@ -1163,6 +1209,10 @@ class Cosmos3OmniTransformer(CachableDiT):
             self.cached_kv[cache_key] = self.language_model(
                 text_ids, text_mask, freqs_und[0], freqs_und[1]
             )
+            if self._can_use_head_sharded_kv_cache():
+                self.cached_kv_head_sharded[cache_key] = (
+                    self._build_head_sharded_kv_cache(self.cached_kv[cache_key])
+                )
             self.cached_freqs_gen[cache_key] = freqs_gen
 
         freqs_gen = self.cached_freqs_gen[cache_key]
@@ -1185,7 +1235,11 @@ class Cosmos3OmniTransformer(CachableDiT):
         # Run GEN layers. `residual` is threaded so each layer's
         # input_layernorm and post_attention_layernorm can use the
         # fused add+rmsnorm path instead of separate add + norm kernels.
-        cached_kv_for_key = self.cached_kv[cache_key]
+        kv_prefix_head_sharded = cache_key in self.cached_kv_head_sharded
+        if kv_prefix_head_sharded:
+            cached_kv_for_key = self.cached_kv_head_sharded[cache_key]
+        else:
+            cached_kv_for_key = self.cached_kv[cache_key]
         residual: torch.Tensor | None = None
         for i, layer in enumerate(self.gen_layers):
             k_und, v_und = cached_kv_for_key[i]
@@ -1196,6 +1250,7 @@ class Cosmos3OmniTransformer(CachableDiT):
                 cos_gen,
                 sin_gen,
                 residual=residual,
+                kv_prefix_head_sharded=kv_prefix_head_sharded,
             )
 
         # Collapse the trailing residual carry. RMSNorm and the linear

--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -526,16 +526,13 @@ class Cosmos3CrossAttention(nn.Module):
         v_und: torch.Tensor,
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
-        kv_prefix_head_sharded: bool = False,
     ) -> torch.Tensor:
         """Cross-attention from GEN to cached UND K/V.
 
         Args:
             hidden_states: [B, S_gen_local, hidden_size] visual tokens (may be sharded)
-            k_und: [B, S_und, H_kv, D] pre-computed UND keys
-                (full/replicated unless ``kv_prefix_head_sharded`` is true)
-            v_und: [B, S_und, H_kv, D] pre-computed UND values
-                (full/replicated unless ``kv_prefix_head_sharded`` is true)
+            k_und: [B, S_und, H_kv, D] pre-computed UND keys (always full/replicated)
+            v_und: [B, S_und, H_kv, D] pre-computed UND values (always full/replicated)
             freqs_cos: [B, S_gen_local, 1, D] cosine part of RoPE (for local shard)
             freqs_sin: [B, S_gen_local, 1, D] sine part of RoPE (for local shard)
         """
@@ -569,14 +566,7 @@ class Cosmos3CrossAttention(nn.Module):
         # K/V = [text (replicated full on every SP rank) | image (sharded same as Q)].
         # USPAttention routes through the registered attention backend (FA, sage,
         # …) and handles the Ulysses all-to-all when SP > 1.
-        out = self.attn.forward_with_replicated_kv_prefix(
-            q,
-            k_und,
-            v_und,
-            k,
-            v,
-            kv_prefix_head_sharded=kv_prefix_head_sharded,
-        )
+        out = self.attn.forward_with_replicated_kv_prefix(q, k_und, v_und, k, v)
         out = out.reshape(batch_size, seq_len_gen, -1)
         out, _ = self.to_out(out)
         return out
@@ -696,7 +686,6 @@ class Cosmos3GenDecoderLayer(nn.Module):
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
         residual: torch.Tensor | None = None,
-        kv_prefix_head_sharded: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Fused add+rmsnorm: each `(hidden_states, residual) = norm(...)`
         # collapses the residual add and RMSNorm into one kernel. The
@@ -709,12 +698,7 @@ class Cosmos3GenDecoderLayer(nn.Module):
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
         hidden_states = self.cross_attention(
-            hidden_states,
-            k_und,
-            v_und,
-            freqs_cos,
-            freqs_sin,
-            kv_prefix_head_sharded=kv_prefix_head_sharded,
+            hidden_states, k_und, v_und, freqs_cos, freqs_sin
         )
 
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
@@ -934,9 +918,6 @@ class Cosmos3OmniTransformer(CachableDiT):
         # This allows maintaining separate caches for conditional and unconditional
         # prompts, avoiding recomputation on every denoising step
         self.cached_kv: dict[str, list[tuple[torch.Tensor, torch.Tensor]]] = {}
-        self.cached_kv_head_sharded: dict[
-            str, list[tuple[torch.Tensor, torch.Tensor]]
-        ] = {}
         self.cached_freqs_gen: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
         self.__post_init__()
@@ -1048,14 +1029,11 @@ class Cosmos3OmniTransformer(CachableDiT):
         if cache_key is None:
             # Reset all caches
             self.cached_kv = {}
-            self.cached_kv_head_sharded = {}
             self.cached_freqs_gen = {}
         else:
             # Reset specific cache
             if cache_key in self.cached_kv:
                 del self.cached_kv[cache_key]
-            if cache_key in self.cached_kv_head_sharded:
-                del self.cached_kv_head_sharded[cache_key]
             if cache_key in self.cached_freqs_gen:
                 del self.cached_freqs_gen[cache_key]
 
@@ -1063,32 +1041,8 @@ class Cosmos3OmniTransformer(CachableDiT):
         """Ensure cache dictionaries exist (for backwards compatibility)."""
         if not isinstance(self.cached_kv, dict):
             self.cached_kv = {}
-        if not isinstance(self.cached_kv_head_sharded, dict):
-            self.cached_kv_head_sharded = {}
         if not isinstance(self.cached_freqs_gen, dict):
             self.cached_freqs_gen = {}
-
-    def _can_use_head_sharded_kv_cache(self) -> bool:
-        return (
-            self.sp_group is not None
-            and self.sp_group.ulysses_world_size > 1
-            and self.sp_group.ring_world_size == 1
-            and self.num_key_value_heads % self.sp_group.ulysses_world_size == 0
-        )
-
-    def _build_head_sharded_kv_cache(
-        self, cached_kv: list[tuple[torch.Tensor, torch.Tensor]]
-    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
-        h_kv_local = self.num_key_value_heads // self.sp_group.ulysses_world_size
-        h_start = self.sp_rank * h_kv_local
-        h_end = h_start + h_kv_local
-        return [
-            (
-                k[:, :, h_start:h_end, :].contiguous(),
-                v[:, :, h_start:h_end, :].contiguous(),
-            )
-            for k, v in cached_kv
-        ]
 
     def forward(
         self,
@@ -1209,10 +1163,6 @@ class Cosmos3OmniTransformer(CachableDiT):
             self.cached_kv[cache_key] = self.language_model(
                 text_ids, text_mask, freqs_und[0], freqs_und[1]
             )
-            if self._can_use_head_sharded_kv_cache():
-                self.cached_kv_head_sharded[cache_key] = (
-                    self._build_head_sharded_kv_cache(self.cached_kv[cache_key])
-                )
             self.cached_freqs_gen[cache_key] = freqs_gen
 
         freqs_gen = self.cached_freqs_gen[cache_key]
@@ -1235,11 +1185,7 @@ class Cosmos3OmniTransformer(CachableDiT):
         # Run GEN layers. `residual` is threaded so each layer's
         # input_layernorm and post_attention_layernorm can use the
         # fused add+rmsnorm path instead of separate add + norm kernels.
-        kv_prefix_head_sharded = cache_key in self.cached_kv_head_sharded
-        if kv_prefix_head_sharded:
-            cached_kv_for_key = self.cached_kv_head_sharded[cache_key]
-        else:
-            cached_kv_for_key = self.cached_kv[cache_key]
+        cached_kv_for_key = self.cached_kv[cache_key]
         residual: torch.Tensor | None = None
         for i, layer in enumerate(self.gen_layers):
             k_und, v_und = cached_kv_for_key[i]
@@ -1250,7 +1196,6 @@ class Cosmos3OmniTransformer(CachableDiT):
                 cos_gen,
                 sin_gen,
                 residual=residual,
-                kv_prefix_head_sharded=kv_prefix_head_sharded,
             )
 
         # Collapse the trailing residual carry. RMSNorm and the linear

--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -428,18 +428,21 @@ class Cosmos3CausalAttention(nn.Module):
         batch_size, seq_len = hidden_states.shape[:2]
 
         qkv, _ = self.to_qkv(hidden_states)
-        # split returns strided views into qkv; .contiguous() before .view()
-        # because the per-head reshape needs row-major memory.
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q = q.contiguous().view(
-            batch_size, seq_len, self.num_attention_heads, self.head_dim
+        qkv = qkv.view(
+            batch_size,
+            seq_len,
+            self.num_attention_heads + 2 * self.num_key_value_heads,
+            self.head_dim,
         )
-        k = k.contiguous().view(
-            batch_size, seq_len, self.num_key_value_heads, self.head_dim
-        )
-        v = v.contiguous().view(
-            batch_size, seq_len, self.num_key_value_heads, self.head_dim
-        )
+        q = qkv[:, :, : self.num_attention_heads, :]
+        k = qkv[
+            :,
+            :,
+            self.num_attention_heads : self.num_attention_heads
+            + self.num_key_value_heads,
+            :,
+        ]
+        v = qkv[:, :, self.num_attention_heads + self.num_key_value_heads :, :]
 
         q = F.rms_norm(
             q, (self.head_dim,), self.norm_q.weight, self.norm_q.variance_epsilon
@@ -536,16 +539,21 @@ class Cosmos3CrossAttention(nn.Module):
         batch_size, seq_len_gen = hidden_states.shape[:2]
 
         qkv, _ = self.to_qkv(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q = q.contiguous().view(
-            batch_size, seq_len_gen, self.num_attention_heads, self.head_dim
+        qkv = qkv.view(
+            batch_size,
+            seq_len_gen,
+            self.num_attention_heads + 2 * self.num_key_value_heads,
+            self.head_dim,
         )
-        k = k.contiguous().view(
-            batch_size, seq_len_gen, self.num_key_value_heads, self.head_dim
-        )
-        v = v.contiguous().view(
-            batch_size, seq_len_gen, self.num_key_value_heads, self.head_dim
-        )
+        q = qkv[:, :, : self.num_attention_heads, :]
+        k = qkv[
+            :,
+            :,
+            self.num_attention_heads : self.num_attention_heads
+            + self.num_key_value_heads,
+            :,
+        ]
+        v = qkv[:, :, self.num_attention_heads + self.num_key_value_heads :, :]
 
         q = F.rms_norm(
             q, (self.head_dim,), self.norm_q.weight, self.norm_q.variance_epsilon
@@ -558,10 +566,7 @@ class Cosmos3CrossAttention(nn.Module):
         # K/V = [text (replicated full on every SP rank) | image (sharded same as Q)].
         # USPAttention routes through the registered attention backend (FA, sage,
         # …) and handles the Ulysses all-to-all when SP > 1.
-        num_und = k_und.shape[1]
-        k = torch.cat([k_und, k], dim=1)
-        v = torch.cat([v_und, v], dim=1)
-        out = self.attn(q, k, v, num_replicated_kv_prefix=num_und)
+        out = self.attn.forward_with_replicated_kv_prefix(q, k_und, v_und, k, v)
         out = out.reshape(batch_size, seq_len_gen, -1)
         out, _ = self.to_out(out)
         return out

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -499,6 +499,7 @@ class Cosmos3DenoisingStage(PipelineStage):
         cache_key: str = "default",
         noisy_frame_mask: torch.Tensor | None = None,
         max_text_seq_len: int | None = None,
+        current_timestep: int | None = None,
     ) -> torch.Tensor:
         """Run transformer forward pass.
 
@@ -513,10 +514,9 @@ class Cosmos3DenoisingStage(PipelineStage):
                 and "uncond" for unconditional to enable cache reuse across steps.
             noisy_frame_mask: Optional [B, 1, T, 1, 1] I2V conditioning mask.
         """
-        with set_forward_context(
-            current_timestep=int(timestep.flatten()[0].item()),
-            attn_metadata=None,
-        ):
+        if current_timestep is None:
+            current_timestep = int(timestep.flatten()[0].item())
+        with set_forward_context(current_timestep=current_timestep, attn_metadata=None):
             return self.transformer(
                 hidden_states=latents,
                 encoder_hidden_states=None,  # Not used by Cosmos3
@@ -641,6 +641,7 @@ class Cosmos3DenoisingStage(PipelineStage):
                         noisy_frame_mask=velocity_mask,
                         cond_text_seq_len=batch.extra["cond_text_seq_len"],
                         uncond_text_seq_len=batch.extra["uncond_text_seq_len"],
+                        current_timestep=i,
                     )
                 elif effective_scale == 1.0:
                     noise_pred = self._run_transformer(
@@ -653,6 +654,7 @@ class Cosmos3DenoisingStage(PipelineStage):
                         cache_key="cond",
                         noisy_frame_mask=velocity_mask,
                         max_text_seq_len=batch.extra["cond_text_seq_len"],
+                        current_timestep=i,
                     )
                 else:
                     noise_pred = self._predict_noise_cfg_batched(
@@ -670,6 +672,7 @@ class Cosmos3DenoisingStage(PipelineStage):
                             batch.extra["cond_text_seq_len"],
                             batch.extra["uncond_text_seq_len"],
                         ),
+                        current_timestep=i,
                     )
             else:
                 noise_pred = self._run_transformer(
@@ -682,6 +685,7 @@ class Cosmos3DenoisingStage(PipelineStage):
                     cache_key="cond",
                     noisy_frame_mask=velocity_mask,
                     max_text_seq_len=batch.extra["cond_text_seq_len"],
+                    current_timestep=i,
                 )
 
             # I2V: zero-velocity at conditioned frames so the scheduler keeps
@@ -717,6 +721,7 @@ class Cosmos3DenoisingStage(PipelineStage):
         guidance_scale: float,
         noisy_frame_mask: torch.Tensor | None = None,
         max_text_seq_len: int | None = None,
+        current_timestep: int | None = None,
     ) -> torch.Tensor:
         """Run CFG by stacking both branches into a batch_size=2 forward.
 
@@ -744,6 +749,7 @@ class Cosmos3DenoisingStage(PipelineStage):
             cache_key="cfg_batched",
             noisy_frame_mask=mask_batched,
             max_text_seq_len=max_text_seq_len,
+            current_timestep=current_timestep,
         )
 
         noise_pred_uncond, noise_pred_cond = noise_pred.chunk(2, dim=0)
@@ -767,6 +773,7 @@ class Cosmos3DenoisingStage(PipelineStage):
         noisy_frame_mask: torch.Tensor | None = None,
         cond_text_seq_len: int | None = None,
         uncond_text_seq_len: int | None = None,
+        current_timestep: int | None = None,
     ) -> torch.Tensor:
         """Run CFG with one branch per CFG rank, combined by all-reduce.
 
@@ -787,6 +794,7 @@ class Cosmos3DenoisingStage(PipelineStage):
                 cache_key="cond",
                 noisy_frame_mask=noisy_frame_mask,
                 max_text_seq_len=cond_text_seq_len,
+                current_timestep=current_timestep,
             )
             partial = guidance_scale * noise_pred
         else:
@@ -800,6 +808,7 @@ class Cosmos3DenoisingStage(PipelineStage):
                 cache_key="uncond",
                 noisy_frame_mask=noisy_frame_mask,
                 max_text_seq_len=uncond_text_seq_len,
+                current_timestep=current_timestep,
             )
             partial = (1.0 - guidance_scale) * noise_pred
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -26,6 +26,7 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
     get_sp_parallel_rank,
     get_sp_world_size,
+    get_world_group,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
@@ -614,7 +615,7 @@ class Cosmos3DenoisingStage(PipelineStage):
             enumerate(timesteps),
             total=len(timesteps),
             desc="Denoising",
-            disable=batch.is_warmup,
+            disable=batch.is_warmup or get_world_group().local_rank != 0,
         )
 
         for i, t in progress_bar:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -26,7 +26,6 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
     get_sp_parallel_rank,
     get_sp_world_size,
-    get_world_group,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
@@ -615,7 +614,7 @@ class Cosmos3DenoisingStage(PipelineStage):
             enumerate(timesteps),
             total=len(timesteps),
             desc="Denoising",
-            disable=batch.is_warmup or get_world_group().local_rank != 0,
+            disable=batch.is_warmup,
         )
 
         for i, t in progress_bar:


### PR DESCRIPTION
## Summary
- avoid materializing the full Cosmos3 `[text KV | visual KV]` prefix before Ulysses cross-attention
- slice fused Cosmos3 QKV by view instead of splitting into separate contiguous tensors
- cache the local Cosmos3 visual RoPE shard instead of slicing it every denoise step
- write Cosmos3 RoPE output directly instead of materializing `rotate_half` concat tensors
- use fused Cosmos3 cross-attention QK norm through the existing guarded `apply_qk_norm` helper
- use the denoise loop step index for Cosmos3 forward context instead of synchronizing the timestep scalar each step
- avoid repeated WanVAE feature-cache decode concatenation by collecting chunks and concatenating once
- postprocess Cosmos3 decoded tensors in place to reduce peak output memory

## Validation
- fixed 4xH200 Cosmos3 Nano T2V 720p/189f/35 steps, CFG parallel 2 + Ulysses 2, speed mode, torch compile/cache DiT/guardrails disabled
- PR base `2fdae94e46`: response `62.1376s`, denoise `53.1809s`, decode `8.9501s`
- previous PR head `eeedd06a26`: response `61.4372s`, denoise `52.4770s`, decode `8.9553s`
- current PR head `50911855f7`: response `61.1944s` / `61.2590s`, denoise `52.2528s` / `52.3041s`, decode `8.9367s` / `8.9365s`, peak memory `48774MB`
- same-session single-cat A/B: `eeedd06a26` baseline response `61.2999s`, denoise `52.3357s`, decode `8.9595s`, peak memory `52588MB`; `fe145b61d5` rerun response `61.2684s`, denoise `52.3347s`, decode `8.9273s`, peak memory `50768MB`
- same-session in-place postprocess A/B: `fe145b61d5` baseline response `61.2240s`, denoise `52.2800s`, decode `8.9383s`, peak memory `50768MB`; `50911855f7` rerun response `61.2590s`, denoise `52.3041s`, decode `8.9365s`, peak memory `48774MB`
- all full T2V runs above produced byte-identical MP4 output: `1fa0f31c0578e95d6f61a77e15c63d3f293909ae470c0653ad25c65793d4136e`
- targeted `cosmos3_nano_t2i` consistency on current head: `1 passed`, bitwise against pinned GT (`clip=1.0`, `ssim=1.0`, `psnr=inf`, `mean_abs_diff=0`)













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26797439278](https://github.com/sgl-project/sglang/actions/runs/26797439278)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26797439172](https://github.com/sgl-project/sglang/actions/runs/26797439172)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
