### PR TITLE
[diffusion] Clamp WanVAE decode output in place

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/wanvae.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/wanvae.py
@@ -997,7 +997,7 @@ class AutoencoderKLWan(ParallelTiledVAE):
                 out = unpatchify(out, patch_size=self.config.patch_size)
 
             out = out.float()
-            out = torch.clamp(out, min=-1.0, max=1.0)
+            out.clamp_(min=-1.0, max=1.0)
             self.clear_cache()
         else:
             out = ParallelTiledVAE.decode(self, z)


### PR DESCRIPTION
## Summary
- clamp the float WanVAE feature-cache decode output in place
- avoid allocating a second full-size FP32 output tensor after decode

## Notes
- preserves the existing float-then-clamp order











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26850345303](https://github.com/sgl-project/sglang/actions/runs/26850345303)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26850345291](https://github.com/sgl-project/sglang/actions/runs/26850345291)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->