### PR TITLE
[lora] Add JIT CUDA + CuTeDSL MoE LoRA-A shrink kernels

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_moe_lora_shrink.py
+++ b/python/sglang/jit_kernel/benchmark/bench_moe_lora_shrink.py
@@ -1,0 +1,119 @@
+"""Benchmark: MoE LoRA-A shrink JIT (moe_lora_shrink) vs the Triton split-K kernel.
+
+Mirrors the qwen3.5-35b local-EP gate_up shrink shape (num_experts=64, hidden=2048,
+rank=16, top_k=8) and sweeps batch size.
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_moe_lora_shrink.py
+"""
+
+import torch
+
+from sglang.jit_kernel.benchmark import marker
+from sglang.jit_kernel.moe_lora_shrink import moe_lora_shrink
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=8, suite="base-b-kernel-benchmark-1-gpu-large")
+
+try:
+    import triton
+
+    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+        moe_align_block_size,
+    )
+    from sglang.srt.lora.triton_ops.virtual_experts import (
+        _fused_virtual_topk_ids,
+        _invoke_moe_lora_shrink_splitk,
+        fused_sanitize_expert_ids,
+    )
+
+    HAS_TRITON_REF = True
+except Exception:
+    HAS_TRITON_REF = False
+
+NUM_EXPERTS = 64
+TOP_K = 8
+HIDDEN = 2048
+RANK = 16
+BLOCK_M = 16
+DTYPE = torch.bfloat16
+
+_TRITON_CONFIG = {
+    "BLOCK_SIZE_M": BLOCK_M,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 4,
+}
+
+
+def _build_routing(topk_ids, tlm):
+    virtual_topk_ids, _, virtual_num_experts = _fused_virtual_topk_ids(
+        topk_ids, tlm, NUM_EXPERTS, shared_outer=False, max_loras=1
+    )
+    sorted_token_ids, expert_ids, npp = moe_align_block_size(
+        virtual_topk_ids, BLOCK_M, virtual_num_experts
+    )
+    num_tokens = topk_ids.numel()
+    max_nonempty = min(num_tokens, virtual_num_experts)
+    tight = triton.cdiv(num_tokens + max_nonempty * (BLOCK_M - 1), BLOCK_M) * BLOCK_M
+    return (
+        sorted_token_ids[:tight].contiguous(),
+        fused_sanitize_expert_ids(expert_ids[: tight // BLOCK_M], virtual_num_experts),
+        npp,
+    )
+
+
+def _jit_call(output, hidden_states, lora_a, sti, eid, npp):
+    moe_lora_shrink(output, hidden_states, lora_a, sti, eid, npp, TOP_K, BLOCK_M)
+
+
+def _triton_call(intermediate, hidden_states, lora_a, topk_ids, sti, eid, npp):
+    _invoke_moe_lora_shrink_splitk(
+        hidden_states,
+        lora_a,
+        intermediate,
+        topk_ids,
+        sti,
+        eid,
+        npp,
+        TOP_K,
+        _TRITON_CONFIG,
+    )
+
+
+@marker.parametrize("bs", [1, 8, 16, 32, 64, 128], [16])
+@marker.benchmark("impl", ["jit", "triton"])
+def benchmark(bs: int, impl: str):
+    if not HAS_TRITON_REF:
+        raise RuntimeError("sglang triton ops required to build routing buffers")
+    device = "cuda"
+    torch.manual_seed(0)
+    topk_ids = torch.stack(
+        [torch.randperm(NUM_EXPERTS, device=device)[:TOP_K] for _ in range(bs)]
+    ).to(torch.int32)
+    tlm = torch.zeros(bs, device=device, dtype=torch.int32)
+    hidden_states = torch.randn(bs, HIDDEN, device=device, dtype=DTYPE) * 0.1
+    lora_a = torch.randn(NUM_EXPERTS, RANK, HIDDEN, device=device, dtype=DTYPE) * 0.1
+    sti, eid, npp = _build_routing(topk_ids, tlm)
+    output = torch.empty(bs * TOP_K, RANK, device=device, dtype=DTYPE)
+
+    if impl == "jit":
+        return marker.do_bench(
+            _jit_call,
+            input_args=(output, hidden_states, lora_a, sti, eid, npp),
+            graph_clone_args=(1, 2, 3, 4, 5),  # read tensors; output (0) is written
+            memory_output=(output,),
+        )
+    else:
+        return marker.do_bench(
+            _triton_call,
+            input_args=(output, hidden_states, lora_a, topk_ids, sti, eid, npp),
+            graph_clone_args=(1, 2, 3, 4, 5, 6),  # output (0) is written
+            memory_output=(output,),
+        )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/python/sglang/jit_kernel/benchmark/bench_shrink_cute.py
+++ b/python/sglang/jit_kernel/benchmark/bench_shrink_cute.py
@@ -1,0 +1,74 @@
+"""Compare the CuTeDSL shrink vs the CUDA JIT pipe kernel vs Triton (rank16 K2048)."""
+
+import torch
+import triton
+
+from sglang.jit_kernel.benchmark import marker
+from sglang.jit_kernel.moe_lora_shrink import moe_lora_shrink as moe_lora_shrink_cuda
+from sglang.jit_kernel.moe_lora_shrink_cute import moe_lora_shrink_cute
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.srt.lora.triton_ops.virtual_experts import (
+    _fused_virtual_topk_ids,
+    _invoke_moe_lora_shrink_splitk,
+    fused_sanitize_expert_ids,
+)
+
+E, TK, H, R, BM, DT = 64, 8, 2048, 16, 16, torch.bfloat16
+TCFG = {
+    "BLOCK_SIZE_M": BM,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 4,
+}
+
+
+def _mk(bs):
+    torch.manual_seed(0)
+    topk = torch.stack([torch.randperm(E, device="cuda")[:TK] for _ in range(bs)]).to(
+        torch.int32
+    )
+    tlm = torch.zeros(bs, device="cuda", dtype=torch.int32)
+    hs = torch.randn(bs, H, device="cuda", dtype=DT) * 0.1
+    la = torch.randn(E, R, H, device="cuda", dtype=DT) * 0.1
+    vt, _, vne = _fused_virtual_topk_ids(topk, tlm, E, False, 1)
+    sti, eid, npp = moe_align_block_size(vt, BM, vne)
+    nt = topk.numel()
+    tight = triton.cdiv(nt + min(nt, vne) * (BM - 1), BM) * BM
+    sti = sti[:tight].contiguous()
+    eid = fused_sanitize_expert_ids(eid[: tight // BM], vne)
+    return topk, hs, la, sti, eid, npp
+
+
+@marker.parametrize("bs", [1, 8, 16, 32, 64, 128], [16])
+@marker.benchmark("impl", ["cute", "cuda", "triton"])
+def benchmark(bs: int, impl: str):
+    topk, hs, la, sti, eid, npp = _mk(bs)
+    out = torch.empty(bs * TK, R, device="cuda", dtype=DT)
+    if impl == "cute":
+        return marker.do_bench(
+            lambda *a: moe_lora_shrink_cute(*a, npp, TK, BM),
+            input_args=(out, hs, la, sti, eid),
+            graph_clone_args=(1, 2, 3, 4),
+            memory_output=(out,),
+        )
+    if impl == "cuda":
+        return marker.do_bench(
+            lambda *a: moe_lora_shrink_cuda(*a, npp, TK, BM),
+            input_args=(out, hs, la, sti, eid),
+            graph_clone_args=(1, 2, 3, 4),
+            memory_output=(out,),
+        )
+    return marker.do_bench(
+        lambda *a: _invoke_moe_lora_shrink_splitk(*a, npp, TK, TCFG),
+        input_args=(hs, la, out, topk, sti, eid),
+        graph_clone_args=(0, 1, 3, 4, 5),
+        memory_output=(out,),
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/python/sglang/jit_kernel/csrc/lora/moe_lora_shrink_kernel.cu
+++ b/python/sglang/jit_kernel/csrc/lora/moe_lora_shrink_kernel.cu
@@ -1,0 +1,2363 @@
+// MoE LoRA-A "shrink" grouped GEMM (SPLIT_K == 1): warp-level m16n8k16
+// tensor cores + cp.async multi-stage pipeline. CUDA port of
+// _moe_lora_shrink_splitk_kernel (sglang/srt/lora/triton_ops/virtual_experts.py),
+// specialized for rank 16/32/64 and K divisible by 256.
+//
+//     output[t, n] = sum_k  hidden_states[t // top_k, k] * lora_a[expert(t), n, k]
+//
+// One block owns one expert token-block (BLOCK_M=16). Each active warp computes
+// one rank-16 x token-8 tile, mapping rank to MMA-M and routed tokens to MMA-N
+// so decode-like blocks with 2-8 tokens/expert avoid the old 16-token WMMA
+// granularity. The gathered hidden rows and LoRA-A rows are streamed through a
+// KSTAGES-deep cp.async ring buffer with 128-bit copies.
+//
+// Layout (row-major, K-contiguous): stride_ak == stride_bk == 1.
+//   hidden_states : [num_tokens_M, K]
+//   lora_a        : [num_virtual_experts, N, K]
+//   output        : [num_tokens_M * top_k, N]   written in place, routed rows only
+
+#include <sgl_kernel/utils.h>  // For RuntimeCheck
+
+#include <sgl_kernel/utils.cuh>  // For LaunchKernel, fp16_t/bf16_t
+
+#include <tvm/ffi/container/tensor.h>  // For tvm::ffi::TensorView
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <mma.h>
+#include <type_traits>
+
+using namespace nvcuda;
+
+namespace {
+
+constexpr int WMMA_M = 16, WMMA_N = 16, WMMA_K = 16;
+constexpr int BLOCK_M = 16;     // one WMMA M-tile per block (routing block_size must be 16)
+constexpr int BLOCK_K = 256;    // K streamed per stage (multiple of WMMA_K); few tiles -> few serial stages
+constexpr int BLOCK_WARPS = 4;  // 128 threads; warp w (< num_n_tiles) owns N-tile w
+constexpr int KSTAGES = 3;      // cp.async ring-buffer depth
+constexpr int VEC = 8;          // 8 x 16-bit = 16B vectorized copy
+constexpr int MAX_N = BLOCK_WARPS * WMMA_N;  // 64
+constexpr int SWAP_TOKEN_N = 8;
+constexpr int SWAP_WARPS = 8;
+constexpr int SWAP_THREADS = SWAP_WARPS * 32;
+constexpr int TCGEN_THREADS = 128;
+constexpr int TCGEN_M = 64;
+constexpr int TCGEN_N = 8;
+constexpr int TCGEN_BLOCK_K = 256;
+constexpr int TCGEN_GROUP_KTILES = 2;
+constexpr int TCGEN_ALLOC_COLS = 32;
+
+__host__ __device__ __forceinline__ size_t align16(size_t n) {
+  return (n + 15) & ~size_t(15);
+}
+__host__ __device__ __forceinline__ size_t align1024(size_t n) {
+  return (n + 1023) & ~size_t(1023);
+}
+
+__device__ __forceinline__ void cp_async_16(void* dst_smem, const void* src_global, int src_bytes) {
+#if __CUDA_ARCH__ >= 800
+  const unsigned s = static_cast<unsigned>(__cvta_generic_to_shared(dst_smem));
+  asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;\n" ::"r"(s), "l"(src_global), "r"(src_bytes));
+#else
+  char* d = static_cast<char*>(dst_smem);
+  const char* g = static_cast<const char*>(src_global);
+#pragma unroll
+  for (int i = 0; i < 16; ++i)
+    d[i] = (i < src_bytes) ? g[i] : char(0);
+#endif
+}
+
+__device__ __forceinline__ void ldmatrix_x4(uint32_t (&regs)[4], const void* smem_ptr) {
+#if __CUDA_ARCH__ >= 800
+  const unsigned s = static_cast<unsigned>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+               : "=r"(regs[0]), "=r"(regs[1]), "=r"(regs[2]), "=r"(regs[3])
+               : "r"(s));
+#endif
+}
+
+__device__ __forceinline__ void ldmatrix_x2(uint32_t (&regs)[2], const void* smem_ptr) {
+#if __CUDA_ARCH__ >= 800
+  const unsigned s = static_cast<unsigned>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n" : "=r"(regs[0]), "=r"(regs[1]) : "r"(s));
+#endif
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ void mma_m16n8k16(const uint32_t (&a_frag)[4], const uint32_t (&b_frag)[2], float (&c)[4]) {
+#if __CUDA_ARCH__ >= 800
+  if constexpr (std::is_same_v<scalar_t, fp16_t>) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        : "r"(a_frag[0]),
+          "r"(a_frag[1]),
+          "r"(a_frag[2]),
+          "r"(a_frag[3]),
+          "r"(b_frag[0]),
+          "r"(b_frag[1]),
+          "f"(c[0]),
+          "f"(c[1]),
+          "f"(c[2]),
+          "f"(c[3]));
+  } else if constexpr (std::is_same_v<scalar_t, bf16_t>) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        : "r"(a_frag[0]),
+          "r"(a_frag[1]),
+          "r"(a_frag[2]),
+          "r"(a_frag[3]),
+          "r"(b_frag[0]),
+          "r"(b_frag[1]),
+          "f"(c[0]),
+          "f"(c[1]),
+          "f"(c[2]),
+          "f"(c[3]));
+  }
+#endif
+}
+
+__device__ __forceinline__ void cp_async_commit() {
+#if __CUDA_ARCH__ >= 800
+  asm volatile("cp.async.commit_group;\n");
+#endif
+}
+
+template <int kKeep>
+__device__ __forceinline__ void cp_async_wait() {
+#if __CUDA_ARCH__ >= 800
+  asm volatile("cp.async.wait_group %0;\n" ::"n"(kKeep));
+#endif
+}
+
+__device__ __forceinline__ uint64_t tcgen_desc_encode(uint32_t smem_addr) {
+  return static_cast<uint64_t>((smem_addr >> 4) & 0x3fff);
+}
+
+__device__ __forceinline__ uint64_t tcgen_make_smem_desc(uint32_t smem_addr) {
+  constexpr uint64_t kSbo = 8 * 128;
+  return tcgen_desc_encode(smem_addr) | (tcgen_desc_encode(kSbo) << 32) | (1ULL << 46) | (2ULL << 61);
+}
+
+__device__ __forceinline__ uint32_t tcgen_swizzle_128b_offset(int row, int k_elem, int rows) {
+  const int k64 = k_elem >> 6;
+  const int seg = (k_elem >> 3) & 7;
+  const int row_group = row >> 3;
+  const int row_in_group = row & 7;
+  return static_cast<uint32_t>(
+      k64 * rows * 128 + row_group * 8 * 128 + row_in_group * 128 + ((seg ^ row_in_group) << 4));
+}
+
+__device__ __forceinline__ uint32_t elect_sync_u32() {
+  uint32_t pred = 0;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile(
+      "{\n\t"
+      ".reg .pred %%p;\n\t"
+      "elect.sync _|%%p, %1;\n\t"
+      "@%%p mov.u32 %0, 1;\n\t"
+      "}\n"
+      : "+r"(pred)
+      : "r"(0xffffffff));
+#endif
+  return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init_shared(uint64_t* mbar, uint32_t arrives) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  const uint32_t smem_addr = static_cast<uint32_t>(__cvta_generic_to_shared(mbar));
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" ::"r"(smem_addr), "r"(arrives) : "memory");
+#endif
+}
+
+__device__ __forceinline__ void mbarrier_init_fence() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("fence.mbarrier_init.release.cluster;\n" ::: "memory");
+#endif
+}
+
+__device__ __forceinline__ void mbarrier_wait_shared(uint64_t* mbar, uint32_t phase) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  const uint32_t smem_addr = static_cast<uint32_t>(__cvta_generic_to_shared(mbar));
+  uint32_t complete = 0;
+  do {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred %%p;\n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64 %%p, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, %%p;\n\t"
+        "}\n"
+        : "=r"(complete)
+        : "r"(smem_addr), "r"(phase)
+        : "memory");
+  } while (!complete);
+#endif
+}
+
+__device__ __forceinline__ void tcgen_alloc(uint32_t* tmem_addr) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  const uint32_t smem_addr = static_cast<uint32_t>(__cvta_generic_to_shared(tmem_addr));
+  asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;\n" ::"r"(smem_addr),
+               "r"(TCGEN_ALLOC_COLS)
+               : "memory");
+#endif
+}
+
+__device__ __forceinline__ void tcgen_relinquish_alloc_permit() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;\n" ::: "memory");
+#endif
+}
+
+__device__ __forceinline__ void tcgen_dealloc(uint32_t tmem_addr) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;\n" ::"r"(tmem_addr), "r"(TCGEN_ALLOC_COLS)
+               : "memory");
+#endif
+}
+
+__device__ __forceinline__ void tcgen_fence_after_thread_sync() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  asm volatile("tcgen05.fence::after_thread_sync;\n" ::: "memory");
+#endif
+}
+
+__device__ __forceinline__ void
+tcgen_mma_f16(uint32_t tmem_addr, uint64_t a_desc, uint64_t b_desc, uint32_t idesc, uint32_t enable_input_d) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  asm volatile(
+      "{\n\t"
+      ".reg .pred %%p;\n\t"
+      "setp.ne.u32 %%p, %4, 0;\n\t"
+      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, %%p;\n\t"
+      "}\n"
+      :
+      : "r"(tmem_addr), "l"(a_desc), "l"(b_desc), "r"(idesc), "r"(enable_input_d)
+      : "memory");
+#endif
+}
+
+__device__ __forceinline__ void tcgen_commit(uint64_t* mbar) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  const uint32_t smem_addr = static_cast<uint32_t>(__cvta_generic_to_shared(mbar));
+  asm volatile("tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [%0];\n" ::"r"(smem_addr)
+               : "memory");
+#endif
+}
+
+__device__ __forceinline__ void tcgen_ld_32x32b_x8(float (&vals)[8], uint32_t tmem_addr, int row, int col) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  const uint32_t addr = tmem_addr + (static_cast<uint32_t>(row) << 16) + static_cast<uint32_t>(col);
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];\n"
+      "tcgen05.wait::ld.sync.aligned;\n"
+      : "=f"(vals[0]),
+        "=f"(vals[1]),
+        "=f"(vals[2]),
+        "=f"(vals[3]),
+        "=f"(vals[4]),
+        "=f"(vals[5]),
+        "=f"(vals[6]),
+        "=f"(vals[7])
+      : "r"(addr)
+      : "memory");
+#endif
+}
+
+__device__ __forceinline__ void atomic_add_bf16(bf16_t* addr, float val) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  atomicAdd(addr, __float2bfloat16(val));
+#endif
+}
+
+// Programmatic Dependent Launch (PDL, sm_90+). When the launch sets
+// cudaLaunchAttributeProgrammaticStreamSerialization, the dependent grid may
+// begin its preamble (grid setup, arg loads) while the prior grid drains.
+// pdl_wait waits for the prior grid's trigger before this grid's dependent work;
+// pdl_trigger releases the next grid. No-ops if the launch didn't opt in.
+__device__ __forceinline__ void pdl_wait() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  cudaGridDependencySynchronize();
+#endif
+}
+
+__device__ __forceinline__ void pdl_trigger() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+// Issue cp.async for one K-tile (offset k0) into a stage's A/B buffers.
+//   As: [BLOCK_M][BLOCK_K] gathered hidden rows (invalid token -> zero-fill)
+//   Bs: [N][BLOCK_K]       lora_a[expert] rows (contiguous in k)
+template <typename scalar_t>
+__device__ __forceinline__ void issue_stage(
+    scalar_t* As,
+    scalar_t* Bs,
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    const int32_t* tok,
+    int64_t b_base,
+    int N,
+    int N_PAD,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_bn,
+    int k0,
+    int tid,
+    int nthreads) {
+  const int nA = BLOCK_M * (BLOCK_K / VEC);
+  for (int cc = tid; cc < nA; cc += nthreads) {
+    const int m = cc / (BLOCK_K / VEC);
+    const int kc = (cc % (BLOCK_K / VEC)) * VEC;
+    const int t = tok[m];
+    const scalar_t* src = a;
+    int src_bytes = 0;
+    if (t < num_valid_tokens) {
+      const int64_t row = static_cast<int64_t>(t) / top_k;
+      src = a + row * stride_am + (k0 + kc);
+      src_bytes = 16;
+    }
+    cp_async_16(&As[m * BLOCK_K + kc], src, src_bytes);
+  }
+  const int nB = N_PAD * (BLOCK_K / VEC);
+  for (int cc = tid; cc < nB; cc += nthreads) {
+    const int n = cc / (BLOCK_K / VEC);
+    const int kc = (cc % (BLOCK_K / VEC)) * VEC;
+    const scalar_t* src = b;
+    int src_bytes = 0;
+    if (n < N) {
+      src = b + b_base + static_cast<int64_t>(n) * stride_bn + (k0 + kc);
+      src_bytes = 16;
+    }
+    cp_async_16(&Bs[n * BLOCK_K + kc], src, src_bytes);
+  }
+}
+
+template <typename scalar_t, int Rank, int Threads>
+__device__ __forceinline__ void issue_swap_stage(
+    scalar_t* Ash,
+    scalar_t* Bsh,
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    const int32_t* tok,
+    int64_t b_base,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_bn,
+    int k0,
+    int tid) {
+  constexpr int kKVecs = BLOCK_K / VEC;
+  constexpr int nA = Rank * kKVecs;
+  for (int cc = tid; cc < nA; cc += Threads) {
+    const int n = cc / (BLOCK_K / VEC);
+    const int kc = (cc % (BLOCK_K / VEC)) * VEC;
+    cp_async_16(&Ash[n * BLOCK_K + kc], b + b_base + static_cast<int64_t>(n) * stride_bn + (k0 + kc), 16);
+  }
+  constexpr int nB = BLOCK_M * kKVecs;
+  for (int cc = tid; cc < nB; cc += Threads) {
+    const int m = cc / (BLOCK_K / VEC);
+    const int kc = (cc % (BLOCK_K / VEC)) * VEC;
+    const int t = tok[m];
+    const scalar_t* src = a;
+    int src_bytes = 0;
+    if (t < num_valid_tokens) {
+      const int64_t row = static_cast<int64_t>(t) / top_k;
+      src = a + row * stride_am + (k0 + kc);
+      src_bytes = 16;
+    }
+    cp_async_16(&Bsh[m * BLOCK_K + kc], src, src_bytes);
+  }
+}
+
+template <typename scalar_t, int Rank, int Threads>
+__device__ __forceinline__ void issue_swap_half_stage(
+    scalar_t* Ash,
+    scalar_t* Bsh,
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    const int32_t* tok,
+    int token_base,
+    int64_t b_base,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_bn,
+    int k0,
+    int tid) {
+  constexpr int kKVecs = TCGEN_BLOCK_K / VEC;
+  constexpr int nA = Rank * kKVecs;
+  for (int cc = tid; cc < nA; cc += Threads) {
+    const int n = cc / kKVecs;
+    const int kc = (cc % kKVecs) * VEC;
+    cp_async_16(&Ash[n * BLOCK_K + kc], b + b_base + static_cast<int64_t>(n) * stride_bn + (k0 + kc), 16);
+  }
+  constexpr int nB = SWAP_TOKEN_N * kKVecs;
+  for (int cc = tid; cc < nB; cc += Threads) {
+    const int local_m = cc / kKVecs;
+    const int kc = (cc % kKVecs) * VEC;
+    const int t = tok[token_base + local_m];
+    const scalar_t* src = a;
+    int src_bytes = 0;
+    if (t < num_valid_tokens) {
+      const int64_t row = static_cast<int64_t>(t) / top_k;
+      src = a + row * stride_am + (k0 + kc);
+      src_bytes = 16;
+    }
+    cp_async_16(&Bsh[local_m * BLOCK_K + kc], src, src_bytes);
+  }
+}
+
+template <typename scalar_t>
+__global__ void __launch_bounds__(BLOCK_WARPS * 32) moe_lora_shrink_wmma_kernel(
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    scalar_t* __restrict__ c,
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    int N,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  const int pid_m = blockIdx.x;
+  if (pid_m * BLOCK_M >= num_tokens_post_padded[0]) return;
+  const int expert = expert_ids[pid_m];
+  if (expert == -1) return;
+
+  const int tid = threadIdx.x;
+  const int warp = tid / 32;
+  const int nthreads = BLOCK_WARPS * 32;
+  const int N_PAD = static_cast<int>(align16(static_cast<size_t>(N)));
+  const int num_n_tiles = N_PAD / WMMA_N;
+
+  // Dynamic shared (sized by padded N host-side): tok | Ash ring | Bsh ring | Csh.
+  extern __shared__ __align__(16) char smem[];
+  const int a_stage = BLOCK_M * BLOCK_K;
+  const int b_stage = N_PAD * BLOCK_K;
+  char* p = smem;
+  int32_t* tok = reinterpret_cast<int32_t*>(p);
+  p += align16(BLOCK_M * sizeof(int32_t));
+  scalar_t* Ash = reinterpret_cast<scalar_t*>(p);
+  p += align16(static_cast<size_t>(KSTAGES) * a_stage * sizeof(scalar_t));
+  scalar_t* Bsh = reinterpret_cast<scalar_t*>(p);
+  p += align16(static_cast<size_t>(KSTAGES) * b_stage * sizeof(scalar_t));
+  float* Csh = reinterpret_cast<float*>(p);
+
+  for (int i = tid; i < BLOCK_M; i += nthreads)
+    tok[i] = sorted_token_ids[pid_m * BLOCK_M + i];
+  __syncthreads();
+
+  const int64_t b_base = static_cast<int64_t>(expert) * stride_be;
+  const int num_k_tiles = K / BLOCK_K;  // K % BLOCK_K == 0 (checked host-side)
+
+  wmma::fragment<wmma::accumulator, WMMA_M, WMMA_N, WMMA_K, float> c_frag;
+  wmma::fill_fragment(c_frag, 0.0f);
+
+  // Prologue: prefetch the first (KSTAGES - 1) K-tiles.
+#pragma unroll
+  for (int s = 0; s < KSTAGES - 1; ++s) {
+    if (s < num_k_tiles) {
+      issue_stage(
+          Ash + s * a_stage,
+          Bsh + s * b_stage,
+          a,
+          b,
+          tok,
+          b_base,
+          N,
+          N_PAD,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          s * BLOCK_K,
+          tid,
+          nthreads);
+    }
+    cp_async_commit();
+  }
+
+  for (int kt = 0; kt < num_k_tiles; ++kt) {
+    cp_async_wait<KSTAGES - 2>();
+    __syncthreads();
+
+    const int cur = kt % KSTAGES;
+    if (warp < num_n_tiles) {
+      const int n0 = warp * WMMA_N;
+      const scalar_t* As_cur = Ash + cur * a_stage;
+      const scalar_t* Bs_cur = Bsh + cur * b_stage;
+#pragma unroll
+      for (int kk = 0; kk < BLOCK_K; kk += WMMA_K) {
+        wmma::fragment<wmma::matrix_a, WMMA_M, WMMA_N, WMMA_K, scalar_t, wmma::row_major> a_frag;
+        wmma::fragment<wmma::matrix_b, WMMA_M, WMMA_N, WMMA_K, scalar_t, wmma::col_major> b_frag;
+        wmma::load_matrix_sync(a_frag, As_cur + kk, BLOCK_K);
+        wmma::load_matrix_sync(b_frag, Bs_cur + n0 * BLOCK_K + kk, BLOCK_K);
+        wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);
+      }
+    }
+    __syncthreads();  // done reading `cur`; safe to refill it
+
+    const int load_idx = kt + KSTAGES - 1;
+    if (load_idx < num_k_tiles) {
+      const int nb = load_idx % KSTAGES;
+      issue_stage(
+          Ash + nb * a_stage,
+          Bsh + nb * b_stage,
+          a,
+          b,
+          tok,
+          b_base,
+          N,
+          N_PAD,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          load_idx * BLOCK_K,
+          tid,
+          nthreads);
+    }
+    cp_async_commit();
+  }
+
+  if (warp < num_n_tiles) {
+    wmma::store_matrix_sync(&Csh[warp * WMMA_M * WMMA_N], c_frag, WMMA_N, wmma::mem_row_major);
+  }
+  __syncthreads();
+
+  for (int w = 0; w < num_n_tiles; ++w) {
+    const int wn0 = w * WMMA_N;
+    for (int idx = tid; idx < WMMA_M * WMMA_N; idx += nthreads) {
+      const int m = idx / WMMA_N;
+      const int n = idx % WMMA_N;
+      const int t = tok[m];
+      if (t < num_valid_tokens && (wn0 + n) < N) {
+        c[static_cast<int64_t>(t) * stride_cm + static_cast<int64_t>(wn0 + n) * stride_cn] =
+            static_cast<scalar_t>(Csh[w * WMMA_M * WMMA_N + m * WMMA_N + n]);
+      }
+    }
+  }
+}
+
+template <typename scalar_t, int Rank, int Threads, int NumKTiles>
+__global__ void __launch_bounds__(Threads) moe_lora_shrink_m16n8_kernel(
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    scalar_t* __restrict__ c,
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  const int pid_m = blockIdx.x;
+  if (pid_m * BLOCK_M >= num_tokens_post_padded[0]) return;
+  const int expert = expert_ids[pid_m];
+  if (expert == -1) return;
+
+  const int warp = threadIdx.x >> 5;
+  const int rank_tile = warp >> 1;
+  const int token_tile = warp & 1;
+  const int n0 = rank_tile * WMMA_M;
+  const int m0 = token_tile * SWAP_TOKEN_N;
+
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  constexpr int RankTiles = Rank / WMMA_M;
+  const bool compute_warp = warp < RankTiles * 2;
+
+  extern __shared__ __align__(16) char smem[];
+  int32_t* tok = reinterpret_cast<int32_t*>(smem);
+  char* p = smem + align16(BLOCK_M * sizeof(int32_t));
+  constexpr int a_stage = Rank * BLOCK_K;
+  constexpr int b_stage = BLOCK_M * BLOCK_K;
+  scalar_t* Ash = reinterpret_cast<scalar_t*>(p);  // [stage][N rank][BLOCK_K]
+  p += align16(static_cast<size_t>(KSTAGES) * a_stage * sizeof(scalar_t));
+  scalar_t* Bsh = reinterpret_cast<scalar_t*>(p);  // [stage][16 token][BLOCK_K]
+
+  for (int i = tid; i < BLOCK_M; i += Threads)
+    tok[i] = sorted_token_ids[pid_m * BLOCK_M + i];
+  __syncthreads();
+
+  // If the first token in this 8-wide half is padding, all later tokens in the
+  // routed block are padding too.
+  if (tok[0] >= num_valid_tokens) return;
+  const bool compute_tile = compute_warp;
+
+  const int64_t b_base = static_cast<int64_t>(expert) * stride_be;
+
+  float acc[4] = {0.f, 0.f, 0.f, 0.f};
+  const int a_ld_row = (lane & 7) + ((lane & 8) ? 8 : 0);
+  const int a_ld_col = (lane & 16) ? 8 : 0;
+  const int b_ld_row = lane & 7;
+  const int b_ld_col = (lane & 8) ? 8 : 0;
+
+  const int num_k_tiles = NumKTiles > 0 ? NumKTiles : K / BLOCK_K;
+#pragma unroll
+  for (int s = 0; s < KSTAGES - 1; ++s) {
+    if constexpr (NumKTiles > 0) {
+      issue_swap_stage<scalar_t, Rank, Threads>(
+          Ash + s * a_stage,
+          Bsh + s * b_stage,
+          a,
+          b,
+          tok,
+          b_base,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          s * BLOCK_K,
+          tid);
+    } else {
+      if (s < num_k_tiles) {
+        issue_swap_stage<scalar_t, Rank, Threads>(
+            Ash + s * a_stage,
+            Bsh + s * b_stage,
+            a,
+            b,
+            tok,
+            b_base,
+            num_valid_tokens,
+            top_k,
+            stride_am,
+            stride_bn,
+            s * BLOCK_K,
+            tid);
+      }
+    }
+    cp_async_commit();
+  }
+
+#pragma unroll
+  for (int kt = 0; kt < num_k_tiles; ++kt) {
+    cp_async_wait<KSTAGES - 2>();
+    __syncthreads();
+
+    const int cur = kt % KSTAGES;
+    const scalar_t* As_cur = Ash + cur * a_stage;
+    const scalar_t* Bs_cur = Bsh + cur * b_stage;
+    if (compute_tile) {
+#pragma unroll
+      for (int kk = 0; kk < BLOCK_K; kk += WMMA_K) {
+        uint32_t a_frag[4];
+        uint32_t b_frag[2];
+        ldmatrix_x4(a_frag, As_cur + (n0 + a_ld_row) * BLOCK_K + kk + a_ld_col);
+        ldmatrix_x2(b_frag, Bs_cur + (m0 + b_ld_row) * BLOCK_K + kk + b_ld_col);
+        mma_m16n8k16<scalar_t>(a_frag, b_frag, acc);
+      }
+    }
+    __syncthreads();
+
+    const int load_idx = kt + KSTAGES - 1;
+    if constexpr (NumKTiles > 0) {
+      if (load_idx < NumKTiles) {
+        const int nb = load_idx % KSTAGES;
+        issue_swap_stage<scalar_t, Rank, Threads>(
+            Ash + nb * a_stage,
+            Bsh + nb * b_stage,
+            a,
+            b,
+            tok,
+            b_base,
+            num_valid_tokens,
+            top_k,
+            stride_am,
+            stride_bn,
+            load_idx * BLOCK_K,
+            tid);
+      }
+    } else if (load_idx < num_k_tiles) {
+      const int nb = load_idx % KSTAGES;
+      issue_swap_stage<scalar_t, Rank, Threads>(
+          Ash + nb * a_stage,
+          Bsh + nb * b_stage,
+          a,
+          b,
+          tok,
+          b_base,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          load_idx * BLOCK_K,
+          tid);
+    }
+    cp_async_commit();
+  }
+
+  if (compute_tile) {
+    const int rank_row0 = n0 + (lane >> 2);
+    const int rank_row1 = rank_row0 + 8;
+    const int token_col = m0 + ((lane & 3) << 1);
+
+    const int t0 = tok[token_col];
+    if (rank_row0 < Rank && token_col < BLOCK_M && t0 < num_valid_tokens) {
+      c[static_cast<int64_t>(t0) * stride_cm + static_cast<int64_t>(rank_row0) * stride_cn] =
+          static_cast<scalar_t>(acc[0]);
+    }
+    const int t1 = tok[token_col + 1];
+    if (rank_row0 < Rank && token_col + 1 < BLOCK_M && t1 < num_valid_tokens) {
+      c[static_cast<int64_t>(t1) * stride_cm + static_cast<int64_t>(rank_row0) * stride_cn] =
+          static_cast<scalar_t>(acc[1]);
+    }
+    if (rank_row1 < Rank && token_col < BLOCK_M && t0 < num_valid_tokens) {
+      c[static_cast<int64_t>(t0) * stride_cm + static_cast<int64_t>(rank_row1) * stride_cn] =
+          static_cast<scalar_t>(acc[2]);
+    }
+    if (rank_row1 < Rank && token_col + 1 < BLOCK_M && t1 < num_valid_tokens) {
+      c[static_cast<int64_t>(t1) * stride_cm + static_cast<int64_t>(rank_row1) * stride_cn] =
+          static_cast<scalar_t>(acc[3]);
+    }
+  }
+}
+
+template <typename scalar_t, int Rank, int Threads, int NumKTiles>
+__global__ void __launch_bounds__(Threads) moe_lora_shrink_m16n8_half_kernel(
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    scalar_t* __restrict__ c,
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  const int pid_m = blockIdx.x >> 1;
+  if (pid_m * BLOCK_M >= num_tokens_post_padded[0]) return;
+  const int token_base = (blockIdx.x & 1) * SWAP_TOKEN_N;
+
+  const int tid = threadIdx.x;
+  extern __shared__ __align__(16) char smem[];
+  int32_t* tok = reinterpret_cast<int32_t*>(smem);
+  for (int i = tid; i < BLOCK_M; i += Threads)
+    tok[i] = sorted_token_ids[pid_m * BLOCK_M + i];
+  __syncthreads();
+
+  if (tok[token_base] >= num_valid_tokens) return;
+  const int expert = expert_ids[pid_m];
+  if (expert == -1) return;
+
+  const int warp = threadIdx.x >> 5;
+  const int lane = tid & 31;
+  constexpr int RankTiles = Rank / WMMA_M;
+  const bool compute_tile = warp < RankTiles;
+  const int n0 = warp * WMMA_M;
+
+  char* p = smem + align16(BLOCK_M * sizeof(int32_t));
+  constexpr int a_stage = Rank * BLOCK_K;
+  constexpr int b_stage = SWAP_TOKEN_N * BLOCK_K;
+  scalar_t* Ash = reinterpret_cast<scalar_t*>(p);  // [stage][N rank][BLOCK_K]
+  p += align16(static_cast<size_t>(KSTAGES) * a_stage * sizeof(scalar_t));
+  scalar_t* Bsh = reinterpret_cast<scalar_t*>(p);  // [stage][8 token][BLOCK_K]
+
+  const int64_t b_base = static_cast<int64_t>(expert) * stride_be;
+
+  float acc[4] = {0.f, 0.f, 0.f, 0.f};
+  const int a_ld_row = (lane & 7) + ((lane & 8) ? 8 : 0);
+  const int a_ld_col = (lane & 16) ? 8 : 0;
+  const int b_ld_row = lane & 7;
+  const int b_ld_col = (lane & 8) ? 8 : 0;
+
+  const int num_k_tiles = NumKTiles > 0 ? NumKTiles : K / BLOCK_K;
+#pragma unroll
+  for (int s = 0; s < KSTAGES - 1; ++s) {
+    if constexpr (NumKTiles > 0) {
+      issue_swap_half_stage<scalar_t, Rank, Threads>(
+          Ash + s * a_stage,
+          Bsh + s * b_stage,
+          a,
+          b,
+          tok,
+          token_base,
+          b_base,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          s * BLOCK_K,
+          tid);
+    } else {
+      if (s < num_k_tiles) {
+        issue_swap_half_stage<scalar_t, Rank, Threads>(
+            Ash + s * a_stage,
+            Bsh + s * b_stage,
+            a,
+            b,
+            tok,
+            token_base,
+            b_base,
+            num_valid_tokens,
+            top_k,
+            stride_am,
+            stride_bn,
+            s * BLOCK_K,
+            tid);
+      }
+    }
+    cp_async_commit();
+  }
+
+#pragma unroll
+  for (int kt = 0; kt < num_k_tiles; ++kt) {
+    cp_async_wait<KSTAGES - 2>();
+    __syncthreads();
+
+    const int cur = kt % KSTAGES;
+    const scalar_t* As_cur = Ash + cur * a_stage;
+    const scalar_t* Bs_cur = Bsh + cur * b_stage;
+    if (compute_tile) {
+#pragma unroll
+      for (int kk = 0; kk < BLOCK_K; kk += WMMA_K) {
+        uint32_t a_frag[4];
+        uint32_t b_frag[2];
+        ldmatrix_x4(a_frag, As_cur + (n0 + a_ld_row) * BLOCK_K + kk + a_ld_col);
+        ldmatrix_x2(b_frag, Bs_cur + b_ld_row * BLOCK_K + kk + b_ld_col);
+        mma_m16n8k16<scalar_t>(a_frag, b_frag, acc);
+      }
+    }
+    __syncthreads();
+
+    const int load_idx = kt + KSTAGES - 1;
+    if constexpr (NumKTiles > 0) {
+      if (load_idx < NumKTiles) {
+        const int nb = load_idx % KSTAGES;
+        issue_swap_half_stage<scalar_t, Rank, Threads>(
+            Ash + nb * a_stage,
+            Bsh + nb * b_stage,
+            a,
+            b,
+            tok,
+            token_base,
+            b_base,
+            num_valid_tokens,
+            top_k,
+            stride_am,
+            stride_bn,
+            load_idx * BLOCK_K,
+            tid);
+      }
+    } else if (load_idx < num_k_tiles) {
+      const int nb = load_idx % KSTAGES;
+      issue_swap_half_stage<scalar_t, Rank, Threads>(
+          Ash + nb * a_stage,
+          Bsh + nb * b_stage,
+          a,
+          b,
+          tok,
+          token_base,
+          b_base,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          load_idx * BLOCK_K,
+          tid);
+    }
+    cp_async_commit();
+  }
+
+  if (compute_tile) {
+    const int rank_row0 = n0 + (lane >> 2);
+    const int rank_row1 = rank_row0 + 8;
+    const int token_col = token_base + ((lane & 3) << 1);
+
+    const int t0 = tok[token_col];
+    if (rank_row0 < Rank && t0 < num_valid_tokens) {
+      c[static_cast<int64_t>(t0) * stride_cm + static_cast<int64_t>(rank_row0) * stride_cn] =
+          static_cast<scalar_t>(acc[0]);
+    }
+    const int t1 = tok[token_col + 1];
+    if (rank_row0 < Rank && t1 < num_valid_tokens) {
+      c[static_cast<int64_t>(t1) * stride_cm + static_cast<int64_t>(rank_row0) * stride_cn] =
+          static_cast<scalar_t>(acc[1]);
+    }
+    if (rank_row1 < Rank && t0 < num_valid_tokens) {
+      c[static_cast<int64_t>(t0) * stride_cm + static_cast<int64_t>(rank_row1) * stride_cn] =
+          static_cast<scalar_t>(acc[2]);
+    }
+    if (rank_row1 < Rank && t1 < num_valid_tokens) {
+      c[static_cast<int64_t>(t1) * stride_cm + static_cast<int64_t>(rank_row1) * stride_cn] =
+          static_cast<scalar_t>(acc[3]);
+    }
+  }
+}
+
+// --------------------------------------------------------------------------
+// Triton-style pipelined shrink: one block per expert token-block (16 tokens),
+// 4 warps each owning an 8-wide rank N-tile (rank padded to PIPE_BLOCK_N=32),
+// streaming K through a KStages-deep cp.async ring buffer. Mirrors the legacy
+// _moe_lora_shrink_splitk_kernel (SPLIT_K==1, BLOCK_N=32, num_stages=4): plain
+// m16n8k16 HMMA with tokens in the MMA-M slot and rank in the MMA-N slot so all
+// four warps stay busy and the K-loop pipeline hides global-load latency.
+// --------------------------------------------------------------------------
+constexpr int PIPE_BLOCK_N = 32;  // rank padded to 32 -> 4 n-tiles of 8
+constexpr int PIPE_WARPS = 4;     // one 8-wide rank N-tile per warp
+constexpr int PIPE_THREADS = PIPE_WARPS * 32;
+
+// 128-byte XOR swizzle for the K-contiguous smem tiles. Each row stores K in
+// 8-element (16-byte) segments; within every 128-byte window (8 segments) the
+// segment index is XORed by (row & 7) so the 8 rows an ldmatrix reads land in
+// distinct shared-memory banks (otherwise stride-BlockK rows alias bank 0 and
+// serialize -> the short-scoreboard stalls that dominate the naive layout).
+template <int BlockK>
+__device__ __forceinline__ int pipe_swz(int row, int k) {  // k a multiple of 8
+  return row * BlockK + (((k >> 3) ^ (row & 7)) << 3);
+}
+
+template <typename scalar_t, int BlockK, int Rank, int NWarps>
+__device__ __forceinline__ void issue_pipe_stage(
+    scalar_t* As,
+    scalar_t* Bs,
+    const scalar_t* __restrict__ a,
+    const scalar_t* const* arow,  // per-token A row base ptr (nullptr -> padding)
+    const scalar_t* const* brow,  // per-rank B row base ptr
+    int k0,
+    int tid) {
+  // Cheap addressing: warp g owns a strided set of rows, lane owns a K-vector.
+  // No per-element divide/modulo or 64-bit pointer rebuild -- those integer ops
+  // (IMAD/LOP3/SHF) dominated the naive cc/kKVecs gather.
+  constexpr int kKVecs = BlockK / VEC;
+  const int g = tid >> 5;
+  const int lane = tid & 31;
+  for (int kv = lane; kv < kKVecs; kv += 32) {
+    const int kc = kv * VEC;
+#pragma unroll
+    for (int r = g; r < BLOCK_M; r += NWarps) {
+      const scalar_t* base = arow[r];
+      cp_async_16(&As[pipe_swz<BlockK>(r, kc)], base ? base + (k0 + kc) : a, base ? 16 : 0);
+    }
+#pragma unroll
+    for (int r = g; r < Rank; r += NWarps) {
+      cp_async_16(&Bs[pipe_swz<BlockK>(r, kc)], brow[r] + (k0 + kc), 16);
+    }
+  }
+}
+
+template <typename scalar_t, int KStages, int BlockK, int Rank, int NWarps, int SplitK>
+__global__ void __launch_bounds__(NWarps * 32) moe_lora_shrink_pipe_kernel(
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    scalar_t* __restrict__ c,
+    float* __restrict__ workspace,  // [SplitK][num_valid_tokens][Rank] fp32 partials (SplitK>1)
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    int N,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  const int pid_m = blockIdx.x;
+  const int pid_sk = SplitK > 1 ? static_cast<int>(blockIdx.y) : 0;
+  if (pid_m * BLOCK_M >= num_tokens_post_padded[0]) return;
+  const int expert = expert_ids[pid_m];
+  if (expert == -1) return;
+
+  constexpr int kThreads = NWarps * 32;
+  const int tid = threadIdx.x;
+  const int warp = tid >> 5;
+  const int lane = tid & 31;
+  // Every warp computes ALL kNTiles rank N-tiles over its slice of the K-substeps
+  // (the K-reduction is split across warps, not the N-tiles). This (a) keeps all
+  // warps balanced at the per-tile __syncthreads -- idle load-helper warps were
+  // the dominant barrier stall; and (b) lets the A fragment (token x k, shared
+  // across N-tiles) be loaded ONCE per substep and reused, instead of reloaded
+  // per N-tile -- redundant A ldmatrix was the dominant short-scoreboard stall.
+  // The kNTiles independent MMAs per substep also supply the ILP that hides
+  // ldmatrix latency. Per-warp partials are summed once in smem at the end.
+  constexpr int kNTiles = Rank / 8;           // 2 (r16) / 4 (r32)
+  constexpr int kSubsteps = BlockK / WMMA_K;  // K-substeps per tile (16 @ bk256)
+  constexpr int kSubPerWarp = (kSubsteps >= NWarps) ? (kSubsteps / NWarps) : 1;
+
+  extern __shared__ __align__(16) char smem[];
+  int32_t* tok = reinterpret_cast<int32_t*>(smem);
+  char* p = smem + align16(BLOCK_M * sizeof(int32_t));
+  const scalar_t** arow = reinterpret_cast<const scalar_t**>(p);  // [16] A row base ptrs
+  p += align16(BLOCK_M * sizeof(const scalar_t*));
+  const scalar_t** brow = reinterpret_cast<const scalar_t**>(p);  // [Rank] B row base ptrs
+  p += align16(Rank * sizeof(const scalar_t*));
+  constexpr int a_stage = BLOCK_M * BlockK;
+  constexpr int b_stage = Rank * BlockK;
+  scalar_t* Ash = reinterpret_cast<scalar_t*>(p);  // [stage][16 token][BlockK]
+  p += align16(static_cast<size_t>(KStages) * a_stage * sizeof(scalar_t));
+  scalar_t* Bsh = reinterpret_cast<scalar_t*>(p);  // [stage][Rank][BlockK]
+  p += align16(static_cast<size_t>(KStages) * b_stage * sizeof(scalar_t));
+  float* redsmem = reinterpret_cast<float*>(p);  // [NWarps][32][kNTiles][4] partial-acc reduction
+
+  // Load routing and precompute per-token A row base pointers ONCE (the t/top_k
+  // map is loop-invariant; recomputing the runtime 64-bit divide per k-element
+  // dominated the issue cost). Padding slots get a nullptr -> zero-filled.
+  const int64_t b_base = static_cast<int64_t>(expert) * stride_be;
+  for (int i = tid; i < BLOCK_M; i += kThreads) {
+    const int t = sorted_token_ids[pid_m * BLOCK_M + i];
+    tok[i] = t;
+    arow[i] = (t < num_valid_tokens) ? (a + static_cast<int64_t>(t) / top_k * stride_am) : nullptr;
+  }
+  for (int i = tid; i < Rank; i += kThreads) {
+    brow[i] = b + b_base + static_cast<int64_t>(i) * stride_bn;
+  }
+  __syncthreads();
+  if (tok[0] >= num_valid_tokens) return;
+
+  // PDL: none of this block's loads (hidden/lora_a/routing) depend on the prior
+  // grid, so wait here only to honor stream ordering; the real win is letting the
+  // next launch's preamble overlap this grid's tail (released by pdl_trigger).
+  pdl_wait();
+
+  // Split-K: this block owns a contiguous run of K-tiles [kt0, kt0+num_k_tiles).
+  // num_k_tiles is kept RUNTIME on purpose: making it compile-time lets nvcc
+  // unroll the K-loop, which spills the per-stage gather addresses and regresses
+  // ~12%. The rolled loop reuses those registers across K-tiles.
+  const int total_k_tiles = K / BlockK;
+  const int num_k_tiles = total_k_tiles / SplitK;
+  const int kt0 = pid_sk * num_k_tiles;
+  const int kk_lo = warp * kSubPerWarp * WMMA_K;  // this warp's K-substep slice
+  const bool active = kk_lo < BlockK;             // false only if NWarps > kSubsteps
+
+  float acc[kNTiles][4];
+#pragma unroll
+  for (int nt = 0; nt < kNTiles; ++nt)
+    acc[nt][0] = acc[nt][1] = acc[nt][2] = acc[nt][3] = 0.f;
+  const int a_ld_row = (lane & 7) + ((lane & 8) ? 8 : 0);
+  const int a_ld_col = (lane & 16) ? 8 : 0;
+  const int b_ld_row = lane & 7;
+  const int b_ld_col = (lane & 8) ? 8 : 0;
+
+#pragma unroll
+  for (int s = 0; s < KStages - 1; ++s) {
+    if (s < num_k_tiles) {
+      issue_pipe_stage<scalar_t, BlockK, Rank, NWarps>(
+          Ash + s * a_stage, Bsh + s * b_stage, a, arow, brow, (kt0 + s) * BlockK, tid);
+    }
+    cp_async_commit();
+  }
+
+  // Cooperative-load software pipeline: all warps fill the whole smem tile (best
+  // global-load locality), the per-tile __syncthreads makes it visible, and the
+  // next K-tile is issued BEFORE the MMA so cp.async overlaps the tensor cores.
+  for (int kt = 0; kt < num_k_tiles; ++kt) {
+    cp_async_wait<KStages - 2>();
+    __syncthreads();
+
+    const int load_idx = kt + KStages - 1;
+    if (load_idx < num_k_tiles) {
+      const int nb = load_idx % KStages;
+      issue_pipe_stage<scalar_t, BlockK, Rank, NWarps>(
+          Ash + nb * a_stage, Bsh + nb * b_stage, a, arow, brow, (kt0 + load_idx) * BlockK, tid);
+    }
+    cp_async_commit();
+
+    if (active) {
+      const scalar_t* As_cur = Ash + (kt % KStages) * a_stage;
+      const scalar_t* Bs_cur = Bsh + (kt % KStages) * b_stage;
+#pragma unroll
+      for (int j = 0; j < kSubPerWarp; ++j) {
+        const int kk = kk_lo + j * WMMA_K;
+        uint32_t a_frag[4];
+        ldmatrix_x4(a_frag, As_cur + pipe_swz<BlockK>(a_ld_row, kk + a_ld_col));  // shared across N-tiles
+#pragma unroll
+        for (int nt = 0; nt < kNTiles; ++nt) {
+          uint32_t b_frag[2];
+          ldmatrix_x2(b_frag, Bs_cur + pipe_swz<BlockK>(nt * 8 + b_ld_row, kk + b_ld_col));
+          mma_m16n8k16<scalar_t>(a_frag, b_frag, acc[nt]);
+        }
+      }
+    }
+  }
+
+  // The K-loop (all global loads + MMAs) is done; release the next grid so its
+  // launch/preamble overlaps this grid's smem-reduction + store tail. All active
+  // threads reach this before the warp>=kNTiles early-return below.
+  pdl_trigger();
+
+  // Sum each N-tile's per-substep partials across all NWarps warps (once, in smem).
+  {
+#pragma unroll
+    for (int nt = 0; nt < kNTiles; ++nt)
+#pragma unroll
+      for (int i = 0; i < 4; ++i)
+        redsmem[((warp * 32 + lane) * kNTiles + nt) * 4 + i] = acc[nt][i];
+    __syncthreads();
+    if (warp >= kNTiles) return;  // kNTiles warps own the kNTiles N-tile stores
+#pragma unroll
+    for (int i = 0; i < 4; ++i)
+      acc[0][i] = 0.f;
+#pragma unroll
+    for (int w = 0; w < NWarps; ++w)
+#pragma unroll
+      for (int i = 0; i < 4; ++i)
+        acc[0][i] += redsmem[((w * 32 + lane) * kNTiles + warp) * 4 + i];
+  }
+
+  // C fragment of m16n8 (M=token, N=rank): rows {lane>>2, (lane>>2)+8}, cols {2*(lane&3), +1}.
+  const int n0 = warp * 8;  // warp `w` (< kNTiles) stores N-tile w
+  const int token_row0 = lane >> 2;
+  const int token_row1 = token_row0 + 8;
+  const int rank_col = n0 + ((lane & 3) << 1);
+  const int t0 = tok[token_row0];
+  const int t1 = tok[token_row1];
+  auto store = [&](int t, int rank, float val) {
+    if (t >= num_valid_tokens) return;
+    if constexpr (SplitK == 1) {
+      c[static_cast<int64_t>(t) * stride_cm + static_cast<int64_t>(rank) * stride_cn] = static_cast<scalar_t>(val);
+    } else {
+      // Split-K: write this split's fp32 partial; a tiny reduction kernel sums
+      // the SplitK partials -> output. Inline bf16 atomic-add was measured ~2x
+      // SLOWER here (emulated CAS + heavy contention: SplitK splits hammer only
+      // num_valid_tokens*Rank locations, adjacent ranks sharing 32-bit words).
+      // The contention-free fp32 staging + sequential reduce wins.
+      workspace[(static_cast<int64_t>(pid_sk) * num_valid_tokens + t) * Rank + rank] = val;
+    }
+  };
+  store(t0, rank_col, acc[0][0]);
+  store(t1, rank_col, acc[0][2]);
+  store(t0, rank_col + 1, acc[0][1]);
+  store(t1, rank_col + 1, acc[0][3]);
+}
+
+// Sum the SplitK fp32 partials -> bf16/fp16 output. Tiny (num_valid_tokens*Rank).
+template <typename scalar_t, int Rank, int SplitK>
+__global__ void __launch_bounds__(256) moe_lora_shrink_splitk_reduce_kernel(
+    const float* __restrict__ workspace,
+    scalar_t* __restrict__ c,
+    int num_valid_tokens,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  const int total = num_valid_tokens * Rank;
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < total; i += gridDim.x * blockDim.x) {
+    const int t = i / Rank;
+    const int rank = i - t * Rank;
+    float acc = 0.f;
+#pragma unroll
+    for (int s = 0; s < SplitK; ++s)
+      acc += workspace[(static_cast<int64_t>(s) * num_valid_tokens + t) * Rank + rank];
+    c[static_cast<int64_t>(t) * stride_cm + static_cast<int64_t>(rank) * stride_cn] = static_cast<scalar_t>(acc);
+  }
+}
+
+// Process-persistent fp32 scratch for split-K partials. Grown (cudaMalloc) on
+// the host path during warm-up, so it is graph-capture safe at replay time.
+inline float* get_shrink_workspace(size_t n_floats) {
+  static float* ptr = nullptr;
+  static size_t cap = 0;
+  if (n_floats > cap) {
+    if (ptr) cudaFree(ptr);
+    host::RuntimeDeviceCheck(cudaMalloc(&ptr, n_floats * sizeof(float)));
+    cap = n_floats;
+  }
+  return ptr;
+}
+
+template <typename scalar_t, int Rank, int NumKTiles>
+__device__ __forceinline__ void issue_tcgen05_stage(
+    char* Ash,
+    char* Bsh,
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    const int32_t* tok,
+    int token_base,
+    int rank_base,
+    int64_t b_base,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_bn,
+    int k0,
+    int tid) {
+  constexpr int kKVecs = BLOCK_K / VEC;
+  for (int cc = tid; cc < TCGEN_M * kKVecs; cc += TCGEN_THREADS) {
+    const int n = cc / kKVecs;
+    const int kc = (cc % kKVecs) * VEC;
+    const uint32_t dst = tcgen_swizzle_128b_offset(n, kc, TCGEN_M);
+    if (n < WMMA_M && rank_base + n < Rank) {
+      cp_async_16(Ash + dst, b + b_base + static_cast<int64_t>(rank_base + n) * stride_bn + (k0 + kc), 16);
+    } else {
+      cp_async_16(Ash + dst, b, 0);
+    }
+  }
+
+  for (int cc = tid; cc < TCGEN_N * kKVecs; cc += TCGEN_THREADS) {
+    const int local_m = cc / kKVecs;
+    const int kc = (cc % kKVecs) * VEC;
+    const int m = token_base + local_m;
+    const int t = tok[m];
+    const scalar_t* src = a;
+    int src_bytes = 0;
+    if (t < num_valid_tokens) {
+      const int64_t row = static_cast<int64_t>(t) / top_k;
+      src = a + row * stride_am + (k0 + kc);
+      src_bytes = 16;
+    }
+    const uint32_t dst = tcgen_swizzle_128b_offset(local_m, kc, TCGEN_N);
+    cp_async_16(Bsh + dst, src, src_bytes);
+  }
+}
+
+template <typename scalar_t, int Rank, int NumKTiles>
+__global__ void __launch_bounds__(TCGEN_THREADS) moe_lora_shrink_tcgen05_kernel(
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    scalar_t* __restrict__ c,
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  static_assert(Rank == 16 || Rank == 32 || Rank == 64);
+  static_assert(NumKTiles > 0);
+
+  const int pid_m = blockIdx.x;
+  const int token_base = static_cast<int>(blockIdx.y) * TCGEN_N;
+  const int rank_base = static_cast<int>(blockIdx.z) * WMMA_M;
+  if (pid_m * BLOCK_M >= num_tokens_post_padded[0]) return;
+
+  const int tid = threadIdx.x;
+  const int warp = tid >> 5;
+  extern __shared__ __align__(16) char smem[];
+  char* p = smem;
+  int32_t* tok = reinterpret_cast<int32_t*>(p);
+  p += align16(BLOCK_M * sizeof(int32_t));
+  uint64_t* mma_mbar = reinterpret_cast<uint64_t*>(p);
+  p += align16(sizeof(uint64_t));
+  uint32_t* tmem_addr_smem = reinterpret_cast<uint32_t*>(p);
+  p += align16(sizeof(uint32_t));
+  p = reinterpret_cast<char*>(align1024(reinterpret_cast<size_t>(p)));
+  char* Ash = p;
+  p += TCGEN_GROUP_KTILES * TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t);
+  char* Bsh = p;
+
+  for (int i = tid; i < BLOCK_M; i += TCGEN_THREADS)
+    tok[i] = sorted_token_ids[pid_m * BLOCK_M + i];
+  if (tid == 0) {
+    *tmem_addr_smem = 0;
+    mbarrier_init_shared(mma_mbar, 1);
+    mbarrier_init_fence();
+  }
+  __syncthreads();
+
+  if (tok[token_base] >= num_valid_tokens) return;
+  const int expert = expert_ids[pid_m];
+  if (expert == -1) return;
+
+  if (tid < 32) {
+    tcgen_alloc(tmem_addr_smem);
+  }
+  __syncthreads();
+  if (tid < 32) {
+    tcgen_relinquish_alloc_permit();
+  }
+  __syncthreads();
+
+  const uint32_t tmem_addr = *tmem_addr_smem;
+  constexpr uint32_t idesc =
+      (1U << 4U) | (1U << 7U) | (1U << 10U) | ((uint32_t(TCGEN_N) >> 3U) << 17U) | ((uint32_t(TCGEN_M) >> 4U) << 24U);
+  const int64_t b_base = static_cast<int64_t>(expert) * stride_be;
+  uint32_t phase = 0;
+
+  constexpr int a_tcgen_stage = TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t);
+  constexpr int b_tcgen_stage = TCGEN_N * TCGEN_BLOCK_K * sizeof(scalar_t);
+
+#pragma unroll
+  for (int group = 0; group < NumKTiles; group += TCGEN_GROUP_KTILES) {
+#pragma unroll
+    for (int s = 0; s < TCGEN_GROUP_KTILES; ++s) {
+      const int kt = group + s;
+      char* As_cur = Ash + s * a_tcgen_stage;
+      char* Bs_cur = Bsh + s * b_tcgen_stage;
+      issue_tcgen05_stage<scalar_t, Rank, NumKTiles>(
+          As_cur,
+          Bs_cur,
+          a,
+          b,
+          tok,
+          token_base,
+          rank_base,
+          b_base,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          kt * TCGEN_BLOCK_K,
+          tid);
+      cp_async_commit();
+    }
+    cp_async_wait<0>();
+    __syncthreads();
+    tcgen_fence_after_thread_sync();
+
+#pragma unroll
+    for (int s = 0; s < TCGEN_GROUP_KTILES; ++s) {
+      const int kt = group + s;
+      char* As_cur = Ash + s * a_tcgen_stage;
+      char* Bs_cur = Bsh + s * b_tcgen_stage;
+      if (warp == 0 && elect_sync_u32()) {
+        const uint32_t a_base = static_cast<uint32_t>(__cvta_generic_to_shared(As_cur));
+        const uint32_t b_base_s = static_cast<uint32_t>(__cvta_generic_to_shared(Bs_cur));
+#pragma unroll
+        for (int k1 = 0; k1 < TCGEN_BLOCK_K / 64; ++k1) {
+#pragma unroll
+          for (int k2 = 0; k2 < 64 / WMMA_K; ++k2) {
+            const uint32_t koff = k1 * TCGEN_M * 128 + k2 * 32;
+            const uint32_t boff = k1 * TCGEN_N * 128 + k2 * 32;
+            const uint64_t a_desc = tcgen_make_smem_desc(a_base + koff);
+            const uint64_t b_desc = tcgen_make_smem_desc(b_base_s + boff);
+            tcgen_mma_f16(tmem_addr, a_desc, b_desc, idesc, (kt != 0 || k1 != 0 || k2 != 0) ? 1U : 0U);
+          }
+        }
+      }
+    }
+
+    __syncthreads();
+    if (warp == 0 && elect_sync_u32()) {
+      tcgen_commit(mma_mbar);
+    }
+    mbarrier_wait_shared(mma_mbar, phase);
+    phase ^= 1;
+    __syncthreads();
+  }
+
+  tcgen_fence_after_thread_sync();
+  if (tid < 32) {
+    float vals0[8];
+    tcgen_ld_32x32b_x8(vals0, tmem_addr, tid, 0);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int t = tok[token_base + i];
+      if (tid < WMMA_M && rank_base + tid < Rank && t < num_valid_tokens) {
+        c[static_cast<int64_t>(t) * stride_cm + static_cast<int64_t>(rank_base + tid) * stride_cn] =
+            static_cast<scalar_t>(vals0[i]);
+      }
+    }
+  }
+  __syncthreads();
+  if (tid < 32) {
+    tcgen_dealloc(tmem_addr);
+  }
+#endif
+}
+
+template <typename scalar_t, int Rank>
+__global__ void __launch_bounds__(256)
+    zero_rank_output_kernel(scalar_t* __restrict__ c, int num_valid_tokens, int64_t stride_cm, int64_t stride_cn) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int total = num_valid_tokens * Rank;
+  for (int i = idx; i < total; i += blockDim.x * gridDim.x) {
+    const int t = i / Rank;
+    const int n = i - t * Rank;
+    c[static_cast<int64_t>(t) * stride_cm + static_cast<int64_t>(n) * stride_cn] = scalar_t(0.0f);
+  }
+}
+
+template <typename scalar_t, int SplitK>
+__global__ void __launch_bounds__(TCGEN_THREADS) moe_lora_shrink_tcgen05_splitk_rank16_kernel(
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    scalar_t* __restrict__ c,
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  static_assert(std::is_same_v<scalar_t, bf16_t>);
+  static_assert(SplitK >= 1 && SplitK <= 8);
+  const int pid_m = blockIdx.x;
+  const int token_base = static_cast<int>(blockIdx.y) * TCGEN_N;
+  const int pid_sk = static_cast<int>(blockIdx.z);
+  if (pid_m * BLOCK_M >= num_tokens_post_padded[0]) return;
+
+  const int tid = threadIdx.x;
+  const int warp = tid >> 5;
+  extern __shared__ __align__(16) char smem[];
+  char* p = smem;
+  int32_t* tok = reinterpret_cast<int32_t*>(p);
+  p += align16(BLOCK_M * sizeof(int32_t));
+  uint64_t* mma_mbar = reinterpret_cast<uint64_t*>(p);
+  p += align16(sizeof(uint64_t));
+  uint32_t* tmem_addr_smem = reinterpret_cast<uint32_t*>(p);
+  p += align16(sizeof(uint32_t));
+  p = reinterpret_cast<char*>(align1024(reinterpret_cast<size_t>(p)));
+  char* Ash = p;
+  p += TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t);
+  char* Bsh = p;
+
+  for (int i = tid; i < BLOCK_M; i += TCGEN_THREADS)
+    tok[i] = sorted_token_ids[pid_m * BLOCK_M + i];
+  if (tid == 0) {
+    *tmem_addr_smem = 0;
+    mbarrier_init_shared(mma_mbar, 1);
+    mbarrier_init_fence();
+  }
+  __syncthreads();
+
+  if (tok[token_base] >= num_valid_tokens) return;
+  const int expert = expert_ids[pid_m];
+  if (expert == -1) return;
+
+  if (tid < 32) {
+    tcgen_alloc(tmem_addr_smem);
+  }
+  __syncthreads();
+  if (tid < 32) {
+    tcgen_relinquish_alloc_permit();
+  }
+  __syncthreads();
+
+  const uint32_t tmem_addr = *tmem_addr_smem;
+  constexpr uint32_t idesc =
+      (1U << 4U) | (1U << 7U) | (1U << 10U) | ((uint32_t(TCGEN_N) >> 3U) << 17U) | ((uint32_t(TCGEN_M) >> 4U) << 24U);
+  const int64_t b_base = static_cast<int64_t>(expert) * stride_be;
+
+  issue_tcgen05_stage<scalar_t, 16, 1>(
+      Ash,
+      Bsh,
+      a,
+      b,
+      tok,
+      token_base,
+      0,
+      b_base,
+      num_valid_tokens,
+      top_k,
+      stride_am,
+      stride_bn,
+      pid_sk * TCGEN_BLOCK_K,
+      tid);
+  cp_async_commit();
+  cp_async_wait<0>();
+  __syncthreads();
+  tcgen_fence_after_thread_sync();
+
+  if (warp == 0 && elect_sync_u32()) {
+    const uint32_t a_base = static_cast<uint32_t>(__cvta_generic_to_shared(Ash));
+    const uint32_t b_base_s = static_cast<uint32_t>(__cvta_generic_to_shared(Bsh));
+#pragma unroll
+    for (int k1 = 0; k1 < TCGEN_BLOCK_K / 64; ++k1) {
+#pragma unroll
+      for (int k2 = 0; k2 < 64 / WMMA_K; ++k2) {
+        const uint32_t koff = k1 * TCGEN_M * 128 + k2 * 32;
+        const uint32_t boff = k1 * TCGEN_N * 128 + k2 * 32;
+        const uint64_t a_desc = tcgen_make_smem_desc(a_base + koff);
+        const uint64_t b_desc = tcgen_make_smem_desc(b_base_s + boff);
+        tcgen_mma_f16(tmem_addr, a_desc, b_desc, idesc, (k1 != 0 || k2 != 0) ? 1U : 0U);
+      }
+    }
+    tcgen_commit(mma_mbar);
+  }
+  mbarrier_wait_shared(mma_mbar, 0);
+  __syncthreads();
+
+  tcgen_fence_after_thread_sync();
+  if (tid < 32) {
+    float vals[8];
+    tcgen_ld_32x32b_x8(vals, tmem_addr, tid, 0);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int t = tok[token_base + i];
+      if (tid < WMMA_M && t < num_valid_tokens) {
+        atomic_add_bf16(
+            reinterpret_cast<bf16_t*>(c + static_cast<int64_t>(t) * stride_cm + static_cast<int64_t>(tid) * stride_cn),
+            vals[i]);
+      }
+    }
+  }
+  __syncthreads();
+  if (tid < 32) {
+    tcgen_dealloc(tmem_addr);
+  }
+#endif
+}
+
+template <typename scalar_t, int SplitK>
+__global__ void __launch_bounds__(TCGEN_THREADS) moe_lora_shrink_tcgen05_splitk_grouped_rank16_kernel(
+    const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b,
+    scalar_t* __restrict__ c,
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  static_assert(std::is_same_v<scalar_t, bf16_t>);
+  static_assert(SplitK >= 1 && SplitK <= 8);
+  constexpr int NumKTiles = 2048 / TCGEN_BLOCK_K;
+  const int pid_m = blockIdx.x;
+  const int token_base = static_cast<int>(blockIdx.y) * TCGEN_N;
+  const int pid_sk = static_cast<int>(blockIdx.z);
+  if (pid_m * BLOCK_M >= num_tokens_post_padded[0]) return;
+
+  const int tid = threadIdx.x;
+  const int warp = tid >> 5;
+  extern __shared__ __align__(16) char smem[];
+  char* p = smem;
+  int32_t* tok = reinterpret_cast<int32_t*>(p);
+  p += align16(BLOCK_M * sizeof(int32_t));
+  uint64_t* mma_mbar = reinterpret_cast<uint64_t*>(p);
+  p += align16(sizeof(uint64_t));
+  uint32_t* tmem_addr_smem = reinterpret_cast<uint32_t*>(p);
+  p += align16(sizeof(uint32_t));
+  p = reinterpret_cast<char*>(align1024(reinterpret_cast<size_t>(p)));
+  char* Ash = p;
+  p += TCGEN_GROUP_KTILES * TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t);
+  char* Bsh = p;
+
+  for (int i = tid; i < BLOCK_M; i += TCGEN_THREADS)
+    tok[i] = sorted_token_ids[pid_m * BLOCK_M + i];
+  if (tid == 0) {
+    *tmem_addr_smem = 0;
+    mbarrier_init_shared(mma_mbar, 1);
+    mbarrier_init_fence();
+  }
+  __syncthreads();
+
+  if (tok[token_base] >= num_valid_tokens) return;
+  const int expert = expert_ids[pid_m];
+  if (expert == -1) return;
+
+  if (tid < 32) {
+    tcgen_alloc(tmem_addr_smem);
+  }
+  __syncthreads();
+  if (tid < 32) {
+    tcgen_relinquish_alloc_permit();
+  }
+  __syncthreads();
+
+  const uint32_t tmem_addr = *tmem_addr_smem;
+  constexpr uint32_t idesc =
+      (1U << 4U) | (1U << 7U) | (1U << 10U) | ((uint32_t(TCGEN_N) >> 3U) << 17U) | ((uint32_t(TCGEN_M) >> 4U) << 24U);
+  const int64_t b_base = static_cast<int64_t>(expert) * stride_be;
+  uint32_t phase = 0;
+
+  constexpr int a_tcgen_stage = TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t);
+  constexpr int b_tcgen_stage = TCGEN_N * TCGEN_BLOCK_K * sizeof(scalar_t);
+  for (int group = pid_sk; group < NumKTiles; group += SplitK * TCGEN_GROUP_KTILES) {
+#pragma unroll
+    for (int s = 0; s < TCGEN_GROUP_KTILES; ++s) {
+      const int kt = group + s * SplitK;
+      if (kt >= NumKTiles) continue;
+      char* As_cur = Ash + s * a_tcgen_stage;
+      char* Bs_cur = Bsh + s * b_tcgen_stage;
+      issue_tcgen05_stage<scalar_t, 16, 1>(
+          As_cur,
+          Bs_cur,
+          a,
+          b,
+          tok,
+          token_base,
+          0,
+          b_base,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_bn,
+          kt * TCGEN_BLOCK_K,
+          tid);
+      cp_async_commit();
+      cp_async_wait<0>();
+      __syncthreads();
+      tcgen_fence_after_thread_sync();
+
+      if (warp == 0 && elect_sync_u32()) {
+        const uint32_t a_base = static_cast<uint32_t>(__cvta_generic_to_shared(As_cur));
+        const uint32_t b_base_s = static_cast<uint32_t>(__cvta_generic_to_shared(Bs_cur));
+#pragma unroll
+        for (int k1 = 0; k1 < TCGEN_BLOCK_K / 64; ++k1) {
+#pragma unroll
+          for (int k2 = 0; k2 < 64 / WMMA_K; ++k2) {
+            const uint32_t koff = k1 * TCGEN_M * 128 + k2 * 32;
+            const uint32_t boff = k1 * TCGEN_N * 128 + k2 * 32;
+            const uint64_t a_desc = tcgen_make_smem_desc(a_base + koff);
+            const uint64_t b_desc = tcgen_make_smem_desc(b_base_s + boff);
+            tcgen_mma_f16(tmem_addr, a_desc, b_desc, idesc, (kt != pid_sk || k1 != 0 || k2 != 0) ? 1U : 0U);
+          }
+        }
+      }
+    }
+
+    __syncthreads();
+    if (warp == 0 && elect_sync_u32()) {
+      tcgen_commit(mma_mbar);
+    }
+    mbarrier_wait_shared(mma_mbar, phase);
+    phase ^= 1;
+    __syncthreads();
+  }
+
+  tcgen_fence_after_thread_sync();
+  if (tid < 32) {
+    float vals[8];
+    tcgen_ld_32x32b_x8(vals, tmem_addr, tid, 0);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int t = tok[token_base + i];
+      if (tid < WMMA_M && t < num_valid_tokens) {
+        bf16_t* dst =
+            reinterpret_cast<bf16_t*>(c + static_cast<int64_t>(t) * stride_cm + static_cast<int64_t>(tid) * stride_cn);
+        if constexpr (SplitK == 1) {
+          *dst = __float2bfloat16(vals[i]);
+        } else {
+          atomic_add_bf16(dst, vals[i]);
+        }
+      }
+    }
+  }
+  __syncthreads();
+  if (tid < 32) {
+    tcgen_dealloc(tmem_addr);
+  }
+#endif
+}
+
+template <typename scalar_t, int Rank, int NumKTiles>
+void launch_m16n8_rank(
+    cudaStream_t stream,
+    int num_m_blocks,
+    const scalar_t* hidden_states,
+    const scalar_t* lora_a,
+    scalar_t* output,
+    const int32_t* sorted_token_ids,
+    const int32_t* expert_ids,
+    const int32_t* num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  static_assert(Rank == 16 || Rank == 32 || Rank == 64);
+  constexpr int Threads = SWAP_THREADS;
+  const size_t smem_bytes = align16(BLOCK_M * sizeof(int32_t)) +
+                            align16(static_cast<size_t>(KSTAGES) * Rank * BLOCK_K * sizeof(scalar_t)) +
+                            align16(static_cast<size_t>(KSTAGES) * BLOCK_M * BLOCK_K * sizeof(scalar_t));
+
+  auto kernel = moe_lora_shrink_m16n8_kernel<scalar_t, Rank, Threads, NumKTiles>;
+  if (smem_bytes > 48 * 1024) {
+    host::RuntimeDeviceCheck(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem_bytes)));
+  }
+
+  host::LaunchKernel(dim3(num_m_blocks), dim3(Threads), stream, smem_bytes)(
+      kernel,
+      hidden_states,
+      lora_a,
+      output,
+      sorted_token_ids,
+      expert_ids,
+      num_tokens_post_padded,
+      K,
+      num_valid_tokens,
+      top_k,
+      stride_am,
+      stride_be,
+      stride_bn,
+      stride_bk,
+      stride_cm,
+      stride_cn);
+}
+
+template <typename scalar_t, int Rank, int NumKTiles>
+void launch_m16n8_half_rank(
+    cudaStream_t stream,
+    int num_m_blocks,
+    const scalar_t* hidden_states,
+    const scalar_t* lora_a,
+    scalar_t* output,
+    const int32_t* sorted_token_ids,
+    const int32_t* expert_ids,
+    const int32_t* num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  static_assert(Rank == 16 || Rank == 32 || Rank == 64);
+  constexpr int Threads = SWAP_THREADS;
+  const size_t smem_bytes = align16(BLOCK_M * sizeof(int32_t)) +
+                            align16(static_cast<size_t>(KSTAGES) * Rank * BLOCK_K * sizeof(scalar_t)) +
+                            align16(static_cast<size_t>(KSTAGES) * SWAP_TOKEN_N * BLOCK_K * sizeof(scalar_t));
+
+  auto kernel = moe_lora_shrink_m16n8_half_kernel<scalar_t, Rank, Threads, NumKTiles>;
+  if (smem_bytes > 48 * 1024) {
+    host::RuntimeDeviceCheck(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem_bytes)));
+  }
+
+  host::LaunchKernel(dim3(num_m_blocks * 2), dim3(Threads), stream, smem_bytes)(
+      kernel,
+      hidden_states,
+      lora_a,
+      output,
+      sorted_token_ids,
+      expert_ids,
+      num_tokens_post_padded,
+      K,
+      num_valid_tokens,
+      top_k,
+      stride_am,
+      stride_be,
+      stride_bn,
+      stride_bk,
+      stride_cm,
+      stride_cn);
+}
+
+template <typename scalar_t, int KStages, int BlockK, int Rank, int NWarps, int SplitK>
+void launch_pipe(
+    cudaStream_t stream,
+    int num_m_blocks,
+    int N,
+    const scalar_t* hidden_states,
+    const scalar_t* lora_a,
+    scalar_t* output,
+    const int32_t* sorted_token_ids,
+    const int32_t* expert_ids,
+    const int32_t* num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  constexpr int kNTiles = Rank / 8;
+  const size_t smem_bytes = align16(BLOCK_M * sizeof(int32_t)) + align16(BLOCK_M * sizeof(const scalar_t*)) +
+                            align16(Rank * sizeof(const scalar_t*)) +
+                            align16(static_cast<size_t>(KStages) * BLOCK_M * BlockK * sizeof(scalar_t)) +
+                            align16(static_cast<size_t>(KStages) * Rank * BlockK * sizeof(scalar_t)) +
+                            align16(static_cast<size_t>(NWarps) * 32 * kNTiles * 4 * sizeof(float));
+
+  // Split-K writes fp32 partials into a persistent scratch (contention-free), then
+  // a tiny reduction kernel sums them into the output. Inline atomic-add (bf16)
+  // was measured ~2x slower at bs=1 -- see the store() comment in the kernel.
+  float* workspace = nullptr;
+  if constexpr (SplitK > 1) {
+    workspace = get_shrink_workspace(static_cast<size_t>(SplitK) * num_valid_tokens * Rank);
+  }
+
+  auto kernel = moe_lora_shrink_pipe_kernel<scalar_t, KStages, BlockK, Rank, NWarps, SplitK>;
+  if (smem_bytes > 48 * 1024) {
+    host::RuntimeDeviceCheck(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem_bytes)));
+  }
+
+  // PDL only for the single-pass path: the split-K path reuses a persistent fp32
+  // workspace across calls, so overlapping consecutive launches could race the
+  // following reduce kernel's read of it. SGLANG_SHRINK_PIPE_PDL=0 disables it.
+  static const bool s_pipe_pdl = []() {
+    const char* v = std::getenv("SGLANG_SHRINK_PIPE_PDL");
+    return v == nullptr || v[0] != '0';
+  }();
+  constexpr bool kPdlSafe = (SplitK == 1);
+
+  host::LaunchKernel(dim3(num_m_blocks, SplitK), dim3(NWarps * 32), stream, smem_bytes)
+      .enable_pdl(s_pipe_pdl && kPdlSafe)(
+          kernel,
+          hidden_states,
+          lora_a,
+          output,
+          workspace,
+          sorted_token_ids,
+          expert_ids,
+          num_tokens_post_padded,
+          N,
+          K,
+          num_valid_tokens,
+          top_k,
+          stride_am,
+          stride_be,
+          stride_bn,
+          stride_bk,
+          stride_cm,
+          stride_cn);
+
+  if constexpr (SplitK > 1) {
+    const int total = num_valid_tokens * Rank;
+    const int red_blocks = std::min(1024, std::max(1, (total + 255) / 256));
+    host::LaunchKernel(dim3(red_blocks), dim3(256), stream)(
+        moe_lora_shrink_splitk_reduce_kernel<scalar_t, Rank, SplitK>,
+        workspace,
+        output,
+        num_valid_tokens,
+        stride_cm,
+        stride_cn);
+  }
+}
+
+template <typename scalar_t, int Rank, int NumKTiles>
+void launch_tcgen05_rank(
+    cudaStream_t stream,
+    int num_m_blocks,
+    const scalar_t* hidden_states,
+    const scalar_t* lora_a,
+    scalar_t* output,
+    const int32_t* sorted_token_ids,
+    const int32_t* expert_ids,
+    const int32_t* num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  static_assert(Rank == 16 || Rank == 32 || Rank == 64);
+  const size_t smem_bytes =
+      align1024(align16(BLOCK_M * sizeof(int32_t)) + align16(sizeof(uint64_t)) + align16(sizeof(uint32_t))) +
+      TCGEN_GROUP_KTILES * TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t) +
+      TCGEN_GROUP_KTILES * TCGEN_N * TCGEN_BLOCK_K * sizeof(scalar_t);
+
+  auto kernel = moe_lora_shrink_tcgen05_kernel<scalar_t, Rank, NumKTiles>;
+  if (smem_bytes > 48 * 1024) {
+    host::RuntimeDeviceCheck(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem_bytes)));
+  }
+
+  host::LaunchKernel(dim3(num_m_blocks, BLOCK_M / TCGEN_N, Rank / WMMA_M), dim3(TCGEN_THREADS), stream, smem_bytes)(
+      kernel,
+      hidden_states,
+      lora_a,
+      output,
+      sorted_token_ids,
+      expert_ids,
+      num_tokens_post_padded,
+      K,
+      num_valid_tokens,
+      top_k,
+      stride_am,
+      stride_be,
+      stride_bn,
+      stride_bk,
+      stride_cm,
+      stride_cn);
+}
+
+template <typename scalar_t>
+void launch_tcgen05_splitk_rank16(
+    cudaStream_t stream,
+    int split_k,
+    int num_m_blocks,
+    const scalar_t* hidden_states,
+    const scalar_t* lora_a,
+    scalar_t* output,
+    const int32_t* sorted_token_ids,
+    const int32_t* expert_ids,
+    const int32_t* num_tokens_post_padded,
+    int K,
+    int num_valid_tokens,
+    int top_k,
+    int64_t stride_am,
+    int64_t stride_be,
+    int64_t stride_bn,
+    int64_t stride_bk,
+    int64_t stride_cm,
+    int64_t stride_cn) {
+  static_assert(std::is_same_v<scalar_t, bf16_t>);
+  constexpr int Rank = 16;
+  if (split_k > 1) {
+    const int zero_blocks = std::min(1024, std::max(1, (num_valid_tokens * Rank + 255) / 256));
+    host::LaunchKernel(dim3(zero_blocks), dim3(256), stream)(
+        zero_rank_output_kernel<scalar_t, Rank>, output, num_valid_tokens, stride_cm, stride_cn);
+  }
+
+  if (split_k == 8) {
+    const size_t smem_bytes =
+        align1024(align16(BLOCK_M * sizeof(int32_t)) + align16(sizeof(uint64_t)) + align16(sizeof(uint32_t))) +
+        TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t) + TCGEN_N * TCGEN_BLOCK_K * sizeof(scalar_t);
+
+    auto kernel = moe_lora_shrink_tcgen05_splitk_rank16_kernel<scalar_t, 8>;
+    if (smem_bytes > 48 * 1024) {
+      host::RuntimeDeviceCheck(
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem_bytes)));
+    }
+
+    host::LaunchKernel(dim3(num_m_blocks, BLOCK_M / TCGEN_N, 8), dim3(TCGEN_THREADS), stream, smem_bytes)(
+        kernel,
+        hidden_states,
+        lora_a,
+        output,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        K,
+        num_valid_tokens,
+        top_k,
+        stride_am,
+        stride_be,
+        stride_bn,
+        stride_bk,
+        stride_cm,
+        stride_cn);
+    return;
+  }
+
+  const size_t smem_bytes =
+      align1024(align16(BLOCK_M * sizeof(int32_t)) + align16(sizeof(uint64_t)) + align16(sizeof(uint32_t))) +
+      TCGEN_GROUP_KTILES * TCGEN_M * TCGEN_BLOCK_K * sizeof(scalar_t) +
+      TCGEN_GROUP_KTILES * TCGEN_N * TCGEN_BLOCK_K * sizeof(scalar_t);
+
+#define SGL_LAUNCH_TCGEN05_SPLITK(SPLIT_K_VALUE)                                                                       \
+  do {                                                                                                                 \
+    auto kernel = moe_lora_shrink_tcgen05_splitk_grouped_rank16_kernel<scalar_t, SPLIT_K_VALUE>;                       \
+    if (smem_bytes > 48 * 1024) {                                                                                      \
+      host::RuntimeDeviceCheck(                                                                                        \
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem_bytes)));    \
+    }                                                                                                                  \
+    host::LaunchKernel(dim3(num_m_blocks, BLOCK_M / TCGEN_N, SPLIT_K_VALUE), dim3(TCGEN_THREADS), stream, smem_bytes)( \
+        kernel,                                                                                                        \
+        hidden_states,                                                                                                 \
+        lora_a,                                                                                                        \
+        output,                                                                                                        \
+        sorted_token_ids,                                                                                              \
+        expert_ids,                                                                                                    \
+        num_tokens_post_padded,                                                                                        \
+        K,                                                                                                             \
+        num_valid_tokens,                                                                                              \
+        top_k,                                                                                                         \
+        stride_am,                                                                                                     \
+        stride_be,                                                                                                     \
+        stride_bn,                                                                                                     \
+        stride_bk,                                                                                                     \
+        stride_cm,                                                                                                     \
+        stride_cn);                                                                                                    \
+  } while (0)
+
+  switch (split_k) {
+    case 8:
+      SGL_LAUNCH_TCGEN05_SPLITK(8);
+      break;
+    case 7:
+      SGL_LAUNCH_TCGEN05_SPLITK(7);
+      break;
+    case 6:
+      SGL_LAUNCH_TCGEN05_SPLITK(6);
+      break;
+    case 5:
+      SGL_LAUNCH_TCGEN05_SPLITK(5);
+      break;
+    case 4:
+      SGL_LAUNCH_TCGEN05_SPLITK(4);
+      break;
+    case 3:
+      SGL_LAUNCH_TCGEN05_SPLITK(3);
+      break;
+    case 2:
+      SGL_LAUNCH_TCGEN05_SPLITK(2);
+      break;
+    default:
+      SGL_LAUNCH_TCGEN05_SPLITK(1);
+      break;
+  }
+
+#undef SGL_LAUNCH_TCGEN05_SPLITK
+}
+
+template <typename scalar_t>
+struct MoeLoraShrinkKernel {
+  static void
+  run(tvm::ffi::TensorView output,
+      tvm::ffi::TensorView hidden_states,
+      tvm::ffi::TensorView lora_a,
+      tvm::ffi::TensorView sorted_token_ids,
+      tvm::ffi::TensorView expert_ids,
+      tvm::ffi::TensorView num_tokens_post_padded,
+      int64_t top_k,
+      int64_t block_size_m) {
+    using namespace host;
+
+    RuntimeCheck(hidden_states.ndim() == 2, "hidden_states must be 2D [num_tokens, K]");
+    RuntimeCheck(lora_a.ndim() == 3, "lora_a must be 3D [num_virtual_experts, N, K]");
+    RuntimeCheck(output.ndim() == 2, "output must be 2D [num_tokens * top_k, N]");
+    RuntimeCheck(block_size_m == BLOCK_M, "m16n8 shrink requires routing block_size_m == 16");
+    RuntimeCheck(hidden_states.stride(1) == 1, "hidden_states must be K-contiguous (stride[1] == 1)");
+    RuntimeCheck(lora_a.stride(2) == 1, "lora_a must be K-contiguous (stride[2] == 1)");
+
+    const int N = static_cast<int>(lora_a.size(1));
+    const int K = static_cast<int>(lora_a.size(2));
+    RuntimeCheck(N == 16 || N == 32 || N == 64, "m16n8 shrink supports rank N in {16, 32, 64}");
+    RuntimeCheck(K % BLOCK_K == 0, "m16n8 shrink requires K divisible by BLOCK_K");
+    RuntimeCheck(hidden_states.size(1) == K, "hidden_states K must match lora_a K");
+    RuntimeCheck(output.size(1) == N, "output N must match lora_a N");
+
+    const int num_m_blocks = static_cast<int>(expert_ids.size(0));
+    const int num_valid_tokens = static_cast<int>(output.size(0));
+    if (num_m_blocks == 0 || N == 0 || num_valid_tokens == 0) return;
+
+    const auto device = hidden_states.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+
+    auto launch_rank = [&]<int Rank, int NumKTiles>() {
+      launch_m16n8_rank<scalar_t, Rank, NumKTiles>(
+          stream,
+          num_m_blocks,
+          static_cast<const scalar_t*>(hidden_states.data_ptr()),
+          static_cast<const scalar_t*>(lora_a.data_ptr()),
+          static_cast<scalar_t*>(output.data_ptr()),
+          static_cast<const int32_t*>(sorted_token_ids.data_ptr()),
+          static_cast<const int32_t*>(expert_ids.data_ptr()),
+          static_cast<const int32_t*>(num_tokens_post_padded.data_ptr()),
+          K,
+          num_valid_tokens,
+          static_cast<int>(top_k),
+          hidden_states.stride(0),
+          lora_a.stride(0),
+          lora_a.stride(1),
+          lora_a.stride(2),
+          output.stride(0),
+          output.stride(1));
+    };
+
+    auto launch_tcgen = [&]<int Rank, int NumKTiles>() {
+      launch_tcgen05_rank<scalar_t, Rank, NumKTiles>(
+          stream,
+          num_m_blocks,
+          static_cast<const scalar_t*>(hidden_states.data_ptr()),
+          static_cast<const scalar_t*>(lora_a.data_ptr()),
+          static_cast<scalar_t*>(output.data_ptr()),
+          static_cast<const int32_t*>(sorted_token_ids.data_ptr()),
+          static_cast<const int32_t*>(expert_ids.data_ptr()),
+          static_cast<const int32_t*>(num_tokens_post_padded.data_ptr()),
+          K,
+          num_valid_tokens,
+          static_cast<int>(top_k),
+          hidden_states.stride(0),
+          lora_a.stride(0),
+          lora_a.stride(1),
+          lora_a.stride(2),
+          output.stride(0),
+          output.stride(1));
+    };
+
+    auto launch_pipe_call = [&]<int KStages, int BlockK, int Rank, int NWarps, int SplitK>() {
+      launch_pipe<scalar_t, KStages, BlockK, Rank, NWarps, SplitK>(
+          stream,
+          num_m_blocks,
+          N,
+          static_cast<const scalar_t*>(hidden_states.data_ptr()),
+          static_cast<const scalar_t*>(lora_a.data_ptr()),
+          static_cast<scalar_t*>(output.data_ptr()),
+          static_cast<const int32_t*>(sorted_token_ids.data_ptr()),
+          static_cast<const int32_t*>(expert_ids.data_ptr()),
+          static_cast<const int32_t*>(num_tokens_post_padded.data_ptr()),
+          K,
+          num_valid_tokens,
+          static_cast<int>(top_k),
+          hidden_states.stride(0),
+          lora_a.stride(0),
+          lora_a.stride(1),
+          lora_a.stride(2),
+          output.stride(0),
+          output.stride(1));
+    };
+
+    // Triton-style pipelined shrink (moe_lora_shrink_pipe_kernel) is the default
+    // for the rank-16 K==2048 hot path. Wins, in order of impact: 128B smem
+    // swizzle (kills ldmatrix bank conflicts), rank-aware no-padding, hoisted
+    // token/top_k divide, cheap warp/lane gather, 8 warps (occupancy hides the
+    // latency), and a K-split layout where every warp computes ALL N-tiles so the
+    // A fragment is loaded once and reused and all warps stay barrier-balanced.
+    //
+    // BlockK defaults to 512 (not 256): K==2048 then streams in 4 tiles instead
+    // of 8, halving the serial cp.async-commit/__syncthreads cycles on the
+    // latency-bound single-block path. Measured flat ~5.16us across bs=1..128 on
+    // B200 (vs ~5.67us at BlockK=256) -- beats cuBLAS (nvjet skinny GEMM + splitK
+    // reduce, ~5.5us GPU / ~8.4us wall) at every bs, and beats production Triton
+    // for bs>=16. See benchmark/moe_lora_shrink_optimization.md.
+    //
+    // Low-occupancy fill: when only a handful of expert token-blocks are active
+    // (bs=1 decode -> ~8 m-blocks on a 148-SM B200) the single-pass K-loop leaves
+    // the machine idle and is purely latency-bound. Split K to fan out ~128 blocks
+    // (same idea as the Triton 128/base_grid heuristic). Our split-K writes fp32
+    // partials + a separate reduce launch (vs Triton's inline atomics), so it only
+    // pays off when occupancy is genuinely low -- gate it at num_m_blocks <= 16.
+    // BlockK drops to 256 there so split-K can reach 8 (capped at K/BlockK).
+    // SGLANG_SHRINK_PIPE=0 disables it; =1 forces it on for any rank-16/32
+    // K%256==0 case. STAGES/BLOCKK/WARPS/SPLITK env overrides win over the defaults.
+    if ((N == 16 || N == 32) && K % 256 == 0) {
+      bool use_pipe = (N == 16 && K == 2048);
+      if (const char* v = std::getenv("SGLANG_SHRINK_PIPE")) use_pipe = (v[0] == '1');
+      if (use_pipe) {
+        {
+          int kstages = 5, blockk = 512, warps = 8, splitk = 1;
+          if (num_m_blocks <= 16) {
+            blockk = 256;
+            splitk = 8;  // 128/8 m-blocks; min(8, K/blockk). Macro handles {1,2,4,8}.
+          }
+          if (const char* s = std::getenv("SGLANG_SHRINK_PIPE_STAGES")) kstages = atoi(s);
+          if (const char* bk = std::getenv("SGLANG_SHRINK_PIPE_BLOCKK")) blockk = atoi(bk);
+          if (const char* w = std::getenv("SGLANG_SHRINK_PIPE_WARPS")) warps = atoi(w);
+          if (const char* sk = std::getenv("SGLANG_SHRINK_PIPE_SPLITK")) splitk = atoi(sk);
+#define SGL_PIPE_KS(BK, RANK, NW, SK)                                \
+  do {                                                               \
+    switch (kstages) {                                               \
+      case 2:                                                        \
+        launch_pipe_call.template operator()<2, BK, RANK, NW, SK>(); \
+        break;                                                       \
+      case 3:                                                        \
+        launch_pipe_call.template operator()<3, BK, RANK, NW, SK>(); \
+        break;                                                       \
+      case 5:                                                        \
+        launch_pipe_call.template operator()<5, BK, RANK, NW, SK>(); \
+        break;                                                       \
+      case 6:                                                        \
+        launch_pipe_call.template operator()<6, BK, RANK, NW, SK>(); \
+        break;                                                       \
+      case 7:                                                        \
+        launch_pipe_call.template operator()<7, BK, RANK, NW, SK>(); \
+        break;                                                       \
+      case 8:                                                        \
+        launch_pipe_call.template operator()<8, BK, RANK, NW, SK>(); \
+        break;                                                       \
+      case 9:                                                        \
+        launch_pipe_call.template operator()<9, BK, RANK, NW, SK>(); \
+        break;                                                       \
+      default:                                                       \
+        launch_pipe_call.template operator()<4, BK, RANK, NW, SK>(); \
+        break;                                                       \
+    }                                                                \
+  } while (0)
+#define SGL_PIPE_SK(BK, RANK, NW)     \
+  do {                                \
+    switch (splitk) {                 \
+      case 2:                         \
+        SGL_PIPE_KS(BK, RANK, NW, 2); \
+        break;                        \
+      case 4:                         \
+        SGL_PIPE_KS(BK, RANK, NW, 4); \
+        break;                        \
+      case 8:                         \
+        SGL_PIPE_KS(BK, RANK, NW, 8); \
+        break;                        \
+      default:                        \
+        SGL_PIPE_KS(BK, RANK, NW, 1); \
+        break;                        \
+    }                                 \
+  } while (0)
+#define SGL_PIPE_WARPS(BK, RANK)   \
+  do {                             \
+    switch (warps) {               \
+      case 2:                      \
+        SGL_PIPE_SK(BK, RANK, 2);  \
+        break;                     \
+      case 8:                      \
+        SGL_PIPE_SK(BK, RANK, 8);  \
+        break;                     \
+      case 16:                     \
+        SGL_PIPE_SK(BK, RANK, 16); \
+        break;                     \
+      default:                     \
+        SGL_PIPE_SK(BK, RANK, 4);  \
+        break;                     \
+    }                              \
+  } while (0)
+#define SGL_PIPE_DISPATCH(RANK)  \
+  do {                           \
+    if (blockk == 128) {         \
+      SGL_PIPE_WARPS(128, RANK); \
+    } else if (blockk == 512) {  \
+      SGL_PIPE_WARPS(512, RANK); \
+    } else {                     \
+      SGL_PIPE_WARPS(256, RANK); \
+    }                            \
+  } while (0)
+          if (N == 16) {
+            SGL_PIPE_DISPATCH(16);
+          } else {
+            SGL_PIPE_DISPATCH(32);
+          }
+#undef SGL_PIPE_DISPATCH
+#undef SGL_PIPE_WARPS
+#undef SGL_PIPE_SK
+#undef SGL_PIPE_KS
+          return;
+        }
+      }
+    }
+
+    const bool use_k2048 = K == 2048;
+    bool use_tcgen05 = false;
+    if constexpr (std::is_same_v<scalar_t, bf16_t>) {
+      int current_device = 0;
+      cudaDeviceProp prop{};
+      RuntimeDeviceCheck(cudaGetDevice(&current_device));
+      RuntimeDeviceCheck(cudaGetDeviceProperties(&prop, current_device));
+      use_tcgen05 = use_k2048 && N == 16 && prop.major >= 10;
+    }
+    switch (N) {
+      case 16:
+        if constexpr (std::is_same_v<scalar_t, bf16_t>) {
+          if (use_tcgen05) {
+            if (num_m_blocks <= 16) {
+              launch_tcgen05_splitk_rank16<scalar_t>(
+                  stream,
+                  8,
+                  num_m_blocks,
+                  static_cast<const scalar_t*>(hidden_states.data_ptr()),
+                  static_cast<const scalar_t*>(lora_a.data_ptr()),
+                  static_cast<scalar_t*>(output.data_ptr()),
+                  static_cast<const int32_t*>(sorted_token_ids.data_ptr()),
+                  static_cast<const int32_t*>(expert_ids.data_ptr()),
+                  static_cast<const int32_t*>(num_tokens_post_padded.data_ptr()),
+                  K,
+                  num_valid_tokens,
+                  static_cast<int>(top_k),
+                  hidden_states.stride(0),
+                  lora_a.stride(0),
+                  lora_a.stride(1),
+                  lora_a.stride(2),
+                  output.stride(0),
+                  output.stride(1));
+            } else {
+              launch_tcgen.template operator()<16, 8>();
+            }
+            break;
+          }
+        }
+        if (use_k2048) {
+          launch_m16n8_half_rank<scalar_t, 16, 8>(
+              stream,
+              num_m_blocks,
+              static_cast<const scalar_t*>(hidden_states.data_ptr()),
+              static_cast<const scalar_t*>(lora_a.data_ptr()),
+              static_cast<scalar_t*>(output.data_ptr()),
+              static_cast<const int32_t*>(sorted_token_ids.data_ptr()),
+              static_cast<const int32_t*>(expert_ids.data_ptr()),
+              static_cast<const int32_t*>(num_tokens_post_padded.data_ptr()),
+              K,
+              num_valid_tokens,
+              static_cast<int>(top_k),
+              hidden_states.stride(0),
+              lora_a.stride(0),
+              lora_a.stride(1),
+              lora_a.stride(2),
+              output.stride(0),
+              output.stride(1));
+        } else {
+          launch_rank.template operator()<16, 0>();
+        }
+        break;
+      case 32:
+        if (use_tcgen05) {
+          launch_tcgen.template operator()<32, 8>();
+        } else if (use_k2048) {
+          launch_m16n8_half_rank<scalar_t, 32, 8>(
+              stream,
+              num_m_blocks,
+              static_cast<const scalar_t*>(hidden_states.data_ptr()),
+              static_cast<const scalar_t*>(lora_a.data_ptr()),
+              static_cast<scalar_t*>(output.data_ptr()),
+              static_cast<const int32_t*>(sorted_token_ids.data_ptr()),
+              static_cast<const int32_t*>(expert_ids.data_ptr()),
+              static_cast<const int32_t*>(num_tokens_post_padded.data_ptr()),
+              K,
+              num_valid_tokens,
+              static_cast<int>(top_k),
+              hidden_states.stride(0),
+              lora_a.stride(0),
+              lora_a.stride(1),
+              lora_a.stride(2),
+              output.stride(0),
+              output.stride(1));
+        } else {
+          launch_rank.template operator()<32, 0>();
+        }
+        break;
+      case 64:
+        if (use_tcgen05) {
+          launch_tcgen.template operator()<64, 8>();
+        } else if (use_k2048) {
+          launch_m16n8_half_rank<scalar_t, 64, 8>(
+              stream,
+              num_m_blocks,
+              static_cast<const scalar_t*>(hidden_states.data_ptr()),
+              static_cast<const scalar_t*>(lora_a.data_ptr()),
+              static_cast<scalar_t*>(output.data_ptr()),
+              static_cast<const int32_t*>(sorted_token_ids.data_ptr()),
+              static_cast<const int32_t*>(expert_ids.data_ptr()),
+              static_cast<const int32_t*>(num_tokens_post_padded.data_ptr()),
+              K,
+              num_valid_tokens,
+              static_cast<int>(top_k),
+              hidden_states.stride(0),
+              lora_a.stride(0),
+              lora_a.stride(1),
+              lora_a.stride(2),
+              output.stride(0),
+              output.stride(1));
+        } else {
+          launch_rank.template operator()<64, 0>();
+        }
+        break;
+    }
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/moe_lora_shrink.py
+++ b/python/sglang/jit_kernel/moe_lora_shrink.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import (
+    cache_once,
+    load_jit,
+    make_cpp_args,
+    override_jit_cuda_arch,
+)
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_moe_lora_shrink_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    arch_env = nullcontext()
+    if torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability()
+        if major >= 10:
+            arch_env = override_jit_cuda_arch(major, minor, suffix="a")
+    with arch_env:
+        return load_jit(
+            "moe_lora_shrink",
+            *args,
+            cuda_files=["lora/moe_lora_shrink_kernel.cu"],
+            cuda_wrappers=[
+                ("moe_lora_shrink", f"MoeLoraShrinkKernel<{args}>::run"),
+            ],
+        )
+
+
+def moe_lora_shrink(
+    output: torch.Tensor,
+    hidden_states: torch.Tensor,
+    lora_a: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    top_k: int,
+    block_size_m: int,
+) -> torch.Tensor:
+    """MoE LoRA-A "shrink" grouped GEMM (SPLIT_K == 1).
+
+    Computes, for every routed (token, top-k slot) ``t``::
+
+        output[t] = hidden_states[t // top_k] @ lora_a[expert(t)].T
+
+    Tokens are grouped by virtual expert via the moe_align routing buffers
+    (``sorted_token_ids`` / ``expert_ids`` / ``num_tokens_post_padded``), the
+    same layout the fused-MoE kernels use. ``block_size_m`` must match the
+    ``block_size`` used to build those routing buffers. Only routed output rows
+    are written (non-owned / sentinel slots are left untouched), matching the
+    Triton SPLIT_K == 1 path.
+
+    Parameters
+    ----------
+    output                  : [num_tokens * top_k, N] CUDA tensor, written in place.
+    hidden_states           : [num_tokens, K] CUDA tensor.
+    lora_a                  : [num_virtual_experts, N, K] merged LoRA-A weights
+                              (N == lora rank, K == hidden size).
+    sorted_token_ids        : int32 routing buffer from moe_align_block_size.
+    expert_ids              : int32 per-m-block expert ids (-1 sentinel for padding).
+    num_tokens_post_padded  : int32 [1] padded token count.
+    top_k                   : router top-k.
+    block_size_m            : routing block size (must equal the align block size).
+
+    Returns
+    -------
+    The ``output`` tensor (written in place).
+    """
+    if hidden_states.dtype not in (torch.float16, torch.bfloat16):
+        raise RuntimeError(
+            f"Unsupported dtype {hidden_states.dtype}. The WMMA shrink supports "
+            "float16, bfloat16 (tensor-core MMA); float32 is not supported."
+        )
+    if block_size_m != 16:
+        raise RuntimeError(
+            f"WMMA shrink requires block_size_m == 16 (one WMMA M-tile), got {block_size_m}"
+        )
+    if not (hidden_states.dtype == lora_a.dtype == output.dtype):
+        raise RuntimeError(
+            "hidden_states, lora_a and output must share dtype, got "
+            f"{hidden_states.dtype}, {lora_a.dtype}, {output.dtype}"
+        )
+    rank = lora_a.shape[1]
+    if rank not in (16, 32, 64):
+        raise RuntimeError(f"m16n8 shrink supports rank 16, 32 or 64, got rank {rank}")
+    hidden = lora_a.shape[2]
+    if hidden % 256 != 0:
+        raise RuntimeError(
+            f"m16n8 shrink requires hidden size divisible by 256, got {hidden}"
+        )
+
+    module = _jit_moe_lora_shrink_module(hidden_states.dtype)
+    module.moe_lora_shrink(
+        output,
+        hidden_states,
+        lora_a,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        top_k,
+        block_size_m,
+    )
+    return output

--- a/python/sglang/jit_kernel/moe_lora_shrink_cute.py
+++ b/python/sglang/jit_kernel/moe_lora_shrink_cute.py
@@ -1,0 +1,462 @@
+"""CuTeDSL port of the MoE LoRA-A "shrink" grouped GEMV.
+
+    out[t, n] = sum_k hidden[t // top_k, k] * lora_a[expert(t), n, k]
+
+Per expert token-block (BM=16 routed tokens), gather the 16 hidden rows + the
+expert's [N, K] LoRA-A weight, stream K in BK tiles through a cp.async pipeline,
+and run a warp m16n8k16 MMA (tokens in MMA-M, rank in MMA-N). Output rows are
+scattered back to the routed positions.
+
+Occupancy / latency hiding (this op is single-block latency-bound: the grid is
+~68 m-blocks on a 148-SM GPU, so half the machine is idle and per-block latency
+dominates). The output tile is only 16xrank, too small to tile M or N across more
+than `rank/8` warps -- so we tile the MMA over K instead: the TiledMma atom layout
+(1, n_tiles, k_split) puts `k_split` warps on the K mode, each reducing a distinct
+K-slice (partition_A/B hand each warp its own slice automatically). Their partial
+accumulators are summed once in shared memory in the epilogue. This is the CuTe
+analogue of the CUDA pipe kernel's "8 warps, K split across warps" design (the
+single biggest lever there): without it the 2-warp kernel is ~2x slower.
+
+The token-row gather (sorted_token_ids // top_k) and the scatter epilogue are
+hand-written -- they do not map to cute's contiguous tiled-copy model -- while
+the inner GEMM uses cute's TiledMma + ldmatrix. CUDA reference:
+csrc/lora/moe_lora_shrink_kernel.cu (moe_lora_shrink_pipe_kernel).
+"""
+
+import math
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+BM = 16
+WMMA_M, WMMA_N, WMMA_K = 16, 8, 16
+
+
+class MoeLoraShrinkCute:
+    def __init__(
+        self,
+        rank: int,
+        bk: int = 256,
+        stages: int = 4,
+        k_split: int = 4,
+        ab_dtype=cutlass.BFloat16,
+        use_pdl: bool = True,
+    ):
+        assert rank in (16, 32)
+        self.use_pdl = use_pdl
+        self.rank = rank
+        self.bk = bk
+        self.stages = stages
+        self.ab_dtype = ab_dtype
+        self.acc_dtype = cutlass.Float32
+        self.n_tiles = rank // WMMA_N  # MMA-N atoms (2 for r16, 4 for r32)
+        # Latency-bound, single-block: the grid (~68 m-blocks) is smaller than the
+        # SM count, so occupancy comes from MORE WARPS PER BLOCK, not more blocks.
+        # We can't tile M (16=one m16 tile) or N (rank tiny) further, so we tile the
+        # MMA over K: `k_split` warps each reduce a distinct slice of K, and their
+        # partial accumulators are summed once in smem. This mirrors the CUDA pipe
+        # kernel's "8 warps, K split across warps" design (the single biggest lever
+        # there: 9.5us -> 4.6us). bk must be divisible by k_split*WMMA_K.
+        assert bk % (k_split * WMMA_K) == 0
+        self.k_split = k_split
+        self.warps = self.n_tiles * k_split
+        self.threads = self.warps * 32
+
+    def _smem_layout(self, rows):
+        # row-major [rows, bk] with 128B XOR swizzle on the K-contiguous segments
+        copy_bits = 128
+        seg = min(self.bk, 64)
+        swizzle_bits = min(int(math.log2(seg * self.ab_dtype.width // copy_bits)), 3)
+        atom = cute.make_composed_layout(
+            cute.make_swizzle(swizzle_bits, 3, 3),
+            0,
+            cute.make_layout((8, seg), stride=(seg, 1)),
+        )
+        return cute.tile_to_shape(atom, (rows, self.bk, self.stages), (0, 1, 2))
+
+    @cute.jit
+    def __call__(
+        self,
+        mHidden: cute.Tensor,  # [num_tokens, K] bf16
+        mLoraA: cute.Tensor,  # [E, N, K] bf16
+        mOut: cute.Tensor,  # [num_valid, N] bf16
+        mTok: cute.Tensor,  # [num_m_blocks * BM] int32
+        mExpert: cute.Tensor,  # [num_m_blocks] int32
+        mNpp: cute.Tensor,  # [1] int32
+        stream: cuda.CUstream,
+        top_k: cutlass.Constexpr,
+        num_valid: cutlass.Int32,
+        num_m_blocks: cutlass.Int32,
+    ):
+        K = mHidden.shape[1]
+
+        op = cute.nvgpu.warp.MmaF16BF16Op(
+            self.ab_dtype, self.acc_dtype, (WMMA_M, WMMA_N, WMMA_K)
+        )
+        # (M=1, N=n_tiles, K=k_split) atoms -> n_tiles*k_split warps. The K-mode
+        # warps each accumulate a distinct K-slice (partition_A/B hand each its own
+        # slice); their partials are reduced in smem in the epilogue.
+        tiled_mma = cute.make_tiled_mma(op, (1, self.n_tiles, self.k_split))
+
+        sA_layout = self._smem_layout(BM)
+        sB_layout = self._smem_layout(self.rank)
+
+        self.kernel(
+            mHidden,
+            mLoraA,
+            mOut,
+            mTok,
+            mExpert,
+            mNpp,
+            tiled_mma,
+            sA_layout,
+            sB_layout,
+            top_k,
+            num_valid,
+            K,
+        ).launch(
+            grid=[num_m_blocks, 1, 1],
+            block=[self.threads, 1, 1],
+            stream=stream,
+            use_pdl=self.use_pdl,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mHidden: cute.Tensor,
+        mLoraA: cute.Tensor,
+        mOut: cute.Tensor,
+        mTok: cute.Tensor,
+        mExpert: cute.Tensor,
+        mNpp: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+        top_k: cutlass.Constexpr,
+        num_valid: cutlass.Int32,
+        K: cutlass.Constexpr,
+    ):
+        bidx, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # ---- shared storage (allocate unconditionally; cheap reservation) ----
+        sC_layout = cute.make_layout((BM, self.rank))
+        # Per-thread partial-acc reduction scratch: [threads, FRAG] fp32 (FRAG=4
+        # for the m16n8 atom). The k_split warps sharing an (n,lane) sum here.
+        sRed_layout = cute.make_layout((self.threads, 4))
+
+        @cute.struct
+        class Smem:
+            a: cute.struct.Align[
+                cute.struct.MemRange[self.ab_dtype, cute.cosize(sA_layout)], 16
+            ]
+            b: cute.struct.Align[
+                cute.struct.MemRange[self.ab_dtype, cute.cosize(sB_layout)], 16
+            ]
+            c: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(sC_layout)], 16
+            ]
+            red: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(sRed_layout)], 16
+            ]
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(Smem.size_in_bytes(), byte_alignment=16)
+        sA = Smem(storage).a.get_tensor(sA_layout)  # [BM, bk, stages]
+        sB = Smem(storage).b.get_tensor(sB_layout)  # [rank, bk, stages]
+        sC = Smem(storage).c.get_tensor(sC_layout)  # [BM, rank] fp32
+        sRed = Smem(storage).red.get_tensor(sRed_layout)  # [threads, 4] fp32
+
+        # PDL: this block's loads (hidden/lora_a/routing) don't depend on the prior
+        # grid's *output*, so the wait only honors stream ordering; the win is letting
+        # the next launch's grid setup overlap this grid's tail (released after the
+        # K-loop via griddepcontrol_launch_dependents). All blocks must reach both.
+        if self.use_pdl:
+            cute.arch.griddepcontrol_wait()
+
+        # Block-uniform early-out folded into a guard (no `return` in @cute.kernel).
+        expert = mExpert[bidx]
+        active = (bidx * BM < mNpp[0]) and (expert != cutlass.Int32(-1))
+        if active:
+            self._compute(
+                mHidden,
+                mLoraA,
+                mOut,
+                mTok,
+                mNpp,
+                tiled_mma,
+                sA,
+                sB,
+                sC,
+                sRed,
+                top_k,
+                num_valid,
+                K,
+                bidx,
+                tidx,
+                expert,
+            )
+        else:
+            if self.use_pdl:
+                cute.arch.griddepcontrol_launch_dependents()
+
+    @cute.jit
+    def _load_tile(self, g2s, rows, mHidden, gB, sA, sB, tidx, kt, stage):
+        # Cheap warp/lane gather (mirrors the CUDA pipe kernel): warp g owns a
+        # strided set of rows, lane owns a 128-bit K-vector. No per-element
+        # divide/modulo or runtime view rebuild -- those integer ops dominated the
+        # naive `cc//kvecs` gather (the kernel was issue-bound on them, so deeper
+        # stages / bigger BK gave 0 improvement).
+        kvecs = self.bk // 8  # 128-bit (8 bf16) vectors per row per tile
+        kbase = kt * kvecs
+        g = tidx // 32
+        lane = tidx % 32
+        nw = self.warps
+        kv_iters = (kvecs + 31) // 32
+        # A rows (gathered hidden rows; rows[m] < 0 -> padding, skip)
+        a_iters = (BM + nw - 1) // nw
+        for j in cutlass.range(a_iters, unroll_full=True):
+            m = g + j * nw
+            if m < BM:
+                rr = rows[m]
+                if rr >= 0:
+                    for kj in cutlass.range(kv_iters, unroll_full=True):
+                        kv = lane + kj * 32
+                        if kv < kvecs:
+                            src = cute.local_tile(
+                                mHidden[rr, None], (8,), (kbase + kv,)
+                            )
+                            dst = cute.local_tile(sA[m, None, stage], (8,), (kv,))
+                            cute.copy(g2s, src, dst)
+        # B rows (contiguous for this expert)
+        b_iters = (self.rank + nw - 1) // nw
+        for j in cutlass.range(b_iters, unroll_full=True):
+            n = g + j * nw
+            if n < self.rank:
+                for kj in cutlass.range(kv_iters, unroll_full=True):
+                    kv = lane + kj * 32
+                    if kv < kvecs:
+                        src = cute.local_tile(gB[n, None], (8,), (kbase + kv,))
+                        dst = cute.local_tile(sB[n, None, stage], (8,), (kv,))
+                        cute.copy(g2s, src, dst)
+        cute.arch.cp_async_commit_group()
+
+    @cute.jit
+    def _compute(
+        self,
+        mHidden,
+        mLoraA,
+        mOut,
+        mTok,
+        mNpp,
+        tiled_mma,
+        sA,
+        sB,
+        sC,
+        sRed,
+        top_k,
+        num_valid,
+        K,
+        bidx,
+        tidx,
+        expert,
+    ):
+        # per-row gathered hidden-row index (-1 = padding)
+        rows = cute.make_rmem_tensor(cute.make_layout(BM), cutlass.Int32)
+        for m in cutlass.range(BM, unroll_full=True):
+            t = mTok[bidx * BM + m]
+            rows[m] = (t // top_k) if t < num_valid else cutlass.Int32(-1)
+
+        gB = mLoraA[expert, None, None]  # [N, K]
+
+        num_k_tiles = K // self.bk
+        kvecs = self.bk // 8  # 128-bit (8 bf16) vectors per row per tile
+
+        # cp.async copy atom (128-bit)
+        g2s = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(
+                cache_mode=cute.nvgpu.cpasync.LoadCacheMode.GLOBAL
+            ),
+            self.ab_dtype,
+            num_bits_per_copy=128,
+        )
+
+        # prologue
+        for s in cutlass.range(self.stages - 1, unroll_full=True):
+            if s < num_k_tiles:
+                self._load_tile(g2s, rows, mHidden, gB, sA, sB, tidx, s, s)
+
+        thr_mma = tiled_mma.get_slice(tidx)
+        tCsC = thr_mma.partition_C(sC)
+        tCrC = tiled_mma.make_fragment_C(tCsC)
+        tCrC.fill(0.0)
+
+        ldA = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(False, 4), self.ab_dtype
+        )
+        ldB = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(False, 4), self.ab_dtype
+        )
+        tc_A = cute.make_tiled_copy_A(ldA, tiled_mma)
+        tc_B = cute.make_tiled_copy_B(ldB, tiled_mma)
+        thr_A = tc_A.get_slice(tidx)
+        thr_B = tc_B.get_slice(tidx)
+
+        read = 0
+        write = self.stages - 1
+        for kt in range(num_k_tiles):
+            cute.arch.cp_async_wait_group(self.stages - 2)
+            cute.arch.sync_threads()
+
+            # Issue the next K-tile's loads BEFORE the MMA so cp.async overlaps the
+            # tensor cores. The target buffer (`write`) is stages-1 ahead of `read`,
+            # so it isn't the tile we're about to consume -> no second barrier needed
+            # (the pipeline depth + cp_async_wait gate the WAR hazard on reuse).
+            ld = kt + self.stages - 1
+            if ld < num_k_tiles:
+                self._load_tile(g2s, rows, mHidden, gB, sA, sB, tidx, ld, write)
+
+            sA_r = sA[None, None, read]
+            sB_r = sB[None, None, read]
+            tCsA = thr_mma.partition_A(sA_r)
+            tCsB = thr_mma.partition_B(sB_r)
+            tCrA = tiled_mma.make_fragment_A(tCsA)
+            tCrB = tiled_mma.make_fragment_B(tCsB)
+            cute.copy(tc_A, thr_A.partition_S(sA_r), thr_A.retile(tCrA))
+            cute.copy(tc_B, thr_B.partition_S(sB_r), thr_B.retile(tCrB))
+            num_kb = cute.size(tCrA, mode=[2])
+            for kb in cutlass.range(num_kb, unroll_full=True):
+                cute.gemm(
+                    tiled_mma, tCrC, tCrA[None, None, kb], tCrB[None, None, kb], tCrC
+                )
+            read = (read + 1) % self.stages
+            write = (write + 1) % self.stages
+
+        # K-loop done: release the next grid so its launch/preamble overlaps this
+        # grid's reduction + store tail.
+        if self.use_pdl:
+            cute.arch.griddepcontrol_launch_dependents()
+
+        # ---- epilogue ----
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        # Cross-(K-warp) reduction. Each of the k_split warps holds a partial
+        # accumulator over its K-slice; warps sharing an (n_tile, lane) own the
+        # SAME logical C coords, so fragment element `i` is the same coord across
+        # them and can be summed element-wise without knowing the coord mapping.
+        # warp = n_idx + k_idx*n_tiles (atom layout (1,n_tiles,k_split), col-major).
+        FRAG = 4
+        warp = tidx // 32
+        lane = tidx % 32
+        n_idx = warp % self.n_tiles
+        k_idx = warp // self.n_tiles
+        for i in cutlass.range(FRAG, unroll_full=True):
+            sRed[tidx, i] = tCrC[i]
+        cute.arch.sync_threads()
+        # k_idx==0 warps reduce their column of partials and write the m16n8 frag.
+        if k_idx == 0:
+            for i in cutlass.range(FRAG, unroll_full=True):
+                acc = tCrC[i]
+                for kk in cutlass.range(1, self.k_split, unroll_full=True):
+                    acc = acc + sRed[(n_idx + kk * self.n_tiles) * 32 + lane, i]
+                tCrC[i] = acc
+            cute.autovec_copy(tCrC, tCsC)
+        cute.arch.sync_threads()
+        total = BM * self.rank
+        for i in cutlass.range(total // self.threads + 1, unroll_full=True):
+            ii = i * self.threads + tidx
+            if ii < total:
+                m = ii // self.rank
+                n = ii % self.rank
+                if rows[m] >= 0:
+                    t = mTok[bidx * BM + m]
+                    mOut[t, n] = sC[m, n].to(self.ab_dtype)
+
+
+_CACHE = {}
+
+
+def moe_lora_shrink_cute(
+    out, hidden, lora_a, sorted_tok, expert_ids, npp, top_k, block_m=16
+):
+    assert block_m == BM
+    rank = lora_a.shape[1]
+    K = lora_a.shape[2]
+    num_m_blocks = expert_ids.shape[0]
+    num_valid = out.shape[0]
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    key = (rank, K, top_k)
+    if key not in _CACHE:
+        _CACHE[key] = cute.compile(
+            MoeLoraShrinkCute(rank).__call__,
+            from_dlpack(hidden, assumed_align=16),
+            from_dlpack(lora_a, assumed_align=16),
+            from_dlpack(out, assumed_align=16),
+            from_dlpack(sorted_tok, assumed_align=4),
+            from_dlpack(expert_ids, assumed_align=4),
+            from_dlpack(npp, assumed_align=4),
+            stream,
+            top_k,
+            cutlass.Int32(num_valid),
+            cutlass.Int32(num_m_blocks),
+        )
+    _CACHE[key](
+        from_dlpack(hidden, assumed_align=16),
+        from_dlpack(lora_a, assumed_align=16),
+        from_dlpack(out, assumed_align=16),
+        from_dlpack(sorted_tok, assumed_align=4),
+        from_dlpack(expert_ids, assumed_align=4),
+        from_dlpack(npp, assumed_align=4),
+        stream,
+        cutlass.Int32(num_valid),
+        cutlass.Int32(num_m_blocks),
+    )
+    return out
+
+
+if __name__ == "__main__":
+    import torch
+    import triton
+
+    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+        moe_align_block_size,
+    )
+    from sglang.srt.lora.triton_ops.virtual_experts import (
+        _fused_virtual_topk_ids,
+        fused_sanitize_expert_ids,
+    )
+
+    E, TK, H, R = 64, 8, 2048, 16
+    dev = "cuda"
+    for bs in [1, 8, 16]:
+        torch.manual_seed(0)
+        topk = torch.stack([torch.randperm(E, device=dev)[:TK] for _ in range(bs)]).to(
+            torch.int32
+        )
+        tlm = torch.zeros(bs, device=dev, dtype=torch.int32)
+        hs = torch.randn(bs, H, device=dev, dtype=torch.bfloat16) * 0.1
+        la = torch.randn(E, R, H, device=dev, dtype=torch.bfloat16) * 0.1
+        vt, _, vne = _fused_virtual_topk_ids(topk, tlm, E, False, 1)
+        sti, eid, npp = moe_align_block_size(vt, BM, vne)
+        nt = topk.numel()
+        tight = triton.cdiv(nt + min(nt, vne) * (BM - 1), BM) * BM
+        sti = sti[:tight].contiguous()
+        eid = fused_sanitize_expert_ids(eid[: tight // BM], vne)
+        out = torch.zeros(bs * TK, R, device=dev, dtype=torch.bfloat16)
+        moe_lora_shrink_cute(out, hs, la, sti, eid, npp, TK, BM)
+        torch.cuda.synchronize()
+        # reference
+        ref = torch.zeros_like(out)
+        for b in range(bs):
+            for k in range(TK):
+                t = b * TK + k
+                e = topk[b, k].item()
+                ref[t] = (hs[b].float() @ la[e].float().T).to(torch.bfloat16)
+        diff = (out.float() - ref.float()).abs().max().item()
+        print(f"bs={bs:3d}  max|Δ|={diff:.4e}  {'OK' if diff < 0.5 else 'MISMATCH'}")

--- a/python/sglang/jit_kernel/tests/test_moe_lora_shrink.py
+++ b/python/sglang/jit_kernel/tests/test_moe_lora_shrink.py
@@ -1,0 +1,134 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.jit_kernel.moe_lora_shrink import moe_lora_shrink
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+
+
+def build_routing(topk_ids: torch.Tensor, num_experts: int, block_m: int):
+    """Pure-python moe_align: group flattened (token, top-k) slots by expert into
+    blocks of ``block_m``, padding short blocks with the ``num_valid`` sentinel.
+
+    Mirrors moe_align_block_size for max_loras == 1 (virtual expert == topk id).
+    Returns int32 (sorted_token_ids, expert_ids, num_tokens_post_padded[1]).
+    """
+    flat = topk_ids.reshape(-1).cpu().tolist()
+    num_valid = len(flat)
+    by_expert = {e: [] for e in range(num_experts)}
+    for slot, e in enumerate(flat):
+        by_expert[e].append(slot)
+
+    sorted_token_ids = []
+    expert_ids = []
+    for e in range(num_experts):
+        slots = by_expert[e]
+        for start in range(0, len(slots), block_m):
+            chunk = slots[start : start + block_m]
+            chunk = chunk + [num_valid] * (block_m - len(chunk))
+            sorted_token_ids.extend(chunk)
+            expert_ids.append(e)
+
+    npp = len(sorted_token_ids)
+    dev = topk_ids.device
+    return (
+        torch.tensor(sorted_token_ids, dtype=torch.int32, device=dev),
+        torch.tensor(expert_ids, dtype=torch.int32, device=dev),
+        torch.tensor([npp], dtype=torch.int32, device=dev),
+    )
+
+
+def ref_shrink(hidden_states, lora_a, topk_ids, top_k):
+    bs = topk_ids.shape[0]
+    rank = lora_a.shape[1]
+    a = lora_a.float()
+    out = torch.zeros(
+        bs * top_k, rank, device=hidden_states.device, dtype=torch.float32
+    )
+    flat = topk_ids.reshape(-1)
+    for t in range(bs * top_k):
+        e = int(flat[t].item())
+        out[t] = hidden_states[t // top_k].float() @ a[e].t()
+    return out
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])  # WMMA: no fp32
+@pytest.mark.parametrize("bs", [1, 16, 64])
+@pytest.mark.parametrize("num_experts", [8, 64])
+@pytest.mark.parametrize("top_k", [1, 8])
+@pytest.mark.parametrize("rank", [16, 32, 64])  # one or more 16-wide WMMA N-tiles
+@pytest.mark.parametrize("hidden", [512, 2048])  # multiple of BLOCK_K=64
+@pytest.mark.parametrize("block_m", [16])  # one WMMA M-tile per block
+def test_moe_lora_shrink(dtype, bs, num_experts, top_k, rank, hidden, block_m):
+    if top_k > num_experts:
+        pytest.skip("top_k must be <= num_experts")
+    device = "cuda"
+    torch.manual_seed(0)
+
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:top_k] for _ in range(bs)]
+    ).to(torch.int32)
+    hidden_states = torch.randn(bs, hidden, device=device, dtype=dtype) * 0.1
+    lora_a = torch.randn(num_experts, rank, hidden, device=device, dtype=dtype) * 0.1
+
+    sorted_token_ids, expert_ids, npp = build_routing(topk_ids, num_experts, block_m)
+
+    output = torch.empty(bs * top_k, rank, device=device, dtype=dtype)
+    moe_lora_shrink(
+        output,
+        hidden_states,
+        lora_a,
+        sorted_token_ids,
+        expert_ids,
+        npp,
+        top_k,
+        block_m,
+    )
+
+    ref = ref_shrink(hidden_states, lora_a, topk_ids, top_k)
+    rtol, atol = (1e-4, 1e-4) if dtype == torch.float32 else (2e-2, 2e-2)
+    torch.testing.assert_close(output.float(), ref, rtol=rtol, atol=atol)
+
+
+def test_moe_lora_shrink_unsupported_rank():
+    device = "cuda"
+    dtype = torch.bfloat16
+    bs, num_experts, top_k, rank, hidden, block_m = 8, 8, 4, 24, 512, 16
+    torch.manual_seed(0)
+
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:top_k] for _ in range(bs)]
+    ).to(torch.int32)
+    hidden_states = torch.randn(bs, hidden, device=device, dtype=dtype) * 0.1
+    lora_a = torch.randn(num_experts, rank, hidden, device=device, dtype=dtype) * 0.1
+    sorted_token_ids, expert_ids, npp = build_routing(topk_ids, num_experts, block_m)
+
+    output = torch.empty(bs * top_k, rank, device=device, dtype=dtype)
+    with pytest.raises(RuntimeError, match="rank"):
+        moe_lora_shrink(
+            output,
+            hidden_states,
+            lora_a,
+            sorted_token_ids,
+            expert_ids,
+            npp,
+            top_k,
+            block_m,
+        )
+
+
+def test_moe_lora_shrink_dtype_mismatch():
+    device = "cuda"
+    hidden_states = torch.randn(4, 64, device=device, dtype=torch.float16)
+    lora_a = torch.randn(8, 16, 64, device=device, dtype=torch.bfloat16)
+    output = torch.empty(4, 16, device=device, dtype=torch.float16)
+    routing = build_routing(torch.zeros(4, 1, dtype=torch.int32, device=device), 8, 16)
+    with pytest.raises(RuntimeError, match="dtype"):
+        moe_lora_shrink(output, hidden_states, lora_a, *routing, 1, 16)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

The MoE LoRA-A **shrink** is a grouped, skinny GEMV run once per layer at decode:

```
output[t] = hidden_states[t // top_k] @ lora_a[expert(t)].T    # [rank] = [K] @ [rank, K].T
```

`rank` (N) is tiny (16/32), `K` is large, and tokens are grouped by virtual expert into blocks of 16 via the `moe_align_block_size` routing buffers — so it is **memory-latency bound**, not compute bound. This PR adds two standalone implementations as an alternative to the production Triton `_moe_lora_shrink_splitk` path, both reusing the existing routing buffers (`sorted_token_ids` / `expert_ids` / `num_tokens_post_padded`).

## What's added (kernels + Python API only)

- **CUDA JIT kernel** — `csrc/lora/moe_lora_shrink_kernel.cu` + `moe_lora_shrink.py`
  Warp `mma.sync.m16n8k16` (HMMA) fed by `ldmatrix`, a `cp.async` multi-stage ring buffer streaming K, 128-byte XOR-swizzled shared memory (bank-conflict-free `ldmatrix`), **8 warps with K split across warps** (per-warp partials reduced once in smem), Programmatic Dependent Launch, and adaptive split-K for low-occupancy decode. rank 16/32/64, `K % 256 == 0`, fp16/bf16.

- **CuTeDSL kernel** — `moe_lora_shrink_cute.py`
  Same structure built on cute's `TiledMma`: the K-split is expressed as the atom layout `(1, n_tiles, k_split)` (each K-mode warp gets a distinct K-slice from `partition_A/B` automatically), with an smem partial-reduction epilogue. rank 16/32.

- **Test** — `tests/test_moe_lora_shrink.py` (pure-python reference, registered for the 1-GPU kernel CI suite).
- **Benchmarks** — `benchmark/bench_moe_lora_shrink.py` and `benchmark/bench_shrink_cute.py` (compare CUDA / CuTe / Triton).

## Benchmarks (B200, rank16 K2048 top_k8 bf16, cold-L2 `do_bench`, µs)

| bs | cute | cuda | triton |
|----:|-----:|-----:|-------:|
| 1   | 5.22 | 4.67 | **3.17** |
| 8   | 5.43 | 4.55 | **4.34** |
| 16  | 5.41 | **4.53** | 5.59 |
| 32  | 5.47 | **4.55** | 5.59 |
| 64  | 5.51 | **4.53** | 5.59 |
| 128 | 5.63 | **4.57** | 5.61 |

The CUDA kernel is fastest at the saturated decode batch sizes (bs≥16); the CuTeDSL kernel beats Triton there too. At bs≤8 Triton's split-K still leads (the low-occupancy regime). All paths read the same cold 4MB `lora_a`.

## Notes

- Both kernels are JIT-compiled at runtime (no `sgl-kernel` rebuild).
- Self-contained against `main` — reuses existing `jit_kernel/utils.py` and `virtual_experts.py` helpers.
- Accurate cold-L2 `do_bench` numbers above were measured with the L2-flush/rotation `do_bench` rework (separate change); they reproduce qualitatively on the current `do_bench`.

## Test

```
python python/sglang/jit_kernel/tests/test_moe_lora_shrink.py -v
python python/sglang/jit_kernel/benchmark/bench_shrink_cute.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26861221863](https://github.com/sgl-project/sglang/actions/runs/26861221863)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26861221733](https://github.com/sgl-project/sglang/actions/runs/26861221733)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->