### PR TITLE
[diffusion] Use Conv2d width padding in WanVAE

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_dist_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_dist_utils.py
@@ -202,23 +202,24 @@ class WanDistConv2d(nn.Conv2d):
 
         self.padding: tuple[int, int]
         if self.height_halo_size > 0:
-            self._padding = (self.padding[1], self.padding[1], 0, 0)
+            self._padding = (0, 0, 0, 0)
         else:
             self._padding = (
-                self.padding[1],
-                self.padding[1],
+                0,
+                0,
                 self.padding[0],
                 self.padding[0],
             )
 
-        self.padding = (0, 0)
+        self.padding = (0, self.padding[1])
         self._halo_recv_top_buf: torch.Tensor | None = None
         self._halo_recv_bottom_buf: torch.Tensor | None = None
         self.rank = get_sp_parallel_rank()
         self.world_size = get_sp_world_size()
 
     def forward(self, x):
-        x = F.pad(x, self._padding)
+        if any(self._padding):
+            x = F.pad(x, self._padding)
 
         x_padded, self._halo_recv_top_buf, self._halo_recv_bottom_buf = halo_exchange(
             x,


### PR DESCRIPTION
## Summary
- Move WanDistConv2d width padding from explicit `F.pad` into Conv2d's native padding.
- Keep height padding / halo exchange semantics unchanged.
- Skip the remaining explicit `F.pad` call when only zero padding remains.

## Validation
- Fixed 4xH200 Cosmos3 Nano T2V, 720p, 189 frames, 35 steps, torch compile/cache/guardrails off.
- Output is byte-identical to baseline: MP4 sha256 `2b05ba6f5d29f8f86bd184a40706b042016b13f1dad79f6c516ad66ff13fb02f`.
- Decode stage improved from baseline `5.2121s` to `5.1284s` / `5.1403s` across two candidate runs.
- Peak memory dropped from baseline `44174MB` to `43522MB` / `42582MB`.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26837572055](https://github.com/sgl-project/sglang/actions/runs/26837572055)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26837571738](https://github.com/sgl-project/sglang/actions/runs/26837571738)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->