### PR TITLE
[diffusion] Avoid FlashAttention forward context lookup

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -7,7 +7,6 @@ import torch
 
 from sglang.jit_kernel.flash_attention import flash_attn_varlen_func
 from sglang.multimodal_gen.runtime.layers.utils import register_custom_op
-from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
 )
@@ -381,7 +380,6 @@ class FlashAttentionImpl(AttentionImpl):
         *,
         return_softmax_lse: bool = False,
     ):
-        attn_metadata: FlashAttentionMetadata = get_forward_context().attn_metadata
         if attn_metadata is not None and attn_metadata.max_seqlen_q is None:
             attn_metadata.max_seqlen_q = query.shape[1]
             attn_metadata.max_seqlen_k = key.shape[1]

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -380,9 +380,11 @@ class FlashAttentionImpl(AttentionImpl):
         *,
         return_softmax_lse: bool = False,
     ):
-        if attn_metadata is not None and attn_metadata.max_seqlen_q is None:
-            attn_metadata.max_seqlen_q = query.shape[1]
-            attn_metadata.max_seqlen_k = key.shape[1]
+        if attn_metadata is not None:
+            if attn_metadata.max_seqlen_q is None:
+                attn_metadata.max_seqlen_q = query.shape[1]
+            if attn_metadata.max_seqlen_k is None:
+                attn_metadata.max_seqlen_k = key.shape[1]
             max_seqlen_q = attn_metadata.max_seqlen_q
             max_seqlen_k = attn_metadata.max_seqlen_k
         else:


### PR DESCRIPTION
## Summary
- stop rereading the global forward context inside `FlashAttentionImpl.forward`
- use the supplied attention metadata when present; otherwise fall back to the dense Q/K shapes already used by the no-metadata path

## Validation
- Cosmos3 Nano T2V 720p, 189 frames, 35 steps, 4xH200, torch compile/cache/guardrails off: MP4 sha matched `2b05ba6f5d29f8f86bd184a40706b042016b13f1dad79f6c516ad66ff13fb02f`
- A/B on PR #27143 stack: candidate denoise `51.0760s` / `51.2251s`, baseline `51.2327s` / `51.2572s`
- main-based head `ad2acbc413`: sha matched, peak memory `41338MB`



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26898792992](https://github.com/sgl-project/sglang/actions/runs/26898792992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26898791051](https://github.com/sgl-project/sglang/actions/runs/26898791051)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->