### PR TITLE
fix: recapture CUDA graphs for RL online weight updates

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -82,6 +82,7 @@ class SchedulerWeightUpdaterManager:
     metrics_collector: Optional[Any] = None
     offload_tags: set = field(default_factory=set)
     stashed_model_static_state: Any = None
+    cuda_graphs_need_recapture: bool = False
 
     @contextmanager
     def _observe_weight_load(self, source: str) -> Iterator[None]:
@@ -105,6 +106,47 @@ class SchedulerWeightUpdaterManager:
             )
             assert flush_cache_success, "Cache flush failed after updating weights"
 
+    def recapture_cuda_graphs_after_weight_update(self) -> None:
+        # Recapture TP worker CUDA graphs
+        tp_model_runner = self.tp_worker.model_runner
+        if tp_model_runner.graph_runner is not None:
+            logger.info("Recapturing TP worker CUDA graphs after weight update")
+            for graph in tp_model_runner.graph_runner.graphs.values():
+                graph.reset()
+            tp_model_runner.graph_runner.graphs.clear()
+            tp_model_runner.graph_runner.output_buffers.clear()
+            tp_model_runner.graph_runner.capture()
+        if getattr(tp_model_runner, "piecewise_cuda_graph_runner", None) is not None:
+            logger.info(
+                "Recapturing TP worker piecewise CUDA graphs after weight update"
+            )
+            tp_model_runner.init_piecewise_cuda_graphs()
+
+        # Recapture draft worker CUDA graphs if present
+        if self.draft_worker is not None:
+            draft_model_runner = _get_draft_model_runner(self.draft_worker)
+            if draft_model_runner is not None:
+                if draft_model_runner.graph_runner is not None:
+                    logger.info(
+                        "Recapturing draft worker CUDA graphs after weight update"
+                    )
+                    for graph in draft_model_runner.graph_runner.graphs.values():
+                        graph.reset()
+                    draft_model_runner.graph_runner.graphs.clear()
+                    draft_model_runner.graph_runner.output_buffers.clear()
+                    draft_model_runner.graph_runner.capture()
+                if (
+                    getattr(draft_model_runner, "piecewise_cuda_graph_runner", None)
+                    is not None
+                ):
+                    logger.info(
+                        "Recapturing draft worker piecewise CUDA graphs after weight update"
+                    )
+                    draft_model_runner.init_piecewise_cuda_graphs()
+
+    def mark_cuda_graphs_stale(self) -> None:
+        self.cuda_graphs_need_recapture = True
+
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
         """In-place update of the weights from disk."""
         with self._observe_weight_load("disk"):
@@ -114,16 +156,15 @@ class SchedulerWeightUpdaterManager:
                 success, message = self.draft_worker.update_weights_from_disk(recv_req)
             if tp_success:
                 self.flush_cache_after_weight_update(recv_req)
+                self.mark_cuda_graphs_stale()
             if not success:
                 logger.error(message)
-            return UpdateWeightFromDiskReqOutput(
-                success=success, message=message, num_paused_requests=0
-            )
+            return UpdateWeightFromDiskReqOutput(success, message, 0)
 
     def init_weights_update_group(self, recv_req: InitWeightsUpdateGroupReqInput):
         """Initialize the online model parameter update group."""
         success, message = self.tp_worker.init_weights_update_group(recv_req)
-        return InitWeightsUpdateGroupReqOutput(success=success, message=message)
+        return InitWeightsUpdateGroupReqOutput(success, message)
 
     def destroy_weights_update_group(
         self,
@@ -131,7 +172,7 @@ class SchedulerWeightUpdaterManager:
     ):
         """Destroy the online model parameter update group."""
         success, message = self.tp_worker.destroy_weights_update_group(recv_req)
-        return DestroyWeightsUpdateGroupReqOutput(success=success, message=message)
+        return DestroyWeightsUpdateGroupReqOutput(success, message)
 
     def update_weights_from_distributed(
         self,
@@ -142,11 +183,10 @@ class SchedulerWeightUpdaterManager:
             success, message = self.tp_worker.update_weights_from_distributed(recv_req)
             if success:
                 self.flush_cache_after_weight_update(recv_req)
+                self.mark_cuda_graphs_stale()
             else:
                 logger.error(message)
-            return UpdateWeightsFromDistributedReqOutput(
-                success=success, message=message
-            )
+            return UpdateWeightsFromDistributedReqOutput(success, message)
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
         """Update the online model parameter from tensors."""
@@ -158,10 +198,11 @@ class SchedulerWeightUpdaterManager:
             success, message = worker.update_weights_from_tensor(recv_req)
             if success:
                 self.flush_cache_after_weight_update(recv_req)
+                self.mark_cuda_graphs_stale()
             else:
                 logger.error(message)
             torch.distributed.barrier(group=self.tp_cpu_group)
-            return UpdateWeightsFromTensorReqOutput(success=success, message=message)
+            return UpdateWeightsFromTensorReqOutput(success, message)
 
     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
         """Update the online model parameter from IPC for checkpoint-engine integration."""
@@ -172,14 +213,15 @@ class SchedulerWeightUpdaterManager:
                 success, message = self.draft_worker.update_weights_from_ipc(recv_req)
             if tp_success:
                 self.flush_cache_after_weight_update(recv_req)
+                self.mark_cuda_graphs_stale()
             if not success:
                 logger.error(message)
             torch.distributed.barrier(group=self.tp_cpu_group)
-            return UpdateWeightsFromIPCReqOutput(success=success, message=message)
+            return UpdateWeightsFromIPCReqOutput(success, message)
 
     def get_weights_by_name(self, recv_req: GetWeightsByNameReqInput):
         parameter = self.tp_worker.get_weights_by_name(recv_req)
-        return GetWeightsByNameReqOutput(parameter=parameter)
+        return GetWeightsByNameReqOutput(parameter)
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
         assert (
@@ -264,21 +306,20 @@ class SchedulerWeightUpdaterManager:
                     if queue is not None:
                         queue.resume_memory_occupation()
 
+        if self.cuda_graphs_need_recapture:
+            self.recapture_cuda_graphs_after_weight_update()
+            self.cuda_graphs_need_recapture = False
+
         return ResumeMemoryOccupationReqOutput()
 
     def check_weights(self, recv_req: CheckWeightsReqInput):
         try:
-            payload = self.tp_worker.model_runner.check_weights(
-                action=recv_req.action, allow_quant_error=recv_req.allow_quant_error
-            )
+            payload = self.tp_worker.model_runner.check_weights(action=recv_req.action)
 
             if self.draft_worker is not None:
                 draft_runner = _get_draft_model_runner(self.draft_worker)
                 if draft_runner is not None:
-                    draft_payload = draft_runner.check_weights(
-                        action=recv_req.action,
-                        allow_quant_error=recv_req.allow_quant_error,
-                    )
+                    draft_payload = draft_runner.check_weights(action=recv_req.action)
                     if payload is not None and draft_payload is not None:
                         payload = _merge_checksum_payloads(payload, draft_payload)
 


### PR DESCRIPTION
## Motivation

  We discovered this bug on 8×H200 GPUs while using slime (https://github.com/THUDM/slime, an RL training framework built on top of SGLang) in colocate mode to train Qwen3.5-35B-A3B — a hybrid architecture model with Gated DeltaNet (linear attention) + Gated Attention + MoE. Its hidden layout is 10 × (3 × (Gated DeltaNet → MoE) → 1 × (Gated Attention → MoE)).

  **Symptom:** Step 0 rollout is normal. Step 1 rollout (after one round of training and weight sync) produces completely garbled text. No crash or error is raised.

  **Root cause:** During CUDA graph capture, the GPU data_ptr of every tensor accessed in the forward pass is baked into the recorded graph. Model weights are updated via param.data.copy_(), which preserves the original data_ptr — so weight addresses remain valid after updates, and CUDA graphs can correctly access the new weight values.

  However, for hybrid models like Qwen3.5-35B-A3B, the linear attention layers maintain recurrent state buffers (conv_state / ssm_state) — analogous to KV cache in full attention, but accessed by direct data_ptr baked into CUDA graphs. These buffers are allocated under the GPU_MEMORY_TYPE_KV_CACHE tag in torch_memory_saver. When pause(KV_CACHE) is called, these buffers are offloaded to CPU and their GPU memory is freed. When resume(KV_CACHE) restores them, the CUDA caching allocator may assign different GPU addresses — but the CUDA graphs still replay with the old data_ptr, causing the model to read garbage data and write to invalid memory for its recurrent state. Even though the weights are correct, the model has completely lost its token-by-token "memory", producing garbled output.

  In slime's RL training loop:

  1. pause(KV_CACHE) offloads linear attention states to CPU, freeing GPU memory
  2. Training runs for minutes, heavily fragmenting GPU memory
  3. resume(KV_CACHE) restores linear attention states, but they may land at different GPU addresses
  4. CUDA graphs still replay with the old data_ptr values → garbled output

  Step 0 works because the first pause/resume cycle has minimal GPU memory activity between them, so tensors happen to restore to the same addresses. After training, GPU memory is completely reshuffled.

  As a comparison, we also tested Qwen3-30B-A3B (GQA + MoE, no linear attention) and found it works correctly, since it has no linear attention recurrent state buffers whose data_ptr would be baked into CUDA graphs.

  ## Modifications

  Mark CUDA graphs as stale after every successful weight update, then recapture in resume_memory_occupation before returning. Only weight_updater.py is modified.

  - Add mark_cuda_graphs_stale() / recapture_cuda_graphs_after_weight_update().
  - Call mark_cuda_graphs_stale() in all 4 weight update paths: update_weights_from_disk, update_weights_from_distributed, update_weights_from_tensor, update_weights_from_ipc.
  - Trigger recapture in resume_memory_occupation if the flag is set.

  ## Accuracy Tests

  Verified on Qwen3.5-35B-A3B (--cuda-graph-bs 1 2 4 8 16 ... 256) using slime's RL training loop:

  - Without fix: step 0 normal, step 1 garbled output
  - With fix: correct output across all training steps

  ## Speed Tests and Profiling

  ---

  ## Checklist

  ---



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28355926431](https://github.com/sgl-project/sglang/actions/runs/28355926431)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28355926315](https://github.com/sgl-project/sglang/actions/runs/28355926315)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->