### PR TITLE
Relax mamba unified cache kl threshold

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
@@ -30,7 +30,8 @@ MAMBA_TRACK_INTERVAL = 128
 class TestUnifiedMambaRadixCache(UnifiedRadixTreeTestMixin, CustomTestCase):
     """Mamba hybrid + UnifiedRadixCache."""
 
-    kl_threshold = 0.003
+    # fp8 cache-hit KL is noisy and flaked at 0.003, match the HiCache variant
+    kl_threshold = 0.005
     prefill_cache_assert = staticmethod(
         make_mamba_prefill_assert(chunk_size=MAMBA_CHUNK_SIZE)
     )


### PR DESCRIPTION
## Motivation

`TestUnifiedMambaRadixCache.test_multiturn_prefill_cache_hit_branching` flakes on fp8 run-to-run noise, not a regression. Over 100 fixed-input runs the prefill cache-hit KL exceeded the 0.003 threshold 6 times and never exceeded 0.005, so raise it to 0.005 to match the HiCache variant in the same file.

Flake: https://github.com/sgl-project/sglang/actions/runs/26756137186/job/78856492547









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26826534182](https://github.com/sgl-project/sglang/actions/runs/26826534182)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26826534192](https://github.com/sgl-project/sglang/actions/runs/26826534192)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->