### PR TITLE
[Bug Fix]Fix m_indices argument passing in BF16 grouped contiguous warmup

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -340,7 +340,7 @@ class _BF16GroupedContWarmupExecutor(_BaseWarmupExecutor):
             self.a[:m],
             self.b,
             self.out[:m],
-            m_indices=self.m_indices[:m],
+            self.m_indices[:m],
         )
 
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

 DeepGEMM >= 2.5.0 (PR   https://github.com/deepseek-ai/DeepGEMM/pull/280) renamed the 4th parameter of
  `m_grouped_bf16_gemm_nt_contiguous` from `m_indices` to `grouped_layout`.
  The BF16 grouped contiguous warmup executor in SGLang uses keyword argument
  `m_indices=`, which causes a TypeError on startup:

 ```bash
TypeError: m_grouped_bf16_gemm_nt_contiguous(): incompatible function arguments. The following argument types are supported:                                            
    1. (a: torch.Tensor, b: torch.Tensor, d: torch.Tensor, grouped_layout: torch.Tensor, compiled_dims: str = 'nk', use_psum_layout: bool = False,                      
expected_m_for_psum_layout: typing.SupportsInt | None = None) -> None
 ```
### Reproduce:
  ```python
  python -c "
  from sglang.srt.layers.deep_gemm_wrapper.compile_utils import _BF16GroupedContWarmupExecutor
  executor = _BF16GroupedContWarmupExecutor(max_m=128, n=128, k=128, num_groups=4)
  executor.execute(m=128)
  "
```

## Modifications

<!-- Detail the changes made in this pull request. -->
- Changed m_indices=self.m_indices[:m] (keyword) to self.m_indices[:m] (positional)
  in _BF16GroupedContWarmupExecutor.execute() to match the DeepGEMM pybind11 API.

 - The parameter functionality is unchanged — it is still an int32 tensor indicating which
  expert group each row belongs to. Only the parameter name was changed upstream.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26806013714](https://github.com/sgl-project/sglang/actions/runs/26806013714)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26806013517](https://github.com/sgl-project/sglang/actions/runs/26806013517)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->