### PR TITLE
fix(reasoner): prevent jump forward during thinking phase

### DIFF
--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -199,6 +199,8 @@ class ReasonerGrammarObject(BaseGrammarObject):
             self._finished = finished
 
     def try_jump_forward(self, tokenizer):
+        if self._is_thinking():
+            return None
         if self.grammar is not None:
             return self.grammar.try_jump_forward(tokenizer)
         return None

--- a/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+++ b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
@@ -117,6 +117,19 @@ class TestReasonerGrammarObject(unittest.TestCase):
         self.assertIs(obj.move_vocab_mask(mask, "cpu"), mask)
         self.assertIsNotNone(obj.apply_vocab_mask)
 
+    def test_try_jump_forward_disabled_during_thinking(self):
+        grammar = MagicMock()
+        grammar.try_jump_forward.return_value = "jump"
+        obj = ReasonerGrammarObject(grammar=grammar, think_end_id=7)
+        obj.maybe_init_reasoning(True)
+
+        self.assertIsNone(obj.try_jump_forward(tokenizer=None))
+        grammar.try_jump_forward.assert_not_called()
+
+        obj.accept_token(7)
+        self.assertEqual(obj.try_jump_forward(tokenizer=None), "jump")
+        grammar.try_jump_forward.assert_called_once_with(None)
+
 
 class TestReasonerGrammarBackend(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Motivation

`ReasonerGrammarObject` should not delegate jump-forward decisions to the wrapped grammar while the model is still in the thinking phase. Doing so can let constrained decoding skip forward before the reasoning end token is emitted.

## Modifications

- Return `None` from `ReasonerGrammarObject.try_jump_forward` while `_is_thinking()` is true.
- Add a regression unit test that verifies jump-forward is disabled during thinking and restored after the think-end token is accepted.

## Accuracy Tests

Not applicable. This PR fixes constrained decoding control flow and adds focused unit coverage. It does not change model weights, kernels, or forward computation.

## Speed Tests and Profiling

Not applicable. This PR only disables jump-forward during the reasoning phase where grammar constraints should not be applied.

## Checklist

- [x] Formatted code and ran code style checks for the changed files.
- [x] Added unit test coverage.
- [x] Ran targeted unit test:
  `PYTHONPATH=/workspace/python pytest test/registered/unit/constrained/test_reasoner_grammar_backend.py -q`
  Result: `20 passed, 8 warnings`.
- [x] `git diff --check origin/main..HEAD`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26804606117](https://github.com/sgl-project/sglang/actions/runs/26804606117)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26804605970](https://github.com/sgl-project/sglang/actions/runs/26804605970)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->