### PR TITLE
[lora] Add opt-in PDL support to LoRA kernels

### DIFF
--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-05-28-mori/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/mori/tco1-new.png"
+          alt="Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"May 28, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-04-29-p2p-update/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"March 25, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-17-rocm-miles-rl-amd/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/rocm_miles_rl/fig_1.png"
-          alt="ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 17, 2026"}
         </p>
       </div>
     </a>

--- a/python/sglang/jit_kernel/csrc/lora/moe_lora_align_kernel.cu
+++ b/python/sglang/jit_kernel/csrc/lora/moe_lora_align_kernel.cu
@@ -272,7 +272,7 @@ SGL_DEVICE void _count_and_sort_expert_tokens(
   }
 }
 
-template <typename scalar_t>
+template <typename scalar_t, bool kUsePDL>
 __global__ void moe_lora_align_block_size_kernel(
     scalar_t* __restrict__ topk_ids,
     int32_t* __restrict__ seg_indptr,
@@ -296,6 +296,8 @@ __global__ void moe_lora_align_block_size_kernel(
     int32_t* lora_ids,
     int32_t* __restrict__ token_mask,
     bool has_expert_map) {
+  device::PDLWaitPrimary<kUsePDL>();
+
   int lora_idx = blockIdx.x / 2;
   int lora_id = lora_ids[lora_idx];
   if (lora_id == -1 || adapter_enabled[lora_id] == 0) {
@@ -350,9 +352,11 @@ __global__ void moe_lora_align_block_size_kernel(
       topk_num,
       &token_mask[(lora_id * num_tokens)],
       has_expert_map);
+
+  device::PDLTriggerSecondary<kUsePDL>();
 }
 
-template <typename scalar_t>
+template <typename scalar_t, bool kUsePDL>
 __global__ void lora_count_and_sort_expert_tokens_kernel(
     const scalar_t* __restrict__ topk_ids,
     int32_t* __restrict__ sorted_token_ids,
@@ -366,6 +370,8 @@ __global__ void lora_count_and_sort_expert_tokens_kernel(
     int32_t* lora_ids,
     int32_t* adapter_enabled,
     bool has_expert_map) {
+  device::PDLWaitPrimary<kUsePDL>();
+
   int lora_idx = blockIdx.x;
   int lora_id = lora_ids[lora_idx];
   if (lora_id == -1 || adapter_enabled[lora_id] == 0) {
@@ -386,9 +392,11 @@ __global__ void lora_count_and_sort_expert_tokens_kernel(
       lora_id,
       topk_num,
       has_expert_map);
+
+  device::PDLTriggerSecondary<kUsePDL>();
 }
 
-template <typename scalar_t, int32_t fill_threads>
+template <typename scalar_t, int32_t fill_threads, bool kUsePDL>
 __global__ void moe_lora_align_block_size_small_batch_expert_kernel(
     scalar_t* __restrict__ topk_ids,
     int32_t* __restrict__ seg_indptr,
@@ -409,6 +417,8 @@ __global__ void moe_lora_align_block_size_small_batch_expert_kernel(
     int32_t* lora_ids,
     int32_t* token_mask,
     bool has_expert_map) {
+  device::PDLWaitPrimary<kUsePDL>();
+
   int lora_idx = blockIdx.x;
   int lora_id = lora_ids[lora_idx];
   if (lora_id == -1 || adapter_enabled[lora_id] == 0) {
@@ -463,13 +473,15 @@ __global__ void moe_lora_align_block_size_small_batch_expert_kernel(
       topk_num,
       &token_mask[(lora_id * num_tokens)],
       has_expert_map);
+
+  device::PDLTriggerSecondary<kUsePDL>();
 }
 
 }  // namespace moe
 
 namespace {
 
-template <typename scalar_t>
+template <typename scalar_t, bool kUsePDL>
 struct MoeLoraAlignBlockSizeKernel {
   static void
   run(tvm::ffi::TensorView topk_ids,
@@ -528,30 +540,31 @@ struct MoeLoraAlignBlockSizeKernel {
       constexpr int32_t fill_threads = 256;
 
       dim3 blockDim(num_thread + fill_threads);
-      auto kernel = moe::moe_lora_align_block_size_small_batch_expert_kernel<scalar_t, fill_threads>;
+      auto kernel = moe::moe_lora_align_block_size_small_batch_expert_kernel<scalar_t, fill_threads, kUsePDL>;
       RuntimeDeviceCheck(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem));
 
-      LaunchKernel(dim3(max_loras), blockDim, stream, shared_mem)(
-          kernel,
-          static_cast<scalar_t*>(topk_ids.data_ptr()),
-          static_cast<int32_t*>(seg_indptr.data_ptr()),
-          static_cast<int32_t*>(req_to_lora.data_ptr()),
-          num_reqs,
-          block_size,
-          expert_map_ptr,
-          num_experts,
-          max_loras,
-          topk_ids.numel(),
-          max_num_tokens_padded,
-          max_num_m_blocks,
-          static_cast<int32_t*>(sorted_token_ids.data_ptr()),
-          static_cast<int32_t*>(expert_ids.data_ptr()),
-          topk_num,
-          static_cast<int32_t*>(num_tokens_post_pad.data_ptr()),
-          static_cast<int32_t*>(adapter_enabled.data_ptr()),
-          static_cast<int32_t*>(lora_ids.data_ptr()),
-          token_mask_ptr,
-          has_expert_map);
+      LaunchKernel(dim3(max_loras), blockDim, stream, shared_mem)
+          .enable_pdl(kUsePDL)(
+              kernel,
+              static_cast<scalar_t*>(topk_ids.data_ptr()),
+              static_cast<int32_t*>(seg_indptr.data_ptr()),
+              static_cast<int32_t*>(req_to_lora.data_ptr()),
+              num_reqs,
+              block_size,
+              expert_map_ptr,
+              num_experts,
+              max_loras,
+              topk_ids.numel(),
+              max_num_tokens_padded,
+              max_num_m_blocks,
+              static_cast<int32_t*>(sorted_token_ids.data_ptr()),
+              static_cast<int32_t*>(expert_ids.data_ptr()),
+              topk_num,
+              static_cast<int32_t*>(num_tokens_post_pad.data_ptr()),
+              static_cast<int32_t*>(adapter_enabled.data_ptr()),
+              static_cast<int32_t*>(lora_ids.data_ptr()),
+              token_mask_ptr,
+              has_expert_map);
 
     } else {
       int num_thread = 1024;
@@ -560,35 +573,36 @@ struct MoeLoraAlignBlockSizeKernel {
 
       size_t shared_mem_size = num_warps * WARP_SIZE * sizeof(int32_t);
 
-      auto align_kernel = moe::moe_lora_align_block_size_kernel<scalar_t>;
+      auto align_kernel = moe::moe_lora_align_block_size_kernel<scalar_t, kUsePDL>;
 
       // launch two threadblocks for each lora
       // blockIdx.x % 2 == 0: counting experts and aligning
       // blockIdx.x % 2 == 1: filling sorted_token_ids
-      LaunchKernel(dim3(max_loras * 2), blockDim, stream, shared_mem_size)(
-          align_kernel,
-          static_cast<scalar_t*>(topk_ids.data_ptr()),
-          static_cast<int32_t*>(seg_indptr.data_ptr()),
-          static_cast<int32_t*>(req_to_lora.data_ptr()),
-          num_reqs,
-          block_size,
-          expert_map_ptr,
-          num_experts,
-          max_loras,
-          topk_ids.numel(),
-          max_num_tokens_padded,
-          max_num_m_blocks,
-          static_cast<int32_t*>(sorted_token_ids.data_ptr()),
-          static_cast<int32_t*>(expert_ids.data_ptr()),
-          topk_num,
-          static_cast<int32_t*>(num_tokens_post_pad.data_ptr()),
-          static_cast<int32_t*>(adapter_enabled.data_ptr()),
-          static_cast<int32_t*>(cumsum_buffer.data_ptr()),
-          WARP_SIZE,
-          padded_num_experts,
-          static_cast<int32_t*>(lora_ids.data_ptr()),
-          token_mask_ptr,
-          has_expert_map);
+      LaunchKernel(dim3(max_loras * 2), blockDim, stream, shared_mem_size)
+          .enable_pdl(kUsePDL)(
+              align_kernel,
+              static_cast<scalar_t*>(topk_ids.data_ptr()),
+              static_cast<int32_t*>(seg_indptr.data_ptr()),
+              static_cast<int32_t*>(req_to_lora.data_ptr()),
+              num_reqs,
+              block_size,
+              expert_map_ptr,
+              num_experts,
+              max_loras,
+              topk_ids.numel(),
+              max_num_tokens_padded,
+              max_num_m_blocks,
+              static_cast<int32_t*>(sorted_token_ids.data_ptr()),
+              static_cast<int32_t*>(expert_ids.data_ptr()),
+              topk_num,
+              static_cast<int32_t*>(num_tokens_post_pad.data_ptr()),
+              static_cast<int32_t*>(adapter_enabled.data_ptr()),
+              static_cast<int32_t*>(cumsum_buffer.data_ptr()),
+              WARP_SIZE,
+              padded_num_experts,
+              static_cast<int32_t*>(lora_ids.data_ptr()),
+              token_mask_ptr,
+              has_expert_map);
 
       const int block_threads = std::min(256, (int)num_thread);
       const int num_blocks = (topk_ids.numel() + block_threads - 1) / block_threads;
@@ -597,22 +611,23 @@ struct MoeLoraAlignBlockSizeKernel {
       const int actual_blocks = std::min(num_blocks, max_blocks);
 
       dim3 gridDims(max_loras, actual_blocks);
-      auto sort_kernel = moe::lora_count_and_sort_expert_tokens_kernel<scalar_t>;
+      auto sort_kernel = moe::lora_count_and_sort_expert_tokens_kernel<scalar_t, kUsePDL>;
 
-      LaunchKernel(gridDims, dim3(block_threads), stream)(
-          sort_kernel,
-          static_cast<scalar_t*>(topk_ids.data_ptr()),
-          static_cast<int32_t*>(sorted_token_ids.data_ptr()),
-          static_cast<int32_t*>(cumsum_buffer.data_ptr()),
-          expert_map_ptr,
-          topk_ids.numel(),
-          num_experts,
-          max_num_tokens_padded,
-          topk_num,
-          token_mask_ptr,
-          static_cast<int32_t*>(lora_ids.data_ptr()),
-          static_cast<int32_t*>(adapter_enabled.data_ptr()),
-          has_expert_map);
+      LaunchKernel(gridDims, dim3(block_threads), stream)
+          .enable_pdl(kUsePDL)(
+              sort_kernel,
+              static_cast<scalar_t*>(topk_ids.data_ptr()),
+              static_cast<int32_t*>(sorted_token_ids.data_ptr()),
+              static_cast<int32_t*>(cumsum_buffer.data_ptr()),
+              expert_map_ptr,
+              topk_ids.numel(),
+              num_experts,
+              max_num_tokens_padded,
+              topk_num,
+              token_mask_ptr,
+              static_cast<int32_t*>(lora_ids.data_ptr()),
+              static_cast<int32_t*>(adapter_enabled.data_ptr()),
+              has_expert_map);
     }
   }
 };

--- a/python/sglang/jit_kernel/moe_lora_align.py
+++ b/python/sglang/jit_kernel/moe_lora_align.py
@@ -4,15 +4,26 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.jit_kernel.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
 
+def _lora_pdl_enabled() -> bool:
+    from sglang.srt.environ import envs
+
+    return envs.SGLANG_OPT_LORA_ENABLE_PDL.get() and is_arch_support_pdl()
+
+
 @cache_once
 def _jit_moe_align_module(dtype: torch.dtype) -> Module:
-    args = make_cpp_args(dtype)
+    args = make_cpp_args(dtype, _lora_pdl_enabled())
     return load_jit(
         "moe_lora_align_block_size",
         *args,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -534,6 +534,9 @@ class Envs:
     SGLANG_SYNC_TOKEN_IDS_ACROSS_TP = EnvBool(False)
     SGLANG_ENABLE_COLOCATED_BATCH_GEN = EnvBool(False)
 
+    # LoRA
+    SGLANG_OPT_LORA_ENABLE_PDL = EnvBool(False)
+
     # Deterministic inference
     SGLANG_ENABLE_DETERMINISTIC_INFERENCE = EnvBool(False)
     # Use 1-stage all-reduce kernel on AMD (deterministic, fixed accumulation order)

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.lora.backend.lmhead_mixing import LoRABackendLmHeadMixing
+from sglang.srt.lora.triton_ops.kernel_utils import get_pdl_launch_metadata
 from sglang.srt.lora.utils import LoRABatchInfo, MoELoRABatchInfo
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
@@ -343,9 +344,13 @@ def _compute_moe_lora_info_kernel(
     num_segments,
     max_len,
     BLOCK_SIZE: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
     num_pid_m = tl.cdiv(max_len, BLOCK_SIZE)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     pid_seg = pid // num_pid_m
     pid_m = pid % num_pid_m
@@ -357,6 +362,10 @@ def _compute_moe_lora_info_kernel(
     valid = offs < seg_len
     lora_id = tl.load(weight_indices_ptr + pid_seg)
     lora_rank = tl.load(lora_ranks_ptr + lora_id)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
     tl.store(
         adapter_enabled_ptr + lora_id,
         (lora_rank > 0).to(tl.int32),
@@ -407,6 +416,7 @@ def _compute_moe_lora_info(
             f"MoE LoRA token-mapping launch under-covers tokens: "
             f"{grid_size=} {block_size=} {num_tokens=}"
         )
+        enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
         _compute_moe_lora_info_kernel[(grid_size,)](
             seg_indptr,
             lora_ranks,
@@ -416,6 +426,8 @@ def _compute_moe_lora_info(
             weight_indices.numel(),
             max_len,
             BLOCK_SIZE=block_size,
+            ENABLE_PDL=enable_pdl,
+            **pdl_kwargs,
         )
         return adapter_enabled, token_lora_mapping
 

--- a/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
@@ -2,7 +2,10 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    get_pdl_launch_metadata,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -36,6 +39,7 @@ def _gate_up_lora_b_kernel(
     BLOCK_K: tl.constexpr,
     # For fused output scaling
     scalings,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     """
     This kernel packs 2 sgemms (gate/up) into a single kernel. The multiplication
@@ -105,6 +109,9 @@ def _gate_up_lora_b_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
@@ -123,6 +130,9 @@ def _gate_up_lora_b_kernel(
 
         x_ptrs += BLOCK_K * x_stride_1
         w_ptrs += BLOCK_K * w_stride_2
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     # Store result to output matrix
     partial_sum *= scaling
@@ -176,6 +186,7 @@ def gate_up_lora_b_fwd(
         output = base_output
 
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
     _gate_up_lora_b_kernel[grid_b](
         x,
         gate_up_lora_b,
@@ -199,6 +210,8 @@ def gate_up_lora_b_fwd(
         BLOCK_OUT,
         BLOCK_R,
         batch_info.scalings,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
 
     return output

--- a/python/sglang/srt/lora/triton_ops/kernel_utils.py
+++ b/python/sglang/srt/lora/triton_ops/kernel_utils.py
@@ -1,6 +1,23 @@
 import triton
 import triton.language as tl
 
+from sglang.jit_kernel.utils import is_arch_support_pdl
+from sglang.srt.environ import envs
+
+
+def lora_pdl_enabled() -> bool:
+    return envs.SGLANG_OPT_LORA_ENABLE_PDL.get() and is_arch_support_pdl()
+
+
+def get_pdl_launch_metadata() -> tuple[bool, dict]:
+    """Return (ENABLE_PDL constexpr value, extra launch kwargs) for LoRA kernels.
+
+    ``launch_pdl`` is NVIDIA-only Triton launch metadata; the HIP backend
+    rejects unknown kwargs, so it is only included when PDL is enabled.
+    """
+    enable_pdl = lora_pdl_enabled()
+    return enable_pdl, ({"launch_pdl": True} if enable_pdl else {})
+
 
 @triton.jit
 def _resolve_token_positions(

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -48,7 +48,10 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    get_pdl_launch_metadata,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 # ---------------------------------------------------------------------------
@@ -136,6 +139,7 @@ def _step_a_q_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -182,6 +186,9 @@ def _step_a_q_kernel(
         head_id * FULL_K
     )  # row offset for this head's K-half (i in [0, qk_nope))
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -210,6 +217,9 @@ def _step_a_q_kernel(
         )
 
         partial_sum += tl.dot(x_tile, w_tile)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     partial_sum = partial_sum.to(x.dtype.element_ty)
     out_offs = (
@@ -251,6 +261,7 @@ def step_a_q_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
 
     _step_a_q_kernel[grid](
         q_nope,
@@ -279,6 +290,8 @@ def step_a_q_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_A_BLOCK_N,
         BLOCK_K=_STEP_A_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
     return out
 
@@ -325,6 +338,7 @@ def _step_b_q_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -367,6 +381,9 @@ def _step_b_q_kernel(
     n_mask = n_offset[None, :] < N
     safe_n = tl.minimum(n_offset, N - 1)
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K_eff, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -394,6 +411,9 @@ def _step_b_q_kernel(
         )
 
         partial_sum += tl.dot(x_tile, w_tile)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     partial_sum *= scaling
     partial_sum = partial_sum.to(x.dtype.element_ty)
@@ -440,6 +460,7 @@ def step_b_q_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
 
     _step_b_q_kernel[grid](
         q_lora_a,
@@ -467,6 +488,8 @@ def step_b_q_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_B_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
     return base_output
 
@@ -512,6 +535,7 @@ def _step_a_v_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -552,6 +576,9 @@ def _step_a_v_kernel(
     safe_row = tl.minimum(s_physical, S - 1)
     safe_n = tl.minimum(n_offset, N_eff - 1)
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -581,6 +608,9 @@ def _step_a_v_kernel(
         )
 
         partial_sum += tl.dot(x_tile, w_tile)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     partial_sum = partial_sum.to(x.dtype.element_ty)
     out_offs = (
@@ -620,6 +650,7 @@ def step_a_v_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
 
     _step_a_v_kernel[grid](
         attn_output,
@@ -646,6 +677,8 @@ def step_a_v_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_A_BLOCK_N,
         BLOCK_K=_STEP_A_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
     return out
 
@@ -695,6 +728,7 @@ def _step_b_v_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -739,6 +773,9 @@ def _step_b_v_kernel(
     # V-half row base for this head: h*FULL_K + qk_nope
     head_row_base = head_id * FULL_K + QK_NOPE_OFFSET
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K_eff, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -767,6 +804,9 @@ def _step_b_v_kernel(
         )
 
         partial_sum += tl.dot(x_tile, w_tile)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     partial_sum *= scaling
     partial_sum = partial_sum.to(x.dtype.element_ty)
@@ -816,6 +856,7 @@ def step_b_v_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
 
     _step_b_v_kernel[grid](
         attn_lora_a,
@@ -845,5 +886,7 @@ def step_b_v_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_B_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
     return base_output

--- a/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
@@ -2,7 +2,10 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    get_pdl_launch_metadata,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -38,6 +41,7 @@ def _qkv_lora_b_kernel(
     BLOCK_K: tl.constexpr,
     # For fused output scaling
     scalings,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     """
     This kernel packs 3 sgemms (q/k/v) into a single kernel. The multiplication
@@ -107,6 +111,9 @@ def _qkv_lora_b_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
@@ -124,6 +131,9 @@ def _qkv_lora_b_kernel(
 
         x_ptrs += BLOCK_K * x_stride_1
         w_ptrs += BLOCK_K * w_stride_2
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     # Store result to output matrix
     partial_sum *= scaling
@@ -187,6 +197,7 @@ def qkv_lora_b_fwd(
         output = base_output
 
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
     _qkv_lora_b_kernel[grid_b](
         x,
         qkv_lora_b,
@@ -211,6 +222,8 @@ def qkv_lora_b_fwd(
         BLOCK_OUT,
         BLOCK_R,
         batch_info.scalings,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
 
     return output

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -2,7 +2,10 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    get_pdl_launch_metadata,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -35,6 +38,7 @@ def _sgemm_lora_a_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     """
     Computes a segmented batched matrix multiplication for the LoRA A matrix.
@@ -92,6 +96,9 @@ def _sgemm_lora_a_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
@@ -109,6 +116,9 @@ def _sgemm_lora_a_kernel(
 
         x_ptrs += BLOCK_K * x_stride_1
         w_ptrs += BLOCK_K * w_stride_2
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     # Store result to output matrix
     partial_sum = partial_sum.to(x.dtype.element_ty)
@@ -153,6 +163,7 @@ def sgemm_lora_a_fwd(
     )
 
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
 
     output = torch.empty((S, R), device=x.device, dtype=x.dtype)
     _sgemm_lora_a_kernel[grid](
@@ -178,5 +189,7 @@ def sgemm_lora_a_fwd(
         BLOCK_S,
         BLOCK_R,
         BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
     return output

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
@@ -2,7 +2,10 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    get_pdl_launch_metadata,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -36,6 +39,7 @@ def _sgemm_lora_b_kernel(
     BLOCK_K: tl.constexpr,
     # For fused output scaling
     scalings,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     """
     Computes a segmented batched matrix multiplication for the LoRA B matrix
@@ -94,6 +98,9 @@ def _sgemm_lora_b_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     # Iterate to compute the block in output matrix
     n_mask = n_offset[None, :] < N
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
@@ -112,6 +119,9 @@ def _sgemm_lora_b_kernel(
 
         x_ptrs += BLOCK_K * x_stride_1
         w_ptrs += BLOCK_K * w_stride_2
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
     # Store result to output matrix
     partial_sum *= scaling
@@ -161,6 +171,7 @@ def sgemm_lora_b_fwd(
         output = base_output
 
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
     _sgemm_lora_b_kernel[grid](
         x,
         weights,
@@ -184,5 +195,7 @@ def sgemm_lora_b_fwd(
         BLOCK_N,
         BLOCK_R,
         batch_info.scalings,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
     return output

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -10,6 +10,7 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.moe_align import moe_align_block_size as jit_moe_align_block_size
+from sglang.srt.lora.triton_ops.kernel_utils import get_pdl_launch_metadata
 
 
 @triton.jit
@@ -22,6 +23,7 @@ def _fused_virtual_topk_ids_kernel(
     M,
     top_k: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     """
     Fuses _get_virtual_topk_ids: comparison + clamp + arithmetic into one kernel.
@@ -40,6 +42,9 @@ def _fused_virtual_topk_ids_kernel(
     total = M * top_k
     valid = offs < total
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     m = offs // top_k
     # k = offs % top_k  # not needed directly
 
@@ -48,6 +53,10 @@ def _fused_virtual_topk_ids_kernel(
     safe_lora = tl.maximum(lora_id, 0)
 
     base = tl.load(topk_ids_ptr + offs, mask=valid, other=0)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
     # Preserve negative sentinel topk_ids (e.g. -1 for non-local experts after
     # EP dispatch). Without this, `-1 + safe_lora * num_experts` would land on
     # a real virtual-expert slot belonging to another adapter and trigger OOB
@@ -90,6 +99,7 @@ def _fused_virtual_topk_ids(
     BLOCK_SIZE = 1024
     grid = ((M * top_k + BLOCK_SIZE - 1) // BLOCK_SIZE,)
 
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
     _fused_virtual_topk_ids_kernel[grid](
         input_topk,
         token_lora_mapping,
@@ -99,6 +109,8 @@ def _fused_virtual_topk_ids(
         M,
         top_k,
         BLOCK_SIZE,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
 
     virtual_num_experts = num_experts_for_weight * max_loras
@@ -112,12 +124,20 @@ def _fused_sanitize_expert_ids_kernel(
     num_virtual_experts,
     N,
     BLOCK_SIZE: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     valid = offs < N
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     eid = tl.load(expert_ids_ptr + offs, mask=valid, other=0)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
     result = tl.where(eid < num_virtual_experts, eid, -1)
     tl.store(output_ptr + offs, result, mask=valid)
 
@@ -137,12 +157,15 @@ def fused_sanitize_expert_ids(
     BLOCK_SIZE = 1024
     grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE,)
 
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
     _fused_sanitize_expert_ids_kernel[grid](
         expert_ids,
         output,
         num_virtual_experts,
         N,
         BLOCK_SIZE,
+        ENABLE_PDL=enable_pdl,
+        **pdl_kwargs,
     )
     return output
 
@@ -175,11 +198,15 @@ def _moe_lora_shrink_splitk_kernel(
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     SPLIT_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr = False,
 ):
     """Split-K grouped GEMM for the LoRA A (shrink) stage with few virtual experts."""
     pid = tl.program_id(0)
     pid_sk = pid % SPLIT_K
     pid_mn = pid // SPLIT_K
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
     num_pid_m = tl.cdiv(num_tokens_post_padded, BLOCK_SIZE_M)
@@ -233,6 +260,9 @@ def _moe_lora_shrink_splitk_kernel(
         a_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_bk
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
     accumulator = accumulator.to(c_ptr.dtype.element_ty)
 
     # Write output
@@ -272,6 +302,7 @@ def _invoke_moe_lora_shrink_splitk(
 
     grid = (SPLIT_K * base_grid,)
 
+    enable_pdl, pdl_kwargs = get_pdl_launch_metadata()
     _moe_lora_shrink_splitk_kernel[grid](
         hidden_states,
         weight,
@@ -295,8 +326,10 @@ def _invoke_moe_lora_shrink_splitk(
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         GROUP_SIZE_M=GROUP_SIZE_M,
         SPLIT_K=SPLIT_K,
+        ENABLE_PDL=enable_pdl,
         num_warps=config.get("num_warps", 4),
         num_stages=config.get("num_stages", 4),
+        **pdl_kwargs,
     )
 
 


### PR DESCRIPTION
## Motivation

Hide kernel launch latency in the LoRA path by enabling Programmatic Dependent Launch (PDL) across the LoRA kernel chain. LoRA decode steps issue many small kernels back-to-back (shrink → expand, routing → align → sanitize → MoE shrink), where per-launch latency is a measurable share of step time. PDL lets each dependent kernel begin its prologue while its predecessor finishes.

The feature is **opt-in and off by default**: `SGLANG_OPT_LORA_ENABLE_PDL=1` (plus a Hopper+ arch check via `is_arch_support_pdl()`). With the flag unset, kernels compile and launch exactly as before.

## Modifications

**Triton kernels** — added `ENABLE_PDL: tl.constexpr` with `tl.extra.cuda.gdc_wait()` / `tl.extra.cuda.gdc_launch_dependents()` and `launch_pdl` launch metadata:

| Kernel | wait | trigger |
|---|---|---|
| `_sgemm_lora_a_kernel`, `_sgemm_lora_b_kernel`, `_qkv_lora_b_kernel`, `_gate_up_lora_b_kernel` | before the K loop | after the K loop |
| `kv_b_lora_absorbed.py` `_step_{a,b}_{q,v}_kernel` (4 kernels) | before the K loop | after the K loop |
| `_moe_lora_shrink_splitk_kernel` | at kernel start (routing buffers come from the immediate predecessor) | after the K loop |
| `_fused_virtual_topk_ids_kernel`, `_fused_sanitize_expert_ids_kernel`, `_compute_moe_lora_info_kernel` | at kernel start | after the last input load, before stores |

Trigger placement rule: `gdc_launch_dependents()` sits right after the kernel's last input load. It does not need to cover the stores because every consumer in this chain issues `gdc_wait()` before reading the producer's outputs.

**CUDA JIT** — `moe_lora_align_kernel.cu`: `bool kUsePDL` template parameter on the three `__global__` kernels and host struct, `device::PDLWaitPrimary` / `PDLTriggerSecondary`, and `.enable_pdl(kUsePDL)` on the `LaunchKernel` sites.

**Env flag** — `SGLANG_OPT_LORA_ENABLE_PDL = EnvBool(False)` in `environ.py` (new `# LoRA` section). All launch sites go through `kernel_utils.get_pdl_launch_metadata()` / `lora_pdl_enabled()`.

## Benchmark

Decode benchmark, split-K LoRA path:

| run | latency (s) | output tok/s | ITL (ms) |
|---|---|---|---|
| split-K (no PDL) | 51.63 | 2,900.7 | 22.06 |
| split-K + PDL | 51.82 | 2,898.2 | 22.08 |

Neutral end-to-end at this configuration (within noise) — keeping the flag default-off while evaluating more shapes/configs.

## Testing

On B200 (PDL active when flag is set):
- `jit_kernel/tests/test_moe_lora_align_block_size.py` — 32 passed (flag on and off)
- `test/registered/lora/{test_virtual_experts_kernels,test_moe_lora_info,test_fused_moe_lora_kernel}.py` — 124 passed, 5 skipped
- Flag matrix verified: default → PDL off; `SGLANG_OPT_LORA_ENABLE_PDL=1` → `launch_pdl` set; legacy `SGL_` prefix auto-converts with a `DeprecationWarning`
- All 8 dense LoRA Triton kernels validated against a torch reference with PDL enabled (rel err ≤ 3.3e-3)

## Checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26906845649](https://github.com/sgl-project/sglang/actions/runs/26906845649)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26906845306](https://github.com/sgl-project/sglang/actions/runs/26906845306)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->