### PR TITLE
Return indexer-topk layer count in metadata

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.layernorm import LayerNorm
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.state_capturer.indexer_topk import (
+    get_global_indexer_capturer,
     maybe_capture_indexer_topk,
 )
 from sglang.srt.utils import (
@@ -312,6 +313,38 @@ class Indexer(MultiPlatformOp):
     ):
         return weights.unsqueeze(-1) * q_scale * self.softmax_scale
 
+    def _raw_topk(
+        self,
+        logits: torch.Tensor,
+        metadata: BaseIndexerMetadata,
+        *,
+        ks: Optional[torch.Tensor] = None,
+        ke_offset: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        from sgl_kernel import fast_topk_v2
+
+        seq_lens_topk = (
+            ke_offset if ke_offset is not None else metadata.get_seqlens_expanded()
+        )
+        return fast_topk_v2(logits, seq_lens_topk, self.index_topk, row_starts=ks)
+
+    def _maybe_capture_raw_topk(
+        self,
+        layer_id: int,
+        logits: torch.Tensor,
+        metadata: BaseIndexerMetadata,
+        *,
+        ks: Optional[torch.Tensor] = None,
+        ke_offset: Optional[torch.Tensor] = None,
+    ) -> None:
+        capturer = get_global_indexer_capturer()
+        if capturer is None or capturer.has_capture_for_layer(layer_id):
+            return
+        maybe_capture_indexer_topk(
+            layer_id,
+            self._raw_topk(logits, metadata, ks=ks, ke_offset=ke_offset),
+        )
+
     def _get_q_k_bf16(
         self,
         q_lora: torch.Tensor,
@@ -539,6 +572,7 @@ class Indexer(MultiPlatformOp):
             )
 
         # NOTE(dark): logits should be cleaned in topk_transform
+        self._maybe_capture_raw_topk(layer_id, logits[:q_offset], metadata)
         topk_result = metadata.topk_transform(logits, self.index_topk)
         # Restore possible padding exist in the hidden states.
         if not _is_hip and q_offset < q_fp8.shape[0]:
@@ -674,6 +708,7 @@ class Indexer(MultiPlatformOp):
             assert logits.shape[0] == len(seq_lens_expanded)
             assert logits.shape[1] == k_offset
 
+            self._maybe_capture_raw_topk(layer_id, logits, metadata, ks=ks)
             raw_topk_result = metadata.topk_transform(logits, self.index_topk, ks=ks)
             topk_result[:q_offset] = raw_topk_result
             return topk_result
@@ -694,6 +729,12 @@ class Indexer(MultiPlatformOp):
             assert (
                 global_topk_offset.shape[0] >= q_offset
             ), f"topk_indices_offset too short: {global_topk_offset.shape[0]} < {q_offset}"
+
+        capturer = get_global_indexer_capturer()
+        capture_raw_topk = capturer is not None and not capturer.has_capture_for_layer(
+            layer_id
+        )
+        raw_topk_result = torch.empty_like(topk_result) if capture_raw_topk else None
 
         start = 0
         while start < q_offset:
@@ -739,7 +780,7 @@ class Indexer(MultiPlatformOp):
                 )
                 batch_idx_chunk = token_to_batch_idx[start:end]
 
-            raw_topk_chunk = metadata.topk_transform(
+            transformed_topk_chunk = metadata.topk_transform(
                 logits_chunk,
                 self.index_topk,
                 ks=ks[start:end],
@@ -748,8 +789,18 @@ class Indexer(MultiPlatformOp):
                 batch_idx_list=batch_idx_chunk,
                 topk_indices_offset_override=topk_offset_chunk,
             )
-            topk_result[start:end] = raw_topk_chunk
+            topk_result[start:end] = transformed_topk_chunk
+            if raw_topk_result is not None:
+                raw_topk_result[start:end] = self._raw_topk(
+                    logits_chunk,
+                    metadata,
+                    ks=ks[start:end],
+                    ke_offset=lengths_chunk,
+                )
             start = end
+
+        if raw_topk_result is not None:
+            maybe_capture_indexer_topk(layer_id, raw_topk_result[:q_offset])
 
         return topk_result
 
@@ -793,6 +844,7 @@ class Indexer(MultiPlatformOp):
             dtype=torch.float32,
             device=x_meta.device,
         )
+        self._maybe_capture_raw_topk(layer_id, dummy_logits, metadata)
         return metadata.topk_transform(dummy_logits, self.index_topk)
 
     def _get_topk_ragged_with_cp(
@@ -885,6 +937,9 @@ class Indexer(MultiPlatformOp):
                     ke,
                     clean_logits=False,
                 )
+            self._maybe_capture_raw_topk(
+                layer_id, logits, metadata, ks=ks, ke_offset=ke_offset
+            )
             topk_result = metadata.topk_transform(
                 logits,
                 self.index_topk,
@@ -931,6 +986,9 @@ class Indexer(MultiPlatformOp):
                     ke,
                     clean_logits=False,
                 )
+            self._maybe_capture_raw_topk(
+                layer_id, logits, metadata, ks=ks, ke_offset=ke_offset
+            )
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -384,6 +384,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             output_hidden_states=recv_obj.output_hidden_states,
             routed_experts=routed_experts,
             indexer_topk=indexer_topk,
+            indexer_topk_num_layers=recv_obj.indexer_topk_num_layers,
             customized_info=recv_obj.customized_info,
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1118,6 +1118,7 @@ class BatchTokenIDOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
     routed_experts: List[Optional[torch.Tensor]]
 
     indexer_topk: List[Optional[torch.Tensor]]
+    indexer_topk_num_layers: List[Optional[int]]
 
     # The information of placeholder tokens (e.g., image token)
     # idx is the index of the token in the prompt after expansion.
@@ -1183,6 +1184,7 @@ class BatchStrOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
     routed_experts: List[Optional[str]]
 
     indexer_topk: List[Optional[str]]
+    indexer_topk_num_layers: List[Optional[int]]
 
     # The information of placeholder tokens (e.g., image token)
     # idx is the index of the token in the prompt after expansion.

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -208,6 +208,9 @@ def _handle_output_by_index(output, i):
             indexer_topk=_extract_field_by_index(
                 output, "indexer_topk", i, check_length=False
             ),
+            indexer_topk_num_layers=_extract_field_by_index(
+                output, "indexer_topk_num_layers", i, check_length=False
+            ),
             retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
@@ -294,6 +297,9 @@ def _handle_output_by_index(output, i):
             ),
             indexer_topk=_extract_field_by_index(
                 output, "indexer_topk", i, check_length=False
+            ),
+            indexer_topk_num_layers=_extract_field_by_index(
+                output, "indexer_topk_num_layers", i, check_length=False
             ),
             customized_info=_extract_field_by_index(
                 output, "customized_info", i, check_length=False

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -1056,6 +1056,7 @@ class SchedulerOutputProcessorMixin:
         load = self.get_loads(GetLoadsReqInput(include=["core"]))
         routed_experts = None
         indexer_topk = None
+        indexer_topk_num_layers = None
         customized_info = {}
 
         time_stats = []
@@ -1244,7 +1245,13 @@ class SchedulerOutputProcessorMixin:
                 if req.return_indexer_topk:
                     if indexer_topk is None:
                         indexer_topk = []
+                        indexer_topk_num_layers = []
                     indexer_topk.append(req.indexer_topk)
+                    indexer_topk_num_layers.append(
+                        req.indexer_topk.shape[1]
+                        if req.indexer_topk is not None
+                        else None
+                    )
 
                 if req.customized_info is not None:
                     for k, v in req.customized_info.items():
@@ -1304,6 +1311,7 @@ class SchedulerOutputProcessorMixin:
                     output_hidden_states=output_hidden_states,
                     routed_experts=routed_experts,
                     indexer_topk=indexer_topk,
+                    indexer_topk_num_layers=indexer_topk_num_layers,
                     customized_info=customized_info,
                     placeholder_tokens_idx=None,
                     placeholder_tokens_val=None,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1751,9 +1751,21 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             if getattr(recv_obj, "indexer_topk", None):
                 val = recv_obj.indexer_topk[i]
                 if val is not None:
+                    if recv_obj.indexer_topk_num_layers is None:
+                        raise ValueError(
+                            "Batch output returned indexer_topk without "
+                            "indexer_topk_num_layers."
+                        )
+                    num_layers = recv_obj.indexer_topk_num_layers[i]
+                    if num_layers is None:
+                        raise ValueError(
+                            "Batch output returned indexer_topk without "
+                            "indexer_topk_num_layers."
+                        )
                     if isinstance(val, torch.Tensor):
                         val = pybase64.b64encode(val.numpy().tobytes()).decode("utf-8")
                     meta_info["indexer_topk"] = val
+                    meta_info["indexer_topk_num_layers"] = num_layers
             if getattr(recv_obj, "customized_info", None):
                 for k, v in recv_obj.customized_info.items():
                     meta_info[k] = v[i]

--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -142,6 +142,15 @@ class BaseTopkCapturer:
         num_tokens = forward_batch.out_cache_loc.shape[0]
         return self.device_cache.buffer[:num_tokens, :, : self.topk_size]
 
+    def _get_out_cache_loc(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: Optional[int],
+    ) -> torch.Tensor:
+        del can_run_graph, cuda_graph_batch  # reserved for subclass override
+        return forward_batch.out_cache_loc
+
     def get_topk(
         self,
         req_pool_idx: int,
@@ -173,12 +182,15 @@ class BaseTopkCapturer:
         slice_gpu = self._get_local_slice(
             forward_batch, can_run_graph, cuda_graph_batch
         )
+        out_cache_loc_gpu = self._get_out_cache_loc(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
         if no_copy_to_cpu:
             return TopkCaptureOutput(
-                out_cache_loc=forward_batch.out_cache_loc,
+                out_cache_loc=out_cache_loc_gpu,
                 topk=slice_gpu,
                 host_cache=self.host_cache,
             )
-        out_cache_loc_cpu = forward_batch.out_cache_loc.cpu()
+        out_cache_loc_cpu = out_cache_loc_gpu.cpu()
         self.host_cache.buffer[out_cache_loc_cpu] = slice_gpu.cpu()
         return None

--- a/python/sglang/srt/state_capturer/indexer_topk.py
+++ b/python/sglang/srt/state_capturer/indexer_topk.py
@@ -6,6 +6,9 @@ import pybase64
 import torch
 
 from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.layers.dp_attention import get_dp_local_slice_cpu
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.state_capturer.base import BaseTopkCapturer
 
 logger = logging.getLogger(__name__)
@@ -28,8 +31,6 @@ class IndexerTopkCapturer(BaseTopkCapturer):
         attn_tp_size = get_attention_tp_size()
         assert attn_tp_size == 1, "IndexerTopkCapturer now only supports DP attention"
 
-        # DP-attention capture is per-rank-local: each rank writes [:local_batch, ...]
-        # to its own device_cache, so the buffer only needs to fit one rank's batch.
         server_args = get_global_server_args()
         max_batch_size = max(server_args.chunked_prefill_size, max_running_requests)
 
@@ -41,6 +42,25 @@ class IndexerTopkCapturer(BaseTopkCapturer):
             device=device,
             name="indexer_topk",
         )
+
+    def _get_local_slice(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: Optional[int],
+    ) -> torch.Tensor:
+        if not is_dp_attention_enabled():
+            return super()._get_local_slice(
+                forward_batch, can_run_graph, cuda_graph_batch
+            )
+
+        local_start_pos, local_num_tokens = get_dp_local_slice_cpu(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
+        local_end_pos = local_start_pos + local_num_tokens
+        return self.device_cache.buffer[
+            local_start_pos:local_end_pos, :, : self.topk_size
+        ]
 
 
 _global_indexer_capturer: Optional[IndexerTopkCapturer] = None

--- a/python/sglang/srt/state_capturer/indexer_topk.py
+++ b/python/sglang/srt/state_capturer/indexer_topk.py
@@ -77,7 +77,9 @@ class IndexerTopkCapturer(BaseTopkCapturer):
             forward_batch, can_run_graph, cuda_graph_batch
         )
         local_end_pos = local_start_pos + local_num_tokens
-        return forward_batch.out_cache_loc[local_start_pos:local_end_pos]
+        if forward_batch.out_cache_loc.shape[0] >= local_end_pos:
+            return forward_batch.out_cache_loc[local_start_pos:local_end_pos]
+        return forward_batch.out_cache_loc[:local_num_tokens]
 
 
 _global_indexer_capturer: Optional[IndexerTopkCapturer] = None

--- a/python/sglang/srt/state_capturer/indexer_topk.py
+++ b/python/sglang/srt/state_capturer/indexer_topk.py
@@ -27,6 +27,7 @@ class IndexerTopkCapturer(BaseTopkCapturer):
 
         self.num_indexer_layers = num_indexer_layers
         self.index_topk = index_topk
+        self._capture_num_tokens: Optional[int] = None
 
         attn_tp_size = get_attention_tp_size()
         assert attn_tp_size == 1, "IndexerTopkCapturer now only supports DP attention"
@@ -43,6 +44,32 @@ class IndexerTopkCapturer(BaseTopkCapturer):
             name="indexer_topk",
         )
 
+    def capture(self, layer_id: int, topk_indices: torch.Tensor):
+        self._capture_num_tokens = topk_indices.shape[0]
+        super().capture(layer_id, topk_indices)
+
+    def _get_dp_slice_info(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: Optional[int],
+    ) -> tuple[int, int, int, bool]:
+        local_start_pos, local_num_tokens = get_dp_local_slice_cpu(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
+        captured_num_tokens = getattr(self, "_capture_num_tokens", None)
+        if captured_num_tokens is None:
+            captured_num_tokens = local_num_tokens
+        uses_global_layout = (
+            captured_num_tokens >= local_start_pos + local_num_tokens
+        )
+        loc_num_tokens = forward_batch.out_cache_loc.shape[0]
+        if uses_global_layout and loc_num_tokens >= local_start_pos + local_num_tokens:
+            num_tokens = local_num_tokens
+        else:
+            num_tokens = min(captured_num_tokens, local_num_tokens, loc_num_tokens)
+        return local_start_pos, local_num_tokens, num_tokens, uses_global_layout
+
     def _get_local_slice(
         self,
         forward_batch: ForwardBatch,
@@ -54,10 +81,12 @@ class IndexerTopkCapturer(BaseTopkCapturer):
                 forward_batch, can_run_graph, cuda_graph_batch
             )
 
-        local_start_pos, local_num_tokens = get_dp_local_slice_cpu(
+        local_start_pos, _, num_tokens, uses_global_layout = self._get_dp_slice_info(
             forward_batch, can_run_graph, cuda_graph_batch
         )
-        local_end_pos = local_start_pos + local_num_tokens
+        if not uses_global_layout:
+            return self.device_cache.buffer[:num_tokens, :, : self.topk_size]
+        local_end_pos = local_start_pos + num_tokens
         return self.device_cache.buffer[
             local_start_pos:local_end_pos, :, : self.topk_size
         ]
@@ -73,13 +102,32 @@ class IndexerTopkCapturer(BaseTopkCapturer):
                 forward_batch, can_run_graph, cuda_graph_batch
             )
 
-        local_start_pos, local_num_tokens = get_dp_local_slice_cpu(
+        local_start_pos, _, num_tokens, uses_global_layout = self._get_dp_slice_info(
             forward_batch, can_run_graph, cuda_graph_batch
         )
-        local_end_pos = local_start_pos + local_num_tokens
-        if forward_batch.out_cache_loc.shape[0] >= local_end_pos:
+        local_end_pos = local_start_pos + num_tokens
+        if (
+            uses_global_layout
+            and forward_batch.out_cache_loc.shape[0] >= local_end_pos
+        ):
             return forward_batch.out_cache_loc[local_start_pos:local_end_pos]
-        return forward_batch.out_cache_loc[:local_num_tokens]
+        return forward_batch.out_cache_loc[:num_tokens]
+
+    def on_forward_end(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: Optional[int],
+        no_copy_to_cpu: bool = False,
+    ):
+        output = super().on_forward_end(
+            forward_batch,
+            can_run_graph,
+            cuda_graph_batch,
+            no_copy_to_cpu=no_copy_to_cpu,
+        )
+        self._capture_num_tokens = None
+        return output
 
 
 _global_indexer_capturer: Optional[IndexerTopkCapturer] = None

--- a/python/sglang/srt/state_capturer/indexer_topk.py
+++ b/python/sglang/srt/state_capturer/indexer_topk.py
@@ -28,6 +28,7 @@ class IndexerTopkCapturer(BaseTopkCapturer):
         self.num_indexer_layers = num_indexer_layers
         self.index_topk = index_topk
         self._capture_num_tokens: Optional[int] = None
+        self._captured_layer_ids: set[int] = set()
 
         attn_tp_size = get_attention_tp_size()
         assert attn_tp_size == 1, "IndexerTopkCapturer now only supports DP attention"
@@ -46,7 +47,11 @@ class IndexerTopkCapturer(BaseTopkCapturer):
 
     def capture(self, layer_id: int, topk_indices: torch.Tensor):
         self._capture_num_tokens = topk_indices.shape[0]
+        self._captured_layer_ids.add(layer_id)
         super().capture(layer_id, topk_indices)
+
+    def has_capture_for_layer(self, layer_id: int) -> bool:
+        return layer_id in self._captured_layer_ids
 
     def _get_dp_slice_info(
         self,
@@ -60,9 +65,7 @@ class IndexerTopkCapturer(BaseTopkCapturer):
         captured_num_tokens = getattr(self, "_capture_num_tokens", None)
         if captured_num_tokens is None:
             captured_num_tokens = local_num_tokens
-        uses_global_layout = (
-            captured_num_tokens >= local_start_pos + local_num_tokens
-        )
+        uses_global_layout = captured_num_tokens >= local_start_pos + local_num_tokens
         loc_num_tokens = forward_batch.out_cache_loc.shape[0]
         if uses_global_layout and loc_num_tokens >= local_start_pos + local_num_tokens:
             num_tokens = local_num_tokens
@@ -106,10 +109,7 @@ class IndexerTopkCapturer(BaseTopkCapturer):
             forward_batch, can_run_graph, cuda_graph_batch
         )
         local_end_pos = local_start_pos + num_tokens
-        if (
-            uses_global_layout
-            and forward_batch.out_cache_loc.shape[0] >= local_end_pos
-        ):
+        if uses_global_layout and forward_batch.out_cache_loc.shape[0] >= local_end_pos:
             return forward_batch.out_cache_loc[local_start_pos:local_end_pos]
         return forward_batch.out_cache_loc[:num_tokens]
 
@@ -127,6 +127,7 @@ class IndexerTopkCapturer(BaseTopkCapturer):
             no_copy_to_cpu=no_copy_to_cpu,
         )
         self._capture_num_tokens = None
+        self._captured_layer_ids.clear()
         return output
 
 
@@ -153,6 +154,8 @@ def maybe_capture_indexer_topk(
     if topk_indices is None:
         return None
     if (cap := get_global_indexer_capturer()) is not None:
+        if cap.has_capture_for_layer(layer_id):
+            return topk_indices
         cap.capture(layer_id=layer_id, topk_indices=topk_indices)
     return topk_indices
 

--- a/python/sglang/srt/state_capturer/indexer_topk.py
+++ b/python/sglang/srt/state_capturer/indexer_topk.py
@@ -62,6 +62,23 @@ class IndexerTopkCapturer(BaseTopkCapturer):
             local_start_pos:local_end_pos, :, : self.topk_size
         ]
 
+    def _get_out_cache_loc(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: Optional[int],
+    ) -> torch.Tensor:
+        if not is_dp_attention_enabled():
+            return super()._get_out_cache_loc(
+                forward_batch, can_run_graph, cuda_graph_batch
+            )
+
+        local_start_pos, local_num_tokens = get_dp_local_slice_cpu(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
+        local_end_pos = local_start_pos + local_num_tokens
+        return forward_batch.out_cache_loc[local_start_pos:local_end_pos]
+
 
 _global_indexer_capturer: Optional[IndexerTopkCapturer] = None
 

--- a/test/registered/8-gpu-models/test_return_indexer_topk.py
+++ b/test/registered/8-gpu-models/test_return_indexer_topk.py
@@ -88,7 +88,8 @@ class TestReturnIndexerTopk(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def test_indexer_topk_generate(self):
-        for topk in self.captured:
+        for topk, num_layers in self.captured:
+            self.assertEqual(num_layers, NUM_INDEXER_LAYERS)
             self._check_shape_and_range(topk)
             self._check_skip_topk_equality(topk)
 
@@ -133,13 +134,19 @@ class TestReturnIndexerTopk(CustomTestCase):
                 for text in cls.texts
             ]
             http_results = await asyncio.gather(*tasks)
-            # Reshape raw int32 bytes into (seqlen-1, num_indexer_layers, index_topk).
-            return [
-                extract_indexer_topk_from_meta_info(res).reshape(
-                    -1, NUM_INDEXER_LAYERS, INDEX_TOPK
+            captured = []
+            for res in http_results:
+                num_layers = res["meta_info"]["indexer_topk_num_layers"]
+                # Reshape raw int32 bytes into (seqlen-1, num_indexer_layers, index_topk).
+                captured.append(
+                    (
+                        extract_indexer_topk_from_meta_info(res).reshape(
+                            -1, num_layers, INDEX_TOPK
+                        ),
+                        num_layers,
+                    )
                 )
-                for res in http_results
-            ]
+            return captured
 
 
 async def make_request(session, url, payload):

--- a/test/registered/unit/test_indexer_topk_capturer.py
+++ b/test/registered/unit/test_indexer_topk_capturer.py
@@ -95,6 +95,43 @@ class TestIndexerTopkCapturer(unittest.TestCase):
             indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
             indexer_topk.get_dp_local_slice_cpu = old_get_dp_local_slice_cpu
 
+    def test_dp_attention_uses_local_cache_locations_when_not_global(self):
+        capturer = self._make_capturer()
+        forward_batch = SimpleNamespace(
+            out_cache_loc=torch.tensor([20, 21], dtype=torch.int64)
+        )
+
+        old_is_dp_attention_enabled = indexer_topk.is_dp_attention_enabled
+        old_get_dp_local_slice_cpu = indexer_topk.get_dp_local_slice_cpu
+        try:
+            indexer_topk.is_dp_attention_enabled = lambda: True
+            indexer_topk.get_dp_local_slice_cpu = (
+                lambda forward_batch, can_run_graph, cuda_graph_batch: (4, 2)
+            )
+
+            output = capturer.on_forward_end(
+                forward_batch,
+                can_run_graph=False,
+                cuda_graph_batch=None,
+                no_copy_to_cpu=True,
+            )
+
+            self.assertEqual(output.out_cache_loc.tolist(), [20, 21])
+            self.assertTrue(
+                torch.equal(output.topk, capturer.device_cache.buffer[4:6, :, :2])
+            )
+
+            output.finalize()
+            self.assertTrue(
+                torch.equal(
+                    capturer.host_cache.buffer[20:22],
+                    capturer.device_cache.buffer[4:6, :, :2],
+                )
+            )
+        finally:
+            indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
+            indexer_topk.get_dp_local_slice_cpu = old_get_dp_local_slice_cpu
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/test_indexer_topk_capturer.py
+++ b/test/registered/unit/test_indexer_topk_capturer.py
@@ -18,6 +18,7 @@ class TestIndexerTopkCapturer(unittest.TestCase):
             buffer=torch.zeros((32, 1, 2), dtype=torch.int32)
         )
         capturer._capture_num_tokens = None
+        capturer._captured_layer_ids = set()
         return capturer
 
     def test_non_dp_attention_uses_forward_batch_length(self):
@@ -59,6 +60,36 @@ class TestIndexerTopkCapturer(unittest.TestCase):
         finally:
             indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
             indexer_topk.get_dp_local_slice_cpu = old_get_dp_local_slice_cpu
+
+    def test_maybe_capture_keeps_first_capture_for_layer(self):
+        class FakeCapturer:
+            def __init__(self):
+                self.calls = []
+                self.captured_layer_ids = set()
+
+            def has_capture_for_layer(self, layer_id):
+                return layer_id in self.captured_layer_ids
+
+            def capture(self, layer_id, topk_indices):
+                self.captured_layer_ids.add(layer_id)
+                self.calls.append((layer_id, topk_indices.clone()))
+
+        capturer = FakeCapturer()
+        raw_topk = torch.tensor([[0, 1]], dtype=torch.int32)
+        transformed_topk = torch.tensor([[100, 101]], dtype=torch.int32)
+
+        old_capturer = indexer_topk.get_global_indexer_capturer()
+        try:
+            indexer_topk.set_global_indexer_capturer(capturer)
+
+            indexer_topk.maybe_capture_indexer_topk(0, raw_topk)
+            indexer_topk.maybe_capture_indexer_topk(0, transformed_topk)
+
+            self.assertEqual(len(capturer.calls), 1)
+            self.assertEqual(capturer.calls[0][0], 0)
+            self.assertTrue(torch.equal(capturer.calls[0][1], raw_topk))
+        finally:
+            indexer_topk.set_global_indexer_capturer(old_capturer)
 
     def test_dp_attention_slices_cache_locations_with_topk(self):
         capturer = self._make_capturer()

--- a/test/registered/unit/test_indexer_topk_capturer.py
+++ b/test/registered/unit/test_indexer_topk_capturer.py
@@ -1,0 +1,60 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+import sglang.srt.state_capturer.indexer_topk as indexer_topk
+from sglang.srt.state_capturer.indexer_topk import IndexerTopkCapturer
+
+
+class TestIndexerTopkCapturer(unittest.TestCase):
+    def _make_capturer(self):
+        capturer = object.__new__(IndexerTopkCapturer)
+        capturer.topk_size = 2
+        capturer.device_cache = SimpleNamespace(
+            buffer=torch.arange(6 * 1 * 3, dtype=torch.int32).reshape(6, 1, 3)
+        )
+        return capturer
+
+    def test_non_dp_attention_uses_forward_batch_length(self):
+        capturer = self._make_capturer()
+        forward_batch = SimpleNamespace(out_cache_loc=torch.empty(4, dtype=torch.int64))
+
+        old_is_dp_attention_enabled = indexer_topk.is_dp_attention_enabled
+        try:
+            indexer_topk.is_dp_attention_enabled = lambda: False
+
+            actual = capturer._get_local_slice(
+                forward_batch, can_run_graph=False, cuda_graph_batch=None
+            )
+
+            expected = capturer.device_cache.buffer[:4, :, :2]
+            self.assertTrue(torch.equal(actual, expected))
+        finally:
+            indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
+
+    def test_dp_attention_uses_dp_local_slice(self):
+        capturer = self._make_capturer()
+        forward_batch = SimpleNamespace(out_cache_loc=torch.empty(4, dtype=torch.int64))
+
+        old_is_dp_attention_enabled = indexer_topk.is_dp_attention_enabled
+        old_get_dp_local_slice_cpu = indexer_topk.get_dp_local_slice_cpu
+        try:
+            indexer_topk.is_dp_attention_enabled = lambda: True
+            indexer_topk.get_dp_local_slice_cpu = (
+                lambda forward_batch, can_run_graph, cuda_graph_batch: (2, 3)
+            )
+
+            actual = capturer._get_local_slice(
+                forward_batch, can_run_graph=True, cuda_graph_batch=8
+            )
+
+            expected = capturer.device_cache.buffer[2:5, :, :2]
+            self.assertTrue(torch.equal(actual, expected))
+        finally:
+            indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
+            indexer_topk.get_dp_local_slice_cpu = old_get_dp_local_slice_cpu
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_indexer_topk_capturer.py
+++ b/test/registered/unit/test_indexer_topk_capturer.py
@@ -14,6 +14,9 @@ class TestIndexerTopkCapturer(unittest.TestCase):
         capturer.device_cache = SimpleNamespace(
             buffer=torch.arange(6 * 1 * 3, dtype=torch.int32).reshape(6, 1, 3)
         )
+        capturer.host_cache = SimpleNamespace(
+            buffer=torch.zeros((32, 1, 2), dtype=torch.int32)
+        )
         return capturer
 
     def test_non_dp_attention_uses_forward_batch_length(self):
@@ -51,6 +54,43 @@ class TestIndexerTopkCapturer(unittest.TestCase):
 
             expected = capturer.device_cache.buffer[2:5, :, :2]
             self.assertTrue(torch.equal(actual, expected))
+        finally:
+            indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
+            indexer_topk.get_dp_local_slice_cpu = old_get_dp_local_slice_cpu
+
+    def test_dp_attention_slices_cache_locations_with_topk(self):
+        capturer = self._make_capturer()
+        forward_batch = SimpleNamespace(
+            out_cache_loc=torch.tensor([10, 11, 12, 13, 14], dtype=torch.int64)
+        )
+
+        old_is_dp_attention_enabled = indexer_topk.is_dp_attention_enabled
+        old_get_dp_local_slice_cpu = indexer_topk.get_dp_local_slice_cpu
+        try:
+            indexer_topk.is_dp_attention_enabled = lambda: True
+            indexer_topk.get_dp_local_slice_cpu = (
+                lambda forward_batch, can_run_graph, cuda_graph_batch: (2, 3)
+            )
+
+            output = capturer.on_forward_end(
+                forward_batch,
+                can_run_graph=False,
+                cuda_graph_batch=None,
+                no_copy_to_cpu=True,
+            )
+
+            self.assertEqual(output.out_cache_loc.tolist(), [12, 13, 14])
+            self.assertTrue(
+                torch.equal(output.topk, capturer.device_cache.buffer[2:5, :, :2])
+            )
+
+            output.finalize()
+            self.assertTrue(
+                torch.equal(
+                    capturer.host_cache.buffer[12:15],
+                    capturer.device_cache.buffer[2:5, :, :2],
+                )
+            )
         finally:
             indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
             indexer_topk.get_dp_local_slice_cpu = old_get_dp_local_slice_cpu

--- a/test/registered/unit/test_indexer_topk_capturer.py
+++ b/test/registered/unit/test_indexer_topk_capturer.py
@@ -17,6 +17,7 @@ class TestIndexerTopkCapturer(unittest.TestCase):
         capturer.host_cache = SimpleNamespace(
             buffer=torch.zeros((32, 1, 2), dtype=torch.int32)
         )
+        capturer._capture_num_tokens = None
         return capturer
 
     def test_non_dp_attention_uses_forward_batch_length(self):
@@ -47,6 +48,7 @@ class TestIndexerTopkCapturer(unittest.TestCase):
             indexer_topk.get_dp_local_slice_cpu = (
                 lambda forward_batch, can_run_graph, cuda_graph_batch: (2, 3)
             )
+            capturer._capture_num_tokens = 5
 
             actual = capturer._get_local_slice(
                 forward_batch, can_run_graph=True, cuda_graph_batch=8
@@ -71,6 +73,7 @@ class TestIndexerTopkCapturer(unittest.TestCase):
             indexer_topk.get_dp_local_slice_cpu = (
                 lambda forward_batch, can_run_graph, cuda_graph_batch: (2, 3)
             )
+            capturer._capture_num_tokens = 5
 
             output = capturer.on_forward_end(
                 forward_batch,
@@ -108,6 +111,7 @@ class TestIndexerTopkCapturer(unittest.TestCase):
             indexer_topk.get_dp_local_slice_cpu = (
                 lambda forward_batch, can_run_graph, cuda_graph_batch: (4, 2)
             )
+            capturer._capture_num_tokens = 2
 
             output = capturer.on_forward_end(
                 forward_batch,
@@ -118,14 +122,52 @@ class TestIndexerTopkCapturer(unittest.TestCase):
 
             self.assertEqual(output.out_cache_loc.tolist(), [20, 21])
             self.assertTrue(
-                torch.equal(output.topk, capturer.device_cache.buffer[4:6, :, :2])
+                torch.equal(output.topk, capturer.device_cache.buffer[:2, :, :2])
             )
 
             output.finalize()
             self.assertTrue(
                 torch.equal(
                     capturer.host_cache.buffer[20:22],
-                    capturer.device_cache.buffer[4:6, :, :2],
+                    capturer.device_cache.buffer[:2, :, :2],
+                )
+            )
+        finally:
+            indexer_topk.is_dp_attention_enabled = old_is_dp_attention_enabled
+            indexer_topk.get_dp_local_slice_cpu = old_get_dp_local_slice_cpu
+
+    def test_dp_attention_truncates_local_locations_to_captured_topk(self):
+        capturer = self._make_capturer()
+        forward_batch = SimpleNamespace(
+            out_cache_loc=torch.tensor([20, 21, 22, 23, 24], dtype=torch.int64)
+        )
+
+        old_is_dp_attention_enabled = indexer_topk.is_dp_attention_enabled
+        old_get_dp_local_slice_cpu = indexer_topk.get_dp_local_slice_cpu
+        try:
+            indexer_topk.is_dp_attention_enabled = lambda: True
+            indexer_topk.get_dp_local_slice_cpu = (
+                lambda forward_batch, can_run_graph, cuda_graph_batch: (4, 5)
+            )
+            capturer._capture_num_tokens = 3
+
+            output = capturer.on_forward_end(
+                forward_batch,
+                can_run_graph=False,
+                cuda_graph_batch=None,
+                no_copy_to_cpu=True,
+            )
+
+            self.assertEqual(output.out_cache_loc.tolist(), [20, 21, 22])
+            self.assertTrue(
+                torch.equal(output.topk, capturer.device_cache.buffer[:3, :, :2])
+            )
+
+            output.finalize()
+            self.assertTrue(
+                torch.equal(
+                    capturer.host_cache.buffer[20:23],
+                    capturer.device_cache.buffer[:3, :, :2],
                 )
             )
         finally:


### PR DESCRIPTION
## Summary
Return `indexer_topk_num_layers` alongside `indexer_topk` in `/generate` metadata.

## Motivation
Consumers need the captured indexer-topk tensor shape to decode the raw int32 bytes. SGLang already returns the byte payload, but the layer count was not carried through the scheduler/detokenizer/tokenizer output path.

## Changes
- Add `indexer_topk_num_layers` to `BatchTokenIDOutput` and `BatchStrOutput`.
- Fill it from the captured tensor shape in the scheduler output path.
- Preserve it through detokenizer and multi-tokenizer splitting.
- Emit it in `meta_info` when `indexer_topk` is returned.
- Update the existing indexer-topk e2e test to use and assert the response field.

## Verification
- `python -m compileall -q python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/scheduler_output_processor_mixin.py python/sglang/srt/managers/detokenizer_manager.py python/sglang/srt/managers/multi_tokenizer_mixin.py python/sglang/srt/managers/tokenizer_manager.py test/registered/8-gpu-models/test_return_indexer_topk.py`
- Local dataclass split check for `BatchTokenIDOutput` and `BatchStrOutput` preserving `indexer_topk_num_layers` through `_handle_output_by_index`.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->