### PR TITLE
ci: full parallelism for run_all_tests dispatch

### DIFF
--- a/.github/workflows/_pr-test-check-changes.yml
+++ b/.github/workflows/_pr-test-check-changes.yml
@@ -111,11 +111,16 @@ jobs:
           # `full=true` lifts the matrix-fanout throttle so each suite's
           # max_parallel = size. Conditions:
           #   1. Scheduled cron run.
-          #   2. pull_request event with the `high priority` label.
+          #   2. run_all_tests run (manual full dispatch / release) -- a full
+          #      run should mirror the cron's parallelism, not just its test set.
+          #   3. pull_request event with the `high priority` label.
           FULL=false
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             FULL=true
             echo "Scheduled run -> full parallelism"
+          elif [[ "${{ inputs.run_all_tests }}" == "true" ]]; then
+            FULL=true
+            echo "run_all_tests -> full parallelism"
           elif [[ "${{ github.event_name }}" == "pull_request" && "${{ contains(github.event.pull_request.labels.*.name, 'high priority') }}" == "true" ]]; then
             FULL=true
             echo "high priority PR -> full parallelism"


### PR DESCRIPTION
Manual `workflow_dispatch` full runs (`run_all_tests=true`) currently get the throttled `max_parallel` because `full-parallel` mode only triggers on `schedule` / `high priority` PR. This makes a `run_all_tests` run also set `full=true`, so a manual full run mirrors the scheduled cron's parallelism (covers base + extra via the shared check-changes).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26791013073](https://github.com/sgl-project/sglang/actions/runs/26791013073)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26791012897](https://github.com/sgl-project/sglang/actions/runs/26791012897)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->