### PR TITLE
feat(hicache): Use NIXL path-mode

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
@@ -51,6 +51,16 @@ class NixlRegistry:
         # from a single monotonic counter.
         self._obj_devid_lock = threading.Lock()
         self._obj_devid_next = 1
+        self.path_mode = mem_type == "FILE" and self._probe_path_mode()
+        if mem_type == "FILE" and self.path_mode:
+            logger.info("HiCacheNixl: path-mode FILE registration active.")
+        elif mem_type == "FILE":
+            # TODO: NIXL 1.3.0 adds path-mode support; remove this fd fallback once 1.3.0 is widely installed.
+            logger.info(
+                "HiCacheNixl: the installed NIXL build does not "
+                "support path-mode FILE registration; using legacy "
+                "fd registration."
+            )
 
     @contextmanager
     def _open_files(self, paths: List[str], create: bool):
@@ -95,6 +105,31 @@ class NixlRegistry:
                 except Exception as e:
                     logger.debug("deregister_memory skipped: %s", e)
 
+    def _probe_path_mode(self) -> bool:
+        """Probe whether NIXL honours path-mode metaInfo.
+
+        Register a FILE_SEG with a valid path-mode string pointing at a
+        nonexistent path (no 'create' flag). A path-mode-capable NIXL tries
+        to open() the path, fails with NIXL_ERR_BACKEND, and raises. A
+        pre-path-mode NIXL ignores metaInfo and returns NIXL_SUCCESS.
+        Error from register_memory => path mode supported.
+        """
+        reg_descs = self.agent.get_reg_descs(
+            [(0, 4096, 1, "rw:/nonexistent-nixl-probe")], "FILE"
+        )
+        if reg_descs is None:
+            return False
+        try:
+            reg = self.agent.register_memory(reg_descs)
+            if reg is not None:
+                try:
+                    self.agent.deregister_memory(reg)
+                except Exception:
+                    pass
+            return False
+        except Exception:
+            return True
+
     @contextmanager
     def storage(self, buffers, keys, direction):
         """Open + register the storage side; deregister and close fds on exit.
@@ -108,18 +143,32 @@ class NixlRegistry:
             return
 
         if self.mem_type == "FILE":
-            with self._open_files(keys, create=(direction == "WRITE")) as fds:
-                if fds is None:
-                    yield None
-                    return
-                tuples = [(0, sizes[i], fds[i], keys[i]) for i in range(len(keys))]
+            if self.path_mode:
+                parts = ["rw", "create"] if direction == "WRITE" else ["ro"]
+                if self.file_manager.use_direct_io:
+                    parts.append("direct")
+                spec = ",".join(parts)
+                tuples = [
+                    (0, sizes[i], i + 1, f"{spec}:{keys[i]}") for i in range(len(keys))
+                ]
                 with self._registered(tuples, "FILE") as reg:
                     if reg is None:
                         yield None
                         return
-                    yield self.agent.get_xfer_descs(
-                        [(0, sizes[i], fds[i]) for i in range(len(fds))], "FILE"
-                    )
+                    yield reg.trim()
+            else:
+                with self._open_files(keys, create=(direction == "WRITE")) as fds:
+                    if fds is None:
+                        yield None
+                        return
+                    tuples = [(0, sizes[i], fds[i], keys[i]) for i in range(len(keys))]
+                    with self._registered(tuples, "FILE") as reg:
+                        if reg is None:
+                            yield None
+                            return
+                        yield self.agent.get_xfer_descs(
+                            [(0, sizes[i], fds[i]) for i in range(len(fds))], "FILE"
+                        )
         else:  # OBJ
             # Reg tuple: (addr=0, size, devId, metaInfo=key).
             # Xfer tuple: (addr=0, size, devId). devId links each xfer desc

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
@@ -3,7 +3,11 @@ import os
 from typing import Optional
 
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.storage.nixl.nixl_routing import route_key
+from sglang.srt.mem_cache.storage.nixl.nixl_routing import (
+    _BUCKET_MASK,
+    BUCKET_HEX_CHARS,
+    route_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +228,7 @@ class NixlFileManager:
         else:
             for base in self.base_dirs:
                 os.makedirs(base, exist_ok=True)
+            self.ensure_all_bucket_dirs()
             logger.debug(
                 f"Initialized file manager with base directories: {self.base_dirs}. Direct I/O: {use_direct_io}"
             )
@@ -246,6 +251,19 @@ class NixlFileManager:
             except Exception as e:
                 logger.error(f"Failed to clear base directory {base}: {e}")
         logger.debug(f"Cleared all files in base directories: {self.base_dirs}")
+
+    def ensure_all_bucket_dirs(self) -> None:
+        """Pre-create every possible bucket directory under each base dir.
+
+        Called once when path mode is active so NIXL O_CREAT writes never
+        fail due to a missing parent directory.
+        """
+        for base in self.base_dirs:
+            for i in range(_BUCKET_MASK + 1):
+                os.makedirs(
+                    os.path.join(base, f"{i:0{BUCKET_HEX_CHARS}x}"),
+                    exist_ok=True,
+                )
 
     def iter_all_base_dirs(self) -> list[str]:
         """Return base directories that may contain NIXL FILE cache entries."""

--- a/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
@@ -382,17 +382,36 @@ class TestNixlUnified(CustomTestCase):
                 num_pages * mock_host.page_size, dtype=torch.int64
             )
 
+            # Distinct data per key so a round trip that mixes keys up (e.g. a
+            # FILE registration that collapses every desc onto one file) is
+            # caught, not just the pass/fail return codes. Non-zero-copy only:
+            # the layer_first layout makes per-page seeding straightforward.
+            if not is_zero_copy_mode:
+                ps = mock_host.page_size
+                for p in range(num_pages):
+                    mock_host.kv_buffer[:, :, p * ps : (p + 1) * ps] = float(p + 1)
+                expected = mock_host.kv_buffer.clone()
+
             set_results = hicache.batch_set_v1(keys, host_indices)
             self.assertTrue(
                 all(set_results),
                 f"batch_set_v1 failed (zero_copy={is_zero_copy_mode}): {set_results}",
             )
 
+            if not is_zero_copy_mode:
+                mock_host.kv_buffer.zero_()
+
             get_results = hicache.batch_get_v1(keys, host_indices)
             self.assertTrue(
                 all(get_results),
                 f"batch_get_v1 failed (zero_copy={is_zero_copy_mode}): {get_results}",
             )
+
+            if not is_zero_copy_mode:
+                self.assertTrue(
+                    torch.equal(mock_host.kv_buffer, expected),
+                    "round trip corrupted or mixed up per-key data",
+                )
         finally:
             agent.get_reg_descs = orig_get_reg
             agent.register_memory = orig_register


### PR DESCRIPTION
## Motivation

The worker process spends a lot of time holding the GIL, thus every `file.open()` called from python introduces a delay because of the GIL lock re-acquire. NIXL can now use the path-mode ( https://github.com/ai-dynamo/nixl/pull/1635 , available since NIXL release 1.3.0 ), which batch-opens the files in the native code side of NIXL and ammortizes the re-acquire over the whole batch of files.

## Modifications

HiCache NIXL detects the feature and if present, uses it to read and write cache files.

## Accuracy Tests

No changes

## Speed Tests and Profiling

Benchmarked on 8xA100 (tp=1 I/O-dominant / tp=4 realistic compute), Qwen-32B, ctx=31768 tokens, SGLANG_HICACHE_NIXL_USE_DIRECT_IO=1. "Warm TTFT" = KV-cache flushed, OS page cache cold for the KV store, L2 host cache warm. Reported as median over 4 warm rounds.

<img width="1080" height="600" alt="image" src="https://github.com/user-attachments/assets/5ac5e2de-5701-4e28-9ff6-1fd1c6bc8247" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [N/A] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). 
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28499135960](https://github.com/sgl-project/sglang/actions/runs/28499135960)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28499135799](https://github.com/sgl-project/sglang/actions/runs/28499135799)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->