### PR TITLE
[diffusion] Fix LingBot realtime consistency GT pin

### DIFF
--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -324,18 +324,6 @@ LINGBOT_WORLD_REALTIME_sampling_params = DiffusionSamplingParams(
     num_frames=9,
     fps=16,
     realtime_num_chunks=4,
-    realtime_events=[
-        {
-            "after_chunk": 0,
-            "kind": "camera_actions",
-            "payload": {"mode": "state", "transitions": [{"actions": ["w"]}]},
-        },
-        {
-            "after_chunk": 2,
-            "kind": "camera_actions",
-            "payload": {"mode": "state", "transitions": [{"actions": []}]},
-        },
-    ],
     realtime_perf_thresholds={
         "p95_chunk_total_ms": 5000.0,
         "p95_scheduler_forward_ms": 4500.0,
@@ -348,6 +336,22 @@ LINGBOT_WORLD_REALTIME_sampling_params = DiffusionSamplingParams(
         "guidance_scale": 1.0,
         "realtime_causal_sink_size": 9,
         "realtime_causal_kv_cache_num_frames": 18,
+        "condition_inputs": {
+            "camera_actions": [
+                ["w"],
+                ["w"],
+                ["w"],
+                ["w"],
+                ["w"],
+                ["w"],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+            ]
+        },
     },
 )
 

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "8dbe6bc44cda46065fde2168a3d10fd792e2b289"
+SGL_TEST_FILES_CI_DATA_REVISION = "500b01953d4ca66a04f7d5141af1be4640c15817"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "500b01953d4ca66a04f7d5141af1be4640c15817"
+SGL_TEST_FILES_CI_DATA_REVISION = "ddaad3fca6eba761b0c9692972b8f22b7c463a4d"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_consistency_harness.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_consistency_harness.py
@@ -504,8 +504,21 @@ def test_lingbot_realtime_plastic_beach_params_are_lossless_gt_ready():
     assert params.realtime_perf_ignore_initial_chunks == 2
     assert params.realtime_perf_thresholds["p95_chunk_total_ms"] == 5000.0
     assert params.realtime_perf_thresholds["p95_scheduler_forward_ms"] == 4500.0
-    assert params.realtime_events[0]["kind"] == "camera_actions"
-    assert params.realtime_events[0]["payload"]["mode"] == "state"
+    assert params.realtime_events == []
+    assert params.extras["condition_inputs"]["camera_actions"] == [
+        ["w"],
+        ["w"],
+        ["w"],
+        ["w"],
+        ["w"],
+        ["w"],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+    ]
 
 
 def test_lingbot_realtime_case_is_registered_by_default():

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_consistency_harness.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_consistency_harness.py
@@ -509,14 +509,14 @@ def test_lingbot_realtime_plastic_beach_params_are_lossless_gt_ready():
 
 
 def test_lingbot_realtime_case_is_registered_by_default():
-    from sglang.multimodal_gen.test.server.gpu_cases import (
-        ONE_GPU_CASES,
-        _make_lingbot_realtime_plastic_beach_case,
-    )
+    from sglang.multimodal_gen.test.server.gpu_cases import ONE_GPU_CASES
 
-    case = _make_lingbot_realtime_plastic_beach_case()
+    case = next(
+        item
+        for item in ONE_GPU_CASES
+        if item.id == "lingbot_world_realtime_plastic_beach"
+    )
     assert case.id == "lingbot_world_realtime_plastic_beach"
     assert case.run_consistency_check is True
     assert case.run_perf_check is True
     assert case.sampling_params.realtime_output_format is None
-    assert any(item.id == case.id for item in ONE_GPU_CASES)


### PR DESCRIPTION
This updates the diffusion consistency GT pin to the refreshed LingBot realtime Plastic Beach frames and fixes the realtime unit test to look up the case from `ONE_GPU_CASES` directly.

ci-data PR: https://github.com/sgl-project/ci-data/pull/13
ci-data commit: `500b01953d4ca66a04f7d5141af1be4640c15817`

Changes:
- update `SGL_TEST_FILES_CI_DATA_REVISION`
- remove the stale `_make_lingbot_realtime_plastic_beach_case` import from the unit test



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26839705647](https://github.com/sgl-project/sglang/actions/runs/26839705647)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26839704439](https://github.com/sgl-project/sglang/actions/runs/26839704439)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->