### PR TITLE
Support Waterfill with dynamic EPLB

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1347,7 +1347,7 @@ def _post_process_topk_ids(
     layer_id: int,
     num_token_non_padded: Optional[torch.Tensor] = None,
     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
-) -> torch.Tensor:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     num_fused_shared_experts = topk_config.num_fused_shared_experts
     fused_shared_experts_scaling_factor = (
         topk_config.fused_shared_experts_scaling_factor
@@ -1357,6 +1357,7 @@ def _post_process_topk_ids(
             layer_id=layer_id,
             topk_indices=topk_ids,
         )
+    recorder_topk_ids = None
     if _is_cuda:
         # When shared experts are fused (appended as extra columns in topk_ids),
         # EPLB dispatch must only remap the routed expert columns.
@@ -1369,10 +1370,17 @@ def _post_process_topk_ids(
                 routed_cols, expert_location_dispatch_info, num_token_non_padded
             )
             topk_ids = torch.cat([routed_cols, shared_cols], dim=-1)
+            # ExpertDistributionRecorder tracks EPLB physical routed experts.
+            # DeepEP dispatch later inserts per-rank shared slots into topk_ids,
+            # so keep the routed physical ids separately for statistics.
+            recorder_topk_ids = routed_cols
         else:
             topk_ids = _biased_grouped_topk_postprocess(
                 topk_ids, expert_location_dispatch_info, num_token_non_padded
             )
+
+    if recorder_topk_ids is None:
+        recorder_topk_ids = topk_ids
 
     if num_fused_shared_experts > 0 and _use_aiter:
         M, N = router_logits.shape
@@ -1411,7 +1419,7 @@ def _post_process_topk_ids(
             topk_config,
         )
 
-    return topk_ids, topk_weights
+    return topk_ids, topk_weights, recorder_topk_ids
 
 
 def select_experts(
@@ -1589,7 +1597,7 @@ def select_experts(
         if k > 0:
             topk_weights = torch.full_like(topk_weights, 1.0 / k)
 
-    topk_ids, topk_weights = _post_process_topk_ids(
+    topk_ids, topk_weights, recorder_topk_ids = _post_process_topk_ids(
         topk_ids=topk_ids,
         topk_weights=topk_weights,
         topk_config=topk_config,
@@ -1599,7 +1607,9 @@ def select_experts(
         expert_location_dispatch_info=expert_location_dispatch_info,
     )
 
-    get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)
+    get_global_expert_distribution_recorder().on_select_experts(
+        topk_ids=recorder_topk_ids
+    )
 
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -390,6 +390,18 @@ def filter_moe_weight_param_global_expert(name, x, num_local_experts):
     )
 
 
+def get_moe_weight_param_eplb_view(
+    name, x, num_local_experts, num_local_physical_experts=None
+):
+    """Return the writable expert-weight view that EPLB may rebalance."""
+    if not filter_moe_weight_param_global_expert(name, x, num_local_experts):
+        return None
+    if num_local_physical_experts is None:
+        return x.data
+    assert 0 < num_local_physical_experts <= num_local_experts
+    return x.data[:num_local_physical_experts]
+
+
 def should_use_flashinfer_cutlass_moe_fp4_allgather():
     """
     Perform FP4 quantize before all-gather for flashinfer cutlass moe to reduce communication cost for high-throughput serving.

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -390,18 +390,6 @@ def filter_moe_weight_param_global_expert(name, x, num_local_experts):
     )
 
 
-def get_moe_weight_param_eplb_view(
-    name, x, num_local_experts, num_local_physical_experts=None
-):
-    """Return the writable expert-weight view that EPLB may rebalance."""
-    if not filter_moe_weight_param_global_expert(name, x, num_local_experts):
-        return None
-    if num_local_physical_experts is None:
-        return x.data
-    assert 0 < num_local_physical_experts <= num_local_experts
-    return x.data[:num_local_physical_experts]
-
-
 def should_use_flashinfer_cutlass_moe_fp4_allgather():
     """
     Perform FP4 quantize before all-gather for flashinfer cutlass moe to reduce communication cost for high-throughput serving.

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -106,7 +106,7 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
 from sglang.srt.layers.moe.topk import TopK, TopKOutputFormat
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
-    get_moe_weight_param_eplb_view,
+    filter_moe_weight_param_global_expert,
     is_deepep_class_backend,
     is_sbo_enabled,
     is_tbo_enabled,
@@ -796,26 +796,19 @@ class DeepseekV2MoE(nn.Module):
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
 
     def get_moe_weights(self):
-        num_local_physical_experts = None
-        if self.num_fused_shared_experts > 0:
-            # EPLB only rebalances physical routed experts. Fused shared expert
-            # slots live after each rank's routed slots; keep them stable while
-            # exposing writable routed-weight views to the updater.
-            num_local_physical_experts = self.experts._num_local_routed
+        # EPLB only rebalances physical routed experts. Fused shared expert
+        # slots live after each rank's routed slots and must stay stable.
+        num_local_experts_for_eplb = (
+            self.experts.num_local_experts - self.num_fused_shared_experts
+        )
 
         return [
-            eplb_view
+            x.data[:num_local_experts_for_eplb]
             for name, x in self.experts.named_parameters()
             if name not in ["correction_bias"]
-            and (
-                eplb_view := get_moe_weight_param_eplb_view(
-                    name,
-                    x,
-                    self.experts.num_local_experts,
-                    num_local_physical_experts,
-                )
+            and filter_moe_weight_param_global_expert(
+                name, x, self.experts.num_local_experts
             )
-            is not None
         ]
 
     def forward(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -106,7 +106,7 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
 from sglang.srt.layers.moe.topk import TopK, TopKOutputFormat
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
-    filter_moe_weight_param_global_expert,
+    get_moe_weight_param_eplb_view,
     is_deepep_class_backend,
     is_sbo_enabled,
     is_tbo_enabled,
@@ -796,13 +796,26 @@ class DeepseekV2MoE(nn.Module):
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
 
     def get_moe_weights(self):
+        num_local_physical_experts = None
+        if self.num_fused_shared_experts > 0:
+            # EPLB only rebalances physical routed experts. Fused shared expert
+            # slots live after each rank's routed slots; keep them stable while
+            # exposing writable routed-weight views to the updater.
+            num_local_physical_experts = self.experts._num_local_routed
+
         return [
-            x.data
+            eplb_view
             for name, x in self.experts.named_parameters()
             if name not in ["correction_bias"]
-            and filter_moe_weight_param_global_expert(
-                name, x, self.experts.num_local_experts
+            and (
+                eplb_view := get_moe_weight_param_eplb_view(
+                    name,
+                    x,
+                    self.experts.num_local_experts,
+                    num_local_physical_experts,
+                )
             )
+            is not None
         ]
 
     def forward(

--- a/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
+++ b/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
@@ -6,10 +6,13 @@ register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 from torch import nn
 
+from sglang.srt.layers.moe import topk as topk_module
+from sglang.srt.layers.moe.topk import TopKConfig
 from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
 from sglang.test.test_utils import CustomTestCase
 
@@ -51,6 +54,47 @@ class TestDeepEPWaterfillEPLB(CustomTestCase):
 
         self.assertEqual(len(weights), 1)
         self.assertEqual(weights[0].shape, (experts.num_local_experts, 2))
+
+    def test_topk_recorder_ids_exclude_deepep_fused_shared_slots(self):
+        topk_ids = torch.tensor([[0, 33, 263, 256]], dtype=torch.int32)
+        topk_weights = torch.ones_like(topk_ids, dtype=torch.float32)
+        topk_config = TopKConfig(
+            top_k=4,
+            num_fused_shared_experts=1,
+            routed_scaling_factor=1.0,
+        )
+        dispatch_info = SimpleNamespace(num_physical_experts=264)
+
+        def fake_eplb_postprocess(
+            ids, expert_location_dispatch_info, num_token_non_padded
+        ):
+            return ids
+
+        with (
+            patch.object(topk_module, "_is_cuda", True),
+            patch.object(topk_module, "_use_aiter", False),
+            patch.object(topk_module, "is_deepep_class_backend", return_value=True),
+            patch.object(
+                topk_module, "get_moe_expert_parallel_world_size", return_value=8
+            ),
+            patch.object(topk_module, "get_moe_expert_parallel_rank", return_value=7),
+            patch.object(
+                topk_module,
+                "_biased_grouped_topk_postprocess",
+                side_effect=fake_eplb_postprocess,
+            ),
+        ):
+            processed_ids, _, recorder_ids = topk_module._post_process_topk_ids(
+                topk_ids=topk_ids.clone(),
+                topk_weights=topk_weights.clone(),
+                topk_config=topk_config,
+                router_logits=torch.empty((1, 256)),
+                layer_id=0,
+                expert_location_dispatch_info=dispatch_info,
+            )
+
+        self.assertTrue(torch.equal(processed_ids, torch.tensor([[0, 34, 270, 271]])))
+        self.assertTrue(torch.equal(recorder_ids, torch.tensor([[0, 33, 263]])))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
+++ b/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
@@ -10,7 +10,6 @@ from types import SimpleNamespace
 import torch
 from torch import nn
 
-from sglang.srt.layers.moe.utils import get_moe_weight_param_eplb_view
 from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
 from sglang.test.test_utils import CustomTestCase
 
@@ -19,7 +18,6 @@ class _FakeExpertParam(nn.Module):
     def __init__(self):
         super().__init__()
         self.num_local_experts = 5
-        self._num_local_routed = 4
         self.weight = nn.Parameter(
             torch.arange(10, dtype=torch.float32).reshape(self.num_local_experts, 2)
         )
@@ -29,45 +27,6 @@ class _FakeExpertParam(nn.Module):
 
 
 class TestDeepEPWaterfillEPLB(CustomTestCase):
-    def test_deepep_waterfill_eplb_view_exposes_only_routed_weights(self):
-        experts = _FakeExpertParam()
-        shared_before = experts.weight.data[-1].clone()
-
-        view = get_moe_weight_param_eplb_view(
-            "weight",
-            experts.weight,
-            experts.num_local_experts,
-            experts._num_local_routed,
-        )
-
-        self.assertEqual(view.shape, (experts._num_local_routed, 2))
-        view[0].copy_(view[1])
-        self.assertTrue(torch.equal(experts.weight.data[0], torch.tensor([2.0, 3.0])))
-        self.assertTrue(torch.equal(experts.weight.data[-1], shared_before))
-
-    def test_default_eplb_view_keeps_existing_weight_shape(self):
-        experts = _FakeExpertParam()
-
-        view = get_moe_weight_param_eplb_view(
-            "weight",
-            experts.weight,
-            experts.num_local_experts,
-        )
-
-        self.assertEqual(view.shape, (experts.num_local_experts, 2))
-
-    def test_eplb_view_skips_global_expert_metadata_param(self):
-        experts = _FakeExpertParam()
-
-        view = get_moe_weight_param_eplb_view(
-            "global_scale",
-            experts.global_scale,
-            experts.num_local_experts,
-            experts._num_local_routed,
-        )
-
-        self.assertIsNone(view)
-
     def test_deepseek_moe_get_moe_weights_excludes_fused_shared_slot(self):
         experts = _FakeExpertParam()
         moe = SimpleNamespace(num_fused_shared_experts=1, experts=experts)
@@ -76,11 +35,22 @@ class TestDeepEPWaterfillEPLB(CustomTestCase):
         weights = DeepseekV2MoE.get_moe_weights(moe)
 
         self.assertEqual(len(weights), 1)
-        self.assertEqual(weights[0].shape, (experts._num_local_routed, 2))
+        self.assertEqual(
+            weights[0].shape,
+            (experts.num_local_experts - moe.num_fused_shared_experts, 2),
+        )
 
         weights[0][-1].zero_()
         self.assertTrue(torch.equal(experts.weight.data[-2], torch.zeros(2)))
         self.assertTrue(torch.equal(experts.weight.data[-1], shared_before))
+
+    def test_deepseek_moe_get_moe_weights_keeps_full_shape_without_fusion(self):
+        experts = _FakeExpertParam()
+        moe = SimpleNamespace(num_fused_shared_experts=0, experts=experts)
+        weights = DeepseekV2MoE.get_moe_weights(moe)
+
+        self.assertEqual(len(weights), 1)
+        self.assertEqual(weights[0].shape, (experts.num_local_experts, 2))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
+++ b/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
@@ -1,0 +1,87 @@
+"""Unit tests for DeepEP Waterfill and EPLB updater compatibility."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from sglang.srt.layers.moe.utils import get_moe_weight_param_eplb_view
+from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
+from sglang.test.test_utils import CustomTestCase
+
+
+class _FakeExpertParam(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_local_experts = 5
+        self._num_local_routed = 4
+        self.weight = nn.Parameter(
+            torch.arange(10, dtype=torch.float32).reshape(self.num_local_experts, 2)
+        )
+        self.correction_bias = nn.Parameter(torch.ones(self.num_local_experts))
+        self.global_scale = nn.Parameter(torch.ones(self.num_local_experts))
+        self.global_scale._sglang_require_global_experts = True
+
+
+class TestDeepEPWaterfillEPLB(CustomTestCase):
+    def test_deepep_waterfill_eplb_view_exposes_only_routed_weights(self):
+        experts = _FakeExpertParam()
+        shared_before = experts.weight.data[-1].clone()
+
+        view = get_moe_weight_param_eplb_view(
+            "weight",
+            experts.weight,
+            experts.num_local_experts,
+            experts._num_local_routed,
+        )
+
+        self.assertEqual(view.shape, (experts._num_local_routed, 2))
+        view[0].copy_(view[1])
+        self.assertTrue(torch.equal(experts.weight.data[0], torch.tensor([2.0, 3.0])))
+        self.assertTrue(torch.equal(experts.weight.data[-1], shared_before))
+
+    def test_default_eplb_view_keeps_existing_weight_shape(self):
+        experts = _FakeExpertParam()
+
+        view = get_moe_weight_param_eplb_view(
+            "weight",
+            experts.weight,
+            experts.num_local_experts,
+        )
+
+        self.assertEqual(view.shape, (experts.num_local_experts, 2))
+
+    def test_eplb_view_skips_global_expert_metadata_param(self):
+        experts = _FakeExpertParam()
+
+        view = get_moe_weight_param_eplb_view(
+            "global_scale",
+            experts.global_scale,
+            experts.num_local_experts,
+            experts._num_local_routed,
+        )
+
+        self.assertIsNone(view)
+
+    def test_deepseek_moe_get_moe_weights_excludes_fused_shared_slot(self):
+        experts = _FakeExpertParam()
+        moe = SimpleNamespace(num_fused_shared_experts=1, experts=experts)
+        shared_before = experts.weight.data[-1].clone()
+
+        weights = DeepseekV2MoE.get_moe_weights(moe)
+
+        self.assertEqual(len(weights), 1)
+        self.assertEqual(weights[0].shape, (experts._num_local_routed, 2))
+
+        weights[0][-1].zero_()
+        self.assertTrue(torch.equal(experts.weight.data[-2], torch.zeros(2)))
+        self.assertTrue(torch.equal(experts.weight.data[-1], shared_before))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
+++ b/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
@@ -96,6 +96,43 @@ class TestDeepEPWaterfillEPLB(CustomTestCase):
         self.assertTrue(torch.equal(processed_ids, torch.tensor([[0, 34, 270, 271]])))
         self.assertTrue(torch.equal(recorder_ids, torch.tensor([[0, 33, 263]])))
 
+    def test_topk_recorder_ids_match_dispatch_ids_for_non_deepep_fusion(self):
+        topk_ids = torch.tensor([[0, 33, 263, 256]], dtype=torch.int32)
+        topk_weights = torch.ones_like(topk_ids, dtype=torch.float32)
+        topk_config = TopKConfig(
+            top_k=4,
+            num_fused_shared_experts=1,
+            routed_scaling_factor=1.0,
+        )
+        dispatch_info = SimpleNamespace(num_physical_experts=264)
+
+        def fake_eplb_postprocess(
+            ids, expert_location_dispatch_info, num_token_non_padded
+        ):
+            return ids + 1
+
+        with (
+            patch.object(topk_module, "_is_cuda", True),
+            patch.object(topk_module, "_use_aiter", False),
+            patch.object(topk_module, "is_deepep_class_backend", return_value=False),
+            patch.object(
+                topk_module,
+                "_biased_grouped_topk_postprocess",
+                side_effect=fake_eplb_postprocess,
+            ),
+        ):
+            processed_ids, _, recorder_ids = topk_module._post_process_topk_ids(
+                topk_ids=topk_ids.clone(),
+                topk_weights=topk_weights.clone(),
+                topk_config=topk_config,
+                router_logits=torch.empty((1, 256)),
+                layer_id=0,
+                expert_location_dispatch_info=dispatch_info,
+            )
+
+        self.assertTrue(torch.equal(processed_ids, torch.tensor([[1, 34, 264, 257]])))
+        self.assertTrue(torch.equal(recorder_ids, processed_ids))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fix fused shared expert MoE weight views used by online EPLB updates.
- Keep EPLB expert distribution stats on logical routed expert ids when shared experts are fused.
- Add focused EPLB unit coverage for fused shared experts, Waterfill, and non-DeepEP recorder ids.

## Tests
- `PYTHONPATH=python python -m pytest -q test/registered/unit/eplb`
- SGLang MMLU64, dynamic EPLB rb32: shared fusion red8 `Score: 0.891`, no NCCL timeout
- SGLang MMLU64, dynamic EPLB rb32: Waterfill red8 `Score: 0.906`, no NCCL timeout
- SGLang MMLU64, dynamic EPLB rb32: disable shared fusion red8 `Score: 0.891`, no NCCL timeout
- SGLang serving perf, dynamic EPLB rb32: shared fusion, Waterfill, and disable shared fusion all completed without timeout











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26878897422](https://github.com/sgl-project/sglang/actions/runs/26878897422)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26878897254](https://github.com/sgl-project/sglang/actions/runs/26878897254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->