### PR TITLE
Fix misleading assert message for enable_mixed_chunk + speculative decoding

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7321,7 +7321,7 @@ class ServerArgs:
         if self.speculative_algorithm is not None:
             assert (
                 not self.enable_mixed_chunk
-            ), "enable_mixed_chunk is required for speculative decoding"
+            ), "enable_mixed_chunk is not supported with speculative decoding"
 
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The assertion message for `enable_mixed_chunk` under speculative decoding contradicts the actual condition.

In `python/sglang/srt/server_args.py` (around L7320–7324):

```python
if self.speculative_algorithm is not None:
    assert (
        not self.enable_mixed_chunk
    ), "enable_mixed_chunk is required for speculative decoding"
```

The condition not self.enable_mixed_chunk requires enable_mixed_chunk to be disabled when speculative decoding is enabled, but the error message says it "is required for speculative decoding", which suggests the opposite. This is misleading for users hitting the assertion.

## Modifications

<!-- Detail the changes made in this pull request. -->

Update the assertion message in python/sglang/srt/server_args.py to correctly reflect the constraint:
Before: "enable_mixed_chunk is required for speculative decoding"
After: "enable_mixed_chunk is not supported with speculative decoding"
No behavior change — message-only fix.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A — this change only affects an error message string and does not touch any model forward / kernel / scheduling logic.


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A — no runtime path is modified.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26871069908](https://github.com/sgl-project/sglang/actions/runs/26871069908)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26871069756](https://github.com/sgl-project/sglang/actions/runs/26871069756)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->