### PR TITLE
Fix mutable prefix-hash list cached by UnifiedTreeNode

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -6,7 +6,7 @@ import threading
 import time
 from array import array
 from collections import defaultdict
-from functools import lru_cache, partial
+from functools import partial
 from queue import Empty
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -114,7 +114,6 @@ class UnifiedTreeNode:
             return None
         return self.hash_value[-1]
 
-    @lru_cache(maxsize=1)
     def get_prefix_hash_values(self, node: UnifiedTreeNode) -> list[str]:
         if node is None or node.hash_value is None:
             return []

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -41,6 +41,8 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+from sglang.srt.mem_cache.unified_cache_components import ComponentType
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedTreeNode
 
 # Test constants
 DEFAULT_PAGE_SIZE = 4
@@ -229,16 +231,21 @@ class TestTreeNode(unittest.TestCase):
 
     def test_get_prefix_hash_values_not_shared_across_calls(self):
         """Regression guard for cached mutable prefix hash lists."""
-        for node_cls in (TreeNode, MambaTreeNode):
-            with self.subTest(node_cls=node_cls.__module__):
-                root = node_cls()
-                n1 = node_cls()
+        node_factories = (
+            ("radix_cache", TreeNode),
+            ("mamba_radix_cache", MambaTreeNode),
+            ("unified_radix_cache", lambda: UnifiedTreeNode((ComponentType.FULL,))),
+        )
+        for label, make_node in node_factories:
+            with self.subTest(node_cls=label):
+                root = make_node()
+                n1 = make_node()
                 n1.parent = root
                 n1.hash_value = ["h1"]
-                n2 = node_cls()
+                n2 = make_node()
                 n2.parent = n1
                 n2.hash_value = ["h2"]
-                n3 = node_cls()
+                n3 = make_node()
                 n3.parent = n2
                 n3.hash_value = ["h3"]
 
@@ -254,7 +261,7 @@ class TestTreeNode(unittest.TestCase):
                 self.assertEqual(second, ["h1", "h2"])
                 self.assertIsNot(second, first)
 
-                n4 = node_cls()
+                n4 = make_node()
                 n4.parent = n3
                 n4.hash_value = ["h4"]
                 self.assertEqual(n4.get_prefix_hash_values(n3), ["h1", "h2", "h3"])


### PR DESCRIPTION
## Summary

`UnifiedTreeNode.get_prefix_hash_values` is decorated with `@lru_cache(maxsize=1)` and returns a `list`. The HiCache storage path extends that returned list **in place**, so the cached value gets corrupted and a later call observes a wrong, over-long prefix-key list.

## Root Cause

`write_backup_storage` passes the result straight into the storage controller:

```python
# unified_radix_cache.py
prefix_keys = node.get_prefix_hash_values(node.parent)   # cached list
```

and the controller mutates it in place while walking pages:

```python
# managers/cache_controller.py
if prefix_keys and len(prefix_keys) > 0:
    prefix_keys += batch_hashes   # in-place extend of the cached list
```

Because `@lru_cache(maxsize=1)` hands back the same list object, the next call for the same node returns the mutated list.

This is the same bug fixed for `TreeNode` / `MambaTreeNode` in #26177. The `UnifiedTreeNode` copy was missed (the regression test added there also did not cover it).

## Changes

- Drop `@lru_cache(maxsize=1)` from `UnifiedTreeNode.get_prefix_hash_values` so each call returns a fresh list.
- Extend `test_get_prefix_hash_values_not_shared_across_calls` to also cover `UnifiedTreeNode`.

## Validation

- `python3 -m py_compile` on both changed files.
- `test_get_prefix_hash_values_not_shared_across_calls` now exercises all three node types; a standalone repro of the exact method body confirms the cached list is polluted with `@lru_cache` and clean without it.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26790793363](https://github.com/sgl-project/sglang/actions/runs/26790793363)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26790793269](https://github.com/sgl-project/sglang/actions/runs/26790793269)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->