### PR TITLE
[Bug][Mamba] Fix tombstone lock_ref race in mamba_radix_cache dec_loc…

### DIFF
--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -45,6 +45,7 @@ from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, HybridReqToToke
 from sglang.srt.mem_cache.radix_cache import (
     RadixKey,
 )
+from sglang.srt.mem_cache.unified_cache_components.tree_component import ComponentType
 from sglang.srt.mem_cache.utils import compute_node_hash_values, split_node_hash_value
 from sglang.srt.observability.metrics_collector import (
     STAT_LOGGER_ROLE_STORAGE,
@@ -1170,11 +1171,18 @@ class HiMambaRadixCache(MambaRadixCache):
             return IncLockRefResult(delta=0)
 
         delta = 0
+        result = IncLockRefResult(delta=delta)
         if node.mamba_value is not None:
             if node.mamba_lock_ref == 0:
                 self.mamba_evictable_size_ -= len(node.mamba_value)
                 self.mamba_protected_size_ += len(node.mamba_value)
             node.mamba_lock_ref += 1
+        else:
+            # Tombstone at acquire time; tell the paired dec to skip the
+            # mamba branch in case load-back revives mamba_value meanwhile.
+            result.skip_lock_node_ids.setdefault(ComponentType.MAMBA, set()).add(
+                node.id
+            )
 
         while node != self.root_node:
             if node.evicted:
@@ -1191,7 +1199,8 @@ class HiMambaRadixCache(MambaRadixCache):
                 self.evictable_full_device_leaves.discard(node)
             node.full_lock_ref += 1
             node = node.parent
-        return IncLockRefResult(delta=delta)
+        result.delta = delta
+        return result
 
     def dec_lock_ref(
         self, node: TreeNode, params: Optional[DecLockRefParams] = None
@@ -1201,7 +1210,14 @@ class HiMambaRadixCache(MambaRadixCache):
 
         delta = 0
 
-        if node.mamba_value is not None and node.mamba_lock_ref > 0:
+        skip_mamba_ids = (
+            params.skip_lock_node_ids.get(ComponentType.MAMBA, ())
+            if params is not None
+            else ()
+        )
+        skip_mamba = node.id in skip_mamba_ids
+
+        if not skip_mamba and node.mamba_value is not None and node.mamba_lock_ref > 0:
             if node.mamba_lock_ref == 1:
                 self.mamba_evictable_size_ += len(node.mamba_value)
                 self.mamba_protected_size_ -= len(node.mamba_value)

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -47,6 +47,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 from sglang.srt.mem_cache.events import KVCacheEventMixin
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache_components.tree_component import ComponentType
 from sglang.srt.mem_cache.utils import split_node_hash_value
 from sglang.srt.server_args import get_global_server_args
 
@@ -840,12 +841,19 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         if self.disable:
             return IncLockRefResult()
 
+        result = IncLockRefResult()
         # protect mamba value in current node if it exists
         if node.mamba_value is not None:
             if node.mamba_lock_ref == 0:
                 self.mamba_evictable_size_ -= len(node.mamba_value)
                 self.mamba_protected_size_ += len(node.mamba_value)
             node.mamba_lock_ref += 1
+        else:
+            # Tombstone at acquire time; tell the paired dec to skip the
+            # mamba branch in case load-back revives mamba_value meanwhile.
+            result.skip_lock_node_ids.setdefault(ComponentType.MAMBA, set()).add(
+                node.id
+            )
 
         while node != self.root_node:
             # lock full from node to root
@@ -857,7 +865,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 self.full_protected_size_ += len(node.value)
             node.full_lock_ref += 1
             node = node.parent
-        return IncLockRefResult()
+        return result
 
     def dec_lock_ref(
         self, node: TreeNode, params: Optional[DecLockRefParams] = None
@@ -870,7 +878,14 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         if self.disable:
             return DecLockRefResult()
 
-        if node.mamba_value is not None:
+        skip_mamba_ids = (
+            params.skip_lock_node_ids.get(ComponentType.MAMBA, ())
+            if params is not None
+            else ()
+        )
+        skip_mamba = node.id in skip_mamba_ids
+
+        if not skip_mamba and node.mamba_value is not None:
             assert (
                 node.mamba_lock_ref > 0
             ), f"dec_lock_ref on node with {node.mamba_lock_ref=}, {node.id=}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix a tombstone race in `MambaRadixCache.dec_lock_ref` / `HiMambaRadixCache.dec_lock_ref` that crashes the scheduler with `AssertionError: evict device leaf: full_lock_ref mismatch`

When `inc_lock_ref` runs on a node whose `mamba_value` is `None` (tombstone), it bumps `full_lock_ref` along the path but does NOT bump `mamba_lock_ref`. If host->device `load_back` revives `mamba_value` before the paired `dec_lock_ref`, dec sees `mamba_value is not None` and goes through the mamba branch even though no inc was made for it.

Fixes #21379

## Modifications

<!-- Detail the changes made in this pull request. -->

- `inc_lock_ref` (both `MambaRadixCache` and `HiMambaRadixCache`):   when the mamba branch is skipped because the node is tombstone, record `node.id` under `ComponentType.MAMBA` in `result.skip_lock_node_ids`, and return that result.
- `dec_lock_ref` (both): read  `params.skip_lock_node_ids[ComponentType.MAMBA]` and bypass the mamba branch when the node was tombstone at inc time, even if `mamba_value` has been revived in between.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26874145420](https://github.com/sgl-project/sglang/actions/runs/26874145420)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26874145097](https://github.com/sgl-project/sglang/actions/runs/26874145097)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->