### PR TITLE
chore: ignore .humanize/ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,5 @@ sgl-kernel/csrc/**/*_musa/
 *.npz
 artifacts/
 .claude/scheduled_tasks.lock
+
+.humanize/


### PR DESCRIPTION
## Motivation

The `.humanize/` directory holds local tooling artifacts generated by the humanize skill workflow. These are per-developer, machine-local files that should never be tracked. Without an ignore rule they surface as untracked noise in `git status` and can be accidentally staged into commits.

## Modifications

- Add `.humanize/` to `.gitignore`.

No code paths are touched; this is a repository-hygiene change only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->