### PR TITLE
[diffusion] Preserve dtype in WanVAE nearest upsample

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
@@ -211,7 +211,9 @@ class WanUpsample(nn.Upsample):
     """
 
     def forward(self, x):
-        return super().forward(x)
+        if current_platform.is_amp_supported():
+            return super().forward(x)
+        return super().forward(x.float()).type_as(x)
 
 
 is_first_frame = None

--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
@@ -211,7 +211,7 @@ class WanUpsample(nn.Upsample):
     """
 
     def forward(self, x):
-        return super().forward(x.float()).type_as(x)
+        return super().forward(x)
 
 
 is_first_frame = None


### PR DESCRIPTION
## Summary
- keep WanVAE nearest-exact upsample in the input dtype on AMP-supported platforms
- keep the existing fp32 upsample fallback on non-AMP platforms

## Validation
- Remote 4xH200 Cosmos3-Nano T2V A/B: MP4 sha matched baseline (`2b05ba6f...`)
- Candidate decode: `5.1732s` / `5.1712s`; base rerun decode: `5.2156s`
- Candidate peak memory: `43982MB`; base rerun peak memory: `44174MB`
- Final PR tip `7444ded7be`: sha matched baseline, decode `5.1742s`, peak memory `43980MB`





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26832952323](https://github.com/sgl-project/sglang/actions/runs/26832952323)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26832951197](https://github.com/sgl-project/sglang/actions/runs/26832951197)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->