### PR TITLE
ci: disable cross-job fast-fail for run_all_tests dispatch

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -62,7 +62,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SKIP_PR_TEST_HEALTH_CHECK: ${{ fromJson(inputs.caller_inputs).skip_pr_test_health_check && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ (fromJson(inputs.caller_inputs).skip_pr_test_health_check || fromJson(inputs.caller_inputs).test_parallel_dispatch || fromJson(inputs.caller_inputs).run_all_tests) && 'true' || 'false' }}
   FORCE_REBUILD_DEEPEP: '1'
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false


### PR DESCRIPTION
Follow-up to #26986. The cross-job `check-pr-test-health` fast-fail (Layer 3) only skips on `schedule` or `SKIP_PR_TEST_HEALTH_CHECK=true`. The stage workflow re-derived that env from only `skip_pr_test_health_check`, dropping `run_all_tests` / `test_parallel_dispatch` — so manual full-run dispatches still fast-failed (unlike the scheduled cron). Mirror `pr-test.yml`'s top-level logic so a `run_all_tests` / `test_parallel_dispatch` dispatch collects all failures instead of fast-failing.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26792593776](https://github.com/sgl-project/sglang/actions/runs/26792593776)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26792593721](https://github.com/sgl-project/sglang/actions/runs/26792593721)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->