### PR TITLE
[SRT] Pool HTTP connections and eagerly decode images for concurrent multimodal URL requests

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -559,6 +559,12 @@ class Envs:
     # preserve the user's original tokens to avoid retokenization drift.
     SGLANG_MM_AVOID_RETOKENIZE = EnvBool(True)
 
+    # VLM: image URL fetch (shared HTTP session pool)
+    SGLANG_HTTP_POOL_CONNS = EnvInt(64)
+    SGLANG_HTTP_POOL_MAXSIZE = EnvInt(128)
+    SGLANG_HTTP_CONNECT_TIMEOUT = EnvFloat(15.0)
+    SGLANG_HTTP_READ_TIMEOUT = EnvFloat(30.0)
+
 
     # VLM Item CUDA IPC Transport
     SGLANG_USE_CUDA_IPC_TRANSPORT = EnvBool(False)

--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -269,7 +269,12 @@ def process_anyres_image(image, processor, grid_pinpoints):
 
 
 def load_image_from_base64(image):
-    return Image.open(BytesIO(pybase64.b64decode(image, validate=True)))
+    # Force the pixel decode here (worker thread) instead of lazily on first
+    # access back on the event-loop/scheduler thread (mirrors vLLM). Same intent
+    # as common.py:_load_image; kept consistent in case this path is used.
+    img = Image.open(BytesIO(pybase64.b64decode(image, validate=True)))
+    img.load()
+    return img
 
 
 def expand2square(pil_img, background_color):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -903,7 +903,11 @@ def _load_image(
             logger.warning(
                 f"Failed to decode JPEG on GPU, falling back to CPU. Error: {e}"
             )
-    return Image.open(BytesIO(image_bytes))
+    # Force PIL to decode pixels now, on this worker thread, instead of lazily
+    # on first access back on the event-loop/scheduler thread (mirrors vLLM).
+    img = Image.open(BytesIO(image_bytes))
+    img.load()
+    return img
 
 
 def load_image(
@@ -946,13 +950,55 @@ def load_image(
     return image, image_size
 
 
+_HTTP_SESSION_LOCK = threading.Lock()
+_HTTP_SESSION: Optional[requests.Session] = None
+
+
+def _get_http_session() -> requests.Session:
+    """Process-wide requests.Session with a tuned urllib3 pool + keep-alive.
+
+    The previous code did a fresh requests.get (new TCP+TLS handshake) per image
+    URL with a 3s timeout; under concurrency that serialized fetches and timed
+    out. A shared pooled session reuses connections across image fetches.
+    """
+    global _HTTP_SESSION
+    if _HTTP_SESSION is None:
+        with _HTTP_SESSION_LOCK:
+            if _HTTP_SESSION is None:
+                from requests.adapters import HTTPAdapter
+                from urllib3.util.retry import Retry
+
+                s = requests.Session()
+                retry = Retry(
+                    total=2,
+                    connect=2,
+                    read=1,
+                    backoff_factor=0.2,
+                    status_forcelist=[502, 503, 504],
+                    allowed_methods=frozenset(["GET"]),
+                    raise_on_status=False,
+                )
+                adapter = HTTPAdapter(
+                    pool_connections=envs.SGLANG_HTTP_POOL_CONNS.get(),
+                    pool_maxsize=envs.SGLANG_HTTP_POOL_MAXSIZE.get(),
+                    max_retries=retry,
+                )
+                s.mount("http://", adapter)
+                s.mount("https://", adapter)
+                _HTTP_SESSION = s
+    return _HTTP_SESSION
+
+
 def get_image_bytes(image_file: Union[str, bytes]) -> bytes:
     """Normalize various image inputs into raw bytes."""
     if isinstance(image_file, bytes):
         return image_file
     if image_file.startswith(("http://", "https://")):
-        timeout = int(os.getenv("REQUEST_TIMEOUT", "3"))
-        response = requests.get(image_file, timeout=timeout)
+        connect_timeout = envs.SGLANG_HTTP_CONNECT_TIMEOUT.get()
+        read_timeout = envs.SGLANG_HTTP_READ_TIMEOUT.get()
+        response = _get_http_session().get(
+            image_file, timeout=(connect_timeout, read_timeout)
+        )
         try:
             response.raise_for_status()
             result = response.content


### PR DESCRIPTION
## Motivation

When many requests arrive concurrently and each carries images fetched from
URLs, two parts of the image-loading path serialize work that should be cheap:

1. **URL fetching** — `get_image_bytes` did a fresh `requests.get` (new TCP+TLS
   handshake) per image with a hardcoded 3 s timeout. Under concurrency the
   handshakes pile up and fetches time out.
2. **PIL lazy decode** — `Image.open(BytesIO(...))` defers the actual pixel
   decode until first access, which happens later on the TokenizerManager event
   loop / scheduler thread instead of on the worker thread that loaded the
   image. (vLLM forces the decode eagerly for the same reason.)

## Modifications

### Shared, pooled HTTP session (`utils/common.py`)

- New process-global `requests.Session` (`_get_http_session`, lazily built under
  a lock) with a tuned `urllib3` `HTTPAdapter`: keep-alive connection pooling +
  bounded retries (2×, backoff, on 502/503/504, GET only). Reuses connections
  across image fetches instead of a handshake per image.
- Split the single hardcoded 3 s timeout into separate **connect** and **read**
  timeouts.

### Eager pixel decode (`utils/common.py`, `multimodal/mm_utils.py`)

- Call `img.load()` right after `Image.open(...)` in `_load_image` and in
  `load_image_from_base64`, so decoding happens on the io worker thread.

### Env vars (registered in `srt/environ.py`, per project conventions)

All new knobs are declared as `EnvField` descriptors on `Envs` and read via
`envs.X.get()` — no raw `os.getenv("SGLANG_...")` call sites.

| Env var | Type | Default | Description |
|---|---|---:|---|
| `SGLANG_HTTP_POOL_CONNS` | int | 64 | urllib3 keep-alive connection pools |
| `SGLANG_HTTP_POOL_MAXSIZE` | int | 128 | urllib3 max connections per pool |
| `SGLANG_HTTP_CONNECT_TIMEOUT` | float | 15.0 | TCP connect timeout (s) |
| `SGLANG_HTTP_READ_TIMEOUT` | float | 30.0 | read timeout after connect (s) |

> Note: this replaces the previous `REQUEST_TIMEOUT` (3 s) hardcoded read of the
> URL path. The defaults are intentionally generous; tune down for low-latency
> internal image stores.

### Scope / coverage

The eager `img.load()` is added to the two **shared** image-loading helpers:
`_load_image` (the URL/bytes path in `common.py`) and `load_image_from_base64`
(`mm_utils.py`) — the canonical paths used by the standard Qwen-VL URL and
base64 flows. The `MiMo-V2` processor (`mimo_v2.py`) has its own bespoke
`Image.open` + `requests.get(stream=True)` sites that bypass these helpers; they
are intentionally left out of scope (separate model, not part of this throughput
effort, and it already `deepcopy`s the decoded image off its `BytesIO`). The
shared HTTP session likewise applies to `get_image_bytes` (the standard URL
path); MiMo-V2's private `requests.get` is unaffected.

## Accuracy Tests

This is an image-*loading* change and does **not** alter pixel data or model
outputs:

- Eager `img.load()` forces the *same* decode PIL would otherwise do lazily on
  first access — identical pixels, only on a different (worker) thread.
- The base64 path's behavior is unchanged apart from that eager decode; it does
  not touch the network code.
- The GPU JPEG fast-path in `_load_image` is untouched; the change only affects
  the CPU `Image.open` fallback and the URL-fetch transport.

## Speed Tests and Profiling

This change targets the image-*loading* path specifically: it removes the
per-image TCP+TLS handshake (one shared keep-alive session instead of a fresh
`requests.get` per image), removes the lazy-decode stall that otherwise lands on
the event loop (eager `img.load()` on the io worker thread), and replaces the
hardcoded 3 s timeout with tunable connect/read timeouts. Under concurrent
multi-image-URL load (e.g. 32 concurrent, 2–4 images/request) the old path
serialized fetches and timed out; these changes cut that TTFT contribution.

This is one part of a broader multimodal-throughput effort. A separate, larger
change (PR 3) that offloads the synchronous HF processor off the TokenizerManager
event loop is the dominant end-to-end-throughput contributor and is submitted on
its own; this PR does not include it. Internal benchmarks showing a large
combined speedup had **both** changes applied together, so those headline numbers
are not attributable to this PR alone — they are omitted here to avoid
overstating this PR's isolated impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (I/O-transport change; verified by `py_compile` + manual concurrent-URL runs. Happy to add a session-reuse / eager-decode unit test if preferred.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (New env vars documented in the table above.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Isolated numbers intentionally omitted — see Speed Tests and Profiling; no model-output change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Files

- `python/sglang/srt/environ.py`
- `python/sglang/srt/utils/common.py`
- `python/sglang/srt/multimodal/mm_utils.py`