### PR TITLE
fix(dependencies): add distro runtime dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -706,6 +706,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
     # Python runtime
     python3.12-full \
     python3.12-dev \
+    python3-distro \
     wget \
     # Core system utilities
     ca-certificates \

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "nvidia-ml-py",
   "openai-harmony==0.0.4",
   "openai==2.6.1",
+  "distro>=1.7,<2",
   "orjson",
   "outlines==0.1.11",
   "packaging",


### PR DESCRIPTION
## Motivation

Ensure the `distro` package is available in both Python package installs and the runtime Docker image when runtime code or dependencies require Linux distribution detection.

## Modifications

- Add `distro>=1.7,<2` to `python/pyproject.toml`.
- Install `python3-distro` in the runtime Dockerfile.

## Accuracy Tests

Not applicable. This PR only changes dependency declarations and Docker runtime packages.

## Speed Tests and Profiling

Not applicable. This PR does not affect inference execution.

## Checklist

- [x] Formatted code and ran code style checks for the changed files.
- [x] `git diff --check origin/main..HEAD`
- [x] Parsed `python/pyproject.toml` with `tomllib` and verified the `distro` dependency is present.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26804594485](https://github.com/sgl-project/sglang/actions/runs/26804594485)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26804594362](https://github.com/sgl-project/sglang/actions/runs/26804594362)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->