### PR TITLE
[AMD] Disable AITER custom all-gather in DeepSeek-R1-MXFP4 8-GPU test

### DIFF
--- a/test/registered/amd/test_deepseek_r1_mxfp4_8gpu.py
+++ b/test/registered/amd/test_deepseek_r1_mxfp4_8gpu.py
@@ -27,6 +27,12 @@ class TestDeepseekR1MXFP4(CustomTestCase):
     def setUpClass(cls):
         cls.model = DEEPSEEK_R1_MODEL_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
+
+        # Workaround: AITER custom all-gather corrupts CUDA-graph IPC buffer
+        # registration and triggers a decode-time "Memory access fault" on
+        # MI35x TP=8. Disable until the AITER-side fix lands (see PR body).
+        envs.SGLANG_USE_AITER_AG.set(False)
+
         other_args = [
             "--tp",
             "8",
@@ -89,6 +95,8 @@ class TestDeepseekR1MXFP4MTP(CustomTestCase):
         cls.base_url = DEFAULT_URL_FOR_TEST
 
         envs.SGLANG_ENABLE_OVERLAP_PLAN_STREAM.set(True)
+        # Same AITER custom all-gather workaround as TestDeepseekR1MXFP4 above.
+        envs.SGLANG_USE_AITER_AG.set(False)
 
         other_args = [
             "--tp",


### PR DESCRIPTION
## Summary
`test/registered/amd/test_deepseek_r1_mxfp4_8gpu.py` (MI35x, TP=8) crashes during the gsm8k decode with a multi-rank `Memory access fault by GPU node-N ... Reason: Unknown`, after weight load and CUDA-graph capture both succeed.
Bisect: last-good `9e717cae`, first-bad `83bc7766`. The only relevant change is PR25093 (*[AMD] Enable AITER custom all-gather on ROCm*), which adds `SGLANG_USE_AITER_AG` (default `True`).
This PR sets `SGLANG_USE_AITER_AG=0` in both test classes as a **workaround**.
## Root cause
Bug is in AITER `CustomAllreduce` CUDA-graph buffer registration. `get_output_buffer_RD` derives its `RankData` slot from the *current* input-buffer count, but `register_graph_buffers` lays buffers out as `[all inputs][all outputs]`. Enabling custom all-gather pushes a per-decode-layer input buffer **after** the broadcast all-reduce's output push, so the output slot is under-counted → mis-indexed `RankData` → cross-rank IPC pointer resolves to wrong/unmapped memory → fault on graph replay (decode). Explains why capture is fine, decode faults, and all ranks fault at once. The real fix belongs in AITER; revert this once it lands.
## Test (with flag, MI35x TP=8) — `Ran 4 tests ... OK`
| Test | Result | Threshold |
|---|---|---|
| gsm8k | acc 0.949 | > 0.94 |
| bs_1_speed | 154.91 tok/s | > 75 |
| mtp gsm8k | acc 0.965 / accept 2.847 | > 0.94 / > 2.04 |
| mtp bs_1_speed | accept 2.69 / 251.71 tok/s | > 2.04 / > 150 |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26887919535](https://github.com/sgl-project/sglang/actions/runs/26887919535)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26911264992](https://github.com/sgl-project/sglang/actions/runs/26911264992)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->