### PR TITLE
[session] Bound streaming-session pinned KV: admission + per-session growth cap

### DIFF
--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -12,7 +12,9 @@
 
 from __future__ import annotations
 
+import enum
 import logging
+import os
 import time
 import uuid
 from typing import TYPE_CHECKING, Dict, Optional
@@ -30,6 +32,21 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 
 logger = logging.getLogger(__name__)
+
+
+class Residency(enum.IntEnum):
+    """How a streaming session's KV is held.
+
+    ISOLATED -- pinned in a streaming slot, invisible to eviction. The pinned
+                set is bounded by admission so it always fits.
+    SHARED   -- a normal evictable radix-tree entry. Eviction (incl. priority
+                policy / HiCache) is the radix cache's job; SHARED sessions
+                simply ride it. Used when admission is full (open) or when a
+                session would grow the pinned tier past budget (save).
+    """
+
+    ISOLATED = 0
+    SHARED = 1
 
 
 class SessionReqNode:
@@ -85,11 +102,19 @@ class Session:
         session_id: Optional[str] = None,
         streaming: bool = False,
         timeout: Optional[float] = None,
+        residency: "Residency" = Residency.ISOLATED,
     ):
         self.session_id = session_id if session_id is not None else uuid.uuid4().hex
         self.capacity_of_str_len = capacity_of_str_len
         self.streaming = streaming
         self.timeout = timeout
+        # KV residency tier; see Residency. ISOLATED pins a slot, SHARED rides
+        # the evictable radix. Set by SessionController admission / pin-budget.
+        self.residency: "Residency" = residency
+        # Open-time footprint reservation (tokens), counted against the pinned
+        # budget while ISOLATED and no slot has materialized yet (in-flight
+        # prefill). Measured slot size supersedes it once the slot exists.
+        self._reserved_est: int = 0
         self.last_active_time: float = time.monotonic()
         self.req_nodes: Dict[str, SessionReqNode] = {}
         self.close_on_finish: bool = False
@@ -270,16 +295,77 @@ class Session:
 
 
 class SessionController:
+    # Fraction of the KV pool the pinned (ISOLATED) tier may hold. The remainder
+    # stays available for active generation + the evictable radix tree, so the
+    # worker cannot deadlock on non-evictable held KV. Override via env.
+    SESSION_KV_FRACTION = float(os.environ.get("SGLANG_SESSION_KV_FRACTION", "0.5"))
+
     def __init__(self, tree_cache: BasePrefixCache):
         self.sessions: Dict[str, Session] = {}
         self._last_reap_time: float = 0.0
         self.tree_cache = tree_cache
+        # Budget (tokens) the pinned tier may hold, derived from the pool size.
+        # None disables the budget (legacy unbounded behavior).
+        self.max_session_tokens: Optional[int] = None
+        try:
+            pool = self.tree_cache.token_to_kv_pool_allocator.size
+            self.max_session_tokens = int(self.SESSION_KV_FRACTION * pool)
+        except Exception:
+            logger.warning("SessionController: could not size KV pool; budget off")
+        # Back-reference so the cache can invoke the pin-budget check after a
+        # slot grows (turn save). See StreamingSession.cache_finished_req.
+        try:
+            self.tree_cache.session_controller = self
+        except Exception:
+            pass
 
     def __contains__(self, session_id: str) -> bool:
         return session_id in self.sessions
 
     def get(self, session_id: str) -> Optional[Session]:
         return self.sessions.get(session_id)
+
+    # -- Pin-budget admission + growth cap ----------------------------------
+    #
+    # Invariant: KV pinned by ISOLATED sessions stays <= max_session_tokens.
+    # Enforced only at the two SAFE boundaries -- open (admission) and slot save
+    # (growth cap) -- and only by tagging SHARED, never by releasing a live
+    # slot (mid-stream release corrupts the lock structure). SHARED sessions are
+    # ordinary evictable radix entries, so eviction stays the radix cache's job.
+
+    def _slot_held(self, session_id: str) -> int:
+        slots = getattr(self.tree_cache, "slots", None)
+        slot = slots.get(session_id) if slots else None
+        if slot is None or not getattr(slot, "is_holding_kv", False):
+            return 0
+        return int(getattr(slot, "kv_allocated_len", 0) or 0)
+
+    def pinned_tokens(self) -> int:
+        # Measured slot size once a slot exists, else the open-time reservation
+        # (covers the in-flight prefill burst before any slot saves).
+        total = 0
+        for sid, s in self.sessions.items():
+            if s.residency != Residency.ISOLATED:
+                continue
+            total += self._slot_held(sid) or s._reserved_est
+        return total
+
+    def on_slot_saved(self, session_id: str) -> None:
+        """Called by the cache after a session's slot grows (turn save). If the
+        pinned tier now exceeds budget, flip this session to SHARED so its
+        FUTURE turns ride the evictable radix -- bounding per-session pin growth.
+        The current slot stays (bounded) and is freed at the session's clean
+        close; no unsafe mid-stream release."""
+        if self.max_session_tokens is None:
+            return
+        s = self.sessions.get(session_id)
+        if s is None or s.residency != Residency.ISOLATED:
+            return
+        if self.pinned_tokens() > self.max_session_tokens:
+            s.residency = Residency.SHARED
+            log_info_on_rank0(
+                logger, f"Session pin-capped ISOLATED->SHARED: {session_id}"
+            )
 
     def open(self, recv_req: OpenSessionReqInput) -> OpenSessionReqOutput:
         session_id = recv_req.session_id
@@ -290,14 +376,31 @@ class SessionController:
             logger.warning("session id is None, cannot open.")
             return OpenSessionReqOutput(session_id, False)
         else:
-            self.sessions[session_id] = Session(
+            # Admission: reserve this session's footprint against the pinned
+            # budget. Over budget -> open SHARED (evictable radix), so a burst of
+            # opens can't all pin and saturate the pool. The session still
+            # exists, so its generate requests are served normally.
+            est = max(1, recv_req.capacity_of_str_len // 4)  # chars -> ~tokens
+            residency = Residency.ISOLATED
+            if (
+                self.max_session_tokens is not None
+                and self.pinned_tokens() + est > self.max_session_tokens
+            ):
+                residency = Residency.SHARED
+            session = Session(
                 recv_req.capacity_of_str_len,
                 session_id,
                 streaming=bool(recv_req.streaming),
                 timeout=recv_req.timeout,
+                residency=residency,
             )
+            session._reserved_est = est if residency == Residency.ISOLATED else 0
+            self.sessions[session_id] = session
             log_info_on_rank0(
-                logger, f"Session opened: {session_id} (active={len(self.sessions)})"
+                logger,
+                f"Session opened: {session_id} (active={len(self.sessions)}, "
+                f"residency={residency.name}, "
+                f"pinned={self.pinned_tokens()}/{self.max_session_tokens})",
             )
             return OpenSessionReqOutput(session_id, True)
 

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -110,7 +110,16 @@ class SessionSlot:
 
 
 def _is_streaming(req: Optional[Req]) -> bool:
-    return req is not None and req.session is not None and req.session.streaming
+    # Only ISOLATED sessions use a pinned slot. SHARED sessions (admission-full
+    # at open, or pin-capped at save) flow through the evictable radix path.
+    from sglang.srt.session.session_controller import Residency
+
+    return (
+        req is not None
+        and req.session is not None
+        and req.session.streaming
+        and req.session.residency == Residency.ISOLATED
+    )
 
 
 class StreamingSession(BasePrefixCache):
@@ -316,6 +325,14 @@ class StreamingSession(BasePrefixCache):
 
         # Update req_nodes to this successfully finished request.
         req.session.finish_req(req)
+
+        # Pin-budget growth cap: this slot just grew. If it pushed the pinned
+        # tier over budget, flip this session to SHARED so its future turns ride
+        # the evictable radix (bounds per-session pin growth). Tag-only, at this
+        # safe turn boundary -- no mid-stream slot release.
+        ctrl = getattr(self, "session_controller", None)
+        if ctrl is not None:
+            ctrl.on_slot_saved(session_id)
 
         self._mark_kv_freed(req)
         return True

--- a/test/registered/unit/mem_cache/test_session_admission_unit.py
+++ b/test/registered/unit/mem_cache/test_session_admission_unit.py
@@ -1,0 +1,106 @@
+"""Unit tests for streaming-session pin-budget admission + growth cap.
+
+Both deadlock causes are covered deterministically with a fake cache (no GPU):
+  1. concurrent burst  -> admission opens over-budget sessions SHARED
+  2. single-session runaway growth -> pin-budget flips it SHARED at slot save
+
+The invariant under test: KV pinned by ISOLATED sessions stays <= budget, and it
+is restored only by tagging SHARED (never by releasing a live slot).
+"""
+
+from types import SimpleNamespace
+
+from sglang.srt.session.session_controller import Residency, SessionController
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeSlot:
+    def __init__(self, kv_allocated_len: int):
+        self.kv_allocated_len = kv_allocated_len
+        self.is_holding_kv = True
+
+
+class _FakeAllocator:
+    def __init__(self, size: int):
+        self.size = size
+
+
+class _FakeCache:
+    """Minimal stand-in for StreamingSession: a slots dict + a sized allocator,
+    and accepts the controller back-reference."""
+
+    def __init__(self, pool_size: int):
+        self.slots = {}
+        self.token_to_kv_pool_allocator = _FakeAllocator(pool_size)
+
+
+def _controller(pool_size: int, fraction: float) -> SessionController:
+    ctrl = SessionController(_FakeCache(pool_size))
+    ctrl.max_session_tokens = int(fraction * pool_size)  # deterministic, env-free
+    return ctrl
+
+
+def _open(ctrl: SessionController, sid: str, capacity: int = 64):
+    return ctrl.open(
+        SimpleNamespace(
+            session_id=sid,
+            capacity_of_str_len=capacity,
+            streaming=True,
+            timeout=300.0,
+        )
+    )
+
+
+def test_admission_caps_concurrent_pinned_sessions():
+    # budget 64; est = capacity//4 = 16 -> exactly 4 sessions fit, rest SHARED.
+    ctrl = _controller(pool_size=128, fraction=0.5)
+    for i in range(6):
+        _open(ctrl, f"s{i}", capacity=64)
+
+    residencies = [ctrl.sessions[f"s{i}"].residency for i in range(6)]
+    assert residencies == [Residency.ISOLATED] * 4 + [Residency.SHARED] * 2
+    assert ctrl.pinned_tokens() <= ctrl.max_session_tokens
+
+
+def test_growth_cap_flips_runaway_session_to_shared():
+    # A single pinned session grows across turns; when its slot crosses budget
+    # the pin-budget check flips it to SHARED -- no release.
+    ctrl = _controller(pool_size=200, fraction=0.5)  # budget 100
+    _open(ctrl, "big", capacity=64)
+    assert ctrl.sessions["big"].residency == Residency.ISOLATED
+
+    # turn 1: slot at 40 (<= budget) -> stays pinned
+    ctrl.tree_cache.slots["big"] = _FakeSlot(40)
+    ctrl.on_slot_saved("big")
+    assert ctrl.sessions["big"].residency == Residency.ISOLATED
+
+    # turn 2: slot grew to 140 (> budget 100) -> flips SHARED
+    ctrl.tree_cache.slots["big"].kv_allocated_len = 140
+    ctrl.on_slot_saved("big")
+    assert ctrl.sessions["big"].residency == Residency.SHARED
+    # Once SHARED it is no longer counted against the pinned budget.
+    assert ctrl.pinned_tokens() == 0
+
+
+def test_growth_cap_keeps_one_session_when_others_idle():
+    # Two pinned sessions; together they exceed budget after growth. The one that
+    # just grew is flipped, leaving the pinned tier within budget.
+    ctrl = _controller(pool_size=200, fraction=0.5)  # budget 100
+    _open(ctrl, "a", capacity=64)
+    _open(ctrl, "b", capacity=64)
+    ctrl.tree_cache.slots["a"] = _FakeSlot(60)
+    ctrl.tree_cache.slots["b"] = _FakeSlot(60)  # total 120 > 100
+    ctrl.on_slot_saved("b")  # b just finished a turn
+    assert ctrl.sessions["b"].residency == Residency.SHARED
+    assert ctrl.sessions["a"].residency == Residency.ISOLATED
+    assert ctrl.pinned_tokens() == 60  # only 'a' still pinned
+
+
+def test_no_budget_is_legacy_unbounded():
+    ctrl = SessionController(_FakeCache(pool_size=128))
+    ctrl.max_session_tokens = None
+    for i in range(10):
+        _open(ctrl, f"s{i}", capacity=64)
+    assert all(s.residency == Residency.ISOLATED for s in ctrl.sessions.values())


### PR DESCRIPTION
## Motivation

Addresses the first deadlock in #27024 (concurrent-burst over-subscription), plus an interim bound for the runaway-growth case.

`--enable-streaming-session` pins a session's KV in slots that are lock-ref'd and invisible to radix eviction, but `SessionController.open()` has no admission control and a session's slot can grow unbounded across turns. Two ways this deadlocks the worker:

1. **Burst:** a set of concurrent sessions whose pinned KV exceeds the pool.
2. **Runaway:** a single session that grows until its own pinned KV fills the pool.

In both, the scheduler can't free pages (session KV is non-evictable) and stalls. Releasing a live session's slot to relieve pressure is unsafe — mid-conversation `release_session` does `dec_lock_ref(slot.last_node)` where `last_node` is the slot's `_VirtualNode` after turn 2+, which has no `lock_ref` and crashes the scheduler (see #27024 for the full write-up).

## Modifications

Keep the pinned tier within a budget (`SGLANG_SESSION_KV_FRACTION` of the KV pool, default `0.5`), enforced only at the two **safe** boundaries and only by **tagging**, never by releasing a live slot:

- A `Residency` tag on `Session` (`ISOLATED` = pinned slot, `SHARED` = ordinary evictable radix entry). `_is_streaming` gates the slot path on `ISOLATED`.
- **Admission in `open()`** (fixes burst): if reserving this session would exceed budget, open it `SHARED`. It still exists, so its generate requests are served normally; its KV is just evictable, so a burst can't oversubscribe the non-evictable tier.
- **Growth cap at turn save** (`cache_finished_req`): if the slot just grew the pinned tier past budget, flip the session to `SHARED` so its future turns ride the evictable radix. The current slot stays bounded and is freed at the session's clean close — no runaway, no unsafe mid-stream release.

Eviction of `SHARED` (overflow) KV stays the radix cache's job (incl. `--radix-eviction-policy priority` / HiCache); this only bounds what gets pinned. With budget < 1.0 there is always evictable headroom, so the worker cannot deadlock on pinned KV. **Unset budget keeps the legacy unbounded behavior** (opt-in).

This is the interim form of the per-session bound. The correct full fix — a bounded pin window that trims the cold prefix into the radix at `save_from_req` so the slot itself never grows past `cap` — is follow-up (tracked in #27024), as is letting pinned KV participate in priority/HiCache demotion.

```
 python/sglang/srt/session/session_controller.py | 107 +++++++++++++++++-
 python/sglang/srt/session/streaming_session.py  |  19 ++-
 test/.../mem_cache/test_session_admission_unit.py | 106 ++++++++++++++++++
```

## Test plan

- [x] CPU unit test (`test_session_admission_unit.py`) covering both deadlock causes with a fake cache, no GPU:
  - `test_admission_caps_concurrent_pinned_sessions` — burst: budget 64, 6 opens -> 4 ISOLATED + 2 SHARED, `pinned_tokens() <= budget`.
  - `test_growth_cap_flips_runaway_session_to_shared` — runaway: a pinned session crossing budget at save flips SHARED, `pinned_tokens() == 0`.
  - `test_growth_cap_keeps_one_session_when_others_idle` — only the session that grew is flipped; the other stays pinned.
  - `test_no_budget_is_legacy_unbounded` — unset budget preserves legacy behavior.
- [x] Live validation on GLM-4.7-Flash, TP2, 2x L40S, `--router-mode kv` + `--enable-streaming-session`: admission (ISOLATED/SHARED split) and the growth-cap flip both fire under concurrent multi-turn load; scheduler does not crash. A real 6-sub-agent run completed at ~98% occupancy where the unpatched path deadlocked.
- [ ] CI (`base-a-test-cpu` suite picks up the new unit test).

## Notes

- `SGLANG_SESSION_KV_FRACTION` unset = today's behavior; this is opt-in and does not change defaults for non-session users.
- Budget is worker-introspected from `token_to_kv_pool_allocator.size`, scaled by the fraction.

Closes #27024 partially (Problem 1 + interim Problem 2 bound); the full bounded-pin-window and priority/HiCache work remain open there.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26802834198](https://github.com/sgl-project/sglang/actions/runs/26802834198)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26802834148](https://github.com/sgl-project/sglang/actions/runs/26802834148)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->