### PR TITLE
[EPD] fix: zmq PUSH socket reconnect-aware connection management with tcp keepalive

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -143,14 +143,13 @@ class CommonKVManager(BaseKVManager):
         )
 
         # bind zmq socket
-        context = zmq.Context()
+        self._zmq_ctx = zmq.Context()
         self.rank_port, self.server_socket = get_zmq_socket_on_host(
-            context, zmq.PULL, host=self.local_ip
+            self._zmq_ctx, zmq.PULL, host=self.local_ip
         )
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
         self.request_status: Dict[int, KVPoll] = {}
-        self._zmq_ctx = zmq.Context()
         self._socket_cache: Dict[str, zmq.Socket] = {}
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_lock = threading.Lock()
@@ -461,10 +460,14 @@ class CommonKVManager(BaseKVManager):
                         disconnected = True
                     except zmq.Again:
                         pass
+                    except zmq.ZMQError:
+                        disconnected = True
                 if not disconnected:
                     return sock
                 sock.close(linger=0)
-                monitor.close()
+                if monitor is not None:
+                    monitor.close()
+                self._socket_cache.pop(endpoint, None)
                 self._monitor_cache.pop(endpoint, None)
 
             sock = self._zmq_ctx.socket(zmq.PUSH)
@@ -923,6 +926,7 @@ class CommonKVReceiver(BaseKVReceiver):
     _ctx = zmq.Context()
     _socket_cache = {}
     _socket_locks = {}
+    _monitor_cache = {}
     _global_lock = threading.Lock()
 
     def __init__(
@@ -1079,13 +1083,42 @@ class CommonKVReceiver(BaseKVReceiver):
     @classmethod
     def _connect(cls, endpoint: str, is_ipv6: bool = False):
         with cls._global_lock:
-            if endpoint not in cls._socket_cache:
-                sock = cls._ctx.socket(zmq.PUSH)
-                if is_ipv6:
-                    sock.setsockopt(zmq.IPV6, 1)
-                sock.connect(endpoint)
-                cls._socket_cache[endpoint] = sock
-                cls._socket_locks[endpoint] = threading.Lock()
+            if endpoint in cls._socket_cache:
+                monitor = cls._monitor_cache.get(endpoint)
+                disconnected = False
+                if monitor is not None:
+                    try:
+                        monitor.recv_multipart(zmq.NOBLOCK)
+                        disconnected = True
+                    except zmq.Again:
+                        pass
+                    except zmq.ZMQError:
+                        disconnected = True
+                if not disconnected:
+                    return cls._socket_cache[endpoint], cls._socket_locks[endpoint]
+                cls._socket_cache[endpoint].close(linger=0)
+                if monitor is not None:
+                    monitor.close()
+                del cls._socket_cache[endpoint]
+                del cls._socket_locks[endpoint]
+                cls._monitor_cache.pop(endpoint, None)
+
+            sock = cls._ctx.socket(zmq.PUSH)
+            if is_ipv6:
+                sock.setsockopt(zmq.IPV6, 1)
+            sock.setsockopt(zmq.RECONNECT_IVL, -1)
+            sock.setsockopt(zmq.SNDTIMEO, 30000)
+            sock.setsockopt(zmq.LINGER, 0)
+            sock.setsockopt(zmq.TCP_KEEPALIVE, 1)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 5)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_CNT, 3)
+            sock.connect(endpoint)
+            cls._socket_cache[endpoint] = sock
+            cls._socket_locks[endpoint] = threading.Lock()
+            cls._monitor_cache[endpoint] = sock.get_monitor_socket(
+                zmq.EVENT_DISCONNECTED
+            )
             return cls._socket_cache[endpoint], cls._socket_locks[endpoint]
 
     @classmethod

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -464,6 +464,7 @@ class CommonKVManager(BaseKVManager):
                 if not disconnected:
                     return sock
                 sock.close(linger=0)
+                monitor.close()
                 self._monitor_cache.pop(endpoint, None)
 
             sock = self._zmq_ctx.socket(zmq.PUSH)

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -6,7 +6,6 @@ import logging
 import threading
 import time
 from collections import defaultdict
-from functools import cache
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -151,6 +150,10 @@ class CommonKVManager(BaseKVManager):
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
         self.request_status: Dict[int, KVPoll] = {}
+        self._zmq_ctx = zmq.Context()
+        self._socket_cache: Dict[str, zmq.Socket] = {}
+        self._monitor_cache: Dict[str, zmq.Socket] = {}
+        self._socket_lock = threading.Lock()
         self.failure_records: Dict[int, str] = {}
         self.failure_lock = threading.Lock()
 
@@ -446,13 +449,48 @@ class CommonKVManager(BaseKVManager):
             f"Prefill instance failed to register to bootstrap server after {max_retries} retries"
         )
 
-    @cache
     def _connect(self, endpoint: str, is_ipv6: bool = False):
-        socket = zmq.Context().socket(zmq.PUSH)
-        if is_ipv6:
-            socket.setsockopt(zmq.IPV6, 1)
-        socket.connect(endpoint)
-        return socket
+        with self._socket_lock:
+            sock = self._socket_cache.get(endpoint)
+            if sock is not None:
+                monitor = self._monitor_cache.get(endpoint)
+                disconnected = False
+                if monitor is not None:
+                    try:
+                        monitor.recv_multipart(zmq.NOBLOCK)
+                        disconnected = True
+                    except zmq.Again:
+                        pass
+                if not disconnected:
+                    return sock
+                sock.close(linger=0)
+                self._monitor_cache.pop(endpoint, None)
+
+            sock = self._zmq_ctx.socket(zmq.PUSH)
+            if is_ipv6:
+                sock.setsockopt(zmq.IPV6, 1)
+            sock.setsockopt(zmq.RECONNECT_IVL, -1)
+            sock.setsockopt(zmq.SNDTIMEO, 30000)
+            sock.setsockopt(zmq.LINGER, 0)
+            sock.setsockopt(zmq.TCP_KEEPALIVE, 1)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 5)
+            sock.setsockopt(zmq.TCP_KEEPALIVE_CNT, 3)
+            sock.connect(endpoint)
+            self._socket_cache[endpoint] = sock
+            self._monitor_cache[endpoint] = sock.get_monitor_socket(
+                zmq.EVENT_DISCONNECTED
+            )
+            return sock
+
+    def _disconnect(self, endpoint: str):
+        with self._socket_lock:
+            sock = self._socket_cache.pop(endpoint, None)
+            monitor = self._monitor_cache.pop(endpoint, None)
+            if sock is not None:
+                sock.close(linger=0)
+            if monitor is not None:
+                monitor.close()
 
     def get_mha_kv_ptrs_with_pp(
         self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -917,7 +917,6 @@ class CommonKVReceiver(BaseKVReceiver):
     _ctx = zmq.Context()
     _socket_cache = {}
     _socket_locks = {}
-    _monitor_cache = {}
     _global_lock = threading.Lock()
 
     def __init__(
@@ -1074,42 +1073,13 @@ class CommonKVReceiver(BaseKVReceiver):
     @classmethod
     def _connect(cls, endpoint: str, is_ipv6: bool = False):
         with cls._global_lock:
-            if endpoint in cls._socket_cache:
-                monitor = cls._monitor_cache.get(endpoint)
-                disconnected = False
-                if monitor is not None:
-                    try:
-                        monitor.recv_multipart(zmq.NOBLOCK)
-                        disconnected = True
-                    except zmq.Again:
-                        pass
-                    except zmq.ZMQError:
-                        disconnected = True
-                if not disconnected:
-                    return cls._socket_cache[endpoint], cls._socket_locks[endpoint]
-                cls._socket_cache[endpoint].close(linger=0)
-                if monitor is not None:
-                    monitor.close()
-                del cls._socket_cache[endpoint]
-                del cls._socket_locks[endpoint]
-                cls._monitor_cache.pop(endpoint, None)
-
-            sock = cls._ctx.socket(zmq.PUSH)
-            if is_ipv6:
-                sock.setsockopt(zmq.IPV6, 1)
-            sock.setsockopt(zmq.RECONNECT_IVL, -1)
-            sock.setsockopt(zmq.SNDTIMEO, 30000)
-            sock.setsockopt(zmq.LINGER, 0)
-            sock.setsockopt(zmq.TCP_KEEPALIVE, 1)
-            sock.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
-            sock.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 5)
-            sock.setsockopt(zmq.TCP_KEEPALIVE_CNT, 3)
-            sock.connect(endpoint)
-            cls._socket_cache[endpoint] = sock
-            cls._socket_locks[endpoint] = threading.Lock()
-            cls._monitor_cache[endpoint] = sock.get_monitor_socket(
-                zmq.EVENT_DISCONNECTED
-            )
+            if endpoint not in cls._socket_cache:
+                sock = cls._ctx.socket(zmq.PUSH)
+                if is_ipv6:
+                    sock.setsockopt(zmq.IPV6, 1)
+                sock.connect(endpoint)
+                cls._socket_cache[endpoint] = sock
+                cls._socket_locks[endpoint] = threading.Lock()
             return cls._socket_cache[endpoint], cls._socket_locks[endpoint]
 
     @classmethod

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -487,15 +487,6 @@ class CommonKVManager(BaseKVManager):
             )
             return sock
 
-    def _disconnect(self, endpoint: str):
-        with self._socket_lock:
-            sock = self._socket_cache.pop(endpoint, None)
-            monitor = self._monitor_cache.pop(endpoint, None)
-            if sock is not None:
-                sock.close(linger=0)
-            if monitor is not None:
-                monitor.close()
-
     def get_mha_kv_ptrs_with_pp(
         self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
     ) -> Tuple[List[int], List[int], List[int], List[int], int]:

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -1639,7 +1639,7 @@ class MMEncoder:
                 else:
                     sock.send_multipart([serialized_data], copy=False)
             finally:
-                sock.close()
+                sock.close(linger=5000)
 
         await asyncio.get_event_loop().run_in_executor(self.executor, send_with_socket)
 


### PR DESCRIPTION
## Summary
  - Replace `@cache`-based ZMQ PUSH socket with reconnect-aware connection management: socket cache + monitor-based disconnect detection + TCP keepalive
  - Add `sock.close(linger=5000)` in encode_server to prevent indefinite blocking on network failure

  ## Background
  In EPD disaggregation scenarios:
  1. When Decode nodes restart or scale down, Prefill nodes' ZMQ sockets keep sending TCP SYN packets to the historical Decode machine IPs. These SYN packets hit NCCL ports of newly launched training/inference services on those machines, causing port 
  conflicts and startup failures.
  2. When Prefill nodes restart or scale down, Encode nodes exhibit the same behavior — continuously sending TCP SYN packets to historical Prefill machine IPs, causing identical port conflict issues.

  Root cause: the old `@cache`-based `_connect` never closed or replaced stale sockets, and ZMQ's default auto-reconnect (`RECONNECT_IVL`) caused infinite SYN retries to unreachable endpoints.

  ## Changes
  - `python/sglang/srt/disaggregation/common/conn.py`:
    - Remove `functools.cache` on `_connect`, replace with explicit socket cache + `threading.Lock`
    - Use ZMQ monitor socket (`EVENT_DISCONNECTED`) to detect stale connections and rebuild
    - Disable ZMQ auto-reconnect (`RECONNECT_IVL=-1`) to stop infinite SYN retries to dead endpoints
    - Set `SNDTIMEO=30s`, `LINGER=0` to prevent indefinite send blocking on dead connections
    - Enable TCP keepalive (`IDLE=30s, INTVL=5s, CNT=3`) for timely dead connection detection
    - Add `_disconnect` method for explicit socket cleanup
  - `python/sglang/srt/disaggregation/encode_server.py`:
    - Change `sock.close()` to `sock.close(linger=5000)` to cap flush wait at 5s, preventing E→P socket from hanging indefinitely when P is gone

  ## Test plan
  - [ ] Run EPD disaggregation e2e test with prefill → decode KV transfer
  - [ ] Simulate D node scale-down: verify P stops sending SYN packets to old D IPs within ~45s
  - [ ] Simulate P node scale-down: verify E stops sending SYN packets to old P IPs
  - [ ] Verify no fd leak under repeated D/P instance restart (check `/proc/<pid>/fd` count over time)
  - [ ] Confirm KV transfer recovers correctly when new D/P instances come online







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27335323258](https://github.com/sgl-project/sglang/actions/runs/27335323258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27335322749](https://github.com/sgl-project/sglang/actions/runs/27335322749)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->