### PR TITLE
[PD] Fail single request instead of killing the mooncake transfer worker

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -639,6 +639,8 @@ class MooncakeKVManager(CommonKVManager):
         ) -> List[Tuple[int, int, int]]:
             transfer_blocks = []
             for prefill_index, decode_index in zip(prefill_kv_blocks, dst_kv_blocks):
+                if len(prefill_index) == 0 or len(decode_index) == 0:
+                    continue
                 src_addr = src_ptr + int(prefill_index[0]) * item_len
                 dst_addr = dst_ptr + int(decode_index[0]) * item_len
                 length = item_len * len(prefill_index)
@@ -1159,6 +1161,7 @@ class MooncakeKVManager(CommonKVManager):
             )
 
         while True:
+            kv_chunk = None
             try:
                 kv_chunk: TransferKVChunk = queue.get()
                 if self.enable_trace:
@@ -1358,10 +1361,38 @@ class MooncakeKVManager(CommonKVManager):
                     self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
 
             except Exception as e:
-                # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
-                raise RuntimeError(
-                    f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
+                # fail only this request; never kill the worker (a dead worker stalls all transfers -> 300s timeouts)
+                failed_room = getattr(kv_chunk, "room", None)
+                logger.error(
+                    f"transfer_worker error (room={failed_room}, "
+                    f"bootstrap_port={self.bootstrap_port}): {e}",
+                    exc_info=True,
                 )
+                # don't flip an already-concluded Success to Failed; .get tolerates a raced clear()
+                current_status = self.request_status.get(failed_room)
+                if current_status is not None and current_status != KVPoll.Success:
+                    self.record_failure(failed_room, f"transfer_worker exception: {e}")
+                    self.update_status(failed_room, KVPoll.Failed)
+                    # notify decode so it fails fast instead of waiting its own timeout
+                    prefill_rank = (
+                        self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
+                        + self.pp_rank * self.attn_cp_size
+                        + self.attn_cp_rank
+                    )
+                    for info in list(self.transfer_infos.get(failed_room, {}).values()):
+                        if info.is_dummy:
+                            continue
+                        try:
+                            self.sync_status_to_decode_endpoint(
+                                info.endpoint,
+                                info.dst_port,
+                                failed_room,
+                                KVPoll.Failed,
+                                prefill_rank,
+                            )
+                        except Exception:
+                            pass
+                continue
 
     def start_prefill_thread(self):
         def bootstrap_thread():


### PR DESCRIPTION
  ## Motivation

  In PD disaggregation (mooncake backend), the prefill-side KV transfer worker re-raised on any exception, which **killed the entire worker thread**. Since each worker drains a shared queue that serves many requests, a dead worker stalls every subsequent transfer on that queue — decode peers then hang until their own ~300s timeout fires, turning a single-request error into a cascading stall.

  A concrete trigger comes from SWA/DSA: a non-empty prefill state-index list can be paired with an empty decode registration, so `set_transfer_blocks` indexed an empty block (`prefill_index[0]` / `decode_index[0]`) and raised `IndexError`, which then tore down the worker.

  ## Modifications

  `python/sglang/srt/disaggregation/mooncake/conn.py`:

  1. **`set_transfer_blocks`** — skip block pairs where either side is empty (an empty side has nothing to transfer), preventing the out-of-bounds index. Defense in depth alongside the empty-side guard already in `group_concurrent_contiguous`.
  2. **`transfer_worker` exception handling** — stop re-raising. On exception, fail only the offending request: log with traceback, mark its room `KVPoll.Failed`, and proactively push `Failed` to the matching decode endpoints so decode fails fast instead of waiting for its own timeout; then `continue` to keep serving other requests.
  3. Initialize `kv_chunk = None` at the top of the loop so the except branch can reference it safely even if `queue.get()` itself raises.
  4. Failure-path robustness: read status via `request_status.get(...)` (not `check_status`) so a concurrent `clear()` cannot raise `KeyError` and re-kill the worker; and skip the failure marking when the room already concluded `Success`, so a post-success error (e.g. tracing/cleanup) cannot flip a completed transfer to `Failed`.

  ## Accuracy Tests

  No change to the normal transfer path or model outputs — this is an error-handling/robustness fix. Suggested regression check on a PD-disagg deployment (especially an SWA model): confirm transfers succeed end-to-end, and that an injected transfer error fails only that request (decode fails fast) while the worker thread stays alive and keeps serving subsequent requests.

  ## Speed Tests and Profiling

  No impact on the steady-state transfer path. Improves the failure case by removing the ~300s decode-timeout stall that previously followed a worker death.

  ## Checklist

  - [ ] Format code with pre-commit.
  - [ ] Add/adjust unit tests (consider a `transfer_worker` test asserting the thread survives an injected exception and the request is marked `Failed`).
  - [ ] Provide accuracy/speed results from a real PD-disagg + SWA run.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26887240142](https://github.com/sgl-project/sglang/actions/runs/26887240142)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26887239339](https://github.com/sgl-project/sglang/actions/runs/26887239339)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->