### PR TITLE
Fix Gemma4 unified attention backend default

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2343,7 +2343,9 @@ class ServerArgs:
             "Gemma4UnifiedForConditionalGeneration",
         ):
             default_attention_backend = (
-                "trtllm_mha" if is_sm100_supported() else "triton"
+                "triton"
+                if model_arch == "Gemma4UnifiedForConditionalGeneration"
+                else "trtllm_mha" if is_sm100_supported() else "triton"
             )
             if self.is_attention_backend_not_set():
                 self.attention_backend = default_attention_backend


### PR DESCRIPTION
## Summary

`google/gemma-4-12B-it` currently inherits the Gemma4 SM10x `trtllm_mha` default and can hit a missing FlashInfer `trtllm-gen` kernel. This changes only the unified Gemma4 default to `triton` while keeping the older Gemma4 SM10x `trtllm_mha` behavior unchanged.

Reproduced on GB300 with:

```bash
CUDA_VISIBLE_DEVICES=3 sglang serve --model-path google/gemma-4-12B-it --reasoning-parser gemma4 --tool-call-parser gemma4 --speculative-algorithm NEXTN --speculative-draft-model-path google/gemma-4-12B-it-assistant --speculative-num-steps 5 --speculative-num-draft-tokens 6 --speculative-eagle-topk 1 --trust-remote-code
```

Exact error:

```text
tvm.error.InternalError: Error in function 'loadKernel' at /workspace/include/flashinfer/trtllm/fmha/fmhaKernels.cuh:961: Trtllm-gen kernels not found: qkvLayout=2, maskType=1, kernelType=3, tileScheduler=0, multiCtasKvMode=1, headDimPerCtaV=512, headDimQk=512, headDimV=512, tileSizeQ=128, tileSizeKv=128, numTokensPerPage=64, dynamicNumTokensPerPage=0, reuseSmemKForV=0, uses2CtaMma=0, sparseMlaType=0, skipsSoftmax=0
```

cc @JustinTong0323 















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26924161604](https://github.com/sgl-project/sglang/actions/runs/26924161604)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26924161492](https://github.com/sgl-project/sglang/actions/runs/26924161492)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->