### PR TITLE
fp8 kv cache: treat non-positive k/v_scale as uncalibrated (default 1.0)

### DIFF
--- a/python/sglang/srt/layers/quantization/kv_cache.py
+++ b/python/sglang/srt/layers/quantization/kv_cache.py
@@ -56,7 +56,7 @@ class BaseKVCacheMethod(QuantizeMethodBase):
             if is_fp8_fnuz():
                 k_scale *= 2
                 v_scale *= 2
-        elif layer.k_scale < 0.0 and layer.v_scale < 0.0:
+        elif layer.k_scale <= 0.0 and layer.v_scale <= 0.0:
             # If no scales were loaded (both scales are invalid negative
             # values), use the default value of 1.0
             k_scale = 1.0


### PR DESCRIPTION
## Problem

DeepSeek-V4 FP8 RL training (miles, colocate) crashes on the **first weight sync** with:

```
File ".../sglang/srt/layers/quantization/kv_cache.py", line 64, in process_weights_after_loading
    assert layer.k_scale > 0.0
AssertionError
```

(all ranks → engine SIGQUIT → trainer ConnectionError).

## Root cause

`attn_mqa.k_scale` / `v_scale` are MLA FP8 KV-cache scales. They are **not in the checkpoint** (the V4 model lists them in `skipped_checking_patterns`) and are **not part of the Megatron→SGLang weight stream**. Their only valid value comes from `process_weights_after_loading`: `create_weights` sets the `-1.0` sentinel, and the `k_scale < 0 and v_scale < 0 → default 1.0` branch sets `1.0` at initial load (works — prefill succeeds).

In colocate with `offload_rollout_level=['kv_cache','weight']`, `pause_generation` calls `memory_saver_adapter.pause(GPU_MEMORY_TYPE_WEIGHTS)`. These scale params live in the weights region, so their pages are released and **re-materialized as zero on resume**. The weight update re-fills the real weights but not the scales, so `k_scale == 0.0`. The post-update `post_process_weights(post_process_quantization=True)` then re-runs `process_weights_after_loading`, and `0.0` falls into neither the `> 0` (loaded) nor the `< 0` (unset) branch → the single-`kv_scale` `else` branch → `assert k_scale > 0.0` fails.

## Fix

A KV-cache quantization scale is a divisor and is only ever valid when strictly positive; `0.0` can only mean "uninitialized / clobbered," which is semantically identical to the `-1.0` sentinel. Treat non-positive `k/v_scale` as uncalibrated and fall back to the `1.0` default:

```python
-        elif layer.k_scale < 0.0 and layer.v_scale < 0.0:
+        elif layer.k_scale <= 0.0 and layer.v_scale <= 0.0:
```

This makes `process_weights_after_loading` idempotent across the colocate offload → update → re-quantize cycle and restores the numerically-correct `1.0`. The `else` branch (and its `assert layer.k_scale > 0.0`) is preserved, so a genuinely mixed/single-`kv_scale` checkpoint still fails loudly.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->