### PR TITLE
test: disable test_gemma4_mtp_26b_a4b_extra from CI

### DIFF
--- a/test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py
+++ b/test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py
@@ -17,7 +17,12 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=720, stage="extra-a", runner_config="2-gpu-large")
+register_cuda_ci(
+    est_time=720,
+    stage="extra-a",
+    runner_config="2-gpu-large",
+    disabled="FIXME(kpham-sgl): temporary drop due to accuracies issue",
+)
 
 MODEL_NAME = "26B-A4B"
 TARGET_PATH = "google/gemma-4-26B-A4B-it"


### PR DESCRIPTION
## Motivation

Temporarily drop the Gemma4 MTP 26B-A4B `extra` test (`test/registered/spec/test_gemma4_mtp_26b_a4b_extra.py`) from CI due to an accuracy issue.

## Modifications

- Set `disabled="FIXME(kpham-sgl): temporary drop due to accuracies issue"` on the test's `register_cuda_ci(...)` call.
- This uses the standard registration-based disable mechanism: a non-`None` `disabled` string makes the AST-based CI collector treat the registry as disabled, so the test is no longer dispatched in CI.
- The test class and `if __name__ == "__main__"` block are untouched, so the file still runs locally via `python3 test_gemma4_mtp_26b_a4b_extra.py`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] This change does not alter runtime behavior; only CI registration metadata is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26840807527](https://github.com/sgl-project/sglang/actions/runs/26840807527)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26840806875](https://github.com/sgl-project/sglang/actions/runs/26840806875)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->