### PR TITLE
[Spec] Add `move_kv_cache` to `MLATokenToKVPool` for EAGLE v2 verify

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1834,6 +1834,20 @@ class MLATokenToKVPool(KVCache):
         get_mla_kv_buffer_triton(kv_buffer, loc, cache_k_nope, cache_k_rope)
         return cache_k_nope, cache_k_rope
 
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Relocate accepted-token combined MLA KV (latent + rope) per layer."""
+        size_limit = self.size + self.page_size
+        maybe_detect_oob(tgt_loc, 0, size_limit, "move_kv_cache tgt_loc")
+        maybe_detect_oob(src_loc, 0, size_limit, "move_kv_cache src_loc")
+
+        if tgt_loc.numel() == 0:
+            return
+
+        tgt_loc_flat = tgt_loc.view(-1).long()
+        src_loc_flat = src_loc.view(-1).long()
+        for kv_cache in self.kv_buffer:
+            kv_cache[tgt_loc_flat] = kv_cache[src_loc_flat]
+
     def get_cpu_copy(self, indices, mamba_indices=None):
         current_platform.synchronize()
         kv_cache_cpu = []
@@ -2080,6 +2094,18 @@ class DSATokenToKVPool(MLATokenToKVPool):
     def _clear_buffers(self):
         del self.kv_buffer
         del self.index_k_with_scale_buffer
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Move latent KV and the DSA indexer cache (key + scale) in lockstep."""
+        super().move_kv_cache(tgt_loc, src_loc)
+
+        if tgt_loc.numel() == 0:
+            return
+
+        tgt_loc_flat = tgt_loc.view(-1).long()
+        src_loc_flat = src_loc.view(-1).long()
+        for index_k in self.index_k_with_scale_buffer:
+            index_k[tgt_loc_flat] = index_k[src_loc_flat]
 
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layer_transfer_counter is not None:


### PR DESCRIPTION
Stacked on #26997 (reland of #26866, the spec v2 tree drafting feature). This PR adds the missing MLA KV-move that the EAGLE v2 verify path requires.

## Background
- EAGLE v2 verify unconditionally calls `move_kv_cache(...)` on the KV pool (`eagle_worker_v2.py`) to relocate accepted draft tokens into their canonical slots.
- `MHATokenToKVPool` and the SWA hybrid pool define it; **`MLATokenToKVPool` never did** — so MLA + EAGLE v2 spec decode crashed with `AttributeError: 'MLATokenToKVPool' object has no attribute 'move_kv_cache'`.
- This is why #26866 was reverted in #26981 — the spec v2 path it enabled hit this missing method on MLA models.

## Changes
- Add `MLATokenToKVPool.move_kv_cache` — moves the single combined `kv_buffer` (latent KV + rope) per layer, with the same OOB-detect guard as the MHA path.
- Override on `DSATokenToKVPool` to move `index_k_with_scale_buffer` in lockstep (otherwise the indexer's quantised key + scale point at stale slots after acceptance, producing wrong sparse-attention scores at decode).
- `MLATokenToKVPoolFP4` inherits the base impl unchanged.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26795663156](https://github.com/sgl-project/sglang/actions/runs/26795663156)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26795663013](https://github.com/sgl-project/sglang/actions/runs/26795663013)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->