### PR TITLE
[Spec] Fix multi-layer EAGLE v2 verify attn metadata init on non-cuda-graph path

### DIFF
--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -775,12 +775,11 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                     else None
                 ),
             )
-        # NOTE: metadata init is skipped here unconditionally, although
-        # prepare_for_v2_verify only plans when cuda-graph replay_prepare ran.
-        # eagle_worker_v2 re-inits the non-graph path instead (post-pad); this
-        # worker has not adopted that fix, so preserve its behavior verbatim.
-        verify_forward_batch.mark_forward_metadata_ready()
-        # Run target verify batch in the main compute stream
+        # Run target verify batch in the main compute stream.
+        # Metadata init is skipped iff cuda-graph already ran replay_prepare —
+        # prepare_for_v2_verify marked the batch in exactly that case; the
+        # non-cuda-graph path stays unmarked and gets forward_extend's init
+        # (post-pad), matching eagle_worker_v2.
         forward_batch_output = self.target_worker.forward_batch_generation(
             batch=None,
             forward_batch=verify_forward_batch,


### PR DESCRIPTION
## Summary

`MultiLayerEagleWorkerV2.verify` skips attention-backend metadata init on the non-cuda-graph target-verify path, leaving it uninitialized. This is the multi-layer counterpart of the single-layer fix in #26244, which was not applied here.

## Root Cause

The shared `EagleVerifyInputV2Mixin.prepare_for_v2_verify` only sets up attention metadata for the cuda-graph path (via `replay_prepare`); on the non-cuda-graph path it intentionally **defers** the init to `forward_extend` (which runs after `prepare_mlp_sync_batch` pads the batch). The pre-#26244 in-method `init_forward_metadata` was removed in #26244:

```python
# eagle_info_v2.py prepare_for_v2_verify
if can_run_cuda_graph:
    graph_runner.replay_prepare(verify_forward_batch)
# Non-cuda-graph: defer init to forward_extend ... (init removed in #26244)
return verify_forward_batch, can_run_cuda_graph
```

For `forward_extend` to actually run that init, the worker must call the target with `skip_attn_backend_init=can_run_cuda_graph`. #26244 fixed the single-layer worker (`eagle_worker_v2.py`) accordingly, but the multi-layer worker still passed `skip_attn_backend_init=True`:

```python
# multi_layer_eagle_worker_v2.py (before)
forward_batch_output = self.target_worker.forward_batch_generation(
    ...
    is_verify=True,
    skip_attn_backend_init=True,   # always skips
)
```

So on the non-cuda-graph verify path neither `prepare_for_v2_verify` nor `forward_extend` initializes the backend, leaving pre-pad shapes (e.g. tripping the DSv4 indexer shape match — the exact failure #26244 describes).

The multi-layer file predates #26244 and this line has always been `True`; it was simply missed when the shared init was removed.

## Fix

Pass `can_run_cuda_graph` (already computed a few lines above from `prepare_for_v2_verify`), matching the single-layer worker:

```python
skip_attn_backend_init=can_run_cuda_graph,
```

- cuda-graph path: skip (replay_prepare already initialized) — unchanged behavior.
- non-cuda-graph path: do not skip, so `forward_extend` runs the post-pad init.

## Test Plan

Affects multi-layer EAGLE v2 (multi-layer MTP, spec-v2) on the non-cuda-graph verify path (e.g. `--disable-cuda-graph` or uncaptured batch sizes). I do not have a multi-GPU/spec environment to reproduce locally; the change is structurally identical to the single-layer fix in #26244 and relies on the same `can_run_cuda_graph` already in scope. Requesting CI / a maintainer with a spec-decoding setup to validate.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27040794916](https://github.com/sgl-project/sglang/actions/runs/27040794916)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27040794883](https://github.com/sgl-project/sglang/actions/runs/27040794883)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->