### PR TITLE
[NPU] --prefill-only-disable-kv-cache adapt npu

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -1002,11 +1002,14 @@ class AscendAttnBackend(AttentionBackend):
         k_ = k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
         v_ = v.view(-1, layer.tp_v_head_num, layer.v_head_dim)
 
-        use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
         causal = not (
             layer.is_cross_attention
             or layer.attn_type == AttentionType.ENCODER_ONLY
         )
+
+        seq_lens = forward_batch.extend_seq_lens_cpu or forward_batch.extend_seq_lens
+        if not hasattr(seq_lens, "shape"):
+            seq_lens = torch.tensor(seq_lens, device=q_.device)
 
         if layer.qk_head_dim != layer.v_head_dim:
             attn_output = q.new_empty(
@@ -1019,33 +1022,72 @@ class AscendAttnBackend(AttentionBackend):
 
         o_ = attn_output.view(-1, layer.tp_q_head_num, layer.v_head_dim)
 
-        q_t = q_.movedim(0, q_.dim() - 2)
-        k_t = k_.movedim(0, k_.dim() - 2)
-        v_t = v_.movedim(0, v_.dim() - 2)
+        if not causal and len(seq_lens) > 1:
+            B = len(seq_lens)
+            max_len = int(seq_lens.max().item())
 
-        seq_lens = forward_batch.extend_seq_lens_cpu or forward_batch.extend_seq_lens
-        if not hasattr(seq_lens, "shape"):
-            seq_lens = torch.tensor(seq_lens)
-        start = 0
-        for idx in range(seq_lens.shape[0]):
-            seq_len = int(seq_lens[idx].item())
-            end = start + seq_len
-
-            per_q = q_t[:, start:end, :].unsqueeze(0)
-            per_k = k_t[:, start:end, :].unsqueeze(0)
-            per_v = v_t[:, start:end, :].unsqueeze(0)
-
-            per_out = torch.nn.functional.scaled_dot_product_attention(
-                per_q,
-                per_k,
-                per_v,
-                enable_gqa=use_gqa,
-                is_causal=causal,
-                scale=layer.scaling,
+            q_pad = q_.new_zeros(
+                B, layer.tp_q_head_num, max_len, layer.qk_head_dim
+            )
+            k_pad = q_.new_zeros(
+                B, layer.tp_k_head_num, max_len, layer.qk_head_dim
+            )
+            v_pad = q_.new_zeros(
+                B, layer.tp_v_head_num, max_len, layer.v_head_dim
             )
 
-            o_[start:end] = per_out.squeeze(0).movedim(o_.dim() - 2, 0)
-            start = end
+            offset = 0
+            for i in range(B):
+                sl = int(seq_lens[i].item())
+                q_pad[i, :, :sl] = q_[offset : offset + sl].transpose(0, 1)
+                k_pad[i, :, :sl] = k_[offset : offset + sl].transpose(0, 1)
+                v_pad[i, :, :sl] = v_[offset : offset + sl].transpose(0, 1)
+                offset += sl
+
+            out = torch.ops.npu.npu_prompt_flash_attention(
+                q_pad,
+                k_pad,
+                v_pad,
+                num_heads=layer.tp_q_head_num,
+                num_key_value_heads=layer.tp_k_head_num,
+                scale_value=layer.scaling,
+                pre_tokens=2147483647,
+                next_tokens=2147483647,
+                input_layout="BNSD",
+                sparse_mode=0,
+            )
+
+            offset = 0
+            for i in range(B):
+                sl = int(seq_lens[i].item())
+                o_[offset : offset + sl] = out[i, :, :sl].transpose(0, 1)
+                offset += sl
+        else:
+            use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
+            q_t = q_.movedim(0, q_.dim() - 2)
+            k_t = k_.movedim(0, k_.dim() - 2)
+            v_t = v_.movedim(0, v_.dim() - 2)
+
+            start = 0
+            for idx in range(len(seq_lens)):
+                seq_len = int(seq_lens[idx].item())
+                end = start + seq_len
+
+                per_q = q_t[:, start:end, :].unsqueeze(0)
+                per_k = k_t[:, start:end, :].unsqueeze(0)
+                per_v = v_t[:, start:end, :].unsqueeze(0)
+
+                per_out = torch.nn.functional.scaled_dot_product_attention(
+                    per_q,
+                    per_k,
+                    per_v,
+                    enable_gqa=use_gqa,
+                    is_causal=causal,
+                    scale=layer.scaling,
+                )
+
+                o_[start:end] = per_out.squeeze(0).movedim(o_.dim() - 2, 0)
+                start = end
 
         return attn_output
 

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -25,6 +25,7 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_kv_cache
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.mem_cache.memory_pool import NoOpMHATokenToKVPool
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import get_bool_env_var, get_current_device_stream_fast
 
@@ -989,6 +990,65 @@ class AscendAttnBackend(AttentionBackend):
 
         return attn_out
 
+    def _forward_extend_no_kv_cache(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+    ):
+        q_ = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        k_ = k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+        v_ = v.view(-1, layer.tp_v_head_num, layer.v_head_dim)
+
+        use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
+        causal = not (
+            layer.is_cross_attention
+            or layer.attn_type == AttentionType.ENCODER_ONLY
+        )
+
+        if layer.qk_head_dim != layer.v_head_dim:
+            attn_output = q.new_empty(
+                (q_.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+            )
+        else:
+            attn_output = torch.empty_like(q_).reshape(
+                -1, layer.tp_q_head_num * layer.v_head_dim
+            )
+
+        o_ = attn_output.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+
+        q_t = q_.movedim(0, q_.dim() - 2)
+        k_t = k_.movedim(0, k_.dim() - 2)
+        v_t = v_.movedim(0, v_.dim() - 2)
+
+        seq_lens = forward_batch.extend_seq_lens_cpu or forward_batch.extend_seq_lens
+        if not hasattr(seq_lens, "shape"):
+            seq_lens = torch.tensor(seq_lens)
+        start = 0
+        for idx in range(seq_lens.shape[0]):
+            seq_len = int(seq_lens[idx].item())
+            end = start + seq_len
+
+            per_q = q_t[:, start:end, :].unsqueeze(0)
+            per_k = k_t[:, start:end, :].unsqueeze(0)
+            per_v = v_t[:, start:end, :].unsqueeze(0)
+
+            per_out = torch.nn.functional.scaled_dot_product_attention(
+                per_q,
+                per_k,
+                per_v,
+                enable_gqa=use_gqa,
+                is_causal=causal,
+                scale=layer.scaling,
+            )
+
+            o_[start:end] = per_out.squeeze(0).movedim(o_.dim() - 2, 0)
+            start = end
+
+        return attn_output
+
     def forward_extend(
         self,
         q,
@@ -1056,7 +1116,9 @@ class AscendAttnBackend(AttentionBackend):
 
             # In cross attention layer, when there is no vision input,the values of k and v is None
             if save_kv_cache and k is not None and v is not None:
-                if is_cp_mode:
+                if isinstance(self.token_to_kv_pool, NoOpMHATokenToKVPool):
+                    pass
+                elif is_cp_mode:
                     # All-gather K/V from all CP ranks and write full sequence to KV pool
                     _cp_allgather_and_save_kv_npu(
                         forward_batch,
@@ -1077,6 +1139,11 @@ class AscendAttnBackend(AttentionBackend):
 
             k_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
             v_cache = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
+
+            if isinstance(self.token_to_kv_pool, NoOpMHATokenToKVPool):
+                return self._forward_extend_no_kv_cache(
+                    q, k, v, layer, forward_batch
+                )
 
             if sinks is not None or (
                 self.is_hybrid_swa and layer.sliding_window_size != -1
@@ -2044,6 +2111,11 @@ class AscendAttnBackend(AttentionBackend):
             )
 
         if not self.use_mla:
+            if isinstance(self.token_to_kv_pool, NoOpMHATokenToKVPool):
+                raise RuntimeError(
+                    "forward_decode called with NoOpMHATokenToKVPool. "
+                    "Decode is not expected in prefill-only mode."
+                )
             # In cross attention layer, when there is no vision input,the values of k and v is None
             if save_kv_cache and k is not None and v is not None:
                 # support cross attention

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -936,7 +936,15 @@ class MHATokenToKVPool(KVCache):
             dtype=torch.uint64,
             device=self.device,
         )
-        self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
+        if self.device == "npu":
+            self.data_ptrs = torch.cat(
+                [self.k_data_ptrs.to(torch.int64), self.v_data_ptrs.to(torch.int64)],
+                dim=0,
+            ).view(torch.uint64)
+        else:
+            self.data_ptrs = torch.cat(
+                [self.k_data_ptrs, self.v_data_ptrs], dim=0
+            )
         self.data_strides = torch.tensor(
             [
                 np.prod(x.shape[1:]) * x.dtype.itemsize
@@ -1199,7 +1207,15 @@ class NoOpMHATokenToKVPool(MHATokenToKVPool):
             dtype=torch.uint64,
             device=self.device,
         )
-        self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
+        if self.device == "npu":
+            self.data_ptrs = torch.cat(
+                [self.k_data_ptrs.to(torch.int64), self.v_data_ptrs.to(torch.int64)],
+                dim=0,
+            ).view(torch.uint64)
+        else:
+            self.data_ptrs = torch.cat(
+                [self.k_data_ptrs, self.v_data_ptrs], dim=0
+            )
         self.data_strides = torch.tensor(
             [
                 np.prod(x.shape[1:]) * x.dtype.itemsize

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -254,10 +254,6 @@ class ModelRunnerKVCacheMixin:
             unsupported_pool_family = "DeepSeekV4TokenToKVPool"
         elif current_platform.is_out_of_tree() and not self.mambaish_config:
             unsupported_pool_family = "out-of-tree platform KV pool"
-        elif (
-            self.server_args.attention_backend == "ascend" and not self.mambaish_config
-        ):
-            unsupported_pool_family = "NPU/Ascend KV pool"
         elif self.use_mla_backend and is_dsa_model:
             unsupported_pool_family = "DSA/MLA KV pool"
         elif self.use_mla_backend and not self.mambaish_config:
@@ -526,20 +522,41 @@ class ModelRunnerKVCacheMixin:
                     NPUMHATokenToKVPool,
                 )
 
-                self.token_to_kv_pool = NPUMHATokenToKVPool(
-                    self.max_total_num_tokens,
-                    page_size=self.page_size,
-                    dtype=self.kv_cache_dtype,
-                    head_num=self.model_config.get_num_kv_heads(
-                        get_attention_tp_size()
-                    ),
-                    head_dim=self.model_config.head_dim,
-                    layer_num=self.num_effective_layers,
-                    device=self.device,
-                    enable_memory_saver=self.server_args.enable_memory_saver,
-                    start_layer=self.start_layer,
-                    end_layer=self.end_layer,
-                )
+                if self.server_args.prefill_only_disable_kv_cache:
+                    self.token_to_kv_pool = NoOpMHATokenToKVPool(
+                        self.max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        head_num=self.model_config.get_num_kv_heads(
+                            get_attention_tp_size()
+                        ),
+                        head_dim=self.model_config.head_dim,
+                        v_head_dim=self.model_config.v_head_dim,
+                        layer_num=self.num_effective_layers,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        start_layer=self.start_layer,
+                        end_layer=self.end_layer,
+                        enable_alt_stream=not self.server_args.enable_pdmux,
+                        enable_kv_cache_copy=(
+                            self.server_args.speculative_algorithm is not None
+                        ),
+                    )
+                else:
+                    self.token_to_kv_pool = NPUMHATokenToKVPool(
+                        self.max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        head_num=self.model_config.get_num_kv_heads(
+                            get_attention_tp_size()
+                        ),
+                        head_dim=self.model_config.head_dim,
+                        layer_num=self.num_effective_layers,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        start_layer=self.start_layer,
+                        end_layer=self.end_layer,
+                    )
         elif self.use_mla_backend and is_dsa_model:
             PoolCls = (
                 HiSparseDSATokenToKVPool if self.enable_hisparse else DSATokenToKVPool

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3676,11 +3676,11 @@ class ServerArgs:
         )
 
         prefill_backend, _ = self.get_attention_backends()
-        if prefill_backend not in ("fa3", "fa4"):
+        if prefill_backend not in ("fa3", "fa4", "ascend"):
             raise ValueError(
                 "--prefill-only-disable-kv-cache currently requires the FA prefill backend "
-                f"(fa3/fa4), but got prefill backend {prefill_backend!r}. Other prefill-only "
-                "workloads and backends may be supported in a future change."
+                f"(fa3/fa4) or the ascend backend, but got prefill backend {prefill_backend!r}. "
+                "Other prefill-only workloads and backends may be supported in a future change."
             )
 
     def _handle_hicache(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In prefill-only workloads (embedding models, scoring, etc.), the KV cache is never read or written — attention operates on raw K/V tensors directly. The original PR introduced a NoOpMHATokenToKVPool that allocates only per-layer placeholder tensors ( page_size × head_num × head_dim ) instead of full-sized buffers. On GPU this works via the FA backend's fa_skip_kv_cache path, which uses flash_attn_varlen_func(Q, K, V, cu_seqlens) to compute attention directly without touching the paged cache.

NPU was explicitly blocked because:

1. The Ascend backend had no fa_skip_kv_cache equivalent — it always goes through the paged cache
2. NoOpMHATokenToKVPool was not integrated into the NPU pool selection path
3. ServerArgs validation rejected the ascend backend for this flag

This change extends the --prefill-only-disable-kv-cache feature (originally CUDA-only, from sgl-project/sglang#23675 ) to work on NPU hardware via the Ascend attention backend. The feature eliminates physical KV cache allocation for prefill-only workloads (embedding models), replacing tens-of-GB KV cache buffers with ~14 KB placeholders.

4 files modified , all changes focused and minimal.
## Modifications

<!-- Detail the changes made in this pull request. -->
1. server_args.py — Allow ascend backend
 All other validation (chunked_prefill_size=-1, disable_radix_cache, is_embedding) is unchanged.
### 2. model_runner_kv_cache_mixin.py — Enable NoOp pool for NPU
Two changes in this file:
2a. Remove NPU pool family restriction

Removed the block that treated NPU/Ascend KV pool as an unsupported pool family. All other restrictions (MLA, SWA, Mamba, FP4, HiSparse) remain.

2b. Select NoOp pool when flag is set
### 3. ascend_backend.py — Core attention logic (3 parts)
This is the main change. Three isinstance(pool, NoOpMHATokenToKVPool) guards are added:

3a. Skip KV cache write in forward_extend

When the pool is NoOp, set_kv_buffer is skipped entirely. NoOpMHATokenToKVPool.set_kv_buffer raises RuntimeError by design, so this guard is necessary.

3b. Route to custom attention path
Bypasses the normal paged-cache attention path ( npu_fused_infer_attention_score with block_table ).

3c. New method _forward_extend_no_kv_cache — two attention paths
def _forward_extend_no_kv_cache(self, q, k, v, layer, forward_batch):
    causal = not (layer.is_cross_attention
                  or layer.attn_type == ENCODER_ONLY)

    if not causal and len(seq_lens) > 1:
        # ENCODER (bidirectional): use NPU native flash attention
        #   Pad flat K/V → BNSD format → npu_prompt_flash_attention
        #   → one kernel call for entire batch
        pad → BNSD →
            torch.ops.npu.npu_prompt_flash_attention(...,
                pre_tokens=MAX, next_tokens=MAX, sparse_mode=0)
        → unpad
    else:
        # DECODER (causal): per-request SDPA fallback
        for each request:
            F.scaled_dot_product_attention(..., is_causal=True, scale=...)
3d. Decode guard

If forward_decode is somehow called with a NoOp pool, raise immediately with a clear error rather than crashing deep inside the cache layer.

### 4. memory_pool.py — NPU uint64 compatibility fix

## Design Decisions
### Why per-request SDPA for causal models?
The only NPU kernel that supports raw K/V + variable-length sequences ( npu_prompt_flash_attention ) does not produce correct causal attention. sparse_mode=3 (explicit mask) requires fixed-size masks incompatible with variable-length batches. Nor does F.scaled_dot_product_attention support cu_seqlens -style batching. So we fall back to iterating per-request with zero-copy views — correct but carries kernel launch overhead.

We attempted a pad+batch approach but the per-layer allocation+copy overhead (~14 MB/layer × 28 layers) outweighed the kernel launch savings.

### What happens when torch_npu gets a cu_seqlens-aware SDPA?
The else branch can simply be swapped to call the native kernel. No architectural changes needed — the routing logic is already in place.

## Caveats & Future Work
1. Causal model throughput — The 22% regression for causal decoder-as-embedding models (Qwen3, Llama, etc.) is a kernel limitation, not an architectural one. It will resolve automatically when Ascend's SDPA supports variable-length causal attention. The 47 GB memory savings make it worthwhile even with the throughput trade-off.
2. Only plain MHA models — MLA (DeepSeek), SWA, Mamba, HiSparse, and FP4 pool families are still blocked. These require separate per-family integration work.
3. Context-parallel attention — Blocked because CP paths write to the pool via cp_allgather_and_save_kv_cache .
5. Scoring / MIS workloads — Not yet covered; their attention paths still read/write the paged cache. Could be extended later.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
6. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26990465719](https://github.com/sgl-project/sglang/actions/runs/26990465719)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26990465650](https://github.com/sgl-project/sglang/actions/runs/26990465650)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->