### PR TITLE
[srt] Batch scheduler cache frees

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2663,6 +2663,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 ),
             )
             eviction_interval = (eviction_interval // page_size) * page_size
+
+            # Coalesce per-req `free_swa` calls in the loop below into one
+            # gather / mask / scatter pair on `full_to_swa_index_mapping` at
+            # group_end (instead of N pairs, one per call). Saves ~3 kernel
+            # launches per request under heavy eviction.
+            self.token_to_kv_pool_allocator.free_group_begin()
             for idx, req in enumerate(self.reqs):
                 if self.forward_mode.is_decode():
                     # We set evict_swa condition here with two reasons:
@@ -2701,6 +2707,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                             self._evict_swa(req, pre_len)
                     else:
                         self._evict_swa(req, pre_len)
+            self.token_to_kv_pool_allocator.free_group_end()
 
     def _evict_swa(self, req: Req, pre_len: int):
         assert self.tree_cache.supports_swa(), "prefix cache must support swa"

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -366,6 +366,13 @@ class MambaPool:
             self.mem_usage = self.mamba_cache.mem_usage_bytes() / GB
             self.num_mamba_layers = num_mamba_layers
 
+        # Deferred-free state. When `is_not_in_free_group` is False, `free`
+        # appends to `_pending_free` instead of issuing a `torch.cat` per call.
+        # `free_group_end` then does a single cat over all pending tensors,
+        # collapsing N kernel launches + N intermediate allocations into one.
+        self.is_not_in_free_group = True
+        self._pending_free: List[torch.Tensor] = []
+
     def get_speculative_mamba2_params_all_layers(self) -> SpeculativeState:
         assert isinstance(self.mamba_cache, self.SpeculativeState)
         return self.mamba_cache
@@ -402,12 +409,30 @@ class MambaPool:
     def free(self, free_index: torch.Tensor):
         if free_index.numel() == 0:
             return
-        self.free_slots = torch.cat((self.free_slots, free_index))
+        if self.is_not_in_free_group:
+            self.free_slots = torch.cat((self.free_slots, free_index))
+        else:
+            self._pending_free.append(free_index)
+
+    def free_group_begin(self):
+        self.is_not_in_free_group = False
+        self._pending_free.clear()
+
+    def free_group_end(self):
+        self.is_not_in_free_group = True
+        if self._pending_free:
+            # Single cat over current free_slots + all pending tensors; this
+            # replaces N per-call torch.cat calls (one per free()) and avoids
+            # the O(N) intermediate allocations they would do.
+            self.free_slots = torch.cat([self.free_slots, *self._pending_free])
+            self._pending_free.clear()
 
     def clear(self):
         self.free_slots = torch.arange(
             1, self.size + 1, dtype=torch.int64, device=self.device
         )
+        self._pending_free.clear()
+        self.is_not_in_free_group = True
 
     def copy_from(self, src_indices: torch.Tensor, dst_indices: torch.Tensor):
         for i in range(len(self.mamba_cache.conv)):

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -380,6 +380,11 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.release_pages = None
         self.is_not_in_free_group = True
         self.free_group = []
+        # Direct `free_swa` callers (e.g. `ScheduleBatch._evict_swa`) bypass
+        # `free`'s free_group routing. Track them separately so we can batch
+        # the gather / mask / scatter on `full_to_swa_index_mapping` across
+        # many small per-request calls within a free_group.
+        self._pending_swa_free: list[torch.Tensor] = []
 
         self._kvcache = kvcache
         self.clear()
@@ -628,11 +633,54 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.full_to_swa_index_mapping[full_indices] = swa_indices
 
     def free_swa(self, free_index: torch.Tensor):
+        if free_index.numel() == 0:
+            return
+        if self.is_not_in_free_group:
+            # Immediate path: gather → mask → free → scatter. Each of these
+            # is a separate CUDA kernel launch on a small tensor; under heavy
+            # eviction (chunked prefill, many requests per batch) the launch
+            # overhead dominates the actual work. Calling
+            # `free_group_begin/end` around batches of `free_swa` calls lets
+            # us batch the gather / mask / scatter as well; see
+            # `_flush_pending_swa_free`.
+            self._do_free_swa(free_index)
+        else:
+            self._pending_swa_free.append(free_index)
+
+    def _do_free_swa(self, free_index: torch.Tensor) -> None:
         self._kvcache.invalidate_loc_cache()
         swa_indices = self.full_to_swa_index_mapping[free_index]
         swa_indices = swa_indices[swa_indices > 0]
         self.swa_attn_allocator.free(swa_indices)
         self.full_to_swa_index_mapping[free_index] = 0
+
+    def _flush_pending_swa_free(self) -> None:
+        """Drain `_pending_swa_free` into a single batched gather / mask / scatter."""
+        if not self._pending_swa_free:
+            return
+        # One torch.cat + one set of gather / mask / scatter kernels replaces
+        # N small per-call sequences. The inner `swa_attn_allocator.free` is
+        # already cheap inside a free_group, but the SWA-mapping ops on the
+        # pool itself are not — they bypass `free_group` and run every call.
+        merged = (
+            self._pending_swa_free[0]
+            if len(self._pending_swa_free) == 1
+            else torch.cat(self._pending_swa_free)
+        )
+        self._pending_swa_free.clear()
+        self._do_free_swa(merged)
+
+    def free_group_begin(self):
+        super().free_group_begin()
+        self._pending_swa_free.clear()
+
+    def free_group_end(self):
+        # Drain SWA-only pending frees first, then let the base class drain
+        # the combined-full+SWA free_group (which routes back through `free`
+        # → `free_swa`, but with `is_not_in_free_group=True` so it bypasses
+        # the pending list).
+        self._flush_pending_swa_free()
+        super().free_group_end()
 
     def backup_state(self):
         return [
@@ -653,6 +701,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_swa_index_mapping[:-1].fill_(0)
         self.is_not_in_free_group = True
         self.free_group = []
+        self._pending_swa_free.clear()
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -489,8 +489,21 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         start_time = time.perf_counter()
         tracker = {ct: 0 for ct in self.tree_components}
 
+        # Coalesce per-leaf allocator.free / free_swa / mamba_pool.free
+        # calls in the components' eviction loops into a single batched
+        # flush at the end. With SWA enabled the savings are dominated by
+        # `free_swa` (4 kernels/call → 4 total per batch).
+        self.token_to_kv_pool_allocator.free_group_begin()
+        has_mamba = ComponentType.MAMBA in self.tree_components
+        if has_mamba:
+            self.req_to_token_pool.mamba_pool.free_group_begin()
+
         for component in self._components_tuple:
             component.drive_eviction(params=params, tracker=tracker)
+
+        if has_mamba:
+            self.req_to_token_pool.mamba_pool.free_group_end()
+        self.token_to_kv_pool_allocator.free_group_end()
 
         if (
             self.cache_controller is not None

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -245,6 +245,80 @@ class TestSWA(unittest.TestCase):
         result = alloc.translate_loc_from_full_to_swa(index)
         print(result)
 
+    def test_free_swa_free_group_batches(self):
+        """Inside free_group_begin/end, many small free_swa calls coalesce.
+
+        Asserts that:
+          1. End state of pool matches the immediate-path equivalent.
+          2. _pending_swa_free is empty after group_end (no leaks).
+          3. mapping is correctly zeroed for every index that was passed in.
+        """
+        size = size_swa = 32
+        page_size = 1
+        head_num, head_dim, num_layers = 4, 64, 8
+        full_attention_layer_ids = [0, 4]
+        swa_attention_layer_ids = [
+            i for i in range(num_layers) if i not in full_attention_layer_ids
+        ]
+        device = get_device()
+
+        pool = SWAKVPool(
+            size=size,
+            size_swa=size_swa,
+            page_size=page_size,
+            dtype=torch.bfloat16,
+            head_num=head_num,
+            head_dim=head_dim,
+            swa_attention_layer_ids=swa_attention_layer_ids,
+            full_attention_layer_ids=full_attention_layer_ids,
+            enable_kvcache_transpose=False,
+            device=device,
+        )
+        alloc = SWATokenToKVPoolAllocator(
+            size=size,
+            size_swa=size_swa,
+            page_size=page_size,
+            dtype=torch.bfloat16,
+            device=device,
+            kvcache=pool,
+            need_sort=False,
+        )
+
+        # Allocate a few small batches so we have full+swa indices populated.
+        idx_batches = [alloc.alloc(2), alloc.alloc(3), alloc.alloc(1), alloc.alloc(4)]
+        for idx in idx_batches:
+            self.assertIsNotNone(idx)
+
+        # Snapshot baseline SWA capacity before freeing.
+        swa_before = alloc.swa_available_size()
+
+        # Inside a free_group, free_swa() should accumulate pending instead
+        # of firing the per-call gather/mask/scatter.
+        alloc.free_group_begin()
+        self.assertEqual(alloc.is_not_in_free_group, False)
+        for idx in idx_batches:
+            alloc.free_swa(idx)
+        # Mid-group: pending entries are queued; SWA capacity should not
+        # yet reflect any of the frees.
+        self.assertEqual(len(alloc._pending_swa_free), len(idx_batches))
+
+        # End of group: flush_pending_swa_free runs first, then base drains.
+        alloc.free_group_end()
+        self.assertEqual(alloc.is_not_in_free_group, True)
+        self.assertEqual(len(alloc._pending_swa_free), 0)
+
+        # All freed indices should map to 0 in full_to_swa_index_mapping.
+        all_freed = torch.cat(idx_batches).to(device=device, dtype=torch.int64)
+        self.assertTrue(
+            torch.equal(
+                alloc.full_to_swa_index_mapping[all_freed],
+                torch.zeros_like(all_freed),
+            )
+        )
+        # SWA capacity should have grown back by the number of SWA slots
+        # held across the freed indices (≤ |all_freed|; some may have been 0).
+        self.assertGreaterEqual(alloc.swa_available_size(), swa_before)
+
     def test_swa_radix_cache_1(self):
         # args
         req_size = 10


### PR DESCRIPTION
## Motivation

Scheduler result processing and SWA maintenance can release cache entries once per request. For hybrid SWA allocators, each direct `free_swa` call performs its own mapping expansion, gather, mask, allocator free, and mapping clear. At large batch sizes, the repeated allocator bookkeeping and kernel launches dominate the scheduler phase.

OSS `main` already groups decode-result frees. This PR applies the same batching to the remaining hot scheduler loops and makes direct SWA frees participate in the allocator's free-group contract.

## Changes

- Group cache frees across prefill result processing.
- Group per-request SWA maintenance frees in `ScheduleBatch.maybe_evict_swa`.
- Add a separate SWA-free queue to the hybrid allocator so direct `free_swa` calls share one mapping gather/mask/clear operation when the group closes.
- Make pure-SWA `free_swa` calls use its existing free group.
- Add focused allocator coverage for deferred SWA frees, mapping cleanup, and reclaimed capacity.

The decode-result loop is intentionally unchanged because current OSS `main` already has its free-group boundary.

## Performance

In a 10-step profile at roughly 1,000 running requests, batching reduced mean `get_next_batch_to_run` CPU time from 38.75 ms to 15.08 ms (-61%) and reduced `aten::_unique2` launches from 111 to 40 (-64%).

## Validation

- `pre-commit run --files` on all changed files
- `python -m py_compile` on all changed Python files
- Isolated CPU allocator checks for hybrid SWA-only frees, mixed full/SWA frees, overlapping indices, and pure-SWA frees
- Added `TestSWA.test_free_swa_batches_with_free_group` for accelerator CI

## Checklist

- [x] Formatted with the repository pre-commit hooks.
- [x] Added unit-test coverage.
