### PR TITLE
[Observability] Break down prefill #cached-token into device / host / storage tiers

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -146,6 +146,19 @@ def _compute_pad_value(hash: int) -> int:
     return MM_PAD_SHIFT_VALUE + (hash % (1 << 30))
 
 
+def compute_cache_hit_split(
+    prefix_len: int, host_hit_length: int, storage_hit_length: int
+) -> tuple:
+    """Return (device, host, storage) token counts. Always sums to prefix_len.
+
+    host_hit_length is capped at prefix_len so the result is correct even
+    when init_load_back loads fewer tokens than expected (e.g. alloc failure).
+    """
+    host_total = min(host_hit_length, prefix_len)
+    storage = min(host_total, storage_hit_length)
+    return prefix_len - host_total, host_total - storage, storage
+
+
 class BaseFinishReason:
     def to_json(self):
         raise NotImplementedError()
@@ -2115,24 +2128,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # Only compute once on FIRST chunk - subsequent chunks in chunked prefill
                 # would incorrectly count previously computed tokens as cache hits.
                 if not req._cache_breakdown_computed:
-                    # At this point, prefix_indices has been extended with host data
-                    # via init_load_back in schedule_policy, so:
-                    # - len(prefix_indices) = device_original + host_loaded
-                    # - host_hit_length = total tokens from host cache (including storage-prefetched)
-                    # - storage_hit_length = tokens loaded from storage backend (L3 hits)
-                    # - device_portion = len(prefix_indices) - host_hit_length
-                    #
-                    # Storage hits are now tracked via scheduler after prefetch completes.
-                    # storage_hit_length is set by scheduler.pop_prefetch_loaded_tokens()
-                    host_total = req.host_hit_length
-                    # Clamp storage to host_total to handle edge cases
-                    storage_portion = min(host_total, req.storage_hit_length)
-                    host_portion = host_total - storage_portion
-                    device_portion = max(0, len(req.prefix_indices) - host_total)
-
-                    req.cached_tokens_device = device_portion
-                    req.cached_tokens_host = host_portion
-                    req.cached_tokens_storage = storage_portion
+                    (
+                        req.cached_tokens_device,
+                        req.cached_tokens_host,
+                        req.cached_tokens_storage,
+                    ) = compute_cache_hit_split(
+                        len(req.prefix_indices),
+                        req.host_hit_length,
+                        req.storage_hit_length,
+                    )
                     req._cache_breakdown_computed = True
 
                 req.already_computed = seq_len

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -147,14 +147,16 @@ def _compute_pad_value(hash: int) -> int:
 
 
 def compute_cache_hit_split(
-    prefix_len: int, host_hit_length: int, storage_hit_length: int
+    prefix_len: int, loaded_host_hit_length: int, storage_hit_length: int
 ) -> tuple:
     """Return (device, host, storage) token counts. Always sums to prefix_len.
 
-    host_hit_length is capped at prefix_len so the result is correct even
-    when init_load_back loads fewer tokens than expected (e.g. alloc failure).
+    loaded_host_hit_length is the number of KV tokens actually restored from
+    host in this scheduling decision. It intentionally differs from
+    host_hit_length, which can be a load-back trigger sentinel for hybrid
+    caches.
     """
-    host_total = min(host_hit_length, prefix_len)
+    host_total = min(loaded_host_hit_length, prefix_len)
     storage = min(host_total, storage_hit_length)
     return prefix_len - host_total, host_total - storage, storage
 
@@ -864,6 +866,7 @@ class Req(ReqDllmMixin):
         self.host_hit_length = 0
         self.swa_host_hit_length = 0
         self.mamba_host_hit_length = 0
+        self.loaded_host_hit_length = 0
         # Total cached prefix length (on-device prefix_indices + host_hit_length),
         # capped at the max allowed prefix. Set during prefix matching at schedule
         # time and used to estimate uncached tokens / sort by longest prefix for
@@ -1208,6 +1211,7 @@ class Req(ReqDllmMixin):
                 match_result.mamba_host_hit_length,
                 match_result.mamba_branching_seqlen,
             )
+            self.loaded_host_hit_length = 0
             if match_result.cache_protected_len is not None:
                 self.cache_protected_len = match_result.cache_protected_len
             else:
@@ -1458,6 +1462,9 @@ class Req(ReqDllmMixin):
         self.last_node = None
         self.cache_protected_len = 0
         self.num_matched_prefix_tokens = 0
+        self.host_hit_length = 0
+        self.loaded_host_hit_length = 0
+        self.storage_hit_length = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False
         self.extend_range = None
@@ -2134,7 +2141,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                         req.cached_tokens_storage,
                     ) = compute_cache_hit_split(
                         len(req.prefix_indices),
-                        req.host_hit_length,
+                        req.loaded_host_hit_length,
                         req.storage_hit_length,
                     )
                     req._cache_breakdown_computed = True

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -38,8 +38,8 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_in_seq_split
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
 from sglang.srt.managers.schedule_batch import (
-    Req, 
-    ScheduleBatch, 
+    Req,
+    ScheduleBatch,
     compute_cache_hit_split,
 )
 from sglang.srt.mem_cache.allocator.hisparse import (

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -462,8 +462,15 @@ class PrefillAdder:
         self.can_run_list = []
         self.preempt_list = []
         self.new_chunked_req = None
+
         self.log_hit_tokens = 0
+
         self.reprocessed_log_hit_tokens = 0
+
+        self.log_hit_tokens_device = 0
+        self.log_hit_tokens_host = 0
+        self.log_hit_tokens_storage = 0
+
         # TODO(lsyin): report the real input tokens excluding page alignment
         self.log_input_tokens = 0
         self.reprocessed_log_input_tokens = 0
@@ -612,6 +619,10 @@ class PrefillAdder:
         extend_input_len: int,
         max_new_tokens: int,
         retracted_stain: bool,
+        *,
+        device_hit_tokens: Optional[int] = None,
+        host_hit_tokens: int = 0,
+        storage_hit_tokens: int = 0,
     ):
         # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
         extend_input_len = self.ceil_paged_tokens(extend_input_len)
@@ -638,6 +649,15 @@ class PrefillAdder:
             self.reprocessed_log_hit_tokens += prefix_len
             self.reprocessed_log_input_tokens += extend_input_len
 
+        # New split. Default keeps old call sites correct: if nobody passes a
+        # split, assume all cached tokens are device/L1 hits.
+        if device_hit_tokens is None:
+            device_hit_tokens = prefix_len
+
+        self.log_hit_tokens_device += int(device_hit_tokens)
+        self.log_hit_tokens_host += int(host_hit_tokens)
+        self.log_hit_tokens_storage += int(storage_hit_tokens)
+
     def _get_dllm_remain_tokens(self) -> int:
         _rem_tokens = min(
             self.rem_dllm_tokens,
@@ -649,7 +669,15 @@ class PrefillAdder:
 
         return _rem_tokens
 
-    def _add_dllm_req(self, req: Req, prefix_len: int):
+    def _add_dllm_req(
+        self,
+        req: Req,
+        prefix_len: int,
+        *,
+        device_hit_tokens: Optional[int] = None,
+        host_hit_tokens: int = 0,
+        storage_hit_tokens: int = 0,
+    ):
         # FIXME: consider the case when rem_dllm_tokens < dllm_block_size,
         # the diffusion unmask process may have some problems
         # Make sure at least one page is available
@@ -663,7 +691,15 @@ class PrefillAdder:
 
         self.can_run_list.append(req)
 
-        self._update_prefill_budget(prefix_len, trunc_len, 0, req.retracted_stain)
+        self._update_prefill_budget(
+            prefix_len,
+            trunc_len,
+            0,
+            req.retracted_stain,
+            device_hit_tokens=device_hit_tokens,
+            host_hit_tokens=host_hit_tokens,
+            storage_hit_tokens=storage_hit_tokens,
+        )
 
     def _req_inc_lock_ref(self, req: Req):
         result = self.tree_cache.inc_lock_ref(req.last_node)
@@ -907,6 +943,35 @@ class PrefillAdder:
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
 
+        # Split cached prefix hits by source before L2 load-back mutates
+        # req.prefix_indices.
+        device_hit_tokens = len(req.prefix_indices)
+        host_hit_tokens_raw = int(getattr(req, "host_hit_length", 0) or 0)
+        storage_hit_tokens = int(getattr(req, "storage_hit_length", 0) or 0)
+
+        # If L3 storage is enabled, storage hits are usually materialized into the
+        # host tier before match/load-back. Keep the accounting mutually exclusive:
+        #   total cached = device + host + storage
+        # For pure L1/L2 HiCache, storage_hit_tokens is 0.
+        storage_hit_tokens = min(storage_hit_tokens, host_hit_tokens_raw)
+        host_hit_tokens = host_hit_tokens_raw - storage_hit_tokens
+
+        if device_hit_tokens + host_hit_tokens + storage_hit_tokens != prefix_len:
+            logger.warning(
+                "Cached-token split mismatch: total=%d, device=%d, host=%d, "
+                "storage=%d, rid=%s",
+                prefix_len,
+                device_hit_tokens,
+                host_hit_tokens,
+                storage_hit_tokens,
+                req.rid,
+            )
+
+        # Cache the split hit tokens in the request
+        req.cached_tokens_device = device_hit_tokens
+        req.cached_tokens_host = host_hit_tokens
+        req.cached_tokens_storage = storage_hit_tokens
+
         if total_tokens >= self.rem_total_tokens:
             return AddReqResult.NO_TOKEN
 
@@ -973,7 +1038,13 @@ class PrefillAdder:
                     truncation_align_size is None
                 ), "truncation_align_size is not supported for dllm prefill"
 
-                self._add_dllm_req(req, prefix_len)
+                self._add_dllm_req(
+                    req,
+                    prefix_len,
+                    device_hit_tokens=device_hit_tokens,
+                    host_hit_tokens=host_hit_tokens,
+                    storage_hit_tokens=storage_hit_tokens,
+                )
                 self._req_inc_lock_ref(req)
             elif self.rem_chunk_tokens is None or input_tokens <= self.rem_chunk_tokens:
                 # Non-chunked prefill — the whole sequence is committed this iter.
@@ -991,6 +1062,9 @@ class PrefillAdder:
                         CLIP_MAX_NEW_TOKENS,
                     ),
                     req.retracted_stain,
+                    device_hit_tokens=device_hit_tokens,
+                    host_hit_tokens=host_hit_tokens,
+                    storage_hit_tokens=storage_hit_tokens,
                 )
             else:
                 # Make sure at least one page is available
@@ -1027,7 +1101,13 @@ class PrefillAdder:
 
                 self._req_inc_lock_ref(req)
                 self._update_prefill_budget(
-                    prefix_len, trunc_len, 0, req.retracted_stain
+                    prefix_len,
+                    trunc_len,
+                    0,
+                    req.retracted_stain,
+                    device_hit_tokens=device_hit_tokens,
+                    host_hit_tokens=host_hit_tokens,
+                    storage_hit_tokens=storage_hit_tokens,
                 )
 
         return self.budget_state()

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -467,10 +467,6 @@ class PrefillAdder:
 
         self.reprocessed_log_hit_tokens = 0
 
-        self.log_hit_tokens_device = 0
-        self.log_hit_tokens_host = 0
-        self.log_hit_tokens_storage = 0
-
         # TODO(lsyin): report the real input tokens excluding page alignment
         self.log_input_tokens = 0
         self.reprocessed_log_input_tokens = 0
@@ -619,10 +615,6 @@ class PrefillAdder:
         extend_input_len: int,
         max_new_tokens: int,
         retracted_stain: bool,
-        *,
-        device_hit_tokens: Optional[int] = None,
-        host_hit_tokens: int = 0,
-        storage_hit_tokens: int = 0,
     ):
         # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
         extend_input_len = self.ceil_paged_tokens(extend_input_len)
@@ -649,15 +641,6 @@ class PrefillAdder:
             self.reprocessed_log_hit_tokens += prefix_len
             self.reprocessed_log_input_tokens += extend_input_len
 
-        # New split. Default keeps old call sites correct: if nobody passes a
-        # split, assume all cached tokens are device/L1 hits.
-        if device_hit_tokens is None:
-            device_hit_tokens = prefix_len
-
-        self.log_hit_tokens_device += int(device_hit_tokens)
-        self.log_hit_tokens_host += int(host_hit_tokens)
-        self.log_hit_tokens_storage += int(storage_hit_tokens)
-
     def _get_dllm_remain_tokens(self) -> int:
         _rem_tokens = min(
             self.rem_dllm_tokens,
@@ -669,15 +652,7 @@ class PrefillAdder:
 
         return _rem_tokens
 
-    def _add_dllm_req(
-        self,
-        req: Req,
-        prefix_len: int,
-        *,
-        device_hit_tokens: Optional[int] = None,
-        host_hit_tokens: int = 0,
-        storage_hit_tokens: int = 0,
-    ):
+    def _add_dllm_req(self, req: Req, prefix_len: int):
         # FIXME: consider the case when rem_dllm_tokens < dllm_block_size,
         # the diffusion unmask process may have some problems
         # Make sure at least one page is available
@@ -696,9 +671,6 @@ class PrefillAdder:
             trunc_len,
             0,
             req.retracted_stain,
-            device_hit_tokens=device_hit_tokens,
-            host_hit_tokens=host_hit_tokens,
-            storage_hit_tokens=storage_hit_tokens,
         )
 
     def _req_inc_lock_ref(self, req: Req):
@@ -943,24 +915,6 @@ class PrefillAdder:
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
 
-        # Split cached prefix hits by source before L2 load-back mutates
-        # req.prefix_indices.
-        device_hit_tokens = len(req.prefix_indices)
-        host_hit_tokens_raw = int(getattr(req, "host_hit_length", 0) or 0)
-        storage_hit_tokens = int(getattr(req, "storage_hit_length", 0) or 0)
-
-        # If L3 storage is enabled, storage hits are usually materialized into the
-        # host tier before match/load-back. Keep the accounting mutually exclusive:
-        #   total cached = device + host + storage
-        # For pure L1/L2 HiCache, storage_hit_tokens is 0.
-        storage_hit_tokens = min(storage_hit_tokens, host_hit_tokens_raw)
-        host_hit_tokens = host_hit_tokens_raw - storage_hit_tokens
-
-        # Cache the split hit tokens in the request
-        req.cached_tokens_device = device_hit_tokens
-        req.cached_tokens_host = host_hit_tokens
-        req.cached_tokens_storage = storage_hit_tokens
-
         if total_tokens >= self.rem_total_tokens:
             return AddReqResult.NO_TOKEN
 
@@ -1027,13 +981,7 @@ class PrefillAdder:
                     truncation_align_size is None
                 ), "truncation_align_size is not supported for dllm prefill"
 
-                self._add_dllm_req(
-                    req,
-                    prefix_len,
-                    device_hit_tokens=device_hit_tokens,
-                    host_hit_tokens=host_hit_tokens,
-                    storage_hit_tokens=storage_hit_tokens,
-                )
+                self._add_dllm_req(req, prefix_len)
                 self._req_inc_lock_ref(req)
             elif self.rem_chunk_tokens is None or input_tokens <= self.rem_chunk_tokens:
                 # Non-chunked prefill — the whole sequence is committed this iter.
@@ -1051,9 +999,6 @@ class PrefillAdder:
                         CLIP_MAX_NEW_TOKENS,
                     ),
                     req.retracted_stain,
-                    device_hit_tokens=device_hit_tokens,
-                    host_hit_tokens=host_hit_tokens,
-                    storage_hit_tokens=storage_hit_tokens,
                 )
             else:
                 # Make sure at least one page is available
@@ -1094,9 +1039,6 @@ class PrefillAdder:
                     trunc_len,
                     0,
                     req.retracted_stain,
-                    device_hit_tokens=device_hit_tokens,
-                    host_hit_tokens=host_hit_tokens,
-                    storage_hit_tokens=storage_hit_tokens,
                 )
 
         return self.budget_state()

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -127,6 +127,7 @@ def match_prefix_for_req(
     req.num_matched_prefix_tokens = min(
         len(req.prefix_indices) + req.host_hit_length, max_len
     )
+    req.loaded_host_hit_length = 0
     if match_result.mamba_branching_seqlen is not None:
         req.mamba_branching_seqlen = match_result.mamba_branching_seqlen
     if match_result.cache_protected_len is not None:
@@ -627,7 +628,7 @@ class PrefillAdder:
         if prefix_len <= 0:
             return
         device, host, storage = compute_cache_hit_split(
-            prefix_len, req.host_hit_length, req.storage_hit_length
+            prefix_len, req.loaded_host_hit_length, req.storage_hit_length
         )
         self.log_hit_tokens_device += device
         self.log_hit_tokens_host += host
@@ -980,9 +981,12 @@ class PrefillAdder:
                         req=req,
                     )
                 )
+                req.loaded_host_hit_length = len(new_indices)
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
+            else:
+                req.loaded_host_hit_length = 0
 
             input_tokens = self.ceil_paged_tokens(
                 len(req.full_untruncated_fill_ids) - len(req.prefix_indices)

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -956,17 +956,6 @@ class PrefillAdder:
         storage_hit_tokens = min(storage_hit_tokens, host_hit_tokens_raw)
         host_hit_tokens = host_hit_tokens_raw - storage_hit_tokens
 
-        if device_hit_tokens + host_hit_tokens + storage_hit_tokens != prefix_len:
-            logger.warning(
-                "Cached-token split mismatch: total=%d, device=%d, host=%d, "
-                "storage=%d, rid=%s",
-                prefix_len,
-                device_hit_tokens,
-                host_hit_tokens,
-                storage_hit_tokens,
-                req.rid,
-            )
-
         # Cache the split hit tokens in the request
         req.cached_tokens_device = device_hit_tokens
         req.cached_tokens_host = host_hit_tokens

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -37,7 +37,11 @@ import torch
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_in_seq_split
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
-from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.managers.schedule_batch import (
+    Req, 
+    ScheduleBatch, 
+    compute_cache_hit_split,
+)
 from sglang.srt.mem_cache.allocator.hisparse import (
     DeepSeekV4HiSparseTokenToKVPoolAllocator,
 )
@@ -622,14 +626,12 @@ class PrefillAdder:
         """
         if prefix_len <= 0:
             return
-        # Cap host_total at prefix_len: if init_load_back loaded fewer tokens
-        # than host_hit_length (e.g. allocation failure), prefix_len is already
-        # the true total and host_hit_length would be stale/too large.
-        host_total = min(req.host_hit_length, prefix_len)
-        storage_portion = min(host_total, req.storage_hit_length)
-        self.log_hit_tokens_storage += storage_portion
-        self.log_hit_tokens_host += host_total - storage_portion
-        self.log_hit_tokens_device += max(0, prefix_len - host_total)
+        device, host, storage = compute_cache_hit_split(
+            prefix_len, req.host_hit_length, req.storage_hit_length
+        )
+        self.log_hit_tokens_device += device
+        self.log_hit_tokens_host += host
+        self.log_hit_tokens_storage += storage
 
     def _update_prefill_budget(
         self,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -615,13 +615,17 @@ class PrefillAdder:
     def _accumulate_hit_token_split(self, req, prefix_len: int) -> None:
         """Accumulate per-source cache-hit split alongside log_hit_tokens.
 
-        Must be called only for non-retracted requests and only once per
-        scheduling decision (not for chunk 2+ of chunked prefill, where
-        prefix_len passed to _update_prefill_budget is 0).
+        Must be called exactly once per scheduling decision (not for chunk 2+
+        of chunked prefill, where prefix_len passed to _update_prefill_budget
+        is 0). Called for both retracted and non-retracted requests so that
+        the split always sums to log_hit_tokens.
         """
         if prefix_len <= 0:
             return
-        host_total = req.host_hit_length
+        # Cap host_total at prefix_len: if init_load_back loaded fewer tokens
+        # than host_hit_length (e.g. allocation failure), prefix_len is already
+        # the true total and host_hit_length would be stale/too large.
+        host_total = min(req.host_hit_length, prefix_len)
         storage_portion = min(host_total, req.storage_hit_length)
         self.log_hit_tokens_storage += storage_portion
         self.log_hit_tokens_host += host_total - storage_portion
@@ -684,8 +688,7 @@ class PrefillAdder:
 
         self.can_run_list.append(req)
 
-        if not req.retracted_stain:
-            self._accumulate_hit_token_split(req, prefix_len)
+        self._accumulate_hit_token_split(req, prefix_len)
         self._update_prefill_budget(
             prefix_len,
             trunc_len,
@@ -1011,8 +1014,7 @@ class PrefillAdder:
                 self.can_run_list.append(req)
 
                 self._req_inc_lock_ref(req)
-                if not req.retracted_stain:
-                    self._accumulate_hit_token_split(req, prefix_len)
+                self._accumulate_hit_token_split(req, prefix_len)
                 self._update_prefill_budget(
                     prefix_len,
                     input_tokens,
@@ -1056,8 +1058,7 @@ class PrefillAdder:
                 self.new_chunked_req = req
 
                 self._req_inc_lock_ref(req)
-                if not req.retracted_stain:
-                    self._accumulate_hit_token_split(req, prefix_len)
+                self._accumulate_hit_token_split(req, prefix_len)
                 self._update_prefill_budget(
                     prefix_len,
                     trunc_len,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -464,6 +464,9 @@ class PrefillAdder:
         self.new_chunked_req = None
 
         self.log_hit_tokens = 0
+        self.log_hit_tokens_device = 0
+        self.log_hit_tokens_host = 0
+        self.log_hit_tokens_storage = 0
 
         self.reprocessed_log_hit_tokens = 0
 
@@ -609,6 +612,21 @@ class PrefillAdder:
 
         return AddReqResult.CONTINUE
 
+    def _accumulate_hit_token_split(self, req, prefix_len: int) -> None:
+        """Accumulate per-source cache-hit split alongside log_hit_tokens.
+
+        Must be called only for non-retracted requests and only once per
+        scheduling decision (not for chunk 2+ of chunked prefill, where
+        prefix_len passed to _update_prefill_budget is 0).
+        """
+        if prefix_len <= 0:
+            return
+        host_total = req.host_hit_length
+        storage_portion = min(host_total, req.storage_hit_length)
+        self.log_hit_tokens_storage += storage_portion
+        self.log_hit_tokens_host += host_total - storage_portion
+        self.log_hit_tokens_device += max(0, prefix_len - host_total)
+
     def _update_prefill_budget(
         self,
         prefix_len: int,
@@ -666,6 +684,8 @@ class PrefillAdder:
 
         self.can_run_list.append(req)
 
+        if not req.retracted_stain:
+            self._accumulate_hit_token_split(req, prefix_len)
         self._update_prefill_budget(
             prefix_len,
             trunc_len,
@@ -991,6 +1011,8 @@ class PrefillAdder:
                 self.can_run_list.append(req)
 
                 self._req_inc_lock_ref(req)
+                if not req.retracted_stain:
+                    self._accumulate_hit_token_split(req, prefix_len)
                 self._update_prefill_budget(
                     prefix_len,
                     input_tokens,
@@ -1034,6 +1056,8 @@ class PrefillAdder:
                 self.new_chunked_req = req
 
                 self._req_inc_lock_ref(req)
+                if not req.retracted_stain:
+                    self._accumulate_hit_token_split(req, prefix_len)
                 self._update_prefill_budget(
                     prefix_len,
                     trunc_len,

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -57,6 +57,9 @@ class PrefillStats:
 
     log_input_tokens: int
     log_hit_tokens: int
+    new_token_ratio: float
+    num_running_reqs: QueueCount
+    num_new_seqs: int  # len(can_run_list)
 
     # Detailed prefix-cache hit split.
     # log_hit_tokens should equal:
@@ -66,9 +69,6 @@ class PrefillStats:
     log_hit_tokens_host: int = 0
     log_hit_tokens_storage: int = 0
 
-    new_token_ratio: float = 0.0
-    num_running_reqs: QueueCount = None
-    num_new_seqs: int = 0  # len(can_run_list)
     reprocessed_log_input_tokens: int = 0
     reprocessed_log_hit_tokens: int = 0
     num_pending_tokens: int = 0
@@ -566,7 +566,7 @@ class SchedulerMetricsReporter:
         )
 
         if (
-            getattr(self, "enable_hicache_storage", False)
+            getattr(self.scheduler, "enable_hicache_storage", False)
             or prefill_stats.log_hit_tokens_storage > 0
         ):
             cache_split_msg += (

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -81,16 +81,24 @@ class PrefillStats:
         enable_priority_scheduling: bool = False,
         num_pending_tokens: int = 0,
     ):
+        log_hit_tokens_device = sum(
+            getattr(req, "cached_tokens_device", 0) for req in adder.can_run_list
+        )
+        log_hit_tokens_host = sum(
+            getattr(req, "cached_tokens_host", 0) for req in adder.can_run_list
+        )
+        log_hit_tokens_storage = sum(
+            getattr(req, "cached_tokens_storage", 0) for req in adder.can_run_list
+        )
+
         return cls(
             log_input_tokens=adder.log_input_tokens,
             log_hit_tokens=adder.log_hit_tokens,
             reprocessed_log_input_tokens=adder.reprocessed_log_input_tokens,
             reprocessed_log_hit_tokens=adder.reprocessed_log_hit_tokens,
-            log_hit_tokens_device=getattr(
-                adder, "log_hit_tokens_device", adder.log_hit_tokens
-            ),
-            log_hit_tokens_host=getattr(adder, "log_hit_tokens_host", 0),
-            log_hit_tokens_storage=getattr(adder, "log_hit_tokens_storage", 0),
+            log_hit_tokens_device=log_hit_tokens_device,
+            log_hit_tokens_host=log_hit_tokens_host,
+            log_hit_tokens_storage=log_hit_tokens_storage,
             new_token_ratio=adder.new_token_ratio,
             num_running_reqs=QueueCount.from_reqs(
                 running_reqs, enable_priority_scheduling

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -81,15 +81,9 @@ class PrefillStats:
         enable_priority_scheduling: bool = False,
         num_pending_tokens: int = 0,
     ):
-        log_hit_tokens_device = sum(
-            getattr(req, "cached_tokens_device", 0) for req in adder.can_run_list
-        )
-        log_hit_tokens_host = sum(
-            getattr(req, "cached_tokens_host", 0) for req in adder.can_run_list
-        )
-        log_hit_tokens_storage = sum(
-            getattr(req, "cached_tokens_storage", 0) for req in adder.can_run_list
-        )
+        log_hit_tokens_device = adder.log_hit_tokens_device
+        log_hit_tokens_host = adder.log_hit_tokens_host
+        log_hit_tokens_storage = adder.log_hit_tokens_storage
 
         return cls(
             log_input_tokens=adder.log_input_tokens,

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -560,7 +560,7 @@ class SchedulerMetricsReporter:
         )
 
         if (
-            getattr(self.scheduler, "enable_hicache_storage", False)
+            self.scheduler.enable_hicache_storage
             or prefill_stats.log_hit_tokens_storage > 0
         ):
             cache_split_msg += (

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -57,9 +57,18 @@ class PrefillStats:
 
     log_input_tokens: int
     log_hit_tokens: int
-    new_token_ratio: float
-    num_running_reqs: QueueCount
-    num_new_seqs: int  # len(can_run_list)
+
+    # Detailed prefix-cache hit split.
+    # log_hit_tokens should equal:
+    #   log_hit_tokens_device + log_hit_tokens_host + log_hit_tokens_storage
+    # when storage accounting is enabled. Without L3 storage, storage is 0.
+    log_hit_tokens_device: int = 0
+    log_hit_tokens_host: int = 0
+    log_hit_tokens_storage: int = 0
+
+    new_token_ratio: float = 0.0
+    num_running_reqs: QueueCount = None
+    num_new_seqs: int = 0  # len(can_run_list)
     reprocessed_log_input_tokens: int = 0
     reprocessed_log_hit_tokens: int = 0
     num_pending_tokens: int = 0
@@ -77,6 +86,11 @@ class PrefillStats:
             log_hit_tokens=adder.log_hit_tokens,
             reprocessed_log_input_tokens=adder.reprocessed_log_input_tokens,
             reprocessed_log_hit_tokens=adder.reprocessed_log_hit_tokens,
+            log_hit_tokens_device=getattr(
+                adder, "log_hit_tokens_device", adder.log_hit_tokens
+            ),
+            log_hit_tokens_host=getattr(adder, "log_hit_tokens_host", 0),
+            log_hit_tokens_storage=getattr(adder, "log_hit_tokens_storage", 0),
             new_token_ratio=adder.new_token_ratio,
             num_running_reqs=QueueCount.from_reqs(
                 running_reqs, enable_priority_scheduling
@@ -538,11 +552,25 @@ class SchedulerMetricsReporter:
         )
         iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
 
+        cache_split_msg = (
+            f"#cached-token-device: {prefill_stats.log_hit_tokens_device}, "
+            f"#cached-token-host: {prefill_stats.log_hit_tokens_host}, "
+        )
+
+        if (
+            getattr(self, "enable_hicache_storage", False)
+            or prefill_stats.log_hit_tokens_storage > 0
+        ):
+            cache_split_msg += (
+                f"#cached-token-storage: {prefill_stats.log_hit_tokens_storage}, "
+            )
+
         msg = (
             f"Prefill batch{iter_msg}, "
             f"#new-seq: {prefill_stats.num_new_seqs}, "
             f"#new-token: {prefill_stats.log_input_tokens}, "
             f"#cached-token: {prefill_stats.log_hit_tokens}, "
+            f"{cache_split_msg}"
             f"{token_usage_msg}"
             f"#running-req: {prefill_stats.num_running_reqs.total}, "
             f"#queue-req: {len(self.scheduler.waiting_queue)}, "

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -555,12 +555,17 @@ class SchedulerMetricsReporter:
         iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
 
         cache_split_msg = (
-            f"#cached-token-device: {prefill_stats.log_hit_tokens_device}, "
-            f"#cached-token-host: {prefill_stats.log_hit_tokens_host}, "
+            (
+                f"#cached-token-device: {prefill_stats.log_hit_tokens_device}, "
+                f"#cached-token-host: {prefill_stats.log_hit_tokens_host}, "
+            )
+            if prefill_stats.log_hit_tokens_host > 0
+            or prefill_stats.log_hit_tokens_device > 0
+            else ""
         )
 
         if (
-            self.scheduler.enable_hicache_storage
+            getattr(self.scheduler, "enable_hicache_storage", False)
             or prefill_stats.log_hit_tokens_storage > 0
         ):
             cache_split_msg += (


### PR DESCRIPTION
## Motivation

The prefill log reports a single aggregate #cached-token for prefix-cache hits. With HiCache (L1 GPU / L2 host / L3 storage), this hides where hits come from — so you can't tell from the logs whether load-back from L2 or storage reuse is happening at all.

## Modifications

Split cached-token accounting in `PrefillAdder` into three tiers and surface them in the scheduler log:

- New counters `log_hit_tokens_device` / `_host` / `_storage` (aggregate `log_hit_tokens` kept).
- In `add_one_req`, the hit is split by source before L2 load-back mutates `req.prefix_indices`: device = current prefix_indices; host/storage from `req.host_hit_length` / `req.storage_hit_length`. Kept mutually exclusive (device + host + storage == total), warning on mismatch; per-request `cached_tokens_{device,host,storage}` recorded.
- `_update_prefill_budget` / `_add_dllm_req` take optional keyword splits; default (device_hit_tokens=None means all device) keeps existing call sites correct.
- `PrefillStats` carries the new fields; the log line emits `#cached-token-device/-host/-storage `(storage shown only when enabled or non-zero).

## How to enable

No flag required — the device/host tier split is emitted in the existing prefill log line automatically. The values are only non-trivial when the corresponding tiers exist.

- The `#cached-token-device` / `#cached-token-host` fields always appear in the prefill log (visible at the default INFO log level).
- `#cached-token-storage` is appended only when storage is enabled (`enable_hicache_storage`) or a non-zero storage hit is observed.


## Benefits

- Direct visibility into HiCache hit distribution across tiers, right in the existing prefill log line — no extra tooling.

## Expected output 

### Prefill log line — without L3 storage 

For example, HiCache L1/L2, 2048-token prefix served partly from host after load-back:

Before:
```text
Prefill batch, #new-seq: 1, #new-token: 512, #cached-token: 2048, token usage: 0.06, #running-req: 1, #queue-req: 0, #pending-token: 0
```

After:

```text
Prefill batch, #new-seq: 1, #new-token: 512, #cached-token: 2048, #cached-token-device: 1536, #cached-token-host: 512, token usage: 0.06, #running-req: 1, #queue-req: 0, #pending-token: 0
```

### Prefill log line — with L3 storage enabled (`#cached-token-storage` appended):

Before:

```text
Prefill batch, #new-seq: 1, #new-token: 256, #cached-token: 4096, token usage: 0.11, #running-req: 1, #queue-req: 0, #pending-token: 0
```

After:

```text
Prefill batch, #new-seq: 1, #new-token: 256, #cached-token: 4096, #cached-token-device: 1024, #cached-token-host: 2048, #cached-token-storage: 1024, token usage: 0.11, #running-req: 1, #queue-req: 0, #pending-token: 0
```

### Non-HiCache (backward compatibility) 

host/storage are 0, device equals the old aggregate:

```text
Prefill batch, #new-seq: 1, #new-token: 512, #cached-token: 1536, #cached-token-device: 1536, #cached-token-host: 0, token usage: 0.05, #running-req: 1, #queue-req: 0, #pending-token: 0
```

## Correctness

- Backward compatible by construction: `device_hit_tokens` defaults to full prefix length, so without HiCache device == old aggregate, host/storage == 0.
- `getattr(..., default)` fallbacks on req and adder keep older/partial paths valid.
- device + host + storage == total invariant logs a warning instead of failing.

## Caveats

- Logging/accounting only — no scheduling, memory, or output change.
- Relies on `req.host_hit_length` / `req.storage_hit_length` being populated; backends that don't set them report all hits as device (same as today).
- storage/host exclusivity uses `min(storage, host)` (common case: storage materialized into host first); exotic tiering may need refinement.

## Accuracy Tests

It does not affect model outputs.

## Speed Tests and Profiling

Negligible overhead.

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).














































































































































































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28265459028](https://github.com/sgl-project/sglang/actions/runs/28265459028)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28265458955](https://github.com/sgl-project/sglang/actions/runs/28265458955)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->