### PR TITLE
[diffusion] Enable Cosmos3 parallel decode

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/cosmos3.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/cosmos3.py
@@ -56,11 +56,10 @@ class Cosmos3Config(PipelineConfig):
         # Encoder is needed for I2V; T2V/T2I never invoke it.
         self.vae_config.load_encoder = True
         self.vae_config.load_decoder = True
-        # WanVAE defaults use_parallel_encode/decode to True, which silently
-        # activates an SP-sharded VAE path when sp_world_size > 1 and produces
-        # garbled pixels for cosmos3's latent shape.
+        # keep WanVAE encode replicated because parallel encode changes I2V
+        # conditioning latents when sp_world_size > 1
         self.vae_config.use_parallel_encode = False
-        self.vae_config.use_parallel_decode = False
+        self.vae_config.use_parallel_decode = True
 
     def adjust_num_frames(self, num_frames: int) -> int:
         """Round ``num_frames`` so ``(n - 1) % 4 == 0`` for the VAE.


### PR DESCRIPTION
## Summary
- keep Cosmos3 WanVAE encode replicated because parallel encode changes I2V conditioning latents with SP
- enable WanVAE parallel decode for Cosmos3 so multi-GPU/SP decode can shard the VAE decode path
- single-GPU runs keep the same effective non-sharded path because `sp_world_size == 1`

## Validation
- remote 4xH200 devbox `cosmos3-finalnorm-4h200-20260602`, torch compile/cache/guardrails disabled
- Cosmos3 Nano T2V 1280x720, 189 frames, 35 steps, seed 0, CFG + Ulysses
- response latency: `61.2696s -> 57.817s`
- decode time: `~8.93s -> 5.203s`
- peak GPU memory: `48774MB -> 45110MB`
- output changed but stayed visually close: global mean abs diff `1.707/255`, global PSNR `40.06dB`, sample SSIMs `0.980 / 0.971 / 0.964`

No local tests run per sglang-diffusion workflow; validation used the remote GPU devbox above.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26806629954](https://github.com/sgl-project/sglang/actions/runs/26806629954)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26806629691](https://github.com/sgl-project/sglang/actions/runs/26806629691)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->