### PR TITLE
fix(mla): size TokenSpeed workspace by query length

### DIFF
--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -36,6 +36,9 @@ import torch
 from sglang.jit_kernel.fp8_quantize import fp8_quantize
 from sglang.jit_kernel.mla_kv_pack_quantize_fp8 import mla_kv_pack_quantize_fp8
 from sglang.jit_kernel.utils import is_arch_support_pdl
+from sglang.srt.layers.attention.tokenspeed_workspace import (
+    tokenspeed_workspace_bytes,
+)
 from sglang.srt.layers.attention.trtllm_mla_backend import (
     TRTLLMMLABackend,
     TRTLLMMLAMultiStepDraftBackend,
@@ -57,23 +60,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Workspace upper bound for tokenspeed_mla_decode:
-#   num_sms * num_heads * max_q_len * (kv_lora_rank + 1) * sizeof(float32)
-# MAX_Q_LEN=8 covers EAGLE3 num_draft_tokens=4 plus headroom.
-_TOKENSPEED_MAX_Q_LEN = 8
-
 _g_tokenspeed_workspace: dict[torch.device, torch.Tensor] = {}
 
 
 def _get_tokenspeed_workspace(
-    device: torch.device, num_heads: int, kv_lora_rank: int
+    device: torch.device, num_heads: int, kv_lora_rank: int, q_len: int
 ) -> torch.Tensor:
-    needed = (
-        tokenspeed_mla.get_num_sm(device)
-        * num_heads
-        * _TOKENSPEED_MAX_Q_LEN
-        * (kv_lora_rank + 1)
-        * 4
+    needed = tokenspeed_workspace_bytes(
+        tokenspeed_mla.get_num_sm(device), num_heads, kv_lora_rank, q_len
     )
     existing = _g_tokenspeed_workspace.get(device)
     if existing is None or existing.numel() < needed:
@@ -116,8 +110,9 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
 
         self._tokenspeed_workspace: Optional[torch.Tensor] = None
         if is_tokenspeed_mla_available():
+            initial_q_len = max(1, self.num_draft_tokens or 1)
             self._tokenspeed_workspace = _get_tokenspeed_workspace(
-                self.device, self.num_q_heads, self.kv_lora_rank
+                self.device, self.num_q_heads, self.kv_lora_rank, initial_q_len
             )
 
             # Pre-JIT the prefill kernel variants. Each cute.compile takes 1-2
@@ -155,6 +150,23 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
                         use_pdl=use_pdl,
                         enable_ex2_emulation=enable_ex2_emulation,
                     )
+
+    def _ensure_workspace(self, device: torch.device, q_len: int) -> torch.Tensor:
+        needed = tokenspeed_workspace_bytes(
+            tokenspeed_mla.get_num_sm(device),
+            self.num_q_heads,
+            self.kv_lora_rank,
+            q_len,
+        )
+        if (
+            self._tokenspeed_workspace is None
+            or self._tokenspeed_workspace.device != device
+            or self._tokenspeed_workspace.numel() < needed
+        ):
+            self._tokenspeed_workspace = _get_tokenspeed_workspace(
+                device, self.num_q_heads, self.kv_lora_rank, q_len
+            )
+        return self._tokenspeed_workspace
 
     def _fused_rope_fp8_quantize(
         self,
@@ -292,7 +304,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         return tokenspeed_mla.tokenspeed_mla_decode(
             query=query,
             kv_cache=kv_cache,
-            workspace_buffer=self._tokenspeed_workspace,
+            workspace_buffer=self._ensure_workspace(query.device, query.shape[1]),
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
             block_tables=block_tables,

--- a/python/sglang/srt/layers/attention/tokenspeed_workspace.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_workspace.py
@@ -1,0 +1,25 @@
+"""Dependency-light helpers for TokenSpeed MLA workspace sizing."""
+
+# Workspace upper bound for tokenspeed_mla_decode:
+#   B * H_eff * S_eff * split_kv * (kv_lora_rank + 1) * sizeof(float32)
+# TokenSpeed's split planner keeps B * split_kv <= num_sms, so an upper bound is:
+#   num_sms * H_eff * S_eff * (kv_lora_rank + 1) * sizeof(float32)
+# For small-head tree verify shapes, TokenSpeed folds q chunks of 8 tokens:
+# q16/q24/q32 become H_eff=128, S_eff=2/3/4. In all supported modes,
+# H_eff * S_eff is bounded by the number of query chunks times the larger of
+# a standard Blackwell M tile and the per-chunk query rows.
+_TOKENSPEED_Q_CHUNK_SIZE = 8
+_TOKENSPEED_MIN_M_ROWS = 128
+
+
+def tokenspeed_workspace_bytes(
+    num_sms: int, num_heads: int, kv_lora_rank: int, q_len: int
+) -> int:
+    q_len = max(1, q_len)
+    q_chunks = (q_len + _TOKENSPEED_Q_CHUNK_SIZE - 1) // _TOKENSPEED_Q_CHUNK_SIZE
+    rows_per_chunk = max(
+        _TOKENSPEED_MIN_M_ROWS,
+        num_heads * min(q_len, _TOKENSPEED_Q_CHUNK_SIZE),
+    )
+    query_rows = q_chunks * rows_per_chunk
+    return num_sms * query_rows * (kv_lora_rank + 1) * 4

--- a/test/registered/unit/layers/test_tokenspeed_workspace.py
+++ b/test/registered/unit/layers/test_tokenspeed_workspace.py
@@ -1,0 +1,64 @@
+import unittest
+
+from sglang.srt.layers.attention.tokenspeed_workspace import (
+    tokenspeed_workspace_bytes,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class TestTokenspeedWorkspaceSizing(unittest.TestCase):
+    def test_small_head_verify_rows_scale_with_raw_q_len(self):
+        num_sms = 120
+        num_heads = 16
+        kv_lora_rank = 512
+
+        q8 = tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 8)
+
+        self.assertEqual(q8, num_sms * 128 * (kv_lora_rank + 1) * 4)
+        self.assertEqual(
+            tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 16),
+            2 * q8,
+        )
+        self.assertEqual(
+            tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 24),
+            3 * q8,
+        )
+        self.assertEqual(
+            tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 32),
+            4 * q8,
+        )
+
+    def test_standard_decode_keeps_one_m_tile_floor(self):
+        self.assertEqual(
+            tokenspeed_workspace_bytes(
+                num_sms=120, num_heads=128, kv_lora_rank=512, q_len=1
+            ),
+            120 * 128 * (512 + 1) * 4,
+        )
+
+    def test_low_head_verify_rows_scale_by_query_chunks(self):
+        num_sms = 120
+        num_heads = 8
+        kv_lora_rank = 512
+
+        q8 = tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 8)
+
+        self.assertEqual(q8, num_sms * 128 * (kv_lora_rank + 1) * 4)
+        self.assertEqual(
+            tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 9),
+            2 * q8,
+        )
+        self.assertEqual(
+            tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 16),
+            2 * q8,
+        )
+        self.assertEqual(
+            tokenspeed_workspace_bytes(num_sms, num_heads, kv_lora_rank, 17),
+            3 * q8,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix TokenSpeed MLA decode workspace sizing so it scales with the actual decode/verify query length instead of a fixed `q_len=8` upper bound.

The previous allocation was safe for standard decode and some short speculative shapes, but target-verify / draft-extend paths can pass larger query lengths. When that happens, the TokenSpeed decode kernel may need more scratch rows than the fixed workspace provides.

This PR:
- adds a dependency-light helper for TokenSpeed MLA workspace byte sizing
- preallocates the workspace for the configured draft-token count
- lazily grows the shared workspace if a larger runtime query length appears
- preserves the standard decode one-tile floor
- covers folded small-head query chunks, including low-head shards where `num_heads * q_len` is not enough

## Validation

- `python3 -m py_compile python/sglang/srt/layers/attention/tokenspeed_workspace.py python/sglang/srt/layers/attention/tokenspeed_mla_backend.py test/registered/unit/layers/test_tokenspeed_workspace.py`
- `git diff --check HEAD`
- Direct helper sanity checks for standard decode, q8/q16/q24/q32 folded query chunks, and low-head q9/q16/q17 chunk scaling
- Added registered CPU unit coverage in `test/registered/unit/layers/test_tokenspeed_workspace.py`
- Extracted from downstream GB200 TokenSpeed MLA speculative decoding validation work where larger verify query shapes were exercised without workspace crashes after the fix







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26801431351](https://github.com/sgl-project/sglang/actions/runs/26801431351)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26801431282](https://github.com/sgl-project/sglang/actions/runs/26801431282)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->