### PR TITLE
Fix dp-attention token alignment in the dumper comparator e2e test

### DIFF
--- a/test/registered/debug_utils/test_engine_dumper_comparator_e2e.py
+++ b/test/registered/debug_utils/test_engine_dumper_comparator_e2e.py
@@ -195,6 +195,14 @@ class TestSourcePatcherE2ESGLang:
         step has tokens on both DP ranks, which breaks the dp:=attn_dp
         single-rank assumption and causes comparator errors.
 
+        The ``concat_steps`` token aligner is required because dp-attention
+        gathers tokens across DP ranks before the dump point, so the
+        non-empty rank's buffer holds the real tokens plus padding tokens
+        contributed by the empty DP rank (with a single request one DP
+        rank is always empty).  The aligner reconstructs the real per-step
+        token sequence from the dumped seq-lens, trimming that padding so
+        the target lines up with the un-padded TP baseline.
+
         mlp_output is allowed to fail because the FusedMoE dispatcher
         combine path may include an implicit all-reduce that makes the
         dumped value differ from the raw partial expert output.  All
@@ -208,6 +216,8 @@ class TestSourcePatcherE2ESGLang:
             extra_target_server_args=["--dp", "2", "--enable-dp-attention"],
             target_patch_config_yaml=PATCH_CONFIG_DP_ATTENTION_YAML,
             extra_comparator_args=[
+                "--token-aligner",
+                "concat_steps",
                 "--end-step",
                 "0",
                 "--allow-failed-pattern",


### PR DESCRIPTION
## Problem

The `test_dp_attention` case of `test/registered/debug_utils/test_engine_dumper_comparator_e2e.py` (nightly-4-gpu) fails: the comparator reports `shape_mismatch` on every tensor and exits non-zero (`passed=0, failed=21`).

## Root cause

dp-attention gathers tokens across DP ranks **before** the decoder-layer dump point. The test sends a single request, so one DP rank is always empty, and the non-empty rank's gathered prefill buffer holds the real tokens **plus a padding token contributed by the empty rank**. The comparator then sees a `[6, *]` target against the un-padded `[5, *]` TP baseline and flags a shape mismatch on every tensor — even though the 5 real tokens are bit-identical to the baseline.

## Fix

Pass `--token-aligner concat_steps` for the dp-attention comparison. That aligner (designed for BS=1) reconstructs the real per-step token sequence from the dumped seq-lens and trims the padding, lining the target up with the un-padded baseline. The `test_patch_dump_and_compare` (TP=2 vs TP=4) case is unchanged.

## Verification

Ran on an H200 (1 node) against `Qwen/Qwen3-30B-A3B`:

```
registered/debug_utils/test_engine_dumper_comparator_e2e.py::TestSourcePatcherE2ESGLang::test_patch_dump_and_compare PASSED
registered/debug_utils/test_engine_dumper_comparator_e2e.py::TestSourcePatcherE2ESGLang::test_dp_attention PASSED
================== 2 passed in 201.38s ===================
```

With the fix, every step-0 dp-attention tensor aligns to `[5, *]` and matches (`mlp_output` still allowed to fail by design; `positions` still allowed to skip).



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26795434003](https://github.com/sgl-project/sglang/actions/runs/26795434003)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26795433973](https://github.com/sgl-project/sglang/actions/runs/26795433973)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->