### PR TITLE
Add num_waiting_uncached_tokens load metric

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2071,6 +2071,14 @@ class GetLoadsReqOutput(BaseReq):
     num_waiting_reqs: int = field(
         metadata={"metric": ("gauge", "Number of waiting requests")}
     )
+    num_waiting_uncached_tokens: int = field(
+        metadata={
+            "metric": (
+                "gauge",
+                "Number of uncached input tokens waiting for prefill compute",
+            )
+        }
+    )
     num_used_tokens: int = field(
         metadata={"metric": ("gauge", "Number of tokens in use")}
     )

--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -123,6 +123,7 @@ CORE_METRIC_FIELDS = (
     "dp_rank",
     "num_running_reqs",
     "num_waiting_reqs",
+    "num_waiting_uncached_tokens",
     "num_used_tokens",
     "num_total_tokens",
     "max_total_num_tokens",
@@ -197,6 +198,7 @@ class LoadSnapshot(msgspec.Struct, omit_defaults=True):
     dp_rank: int = 0
     num_running_reqs: int = 0
     num_waiting_reqs: int = 0
+    num_waiting_uncached_tokens: int = 0
     num_used_tokens: int = 0
     num_total_tokens: int = 0
     max_total_num_tokens: int = 0
@@ -271,6 +273,7 @@ class LoadSnapshot(msgspec.Struct, omit_defaults=True):
             "dp_rank": self.dp_rank,
             "num_running_reqs": self.num_running_reqs,
             "num_waiting_reqs": self.num_waiting_reqs,
+            "num_waiting_uncached_tokens": self.num_waiting_uncached_tokens,
             "num_used_tokens": self.num_used_tokens,
             "num_total_tokens": self.num_total_tokens,
             "max_total_num_tokens": self.max_total_num_tokens,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -812,6 +812,8 @@ class Req(ReqDllmMixin):
         self.last_host_node: Any = None
         self.best_match_node: Any = None
         self.host_hit_length = 0
+        # Cached prefix length from prefix matching
+        self.matched_prefix_len = 0
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
         # The node to lock until for swa radix tree lock ref
@@ -1311,6 +1313,7 @@ class Req(ReqDllmMixin):
         self.indexer_topk = None
         self.last_node = None
         self.cache_protected_len = 0
+        self.matched_prefix_len = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False
         self.extend_input_len = 0

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -812,8 +812,10 @@ class Req(ReqDllmMixin):
         self.last_host_node: Any = None
         self.best_match_node: Any = None
         self.host_hit_length = 0
-        # Cached prefix length from prefix matching
-        self.matched_prefix_len = 0
+        # Number of input tokens already covered by cache (device prefix_indices
+        # + host hit), capped at the max matchable prefix length. Used to compute
+        # uncached waiting tokens; not a raw len() of any list.
+        self.num_matched_prefix_tokens = 0
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
         # The node to lock until for swa radix tree lock ref
@@ -1313,7 +1315,7 @@ class Req(ReqDllmMixin):
         self.indexer_topk = None
         self.last_node = None
         self.cache_protected_len = 0
-        self.matched_prefix_len = 0
+        self.num_matched_prefix_tokens = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False
         self.extend_input_len = 0

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -812,9 +812,10 @@ class Req(ReqDllmMixin):
         self.last_host_node: Any = None
         self.best_match_node: Any = None
         self.host_hit_length = 0
-        # Number of input tokens already covered by cache (device prefix_indices
-        # + host hit), capped at the max matchable prefix length. Used to compute
-        # uncached waiting tokens; not a raw len() of any list.
+        # Total cached prefix length (on-device prefix_indices + host_hit_length),
+        # capped at the max allowed prefix. Set during prefix matching at schedule
+        # time and used to estimate uncached tokens / sort by longest prefix for
+        # load reporting.
         self.num_matched_prefix_tokens = 0
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -116,7 +116,9 @@ def match_prefix_for_req(
         match_result.host_hit_length,
     )
     max_len = req._compute_max_prefix_len(len(token_ids))
-    req.matched_prefix_len = min(len(req.prefix_indices) + req.host_hit_length, max_len)
+    req.num_matched_prefix_tokens = min(
+        len(req.prefix_indices) + req.host_hit_length, max_len
+    )
     if match_result.mamba_branching_seqlen is not None:
         req.mamba_branching_seqlen = match_result.mamba_branching_seqlen
     if match_result.cache_protected_len is not None:
@@ -166,7 +168,7 @@ class SchedulePolicy:
     ) -> None:
         policy = self._determine_active_policy(waiting_queue)
 
-        # Populate req.matched_prefix_len at schedule time. Cache-aware policies
+        # Populate req.num_matched_prefix_tokens at schedule time. Cache-aware policies
         # set it in _compute_prefix_matches; do the same full match for
         # cache-agnostic policies when the radix supports it, so the load
         # snapshot has it. Skip on decode (never prefills).
@@ -293,7 +295,7 @@ class SchedulePolicy:
         """Sorts the waiting queue based on the longest prefix match."""
         waiting_queue.sort(
             key=lambda r: (
-                -r.matched_prefix_len
+                -r.num_matched_prefix_tokens
                 if r.rid not in temporary_deprioritized
                 else float("inf")
             )

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -50,7 +50,7 @@ from sglang.srt.mem_cache.hisparse_memory_pool import (
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
-from sglang.srt.server_args import ServerArgs
+from sglang.srt.server_args import ServerArgs, get_global_server_args
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
@@ -115,6 +115,8 @@ def match_prefix_for_req(
         match_result.best_match_node,
         match_result.host_hit_length,
     )
+    max_len = req._compute_max_prefix_len(len(token_ids))
+    req.matched_prefix_len = min(len(req.prefix_indices) + req.host_hit_length, max_len)
     if match_result.mamba_branching_seqlen is not None:
         req.mamba_branching_seqlen = match_result.mamba_branching_seqlen
     if match_result.cache_protected_len is not None:
@@ -162,14 +164,26 @@ class SchedulePolicy:
     def calc_priority(
         self, waiting_queue: List[Req], running_batch: Optional[ScheduleBatch] = None
     ) -> None:
+        policy = self._determine_active_policy(waiting_queue)
+
+        # Populate req.matched_prefix_len at schedule time. Cache-aware policies
+        # set it in _compute_prefix_matches; do the same full match for
+        # cache-agnostic policies when the radix supports it, so the load
+        # snapshot has it. Skip on decode (never prefills).
+        if (
+            not isinstance(policy, CacheAwarePolicy)
+            and self.tree_cache.supports_fast_match_prefix()
+            and get_global_server_args().disaggregation_mode != "decode"
+        ):
+            for r in waiting_queue:
+                match_prefix_for_req(self.tree_cache, r)
+
         if self.policy == CacheAgnosticPolicy.FCFS:
             if self.enable_priority_scheduling:
                 SchedulePolicy._sort_by_priority_and_fcfs(
                     waiting_queue, self.priority_sign
                 )
             return
-
-        policy = self._determine_active_policy(waiting_queue)
 
         if isinstance(policy, CacheAwarePolicy):
             temporary_deprioritized = self._compute_prefix_matches(
@@ -279,7 +293,7 @@ class SchedulePolicy:
         """Sorts the waiting queue based on the longest prefix match."""
         waiting_queue.sort(
             key=lambda r: (
-                -len(r.prefix_indices)
+                -r.matched_prefix_len
                 if r.rid not in temporary_deprioritized
                 else float("inf")
             )

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -79,7 +79,7 @@ class SchedulerLoadInquirer:
         num_tokens = 0
         for req in self.get_waiting_queue():
             # if match-in-waiting-queue disabled, this metric returns seq_lens
-            num_tokens += max(0, req.seqlen - req.matched_prefix_len)
+            num_tokens += max(0, req.seqlen - req.num_matched_prefix_tokens)
         cr = self.get_chunked_req()
         if cr is not None:
             num_tokens += max(0, cr.seqlen - len(cr.prefix_indices))

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -72,6 +72,19 @@ class SchedulerLoadInquirer:
             num_pending_tokens += req.seqlen - len(req.prefix_indices) - chunk_deduct
         return num_pending_tokens
 
+    def get_num_waiting_uncached_tokens(self) -> int:
+        """Get uncached input tokens waiting for prefill compute."""
+        if self.disaggregation_mode == DisaggregationMode.DECODE:
+            return 0
+        num_tokens = 0
+        for req in self.get_waiting_queue():
+            # if match-in-waiting-queue disabled, this metric returns seq_lens
+            num_tokens += max(0, req.seqlen - req.matched_prefix_len)
+        cr = self.get_chunked_req()
+        if cr is not None:
+            num_tokens += max(0, cr.seqlen - len(cr.prefix_indices))
+        return num_tokens
+
     def get_loads(self, req: GetLoadsReqInput = None) -> GetLoadsReqOutput:
         """
         Get comprehensive load metrics for /v1/loads endpoint.
@@ -101,6 +114,7 @@ class SchedulerLoadInquirer:
             )
 
         num_waiting_reqs = sum(len(queue) for queue in waiting_queues)
+        num_waiting_uncached_tokens = self.get_num_waiting_uncached_tokens()
         num_used_tokens, kv_token_usage = (
             self.pool_stats_observer.get_pool_stats().get_kv_token_stats()
         )
@@ -193,6 +207,7 @@ class SchedulerLoadInquirer:
             timestamp=time.time(),
             num_running_reqs=num_running_reqs,
             num_waiting_reqs=num_waiting_reqs,
+            num_waiting_uncached_tokens=num_waiting_uncached_tokens,
             num_used_tokens=num_used_tokens,
             num_total_tokens=num_total_tokens,
             max_total_num_tokens=self.max_total_num_tokens,

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -237,6 +237,9 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         pass
 
+    def supports_fast_match_prefix(self) -> bool:
+        return False
+
     @abstractmethod
     def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs):
         pass

--- a/test/registered/unit/mem_cache/test_radix_force_miss.py
+++ b/test/registered/unit/mem_cache/test_radix_force_miss.py
@@ -36,8 +36,12 @@ class _StubReq:
         self.last_host_node = None
         self.best_match_node = None
         self.host_hit_length = None
+        self.num_matched_prefix_tokens = 0
         self.mamba_branching_seqlen = None
         self.cache_protected_len = None
+
+    def _compute_max_prefix_len(self, input_len):
+        return max(input_len - 1, 0)
 
 
 class TestZeroMatchResult(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add `num_waiting_uncached_tokens` to `/v1/loads` — reports the number of input tokens still needing prefill compute across all waiting requests, accounting for prefix cache hits.
- Store `num_matched_prefix_tokens ` on `Req` during prefix matching so the load metric can read it without an extra tree walk.
- For cache-agnostic scheduling policies (e.g. FCFS), populate `num_matched_prefix_tokens ` at schedule time when the cache supports it.

## Motivation

`num_waiting_reqs` alone doesn't distinguish a queue of 50 short prompts from 50 long ones nor 99% cached requests and 1% cached requests. Routers and autoscalers need the token-level signal to make informed decisions about prefill backpressure.

## Behavior

| Scenario | `num_waiting_uncached_tokens` |
|---|---|
| Prefix cache hit | `seqlen - num_matched_prefix_tokens ` (subtracts cached portion) |
| No fast prefix match | `seqlen` (conservative upper bound, zero overhead) |
| Decode workers (disagg) | Always 0 |
| Chunked prefill in flight | Adds remaining `seqlen - len(prefix_indices)` |

Available in both JSON and Prometheus response formats.

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26918430570](https://github.com/sgl-project/sglang/actions/runs/26918430570)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26918430465](https://github.com/sgl-project/sglang/actions/runs/26918430465)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->