### PR TITLE
ci: fix LMSYS blog sync to open a PR via gh and only run on main

### DIFF
--- a/.github/workflows/sync-lmsys-sglang-blogs.yml
+++ b/.github/workflows/sync-lmsys-sglang-blogs.yml
@@ -11,13 +11,6 @@ permissions:
 
 jobs:
   sync:
-    # Only run on the canonical repository's main branch:
-    # - The repository guard stops every fork that has Actions enabled from
-    #   running this scheduled job and pushing the generated commit to its own
-    #   (unprotected) branch, which then leaks into contributors' pull requests.
-    # - The ref guard stops a stray manual `workflow_dispatch` on any other
-    #   branch from operating against a non-main ref. (Scheduled runs already
-    #   only ever run on the default branch.)
     if: github.repository == 'sgl-project/sglang' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -35,10 +28,6 @@ jobs:
         run: python docs_new/scripts/update_lmsys_sglang_blogs.py
 
       - name: Open or update pull request
-        # `main` is protected and cannot be pushed to directly, so propose the
-        # change through a pull request opened with the GitHub CLI (`gh`, which
-        # is pre-installed on the runner -- no third-party action). This step is
-        # a no-op when the generated cards are unchanged.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -51,7 +40,7 @@ jobs:
 
           BRANCH="auto/lmsys-blog-cards"
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Recreate the bot branch as "current main + card diff" and overwrite
           # any previous state, so the PR always shows a clean single-commit diff.

--- a/.github/workflows/sync-lmsys-sglang-blogs.yml
+++ b/.github/workflows/sync-lmsys-sglang-blogs.yml
@@ -7,9 +7,18 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:
+    # Only run on the canonical repository's main branch:
+    # - The repository guard stops every fork that has Actions enabled from
+    #   running this scheduled job and pushing the generated commit to its own
+    #   (unprotected) branch, which then leaks into contributors' pull requests.
+    # - The ref guard stops a stray manual `workflow_dispatch` on any other
+    #   branch from operating against a non-main ref. (Scheduled runs already
+    #   only ever run on the default branch.)
+    if: github.repository == 'sgl-project/sglang' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -25,16 +34,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python docs_new/scripts/update_lmsys_sglang_blogs.py
 
-      - name: Commit and push changes
+      - name: Open or update pull request
+        # `main` is protected and cannot be pushed to directly, so propose the
+        # change through a pull request opened with the GitHub CLI (`gh`, which
+        # is pre-installed on the runner -- no third-party action). This step is
+        # a no-op when the generated cards are unchanged.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           if git diff --quiet -- docs_new/index.mdx; then
-            echo "No blog card changes to commit."
+            echo "No blog card changes; nothing to do."
             exit 0
           fi
 
+          BRANCH="auto/lmsys-blog-cards"
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Recreate the bot branch as "current main + card diff" and overwrite
+          # any previous state, so the PR always shows a clean single-commit diff.
+          git checkout -B "$BRANCH"
           git add docs_new/index.mdx
-          git diff --cached --quiet && exit 0
           git commit -m "docs: sync LMSYS SGLang blog cards"
-          git push
+          git push --force origin "$BRANCH"
+
+          # Open a PR only if one is not already open for this branch; otherwise
+          # the force-push above has already updated the existing PR in place.
+          if [ -z "$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "docs: sync LMSYS SGLang blog cards" \
+              --body 'Automated sync of the LMSYS SGLang blog cards in `docs_new/index.mdx`, opened by the `Sync LMSYS SGLang blogs` workflow.'
+          fi


### PR DESCRIPTION
## Problem

The `Sync LMSYS SGLang blogs` workflow (`.github/workflows/sync-lmsys-sglang-blogs.yml`) regenerates the blog cards in `docs_new/index.mdx` on a 12-hour schedule and then **pushes the commit directly to `main`**. That has two failure modes:

1. **It never updates the real docs.** On `sgl-project/sglang`, `main` is protected, so every scheduled run fails on push:
   ```
   remote: error: GH013: Repository rule violations found for refs/heads/main.
   remote: - Changes must be made through a pull request.
    ! [remote rejected] main -> main (push declined due to repository rule violations)
   ```
   The cards in `docs_new/index.mdx` have been frozen since this workflow merged (~late April).

2. **It leaks bot commits into contributors' PRs.** Because the workflow lives on `main`, every fork that has Actions enabled inherits the cron. On a fork the default branch is *not* protected, so the push succeeds and lands a `docs: sync LMSYS SGLang blog cards` commit there. When that contributor branches off (or merges/​updates from) their default branch and opens a PR, the bot commits ride along — e.g. [#26347](https://github.com/sgl-project/sglang/pull/26347) carries two such commits (`b4f0a5e`, `9dd0556`) at the base of its branch.

## Fix

- **Guard the job to the canonical repo *and* its main branch:**
  `if: github.repository == 'sgl-project/sglang' && github.ref == 'refs/heads/main'`.
  The repo guard stops forks from running the cron; the ref guard additionally blocks a stray manual `workflow_dispatch` on any non-main branch (scheduled runs are already main-only).
- **Open a pull request with the GitHub CLI (`gh`) instead of pushing to the protected `main`.** `gh` is pre-installed on the runner, so this adds **no third-party action** (only the first-party `actions/checkout` + `actions/setup-python` remain). The step is a no-op when the cards are unchanged, and it reuses a single `auto/lmsys-blog-cards` branch/PR (force-push updates the open PR in place rather than opening duplicates).

## Note for maintainers

For `gh` to open PRs with the default `GITHUB_TOKEN`, **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** must be enabled (this requirement is inherent to `GITHUB_TOKEN`, not to any particular tool). Auto-created PRs won't trigger the required status checks on their own (a `GITHUB_TOKEN`-authored event doesn't spawn new workflow runs); a maintainer can close/reopen to kick CI, or merge with admin rights, since this is a docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26984898674](https://github.com/sgl-project/sglang/actions/runs/26984898674)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26984898569](https://github.com/sgl-project/sglang/actions/runs/26984898569)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->