### PR TITLE
[diffusion] Add realtime WebUI super resolution controls

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -111,6 +111,7 @@ diffusion = [
   "av==16.1.0",
   "scikit-image==0.25.2",
   "trimesh>=4.0.0",
+  "websockets",
   "xatlas",
 ]
 

--- a/python/sglang/multimodal_gen/apps/realtime_webui/app.js
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/app.js
@@ -10,6 +10,8 @@ const DEFAULT_PREVIEW_OUTPUT_QUALITY = 95;
 const DEFAULT_TARGET_FPS = 25;
 const DEFAULT_FRAME_INTERPOLATION_EXP = 1;
 const DEFAULT_FRAME_INTERPOLATION_SCALE = 1.0;
+const DEFAULT_UPSCALING_SCALE = 2;
+const DEFAULT_VIEW_MODE = "fit";
 const RECONNECT_CLOSE_TIMEOUT_MS = 15000;
 const LIVE_QUEUE_SECONDS = 0.45;
 const LOW_LATENCY_FPS_FLOOR = 10;
@@ -225,6 +227,7 @@ let socketServerError = "";
 const decodeRequests = new Map();
 let controlStateController = null;
 
+const stage = document.querySelector(".stage");
 const canvas = $("viewport");
 const ctx = canvas.getContext("2d", { alpha: false });
 const scratchCanvas = document.createElement("canvas");
@@ -290,6 +293,7 @@ function resetStreamStats() {
   $("theoreticalFpsText").textContent = "-";
   $("chunkText").textContent = "chunk -";
   $("payloadMode").textContent = selectedTransportLabel();
+  updateOutputSizeText();
 }
 
 function rejectPendingDecodes(message) {
@@ -659,6 +663,7 @@ async function payloadToArrayBuffer(data) {
 function drawFrame(image) {
   const sourceWidth = image.width;
   const sourceHeight = image.height;
+  setNativeViewportSize(sourceWidth, sourceHeight);
   let drawSource = image;
   if (image instanceof ImageData) {
     if (scratchCanvas.width !== sourceWidth || scratchCanvas.height !== sourceHeight) {
@@ -851,6 +856,7 @@ async function connect() {
     }
     const previewTransportParams = readPreviewTransportParams();
     const frameInterpolationParams = readFrameInterpolationParams();
+    const superResolutionParams = readSuperResolutionParams();
     const init = compact({
       type: "init",
       model: $("model").value,
@@ -867,6 +873,7 @@ async function connect() {
       first_frame: firstFrame,
       ...previewTransportParams,
       ...frameInterpolationParams,
+      ...superResolutionParams,
     });
     document.activeElement?.blur?.();
     canvas.tabIndex = 0;
@@ -1019,6 +1026,7 @@ async function decodeAndEnqueueFrameBatch(header, data, epoch) {
   frames += chunkFrameCount;
   bytes += payloadBytes;
   $("payloadMode").textContent = header.encoding || "raw RGB";
+  updateOutputSizeFromHeader(header);
   updatePlaybackPace(header, performance.now(), chunkFrameCount);
   setStatus("Live", "live");
   updateStats(header);
@@ -1114,6 +1122,7 @@ async function applyPreset(preset, options = {}) {
   $("prompt").value = preset.prompt;
   $("size").value = preset.size;
   $("fps").value = preset.fps;
+  updateOutputSizeText();
   await setPresetReference(preset);
   if (sendRuntimeEvents) {
     sendEvent("prompt", preset.prompt, `prompt update · ${preset.name}`);
@@ -1249,6 +1258,72 @@ function readFrameInterpolationParams() {
   };
 }
 
+function readUpscalingScale() {
+  return Number($("upscalingScale").value || DEFAULT_UPSCALING_SCALE);
+}
+
+function readSuperResolutionParams() {
+  if (!$("superResolution").checked) return {};
+  return {
+    enable_upscaling: true,
+    upscaling_scale: readUpscalingScale(),
+  };
+}
+
+function parseSizeValue(sizeText) {
+  const match = /^(\d+)\s*x\s*(\d+)$/i.exec(String(sizeText || "").trim());
+  if (!match) return null;
+  return {
+    width: Number(match[1]),
+    height: Number(match[2]),
+  };
+}
+
+function updateOutputSizeText(width = null, height = null) {
+  let outputWidth = Number(width || 0);
+  let outputHeight = Number(height || 0);
+  const srEnabled = $("superResolution").checked;
+  const scale = srEnabled ? readUpscalingScale() : 1;
+  if (!outputWidth || !outputHeight) {
+    const base = parseSizeValue($("size").value);
+    if (base) {
+      outputWidth = base.width * scale;
+      outputHeight = base.height * scale;
+    }
+  }
+  $("outputSizeText").textContent = outputWidth && outputHeight
+    ? `${outputWidth}x${outputHeight}${srEnabled ? ` · SR ${scale}x` : ""}`
+    : "-";
+}
+
+function updateOutputSizeFromHeader(header) {
+  const width = Number(header.width || 0);
+  const height = Number(header.height || 0);
+  if (width && height) updateOutputSizeText(width, height);
+}
+
+function updateSuperResolutionControls() {
+  $("upscalingScale").disabled = !$("superResolution").checked;
+  updateOutputSizeText();
+}
+
+function setNativeViewportSize(width, height) {
+  if (!stage) return;
+  stage.style.setProperty("--native-preview-width", `${width}px`);
+  stage.style.setProperty("--native-preview-height", `${height}px`);
+}
+
+function setPreviewMode(mode) {
+  if (!stage) return;
+  const viewMode = mode || DEFAULT_VIEW_MODE;
+  stage.dataset.viewMode = viewMode;
+  document.querySelectorAll("[data-view-mode]").forEach((btn) => {
+    const active = btn.dataset.viewMode === viewMode;
+    btn.classList.toggle("is-active", active);
+    btn.setAttribute("aria-pressed", active ? "true" : "false");
+  });
+}
+
 function selectedTransportLabel() {
   const select = $("transportFormat");
   return select.options[select.selectedIndex]?.textContent || "raw RGB";
@@ -1299,6 +1374,12 @@ async function applyQueryParams() {
   if (model) $("model").value = model;
   $("transportFormat").value = params.get("transport") || DEFAULT_PREVIEW_OUTPUT_FORMAT;
   $("transportQuality").value = params.get("quality") || String(DEFAULT_PREVIEW_OUTPUT_QUALITY);
+  const srParam = params.get("sr");
+  $("superResolution").checked = srParam === "1" || srParam === "true";
+  $("upscalingScale").value = params.get("sr_scale") || String(DEFAULT_UPSCALING_SCALE);
+  const viewMode = params.get("view") || DEFAULT_VIEW_MODE;
+  setPreviewMode(viewMode);
+  updateSuperResolutionControls();
   return {
     model: Boolean(model),
     preset: Boolean(presetKey && appliedPreset),
@@ -1394,6 +1475,8 @@ function unpack(buf) {
 
 renderPresets();
 drawIdle();
+setPreviewMode(DEFAULT_VIEW_MODE);
+updateSuperResolutionControls();
 applyPreset(presets[0], { sendRuntimeEvents: false })
   .then(applyQueryParams)
   .then((query) => queryServerModelInfo({
@@ -1406,6 +1489,12 @@ $("stopBtn").onclick = () => closeSession();
 $("sendPromptBtn").onclick = () => sendEvent("prompt", $("prompt").value);
 $("enhanceBtn").onclick = enhancePrompt;
 $("firstFrame").onchange = () => drawReferencePreview($("firstFrame").files[0]);
+$("size").addEventListener("input", () => updateOutputSizeText());
+$("superResolution").addEventListener("change", updateSuperResolutionControls);
+$("upscalingScale").addEventListener("change", () => updateOutputSizeText());
+document.querySelectorAll("[data-view-mode]").forEach((btn) => {
+  btn.addEventListener("click", () => setPreviewMode(btn.dataset.viewMode));
+});
 $("serverUrl").addEventListener("change", () => {
   queryServerModelInfo({ applyPresetForModel: true }).catch(showError);
 });

--- a/python/sglang/multimodal_gen/apps/realtime_webui/app.js
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/app.js
@@ -745,7 +745,7 @@ function drawFrame(image) {
 function renderLoop(now) {
   const targetFps = playbackFps || Number($("fps").value || DEFAULT_TARGET_FPS);
   const queueSeconds = queue.length / Math.max(1, targetFps);
-  const catchupFps = queueSeconds > LOW_LATENCY_QUEUE_SECONDS
+  const catchupFps = !$("superResolution").checked && queueSeconds > LOW_LATENCY_QUEUE_SECONDS
     ? Math.min(MAX_CATCHUP_FPS, Math.ceil(queue.length / LOW_LATENCY_QUEUE_SECONDS))
     : targetFps;
   const targetMs = 1000 / Math.max(1, catchupFps);
@@ -1125,9 +1125,10 @@ function updatePlaybackPace(header, now, frameCount) {
   if (waitSeconds > 0) {
     const generatedFps = currentReceiveChunkFrames / Math.max(0.001, waitSeconds);
     const requestedFps = Number($("fps").value || DEFAULT_TARGET_FPS);
+    const playbackFloor = $("superResolution").checked ? 1 : LOW_LATENCY_FPS_FLOOR;
     playbackFps = Math.min(
       requestedFps,
-      Math.max(LOW_LATENCY_FPS_FLOOR, generatedFps * 1.05),
+      Math.max(playbackFloor, generatedFps * 1.05),
     );
     const latencyText = `${waitSeconds.toFixed(1)}s · ${playbackFps.toFixed(1)}fps`;
     $("latencyText").textContent = latencyText;

--- a/python/sglang/multimodal_gen/apps/realtime_webui/app.js
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/app.js
@@ -262,59 +262,33 @@ function drawIdle() {
   }
   setPreviewState("idle");
   renderedPreviewFrames = 0;
-  const sky = ctx.createLinearGradient(0, 0, w, h);
-  sky.addColorStop(0, "#10150f");
-  sky.addColorStop(0.46, "#182318");
-  sky.addColorStop(1, "#0f1719");
-  ctx.fillStyle = sky;
+  ctx.fillStyle = "#11140f";
   ctx.fillRect(0, 0, w, h);
 
-  const blueGlow = ctx.createRadialGradient(w * 0.23, h * 0.26, 20, w * 0.23, h * 0.26, 380);
-  blueGlow.addColorStop(0, "rgba(63,96,124,0.38)");
-  blueGlow.addColorStop(1, "rgba(63,96,124,0)");
-  ctx.fillStyle = blueGlow;
+  const surface = ctx.createLinearGradient(0, 0, 0, h);
+  surface.addColorStop(0, "rgba(238,241,236,0.045)");
+  surface.addColorStop(0.5, "rgba(238,241,236,0.012)");
+  surface.addColorStop(1, "rgba(0,0,0,0.16)");
+  ctx.fillStyle = surface;
   ctx.fillRect(0, 0, w, h);
 
-  const amberGlow = ctx.createRadialGradient(w * 0.76, h * 0.2, 12, w * 0.76, h * 0.2, 330);
-  amberGlow.addColorStop(0, "rgba(185,84,60,0.24)");
-  amberGlow.addColorStop(1, "rgba(185,84,60,0)");
-  ctx.fillStyle = amberGlow;
-  ctx.fillRect(0, 0, w, h);
-
-  ctx.strokeStyle = "rgba(238,241,236,0.16)";
-  ctx.lineWidth = 1.2;
-  for (let i = 0; i < 12; i++) {
-    const y = h * 0.58 + i * 28;
-    ctx.beginPath();
-    ctx.moveTo(110 - i * 20, y);
-    ctx.lineTo(w - 110 + i * 20, y + i * 10);
-    ctx.stroke();
-  }
-  const vanishingX = w * 0.52;
-  const vanishingY = h * 0.58;
-  for (let i = -7; i <= 7; i++) {
-    ctx.beginPath();
-    ctx.moveTo(vanishingX, vanishingY);
-    ctx.lineTo(w * 0.5 + i * 118, h - 56);
-    ctx.stroke();
-  }
-
-  ctx.strokeStyle = "rgba(238,241,236,0.28)";
-  ctx.lineWidth = 2;
-  ctx.strokeRect(58, 58, w - 116, h - 116);
-  ctx.strokeStyle = "rgba(185,84,60,0.44)";
+  ctx.strokeStyle = "rgba(238,241,236,0.11)";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(0.5, 0.5, w - 1, h - 1);
+  ctx.strokeStyle = "rgba(238,241,236,0.08)";
   ctx.beginPath();
-  ctx.moveTo(58, 150);
-  ctx.lineTo(58, 58);
-  ctx.lineTo(172, 58);
-  ctx.moveTo(w - 58, h - 150);
-  ctx.lineTo(w - 58, h - 58);
-  ctx.lineTo(w - 172, h - 58);
+  if (ctx.roundRect) {
+    ctx.roundRect(w * 0.38, h * 0.42, w * 0.24, h * 0.16, 18);
+  } else {
+    ctx.rect(w * 0.38, h * 0.42, w * 0.24, h * 0.16);
+  }
   ctx.stroke();
 
-  ctx.fillStyle = "rgba(238,241,236,0.72)";
-  for (let i = 0; i < 4; i++) {
-    ctx.fillRect(w * 0.5 - 54 + i * 34, h * 0.49, 20, 4);
+  ctx.fillStyle = "rgba(238,241,236,0.22)";
+  for (let i = -1; i <= 1; i++) {
+    ctx.beginPath();
+    ctx.arc(w * 0.5 + i * 22, h * 0.5, 4.5, 0, Math.PI * 2);
+    ctx.fill();
   }
 }
 

--- a/python/sglang/multimodal_gen/apps/realtime_webui/app.js
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/app.js
@@ -11,7 +11,7 @@ const DEFAULT_TARGET_FPS = 25;
 const DEFAULT_FRAME_INTERPOLATION_EXP = 1;
 const DEFAULT_FRAME_INTERPOLATION_SCALE = 1.0;
 const DEFAULT_UPSCALING_SCALE = 2;
-const DEFAULT_VIEW_MODE = "fit";
+const DEFAULT_PREVIEW_SCALE = 120;
 const RECONNECT_CLOSE_TIMEOUT_MS = 15000;
 const LIVE_QUEUE_SECONDS = 0.45;
 const LOW_LATENCY_FPS_FLOOR = 10;
@@ -224,10 +224,13 @@ let encodedDecodeErrors = 0;
 let socketHadError = false;
 let socketCloseExpected = false;
 let socketServerError = "";
+let renderedPreviewFrames = 0;
+let previewScaleFrame = 0;
 const decodeRequests = new Map();
 let controlStateController = null;
 
 const stage = document.querySelector(".stage");
+const previewFrame = document.querySelector(".preview-frame");
 const canvas = $("viewport");
 const ctx = canvas.getContext("2d", { alpha: false });
 const scratchCanvas = document.createElement("canvas");
@@ -238,6 +241,12 @@ function setStatus(text, kind = "") {
   $("statusDot").className = "dot" + (kind ? ` ${kind}` : "");
 }
 
+function setPreviewState(state) {
+  if (!stage) return;
+  stage.dataset.previewState = state;
+  canvas.setAttribute("aria-busy", state === "waiting" ? "true" : "false");
+}
+
 function addHistory(text) {
   const item = document.createElement("span");
   item.textContent = text;
@@ -246,19 +255,66 @@ function addHistory(text) {
 }
 
 function drawIdle() {
-  const w = canvas.width, h = canvas.height;
-  const g = ctx.createLinearGradient(0, 0, w, h);
-  g.addColorStop(0, "#171a16");
-  g.addColorStop(0.58, "#253628");
-  g.addColorStop(1, "#8f4a37");
-  ctx.fillStyle = g;
+  const w = 1280, h = 720;
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w;
+    canvas.height = h;
+  }
+  setPreviewState("idle");
+  renderedPreviewFrames = 0;
+  const sky = ctx.createLinearGradient(0, 0, w, h);
+  sky.addColorStop(0, "#10150f");
+  sky.addColorStop(0.46, "#182318");
+  sky.addColorStop(1, "#0f1719");
+  ctx.fillStyle = sky;
   ctx.fillRect(0, 0, w, h);
-  ctx.fillStyle = "rgba(238,241,236,.82)";
-  ctx.font = "600 46px Avenir Next, sans-serif";
-  ctx.fillText("sglang-diffusion", 56, 86);
-  for (let i = 0; i < 18; i++) {
-    ctx.fillStyle = `rgba(238,241,236,${0.05 + i * 0.015})`;
-    ctx.fillRect(56 + i * 64, h - 86 - i * 7, 42, 42 + i * 4);
+
+  const blueGlow = ctx.createRadialGradient(w * 0.23, h * 0.26, 20, w * 0.23, h * 0.26, 380);
+  blueGlow.addColorStop(0, "rgba(63,96,124,0.38)");
+  blueGlow.addColorStop(1, "rgba(63,96,124,0)");
+  ctx.fillStyle = blueGlow;
+  ctx.fillRect(0, 0, w, h);
+
+  const amberGlow = ctx.createRadialGradient(w * 0.76, h * 0.2, 12, w * 0.76, h * 0.2, 330);
+  amberGlow.addColorStop(0, "rgba(185,84,60,0.24)");
+  amberGlow.addColorStop(1, "rgba(185,84,60,0)");
+  ctx.fillStyle = amberGlow;
+  ctx.fillRect(0, 0, w, h);
+
+  ctx.strokeStyle = "rgba(238,241,236,0.16)";
+  ctx.lineWidth = 1.2;
+  for (let i = 0; i < 12; i++) {
+    const y = h * 0.58 + i * 28;
+    ctx.beginPath();
+    ctx.moveTo(110 - i * 20, y);
+    ctx.lineTo(w - 110 + i * 20, y + i * 10);
+    ctx.stroke();
+  }
+  const vanishingX = w * 0.52;
+  const vanishingY = h * 0.58;
+  for (let i = -7; i <= 7; i++) {
+    ctx.beginPath();
+    ctx.moveTo(vanishingX, vanishingY);
+    ctx.lineTo(w * 0.5 + i * 118, h - 56);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = "rgba(238,241,236,0.28)";
+  ctx.lineWidth = 2;
+  ctx.strokeRect(58, 58, w - 116, h - 116);
+  ctx.strokeStyle = "rgba(185,84,60,0.44)";
+  ctx.beginPath();
+  ctx.moveTo(58, 150);
+  ctx.lineTo(58, 58);
+  ctx.lineTo(172, 58);
+  ctx.moveTo(w - 58, h - 150);
+  ctx.lineTo(w - 58, h - 58);
+  ctx.lineTo(w - 172, h - 58);
+  ctx.stroke();
+
+  ctx.fillStyle = "rgba(238,241,236,0.72)";
+  for (let i = 0; i < 4; i++) {
+    ctx.fillRect(w * 0.5 - 54 + i * 34, h * 0.49, 20, 4);
   }
 }
 
@@ -280,6 +336,7 @@ function resetStreamStats() {
   currentReceiveChunk = null;
   currentReceiveChunkFrames = 0;
   encodedDecodeErrors = 0;
+  renderedPreviewFrames = 0;
   controlStateController?.reset({ sendRelease: false });
   resetDecoderState();
   updateStats();
@@ -663,7 +720,6 @@ async function payloadToArrayBuffer(data) {
 function drawFrame(image) {
   const sourceWidth = image.width;
   const sourceHeight = image.height;
-  setNativeViewportSize(sourceWidth, sourceHeight);
   let drawSource = image;
   if (image instanceof ImageData) {
     if (scratchCanvas.width !== sourceWidth || scratchCanvas.height !== sourceHeight) {
@@ -674,20 +730,15 @@ function drawFrame(image) {
     drawSource = scratchCanvas;
   }
 
-  const rect = canvas.getBoundingClientRect();
-  const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
-  const targetWidth = Math.max(1, Math.round(rect.width * dpr));
-  const targetHeight = Math.max(
-    1,
-    Math.round((targetWidth * sourceHeight) / sourceWidth),
-  );
-  if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
-    canvas.width = targetWidth;
-    canvas.height = targetHeight;
+  if (canvas.width !== sourceWidth || canvas.height !== sourceHeight) {
+    canvas.width = sourceWidth;
+    canvas.height = sourceHeight;
   }
   ctx.imageSmoothingEnabled = true;
   ctx.imageSmoothingQuality = "high";
-  ctx.drawImage(drawSource, 0, 0, canvas.width, canvas.height);
+  ctx.drawImage(drawSource, 0, 0, sourceWidth, sourceHeight);
+  renderedPreviewFrames += 1;
+  setPreviewState("live");
   if (!(image instanceof ImageData)) image.close?.();
 }
 
@@ -775,6 +826,7 @@ async function setPresetReference(preset) {
 
 function showError(error) {
   setStatus("Reference load failed", "error");
+  if (!renderedPreviewFrames) setPreviewState("idle");
   addHistory(error.message || "reference load failed");
 }
 
@@ -800,10 +852,12 @@ function abortCurrentSession(reason = "session closed by client", {
     clearQueueOnClose = false;
     if (!keepConnectDisabled) $("connectBtn").disabled = false;
     setStatus("Closed");
+    if (!renderedPreviewFrames) setPreviewState("idle");
     return null;
   }
   if (!keepConnectDisabled) $("connectBtn").disabled = false;
   setStatus(expectedClose ? "Closing" : "Aborting");
+  if (!renderedPreviewFrames) setPreviewState("idle");
   addHistory(reason);
   socket.close(expectedClose ? 1000 : 1011, reason.slice(0, 120));
   return socket;
@@ -833,6 +887,7 @@ function waitForSocketClose(socket, timeoutMs = RECONNECT_CLOSE_TIMEOUT_MS) {
 async function connect() {
   $("connectBtn").disabled = true;
   setStatus("Preparing");
+  setPreviewState("waiting");
   addHistory("preparing session");
   try {
     if (ws && ws.readyState !== WebSocket.CLOSED) {
@@ -850,6 +905,7 @@ async function connect() {
     const firstFrame = await readFirstFrame();
     if (!firstFrame) {
       setStatus("Pick a reference", "error");
+      setPreviewState("idle");
       addHistory("reference image required");
       $("connectBtn").disabled = false;
       return;
@@ -915,6 +971,7 @@ async function connect() {
         setStatus("Closed");
         addHistory(closeText);
       }
+      if (!renderedPreviewFrames) setPreviewState("idle");
       socketCloseExpected = false;
     };
     socket.onerror = () => {
@@ -935,6 +992,7 @@ async function connect() {
   } catch (error) {
     $("connectBtn").disabled = false;
     setStatus("Init failed", "error");
+    if (!renderedPreviewFrames) setPreviewState("idle");
     addHistory(error.message || "init failed");
   }
 }
@@ -1307,20 +1365,15 @@ function updateSuperResolutionControls() {
   updateOutputSizeText();
 }
 
-function setNativeViewportSize(width, height) {
-  if (!stage) return;
-  stage.style.setProperty("--native-preview-width", `${width}px`);
-  stage.style.setProperty("--native-preview-height", `${height}px`);
-}
-
-function setPreviewMode(mode) {
-  if (!stage) return;
-  const viewMode = mode || DEFAULT_VIEW_MODE;
-  stage.dataset.viewMode = viewMode;
-  document.querySelectorAll("[data-view-mode]").forEach((btn) => {
-    const active = btn.dataset.viewMode === viewMode;
-    btn.classList.toggle("is-active", active);
-    btn.setAttribute("aria-pressed", active ? "true" : "false");
+function setPreviewScale(value) {
+  if (!previewFrame) return;
+  const scale = Math.max(80, Math.min(170, Number(value || DEFAULT_PREVIEW_SCALE)));
+  $("previewScale").value = String(scale);
+  $("previewScaleText").textContent = `${scale}%`;
+  if (previewScaleFrame) cancelAnimationFrame(previewScaleFrame);
+  previewScaleFrame = requestAnimationFrame(() => {
+    previewScaleFrame = 0;
+    previewFrame.style.setProperty("--preview-scale", String(scale / 100));
   });
 }
 
@@ -1377,8 +1430,7 @@ async function applyQueryParams() {
   const srParam = params.get("sr");
   $("superResolution").checked = srParam === "1" || srParam === "true";
   $("upscalingScale").value = params.get("sr_scale") || String(DEFAULT_UPSCALING_SCALE);
-  const viewMode = params.get("view") || DEFAULT_VIEW_MODE;
-  setPreviewMode(viewMode);
+  setPreviewScale(params.get("preview_scale") || params.get("zoom"));
   updateSuperResolutionControls();
   return {
     model: Boolean(model),
@@ -1475,7 +1527,7 @@ function unpack(buf) {
 
 renderPresets();
 drawIdle();
-setPreviewMode(DEFAULT_VIEW_MODE);
+setPreviewScale(DEFAULT_PREVIEW_SCALE);
 updateSuperResolutionControls();
 applyPreset(presets[0], { sendRuntimeEvents: false })
   .then(applyQueryParams)
@@ -1492,9 +1544,7 @@ $("firstFrame").onchange = () => drawReferencePreview($("firstFrame").files[0]);
 $("size").addEventListener("input", () => updateOutputSizeText());
 $("superResolution").addEventListener("change", updateSuperResolutionControls);
 $("upscalingScale").addEventListener("change", () => updateOutputSizeText());
-document.querySelectorAll("[data-view-mode]").forEach((btn) => {
-  btn.addEventListener("click", () => setPreviewMode(btn.dataset.viewMode));
-});
+$("previewScale").addEventListener("input", () => setPreviewScale($("previewScale").value));
 $("serverUrl").addEventListener("change", () => {
   queryServerModelInfo({ applyPresetForModel: true }).catch(showError);
 });

--- a/python/sglang/multimodal_gen/apps/realtime_webui/index.html
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>sglang-diffusion Realtime Studio</title>
-    <link rel="stylesheet" href="./styles.css?v=realtime-sr-v35" />
+    <link rel="stylesheet" href="./styles.css?v=realtime-sr-v36" />
   </head>
   <body>
     <main class="shell">
@@ -145,6 +145,6 @@
         </section>
       </section>
     </main>
-    <script src="./app.js?v=realtime-sr-v35"></script>
+    <script src="./app.js?v=realtime-sr-v36"></script>
   </body>
 </html>

--- a/python/sglang/multimodal_gen/apps/realtime_webui/index.html
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>sglang-diffusion Realtime Studio</title>
-    <link rel="stylesheet" href="./styles.css?v=realtime-sr-v36" />
+    <link rel="stylesheet" href="./styles.css?v=realtime-sr-v37" />
   </head>
   <body>
     <main class="shell">
@@ -145,6 +145,6 @@
         </section>
       </section>
     </main>
-    <script src="./app.js?v=realtime-sr-v36"></script>
+    <script src="./app.js?v=realtime-sr-v37"></script>
   </body>
 </html>

--- a/python/sglang/multimodal_gen/apps/realtime_webui/index.html
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>sglang-diffusion Realtime Studio</title>
-    <link rel="stylesheet" href="./styles.css?v=realtime-sr-v32" />
+    <link rel="stylesheet" href="./styles.css?v=realtime-sr-v35" />
   </head>
   <body>
     <main class="shell">
@@ -69,76 +69,82 @@
         <button id="sendPromptBtn" class="wide">Send prompt update</button>
       </section>
 
-      <section class="stage" aria-label="Realtime preview">
-        <div class="topbar">
-          <span id="statusDot" class="dot"></span>
-          <span id="statusText">Idle</span>
-          <span id="chunkText">chunk -</span>
-          <span class="topbar-spacer"></span>
-          <div class="view-mode" aria-label="Preview size">
-            <button type="button" data-view-mode="fit" class="is-active">Fit</button>
-            <button type="button" data-view-mode="large">Large</button>
-            <button type="button" data-view-mode="native">Native</button>
+      <section class="workspace" aria-label="Realtime workspace">
+        <section class="stage" aria-label="Realtime preview">
+          <div class="topbar">
+            <span id="statusDot" class="dot"></span>
+            <span id="statusText">Idle</span>
+            <span id="chunkText">chunk -</span>
+            <span class="topbar-spacer"></span>
+            <label class="preview-scale-control">Preview
+              <input id="previewScale" type="range" min="80" max="170" value="120" />
+              <b id="previewScaleText">120%</b>
+            </label>
+            <span class="stage-stat">output <b id="outputSizeText">832x480</b></span>
+            <span class="stage-stat">render <b id="renderFps">0</b> fps</span>
+            <span class="stage-stat">theoretical <b id="theoreticalFpsText">-</b></span>
+            <span class="stage-stat">wait <b id="stageLatencyText">-</b></span>
           </div>
-          <span class="stage-stat">output <b id="outputSizeText">832x480</b></span>
-          <span class="stage-stat">render <b id="renderFps">0</b> fps</span>
-          <span class="stage-stat">theoretical <b id="theoreticalFpsText">-</b></span>
-          <span class="stage-stat">wait <b id="stageLatencyText">-</b></span>
-        </div>
-        <canvas id="viewport" width="1280" height="720"></canvas>
-        <div class="stage-controls" aria-label="Camera controls">
-          <div class="control-cluster" aria-label="Move camera">
-            <span class="control-title">Move</span>
-            <div class="camera-pad move-pad">
-              <span></span>
-              <button data-action="w" data-key="W">Forward</button>
-              <span></span>
-              <button data-action="a" data-key="A">Left</button>
-              <button data-action="s" data-key="S">Back</button>
-              <button data-action="d" data-key="D">Right</button>
+          <div class="preview-frame">
+            <canvas id="viewport" width="1280" height="720"></canvas>
+            <div id="previewOverlay" class="preview-overlay" aria-hidden="true">
+              <span class="preview-loader"></span>
             </div>
           </div>
-          <div class="control-cluster" aria-label="Look around">
-            <span class="control-title">Look</span>
-            <div class="camera-pad look-pad">
-              <span></span>
-              <button data-action="i" data-key="↑">Pitch +</button>
-              <span></span>
-              <button data-action="j" data-key="←">Yaw -</button>
-              <button data-action="k" data-key="↓">Pitch -</button>
-              <button data-action="l" data-key="→">Yaw +</button>
+          <div class="stage-controls" aria-label="Camera controls">
+            <div class="control-cluster" aria-label="Move camera">
+              <span class="control-title">Move</span>
+              <div class="camera-pad move-pad">
+                <span></span>
+                <button data-action="w" data-key="W">Forward</button>
+                <span></span>
+                <button data-action="a" data-key="A">Left</button>
+                <button data-action="s" data-key="S">Back</button>
+                <button data-action="d" data-key="D">Right</button>
+              </div>
+            </div>
+            <div class="control-cluster" aria-label="Look around">
+              <span class="control-title">Look</span>
+              <div class="camera-pad look-pad">
+                <span></span>
+                <button data-action="i" data-key="↑">Pitch +</button>
+                <span></span>
+                <button data-action="j" data-key="←">Yaw -</button>
+                <button data-action="k" data-key="↓">Pitch -</button>
+                <button data-action="l" data-key="→">Yaw +</button>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="timeline">
-          <span id="queueText">queue 0</span>
-          <span id="frameText">frames 0</span>
-          <span id="byteText">0 MB</span>
-        </div>
-        <div class="telemetry stage-telemetry">
-          <span>Payload<b id="payloadMode">webp</b></span>
-          <span>Server send<b id="serverSendText">-</b></span>
-          <span>Chunk bytes<b id="chunkPayloadText">-</b></span>
-          <span>Chunk wait<b id="latencyText">-</b></span>
-          <span>Decode<b id="decodeText">-</b></span>
-          <span>Display lag<b id="displayLagText">-</b></span>
-        </div>
-      </section>
+          <div class="timeline">
+            <span id="queueText">queue 0</span>
+            <span id="frameText">frames 0</span>
+            <span id="byteText">0 MB</span>
+          </div>
+          <div class="telemetry stage-telemetry">
+            <span>Payload<b id="payloadMode">webp</b></span>
+            <span>Server send<b id="serverSendText">-</b></span>
+            <span>Chunk bytes<b id="chunkPayloadText">-</b></span>
+            <span>Chunk wait<b id="latencyText">-</b></span>
+            <span>Decode<b id="decodeText">-</b></span>
+            <span>Display lag<b id="displayLagText">-</b></span>
+          </div>
+        </section>
 
-      <section class="panel presets" aria-label="Presets and camera">
-        <div class="section-title">LingBot</div>
-        <div class="spec-grid">
-          <span><b>25 fps</b> target</span>
-          <span><b>chunked</b> stream</span>
-          <span><b>480p/720p</b></span>
-          <span><b>Cam + Act</b></span>
-        </div>
-        <div class="section-title">Presets</div>
-        <div id="presetList" class="preset-list"></div>
-        <div class="section-title">History</div>
-        <div id="historyList" class="history-list"></div>
+        <section class="panel presets" aria-label="Presets and camera">
+          <div class="section-title">LingBot</div>
+          <div class="spec-grid">
+            <span><b>25 fps</b> target</span>
+            <span><b>chunked</b> stream</span>
+            <span><b>480p/720p</b></span>
+            <span><b>Cam + Act</b></span>
+          </div>
+          <div class="section-title">Presets</div>
+          <div id="presetList" class="preset-list"></div>
+          <div class="section-title">History</div>
+          <div id="historyList" class="history-list"></div>
+        </section>
       </section>
     </main>
-    <script src="./app.js?v=realtime-sr-v32"></script>
+    <script src="./app.js?v=realtime-sr-v35"></script>
   </body>
 </html>

--- a/python/sglang/multimodal_gen/apps/realtime_webui/index.html
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>sglang-diffusion Realtime Studio</title>
-    <link rel="stylesheet" href="./styles.css?v=realtime-fixes-v25" />
+    <link rel="stylesheet" href="./styles.css?v=realtime-sr-v32" />
   </head>
   <body>
     <main class="shell">
@@ -51,6 +51,15 @@
           </label>
           <label>Quality<input id="transportQuality" type="number" value="95" min="1" max="100" /></label>
         </div>
+        <div class="split output-options">
+          <label class="toggle-row"><input id="superResolution" type="checkbox" />Super resolution</label>
+          <label>Scale
+            <select id="upscalingScale">
+              <option value="2" selected>2x</option>
+              <option value="4">4x</option>
+            </select>
+          </label>
+        </div>
         <label class="toggle-row"><input id="frameInterpolation" type="checkbox" />Smooth 2x frames</label>
         <label class="toggle-row"><input id="continuous" type="checkbox" checked />Continuous session</label>
         <div class="actions">
@@ -66,6 +75,12 @@
           <span id="statusText">Idle</span>
           <span id="chunkText">chunk -</span>
           <span class="topbar-spacer"></span>
+          <div class="view-mode" aria-label="Preview size">
+            <button type="button" data-view-mode="fit" class="is-active">Fit</button>
+            <button type="button" data-view-mode="large">Large</button>
+            <button type="button" data-view-mode="native">Native</button>
+          </div>
+          <span class="stage-stat">output <b id="outputSizeText">832x480</b></span>
           <span class="stage-stat">render <b id="renderFps">0</b> fps</span>
           <span class="stage-stat">theoretical <b id="theoreticalFpsText">-</b></span>
           <span class="stage-stat">wait <b id="stageLatencyText">-</b></span>
@@ -124,6 +139,6 @@
         <div id="historyList" class="history-list"></div>
       </section>
     </main>
-    <script src="./app.js?v=realtime-model-info-v31"></script>
+    <script src="./app.js?v=realtime-sr-v32"></script>
   </body>
 </html>

--- a/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
@@ -136,6 +136,13 @@ textarea { resize: vertical; line-height: 1.45; }
 input:focus, textarea:focus, select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(185, 84, 60, 0.12); }
 
 .split { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.output-options {
+  align-items: end;
+}
+.output-options .toggle-row {
+  min-height: 40px;
+  margin: 12px 0;
+}
 .actions { display: grid; grid-template-columns: 1fr 0.7fr; gap: 10px; margin-top: 16px; }
 .toggle-row {
   display: flex;
@@ -223,6 +230,16 @@ button:focus-visible {
   box-shadow: var(--shadow);
 }
 
+.stage[data-view-mode="large"] {
+  max-width: min(1500px, calc(100vw - 36px));
+}
+
+.stage[data-view-mode="native"] {
+  width: min-content;
+  max-width: calc(100vw - 36px);
+  overflow: auto;
+}
+
 .topbar, .timeline {
   display: flex;
   align-items: center;
@@ -235,6 +252,34 @@ button:focus-visible {
 }
 
 .topbar-spacer { flex: 1; }
+.view-mode {
+  display: inline-grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid rgba(232, 234, 223, 0.16);
+  border-radius: 6px;
+  background: rgba(255, 253, 247, 0.06);
+}
+.view-mode button {
+  min-height: 24px;
+  border: 0;
+  border-radius: 4px;
+  padding: 0 8px;
+  background: transparent;
+  color: rgba(232, 234, 223, 0.68);
+  font-size: 11px;
+}
+.view-mode button:hover:not(:disabled) {
+  background: rgba(255, 253, 247, 0.1);
+  box-shadow: none;
+  color: #fffdf7;
+  transform: none;
+}
+.view-mode button.is-active {
+  background: #eef1ec;
+  color: #11140f;
+}
 #statusText {
   display: inline-block;
   min-width: 92px;
@@ -268,6 +313,16 @@ button:focus-visible {
   min-height: 0;
   object-fit: contain;
   image-rendering: auto;
+}
+
+.stage[data-view-mode="large"] #viewport {
+  max-height: min(74vh, 920px);
+}
+
+.stage[data-view-mode="native"] #viewport {
+  width: var(--native-preview-width, 100%);
+  max-width: none;
+  max-height: none;
 }
 
 .stage-controls {
@@ -505,4 +560,13 @@ button:focus-visible {
   .stage-telemetry { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .topbar { flex-wrap: wrap; height: auto; min-height: 44px; padding: 10px 14px; }
   .topbar-spacer { display: none; }
+  .stage[data-view-mode="large"],
+  .stage[data-view-mode="native"] {
+    width: 100%;
+    max-width: none;
+  }
+  .stage[data-view-mode="native"] #viewport {
+    width: 100%;
+    max-height: none;
+  }
 }

--- a/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
@@ -243,10 +243,7 @@ button:focus-visible {
   justify-self: center;
   width: min(calc(1040px * var(--preview-scale, 1.2)), 100%);
   overflow: hidden;
-  background:
-    radial-gradient(circle at 22% 22%, rgba(63, 96, 124, 0.26), transparent 32%),
-    radial-gradient(circle at 76% 16%, rgba(185, 84, 60, 0.18), transparent 28%),
-    linear-gradient(145deg, #10150f 0%, #172016 48%, #0f1719 100%);
+  background: #11140f;
   contain: paint;
   isolation: isolate;
 }
@@ -257,34 +254,20 @@ button:focus-visible {
   inset: 0;
   z-index: 0;
   pointer-events: none;
-  background:
-    linear-gradient(90deg, rgba(238, 241, 236, 0.06) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(238, 241, 236, 0.04) 1px, transparent 1px);
-  background-size: 48px 48px;
-  mask-image: radial-gradient(circle at 50% 50%, black 0%, transparent 74%);
+  background: linear-gradient(
+    180deg,
+    rgba(238, 241, 236, 0.045),
+    transparent 34%,
+    rgba(0, 0, 0, 0.18)
+  );
 }
 
 .preview-frame::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  pointer-events: none;
-  opacity: 0;
-  background: linear-gradient(
-    100deg,
-    transparent 0%,
-    transparent 37%,
-    rgba(238, 241, 236, 0.22) 50%,
-    transparent 63%,
-    transparent 100%
-  );
-  transform: translateX(-130%);
+  content: none;
 }
 
 .stage[data-preview-state="waiting"] .preview-frame::after {
-  opacity: 1;
-  animation: previewSweep 1.35s ease-in-out infinite;
+  animation: none;
 }
 
 .topbar, .timeline {
@@ -366,7 +349,7 @@ button:focus-visible {
   display: none;
   place-items: center;
   pointer-events: none;
-  background: radial-gradient(circle at 50% 50%, rgba(17, 20, 15, 0.12), transparent 44%);
+  background: transparent;
 }
 
 .stage[data-preview-state="waiting"] .preview-overlay {
@@ -375,30 +358,33 @@ button:focus-visible {
 
 .preview-loader {
   position: relative;
-  width: 54px;
-  height: 54px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
-  background:
-    conic-gradient(from 0deg, transparent 0 22%, rgba(238, 241, 236, 0.95) 23% 34%, transparent 35% 100%),
-    radial-gradient(circle, transparent 56%, rgba(238, 241, 236, 0.2) 58% 63%, transparent 66%);
-  box-shadow: 0 0 34px rgba(238, 241, 236, 0.18);
-  animation: previewSpin 900ms linear infinite;
+  background: rgba(238, 241, 236, 0.88);
+  animation: previewDotPulse 1.05s ease-in-out infinite;
 }
 
 .preview-loader::before,
 .preview-loader::after {
   content: "";
   position: absolute;
-  inset: 13px;
+  top: 0;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
-  border: 1px solid rgba(238, 241, 236, 0.32);
+  background: rgba(238, 241, 236, 0.88);
+  animation: previewDotPulse 1.05s ease-in-out infinite;
+}
+
+.preview-loader::before {
+  left: -16px;
+  animation-delay: -0.18s;
 }
 
 .preview-loader::after {
-  inset: 22px;
-  background: rgba(238, 241, 236, 0.88);
-  border: 0;
-  animation: previewPulse 1.1s ease-in-out infinite;
+  left: 16px;
+  animation-delay: 0.18s;
 }
 
 .stage-controls {
@@ -640,15 +626,7 @@ button:focus-visible {
   .preview-scale-control { min-width: 160px; }
 }
 
-@keyframes previewSweep {
-  to { transform: translateX(130%); }
-}
-
-@keyframes previewSpin {
-  to { transform: rotate(360deg); }
-}
-
-@keyframes previewPulse {
-  0%, 100% { opacity: 0.42; transform: scale(0.86); }
-  50% { opacity: 1; transform: scale(1); }
+@keyframes previewDotPulse {
+  0%, 80%, 100% { opacity: 0.32; }
+  40% { opacity: 1; }
 }

--- a/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
@@ -32,7 +32,7 @@ button:disabled { cursor: wait; opacity: 0.64; transform: none; }
 
 .shell {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) minmax(420px, 1fr) minmax(260px, 320px);
+  grid-template-columns: minmax(260px, 320px) minmax(560px, 1fr);
   gap: 18px;
   min-height: 100vh;
   padding: 18px;
@@ -215,6 +215,12 @@ button:focus-visible {
 }
 .wide { width: 100%; margin-top: 10px; }
 
+.workspace {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
 .stage {
   position: relative;
   display: grid;
@@ -222,7 +228,7 @@ button:focus-visible {
   align-self: start;
   justify-self: center;
   width: 100%;
-  max-width: 1040px;
+  max-width: min(1500px, 100%);
   overflow: hidden;
   border: 1px solid #11140f;
   border-radius: 8px;
@@ -230,14 +236,55 @@ button:focus-visible {
   box-shadow: var(--shadow);
 }
 
-.stage[data-view-mode="large"] {
-  max-width: min(1500px, calc(100vw - 36px));
+.preview-frame {
+  position: relative;
+  display: grid;
+  place-items: center;
+  justify-self: center;
+  width: min(calc(1040px * var(--preview-scale, 1.2)), 100%);
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 22% 22%, rgba(63, 96, 124, 0.26), transparent 32%),
+    radial-gradient(circle at 76% 16%, rgba(185, 84, 60, 0.18), transparent 28%),
+    linear-gradient(145deg, #10150f 0%, #172016 48%, #0f1719 100%);
+  contain: paint;
+  isolation: isolate;
 }
 
-.stage[data-view-mode="native"] {
-  width: min-content;
-  max-width: calc(100vw - 36px);
-  overflow: auto;
+.preview-frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(238, 241, 236, 0.06) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(238, 241, 236, 0.04) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(circle at 50% 50%, black 0%, transparent 74%);
+}
+
+.preview-frame::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 0%,
+    transparent 37%,
+    rgba(238, 241, 236, 0.22) 50%,
+    transparent 63%,
+    transparent 100%
+  );
+  transform: translateX(-130%);
+}
+
+.stage[data-preview-state="waiting"] .preview-frame::after {
+  opacity: 1;
+  animation: previewSweep 1.35s ease-in-out infinite;
 }
 
 .topbar, .timeline {
@@ -252,33 +299,27 @@ button:focus-visible {
 }
 
 .topbar-spacer { flex: 1; }
-.view-mode {
-  display: inline-grid;
-  grid-template-columns: repeat(3, auto);
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid rgba(232, 234, 223, 0.16);
-  border-radius: 6px;
-  background: rgba(255, 253, 247, 0.06);
-}
-.view-mode button {
-  min-height: 24px;
-  border: 0;
-  border-radius: 4px;
-  padding: 0 8px;
-  background: transparent;
-  color: rgba(232, 234, 223, 0.68);
+.preview-scale-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 190px;
+  margin: 0;
+  color: rgba(232, 234, 223, 0.72);
   font-size: 11px;
 }
-.view-mode button:hover:not(:disabled) {
-  background: rgba(255, 253, 247, 0.1);
-  box-shadow: none;
-  color: #fffdf7;
-  transform: none;
+.preview-scale-control input {
+  width: 92px;
+  min-width: 72px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  accent-color: #eef1ec;
 }
-.view-mode button.is-active {
-  background: #eef1ec;
-  color: #11140f;
+.preview-scale-control b {
+  min-width: 36px;
+  color: #fffdf7;
+  font-weight: 650;
 }
 #statusText {
   display: inline-block;
@@ -306,23 +347,58 @@ button:focus-visible {
 .dot.error { background: var(--accent); }
 
 #viewport {
+  position: relative;
+  z-index: 1;
   display: block;
   width: 100%;
   height: auto;
-  max-height: min(56vh, 560px);
+  max-height: min(calc(56vh * var(--preview-scale, 1.2)), 82vh);
   min-height: 0;
   object-fit: contain;
   image-rendering: auto;
+  transform: translateZ(0);
 }
 
-.stage[data-view-mode="large"] #viewport {
-  max-height: min(74vh, 920px);
+.preview-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: none;
+  place-items: center;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 50%, rgba(17, 20, 15, 0.12), transparent 44%);
 }
 
-.stage[data-view-mode="native"] #viewport {
-  width: var(--native-preview-width, 100%);
-  max-width: none;
-  max-height: none;
+.stage[data-preview-state="waiting"] .preview-overlay {
+  display: grid;
+}
+
+.preview-loader {
+  position: relative;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background:
+    conic-gradient(from 0deg, transparent 0 22%, rgba(238, 241, 236, 0.95) 23% 34%, transparent 35% 100%),
+    radial-gradient(circle, transparent 56%, rgba(238, 241, 236, 0.2) 58% 63%, transparent 66%);
+  box-shadow: 0 0 34px rgba(238, 241, 236, 0.18);
+  animation: previewSpin 900ms linear infinite;
+}
+
+.preview-loader::before,
+.preview-loader::after {
+  content: "";
+  position: absolute;
+  inset: 13px;
+  border-radius: 50%;
+  border: 1px solid rgba(238, 241, 236, 0.32);
+}
+
+.preview-loader::after {
+  inset: 22px;
+  background: rgba(238, 241, 236, 0.88);
+  border: 0;
+  animation: previewPulse 1.1s ease-in-out infinite;
 }
 
 .stage-controls {
@@ -421,7 +497,7 @@ button:focus-visible {
 
 .spec-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
   gap: 8px;
   margin-bottom: 12px;
 }
@@ -445,18 +521,18 @@ button:focus-visible {
 }
 
 .presets {
-  position: sticky;
-  top: 18px;
-  max-height: calc(100vh - 36px);
-  overflow: auto;
+  position: static;
+  max-height: none;
+  overflow: visible;
   scrollbar-gutter: stable;
 }
 
 .preset-list {
   display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 7px;
-  min-height: 320px;
-  max-height: min(54vh, 560px);
+  min-height: 0;
+  max-height: 230px;
   margin-bottom: 12px;
   overflow: auto;
   padding-right: 3px;
@@ -538,7 +614,7 @@ button:focus-visible {
 .history-list {
   display: grid;
   gap: 7px;
-  max-height: 76px;
+  max-height: 92px;
   overflow: auto;
 }
 
@@ -554,19 +630,25 @@ button:focus-visible {
 @media (max-width: 980px) {
   .shell { grid-template-columns: 1fr; }
   .presets { position: static; max-height: none; overflow: visible; }
+  .spec-grid { grid-template-columns: repeat(2, 1fr); }
   .preset-list { min-height: 260px; max-height: 420px; }
   #viewport { max-height: 420px; }
   .stage-controls { grid-template-columns: 1fr; }
   .stage-telemetry { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .topbar { flex-wrap: wrap; height: auto; min-height: 44px; padding: 10px 14px; }
   .topbar-spacer { display: none; }
-  .stage[data-view-mode="large"],
-  .stage[data-view-mode="native"] {
-    width: 100%;
-    max-width: none;
-  }
-  .stage[data-view-mode="native"] #viewport {
-    width: 100%;
-    max-height: none;
-  }
+  .preview-scale-control { min-width: 160px; }
+}
+
+@keyframes previewSweep {
+  to { transform: translateX(130%); }
+}
+
+@keyframes previewSpin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes previewPulse {
+  0%, 100% { opacity: 0.42; transform: scale(0.86); }
+  50% { opacity: 1; transform: scale(1); }
 }

--- a/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
@@ -27,6 +27,11 @@ logger = init_logger(__name__)
 # Default HuggingFace repo and filename for Real-ESRGAN weights
 _DEFAULT_REALESRGAN_HF_REPO = "ai-forever/Real-ESRGAN"
 _DEFAULT_REALESRGAN_FILENAME = "RealESRGAN_x4.pth"
+_DEFAULT_REALESRGAN_FILENAMES_BY_SCALE = {
+    2: "RealESRGAN_x2.pth",
+    4: "RealESRGAN_x4.pth",
+    8: "RealESRGAN_x8.pth",
+}
 _LOW_MEMORY_TILED_UPSCALE_FREE_BYTES = 2 * 1024**3
 _REALESRGAN_TILE_SIZE = 256
 _REALESRGAN_TILE_PAD = 32
@@ -34,6 +39,14 @@ _REALESRGAN_TILE_PAD = 32
 # Module-level cache: model_path -> UpscalerModel instance
 _MODEL_CACHE: dict[str, "UpscalerModel"] = {}
 _RESOLVED_MODEL_PATH_CACHE: dict[str, str] = {}
+
+
+def _default_model_path_for_scale(scale: int) -> str:
+    filename = _DEFAULT_REALESRGAN_FILENAMES_BY_SCALE.get(
+        int(scale),
+        _DEFAULT_REALESRGAN_FILENAME,
+    )
+    return f"{_DEFAULT_REALESRGAN_HF_REPO}:{filename}"
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +210,17 @@ def _build_net_from_state_dict(state_dict: dict) -> nn.Module:
     if "conv_first.weight" in state_dict:
         # RRDBNet (e.g., RealESRGAN_x4plus)
         num_feat = state_dict["conv_first.weight"].shape[0]
+        in_channels = state_dict["conv_first.weight"].shape[1]
+        if in_channels == 3:
+            scale = 4
+        elif in_channels == 12:
+            scale = 2
+        elif in_channels == 48:
+            scale = 1
+        else:
+            raise ValueError(
+                f"Unsupported RRDBNet conv_first input channels: {in_channels}"
+            )
         num_block = sum(
             1
             for k in state_dict
@@ -204,15 +228,16 @@ def _build_net_from_state_dict(state_dict: dict) -> nn.Module:
         )
         num_grow_ch = state_dict["body.0.rdb1.conv1.weight"].shape[0]
         logger.info(
-            "Detected RRDBNet: num_feat=%d, num_block=%d, num_grow_ch=%d",
+            "Detected RRDBNet: num_feat=%d, num_block=%d, num_grow_ch=%d, scale=%d",
             num_feat,
             num_block,
             num_grow_ch,
+            scale,
         )
         return RRDBNet(
             num_in_ch=3,
             num_out_ch=3,
-            scale=4,
+            scale=scale,
             num_feat=num_feat,
             num_block=num_block,
             num_grow_ch=num_grow_ch,
@@ -545,7 +570,7 @@ class ImageUpscaler:
 
     def _ensure_model_loaded(self) -> UpscalerModel:
         """Download/load Real-ESRGAN weights, detect arch, and cache globally."""
-        model_path = self._model_path or _DEFAULT_REALESRGAN_HF_REPO
+        model_path = self._model_path or _default_model_path_for_scale(self._scale)
 
         # Resolve: local .pth pass-through, or HF repo → download single file
         resolved_path = _resolve_model_path(model_path)

--- a/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
@@ -33,6 +33,7 @@ _REALESRGAN_TILE_PAD = 32
 
 # Module-level cache: model_path -> UpscalerModel instance
 _MODEL_CACHE: dict[str, "UpscalerModel"] = {}
+_RESOLVED_MODEL_PATH_CACHE: dict[str, str] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -668,7 +669,12 @@ def _resolve_model_path(model_path: str) -> str:
     - A HuggingFace ``repo_id:filename`` → downloads *filename* from *repo_id*,
       allowing users to specify custom weight files hosted on HF.
     """
+    cached_path = _RESOLVED_MODEL_PATH_CACHE.get(model_path)
+    if cached_path is not None:
+        return cached_path
+
     if os.path.isfile(model_path):
+        _RESOLVED_MODEL_PATH_CACHE[model_path] = model_path
         return model_path
 
     # Parse optional "repo_id:filename" syntax; fall back to default filename.
@@ -704,6 +710,7 @@ def _resolve_model_path(model_path: str) -> str:
             f"'repo_id:filename' format (e.g. 'my-org/my-esrgan:weights.pth'). "
             f"Original error: {e}"
         ) from e
+    _RESOLVED_MODEL_PATH_CACHE[model_path] = local_path
     return local_path
 
 

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_output_materialization.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_output_materialization.py
@@ -114,3 +114,60 @@ def test_raw_rgb_frame_batches_convert_batched_video_tensor_to_thwc_bytes():
     assert np.all(first[..., 0] == 255)
     assert np.all(first[..., 1] == 127)
     assert np.all(first[..., 2] == 0)
+
+
+def test_raw_rgb_frame_batches_apply_realtime_upscaling(monkeypatch):
+    calls = []
+
+    def fake_batch_upscale_frames(frames, *, model_path, scale):
+        calls.append((model_path, scale, [frame.shape for frame in frames]))
+        return [
+            np.repeat(np.repeat(frame, scale, axis=0), scale, axis=1)
+            for frame in frames
+        ]
+
+    from sglang.multimodal_gen.runtime import postprocess
+
+    monkeypatch.setattr(postprocess, "batch_upscale_frames", fake_batch_upscale_frames)
+
+    req = type(
+        "Req",
+        (),
+        {
+            "data_type": DataType.VIDEO,
+            "fps": 24,
+            "output_compression": None,
+            "enable_frame_interpolation": False,
+            "frame_interpolation_exp": 1,
+            "frame_interpolation_scale": 1.0,
+            "frame_interpolation_model_path": None,
+            "enable_upscaling": True,
+            "upscaling_model_path": "mock-sr",
+            "upscaling_scale": 2,
+            "request_id": "req",
+            "block_idx": 0,
+        },
+    )()
+    output_batch = OutputBatch(audio_sample_rate=None)
+
+    def post_process_sample(_sample, *_args, **kwargs):
+        assert kwargs["enable_upscaling"] is False
+        return [np.array([[[1, 2, 3]]], dtype=np.uint8)]
+
+    frame_batches, metadata = build_raw_rgb_frame_batches(
+        torch.zeros(1, 3, 1, 1, 1),
+        req,
+        output_batch,
+        post_process_sample,
+    )
+
+    assert calls == [("mock-sr", 2, [(1, 1, 3)])]
+    assert metadata == {
+        "format": "rgb24",
+        "width": 2,
+        "height": 2,
+        "channels": 3,
+        "bytes_per_frame": 12,
+    }
+    assert len(frame_batches) == 1
+    assert frame_batches[0][0] == bytes([1, 2, 3] * 4)

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_webui.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_webui.py
@@ -24,8 +24,11 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert 'id="fps" type="number" value="25"' in index_html
     assert 'id="superResolution" type="checkbox"' in index_html
     assert 'id="upscalingScale"' in index_html
-    assert 'data-view-mode="large"' in index_html
-    assert 'data-view-mode="native"' in index_html
+    assert 'class="workspace"' in index_html
+    assert 'class="preview-frame"' in index_html
+    assert 'id="previewOverlay" class="preview-overlay"' in index_html
+    assert 'id="previewScale" type="range" min="80" max="170" value="120"' in index_html
+    assert 'id="previewScaleText"' in index_html
     assert 'id="outputSizeText"' in index_html
     assert 'id="frameInterpolation" type="checkbox" />' in index_html
     assert (
@@ -45,13 +48,19 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert "Info" not in index_html
     assert 'id="steps" type="number" value="4"' in index_html
     assert 'id="guidance" type="number" value="1"' in index_html
-    assert "styles.css?v=realtime-sr-v32" in index_html
-    assert "app.js?v=realtime-sr-v32" in index_html
+    assert "styles.css?v=realtime-sr-v35" in index_html
+    assert "app.js?v=realtime-sr-v35" in index_html
     assert 'const DECODER_WORKER_URL = "./decoder_worker.js?v=rgb-worker-v6";' in app_js
     assert "const DEFAULT_TARGET_FPS = 25;" in app_js
     assert "const DEFAULT_FRAME_INTERPOLATION_EXP = 1;" in app_js
     assert "const DEFAULT_FRAME_INTERPOLATION_SCALE = 1.0;" in app_js
     assert "const DEFAULT_UPSCALING_SCALE = 2;" in app_js
+    assert "const DEFAULT_PREVIEW_SCALE = 120;" in app_js
+    assert "setPreviewState(\"waiting\")" in app_js
+    assert "stage.dataset.previewState = state" in app_js
+    assert 'document.querySelector(".preview-frame")' in app_js
+    assert 'previewFrame.style.setProperty("--preview-scale"' in app_js
+    assert "cancelAnimationFrame(previewScaleFrame)" in app_js
     assert "enable_frame_interpolation: true" in app_js
     assert "frame_interpolation_exp: DEFAULT_FRAME_INTERPOLATION_EXP" in app_js
     assert "frame_interpolation_scale: DEFAULT_FRAME_INTERPOLATION_SCALE" in app_js
@@ -59,7 +68,8 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert "enable_upscaling: true" in app_js
     assert "upscaling_scale: readUpscalingScale()" in app_js
     assert "updateOutputSizeFromHeader(header)" in app_js
-    assert "setPreviewMode(DEFAULT_VIEW_MODE)" in app_js
+    assert "setPreviewScale(DEFAULT_PREVIEW_SCALE)" in app_js
+    assert "preview_scale" in app_js
     assert "sr_scale" in app_js
     assert "elapsedMs % targetMs" in app_js
     assert "liveQueueFrameFloor(header, chunkFrameCount)" in app_js
@@ -89,6 +99,9 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert 'message.type === "chunk_stats"' in app_js
     assert "chunkTotal > 0 ? numFrames / chunkTotal" in app_js
     assert ".stage-stat" in styles_css
-    assert ".view-mode" in styles_css
-    assert '.stage[data-view-mode="large"]' in styles_css
-    assert "--native-preview-width" in styles_css
+    assert ".workspace" in styles_css
+    assert ".preview-frame" in styles_css
+    assert ".preview-overlay" in styles_css
+    assert "@keyframes previewSweep" in styles_css
+    assert ".preview-scale-control" in styles_css
+    assert "--preview-scale" in styles_css

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_webui.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_webui.py
@@ -56,7 +56,7 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert "const DEFAULT_FRAME_INTERPOLATION_SCALE = 1.0;" in app_js
     assert "const DEFAULT_UPSCALING_SCALE = 2;" in app_js
     assert "const DEFAULT_PREVIEW_SCALE = 120;" in app_js
-    assert "setPreviewState(\"waiting\")" in app_js
+    assert 'setPreviewState("waiting")' in app_js
     assert "stage.dataset.previewState = state" in app_js
     assert 'document.querySelector(".preview-frame")' in app_js
     assert 'previewFrame.style.setProperty("--preview-scale"' in app_js

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_webui.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_webui.py
@@ -22,6 +22,11 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert 'const DEFAULT_PREVIEW_OUTPUT_FORMAT = "webp";' in app_js
     assert 'id="transportFormat"' in index_html
     assert 'id="fps" type="number" value="25"' in index_html
+    assert 'id="superResolution" type="checkbox"' in index_html
+    assert 'id="upscalingScale"' in index_html
+    assert 'data-view-mode="large"' in index_html
+    assert 'data-view-mode="native"' in index_html
+    assert 'id="outputSizeText"' in index_html
     assert 'id="frameInterpolation" type="checkbox" />' in index_html
     assert (
         'id="serverUrl" value="ws://127.0.0.1:30000/v1/realtime_video/generate"'
@@ -40,15 +45,22 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert "Info" not in index_html
     assert 'id="steps" type="number" value="4"' in index_html
     assert 'id="guidance" type="number" value="1"' in index_html
-    assert "styles.css?v=realtime-fixes-v25" in index_html
-    assert "app.js?v=realtime-fixes-v30" in index_html
+    assert "styles.css?v=realtime-sr-v32" in index_html
+    assert "app.js?v=realtime-sr-v32" in index_html
     assert 'const DECODER_WORKER_URL = "./decoder_worker.js?v=rgb-worker-v6";' in app_js
     assert "const DEFAULT_TARGET_FPS = 25;" in app_js
     assert "const DEFAULT_FRAME_INTERPOLATION_EXP = 1;" in app_js
     assert "const DEFAULT_FRAME_INTERPOLATION_SCALE = 1.0;" in app_js
+    assert "const DEFAULT_UPSCALING_SCALE = 2;" in app_js
     assert "enable_frame_interpolation: true" in app_js
     assert "frame_interpolation_exp: DEFAULT_FRAME_INTERPOLATION_EXP" in app_js
     assert "frame_interpolation_scale: DEFAULT_FRAME_INTERPOLATION_SCALE" in app_js
+    assert "readSuperResolutionParams()" in app_js
+    assert "enable_upscaling: true" in app_js
+    assert "upscaling_scale: readUpscalingScale()" in app_js
+    assert "updateOutputSizeFromHeader(header)" in app_js
+    assert "setPreviewMode(DEFAULT_VIEW_MODE)" in app_js
+    assert "sr_scale" in app_js
     assert "elapsedMs % targetMs" in app_js
     assert "liveQueueFrameFloor(header, chunkFrameCount)" in app_js
     assert (
@@ -77,3 +89,6 @@ def test_realtime_webui_presets_do_not_emit_camera_scripts():
     assert 'message.type === "chunk_stats"' in app_js
     assert "chunkTotal > 0 ? numFrames / chunkTotal" in app_js
     assert ".stage-stat" in styles_css
+    assert ".view-mode" in styles_css
+    assert '.stage[data-view-mode="large"]' in styles_css
+    assert "--native-preview-width" in styles_css


### PR DESCRIPTION
## Summary
- add realtime WebUI controls for server-side super resolution and scale selection
- add Fit/Large/Native preview sizing plus output-size telemetry for SR outputs
- add unit coverage for realtime raw-frame upscaling materialization without loading a real SR model

## Testing
- Static WebUI preview checked locally at `http://127.0.0.1:18082/index.html?sr=1&sr_scale=2&view=large`.
- Not running local pytest per diffusion development instructions; relying on CI for test execution.

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26812633453](https://github.com/sgl-project/sglang/actions/runs/26812633453)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26812633251](https://github.com/sgl-project/sglang/actions/runs/26812633251)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->