### PR TITLE
[diffusion] optimize realtime video postprocess

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -24,6 +24,10 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.protocol import (
 from sglang.multimodal_gen.runtime.entrypoints.openai.realtime import (
     realtime_video_api,
 )
+from sglang.multimodal_gen.runtime.entrypoints.openai.realtime.warmup import (
+    realtime_warmup_enabled,
+    run_realtime_warmup,
+)
 from sglang.multimodal_gen.runtime.entrypoints.openai.utils import build_sampling_params
 from sglang.multimodal_gen.runtime.entrypoints.post_training import (
     rollout_api,
@@ -77,32 +81,36 @@ async def _run_server_warmup_after_http_ready(
     server_args: ServerArgs, warmup_done: asyncio.Event
 ) -> None:
     try:
-        if (
-            not server_args.warmup
-            or not server_args.server_warmup
-            or server_args.warmup_resolutions is not None
-        ):
+        run_standard_warmup = (
+            server_args.warmup
+            and server_args.server_warmup
+            and server_args.warmup_resolutions is None
+        )
+        if not run_standard_warmup and not realtime_warmup_enabled():
             warmup_done.set()
             return
 
         await _wait_until_http_ready(server_args)
 
-        warmup_input_path = None
-        if should_include_warmup_image(server_args, server_based_warmup=True):
-            warmup_input_path = await prepare_warmup_image_path(server_args)
+        if run_standard_warmup:
+            warmup_input_path = None
+            if should_include_warmup_image(server_args, server_based_warmup=True):
+                warmup_input_path = await prepare_warmup_image_path(server_args)
 
-        warmup_reqs = build_warmup_reqs(
-            server_args,
-            warmup_resolutions=None,
-            warmup_input_path=warmup_input_path,
-            return_warmup_result=True,
-            server_based_warmup=True,
-            use_model_sampling_defaults=True,
-        )
-        for req in warmup_reqs:
-            response = await async_scheduler_client.forward(req)
-            if response.error is not None:
-                raise RuntimeError(response.error)
+            warmup_reqs = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=None,
+                warmup_input_path=warmup_input_path,
+                return_warmup_result=True,
+                server_based_warmup=True,
+                use_model_sampling_defaults=True,
+            )
+            for req in warmup_reqs:
+                response = await async_scheduler_client.forward(req)
+                if response.error is not None:
+                    raise RuntimeError(response.error)
+
+        await run_realtime_warmup(server_args, async_scheduler_client)
 
         logger.info("The server is fired up and ready to roll!")
         warmup_done.set()
@@ -129,7 +137,7 @@ async def lifespan(app: FastAPI):
     # 2. Start the ZMQ Broker in the background to handle offline requests
     broker_task = asyncio.create_task(run_zeromq_broker(server_args))
     warmup_task = None
-    if server_args.server_warmup:
+    if server_args.server_warmup or realtime_warmup_enabled():
         warmup_task = asyncio.create_task(
             _run_server_warmup_after_http_ready(server_args, warmup_done)
         )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_video_api.py
@@ -3,6 +3,7 @@
 import asyncio
 import shutil
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import msgspec.msgpack
@@ -36,13 +37,26 @@ from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 if TYPE_CHECKING:
-    from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+    from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+        OutputBatch,
+        Req,
+    )
 
 logger = init_logger(__name__)
 router = APIRouter(prefix="/v1/realtime_video", tags=["realtime"])
 _ACTIVE_SESSION_IDS: set[str] = set()
 _ACTIVE_SESSION_WAIT_SECONDS = 1.0
 _ACTIVE_SESSION_WAIT_INTERVAL_SECONDS = 0.1
+
+
+@dataclass
+class _RealtimeSendQueueItem:
+    chunk: RealtimeChunkContext
+    batch: "Req"
+    result: "OutputBatch"
+    request_prepare_ms: float
+    scheduler_forward_ms: float
+    chunk_started: float
 
 
 def _transport_ms(value: float) -> int:
@@ -144,14 +158,13 @@ async def _generate_loop(ws: WebSocket, session: GenerateSession):
     if adapter is None:
         raise ValueError("realtime adapter is not initialized")
 
-    pending_send_task = None
-    while not session.reached_max_chunks():
-        try:
-            if pending_send_task is not None and pending_send_task.done():
-                await pending_send_task
-                pending_send_task = None
-
-            # send to scheduler and generate video chunk
+    send_queue: asyncio.Queue[_RealtimeSendQueueItem | None] = asyncio.Queue(maxsize=1)
+    sender_task = asyncio.create_task(
+        _send_realtime_chunk_loop(ws, session, send_queue)
+    )
+    try:
+        while not session.reached_max_chunks():
+            _raise_if_sender_failed(sender_task)
             server_args = get_global_server_args()
 
             await adapter.wait_for_next_chunk(session)
@@ -179,70 +192,117 @@ async def _generate_loop(ws: WebSocket, session: GenerateSession):
 
             # finish
             adapter.on_chunk_complete(session, result)
-            if pending_send_task is not None:
-                await pending_send_task
-            if batch.realtime_output_pacing:
-                await _send_output_and_log(
-                    ws,
-                    session,
-                    chunk,
-                    batch,
-                    result,
-                    request_prepare_ms,
-                    scheduler_forward_ms,
-                    chunk_started,
-                )
-                pending_send_task = None
-            else:
-                pending_send_task = asyncio.create_task(
-                    _send_output_and_log(
-                        ws,
-                        session,
-                        chunk,
-                        batch,
-                        result,
-                        request_prepare_ms,
-                        scheduler_forward_ms,
-                        chunk_started,
-                    )
-                )
-
-        except asyncio.CancelledError:
-            if pending_send_task is not None:
-                pending_send_task.cancel()
-                await _await_realtime_task(pending_send_task)
-            logger.info("generation completed, session_id=%s", session.id)
-            break
-        except WebSocketDisconnect:
-            if pending_send_task is not None:
-                pending_send_task.cancel()
-                await _await_realtime_task(pending_send_task)
-            logger.info(
-                "client disconnected during generation, session_id=%s", session.id
+            _raise_if_sender_failed(sender_task)
+            await _enqueue_realtime_send_item(
+                send_queue,
+                sender_task,
+                _RealtimeSendQueueItem(
+                    chunk=chunk,
+                    batch=batch,
+                    result=result,
+                    request_prepare_ms=request_prepare_ms,
+                    scheduler_forward_ms=scheduler_forward_ms,
+                    chunk_started=chunk_started,
+                ),
             )
-            break
-        except Exception as e:
-            if pending_send_task is not None:
-                pending_send_task.cancel()
-                await _await_realtime_task(pending_send_task)
-            err_msg = str(e).splitlines()[0]
-            logger.error("error during generate loop: %s", err_msg)
-            try:
-                await write_error_msg(f"error during generate loop: {err_msg}", ws)
-            except Exception as send_error:
-                logger.error(
-                    "error during sending complete msg: %s",
-                    send_error,
-                )
-            break
-    else:
-        if pending_send_task is not None:
-            await pending_send_task
+
+        await _join_realtime_send_queue(send_queue, sender_task)
+        _raise_if_sender_failed(sender_task)
+        await send_queue.put(None)
+        await sender_task
         logger.info(
             "generation reached max chunks, session_id=%s, max_chunks=%s",
             session.id,
             session.request.max_chunks if session.request is not None else None,
         )
+    except asyncio.CancelledError:
+        logger.info("generation completed, session_id=%s", session.id)
+    except WebSocketDisconnect:
+        logger.info("client disconnected during generation, session_id=%s", session.id)
+    except Exception as e:
+        err_msg = str(e).splitlines()[0]
+        logger.error("error during generate loop: %s", err_msg)
+        try:
+            await write_error_msg(f"error during generate loop: {err_msg}", ws)
+        except Exception as send_error:
+            logger.error(
+                "error during sending complete msg: %s",
+                send_error,
+            )
+    finally:
+        if not sender_task.done():
+            sender_task.cancel()
+            await _await_realtime_task(sender_task)
+
+
+async def _send_realtime_chunk_loop(
+    ws: WebSocket,
+    session: GenerateSession,
+    send_queue: asyncio.Queue[_RealtimeSendQueueItem | None],
+) -> None:
+    while True:
+        item = await send_queue.get()
+        try:
+            if item is None:
+                return
+            await _send_output_and_log(
+                ws,
+                session,
+                item.chunk,
+                item.batch,
+                item.result,
+                item.request_prepare_ms,
+                item.scheduler_forward_ms,
+                item.chunk_started,
+            )
+        finally:
+            send_queue.task_done()
+
+
+def _raise_if_sender_failed(sender_task: asyncio.Task) -> None:
+    if not sender_task.done():
+        return
+    if sender_task.cancelled():
+        raise asyncio.CancelledError()
+    exc = sender_task.exception()
+    if exc is not None:
+        raise exc
+    raise RuntimeError("realtime sender task exited unexpectedly")
+
+
+async def _enqueue_realtime_send_item(
+    send_queue: asyncio.Queue[_RealtimeSendQueueItem | None],
+    sender_task: asyncio.Task,
+    item: _RealtimeSendQueueItem,
+) -> None:
+    put_task = asyncio.create_task(send_queue.put(item))
+    done, pending = await asyncio.wait(
+        {put_task, sender_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    if sender_task in done:
+        for task in pending:
+            task.cancel()
+            await _await_realtime_task(task)
+        _raise_if_sender_failed(sender_task)
+    await put_task
+
+
+async def _join_realtime_send_queue(
+    send_queue: asyncio.Queue[_RealtimeSendQueueItem | None],
+    sender_task: asyncio.Task,
+) -> None:
+    join_task = asyncio.create_task(send_queue.join())
+    done, pending = await asyncio.wait(
+        {join_task, sender_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    if sender_task in done:
+        for task in pending:
+            task.cancel()
+            await _await_realtime_task(task)
+        _raise_if_sender_failed(sender_task)
+    await join_task
 
 
 async def _send_output_and_log(

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/warmup.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/warmup.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from typing import TYPE_CHECKING
+
+from sglang.multimodal_gen.runtime.entrypoints.openai.realtime.generate_session import (
+    GenerateSession,
+)
+from sglang.multimodal_gen.runtime.entrypoints.openai.realtime.registry import (
+    get_realtime_model_adapter,
+)
+from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
+    process_generation_batch,
+)
+from sglang.multimodal_gen.runtime.entrypoints.utils import ReleaseRealtimeSessionReq
+from sglang.multimodal_gen.runtime.postprocess.realesrgan_upscaler import (
+    REALESRGAN_TORCH_COMPILE_ENV,
+)
+from sglang.multimodal_gen.runtime.postprocess.rife_interpolator import (
+    RIFE_TORCH_COMPILE_ENV,
+)
+from sglang.multimodal_gen.runtime.server_warmup import (
+    MINIMUM_PICTURE_BASE64_FOR_WARMUP,
+)
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.entrypoints.openai.protocol import (
+        RealtimeVideoGenerationsRequest,
+    )
+    from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
+    from sglang.multimodal_gen.runtime.server_args import ServerArgs
+
+logger = init_logger(__name__)
+
+REALTIME_WARMUP_DEFAULT_CHUNKS = 2
+REALTIME_WARMUP_DEFAULT_SIZES = ("832x480", "480x832")
+REALTIME_WARMUP_SIZE_ENV = "SGLANG_REALTIME_WARMUP_SIZE"
+REALTIME_WARMUP_SIZES_ENV = "SGLANG_REALTIME_WARMUP_SIZES"
+
+
+def _compile_env_enabled(name: str) -> bool:
+    return os.environ.get(name, "0") == "1"
+
+
+def _upscaling_compile_enabled() -> bool:
+    return _compile_env_enabled(REALESRGAN_TORCH_COMPILE_ENV)
+
+
+def _frame_interpolation_compile_enabled() -> bool:
+    return _compile_env_enabled(RIFE_TORCH_COMPILE_ENV)
+
+
+def realtime_warmup_enabled() -> bool:
+    return _upscaling_compile_enabled() or _frame_interpolation_compile_enabled()
+
+
+def _realtime_warmup_sizes() -> list[str]:
+    value = os.environ.get(REALTIME_WARMUP_SIZES_ENV)
+    if value is None:
+        value = os.environ.get(REALTIME_WARMUP_SIZE_ENV)
+    if value is None:
+        return list(REALTIME_WARMUP_DEFAULT_SIZES)
+
+    sizes = []
+    for size in value.split(","):
+        size = size.strip()
+        if size and size not in sizes:
+            sizes.append(size)
+    if not sizes:
+        raise ValueError(f"{REALTIME_WARMUP_SIZES_ENV} must contain at least one size")
+    return sizes
+
+
+def _build_realtime_warmup_request(
+    server_args: ServerArgs,
+    *,
+    warmup_chunks: int,
+    size: str,
+) -> "RealtimeVideoGenerationsRequest":
+    from sglang.multimodal_gen.runtime.entrypoints.openai.protocol import (
+        RealtimeVideoGenerationsRequest,
+    )
+
+    chunk_size = int(
+        server_args.pipeline_config.dit_config.arch_config.num_frames_per_block
+    )
+    camera_actions = [[] for _ in range(chunk_size * warmup_chunks)]
+    upscaling_enabled = _upscaling_compile_enabled()
+    frame_interpolation_enabled = _frame_interpolation_compile_enabled()
+    return RealtimeVideoGenerationsRequest(
+        type="init",
+        prompt="warmup",
+        first_frame=MINIMUM_PICTURE_BASE64_FOR_WARMUP,
+        condition_inputs={"camera_actions": camera_actions},
+        max_chunks=warmup_chunks,
+        size=size,
+        seed=42,
+        guidance_scale=1.0,
+        realtime_output_format="raw",
+        enable_upscaling=upscaling_enabled,
+        upscaling_model_path=os.environ.get(
+            "SGLANG_REALTIME_WARMUP_REALESRGAN_MODEL_PATH"
+        ),
+        upscaling_scale=4,
+        enable_frame_interpolation=frame_interpolation_enabled,
+        frame_interpolation_exp=1,
+        frame_interpolation_scale=1.0,
+        frame_interpolation_model_path=os.environ.get(
+            "SGLANG_REALTIME_WARMUP_RIFE_MODEL_PATH"
+        ),
+    )
+
+
+async def _release_realtime_warmup_session(
+    scheduler_client: AsyncSchedulerClient,
+    session_id: str,
+) -> None:
+    try:
+        await scheduler_client.forward(ReleaseRealtimeSessionReq(session_id=session_id))
+    except Exception as e:
+        logger.warning(
+            "failed to release realtime warmup session, session_id=%s, error=%s",
+            session_id,
+            e,
+        )
+
+
+async def _run_realtime_warmup_for_size(
+    server_args: ServerArgs,
+    scheduler_client: AsyncSchedulerClient,
+    *,
+    size: str,
+    warmup_chunks: int,
+) -> None:
+    session = GenerateSession()
+    scheduler_session_started = False
+    start_time = time.perf_counter()
+    logger.info(
+        "Starting realtime warmup, session_id=%s, size=%s, chunks=%s",
+        session.id,
+        size,
+        warmup_chunks,
+    )
+    try:
+        adapter = get_realtime_model_adapter(server_args)
+        session.set_adapter(adapter)
+        realtime_req = _build_realtime_warmup_request(
+            server_args,
+            warmup_chunks=warmup_chunks,
+            size=size,
+        )
+        await adapter.on_init(session, realtime_req)
+        session.set_request(realtime_req)
+
+        for chunk_idx in range(warmup_chunks):
+            await adapter.wait_for_next_chunk(session)
+            chunk = session.new_chunk()
+            batch = adapter.prepare_next_request(session, server_args, chunk)
+            batch.suppress_logs = True
+            batch.extra["realtime_warmup"] = True
+
+            scheduler_session_started = True
+            _, result = await process_generation_batch(scheduler_client, batch)
+            if result.error is not None:
+                raise RuntimeError(result.error)
+            adapter.on_chunk_complete(session, result)
+            logger.info(
+                "Realtime warmup chunk processed, session_id=%s, size=%s, chunk_idx=%s",
+                session.id,
+                size,
+                chunk_idx,
+            )
+
+        elapsed = time.perf_counter() - start_time
+        logger.info(
+            "Realtime warmup size finished, session_id=%s, size=%s, chunks=%s, elapsed=%.2fs",
+            session.id,
+            size,
+            warmup_chunks,
+            elapsed,
+        )
+    finally:
+        if scheduler_session_started:
+            await _release_realtime_warmup_session(scheduler_client, session.id)
+        if session.input_temp_dir is not None:
+            shutil.rmtree(session.input_temp_dir, ignore_errors=True)
+        session.dispose()
+
+
+async def run_realtime_warmup(
+    server_args: ServerArgs,
+    scheduler_client: AsyncSchedulerClient,
+) -> None:
+    if not realtime_warmup_enabled():
+        return
+
+    warmup_chunks = REALTIME_WARMUP_DEFAULT_CHUNKS
+    sizes = _realtime_warmup_sizes()
+    start_time = time.perf_counter()
+    logger.info(
+        "Starting realtime warmup, sizes=%s, chunks_per_size=%s",
+        sizes,
+        warmup_chunks,
+    )
+    try:
+        get_realtime_model_adapter(server_args)
+    except ValueError as e:
+        logger.info("Skipping realtime warmup: %s", e)
+        return
+
+    for size in sizes:
+        await _run_realtime_warmup_for_size(
+            server_args,
+            scheduler_client,
+            size=size,
+            warmup_chunks=warmup_chunks,
+        )
+
+    elapsed = time.perf_counter() - start_time
+    logger.info(
+        "Realtime warmup finished, sizes=%s, chunks_per_size=%s, elapsed=%.2fs",
+        sizes,
+        warmup_chunks,
+        elapsed,
+    )

--- a/python/sglang/multimodal_gen/runtime/postprocess/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/__init__.py
@@ -5,16 +5,20 @@ from sglang.multimodal_gen.runtime.postprocess.realesrgan_upscaler import (
     ImageUpscaler,
     batch_upscale_frames,
     upscale_frames,
+    upscale_tensor,
 )
 from sglang.multimodal_gen.runtime.postprocess.rife_interpolator import (
     FrameInterpolator,
     interpolate_video_frames,
+    interpolate_video_tensor,
 )
 
 __all__ = [
     "FrameInterpolator",
     "interpolate_video_frames",
+    "interpolate_video_tensor",
     "ImageUpscaler",
     "batch_upscale_frames",
     "upscale_frames",
+    "upscale_tensor",
 ]

--- a/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
@@ -37,10 +37,17 @@ _DEFAULT_REALESRGAN_FILENAMES_BY_SCALE = {
 _LOW_MEMORY_TILED_UPSCALE_FREE_BYTES = 2 * 1024**3
 _REALESRGAN_TILE_SIZE = 256
 _REALESRGAN_TILE_PAD = 32
+REALESRGAN_TORCH_COMPILE_ENV = "SGLANG_REALESRGAN_TORCH_COMPILE"
+REALESRGAN_TORCH_COMPILE_MODE_ENV = "SGLANG_REALESRGAN_TORCH_COMPILE_MODE"
 
 # Module-level cache: model_path -> UpscalerModel instance
 _MODEL_CACHE: dict[str, "UpscalerModel"] = {}
 _RESOLVED_MODEL_PATH_CACHE: dict[str, str] = {}
+
+
+def _is_inference_tensor(tensor: torch.Tensor) -> bool:
+    is_inference = getattr(tensor, "is_inference", None)
+    return bool(is_inference()) if is_inference is not None else False
 
 
 def _default_model_path_for_scale(scale: int) -> str:
@@ -287,9 +294,15 @@ def _build_net_from_state_dict(state_dict: dict) -> nn.Module:
 class UpscalerModel:
     """Wraps a Real-ESRGAN network, provides load() and upscale() API."""
 
-    def __init__(self, net: nn.Module, scale: int):
+    def __init__(
+        self,
+        net: nn.Module,
+        scale: int,
+        uses_torch_compile: bool = False,
+    ):
         self.net = net
         self.scale = scale  # the model's native upscaling factor (e.g. 4)
+        self.uses_torch_compile = uses_torch_compile
 
     @property
     def device(self) -> torch.device:
@@ -303,14 +316,44 @@ class UpscalerModel:
         return torch.from_numpy(frames).to(self.device)
 
     def _preprocess_input_tensor(self, imgs_t: torch.Tensor) -> torch.Tensor:
-        imgs_t = imgs_t.permute(0, 3, 1, 2).to(dtype=self.dtype).mul_(1.0 / 255.0)
+        imgs_t = imgs_t.permute(0, 3, 1, 2).to(dtype=self.dtype).mul(1.0 / 255.0)
         if self.device.type == "cuda":
             imgs_t = imgs_t.contiguous(memory_format=torch.channels_last)
         return imgs_t
 
+    def _prepare_nchw_tensor(self, frames: torch.Tensor) -> torch.Tensor:
+        if frames.dim() == 3:
+            frames = frames.unsqueeze(0)
+        if frames.dim() != 4:
+            raise ValueError(
+                f"RealESRGAN tensor input must be NCHW, got shape={tuple(frames.shape)}"
+            )
+        if frames.shape[1] == 1:
+            frames = frames.repeat(1, 3, 1, 1)
+        elif frames.shape[1] > 3:
+            frames = frames[:, :3]
+        elif frames.shape[1] != 3:
+            raise ValueError(
+                f"RealESRGAN tensor input must have 1, 3, or 4 channels, got {frames.shape[1]}"
+            )
+
+        frames = frames.to(device=self.device)
+        if frames.dtype == torch.uint8:
+            frames = frames.to(dtype=self.dtype).mul(1.0 / 255.0)
+        else:
+            frames = frames.to(dtype=self.dtype)
+
+        if self.device.type == "cuda":
+            if self.uses_torch_compile and _is_inference_tensor(frames):
+                return frames.clone(memory_format=torch.channels_last)
+            return frames.contiguous(memory_format=torch.channels_last)
+        if self.uses_torch_compile and _is_inference_tensor(frames):
+            return frames.clone(memory_format=torch.contiguous_format)
+        return frames.contiguous()
+
     @staticmethod
     def _postprocess_output_tensor(out: torch.Tensor) -> torch.Tensor:
-        out = out.permute(0, 2, 3, 1).clamp(0.0, 1.0).mul_(255.0)
+        out = out.permute(0, 2, 3, 1).clamp(0.0, 1.0).mul(255.0)
         return out.to(torch.uint8).contiguous()
 
     @staticmethod
@@ -441,6 +484,58 @@ class UpscalerModel:
         out_np = out.squeeze(0).permute(1, 2, 0).clamp(0.0, 1.0).cpu().numpy()
         return (out_np * 255.0).astype(np.uint8)
 
+    def upscale_tensor(
+        self, frames: torch.Tensor, outscale: float | None = None
+    ) -> torch.Tensor:
+        """Upscale NCHW RGB frames and keep the result as a float tensor."""
+        imgs_t = self._prepare_nchw_tensor(frames)
+        _, _, h, w = imgs_t.shape
+
+        with torch.inference_mode():
+            if self._should_use_tiled_upscale(h, w):
+                logger.info(
+                    "Using tiled Real-ESRGAN tensor upscale for low GPU memory: "
+                    "batch=%d frame=%dx%d, tile_size=%d, tile_pad=%d",
+                    imgs_t.shape[0],
+                    w,
+                    h,
+                    _REALESRGAN_TILE_SIZE,
+                    _REALESRGAN_TILE_PAD,
+                )
+                out = torch.cat(
+                    [
+                        self._upscale_tiled_to_cpu(img_t.unsqueeze(0))
+                        for img_t in imgs_t
+                    ],
+                    dim=0,
+                )
+            else:
+                try:
+                    out = self.net(imgs_t)
+                except torch.cuda.OutOfMemoryError:
+                    if self.device.type != "cuda":
+                        raise
+                    torch.cuda.empty_cache()
+                    logger.warning(
+                        "Real-ESRGAN tensor upscale OOM; retrying with tiled upscale"
+                    )
+                    out = torch.cat(
+                        [
+                            self._upscale_tiled_to_cpu(img_t.unsqueeze(0))
+                            for img_t in imgs_t
+                        ],
+                        dim=0,
+                    )
+
+        if outscale is not None and outscale != self.scale:
+            target_h = int(h * outscale)
+            target_w = int(w * outscale)
+            out = F.interpolate(
+                out, size=(target_h, target_w), mode="bicubic", align_corners=False
+            )
+
+        return out.clamp(0.0, 1.0)
+
     def upscale_batch(
         self, frames: list[np.ndarray], outscale: float | None = None
     ) -> list[np.ndarray]:
@@ -565,10 +660,12 @@ class ImageUpscaler:
         model_path: Optional[str] = None,
         scale: int = 4,
         half_precision: bool = False,
+        optimize_for_realtime: bool = False,
     ):
         self._model_path = model_path
         self._scale = scale
         self._half_precision = half_precision
+        self._optimize_for_realtime = optimize_for_realtime
 
     def _ensure_model_loaded(self) -> UpscalerModel:
         """Download/load Real-ESRGAN weights, detect arch, and cache globally."""
@@ -576,9 +673,24 @@ class ImageUpscaler:
 
         # Resolve: local .pth pass-through, or HF repo → download single file
         resolved_path = _resolve_model_path(model_path)
+        device = current_platform.get_local_torch_device()
+        compile_enabled = (
+            self._optimize_for_realtime
+            and os.environ.get(REALESRGAN_TORCH_COMPILE_ENV, "0") == "1"
+        )
+        compile_mode = os.environ.get(
+            REALESRGAN_TORCH_COMPILE_MODE_ENV,
+            "reduce-overhead",
+        )
+        cache_key = (
+            f"{resolved_path}|device={device}|half={self._half_precision}"
+            f"|realtime_opt={self._optimize_for_realtime}"
+            f"|compile={compile_enabled}"
+            f"|mode={compile_mode if compile_enabled else ''}"
+        )
 
-        if resolved_path in _MODEL_CACHE:
-            return _MODEL_CACHE[resolved_path]
+        if cache_key in _MODEL_CACHE:
+            return _MODEL_CACHE[cache_key]
 
         logger.info("Loading Real-ESRGAN weights from %s", resolved_path)
         try:
@@ -610,25 +722,41 @@ class ImageUpscaler:
             ) from e
         net.eval()
 
-        device = current_platform.get_local_torch_device()
-        if self._half_precision:
-            net = net.half()
-        net = net.to(device)
-
-        # Detect the model's native scale from network architecture
-        native_scale = 4  # sensible default
+        # Detect the model's native scale before optional torch.compile wraps it.
+        native_scale = 4
         if hasattr(net, "upscale"):
             native_scale = net.upscale
         elif hasattr(net, "scale"):
             native_scale = net.scale
 
-        model = UpscalerModel(net=net, scale=native_scale)
-        _MODEL_CACHE[resolved_path] = model
+        if self._half_precision:
+            net = net.half()
+        net = net.to(device)
+        if self._optimize_for_realtime and current_platform.is_cuda():
+            net = net.to(memory_format=torch.channels_last)
+
+        if compile_enabled:
+            try:
+                net = torch.compile(net, mode=compile_mode)
+                logger.info(
+                    "Enabled torch.compile for Real-ESRGAN: mode=%s",
+                    compile_mode,
+                )
+            except Exception as e:
+                logger.warning("Failed to torch.compile Real-ESRGAN: %s", e)
+
+        model = UpscalerModel(
+            net=net,
+            scale=native_scale,
+            uses_torch_compile=compile_enabled,
+        )
+        _MODEL_CACHE[cache_key] = model
         logger.info(
-            "Real-ESRGAN model loaded on device: %s (native_scale=%dx, outscale=%s)",
+            "Real-ESRGAN model loaded on device: %s (native_scale=%dx, outscale=%s, dtype=%s)",
             device,
             native_scale,
             f"{self._scale}x" if self._scale != native_scale else "native",
+            model.dtype,
         )
         return model
 
@@ -679,6 +807,14 @@ class ImageUpscaler:
             len(groups),
         )
         return [frame for frame in output_frames if frame is not None]
+
+    def upscale_tensor(self, frames: torch.Tensor) -> torch.Tensor:
+        """Upscale NCHW RGB frames without a CPU round trip."""
+        if frames.numel() == 0:
+            return frames
+        model = self._ensure_model_loaded()
+        outscale = self._scale if self._scale != model.scale else None
+        return model.upscale_tensor(frames, outscale=outscale)
 
 
 # ---------------------------------------------------------------------------
@@ -818,5 +954,22 @@ def batch_upscale_frames(
         model_path=model_path,
         scale=scale,
         half_precision=current_platform.is_cuda(),
+        optimize_for_realtime=True,
     )
     return upscaler.upscale_batched(frames)
+
+
+def upscale_tensor(
+    frames: torch.Tensor,
+    model_path: Optional[str] = None,
+    scale: int = 4,
+    half_precision: bool = False,
+) -> torch.Tensor:
+    """Batched Real-ESRGAN upscaling for NCHW RGB tensors."""
+    upscaler = ImageUpscaler(
+        model_path=model_path,
+        scale=scale,
+        half_precision=half_precision,
+        optimize_for_realtime=True,
+    )
+    return upscaler.upscale_tensor(frames)

--- a/python/sglang/multimodal_gen/runtime/postprocess/rife_interpolator.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/rife_interpolator.py
@@ -26,10 +26,17 @@ logger = init_logger(__name__)
 
 # Default HuggingFace repo for RIFE 4.22.lite weights
 _DEFAULT_RIFE_HF_REPO = "elfgum/RIFE-4.22.lite"
+RIFE_TORCH_COMPILE_ENV = "SGLANG_RIFE_TORCH_COMPILE"
+RIFE_TORCH_COMPILE_MODE_ENV = "SGLANG_RIFE_TORCH_COMPILE_MODE"
 
 # Module-level cache: model_path -> Model instance
 _MODEL_CACHE: dict[str, "Model"] = {}
 _MAX_RIFE_BATCH_PAIRS = 16
+
+
+def _is_inference_tensor(tensor: torch.Tensor) -> bool:
+    is_inference = getattr(tensor, "is_inference", None)
+    return bool(is_inference()) if is_inference is not None else False
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +274,7 @@ class Model:
     def __init__(self):
         self.flownet = IFNet()
         self.device_type: str = "cpu"
+        self.uses_torch_compile = False
 
     def eval(self) -> "Model":
         self.flownet.eval()
@@ -348,8 +356,13 @@ class FrameInterpolator:
     per model_path to avoid reloading across requests.
     """
 
-    def __init__(self, model_path: Optional[str] = None):
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        optimize_for_realtime: bool = False,
+    ):
         self._model_path = model_path
+        self._optimize_for_realtime = optimize_for_realtime
         self._resolved_path: Optional[str] = None
 
     def _ensure_model_loaded(self) -> Model:
@@ -369,16 +382,33 @@ class FrameInterpolator:
         model_path = maybe_download_model(model_path)
 
         self._resolved_path = model_path
+        compile_enabled = (
+            self._optimize_for_realtime
+            and os.environ.get(RIFE_TORCH_COMPILE_ENV, "0") == "1"
+        )
+        compile_mode = os.environ.get(RIFE_TORCH_COMPILE_MODE_ENV, "reduce-overhead")
+        cache_key = (
+            f"{model_path}|realtime_opt={self._optimize_for_realtime}"
+            f"|compile={compile_enabled}"
+            f"|mode={compile_mode if compile_enabled else ''}"
+        )
 
-        if model_path in _MODEL_CACHE:
-            return _MODEL_CACHE[model_path]
+        if cache_key in _MODEL_CACHE:
+            return _MODEL_CACHE[cache_key]
 
         device = current_platform.get_local_torch_device()
         model = Model()
         model.load_model(model_path, strip_module_prefix=True)
         model.eval()
         model.flownet = model.flownet.to(device)
-        _MODEL_CACHE[model_path] = model
+        if compile_enabled:
+            try:
+                model.flownet = torch.compile(model.flownet, mode=compile_mode)
+                model.uses_torch_compile = True
+                logger.info("Enabled torch.compile for RIFE: mode=%s", compile_mode)
+            except Exception as e:
+                logger.warning("Failed to torch.compile RIFE: %s", e)
+        _MODEL_CACHE[cache_key] = model
         logger.info("RIFE model loaded on device: %s", device)
         return model
 
@@ -471,6 +501,8 @@ class FrameInterpolator:
                 "Frame interpolation requires at least 2 frames; returning input unchanged."
             )
             return frames, 1
+        if exp <= 0:
+            return frames, 1
 
         model = self._ensure_model_loaded()
         device = model.device()
@@ -509,6 +541,80 @@ class FrameInterpolator:
         )
         return result, multiplier
 
+    def interpolate_tensor(
+        self,
+        frames: torch.Tensor,
+        exp: int = 1,
+        scale: float = 1.0,
+    ) -> tuple[torch.Tensor, int]:
+        """Interpolate NCHW RGB frames without converting through numpy."""
+        if frames.dim() == 3:
+            frames = frames.unsqueeze(0)
+        if frames.dim() != 4:
+            raise ValueError(
+                f"RIFE tensor input must be NCHW, got shape={tuple(frames.shape)}"
+            )
+        if frames.shape[0] < 2 or exp <= 0:
+            return frames, 1
+
+        model = self._ensure_model_loaded()
+        device = model.device()
+
+        if frames.shape[1] == 1:
+            frames = frames.repeat(1, 3, 1, 1)
+        elif frames.shape[1] > 3:
+            frames = frames[:, :3]
+        elif frames.shape[1] != 3:
+            raise ValueError(
+                f"RIFE tensor input must have 1, 3, or 4 channels, got {frames.shape[1]}"
+            )
+
+        frames = frames.to(device=device)
+        if frames.dtype == torch.uint8:
+            frames = frames.float().mul(1.0 / 255.0)
+        else:
+            frames = frames.float()
+        if model.uses_torch_compile and _is_inference_tensor(frames):
+            frames = frames.clone(memory_format=torch.contiguous_format)
+        else:
+            frames = frames.contiguous()
+
+        start_time = time.perf_counter()
+        if exp == 1:
+            middle_tensors = model.inference(
+                frames[:-1],
+                frames[1:],
+                scale=scale,
+            )
+            out = torch.empty(
+                (frames.shape[0] * 2 - 1, *frames.shape[1:]),
+                dtype=middle_tensors.dtype,
+                device=middle_tensors.device,
+            )
+            out[0::2] = frames
+            out[1::2] = middle_tensors
+            logger.info(
+                "RIFE tensor interpolation completed in %.3f seconds for %d frames",
+                time.perf_counter() - start_time,
+                frames.shape[0],
+            )
+            return out, 2
+
+        n_intermediate = 2**exp // 2
+        result: list[torch.Tensor] = []
+        for i in range(frames.shape[0] - 1):
+            I0 = frames[i : i + 1]
+            I1 = frames[i + 1 : i + 2]
+            result.append(I0)
+            result.extend(self._make_inference(model, I0, I1, n_intermediate, scale))
+        result.append(frames[-1:])
+        logger.info(
+            "RIFE tensor interpolation completed in %.3f seconds for %d frames",
+            time.perf_counter() - start_time,
+            frames.shape[0],
+        )
+        return torch.cat(result, dim=0), 2**exp
+
 
 # ---------------------------------------------------------------------------
 # Module-level convenience function
@@ -536,3 +642,17 @@ def interpolate_video_frames(
     """
     interpolator = FrameInterpolator(model_path=model_path)
     return interpolator.interpolate(frames, exp=exp, scale=scale)
+
+
+def interpolate_video_tensor(
+    frames: torch.Tensor,
+    exp: int = 1,
+    scale: float = 1.0,
+    model_path: Optional[str] = None,
+) -> tuple[torch.Tensor, int]:
+    """Convenience wrapper around FrameInterpolator.interpolate_tensor."""
+    interpolator = FrameInterpolator(
+        model_path=model_path,
+        optimize_for_realtime=True,
+    )
+    return interpolator.interpolate_tensor(frames, exp=exp, scale=scale)

--- a/python/sglang/multimodal_gen/runtime/utils/realtime_video.py
+++ b/python/sglang/multimodal_gen/runtime/utils/realtime_video.py
@@ -243,7 +243,9 @@ def _tensor_sample_to_nchw_rgb_tensor(sample: torch.Tensor) -> torch.Tensor:
     elif sample.dim() == 4:
         frames = sample.permute(1, 0, 2, 3)
     else:
-        raise ValueError(f"Unexpected realtime tensor sample shape: {tuple(sample.shape)}")
+        raise ValueError(
+            f"Unexpected realtime tensor sample shape: {tuple(sample.shape)}"
+        )
 
     if frames.shape[1] == 1:
         frames = frames.repeat(1, 3, 1, 1)

--- a/python/sglang/multimodal_gen/runtime/utils/realtime_video.py
+++ b/python/sglang/multimodal_gen/runtime/utils/realtime_video.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import torch
 
+from sglang.multimodal_gen.configs.sample.sampling_params import DataType
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 if TYPE_CHECKING:
@@ -119,12 +121,8 @@ def build_raw_rgb_frame_batches(
 
     for sample in outputs:
         stage_start = time.monotonic()
-        if (
-            isinstance(sample, torch.Tensor)
-            and not req.enable_frame_interpolation
-            and not req.enable_upscaling
-        ):
-            frames = _tensor_sample_to_rgb24_array(sample)
+        if isinstance(sample, torch.Tensor):
+            frames = _tensor_sample_to_processed_rgb24_array(sample, req)
         else:
             frames = post_process_sample_fn(
                 sample,
@@ -204,8 +202,72 @@ def build_raw_rgb_frame_batches(
     return frame_batches, frame_metadata
 
 
-def _tensor_sample_to_rgb24_array(sample: torch.Tensor) -> np.ndarray:
+def _tensor_sample_to_processed_rgb24_array(
+    sample: torch.Tensor,
+    req: Req,
+) -> np.ndarray:
+    frames_t = _tensor_sample_to_nchw_rgb_tensor(sample)
+
+    if (
+        req.enable_frame_interpolation
+        and req.data_type == DataType.VIDEO
+        and frames_t.shape[0] > 1
+    ):
+        from sglang.multimodal_gen.runtime.postprocess import (
+            interpolate_video_tensor,
+        )
+
+        frames_t, _ = interpolate_video_tensor(
+            frames_t,
+            exp=req.frame_interpolation_exp,
+            scale=req.frame_interpolation_scale,
+            model_path=req.frame_interpolation_model_path,
+        )
+
+    if req.enable_upscaling and frames_t.numel() > 0:
+        from sglang.multimodal_gen.runtime.postprocess import upscale_tensor
+
+        frames_t = upscale_tensor(
+            frames_t,
+            model_path=req.upscaling_model_path,
+            scale=req.upscaling_scale,
+            half_precision=current_platform.is_cuda(),
+        )
+
+    return _nchw_rgb_tensor_to_rgb24_array(frames_t)
+
+
+def _tensor_sample_to_nchw_rgb_tensor(sample: torch.Tensor) -> torch.Tensor:
     if sample.dim() == 3:
-        sample = sample.unsqueeze(1)
-    sample = (sample * 255).clamp(0, 255).to(torch.uint8)
-    return sample.permute(1, 2, 3, 0).contiguous().cpu().numpy()
+        frames = sample.unsqueeze(0)
+    elif sample.dim() == 4:
+        frames = sample.permute(1, 0, 2, 3)
+    else:
+        raise ValueError(f"Unexpected realtime tensor sample shape: {tuple(sample.shape)}")
+
+    if frames.shape[1] == 1:
+        frames = frames.repeat(1, 3, 1, 1)
+    elif frames.shape[1] > RAW_RGB_CHANNELS:
+        frames = frames[:, :RAW_RGB_CHANNELS]
+    elif frames.shape[1] != RAW_RGB_CHANNELS:
+        raise ValueError(f"Unexpected realtime tensor channel count: {frames.shape[1]}")
+    return frames.contiguous()
+
+
+def _nchw_rgb_tensor_to_rgb24_array(frames: torch.Tensor) -> np.ndarray:
+    if frames.dim() == 3:
+        frames = frames.unsqueeze(0)
+    if frames.dim() != 4:
+        raise ValueError(f"Unexpected NCHW RGB tensor shape: {tuple(frames.shape)}")
+    if frames.shape[1] == 1:
+        frames = frames.repeat(1, 3, 1, 1)
+    elif frames.shape[1] > RAW_RGB_CHANNELS:
+        frames = frames[:, :RAW_RGB_CHANNELS]
+    elif frames.shape[1] != RAW_RGB_CHANNELS:
+        raise ValueError(f"Unexpected NCHW RGB channel count: {frames.shape[1]}")
+
+    if frames.dtype == torch.uint8:
+        frames_u8 = frames
+    else:
+        frames_u8 = (frames * 255).clamp(0, 255).to(torch.uint8)
+    return frames_u8.permute(0, 2, 3, 1).contiguous().cpu().numpy()


### PR DESCRIPTION
## Summary
closes #27146 

This rebases the runtime-only optimization pieces from #27146 onto the current realtime WebUI stack.

Credit: the original optimization work came from HuangJi / IPostYellow in #27146. This PR keeps the original author as the commit author (`fn <huangji.huang@antgroup.com>`) and adapts the change set to avoid bringing in stale WebUI edits.

Changes:
- keep realtime tensor outputs on GPU through RIFE / Real-ESRGAN postprocess when possible
- add bounded async sender queue so chunk generation can overlap websocket output sending
- add optional realtime warmup for torch-compiled RIFE / Real-ESRGAN paths, gated by env vars

## Deployment check

Deployed on `lingbot-experience-8b200-v58-20260603` with the existing public tunnels:
- UI: https://invoice-likewise-latinas-expense.trycloudflare.com
- API health: https://environments-drain-diane-changes.trycloudflare.com/health

Measured via local websocket on the server, 6 chunks per case, averages exclude chunk 0.

| case | before scheduler | after scheduler | before chunk total | after chunk total |
| --- | ---: | ---: | ---: | ---: |
| no postprocess | 369.8 ms | 293.4 ms | 456.4 ms | pacing-overlapped, not directly comparable |
| smooth only | 371.8 ms | 418.8 ms | 446.2 ms | 484.2 ms |
| SR only | 668.2 ms | 419.4 ms | 713.0 ms | 583.6 ms |
| smooth + SR | 1084.0 ms | 575.6 ms | 1115.6 ms | 607.2 ms |

The clear win is the SR path and especially smooth+SR. Smooth-only did not improve in this measurement.

## Notes

No local pytest was run; this is diffusion/GPU runtime work and was verified through the remote deployment path above.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26921889049](https://github.com/sgl-project/sglang/actions/runs/26921889049)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26921888917](https://github.com/sgl-project/sglang/actions/runs/26921888917)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->