### PR TITLE
[AMD] Minimax M25 : FP8 block-scale GEMM dispatch for ROCm 7.0 on gfx950

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -87,6 +87,7 @@ def use_aiter_triton_gemm_w8a8_tuned_gfx950(n: int, k: int) -> bool:
 
 if _use_aiter:
     import aiter
+    from aiter import gemm_a8w8_blockscale as ck_gemm_a8w8_blockscale
     from aiter import (
         gemm_a8w8_blockscale_bpreshuffle,
         gemm_a8w8_bpreshuffle,
@@ -773,6 +774,8 @@ def aiter_w8a8_block_fp8_linear(
 
     if _use_aiter_bpreshuffle_gfx95:
         use_triton = use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k)
+    elif _use_aiter_gfx95:
+        use_triton = use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k)
     else:
         use_triton = True
 
@@ -780,20 +783,21 @@ def aiter_w8a8_block_fp8_linear(
     if input_scale is not None:
         q_input = input_2d
         x_scale = input_scale
-        if not use_triton:
+        if _use_aiter_bpreshuffle_gfx95 and not use_triton:
             x_scale = x_scale.transpose(-1, -2).contiguous().view(*x_scale.shape)
     else:
         q_input, x_scale = aiter_per1x128_quant(
             input_2d,
             quant_dtype=aiter.dtypes.fp8,
-            transpose_scale=not use_triton,
+            transpose_scale=(_use_aiter_bpreshuffle_gfx95 and not use_triton),
         )
 
     if use_triton:
         gemm_a8w8_blockscale_op = triton_gemm_a8w8_blockscale
-    else:
-        # TODO(1am9trash), to deal with chance of this branch changes
+    elif _use_aiter_bpreshuffle_gfx95:
         gemm_a8w8_blockscale_op = gemm_a8w8_blockscale_bpreshuffle
+    else:
+        gemm_a8w8_blockscale_op = ck_gemm_a8w8_blockscale
 
     output = gemm_a8w8_blockscale_op(
         q_input,


### PR DESCRIPTION
## Summary
On ROCm 7.0 with gfx950 (MI355X), the current code forces all non-tuned FP8 block-scale GEMM shapes to use the Triton kernel. 
This PR adds a fallback to the CK (`gemm_a8w8_blockscale`) kernel for non-tuned shapes, which is significantly faster than the generic Triton path for MoE models with many diverse GEMM dimensions (e.g., MiniMax-M2.5).
The `gemm_a8w8_blockscale_bpreshuffle` kernel remains guarded behind `get_hip_version() >= (7, 2, 0)` due to the known hipcc miscompilation issue (PR 23319). 
The CK kernel does not require scale transposition, so `transpose_scale` is only applied for the bpreshuffle path.

### Dispatch logic after this PR:
- **Tuned shapes** → Triton (all ROCm versions)
- **Non-tuned, ROCm ≥ 7.2** → `gemm_a8w8_blockscale_bpreshuffle`
- **Non-tuned, ROCm 7.0 on gfx950** → `ck_gemm_a8w8_blockscale` 
- **Non-gfx950** → Triton (unchanged)
## Performance
Benchmarked on MI355X (gfx950), MiniMax-M2.5, TP=4, FP8, ISL=8192/OSL=1024:
+8% ~ 16% throughput across all concurrency levels vs the regressed state.
GSM8K accuracy verified: 94.1% (unchanged from baseline).

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26869039980](https://github.com/sgl-project/sglang/actions/runs/26869039980)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26869039799](https://github.com/sgl-project/sglang/actions/runs/26869039799)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->