### PR TITLE
[SWA] Improve SWA prefix-cache retention under memory pressure

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -688,6 +688,15 @@ class Envs:
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT = EnvBool(False)
     SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW = EnvBool(False)
     SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN = EnvBool(False)
+    # SWA eviction (both UnifiedRadixCache and legacy SWARadixCache):
+    # when reclaiming a long-SWA internal node, split it so the last
+    # (page-aligned) sliding_window_size tokens are retained as a smaller
+    # suffix child, and only the older prefix portion is tombstoned. First
+    # eviction pass skips retained suffix nodes; second pass only picks
+    # them up if the first pass can't meet the deficit. Improves SWA
+    # retention near branch points for hybrid SWA models under memory
+    # pressure.
+    SGLANG_OPT_SWA_EVICT_KEEP_WINDOW = EnvBool(False)
 
     # DeepGemm Mega MoE
     SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE = EnvBool(False)

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -210,6 +210,31 @@ class LRUList:
         self.cache[node.id] = node
         self._add_node(node)
 
+    def insert_after(self, prev_node, node):
+        """Insert ``node`` immediately on the LRU-side of ``prev_node``.
+
+        Used by ``_split_node(preserve_lru_position=True)`` so split halves
+        keep the original node's LRU slot rather than getting promoted to
+        MRU (which would make an eviction-time split look like a cache
+        hit).
+        """
+        assert (
+            not self.is_swa_list or not node.swa_tombstone
+        ), f"Inserting swa tombstone node in swa lru list: {node.id=}"
+        assert (
+            node.id not in self.cache
+        ), f"Inserting node {node.id=} already in lru list"
+        self.cache[node.id] = node
+        self._add_node_after(prev_node, node)
+
+    def get_raw_prev(self, node: TreeNode):
+        """Return ``node``'s immediate LRU predecessor without skipping
+        locked nodes (may be the sentinel head). Used to capture an LRU
+        anchor before a split.
+        """
+        assert node.id in self.cache, f"Getting raw_prev of node {node.id=} not in lru list"
+        return getattr(node, self.prv)
+
     def remove_node(self, node: TreeNode):
         """
         Remove node from lru list
@@ -360,6 +385,11 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             self.init_metrics_collector()
 
         self.sliding_window_size = params.sliding_window_size
+        self._window_aligned_size = (
+            (self.sliding_window_size + self.page_size - 1)
+            // self.page_size
+            * self.page_size
+        )
         self.reset()
 
     ##### Public API #####
@@ -607,65 +637,178 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                 x = x_next
 
         if swa_num_evicted < swa_num_tokens:
-            # get the least recently used node that is not locked, doesn't have to be a leaf
-            x = self.swa_lru_list.get_lru_no_lock()
-
-            # evict lru leaf nodes until swa_num_tokens is reached
-            while swa_num_evicted < swa_num_tokens and (self.swa_lru_list.in_list(x)):
-                assert not x.swa_tombstone, f"duplicate swa tombstone node, {x.id=}"
-                assert x != self.root_node, f"root node is not evictable, {x.id=}"
-                assert x.swa_lock_ref == 0, f"node is in use by swa kv indices, {x.id=}"
-
-                if len(x.children) > 0:
-                    # 1. an internal node, free swa tokens.
-                    self.token_to_kv_pool_allocator.free_swa(x.value)
-                    swa_num_evicted += len(x.value)
-
-                    # 2. get the next node, update the lru lists
-                    x_next = self.swa_lru_list.get_prev_no_lock(x)
-                    self.swa_lru_list.remove_node(x)
-
-                    # 3. tombstone the node
-                    self._tombstone_internal_node(x)
-                elif x.full_lock_ref > 0:
-                    # Leaf still holds a full-side lock (can happen when the
-                    # SWA leaf-lock early-release optimization revived a
-                    # tombstoned leaf. Treat it like an internal tombstone.
-                    self.token_to_kv_pool_allocator.free_swa(x.value)
-                    swa_num_evicted += len(x.value)
-
-                    x_next = self.swa_lru_list.get_prev_no_lock(x)
-                    self.swa_lru_list.remove_node(x)
-
-                    self.swa_evictable_size_ -= len(x.value)
-                    x.swa_tombstone = True
-                else:
-                    assert (
-                        x.full_lock_ref == 0
-                    ), f"leaf node with full lock must also have swa lock, {x.id=}"
-                    # 1. a leaf node, free full and swa tokens
-                    self._record_remove_event(x)
-                    self.token_to_kv_pool_allocator.free(x.value)
-                    full_num_evicted += len(x.value)
-                    swa_num_evicted += len(x.value)
-
-                    # 2. get the next node, update the lru lists
-                    x_next = self.swa_lru_list.get_prev_no_lock(x)
-                    self.full_lru_list.remove_node(x)
-                    self.swa_lru_list.remove_node(x)
-
-                    # 3. delete the leaf node
-                    self._delete_leaf(x)
-
-                    # 4. Iteratively delete tombstone leaves to maintain invariant that leaf nodes are not tombstone
-                    self._iteratively_delete_tombstone_leaf(x)
-
-                x = x_next
+            if envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.get():
+                fe, se = self._evict_swa_keep_window(
+                    swa_num_tokens - swa_num_evicted
+                )
+            else:
+                fe, se = self._evict_swa_legacy(swa_num_tokens - swa_num_evicted)
+            full_num_evicted += fe
+            swa_num_evicted += se
 
         self.update_eviction_metrics(full_num_evicted + swa_num_evicted, start_time)
         return EvictResult(
             num_tokens_evicted=full_num_evicted, swa_num_tokens_evicted=swa_num_evicted
         )
+
+    def _evict_swa_legacy(self, swa_num_tokens: int) -> Tuple[int, int]:
+        """Legacy single-pass SWA eviction: walk SWA LRU from oldest,
+        wholesale-tombstone or delete-leaf each node until the deficit is met.
+        """
+        full_num_evicted = 0
+        swa_num_evicted = 0
+        x = self.swa_lru_list.get_lru_no_lock()
+        while swa_num_evicted < swa_num_tokens and self.swa_lru_list.in_list(x):
+            assert not x.swa_tombstone, f"duplicate swa tombstone node, {x.id=}"
+            assert x != self.root_node, f"root node is not evictable, {x.id=}"
+            assert x.swa_lock_ref == 0, f"node is in use by swa kv indices, {x.id=}"
+            x_next, fe, se = self._evict_swa_node_wholesale(x)
+            full_num_evicted += fe
+            swa_num_evicted += se
+            x = x_next
+        return full_num_evicted, swa_num_evicted
+
+    def _evict_swa_keep_window(self, swa_num_tokens: int) -> Tuple[int, int]:
+        """Two-pass SWA eviction (SGLANG_OPT_SWA_EVICT_KEEP_WINDOW):
+
+        - Pass 1 defers window-sized SWA nodes (including
+          retained suffixes produced by an earlier keep-window split).
+          For longer internal nodes, the older prefix is split off and
+          tombstoned; the last window-sized suffix stays alive at the
+          original LRU slot via
+          ``_split_node(preserve_lru_position=True)``. Longer leaves
+          still go through the legacy wholesale path.
+        - Pass 2 evicts the deferred window-sized nodes if pass 1 alone
+          cannot satisfy the deficit.
+
+        Retained nodes are identified STRUCTURALLY by size
+        (``len(value) ≤ window_aligned``), not by a marker. This avoids
+        the need to propagate a marker through every later ``_split_node``
+        (match_prefix mid-walk, overlap insert, etc.), at the cost of
+        also deferring naturally short nodes that were never produced
+        by keep-window. The strategy prefers this false positive over
+        the false negative of accidentally tombstoning a real retained
+        window after it becomes a leaf. Deferred nodes remain evictable
+        in pass 2 so they don't permanently wedge the SWA pool.
+        """
+        full_num_evicted = 0
+        swa_num_evicted = 0
+        fe, se = self._evict_swa_keep_window_pass(
+            swa_num_tokens, evict_window_sized=False
+        )
+        full_num_evicted += fe
+        swa_num_evicted += se
+        if swa_num_evicted < swa_num_tokens:
+            fe, se = self._evict_swa_keep_window_pass(
+                swa_num_tokens - swa_num_evicted, evict_window_sized=True
+            )
+            full_num_evicted += fe
+            swa_num_evicted += se
+        return full_num_evicted, swa_num_evicted
+
+    def _evict_swa_keep_window_pass(
+        self, swa_num_tokens: int, evict_window_sized: bool
+    ) -> Tuple[int, int]:
+        full_num_evicted = 0
+        swa_num_evicted = 0
+        window_aligned = self._window_aligned_size
+
+        x = self.swa_lru_list.get_lru_no_lock()
+        while swa_num_evicted < swa_num_tokens and self.swa_lru_list.in_list(x):
+            assert not x.swa_tombstone, f"duplicate swa tombstone node, {x.id=}"
+            assert x != self.root_node, f"root node is not evictable, {x.id=}"
+            assert x.swa_lock_ref == 0, f"node is in use by swa kv indices, {x.id=}"
+
+            # Pass 1: this is a window-sized SWA node. That includes
+            # retained suffixes that later became leaves after their
+            # children were evicted; without this guard they would be
+            # deleted as ordinary leaves in the next pass-1 scan.
+            if not evict_window_sized and len(x.value) <= window_aligned:
+                x = self.swa_lru_list.get_prev_no_lock(x)
+                continue
+
+            if len(x.children) > 0:
+                # Internal node: keep-window split by size.
+                if not evict_window_sized and len(x.value) > window_aligned:
+                    # Pass 1: split off the older prefix; keep the
+                    # window-sized suffix at the original LRU slot.
+                    x_next = self.swa_lru_list.get_prev_no_lock(x)
+                    split_at = len(x.value) - window_aligned
+                    new_parent = self._split_node(
+                        x.key, x, split_at, preserve_lru_position=True
+                    )
+                    self.token_to_kv_pool_allocator.free_swa(new_parent.value)
+                    swa_num_evicted += len(new_parent.value)
+                    self.swa_lru_list.remove_node(new_parent)
+                    self._tombstone_internal_node(new_parent)
+                    x = x_next
+                    continue
+                # Pass 2 (evict_window_sized=True): wholesale tombstone.
+                x_next, fe, se = self._evict_swa_node_wholesale(x)
+            else:
+                # Leaf — always evict atomically (matches legacy).
+                x_next, fe, se = self._evict_swa_node_wholesale(x)
+
+            full_num_evicted += fe
+            swa_num_evicted += se
+            x = x_next
+
+        return full_num_evicted, swa_num_evicted
+
+    def _evict_swa_node_wholesale(
+        self, x: TreeNode
+    ) -> Tuple[Optional[TreeNode], int, int]:
+        """Wholesale-evict a single SWA LRU node (no split). Returns
+        (x_next, full_evicted, swa_evicted). Mirrors the three legacy
+        branches: internal-tombstone / revived-leaf-tombstone / leaf-delete.
+        """
+        full_num_evicted = 0
+        swa_num_evicted = 0
+        if len(x.children) > 0:
+            # 1. an internal node, free swa tokens.
+            self.token_to_kv_pool_allocator.free_swa(x.value)
+            swa_num_evicted += len(x.value)
+
+            # 2. get the next node, update the lru lists
+            x_next = self.swa_lru_list.get_prev_no_lock(x)
+            self.swa_lru_list.remove_node(x)
+
+            # 3. tombstone the node
+            self._tombstone_internal_node(x)
+        elif x.full_lock_ref > 0:
+            # Leaf still holds a full-side lock (can happen when the
+            # SWA leaf-lock early-release optimization revived a
+            # tombstoned leaf. Treat it like an internal tombstone.
+            self.token_to_kv_pool_allocator.free_swa(x.value)
+            swa_num_evicted += len(x.value)
+
+            x_next = self.swa_lru_list.get_prev_no_lock(x)
+            self.swa_lru_list.remove_node(x)
+
+            self.swa_evictable_size_ -= len(x.value)
+            x.swa_tombstone = True
+        else:
+            assert (
+                x.full_lock_ref == 0
+            ), f"leaf node with full lock must also have swa lock, {x.id=}"
+            # 1. a leaf node, free full and swa tokens
+            self._record_remove_event(x)
+            self.token_to_kv_pool_allocator.free(x.value)
+            full_num_evicted += len(x.value)
+            swa_num_evicted += len(x.value)
+
+            # 2. get the next node, update the lru lists
+            x_next = self.swa_lru_list.get_prev_no_lock(x)
+            self.full_lru_list.remove_node(x)
+            self.swa_lru_list.remove_node(x)
+
+            # 3. delete the leaf node
+            self._delete_leaf(x)
+
+            # 4. Iteratively delete tombstone leaves to maintain invariant that leaf nodes are not tombstone
+            self._iteratively_delete_tombstone_leaf(x)
+
+        return x_next, full_num_evicted, swa_num_evicted
 
     def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
         """
@@ -1029,12 +1172,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         ):
             return leaf
 
-        # Smallest page-aligned size that still covers the sliding window.
-        tail_size = (
-            (self.sliding_window_size + self.page_size - 1)
-            // self.page_size
-            * self.page_size
-        )
+        tail_size = self._window_aligned_size
         if len(leaf.value) <= tail_size:
             return leaf
 
@@ -1050,7 +1188,26 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         self._split_node(leaf.key, leaf, split_at)
         return leaf
 
-    def _split_node(self, key: RadixKey, child: TreeNode, split_len: int) -> TreeNode:
+    def _split_node(
+        self,
+        key: RadixKey,
+        child: TreeNode,
+        split_len: int,
+        preserve_lru_position: bool = False,
+    ) -> TreeNode:
+        """Split ``child`` at ``split_len`` into a new prefix parent + suffix.
+
+        When ``preserve_lru_position`` is True, the split halves are
+        reinserted at child's original slot — concretely, the post-split
+        MRU→LRU order is
+        ``anchor → new_node → child → (child's old LRU-side neighbor)``,
+        i.e. new_node ends up on the MRU-side of child and the suffix
+        child keeps the same LRU-side neighbor it had before the split.
+        ``child.last_access_time`` is preserved. Used by SWA keep-window
+        eviction so splitting under memory pressure does not get
+        promoted to MRU (which would look like a fresh cache hit and
+        starve true LRU candidates).
+        """
         # new_node -> child
         new_node = TreeNode()
         new_node.children = {key[split_len:].child_key(self.page_size): child}
@@ -1064,8 +1221,37 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         # parent inherits the swa_uuid from child for swa lock ref
         new_node.swa_uuid = child.swa_uuid
         child.swa_uuid = None
-        # child time should be later than parent's time for swa tombstone
-        child.last_access_time = get_last_access_time()
+
+        if preserve_lru_position:
+            # Capture each LRU's raw predecessor of child BEFORE we remove
+            # child from the list. Both halves get reinserted right after
+            # this anchor so MRU→LRU order ends up as
+            #   anchor → new_node → child → (child's old LRU-side neighbor)
+            # i.e. new_node sits on the MRU-side of child, and child
+            # keeps its LRU-side neighbor. The split is invisible to LRU
+            # ordering and is not treated as a cache hit.
+            #
+            # Time invariant: legacy ``sanity_check`` heap-orders LRU by
+            # ``last_access_time`` (TreeNode.__lt__ compares times). Since
+            # new_node is more MRU than child post-split, it must compare
+            # strictly GREATER than child and strictly LESS than child's
+            # old MRU-side neighbor. ``_match_post_processor`` uses 1e-5
+            # decrements per ancestor; 1e-6 is below that floor and never
+            # collides with any other node's slotted time, while also
+            # fitting inside the >= 1.0 gap left by the integer-stepped
+            # counter for naturally-spaced nodes.
+            new_node.last_access_time = child.last_access_time + 1e-6
+            full_lru_prev = self.full_lru_list.get_raw_prev(child)
+            swa_lru_prev = (
+                self.swa_lru_list.get_raw_prev(child)
+                if not child.swa_tombstone
+                else None
+            )
+        else:
+            # child time should be later than parent's time for swa tombstone
+            child.last_access_time = get_last_access_time()
+            full_lru_prev = None
+            swa_lru_prev = None
 
         # remove the child from the lru lists because it is being split
         self.full_lru_list.remove_node(child)
@@ -1080,13 +1266,24 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             child.hash_value, split_len, self.page_size
         )
 
-        # insert the new node and child into the lru lists, insert
-        # parent first so that parent is after child in the lru list
-        self.full_lru_list.insert_mru(new_node)
-        self.full_lru_list.insert_mru(child)
-        if not new_node.swa_tombstone:
-            self.swa_lru_list.insert_mru(new_node)
-            self.swa_lru_list.insert_mru(child)
+        if preserve_lru_position:
+            # Reinsert at the original slot. anchor was captured as
+            # child's MRU-side neighbor; insert_after(anchor, X) places
+            # X on anchor's LRU-side. Final MRU→LRU order:
+            #   anchor → new_node → child → (child's old LRU-side neighbor).
+            self.full_lru_list.insert_after(full_lru_prev, new_node)
+            self.full_lru_list.insert_after(new_node, child)
+            if not new_node.swa_tombstone:
+                self.swa_lru_list.insert_after(swa_lru_prev, new_node)
+                self.swa_lru_list.insert_after(new_node, child)
+        else:
+            # insert the new node and child into the lru lists, insert
+            # parent first so that parent is after child in the lru list
+            self.full_lru_list.insert_mru(new_node)
+            self.full_lru_list.insert_mru(child)
+            if not new_node.swa_tombstone:
+                self.swa_lru_list.insert_mru(new_node)
+                self.swa_lru_list.insert_mru(child)
         return new_node
 
     def _insert_helper(

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefParams,
     EvictParams,
@@ -51,6 +52,11 @@ class SWAComponent(TreeComponent):
         ), f"SWAComponent requires SWATokenToKVPoolAllocator, got {type(cache.token_to_kv_pool_allocator)}"
         super().__init__(cache, params)
         self.sliding_window_size = params.sliding_window_size
+        self._window_aligned_size = (
+            (self.sliding_window_size + self.cache.page_size - 1)
+            // self.cache.page_size
+            * self.cache.page_size
+        )
         # HiCache state: set to host SWA pool when HiCache enabled
         self._swa_kv_pool_host = None
 
@@ -382,24 +388,137 @@ class SWAComponent(TreeComponent):
         request = params.swa_num_tokens
         ct = self.component_type
         lru = self.cache.lru_lists[ct]
+        keep_window = envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.get()
+
+        if not keep_window:
+            # Legacy single-pass eviction. Preserved verbatim to keep the
+            # behavior identical when the opt is off.
+            x = lru.get_lru_no_lock()
+            while tracker[ct] < request and x is not None and lru.in_list(x):
+                assert x.component_data[ct].value is not None
+                if x in self.cache.evictable_device_leaves:
+                    # D-leaf: atomic eviction of all components
+                    x_next = lru.get_prev_no_lock(x)
+                    self.cache._evict_device_leaf(x, tracker)
+                    if not lru.in_list(x_next):
+                        x_next = lru.get_lru_no_lock()
+                    x = x_next
+                else:
+                    # Internal: tombstone SWA + cascade
+                    x_next = lru.get_prev_no_lock(x)
+                    self.cache._evict_component_and_detach_lru(
+                        x, self, target=EvictLayer.DEVICE, tracker=tracker
+                    )
+                    self.cache._cascade_evict(x, self, tracker)
+                    x = x_next
+            return
+
+        # ----- evict-prefix-keep-window two-pass strategy -----
+        # Pass 1 defers window-sized SWA nodes (including
+        # retained suffixes produced by an earlier keep-window split).
+        # For longer internal nodes, the older prefix is split off and
+        # tombstoned; the last window-sized suffix stays alive at the
+        # original LRU slot. Longer D-leaves still evict atomically.
+        # Retained nodes are identified STRUCTURALLY by size
+        # (``len(value) ≤ window_aligned``), not by a marker. This
+        # avoids the need to propagate a marker through every later
+        # ``_split_node`` (match_prefix mid-walk, overlap insert, etc.),
+        # at the cost of also deferring naturally short nodes that were
+        # never produced by keep-window. The strategy prefers this false
+        # positive over the false negative of accidentally tombstoning a
+        # real retained window after it becomes a leaf.
+        # Pass 2 evicts the deferred window-sized nodes if pass 1 alone
+        # cannot satisfy the deficit, so they remain evictable under
+        # sustained pressure.
+        self._drive_eviction_pass(request, tracker, evict_window_sized=False)
+        if tracker[ct] < request:
+            self._drive_eviction_pass(request, tracker, evict_window_sized=True)
+
+    def _drive_eviction_pass(
+        self,
+        request: int,
+        tracker: dict[ComponentType, int],
+        evict_window_sized: bool,
+    ) -> None:
+        ct = self.component_type
+        lru = self.cache.lru_lists[ct]
+        window_aligned = self._window_aligned_size
+
         x = lru.get_lru_no_lock()
         while tracker[ct] < request and x is not None and lru.in_list(x):
-            assert x.component_data[ct].value is not None
+            cd = x.component_data[ct]
+            assert cd.value is not None
+            x_next = lru.get_prev_no_lock(x)
+
+            if not evict_window_sized and len(cd.value) <= window_aligned:
+                # A retained suffix can become a D-leaf after its children
+                # are evicted. Keep the same first-pass protection for that
+                # leaf form; pass 2 can still drain it under sustained
+                # pressure.
+                x = x_next
+                continue
+
             if x in self.cache.evictable_device_leaves:
-                # D-leaf: atomic eviction of all components
-                x_next = lru.get_prev_no_lock(x)
+                # Longer D-leaves evict atomically — leaf SWA is by
+                # definition the tail of a chain, splitting it would
+                # also free the FULL component since the two are bound
+                # by the leaf identity.
                 self.cache._evict_device_leaf(x, tracker)
-                if not lru.in_list(x_next):
-                    x_next = lru.get_lru_no_lock()
-                x = x_next
             else:
-                # Internal: tombstone SWA + cascade
-                x_next = lru.get_prev_no_lock(x)
-                self.cache._evict_component_and_detach_lru(
-                    x, self, target=EvictLayer.DEVICE, tracker=tracker
+                # Internal node
+                target_node = self._window_retention_evict_node(
+                    x, evict_window_sized=evict_window_sized
                 )
-                self.cache._cascade_evict(x, self, tracker)
-                x = x_next
+                if target_node is None:
+                    # Pass 1 deferral: this internal node is already at
+                    # or below window size, keep it as the retained
+                    # window. Pass 2 ignores this branch entirely.
+                    x = x_next
+                    continue
+                self.cache._evict_component_and_detach_lru(
+                    target_node, self, target=EvictLayer.DEVICE, tracker=tracker
+                )
+                self.cache._cascade_evict(target_node, self, tracker)
+
+            if x_next is None or not lru.in_list(x_next):
+                x_next = lru.get_lru_no_lock()
+            x = x_next
+
+    def _window_retention_evict_node(
+        self, node: UnifiedTreeNode, evict_window_sized: bool
+    ) -> Optional[UnifiedTreeNode]:
+        """Decide what to evict for an internal SWA node under keep-window.
+
+        Returns ``None`` to defer (pass-1 only), the node itself to evict
+        wholesale, or a freshly-split prefix parent to evict only the
+        older prefix while keeping a window-sized suffix child alive.
+        """
+        cd = node.component_data[self.component_type]
+        value_len = len(cd.value)
+        window_aligned = self._window_aligned_size
+
+        if evict_window_sized:
+            # Pass 2: pass-1 already split everything that could be split,
+            # so any internal node left in the LRU is at or below window
+            # size. Evict it wholesale.
+            return node
+
+        if value_len <= window_aligned:
+            # Pass 1: this IS the retained window (size-based identification
+            # is structurally invariant — any further mid-node ``_split_node``
+            # caused by match_prefix walking mid-node or by an overlapping
+            # insert produces two halves both ≤ window_aligned, so both
+            # remain deferred without needing an explicit marker).
+            return None
+
+        # Long internal node: split off the older prefix and tombstone it.
+        # ``preserve_lru_position=True`` so the suffix child stays at the
+        # original LRU slot — splitting under memory pressure must not be
+        # treated as a fresh cache hit (which insert_mru would imply).
+        split_at = value_len - window_aligned
+        return self.cache._split_node(
+            node.key, node, split_at, preserve_lru_position=True
+        )
 
     def acquire_component_lock(
         self,

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -162,6 +162,17 @@ class UnifiedLRUList:
         self.cache[node.id] = node
         self._add_node(node)
 
+    def insert_after(self, prev_node: UnifiedTreeNode, node: UnifiedTreeNode):
+        """Insert ``node`` immediately on the LRU-side of ``prev_node``.
+
+        Used by ``_split_node(preserve_lru_position=True)`` to put split
+        halves back at the original child's position rather than promoting
+        them to MRU (which would treat an eviction-time split as a hit).
+        """
+        assert node.id not in self.cache
+        self.cache[node.id] = node
+        self._add_node_after(prev_node, node)
+
     def remove_node(self, node: UnifiedTreeNode):
         assert node.id in self.cache
         del self.cache[node.id]
@@ -207,6 +218,14 @@ class UnifiedLRUList:
 
     def in_list(self, node: Optional[UnifiedTreeNode]):
         return node is not None and node.id in self.cache
+
+    def get_raw_prev(self, node: UnifiedTreeNode) -> UnifiedTreeNode:
+        """Return ``node``'s immediate LRU predecessor without skipping locked
+        nodes (may be the sentinel head). Used to capture an LRU anchor before
+        a split so the post-split halves can be reinserted at the same slot.
+        """
+        assert node.id in self.cache
+        return node.lru_prev[self._pt]
 
     def get_prev_no_lock(self, node: UnifiedTreeNode, check_id: bool = True):
         if check_id:
@@ -859,14 +878,40 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         return result
 
     def _split_node(
-        self, key: RadixKey, child: UnifiedTreeNode, split_len: int
+        self,
+        key: RadixKey,
+        child: UnifiedTreeNode,
+        split_len: int,
+        preserve_lru_position: bool = False,
     ) -> UnifiedTreeNode:
+        """Split ``child`` at ``split_len`` into a new prefix parent + suffix.
+
+        When ``preserve_lru_position`` is True, the non-BASE device LRU
+        entries for new_parent + child are reinserted at child's original
+        slot — concretely, the post-split MRU→LRU order is
+        ``anchor → new_parent → child → (child's old LRU-side neighbor)``,
+        i.e. new_parent ends up on the MRU-side of child and the suffix
+        child keeps the same LRU-side neighbor it had before the split.
+        ``child.last_access_time`` is preserved. This avoids promoting
+        an eviction-time split to MRU, which would otherwise mask a
+        degraded retention as a fresh cache hit.
+        """
         new_node = UnifiedTreeNode(self.tree_components, priority=child.priority)
         new_node.children = {key[split_len:].child_key(self.page_size): child}
         new_node.parent = child.parent
         new_node.key = child.key[:split_len]
         new_node.hit_count = child.hit_count
         new_node.creation_time = child.creation_time
+
+        device_lru_prev: dict[int, UnifiedTreeNode] = {}
+        if preserve_lru_position:
+            new_node.last_access_time = child.last_access_time
+            for ct in self.tree_components:
+                if ct == BASE_COMPONENT_TYPE:
+                    continue
+                lru = self.lru_lists[ct]
+                if lru.in_list(child):
+                    device_lru_prev[ct] = lru.get_raw_prev(child)
 
         self._for_each_component_lru(child, UnifiedLRUList.remove_node)
 
@@ -880,13 +925,29 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             component.redistribute_on_node_split(new_parent=new_node, child=child)
         new_node.parent.children[key.child_key(self.page_size)] = new_node
 
-        self._for_each_component_lru(
-            new_node, UnifiedLRUList.insert_mru, skip_existing=True
-        )
-        self._for_each_component_lru(
-            child, UnifiedLRUList.insert_mru, skip_existing=True
-        )
-        child.last_access_time = get_and_increase_time_counter()
+        if preserve_lru_position:
+            # Reinsert at the original slot. MRU→LRU order ends up as
+            # anchor → new_node → child → (child's old LRU-side neighbor),
+            # so new_node sits on the MRU-side of child and child keeps
+            # its LRU-side neighbor. BASE LRU (if any) is not tracked
+            # here; preserve_lru_position is for SWA-style splits that
+            # already operate on device LRU.
+            for ct, prev_node in device_lru_prev.items():
+                lru = self.lru_lists[ct]
+                anchor = prev_node
+                if new_node.component_data[ct].value is not None:
+                    lru.insert_after(anchor, new_node)
+                    anchor = new_node
+                if child.component_data[ct].value is not None:
+                    lru.insert_after(anchor, child)
+        else:
+            self._for_each_component_lru(
+                new_node, UnifiedLRUList.insert_mru, skip_existing=True
+            )
+            self._for_each_component_lru(
+                child, UnifiedLRUList.insert_mru, skip_existing=True
+            )
+            child.last_access_time = get_and_increase_time_counter()
 
         self._update_evictable_leaf_sets(new_node)
         self._update_evictable_leaf_sets(child)

--- a/test/registered/unit/mem_cache/test_swa_evict_keep_window.py
+++ b/test/registered/unit/mem_cache/test_swa_evict_keep_window.py
@@ -1,0 +1,387 @@
+"""Unit tests for SWA evict-prefix-keep-window strategy (unified path).
+
+Tests the SGLANG_OPT_SWA_EVICT_KEEP_WINDOW path in
+``SWAComponent.drive_eviction`` and the ``preserve_lru_position`` mode
+of ``UnifiedRadixCache._split_node``:
+
+* When the env var is off, eviction matches the legacy single-pass
+  path (whole internal SWA chunks are tombstoned).
+* When on, a long-SWA internal node is split at eviction time so the
+  last ``ceil(sliding_window_size / page_size) * page_size`` tokens
+  are retained as a smaller suffix child; only the older prefix half
+  is tombstoned. "Retained" is identified by SIZE
+  (``len(value) <= window_aligned``), no explicit marker — so any
+  subsequent ``_split_node`` mid-walk produces two halves both
+  ≤ window and both remain deferred without extra bookkeeping.
+* A second pass evicts the window-sized nodes only if the
+  first pass cannot satisfy the requested deficit.
+* The split preserves the LRU position and ``last_access_time`` of
+  the suffix child — splitting under memory pressure must not be
+  treated as a fresh cache hit.
+
+Setup notes:
+
+* ``base`` uses 12 tokens (not 8) on purpose: the unified path
+  unconditionally invokes ``SWAComponent._maybe_split_leaf_for_swa_lock``
+  in ``commit_insert_component_data``, which splits any fresh leaf
+  longer than ``tail_size = window_aligned``. With ``base = 12`` and
+  ``window_aligned = 4`` the post-#26919 tree starts as
+  ``root → A[1..8] (internal, value=8) → B[9..12] (leaf, value=4)``,
+  which leaves an 8-token internal node ``A`` that our keep-window
+  split can actually exercise. With ``base = 8`` ``A`` would already
+  be 4 tokens (= window) and the split branch would never fire.
+
+* ``match_prefix`` is intentionally avoided before ``evict`` — it
+  would bump the long internal to MRU and let the chain leaf at LRU
+  absorb the request. Long internals are fetched via
+  ``tree.root_node.children`` instead.
+"""
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool, SWATokenToKVPoolAllocator
+from sglang.srt.mem_cache.unified_cache_components.tree_component import ComponentType
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.utils import get_device
+from sglang.test.test_utils import CustomTestCase
+
+
+def _build_unified_swa_tree(
+    page_size: int = 2,
+    sliding_window_size: int = 4,
+    kv_size: int = 128,
+    kv_size_swa: int = 128,
+    max_context_len: int = 128,
+):
+    """Construct a UnifiedRadixCache with FULL + SWA components."""
+    head_num = 2
+    head_dim = 64
+    num_layers = 8
+    dtype = torch.bfloat16
+    device = get_device()
+    full_attention_layer_ids = list(range(0, num_layers, 2))
+    swa_attention_layer_ids = [
+        i for i in range(num_layers) if i not in set(full_attention_layer_ids)
+    ]
+
+    req_to_token_pool = ReqToTokenPool(
+        size=8,
+        max_context_len=max_context_len,
+        device=device,
+        enable_memory_saver=False,
+    )
+    kv_pool = SWAKVPool(
+        size=kv_size,
+        size_swa=kv_size_swa,
+        page_size=page_size,
+        dtype=dtype,
+        head_num=head_num,
+        head_dim=head_dim,
+        swa_attention_layer_ids=swa_attention_layer_ids,
+        full_attention_layer_ids=full_attention_layer_ids,
+        enable_kvcache_transpose=False,
+        device=device,
+    )
+    allocator = SWATokenToKVPoolAllocator(
+        size=kv_size,
+        size_swa=kv_size_swa,
+        page_size=page_size,
+        dtype=dtype,
+        device=device,
+        kvcache=kv_pool,
+        need_sort=False,
+    )
+    tree = UnifiedRadixCache(
+        params=CacheInitParams(
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=page_size,
+            disable=False,
+            sliding_window_size=sliding_window_size,
+            tree_components=(ComponentType.FULL, ComponentType.SWA),
+        ),
+    )
+    return tree, allocator, req_to_token_pool
+
+
+def _alloc(allocator, need_size: int):
+    assert need_size % allocator.page_size == 0
+    full_indices = allocator.full_attn_allocator.alloc(need_size)
+    swa_indices = allocator.swa_attn_allocator.alloc(need_size)
+    assert full_indices is not None and swa_indices is not None
+    allocator.full_to_swa_index_mapping[full_indices] = swa_indices
+    return full_indices
+
+
+def _insert(tree, allocator, token_ids):
+    indices = _alloc(allocator, len(token_ids))
+    tree.insert(InsertParams(key=RadixKey(array("q", token_ids)), value=indices))
+
+
+def _make_seq(start: int, length: int) -> list[int]:
+    return list(range(start, start + length))
+
+
+def _only_child(node):
+    """Fetch the single child of `node` without touching LRU order."""
+    assert len(node.children) == 1, f"expected one child, got {len(node.children)}"
+    return next(iter(node.children.values()))
+
+
+class TestSWAEvictKeepWindow(CustomTestCase):
+    """Layout: page_size=2, sliding_window_size=4 → window_aligned=4.
+
+    After #26919's leaf-cap split, inserting ``base = [1..12]`` yields
+    ``root → A[1..8] (internal, value=8) → B[9..12] (leaf, value=4)``.
+    A is the long internal our keep-window split targets.
+    """
+
+    def _swa_value_len(self, node):
+        v = node.component_data[ComponentType.SWA].value
+        return 0 if v is None else len(v)
+
+    def test_keep_window_off_legacy_path(self):
+        """Env off: internal SWA evicted wholesale, no keep-window split."""
+        tree, allocator, _ = _build_unified_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(False):
+            base = _make_seq(1, 12)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+
+            base_node = _only_child(tree.root_node)
+            self.assertEqual(self._swa_value_len(base_node), 8)
+            self.assertGreater(len(base_node.children), 0)
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=8))
+
+            # Whole SWA tombstoned, no structural split (key unchanged).
+            self.assertIsNone(base_node.component_data[ComponentType.SWA].value)
+            self.assertEqual(len(base_node.key), 8)
+        tree.sanity_check()
+
+    def test_keep_window_on_splits_and_retains_suffix(self):
+        """Env on: long internal node split. Prefix tombstoned, last
+        window-aligned tokens retained as a suffix child."""
+        tree, allocator, _ = _build_unified_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 12)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+
+            base_node_pre = _only_child(tree.root_node)
+            self.assertEqual(self._swa_value_len(base_node_pre), 8)
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            # After split: root → new_parent ([1..4], SWA tombstoned)
+            #              → suffix ([5..8], SWA alive, == base_node_pre).
+            new_parent = _only_child(tree.root_node)
+            self.assertEqual(len(new_parent.key), 4)
+            self.assertIsNone(
+                new_parent.component_data[ComponentType.SWA].value,
+                "prefix half should be SWA-tombstoned",
+            )
+            suffix = _only_child(new_parent)
+            self.assertIs(
+                suffix,
+                base_node_pre,
+                "split keeps the original node as the suffix child",
+            )
+            self.assertEqual(len(suffix.key), 4)
+            self.assertEqual(self._swa_value_len(suffix), 4)
+        tree.sanity_check()
+
+    def test_keep_window_eventually_drains_window_sized(self):
+        """Under sustained pressure, pass 2 drains what pass 1 has
+        deferred. Verifies that the retained suffix doesn't permanently
+        wedge the SWA pool.
+
+        Note: this asserts the END state (``swa_evictable_size == 0``),
+        not specifically that pass-2 evicted the suffix AS an internal
+        node — in this fixture pass 1 first deletes the chain leaf (a
+        D-leaf) wholesale, leaving the suffix childless. The suffix
+        remains deferred by size and pass 2 evicts it via the leaf-delete
+        branch. Either way the suffix is gone, which is what the
+        keep-window contract promises.
+        """
+        tree, allocator, _ = _build_unified_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 12)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+
+            # Pass 1 splits base_node and tombstones the prefix (4 tokens).
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            # Now request all remaining SWA. Pass 1 alone can't satisfy
+            # this (all surviving internals are window-sized → deferred).
+            # Pass 2 picks them up.
+            remaining = tree.swa_evictable_size()
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=remaining))
+            self.assertEqual(tree.swa_evictable_size(), 0)
+        tree.sanity_check()
+
+    def test_window_sized_leaf_deferred_in_pass1(self):
+        """Pass 1 must defer any SWA node with ``len(value) ≤
+        window_aligned``, including D-leaves. This is the structural
+        guarantee that protects a retained suffix even after its
+        descendants are evicted and it becomes a leaf itself
+        (otherwise the next pass-1 scan would atom-delete exactly the
+        window we wanted to keep).
+
+        Direct test of the invariant: insert a window-sized leaf that
+        sits at the LRU end, plus a longer branch pass 1 can pull from.
+        Pass 1 must skip the short leaf and evict from the long branch.
+        """
+        tree, allocator, _ = _build_unified_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            # Short standalone leaf (== window_aligned tokens; #26919's
+            # leaf-cap split returns early since len ≤ tail_size).
+            short = _make_seq(1, 4)
+            _insert(tree, allocator, short)
+            short_node = _only_child(tree.root_node)
+            self.assertEqual(self._swa_value_len(short_node), 4)
+            self.assertIn(short_node, tree.evictable_device_leaves)
+
+            # Long branch: #26919 splits the 12-token leaf into an
+            # 8-token internal + 4-token leaf, then the chain extension
+            # creates more internals. Pass 1 has a long internal it can
+            # split-and-tombstone instead of touching short_node.
+            long_base = _make_seq(2000, 12)
+            long_chain = long_base + _make_seq(3000, 8)
+            _insert(tree, allocator, long_base)
+            _insert(tree, allocator, long_chain)
+            self.assertIs(
+                tree.lru_lists[ComponentType.SWA].get_lru_no_lock(),
+                short_node,
+                "short window-sized leaf must be the pass-1 candidate",
+            )
+
+            # Small request — pass 1 alone must satisfy by splitting the
+            # long internal (frees 4 SWA), without atom-deleting
+            # short_node.
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            self.assertIsNotNone(
+                short_node.component_data[ComponentType.SWA].value,
+                "window-sized leaf must be deferred in pass 1",
+            )
+            self.assertEqual(self._swa_value_len(short_node), 4)
+            self.assertIn(short_node, tree.evictable_device_leaves)
+        tree.sanity_check()
+
+    def test_split_preserves_lru_position_and_access_time(self):
+        """``preserve_lru_position=True``: the suffix child stays at the
+        original LRU slot and keeps its ``last_access_time``. Splitting
+        under memory pressure must not be treated as a fresh cache hit
+        (which insert_mru would imply)."""
+        tree, allocator, _ = _build_unified_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 12)
+            full_chain = base + _make_seq(900, 8)
+            other_base = _make_seq(2000, 12)
+            other_chain = other_base + _make_seq(3000, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+            _insert(tree, allocator, other_base)
+            _insert(tree, allocator, other_chain)
+
+            swa_lru = tree.lru_lists[ComponentType.SWA]
+            pt = swa_lru._pt
+            # The 8-token internal A from the base branch is at LRU
+            # (inserted first; nothing bumped it). Capture its raw next
+            # pointer (toward tail) and access time so we can verify
+            # they survive the split.
+            old_lru = swa_lru.get_lru_no_lock()
+            old_next = old_lru.lru_next[pt]
+            old_access_time = old_lru.last_access_time
+            self.assertEqual(self._swa_value_len(old_lru), 8)
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            # After split: suffix sits at the original LRU position.
+            suffix = swa_lru.get_lru_no_lock()
+            self.assertIs(
+                suffix,
+                old_lru,
+                "suffix child should reuse the original LRU slot",
+            )
+            self.assertIs(
+                suffix.lru_next[pt],
+                old_next,
+                "suffix's LRU-side neighbor must be unchanged",
+            )
+            self.assertEqual(
+                suffix.last_access_time,
+                old_access_time,
+                "last_access_time must be preserved (no MRU promotion)",
+            )
+            self.assertIsNotNone(suffix.component_data[ComponentType.SWA].value)
+        tree.sanity_check()
+
+    def test_mid_split_keeps_both_halves_under_window(self):
+        """Regression for the marker-propagation worry: with size-based
+        identification, if a retained suffix is later split mid-node
+        (e.g. by an overlapping insert), BOTH halves are still
+        ≤ window_aligned by construction, so pass 1 keeps deferring
+        both — no marker propagation needed.
+        """
+        tree, allocator, _ = _build_unified_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 12)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            # Tree now: root → tombstoned_prefix ([1..4]) → retained
+            # ([5..8]) → ... (chain below).
+            tombstoned_prefix = _only_child(tree.root_node)
+            retained = _only_child(tombstoned_prefix)
+            self.assertEqual(len(retained.key), 4)
+            self.assertIsNotNone(
+                retained.component_data[ComponentType.SWA].value
+            )
+
+            # Insert sibling = base[:6] + [700, 701]: walks through
+            # tombstoned_prefix (full match, gets revived), then matches
+            # 2/4 of retained's key → _split_node fires inside retained
+            # at position 2, yielding split_parent ([5,6]) + retained' ([7,8]).
+            sibling = base[:6] + _make_seq(700, 2)
+            _insert(tree, allocator, sibling)
+
+            self.assertEqual(len(retained.key), 2, "retained becomes 2-token suffix")
+            split_parent = retained.parent
+            self.assertEqual(len(split_parent.key), 2)
+            self.assertIs(split_parent.parent, tombstoned_prefix)
+
+            # Both halves are ≤ window_aligned = 4 → pass 1 defers both.
+            window_aligned = 4
+            self.assertLessEqual(self._swa_value_len(split_parent), window_aligned)
+            self.assertLessEqual(self._swa_value_len(retained), window_aligned)
+            # Both retain alive SWA values (deferral didn't lose them).
+            self.assertIsNotNone(
+                split_parent.component_data[ComponentType.SWA].value
+            )
+            self.assertIsNotNone(
+                retained.component_data[ComponentType.SWA].value
+            )
+        tree.sanity_check()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_swa_radix_keep_window.py
+++ b/test/registered/unit/mem_cache/test_swa_radix_keep_window.py
@@ -1,0 +1,325 @@
+"""Unit tests for legacy SWARadixCache evict-prefix-keep-window strategy.
+
+Mirrors test_swa_evict_keep_window.py (unified path) but targets the
+legacy SWARadixCache. Verifies:
+
+* Env off: legacy single-pass eviction preserved verbatim.
+* Env on: long internal node split, suffix retained at the original
+  LRU slot. "Retained" is identified by SIZE
+  (``len(value) <= window_aligned``), no explicit marker.
+* Pass 2 drains window-sized nodes when pass 1 alone can't
+  satisfy the deficit.
+* ``_split_node(preserve_lru_position=True)`` keeps the suffix at the
+  original LRU position and last_access_time (no MRU promotion).
+* A subsequent mid-node split (e.g. via overlapping insert) leaves
+  BOTH halves ≤ window — the structural invariant carries the
+  retention semantics without a marker.
+
+Setup avoids ``match_prefix`` before ``evict``: the legacy SWA
+eviction freely deletes leaves, so a match_prefix-bumped LRU order
+(internal at MRU, chain leaf at LRU) would let the leaf absorb the
+request and never split the internal node we want to test.
+"""
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool, SWATokenToKVPoolAllocator
+from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
+from sglang.srt.utils import get_device
+from sglang.test.test_utils import CustomTestCase
+
+
+def _build_swa_tree(
+    page_size: int = 2,
+    sliding_window_size: int = 4,
+    kv_size: int = 128,
+    kv_size_swa: int = 128,
+    max_context_len: int = 128,
+):
+    head_num = 2
+    head_dim = 64
+    num_layers = 8
+    dtype = torch.bfloat16
+    device = get_device()
+    full_attention_layer_ids = list(range(0, num_layers, 2))
+    swa_attention_layer_ids = [
+        i for i in range(num_layers) if i not in set(full_attention_layer_ids)
+    ]
+
+    req_to_token_pool = ReqToTokenPool(
+        size=8,
+        max_context_len=max_context_len,
+        device=device,
+        enable_memory_saver=False,
+    )
+    kv_pool = SWAKVPool(
+        size=kv_size,
+        size_swa=kv_size_swa,
+        page_size=page_size,
+        dtype=dtype,
+        head_num=head_num,
+        head_dim=head_dim,
+        swa_attention_layer_ids=swa_attention_layer_ids,
+        full_attention_layer_ids=full_attention_layer_ids,
+        enable_kvcache_transpose=False,
+        device=device,
+    )
+    allocator = SWATokenToKVPoolAllocator(
+        size=kv_size,
+        size_swa=kv_size_swa,
+        page_size=page_size,
+        dtype=dtype,
+        device=device,
+        kvcache=kv_pool,
+        need_sort=False,
+    )
+    tree = SWARadixCache(
+        params=CacheInitParams(
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=page_size,
+            disable=False,
+            is_eagle=False,
+            sliding_window_size=sliding_window_size,
+        ),
+    )
+    return tree, allocator, req_to_token_pool
+
+
+def _alloc(allocator, need_size: int):
+    assert need_size % allocator.page_size == 0
+    full_indices = allocator.full_attn_allocator.alloc(need_size)
+    swa_indices = allocator.swa_attn_allocator.alloc(need_size)
+    assert full_indices is not None and swa_indices is not None
+    allocator.full_to_swa_index_mapping[full_indices] = swa_indices
+    return full_indices
+
+
+def _insert(tree, allocator, token_ids):
+    indices = _alloc(allocator, len(token_ids))
+    tree.insert(InsertParams(key=RadixKey(array("q", token_ids)), value=indices))
+
+
+def _make_seq(start: int, length: int) -> list[int]:
+    return list(range(start, start + length))
+
+
+def _only_child(node):
+    assert len(node.children) == 1, f"expected one child, got {len(node.children)}"
+    return next(iter(node.children.values()))
+
+
+class TestSWARadixKeepWindow(CustomTestCase):
+    """Layout: page_size=2, sliding_window_size=4 → window_aligned=4.
+
+    Chain: root → A (8 tokens) → B (8 tokens). A is internal with
+    ``len(value) = 8 > 4``, so pass 1 splits it under keep-window.
+    """
+
+    def test_keep_window_off_legacy_path(self):
+        """Env off: internal SWA evicted wholesale, no split."""
+        tree, allocator, _ = _build_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(False):
+            base = _make_seq(1, 8)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+
+            base_node = _only_child(tree.root_node)
+            self.assertGreater(len(base_node.children), 0)
+            self.assertEqual(len(base_node.value), 8)
+            self.assertFalse(base_node.swa_tombstone)
+
+            # base_node at LRU (chain_leaf is MRU), so the internal-
+            # tombstone path fires after just 8 tokens — the leaf isn't
+            # touched.
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=8))
+
+            self.assertTrue(base_node.swa_tombstone)
+            self.assertEqual(len(base_node.key), 8)
+        tree.sanity_check()
+
+    def test_keep_window_on_splits_and_retains_suffix(self):
+        """Env on: long internal node split. Prefix tombstoned, last
+        window-aligned tokens retained as a suffix child."""
+        tree, allocator, _ = _build_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 8)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+
+            base_node_pre = _only_child(tree.root_node)
+            self.assertEqual(len(base_node_pre.value), 8)
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            # After split: root → new_parent ([1..4], tombstoned)
+            #              → suffix ([5..8], alive, == base_node_pre).
+            new_parent = _only_child(tree.root_node)
+            self.assertEqual(len(new_parent.key), 4)
+            self.assertTrue(
+                new_parent.swa_tombstone, "prefix half should be SWA-tombstoned"
+            )
+            suffix = _only_child(new_parent)
+            self.assertIs(suffix, base_node_pre)
+            self.assertEqual(len(suffix.key), 4)
+            self.assertEqual(len(suffix.value), 4)
+            self.assertFalse(suffix.swa_tombstone)
+        tree.sanity_check()
+
+    def test_keep_window_eventually_drains_window_sized(self):
+        """Under sustained pressure, pass 2 drains what pass 1 has
+        deferred. Verifies that the retained suffix doesn't permanently
+        wedge the SWA pool.
+
+        Note: this asserts the END state (``swa_evictable_size == 0``),
+        not specifically that pass-2 evicted the suffix AS an internal
+        node — in this fixture pass 1 first deletes ``chain_leaf`` (a
+        leaf) wholesale, leaving the suffix childless. The suffix remains
+        deferred by size and pass 2 evicts it via the leaf-delete branch.
+        Either way the suffix is gone, which is what the keep-window
+        contract promises.
+        """
+        tree, allocator, _ = _build_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 8)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+            remaining = tree.swa_evictable_size()
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=remaining))
+            self.assertEqual(tree.swa_evictable_size(), 0)
+        tree.sanity_check()
+
+    def test_window_sized_suffix_leaf_deferred_in_pass1(self):
+        """A retained suffix can become a leaf after its children are
+        evicted. It must keep first-pass protection; otherwise a later
+        SWA eviction deletes exactly the window we retained.
+        """
+        tree, allocator, _ = _build_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 8)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+            # Capture the base-chain top BEFORE adding the other branch:
+            # afterwards root will have two children and ``_only_child``
+            # no longer works. The captured Python object is the same one
+            # that ``_split_node`` will later rename in-place as the
+            # retained suffix.
+            base_chain_top = _only_child(tree.root_node)
+            other = _make_seq(2000, 8)
+            _insert(tree, allocator, other)
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+            # Same Python object, now sliced to the window-sized suffix.
+            suffix = base_chain_top
+            tombstoned_prefix = suffix.parent
+            self.assertTrue(tombstoned_prefix.swa_tombstone)
+            self.assertEqual(len(suffix.key), 4)
+            self.assertGreater(len(suffix.children), 0)
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=8))
+            self.assertEqual(len(suffix.children), 0)
+            self.assertFalse(suffix.swa_tombstone)
+            self.assertIn(suffix.id, tree.swa_lru_list.cache)
+            self.assertIs(
+                tree.swa_lru_list.get_lru_no_lock(),
+                suffix,
+                "retained suffix leaf must be the pass-1 candidate",
+            )
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+            self.assertFalse(suffix.swa_tombstone)
+            self.assertIn(suffix.id, tree.swa_lru_list.cache)
+        tree.sanity_check()
+
+    def test_split_preserves_lru_position_and_access_time(self):
+        """``preserve_lru_position=True``: suffix child keeps the
+        original LRU slot and ``last_access_time``."""
+        tree, allocator, _ = _build_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 8)
+            full_chain = base + _make_seq(900, 8)
+            other_base = _make_seq(2000, 8)
+            other_chain = other_base + _make_seq(3000, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+            _insert(tree, allocator, other_base)
+            _insert(tree, allocator, other_chain)
+
+            swa_lru = tree.swa_lru_list
+            old_lru = swa_lru.get_lru_no_lock()
+            old_next = old_lru.swa_next
+            old_access_time = old_lru.last_access_time
+
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            suffix = swa_lru.get_lru_no_lock()
+            self.assertIs(
+                suffix, old_lru, "suffix child should reuse the original LRU slot"
+            )
+            self.assertIs(
+                suffix.swa_next,
+                old_next,
+                "suffix's LRU-side neighbor must be unchanged",
+            )
+            self.assertEqual(
+                suffix.last_access_time,
+                old_access_time,
+                "last_access_time must be preserved (no MRU promotion)",
+            )
+            self.assertFalse(suffix.swa_tombstone)
+        tree.sanity_check()
+
+    def test_mid_split_keeps_both_halves_under_window(self):
+        """With size-based identification, a subsequent ``_split_node``
+        on the retained suffix yields two halves both ≤ window, so
+        pass 1 keeps deferring both. No marker needed.
+        """
+        tree, allocator, _ = _build_swa_tree()
+        with envs.SGLANG_OPT_SWA_EVICT_KEEP_WINDOW.override(True):
+            base = _make_seq(1, 8)
+            full_chain = base + _make_seq(900, 8)
+            _insert(tree, allocator, base)
+            _insert(tree, allocator, full_chain)
+            tree.evict(EvictParams(num_tokens=0, swa_num_tokens=4))
+
+            tombstoned_prefix = _only_child(tree.root_node)
+            retained = _only_child(tombstoned_prefix)
+            self.assertEqual(len(retained.key), 4)
+            self.assertFalse(retained.swa_tombstone)
+
+            # Insert sibling triggers mid-split of the retained suffix.
+            sibling = base[:6] + _make_seq(700, 2)
+            _insert(tree, allocator, sibling)
+
+            self.assertEqual(len(retained.key), 2)
+            split_parent = retained.parent
+            self.assertEqual(len(split_parent.key), 2)
+            self.assertIs(split_parent.parent, tombstoned_prefix)
+
+            window_aligned = 4
+            self.assertLessEqual(len(split_parent.value), window_aligned)
+            self.assertLessEqual(len(retained.value), window_aligned)
+            self.assertFalse(split_parent.swa_tombstone)
+            self.assertFalse(retained.swa_tombstone)
+        tree.sanity_check()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SWA only needs the latest sliding-window tokens, but radix-cache retention and eviction can still operate at coarse node granularity. Under long-prefix, multi-turn workloads, useful SWA suffix windows may be evicted too aggressively, while out-of-window SWA nodes may receive unnecessary LRU refreshes. This hurts prefix-cache reuse for hybrid SWA models such as DeepSeek V4.

## Summary

This PR improves SWA prefix-cache retention for both UnifiedRadixCache and SWARadixCache.

When `SGLANG_OPT_SWA_EVICT_KEEP_WINDOW=0`, the new keep-window eviction path is disabled and legacy eviction behavior is preserved.

## Modifications

- Add `SGLANG_OPT_SWA_EVICT_KEEP_WINDOW`.
- Add window-bounded SWA LRU refresh in UnifiedRadixCache:
  - skip broad SWA ancestor refresh during walk-down
  - refresh only the active SWA window at match/insert completion
- Add keep-window SWA eviction for UnifiedRadixCache and SWARadixCache:
  - split long internal SWA nodes under SWA memory pressure
  - tombstone only the older prefix portion
  - retain the latest page-aligned sliding-window suffix
  - preserve the retained suffix's original LRU position
- Use size-based retained-window identification instead of explicit markers.
- Defer window-sized SWA nodes in pass 1, including retained suffixes that later become leaves.
- Drain deferred window-sized nodes in pass 2 only when pass 1 cannot satisfy the eviction deficit.
- Keep longer leaf/D-leaf eviction atomic.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26798926775](https://github.com/sgl-project/sglang/actions/runs/26798926775)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26798926697](https://github.com/sgl-project/sglang/actions/runs/26798926697)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->