### PR TITLE
docs: add DeepSeek-V4 EPLB Waterfill tips

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -115,12 +115,12 @@ The generator currently picks values on the **conservative** side (mirroring an 
 - `max-throughput`: MTP disabled — at saturation the verify step costs more than it saves.
 - MTP currently requires `SGLANG_ENABLE_SPEC_V2=1`.
 
-**EPLB + DeepEP Waterfill**
+**EPLB + DeepEP Waterfill (Experimental)**
 
 For recorded/static EPLB reproduction, first record an expert-distribution file by following
-[Capture expert selection distribution in MoE models](/docs/basic_usage/native_api#capture-expert-selection-distribution-in-moe-models).
+[Capture expert selection distribution in MoE models](../../../docs/basic_usage/native_api#capture-expert-selection-distribution-in-moe-models).
 For reproduction runs, use the generated `expert_distribution_recorder_*.pt` as
-the initial expert location.
+the initial expert location. **Please checkout to latest main branch for this feature.**
 
 For non-PD reproduction, use:
 
@@ -151,6 +151,10 @@ flag to both commands:
 
 You can also add `--ep-num-redundant-experts` and `--eplb-algorithm` to customize
 EPLB placement.
+
+MegaMoE is not supported with this DeepEP Waterfill recipe yet. Waterfill routes
+the shared expert through DeepEP for load balancing, so `--enable-deepep-waterfill`
+requires `--moe-a2a-backend deepep`.
 
 <a id="hopper-note" />
 

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -115,6 +115,43 @@ The generator currently picks values on the **conservative** side (mirroring an 
 - `max-throughput`: MTP disabled — at saturation the verify step costs more than it saves.
 - MTP currently requires `SGLANG_ENABLE_SPEC_V2=1`.
 
+**EPLB + DeepEP Waterfill**
+
+For recorded/static EPLB reproduction, first record an expert-distribution file by following
+[Capture expert selection distribution in MoE models](/docs/basic_usage/native_api#capture-expert-selection-distribution-in-moe-models).
+For reproduction runs, use the generated `expert_distribution_recorder_*.pt` as
+the initial expert location.
+
+For non-PD reproduction, use:
+
+```bash Command
+--moe-a2a-backend deepep \
+--deepep-mode auto \
+--init-expert-location /path/to/expert_distribution_recorder_*.pt \
+--enable-deepep-waterfill
+```
+
+For PD-Disagg reproduction, use `normal` mode on the prefill server and
+`low_latency` mode on the decode server. Add the same `--init-expert-location`
+flag to both commands:
+
+```bash Command
+# prefill
+--moe-a2a-backend deepep \
+--deepep-mode normal \
+--init-expert-location /path/to/expert_distribution_recorder_*.pt \
+--enable-deepep-waterfill
+
+# decode
+--moe-a2a-backend deepep \
+--deepep-mode low_latency \
+--init-expert-location /path/to/expert_distribution_recorder_*.pt \
+--enable-deepep-waterfill
+```
+
+You can also add `--ep-num-redundant-experts` and `--eplb-algorithm` to customize
+EPLB placement.
+
 <a id="hopper-note" />
 
 **Hopper (H200) note**

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -118,7 +118,7 @@ The generator currently picks values on the **conservative** side (mirroring an 
 **EPLB + DeepEP Waterfill (Experimental)**
 
 For recorded/static EPLB reproduction, first record an expert-distribution file by following
-[Capture expert selection distribution in MoE models](../../../docs/basic_usage/native_api#capture-expert-selection-distribution-in-moe-models).
+[Capture expert selection distribution in MoE models](../../../docs/basic_usage/native_api.mdx#capture-expert-selection-distribution-in-moe-models).
 For reproduction runs, use the generated `expert_distribution_recorder_*.pt` as
 the initial expert location. **Please checkout to latest main branch for this feature.**
 


### PR DESCRIPTION
## Summary
- add DeepSeek-V4 configuration tips for online EPLB with DeepEP Waterfill
- document the reproduction-style flow using a recorded EPLB expert-distribution .pt file plus --enable-deepep-waterfill
- note DeepEP mode and MegaMoE compatibility constraints

## Checks
- git diff --check
- pre-commit hooks from git commit







































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26857986793](https://github.com/sgl-project/sglang/actions/runs/26857986793)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26857986674](https://github.com/sgl-project/sglang/actions/runs/26857986674)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->