### PR TITLE
[Bug] Fix circular import in `forward_batch_info` from runtime `cp_utils` import

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -54,7 +54,6 @@ from sglang.srt.layers.dp_attention import (
     set_dp_buffer_len,
     set_is_extend_in_batch,
 )
-from sglang.srt.layers.utils.cp_utils import ContextParallelMetadata
 from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     ForwardBatchDeepSeekMHAMixin,
 )
@@ -69,6 +68,7 @@ from sglang.srt.utils.common import ceil_align, is_pin_memory_available
 
 if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+    from sglang.srt.layers.utils.cp_utils import ContextParallelMetadata
     from sglang.srt.managers.schedule_batch import MultimodalInputs, ScheduleBatch
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo


### PR DESCRIPTION
## Summary
- Move `forward_batch_info`'s `ContextParallelMetadata` import (from `cp_utils`) under `TYPE_CHECKING` — it is typing-only and was creating a runtime circular import.

## Background
- `forward_batch_info` imported `ContextParallelMetadata` at runtime, but it is only referenced in the `Optional[ContextParallelMetadata]` annotation, and the module already has `from __future__ import annotations` (so the annotation is a string and never evaluated).
- That eager import drags in `cp_utils -> layers.moe -> ... -> deep_gemm_wrapper.compile_utils`, and `compile_utils` imports `ForwardMode` back from `forward_batch_info`.
- When `forward_batch_info` is the entry of the chain (e.g. `http_server -> anthropic.serving -> req_time_stats`), it is still partially initialized when `compile_utils` runs, raising `ImportError: cannot import name 'ForwardMode' from partially initialized module`.

## Fix
- Drop the runtime dependency: import `ContextParallelMetadata` only under `TYPE_CHECKING`. `forward_batch_info` (a core data-structure module) no longer pulls the MoE / deep_gemm subsystem at import time, breaking the cycle at its root.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26800681902](https://github.com/sgl-project/sglang/actions/runs/26800681902)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26800681808](https://github.com/sgl-project/sglang/actions/runs/26800681808)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->