### PR TITLE
[hicache] Fix UnifiedRadixCache write-back load_back / eviction crashes

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1373,7 +1373,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 self.cache_controller is not None
                 and self.cache_controller.write_policy == "write_back"
             ):
-                self.write_backup(node, write_back=True)
+                written = self.write_backup(node, write_back=True)
+                if written == 0:
+                    return
                 self.writing_check(write_back=True)
                 self._evict_to_host(node, tracker)
                 return
@@ -1579,7 +1581,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             avail = self.token_to_kv_pool_allocator.available_size()
         if avail < kv_tokens:
             needed = kv_tokens - avail
+            host_lock = self.inc_host_lock_ref(best_match_node)
             result = self.evict(EvictParams(num_tokens=needed))
+            self.dec_host_lock_ref(best_match_node, host_lock.to_dec_params())
             if result.num_tokens_evicted < needed:
                 self.dec_lock_ref(best_match_node, ancestor_lock_params)
                 return False

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1581,9 +1581,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             avail = self.token_to_kv_pool_allocator.available_size()
         if avail < kv_tokens:
             needed = kv_tokens - avail
-            host_lock = self.inc_host_lock_ref(best_match_node)
             result = self.evict(EvictParams(num_tokens=needed))
-            self.dec_host_lock_ref(best_match_node, host_lock.to_dec_params())
             if result.num_tokens_evicted < needed:
                 self.dec_lock_ref(best_match_node, ancestor_lock_params)
                 return False

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2336,6 +2336,76 @@ class UnifiedRadixCacheSuite:
             [conv[:, mamba_indices].float().cpu().clone() for conv in mamba_cache.conv],
         )
 
+    def _make_host_leaf(self, tree, allocator, req_to_token_pool, start):
+        seq = self._make_seq(start, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        node = m.last_device_node
+        self.assertIsNot(node, tree.root_node)
+        self._backup_node(tree, node)
+        tree.evict(EvictParams(num_tokens=len(seq)))
+        self.assertTrue(node.evicted and node.backuped)
+        return node
+
+    def test_hicache_load_back_host_lock_protects_node_from_eviction(self):
+        """A host-locked leaf should survive a host-eviction sweep."""
+        if self._skip_unsupported_hicache_test():
+            return
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        self._init_hicache(tree, write_policy="write_back")
+        ct = ComponentType.FULL
+
+        locked = self._make_host_leaf(tree, allocator, req_to_token_pool, start=1)
+        victim = self._make_host_leaf(tree, allocator, req_to_token_pool, start=5000)
+        self.assertIn(locked, tree.evictable_host_leaves)
+        self.assertIn(victim, tree.evictable_host_leaves)
+
+        tree.inc_host_lock_ref(locked)
+        self.assertGreater(locked.component_data[ct].host_lock_ref, 0)
+        self.assertNotIn(locked, tree.evictable_host_leaves)
+
+        # Sweep enough host tokens to want both leaves; the locked one is skipped.
+        tree.evict_host(len(locked.key) + len(victim.key))
+
+        self.assertIsNotNone(locked.component_data[ct].host_value)
+        self.assertTrue(locked.evicted)
+        self.assertIsNone(victim.component_data[ct].host_value)
+
+        tree.dec_host_lock_ref(locked)
+        self.assertEqual(locked.component_data[ct].host_lock_ref, 0)
+        self.assertIn(locked, tree.evictable_host_leaves)
+        tree.sanity_check()
+
+    def test_hicache_evict_device_leaf_aborts_demote_when_backup_fails(self):
+        """when write_backup cannot allocate host pool,
+        _evict_device_leaf should not evict it to host."""
+        if self._skip_unsupported_hicache_test():
+            return
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        self._init_hicache(tree, write_policy="write_back")
+        ct = ComponentType.FULL
+
+        seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        node = m.last_device_node
+        self.assertIsNot(node, tree.root_node)
+        self.assertFalse(node.backuped)
+        self.assertFalse(node.evicted)
+
+        tracker = {c: 0 for c in tree.tree_components}
+        with mock.patch.object(tree, "write_backup", return_value=0):
+            tree._evict_device_leaf(node, tracker)
+
+        self.assertFalse(node.evicted)
+        self.assertIsNotNone(node.component_data[ct].value)
+        self.assertIsNone(node.component_data[ct].host_value)
+
+        with self.assertRaises(AssertionError):
+            tree._evict_to_host(node, {c: 0 for c in tree.tree_components})
+
+        tree.sanity_check()
+
     def test_hicache_node_states(self):
         """Verify device-only to device+host transition after real backup."""
         if self._skip_unsupported_hicache_test():

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2336,46 +2336,6 @@ class UnifiedRadixCacheSuite:
             [conv[:, mamba_indices].float().cpu().clone() for conv in mamba_cache.conv],
         )
 
-    def _make_host_leaf(self, tree, allocator, req_to_token_pool, start):
-        seq = self._make_seq(start, 2)
-        self._insert(tree, allocator, req_to_token_pool, seq)
-        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
-        node = m.last_device_node
-        self.assertIsNot(node, tree.root_node)
-        self._backup_node(tree, node)
-        tree.evict(EvictParams(num_tokens=len(seq)))
-        self.assertTrue(node.evicted and node.backuped)
-        return node
-
-    def test_hicache_load_back_host_lock_protects_node_from_eviction(self):
-        """A host-locked leaf should survive a host-eviction sweep."""
-        if self._skip_unsupported_hicache_test():
-            return
-        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
-        self._init_hicache(tree, write_policy="write_back")
-        ct = ComponentType.FULL
-
-        locked = self._make_host_leaf(tree, allocator, req_to_token_pool, start=1)
-        victim = self._make_host_leaf(tree, allocator, req_to_token_pool, start=5000)
-        self.assertIn(locked, tree.evictable_host_leaves)
-        self.assertIn(victim, tree.evictable_host_leaves)
-
-        tree.inc_host_lock_ref(locked)
-        self.assertGreater(locked.component_data[ct].host_lock_ref, 0)
-        self.assertNotIn(locked, tree.evictable_host_leaves)
-
-        # Sweep enough host tokens to want both leaves; the locked one is skipped.
-        tree.evict_host(len(locked.key) + len(victim.key))
-
-        self.assertIsNotNone(locked.component_data[ct].host_value)
-        self.assertTrue(locked.evicted)
-        self.assertIsNone(victim.component_data[ct].host_value)
-
-        tree.dec_host_lock_ref(locked)
-        self.assertEqual(locked.component_data[ct].host_lock_ref, 0)
-        self.assertIn(locked, tree.evictable_host_leaves)
-        tree.sanity_check()
-
     def test_hicache_evict_device_leaf_aborts_demote_when_backup_fails(self):
         """when write_backup cannot allocate host pool,
         _evict_device_leaf should not evict it to host."""


### PR DESCRIPTION
## Summary
Fixes two write-back HiCache crashes in `UnifiedRadixCache`.

## 1. `_evict_device_leaf` triggers host eviction even if `write_backup` fails with host page allocation.
The current logic of `_evict_device_leaf` is:
```python
# unified_radix_cache.py
        if not node.backuped:
            if (
                self.cache_controller is not None
                and self.cache_controller.write_policy == "write_back"
            ):
                self.write_backup(node, write_back=True)
                self.writing_check(write_back=True)
                self._evict_to_host(node, tracker)
                return
```
where `self.write_backup` may fails due to host allocation fails, e.g., if most host pages are locked and host page allocation fails at `host_indices = self.cache_controller.write(...)`. `self.write_backup` returns 0. In this case, we cannot treat the node as backed up and cannot do `self._evict_to_host(...)`. In `hiradix_cache.py`:
```python
# hiradix_cache.py
def evict(self, params: EvictParams):
       ...
       if not x.backuped:
                if self.cache_controller.write_policy == "write_back":
                    # write to host if the node is not backuped
                    written = self.write_backup(x, write_back=True)
                    num_evicted += written
                    if written > 0:
                        write_back_nodes.append(x)
      ...

        if self.cache_controller.write_policy == "write_back":
            self.writing_check(write_back=True)
            for node in write_back_nodes:
                assert node.backuped
                self._evict_backuped(node)
```
For the nodes that fails backup, they will not be evicted. To match this logic, we can do:
```python
            if (
                self.cache_controller is not None
                and self.cache_controller.write_policy == "write_back"
            ):
                written = self.write_backup(node, write_back=True)
                if written == 0:
                    return
                self.writing_check(write_back=True)
                self._evict_to_host(node, tracker)
                return
```
Or alternatively, we can just drop the device node without backing it up.

Without the fix, we will trigger:
```
assert node.backuped                                  # _evict_to_host
```

## 2. `load_back` does not lock the host value of the nodes to load back, causing device eviction's `write_backup` evicting the host values.

In `load_back`, if there is not enough device KV pages, a device eviction will trigger to release enough pages.
```python
        if avail < kv_tokens:
            needed = kv_tokens - avail
            result = self.evict(EvictParams(num_tokens=needed))
            if result.num_tokens_evicted < needed:
                self.dec_lock_ref(best_match_node, ancestor_lock_params)
                return False
```
However, during the evict, evicted device nodes will trigger `self.write_backup`, potentially causing host eviction. The nodes to be loaded back's host values must be protected. `hiradix_cache.py` does not have this problem because 
```
# hiradix_cache.py
    def load_back(
        self, node: TreeNode, mem_quota: Optional[int] = None
    ) -> Optional[torch.Tensor]:

        # protect the ancestor nodes from eviction
        result = self.inc_lock_ref(ancester_node)
        delta = result.delta

    def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
        if self.disable:
            return IncLockRefResult(delta=0)

        delta = 0
        while node != self.root_node:
            if node.lock_ref == 0:
                self.evictable_size_ -= len(node.key)
                self.protected_size_ += len(node.key)
                delta -= len(node.key)
            node.lock_ref += 1
            self._update_leaf_status(node)
            self._update_host_leaf_status(node)
            node = node.parent
        return IncLockRefResult(delta=delta)
```

`inc_lock_ref` protects the nodes whether it has device values or not (whether it's in device or host). In the unified radix cache, since there is SWA, `acquire_component_lock` adds an mechanism to skip nodes without device values, and it is also applied on full_component:
```python
# unified_cache_components/full_component.py
    def acquire_component_lock(
        self,
        node: UnifiedTreeNode,
        result: IncLockRefResult,
        lock_host: bool = False,
    ) -> IncLockRefResult:

        # Skip the bottom evicted segment
        while cur is not root and cur.component_data[ct].value is None:
            result.skip_lock_node_ids.setdefault(ct, set()).add(cur.id)
            cur = cur.parent
```
Hence, I think we need to lock the host values of the load back nodes, preventing them from eviction. This would happens when, e.g., we have 2 long requests. One request is fresh in GPU, while the other in host. Once the host side request is hit again, during its load back the device side request is evicted, `write_backup` triggered, and host pages need to be freed to accommodate it. 

We can directly use `inc_host_lock_ref` and `dec_host_lock_ref` for this.

Without the fix, we will trigger:
```
                assert cd.host_value is not None    # build_hicache_transfers in full_component.py
```

## Tests
Adds two unit tests in
`test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py`
(run across the FULL / FULL+SWA / FULL+Mamba configs):
- a host-locked leaf survives a host-eviction sweep that frees an unlocked one,
  and the lock is correctly released;
- `_evict_device_leaf` leaves the node on device when `write_backup` returns 0
  (with a negative control asserting `_evict_to_host` would otherwise raise).

## Original commits
- `032756d33`
- `e7147dd8e`























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27252243793](https://github.com/sgl-project/sglang/actions/runs/27252243793)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27252243636](https://github.com/sgl-project/sglang/actions/runs/27252243636)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->