### PR TITLE
[Multimodal][Perf] Offload the sync HF processor off the TokenizerManager event loop

### DIFF
--- a/benchmark/bench_mm_processor_offload.py
+++ b/benchmark/bench_mm_processor_offload.py
@@ -1,0 +1,189 @@
+"""Microbenchmark for the multimodal-processor offload (SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD).
+
+It isolates the *exact* work the offload moves off the TokenizerManager asyncio
+event loop -- the synchronous HF processor in `process_and_combine_mm_data`
+(resize/patchify the images + tokenize the text) -- and drives it through asyncio
+at a fixed concurrency, comparing the two modes:
+
+  inline   : run the work directly in the coroutine (blocks the event loop)
+             == SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD off
+  offload  : await loop.run_in_executor(threadpool, work)
+             == SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD on (SGLANG_MM_PROC_WORKERS workers)
+
+CPU-only (no GPU / server / JIT) so it is cheap and portable. A 5ms "event-loop
+ticker" runs during the load to measure how long the loop is starved -- a proxy
+for the TTFT/streaming smoothness of *other* in-flight requests.
+
+Metrics:
+  * preprocessing throughput (req/s)            -- the headline win
+  * event-loop max stall (ms)                   -- why TTFT improves under load
+  * per-request preprocessing latency (ms)      -- see NOTE below
+
+NOTE on per-request latency: the two modes are not apples-to-apples (Little's law
+W = L / throughput). Inline blocks the loop, so only L~=1 request is ever truly
+"in work" while the rest are frozen (its low latency hides the stall). Offload
+runs all L=concurrency requests at once against the worker pool, so latency =
+concurrency / throughput is naturally higher -- it reflects real concurrent
+processing bounded by the GIL-limited fraction of the HF processor, plus pool
+queue wait. In production the GPU forward paces the pipeline so preprocessing is
+not saturated this deep; the transferable wins are throughput and loop responsiveness.
+
+Example:
+  python benchmark/bench_mm_processor_offload.py \
+      --model-path Qwen/Qwen3-VL-30B-A3B-Instruct \
+      --num-requests 96 --concurrency 32 --images-per-req 4 --workers 16
+"""
+
+import argparse
+import asyncio
+import concurrent.futures
+import os
+import statistics
+import time
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
+from PIL import Image, ImageDraw
+from transformers import AutoProcessor
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--model-path",
+        required=True,
+        help="HF model/processor path with an image processor (e.g. a Qwen-VL).",
+    )
+    p.add_argument("--num-requests", type=int, default=96)
+    p.add_argument("--concurrency", type=int, default=32)
+    p.add_argument("--images-per-req", type=int, default=4)
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=16,
+        help="offload thread-pool size (= SGLANG_MM_PROC_WORKERS)",
+    )
+    p.add_argument("--text-tokens", type=int, default=3800)
+    p.add_argument("--image-width", type=int, default=1536)
+    p.add_argument("--image-height", type=int, default=2170)
+    p.add_argument(
+        "--distinct-images",
+        type=int,
+        default=128,
+        help="size of the synthetic image pool",
+    )
+    return p.parse_args()
+
+
+def make_image(idx: int, w: int, h: int) -> Image.Image:
+    bg = ((idx * 37) % 200 + 30, (idx * 71) % 200 + 30, (idx * 113) % 200 + 30)
+    im = Image.new("RGB", (w, h), bg)
+    d = ImageDraw.Draw(im)
+    for k in range(12):
+        y = 60 + k * (h // 13)
+        d.rectangle(
+            [80, y, w - 80, y + 90],
+            fill=((idx + k * 17) % 255, (k * 23) % 255, (idx * 5) % 255),
+        )
+    d.text((90, 30), f"DOC {idx:05d}", fill=(255, 255, 255))
+    return im
+
+
+async def _ticker(stop, gaps, period=0.005):
+    last = time.perf_counter()
+    while not stop.is_set():
+        await asyncio.sleep(period)
+        now = time.perf_counter()
+        gaps.append((now - last - period) * 1000.0)
+        last = now
+
+
+async def run_mode(mode, work, num_requests, concurrency, pool):
+    loop = asyncio.get_running_loop()
+    sem = asyncio.Semaphore(concurrency)
+    lat = []
+
+    async def req(i):
+        async with sem:
+            t = time.perf_counter()
+            if mode == "inline":
+                work(i)
+            else:
+                await loop.run_in_executor(pool, work, i)
+            lat.append((time.perf_counter() - t) * 1000.0)
+
+    stop = asyncio.Event()
+    gaps = []
+    tk = asyncio.create_task(_ticker(stop, gaps))
+    t0 = time.perf_counter()
+    await asyncio.gather(*(req(i) for i in range(num_requests)))
+    wall = time.perf_counter() - t0
+    stop.set()
+    await tk
+    lat.sort()
+    pct = lambda a, q: a[min(len(a) - 1, int(q * len(a)))]
+    print(f"\n===== {mode} (concurrency={concurrency}, n={num_requests}) =====")
+    print(f"  throughput: {num_requests / wall:.2f} req/s   (wall {wall:.2f}s)")
+    print(
+        f"  per-req preprocessing ms: p50 {pct(lat, .5):.0f}  p90 {pct(lat, .9):.0f}  p99 {pct(lat, .99):.0f}"
+    )
+    print(
+        f"  event-loop max stall ms: {max(gaps):.0f}  (p50 {statistics.median(gaps):.1f})"
+    )
+    return {"rps": num_requests / wall, "p99": pct(lat, 0.99), "loop_max_ms": max(gaps)}
+
+
+async def main():
+    args = parse_args()
+    print(f"loading processor: {args.model_path}", flush=True)
+    proc = AutoProcessor.from_pretrained(args.model_path, trust_remote_code=True)
+    imgproc, tok = proc.image_processor, proc.tokenizer
+
+    imgs = [
+        make_image(i, args.image_width, args.image_height)
+        for i in range(args.distinct_images)
+    ]
+    text = tok.decode(
+        tok("doc page content " * 1000, add_special_tokens=False).input_ids[
+            : args.text_tokens
+        ]
+    )
+    ipr = args.images_per_req
+
+    def work(req_idx):
+        sel = [imgs[(req_idx * ipr + k) % len(imgs)] for k in range(ipr)]
+        imgproc(images=sel, return_tensors="pt")
+        tok(text, return_tensors="pt")
+
+    work(0)  # warm
+    t = time.perf_counter()
+    for i in range(5):
+        work(i)
+    print(
+        f"single preprocessing call: {(time.perf_counter() - t) / 5 * 1000:.0f} ms "
+        f"({ipr} imgs @{args.image_width}x{args.image_height} + {args.text_tokens} tok)"
+    )
+
+    off = await run_mode("inline", work, args.num_requests, args.concurrency, None)
+    pool = concurrent.futures.ThreadPoolExecutor(
+        max_workers=args.workers, thread_name_prefix="sgl-mmproc"
+    )
+    on = await run_mode("offload", work, args.num_requests, args.concurrency, pool)
+    pool.shutdown()
+
+    print("\n================ offload OFF -> ON ================")
+    print(
+        f"  throughput:           {off['rps']:.2f} -> {on['rps']:.2f} req/s  ({on['rps'] / off['rps']:.2f}x)"
+    )
+    print(
+        f"  event-loop max stall: {off['loop_max_ms']:.0f} -> {on['loop_max_ms']:.0f} ms"
+    )
+    print(
+        f"  per-req p99:          {off['p99']:.0f} -> {on['p99']:.0f} ms  (see NOTE in module docstring)"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -568,6 +568,14 @@ class Envs:
     # preserve the user's original tokens to avoid retokenization drift.
     SGLANG_MM_AVOID_RETOKENIZE = EnvBool(True)
 
+    # VLM: multimodal processor offload (run the sync HF processor off the
+    # TokenizerManager event loop on a thread pool). SGLANG_TOKENIZER_SAFETY picks
+    # how the shared HF fast tokenizer is made thread-safe under the offload:
+    # "lock" (zero-copy RLock) or "pool" (deepcopy pool of WORKERS+1 tokenizers).
+    SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD = EnvBool(False)
+    SGLANG_MM_PROC_WORKERS = EnvInt(4)
+    SGLANG_TOKENIZER_SAFETY = EnvStr("lock")
+
 
     # VLM Item CUDA IPC Transport
     SGLANG_USE_CUDA_IPC_TRANSPORT = EnvBool(False)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -249,6 +249,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Initialize tokenizer and multimodalprocessor
         self.init_tokenizer_and_processor()
 
+        # Make the shared HF tokenizer thread-safe when the mm processor is offloaded
+        self.maybe_init_thread_safe_tokenizer()
+
         # Init inter-process communication
         self.init_ipc_channels(port_args)
 
@@ -355,6 +358,36 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             )
         else:
             self.async_dynamic_batch_tokenizer = None
+
+    def maybe_init_thread_safe_tokenizer(self):
+        # When the multimodal processor is offloaded to threads
+        # (SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD), the shared HF fast tokenizer (a PyO3 RefCell) is
+        # called concurrently from the TM event loop and the offload threads,
+        # which races with "RuntimeError: Already borrowed". Wrap it in-place so
+        # every aliased reference becomes thread-safe. SGLANG_TOKENIZER_SAFETY
+        # selects the strategy: "pool" (deepcopy pool) or "lock" (shared RLock,
+        # zero-copy).
+        if self.tokenizer is None or not envs.SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD.get():
+            return
+        try:
+            from sglang.srt.utils.thread_safe_tokenizer import (
+                maybe_make_thread_pool,
+                maybe_make_thread_safe_lock,
+            )
+
+            if envs.SGLANG_TOKENIZER_SAFETY.get().lower() == "pool":
+                pool_copies = envs.SGLANG_MM_PROC_WORKERS.get() + 1
+                maybe_make_thread_pool(self.tokenizer, copies=pool_copies)
+                logger.info(
+                    "Tokenizer thread-safe POOL enabled: copies=%d", pool_copies
+                )
+            else:
+                maybe_make_thread_safe_lock(self.tokenizer)
+                logger.info("Tokenizer thread-safe LOCK enabled (zero-copy)")
+        except Exception as e:
+            logger.warning(
+                "Tokenizer thread-safe init failed: %s; continuing without", e
+            )
 
     def init_ipc_channels(self, port_args: PortArgs):
         context = zmq.asyncio.Context(2)

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -211,6 +211,16 @@ class BaseMultimodalProcessor(ABC):
             mp_context=mp.get_context("fork"),
             max_workers=int(os.environ.get("SGLANG_CPU_WORKERS", os.cpu_count())),
         )
+        # Dedicated pool to offload the sync HF processor (process_and_combine_mm_data,
+        # which tokenizes text + resize/patchifies images, ~hundreds of ms) off the
+        # TokenizerManager event loop so concurrent image requests don't serialize on
+        # it. Separate from io_executor so it doesn't starve image decode/fetch. Safe
+        # because the shared HF fast tokenizer is wrapped thread-safe at TM init (see
+        # TokenizerManager.maybe_init_thread_safe_tokenizer / thread_safe_tokenizer.py).
+        self.mm_processor_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=envs.SGLANG_MM_PROC_WORKERS.get(),
+            thread_name_prefix="sgl-mmproc",
+        )
 
         # Mapping from attribute names to modality types
         self.ATTR_NAME_TO_MODALITY = {

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1211,6 +1211,15 @@ class BaseMultimodalProcessor(ABC):
         )
         if isinstance(available_slice, torch.Tensor):
             available_slice.copy_(tensor.view(torch.int8).view(-1), non_blocking=True)
+            # CRITICAL ordering fix: ensure the device-local write into the shared
+            # pool has actually landed before this proxy (which carries the pool
+            # offset) can be sent to and read by the consumer PROCESS. Producer and
+            # consumer use independent CUDA contexts/streams, so the shm flag is the
+            # only cross-process signal and it cannot order GPU work -- without this
+            # sync the consumer may read a not-yet-written slice. Cheap: the
+            # tokenizer-worker process has little other GPU work and the copy is
+            # usually already complete by the time we reach here.
+            torch.cuda.current_stream(available_slice.device).synchronize()
             return CudaIpcTensorTransportProxy(
                 data=available_slice,
                 info_data=tensor,

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -1,3 +1,5 @@
+import asyncio
+import functools
 import math
 import os
 import re
@@ -706,16 +708,28 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             "qwen3_5_moe",
             "intern_s2_preview",
         ):
-            mm_items, input_ids, ret = self.process_and_combine_mm_data(
+            _proc = functools.partial(
+                self.process_and_combine_mm_data,
                 base_output,
                 self.mm_tokens,
                 video_metadata=video_metadata,
                 do_sample_frames=False,
             )
         else:
-            mm_items, input_ids, ret = self.process_and_combine_mm_data(
-                base_output, self.mm_tokens
+            _proc = functools.partial(
+                self.process_and_combine_mm_data, base_output, self.mm_tokens
             )
+
+        # Offload the heavy sync HF processor (tokenize + resize/patchify) off the
+        # TokenizerManager event loop so concurrent (esp. URL) requests don't
+        # serialize on it. Safe because the shared fast tokenizer is wrapped
+        # thread-safe at TM init. Gated by SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD.
+        if envs.SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD.get():
+            mm_items, input_ids, ret = await asyncio.get_running_loop().run_in_executor(
+                self.mm_processor_executor, _proc
+            )
+        else:
+            mm_items, input_ids, ret = _proc()
 
         audio_feature_lengths = None
 

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -65,6 +65,27 @@ def _pool_handle_cache_clear():
         _pool_storage_cache.clear()
 
 
+# Dedicated CUDA stream(s) for IPC copy-out, one per device. The host-side sync
+# that enforces correct producer->consumer ordering (see _copy_slice_tensor_to_target)
+# is issued on this stream so it waits ONLY for the small device-local feature
+# copy, not for unrelated ViT/LLM work already queued on the consumer's default
+# stream.
+_ipc_copy_streams: dict = {}
+_ipc_copy_streams_lock = threading.Lock()
+
+
+def _get_ipc_copy_stream(device: torch.device):
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    stream = _ipc_copy_streams.get(idx)
+    if stream is None:
+        with _ipc_copy_streams_lock:
+            stream = _ipc_copy_streams.get(idx)
+            if stream is None:
+                stream = torch.cuda.Stream(device=idx)
+                _ipc_copy_streams[idx] = stream
+    return stream
+
+
 class ShmSyncBuffer:
     def __init__(self, byte_size: int = 4):
         self.buffer = shared_memory.SharedMemory(create=True, size=byte_size)
@@ -408,11 +429,32 @@ class CudaIpcTensorTransportProxy:
         recons_shape,
         recons_dtype,
     ):
+        copy_stream = _get_ipc_copy_stream(rebuild_device)
         with torch.cuda.device(rebuild_device):
-            reconstructed_tensor = torch.empty(
-                recons_shape, dtype=recons_dtype, device=rebuild_device
-            ).contiguous()
-            reconstructed_tensor.view(torch.int8).view(-1).copy_(slice_tensor)
+            # Run the copy-out on a dedicated stream (and allocate the destination
+            # there too) so the mandatory host-side sync below waits ONLY for this
+            # device-local copy -- not for any ViT/LLM work already queued on the
+            # consumer's default stream.
+            with torch.cuda.stream(copy_stream):
+                reconstructed_tensor = torch.empty(
+                    recons_shape, dtype=recons_dtype, device=rebuild_device
+                ).contiguous()
+                reconstructed_tensor.view(torch.int8).view(-1).copy_(slice_tensor)
+
+            # CRITICAL ordering fix: block until the copy-out has actually
+            # COMPLETED before signalling (via the shm flag) that the producer may
+            # recycle this pool slice. Without it the flag is raised while the copy
+            # is still in flight; the recycler (default 50ms) then reclaims the
+            # slice, a new request overwrites it, and this tensor ends up holding
+            # ANOTHER request's image -> cross-request leakage (use-after-free).
+            copy_stream.synchronize()
+
+            # The destination was allocated on copy_stream but is consumed on the
+            # caller's stream; record it so the caching allocator does not reuse
+            # its memory while downstream work still reads it.
+            reconstructed_tensor.record_stream(
+                torch.cuda.current_stream(rebuild_device)
+            )
 
             open(SHM_LOCK_FILE, "a").close()
             # write the shm_sync_buffer with a file lock

--- a/python/sglang/srt/utils/thread_safe_tokenizer.py
+++ b/python/sglang/srt/utils/thread_safe_tokenizer.py
@@ -1,0 +1,210 @@
+# Ported from vLLM (vllm/tokenizers/hf.py:19-101, Apache-2.0).
+#
+# Phase 2.1 of SGLang multimodal offload work — see
+# artifacts/PHASE2_BLOCKED.md for background. The shared HF fast tokenizer
+# (a PyO3 RefCell under the hood) races between TokenizerManager's own
+# apply_chat_template() coroutine and the offloaded mm_processor threads,
+# producing `RuntimeError: Already borrowed`.
+#
+# This port mirrors vLLM verbatim:
+#   * deepcopy `copies` tokenizers into a queue.Queue
+#   * synthesize a subclass that wraps every public method to borrow / return
+#   * in-place monkey-patch the tokenizer's __class__ so EVERY existing
+#     reference (TM.tokenizer, processor.tokenizer, mm_processor._tokenizer,
+#     mm_processor._processor.tokenizer — all aliases of one Rust object)
+#     transparently gains the borrowing behavior. No reference swapping
+#     anywhere in callers.
+#
+# Mechanical port. Deviations from upstream:
+#   - logger: SGLang's stdlib `logging.getLogger(__name__)` instead of
+#     `from vllm.logger import init_logger`.
+#   - types: just `PreTrainedTokenizerFast` from transformers; SGLang has no
+#     equivalent of vLLM's `TokenizerLike` protocol.
+#   - no `get_cached_tokenizer` / `CachedHfTokenizer` (out of scope for the
+#     race fix).
+
+import contextlib
+import copy
+import logging
+import queue
+import threading
+from typing import TypeVar
+
+from transformers import PreTrainedTokenizerFast
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+class ThreadSafeHFTokenizerMixin:
+    """Marker mixin so we can detect (and skip) already-wrapped tokenizers."""
+
+    pass
+
+
+def maybe_make_thread_pool(tokenizer: _T, copies: int = 1) -> _T:
+    """
+    If ``tokenizer`` is a ``PreTrainedTokenizerFast``, modify the tokenizer
+    in-place so its public interface is thread-safe by routing calls through
+    a pool of deep-copied tokenizers.
+
+    Returns the (now-wrapped, but same object identity) tokenizer.
+
+    Notes:
+        * Only the public interface is thread-safe. Direct access to the inner
+          ``_tokenizer`` property or mutation methods like
+          ``add_special_tokens`` / ``add_tokens`` is NOT routed through the
+          pool and remains race-prone if called concurrently.
+        * Adjacent method calls may execute on different deep copies of the
+          tokenizer. As long as no caller mutates the tokenizer's state via
+          a public-but-stateful method, this is transparent.
+        * Python attributes set on the wrapper *before* this call (e.g.
+          ``additional_stop_token_ids``) are preserved on the original object,
+          because the ``__class__`` swap is in-place and Python attribute
+          lookup hits the original ``__dict__`` first.
+    """
+    if not isinstance(tokenizer, PreTrainedTokenizerFast) or isinstance(
+        tokenizer, ThreadSafeHFTokenizerMixin
+    ):
+        return tokenizer
+
+    og_tokenizer = copy.copy(tokenizer)
+
+    tokenizer_pool: "queue.Queue[PreTrainedTokenizerFast]" = queue.Queue()
+    for _ in range(copies):
+        tokenizer_pool.put(copy.deepcopy(og_tokenizer))
+
+    @contextlib.contextmanager
+    def _borrow_from_pool():
+        try:
+            tok = tokenizer_pool.get_nowait()
+            yield tok
+        except queue.Empty:
+            tok = copy.deepcopy(og_tokenizer)
+            yield tok
+        finally:
+            tokenizer_pool.put(tok)
+
+    class TokenizerPool(tokenizer.__class__, ThreadSafeHFTokenizerMixin):  # type: ignore[misc, valid-type]
+        def apply_chat_template(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.apply_chat_template(*args, **kwargs)
+
+        def batch_decode(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.batch_decode(*args, **kwargs)
+
+        def batch_encode(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.batch_encode(*args, **kwargs)
+
+        def convert_tokens_to_ids(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.convert_tokens_to_ids(*args, **kwargs)
+
+        def convert_ids_to_tokens(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.convert_ids_to_tokens(*args, **kwargs)
+
+        def convert_tokens_to_string(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.convert_tokens_to_string(*args, **kwargs)
+
+        def decode(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.decode(*args, **kwargs)
+
+        def encode(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok.encode(*args, **kwargs)
+
+        def __call__(self, *args, **kwargs):
+            with _borrow_from_pool() as tok:
+                return tok(*args, **kwargs)
+
+        def __reduce__(self):
+            # Allow pickling: rebuild from the un-wrapped tokenizer.
+            return maybe_make_thread_pool, (og_tokenizer, copies)
+
+    TokenizerPool.__name__ = f"TokenizerPool{og_tokenizer.__class__.__name__}"
+
+    tokenizer.__class__ = TokenizerPool
+    logger.debug(
+        "Wrapped tokenizer %s with %d-copy thread pool",
+        og_tokenizer.__class__.__name__,
+        copies,
+    )
+    return tokenizer
+
+
+def maybe_make_thread_safe_lock(tokenizer: _T) -> _T:
+    """Thread-safe alternative to ``maybe_make_thread_pool`` with ~zero memory.
+
+    Instead of deep-copying N tokenizers, serialize all public tokenizer calls
+    through a single ``threading.Lock`` via the same in-place ``__class__`` swap.
+    Prevents the PyO3 ``RefCell`` race (``RuntimeError: Already borrowed``) by
+    ensuring only one thread is inside the Rust tokenizer at a time.
+
+    Trade-off vs the pool: tokenizer calls cannot run in parallel. This is fine
+    when tokenization is NOT the bottleneck (e.g. URL workloads bound by image
+    fetch / GPU), where it matches the pool's throughput at no RAM cost. Avoid
+    if concurrent CPU-bound tokenization of huge texts is the hot path.
+    """
+    if not isinstance(tokenizer, PreTrainedTokenizerFast) or isinstance(
+        tokenizer, ThreadSafeHFTokenizerMixin
+    ):
+        return tokenizer
+
+    # RLock (reentrant) — NOT a plain Lock: apply_chat_template(tokenize=True)
+    # internally calls self.encode/__call__ which re-enter on the SAME thread; a
+    # non-reentrant lock would self-deadlock. RLock still blocks OTHER threads, so
+    # cross-thread safety (the actual PyO3 race) is preserved.
+    _lock = threading.RLock()
+    # Shallow copy (shares the Rust backend, ~0 mem) kept only for pickling.
+    og_tokenizer = copy.copy(tokenizer)
+
+    class TokenizerLock(tokenizer.__class__, ThreadSafeHFTokenizerMixin):  # type: ignore[misc, valid-type]
+        def __reduce__(self):
+            return maybe_make_thread_safe_lock, (og_tokenizer,)
+
+        def apply_chat_template(self, *args, **kwargs):
+            with _lock:
+                return super().apply_chat_template(*args, **kwargs)
+
+        def batch_decode(self, *args, **kwargs):
+            with _lock:
+                return super().batch_decode(*args, **kwargs)
+
+        def batch_encode(self, *args, **kwargs):
+            with _lock:
+                return super().batch_encode(*args, **kwargs)
+
+        def convert_tokens_to_ids(self, *args, **kwargs):
+            with _lock:
+                return super().convert_tokens_to_ids(*args, **kwargs)
+
+        def convert_ids_to_tokens(self, *args, **kwargs):
+            with _lock:
+                return super().convert_ids_to_tokens(*args, **kwargs)
+
+        def convert_tokens_to_string(self, *args, **kwargs):
+            with _lock:
+                return super().convert_tokens_to_string(*args, **kwargs)
+
+        def decode(self, *args, **kwargs):
+            with _lock:
+                return super().decode(*args, **kwargs)
+
+        def encode(self, *args, **kwargs):
+            with _lock:
+                return super().encode(*args, **kwargs)
+
+        def __call__(self, *args, **kwargs):
+            with _lock:
+                return super().__call__(*args, **kwargs)
+
+    TokenizerLock.__name__ = f"TokenizerLock{tokenizer.__class__.__name__}"
+    tokenizer.__class__ = TokenizerLock
+    logger.debug("Wrapped tokenizer with a shared lock (zero-copy thread safety)")
+    return tokenizer


### PR DESCRIPTION
## Motivation

Two coupled problems on the multimodal path under concurrency:

1. **Serial mm preprocessing.** `process_and_combine_mm_data` (tokenize text +
   resize/patchify images, ~hundreds of ms) runs **synchronously on the
   TokenizerManager asyncio event loop**. Concurrent image requests serialize on
   it, inflating TTFT under multi-image / URL workloads.

2. **A latent data race in the CUDA IPC feature transport.** The transport
   (`SGLANG_USE_CUDA_IPC_TRANSPORT=1`) coordinates a producer GPU write and a
   consumer GPU read **across two processes using only a CPU-side shm flag, with
   no CUDA synchronization**. Under enough concurrency this delivers the wrong
   bytes — images leak across requests. Offloading mm preprocessing (problem 1)
   raises concurrency and makes the race reliably reproducible, so it must be
   fixed in the same change.

This PR is two commits: first the IPC transport synchronization fix (a
correctness prerequisite), then the offload feature. All offload behavior is
opt-in via `SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD` (off by default); with it off the path is
byte-for-byte unchanged.

## Modifications

### Commit 1 - CUDA IPC transport synchronization (correctness prerequisite)

The transport has no CUDA synchronization; two windows corrupt data:
- **Use-after-free:** `_copy_slice_tensor_to_target` bumps the shm flag right
  after *enqueuing* its async copy-out, before it completes. The recycler
  (default 50 ms) then reclaims the pool slice and a later request overwrites it
  while the earlier read is still in flight.
- **Write not ordered before read:** `_wrap_tensor_for_cuda_ipc` returns the
  proxy without waiting for its async copy into the pool slice to land.

Fix (`utils/cuda_ipc_transport_utils.py`, `multimodal/processors/base_processor.py`):
- Consumer: copy-out on a dedicated per-device stream, `synchronize()` it
  **before** raising the shm flag (so "done" means read-complete), `record_stream`
  the destination. The dedicated stream keeps the host wait off the default
  stream (no ViT/LLM stall).
- Producer: synchronize the copy into the pool slice before sending the proxy.

### Commit 2 - mm processor offload (throughput)

- `base_processor`: add `self.mm_processor_executor`
  (`SGLANG_MM_PROC_WORKERS` workers), separate from `io_executor` so it does not
  starve image decode/fetch.
- `qwen_vl.process_mm_data_async`: run `process_and_combine_mm_data` in that
  executor when `SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD` is set, else inline as before.
- `TokenizerManager`: the shared HF fast tokenizer is a PyO3 `RefCell` that races
  ("Already borrowed") when called from both the event loop and the offload
  threads. New `maybe_init_thread_safe_tokenizer()` helper (added as an `init_*`
  helper per the `__init__` style convention) wraps it in-place;
  `SGLANG_TOKENIZER_SAFETY` selects `"lock"` (zero-copy RLock) or `"pool"`
  (deepcopy pool of `SGLANG_MM_PROC_WORKERS + 1`). Helper in
  `utils/thread_safe_tokenizer.py`, ported from vLLM (Apache-2.0).
- New env vars registered in `environ.py` as typed descriptors, read via
  `envs.*.get()` (no raw `os.getenv`):

  | Env var | Type | Default | Meaning |
  |---|---|---:|---|
  | `SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD` | bool | `False` | offload mm preprocessing to the thread pool |
  | `SGLANG_MM_PROC_WORKERS` | int | `4` | offload pool size |
  | `SGLANG_TOKENIZER_SAFETY` | str | `"lock"` | tokenizer thread-safety strategy: `lock` or `pool` |

## Accuracy Tests

- **`SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD` off (default): no change** — same code path as today.
- **Offload on:** the same HF processor runs, only on a worker thread; outputs
  are unchanged. The tokenizer wrapper serializes/duplicates the PyO3 tokenizer
  so concurrent calls are safe (no "Already borrowed").
- **IPC sync fix:** makes IPC-transported features match a non-IPC
  (`SGLANG_USE_CUDA_IPC_TRANSPORT=0`) run; before, concurrent multi-image
  requests intermittently returned a response describing another request's image.

## Speed Tests and Profiling

### Workload / environment

Developed and exercised against:

- **Model:** Qwen3.6-35B-A3B (MoE), `--tp 1`
- **HW:** AMD Instinct MI350X (ROCm), rocm-7.2.0, build from source
- **Requests:** document visual QA — 2–4 remote **image URLs** per request,
  portrait docs ~1536×2170 px, 3k–12k input text tokens (avg)
- **Load:** ~20–40 concurrent requests, streaming

At this image size each request's `pixel_values` are large, so the IPC feature
pool churns (motivating the commit-1 synchronization fix) and the synchronous HF
preprocessing on the event loop becomes a visible TTFT cost under the concurrency
above (motivating the offload). TP=1 means a single IPC consumer, but the
flag-before-copy-complete race still applies.

- The offload removes the event-loop serialization of mm preprocessing, lowering
  TTFT under concurrent multi-image / URL load. (Headline numbers depend on
  workload/hardware and should be reported by the submitter; per #26995 the large
  measured speedup was with the loading PR and this offload applied together.)
- The IPC sync adds two synchronizations of small device-local copies (consumer
  on a dedicated stream — no model-stream stall; producer in the lightly-loaded
  TM process) and **preserves the GPU-direct transport** (no CPU round-trip).
- No change when `SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD` is off.

### Measured - offload microbenchmark

The numbers below isolate the *exact* work the offload moves off the event loop —
the HF processor (resize/patchify the images + tokenize the text) — driven
through asyncio at the target concurrency, CPU-only (AMD EPYC 9575F, 192 cores),
`SGLANG_MM_PROC_WORKERS=16`. Per request: **4 images @1536×2170 + 3800 text
tokens ≈ 313 ms** of synchronous HF preprocessing; 96 requests at concurrency 32:

| metric | offload OFF (inline) | offload ON (threadpool) |
|---|---:|---:|
| preprocessing throughput | 3.8 req/s | **15.0 req/s (3.9×)** |
| event-loop max stall | **25,200 ms** (loop blocked the whole batch) | **103 ms** |
| per-req preprocessing p99 | 303 ms | 2,483 ms |

The headline is the **event loop**: inline, the single TokenizerManager loop
thread is blocked ~25 s straight, so *every* concurrent request stalls (no token
streaming, no new accepts, no scheduler comms) — directly inflating TTFT under
load. Offloaded, the loop stays responsive (~0.1 s max stall) and preprocessing
throughput rises ~3.9× (not ~16× — that ceiling is the GIL-bound fraction of the
HF processor; only its numpy/PIL-C/rust-tokenizer parts release the GIL).

#### Why per-request p99 rises OFF -> ON (and why it is *not* a regression)

The two columns are not measuring the same thing — it is **Little's Law**,
`W = L / λ` (latency = in-flight requests ÷ throughput):

- **Inline (OFF):** `work()` blocks the single event-loop thread, so at any
  instant only **L ≈ 1** request is actually executing while the other 31 are
  frozen (and not counted in their own latency window). λ ≈ 3.8 req/s ⇒
  W ≈ 1 / 3.8 ≈ **0.26 s**. That low p99 is an *illusion*: it times only the one
  request holding the thread, and hides the ~25 s the other 31 make zero progress.
- **Offload (ON):** all **L = 32** admitted requests run concurrently against the
  16-worker pool. λ ≈ 15 req/s ⇒ W ≈ 32 / 15 ≈ **2.1 s** (matches the measured
  p99). It reflects *genuine* concurrent processing of 32 requests, bounded by
  two things: the **GIL** (the HF processor's Python sections serialize, so they
  do not parallelize across workers) plus **thread-pool queue wait** (32 submitted,
  16 workers → ~half wait for a free worker).

So the p99 rise is an artifact of the microbench saturating *only* the
preprocessing stage 32-deep with nothing downstream to pace it. In the served
path the GPU forward (ViT + prefill + decode) gates how fast requests even reach
preprocessing, so it is never 32-deep like this; what improves end-to-end is the
**freed event loop → lower TTFT and smooth streaming**. Net: throughput and
loop-responsiveness improve, while per-request *served* latency does not regress.
Lower `--workers` trades a little throughput for lower preprocessing latency if a
deployment is preprocessing-bound rather than event-loop-bound.

Reproduce (CPU-only, included in this PR):

```
python benchmark/bench_mm_processor_offload.py --model-path <a Qwen-VL> \
    --num-requests 96 --concurrency 32 --images-per-req 4 --workers 16
```

> The full Qwen3.6 server could not be launched in the dev `sgl` env to get
> end-to-end TTFT (its `clang++` rejects the `-amdgpu-coerce-illegal-types` flag
> SGLang's JIT passes for gfx950, so runtime kernels won't compile — the prod
> `rocm720` image has the matching toolchain). The e2e harness lives in `bench/`
> (`bench_encode.py` + a local image server); run inside the prod image, OFF vs
> `SGLANG_ENABLE_MM_PROCESSOR_OFFLOAD=1 SGLANG_TOKENIZER_SAFETY=pool SGLANG_MM_PROC_WORKERS=16`,
> with 4 imgs/req, ccr 32, isl≈8192, osl=8.

## Related PRs

A multimodal throughput + correctness effort, split into independent PRs (each
reviewable / mergeable on its own):

- #26992 — *[Qwen3-VL] Fix torch.cat device mismatch in image/video feature
  concat under CUDA IPC pool spill* (the crash on pool→CPU spill).
- #26995 — *[SRT] Pool HTTP connections and eagerly decode images for concurrent
  multimodal URL requests* (image-loading path).
- **(this PR)** — *[Multimodal] Offload the sync HF processor off the
  TokenizerManager event loop*, including the CUDA IPC transport synchronization
  fix that the offload's concurrency would otherwise expose as cross-request
  image leakage.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) (isort + ruff `F401,F821` + black pass).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Add unit tests — recommended: a `thread_safe_tokenizer` concurrency test (many threads calling `encode`/`decode`, assert no "Already borrowed"). The cross-process IPC race is not deterministically unit-testable (see Accuracy Tests for the IPC-on vs IPC-off comparison).
- [ ] Update documentation — the three new env vars are described in the table above.
- [ ] Provide accuracy and speed benchmark — offload is opt-in and output-preserving; benchmark numbers to be supplied for the target workload.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26865202818](https://github.com/sgl-project/sglang/actions/runs/26865202818)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26865202652](https://github.com/sgl-project/sglang/actions/runs/26865202652)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->