### PR TITLE
fix(router): prioritize worker API key over user Authorization header

### DIFF
--- a/sgl-model-gateway/src/routers/header_utils.rs
+++ b/sgl-model-gateway/src/routers/header_utils.rs
@@ -79,10 +79,7 @@ pub fn apply_request_headers(
     skip_content_headers: bool,
 ) -> reqwest::RequestBuilder {
     // Always forward Authorization header first if present
-    if let Some(auth) = headers
-        .get("authorization")
-        .or_else(|| headers.get("Authorization"))
-    {
+    if let Some(auth) = headers.get("authorization") {
         request_builder = request_builder.header("Authorization", auth.clone());
     }
 
@@ -176,31 +173,23 @@ pub fn apply_provider_headers(
     req
 }
 
-/// Extract auth header with passthrough semantics.
+/// Extract auth header for upstream worker requests.
 ///
-/// Passthrough mode: User's Authorization header takes priority.
-/// Fallback: Worker's API key is used only if user didn't provide auth.
-///
-/// This enables use cases where:
-/// 1. Users send their own API keys (multi-tenant, BYOK)
-/// 2. Router has a default key for users who don't provide one
+/// Worker-key-first: If the worker has its own API key, always use it.
+/// The user's Authorization header authenticates to the gateway, not to
+/// the upstream backend. Only forward user auth when no worker key is
+/// configured (passthrough / BYOK mode).
 pub fn extract_auth_header(
     headers: Option<&HeaderMap>,
     worker_api_key: &Option<String>,
 ) -> Option<HeaderValue> {
-    // Passthrough: Try user's auth header first
-    let user_auth = headers.and_then(|h| {
-        h.get("authorization")
-            .or_else(|| h.get("Authorization"))
-            .cloned()
-    });
+    // Worker has its own credential for the upstream service — use it.
+    if let Some(key) = worker_api_key.as_ref() {
+        return HeaderValue::from_str(&format!("Bearer {}", key)).ok();
+    }
 
-    // Return user's auth if provided, otherwise use worker's API key
-    user_auth.or_else(|| {
-        worker_api_key
-            .as_ref()
-            .and_then(|k| HeaderValue::from_str(&format!("Bearer {}", k)).ok())
-    })
+    // No worker key: passthrough user's auth header (BYOK / multi-tenant)
+    headers.and_then(|h| h.get("authorization").cloned())
 }
 
 #[inline]

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -3,7 +3,10 @@ use std::{sync::Arc, time::Instant};
 use axum::{
     body::{to_bytes, Body},
     extract::Request,
-    http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, Method, StatusCode},
+    http::{
+        header::{AUTHORIZATION, CONTENT_TYPE},
+        HeaderMap, HeaderValue, Method, StatusCode,
+    },
     response::{IntoResponse, Response},
     Json,
 };
@@ -79,13 +82,13 @@ impl Router {
         })
     }
 
-    fn select_first_worker(&self) -> Result<String, String> {
+    fn select_first_worker(&self) -> Result<Arc<dyn Worker>, String> {
         let workers = self.worker_registry.get_all();
         let healthy_workers: Vec<_> = workers.iter().filter(|w| w.is_healthy()).collect();
         if healthy_workers.is_empty() {
             Err("No workers are available".to_string())
         } else {
-            Ok(healthy_workers[0].url().to_string())
+            Ok(Arc::clone(healthy_workers[0]))
         }
     }
 
@@ -93,10 +96,22 @@ impl Router {
         let headers = header_utils::copy_request_headers(&req);
 
         match self.select_first_worker() {
-            Ok(worker_url) => {
+            Ok(worker) => {
+                let worker_url = worker.url();
+                let api_key = worker.api_key().clone();
+                let has_worker_api_key = api_key.is_some();
+
                 let mut request_builder = self.client.get(format!("{}/{}", worker_url, endpoint));
+
+                if let Some(key) = api_key {
+                    request_builder = request_builder.bearer_auth(&key);
+                }
+
                 for (name, value) in headers {
                     if header_utils::should_forward_request_header(&name) {
+                        if has_worker_api_key && name == AUTHORIZATION.as_str() {
+                            continue;
+                        }
                         request_builder = request_builder.header(name, value);
                     }
                 }
@@ -380,6 +395,7 @@ impl Router {
                 let headers = filtered_headers.clone();
 
                 let api_key = worker.api_key().clone();
+                let has_worker_api_key = api_key.is_some();
 
                 async move {
                     let mut request_builder = match method {
@@ -394,13 +410,13 @@ impl Router {
                     };
 
                     if let Some(key) = api_key {
-                        let mut auth_header = String::with_capacity(7 + key.len());
-                        auth_header.push_str("Bearer ");
-                        auth_header.push_str(&key);
-                        request_builder = request_builder.header("Authorization", auth_header);
+                        request_builder = request_builder.bearer_auth(&key);
                     }
 
                     for (name, value) in headers {
+                        if has_worker_api_key && name == AUTHORIZATION.as_str() {
+                            continue;
+                        }
                         request_builder = request_builder.header(name.clone(), value.clone());
                     }
 
@@ -495,6 +511,7 @@ impl Router {
     ) -> Response {
         let worker_url = worker.url();
         let api_key = worker.api_key().clone();
+        let has_worker_api_key = api_key.is_some();
 
         // Static key string to avoid per-request allocations
         const DP_RANK_KEY: &str = "data_parallel_rank";
@@ -544,20 +561,19 @@ impl Router {
         } else {
             self.client
                 .post(format!("{}{}", worker_url, route))
-                .json(typed_req) // Use json() directly with typed request
+                .json(typed_req)
         };
 
         if let Some(key) = api_key {
-            // Pre-allocate string with capacity to avoid reallocation
-            let mut auth_header = String::with_capacity(7 + key.len());
-            auth_header.push_str("Bearer ");
-            auth_header.push_str(&key);
-            request_builder = request_builder.header("Authorization", auth_header);
+            request_builder = request_builder.bearer_auth(&key);
         }
 
         if let Some(headers) = headers {
             for (name, value) in headers {
                 if header_utils::should_forward_request_header(name.as_str()) {
+                    if has_worker_api_key && name == AUTHORIZATION {
+                        continue;
+                    }
                     request_builder = request_builder.header(name, value);
                 }
             }
@@ -907,7 +923,8 @@ mod tests {
         let result = router.select_first_worker();
 
         assert!(result.is_ok());
-        let url = result.unwrap();
+        let worker = result.unwrap();
+        let url = worker.url();
         // DashMap doesn't guarantee order, so just check we get one of the workers
         assert!(url == "http://worker1:8080" || url == "http://worker2:8080");
     }
@@ -918,9 +935,7 @@ mod tests {
         let result = router.select_first_worker();
 
         assert!(result.is_ok());
-        let url = result.unwrap();
-
-        let worker = router.worker_registry.get_by_url(&url).unwrap();
+        let worker = result.unwrap();
         assert!(worker.is_healthy());
     }
 }


### PR DESCRIPTION
Summary

  - Fix auth header priority: when a worker has its own API key, the gateway now always uses the worker key for upstream requests, preventing the user's Authorization header from leaking to backends
  - Strip user auth in header forwarding: both send_raw_request and send_typed_request now skip forwarding the Authorization header when the worker has a configured API key
  - Preserve BYOK mode: when no worker key is configured, user auth headers are still passed through for multi-tenant / BYOK use cases

  Before (broken)

  User's Authorization header took priority over worker API key → user gateway credentials leaked to upstream workers that expect the worker's own key.

  After (fixed)
  
  Worker key takes priority. User's Authorization authenticates to the gateway only; it is never forwarded when the worker has its own credential.

  Files changed

  - src/routers/header_utils.rs — extract_auth_header() reordered: worker key first, user header as fallback
  - src/routers/http/router.rs — added has_worker_api_key guard in both send_raw_request and send_typed_request to skip forwarding Authorization header

  Test plan

  - [ ] Existing routing integration tests pass
  - [ ] Manual test: configure worker with API key → verify upstream receives worker key, not user's header
  - [ ] Manual test: no worker API key → verify user's Authorization header passes through









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27949916068](https://github.com/sgl-project/sglang/actions/runs/27949916068)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27949915880](https://github.com/sgl-project/sglang/actions/runs/27949915880)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->