### PR TITLE
[LoRA] Speed up LoRA-B Triton kernels: atomic_add + single-K-block + 3D grid

### DIFF
--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-05-28-mori/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/mori/tco1-new.png"
+          alt="Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"May 28, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-04-29-p2p-update/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"March 25, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-17-rocm-miles-rl-amd/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/rocm_miles_rl/fig_1.png"
-          alt="ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 17, 2026"}
         </p>
       </div>
     </a>

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -89,6 +89,7 @@ class TritonLoRABackend(BaseLoRABackend):
         max_qkv_out_dim: int,
         base_output: torch.Tensor = None,
         n_slices: int = 3,
+        output_offset_cpu: torch.Tensor = None,
         *args,
         **kwargs,
     ) -> torch.Tensor:
@@ -108,6 +109,7 @@ class TritonLoRABackend(BaseLoRABackend):
             max_qkv_out_dim,
             base_output,
             n_slices=n_slices,
+            output_offset_cpu=output_offset_cpu,
         )
         return lora_output
 

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -336,6 +336,24 @@ class LoRAManager:
             lora_ranks[wi] > 0 for wi in weight_indices
         )
 
+        active_indices = set(weight_indices)
+        uniform_weight_index = (
+            active_indices.pop() if len(active_indices) == 1 else None
+        )
+        if uniform_weight_index is not None and lora_ranks[uniform_weight_index] > 0:
+            uniform_rank = lora_ranks[uniform_weight_index]
+            uniform_scaling = scalings[uniform_weight_index]
+        else:
+            uniform_weight_index = uniform_rank = uniform_scaling = None
+        for info in (
+            self.lora_backend.batch_info,
+            getattr(self.lora_backend, "sgemm_batch_info", None),
+        ):
+            if info is not None:
+                info.uniform_weight_index = uniform_weight_index
+                info.uniform_rank = uniform_rank
+                info.uniform_scaling = uniform_scaling
+
     def update_lora_info(self):
         """
         Update all LoRA modules to associate them with the latest memory buffer.

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -1179,6 +1179,10 @@ class LoRAMemoryPool:
                             weights,
                         )
                     load_lora_weight_tensor(buffer_view, weights)
+                    # Zero beyond loaded rank -- the dense LoRA-B kernel
+                    # (sgemm_lora_b / qkv_lora_b) contracts over the full padded
+                    # max_rank, so the [lora_rank:] tail must be clean.
+                    target_buffer[buffer_id, :, lora_rank:].zero_()
 
         if lora_adapter.embedding_layers:
             org_vocab_size = self.base_hf_config.vocab_size

--- a/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
@@ -5,6 +5,11 @@ import triton.language as tl
 from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
 from sglang.srt.lora.utils import LoRABatchInfo
 
+# Minimum total_tokens * rank for the single-adapter cuBLAS path; below this
+# the Triton kernel is faster (crossover measured at output_dim=1536/GPU:
+# cuBLAS wins rank64 from S>=256 and rank16 only from S>=2048).
+_CUBLAS_MIN_S_RANK = 16384
+
 
 @triton.jit
 def _gate_up_lora_b_kernel(
@@ -137,6 +142,32 @@ def _gate_up_lora_b_kernel(
     tl.store(output_ptr, partial_sum, mask=output_mask)
 
 
+def _gate_up_lora_b_cublas(
+    x: torch.Tensor,
+    gate_up_lora_b: torch.Tensor,
+    batch_info: LoRABatchInfo,
+    output_dim: int,
+    base_output: torch.Tensor,
+) -> torch.Tensor:
+    """Single-adapter dense path: one cuBLAS addmm_ per gate/up slice.
+
+    The LoRA-A output is rank-packed (slice i at columns [i*rank, (i+1)*rank)),
+    matching the Triton kernel's K = min(K, rank) slice stride. Slices are
+    disjoint output regions, so in-place addmm_ writes never collide.
+    """
+    r = batch_info.uniform_rank
+    if base_output is None:
+        base_output = torch.zeros(
+            (x.shape[0], 2 * output_dim), device=x.device, dtype=x.dtype
+        )
+    w = gate_up_lora_b[batch_info.uniform_weight_index]
+    x_scaled = x[:, : 2 * r] * batch_info.uniform_scaling
+    for i in range(2):
+        lo, hi = i * output_dim, (i + 1) * output_dim
+        base_output[:, lo:hi].addmm_(x_scaled[:, i * r : (i + 1) * r], w[lo:hi, :r].t())
+    return base_output
+
+
 def gate_up_lora_b_fwd(
     x: torch.Tensor,
     gate_up_lora_b: torch.Tensor,
@@ -159,6 +190,15 @@ def gate_up_lora_b_fwd(
     input_dim = x.shape[1]
     r = gate_up_lora_b.shape[-1]
     assert input_dim == 2 * r
+
+    if (
+        batch_info.uniform_weight_index is not None
+        and not batch_info.use_cuda_graph
+        and s * batch_info.uniform_rank >= _CUBLAS_MIN_S_RANK
+    ):
+        return _gate_up_lora_b_cublas(
+            x, gate_up_lora_b, batch_info, output_dim, base_output
+        )
 
     BLOCK_S = 16
     BLOCK_R = 16

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -141,6 +141,7 @@ def _step_a_q_kernel(
     # meta
     FULL_K: tl.constexpr,  # per-head row stride in B (qk_nope + v_head_dim)
     SORTED_BY_ADAPTER: tl.constexpr,
+    K_DIV: tl.constexpr,  # K % BLOCK_K == 0 -> drop safe_k (keep contraction load coalesced)
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -194,7 +195,7 @@ def _step_a_q_kernel(
     for k_block in range(0, tl.cdiv(K, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
         k_mask = cur_k < K
-        safe_k = tl.minimum(cur_k, K - 1)
+        safe_k = cur_k if K_DIV else tl.minimum(cur_k, K - 1)
 
         # x[s, h, k]
         x_tile = tl.load(
@@ -285,6 +286,7 @@ def step_a_q_fwd(
         num_segments,
         FULL_K=full_K_per_head,
         SORTED_BY_ADAPTER=sorted_by_adapter,
+        K_DIV=(qk_nope_dim % _STEP_A_Q_BLOCK_K == 0),
         BLOCK_S=_BLOCK_S,
         BLOCK_N=block_n,
         BLOCK_K=_STEP_A_Q_BLOCK_K,
@@ -522,6 +524,7 @@ def _step_a_v_kernel(
     num_segments,
     # meta
     SORTED_BY_ADAPTER: tl.constexpr,
+    K_DIV: tl.constexpr,  # K % BLOCK_K == 0 -> drop safe_k (keep contraction load coalesced)
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -569,7 +572,7 @@ def _step_a_v_kernel(
     for k_block in range(0, tl.cdiv(K, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
         k_mask = cur_k < K
-        safe_k = tl.minimum(cur_k, K - 1)
+        safe_k = cur_k if K_DIV else tl.minimum(cur_k, K - 1)
 
         # x[s, h, k]
         x_tile = tl.load(
@@ -657,6 +660,7 @@ def step_a_v_fwd(
         batch_info.permutation,
         num_segments,
         SORTED_BY_ADAPTER=sorted_by_adapter,
+        K_DIV=(kv_lora_rank % _STEP_A_V_BLOCK_K == 0),
         BLOCK_S=_BLOCK_S,
         BLOCK_N=block_n,
         BLOCK_K=_STEP_A_V_BLOCK_K,

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -74,12 +74,12 @@ _BLOCK_S = 16
 # Tuned per kernel (B200; H=16, kv_lora_rank=512, qk_nope=v_head_dim=128, rank 16/32).
 # The a/b pair don't share: step_a contracts a wide K into a tiny N=rank output,
 # step_b is the inverse, so they want opposite tiles.
+# step_a output N == rank, so BLOCK_N = next_power_of_2(rank) (set per call) covers it
+# in one tile and adapts to any rank (16/32/64/...), like sgemm/qkv's BLOCK_R.
 _STEP_A_Q_BLOCK_K = 128  # step_a_q: K=qk_nope (~128) -> single contraction block
-_STEP_A_Q_BLOCK_N = 16  # output is rank
 _STEP_A_V_BLOCK_K = (
     256  # step_a_v: K=kv_lora_rank (~512); 256 -> 2 iters (was 8) ~-25..-40%
 )
-_STEP_A_V_BLOCK_N = 32  # output is rank; 32 covers rank-32 in one tile
 _STEP_B_BLOCK_K = 16  # step_b contraction is rank (q and v agree here)
 _STEP_B_Q_BLOCK_N = 128  # step_b_q output is kv_lora_rank (~512); 128 ~-6..-16%
 _STEP_B_V_BLOCK_N = 64  # step_b_v output is v_head_dim (~128); 64 already optimal
@@ -248,13 +248,14 @@ def step_a_q_fwd(
     """
     S, H, qk_nope_dim = q_nope.shape
     rank = B_buf.shape[-1]
+    block_n = triton.next_power_of_2(rank)  # output N == rank -> one tile
     out = torch.empty((S, H, rank), device=q_nope.device, dtype=q_nope.dtype)
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
 
     grid = (
-        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, _STEP_A_Q_BLOCK_N),
+        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, block_n),
         H,
         segment_grid,
     )
@@ -285,7 +286,7 @@ def step_a_q_fwd(
         FULL_K=full_K_per_head,
         SORTED_BY_ADAPTER=sorted_by_adapter,
         BLOCK_S=_BLOCK_S,
-        BLOCK_N=_STEP_A_Q_BLOCK_N,
+        BLOCK_N=block_n,
         BLOCK_K=_STEP_A_Q_BLOCK_K,
     )
     return out
@@ -621,13 +622,14 @@ def step_a_v_fwd(
     """
     S, H, kv_lora_rank = attn_output.shape
     rank = A_buf.shape[1]
+    block_n = triton.next_power_of_2(rank)  # output N == rank -> one tile
     out = torch.empty((S, H, rank), device=attn_output.device, dtype=attn_output.dtype)
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
 
     grid = (
-        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, _STEP_A_V_BLOCK_N),
+        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, block_n),
         H,
         segment_grid,
     )
@@ -656,7 +658,7 @@ def step_a_v_fwd(
         num_segments,
         SORTED_BY_ADAPTER=sorted_by_adapter,
         BLOCK_S=_BLOCK_S,
-        BLOCK_N=_STEP_A_V_BLOCK_N,
+        BLOCK_N=block_n,
         BLOCK_K=_STEP_A_V_BLOCK_K,
     )
     return out

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -322,6 +322,7 @@ def _step_b_q_kernel(
     num_segments,
     # meta
     SORTED_BY_ADAPTER: tl.constexpr,
+    N_DIV: tl.constexpr,  # N % BLOCK_N == 0 -> drop safe_n (keep the store coalesced)
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -365,7 +366,10 @@ def _step_b_q_kernel(
     row_mask = s_offset < seg_len
     safe_row = tl.minimum(s_physical, S - 1)
     n_mask = n_offset[None, :] < N
-    safe_n = tl.minimum(n_offset, N - 1)
+    # safe_n only matters when N isn't a BLOCK_N multiple; otherwise the raw affine
+    # index keeps the W load + output store coalesced. Clamping the contiguous
+    # kv_lora_rank axis here is a ~4-5x scatter/gather cliff (forces non-affine addrs).
+    safe_n = n_offset if N_DIV else tl.minimum(n_offset, N - 1)
 
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K_eff, BLOCK_K)):
@@ -463,6 +467,7 @@ def step_b_q_fwd(
         batch_info.scalings,
         num_segments,
         SORTED_BY_ADAPTER=sorted_by_adapter,
+        N_DIV=(kv_lora_rank % _STEP_B_BLOCK_N == 0),
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_B_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
@@ -691,6 +696,7 @@ def _step_b_v_kernel(
     FULL_K: tl.constexpr,  # qk_nope + v_head_dim
     QK_NOPE_OFFSET: tl.constexpr,  # offset of V-half within each head's row block
     SORTED_BY_ADAPTER: tl.constexpr,
+    N_DIV: tl.constexpr,  # N % BLOCK_N == 0 -> drop safe_n (keep the store coalesced)
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -733,7 +739,10 @@ def _step_b_v_kernel(
     row_mask = s_offset < seg_len
     safe_row = tl.minimum(s_physical, S - 1)
     n_mask = n_offset[None, :] < N
-    safe_n = tl.minimum(n_offset, N - 1)
+    # safe_n only matters when N isn't a BLOCK_N multiple; otherwise the raw affine
+    # index keeps the W load + output store coalesced. Clamping the contiguous
+    # v_head_dim axis here is a ~4-5x scatter/gather cliff (forces non-affine addrs).
+    safe_n = n_offset if N_DIV else tl.minimum(n_offset, N - 1)
 
     # V-half row base for this head: h*FULL_K + qk_nope
     head_row_base = head_id * FULL_K + QK_NOPE_OFFSET
@@ -840,6 +849,7 @@ def step_b_v_fwd(
         FULL_K=full_K_per_head,
         QK_NOPE_OFFSET=qk_nope_head_dim,
         SORTED_BY_ADAPTER=sorted_by_adapter,
+        N_DIV=(v_head_dim % _STEP_B_BLOCK_N == 0),
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_B_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -71,10 +71,18 @@ from sglang.srt.lora.utils import LoRABatchInfo
 # ---------------------------------------------------------------------------
 
 _BLOCK_S = 16
-_STEP_A_BLOCK_K = 64  # contraction over qk_nope (~128) or kv_lora_rank (~512)
-_STEP_A_BLOCK_N = 16  # output is rank
-_STEP_B_BLOCK_K = 16  # contraction is rank
-_STEP_B_BLOCK_N = 64  # output is kv_lora_rank (~512) or v_head_dim (~128)
+# Tuned per kernel (B200; H=16, kv_lora_rank=512, qk_nope=v_head_dim=128, rank 16/32).
+# The a/b pair don't share: step_a contracts a wide K into a tiny N=rank output,
+# step_b is the inverse, so they want opposite tiles.
+_STEP_A_Q_BLOCK_K = 128  # step_a_q: K=qk_nope (~128) -> single contraction block
+_STEP_A_Q_BLOCK_N = 16  # output is rank
+_STEP_A_V_BLOCK_K = (
+    256  # step_a_v: K=kv_lora_rank (~512); 256 -> 2 iters (was 8) ~-25..-40%
+)
+_STEP_A_V_BLOCK_N = 32  # output is rank; 32 covers rank-32 in one tile
+_STEP_B_BLOCK_K = 16  # step_b contraction is rank (q and v agree here)
+_STEP_B_Q_BLOCK_N = 128  # step_b_q output is kv_lora_rank (~512); 128 ~-6..-16%
+_STEP_B_V_BLOCK_N = 64  # step_b_v output is v_head_dim (~128); 64 already optimal
 
 
 def _num_segments(batch_info: LoRABatchInfo) -> int:
@@ -246,7 +254,7 @@ def step_a_q_fwd(
     segment_grid = _segment_grid_size(batch_info, num_segments)
 
     grid = (
-        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, _STEP_A_BLOCK_N),
+        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, _STEP_A_Q_BLOCK_N),
         H,
         segment_grid,
     )
@@ -277,8 +285,8 @@ def step_a_q_fwd(
         FULL_K=full_K_per_head,
         SORTED_BY_ADAPTER=sorted_by_adapter,
         BLOCK_S=_BLOCK_S,
-        BLOCK_N=_STEP_A_BLOCK_N,
-        BLOCK_K=_STEP_A_BLOCK_K,
+        BLOCK_N=_STEP_A_Q_BLOCK_N,
+        BLOCK_K=_STEP_A_Q_BLOCK_K,
     )
     return out
 
@@ -438,7 +446,7 @@ def step_b_q_fwd(
 
     grid = (
         triton.cdiv(max_segment_len, _BLOCK_S)
-        * triton.cdiv(kv_lora_rank, _STEP_B_BLOCK_N),
+        * triton.cdiv(kv_lora_rank, _STEP_B_Q_BLOCK_N),
         H,
         segment_grid,
     )
@@ -467,9 +475,9 @@ def step_b_q_fwd(
         batch_info.scalings,
         num_segments,
         SORTED_BY_ADAPTER=sorted_by_adapter,
-        N_DIV=(kv_lora_rank % _STEP_B_BLOCK_N == 0),
+        N_DIV=(kv_lora_rank % _STEP_B_Q_BLOCK_N == 0),
         BLOCK_S=_BLOCK_S,
-        BLOCK_N=_STEP_B_BLOCK_N,
+        BLOCK_N=_STEP_B_Q_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
     )
     return base_output
@@ -619,7 +627,7 @@ def step_a_v_fwd(
     segment_grid = _segment_grid_size(batch_info, num_segments)
 
     grid = (
-        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, _STEP_A_BLOCK_N),
+        triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, _STEP_A_V_BLOCK_N),
         H,
         segment_grid,
     )
@@ -648,8 +656,8 @@ def step_a_v_fwd(
         num_segments,
         SORTED_BY_ADAPTER=sorted_by_adapter,
         BLOCK_S=_BLOCK_S,
-        BLOCK_N=_STEP_A_BLOCK_N,
-        BLOCK_K=_STEP_A_BLOCK_K,
+        BLOCK_N=_STEP_A_V_BLOCK_N,
+        BLOCK_K=_STEP_A_V_BLOCK_K,
     )
     return out
 
@@ -818,7 +826,7 @@ def step_b_v_fwd(
 
     grid = (
         triton.cdiv(max_segment_len, _BLOCK_S)
-        * triton.cdiv(v_head_dim, _STEP_B_BLOCK_N),
+        * triton.cdiv(v_head_dim, _STEP_B_V_BLOCK_N),
         H,
         segment_grid,
     )
@@ -849,9 +857,9 @@ def step_b_v_fwd(
         FULL_K=full_K_per_head,
         QK_NOPE_OFFSET=qk_nope_head_dim,
         SORTED_BY_ADAPTER=sorted_by_adapter,
-        N_DIV=(v_head_dim % _STEP_B_BLOCK_N == 0),
+        N_DIV=(v_head_dim % _STEP_B_V_BLOCK_N == 0),
         BLOCK_S=_BLOCK_S,
-        BLOCK_N=_STEP_B_BLOCK_N,
+        BLOCK_N=_STEP_B_V_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
     )
     return base_output

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -405,8 +405,7 @@ def _step_b_q_kernel(
         + safe_n[None, :] * b_stride_n
     )
     out_mask = row_mask[:, None] & n_mask
-    partial_sum += tl.load(base + base_offs, mask=out_mask, other=0.0)
-    tl.store(base + base_offs, partial_sum, mask=out_mask)
+    tl.atomic_add(base + base_offs, partial_sum, mask=out_mask, sem="relaxed")
 
 
 def step_b_q_fwd(
@@ -777,8 +776,7 @@ def _step_b_v_kernel(
         + safe_n[None, :] * b_stride_n
     )
     out_mask = row_mask[:, None] & n_mask
-    partial_sum += tl.load(base + base_offs, mask=out_mask, other=0.0)
-    tl.store(base + base_offs, partial_sum, mask=out_mask)
+    tl.atomic_add(base + base_offs, partial_sum, mask=out_mask, sem="relaxed")
 
 
 def step_b_v_fwd(

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -71,18 +71,6 @@ from sglang.srt.lora.utils import LoRABatchInfo
 # ---------------------------------------------------------------------------
 
 _BLOCK_S = 16
-# Tuned per kernel (B200; H=16, kv_lora_rank=512, qk_nope=v_head_dim=128, rank 16/32).
-# The a/b pair don't share: step_a contracts a wide K into a tiny N=rank output,
-# step_b is the inverse, so they want opposite tiles.
-# step_a output N == rank, so BLOCK_N = next_power_of_2(rank) (set per call) covers it
-# in one tile and adapts to any rank (16/32/64/...), like sgemm/qkv's BLOCK_R.
-_STEP_A_Q_BLOCK_K = 128  # step_a_q: K=qk_nope (~128) -> single contraction block
-_STEP_A_V_BLOCK_K = (
-    256  # step_a_v: K=kv_lora_rank (~512); 256 -> 2 iters (was 8) ~-25..-40%
-)
-_STEP_B_BLOCK_K = 16  # step_b contraction is rank (q and v agree here)
-_STEP_B_Q_BLOCK_N = 128  # step_b_q output is kv_lora_rank (~512); 128 ~-6..-16%
-_STEP_B_V_BLOCK_N = 64  # step_b_v output is v_head_dim (~128); 64 already optimal
 
 
 def _num_segments(batch_info: LoRABatchInfo) -> int:
@@ -141,7 +129,7 @@ def _step_a_q_kernel(
     # meta
     FULL_K: tl.constexpr,  # per-head row stride in B (qk_nope + v_head_dim)
     SORTED_BY_ADAPTER: tl.constexpr,
-    K_DIV: tl.constexpr,  # K % BLOCK_K == 0 -> drop safe_k (keep contraction load coalesced)
+    K_DIV: tl.constexpr,
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -254,6 +242,7 @@ def step_a_q_fwd(
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
+    _STEP_A_Q_BLOCK_K = 128
 
     grid = (
         triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, block_n),
@@ -333,7 +322,7 @@ def _step_b_q_kernel(
     num_segments,
     # meta
     SORTED_BY_ADAPTER: tl.constexpr,
-    N_DIV: tl.constexpr,  # N % BLOCK_N == 0 -> drop safe_n (keep the store coalesced)
+    N_DIV: tl.constexpr,
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -377,9 +366,6 @@ def _step_b_q_kernel(
     row_mask = s_offset < seg_len
     safe_row = tl.minimum(s_physical, S - 1)
     n_mask = n_offset[None, :] < N
-    # safe_n only matters when N isn't a BLOCK_N multiple; otherwise the raw affine
-    # index keeps the W load + output store coalesced. Clamping the contiguous
-    # kv_lora_rank axis here is a ~4-5x scatter/gather cliff (forces non-affine addrs).
     safe_n = n_offset if N_DIV else tl.minimum(n_offset, N - 1)
 
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
@@ -446,6 +432,8 @@ def step_b_q_fwd(
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
+    _STEP_B_Q_BLOCK_N = 128
+    _STEP_B_BLOCK_K = 16
 
     grid = (
         triton.cdiv(max_segment_len, _BLOCK_S)
@@ -524,7 +512,7 @@ def _step_a_v_kernel(
     num_segments,
     # meta
     SORTED_BY_ADAPTER: tl.constexpr,
-    K_DIV: tl.constexpr,  # K % BLOCK_K == 0 -> drop safe_k (keep contraction load coalesced)
+    K_DIV: tl.constexpr,
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -625,11 +613,12 @@ def step_a_v_fwd(
     """
     S, H, kv_lora_rank = attn_output.shape
     rank = A_buf.shape[1]
-    block_n = triton.next_power_of_2(rank)  # output N == rank -> one tile
+    block_n = triton.next_power_of_2(rank)
     out = torch.empty((S, H, rank), device=attn_output.device, dtype=attn_output.dtype)
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
+    _STEP_A_V_BLOCK_K = 256
 
     grid = (
         triton.cdiv(max_segment_len, _BLOCK_S) * triton.cdiv(rank, block_n),
@@ -753,9 +742,6 @@ def _step_b_v_kernel(
     row_mask = s_offset < seg_len
     safe_row = tl.minimum(s_physical, S - 1)
     n_mask = n_offset[None, :] < N
-    # safe_n only matters when N isn't a BLOCK_N multiple; otherwise the raw affine
-    # index keeps the W load + output store coalesced. Clamping the contiguous
-    # v_head_dim axis here is a ~4-5x scatter/gather cliff (forces non-affine addrs).
     safe_n = n_offset if N_DIV else tl.minimum(n_offset, N - 1)
 
     # V-half row base for this head: h*FULL_K + qk_nope
@@ -829,6 +815,8 @@ def step_b_v_fwd(
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
+    _STEP_B_V_BLOCK_N = 64
+    _STEP_B_BLOCK_K = 16
 
     grid = (
         triton.cdiv(max_segment_len, _BLOCK_S)

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -73,6 +73,23 @@ from sglang.srt.lora.utils import LoRABatchInfo
 _BLOCK_S = 16
 
 
+def _dense_1adapter(batch_info: LoRABatchInfo):
+    """(slot, rank, scaling) for the single-adapter cuBLAS path, else None.
+
+    cuBLAS beats the SGMM kernels in every measured regime for step_a_q
+    (per-head bmm), step_b_q, and step_a_v (one flattened (S*H, .) GEMM each)
+    -- with one adapter the head axis multiplies GEMM M by H, so there is no
+    small-M regime. step_b_v stays Triton (bmm + add_ loses there).
+    """
+    if batch_info.use_cuda_graph or batch_info.uniform_weight_index is None:
+        return None
+    return (
+        batch_info.uniform_weight_index,
+        batch_info.uniform_rank,
+        batch_info.uniform_scaling,
+    )
+
+
 def _num_segments(batch_info: LoRABatchInfo) -> int:
     return batch_info.num_segments or batch_info.bs
 
@@ -237,6 +254,15 @@ def step_a_q_fwd(
     """
     S, H, qk_nope_dim = q_nope.shape
     rank = B_buf.shape[-1]
+
+    dense = _dense_1adapter(batch_info)
+    if dense is not None:
+        wi, r, _ = dense
+        # (S,H,r) view of a (H,S,r)-contiguous bmm result; step_b_q's dense
+        # path flattens in (h,s) order, so the chain needs no copies.
+        w_kc = B_buf[wi].view(H, full_K_per_head, -1)[:, :qk_nope_dim, :r]
+        return torch.bmm(q_nope.transpose(0, 1), w_kc).transpose(0, 1)
+
     block_n = triton.next_power_of_2(rank)  # output N == rank -> one tile
     out = torch.empty((S, H, rank), device=q_nope.device, dtype=q_nope.dtype)
     num_segments = _num_segments(batch_info)
@@ -429,6 +455,24 @@ def step_b_q_fwd(
     """
     S, H, rank = q_lora_a.shape
     kv_lora_rank = A_buf.shape[-1]
+
+    dense = _dense_1adapter(batch_info)
+    if dense is not None:
+        wi, r, scaling = dense
+        # Flatten (S,H) in whichever order base_output's storage allows
+        # without a copy (the absorbed q path passes a transpose view of a
+        # (H,S,kv)-contiguous bmm result). x is small; reshape may copy it.
+        base2d = x2d = None
+        if base_output.is_contiguous():
+            base2d = base_output.view(-1, kv_lora_rank)
+            x2d = q_lora_a[..., :r].reshape(-1, r)
+        elif base_output.transpose(0, 1).is_contiguous():
+            base2d = base_output.transpose(0, 1).view(-1, kv_lora_rank)
+            x2d = q_lora_a[..., :r].transpose(0, 1).reshape(-1, r)
+        if base2d is not None:
+            base2d.addmm_(x2d, A_buf[wi, :r, :], alpha=scaling)
+            return base_output
+
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
@@ -613,6 +657,14 @@ def step_a_v_fwd(
     """
     S, H, kv_lora_rank = attn_output.shape
     rank = A_buf.shape[1]
+
+    dense = _dense_1adapter(batch_info)
+    if dense is not None and attn_output.is_contiguous():
+        wi, r, _ = dense
+        return torch.mm(attn_output.view(-1, kv_lora_rank), A_buf[wi, :r, :].t()).view(
+            S, H, r
+        )
+
     block_n = triton.next_power_of_2(rank)
     out = torch.empty((S, H, rank), device=attn_output.device, dtype=attn_output.dtype)
     num_segments = _num_segments(batch_info)

--- a/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
@@ -78,7 +78,10 @@ def _qkv_lora_b_kernel(
     n_start = tl.load(n_offs + qkv_id)
     n_size = tl.load(n_offs + qkv_id + 1) - n_start
     scaling = tl.load(scalings + w_index)
-    # Adjust K (rank) according to the specific LoRA adapter
+    # Adjust K (rank) according to the specific LoRA adapter.
+    # NOTE: this clamp is load-bearing beyond truncating the contraction -- it also
+    # sets the x slice offset `qkv_id * K` below, since the LoRA-A output packs the
+    # q/k/v slices by *actual* rank. So (unlike sgemm_lora_b) it can NOT be dropped.
     K = tl.minimum(K, rank)
 
     # The tile in output matrix will have (pid_s, pid_n) as id
@@ -107,23 +110,18 @@ def _qkv_lora_b_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
-    # Iterate to compute the block in output matrix
-    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
-            other=0.0,
-        )
-        w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & (n_offset[None, :] < n_size),
-            other=0.0,
-        )
-        partial_sum += tl.dot(x_tile, w_tile)
-
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
+    n_mask = n_offset[None, :] < n_size
+    x_tile = tl.load(
+        x_ptrs,
+        mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K),
+        other=0.0,
+    )
+    w_tile = tl.load(
+        w_ptrs,
+        mask=(k_offset[:, None] < K) & n_mask,
+        other=0.0,
+    )
+    partial_sum = tl.dot(x_tile, w_tile)
 
     # Store result to output matrix
     partial_sum *= scaling
@@ -134,8 +132,7 @@ def _qkv_lora_b_kernel(
         + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
     )
     output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < n_size)
-    partial_sum += tl.load(output_ptr, mask=output_mask)
-    tl.store(output_ptr, partial_sum, mask=output_mask)
+    tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
 
 
 def qkv_lora_b_fwd(
@@ -171,7 +168,7 @@ def qkv_lora_b_fwd(
     assert output_offset.shape[0] == n_slices + 1
 
     BLOCK_S = 16
-    BLOCK_R = 16
+    BLOCK_R = triton.next_power_of_2(r)
     BLOCK_OUT = 64
 
     grid_b = (

--- a/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
@@ -1,9 +1,16 @@
+from typing import Optional
+
 import torch
 import triton
 import triton.language as tl
 
 from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
 from sglang.srt.lora.utils import LoRABatchInfo
+
+# Minimum max_len (longest segment) for the single-adapter cuBLAS path; below
+# this the Triton kernel is faster (measured crossover at the smallest
+# realistic N=768, where cuBLAS is weakest).
+_CUBLAS_MIN_MAX_LEN = 8
 
 
 @triton.jit
@@ -79,9 +86,6 @@ def _qkv_lora_b_kernel(
     n_size = tl.load(n_offs + qkv_id + 1) - n_start
     scaling = tl.load(scalings + w_index)
     # Adjust K (rank) according to the specific LoRA adapter.
-    # NOTE: this clamp is load-bearing beyond truncating the contraction -- it also
-    # sets the x slice offset `qkv_id * K` below, since the LoRA-A output packs the
-    # q/k/v slices by *actual* rank. So (unlike sgemm_lora_b) it can NOT be dropped.
     K = tl.minimum(K, rank)
 
     # The tile in output matrix will have (pid_s, pid_n) as id
@@ -135,6 +139,35 @@ def _qkv_lora_b_kernel(
     tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
 
 
+def _qkv_lora_b_cublas(
+    x: torch.Tensor,
+    qkv_lora_b: torch.Tensor,
+    batch_info: LoRABatchInfo,
+    output_offset_cpu: torch.Tensor,
+    base_output: Optional[torch.Tensor],
+    n_slices: int,
+) -> torch.Tensor:
+    """Single-adapter dense path: one cuBLAS addmm_ per q/k/v slice.
+
+    The LoRA-A output is rank-packed (slice i at columns [i*rank, (i+1)*rank)),
+    matching the Triton kernel's K = min(K, rank) slice stride. Slice offsets
+    come from the pinned CPU copy (no GPU sync); slices are disjoint output
+    regions, so in-place addmm_ writes never collide.
+    """
+    r = batch_info.uniform_rank
+    if base_output is None:
+        base_output = torch.zeros(
+            (x.shape[0], qkv_lora_b.shape[-2]), device=x.device, dtype=x.dtype
+        )
+    w = qkv_lora_b[batch_info.uniform_weight_index]
+    x_scaled = x[:, : n_slices * r] * batch_info.uniform_scaling
+    offsets = output_offset_cpu.tolist()
+    for i in range(n_slices):
+        lo, hi = offsets[i], offsets[i + 1]
+        base_output[:, lo:hi].addmm_(x_scaled[:, i * r : (i + 1) * r], w[lo:hi, :r].t())
+    return base_output
+
+
 def qkv_lora_b_fwd(
     x: torch.Tensor,
     qkv_lora_b: torch.Tensor,
@@ -143,6 +176,7 @@ def qkv_lora_b_fwd(
     max_qkv_out_dim: int,
     base_output: torch.Tensor = None,
     n_slices: int = 3,
+    output_offset_cpu: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
 
     # x: (s, n_slices * r)
@@ -166,6 +200,16 @@ def qkv_lora_b_fwd(
     output_dim = qkv_lora_b.shape[-2]
     assert input_dim == n_slices * r
     assert output_offset.shape[0] == n_slices + 1
+
+    if (
+        output_offset_cpu is not None
+        and batch_info.uniform_weight_index is not None
+        and not batch_info.use_cuda_graph
+        and batch_info.max_len >= _CUBLAS_MIN_MAX_LEN
+    ):
+        return _qkv_lora_b_cublas(
+            x, qkv_lora_b, batch_info, output_offset_cpu, base_output, n_slices
+        )
 
     BLOCK_S = 16
     BLOCK_R = triton.next_power_of_2(r)

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
@@ -54,9 +54,9 @@ def _sgemm_lora_b_kernel(
             the base model's output for a fused add operation.
     """
 
-    # Current block computes sequence with batch_id,
-    # which starts from row seg_start of x with length seg_len
-    batch_id = tl.program_id(axis=1)
+    pid_s = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    batch_id = tl.program_id(axis=2)
     w_index = tl.load(weight_indices + batch_id)
     rank = tl.load(lora_ranks + w_index)
 
@@ -64,25 +64,12 @@ def _sgemm_lora_b_kernel(
     if rank == 0:
         return
 
-    pid = tl.program_id(axis=0)
     seg_len = tl.load(seg_lens + batch_id)
-    if seg_len == 0:
+    if pid_s * BLOCK_S >= seg_len:  # also covers seg_len == 0
         return
     seg_start = tl.load(seg_indptr + batch_id)
     scaling = tl.load(scalings + w_index)
-    # Adjust K (rank) according to the specific LoRA adapter
-    K = tl.minimum(K, rank)
 
-    # The tile in output matrix will have (pid_s, pid_n) as id
-    num_pid_n = tl.cdiv(N, BLOCK_N)
-    pid_s = pid // num_pid_n
-    pid_n = pid % num_pid_n
-    if pid_s * BLOCK_S >= seg_len:
-        return
-
-    # Create pointers for the first block of x and weights[batch_id]
-    # The pointers will be advanced as we move in the K direction
-    # and accumulate
     s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
     n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
     k_offset = tl.arange(0, BLOCK_K)
@@ -94,34 +81,28 @@ def _sgemm_lora_b_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
-    # Iterate to compute the block in output matrix
     n_mask = n_offset[None, :] < N
-    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
-            other=0.0,
-        )
-        w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & n_mask,
-            other=0.0,
-        )
-        partial_sum += tl.dot(x_tile, w_tile)
-
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
-
-    # Store result to output matrix
-    partial_sum *= scaling
-    partial_sum = partial_sum.to(x.dtype.element_ty)
     output_ptr = output + (
         s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
     )
     output_mask = (s_offset[:, None] < seg_len) & n_mask
-    partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
-    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+    x_tile = tl.load(
+        x_ptrs,
+        mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K),
+        other=0.0,
+    )
+    w_tile = tl.load(
+        w_ptrs,
+        mask=(k_offset[:, None] < K) & n_mask,
+        other=0.0,
+    )
+
+    partial_sum = tl.dot(x_tile, w_tile) * scaling
+
+    # Store result to output matrix
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
 
 
 def sgemm_lora_b_fwd(
@@ -147,11 +128,12 @@ def sgemm_lora_b_fwd(
 
     # Block shapes
     BLOCK_S = 16
-    BLOCK_R = 16
+    BLOCK_R = triton.next_power_of_2(R)
     BLOCK_N = 256
 
     grid = (
-        triton.cdiv(batch_info.max_len, BLOCK_S) * triton.cdiv(N, BLOCK_N),
+        triton.cdiv(batch_info.max_len, BLOCK_S),
+        triton.cdiv(N, BLOCK_N),
         batch_info.bs,
     )
 

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -64,6 +64,13 @@ class LoRABatchInfo:
     # Computed from Python lists in prepare_lora_batch to avoid GPU sync.
     has_active_lora: bool = False
 
+    # CPU-side single-adapter info: when every request in the batch uses the
+    # same adapter slot with rank > 0, the slot index, rank, and scaling; else
+    # None. Computed from Python lists in prepare_lora_batch to avoid GPU sync.
+    uniform_weight_index: Optional[int] = None
+    uniform_rank: Optional[int] = None
+    uniform_scaling: Optional[float] = None
+
     # Per-request segment indptrs, shape (bs + 1,). Required by MoE virtual
     # experts which map tokens to requests regardless of the dense-LoRA
     # backend's internal segmentation.  For the triton backend these are


### PR DESCRIPTION
## Motivation

The LoRA-B expand Triton kernels (`sgemm_lora_b`, `qkv_lora_b`, and the absorbed-MLA
`kv_b` step-B kernels) are small, latency-bound ops on the decode hot path. They had
two avoidable overheads:

1. A read-modify-write accumulate into the (shared) base output — `partial_sum +=
   tl.load(out); tl.store(out)` — an extra global read plus a store dependency, and a
   hazard when the base GEMM and the LoRA add run on different streams.
2. A `for k in range(cdiv(K, BLOCK_K))` contraction loop over the LoRA rank, even
   though the rank (≤ a few hundred, in practice 16/32) trivially fits one block.

This PR removes both, plus a small grid cleanup for `sgemm_lora_b`.

## Modifications

**`sgemm_lora_b.py`**
- Accumulate with `tl.atomic_add` instead of load-add-store (also makes the kernel safe
  to overlap with the base GEMM on a separate stream).
- Collapse the K-loop into a single block (`BLOCK_R = next_pow2(R)`), and contract over
  the full padded `max_rank` instead of clamping `K = min(K, rank)` per adapter. Dropping
  that clamp is what unlocks the speedup: with `K` the (divisible-by-16) kernel arg, Triton
  elides the K-mask; masking by the in-kernel loaded `rank` defeats that specialization and
  is ~2× slower. **Correctness for `rank < max_rank` now relies on the LoRA-B buffer tail
  `[rank:max_rank]` being zero** (see the mem_pool change). The `x` (LoRA-A output) tail is
  uninitialized, but `garbage * 0 == 0`.
- 3-D grid `(pid_s, pid_n, batch_id)` so the s/n tile ids come straight from `program_id`
  instead of `//` and `%` on a flattened axis.

**`mem_pool.py`** (correctness pairing for the above)
- Zero the dense LoRA-B buffer tail `[buffer_id, :, lora_rank:]` after loading an adapter.
  The kernel now reads the full `max_rank`; on slot reuse across ranks (e.g. a rank-16
  adapter loaded into a slot that held rank-32) the `[16:32]` tail would otherwise retain
  stale weights and contaminate the output. Mirrors the existing MoE `down_proj` convention.

**`qkv_lora_b.py`**
- Collapse the K-loop into a single block (`BLOCK_R = next_pow2(r)`) and switch to
  `tl.atomic_add`. **The `K = min(K, rank)` clamp is kept here** — it is load-bearing
  beyond truncating the contraction: it also sets the x slice offset `qkv_id * K`, because
  the qkv LoRA-A output packs the q/k/v slices by *actual* rank. So this kernel does not
  depend on the buffer-tail zeroing.

**`kv_b_lora_absorbed.py`** (absorbed-MLA step-B)
- Switch the accumulate to `tl.atomic_add`. The single-K-block change was evaluated and
  **reverted**: these kernels are the inverse shape (fat output N≈512, thin K=rank) with
  *strided* weight loads, where a larger `BLOCK_K` regresses (+14% at rank-32). The K-loop
  and `K_eff = min(K, cur_rank)` clamp are intentionally retained.
- **Gate the `safe_n` index clamp** in `step_b_q`/`step_b_v`. These kernels clamp the
  output-column index (`safe_n = min(n_offset, N-1)`) on the *contiguous* `kv_lora_rank` /
  `v_head_dim` axis, which forces the W load + output store non-affine → scatter/gather →
  **~4–5× slower**. Gated on a `constexpr N_DIV = (N % BLOCK_N == 0)`: raw affine index in
  the common divisible case (kv_lora_rank=512, v_head_dim=128 → coalesced), clamp retained
  otherwise so odd shapes keep the pointer-OOB safety. Bit-identical on both paths.
- **Gate the `safe_k` index clamp** in `step_a_q`/`step_a_v` — the mirror image: step_a's
  *contraction* axis (qk_nope / kv_lora_rank) is the contiguous axis of both the x and
  weight loads, so `safe_k = min(cur_k, K-1)` is the scatter/gather cliff there. Decomposed
  on `step_a_v`: `+safe_k` is **+60–150%**, while `safe_row` is free and `safe_n` is +5–10%.
  Gated on `constexpr K_DIV = (K % BLOCK_K == 0)` (qk_nope=128%128, kv_lora_rank=512%256).
  Takes `step_a_v` 6.7 → ~3.4 µs (−47%); combined with the block-size tuning the full
  `step_a_v` win vs the original default is **−60 to −70%**. Bit-identical.
- **Per-kernel block-size tuning.** The four step kernels were sharing `_STEP_A_*` /
  `_STEP_B_*` block constants, but they're opposite shapes (step_a: wide-K → tiny N=rank;
  step_b: K=rank → wide N). Split them and retuned from a 4-kernel sweep: `step_a_v`
  `BLOCK_K` 64→256 (512-wide contraction: 8 loop iters → 2) + `BLOCK_N` 16→32; `step_a_q`
  `BLOCK_K` 64→128; `step_b_q` `BLOCK_N` 64→128; `step_b_v` unchanged.

## Accuracy

All on B200, bf16. New regression tests added under `triton_ops/` (correctness +
padding-contract probe):

- `sgemm_lora_b`: bit-equivalent to a torch reference (max_err = 0) across all paths —
  N divisible / not by `BLOCK_N`, rank power-of-2 / not, sorted / unsorted, multi-segment
  mixed-rank, and rank-0 (no-op) segments.
- Mixed rank-16/32 **slot-reuse contamination probe**: with a stale buffer tail the output
  is wrong (max_abs_err ≈ 25); after the mem_pool zero-pad it is correct (≈ 0.04, bf16
  noise). Confirms the kernel↔loader contract.
- `qkv_lora_b` and absorbed `step_b_q`/`step_b_v`: match a per-slice / per-segment torch
  reference under mixed ranks (rel err < 0.4%, bf16 noise) — and for the `safe_n` gate,
  on **both** branches: divisible N (512/128 → `N_DIV` fast path) and non-divisible N
  (520/96 → clamp path).

## Speed

B200, bf16, CUDA-graph capture + L2-cold (`marker.do_bench`), median µs (`N` given per
section/row).

### `sgemm_lora_b` — base (RMW + K-loop + clamp) vs new

`N` is the per-GPU LoRA-B output dim at **TP=8** for two DeepSeek-V3 shapes —
`N=896` (hidden 7168 / 8) and `N=2304` (dense-FFN 18432 / 8), i.e. the
column-parallel q/k/v/gate/up expand.

decode (`seg_len = 1`):

| N | rank | bs | base µs | new µs | speedup |
|---:|---:|---:|---:|---:|---:|
| 896 | 16 | 1 | 3.22 | 2.24 | 1.4× |
| 896 | 16 | 64 | 3.96 | 2.57 | 1.5× |
| 896 | 16 | 128 | 6.72 | 2.99 | 2.2× |
| 896 | 32 | 64 | 5.94 | 2.96 | 2.0× |
| 896 | 32 | 128 | 10.46 | 3.58 | 2.9× |
| 896 | 64 | 64 | 12.92 | 3.44 | 3.8× |
| 896 | 64 | 128 | 24.17 | 4.56 | 5.3× |
| 2304 | 16 | 64 | 6.93 | 3.15 | 2.2× |
| 2304 | 16 | 128 | 12.39 | 3.96 | 3.1× |
| 2304 | 32 | 64 | 10.49 | 3.69 | 2.8× |
| 2304 | 32 | 128 | 19.31 | 5.09 | 3.8× |
| 2304 | 64 | 64 | 24.91 | 4.75 | 5.2× |
| 2304 | 64 | 128 | 47.41 | 8.35 | 5.7× |

prefill-ish (`bs = 1`): N=896 seg=512/r16 3.54 → 2.51 (1.4×), seg=2048/r32 10.37 → 4.07 (2.5×);
N=2304 seg=512/r16 4.24 → 2.94 (1.4×), seg=2048/r32 19.00 → 5.93 (3.2×).

The gap widens with N, bs, and rank because the base cost scaled with the K-loop iterations
and the per-tile read-modify-write; the new kernel stays near-flat.

### `qkv_lora_b` — legacy K-loop vs new single-block (loop removal only; clamp kept)

| case | legacy µs | new µs | Δ |
|---|---:|---:|---:|
| decode bs8 r16 | 6.24 | 5.31 | −15% |
| decode bs128 r16 | 56.30 | 45.51 | −19% |
| decode bs128 r32 | 70.33 | 59.56 | −15% |
| sorted seg256 r32 | 22.81 | 18.08 | −21% |

### `kv_b_lora_absorbed` — `step_b_q`, `safe_n` gate (H=16, kv_lora_rank=512)

| case | before (clamped) | after (gated) | speedup |
|---|---:|---:|---:|
| S8 r16 | 12.4 | 2.34 | 5.3× |
| S64 r16 | 14.3 | 3.12 | 4.6× |
| S128 r16 | 20.6 | 3.71 | 5.6× |
| S8 r32 | 13.1 | 2.83 | 4.6× |
| S64 r32 | 15.9 | 3.55 | 4.5× |
| S128 r32 | 23.4 | 4.49 | 5.2× |

`step_b_v` behaves the same way. The K-loop itself is retained (loop-removal was neutral
/ regressive for these shapes); the win is purely from dropping the `safe_n` scatter/gather
in the divisible-N case.

Block-size tuning, default → tuned (µs, same setup):

| kernel | default | tuned | win |
|---|---:|---:|---:|
| `step_a_v` S128 r32 | 11.21 | 6.74 (K256 N32) | **−40%** |
| `step_a_v` S64 r16 | 8.73 | 6.22 (K256 N32) | −29% |
| `step_a_v` S8 r16 | 7.31 | 4.88 (K256 N32) | −33% |
| `step_a_q` S128 r16 | 3.72 | 3.53 (K128) | −5% |
| `step_a_q` S64 r16 | 3.61 | 3.42 (K128) | −5% |
| `step_b_q` S128 r32 | 4.49 | 3.89 (N128) | −13% |
| `step_b_q` S64 r16 | 3.09 | 2.91 (N128) | −6% |

(`step_b_q` here is *after* the `safe_n` gate; the block-size win stacks on top of the
4–5× above.)

`step_a` `safe_k` gate (on top of the block tuning), default → tuned → +safe_k-gate (µs):

| kernel | orig default | block-tuned | + safe_k gate | total win |
|---|---:|---:|---:|---:|
| `step_a_v` S128 r32 | 11.21 | 6.74 | 3.54 | **−68%** |
| `step_a_v` S64 r16 | 8.73 | 6.56 | 3.39 | −61% |
| `step_a_v` S8 r16 | 7.31 | 5.00 | 2.96 | −60% |
| `step_a_q` S128 r32 | 5.22 | 4.55 | 4.09 | −22% |
| `step_a_q` S8 r16 | 3.13 | 2.83 | 2.66 | −15% |

`safe_k` is the dominant lever for `step_a_v` (contiguous contraction axis); for `step_a_q`
its contraction axis is partly strided so the gate helps less. `safe_row` stays (free);
`safe_n` (+5–10% on step_a) is left clamped.

## Relationship to #24576

This PR touches the same kernels as the open PR #24576 (`sgemm_lora_b`, `qkv_lora_b`, …),
so the two will conflict and should be coordinated. They address *different* clamps:

- **#24576** adds a *safe-index* clamp (`safe_row/safe_n/safe_k = tl.minimum(idx, dim-1)`)
  so masked-out lanes don't materialize an out-of-bounds *pointer* (IMA on some
  Triton/driver combos). It keeps the rank-semantic clamp.
- **This PR** drops the *rank-semantic* clamp (`K = min(K, rank)`) in `sgemm_lora_b`,
  substituting a zero-padded buffer tail.

These are orthogonal and composable. This PR preserves the existing mask-based bounds
handling and does **not** add the safe-index clamp.

**Measured cost of the safe-index clamp on top of this PR's `sgemm_lora_b`** (B200, bf16,
CUDA-graph + L2-cold), median µs, decomposed per axis. `current` = this PR's kernel; each
`+safe_*` column re-adds one #24576-style `tl.minimum(idx, dim-1)` clamp:

| case | current | +safe_row | +safe_k | +safe_n | +all |
|---|---:|---:|---:|---:|---:|
| decode bs64 r16 N4096 | 4.02 | 3.88 | 4.88 | **76.12** | 76.44 |
| decode bs128 r32 N4096 | 7.83 | 7.73 | 11.40 | **117.11** | 120.11 |
| sorted bs1 seg256 r32 N4096 | 3.20 | 3.54 | 3.80 | **43.11** | 44.04 |
| nondiv-N bs64 r32 N4000 | 5.75 | 4.81 | 7.22 | **76.54** | 78.04 |

`safe_row` is ~free, `safe_k` is a modest +12–52%, but `safe_n` is a **13–19× cliff**
(e.g. 7.8 → 117 µs), and `+all` is dominated by it.

`n` is the **contiguous** axis of the wide output store (`output_stride_1 == 1`) and the
large axis of the W load; wrapping it in `tl.minimum` makes those addresses non-affine, so
Triton drops the vectorized/coalesced load+store and falls back to scatter/gather —
fatal on this memory-bound kernel. (It is slow even at N=4096 where the clamp never fires
at runtime: the mere *presence* of `min()` defeats the compile-time contiguity analysis.)

So adopting #24576's clamp wholesale would erase the speedup here. The `safe_row` part
(the row-OOB case) is essentially free and can be added if pointer-OOB hardening is wanted;
the `safe_n` part needs a non-clamping approach instead — e.g. pad `N` up to a `BLOCK_N`
multiple so `n_offset < N` always holds, `constexpr`-gate the clamp to the `N % BLOCK_N != 0`
tail only, or use `tl.max_contiguous` / `tl.multiple_of` hints to preserve coalescing. Happy
to coordinate ordering / rebase in whichever direction maintainers prefer.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests — correctness was verified locally (harnesses described above); happy to fold them into `test/manual/lora/test_lora_ops.py` if preferred.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).











































### Investigated (this session): does a `num_adapter==1` cuBLAS fast path beat these Triton expands?

For a single loaded adapter every token routes to slot 0, so the segmented SGMM
collapses to a plain dense GEMM. The pool already zeroes the B `[rank:]` tail, so a
cuBLAS path contracting over the full padded `R` is **bit-identical** to Triton
(`max_err = 0.0000` everywhere below). Scaling is folded into `x` on-device and slice
offsets baked as host ints, so the path is CUDA-graph capturable (indexing the GPU
`output_offset` forces an illegal capture-time sync). Benched triton-vs-cublas on B200
with `do_bench` (cuda-graph + L2-cold). `speedup = triton_us / cublas_us` (>1 ⇒ cuBLAS wins):

**`sgemm_lora_b` — cuBLAS LOSES across decode; keep Triton.**

| regime | speedup | winner |
|---|---|---|
| bs 1–64, N 896/2304, rank 16–64 | 0.45–0.87 | Triton (1.2–2.4×) |
| bs=128 + N=2304 + rank=64 | 1.63 | cuBLAS (compute-bound tail) |

The expand's contraction `K = rank` is tiny (16–64), a "fat, tiny-K" GEMM that
under-utilizes cuBLAS and pays its ~3.2 µs launch/heuristic floor — more than Triton's
whole ~1.9–2.6 µs runtime. (Opposite of the LoRA-A *shrink*, where the large-K
contraction lets `F.linear` win 1.2–1.7×.) **No dispatch added** — `sgemm_lora_b.py`
is unchanged; a `weights.shape[0]==1 → addmm` branch was prototyped then reverted
because it regresses decode ~1.5–2×.

**`qkv_lora_b` — shape-dependent; cuBLAS wins high-batch + prefill, loses low-bs decode.**

| shape | bs≤32 decode | bs 64–128 | prefill (seg 512/2048) |
|---|---|---|---|
| TP8 GQA per-GPU, N=768 | Triton (0.5–0.8) | cuBLAS from bs128 (1.2–1.8×) | cuBLAS (1.3–1.8×) |
| Kimi single-slice, N=1536 | ~tie (0.9–1.3) | cuBLAS (1.7–3.0×) | cuBLAS (1.9–3.2×) |
| full GQA, N=6144 (no TP) | cuBLAS from bs16 | cuBLAS up to **9.8×** | cuBLAS (3–6×) |

The fused qkv kernel tiles each length-1 decode segment independently (grid axis2 = bs,
`BLOCK_S=16` wastes 15/16 rows, × `n_slices` × `BLOCK_OUT=64` fine N-tiles), so its real
GPU time grows ~linearly with bs (45–81 µs at bs=128, N=6144) while the dense cuBLAS path
stays flat ~7 µs. A **bs/seg-gated** cuBLAS dispatch for `qkv_lora_b` is a plausible
follow-up (helps high-concurrency decode + prefill), but it is not a clean low-bs decode
win and is left out of this PR.

Benches added (standalone, not wired into CI): `bench_sgemm_lora_b_cublas.py`,
`bench_qkv_lora_b_cublas.py` (`--slice-dims`).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26914504352](https://github.com/sgl-project/sglang/actions/runs/26914504352)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26914503573](https://github.com/sgl-project/sglang/actions/runs/26914503573)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->








