### PR TITLE
Fix stale import after kl_nightly rename

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 import unittest
 
-from test_unified_radix_cache_kl_hicache_nightly import AccuracyTwoPassMixin
+from test_unified_radix_cache_kl_nightly import AccuracyTwoPassMixin
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci


### PR DESCRIPTION
PR #26927 renamed `test_unified_radix_cache_kl_hicache_nightly.py` → `test_unified_radix_cache_kl_nightly.py` but missed updating `test_unified_radix_cache_kl_mamba.py:6`, breaking nightly CI on `test_unified_radix_cache_kl_mamba.py` (ModuleNotFoundError). One-line fix.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26822173356](https://github.com/sgl-project/sglang/actions/runs/26822173356)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26822172477](https://github.com/sgl-project/sglang/actions/runs/26822172477)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->