### PR TITLE
fix(disagg): correct DSA/SWA state-page transfer mismatch in PD disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -98,8 +98,18 @@ def group_concurrent_contiguous(
     src_indices: npt.NDArray[np.int32], dst_indices: npt.NDArray[np.int32]
 ) -> Tuple[List[npt.NDArray[np.int32]], List[npt.NDArray[np.int32]]]:
     """Vectorised NumPy implementation."""
-    if src_indices.size == 0:
+    # src/dst indices are transferred pairwise, so an empty side means there is
+    # nothing to transfer. Guarding both sides (not just src) avoids a cryptic
+    # NumPy broadcast error from np.diff() below when only one side is empty, e.g.
+    # a non-empty prefill DSA/SWA state list paired with an empty decode registration.
+    if src_indices.size == 0 or dst_indices.size == 0:
         return [], []
+
+    if src_indices.size != dst_indices.size:
+        raise ValueError(
+            "group_concurrent_contiguous requires equal-length src/dst index arrays, "
+            f"got {src_indices.size} and {dst_indices.size}"
+        )
 
     brk = np.where((np.diff(src_indices) != 1) | (np.diff(dst_indices) != 1))[0] + 1
     src_groups = np.split(src_indices, brk)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -801,7 +801,13 @@ class SchedulerDisaggregationPrefillMixin:
         if last_chunk:
             self.disagg_metadata_buffers.set_buf(req)
 
-            seq_len = len(req.fill_ids)
+            # fill_ids includes the token sampled during prefill, but decode
+            # registers state pages over origin_input_ids (DecodePreallocQueue)
+            # and the main pool send is clamped to end_idx above. Matching that
+            # length here avoids emitting an extra state page when the sampled
+            # token crosses a page boundary, which mismatched src/dst lengths in
+            # group_concurrent_contiguous.
+            seq_len = min(len(req.fill_ids), len(req.origin_input_ids))
 
             def _mamba_payload():
                 return [

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from sglang.srt.disaggregation.common.utils import (
+    group_concurrent_contiguous,
     pack_int_lists,
     pack_list_of_buffers,
     unpack_int_lists,
@@ -43,6 +44,50 @@ class TestDisaggregationWire(unittest.TestCase):
     def test_list_of_buffers_roundtrip(self):
         bufs = [b"abc", b"", b"de", b"x" * 17]
         self.assertEqual(unpack_list_of_buffers(pack_list_of_buffers(bufs)), bufs)
+
+
+class TestGroupConcurrentContiguous(unittest.TestCase):
+    @staticmethod
+    def _arr(values):
+        return np.array(values, dtype=np.int32)
+
+    def test_single_contiguous_group(self):
+        src = self._arr([10, 11, 12])
+        dst = self._arr([5, 6, 7])
+        self.assertEqual(
+            group_concurrent_contiguous(src, dst),
+            ([[10, 11, 12]], [[5, 6, 7]]),
+        )
+
+    def test_splits_on_discontiguous_indices(self):
+        src = self._arr([10, 11, 20])
+        dst = self._arr([5, 6, 7])
+        self.assertEqual(
+            group_concurrent_contiguous(src, dst),
+            ([[10, 11], [20]], [[5, 6], [7]]),
+        )
+
+    def test_both_empty(self):
+        self.assertEqual(
+            group_concurrent_contiguous(self._arr([]), self._arr([])), ([], [])
+        )
+
+    def test_empty_src_nonempty_dst(self):
+        self.assertEqual(
+            group_concurrent_contiguous(self._arr([]), self._arr([1, 2])), ([], [])
+        )
+
+    def test_nonempty_src_empty_dst(self):
+        # Regression: a non-empty source paired with an empty destination must not
+        # raise a NumPy broadcast error (observed transferring DSA sparse-attention
+        # state on a disaggregated GLM deployment when decode registered zero dst indices).
+        self.assertEqual(
+            group_concurrent_contiguous(self._arr([1, 2]), self._arr([])), ([], [])
+        )
+
+    def test_mismatched_nonempty_lengths_raise(self):
+        with self.assertRaises(ValueError):
+            group_concurrent_contiguous(self._arr([1, 2, 3]), self._arr([1, 2]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# fix(disagg): correct DSA/SWA state-page transfer mismatch in PD disaggregation

## Motivation

On a disaggregated (PD) deployment of a DSA (sparse-attention, formerly NSA)
model — observed with GLM/DSA-FP8, `page_size=64`, mooncake transfer backend —
the prefill transfer worker can crash while sending the hybrid "state/extra"
pool to decode:

```
File ".../disaggregation/mooncake/conn.py", in _send_kvcache_generic
    prefill_kv_blocks, dst_kv_blocks = group_concurrent_contiguous(...)
File ".../disaggregation/common/utils.py", in group_concurrent_contiguous
    brk = np.where((np.diff(src_indices) != 1) | (np.diff(dst_indices) != 1))[0] + 1
ValueError: operands could not be broadcast together with shapes (2,) (0,)
```

There are two layered problems:

1. **Root cause (length mismatch).** On the last chunk, the prefill side
   enumerates its DSA/SWA state-page list over `seq_len = len(req.fill_ids)`. By
   send time `fill_ids` already includes the token sampled during prefill
   (`output_ids` is appended before `send_kv_chunk(last_chunk=True)`), so it is
   longer than the prompt. But the decode side registers its destination state
   pages over `len(origin_input_ids)` (`DecodePreallocQueue`), and the main
   KV-pool transfer is already clamped to
   `min(len(fill_ids), len(origin_input_ids))`. When the sampled token crosses a
   page boundary, prefill emits one extra state page that decode never
   registered, so the prefill (src) and decode (dst) index arrays differ in
   length.

2. **Fragile helper.** `group_concurrent_contiguous` only early-returns when the
   *source* is empty and otherwise assumes equal-length inputs. Unequal lengths
   either raise a cryptic NumPy broadcast error (non-broadcastable shapes) or
   silently produce wrong groupings (broadcastable shapes).

## Modifications

- `disaggregation/prefill.py` (`SchedulerDisaggregationPrefillMixin.send_kv_chunk`):
  compute the last-chunk state `seq_len` as
  `min(len(req.fill_ids), len(req.origin_input_ids))`, matching the decode-side
  registration and the clamped main-pool transfer range. The value is shared by
  `_dsa_payload` and `_swa_payload`, so both hybrid-state paths are corrected.
- `disaggregation/common/utils.py` (`group_concurrent_contiguous`): early-return
  `[], []` when *either* index array is empty, and raise a descriptive
  `ValueError` when both are non-empty but of unequal length — converting a
  cryptic broadcast error / silent mis-grouping into a clean no-op or a clear
  failure. Defense-in-depth in case other callers pass mismatched arrays.
- `test/registered/unit/disaggregation/test_disaggregation_wire.py`: add CPU unit
  tests for `group_concurrent_contiguous` covering contiguous/discontiguous
  grouping, both-empty, empty-src, the empty-dst regression, and the
  mismatched-length error.

## Accuracy Tests

No model-forward changes. The prefill `seq_len` fix equals the previous
`len(fill_ids)` in the common case (no page-boundary crossing), so behaviour is
unchanged; it only removes the over-enumerated trailing state page. The helper
change is unchanged for equal-length inputs. End-to-end validation on a DSA
PD-disaggregated deployment is recommended.

## Speed Tests and Profiling

No performance impact (two size checks; one `min()`).

## Checklist

- [x] Format your code according to pre-commit (black/isort/ruff pass).
- [x] Add unit tests.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26797042843](https://github.com/sgl-project/sglang/actions/runs/26797042843)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26797042754](https://github.com/sgl-project/sglang/actions/runs/26797042754)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->