### PR TITLE
Revert "Fix hybrid linear attention misrouting plain-RadixAttention linear layers to the full backend (Ring-2.5-1T)"

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -782,17 +782,22 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.req_to_token_pool = full_attn_backend.req_to_token_pool
 
     def _is_full_attn(
-        self,
-        layer: Optional[Union[RadixAttention, RadixLinearAttention]],
-        layer_id: Optional[int] = None,
+        self, layer: Optional[RadixAttention], layer_id: Optional[int] = None
     ) -> bool:
-        # RadixLinearAttention is unambiguously a linear-attention layer.
-        # Everything else (including plain RadixAttention) must be classified by
-        # layer id: models like Bailing/Ring use a plain RadixAttention for their
-        # linear layers, so an `isinstance(layer, RadixAttention) -> full` shortcut
-        # would misroute those linear layers to the full-attention backend.
+        # Explicit linear-attention subclass → strong linear signal (KDA, GDN,
+        # Qwen3-Next, Qwen3.5 main linear layers).
         if isinstance(layer, RadixLinearAttention):
             return False
+        # Some hybrid models (Ling-2.5/2.6) wrap their linear layers in plain
+        # `RadixAttention` rather than `RadixLinearAttention`. Those wrappers
+        # set `_is_linear_attention=True` on the attn module so we can
+        # distinguish them from full-attention RadixAttention instances —
+        # including MTP/NEXTN draft layers, which are full and must default to
+        # the full-attn path.
+        if layer is not None and getattr(layer, "_is_linear_attention", False):
+            return False
+        if isinstance(layer, RadixAttention):
+            return True
 
         if layer is not None:
             layer_id = layer.layer_id

--- a/python/sglang/srt/models/bailing_moe_linear.py
+++ b/python/sglang/srt/models/bailing_moe_linear.py
@@ -508,6 +508,12 @@ class BailingMoELinearAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
         )
+        # Marker for HybridLinearAttnBackend._is_full_attn: Bailing wraps
+        # linear-attention layers in a plain RadixAttention, so the
+        # dispatcher can't tell from the type alone that this is a linear
+        # layer (would otherwise default to the full-attn backend, e.g. the
+        # same way MTP/NEXTN draft layers are routed).
+        self.attn._is_linear_attention = True
 
         self.group_norm_size = getattr(config, "group_norm_size", 1)
         self.rms_norm_eps = float(getattr(config, "rms_norm_eps", 1e-5))

--- a/test/registered/8-gpu-models/test_ling_2_6_flash.py
+++ b/test/registered/8-gpu-models/test_ling_2_6_flash.py
@@ -1,18 +1,16 @@
 """GSM8K accuracy test for Ling-2.6-flash (BailingMoELinearForCausalLM).
-
 Guards the hybrid linear / full attention dispatcher: Ling-2.5/2.6
 has 32 layers with `layer_group_size=8`, so layers {7, 15, 23, 31}
 are full attention (MLA) and the rest are linear (Lightning seg_la).
-Runs on the 8-GPU H200 runner with TP=4.
+Runs nightly on the 8-GPU H200 runner with TP=4.
 """
 
 import unittest
-
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_cuda_ci(est_time=600, stage="base-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=600, suite="nightly-8-gpu-common", nightly=True)
 
 
 class TestLing26Flash(GSM8KMixin, DefaultServerBase):

--- a/test/registered/8-gpu-models/test_ling_2_6_flash.py
+++ b/test/registered/8-gpu-models/test_ling_2_6_flash.py
@@ -1,15 +1,19 @@
 """GSM8K accuracy test for Ling-2.6-flash (BailingMoELinearForCausalLM).
+
 Guards the hybrid linear / full attention dispatcher: Ling-2.5/2.6
 has 32 layers with `layer_group_size=8`, so layers {7, 15, 23, 31}
 are full attention (MLA) and the rest are linear (Lightning seg_la).
 Runs nightly on the 8-GPU H200 runner with TP=4.
 """
+
 import unittest
+
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
 register_cuda_ci(est_time=600, suite="nightly-8-gpu-common", nightly=True)
+
 
 class TestLing26Flash(GSM8KMixin, DefaultServerBase):
     model = "inclusionAI/Ling-2.6-flash"

--- a/test/registered/8-gpu-models/test_ling_2_6_flash.py
+++ b/test/registered/8-gpu-models/test_ling_2_6_flash.py
@@ -3,7 +3,7 @@
 Guards the hybrid linear / full attention dispatcher: Ling-2.5/2.6
 has 32 layers with `layer_group_size=8`, so layers {7, 15, 23, 31}
 are full attention (MLA) and the rest are linear (Lightning seg_la).
-Runs nightly on the 8-GPU H200 runner with TP=4.
+Runs on the 8-GPU H200 runner with TP=4.
 """
 
 import unittest
@@ -12,7 +12,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_cuda_ci(est_time=600, suite="nightly-8-gpu-common", nightly=True)
+register_cuda_ci(est_time=600, stage="base-c", runner_config="8-gpu-h200")
 
 
 class TestLing26Flash(GSM8KMixin, DefaultServerBase):

--- a/test/registered/8-gpu-models/test_ling_2_6_flash.py
+++ b/test/registered/8-gpu-models/test_ling_2_6_flash.py
@@ -4,14 +4,12 @@ has 32 layers with `layer_group_size=8`, so layers {7, 15, 23, 31}
 are full attention (MLA) and the rest are linear (Lightning seg_la).
 Runs nightly on the 8-GPU H200 runner with TP=4.
 """
-
 import unittest
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
 register_cuda_ci(est_time=600, suite="nightly-8-gpu-common", nightly=True)
-
 
 class TestLing26Flash(GSM8KMixin, DefaultServerBase):
     model = "inclusionAI/Ling-2.6-flash"


### PR DESCRIPTION
Reverts sgl-project/sglang#26623









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26867702273](https://github.com/sgl-project/sglang/actions/runs/26867702273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26867702139](https://github.com/sgl-project/sglang/actions/runs/26867702139)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->