### PR TITLE
Support greedy grammar-constrained decoding for DFlash verification

### DIFF
--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -24,6 +24,72 @@ from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
 
 
+def _is_token_allowed_by_bitmask(
+    bitmask_row: torch.Tensor, token_id: int, vocab_size: int
+) -> bool:
+    if token_id < 0 or token_id >= vocab_size:
+        return False
+    return (int(bitmask_row[token_id // 32].item()) & (1 << (token_id % 32))) != 0
+
+
+def _build_linear_grammar_vocab_mask(
+    *,
+    batch: ScheduleBatch,
+    candidates_cpu: torch.Tensor,
+    vocab_size: int,
+) -> tuple[torch.Tensor | None, object | None]:
+    """Build per-position grammar masks for a linear DFlash verify block.
+
+    DFlash verifies a chain rather than a tree. Row `t` of each request masks the
+    target logits for the next-token distribution after accepting draft tokens
+    `1..t` from the same chain. If a draft token is invalid under the grammar, all
+    later rows are unreachable for acceptance and can remain unfilled.
+    """
+
+    bs, draft_token_num = candidates_cpu.shape
+    allocate_token_bitmask = None
+    apply_grammar = None
+
+    for i, req in enumerate(batch.reqs):
+        grammar = req.grammar
+        if grammar is None:
+            continue
+
+        if allocate_token_bitmask is None:
+            allocate_token_bitmask = grammar.allocate_vocab_mask(
+                vocab_size=vocab_size,
+                batch_size=bs * draft_token_num,
+                device="cpu",
+            )
+        if apply_grammar is None:
+            apply_grammar = grammar
+
+        req_mask = allocate_token_bitmask[
+            i * draft_token_num : (i + 1) * draft_token_num
+        ]
+        accepted_for_mask = 0
+        try:
+            for t in range(draft_token_num):
+                if grammar.is_terminated():
+                    break
+
+                grammar.fill_vocab_mask(req_mask, t)
+                if t == draft_token_num - 1:
+                    break
+
+                token_id = int(candidates_cpu[i, t + 1].item())
+                if not _is_token_allowed_by_bitmask(req_mask[t], token_id, vocab_size):
+                    break
+
+                grammar.accept_token(token_id)
+                accepted_for_mask += 1
+        finally:
+            if accepted_for_mask > 0:
+                grammar.rollback(accepted_for_mask)
+
+    return allocate_token_bitmask, apply_grammar
+
+
 def _compute_paged_keep_slots(
     *,
     prefix_lens: torch.Tensor,
@@ -333,13 +399,38 @@ class DFlashVerifyInput(SpecInput):
         device = logits_output.next_token_logits.device
 
         sampling_info = batch.sampling_info
-        if sampling_info is not None:
-            if len(sampling_info) != bs:
+        if sampling_info is not None and len(sampling_info) != bs:
+            raise RuntimeError(
+                "DFLASH verify sampling_info size mismatch: "
+                f"len(sampling_info)={len(sampling_info)}, bs={bs}."
+            )
+
+        candidates = self.draft_token.view(bs, self.draft_token_num)
+        vocab_mask = None
+        apply_grammar = None
+        if batch.has_grammar:
+            if sampling_info is not None and not sampling_info.is_all_greedy:
                 raise RuntimeError(
-                    "DFLASH verify sampling_info size mismatch: "
-                    f"len(sampling_info)={len(sampling_info)}, bs={bs}."
+                    "DFLASH grammar-constrained verification currently supports "
+                    "greedy requests only."
                 )
 
+            vocab_size = (
+                sampling_info.vocab_size
+                if sampling_info is not None
+                else logits_output.next_token_logits.shape[-1]
+            )
+            vocab_mask, apply_grammar = _build_linear_grammar_vocab_mask(
+                batch=batch,
+                candidates_cpu=candidates.cpu(),
+                vocab_size=int(vocab_size),
+            )
+            if sampling_info is not None and vocab_mask is not None:
+                # The normal one-step grammar mask is for the current prefix only.
+                # DFlash verify needs a different mask for each block position.
+                sampling_info.vocab_mask = None
+
+        if sampling_info is not None:
             # Keep speculative verify semantics consistent with normal sampling path.
             if sampling_info.has_custom_logit_processor:
                 apply_custom_logit_processor(
@@ -362,7 +453,13 @@ class DFlashVerifyInput(SpecInput):
                     torch.repeat_interleave(linear_penalty, self.draft_token_num, dim=0)
                 )
 
-        candidates = self.draft_token.view(bs, self.draft_token_num)
+        if vocab_mask is not None:
+            assert apply_grammar is not None
+            vocab_mask = vocab_mask.to(device)
+            apply_grammar.apply_vocab_mask(
+                logits=logits_output.next_token_logits, vocab_mask=vocab_mask
+            )
+
         if (
             sampling_info is not None
             and not sampling_info.is_all_greedy

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -643,15 +643,16 @@ def validate_dflash_request(req: Req) -> Optional[str]:
     if req.return_logprob:
         return "DFLASH speculative decoding does not support return_logprob yet."
 
-    if (
+    has_grammar_constraint = (
         req.sampling_params.json_schema is not None
         or req.sampling_params.regex is not None
         or req.sampling_params.ebnf is not None
         or req.sampling_params.structural_tag is not None
-    ):
+    )
+    if has_grammar_constraint and req.sampling_params.top_k > 1:
         return (
             "DFLASH speculative decoding does not support "
-            "grammar-constrained decoding yet."
+            "non-greedy grammar-constrained decoding yet."
         )
 
     return None

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -528,10 +528,6 @@ class DFlashWorker:
         if batch.forward_mode.is_extend() or batch.forward_mode.is_idle():
             return
 
-        if batch.has_grammar:
-            raise RuntimeError(
-                "Invariant broken: DFLASH batch has grammar constraints, but scheduler should have rejected this request."
-            )
         if batch.sampling_info is not None and not batch.sampling_info.is_all_greedy:
             if (
                 not is_dflash_sampling_verify_available()

--- a/test/registered/unit/spec/test_dflash_grammar_mask.py
+++ b/test/registered/unit/spec/test_dflash_grammar_mask.py
@@ -1,0 +1,155 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative.dflash_info import (
+    DFlashVerifyInput,
+    _build_linear_grammar_vocab_mask,
+)
+from sglang.srt.speculative.dflash_utils import validate_dflash_request
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+def _is_allowed(bitmask_row: torch.Tensor, token_id: int) -> bool:
+    return (int(bitmask_row[token_id // 32].item()) & (1 << (token_id % 32))) != 0
+
+
+class FakeGrammar:
+    def __init__(self, allowed_by_state):
+        self.allowed_by_state = allowed_by_state
+        self.state = 0
+        self.accept_calls = []
+        self.fill_calls = []
+        self.rollback_calls = []
+
+    def allocate_vocab_mask(self, vocab_size: int, batch_size: int, device):
+        width = (vocab_size + 31) // 32
+        return torch.zeros((batch_size, width), dtype=torch.int32, device=device)
+
+    def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
+        self.fill_calls.append((self.state, idx))
+        vocab_mask[idx].zero_()
+        for token_id in self.allowed_by_state[self.state]:
+            word = token_id // 32
+            bit = 1 << (token_id % 32)
+            vocab_mask[idx, word] = int(vocab_mask[idx, word].item()) | bit
+
+    def accept_token(self, token_id: int) -> None:
+        self.accept_calls.append(token_id)
+        self.state += 1
+
+    def rollback(self, num_tokens: int) -> None:
+        self.rollback_calls.append(num_tokens)
+        self.state -= num_tokens
+
+    def is_terminated(self) -> bool:
+        return False
+
+
+class FakeSamplingInfo:
+    is_all_greedy = False
+    vocab_size = 16
+
+    def __len__(self):
+        return 1
+
+
+class TestDFlashGrammarMask(unittest.TestCase):
+    def test_validate_dflash_request_allows_greedy_grammar(self):
+        req = SimpleNamespace(
+            return_logprob=False,
+            sampling_params=SimpleNamespace(
+                json_schema=None,
+                regex=r"^\d{3}$",
+                ebnf=None,
+                structural_tag=None,
+                top_k=1,
+            ),
+        )
+
+        self.assertIsNone(validate_dflash_request(req))
+
+    def test_validate_dflash_request_rejects_non_greedy_grammar(self):
+        req = SimpleNamespace(
+            return_logprob=False,
+            sampling_params=SimpleNamespace(
+                json_schema=None,
+                regex=r"^\d{3}$",
+                ebnf=None,
+                structural_tag=None,
+                top_k=20,
+            ),
+        )
+
+        self.assertIn("non-greedy", validate_dflash_request(req))
+
+    def test_returns_none_without_grammar(self):
+        batch = SimpleNamespace(reqs=[SimpleNamespace(grammar=None)])
+        candidates = torch.tensor([[0, 5, 7]], dtype=torch.long)
+
+        vocab_mask, apply_grammar = _build_linear_grammar_vocab_mask(
+            batch=batch,
+            candidates_cpu=candidates,
+            vocab_size=16,
+        )
+
+        self.assertIsNone(vocab_mask)
+        self.assertIsNone(apply_grammar)
+
+    def test_advances_and_rolls_back_for_linear_chain(self):
+        grammar = FakeGrammar([{5}, {7}, {1}])
+        batch = SimpleNamespace(reqs=[SimpleNamespace(grammar=grammar)])
+        candidates = torch.tensor([[0, 5, 7, 9]], dtype=torch.long)
+
+        vocab_mask, apply_grammar = _build_linear_grammar_vocab_mask(
+            batch=batch,
+            candidates_cpu=candidates,
+            vocab_size=16,
+        )
+
+        self.assertIs(apply_grammar, grammar)
+        self.assertEqual(grammar.accept_calls, [5, 7])
+        self.assertEqual(grammar.rollback_calls, [2])
+        self.assertEqual(grammar.state, 0)
+        self.assertEqual(grammar.fill_calls, [(0, 0), (1, 1), (2, 2)])
+
+        self.assertTrue(_is_allowed(vocab_mask[0], 5))
+        self.assertTrue(_is_allowed(vocab_mask[1], 7))
+        self.assertTrue(_is_allowed(vocab_mask[2], 1))
+        self.assertFalse(_is_allowed(vocab_mask[2], 9))
+        self.assertEqual(vocab_mask[3].sum().item(), 0)
+
+    def test_verify_rejects_non_greedy_grammar(self):
+        verify_input = DFlashVerifyInput(
+            draft_token=torch.tensor([0, 5], dtype=torch.long),
+            positions=torch.tensor([0, 1], dtype=torch.long),
+            draft_token_num=2,
+        )
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.TARGET_VERIFY,
+            device=torch.device("cpu"),
+            sampling_info=FakeSamplingInfo(),
+            has_grammar=True,
+            reqs=[SimpleNamespace(grammar=FakeGrammar([{5}]))],
+            batch_size=lambda: 1,
+        )
+        logits_output = LogitsProcessorOutput(
+            next_token_logits=torch.zeros((2, 16), dtype=torch.float32),
+            hidden_states=torch.zeros((2, 1), dtype=torch.float32),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "greedy requests only"):
+            verify_input.verify(
+                batch=batch,
+                logits_output=logits_output,
+                page_size=1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds support for greedy grammar-constrained decoding with DFlash speculative verification.

DFlash verifies a linear draft chain. For grammar-constrained requests, the target verification logits need a different vocabulary mask at each position of the verify block, because each position corresponds to the grammar state after accepting the preceding draft tokens.

This PR:
- builds per-position grammar vocab masks for DFlash linear verification
- applies the masks before greedy target verification
- allows greedy grammar-constrained DFlash requests
- keeps non-greedy grammar-constrained DFlash requests rejected
- removes the previous worker-level grammar rejection

## Tests

```bash
PYTHONPATH=python python -m pytest test/registered/unit/spec/test_dflash_grammar_mask.py
python -m ruff check python/sglang/srt/speculative/dflash_info.py python/sglang/srt/speculative/dflash_utils.py python/sglang/srt/speculative/dflash_worker.py test/registered/unit/spec/test_dflash_grammar_mask.py
```

Result:
- `5 passed`
- `ruff`: all checks passed

## Benchmark

Model: Qwen3-8B
Draft model: Qwen3-8B-DFlash-b16
Dataset: JSONSchemaBench
Batch size: 1
Server config: `--max-running-requests 1 --cuda-graph-bs 1`
Sampling: greedy, `temperature=0`, JSON schema constrained decoding

| dataset | vanilla lat | DFlash lat | speedup | vanilla tok/s | DFlash tok/s | valid | exact match | accept len |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Github_easy | 0.440s | 0.306s | 1.44x | 61.8 | 88.8 | 10/10 | 10/10 | 3.91 |
| Glaiveai2K | 0.528s | 0.260s | 2.03x | 91.3 | 185.5 | 10/10 | 10/10 | 3.99 |
| JSONSchemaBench-20 | 0.484s | 0.283s | 1.71x | 77.9 | 133.2 | 20/20 | 20/20 | 3.95 |
