### PR TITLE
ci: cache HF hub for base-a-test-cpu to avoid Hub 429 flakes

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -267,6 +267,8 @@ jobs:
       (needs.check-changes.outputs.main_package == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    env:
+      HF_HOME: ${{ github.workspace }}/.hf-cache
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-cpu'].max_parallel }}
@@ -315,6 +317,16 @@ jobs:
           UV_SYSTEM_PYTHON: "1"
         run: |
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
+
+      # Hosted runners are ephemeral, so models are re-fetched every run and the
+      # Hub occasionally returns 429s. Persist the HF cache in GitHub's cache
+      # storage (rolling key + restore-keys) so warm runs never hit the network.
+      - name: Cache HF hub
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.hf-cache
+          key: hf-cpu-${{ matrix.partition }}-${{ github.run_id }}
+          restore-keys: hf-cpu-${{ matrix.partition }}-
 
       - name: Run test
         timeout-minutes: 10


### PR DESCRIPTION
## Problem

`base-a-test-cpu` runs on ephemeral GitHub-hosted runners with no HF cache, so every run cold-downloads tokenizers/models from the Hub. When the Hub returns `429 Too Many Requests`, tests fail spuriously after exhausting retries — unrelated to the PR under test.

Example: https://github.com/sgl-project/sglang/actions/runs/26848570606/job/79174756979

```
httpx.HTTPStatusError: Client error '429 Too Many Requests' for url
'https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct/resolve/main/config.json'
→ RuntimeError: fastokens failed to load tokenizer for 'Qwen/Qwen2.5-1.5B-Instruct'
→ Exception: retry() exceed maximum number of retries.
```

## Fix

Persist the HF hub cache via `actions/cache` (rolling key + `restore-keys`) and point `HF_HOME` at it. Warm runs restore models from GitHub's cache storage and never hit the network; the per-partition rolling key lets the cache accumulate as the suite evolves.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26854978830](https://github.com/sgl-project/sglang/actions/runs/26854978830)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26854978699](https://github.com/sgl-project/sglang/actions/runs/26854978699)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->