### PR TITLE
Fix hybrid linear attention dispatch by layer id with draft-worker awareness

### DIFF
--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -314,7 +314,11 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                     "If this is a custom hybrid model, use register_linear_attn_model() "
                     "from sglang.srt.configs.linear_attn_model_registry."
                 )
-        full_attn_layers = cfg.full_attention_layer_ids
+        if runner.is_draft_worker:
+            # FIXME: we assume that MTP/NEXTN always use full-attention.
+            full_attn_layers = [0]
+        else:
+            full_attn_layers = cfg.full_attention_layer_ids
         return HybridLinearAttnBackend(
             full_attn_backend, linear_attn_backend, full_attn_layers
         )

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -16,7 +16,6 @@ from sglang.srt.layers.attention.mamba.mamba_state_scatter_triton import (
     fused_mamba_state_scatter_with_mask,
 )
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -784,21 +783,6 @@ class HybridLinearAttnBackend(AttentionBackend):
     def _is_full_attn(
         self, layer: Optional[RadixAttention], layer_id: Optional[int] = None
     ) -> bool:
-        # Explicit linear-attention subclass → strong linear signal (KDA, GDN,
-        # Qwen3-Next, Qwen3.5 main linear layers).
-        if isinstance(layer, RadixLinearAttention):
-            return False
-        # Some hybrid models (Ling-2.5/2.6) wrap their linear layers in plain
-        # `RadixAttention` rather than `RadixLinearAttention`. Those wrappers
-        # set `_is_linear_attention=True` on the attn module so we can
-        # distinguish them from full-attention RadixAttention instances —
-        # including MTP/NEXTN draft layers, which are full and must default to
-        # the full-attn path.
-        if layer is not None and getattr(layer, "_is_linear_attention", False):
-            return False
-        if isinstance(layer, RadixAttention):
-            return True
-
         if layer is not None:
             layer_id = layer.layer_id
         assert layer_id is not None, "either layer or layer_id must be provided"

--- a/python/sglang/srt/models/bailing_moe_linear.py
+++ b/python/sglang/srt/models/bailing_moe_linear.py
@@ -508,12 +508,6 @@ class BailingMoELinearAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
         )
-        # Marker for HybridLinearAttnBackend._is_full_attn: Bailing wraps
-        # linear-attention layers in a plain RadixAttention, so the
-        # dispatcher can't tell from the type alone that this is a linear
-        # layer (would otherwise default to the full-attn backend, e.g. the
-        # same way MTP/NEXTN draft layers are routed).
-        self.attn._is_linear_attention = True
 
         self.group_norm_size = getattr(config, "group_norm_size", 1)
         self.rms_norm_eps = float(getattr(config, "rms_norm_eps", 1e-5))


### PR DESCRIPTION
## Motivation

`HybridLinearAttnBackend._is_full_attn` dispatched by the layer's runtime type: `RadixLinearAttention` → linear, plain `RadixAttention` → full. This misroutes hybrid models whose linear layers wrap a plain `RadixAttention` (Bailing/Ring, see #26623), which was patched with an `_is_linear_attention` marker attribute — a workaround rather than a fix (see the revert in #27116).

This PR replaces the type/marker-based dispatch with a pure layer-id check against `full_attention_layer_ids`.

Layer-id dispatch alone, however, breaks speculative decoding: MTP/NEXTN draft models (Qwen3-Next MTP, Qwen3.5 MTP, Bailing NEXTN) run a single full-attention layer with `layer_id=0`, while the draft runner's `cfg.full_attention_layer_ids` still describes the **target** model's layout (e.g. `[3, 7, ...]` for Qwen3-Next). The draft's full-attention layer would therefore be misrouted to the linear backend.

## Modifications

- `hybrid_linear_attn_backend.py`: `_is_full_attn` now dispatches purely by layer id; drop the `RadixLinearAttention` isinstance shortcut and the `_is_linear_attention` marker check.
- `bailing_moe_linear.py`: remove the `_is_linear_attention` marker (linear layers route correctly via layer id).
- `attention_registry.py`: in `attn_backend_wrapper`, pass `full_attn_layers=[0]` for draft workers, matching the draft-worker KV pool construction in `model_runner_kv_cache_mixin.py` (`full_attention_layer_ids=[0]`), so dispatch and KV storage agree. Annotated with `FIXME: we assume that MTP/NEXTN always use full-attention.`

NemotronH MTP (`"*E"` patterns) is unaffected: its draft worker bypasses `HybridLinearAttnBackend` entirely (`mamba2_config` returns `None`).

## Accuracy Tests

Routing-only change: every layer reaches the same backend as before for all supported models (hybrid targets via layer id, MTP/NEXTN draft layers via the draft-worker `[0]` layout), so model outputs are unchanged.

## Speed Tests and Profiling

No performance impact: the dispatch check is a list membership test on a few-element list, executed once per layer per forward.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26873119755](https://github.com/sgl-project/sglang/actions/runs/26873119755)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26873119380](https://github.com/sgl-project/sglang/actions/runs/26873119380)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->