### PR TITLE
support aiter backend for mimo models

### DIFF
--- a/docs_new/docs/hardware-platforms/amd_gpu.mdx
+++ b/docs_new/docs/hardware-platforms/amd_gpu.mdx
@@ -191,6 +191,21 @@ drun -p 30000:30000 \
     --port 30000
 ```
 
+### Running MiMo-V2-Flash
+
+MiMo-V2-Flash uses non-square attention (`qk_head_dim=192`, `v_head_dim=128`) with a
+128-token sliding window. Use TP=4 with the aiter backend:
+
+```bash
+python3 -m sglang.launch_server \
+    --model XiaomiMiMo/MiMo-V2-Flash \
+    --tp 4 \
+    --trust-remote-code \
+    --attention-backend aiter \
+    --host 0.0.0.0 \
+    --port 30000
+```
+
 ### Warmup Step
 
 When the server displays `The server is fired up and ready to roll!`, it means the startup is successful.

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -124,6 +124,9 @@ class AiterAttnBackend(AttentionBackend):
     ):
         super().__init__()
         # Lazy import to avoid the initialization of cuda context
+        from sglang.srt.layers.attention.triton_ops.decode_attention import (
+            decode_attention_fwd,
+        )
         from sglang.srt.layers.attention.triton_ops.extend_attention import (
             extend_attention_fwd,
         )
@@ -132,6 +135,10 @@ class AiterAttnBackend(AttentionBackend):
 
         self.page_size = model_runner.server_args.page_size
 
+        # Fallbacks for models where qk_head_dim != v_head_dim (non-square attention).
+        # unified_attention / mha_batch_prefill_func both assume equal K/V head dims;
+        # these Triton kernels handle arbitrary Lk != Lv.
+        self.decode_attention_fwd = torch.compiler.disable(decode_attention_fwd)
         self.extend_attention_fwd = torch.compiler.disable(extend_attention_fwd)
 
         self.device = model_runner.device
@@ -257,6 +264,33 @@ class AiterAttnBackend(AttentionBackend):
         self.logits_soft_cap = 0.0
 
         self.forward_metadata: ForwardMetadata = None
+
+        # --- Non-square attention state (qk_head_dim != v_head_dim) ---
+        # All buffers are pre-allocated (None = lazy on first use) so that
+        # no torch.empty() call occurs inside CUDA graph capture.
+        self.sliding_window_size = (
+            getattr(model_runner, "sliding_window_size", None) or 0
+        )
+        self._nonsq_max_bs = max_bs
+        self._nonsq_max_kv_splits = 32
+        self._nonsq_decode_attn_logits = None  # (bs, q_heads, kv_splits, v_head_dim)
+        self._nonsq_decode_attn_lse = None  # (bs, q_heads, kv_splits)
+        self._nonsq_decode_num_kv_splits = None  # (bs,)
+        # BF16 scratch for dequantising FP8 KV cache before passing to decode_attention_fwd.
+        self._nonsq_k_bf16_full = None
+        self._nonsq_v_bf16_full = None
+        self._nonsq_k_bf16_swa = None
+        self._nonsq_v_bf16_swa = None
+        # .item() is a CPU-GPU sync; extract scales once in metadata init, not per forward.
+        self._nonsq_k_scale_val: float = 1.0
+        self._nonsq_v_scale_val: float = 1.0
+        # Fixed-stride buffers so kv_indices_ptr_stride (tl.constexpr) never changes;
+        # a constexpr change on AMD/ROCm triggers a Triton recompile that crashes.
+        self._unified_kv_indices_buf = None  # (max_bs, max_context_len)
+        self._unified_swa_page_table_buf = None  # (max_bs, max_context_len)
+        # Windowed indptr/start for SWA decode: only last sliding_window_size KV slots.
+        self._nonsq_swa_kv_indptr = None
+        self._nonsq_swa_kv_start = None
 
         if self.use_mla:
             _valid_heads = self.num_head in (4, 8) or (
@@ -695,6 +729,82 @@ class AiterAttnBackend(AttentionBackend):
             )
         return self._kv_indices_scratch[:required_tokens]
 
+    def _build_nonsq_flat_indices(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        swa_page_table,
+    ) -> None:
+        """Build flat token-level KV index buffers for non-square decode_attention_fwd.
+
+        decode_attention_fwd requires a flat per-token index array (not paged), and
+        natively handles Lk != Lv.  For SWA layers the array is windowed to the last
+        sliding_window_size tokens so the kernel never sees out-of-window slots.
+        All buffers are lazily allocated here rather than in __init__ to keep __init__
+        CUDA-graph-safe (no torch.empty inside graph capture).
+        """
+        if not hasattr(self, "_nonsq_flat_full_kv_indices"):
+            buf_numel = (
+                self._nonsq_max_bs
+                * ((self.max_context_len + self.page_size - 1) // self.page_size)
+                * self.page_size
+            )
+            self._nonsq_flat_full_kv_indices = torch.zeros(
+                buf_numel, dtype=torch.int32, device=self.device
+            )
+            self._nonsq_flat_swa_kv_indices = torch.zeros(
+                buf_numel, dtype=torch.int32, device=self.device
+            )
+            self._nonsq_seq_req_indices = torch.arange(
+                self._nonsq_max_bs, dtype=torch.int32, device=self.device
+            )
+        if self._nonsq_swa_kv_indptr is None:
+            self._nonsq_swa_kv_indptr = torch.zeros(
+                self._nonsq_max_bs + 1, dtype=torch.int32, device=self.device
+            )
+            self._nonsq_swa_kv_start = torch.zeros(
+                self._nonsq_max_bs, dtype=torch.int32, device=self.device
+            )
+        kv_indptr = self.kv_indptr
+        kv_indptr[0] = 0
+        kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens[:bs], dim=0)
+        create_flashinfer_kv_indices_triton[(bs,)](
+            self.req_to_token,
+            req_pool_indices,
+            seq_lens,
+            kv_indptr,
+            None,
+            self._nonsq_flat_full_kv_indices,
+            self.req_to_token.stride(0),
+        )
+        if self.use_sliding_window_kv_pool:
+            _swa_lens = torch.clamp(seq_lens[:bs], max=self.sliding_window_size)
+            _swa_start = seq_lens[:bs] - _swa_lens
+            swa_kv_indptr = self._nonsq_swa_kv_indptr
+            swa_kv_indptr[0] = 0
+            swa_kv_indptr[1 : bs + 1] = torch.cumsum(_swa_lens, dim=0)
+            self._nonsq_swa_kv_start[:bs].copy_(_swa_start)
+            create_flashinfer_kv_indices_triton[(bs,)](
+                swa_page_table,
+                self._nonsq_seq_req_indices,
+                _swa_lens,
+                swa_kv_indptr,
+                self._nonsq_swa_kv_start,
+                self._nonsq_flat_swa_kv_indices,
+                swa_page_table.stride(0),
+            )
+        self._nonsq_k_scale_val = (
+            self.k_scale.item()
+            if isinstance(self.k_scale, torch.Tensor)
+            else float(self.k_scale)
+        )
+        self._nonsq_v_scale_val = (
+            self.v_scale.item()
+            if isinstance(self.v_scale, torch.Tensor)
+            else float(self.v_scale)
+        )
+
     def _set_uniform_qo_indptr(
         self, bs: int, tokens_per_req: int, device: torch.device
     ) -> torch.Tensor:
@@ -864,34 +974,54 @@ class AiterAttnBackend(AttentionBackend):
                     max_q_len = 1
                     page_size = self.page_size
                     max_num_blocks_per_seq = (max_kv_len + page_size - 1) // page_size
-                    kv_indices = torch.zeros(
-                        bs, max_kv_len, dtype=torch.int32, device=self.device
-                    )
-
+                    # Use a pre-allocated fixed-shape buffer so the Triton
+                    # constexpr kv_indices_ptr_stride never changes between calls
+                    # (a constexpr change on AMD/ROCm crashes the Triton compiler).
+                    if self._unified_kv_indices_buf is None:
+                        self._unified_kv_indices_buf = torch.zeros(
+                            (self._nonsq_max_bs, self.max_context_len),
+                            dtype=torch.int32,
+                            device=self.device,
+                        )
+                    kv_indices = self._unified_kv_indices_buf[:bs, :max_kv_len]
                     create_flashmla_kv_indices_triton[(bs,)](
                         self.req_to_token,
                         forward_batch.req_pool_indices,
                         forward_batch.seq_lens,
                         None,
-                        kv_indices,
+                        self._unified_kv_indices_buf[:bs],
                         self.req_to_token.stride(0),
-                        max_kv_len,
+                        self.max_context_len,  # fixed constexpr stride
                         1,
                     )
-
                     if self.use_sliding_window_kv_pool:
-                        swa_page_table = (
+                        if self._unified_swa_page_table_buf is None:
+                            self._unified_swa_page_table_buf = torch.zeros(
+                                (self._nonsq_max_bs, self.max_context_len),
+                                dtype=torch.int32,
+                                device=self.device,
+                            )
+                        _swa_translated = (
                             self.token_to_kv_pool.translate_loc_from_full_to_swa(
                                 kv_indices
                             )
                         )
-
+                        self._unified_swa_page_table_buf[:bs, :max_kv_len].copy_(
+                            _swa_translated
+                        )
+                        swa_page_table = self._unified_swa_page_table_buf[:bs]
                         kv_indices = self._transform_table_1_to_real(kv_indices)
                         swa_page_table = self._transform_table_1_to_real(swa_page_table)
                     elif self.page_size > 1:
                         kv_indices = self._transform_table_1_to_real(kv_indices)
-
                     qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
+                    if self.head_dim != self.v_head_dim:
+                        self._build_nonsq_flat_indices(
+                            bs,
+                            forward_batch.req_pool_indices,
+                            forward_batch.seq_lens,
+                            swa_page_table,
+                        )
 
             else:
                 if self.use_triton_unified_attention and not self.use_mla:
@@ -1602,6 +1732,17 @@ class AiterAttnBackend(AttentionBackend):
                             new_cols = page_indices.shape[1]
                             kv_indices[:new_rows, :new_cols].copy_(page_indices)
 
+                    if self.head_dim != self.v_head_dim:
+                        self._build_nonsq_flat_indices(
+                            bs,
+                            req_pool_indices,
+                            seq_lens,
+                            (
+                                self.cuda_graph_swa_page_table
+                                if self.use_sliding_window_kv_pool
+                                else None
+                            ),
+                        )
                     qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
 
                     kv_indptr = None
@@ -1973,6 +2114,7 @@ class AiterAttnBackend(AttentionBackend):
                 if (
                     self.use_triton_unified_attention
                     and self.use_sliding_window_kv_pool
+                    and layer.qk_head_dim == layer.v_head_dim
                 ):
                     token_to_kv_pool = self.token_to_kv_pool
                     k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(
@@ -1998,6 +2140,25 @@ class AiterAttnBackend(AttentionBackend):
                         k_scale=k_descale,
                         v_scale=v_descale,
                     )
+                elif (
+                    self.use_triton_unified_attention
+                    and self.use_sliding_window_kv_pool
+                    and layer.qk_head_dim != layer.v_head_dim
+                ):
+                    # launch_reshape_and_cache_flash uses key.shape[2] for both K and V
+                    # head_dim, corrupting the cache when qk_head_dim != v_head_dim.
+                    # Write directly using the SWA slot mapping instead.
+                    pool = self.token_to_kv_pool
+                    k_cache, v_cache = pool.get_kv_buffer(layer.layer_id)
+                    if (
+                        layer.sliding_window_size is not None
+                        and layer.sliding_window_size > -1
+                    ):
+                        loc = pool.full_to_swa_index_mapping[cache_loc].to(torch.int64)
+                    else:
+                        loc = cache_loc.to(torch.int64)
+                    k_cache[loc] = k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                    v_cache[loc] = v.view(-1, layer.tp_v_head_num, layer.v_head_dim)
                 elif self.use_mla:
                     self.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
                 else:
@@ -2361,6 +2522,67 @@ class AiterAttnBackend(AttentionBackend):
                 if self.forward_metadata.swa_page_table is not None:
                     page_table = self.forward_metadata.swa_page_table
 
+            if layer.qk_head_dim != layer.v_head_dim:
+                # mha_batch_prefill_func requires K and V to have equal last dims
+                # (it views k_cache with a single head_dim for both).  Fall back to
+                # extend_attention_fwd, which handles arbitrary Lk != Lv.
+                # extend_attention_fwd expects kv_indptr/kv_indices covering only
+                # prefix tokens, so rebuild them from extend_prefix_lens.
+                bs = forward_batch.batch_size
+                prefix_lens = forward_batch.extend_prefix_lens
+                prefix_kv_indptr = torch.zeros(
+                    bs + 1, dtype=torch.int32, device=q.device
+                )
+                prefix_kv_indptr[1:] = torch.cumsum(prefix_lens, dim=0)
+                prefix_lens_sum = int(prefix_kv_indptr[-1].item())
+                prefix_kv_indices = torch.empty(
+                    prefix_lens_sum + 1, dtype=torch.int32, device=q.device
+                )
+                if prefix_lens_sum > 0:
+                    create_flashinfer_kv_indices_triton[(bs,)](
+                        self.req_to_token,
+                        forward_batch.req_pool_indices,
+                        prefix_lens,
+                        prefix_kv_indptr,
+                        None,
+                        prefix_kv_indices,
+                        self.req_to_token.stride(0),
+                    )
+                sliding_window = (
+                    layer.sliding_window_size
+                    if (
+                        layer.sliding_window_size is not None
+                        and layer.sliding_window_size > -1
+                    )
+                    else -1
+                )
+                max_extend_len = max(forward_batch.extend_seq_lens_cpu)
+                o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+                self.extend_attention_fwd(
+                    q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                    k.contiguous(),
+                    v.contiguous(),
+                    o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                    k_cache,
+                    v_cache,
+                    self.qo_indptr[:bs0],
+                    prefix_kv_indptr,
+                    prefix_kv_indices,
+                    None,
+                    True,
+                    None,
+                    max_extend_len,
+                    1.0,
+                    1.0,
+                    layer.scaling,
+                    logit_cap=layer.logit_cap,
+                    sliding_window_size=sliding_window,
+                    sinks=sinks,
+                )
+                if o.dtype != self.input_dtype:
+                    o = o.to(self.input_dtype)
+                return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
             o = mha_batch_prefill_func(
                 q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
                 k_cache,
@@ -2409,12 +2631,11 @@ class AiterAttnBackend(AttentionBackend):
             v_descale = layer.v_scale if layer.v_scale is not None else self.k_scale
 
         if save_kv_cache:
-            # Only use SWA-specific kv cache write (reshape_and_cache_flash) when
-            # both unified attention and sliding window kv pool are active.
-            # Non-SWA models (e.g. Qwen3-VL) enabled via SGLANG_USE_AITER_UNIFIED_ATTN
-            # use standard set_kv_buffer, as they lack SWA-specific attributes
-            # like full_to_swa_index_mapping.
-            if self.use_triton_unified_attention and self.use_sliding_window_kv_pool:
+            if (
+                self.use_triton_unified_attention
+                and self.use_sliding_window_kv_pool
+                and layer.qk_head_dim == layer.v_head_dim
+            ):
                 token_to_kv_pool = self.token_to_kv_pool
                 k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
                 slot_mapping_swa = token_to_kv_pool.full_to_swa_index_mapping
@@ -2433,10 +2654,27 @@ class AiterAttnBackend(AttentionBackend):
                     k_scale=k_descale,
                     v_scale=v_descale,
                 )
+            elif (
+                self.use_triton_unified_attention
+                and self.use_sliding_window_kv_pool
+                and layer.qk_head_dim != layer.v_head_dim
+            ):
+                # Same rationale as forward_extend: bypass launch_reshape_and_cache_flash
+                # and write directly so K and V use their own head_dim shapes.
+                pool = self.token_to_kv_pool
+                k_cache, v_cache = pool.get_kv_buffer(layer.layer_id)
+                if (
+                    layer.sliding_window_size is not None
+                    and layer.sliding_window_size > -1
+                ):
+                    loc = pool.full_to_swa_index_mapping[
+                        forward_batch.out_cache_loc
+                    ].to(torch.int64)
+                else:
+                    loc = forward_batch.out_cache_loc.to(torch.int64)
+                k_cache[loc] = k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                v_cache[loc] = v.view(-1, layer.tp_v_head_num, layer.v_head_dim)
             elif self.use_triton_unified_attention and self.kv_cache_dtype == fp8_dtype:
-                # [PATCH] FP8 non-SWA: use launch_reshape_and_cache_flash to
-                # fuse bf16→fp8 cast + paged write in one Triton kernel,
-                # eliminating separate float8_copy + store_kvcache overhead.
                 token_to_kv_pool = self.token_to_kv_pool
                 k_cache, v_cache = token_to_kv_pool.get_kv_buffer(layer.layer_id)
                 launch_reshape_and_cache_flash(
@@ -2503,7 +2741,10 @@ class AiterAttnBackend(AttentionBackend):
             else:
                 o = torch.empty_like(q, dtype=self.input_dtype)
 
-            if self.use_triton_unified_attention:
+            if (
+                self.use_triton_unified_attention
+                and layer.qk_head_dim == layer.v_head_dim
+            ):
                 bs = forward_batch.batch_size
                 window_size = (-1, -1)
                 page_table = self.forward_metadata.kv_indices
@@ -2539,6 +2780,102 @@ class AiterAttnBackend(AttentionBackend):
                     q_descale=None,
                     k_descale=k_descale,
                     v_descale=v_descale,
+                    sinks=sinks,
+                )
+            elif (
+                self.use_triton_unified_attention
+                and layer.qk_head_dim != layer.v_head_dim
+            ):
+                # unified_attention views k_cache/v_cache with a single head_dim, which
+                # corrupts memory when qk_head_dim != v_head_dim.  Use decode_attention_fwd
+                # (Triton) which accepts separate Lk and Lv.  For SWA layers pass only the
+                # last sliding_window_size token slots via the windowed indptr/indices built
+                # by _build_nonsq_flat_indices.  FP8 caches are dequantised to BF16 first
+                # because decode_attention_fwd does not support FP8 input.
+                bs = forward_batch.batch_size
+                if self._nonsq_decode_attn_logits is None:
+                    _mk = self._nonsq_max_kv_splits
+                    _mbs = self._nonsq_max_bs
+                    self._nonsq_decode_attn_logits = torch.zeros(
+                        (_mbs, layer.tp_q_head_num, _mk, layer.v_head_dim),
+                        dtype=torch.float32,
+                        device=q.device,
+                    )
+                    self._nonsq_decode_attn_lse = torch.zeros(
+                        (_mbs, layer.tp_q_head_num, _mk),
+                        dtype=torch.float32,
+                        device=q.device,
+                    )
+                    self._nonsq_decode_num_kv_splits = torch.full(
+                        (_mbs,),
+                        self._nonsq_max_kv_splits,
+                        dtype=torch.int32,
+                        device=q.device,
+                    )
+                attn_logits = self._nonsq_decode_attn_logits[:bs]
+                attn_lse = self._nonsq_decode_attn_lse[:bs]
+                num_kv_splits = self._nonsq_decode_num_kv_splits[:bs]
+                _max_kv_splits = self._nonsq_max_kv_splits
+                k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+                v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
+                k_scale_val = self._nonsq_k_scale_val
+                v_scale_val = self._nonsq_v_scale_val
+                is_swa_layer = (
+                    layer.sliding_window_size is not None
+                    and layer.sliding_window_size > -1
+                )
+                if is_swa_layer and self.use_sliding_window_kv_pool:
+                    kv_indptr = self._nonsq_swa_kv_indptr[: bs + 1]
+                    kv_indices = self._nonsq_flat_swa_kv_indices
+                else:
+                    kv_indptr = self.kv_indptr[: bs + 1]
+                    kv_indices = self._nonsq_flat_full_kv_indices
+                if self.kv_cache_dtype == fp8_dtype:
+                    if is_swa_layer and self.use_sliding_window_kv_pool:
+                        if self._nonsq_k_bf16_swa is None:
+                            self._nonsq_k_bf16_swa = torch.empty_like(
+                                k_buffer, dtype=self.input_dtype
+                            )
+                            self._nonsq_v_bf16_swa = torch.empty_like(
+                                v_buffer, dtype=self.input_dtype
+                            )
+                        _k_bf16 = self._nonsq_k_bf16_swa
+                        _v_bf16 = self._nonsq_v_bf16_swa
+                    else:
+                        if self._nonsq_k_bf16_full is None:
+                            self._nonsq_k_bf16_full = torch.empty_like(
+                                k_buffer, dtype=self.input_dtype
+                            )
+                            self._nonsq_v_bf16_full = torch.empty_like(
+                                v_buffer, dtype=self.input_dtype
+                            )
+                        _k_bf16 = self._nonsq_k_bf16_full
+                        _v_bf16 = self._nonsq_v_bf16_full
+                    _k_bf16.copy_(k_buffer)
+                    if k_scale_val != 1.0:
+                        _k_bf16.mul_(k_scale_val)
+                    _v_bf16.copy_(v_buffer)
+                    if v_scale_val != 1.0:
+                        _v_bf16.mul_(v_scale_val)
+                    k_buffer = _k_bf16
+                    v_buffer = _v_bf16
+                    k_scale_val = 1.0
+                    v_scale_val = 1.0
+                self.decode_attention_fwd(
+                    q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                    k_buffer,
+                    v_buffer,
+                    o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                    kv_indptr,
+                    kv_indices,
+                    attn_logits,
+                    attn_lse,
+                    num_kv_splits,
+                    _max_kv_splits,
+                    layer.scaling,
+                    k_scale_val,
+                    v_scale_val,
+                    logit_cap=self.logits_soft_cap,
                     sinks=sinks,
                 )
             else:

--- a/test/registered/amd/accuracy/mi35x/test_mimo_v2_flash_aiter_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_mimo_v2_flash_aiter_eval_mi35x.py
@@ -1,0 +1,213 @@
+"""MI355X MiMo-V2-Flash aiter backend accuracy test (4-GPU).
+
+MiMo-V2-Flash uses non-square attention (qk_head_dim=192, v_head_dim=128) with a
+128-token sliding window across all 48 layers.  The aiter unified-attention kernel
+assumes equal K/V head dims, so this PR introduces Triton fallback paths for prefill
+and decode when qk_head_dim != v_head_dim.  This test validates that those paths
+produce correct outputs by measuring GSM8K accuracy.
+
+NOTE: TP=4 is required.  MiMo-V2-Flash has 64 attention heads; TP=8 would give
+64/8 = 8 heads per rank which is too few for the aiter unified-attention path.
+TP=4 gives 64/4 = 16 heads per rank.
+
+Registry: nightly-amd-accuracy-8-gpu-mi355x-mimo-v2-flash-aiter suite
+"""
+
+import os
+
+os.environ.setdefault("HF_HOME", "/mnt/hf_hub_cache")
+os.environ.setdefault("HF_HUB_CACHE", "/mnt/hf_hub_cache")
+
+import unittest
+from dataclasses import dataclass
+from typing import List, Optional
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+register_amd_ci(
+    est_time=7200,
+    suite="nightly-amd-accuracy-8-gpu-mi355x-mimo-v2-flash-aiter",
+    nightly=True,
+)
+
+MIMO_V2_FLASH_LOCAL_PATH = "/mnt/hf_hub_cache/MiMo-V2-Flash"
+MIMO_V2_FLASH_HF_MODEL_ID = "XiaomiMiMo/MiMo-V2-Flash"
+
+
+def get_model_path() -> str:
+    """Return effective model path: env var > local cache > HF model ID."""
+    env_path = os.environ.get("MIMO_V2_FLASH_MODEL_PATH")
+    if env_path:
+        return env_path
+    if os.path.exists(MIMO_V2_FLASH_LOCAL_PATH):
+        return MIMO_V2_FLASH_LOCAL_PATH
+    return MIMO_V2_FLASH_HF_MODEL_ID
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a single test variant."""
+
+    model_path: str
+    tp_size: int = 4
+    accuracy_threshold: float = 0.78
+    other_args: Optional[List[str]] = None
+    env_vars: Optional[dict] = None
+    timeout: Optional[int] = None
+    variant: Optional[str] = None
+
+    def __post_init__(self):
+        if self.other_args is None:
+            self.other_args = []
+        if self.env_vars is None:
+            self.env_vars = {}
+
+    def get_display_name(self) -> str:
+        if self.variant:
+            return f"{self.model_path} ({self.variant})"
+        return self.model_path
+
+
+def get_mimo_v2_flash_models() -> List[ModelConfig]:
+    """Return the list of model configs to test."""
+    model_path = get_model_path()
+    common_args = [
+        "--attention-backend",
+        "aiter",
+        "--disable-radix-cache",
+        "--mem-fraction-static",
+        "0.8",
+        "--chunked-prefill-size",
+        "131072",
+        "--max-running-requests",
+        "128",
+        "--trust-remote-code",
+        "--watchdog-timeout",
+        "1200",
+    ]
+    return [
+        ModelConfig(
+            model_path=model_path,
+            tp_size=4,
+            accuracy_threshold=0.80,
+            timeout=7200,
+            variant="bf16",
+            other_args=common_args,
+        ),
+    ]
+
+
+class TestMiMoV2FlashAiterEvalMI355x(unittest.TestCase):
+    """GSM8K accuracy test for MiMo-V2-Flash with the aiter backend on MI355X.
+
+    Validates that the non-square attention fallback paths (qk_head_dim != v_head_dim)
+    introduced for the aiter backend produce correct model outputs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = get_mimo_v2_flash_models()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "1319"))
+
+    def test_mimo_v2_flash_accuracy(self):
+        """Test MiMo-V2-Flash on GSM8K with the aiter backend."""
+        from types import SimpleNamespace
+
+        from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+
+        all_results = []
+        summary = "### MiMo-V2-Flash aiter backend (MI355X)\n\n"
+        summary += "| Model | Variant | TP | Accuracy | Threshold | Status |\n"
+        summary += "| ----- | ------- | -- | -------- | --------- | ------ |\n"
+
+        for config in self.models:
+            display_name = config.get_display_name()
+            with self.subTest(model=display_name):
+                model_path = config.model_path
+                is_local = model_path.startswith("/")
+                if is_local and not os.path.exists(model_path):
+                    self.skipTest(f"Local model not found at {model_path}")
+
+                other_args = list(config.other_args) + ["--tp", str(config.tp_size)]
+                timeout = config.timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+                env = os.environ.copy()
+                for key, value in config.env_vars.items():
+                    env[key] = value
+
+                try:
+                    process = popen_launch_server(
+                        model=model_path,
+                        base_url=self.base_url,
+                        timeout=timeout,
+                        other_args=other_args,
+                        env=env,
+                    )
+
+                    try:
+                        args = SimpleNamespace(
+                            num_shots=8,
+                            data_path=None,
+                            num_questions=self.num_questions,
+                            parallel=self.num_questions,
+                            max_new_tokens=512,
+                            host="http://127.0.0.1",
+                            port=int(self.base_url.split(":")[-1]),
+                        )
+                        metrics = run_eval_few_shot_gsm8k(args)
+                        acc = metrics["accuracy"]
+
+                        passed = acc >= config.accuracy_threshold
+                        status = "PASS" if passed else "FAIL"
+                        print(
+                            f"  accuracy={acc:.4f} threshold={config.accuracy_threshold} {status}"
+                        )
+
+                        all_results.append(
+                            {"model": display_name, "accuracy": acc, "passed": passed}
+                        )
+                        summary += (
+                            f"| {model_path} | {config.variant or 'N/A'} "
+                            f"| {config.tp_size} | {acc:.4f} "
+                            f"| {config.accuracy_threshold} | {status} |\n"
+                        )
+
+                    finally:
+                        kill_process_tree(process.pid)
+
+                except Exception as e:
+                    summary += (
+                        f"| {model_path} | {config.variant or 'N/A'} "
+                        f"| {config.tp_size} | N/A "
+                        f"| {config.accuracy_threshold} | ERROR |\n"
+                    )
+                    all_results.append(
+                        {
+                            "model": display_name,
+                            "accuracy": None,
+                            "passed": False,
+                            "error": str(e),
+                        }
+                    )
+
+        if is_in_ci():
+            write_github_step_summary(summary)
+
+        failed = [r for r in all_results if not r["passed"]]
+        if failed:
+            raise AssertionError(
+                f"Failed model variants: {[r['model'] for r in failed]}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi35x/test_mimo_v2_flash_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_mimo_v2_flash_perf_mi35x.py
@@ -1,0 +1,151 @@
+"""MI355X nightly performance benchmark for MiMo-V2-Flash (4-GPU).
+
+Benchmarks MiMo-V2-Flash with the aiter attention backend on MI355X using TP=4.
+MiMo-V2-Flash has non-square attention (qk_head_dim=192, v_head_dim=128) with a
+128-token sliding window; this benchmark validates throughput after the fallback
+paths introduced for the aiter backend.
+
+The model path can be configured via MIMO_V2_FLASH_MODEL_PATH environment variable.
+
+Registry: nightly-perf-8-gpu-mi355x-mimo-v2-flash suite
+
+Example usage:
+    python -m pytest test_mimo_v2_flash_perf_mi35x.py -v
+"""
+
+import os
+
+os.environ.setdefault("HF_HOME", "/mnt/hf_hub_cache")
+os.environ.setdefault("HF_HUB_CACHE", "/mnt/hf_hub_cache")
+
+import unittest
+from typing import List
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+register_amd_ci(
+    est_time=5400, suite="nightly-perf-8-gpu-mi355x-mimo-v2-flash", nightly=True
+)
+
+MIMO_V2_FLASH_MODEL_PATH = os.environ.get(
+    "MIMO_V2_FLASH_MODEL_PATH", "/mnt/hf_hub_cache/MiMo-V2-Flash"
+)
+PROFILE_DIR = "performance_profiles_mimo_v2_flash_mi355x"
+
+
+def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
+    """Generate a markdown table from benchmark results.
+
+    Skips the first entry if it is a warmup run (same batch_size as second entry).
+    """
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", "MI355X")
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += (
+            f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} "
+            f"| {result.input_throughput:.2f} | {result.output_throughput:.2f} "
+            f"| {itl:.2f} |\n"
+        )
+
+    return summary
+
+
+class TestNightlyMiMoV2FlashPerformanceMI355x(unittest.TestCase):
+    """MI355X nightly performance benchmark for MiMo-V2-Flash.
+
+    Tests MiMo-V2-Flash with TP=4 and the aiter attention backend.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        cls.model_config = {
+            "name": "mimo-v2-flash-tp4-aiter",
+            "model_path": MIMO_V2_FLASH_MODEL_PATH,
+            "other_args": [
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--attention-backend",
+                "aiter",
+                "--disable-radix-cache",
+                "--mem-fraction-static",
+                "0.8",
+                "--chunked-prefill-size",
+                "131072",
+                "--max-running-requests",
+                "128",
+                "--watchdog-timeout",
+                "1200",
+            ],
+            "env_vars": {},
+        }
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_bench_mimo_v2_flash(self):
+        """Run throughput benchmark for MiMo-V2-Flash on MI355X."""
+        old_env = {}
+        for key, value in self.model_config.get("env_vars", {}).items():
+            old_env[key] = os.environ.get(key)
+            os.environ[key] = value
+            print(f"Setting env: {key}={value}")
+
+        try:
+            result_tuple = self.runner.run_benchmark_for_model(
+                model_path=self.model_config["model_path"],
+                batch_sizes=self.batch_sizes,
+                input_lens=self.input_lens,
+                output_lens=self.output_lens,
+                other_args=self.model_config["other_args"],
+                variant=self.model_config["name"],
+                extra_bench_args=["--trust-remote-code"],
+                enable_profile=False,
+                timeout=5400,
+            )
+            results = result_tuple[0]
+            success = result_tuple[1]
+
+            if results:
+                self.runner.full_report += (
+                    generate_simple_markdown_report(results) + "\n"
+                )
+
+            self.assertTrue(success, "Benchmark failed for MiMo-V2-Flash on MI355X")
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            self.runner.write_final_report()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

[Xiaomi MiMo-V2-Flash](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash) is a hybrid MoE reasoning model with an unusual attention geometry: the Q/K head dimension is 192 while the V head dimension is 128 (\`qk_head_dim != v_head_dim\`). All 48 layers also use a 128-token sliding-window attention (SWA).

The SGLang aiter backend (\`AiterAttnBackend\`) previously assumed that K and V share the same head dimension throughout. This assumption is embedded in three places:

1. **Prefill** – \`mha_batch_prefill_func\` (AIter's batch-prefill kernel) internally views the K and V caches with a single \`head_dim\`, producing corrupted output when the two dims differ.
2. **Decode** – \`unified_attention\` (AIter's paged-attention kernel) has the same equal-dim assumption, causing silent memory corruption during token generation.
3. **KV-cache write** – \`launch_reshape_and_cache_flash\` uses \`key.shape[2]\` as the head dim for *both* K and V cache writes, writing V tokens into the wrong memory locations whenever \`v_head_dim < qk_head_dim\`.

Without this fix, launching MiMo-V2-Flash with \`--attention-backend aiter\` produces incorrect output or crashes. This PR adds targeted fallback paths that activate only when \`layer.qk_head_dim != layer.v_head_dim\`, leaving the existing fast paths completely unchanged for standard square-attention models.

## Modifications

All changes are confined to \`python/sglang/srt/layers/attention/aiter_backend.py\`.

### 1. Prefill fallback (\`forward_extend\`)

When \`layer.qk_head_dim != layer.v_head_dim\`, skip \`mha_batch_prefill_func\` and call the Triton \`extend_attention_fwd\` kernel instead. This kernel accepts arbitrary \`Lk\` and \`Lv\` values. The prefix KV indices are rebuilt from \`extend_prefix_lens\` so that only the cached (prefix) tokens are passed as context, exactly as required by the kernel's API.

### 2. Decode fallback (\`forward_decode\`)

When \`layer.qk_head_dim != layer.v_head_dim\`, skip \`unified_attention\` and call the Triton \`decode_attention_fwd\` kernel. This kernel accepts separate key and value buffers with independent head dims. Key implementation details:

- **Flat index arrays** – \`decode_attention_fwd\` expects a flat per-token index array (not paged). A new helper \`_build_nonsq_flat_indices\` builds these from \`req_to_token\` using the existing \`create_flashinfer_kv_indices_triton\` Triton kernel. For SWA layers, the index array is windowed to the last \`sliding_window_size\` tokens.
- **Pre-allocated buffers** – All scratch buffers (\`attn_logits\`, \`attn_lse\`, \`num_kv_splits\`, flat index arrays) are allocated once on the first call and reused, keeping the path CUDA-graph-safe (no \`torch.empty\` inside graph capture).
- **Fixed-stride buffers** – The \`kv_indices_ptr_stride\` argument to the Triton kernel is a \`tl.constexpr\`. On AMD/ROCm, changing a constexpr value between calls triggers a Triton recompile that crashes. Two pre-allocated fixed-shape index buffers with stride equal to \`max_context_len\` are used so the constexpr never changes.
- **FP8 KV dequantization** – \`decode_attention_fwd\` does not support FP8 KV input. When \`kv_cache_dtype == fp8\`, the K and V buffers are dequantized to BF16 before the call using pre-allocated BF16 scratch tensors.
- **Scale extraction** – \`k_scale.item()\` would be a CPU-GPU sync inside the forward pass. Scales are extracted once during metadata initialization and cached as Python floats.

### 3. KV-cache write fix

When \`qk_head_dim != v_head_dim\`, bypass \`launch_reshape_and_cache_flash\` (which uses a single head dim for both K and V) and instead write directly:

\`\`\`python
k_cache[loc] = k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
v_cache[loc] = v.view(-1, layer.tp_v_head_num, layer.v_head_dim)
\`\`\`

For SWA layers, \`loc\` is obtained from \`pool.full_to_swa_index_mapping[cache_loc]\`. This applies to both the extend (prefill) and decode cache-write paths.

## Accuracy Tests

**Model:** XiaomiMiMo/MiMo-V2-Flash
**Hardware:** 4x AMD Instinct MI355X (TP=4)
**Backend:** \`--attention-backend aiter\`
**Eval:** GSM8K 8-shot completion, 1319 questions

| Metric | Score |
| ------ | ----- |
| Accuracy (strict match) | **79.9%** (1054/1319) |
| Invalid responses | 0.0% |
| Output throughput | 2013 tok/s |

## Speed Tests and Profiling

**Hardware:** 4x AMD Instinct MI355X (TP=4)
**Backend:** \`--attention-backend aiter\`
**Tool:** \`python3 -m sglang.bench_serving --backend sglang --dataset-name random\`

| Input len | Output len | Concurrency | Input tok/s | Output tok/s | Mean TTFT (ms) | Mean ITL (ms) |
| --------- | ---------- | ----------- | ----------- | ------------ | -------------- | ------------- |
| 256 | 128 | 1 | 414 | 141 | 50.1 | 6.2 |
| 1024 | 512 | 16 | 2,379 | 1,077 | 107.6 | 12.9 |
| 4096 | 512 | 16 | **8,343** | 958 | 233.1 | 14.3 |

At concurrency=16 with 4096-token inputs, input token throughput reaches **8,343 tok/s**.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include \`/tag-and-rerun-ci\`, \`/tag-run-ci-label\`, \`/rerun-failed-ci\`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.