### PR TITLE
fix(triton): define masked softcap loads

### DIFF
--- a/python/sglang/srt/layers/triton_ops/softcap.py
+++ b/python/sglang/srt/layers/triton_ops/softcap.py
@@ -39,7 +39,7 @@ def softcap_out_kernel(
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_ele
-    x = tl.load(input_ptr + offsets, mask=mask)
+    x = tl.load(input_ptr + offsets, mask=mask, other=0.0)
     fx = x.to(tl.float32)
     fxs = fx / softcap_const
     exped = tl.exp(2 * fxs)
@@ -84,7 +84,7 @@ def softcap_inplace_logits_kernel(
 
     # Load values
     row_ptr = full_logits_ptr + row * row_stride
-    x = tl.load(row_ptr + offsets, mask=mask)
+    x = tl.load(row_ptr + offsets, mask=mask, other=0.0)
 
     # Perform operations in-place
     x = x / softcapping_value


### PR DESCRIPTION
## Summary

Fixes #27074.

The softcap Triton kernels load masked vectors without an explicit `other` value. Triton's `tl.load` leaves masked-out lanes undefined when `other` is omitted, so the tail lanes can feed undefined values through the softcap math before the final masked store.

This sets `other=0.0` on the two masked softcap loads in `softcap.py`. The value is neutral for the invalid lanes because those lanes are not stored, and it keeps the intermediate math defined.

## Validation

- `python -m py_compile python/sglang/srt/layers/triton_ops/softcap.py`
- `python -m ruff check python/sglang/srt/layers/triton_ops/softcap.py`
- `git diff --check`

I did not run the CUDA/Triton kernel path on this Windows CPU-only environment.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26880649813](https://github.com/sgl-project/sglang/actions/runs/26880649813)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26880649233](https://github.com/sgl-project/sglang/actions/runs/26880649233)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->