### PR TITLE
[diffusion] CI: ad lingbot case

### DIFF
--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -56,23 +56,6 @@ from sglang.multimodal_gen.test.test_utils import (
 _CACHE_DIT_CONFIG_DIR = Path(__file__).parent / "configs"
 
 
-def _make_lingbot_realtime_plastic_beach_case() -> DiffusionTestCase:
-    return DiffusionTestCase(
-        "lingbot_world_realtime_plastic_beach",
-        DiffusionServerArgs(
-            model_path="robbyant/lingbot-world-fast-diffusers",
-            modality="video",
-            num_gpus=1,
-            extras=["--pipeline-class-name LingBotWorldCausalDMDPipeline"],
-            text_encoder_cpu_offload=True,
-        ),
-        LINGBOT_WORLD_REALTIME_sampling_params,
-        run_component_accuracy_check=False,
-        run_models_api_check=False,
-        run_t2v_input_reference_check=False,
-    )
-
-
 # All test cases with clean default values
 # To test different models, simply add more DiffusionCase entries
 ONE_GPU_CASES: list[DiffusionTestCase] = [
@@ -414,6 +397,20 @@ ONE_GPU_CASES: list[DiffusionTestCase] = [
             },
         ),
         run_component_accuracy_check=False,
+    ),
+    DiffusionTestCase(
+        "lingbot_world_realtime_plastic_beach",
+        DiffusionServerArgs(
+            model_path="robbyant/lingbot-world-fast-diffusers",
+            modality="video",
+            num_gpus=1,
+            extras=["--pipeline-class-name LingBotWorldCausalDMDPipeline"],
+            text_encoder_cpu_offload=True,
+        ),
+        LINGBOT_WORLD_REALTIME_sampling_params,
+        run_component_accuracy_check=False,
+        run_models_api_check=False,
+        run_t2v_input_reference_check=False,
     ),
 ]
 
@@ -761,8 +758,6 @@ if not current_platform.is_hip():
             MULTI_IMAGE_TI2I_UPLOAD_sampling_params,
         )
     )
-
-ONE_GPU_CASES.append(_make_lingbot_realtime_plastic_beach_case())
 
 ONE_GPU_CASES += ONE_GPU_MODELOPT_FP8_CASES
 TWO_GPU_CASES = _with_default_num_gpus(TWO_GPU_CASES, 2)

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "4a62a21f0f8bcc54c3bc6de5dbf25515bcb92b7e"
+SGL_TEST_FILES_CI_DATA_REVISION = "8dbe6bc44cda46065fde2168a3d10fd792e2b289"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"


### PR DESCRIPTION
## Summary
- inline the LingBot realtime Plastic Beach case in `ONE_GPU_CASES`
- remove the one-off factory/append registration so the AST-based diffusion partition parser sees the case directly

## Test
- not run locally

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26819093321](https://github.com/sgl-project/sglang/actions/runs/26819093321)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26819092713](https://github.com/sgl-project/sglang/actions/runs/26819092713)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->