### PR TITLE
[sglang] Fix Mamba COW over-releasing SWA locks (cascade-evict assert crash)

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -92,10 +92,15 @@ class MambaComponent(TreeComponent):
             if req.mamba_pool_idx is None:
                 dst_index = self.cache.req_to_token_pool.mamba_pool.alloc(1)
                 if dst_index is None:
-                    self.cache.inc_lock_ref(last_node)
+                    # Capture the inc result and thread swa_uuid_for_lock back
+                    # into dec. Without it, SWA's release walks past this
+                    # request's window boundary all the way to root and
+                    # over-decrements SWA locks held by other resident requests
+                    # on ancestor nodes.
+                    lock_result = self.cache.inc_lock_ref(last_node)
                     self.cache.evict(EvictParams(num_tokens=0, mamba_num=1))
                     dst_index = self.cache.req_to_token_pool.mamba_pool.alloc(1)
-                    self.cache.dec_lock_ref(last_node)
+                    self.cache.dec_lock_ref(last_node, lock_result.to_dec_params())
                     assert dst_index is not None, "Can not alloc mamba cache"
                 req.mamba_pool_idx = dst_index[0]
             req.mamba_cow_src_index = mamba_value


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The Mamba copy-on-write path in MambaComponent.finalize_match_result takes a temporary tree lock around its inner eviction but releases it without the swa_uuid_for_lock boundary token. Since SWA release walks the prefix chain until it hits that uuid, a missing uuid makes it walk all the way to root and over-decrement SWA locks held by other resident requests on ancestor nodes.
This decouples a node's SWA lock from its Mamba/Full locks: SWA drops to 0 (so the SWA LRU treats the node as evictable) while Mamba is still locked by a parked, decoding request. A later SWA eviction then cascades into the locked Mamba and trips the lock_ref == 0 assertion, crashing the server.

Fix
Capture the inc_lock_ref result and pass to_dec_params() into dec_lock_ref, so SWA release stops at the request's window boundary instead of walking to root. Every other lock site in the unified cache already threads the uuid through; the COW path was the lone exception.



## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26807082780](https://github.com/sgl-project/sglang/actions/runs/26807082780)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26807082576](https://github.com/sgl-project/sglang/actions/runs/26807082576)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->