### PR TITLE
[test] add pure-PyTorch RoPE reference for jit kernel cross-check

### DIFF
--- a/test/registered/kernels/ops/attention/test_rope.py
+++ b/test/registered/kernels/ops/attention/test_rope.py
@@ -296,6 +296,38 @@ def test_rope_store_mixed_q_dtype(is_neox: bool) -> None:
 
 
 @pytest.mark.parametrize("batch_size", BS_LIST)
+@pytest.mark.parametrize("rope_dim", ROPE_DIM_LIST)
+@pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
+@pytest.mark.parametrize("dtype", DTYPE_LIST)
+def test_rope_torch_reference(
+    batch_size: int,
+    rope_dim: int,
+    is_neox: bool,
+    dtype: torch.dtype,
+) -> None:
+    """Cross-check sglang_jit_rope against a pure-PyTorch reference."""
+    num_qo_heads, num_kv_heads = 8, 2
+    q = torch.randn(batch_size, num_qo_heads, rope_dim, device=DEVICE, dtype=dtype)
+    k = torch.randn(batch_size, num_kv_heads, rope_dim, device=DEVICE, dtype=dtype)
+    positions = torch.randint(
+        0, MAX_SEQ_LEN, (batch_size,), device=DEVICE, dtype=torch.int64
+    )
+    cos_sin_cache = create_cos_sin_cache(rope_dim)
+
+    q_torch, k_torch = q.clone(), k.clone()
+    q_jit, k_jit = q.clone(), k.clone()
+
+    torch_impl_rope(q_torch, k_torch, cos_sin_cache, positions, is_neox)
+    sglang_jit_rope(q_jit, k_jit, cos_sin_cache, positions, is_neox)
+
+    # torch_impl_rope mirrors the kernel's fp32 internal precision. fp16 is
+    # accurate to ~5e-4; bf16 hits 1 ULP (~8e-3) on fp32->dtype cast edges.
+    atol = rtol = 1e-3 if dtype == torch.float16 else 1e-2
+    triton.testing.assert_close(q_torch, q_jit, atol=atol, rtol=rtol)
+    triton.testing.assert_close(k_torch, k_jit, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("batch_size", BS_LIST)
 @pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
 @pytest.mark.parametrize("rope_dim", PARTIAL_ROPE_DIM_LIST)
 @pytest.mark.parametrize("head_dim", HEAD_DIM_LIST)


### PR DESCRIPTION
## Motivation

Fills the `torch_impl_rope` stub left as a TODO in `test_rope.py:88` by #18844.

> implement a pure-PyTorch reference for extra coverage

## Modifications

- Implement `torch_impl_rope` with fp32 intermediate.
- Add `test_rope_torch_reference` cross-checking `sglang_jit_rope` against it.

Note: Used separate `mul + sub` rather than `torch.addcmul` / `torch.compile`. The latter lets inductor fuse to a single fp32 fma and become bit-identical to the kernel, but that defeats the purpose of an independent oracle for catching future numerical regressions.

## Accuracy Tests

All cases pass locally on H200 with torch 2.11.0+cu128.

## Benchmarking and Profiling

N/A — test-only change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30372636552](https://github.com/sgl-project/sglang/actions/runs/30372636552)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30372635271](https://github.com/sgl-project/sglang/actions/runs/30372635271)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->