### PR TITLE
Fix hybrid attention routing for speculative draft layers

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -799,6 +799,23 @@ class HybridLinearAttnBackend(AttentionBackend):
         assert layer_id is not None, "either layer or layer_id must be provided"
         return layer_id in self.full_attn_layers
 
+    def _is_full_attn_call(
+        self,
+        layer: Optional[Union[RadixAttention, RadixLinearAttention]],
+        layer_id: Optional[int] = None,
+        q: Optional[torch.Tensor] = None,
+        k: Optional[torch.Tensor] = None,
+        v: Optional[torch.Tensor] = None,
+        mixed_qkv: Optional[torch.Tensor] = None,
+    ) -> bool:
+        # Speculative draft layers can reuse base-model layer ids. When a
+        # full-attention draft layer overlaps a base linear-attention layer id,
+        # the payload is still an unambiguous q/k/v call and must not be routed
+        # to the linear backend.
+        if mixed_qkv is None and q is not None:
+            return True
+        return self._is_full_attn(layer, layer_id)
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -866,7 +883,14 @@ class HybridLinearAttnBackend(AttentionBackend):
         b: Optional[torch.Tensor] = None,  # For GDN linear attention
         **kwargs,
     ):
-        if self._is_full_attn(layer, kwargs.get("layer_id")):
+        if self._is_full_attn_call(
+            layer,
+            kwargs.get("layer_id"),
+            q=q,
+            k=k,
+            v=v,
+            mixed_qkv=mixed_qkv,
+        ):
             return self.full_attn_backend.forward_decode(
                 q, k, v, layer, forward_batch, save_kv_cache, **kwargs
             )
@@ -897,7 +921,14 @@ class HybridLinearAttnBackend(AttentionBackend):
         b: Optional[torch.Tensor] = None,  # For GDN linear attention
         **kwargs,
     ):
-        if self._is_full_attn(layer, kwargs.get("layer_id")):
+        if self._is_full_attn_call(
+            layer,
+            kwargs.get("layer_id"),
+            q=q,
+            k=k,
+            v=v,
+            mixed_qkv=mixed_qkv,
+        ):
             return self.full_attn_backend.forward_extend(
                 q, k, v, layer, forward_batch, save_kv_cache, **kwargs
             )
@@ -928,7 +959,14 @@ class HybridLinearAttnBackend(AttentionBackend):
         b: Optional[torch.Tensor] = None,  # For linear attention
         **kwargs,
     ):
-        is_linear_attn = not self._is_full_attn(layer, kwargs.get("layer_id"))
+        is_linear_attn = not self._is_full_attn_call(
+            layer,
+            kwargs.get("layer_id"),
+            q=q,
+            k=k,
+            v=v,
+            mixed_qkv=mixed_qkv,
+        )
 
         if forward_batch.forward_mode.is_idle():
             if is_linear_attn:

--- a/test/registered/attention/unittests/mamba/test_mamba2.py
+++ b/test/registered/attention/unittests/mamba/test_mamba2.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     HybridLinearAttnBackend,
     MambaAttnBackendBase,
 )
+from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.test_utils import CustomTestCase
 
@@ -341,6 +342,61 @@ class TestTritonMamba2BackendCorrectness(CustomTestCase):
             input_ids=object(),
             out_cache_loc=None,
         )
+
+    def _make_sentinel_radix_attention(self, layer_id=0):
+        return RadixAttention(
+            num_heads=1,
+            head_dim=8,
+            scaling=1.0,
+            num_kv_heads=1,
+            layer_id=layer_id,
+        )
+
+    def test_hybrid_dispatch_full_qkv_payload_overrides_layer_id(self):
+        backend, full_attn_backend, linear_attn_backend = (
+            self._make_dispatch_spy_backend()
+        )
+        layer = self._make_sentinel_radix_attention(layer_id=0)
+        forward_batch = object()
+        q = torch.empty(1, 8)
+        k = torch.empty(1, 8)
+        v = torch.empty(1, 8)
+
+        backend.forward_extend(
+            layer=layer,
+            forward_batch=forward_batch,
+            q=q,
+            k=k,
+            v=v,
+            mixed_qkv=None,
+        )
+
+        self._assert_fanout_forwarded(
+            full_attn_backend.forward_extend, q, k, v, layer, forward_batch
+        )
+        linear_attn_backend.forward_extend.assert_not_called()
+
+    def test_hybrid_dispatch_plain_radix_attention_linear_by_layer_id(self):
+        backend, full_attn_backend, linear_attn_backend = (
+            self._make_dispatch_spy_backend()
+        )
+        layer = self._make_sentinel_radix_attention(layer_id=0)
+        forward_batch = object()
+        mixed_qkv = torch.empty(1, 24)
+
+        backend.forward_extend(
+            layer=layer,
+            forward_batch=forward_batch,
+            q=None,
+            k=None,
+            v=None,
+            mixed_qkv=mixed_qkv,
+        )
+
+        self._assert_fanout_forwarded(
+            linear_attn_backend.forward_extend, mixed_qkv, layer, forward_batch
+        )
+        full_attn_backend.forward_extend.assert_not_called()
 
     def test_hybrid_dispatch_replay_init_forward_metadata_fan_out(self):
         backend, full_attn_backend, linear_attn_backend = (


### PR DESCRIPTION
## Summary
- route unambiguous full-attention q/k/v payloads to the full attention backend before layer-id classification
- preserve layer-id routing for plain RadixAttention linear layers used by Bailing/Ring-style hybrid models
- add hybrid dispatch regression coverage for the speculative draft overlap case

## Regression
The scheduled main run failed in `test_pcg_with_speculative_decoding_extra.py::TestPCGWithMTP` after commit `76c9899d`, where a Qwen3.5 MTP draft full-attention layer reused a base-model linear layer id and was routed into GDN. That sent `mixed_qkv=None` to `GDNAttnBackend.forward_extend`, tripping `assert isinstance(mixed_qkv, torch.Tensor)`.

## Test plan
- `python3 -m py_compile python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py test/registered/attention/unittests/mamba/test_mamba2.py`
- `git diff --check`
- Tried focused unit test locally, but this desktop Python does not have `torch` installed: `ModuleNotFoundError: No module named 'torch'`

I will trigger `/rerun-test test_pcg_with_speculative_decoding_extra.py` after opening the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26863271814](https://github.com/sgl-project/sglang/actions/runs/26863271814)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #26863303477](https://github.com/sgl-project/sglang/actions/runs/26863303477)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->