### PR TITLE
LoRA Async Pipelining Per Requeust Load

### DIFF
--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -25,6 +25,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from sglang.srt.lora.backend.base_backend import BaseLoRABackend
+from sglang.srt.lora.lora_pipeline_sync import LoRAPipelineFlag
 from sglang.srt.lora.utils import LoRABatchInfo, get_lm_head_lora_b_shard_size
 from sglang.srt.runtime_context import get_parallel
 
@@ -51,6 +52,22 @@ class BaseLayerWithLoRA(nn.Module):
         # LoRA-wrapped.
         if hasattr(self.base_layer, "reduce_results"):
             self.reduce_results = self.base_layer.reduce_results
+
+        # Pipeline sync flag -- initialized by LoRAManager when overlap loading is enabled.
+        # All modules within the same transformer layer share a single flag
+        # since their weights are loaded together in one DMA batch.
+        self._pipeline_flag: Optional[LoRAPipelineFlag] = None
+
+    def init_pipeline_flag(self, flag: LoRAPipelineFlag) -> None:
+        """Set the pipeline synchronization flag for this module."""
+        self._pipeline_flag = flag
+
+    def _sync_lora_loads(self) -> None:
+        """Wait for LoRA weights to be ready before forward computation.
+        Only called during prefill. Decode skips this entirely.
+        """
+        if self._pipeline_flag is not None and self._pipeline_flag.needs_wait:
+            self._pipeline_flag.wait_until_ready(torch.cuda.current_stream())
 
     def forward(self, x: torch.Tensor):
         return self.base_layer.forward(x)
@@ -212,6 +229,8 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         Extra tokens (tokens >= vocab_size) are now handled efficiently
         in the backend's run_lora_a_embedding method.
         """
+        self._sync_lora_loads()
+
         batch_info = self.lora_backend.batch_info
 
         # Get base embedding output
@@ -390,6 +409,8 @@ class ParallelLMHeadWithLoRA(BaseLayerWithLoRA):
         return lora_output
 
     def forward(self, hidden_states: torch.Tensor):
+        self._sync_lora_loads()
+
         # Apply base linear transformation
         base_output = F.linear(
             hidden_states, self.weight, bias=getattr(self.base_layer, "bias", None)
@@ -478,6 +499,8 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         return lora_output
 
     def forward(self, input_: torch.Tensor):
+        self._sync_lora_loads()
+
         # duplicate the logic in ColumnParallelLinear
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
         output_parallel = self.base_layer.quant_method.apply(
@@ -769,6 +792,8 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
         return lora_output
 
     def forward(self, input_: torch.Tensor, skip_all_reduce=False, forward_batch=None):
+        self._sync_lora_loads()
+
         if self.base_layer.input_is_parallel:
             input_parallel = input_
         else:
@@ -914,6 +939,8 @@ class ReplicatedLinearWithLoRA(BaseLayerWithLoRA):
         return lora_output
 
     def forward(self, x: torch.Tensor):
+        self._sync_lora_loads()
+
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
         output = self.base_layer.quant_method.apply(self.base_layer, x, bias)
         if self.lora_active:
@@ -1120,9 +1147,13 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         1. After gate_up projection, before activation
         2. After down projection, before final reduction
         """
-        # DP-attention idle forward: no batch_info, run the base MoE path.
+        # DP-attention idle forward: no batch_info, so no LoRA weights are read
+        # here. Skip the sync — a pending wait stays armed and is consumed by
+        # the next forward that actually uses this layer's weights.
         if self.lora_backend.batch_info is None:
             return self.base_layer.forward(hidden_states, topk_output, **kwargs)
+
+        self._sync_lora_loads()
 
         # Build LoRA info for this batch
         lora_info = self._get_lora_info()

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -390,9 +390,17 @@ class LoRAManager:
         return required_slots <= mem_pool_vacancy
 
     def fetch_new_loras(
-        self, new_loras: set[Optional[str]], running_loras: set[Optional[str]] = set()
+        self,
+        new_loras: set[Optional[str]],
+        running_loras: set[Optional[str]] = set(),
+        loading_stream: Optional[torch.cuda.Stream] = None,
     ):
-        # Load active loras into lora memory pool
+        """
+        Load active LoRA adapters into the memory pool.
+
+        If loading_stream is provided, emits per-layer pipeline signals so the
+        compute stream can overlap with weight loading.
+        """
         cur_uids = new_loras | running_loras
 
         assert len(cur_uids) <= self.max_loras_per_batch
@@ -403,9 +411,10 @@ class LoRAManager:
             cur_uids=cur_uids,
             lora_adapters=self.loras,
             lora_modules=self.lora_modules,
-            lora_refs=self.lora_refs.copy(),  # copy snapshot of current lora_refs to avoid mutation during the batch preparation.
-            lora_embed_tokens_module=self.embed_tokens_module,  # merge into embedding or lora module
-            lora_lm_head_module=self.lm_head_module,  # merge into embedding or lora module
+            lora_refs=self.lora_refs.copy(),
+            lora_embed_tokens_module=self.embed_tokens_module,
+            lora_lm_head_module=self.lm_head_module,
+            loading_stream=loading_stream,
         )
         if new_uids:
             changed_slots = {self.memory_pool.uid_to_buffer_id[uid] for uid in new_uids}
@@ -971,9 +980,8 @@ class LoRAManager:
                 layer_id = get_layer_id(module_name)
                 if layer_id is None:
                     continue
-                self.lora_modules[layer_id][module_name] = self.set_lora_module(
-                    module_name, module
-                )
+                lora_module = self.set_lora_module(module_name, module)
+                self.lora_modules[layer_id][module_name] = lora_module
                 continue
 
             if isinstance(module, (FusedMoE, InklingBatchDenseMLP)) and all(
@@ -1001,6 +1009,24 @@ class LoRAManager:
                     )
                     lora_module.lora_use_virtual_experts = self.lora_use_virtual_experts
                 self.lora_modules[layer_id][module_name] = lora_module
+
+        # Initialize pipeline flags for pipelined LoRA loading.
+        # All modules within the same transformer layer share a single flag
+        # since their weights are loaded together in one DMA batch.
+        if self.enable_lora_overlap_loading:
+            from sglang.srt.lora.lora_pipeline_sync import LoRAPipelineFlag
+
+            for layer_id in range(len(self.lora_modules)):
+                layer_flag = LoRAPipelineFlag(self.device)
+                for module in self.lora_modules[layer_id].values():
+                    module.init_pipeline_flag(layer_flag)
+            # embed_tokens and lm_head get their own flags (loaded separately)
+            if self.embed_tokens_module is not None:
+                self.embed_tokens_module.init_pipeline_flag(
+                    LoRAPipelineFlag(self.device)
+                )
+            if self.lm_head_module is not None:
+                self.lm_head_module.init_pipeline_flag(LoRAPipelineFlag(self.device))
 
 
 def init_lora_cuda_graph_moe_buffers(

--- a/python/sglang/srt/lora/lora_overlap_loader.py
+++ b/python/sglang/srt/lora/lora_overlap_loader.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum, auto
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
 import torch
 from torch.cuda import Event as CudaEvent
@@ -30,13 +30,26 @@ class LoRAOverlapLoader:
             self.lora_manager.pending_lora_load_events
         )
 
+        # Track adapters whose pipelined loading has started (forward can proceed)
+        self.pipelined_loading_loras: Set[Optional[str]] = set()
+
     def try_overlap_load_lora(
         self, lora_id: Optional[str], running_loras: set[Optional[str]]
     ) -> bool:
         """
-        Check a LoRA adapter's asynchronous load status, and try to load it if there's capacity
-        in the memory pool. Returns whether or not the adapter has been loaded.
+        Check a LoRA adapter's asynchronous load status, and try to load it if there's
+        capacity in the memory pool. Returns whether or not the adapter is ready for
+        forward pass execution.
+
+        Returns True as soon as loading has STARTED (not finished),
+        because per-layer flags in forward() will gate execution.
         """
+        if lora_id in self.pipelined_loading_loras:
+            # Verify adapter is still in GPU memory (not evicted)
+            if lora_id in self.lora_manager.memory_pool.uid_to_buffer_id:
+                return True
+            self.pipelined_loading_loras.discard(lora_id)
+
         # Drain completed async loads before status/capacity checks so finished
         # adapters no longer count as in-flight.
         self._drain_completed_overlap_loads()
@@ -48,10 +61,14 @@ class LoRAOverlapLoader:
             res = self._try_start_overlap_load(lora_id, running_loras)
             if res:
                 logger.debug(f"Loading LoRA adapter {lora_id} asynchronously")
-
+                # will synchronize inside forward()
+                self.pipelined_loading_loras.add(lora_id)
+                return True
             return False
         else:
             assert lora_pipeline_load_status == LoRAOverlapLoadStatus.LOADED
+            # Clean up pipelined tracking
+            self.pipelined_loading_loras.discard(lora_id)
             return True
 
     def _check_overlap_load_status(
@@ -87,7 +104,12 @@ class LoRAOverlapLoader:
             return False
 
         with self.load_stream_context:
-            self.lora_manager.fetch_new_loras({lora_id}, loras_to_be_loaded)
+            self.lora_manager.fetch_new_loras(
+                {lora_id},
+                loras_to_be_loaded,
+                loading_stream=self.load_stream,
+            )
+
             event = self.device_module.Event()
             event.record(self.load_stream)
 

--- a/python/sglang/srt/lora/lora_pipeline_sync.py
+++ b/python/sglang/srt/lora/lora_pipeline_sync.py
@@ -1,0 +1,62 @@
+"""
+Per-layer GPU-side signaling for pipelined LoRA weight loading.
+Uses torch.cuda.Event for synchronization between a loading stream
+and the compute stream. This only runs during prefill (not CUDA graph
+captured).
+
+The protocol:
+  Loading stream:  [DMA weights for layer N]  ->  mark_ready() records an event
+  Compute stream:  wait_until_ready() -> current_stream.wait_event(event) -> [use weights]
+"""
+
+import torch
+
+
+class LoRAPipelineFlag:
+    """
+    A per-layer event used to synchronize weight loading with forward compute.
+    Protocol:
+        - Loading stream calls mark_loading() before / mark_ready() after writing
+          this layer's weights.
+        - Compute stream calls wait_until_ready() before using the weights; it
+          consumes the pending wait exactly once.
+    """
+
+    def __init__(self, device: torch.device):
+        self._event = torch.cuda.Event()
+        # Start as "ready" — record a completed event so an un-loaded flag never
+        # forces a wait.
+        self._event.record(torch.cuda.current_stream(device))
+        # True from the start of a load until the compute stream consumes the wait.
+        self._pending = False
+
+    @property
+    def needs_wait(self) -> bool:
+        """Whether a load is outstanding and the compute stream still owes a wait."""
+        return self._pending
+
+    def mark_loading(self) -> None:
+        """Signal that weight loading is about to start for this layer.
+
+        Marks a wait as pending; it stays pending until wait_until_ready() consumes
+        it, so the compute stream cannot race ahead even though this runs (on the
+        CPU) long before the DMA completes on the GPU.
+        """
+        self._pending = True
+
+    def mark_ready(self, loading_stream: torch.cuda.Stream) -> None:
+        """Record this layer's load-completion event on the loading stream.
+
+        Does NOT clear `_pending`: the wait is only satisfied once the compute
+        stream has actually waited on this event.
+        """
+        self._event.record(loading_stream)
+
+    def wait_until_ready(self, compute_stream: torch.cuda.Stream) -> None:
+        """Make the compute stream wait for this layer's weights, exactly once.
+
+        No-op if no load is pending (e.g. decode).
+        """
+        if self._pending:
+            compute_stream.wait_event(self._event)
+            self._pending = False

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -737,6 +737,17 @@ class LoRAMemoryPool:
 
         return cached_weight
 
+    @staticmethod
+    def _get_layer_pipeline_flag(layer_modules):
+        """Get the shared pipeline flag for a layer's modules.
+
+        All modules in a layer share one flag, so just return the first one found.
+        """
+        for module in layer_modules.values():
+            if module._pipeline_flag is not None:
+                return module._pipeline_flag
+        return None
+
     def prepare_lora_batch(
         self,
         cur_uids: Set[Optional[str]],
@@ -745,7 +756,15 @@ class LoRAMemoryPool:
         lora_refs: Dict[str, LoRARef],
         lora_embed_tokens_module: Optional[BaseLayerWithLoRA],
         lora_lm_head_module: Optional[BaseLayerWithLoRA],
+        loading_stream: Optional[torch.cuda.Stream] = None,
     ):
+        """
+        Prepare LoRA batch for inference.
+
+        If loading_stream is provided, enables pipelined loading with per-module
+        synchronization signals, allowing the compute stream to begin before all
+        layers are loaded.
+        """
         # Python hash seeds differ by TP process; slot and LRU updates must not.
         ordered_uids = sorted(cur_uids, key=lambda uid: (uid is not None, uid or ""))
 
@@ -775,7 +794,8 @@ class LoRAMemoryPool:
 
             if not candidates:
                 raise ValueError(
-                    "No available buffer slots found. Please ensure the number of active (pinned) loras is less than max_loras_per_batch."
+                    "No available buffer slots found. Please ensure the number of "
+                    "active (pinned) loras is less than max_loras_per_batch."
                 )
 
             # Prefer evicting LoRA adapters over the base model (None).
@@ -783,10 +803,8 @@ class LoRAMemoryPool:
             # and no other adapters can be evicted.
             non_none_candidates = candidates - {None}
             if non_none_candidates:
-                # Prioritize evicting actual LoRA adapters
                 candidates_to_use = non_none_candidates
             else:
-                # Only None is available for eviction (batch is all LoRA requests)
                 candidates_to_use = candidates
 
             # Select victim using eviction policy
@@ -817,6 +835,7 @@ class LoRAMemoryPool:
                     lora_modules,
                     lora_embed_tokens_module,
                     lora_lm_head_module,
+                    loading_stream=loading_stream,
                 )
                 self.uid_to_buffer_id[uid] = buffer_id
                 self.buffer_id_to_uid[buffer_id] = uid
@@ -856,7 +875,17 @@ class LoRAMemoryPool:
         lora_modules: List[Dict[str, torch.nn.Module]],
         lora_embed_tokens_module: Optional[BaseLayerWithLoRA],
         lora_lm_head_module: Optional[BaseLayerWithLoRA],
+        loading_stream: Optional[torch.cuda.Stream] = None,
     ):
+        """
+        Load LoRA weights into the buffer slot.
+
+        If loading_stream is provided, emits per-module pipeline signals
+        (mark_loading before DMA, mark_ready after) so the compute stream
+        can overlap with weight loading.
+        """
+        pipelined = loading_stream is not None
+
         def load_lora_weight_tensor(
             buffer_view: torch.Tensor, weight: Optional[torch.Tensor]
         ):
@@ -870,11 +899,26 @@ class LoRAMemoryPool:
                 ), f"LoRA buffer shape {buffer_view.shape} does not match weight shape {weight.shape}."
                 copy_weight_into_buffer(buffer_view, weight)
 
+        def sliced_or_cached(slice_fn, temp_buffer, temp_cache_keys):
+            """Return (weight, tp_key) for the current target_module, reusing
+            the pinned cache to skip the (possibly concat-heavy) slice on a hit.
+            `target_module` and `pinned_layer_weights` are read from the loop scope.
+            """
+            cache_keys = temp_cache_keys[target_module]
+            assert cache_keys is not None
+            key = append_cache_key_suffix(cache_keys, f"tp{self.tp_rank}")
+            cached = pinned_layer_weights.get(key)
+            weight = (
+                cached if cached is not None else slice_fn(temp_buffer[target_module])
+            )
+            return weight, key
+
         if uid is None:
             self._clear_buffer_slot_for_base(buffer_id)
             return
 
         assert lora_adapter is not None
+
         lora_rank = lora_adapter.config.r
 
         # Pre-validate weight names against target modules across all layers
@@ -914,6 +958,13 @@ class LoRAMemoryPool:
                 logger.warning(msg)
 
         for layer_id in range(self.num_layer):
+            # Signal this layer's shared flag as LOADING before DMA.
+            # All modules in a layer share one flag, so we only signal once.
+            if pipelined:
+                layer_flag = self._get_layer_pipeline_flag(lora_modules[layer_id])
+                if layer_flag is not None:
+                    layer_flag.mark_loading()
+
             layer = lora_adapter.layers[layer_id]
             layer_weights = layer.weights
             pinned_layer_weights = layer.pinned_weights
@@ -1075,25 +1126,20 @@ class LoRAMemoryPool:
                     # Skip weight slicing if the weight is not present in the adapter
                     continue
 
-                # Handle standard modules
-                temp_A_buffer[target_module] = module.slice_lora_a_weights(
-                    temp_A_buffer[target_module]
+                # Handle standard modules. slice_lora_*_weights can be
+                # expensive (fused QKV / gate_up_proj call torch.concat).
+                # The sliced result is deterministic per (weight, tp_rank) and
+                # the pinned-weight cache already stores it under the
+                # tp-suffixed key, so on a hit we reuse it and skip the slice.
+                temp_A_buffer[target_module], temp_A_cache_keys[target_module] = (
+                    sliced_or_cached(
+                        module.slice_lora_a_weights, temp_A_buffer, temp_A_cache_keys
+                    )
                 )
-                cache_keys = temp_A_cache_keys[target_module]
-                assert cache_keys is not None
-                temp_A_cache_keys[target_module] = append_cache_key_suffix(
-                    cache_keys,
-                    f"tp{self.tp_rank}",
-                )
-
-                temp_B_buffer[target_module] = module.slice_lora_b_weights(
-                    temp_B_buffer[target_module]
-                )
-                cache_keys = temp_B_cache_keys[target_module]
-                assert cache_keys is not None
-                temp_B_cache_keys[target_module] = append_cache_key_suffix(
-                    cache_keys,
-                    f"tp{self.tp_rank}",
+                temp_B_buffer[target_module], temp_B_cache_keys[target_module] = (
+                    sliced_or_cached(
+                        module.slice_lora_b_weights, temp_B_buffer, temp_B_cache_keys
+                    )
                 )
 
             for name, weights in temp_A_buffer.items():
@@ -1336,6 +1382,25 @@ class LoRAMemoryPool:
                         # contracts over the full padded max_rank, so the tail must be clean.
                         target_buffer[buffer_id, :, lora_rank:].zero_()
 
+            # Signal this layer's shared flag as READY after DMA
+            if pipelined:
+                layer_flag = self._get_layer_pipeline_flag(lora_modules[layer_id])
+                if layer_flag is not None:
+                    layer_flag.mark_ready(loading_stream)
+
+        # Signal embed_tokens and lm_head as LOADING before embedding DMA
+        if pipelined:
+            if (
+                lora_embed_tokens_module is not None
+                and lora_embed_tokens_module._pipeline_flag is not None
+            ):
+                lora_embed_tokens_module._pipeline_flag.mark_loading()
+            if (
+                lora_lm_head_module is not None
+                and lora_lm_head_module._pipeline_flag is not None
+            ):
+                lora_lm_head_module._pipeline_flag.mark_loading()
+
         if lora_adapter.embedding_layers:
             org_vocab_size = self.base_hf_config.vocab_size
             lora_added_tokens_size = lora_adapter.config.lora_added_tokens_size
@@ -1477,6 +1542,19 @@ class LoRAMemoryPool:
                 and "input_embeddings" in self.new_embeddings_buffer
             ):
                 self.new_embeddings_buffer["input_embeddings"][buffer_id].zero_()
+
+        # Signal embed_tokens and lm_head as READY after embedding DMA
+        if pipelined:
+            if (
+                lora_embed_tokens_module is not None
+                and lora_embed_tokens_module._pipeline_flag is not None
+            ):
+                lora_embed_tokens_module._pipeline_flag.mark_ready(loading_stream)
+            if (
+                lora_lm_head_module is not None
+                and lora_lm_head_module._pipeline_flag is not None
+            ):
+                lora_lm_head_module._pipeline_flag.mark_ready(loading_stream)
 
     def get_embedding_tensor(
         self, target_module: str, lora_type: LoRAType

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8985,15 +8985,10 @@ class ServerArgs:
                     "check_lora_server_args", enable_lora_overlap_loading=False
                 )
 
-            if self.enable_lora_overlap_loading:
-                # TODO (glenliu21): use some sort of buffer with eviction instead of enforcing a limit
-                max_loaded_loras_limit = self.max_loras_per_batch * 2
-                assert (
-                    self.max_loaded_loras is not None
-                    and self.max_loaded_loras <= max_loaded_loras_limit
-                ), (
-                    "Enabling LoRA overlap loading requires pinning LoRA adapter weights in CPU memory, "
-                    f"so --max-loaded-loras must be less than or equal to double --max-loras-per-batch: {max_loaded_loras_limit}"
+            if self.enable_lora_overlap_loading and self.max_loaded_loras is None:
+                self.override(
+                    "check_lora_server_args",
+                    max_loaded_loras=self.max_loras_per_batch,
                 )
 
             # Validate compatibility with speculative decoding
@@ -9087,10 +9082,13 @@ class ServerArgs:
                     "max_loaded_loras should be greater than or equal to max_loras_per_batch. "
                     f"max_loaded_loras={self.max_loaded_loras}, max_loras_per_batch={self.max_loras_per_batch}"
                 )
-                assert len(self.lora_paths) <= self.max_loaded_loras, (
-                    "The number of LoRA paths should not exceed max_loaded_loras. "
-                    f"max_loaded_loras={self.max_loaded_loras}, lora_paths={len(self.lora_paths)}"
-                )
+                # With overlap loading, adapters stream in on demand, so the
+                # number of registered paths may exceed the pool capacity.
+                if not self.enable_lora_overlap_loading:
+                    assert len(self.lora_paths) <= self.max_loaded_loras, (
+                        "The number of LoRA paths should not exceed max_loaded_loras. "
+                        f"max_loaded_loras={self.max_loaded_loras}, lora_paths={len(self.lora_paths)}"
+                    )
 
             if self.max_lora_chunk_size is not None:
                 assert (

--- a/test/registered/lora/test_lora_overlap_loading.py
+++ b/test/registered/lora/test_lora_overlap_loading.py
@@ -14,270 +14,133 @@
 
 import multiprocessing as mp
 import unittest
-from typing import cast
-from unittest.mock import MagicMock, patch
 
 import torch
-from torch.cuda import Event as CudaEvent
-from torch.cuda import Stream as CudaStream
 
-from sglang.srt.lora.lora_manager import LoRAManager
-from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader, LoRAOverlapLoadStatus
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.lora_utils import (
-    CI_MULTI_LORA_MODELS,
-    run_lora_batch_splitting_equivalence_test,
+    TORCH_DTYPES,
+    LoRAAdaptor,
+    LoRAModelCase,
+    run_lora_test_one_by_one,
 )
+from sglang.test.runners import SRTRunner
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=380, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=75, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=90, suite="stage-b-test-1-gpu-small-amd")
+
+# Two adapters on a freely available base model
+LORA_A = "algoprog/fact-generation-llama-3.1-8b-instruct-lora"
+LORA_B = "nvidia/llama-3.1-nemoguard-8b-topic-control"
+BASE_MODEL = "meta-llama/Llama-3.1-8B-Instruct"
+
+PROMPT_1 = "AI is a field of computer science focused on"
+PROMPT_2 = "The capital of France is"
 
 
-class TestLoRAOverlapLoading(CustomTestCase):
-    def test_ci_lora_models_batch_splitting(self):
-        run_lora_batch_splitting_equivalence_test(
-            CI_MULTI_LORA_MODELS, enable_lora_overlap_loading=True
+class TestLoRAOverlapLoadingSingleRequest(CustomTestCase):
+    """1. Single request, single LoRA loading with max 1 LoRA in GPU."""
+
+    def test_single_request_single_lora(self):
+        model_case = LoRAModelCase(
+            base=BASE_MODEL,
+            adaptors=[LoRAAdaptor(name=LORA_A)],
+            max_loras_per_batch=1,
+            max_loaded_loras=1,
         )
-
-
-class TestLoRAOverlapLoaderUnitTests(CustomTestCase):
-
-    mock_lora_manager: MagicMock
-    mock_stream: MagicMock
-    mock_stream_context: MagicMock
-    mock_device_module: MagicMock
-    mock_torch: MagicMock
-
-    def setUp(self):
-        self.torch_patcher = patch("sglang.srt.lora.lora_overlap_loader.torch")
-        self.mock_torch = self.torch_patcher.start()
-
-        self.mock_device_module = MagicMock()
-        self.mock_stream = MagicMock(spec=CudaStream)
-        self.mock_stream_context = MagicMock()
-        self.mock_event = MagicMock(spec=CudaEvent)
-
-        self.mock_device_module.Stream.return_value = self.mock_stream
-        self.mock_device_module.stream.return_value = self.mock_stream_context
-        self.mock_device_module.Event.return_value = self.mock_event
-        self.mock_torch.get_device_module.return_value = self.mock_device_module
-        self.mock_torch.cuda.current_stream.return_value = MagicMock(spec=CudaStream)
-
-        self.mock_lora_manager = MagicMock(spec=LoRAManager)
-        self.mock_lora_manager.device = "cuda:0"
-        self.mock_lora_manager.memory_pool = MagicMock()
-        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {}
-        self.mock_lora_manager.validate_lora_batch.return_value = True
-        self.mock_lora_manager.fetch_new_loras.side_effect = self._mark_loras_loaded
-        self.mock_lora_manager.pending_lora_load_events = {}
-
-    def tearDown(self):
-        self.torch_patcher.stop()
-
-    def _create_loader(self) -> LoRAOverlapLoader:
-        return LoRAOverlapLoader(cast(LoRAManager, self.mock_lora_manager))
-
-    def _mark_loras_loaded(self, new_loras, _loras_to_be_loaded):
-        for lora_id in new_loras:
-            self.mock_lora_manager.memory_pool.uid_to_buffer_id[lora_id] = len(
-                self.mock_lora_manager.memory_pool.uid_to_buffer_id
+        for torch_dtype in TORCH_DTYPES:
+            run_lora_test_one_by_one(
+                [PROMPT_1],
+                model_case,
+                torch_dtype,
+                max_new_tokens=32,
+                enable_lora_overlap_loading=True,
+                disable_cuda_graph=True,
+                disable_radix_cache=True,
+                test_tag="overlap_single_request_single_lora",
             )
 
-    def _create_mock_event(self, query_return: bool = False) -> MagicMock:
-        event = MagicMock(spec=CudaEvent)
-        event.query.return_value = query_return
-        return event
 
-    def test_completed_stale_loads_are_reaped_before_capacity_check(self):
-        loader = self._create_loader()
-        events = [
-            self._create_mock_event(query_return=True),
-            self._create_mock_event(query_return=False),
-        ]
-        self.mock_device_module.Event.side_effect = events
-        self.mock_lora_manager.validate_lora_batch.side_effect = (
-            lambda lora_ids: len(lora_ids) <= 1
-        )
+class TestLoRAOverlapLoadingBatchReplace(CustomTestCase):
+    """2. Two new LoRAs replace two in GPU, batch runs with correct output."""
 
-        self.assertTrue(
-            loader._try_start_overlap_load("stale_lora", running_loras=set())
-        )
-        self.assertIn("stale_lora", loader.lora_to_overlap_load_event)
-
-        self.mock_lora_manager.fetch_new_loras.reset_mock()
-        result = loader.try_overlap_load_lora("new_lora", running_loras=set())
-
-        self.assertFalse(result)
-        self.assertNotIn("stale_lora", loader.lora_to_overlap_load_event)
-        self.assertIn("new_lora", loader.lora_to_overlap_load_event)
-        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
-            {"new_lora"}, set()
-        )
-
-    def test_loaded_lora_reused_after_stale_event_drain(self):
-        loader = self._create_loader()
-        self.mock_lora_manager.memory_pool = MagicMock()
-        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {}
-        events = [
-            self._create_mock_event(query_return=True),
-            self._create_mock_event(query_return=False),
-        ]
-        self.mock_device_module.Event.side_effect = events
-        self.mock_lora_manager.validate_lora_batch.side_effect = (
-            lambda lora_ids: len(lora_ids) <= 2
-        )
-
-        self.assertTrue(loader._try_start_overlap_load("lora_A", running_loras=set()))
-        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
-
-        self.mock_lora_manager.fetch_new_loras.reset_mock()
-        self.assertFalse(loader.try_overlap_load_lora("lora_B", running_loras=set()))
-        self.assertNotIn("lora_A", loader.lora_to_overlap_load_event)
-        self.assertIn("lora_B", loader.lora_to_overlap_load_event)
-        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
-            {"lora_B"}, set()
-        )
-
-        self.mock_lora_manager.fetch_new_loras.reset_mock()
-        self.assertTrue(loader.try_overlap_load_lora("lora_A", running_loras=set()))
-        self.assertIn("lora_B", loader.lora_to_overlap_load_event)
-        self.mock_lora_manager.fetch_new_loras.assert_not_called()
-
-    def test_pending_lora_load_must_complete_even_if_memory_pool_has_slot(self):
-        loader = self._create_loader()
-        self.mock_lora_manager.memory_pool = MagicMock()
-        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {"lora_A": 0}
-
-        loader.lora_to_overlap_load_event["lora_A"] = self._create_mock_event(False)
-
-        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
-
-        self.assertFalse(result)
-        self.mock_lora_manager.fetch_new_loras.assert_not_called()
-        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
-
-    def test_loader_uses_manager_pending_event_store(self):
-        loader = self._create_loader()
-
-        self.assertIs(
-            loader.lora_to_overlap_load_event,
-            self.mock_lora_manager.pending_lora_load_events,
-        )
-
-    def test_pending_load_is_synchronized_before_unload(self):
-        manager = LoRAManager.__new__(LoRAManager)
-        manager.device = torch.device("cuda:0")
-        manager.pending_lora_load_events = {}
-        manager.memory_pool = MagicMock()
-        manager.configs = {"lora_A": object()}
-        manager.loras = {"lora_A": object()}
-        lora_ref = MagicMock()
-        lora_ref.lora_id = "lora_A"
-        lora_ref.lora_name = "lora_A"
-        lora_ref.lora_path = "/tmp/lora_A"
-        lora_ref.pinned = False
-        manager.lora_refs = {"lora_A": lora_ref}
-        manager.num_pinned_loras = 0
-        manager.lora_modules = []
-
-        order = []
-        event = self._create_mock_event(False)
-        event.synchronize.side_effect = lambda: order.append("synchronize")
-        manager.memory_pool.remove_lora.side_effect = lambda _uid: (
-            order.append("remove") or 0
-        )
-        loader = LoRAOverlapLoader(manager)
-        loader.lora_to_overlap_load_event["lora_A"] = event
-
-        result = manager.unload_lora_adapter(lora_ref)
-
-        self.assertTrue(result.success)
-        self.assertEqual(order, ["synchronize", "remove"])
-        event.synchronize.assert_called_once_with()
-        self.assertNotIn("lora_A", manager.pending_lora_load_events)
-
-    def test_full_lifecycle_single_lora_load(self):
-        loader = self._create_loader()
-
-        # Initially not loaded
-        status = loader._check_overlap_load_status("lora_A")
-        self.assertEqual(status, LoRAOverlapLoadStatus.NOT_LOADED)
-
-        # First call starts async load, returns False
-        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
-        self.assertFalse(result)
-        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
-        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
-            {"lora_A"}, set()
-        )
-
-        # Simulate load still in progress - returns False, event persists
-        loader.lora_to_overlap_load_event["lora_A"].query.return_value = False
-        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
-        self.assertFalse(result)
-        self.assertEqual(
-            loader._check_overlap_load_status("lora_A"), LoRAOverlapLoadStatus.LOADING
-        )
-
-        # Simulate load complete - returns True, event removed
-        loader.lora_to_overlap_load_event["lora_A"].query.return_value = True
-        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
-        self.assertTrue(result)
-        self.assertNotIn("lora_A", loader.lora_to_overlap_load_event)
-
-    def test_capacity_constraints_block_new_loads(self):
-        loader = self._create_loader()
-
-        events = [self._create_mock_event() for _ in range(4)]
-        self.mock_device_module.Event.side_effect = events
-
-        # Load 3 loras successfully
-        for i in range(3):
-            self.assertTrue(
-                loader._try_start_overlap_load(f"lora_{i}", running_loras=set())
+    def test_two_loras_batch_replace(self):
+        with SRTRunner(
+            BASE_MODEL,
+            torch_dtype=torch.float16,
+            model_type="generation",
+            lora_paths=[LORA_A, LORA_B],
+            enable_lora_overlap_loading=True,
+            max_loras_per_batch=2,
+            max_loaded_loras=2,
+            disable_cuda_graph=True,
+            disable_radix_cache=True,
+            sleep_on_idle=True,
+        ) as srt_runner:
+            # Batch with both LoRAs
+            outputs = srt_runner.batch_forward(
+                [PROMPT_1, PROMPT_2],
+                max_new_tokens=32,
+                lora_paths=[LORA_A, LORA_B],
             )
-        self.assertEqual(len(loader.lora_to_overlap_load_event), 3)
+            # Different adapters should produce different outputs
+            self.assertNotEqual(
+                outputs.output_strs[0].strip(),
+                outputs.output_strs[1].strip(),
+                "Two different LoRA adapters produced identical output",
+            )
+            # Both should produce non-empty output
+            self.assertTrue(len(outputs.output_strs[0].strip()) > 0)
+            self.assertTrue(len(outputs.output_strs[1].strip()) > 0)
 
-        # Capacity full - new load blocked
-        self.mock_lora_manager.validate_lora_batch.return_value = False
-        self.mock_lora_manager.fetch_new_loras.reset_mock()
-        result = loader.try_overlap_load_lora("lora_3", running_loras=set())
-        self.assertFalse(result)
-        self.mock_lora_manager.fetch_new_loras.assert_not_called()
-        self.assertNotIn("lora_3", loader.lora_to_overlap_load_event)
 
-        # First lora completes, freeing capacity
-        loader.lora_to_overlap_load_event["lora_0"].query.return_value = True
+class TestLoRAOverlapLoadingEviction(CustomTestCase):
+    """3. Two requests: one LoRA already in GPU, one needs loading (eviction).
+    Max 2 LoRAs means one must be replaced. Verify correct output."""
 
-        loader._drain_completed_overlap_loads()
-        self.assertEqual(
-            loader._check_overlap_load_status("lora_0"), LoRAOverlapLoadStatus.LOADED
-        )
+    def test_eviction_on_new_lora(self):
+        with SRTRunner(
+            BASE_MODEL,
+            torch_dtype=torch.float16,
+            model_type="generation",
+            lora_paths=[LORA_A, LORA_B],
+            enable_lora_overlap_loading=True,
+            max_loras_per_batch=2,
+            max_loaded_loras=2,
+            disable_cuda_graph=True,
+            disable_radix_cache=True,
+            sleep_on_idle=True,
+        ) as srt_runner:
+            # First batch: load LORA_A into GPU
+            out1 = srt_runner.batch_forward(
+                [PROMPT_1],
+                max_new_tokens=32,
+                lora_paths=[LORA_A],
+            )
+            self.assertTrue(len(out1.output_strs[0].strip()) > 0)
 
-        # Now new load succeeds
-        self.mock_lora_manager.validate_lora_batch.return_value = True
-        self.assertTrue(loader._try_start_overlap_load("lora_3", running_loras=set()))
+            # Second batch: LORA_A already loaded, LORA_B needs loading
+            out2 = srt_runner.batch_forward(
+                [PROMPT_1, PROMPT_2],
+                max_new_tokens=32,
+                lora_paths=[LORA_A, LORA_B],
+            )
+            # Both should produce non-empty, different outputs
+            self.assertTrue(len(out2.output_strs[0].strip()) > 0)
+            self.assertTrue(len(out2.output_strs[1].strip()) > 0)
+            self.assertNotEqual(
+                out2.output_strs[0].strip(),
+                out2.output_strs[1].strip(),
+                "Different adapters should produce different outputs",
+            )
 
-    def test_validation_includes_pending_and_running_loras(self):
-        loader = self._create_loader()
-
-        events = [self._create_mock_event() for _ in range(5)]
-        self.mock_device_module.Event.side_effect = events
-
-        # Start pending loads
-        loader._try_start_overlap_load("pending_1", running_loras=set())
-        loader._try_start_overlap_load("pending_2", running_loras=set())
-
-        # Load new lora with running_loras
-        self.mock_lora_manager.validate_lora_batch.reset_mock()
-        running = {"running_1", "running_2"}
-        loader.try_overlap_load_lora("new_lora", running_loras=running)
-
-        # Validation should include: pending + running + new
-        call_args = self.mock_lora_manager.validate_lora_batch.call_args[0][0]
-        expected = {"pending_1", "pending_2", "running_1", "running_2", "new_lora"}
-        self.assertEqual(call_args, expected)
+            # Verify LORA_A output is consistent across batches
+            self.assertEqual(
+                out1.output_strs[0].strip(),
+                out2.output_strs[0].strip(),
+                "Same adapter + prompt should produce consistent output",
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/lora/test_lora_tp.py
+++ b/test/registered/lora/test_lora_tp.py
@@ -24,6 +24,7 @@ from sglang.test.lora_utils import (
     CI_MULTI_LORA_MODELS,
     DEFAULT_PROMPTS,
     TORCH_DTYPES,
+    LoRAAdaptor,
     LoRAModelCase,
     run_lora_test_one_by_one,
 )
@@ -76,6 +77,32 @@ class TestLoRATP(CustomTestCase):
         self._run_tp_on_model_cases(
             CI_MULTI_LORA_MODELS, enable_lora_overlap_loading=True
         )
+
+    def test_lora_overlap_loading_single_lora_tp2(self):
+        """TP=2 single LoRA pipelined loading with max 1 LoRA in GPU."""
+        model_case = LoRAModelCase(
+            base="meta-llama/Llama-3.1-8B-Instruct",
+            adaptors=[
+                LoRAAdaptor(
+                    name="algoprog/fact-generation-llama-3.1-8b-instruct-lora",
+                )
+            ],
+            tp_size=2,
+            max_loras_per_batch=1,
+            max_loaded_loras=1,
+        )
+        for torch_dtype in TORCH_DTYPES:
+            run_lora_test_one_by_one(
+                [DEFAULT_PROMPTS[0]],
+                model_case,
+                torch_dtype,
+                max_new_tokens=32,
+                enable_lora_overlap_loading=True,
+                disable_cuda_graph=True,
+                disable_radix_cache=True,
+                test_tag="overlap_tp2_single_lora_max1",
+                attention_backend="fa3",
+            )
 
     def test_all_lora_models(self):
         if is_in_ci():

--- a/test/registered/unit/lora/test_lora_overlap_loader_unit.py
+++ b/test/registered/unit/lora/test_lora_overlap_loader_unit.py
@@ -1,0 +1,378 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch.cuda import Event as CudaEvent
+from torch.cuda import Stream as CudaStream
+
+from sglang.srt.lora.lora_manager import LoRAManager
+from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader, LoRAOverlapLoadStatus
+from sglang.srt.lora.lora_pipeline_sync import LoRAPipelineFlag
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=15, suite="stage-b-test-1-gpu-small-amd")
+
+
+class TestLoRAOverlapLoaderUnitTests(CustomTestCase):
+
+    mock_lora_manager: MagicMock
+    mock_stream: MagicMock
+    mock_stream_context: MagicMock
+    mock_device_module: MagicMock
+    mock_torch: MagicMock
+
+    def setUp(self):
+        self.torch_patcher = patch("sglang.srt.lora.lora_overlap_loader.torch")
+        self.mock_torch = self.torch_patcher.start()
+
+        self.mock_device_module = MagicMock()
+        self.mock_stream = MagicMock(spec=CudaStream)
+        self.mock_stream_context = MagicMock()
+        self.mock_event = MagicMock(spec=CudaEvent)
+
+        self.mock_device_module.Stream.return_value = self.mock_stream
+        self.mock_device_module.stream.return_value = self.mock_stream_context
+        self.mock_device_module.Event.return_value = self.mock_event
+        self.mock_torch.get_device_module.return_value = self.mock_device_module
+        self.mock_torch.cuda.current_stream.return_value = MagicMock(spec=CudaStream)
+
+        self.mock_lora_manager = MagicMock(spec=LoRAManager)
+        self.mock_lora_manager.device = "cuda:0"
+        self.mock_lora_manager.memory_pool = MagicMock()
+        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {}
+        self.mock_lora_manager.validate_lora_batch.return_value = True
+        self.mock_lora_manager.fetch_new_loras.side_effect = self._mark_loras_loaded
+        self.mock_lora_manager.pending_lora_load_events = {}
+
+    def tearDown(self):
+        self.torch_patcher.stop()
+
+    def _create_loader(self) -> LoRAOverlapLoader:
+        return LoRAOverlapLoader(cast(LoRAManager, self.mock_lora_manager))
+
+    def _mark_loras_loaded(self, new_loras, _loras_to_be_loaded, **kwargs):
+        for lora_id in new_loras:
+            self.mock_lora_manager.memory_pool.uid_to_buffer_id[lora_id] = len(
+                self.mock_lora_manager.memory_pool.uid_to_buffer_id
+            )
+
+    def _create_mock_event(self, query_return: bool = False) -> MagicMock:
+        event = MagicMock(spec=CudaEvent)
+        event.query.return_value = query_return
+        return event
+
+    def test_completed_stale_loads_are_reaped_before_capacity_check(self):
+        loader = self._create_loader()
+        events = [
+            self._create_mock_event(query_return=True),
+            self._create_mock_event(query_return=False),
+        ]
+        self.mock_device_module.Event.side_effect = events
+        self.mock_lora_manager.validate_lora_batch.side_effect = (
+            lambda lora_ids: len(lora_ids) <= 1
+        )
+
+        self.assertTrue(
+            loader._try_start_overlap_load("stale_lora", running_loras=set())
+        )
+        self.assertIn("stale_lora", loader.lora_to_overlap_load_event)
+
+        self.mock_lora_manager.fetch_new_loras.reset_mock()
+        result = loader.try_overlap_load_lora("new_lora", running_loras=set())
+
+        # With pipelining, returns True as soon as load starts
+        self.assertTrue(result)
+        self.assertNotIn("stale_lora", loader.lora_to_overlap_load_event)
+        self.assertIn("new_lora", loader.lora_to_overlap_load_event)
+        self.assertIn("new_lora", loader.pipelined_loading_loras)
+        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
+            {"new_lora"}, set(), loading_stream=self.mock_stream
+        )
+
+    def test_loaded_lora_reused_after_stale_event_drain(self):
+        loader = self._create_loader()
+        self.mock_lora_manager.memory_pool = MagicMock()
+        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {}
+        events = [
+            self._create_mock_event(query_return=True),
+            self._create_mock_event(query_return=False),
+        ]
+        self.mock_device_module.Event.side_effect = events
+        self.mock_lora_manager.validate_lora_batch.side_effect = (
+            lambda lora_ids: len(lora_ids) <= 2
+        )
+
+        self.assertTrue(loader._try_start_overlap_load("lora_A", running_loras=set()))
+        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
+
+        self.mock_lora_manager.fetch_new_loras.reset_mock()
+        # With pipelining, returns True as soon as load starts
+        self.assertTrue(loader.try_overlap_load_lora("lora_B", running_loras=set()))
+        self.assertNotIn("lora_A", loader.lora_to_overlap_load_event)
+        self.assertIn("lora_B", loader.lora_to_overlap_load_event)
+        self.assertIn("lora_B", loader.pipelined_loading_loras)
+        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
+            {"lora_B"}, set(), loading_stream=self.mock_stream
+        )
+
+        self.mock_lora_manager.fetch_new_loras.reset_mock()
+        self.assertTrue(loader.try_overlap_load_lora("lora_A", running_loras=set()))
+        self.assertIn("lora_B", loader.lora_to_overlap_load_event)
+        self.mock_lora_manager.fetch_new_loras.assert_not_called()
+
+    def test_pending_lora_load_must_complete_even_if_memory_pool_has_slot(self):
+        loader = self._create_loader()
+        self.mock_lora_manager.memory_pool = MagicMock()
+        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {"lora_A": 0}
+
+        loader.lora_to_overlap_load_event["lora_A"] = self._create_mock_event(False)
+
+        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
+
+        self.assertFalse(result)
+        self.mock_lora_manager.fetch_new_loras.assert_not_called()
+        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
+
+    def test_loader_uses_manager_pending_event_store(self):
+        loader = self._create_loader()
+
+        self.assertIs(
+            loader.lora_to_overlap_load_event,
+            self.mock_lora_manager.pending_lora_load_events,
+        )
+
+    def test_pending_load_is_synchronized_before_unload(self):
+        manager = LoRAManager.__new__(LoRAManager)
+        manager.device = torch.device("cuda:0")
+        manager.pending_lora_load_events = {}
+        manager.memory_pool = MagicMock()
+        manager.configs = {"lora_A": object()}
+        manager.loras = {"lora_A": object()}
+        lora_ref = MagicMock()
+        lora_ref.lora_id = "lora_A"
+        lora_ref.lora_name = "lora_A"
+        lora_ref.lora_path = "/tmp/lora_A"
+        lora_ref.pinned = False
+        manager.lora_refs = {"lora_A": lora_ref}
+        manager.num_pinned_loras = 0
+        manager.lora_modules = []
+
+        order = []
+        event = self._create_mock_event(False)
+        event.synchronize.side_effect = lambda: order.append("synchronize")
+        manager.memory_pool.remove_lora.side_effect = lambda _uid: (
+            order.append("remove") or 0
+        )
+        loader = LoRAOverlapLoader(manager)
+        loader.lora_to_overlap_load_event["lora_A"] = event
+
+        result = manager.unload_lora_adapter(lora_ref)
+
+        self.assertTrue(result.success)
+        self.assertEqual(order, ["synchronize", "remove"])
+        event.synchronize.assert_called_once_with()
+        self.assertNotIn("lora_A", manager.pending_lora_load_events)
+
+    def test_full_lifecycle_single_lora_load(self):
+        loader = self._create_loader()
+
+        # Initially not loaded
+        status = loader._check_overlap_load_status("lora_A")
+        self.assertEqual(status, LoRAOverlapLoadStatus.NOT_LOADED)
+
+        # First call starts async load, returns True immediately (pipelined)
+        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
+        self.assertTrue(result)
+        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
+        self.assertIn("lora_A", loader.pipelined_loading_loras)
+        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
+            {"lora_A"}, set(), loading_stream=self.mock_stream
+        )
+
+        # While pipelined and still in memory pool, returns True (forward gates on per-layer flags)
+        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
+        self.assertTrue(result)
+
+        # Even after event completes, pipelined path keeps returning True
+        # as long as adapter remains in memory pool
+        loader.lora_to_overlap_load_event["lora_A"].query.return_value = True
+        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
+        self.assertTrue(result)
+
+    def test_capacity_constraints_block_new_loads(self):
+        loader = self._create_loader()
+
+        events = [self._create_mock_event() for _ in range(4)]
+        self.mock_device_module.Event.side_effect = events
+
+        # Load 3 loras successfully
+        for i in range(3):
+            self.assertTrue(
+                loader._try_start_overlap_load(f"lora_{i}", running_loras=set())
+            )
+        self.assertEqual(len(loader.lora_to_overlap_load_event), 3)
+
+        # Capacity full - new load blocked
+        self.mock_lora_manager.validate_lora_batch.return_value = False
+        self.mock_lora_manager.fetch_new_loras.reset_mock()
+        result = loader.try_overlap_load_lora("lora_3", running_loras=set())
+        self.assertFalse(result)
+        self.mock_lora_manager.fetch_new_loras.assert_not_called()
+        self.assertNotIn("lora_3", loader.lora_to_overlap_load_event)
+
+        # First lora completes, freeing capacity
+        loader.lora_to_overlap_load_event["lora_0"].query.return_value = True
+
+        loader._drain_completed_overlap_loads()
+        self.assertEqual(
+            loader._check_overlap_load_status("lora_0"), LoRAOverlapLoadStatus.LOADED
+        )
+
+        # Now new load succeeds
+        self.mock_lora_manager.validate_lora_batch.return_value = True
+        self.assertTrue(loader._try_start_overlap_load("lora_3", running_loras=set()))
+
+    def test_validation_includes_pending_and_running_loras(self):
+        loader = self._create_loader()
+
+        events = [self._create_mock_event() for _ in range(5)]
+        self.mock_device_module.Event.side_effect = events
+
+        # Start pending loads
+        loader._try_start_overlap_load("pending_1", running_loras=set())
+        loader._try_start_overlap_load("pending_2", running_loras=set())
+
+        # Load new lora with running_loras
+        self.mock_lora_manager.validate_lora_batch.reset_mock()
+        running = {"running_1", "running_2"}
+        loader.try_overlap_load_lora("new_lora", running_loras=running)
+
+        # Validation should include: pending + running + new
+        call_args = self.mock_lora_manager.validate_lora_batch.call_args[0][0]
+        expected = {"pending_1", "pending_2", "running_1", "running_2", "new_lora"}
+        self.assertEqual(call_args, expected)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestLoRAPipelineSync(CustomTestCase):
+    """Tests for per-layer pipelined LoRA loading synchronization primitives."""
+
+    def test_flag_initial_state(self):
+        """Flag starts ready (no load in progress)."""
+        flag = LoRAPipelineFlag(torch.device("cuda:0"))
+        flag.wait_until_ready(torch.cuda.current_stream())
+
+    def test_mark_loading_and_ready(self):
+        """Test basic mark_loading -> mark_ready cycle."""
+        flag = LoRAPipelineFlag(torch.device("cuda:0"))
+        stream = torch.cuda.Stream()
+
+        flag.mark_loading()
+        with torch.cuda.stream(stream):
+            t = torch.zeros(256, 256, device="cuda:0")
+            t.fill_(1.0)
+        flag.mark_ready(stream)
+
+        flag.wait_until_ready(torch.cuda.current_stream())
+        torch.cuda.current_stream().synchronize()
+        self.assertEqual(t[0, 0].item(), 1.0)
+
+    def test_cross_stream_synchronization(self):
+        """Compute stream waits for loading stream to finish."""
+        flag = LoRAPipelineFlag(torch.device("cuda:0"))
+        load_stream = torch.cuda.Stream()
+
+        flag.mark_loading()
+        with torch.cuda.stream(load_stream):
+            large_tensor = torch.zeros(1024, 1024, device="cuda:0")
+            large_tensor.fill_(42.0)
+        flag.mark_ready(load_stream)
+
+        flag.wait_until_ready(torch.cuda.current_stream())
+        torch.cuda.current_stream().synchronize()
+        self.assertEqual(large_tensor[0, 0].item(), 42.0)
+
+    def test_no_wait_when_not_loading(self):
+        """wait_until_ready is a no-op when no load is in progress."""
+        flag = LoRAPipelineFlag(torch.device("cuda:0"))
+        flag.wait_until_ready(torch.cuda.current_stream())
+        flag.wait_until_ready(torch.cuda.current_stream())
+
+    def test_multiple_flags_independent(self):
+        """Multiple flags operate independently."""
+        flag1 = LoRAPipelineFlag(torch.device("cuda:0"))
+        flag2 = LoRAPipelineFlag(torch.device("cuda:0"))
+        stream = torch.cuda.Stream()
+
+        flag1.mark_loading()
+        flag2.wait_until_ready(torch.cuda.current_stream())
+
+        flag1.mark_ready(stream)
+        stream.synchronize()
+
+    def test_mark_ready_does_not_clear_pending_wait(self):
+        """Regression guard: recording the completion event must NOT satisfy the
+        pending wait."""
+        flag = LoRAPipelineFlag(torch.device("cuda:0"))
+        load_stream = torch.cuda.Stream()
+
+        # Fresh flag owes no wait.
+        self.assertFalse(flag.needs_wait)
+
+        # A load starts -> a wait is owed.
+        flag.mark_loading()
+        self.assertTrue(flag.needs_wait)
+
+        # Recording completion must NOT clear the owed wait.
+        flag.mark_ready(load_stream)
+        self.assertTrue(flag.needs_wait)
+
+        # Only the compute stream consuming the wait clears it, and it is a no-op
+        # thereafter (e.g. a subsequent decode step).
+        flag.wait_until_ready(torch.cuda.current_stream())
+        self.assertFalse(flag.needs_wait)
+        flag.wait_until_ready(torch.cuda.current_stream())
+        self.assertFalse(flag.needs_wait)
+
+    def test_pending_wait_re_arms_on_each_load(self):
+        """A per-layer flag is reused across successive adapter loads; each new
+        load must re-arm its own pending wait.
+        """
+        flag = LoRAPipelineFlag(torch.device("cuda:0"))
+        load_stream = torch.cuda.Stream()
+        compute_stream = torch.cuda.current_stream()
+
+        # First load cycle.
+        flag.mark_loading()
+        flag.mark_ready(load_stream)
+        flag.wait_until_ready(compute_stream)
+        self.assertFalse(flag.needs_wait)
+
+        # Second load on the same flag must arm a fresh wait.
+        flag.mark_loading()
+        self.assertTrue(flag.needs_wait)
+        flag.mark_ready(load_stream)
+        self.assertTrue(flag.needs_wait)
+        flag.wait_until_ready(compute_stream)
+        self.assertFalse(flag.needs_wait)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore")


### PR DESCRIPTION
## Motivation

Currently LoRA Loading for Per Request needs to first sequentially **load all the LoRA layers** before **beginning Pre-Fill**. This adds significant overhead in TTFT. If you are using the current overlap loading you can only get gain of Pre-Fill of the previous run with incoming LoRA. This enhances that with **current LoRA load** with **current Pre-Fill**.

<img width="583" height="332" alt="Screenshot 2026-07-11 at 2 03 59 PM" src="https://github.com/user-attachments/assets/3ab913b4-8707-4cd8-9516-7a8e2f43d59a" />

However, **Pre-Fill** is a layer by layer process and for large enough input tokens(**> 1000 tokens**) it is **longer than LoRA Loading time**. If we run **LoRA loading and Compute in separate streams(CUDA or otherwise)** we can hid significant part of the LoRA loading  time with **Sync points** in each LoRA layer of the forward pass to make sure the LoRA layer is loaded.

<img width="832" height="352" alt="Screenshot 2026-07-11 at 2 07 22 PM" src="https://github.com/user-attachments/assets/d1cbf00a-344f-49d7-8529-3e019b01b1b9" />


**This specifically complements Overlap Loading in SGLang** which was already implemented which starts early loading for the next request while the previous request is running compute.

  ## Modifications
- Enhance Overlap loading to also Pipeline LoRA Loading with Forward Pass
- **mem_pool** slice caching so **lora_a**/**lora_b** used cached weights.
- **max-loaded-loras**: with overlap loading, defaults to **max_loras_per_batch** when unset. 
- Added unit tests in **test/registered/unit/lora/test_lora_overlap_loader_unit.py**
- Add integration tests in *test_lora_tp** and **test_lora_overlap_loading.py**

## Accuracy Tests

  - Unit tests (test/registered/unit/lora/test_lora_overlap_loader_unit.py): **LoRAPipelineFlag**
  cross-stream sync + loader state machine (capacity, eviction, pipelined bookkeeping).
  - Integration (test_lora_overlap_loading.py, test_lora_tp.py): single-request, two-adapter
  batch replace, eviction, and TP=2 overlap loading — verified correct outputs.

 ## Speed Tests and Profiling
We are seeing gains in TTFT around **20%** to **50%** TTFT based on how useful mem_pool slice caching is on top of the Pipelining for faster CPU command.


Before **LoRA Pipelining**:

**Serving Command**:
```
CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server --model-path Qwen/Qwen3-32B --enable-lora --lora-paths legal0=pyloxsystems/legal-qwen3-32b-lora legal1=pyloxsystems/legal-qwen3-32b-lora legal2=pyloxsystems/legal-qwen3-32b-lora legal3=pyloxsystems/legal-qwen3-32b-lora --max-lora-rank 64 --max-loras-per-batch 1 --max-loaded-loras 4 --tp 1 --mem-fraction-static 0.9 --port 30000
```

**Benchmarking Command ** :

```
python -m sglang.bench_serving --backend sglang --port 30000 --dataset-name random --random-input-len 1600 --random-output-len 200 --num-prompts 200 --max-concurrency 1 --seed 42 --lora-name legal0 legal1 legal2 legal3 --lora-request-distribution distinct --output-file baseline_A.jsonl
```

**Results**
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 1
Successful requests:                     200
Benchmark duration (s):                  944.88
Total input tokens:                      171683
Total input text tokens:                 171683
Total generated tokens:                  22393
Total generated tokens (retokenized):    22393
Request throughput (req/s):              0.21
Input token throughput (tok/s):          181.70
Output token throughput (tok/s):         23.70
Peak output token throughput (tok/s):    26.00
Peak concurrent requests:                3
Total token throughput (tok/s):          205.40
Concurrency:                             1.00
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4723.69
Median E2E Latency (ms):                 4939.96
P90 E2E Latency (ms):                    7638.16
P95 E2E Latency (ms):                    7912.46
P99 E2E Latency (ms):                    8194.44
---------------Time to First Token----------------
Mean TTFT (ms):                          370.91
Median TTFT (ms):                        374.63
P90 TTFT (ms):                           475.46
P95 TTFT (ms):                           486.07
P99 TTFT (ms):                           491.54
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          39.22
Median TPOT (ms):                        39.30
P90 TPOT (ms):                           39.32
P95 TPOT (ms):                           39.33
P99 TPOT (ms):                           39.34
---------------Inter-Token Latency----------------
Mean ITL (ms):                           39.23
Median ITL (ms):                         39.28
P90 ITL (ms):                            39.44
P95 ITL (ms):                            39.50
P99 ITL (ms):                            39.65
Max ITL (ms):                            40.19
==================================================
```

After  **LoRA Pipelining with Caching Added**:

**Serving Command**:
```
CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server --model-path Qwen/Qwen3-32B --enable-lora --lora-paths
  legal0=pyloxsystems/legal-qwen3-32b-lora legal1=pyloxsystems/legal-qwen3-32b-lora
  legal2=pyloxsystems/legal-qwen3-32b-lora legal3=pyloxsystems/legal-qwen3-32b-lora --max-lora-rank 64
  --max-loras-per-batch 1 --max-loaded-loras 4 --enable-lora-overlap-loading --tp 1 --mem-fraction-static 0--port 30000
```

**Benchmarking Command**
```
CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server --model-path Qwen/Qwen3-32B --enable-lora --lora-paths legal0=pyloxsystems/legal-qwen3-32b-lora legal1=pyloxsystems/legal-qwen3-32b-lora legal2=pyloxsystems/legal-qwen3-32b-lora legal3=pyloxsystems/legal-qwen3-32b-lora --max-lora-rank 64 --max-loras-per-batch 1 --max-loaded-loras 4 --enable-lora-overlap-loading --tp 1 --mem-fraction-static 0.9 --port 30000
```

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 1
Successful requests:                     200
Benchmark duration (s):                  918.31
Total input tokens:                      171683
Total input text tokens:                 171683
Total generated tokens:                  22393
Total generated tokens (retokenized):    22393
Request throughput (req/s):              0.22
Input token throughput (tok/s):          186.96
Output token throughput (tok/s):         24.39
Peak output token throughput (tok/s):    26.00
Peak concurrent requests:                3
Total token throughput (tok/s):          211.34
Concurrency:                             1.00
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4590.87
Median E2E Latency (ms):                 4799.07
P90 E2E Latency (ms):                    7494.01
P95 E2E Latency (ms):                    7765.50
P99 E2E Latency (ms):                    8082.23
---------------Time to First Token----------------
Mean TTFT (ms):                          229.64
Median TTFT (ms):                        216.57
P90 TTFT (ms):                           322.11
P95 TTFT (ms):                           334.12
P99 TTFT (ms):                           956.32
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          39.30
Median TPOT (ms):                        39.33
P90 TPOT (ms):                           39.36
P95 TPOT (ms):                           39.38
P99 TPOT (ms):                           39.48
---------------Inter-Token Latency----------------
Mean ITL (ms):                           39.30
Median ITL (ms):                         39.32
P90 ITL (ms):                            39.50
P95 ITL (ms):                            39.57
P99 ITL (ms):                            39.70
Max ITL (ms):                            40.38
==================================================
```

  ## Checklist

  - [x] Format code with pre-commit
  - [x] Add/update unit tests
  - [ ] Update documentation
  - [x] Follow SGLang code style guidance
































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31228865740](https://github.com/sgl-project/sglang/actions/runs/31228865740)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31228865613](https://github.com/sgl-project/sglang/actions/runs/31228865613)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->