### PR TITLE
[router] Configure experimental sgl-router via CLI flags instead of a config file

### DIFF
--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -37,10 +37,6 @@ reqwest = { version = "0.12", features = ["stream", "json", "rustls-tls"], defau
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-# `humantime-serde` lets `WorkerConfig.request_timeout` accept human-readable
-# durations like `"60s"` / `"500ms"` / `"2m"` in YAML / TOML, rather than
-# forcing operators to write raw milliseconds.
-humantime-serde = "1"
 
 # Utilities
 anyhow = "1"
@@ -53,8 +49,6 @@ bytes = "1"
 rand = "0.8"
 tokio-stream = "0.1"
 dashmap = "6"
-serde_yaml = "0.9"
-toml = "0.8"
 kube = { version = "0.96", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.23", features = ["v1_31"] }
 tokio-util = "0.7"

--- a/experimental/sgl-router/README.md
+++ b/experimental/sgl-router/README.md
@@ -2,11 +2,11 @@
 
 Slim, KV-aware, OpenAI-compatible router for SGLang workers.
 
-**Status:** functional single-worker HTTP proxy. Exposes `/v1/tokenize`,
-`/v1/detokenize`, `/v1/models`, `/v1/chat/completions` (buffered and SSE),
-plus `/healthz` / `/readyz`. Forwards to one configured worker via reqwest;
-parity-tested against `transformers.AutoTokenizer`. Multi-worker routing,
-service discovery, and observability still pending.
+Serves a single model and routes across its workers. Exposes
+`/v1/tokenize`, `/v1/detokenize`, `/v1/models`, `/v1/chat/completions`
+(buffered and SSE), plus `/healthz` / `/readyz` and `/metrics`. Worker
+pools come from either a static URL list or Kubernetes EndpointSlice
+discovery.
 
 ## Building
 
@@ -14,6 +14,39 @@ service discovery, and observability still pending.
 cd experimental/sgl-router
 cargo build --release
 ```
+
+## Running
+
+The router is configured entirely through CLI flags (run
+`sgl-router --help` for the full list). It serves exactly one model, so
+`--model-id` and `--tokenizer-path` are required, along with exactly one
+discovery backend.
+
+Static worker list:
+
+```bash
+sgl-router \
+  --host 0.0.0.0 --port 30000 \
+  --model-id qwen3 \
+  --tokenizer-path /models/qwen3/tokenizer.json \
+  --worker-urls http://10.0.0.1:30000 http://10.0.0.2:30000
+```
+
+Kubernetes EndpointSlice discovery:
+
+```bash
+sgl-router \
+  --host 0.0.0.0 --port 30000 \
+  --model-id qwen3 \
+  --tokenizer-path /models/qwen3/tokenizer.json \
+  --service-discovery \
+  --service-discovery-namespace prod \
+  --selector app=engines-qwen3
+```
+
+Omit `--service-discovery-namespace` to watch all namespaces (requires
+cluster-wide RBAC). For prefill/decode disaggregation, replace `--selector`
+with `--prefill-selector` and `--decode-selector`.
 
 ## License
 

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -1,0 +1,678 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Command-line interface. The router is configured entirely through
+//! flags — there is no config file. [`Cli::into_config`] resolves the
+//! flags into a validated [`Config`].
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use std::num::NonZeroU32;
+
+use crate::config::{
+    default_cb_cool_down, default_proxy_request_timeout_secs, default_stale_request_timeout_secs,
+    resolve_mode, ActiveLoadConfig, CacheAwareConfig, CircuitBreakerConfig, Config,
+    DiscoveryBackend, K8sDiscoveryConfig, LogFormat, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+};
+
+/// `sgl-router` — slim KV-aware OpenAI-compatible router for SGLang workers.
+///
+/// Discovery is mutually exclusive: pass `--worker-urls` for a static
+/// worker list, or `--service-discovery` for Kubernetes EndpointSlice
+/// discovery — exactly one is required.
+#[derive(Parser, Debug)]
+#[command(
+    name = "sgl-router",
+    version,
+    about = "Slim KV-aware OpenAI-compatible router for SGLang workers"
+)]
+pub struct Cli {
+    // ---- server ----
+    /// Address to bind the HTTP server to.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+    /// Port to bind the HTTP server to.
+    #[arg(long, default_value_t = 30000)]
+    pub port: u16,
+
+    // ---- model (exactly one) ----
+    /// Model id this router serves (the OpenAI `model` field).
+    #[arg(long)]
+    pub model_id: String,
+    /// Filesystem path to the model's `tokenizer.json`.
+    #[arg(long)]
+    pub tokenizer_path: String,
+    /// Routing policy.
+    #[arg(long, value_enum, default_value = "round_robin")]
+    pub policy: PolicyKind,
+
+    // ---- circuit breaker (opt-in via --cb-threshold) ----
+    /// Consecutive upstream failures before the circuit breaker opens.
+    /// Setting this enables the circuit breaker; `0` is rejected.
+    #[arg(long)]
+    pub cb_threshold: Option<NonZeroU32>,
+    /// Circuit-breaker cool-down in seconds. Only meaningful with
+    /// `--cb-threshold`; defaults to 30 when the breaker is enabled.
+    #[arg(long)]
+    pub cb_cool_down_secs: Option<u64>,
+
+    // ---- cache-aware-zmq tuning (only used by that policy) ----
+    /// Min `matched_blocks / total_blocks` for a cache match to win.
+    #[arg(long)]
+    pub cache_threshold: Option<f32>,
+    /// Absolute load spread above which the cache check is skipped.
+    #[arg(long)]
+    pub balance_abs_threshold: Option<usize>,
+    /// Multiplicative load spread gating the absolute balance check.
+    #[arg(long)]
+    pub balance_rel_threshold: Option<f32>,
+
+    // ---- discovery: static ----
+    /// Static worker URLs (space-separated or repeated). Mutually
+    /// exclusive with `--service-discovery`.
+    #[arg(long, num_args = 1..)]
+    pub worker_urls: Vec<String>,
+
+    // ---- discovery: kubernetes ----
+    /// Enable Kubernetes EndpointSlice discovery.
+    #[arg(long)]
+    pub service_discovery: bool,
+    /// Namespace to watch. Unset/empty watches all namespaces (requires
+    /// cluster-wide RBAC).
+    #[arg(long)]
+    pub service_discovery_namespace: Option<String>,
+    /// Plain-mode label selector terms, e.g. `app=engines-qwen3`
+    /// (space-separated or repeated `key=value`, AND-joined). Mutually
+    /// exclusive with the prefill/decode selectors.
+    #[arg(long, num_args = 1..)]
+    pub selector: Vec<String>,
+    /// PD-mode prefill label selector terms. Requires `--decode-selector`.
+    #[arg(long, num_args = 1..)]
+    pub prefill_selector: Vec<String>,
+    /// PD-mode decode label selector terms. Requires `--prefill-selector`.
+    #[arg(long, num_args = 1..)]
+    pub decode_selector: Vec<String>,
+
+    // ---- proxy / active-load ----
+    /// Per-request upstream timeout in seconds.
+    #[arg(long, default_value_t = default_proxy_request_timeout_secs())]
+    pub request_timeout_secs: u64,
+    /// Max lifetime of an in-flight request entry before the janitor
+    /// reaps it (returns 504 `stale_request_expired`).
+    #[arg(long, default_value_t = default_stale_request_timeout_secs())]
+    pub stale_request_timeout_secs: u64,
+
+    // ---- observability ----
+    /// Default tracing level (overridden by `RUST_LOG`).
+    #[arg(long, default_value = "info")]
+    pub log_level: String,
+    /// Log output format.
+    #[arg(long, value_enum, default_value = "text")]
+    pub log_format: LogFormat,
+}
+
+impl Cli {
+    /// Resolve parsed flags into a validated [`Config`].
+    ///
+    /// Builds the [`DiscoveryBackend`] (enforcing static-vs-k8s mutual
+    /// exclusivity and resolving the k8s selector grammar via
+    /// [`resolve_mode`]), assembles the single [`ModelConfig`], then runs
+    /// [`Config::validate`] for the remaining value-level invariants
+    /// (model id, static worker URLs).
+    pub fn into_config(self) -> Result<Config> {
+        let discovery = self.build_discovery()?;
+
+        // Reject knobs that only take effect alongside another flag, rather
+        // than silently dropping them — mirrors the discovery mutual-exclusion
+        // checks. Otherwise an operator believes they tuned something that has
+        // no effect.
+        if self.cb_cool_down_secs.is_some() && self.cb_threshold.is_none() {
+            return Err(anyhow!(
+                "--cb-cool-down-secs requires --cb-threshold (the circuit breaker is \
+                 enabled by --cb-threshold)"
+            ));
+        }
+        let tuned_cache_aware = self.cache_threshold.is_some()
+            || self.balance_abs_threshold.is_some()
+            || self.balance_rel_threshold.is_some();
+        if tuned_cache_aware && self.policy != PolicyKind::CacheAwareZmq {
+            return Err(anyhow!(
+                "--cache-threshold / --balance-abs-threshold / --balance-rel-threshold \
+                 require --policy cache_aware_zmq"
+            ));
+        }
+
+        let circuit_breaker = self.cb_threshold.map(|threshold| CircuitBreakerConfig {
+            threshold,
+            cool_down_secs: self.cb_cool_down_secs.unwrap_or_else(default_cb_cool_down),
+        });
+
+        // Only build a CacheAwareConfig when the operator tuned at least
+        // one knob; otherwise leave it None so the policy uses its own
+        // defaults. Unset knobs fall back to the per-field defaults.
+        let cache_aware = if tuned_cache_aware {
+            let d = CacheAwareConfig::default();
+            Some(CacheAwareConfig {
+                cache_threshold: self.cache_threshold.unwrap_or(d.cache_threshold),
+                balance_abs_threshold: self
+                    .balance_abs_threshold
+                    .unwrap_or(d.balance_abs_threshold),
+                balance_rel_threshold: self
+                    .balance_rel_threshold
+                    .unwrap_or(d.balance_rel_threshold),
+            })
+        } else {
+            None
+        };
+
+        let config = Config {
+            server: ServerConfig {
+                host: self.host,
+                port: self.port,
+            },
+            observability: ObservabilityConfig {
+                log_level: self.log_level,
+                log_format: self.log_format,
+            },
+            model: ModelConfig {
+                id: self.model_id,
+                tokenizer_path: self.tokenizer_path,
+                policy: self.policy,
+                circuit_breaker,
+                cache_aware,
+            },
+            discovery,
+            proxy: ProxyConfig {
+                request_timeout_secs: self.request_timeout_secs,
+            },
+            active_load: ActiveLoadConfig {
+                stale_request_timeout_secs: self.stale_request_timeout_secs,
+            },
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Resolve the discovery flags into a [`DiscoveryBackend`].
+    ///
+    /// `--worker-urls` (static) and `--service-discovery` (k8s) are
+    /// mutually exclusive and exactly one is required. K8s-only flags
+    /// passed without `--service-discovery` are rejected so a typo can't
+    /// silently fall back to the static (empty) path. The k8s selector
+    /// grammar (plain vs PD) is validated eagerly here by [`resolve_mode`]
+    /// before the `K8sDiscoveryConfig` is constructed, so an invalid
+    /// combination is never stored.
+    fn build_discovery(&self) -> Result<DiscoveryBackend> {
+        let has_static = !self.worker_urls.is_empty();
+        let backend = match (has_static, self.service_discovery) {
+            (true, true) => {
+                return Err(anyhow!(
+                    "--worker-urls and --service-discovery are mutually exclusive; pass exactly one"
+                ))
+            }
+            (false, false) => {
+                return Err(anyhow!(
+                    "no discovery backend selected; pass --worker-urls <URL...> (static) \
+                     or --service-discovery (kubernetes)"
+                ))
+            }
+            (true, false) => {
+                if self.service_discovery_namespace.is_some()
+                    || !self.selector.is_empty()
+                    || !self.prefill_selector.is_empty()
+                    || !self.decode_selector.is_empty()
+                {
+                    return Err(anyhow!(
+                        "--service-discovery-namespace / --selector / --prefill-selector / \
+                         --decode-selector require --service-discovery"
+                    ));
+                }
+                DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+                    urls: self.worker_urls.clone(),
+                })
+            }
+            (false, true) => {
+                // Resolve (and validate) the selector flags into a
+                // K8sDiscoveryMode here, so an invalid combination can't be
+                // stored. Surfaces ConfigError as anyhow for the CLI.
+                let mode = resolve_mode(
+                    join_selector(&self.selector).as_deref(),
+                    join_selector(&self.prefill_selector).as_deref(),
+                    join_selector(&self.decode_selector).as_deref(),
+                )
+                .map_err(|e| anyhow!("{e}"))?;
+                DiscoveryBackend::K8s(K8sDiscoveryConfig {
+                    namespace: self.service_discovery_namespace.clone().unwrap_or_default(),
+                    mode,
+                })
+            }
+        };
+        Ok(backend)
+    }
+}
+
+/// Join space/repeated `key=value` selector terms into the single
+/// comma-joined string the k8s backend's `labels_match_selector`
+/// expects. `None` for an empty term list so [`resolve_mode`] can apply
+/// its plain-vs-PD rules (and surface `NoSelector`).
+fn join_selector(terms: &[String]) -> Option<String> {
+    if terms.is_empty() {
+        None
+    } else {
+        Some(terms.join(","))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DiscoveryBackend, K8sDiscoveryMode};
+
+    /// Parse argv (without the leading binary name) into a `Config`.
+    fn into_config(args: &[&str]) -> Result<Config> {
+        let argv = std::iter::once("sgl-router").chain(args.iter().copied());
+        let cli = Cli::try_parse_from(argv).map_err(|e| anyhow!("{e}"))?;
+        cli.into_config()
+    }
+
+    const MODEL_ARGS: &[&str] = &[
+        "--model-id",
+        "qwen3-0.6b",
+        "--tokenizer-path",
+        "/tmp/qwen.json",
+    ];
+
+    fn with_model(extra: &[&str]) -> Vec<String> {
+        MODEL_ARGS
+            .iter()
+            .chain(extra.iter())
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn into_config_owned(args: Vec<String>) -> Result<Config> {
+        let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        into_config(&refs)
+    }
+
+    #[test]
+    fn defaults_host_port_and_policy() {
+        let c = into_config_owned(with_model(&["--worker-urls", "http://10.0.0.1:30000"])).unwrap();
+        assert_eq!(c.server.host, "127.0.0.1");
+        assert_eq!(c.server.port, 30000);
+        assert_eq!(c.model.policy, PolicyKind::RoundRobin);
+        assert_eq!(c.model.id, "qwen3-0.6b");
+        assert_eq!(c.proxy.request_timeout_secs, 300);
+        assert_eq!(c.active_load.stale_request_timeout_secs, 600);
+    }
+
+    #[test]
+    fn static_urls_backend() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://10.0.0.1:30000",
+            "http://10.0.0.2:30000",
+        ]))
+        .unwrap();
+        match &c.discovery {
+            DiscoveryBackend::StaticUrls(s) => assert_eq!(
+                s.urls,
+                vec![
+                    "http://10.0.0.1:30000".to_string(),
+                    "http://10.0.0.2:30000".to_string()
+                ]
+            ),
+            _ => panic!("expected static_urls backend"),
+        }
+    }
+
+    #[test]
+    fn rejects_no_discovery_backend() {
+        let err = into_config_owned(with_model(&[])).unwrap_err().to_string();
+        assert!(err.contains("no discovery backend"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_both_discovery_backends() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--service-discovery",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("mutually exclusive"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_k8s_flags_without_service_discovery() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--selector",
+            "app=sglang",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("require --service-discovery"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_static_urls_duplicate() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "http://x:30000",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_static_urls_schemeless() {
+        let err = into_config_owned(with_model(&["--worker-urls", "10.0.0.1:30000"]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("not a valid URL") || err.contains("unsupported scheme"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_static_urls_non_http_scheme() {
+        let err = into_config_owned(with_model(&["--worker-urls", "ws://x:30000"]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unsupported scheme"), "got: {err}");
+    }
+
+    #[test]
+    fn k8s_plain_backend() {
+        let c = into_config_owned(with_model(&[
+            "--service-discovery",
+            "--service-discovery-namespace",
+            "prod",
+            "--selector",
+            "app=engines-qwen3",
+        ]))
+        .unwrap();
+        match &c.discovery {
+            DiscoveryBackend::K8s(k) => {
+                assert_eq!(k.namespace, "prod");
+                assert_eq!(
+                    k.mode,
+                    K8sDiscoveryMode::Plain {
+                        label_selector: "app=engines-qwen3".to_string()
+                    }
+                );
+            }
+            _ => panic!("expected k8s backend"),
+        }
+    }
+
+    /// Multiple `--selector` terms AND-join into one comma-separated
+    /// label selector (matches the Python router's space-separated form).
+    #[test]
+    fn k8s_plain_selector_joins_multiple_terms() {
+        let c = into_config_owned(with_model(&[
+            "--service-discovery",
+            "--selector",
+            "app=sglang",
+            "zone=us-east",
+        ]))
+        .unwrap();
+        match &c.discovery {
+            DiscoveryBackend::K8s(k) => assert_eq!(
+                k.mode,
+                K8sDiscoveryMode::Plain {
+                    label_selector: "app=sglang,zone=us-east".to_string()
+                }
+            ),
+            _ => panic!("expected k8s backend"),
+        }
+    }
+
+    /// Empty namespace is intentional — it triggers a cluster-wide watch.
+    #[test]
+    fn k8s_empty_namespace_watches_all() {
+        let c = into_config_owned(with_model(&[
+            "--service-discovery",
+            "--selector",
+            "app=sglang",
+        ]))
+        .unwrap();
+        match &c.discovery {
+            DiscoveryBackend::K8s(k) => assert_eq!(k.namespace, ""),
+            _ => panic!("expected k8s backend"),
+        }
+    }
+
+    #[test]
+    fn k8s_pd_backend() {
+        let c = into_config_owned(with_model(&[
+            "--service-discovery",
+            "--service-discovery-namespace",
+            "default",
+            "--prefill-selector",
+            "app=sglang,role=prefill",
+            "--decode-selector",
+            "app=sglang,role=decode",
+        ]))
+        .unwrap();
+        match &c.discovery {
+            DiscoveryBackend::K8s(k) => assert_eq!(
+                k.mode,
+                K8sDiscoveryMode::PdDisaggregation {
+                    prefill_selector: "app=sglang,role=prefill".to_string(),
+                    decode_selector: "app=sglang,role=decode".to_string(),
+                }
+            ),
+            _ => panic!("expected k8s backend"),
+        }
+    }
+
+    /// `--service-discovery` with no selector at all fails `resolve_mode`
+    /// validation with the `NoSelector` wording.
+    #[test]
+    fn rejects_k8s_without_selector() {
+        let err = into_config_owned(with_model(&["--service-discovery"]))
+            .unwrap_err()
+            .to_string()
+            .to_lowercase();
+        assert!(err.contains("none were set"), "got: {err}");
+    }
+
+    /// `--prefill-selector` without `--decode-selector` is rejected through
+    /// the full CLI path — pins that `build_discovery` feeds the right
+    /// selectors into `resolve_mode` (a positional mix-up would surface a
+    /// different error or none).
+    #[test]
+    fn rejects_k8s_partial_pd_selectors() {
+        let err = into_config_owned(with_model(&[
+            "--service-discovery",
+            "--prefill-selector",
+            "app=sglang,role=prefill",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("PD mode requires BOTH"),
+            "expected PartialPdSelectors wording, got: {err}"
+        );
+    }
+
+    /// Identical prefill/decode selectors are rejected through the full CLI
+    /// path (would silently leave the decode pool empty at runtime).
+    #[test]
+    fn rejects_k8s_identical_pd_selectors() {
+        let err = into_config_owned(with_model(&[
+            "--service-discovery",
+            "--prefill-selector",
+            "app=sglang",
+            "--decode-selector",
+            "app=sglang",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("must differ"),
+            "expected IdenticalPdSelectors wording, got: {err}"
+        );
+    }
+
+    /// clap rejects an unknown `--policy` value at parse time.
+    #[test]
+    fn rejects_unknown_policy() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--policy",
+            "bogus_policy",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("bogus_policy") || err.contains("policy"),
+            "got: {err}"
+        );
+    }
+
+    /// clap rejects `--cb-threshold 0` because the field is `NonZeroU32`.
+    #[test]
+    fn rejects_zero_cb_threshold() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--cb-threshold",
+            "0",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("cb-threshold"), "got: {err}");
+    }
+
+    #[test]
+    fn cb_threshold_enables_circuit_breaker_with_default_cool_down() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--cb-threshold",
+            "5",
+        ]))
+        .unwrap();
+        let cb = c.model.circuit_breaker.expect("cb enabled");
+        assert_eq!(cb.threshold.get(), 5);
+        assert_eq!(cb.cool_down_secs, 30);
+    }
+
+    #[test]
+    fn cb_cool_down_honors_explicit_override() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--cb-threshold",
+            "3",
+            "--cb-cool-down-secs",
+            "10",
+        ]))
+        .unwrap();
+        let cb = c.model.circuit_breaker.expect("cb enabled");
+        assert_eq!(cb.cool_down_secs, 10);
+    }
+
+    #[test]
+    fn rejects_cb_cool_down_without_threshold() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--cb-cool-down-secs",
+            "10",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("--cb-cool-down-secs requires --cb-threshold"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn cache_aware_knob_builds_partial_config() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--policy",
+            "cache_aware_zmq",
+            "--cache-threshold",
+            "0.7",
+        ]))
+        .unwrap();
+        let ca = c.model.cache_aware.expect("cache_aware set");
+        assert_eq!(ca.cache_threshold, 0.7);
+        // Untouched knobs fall back to defaults.
+        assert_eq!(ca.balance_abs_threshold, 32);
+    }
+
+    #[test]
+    fn no_cache_aware_flags_leaves_none() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--policy",
+            "cache_aware_zmq",
+        ]))
+        .unwrap();
+        assert!(c.model.cache_aware.is_none());
+    }
+
+    #[test]
+    fn rejects_cache_aware_knob_without_cache_aware_policy() {
+        // Default policy is round_robin, so a cache knob has no effect —
+        // reject rather than silently ignore it.
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--cache-threshold",
+            "0.7",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("require --policy cache_aware_zmq"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn log_format_parses_json() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--log-format",
+            "json",
+        ]))
+        .unwrap();
+        assert_eq!(c.observability.log_format, LogFormat::Json);
+    }
+
+    /// Pins that the two timeout overrides land in the right fields — they
+    /// are adjacent `u64`s with similar names, so a copy-paste swap would
+    /// otherwise go unnoticed (and `stale` must sit above `proxy`).
+    #[test]
+    fn timeout_overrides_land_in_distinct_fields() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--request-timeout-secs",
+            "120",
+            "--stale-request-timeout-secs",
+            "240",
+        ]))
+        .unwrap();
+        assert_eq!(c.proxy.request_timeout_secs, 120);
+        assert_eq!(c.active_load.stale_request_timeout_secs, 240);
+    }
+}

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -1,42 +1,21 @@
+pub mod cli;
 pub mod types;
+pub use cli::Cli;
 pub use types::*;
 
-use anyhow::Context as _;
 use anyhow::{anyhow, Result};
-use std::path::Path;
 
 impl Config {
-    pub fn from_path(p: &Path) -> Result<Self> {
-        let raw =
-            std::fs::read_to_string(p).with_context(|| format!("read config {}", p.display()))?;
-        let ext = p.extension().and_then(|s| s.to_str()).unwrap_or("");
-        let cfg: Config = match ext {
-            "yaml" | "yml" => serde_yaml::from_str(&raw)
-                .map_err(|e| anyhow!("parse yaml {}: {e}", p.display()))?,
-            "toml" => {
-                toml::from_str(&raw).map_err(|e| anyhow!("parse toml {}: {e}", p.display()))?
-            }
-            other => {
-                return Err(anyhow!(
-                    "unsupported config extension {other:?}; want yaml/yml/toml"
-                ))
-            }
-        };
-        cfg.validate()?;
-        Ok(cfg)
-    }
-
-    fn validate(&self) -> Result<()> {
-        // Unknown policy names are rejected by serde via `PolicyKind`'s
-        // `rename_all = "snake_case"`; threshold = 0 is rejected by
-        // `NonZeroU32`.  Only fields without a type-system constraint are
-        // checked here.
-        for m in &self.models {
-            if m.id.is_empty() {
-                return Err(anyhow!("model.id must be non-empty"));
-            }
+    /// Check invariants the type system and `clap` don't already enforce.
+    /// Called by [`cli::Cli::into_config`] after assembling the `Config`
+    /// from flags. Unknown policy names and `--cb-threshold 0` are
+    /// rejected at parse time (`ValueEnum` / `NonZeroU32`); only the
+    /// remaining value-level invariants are checked here.
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.model.id.is_empty() {
+            return Err(anyhow!("model id must be non-empty"));
         }
-        match &self.discovery.backend {
+        match &self.discovery {
             DiscoveryBackend::StaticUrls(s) => {
                 if s.urls.is_empty() {
                     return Err(anyhow!(
@@ -44,7 +23,7 @@ impl Config {
                     ));
                 }
                 // Validate every entry up front so typos surface at
-                // config-load with a precise diagnostic instead of as
+                // startup with a precise diagnostic instead of as
                 // per-worker introspect failures or as two registry
                 // entries pointing at the same SGLang (trailing-slash
                 // near-duplicates). Dedupe runs against a normalized
@@ -77,14 +56,11 @@ impl Config {
                     }
                 }
             }
-            DiscoveryBackend::K8s(k) => {
-                // Empty namespace is intentional: triggers `Api::all(client)`
-                // for cluster-wide EndpointSlice watch (see
-                // `discovery::k8s::spawn`). Only validate the selector
-                // combination here.
-                let _ = &k.namespace;
-                k.mode().map_err(|e| anyhow!("{e}"))?;
-            }
+            // K8s selector validity is resolved at construction time
+            // (`resolve_mode` in `Cli::build_discovery`), so the stored
+            // `K8sDiscoveryMode` is already valid here. Any namespace
+            // (including empty, for a cluster-wide watch) is accepted.
+            DiscoveryBackend::K8s(_) => {}
         }
         Ok(())
     }
@@ -94,447 +70,85 @@ impl Config {
 mod tests {
     use super::*;
 
-    /// Write `body` to a temp file with the given extension and load it
-    /// through `Config::from_path`. Failures still surface the offending
-    /// config because each call site passes its body inline.
-    fn load(ext: &str, body: &str) -> Result<Config> {
-        let dir = tempfile::tempdir().unwrap();
-        let p = dir.path().join(format!("c.{ext}"));
-        std::fs::write(&p, body).unwrap();
-        Config::from_path(&p)
-    }
-
-    #[test]
-    fn loads_minimal_yaml() {
-        let c = load(
-            "yaml",
-            r#"
-server:
-  host: "0.0.0.0"
-  port: 8090
-models:
-  - id: "qwen3-0.6b"
-    tokenizer_path: "/tmp/qwen.json"
-discovery:
-  backend: static_urls
-  static_urls:
-    urls:
-      - "http://10.0.0.1:30000"
-"#,
-        )
-        .unwrap();
-        assert_eq!(c.server.port, 8090);
-        assert_eq!(c.models[0].id, "qwen3-0.6b");
-        match &c.discovery.backend {
-            DiscoveryBackend::StaticUrls(s) => {
-                assert_eq!(s.urls, vec!["http://10.0.0.1:30000".to_string()])
-            }
-            _ => panic!("expected static_urls backend"),
+    /// Build a minimal valid-shape `Config` with the given static worker
+    /// URLs and model id, so the `validate()` branches can be exercised
+    /// directly. CLI parsing and the static-vs-k8s mapping are covered in
+    /// the `cli` module tests; the k8s selector grammar in `types`.
+    fn cfg(model_id: &str, urls: &[&str]) -> Config {
+        Config {
+            server: ServerConfig {
+                host: "127.0.0.1".into(),
+                port: 30000,
+            },
+            observability: ObservabilityConfig::default(),
+            model: ModelConfig {
+                id: model_id.into(),
+                tokenizer_path: "/tmp/tok.json".into(),
+                policy: PolicyKind::RoundRobin,
+                circuit_breaker: None,
+                cache_aware: None,
+            },
+            discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+                urls: urls.iter().map(|s| s.to_string()).collect(),
+            }),
+            proxy: ProxyConfig::default(),
+            active_load: ActiveLoadConfig::default(),
         }
     }
 
     #[test]
-    fn loads_minimal_toml() {
-        let c = load(
-            "toml",
-            r#"
-[server]
-host = "0.0.0.0"
-port = 8090
-[[models]]
-id = "qwen3-0.6b"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["http://10.0.0.1:30000"]
-"#,
-        )
-        .unwrap();
-        assert_eq!(c.server.port, 8090);
-        match &c.discovery.backend {
-            DiscoveryBackend::StaticUrls(s) => {
-                assert_eq!(s.urls, vec!["http://10.0.0.1:30000".to_string()])
-            }
-            _ => panic!("expected static_urls backend"),
-        }
+    fn accepts_minimal_static_config() {
+        cfg("qwen3", &["http://10.0.0.1:30000"]).validate().unwrap();
     }
 
     #[test]
-    fn rejects_missing_discovery_section() {
-        let err = load(
-            "yaml",
-            "server:\n  host: \"0.0.0.0\"\n  port: 8090\nmodels: []\n",
-        )
-        .unwrap_err();
-        let msg = err.to_string().to_lowercase();
-        assert!(
-            msg.contains("discovery") || msg.contains("missing"),
-            "got: {err}"
-        );
+    fn rejects_empty_model_id() {
+        let err = cfg("", &["http://10.0.0.1:30000"])
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("model id"), "got: {err}");
     }
 
     #[test]
-    fn rejects_unknown_extension() {
-        let err = load("txt", "").unwrap_err();
-        assert!(err.to_string().contains("yaml") && err.to_string().contains("toml"));
-    }
-
-    #[test]
-    fn loads_static_urls_discovery() {
-        let c = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "qwen3-0.6b"
-tokenizer_path = "/tmp/qwen.json"
-policy = "round_robin"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["http://10.0.0.1:30000", "http://10.0.0.2:30000"]
-"#,
-        )
-        .unwrap();
-        match &c.discovery.backend {
-            DiscoveryBackend::StaticUrls(s) => {
-                assert_eq!(
-                    s.urls,
-                    vec![
-                        "http://10.0.0.1:30000".to_string(),
-                        "http://10.0.0.2:30000".to_string(),
-                    ],
-                );
-            }
-            _ => panic!("expected static_urls backend"),
-        }
-        assert_eq!(c.models[0].policy, PolicyKind::RoundRobin);
-    }
-
-    #[test]
-    fn rejects_static_urls_with_empty_list() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "m"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = []
-"#,
-        )
-        .unwrap_err()
-        .to_string();
+    fn rejects_empty_static_urls_list() {
+        let err = cfg("qwen3", &[]).validate().unwrap_err().to_string();
         assert!(err.contains("non-empty"), "got: {err}");
     }
 
     #[test]
-    fn rejects_static_urls_with_duplicate_entry() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "m"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["http://x:30000", "http://x:30000"]
-"#,
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("duplicate"), "got: {err}");
-    }
-
-    #[test]
-    fn rejects_static_urls_with_empty_entry() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "m"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["http://x:30000", ""]
-"#,
-        )
-        .unwrap_err()
-        .to_string();
+    fn rejects_static_urls_empty_entry() {
+        let err = cfg("qwen3", &["http://x:30000", ""])
+            .validate()
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("empty"), "got: {err}");
     }
 
-    /// Whitespace-only entries are user typos that previously slipped
-    /// through `is_empty()` checks and surfaced as "introspect against
-    /// `   /server_info` failed" at runtime. Catch at load.
     #[test]
-    fn rejects_static_urls_with_whitespace_only_entry() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "m"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["http://x:30000", "   "]
-"#,
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("whitespace"), "got: {err}");
+    fn rejects_static_urls_whitespace_only_entry() {
+        let err = cfg("qwen3", &["http://x:30000", "   "])
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("empty or whitespace"), "got: {err}");
     }
 
-    /// `"10.0.0.1:30000"` (missing scheme) used to pass validation; the
-    /// scheme/`http://` would only fail (or worse, silently degrade
-    /// because of the `parse_bootstrap_host` localhost fallback) at
-    /// introspect time. Reject at load.
     #[test]
-    fn rejects_static_urls_with_schemeless_entry() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "m"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["10.0.0.1:30000"]
-"#,
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(
-            err.contains("not a valid URL") || err.contains("unsupported scheme"),
-            "got: {err}"
-        );
-    }
-
-    /// Non-http(s) schemes are rejected. The router speaks HTTP to
-    /// workers; a `tcp://` or `ws://` entry is almost certainly an
-    /// operator typo.
-    #[test]
-    fn rejects_static_urls_with_non_http_scheme() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "m"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["ws://x:30000"]
-"#,
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("unsupported scheme"), "got: {err}");
-    }
-
-    /// Trailing-slash near-duplicates collide in the registry but used
-    /// to pass byte-equality dedupe. Normalize before checking so two
-    /// pointers at the same SGLang surface as a config error.
-    #[test]
-    fn rejects_static_urls_with_trailing_slash_near_duplicate() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "m"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["http://x:30000", "http://x:30000/"]
-"#,
-        )
-        .unwrap_err()
-        .to_string();
+    fn rejects_static_urls_trailing_slash_near_duplicate() {
+        let err = cfg("qwen3", &["http://x:30000", "http://x:30000/"])
+            .validate()
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("duplicate"), "got: {err}");
     }
 
     #[test]
-    fn loads_k8s_discovery() {
-        let c = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "qwen3-0.6b"
-tokenizer_path = "/tmp/qwen.json"
-policy = "round_robin"
-[discovery]
-backend = "k8s"
-[discovery.k8s]
-namespace = "default"
-label_selector = "app=sglang"
-"#,
-        )
-        .unwrap();
-        match &c.discovery.backend {
-            DiscoveryBackend::K8s(k) => {
-                assert_eq!(k.namespace, "default");
-                assert_eq!(k.label_selector.as_deref(), Some("app=sglang"));
-                assert!(k.prefill_selector.is_none());
-                assert!(k.decode_selector.is_none());
-            }
-            _ => panic!("expected k8s backend"),
-        }
-    }
-
-    /// K8s PD selectors drive slice-classification only; per-worker
-    /// bootstrap_port comes from `/server_info` post-discovery
-    /// (`crate::workers::introspect`). This test pins the wire-shape;
-    /// the selector grammar itself is covered in `types.rs`.
-    #[test]
-    fn loads_k8s_pd_discovery_with_prefill_and_decode_selectors() {
-        let c = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "qwen3-0.6b"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "k8s"
-[discovery.k8s]
-namespace = "default"
-prefill_selector = "app=sglang,role=prefill"
-decode_selector = "app=sglang,role=decode"
-"#,
-        )
-        .expect("k8s PD config must load");
-        match &c.discovery.backend {
-            DiscoveryBackend::K8s(k) => {
-                assert_eq!(k.namespace, "default");
-                assert_eq!(
-                    k.prefill_selector.as_deref(),
-                    Some("app=sglang,role=prefill")
-                );
-                assert_eq!(k.decode_selector.as_deref(), Some("app=sglang,role=decode"));
-                assert!(k.label_selector.is_none());
-            }
-            _ => panic!("expected k8s backend"),
-        }
-    }
-
-    #[test]
-    fn rejects_k8s_config_with_no_selector() {
-        let err = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "qwen"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "k8s"
-[discovery.k8s]
-namespace = "default"
-"#,
-        )
-        .unwrap_err();
-        // Pin the specific variant: `ConfigError::NoSelector` ("none were
-        // set"). A bare `contains("selector")` would also pass for
-        // EmptyPdSelector / PartialPdSelectors / IdenticalPdSelectors /
-        // UnsupportedSelectorGrammar — variants that have semantically
-        // different error wording but all mention "selector". A future
-        // regression that returned, say, `PartialPdSelectors` for the
-        // all-None input would be caught here.
-        let msg = err.to_string().to_lowercase();
-        assert!(
-            msg.contains("none were set"),
-            "expected NoSelector wording (\"none were set\"); got: {err}",
-        );
-    }
-
-    // Direct `K8sDiscoveryConfig::mode()` unit tests live alongside the
-    // type in `src/config/types.rs::k8s_discovery_config_tests`.
-    // The tests in this module exercise the `Config::from_path` ↔ K8s
-    // selector wiring, not the selector grammar itself.
-
-    #[test]
-    fn rejects_unknown_policy_name() {
-        let err = load(
-            "yaml",
-            "
-server:
-  host: 0.0.0.0
-  port: 8090
-discovery:
-  backend: static_urls
-  static_urls:
-    urls:
-      - http://x:30000
-models:
-  - id: qwen
-    tokenizer_path: /tmp/qwen.json
-    policy: bogus_policy
-",
-        )
-        .unwrap_err();
-        let msg = err.to_string().to_lowercase();
-        assert!(
-            msg.contains("bogus_policy") || msg.contains("policy"),
-            "got: {err}"
-        );
-    }
-
-    #[test]
-    fn defaults_policy_to_round_robin() {
-        let c = load(
-            "toml",
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8090
-[[models]]
-id = "qwen"
-tokenizer_path = "/tmp/qwen.json"
-[discovery]
-backend = "static_urls"
-[discovery.static_urls]
-urls = ["http://x:30000"]
-"#,
-        )
-        .unwrap();
-        assert_eq!(c.models[0].policy, PolicyKind::RoundRobin);
+    fn rejects_static_urls_non_http_scheme() {
+        let err = cfg("qwen3", &["ws://x:30000"])
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unsupported scheme"), "got: {err}");
     }
 }

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -1,32 +1,35 @@
-use serde::{Deserialize, Serialize};
 use std::num::NonZeroU32;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// In-memory router configuration, built from CLI flags by
+/// [`crate::config::cli::Cli::into_config`] and validated by
+/// [`Config::validate`]. The router serves exactly one model.
+#[derive(Debug, Clone)]
 pub struct Config {
     pub server: ServerConfig,
-    #[serde(default)]
     pub observability: ObservabilityConfig,
-    pub models: Vec<ModelConfig>,
-    pub discovery: DiscoveryConfig,
-    #[serde(default)]
+    pub model: ModelConfig,
+    /// Selected discovery backend. Built from CLI flags by
+    /// [`crate::config::cli::Cli::into_config`]: the static-vs-k8s choice
+    /// and the k8s selector grammar are resolved there (the latter via
+    /// [`resolve_mode`]); static worker-URL validity is checked by
+    /// [`Config::validate`].
+    pub discovery: DiscoveryBackend,
     pub proxy: ProxyConfig,
-    #[serde(default)]
     pub active_load: ActiveLoadConfig,
 }
 
 /// Outbound proxy tuning. Default mirrors SGLang's typical prefill /
 /// decode latency budget; e2e tests lower it so per-request failures
 /// trip the circuit breaker within the test's wall-time.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
 pub struct ProxyConfig {
     /// Maximum time to wait for a single upstream HTTP request to
     /// return headers + body. Default 300 s. The circuit breaker
     /// records a failure when this fires.
-    #[serde(default = "default_proxy_request_timeout_secs")]
     pub request_timeout_secs: u64,
 }
 
-fn default_proxy_request_timeout_secs() -> u64 {
+pub fn default_proxy_request_timeout_secs() -> u64 {
     300
 }
 
@@ -42,16 +45,15 @@ impl Default for ProxyConfig {
 /// sits above `proxy.request_timeout_secs` so the proxy timeout is the
 /// one users hit first for normal slow upstreams; tests lower it to
 /// let the janitor fire within their wall-time budget.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
 pub struct ActiveLoadConfig {
     /// How long a request entry can live in the registry before the
     /// janitor fires its `cancel_token` and the chat handler returns
     /// 504 `stale_request_expired`. Default 600 s.
-    #[serde(default = "default_stale_request_timeout_secs")]
     pub stale_request_timeout_secs: u64,
 }
 
-fn default_stale_request_timeout_secs() -> u64 {
+pub fn default_stale_request_timeout_secs() -> u64 {
     600
 }
 
@@ -63,51 +65,52 @@ impl Default for ActiveLoadConfig {
     }
 }
 
-/// Routing policy selector — the enum form lets serde reject unknown
-/// values at deserialization time and removes the runtime string match in
-/// the policy factory.
+/// Routing policy selector — the enum form lets `clap` reject unknown
+/// values at parse time and removes the runtime string match in the
+/// policy factory.
 ///
-/// Serialised as `"round_robin"` / `"random"` / `"power_of_two"` /
-/// `"cache_aware_zmq"`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+/// Accepted on the CLI (`--policy`) as `round_robin` / `random` /
+/// `power_of_two` / `cache_aware_zmq`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
 pub enum PolicyKind {
     #[default]
+    #[value(name = "round_robin")]
     RoundRobin,
+    #[value(name = "random")]
     Random,
+    #[value(name = "power_of_two")]
     PowerOfTwo,
     /// Cache-aware routing fed by SGLang's ZMQ KV-cache event publisher.
     /// Requires the model to have a tokenizer loaded; cache_aware tuning
     /// lives on `ModelConfig::cache_aware`.
+    #[value(name = "cache_aware_zmq")]
     CacheAwareZmq,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ObservabilityConfig {
-    #[serde(default = "default_log_level")]
     pub log_level: String,
-    /// Selects the tracing-subscriber output format. Serde rejects
-    /// unrecognized values at config-load (`"jsonl"` and similar
-    /// plausible typos surface as an error instead of silently
-    /// degrading to text), matching the discoverability pattern used
-    /// by `policy` and `discovery.backend`.
-    #[serde(default)]
+    /// Selects the tracing-subscriber output format. `clap` rejects
+    /// unrecognized values at parse time (`--log-format jsonl` and
+    /// similar typos surface as an error instead of silently degrading
+    /// to text).
     pub log_format: LogFormat,
 }
 
 /// `text` for human-readable dev output, `json` for one-line-per-record
 /// JSON suitable for k8s log aggregators (fluent-bit / vector / Loki).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum LogFormat {
     #[default]
+    #[value(name = "text")]
     Text,
+    #[value(name = "json")]
     Json,
 }
 
@@ -124,40 +127,34 @@ impl Default for ObservabilityConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ModelConfig {
     pub id: String,
     pub tokenizer_path: String,
-    #[serde(default)]
     pub policy: PolicyKind,
-    #[serde(default)]
     pub circuit_breaker: Option<CircuitBreakerConfig>,
     /// Tuning for the cache-aware ZMQ policy. Ignored unless
     /// `policy = "cache_aware_zmq"`. `None` falls back to defaults at
     /// policy construction time.
-    #[serde(default)]
     pub cache_aware: Option<CacheAwareConfig>,
 }
 
 /// Per-model cache-aware-ZMQ tuning.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
 pub struct CacheAwareConfig {
     /// Lower bound on `matched_blocks / total_blocks` for the tree match
     /// to win the selection. Below this, the policy falls back to
     /// min-load. Default 0.5 — a half-cached prompt is still a strong
     /// signal but not so weak that random hash collisions could trigger
     /// affinity to an arbitrary worker.
-    #[serde(default = "default_cache_threshold")]
     pub cache_threshold: f32,
     /// Absolute load spread (`max - min`) above which the cache check is
     /// skipped in favour of min-load. Default 32 — picked to dominate
     /// over typical batch-of-8 effect.
-    #[serde(default = "default_balance_abs")]
     pub balance_abs_threshold: usize,
     /// Multiplicative load spread (`max > min * balance_rel_threshold`)
     /// that the absolute check is gated on. Default 1.1 — 10 % relative
     /// difference triggers re-balancing.
-    #[serde(default = "default_balance_rel")]
     pub balance_rel_threshold: f32,
 }
 
@@ -181,123 +178,20 @@ fn default_balance_rel() -> f32 {
     1.1
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct CircuitBreakerConfig {
-    /// Consecutive failures required before the breaker opens.  Encoded
-    /// as `NonZeroU32` so a config setting `threshold = 0` (which would
-    /// open the breaker before any failure) is rejected at deserialization
-    /// rather than silently behaving as "always open".
-    #[serde(default = "default_cb_threshold")]
+    /// Consecutive failures required before the breaker opens. Encoded
+    /// as `NonZeroU32` so `--cb-threshold 0` (which would open the
+    /// breaker before any failure) is rejected at CLI-parse time rather
+    /// than silently behaving as "always open".
     pub threshold: NonZeroU32,
-    #[serde(default = "default_cb_cool_down")]
     pub cool_down_secs: u64,
 }
 
-fn default_cb_threshold() -> NonZeroU32 {
-    NonZeroU32::new(3).unwrap()
-}
-fn default_cb_cool_down() -> u64 {
+/// Default circuit-breaker cool-down, applied when `--cb-threshold` is
+/// set without an explicit `--cb-cool-down-secs`.
+pub fn default_cb_cool_down() -> u64 {
     30
-}
-
-/// Config-level discovery section. Deserialized from:
-///
-/// TOML:
-/// ```toml
-/// [discovery]
-/// backend = "static_urls"
-/// [discovery.static_urls]
-/// urls = ["http://10.0.0.1:30000", "http://10.0.0.2:30000"]
-/// ```
-///
-/// YAML:
-/// ```yaml
-/// discovery:
-///   backend: static_urls
-///   static_urls:
-///     urls:
-///       - http://10.0.0.1:30000
-///       - http://10.0.0.2:30000
-/// ```
-///
-/// The custom `Deserialize` impl on [`DiscoveryConfig`] converts the
-/// raw fields into the resolved `DiscoveryBackend` enum via `try_from`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DiscoveryConfigRaw {
-    pub backend: String,
-    pub static_urls: Option<StaticUrlsDiscoveryConfig>,
-    pub k8s: Option<K8sDiscoveryConfig>,
-}
-
-/// Post-validation discovery config with a resolved `DiscoveryBackend` enum.
-/// Constructed by `Config::from_path` after `validate()`.
-#[derive(Debug, Clone)]
-pub struct DiscoveryConfig {
-    pub backend: DiscoveryBackend,
-}
-
-impl<'de> Deserialize<'de> for DiscoveryConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let raw = DiscoveryConfigRaw::deserialize(deserializer)?;
-        raw.try_into().map_err(serde::de::Error::custom)
-    }
-}
-
-impl Serialize for DiscoveryConfig {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let raw: DiscoveryConfigRaw = self.clone().into();
-        raw.serialize(serializer)
-    }
-}
-
-impl TryFrom<DiscoveryConfigRaw> for DiscoveryConfig {
-    type Error = String;
-
-    fn try_from(raw: DiscoveryConfigRaw) -> Result<Self, Self::Error> {
-        let backend = match raw.backend.as_str() {
-            "static_urls" => {
-                let s = raw.static_urls.ok_or(
-                    "discovery.backend = \"static_urls\" requires [discovery.static_urls] section",
-                )?;
-                DiscoveryBackend::StaticUrls(s)
-            }
-            "k8s" => {
-                let k = raw
-                    .k8s
-                    .ok_or("discovery.backend = \"k8s\" requires [discovery.k8s] section")?;
-                DiscoveryBackend::K8s(k)
-            }
-            other => {
-                return Err(format!(
-                    "unknown discovery.backend = {other:?}; valid: \"static_urls\", \"k8s\""
-                ))
-            }
-        };
-        Ok(DiscoveryConfig { backend })
-    }
-}
-
-impl From<DiscoveryConfig> for DiscoveryConfigRaw {
-    fn from(cfg: DiscoveryConfig) -> Self {
-        match cfg.backend {
-            DiscoveryBackend::StaticUrls(s) => DiscoveryConfigRaw {
-                backend: "static_urls".to_string(),
-                static_urls: Some(s),
-                k8s: None,
-            },
-            DiscoveryBackend::K8s(k) => DiscoveryConfigRaw {
-                backend: "k8s".to_string(),
-                static_urls: None,
-                k8s: Some(k),
-            },
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -311,30 +205,25 @@ pub enum DiscoveryBackend {
 /// from `/server_info` (see [`crate::workers::introspect`]).
 ///
 /// No file watcher, no hot-reload: topology change requires a restart.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct StaticUrlsDiscoveryConfig {
     pub urls: Vec<String>,
 }
 
 /// Configuration for the Kubernetes `EndpointSlice` discovery backend.
+/// Built from the `--service-discovery*` / `--selector` / `--prefill-selector`
+/// / `--decode-selector` flags by [`crate::config::cli::Cli::build_discovery`].
 ///
-/// Two operating modes, distinguished by which selector fields are set:
+/// Two operating modes, distinguished by which selector flags are set:
 ///
 /// 1. **Plain** — all matched workers share the same role:
-///    ```toml
-///    [discovery.k8s]
-///    namespace = "default"
-///    label_selector = "app=sglang"
-///    ```
+///    `--service-discovery-namespace default --selector app=sglang`
 ///
 /// 2. **PD disaggregation** — prefill and decode workers are separated by
 ///    different selectors:
-///    ```toml
-///    [discovery.k8s]
-///    namespace = "default"
-///    prefill_selector = "app=sglang,role=prefill"
-///    decode_selector  = "app=sglang,role=decode"
-///    ```
+///    `--service-discovery-namespace default
+///    --prefill-selector app=sglang,role=prefill
+///    --decode-selector app=sglang,role=decode`
 ///
 /// In PD mode, the selectors drive **slice-classification** (which
 /// EndpointSlices feed the prefill pool vs the decode pool). The actual
@@ -344,20 +233,19 @@ pub struct StaticUrlsDiscoveryConfig {
 /// [`crate::workers::introspect`] for the `disaggregation_mode` and
 /// `disaggregation_bootstrap_port` extraction.
 ///
-/// `mode()` validates the combination and returns the resolved
-/// [`K8sDiscoveryMode`]; any other selector combination is rejected.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// [`resolve_mode`] validates the selector flags and produces the
+/// resolved [`K8sDiscoveryMode`] once, at construction in
+/// [`crate::config::cli::Cli::build_discovery`] — so an invalid selector
+/// combination is unrepresentable here.
+#[derive(Debug, Clone)]
 pub struct K8sDiscoveryConfig {
     pub namespace: String,
-    #[serde(default)]
-    pub label_selector: Option<String>,
-    #[serde(default)]
-    pub prefill_selector: Option<String>,
-    #[serde(default)]
-    pub decode_selector: Option<String>,
+    /// Resolved + validated selector mode (plain vs PD).
+    pub mode: K8sDiscoveryMode,
 }
 
-/// Resolved discovery mode derived from a [`K8sDiscoveryConfig`].
+/// Resolved discovery mode, produced by [`resolve_mode`] from the CLI
+/// selector flags and stored on [`K8sDiscoveryConfig`].
 ///
 /// The discovery backend uses this to:
 /// * pick the server-side `LIST` label selector (Plain: the single selector;
@@ -377,8 +265,8 @@ pub enum K8sDiscoveryMode {
     },
 }
 
-/// Error returned by [`K8sDiscoveryConfig::mode`] when the selector
-/// combination is invalid.
+/// Error returned by [`resolve_mode`] when the selector combination is
+/// invalid.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     #[error("discovery.k8s requires either `label_selector` (plain) or both `prefill_selector` and `decode_selector` (PD); none were set")]
@@ -391,7 +279,7 @@ pub enum ConfigError {
         "discovery.k8s: {selector}_selector `{value}` uses unsupported syntax — \
          only equality terms (`key=value` or `key==value`) joined by `,` are accepted. \
          Set-based operators (`in`, `notin`), presence tests, and `!=` silently match \
-         zero endpoints at runtime and are rejected at config-load time."
+         zero endpoints at runtime and are rejected at startup."
     )]
     UnsupportedSelectorGrammar {
         selector: &'static str,
@@ -487,80 +375,79 @@ fn is_equality_selector(selector: &str) -> bool {
     true
 }
 
-impl K8sDiscoveryConfig {
-    /// Validate the selector combination and return the resolved mode.
-    pub fn mode(&self) -> Result<K8sDiscoveryMode, ConfigError> {
-        let plain = self.label_selector.as_deref();
-        let prefill = self.prefill_selector.as_deref();
-        let decode = self.decode_selector.as_deref();
-
-        match (plain, prefill, decode) {
-            (Some(label), None, None) => {
-                // Plain mode pushes `label` to the K8s API as the
-                // server-side `labelSelector` of the EndpointSlice
-                // watcher (`watcher::Config::default().labels(&label)`
-                // in `discovery::k8s::spawn`). K8s itself parses the
-                // full label-selector grammar — equality, set-based
-                // (`in` / `notin`), presence (`key` / `!key`), and
-                // `!=` — and rejects malformed selectors at
-                // watch-start time. So at config-load we don't
-                // grammar-check `label` and let the K8s API be the
-                // syntax authority (README.md:25 and the multi-model
-                // e2e in tests/e2e/k8s_integration/test_multi_model.py
-                // depend on this). PD mode, in contrast, evaluates
-                // selectors client-side via `labels_match_selector`
-                // which only understands equality — so PD selectors
-                // are still grammar-checked below.
-                Ok(K8sDiscoveryMode::Plain {
-                    label_selector: label.to_string(),
-                })
-            }
-            (None, Some(prefill), Some(decode)) => {
-                // Both selectors validated individually so the operator
-                // sees which one is malformed. WorkerMode + bootstrap_port
-                // for each prefill pod are filled in by the worker
-                // manager from each worker's `/server_info` — these
-                // selectors only drive client-side classification per
-                // EndpointSlice (see `classify_mode` in discovery/k8s.rs).
-                if !is_equality_selector(prefill) {
-                    return Err(ConfigError::UnsupportedSelectorGrammar {
-                        selector: "prefill",
-                        value: prefill.to_string(),
-                    });
-                }
-                if !is_equality_selector(decode) {
-                    return Err(ConfigError::UnsupportedSelectorGrammar {
-                        selector: "decode",
-                        value: decode.to_string(),
-                    });
-                }
-                // Empty PD selector matches every EndpointSlice at
-                // runtime; combined with classify_mode's prefill-first
-                // ordering, an empty selector would silently funnel all
-                // workers into one role. Reject up front.
-                if is_selector_empty(prefill) {
-                    return Err(ConfigError::EmptyPdSelector {
-                        selector: "prefill",
-                    });
-                }
-                if is_selector_empty(decode) {
-                    return Err(ConfigError::EmptyPdSelector { selector: "decode" });
-                }
-                // Identical selectors degrade the same way as an empty
-                // one: every slice matches both, prefill wins, decode
-                // stays empty.
-                if canonical_selector(prefill) == canonical_selector(decode) {
-                    return Err(ConfigError::IdenticalPdSelectors);
-                }
-                Ok(K8sDiscoveryMode::PdDisaggregation {
-                    prefill_selector: prefill.to_string(),
-                    decode_selector: decode.to_string(),
-                })
-            }
-            (None, None, None) => Err(ConfigError::NoSelector),
-            (None, Some(_), None) | (None, None, Some(_)) => Err(ConfigError::PartialPdSelectors),
-            (Some(_), _, _) => Err(ConfigError::MixedModes),
+/// Validate the selector combination and return the resolved
+/// [`K8sDiscoveryMode`]. Called once at construction by
+/// [`crate::config::cli::Cli::build_discovery`], so an invalid
+/// combination can never be stored on a [`K8sDiscoveryConfig`].
+pub fn resolve_mode(
+    label_selector: Option<&str>,
+    prefill_selector: Option<&str>,
+    decode_selector: Option<&str>,
+) -> Result<K8sDiscoveryMode, ConfigError> {
+    match (label_selector, prefill_selector, decode_selector) {
+        (Some(label), None, None) => {
+            // Plain mode pushes `label` to the K8s API as the
+            // server-side `labelSelector` of the EndpointSlice
+            // watcher (`watcher::Config::default().labels(&label)`
+            // in `discovery::k8s::spawn`). K8s itself parses the
+            // full label-selector grammar — equality, set-based
+            // (`in` / `notin`), presence (`key` / `!key`), and
+            // `!=` — and rejects malformed selectors at
+            // watch-start time. So we don't grammar-check `label`
+            // here and let the K8s API be the syntax authority. PD
+            // mode, in contrast, evaluates selectors client-side via
+            // `labels_match_selector` which only understands
+            // equality — so PD selectors are still grammar-checked
+            // below.
+            Ok(K8sDiscoveryMode::Plain {
+                label_selector: label.to_string(),
+            })
         }
+        (None, Some(prefill), Some(decode)) => {
+            // Both selectors validated individually so the operator
+            // sees which one is malformed. WorkerMode + bootstrap_port
+            // for each prefill pod are filled in by the worker
+            // manager from each worker's `/server_info` — these
+            // selectors only drive client-side classification per
+            // EndpointSlice (see `classify_mode` in discovery/k8s.rs).
+            if !is_equality_selector(prefill) {
+                return Err(ConfigError::UnsupportedSelectorGrammar {
+                    selector: "prefill",
+                    value: prefill.to_string(),
+                });
+            }
+            if !is_equality_selector(decode) {
+                return Err(ConfigError::UnsupportedSelectorGrammar {
+                    selector: "decode",
+                    value: decode.to_string(),
+                });
+            }
+            // Empty PD selector matches every EndpointSlice at
+            // runtime; combined with classify_mode's prefill-first
+            // ordering, an empty selector would silently funnel all
+            // workers into one role. Reject up front.
+            if is_selector_empty(prefill) {
+                return Err(ConfigError::EmptyPdSelector {
+                    selector: "prefill",
+                });
+            }
+            if is_selector_empty(decode) {
+                return Err(ConfigError::EmptyPdSelector { selector: "decode" });
+            }
+            // Identical selectors degrade the same way as an empty
+            // one: every slice matches both, prefill wins, decode
+            // stays empty.
+            if canonical_selector(prefill) == canonical_selector(decode) {
+                return Err(ConfigError::IdenticalPdSelectors);
+            }
+            Ok(K8sDiscoveryMode::PdDisaggregation {
+                prefill_selector: prefill.to_string(),
+                decode_selector: decode.to_string(),
+            })
+        }
+        (None, None, None) => Err(ConfigError::NoSelector),
+        (None, Some(_), None) | (None, None, Some(_)) => Err(ConfigError::PartialPdSelectors),
+        (Some(_), _, _) => Err(ConfigError::MixedModes),
     }
 }
 
@@ -568,23 +455,13 @@ impl K8sDiscoveryConfig {
 mod k8s_discovery_config_tests {
     use super::*;
 
-    fn cfg(plain: Option<&str>, prefill: Option<&str>, decode: Option<&str>) -> K8sDiscoveryConfig {
-        K8sDiscoveryConfig {
-            namespace: "ns".to_string(),
-            label_selector: plain.map(str::to_string),
-            prefill_selector: prefill.map(str::to_string),
-            decode_selector: decode.map(str::to_string),
-        }
-    }
-
     #[test]
     fn mode_constructs_pd_disaggregation_from_prefill_and_decode_selectors() {
         // K8s PD now works without per-pod annotations: each worker's
         // `/server_info` carries `disaggregation_bootstrap_port`, and the
         // worker manager applies it post-discovery. The K8s config layer's
         // job is just to validate the selector combination.
-        let m = cfg(None, Some("app=sglang,role=p"), Some("app=sglang,role=d"))
-            .mode()
+        let m = resolve_mode(None, Some("app=sglang,role=p"), Some("app=sglang,role=d"))
             .expect("PD mode is now valid");
         assert_eq!(
             m,
@@ -600,9 +477,8 @@ mod k8s_discovery_config_tests {
         // Both PD selectors get the same equality-only grammar check as
         // the plain label_selector. A set-based prefill selector would
         // silently match zero pods at runtime → fail-fast at load.
-        let err = cfg(None, Some("app in (sglang, vllm)"), Some("app=sglang"))
-            .mode()
-            .unwrap_err();
+        let err =
+            resolve_mode(None, Some("app in (sglang, vllm)"), Some("app=sglang")).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -617,9 +493,8 @@ mod k8s_discovery_config_tests {
 
     #[test]
     fn mode_pd_rejects_set_based_decode_selector() {
-        let err = cfg(None, Some("app=sglang"), Some("app in (sglang, vllm)"))
-            .mode()
-            .unwrap_err();
+        let err =
+            resolve_mode(None, Some("app=sglang"), Some("app in (sglang, vllm)")).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -634,7 +509,7 @@ mod k8s_discovery_config_tests {
 
     #[test]
     fn mode_accepts_plain_with_equality_selector() {
-        let m = cfg(Some("app=sglang"), None, None).mode().unwrap();
+        let m = resolve_mode(Some("app=sglang"), None, None).unwrap();
         assert_eq!(
             m,
             K8sDiscoveryMode::Plain {
@@ -646,15 +521,12 @@ mod k8s_discovery_config_tests {
     /// Plain mode pushes its selector to the K8s API server-side
     /// (`watcher::Config::default().labels(&selector)` in
     /// `discovery::k8s::spawn`), so the full K8s label-selector grammar
-    /// — including set-based operators — is supported. README.md:25
-    /// advertises this, and `tests/e2e/k8s_integration/test_multi_model.py`
-    /// relies on it (`label_selector = "app in (sglang,sglang-small)"`).
-    /// Rejecting set-based selectors at config-load broke the documented
-    /// multi-model k8s path.
+    /// — including set-based operators like `app in (a,b)` — is
+    /// supported and must not be grammar-checked at startup. PD mode
+    /// (checked client-side) is the opposite; see the PD tests below.
     #[test]
     fn mode_accepts_set_based_selector_in_plain_mode() {
-        let m = cfg(Some("app in (sglang,sglang-small)"), None, None)
-            .mode()
+        let m = resolve_mode(Some("app in (sglang,sglang-small)"), None, None)
             .expect("plain mode must accept set-based selectors");
         assert_eq!(
             m,
@@ -675,8 +547,7 @@ mod k8s_discovery_config_tests {
             "!deprecated",
             "tier!=canary",
         ] {
-            let m = cfg(Some(raw), None, None)
-                .mode()
+            let m = resolve_mode(Some(raw), None, None)
                 .unwrap_or_else(|e| panic!("plain mode must accept `{raw}`, got {e:?}"));
             assert_eq!(
                 m,
@@ -699,9 +570,8 @@ mod k8s_discovery_config_tests {
     /// — both must keep failing.
     #[test]
     fn mode_pd_rejects_notin_prefill_selector() {
-        let err = cfg(None, Some("app notin (vllm, trtllm)"), Some("app=sglang"))
-            .mode()
-            .unwrap_err();
+        let err =
+            resolve_mode(None, Some("app notin (vllm, trtllm)"), Some("app=sglang")).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -717,9 +587,7 @@ mod k8s_discovery_config_tests {
     #[test]
     fn mode_accepts_comma_separated_equality_terms() {
         // The canonical Plain-mode selector form: `key1=v1,key2=v2`.
-        let m = cfg(Some("app=sglang,zone=us-east"), None, None)
-            .mode()
-            .unwrap();
+        let m = resolve_mode(Some("app=sglang,zone=us-east"), None, None).unwrap();
         assert_eq!(
             m,
             K8sDiscoveryMode::Plain {
@@ -730,30 +598,29 @@ mod k8s_discovery_config_tests {
 
     #[test]
     fn mode_rejects_when_no_selector_is_set() {
-        let err = cfg(None, None, None).mode().unwrap_err();
+        let err = resolve_mode(None, None, None).unwrap_err();
         assert!(matches!(err, ConfigError::NoSelector), "got {err:?}");
     }
 
     #[test]
     fn mode_rejects_mixed_plain_and_pd_selectors() {
-        let err = cfg(
+        let err = resolve_mode(
             Some("app=sglang"),
             Some("role=prefill"),
             Some("role=decode"),
         )
-        .mode()
         .unwrap_err();
         assert!(matches!(err, ConfigError::MixedModes), "got {err:?}");
     }
 
     #[test]
     fn mode_rejects_partial_pd_selectors() {
-        let err = cfg(None, Some("role=prefill"), None).mode().unwrap_err();
+        let err = resolve_mode(None, Some("role=prefill"), None).unwrap_err();
         assert!(
             matches!(err, ConfigError::PartialPdSelectors),
             "got {err:?}"
         );
-        let err = cfg(None, None, Some("role=decode")).mode().unwrap_err();
+        let err = resolve_mode(None, None, Some("role=decode")).unwrap_err();
         assert!(
             matches!(err, ConfigError::PartialPdSelectors),
             "got {err:?}"
@@ -765,7 +632,7 @@ mod k8s_discovery_config_tests {
     /// operator opts in by setting plain mode at all).
     #[test]
     fn mode_accepts_empty_plain_label_selector() {
-        let m = cfg(Some(""), None, None).mode().unwrap();
+        let m = resolve_mode(Some(""), None, None).unwrap();
         assert_eq!(
             m,
             K8sDiscoveryMode::Plain {
@@ -782,7 +649,7 @@ mod k8s_discovery_config_tests {
     /// at config load.
     #[test]
     fn mode_pd_rejects_empty_prefill_selector() {
-        let err = cfg(None, Some(""), Some("role=decode")).mode().unwrap_err();
+        let err = resolve_mode(None, Some(""), Some("role=decode")).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -796,9 +663,7 @@ mod k8s_discovery_config_tests {
 
     #[test]
     fn mode_pd_rejects_empty_decode_selector() {
-        let err = cfg(None, Some("role=prefill"), Some(""))
-            .mode()
-            .unwrap_err();
+        let err = resolve_mode(None, Some("role=prefill"), Some("")).unwrap_err();
         assert!(
             matches!(err, ConfigError::EmptyPdSelector { selector: "decode" },),
             "expected EmptyPdSelector(decode), got {err:?}",
@@ -810,9 +675,7 @@ mod k8s_discovery_config_tests {
     /// failure mode as a literal empty string.
     #[test]
     fn mode_pd_rejects_whitespace_only_prefill_selector() {
-        let err = cfg(None, Some("  ,  "), Some("role=decode"))
-            .mode()
-            .unwrap_err();
+        let err = resolve_mode(None, Some("  ,  "), Some("role=decode")).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -829,9 +692,7 @@ mod k8s_discovery_config_tests {
     /// so the decode pool stays empty.
     #[test]
     fn mode_pd_rejects_identical_prefill_and_decode_selectors() {
-        let err = cfg(None, Some("app=sglang"), Some("app=sglang"))
-            .mode()
-            .unwrap_err();
+        let err = resolve_mode(None, Some("app=sglang"), Some("app=sglang")).unwrap_err();
         assert!(
             matches!(err, ConfigError::IdenticalPdSelectors),
             "expected IdenticalPdSelectors, got {err:?}",
@@ -842,9 +703,7 @@ mod k8s_discovery_config_tests {
     /// identical-selector check.
     #[test]
     fn mode_pd_rejects_identical_selectors_under_whitespace_normalization() {
-        let err = cfg(None, Some("app=sglang"), Some("  app=sglang  "))
-            .mode()
-            .unwrap_err();
+        let err = resolve_mode(None, Some("app=sglang"), Some("  app=sglang  ")).unwrap_err();
         assert!(
             matches!(err, ConfigError::IdenticalPdSelectors),
             "expected IdenticalPdSelectors, got {err:?}",
@@ -861,9 +720,7 @@ mod k8s_discovery_config_tests {
     /// string level.
     #[test]
     fn mode_pd_rejects_identical_selectors_under_eq_alias() {
-        let err = cfg(None, Some("app=sglang"), Some("app==sglang"))
-            .mode()
-            .unwrap_err();
+        let err = resolve_mode(None, Some("app=sglang"), Some("app==sglang")).unwrap_err();
         assert!(
             matches!(err, ConfigError::IdenticalPdSelectors),
             "expected IdenticalPdSelectors, got {err:?}",
@@ -877,9 +734,7 @@ mod k8s_discovery_config_tests {
     /// form must agree.
     #[test]
     fn mode_pd_rejects_identical_selectors_under_inner_whitespace() {
-        let err = cfg(None, Some("app=sglang"), Some("app =  sglang"))
-            .mode()
-            .unwrap_err();
+        let err = resolve_mode(None, Some("app=sglang"), Some("app =  sglang")).unwrap_err();
         assert!(
             matches!(err, ConfigError::IdenticalPdSelectors),
             "expected IdenticalPdSelectors, got {err:?}",
@@ -893,9 +748,8 @@ mod k8s_discovery_config_tests {
     /// reintroduce the silent-failure bug.)
     #[test]
     fn mode_pd_rejects_identical_selectors_under_term_order_permutation() {
-        let err = cfg(None, Some("role=p,app=sglang"), Some("app=sglang,role=p"))
-            .mode()
-            .unwrap_err();
+        let err =
+            resolve_mode(None, Some("role=p,app=sglang"), Some("app=sglang,role=p")).unwrap_err();
         assert!(
             matches!(err, ConfigError::IdenticalPdSelectors),
             "expected IdenticalPdSelectors, got {err:?}",
@@ -907,12 +761,11 @@ mod k8s_discovery_config_tests {
     /// aggressive that it false-positives on legitimate PD configs.
     #[test]
     fn mode_pd_accepts_truly_distinct_selectors() {
-        let m = cfg(
+        let m = resolve_mode(
             None,
             Some("app=sglang,role=prefill"),
             Some("app=sglang,role=decode"),
         )
-        .mode()
         .expect("distinct selectors must validate");
         assert!(matches!(m, K8sDiscoveryMode::PdDisaggregation { .. }));
     }

--- a/experimental/sgl-router/src/discovery/k8s.rs
+++ b/experimental/sgl-router/src/discovery/k8s.rs
@@ -328,16 +328,18 @@ pub async fn spawn(
     cfg: K8sDiscoveryConfig,
     tx: mpsc::Sender<DiscoveryEvent>,
 ) -> Result<tokio::task::JoinHandle<()>> {
-    let mode = cfg.mode().context("validate k8s discovery selectors")?;
+    // The mode was resolved + validated at construction (`resolve_mode` in
+    // `Cli::build_discovery`); just destructure it here.
+    let K8sDiscoveryConfig { namespace, mode } = cfg;
 
     let client = Client::try_default()
         .await
         .context("kube client default config")?;
 
-    let api: Api<EndpointSlice> = if cfg.namespace.is_empty() {
+    let api: Api<EndpointSlice> = if namespace.is_empty() {
         Api::all(client)
     } else {
-        Api::namespaced(client, &cfg.namespace)
+        Api::namespaced(client, &namespace)
     };
 
     // Plain mode pushes the single selector to the server side so the LIST
@@ -350,6 +352,36 @@ pub async fn spawn(
         K8sDiscoveryMode::PdDisaggregation { .. } => String::new(),
     };
     let watcher_cfg = watcher::Config::default().labels(&server_side_selector);
+
+    // Log the resolved namespace + selector(s) at startup. We can't
+    // verify the namespace exists (the router's RBAC covers
+    // endpointslices/services/pods, not namespaces, and a correct
+    // namespace legitimately has zero matching workers until they come
+    // up), so a typo'd `--service-discovery-namespace` silently watches
+    // an empty namespace. Surfacing the watch target here lets an
+    // operator spot the typo in the first log lines instead of only
+    // discovering it via later `no workers available` request failures.
+    let namespace_display: &str = if namespace.is_empty() {
+        "<all namespaces>"
+    } else {
+        &namespace
+    };
+    match &mode {
+        K8sDiscoveryMode::Plain { label_selector } => tracing::info!(
+            namespace = %namespace_display,
+            label_selector = %label_selector,
+            "k8s discovery starting (plain mode); a wrong namespace or selector matches zero EndpointSlices"
+        ),
+        K8sDiscoveryMode::PdDisaggregation {
+            prefill_selector,
+            decode_selector,
+        } => tracing::info!(
+            namespace = %namespace_display,
+            prefill_selector = %prefill_selector,
+            decode_selector = %decode_selector,
+            "k8s discovery starting (PD mode); a wrong namespace or selector matches zero EndpointSlices"
+        ),
+    }
 
     let handle = tokio::spawn(async move {
         let stream = watcher(api, watcher_cfg);

--- a/experimental/sgl-router/src/discovery/mod.rs
+++ b/experimental/sgl-router/src/discovery/mod.rs
@@ -25,7 +25,7 @@ pub async fn spawn_discovery(
     cfg: &Config,
 ) -> Result<(mpsc::Receiver<DiscoveryEvent>, tokio::task::JoinHandle<()>)> {
     let (tx, rx) = mpsc::channel(DISCOVERY_CHANNEL_CAP);
-    let handle = match &cfg.discovery.backend {
+    let handle = match &cfg.discovery {
         DiscoveryBackend::StaticUrls(s) => static_urls::spawn(s.clone(), tx).await?,
         DiscoveryBackend::K8s(k) => k8s::spawn(k.clone(), tx).await?,
     };

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -3,17 +3,9 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use sgl_router::config::LogFormat;
-use std::path::PathBuf;
+use sgl_router::config::{Cli, LogFormat};
 use std::sync::Arc;
 use tokio::signal::unix::{signal, Signal, SignalKind};
-
-#[derive(Parser, Debug)]
-#[command(name = "sgl-router", version)]
-struct Cli {
-    #[arg(long, env = "SGL_ROUTER_CONFIG")]
-    config: PathBuf,
-}
 
 /// Install the global tracing subscriber.
 ///
@@ -54,13 +46,13 @@ fn init_tracing(default_level: &str, format: LogFormat) -> Result<()> {
     Ok(())
 }
 
-/// Install a minimal text-format subscriber BEFORE config parsing so a
-/// config-load error has somewhere to surface. The real subscriber
+/// Install a minimal text-format subscriber BEFORE config resolution so a
+/// config-resolution error has somewhere to surface. The real subscriber
 /// (driven by `Config.observability`) is installed after; the second
 /// `try_init` is a no-op because a subscriber is already present.
 /// The bootstrap subscriber respects `RUST_LOG` so an operator can
-/// debug startup with `RUST_LOG=debug` even when the config file is
-/// missing or malformed.
+/// debug startup with `RUST_LOG=debug` even when configuration resolution
+/// fails.
 fn install_bootstrap_subscriber() {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
@@ -83,12 +75,13 @@ fn install_signal_handlers() -> Result<(Signal, Signal)> {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    // Bootstrap subscriber so a Config::from_path error has structured
+    // Bootstrap subscriber so a config-resolution error has structured
     // output. The configured-format subscriber installs after this and
     // becomes a no-op via try_init's idempotency.
     install_bootstrap_subscriber();
-    let cfg = sgl_router::config::Config::from_path(&cli.config)
-        .with_context(|| format!("load config from {}", cli.config.display()))?;
+    let cfg = cli
+        .into_config()
+        .context("resolve configuration from CLI flags")?;
 
     init_tracing(&cfg.observability.log_level, cfg.observability.log_format)?;
 

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -292,20 +292,18 @@ mod tests {
                 port: 0,
             },
             observability: Default::default(),
-            models: vec![crate::config::ModelConfig {
+            model: crate::config::ModelConfig {
                 id: "tiny".into(),
                 tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
                 policy: crate::config::PolicyKind::RoundRobin,
                 circuit_breaker: None,
                 cache_aware: None,
-            }],
-            discovery: crate::config::DiscoveryConfig {
-                backend: crate::config::DiscoveryBackend::StaticUrls(
-                    crate::config::StaticUrlsDiscoveryConfig {
-                        urls: vec!["http://placeholder:0".into()],
-                    },
-                ),
             },
+            discovery: crate::config::DiscoveryBackend::StaticUrls(
+                crate::config::StaticUrlsDiscoveryConfig {
+                    urls: vec!["http://placeholder:0".into()],
+                },
+            ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
         };

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -76,17 +76,16 @@ pub fn build_registry(
     block_size_oracle: Arc<BlockSizeOracle>,
 ) -> Result<PolicyRegistry> {
     let reg = PolicyRegistry::default();
-    for m in &cfg.models {
-        reg.insert(
-            ModelId(m.id.clone()),
-            build_policy(
-                m,
-                Arc::clone(&tree),
-                Arc::clone(&tokenizers),
-                Arc::clone(&block_size_oracle),
-            ),
-        );
-    }
+    let m = &cfg.model;
+    reg.insert(
+        ModelId(m.id.clone()),
+        build_policy(
+            m,
+            Arc::clone(&tree),
+            Arc::clone(&tokenizers),
+            Arc::clone(&block_size_oracle),
+        ),
+    );
     Ok(reg)
 }
 
@@ -111,34 +110,29 @@ pub fn build_registry_with_defaults(cfg: &Config) -> Result<PolicyRegistry> {
 mod tests {
     use super::*;
     use crate::config::{
-        ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ModelConfig, ProxyConfig,
-        ServerConfig, StaticUrlsDiscoveryConfig,
+        ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ProxyConfig, ServerConfig,
+        StaticUrlsDiscoveryConfig,
     };
 
     use crate::config::PolicyKind;
 
-    fn cfg_with_models(policies: &[(&str, PolicyKind)]) -> Config {
+    fn cfg_with_model(id: &str, policy: PolicyKind) -> Config {
         Config {
             server: ServerConfig {
                 host: "0".into(),
                 port: 0,
             },
             observability: Default::default(),
-            models: policies
-                .iter()
-                .map(|(id, p)| ModelConfig {
-                    id: (*id).into(),
-                    tokenizer_path: "/tmp/x".into(),
-                    policy: *p,
-                    circuit_breaker: None,
-                    cache_aware: None,
-                })
-                .collect(),
-            discovery: DiscoveryConfig {
-                backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                    urls: vec!["http://placeholder:0".into()],
-                }),
+            model: ModelConfig {
+                id: id.into(),
+                tokenizer_path: "/tmp/x".into(),
+                policy,
+                circuit_breaker: None,
+                cache_aware: None,
             },
+            discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+                urls: vec!["http://placeholder:0".into()],
+            }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
         }
@@ -154,22 +148,18 @@ mod tests {
     }
 
     #[test]
-    fn registry_assigns_per_model() {
-        let cfg = cfg_with_models(&[
-            ("qwen", PolicyKind::RoundRobin),
-            ("deepseek", PolicyKind::Random),
-        ]);
+    fn registry_assigns_configured_model() {
+        let cfg = cfg_with_model("qwen", PolicyKind::RoundRobin);
         let tree = Arc::new(HashTree::new());
         let tokenizers = Arc::new(TokenizerRegistry::default());
         let reg = build_registry(&cfg, tree, tokenizers, BlockSizeOracle::new()).unwrap();
         assert!(reg.get(&ModelId("qwen".into())).is_some());
-        assert!(reg.get(&ModelId("deepseek".into())).is_some());
         assert!(reg.get(&ModelId("missing".into())).is_none());
     }
 
     #[test]
     fn cache_aware_zmq_builds_via_factory() {
-        let cfg = cfg_with_models(&[("modelA", PolicyKind::CacheAwareZmq)]);
+        let cfg = cfg_with_model("modelA", PolicyKind::CacheAwareZmq);
         let tree = Arc::new(HashTree::new());
         let tokenizers = Arc::new(TokenizerRegistry::default());
         let reg = build_registry(&cfg, tree, tokenizers, BlockSizeOracle::new()).unwrap();

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -100,14 +100,18 @@ impl AppContext {
                     port: 0,
                 },
                 observability: Default::default(),
-                models: vec![],
-                discovery: crate::config::DiscoveryConfig {
-                    backend: crate::config::DiscoveryBackend::StaticUrls(
-                        crate::config::StaticUrlsDiscoveryConfig {
-                            urls: vec!["http://placeholder:0".into()],
-                        },
-                    ),
+                model: crate::config::ModelConfig {
+                    id: "stub-model".into(),
+                    tokenizer_path: "stub".into(),
+                    policy: crate::config::PolicyKind::RoundRobin,
+                    circuit_breaker: None,
+                    cache_aware: None,
                 },
+                discovery: crate::config::DiscoveryBackend::StaticUrls(
+                    crate::config::StaticUrlsDiscoveryConfig {
+                        urls: vec!["http://placeholder:0".into()],
+                    },
+                ),
                 proxy: crate::config::ProxyConfig::default(),
                 active_load: crate::config::ActiveLoadConfig::default(),
             },

--- a/experimental/sgl-router/src/server/routes/models.rs
+++ b/experimental/sgl-router/src/server/routes/models.rs
@@ -21,16 +21,14 @@ pub struct ModelEntry {
 }
 
 pub async fn list_models(State(ctx): State<Arc<AppContext>>) -> Json<ModelsList> {
-    let data = ctx
-        .config
-        .models
-        .iter()
-        .map(|m| ModelEntry {
-            id: m.id.clone(),
-            object: "model",
-            owned_by: "sglang",
-        })
-        .collect();
+    // The router serves a single configured model; OpenAI clients still
+    // expect a list shape, so return a one-element `data` array.
+    let m = &ctx.config.model;
+    let data = vec![ModelEntry {
+        id: m.id.clone(),
+        object: "model",
+        owned_by: "sglang",
+    }];
     Json(ModelsList {
         object: "list",
         data,
@@ -47,24 +45,15 @@ mod tests {
     use crate::config::PolicyKind;
 
     #[tokio::test]
-    async fn lists_configured_models() {
+    async fn lists_configured_model() {
         let mut ctx = crate::server::app_context::AppContext::stub();
-        ctx.config.models = vec![
-            crate::config::ModelConfig {
-                id: "qwen3".into(),
-                tokenizer_path: "x".into(),
-                policy: PolicyKind::RoundRobin,
-                circuit_breaker: None,
-                cache_aware: None,
-            },
-            crate::config::ModelConfig {
-                id: "deepseek".into(),
-                tokenizer_path: "y".into(),
-                policy: PolicyKind::RoundRobin,
-                circuit_breaker: None,
-                cache_aware: None,
-            },
-        ];
+        ctx.config.model = crate::config::ModelConfig {
+            id: "qwen3".into(),
+            tokenizer_path: "x".into(),
+            policy: PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
+        };
         let app = crate::server::app::build_router(std::sync::Arc::new(ctx));
         let res = app
             .oneshot(
@@ -85,13 +74,12 @@ mod tests {
             .iter()
             .map(|m| m["id"].as_str().unwrap())
             .collect();
-        assert_eq!(ids, vec!["qwen3", "deepseek"]);
+        assert_eq!(ids, vec!["qwen3"]);
         assert_eq!(v["data"][0]["object"], "model");
         // Pin `owned_by` so a refactor that flips the hardcoded value to
         // "openai" / "" / a typo would fail loudly here. OpenAI clients
         // expect this field and some (e.g. langchain-openai) treat
         // `owned_by != "system"` as a meaningful signal.
         assert_eq!(v["data"][0]["owned_by"], "sglang");
-        assert_eq!(v["data"][1]["owned_by"], "sglang");
     }
 }

--- a/experimental/sgl-router/src/server/routes/tokenize.rs
+++ b/experimental/sgl-router/src/server/routes/tokenize.rs
@@ -114,20 +114,18 @@ mod tests {
                 port: 0,
             },
             observability: Default::default(),
-            models: vec![crate::config::ModelConfig {
+            model: crate::config::ModelConfig {
                 id: "tiny".into(),
                 tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
                 policy: PolicyKind::RoundRobin,
                 circuit_breaker: None,
                 cache_aware: None,
-            }],
-            discovery: crate::config::DiscoveryConfig {
-                backend: crate::config::DiscoveryBackend::StaticUrls(
-                    crate::config::StaticUrlsDiscoveryConfig {
-                        urls: vec!["http://placeholder:0".into()],
-                    },
-                ),
             },
+            discovery: crate::config::DiscoveryBackend::StaticUrls(
+                crate::config::StaticUrlsDiscoveryConfig {
+                    urls: vec!["http://placeholder:0".into()],
+                },
+            ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
         };

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -24,10 +24,9 @@ impl std::fmt::Debug for TokenizerRegistry {
 impl TokenizerRegistry {
     pub fn load_from_config(cfg: &crate::config::Config) -> Result<Self> {
         let me = TokenizerRegistry::default();
-        for m in &cfg.models {
-            let t = adapter::load(&m.tokenizer_path)?;
-            me.inner.insert(m.id.clone(), t);
-        }
+        let m = &cfg.model;
+        let t = adapter::load(&m.tokenizer_path)?;
+        me.inner.insert(m.id.clone(), t);
         Ok(me)
     }
 
@@ -54,20 +53,18 @@ mod tests {
                 port: 0,
             },
             observability: Default::default(),
-            models: vec![crate::config::ModelConfig {
+            model: crate::config::ModelConfig {
                 id: "tiny".into(),
                 tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
                 policy: PolicyKind::RoundRobin,
                 circuit_breaker: None,
                 cache_aware: None,
-            }],
-            discovery: crate::config::DiscoveryConfig {
-                backend: crate::config::DiscoveryBackend::StaticUrls(
-                    crate::config::StaticUrlsDiscoveryConfig {
-                        urls: vec!["http://placeholder:0".into()],
-                    },
-                ),
             },
+            discovery: crate::config::DiscoveryBackend::StaticUrls(
+                crate::config::StaticUrlsDiscoveryConfig {
+                    urls: vec!["http://placeholder:0".into()],
+                },
+            ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
         }
@@ -192,7 +189,7 @@ mod tests {
     #[test]
     fn missing_file_errors() {
         let mut c = cfg();
-        c.models[0].tokenizer_path = "/nonexistent.json".into();
+        c.model.tokenizer_path = "/nonexistent.json".into();
         let err = TokenizerRegistry::load_from_config(&c).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("tokenizer"));
     }

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -16,18 +16,17 @@ use tokio::task::JoinHandle;
 
 /// Resolve the circuit-breaker config for all model IDs carried by a spec.
 ///
-/// Workers may serve multiple models; we use the config of the **first** model
-/// that has an explicit CB config, falling back to `None` (default config).
+/// The router serves a single configured model; apply its circuit-breaker
+/// config when this worker advertises that model id. Falls back to `None`
+/// (default config) otherwise.
 fn cb_config_for_spec(spec: &WorkerSpec, cfg: &Config) -> Option<CircuitBreakerConfig> {
-    for model_id in &spec.model_ids {
-        if let Some(mc) = cfg.models.iter().find(|m| m.id == model_id.0) {
-            if let Some(cbc) = &mc.circuit_breaker {
-                return Some(CircuitBreakerConfig {
-                    threshold: cbc.threshold,
-                    cool_down: Duration::from_secs(cbc.cool_down_secs),
-                });
-            }
-        }
+    let model = &cfg.model;
+    let cbc = model.circuit_breaker.as_ref()?;
+    if spec.model_ids.iter().any(|id| id.0 == model.id) {
+        return Some(CircuitBreakerConfig {
+            threshold: cbc.threshold,
+            cool_down: Duration::from_secs(cbc.cool_down_secs),
+        });
     }
     None
 }
@@ -279,8 +278,8 @@ async fn register_one(
 mod tests {
     use super::*;
     use crate::config::{
-        ActiveLoadConfig, CircuitBreakerConfig as RawCbConfig, DiscoveryBackend, DiscoveryConfig,
-        ModelConfig, PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+        ActiveLoadConfig, CircuitBreakerConfig as RawCbConfig, DiscoveryBackend, ModelConfig,
+        PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
     };
     use crate::discovery::{WorkerId, WorkerMode};
     use axum::{routing::get, Json, Router};
@@ -296,7 +295,7 @@ mod tests {
                 port: 0,
             },
             observability: Default::default(),
-            models: vec![ModelConfig {
+            model: ModelConfig {
                 id: id.into(),
                 tokenizer_path: "/tmp/x".into(),
                 policy: PolicyKind::RoundRobin,
@@ -305,12 +304,10 @@ mod tests {
                     cool_down_secs,
                 }),
                 cache_aware: None,
-            }],
-            discovery: DiscoveryConfig {
-                backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                    urls: vec!["http://test:30000".into()],
-                }),
             },
+            discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+                urls: vec!["http://test:30000".into()],
+            }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
         }

--- a/experimental/sgl-router/tests/component/discovery/static_urls.rs
+++ b/experimental/sgl-router/tests/component/discovery/static_urls.rs
@@ -90,8 +90,7 @@ async fn static_urls_pd_role_resolved_end_to_end() {
     use axum::{routing::get, Json, Router};
     use serde_json::json;
     use sgl_router::config::{
-        ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ObservabilityConfig,
-        ProxyConfig, ServerConfig,
+        ActiveLoadConfig, Config, DiscoveryBackend, ObservabilityConfig, ProxyConfig, ServerConfig,
     };
     use sgl_router::discovery::{spawn_discovery, WorkerId};
     use sgl_router::workers::{manager, WorkerRegistry};
@@ -127,12 +126,16 @@ async fn static_urls_pd_role_resolved_end_to_end() {
             port: 0,
         },
         observability: ObservabilityConfig::default(),
-        models: vec![],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec![url.clone()],
-            }),
+        model: sgl_router::config::ModelConfig {
+            id: "tiny".into(),
+            tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
+            policy: sgl_router::config::PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec![url.clone()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     };

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -65,20 +65,18 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
             port: 0,
         },
         observability: Default::default(),
-        models: vec![sgl_router::config::ModelConfig {
+        model: sgl_router::config::ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: sgl_router::config::PolicyKind::CacheAwareZmq,
             circuit_breaker: None,
             cache_aware: None,
-        }],
-        discovery: sgl_router::config::DiscoveryConfig {
-            backend: sgl_router::config::DiscoveryBackend::StaticUrls(
-                sgl_router::config::StaticUrlsDiscoveryConfig {
-                    urls: vec!["http://placeholder:0".into()],
-                },
-            ),
         },
+        discovery: sgl_router::config::DiscoveryBackend::StaticUrls(
+            sgl_router::config::StaticUrlsDiscoveryConfig {
+                urls: vec!["http://placeholder:0".into()],
+            },
+        ),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     };

--- a/experimental/sgl-router/tests/e2e/conftest.py
+++ b/experimental/sgl-router/tests/e2e/conftest.py
@@ -166,81 +166,64 @@ def _find_tokenizer_path(model: str) -> str:
     return model
 
 
-def build_smoke_router_config(
+def build_smoke_router_args(
     *,
     host: str,
     port: int,
     model: str,
     tokenizer_path: str,
     sglang_url: str,
-) -> str:
-    """Build the TOML the smoke `router` fixture writes to disk.
+) -> list[str]:
+    """Build the sgl-router CLI flags the smoke ``router`` fixture launches.
 
-    Returns ``main_config_text`` carrying ``[server]``, ``[[models]]``,
-    and ``[discovery] backend = "static_urls"`` with the worker URL
-    inline. The Rust ``Config`` struct requires a ``[discovery]``
-    section (``DiscoveryConfig`` has no ``#[serde(default)]``) and has
-    no top-level ``workers`` field. The previous ``static_file``
-    backend was replaced by ``static_urls`` (which holds the URL list
-    inline rather than via a side-car file).
+    Static single-worker discovery (``--worker-urls``) pointed at the one
+    SGLang worker, serving exactly one model.
     """
-    return f"""\
-[server]
-host = "{host}"
-port = {port}
-
-[[models]]
-id = "{model}"
-tokenizer_path = "{tokenizer_path}"
-
-[discovery]
-backend = "static_urls"
-
-[discovery.static_urls]
-urls = ["{sglang_url}"]
-"""
+    return [
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--model-id",
+        model,
+        "--tokenizer-path",
+        tokenizer_path,
+        "--worker-urls",
+        sglang_url,
+    ]
 
 
 @pytest.fixture(scope="session")
 def router(sglang_server):  # noqa: ARG001  (sglang_server must start first)
     """Launch sgl-router on port 8090 pointed at the SGLang worker."""
     tok_path = _find_tokenizer_path(MODEL)
-    cfg_handle = tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False)
-    cfg_path = Path(cfg_handle.name)
-    main_text = build_smoke_router_config(
+    args = build_smoke_router_args(
         host="0.0.0.0",
         port=ROUTER_PORT,
         model=MODEL,
         tokenizer_path=tok_path,
         sglang_url=f"http://localhost:{SGLANG_PORT}",
     )
-    cfg_handle.write(main_text)
-    cfg_handle.close()
 
+    proc = subprocess.Popen(
+        [str(_BINARY), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    # try/finally so the router is always reaped — on a readiness-probe
+    # failure, a test-body error, or a session-teardown exception alike.
     try:
-        proc = subprocess.Popen(
-            [str(_BINARY), "--config", str(cfg_path)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-
-        try:
-            _wait_http(f"http://localhost:{ROUTER_PORT}/readyz", timeout=60)
-        except Exception:
-            proc.send_signal(signal.SIGTERM)
-            proc.wait(timeout=30)
-            raise
-
+        _wait_http(f"http://localhost:{ROUTER_PORT}/readyz", timeout=60)
         yield f"http://localhost:{ROUTER_PORT}"
-
-        proc.send_signal(signal.SIGTERM)
-        try:
-            proc.wait(timeout=30)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
     finally:
-        cfg_path.unlink(missing_ok=True)
+        if proc.poll() is None:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
 
 
 # ---------------------------------------------------------------------------

--- a/experimental/sgl-router/tests/e2e/infra/gateway.py
+++ b/experimental/sgl-router/tests/e2e/infra/gateway.py
@@ -1,23 +1,22 @@
-"""Minimal sgl-router Gateway class — adapted from SMG's e2e_test/infra/gateway.py.
+"""Minimal sgl-router Gateway class for e2e tests.
 
-Differences from SMG:
-  - SMG drives a Python launcher (`python3 -m sglang_router.launch_router`)
-    with worker URLs on the CLI.
-  - sgl-router uses a Rust binary (`experimental/sgl-router/target/release/sgl-router`)
-    with a TOML config file. Worker discovery is config-file-based; this
-    Gateway writes a TOML to a tempfile and execs the binary with
-    `--config <tempfile>`.
+sgl-router is a Rust binary
+(`experimental/sgl-router/target/release/sgl-router`) configured entirely
+through CLI flags. This Gateway execs the binary with `--worker-urls <...>`
+(static discovery) plus the model + policy flags.
 
 Supported lifecycles:
   - Regular mode: one model, N worker URLs, single policy.
-  - PD mode: one model, prefill_workers + decode_workers (lists of URLs),
-    discovery emits separate `WorkerMode::Prefill` / `WorkerMode::Decode`
-    entries. The router resolves PD pool isolation at request time.
+  - PD mode: one model; prefill + decode URLs all go into one
+    `--worker-urls` static list. Each worker is seeded as
+    `WorkerMode::Plain` and its actual prefill/decode role + bootstrap
+    port are resolved from `/server_info` introspection, after which the
+    router isolates the PD pools at request time.
 
 Use as a context manager:
 
     with Gateway() as gw:
-        gw.start_regular(model_path="...", worker_urls=[...])
+        gw.start_regular(model_id="...", tokenizer_path="...", worker_urls=[...])
         resp = httpx.post(f"{gw.base_url}/v1/chat/completions", json=...)
 
 or pytest fixture style (see e2e_test/conftest.py).
@@ -30,7 +29,6 @@ import os
 import signal
 import socket
 import subprocess
-import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -93,8 +91,11 @@ def _resolve_tokenizer_path(tokenizer_path: str) -> str:
         cached = try_to_load_from_cache(tokenizer_path, "tokenizer.json")
         if cached and Path(cached).is_file():
             return str(cached)
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as exc:  # noqa: BLE001
+        # A cache miss is normal; log other failures (corrupt cache,
+        # signature change) so a later tokenizer-load error is traceable
+        # rather than mysterious.
+        logger.debug("HF tokenizer cache lookup failed for %r: %s", tokenizer_path, exc)
     return tokenizer_path
 
 
@@ -150,7 +151,6 @@ class Gateway:
         self.stale_request_timeout_secs = stale_request_timeout_secs
 
         self.process: subprocess.Popen | None = None
-        self._config_path: Path | None = None
         self._started: bool = False
         # Track child workers we spawned so __exit__ can tear them down.
         self._owned_workers: list[subprocess.Popen] = []
@@ -172,7 +172,6 @@ class Gateway:
         tokenizer_path: str,
         worker_urls: list[str],
         policy: str = "round_robin",
-        extra_models: list[dict] | None = None,
         timeout: float = 60.0,
     ) -> None:
         """Start the router in regular (non-PD) mode.
@@ -190,12 +189,11 @@ class Gateway:
             timeout: How long to wait for ``/readyz`` before giving up.
         """
         self._launch(
-            self._build_config(
+            self._build_args(
                 model_id=model_id,
                 tokenizer_path=tokenizer_path,
                 urls=list(worker_urls),
                 policy=policy,
-                extra_models=extra_models or [],
             ),
             timeout=timeout,
         )
@@ -222,12 +220,11 @@ class Gateway:
         assumed.
         """
         self._launch(
-            self._build_config(
+            self._build_args(
                 model_id=model_id,
                 tokenizer_path=tokenizer_path,
                 urls=list(prefill_urls) + list(decode_urls),
                 policy=policy,
-                extra_models=[],
             ),
             timeout=timeout,
         )
@@ -247,9 +244,6 @@ class Gateway:
             except ProcessLookupError:
                 pass
         self.process = None
-        if self._config_path and self._config_path.exists():
-            self._config_path.unlink(missing_ok=True)
-        self._config_path = None
         self._started = False
         # Tear down any owned upstream workers.
         for w in self._owned_workers:
@@ -292,77 +286,53 @@ class Gateway:
 
     # ----- internals ------------------------------------------------------
 
-    def _build_config(
+    def _build_args(
         self,
         *,
         model_id: str,
         tokenizer_path: str,
         urls: list[str],
         policy: str,
-        extra_models: list[dict],
-    ) -> str:
+    ) -> list[str]:
         resolved_tokenizer = _resolve_tokenizer_path(tokenizer_path)
 
-        extra_model_toml = ""
-        for em in extra_models:
-            extra_model_toml += (
-                f'\n[[models]]\nid = "{em["id"]}"\n'
-                f'tokenizer_path = "{_resolve_tokenizer_path(em["tokenizer_path"])}"\n'
-                f'policy = "{em.get("policy", policy)}"\n'
-            )
-
-        # Optional tunables — only emit the [proxy] and [active_load]
-        # sections if a test has overridden them, so production defaults
-        # apply otherwise.
-        proxy_section = ""
+        args = [
+            "--host",
+            self.host,
+            "--port",
+            str(self.port),
+            "--model-id",
+            model_id,
+            "--tokenizer-path",
+            resolved_tokenizer,
+            "--policy",
+            policy,
+        ]
+        # Optional tunables — only pass them if a test overrode them, so
+        # the router's production defaults apply otherwise.
         if self.proxy_request_timeout_secs is not None:
-            proxy_section = (
-                f"\n[proxy]\nrequest_timeout_secs = {self.proxy_request_timeout_secs}\n"
-            )
-        active_load_section = ""
+            args += ["--request-timeout-secs", str(self.proxy_request_timeout_secs)]
         if self.stale_request_timeout_secs is not None:
-            active_load_section = (
-                f"\n[active_load]\nstale_request_timeout_secs = "
-                f"{self.stale_request_timeout_secs}\n"
-            )
+            args += [
+                "--stale-request-timeout-secs",
+                str(self.stale_request_timeout_secs),
+            ]
+        # `--worker-urls` is multi-valued; keep it last so clap doesn't
+        # absorb a following flag as a URL.
+        args += ["--worker-urls", *urls]
+        return args
 
-        urls_toml = ", ".join(f'"{u}"' for u in urls)
-
-        return f"""\
-[server]
-host = "{self.host}"
-port = {self.port}
-
-[[models]]
-id = "{model_id}"
-tokenizer_path = "{resolved_tokenizer}"
-policy = "{policy}"
-{extra_model_toml}
-
-[discovery]
-backend = "static_urls"
-
-[discovery.static_urls]
-urls = [{urls_toml}]
-{proxy_section}{active_load_section}"""
-
-    def _launch(self, config_text: str, *, timeout: float) -> None:
+    def _launch(self, args: list[str], *, timeout: float) -> None:
         if not self.binary.exists():
             raise RuntimeError(
                 f"sgl-router binary not found at {self.binary}. "
                 "Build it first: `cd experimental/sgl-router && cargo build --release` "
                 "or set SGL_ROUTER_BINARY to the binary path."
             )
-        # Write the main config.
-        fd, path = tempfile.mkstemp(suffix=".toml", prefix="sgl-router-")
-        os.close(fd)
-        self._config_path = Path(path)
-        self._config_path.write_text(config_text, encoding="utf-8")
-        logger.info("sgl-router config: %s", self._config_path)
-        logger.debug("sgl-router config text:\n%s", config_text)
+        logger.info("sgl-router args: %s", args)
 
         self.process = subprocess.Popen(
-            [str(self.binary), "--config", str(self._config_path)],
+            [str(self.binary), *args],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             start_new_session=True,
@@ -380,16 +350,19 @@ urls = [{urls_toml}]
         last_exc: Exception | None = None
         while time.time() < deadline:
             if self.process is not None and self.process.poll() is not None:
-                # Process exited early — surface stdout/stderr.
-                out = b""
+                # Process exited early — surface stdout/stderr. This is the
+                # primary startup-failure diagnostic, so if the read itself
+                # fails, report that instead of blanking the output.
                 try:
+                    out = b""
                     if self.process.stdout is not None:
                         out = self.process.stdout.read() or b""
-                except Exception:  # noqa: BLE001
-                    pass
+                    output = out.decode(errors="replace")
+                except Exception as read_exc:  # noqa: BLE001
+                    output = f"<failed to read router stdout: {read_exc}>"
                 raise RuntimeError(
                     f"sgl-router exited during startup with code "
-                    f"{self.process.returncode}. output:\n{out.decode(errors='replace')}",
+                    f"{self.process.returncode}. output:\n{output}",
                 )
             try:
                 resp = httpx.get(f"{self.base_url}/readyz", timeout=2.0)

--- a/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router-cluster-scoped.yaml
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router-cluster-scoped.yaml
@@ -20,9 +20,23 @@ spec:
         - name: router
           image: sgl-router:e2e
           imagePullPolicy: Never
+          # Configured entirely via CLI flags. No --service-discovery-namespace
+          # means a cluster-wide EndpointSlice watch (all namespaces); the
+          # `cross-ns-test=true` selector term scopes it to this test's workers.
           args:
-            - "--config"
-            - "/etc/config/router-cluster.toml"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8091"
+            - "--model-id"
+            - "tiny"
+            - "--tokenizer-path"
+            - "/etc/tokenizer/tiny.json"
+            - "--policy"
+            - "round_robin"
+            - "--service-discovery"
+            - "--selector"
+            - "app=sglang,cross-ns-test=true"
           ports:
             - containerPort: 8091
               name: http
@@ -38,13 +52,6 @@ spec:
               port: 8091
             initialDelaySeconds: 5
             periodSeconds: 10
-          volumeMounts:
-            - name: config
-              mountPath: /etc/config
-      volumes:
-        - name: config
-          configMap:
-            name: sgl-router-cluster-config
 ---
 apiVersion: v1
 kind: Service

--- a/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router.yaml
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router.yaml
@@ -18,9 +18,32 @@ spec:
         - name: router
           image: sgl-router:e2e
           imagePullPolicy: Never
+          # Configured entirely via CLI flags. K8s EndpointSlice discovery
+          # watches `app=sglang` pods in this namespace. The aggressive
+          # circuit breaker (threshold 1, 5s cool-down) lets a terminating
+          # pod's connection-refused immediately drop it from the candidate
+          # set — the reconciliation tests scale workers rapidly and depend
+          # on fast eviction to absorb the churn.
           args:
-            - "--config"
-            - "/etc/config/router.toml"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8090"
+            - "--model-id"
+            - "tiny"
+            - "--tokenizer-path"
+            - "/etc/tokenizer/tiny.json"
+            - "--policy"
+            - "round_robin"
+            - "--cb-threshold"
+            - "1"
+            - "--cb-cool-down-secs"
+            - "5"
+            - "--service-discovery"
+            - "--service-discovery-namespace"
+            - "sgl-router-test"
+            - "--selector"
+            - "app=sglang"
           ports:
             - containerPort: 8090
               name: http
@@ -36,13 +59,6 @@ spec:
               port: 8090
             initialDelaySeconds: 5
             periodSeconds: 10
-          volumeMounts:
-            - name: config
-              mountPath: /etc/config
-      volumes:
-        - name: config
-          configMap:
-            name: sgl-router-config
 ---
 apiVersion: v1
 kind: Service

--- a/experimental/sgl-router/tests/e2e/k8s_integration/setup.sh
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/setup.sh
@@ -141,38 +141,9 @@ log "Waiting for fake-worker rollout..."
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/fake-worker --timeout=120s
 
 # ---------------------------------------------------------------------------
-# Step 6: Create sgl-router ConfigMap with k8s discovery pointing at the
-#         namespace where fake-worker pods live.
-# ---------------------------------------------------------------------------
-log "Creating sgl-router-config ConfigMap..."
-ROUTER_CONFIG="[server]
-host = \"0.0.0.0\"
-port = 8090
-
-[[models]]
-id = \"tiny\"
-tokenizer_path = \"/etc/tokenizer/tiny.json\"
-policy = \"round_robin\"
-# Aggressive breaker so a terminating pod's connection-refused
-# immediately excludes it from the next request's candidate set —
-# the reconciliation tests scale workers rapidly and depend on
-# fast worker eviction to absorb the churn.
-circuit_breaker = { threshold = 1, cool_down_secs = 5 }
-
-[discovery]
-backend = \"k8s\"
-
-[discovery.k8s]
-namespace = \"${NAMESPACE}\"
-label_selector = \"app=sglang\""
-
-kubectl --context "${CONTEXT}" -n "${NAMESPACE}" create configmap sgl-router-config \
-    --from-literal=router.toml="${ROUTER_CONFIG}" \
-    --dry-run=client -o yaml \
-    | kubectl --context "${CONTEXT}" apply -f -
-
-# ---------------------------------------------------------------------------
-# Step 7: Deploy sgl-router
+# Step 6: Deploy sgl-router. It is configured entirely via CLI flags in
+#         router.yaml — k8s EndpointSlice discovery watches `app=sglang`
+#         pods in the sgl-router-test namespace (where fake-worker lives).
 # ---------------------------------------------------------------------------
 log "Deploying sgl-router..."
 kubectl --context "${CONTEXT}" apply -f "${MANIFESTS_DIR}/router.yaml"

--- a/experimental/sgl-router/tests/e2e/k8s_integration/test_cross_namespace.py
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/test_cross_namespace.py
@@ -149,49 +149,9 @@ def cluster_scoped_router(k8s_cluster):
     _ensure_namespace(EXTRA_NAMESPACE)
     _ensure_service_in_ns(EXTRA_NAMESPACE)
 
-    # ConfigMap for the cluster-scoped router: empty namespace = watch all
-    cluster_config = """[server]
-host = "0.0.0.0"
-port = 8091
-
-[[models]]
-id = "tiny"
-tokenizer_path = "/etc/tokenizer/tiny.json"
-policy = "round_robin"
-
-[discovery]
-backend = "k8s"
-
-[discovery.k8s]
-namespace = ""
-label_selector = "app=sglang,cross-ns-test=true"
-"""
-    _kubectl(
-        "create",
-        "configmap",
-        "sgl-router-cluster-config",
-        f"--from-literal=router-cluster.toml={cluster_config}",
-        "-n",
-        NAMESPACE,
-        "--dry-run=client",
-        "-o",
-        "yaml",
-        check=True,
-    )
-    # pipe through apply
-    proc = _kubectl(
-        "create",
-        "configmap",
-        "sgl-router-cluster-config",
-        f"--from-literal=router-cluster.toml={cluster_config}",
-        "-n",
-        NAMESPACE,
-        "--dry-run=client",
-        "-o",
-        "yaml",
-    )
-    _apply_from_stdin(proc.stdout)
-
+    # The cluster-scoped router is configured via CLI flags in
+    # router-cluster-scoped.yaml: no --service-discovery-namespace (watch
+    # all namespaces) and --selector app=sglang,cross-ns-test=true.
     _kubectl("apply", "-f", str(router_manifest))
 
     # The cluster-scoped router's /readyz blocks on registry-not-empty, so

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ModelConfig, ObservabilityConfig,
-    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -29,18 +29,16 @@ fn config_for(_worker_url: &str) -> Config {
             port: 0,
         },
         observability: ObservabilityConfig::default(),
-        models: vec![ModelConfig {
+        model: ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: PolicyKind::RoundRobin,
             circuit_breaker: None,
             cache_aware: None,
-        }],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec!["http://placeholder:0".into()],
-            }),
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     }
@@ -619,7 +617,7 @@ async fn no_healthy_workers_returns_503() {
     );
 }
 
-/// A worker is registered for a model that is NOT in `cfg.models` (so the
+/// A worker is registered for a model that is NOT the configured `cfg.model` (so the
 /// policy registry has no entry for it).  The handler returns 404
 /// `model_not_found` rather than 500 — clients can recover by sending a
 /// different model name; an internal_error would mask the misconfiguration.

--- a/experimental/sgl-router/tests/proxy/failover.rs
+++ b/experimental/sgl-router/tests/proxy/failover.rs
@@ -31,7 +31,7 @@ async fn failover_when_one_worker_dies() {
             port: 0,
         },
         observability: Default::default(),
-        models: vec![ModelConfig {
+        model: ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: PolicyKind::RoundRobin,
@@ -40,12 +40,10 @@ async fn failover_when_one_worker_dies() {
                 cool_down_secs: 30,
             }),
             cache_aware: None,
-        }],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec![w1.url.clone(), w2.url.clone(), w3.url.clone()],
-            }),
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec![w1.url.clone(), w2.url.clone(), w3.url.clone()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     };

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -16,8 +16,8 @@
 
 use bytes::Bytes;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ModelConfig, ObservabilityConfig,
-    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults;
@@ -40,18 +40,16 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
             port: 0,
         },
         observability: ObservabilityConfig::default(),
-        models: vec![ModelConfig {
+        model: ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: PolicyKind::RoundRobin,
             circuit_breaker: None,
             cache_aware: None,
-        }],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec!["http://placeholder:0".into()],
-            }),
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     };

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -4,8 +4,8 @@
 use axum::body::Body;
 use axum::http::Request;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ModelConfig, ObservabilityConfig,
-    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -27,18 +27,16 @@ async fn forwards_whitelisted_headers_strips_others() {
             port: 0,
         },
         observability: ObservabilityConfig::default(),
-        models: vec![ModelConfig {
+        model: ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: PolicyKind::RoundRobin,
             circuit_breaker: None,
             cache_aware: None,
-        }],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec!["http://placeholder:0".into()],
-            }),
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     };

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -21,8 +21,8 @@ use axum::http::{Request, StatusCode};
 use bytes::Bytes;
 use serde_json::{json, Value};
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ModelConfig, ObservabilityConfig,
-    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults;
@@ -42,18 +42,16 @@ fn config() -> Config {
             port: 0,
         },
         observability: ObservabilityConfig::default(),
-        models: vec![ModelConfig {
+        model: ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: PolicyKind::RoundRobin,
             circuit_breaker: None,
             cache_aware: None,
-        }],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec!["http://placeholder:0".into()],
-            }),
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     }

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -20,8 +20,8 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ModelConfig, ObservabilityConfig,
-    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults;
@@ -41,18 +41,16 @@ fn config() -> Config {
             port: 0,
         },
         observability: ObservabilityConfig::default(),
-        models: vec![ModelConfig {
+        model: ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: PolicyKind::RoundRobin,
             circuit_breaker: None,
             cache_aware: None,
-        }],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec!["http://placeholder:0".into()],
-            }),
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     }

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -13,8 +13,8 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, DiscoveryConfig, ModelConfig, ObservabilityConfig,
-    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -34,18 +34,16 @@ fn config(_worker_url: &str) -> Config {
             port: 0,
         },
         observability: ObservabilityConfig::default(),
-        models: vec![ModelConfig {
+        model: ModelConfig {
             id: "tiny".into(),
             tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
             policy: PolicyKind::RoundRobin,
             circuit_breaker: None,
             cache_aware: None,
-        }],
-        discovery: DiscoveryConfig {
-            backend: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
-                urls: vec!["http://placeholder:0".into()],
-            }),
         },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
     }


### PR DESCRIPTION
## Motivation

The experimental Rust `sgl-router` (`experimental/sgl-router/`) was config-file-only: its sole CLI arg was `--config <path>` pointing at a TOML/YAML file. This made it awkward to launch the way operators already launch the Python `sglang_router.launch_router` (`--host/--port/--service-discovery/--selector/...`). This PR makes the experimental router fully CLI-flag-driven and fixes it to serve exactly one model.

## Modifications

- **Single model.** `Config.models: Vec<ModelConfig>` → `Config.model: ModelConfig`, with every consumer updated (tokenizer registry, policy factory, worker manager, `/v1/models`).
- **CLI.** New `config/cli.rs` with a clap `Cli` + `into_config()` that builds a validated `Config`. Flags mirror the Python router: `--host` (default `127.0.0.1`), `--port` (default `30000`), `--model-id`, `--tokenizer-path`, `--policy`, `--worker-urls`, `--service-discovery`, `--service-discovery-namespace`, `--selector`, `--prefill-selector`, `--decode-selector`, plus `--cb-threshold/--cb-cool-down-secs`, the cache-aware knobs, `--request-timeout-secs`, `--stale-request-timeout-secs`, and `--log-level/--log-format`.
- **Discovery is mutually exclusive:** `--worker-urls` (static) XOR `--service-discovery` (k8s), exactly one required. Knobs that require another flag (`--cb-cool-down-secs` without `--cb-threshold`; cache-aware knobs without `--policy cache_aware_zmq`) are rejected rather than silently ignored. The existing `Config::validate` (URL/selector grammar) still runs.
- **Removed** `Config::from_path`, the serde (de)serialize plumbing, `DiscoveryConfigRaw`, and the `serde_yaml` / `toml` / `humantime-serde` deps. `PolicyKind` / `LogFormat` now derive `clap::ValueEnum`.
- **e2e migrated to flags:** `tests/e2e/conftest.py`, `tests/e2e/infra/gateway.py`, the k8s manifests (drop the ConfigMap mount, pass args inline), `setup.sh`, and `test_cross_namespace.py`.
- **README** refreshed with static + k8s `Running` examples.

### Example

```bash
sgl-router \
  --host 0.0.0.0 --port 30000 \
  --model-id qwen3 \
  --tokenizer-path /models/qwen3/tokenizer.json \
  --service-discovery \
  --service-discovery-namespace prod \
  --selector app=engines-qwen3
```

## Test

- `cargo test --all-targets` — 384 tests pass (config-file tests replaced by `Cli`→`Config` parsing tests in `cli.rs` and direct `validate()` tests in `mod.rs`; the k8s selector-grammar suite is unchanged).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` and `pre-commit run` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26828015984](https://github.com/sgl-project/sglang/actions/runs/26828015984)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #26828647311](https://github.com/sgl-project/sglang/actions/runs/26828647311)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->