### PR TITLE
[Bugfix] Handle negated literals in stop regex length

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -226,6 +226,7 @@ def _max_length_from_subpattern(subpattern: sre_parse.SubPattern):
     for token, value in subpattern:
         if token in {
             sre_parse.LITERAL,  # `value` is any one character
+            sre_parse.NOT_LITERAL,  # Any character except `value`, e.g. `[^a]`
             sre_parse.IN,  # Any character within `value`
             sre_parse.ANY,  # "."
         }:

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -343,6 +343,14 @@ class TestRegexMaxLength(CustomTestCase):
         """Test that character class '[a-z]' gives max length 1."""
         self.assertEqual(get_max_seq_length("[a-z]"), 1)
 
+    def test_negated_literal(self):
+        """Test that negated literal '[^a]' still consumes exactly one character."""
+        self.assertEqual(get_max_seq_length("[^a]"), 1)
+
+    def test_repeated_negated_literal(self):
+        """Test that repeated negated literal '[^a]{3}' uses the repeat upper bound."""
+        self.assertEqual(get_max_seq_length("[^a]{3}"), 3)
+
     def test_dot_any(self):
         """Test that dot wildcard '.' gives max length 1."""
         self.assertEqual(get_max_seq_length("."), 1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`get_max_seq_length()` currently treats unhandled regex parser tokens as `MAX_LEN`. Python parses `[^a]` as `NOT_LITERAL`, so negated single-character stop regex patterns can be overestimated as unbounded. This makes stop regex tail buffering unnecessarily large.

## Modifications

- Treat `sre_parse.NOT_LITERAL` as a single-character regex token.
- Add regression tests for `[^a]` and `[^a]{3}`.

## Accuracy Tests

N/A. This change only affects stop regex length estimation.

## Speed Tests and Profiling

N/A. This is a Python-only bug fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26895018449](https://github.com/sgl-project/sglang/actions/runs/26895018449)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26895018283](https://github.com/sgl-project/sglang/actions/runs/26895018283)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->