### PR TITLE
docs: fix Nemotron Super MTP deployment command (spec-v2 + B200)

### DIFF
--- a/docs_new/src/snippets/autoregressive/nemotron3-super-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/nemotron3-super-deployment.jsx
@@ -79,7 +79,7 @@ export const Nemotron3SuperDeployment = () => {
     const modelPath = MODEL_PATHS[model] || MODEL_PATHS['bf16'];
 
     const specV2Env = values.mtp === 'enabled' ? 'SGLANG_ENABLE_SPEC_V2=1 ' : '';
-    let cmd = `${specV2Env}python3 -m sglang.launch_server \\\n`;
+    let cmd = `${specV2Env}sglang serve \\\n`;
     cmd += `  --model-path ${modelPath} \\\n`;
     cmd += `  --trust-remote-code \\\n`;
     cmd += `  --tp ${tp} \\\n`;

--- a/docs_new/src/snippets/autoregressive/nemotron3-super-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/nemotron3-super-deployment.jsx
@@ -39,7 +39,10 @@ export const Nemotron3SuperDeployment = () => {
         { id: 'enabled', label: 'Enabled', default: false },
         { id: 'disabled', label: 'Disabled', default: true }
       ],
-      commandRule: (value) => value === 'enabled' ? '--speculative-algorithm EAGLE \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4 \\\n  --disable-radix-cache' : null
+      // trtllm_mha is Blackwell-only; on B200 it replaces the flashinfer default,
+      // whose per-step plan() host-sync breaks the spec-v2 overlap scheduler. H200
+      // defaults to fa3 (no such sync), so no override is needed there.
+      commandRule: (value, state) => value === 'enabled' ? '--speculative-algorithm EAGLE \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4 \\\n  --mamba-scheduler-strategy extra_buffer' + (state.hardware === 'b200' ? ' \\\n  --attention-backend trtllm_mha' : '') : null
     },
     kvcache: {
       name: 'kvcache',
@@ -75,7 +78,8 @@ export const Nemotron3SuperDeployment = () => {
 
     const modelPath = MODEL_PATHS[model] || MODEL_PATHS['bf16'];
 
-    let cmd = 'python3 -m sglang.launch_server \\\n';
+    const specV2Env = values.mtp === 'enabled' ? 'SGLANG_ENABLE_SPEC_V2=1 ' : '';
+    let cmd = `${specV2Env}python3 -m sglang.launch_server \\\n`;
     cmd += `  --model-path ${modelPath} \\\n`;
     cmd += `  --trust-remote-code \\\n`;
     cmd += `  --tp ${tp} \\\n`;
@@ -86,7 +90,7 @@ export const Nemotron3SuperDeployment = () => {
 
     for (const [key, option] of Object.entries(options)) {
       if (option.commandRule) {
-        const rule = option.commandRule(values[key]);
+        const rule = option.commandRule(values[key], values);
         if (rule) {
           cmd += `  ${rule} \\\n`;
         }


### PR DESCRIPTION
## Summary
Fix Nemotron3 Super cookbook MTP command: keep radix cache under spec decode, run on B200.

## Symptom & Reproduction
- **Symptom:** With MTP enabled the generated command drops radix cache; on B200 its default attention backend stalls the spec-v2 overlap scheduler.
- **Reproduction:** In the cookbook UI set MTP = Enabled, copy the generated command, launch on B200.

## Root Cause
1. EAGLE spec decode on Nemotron-H is incompatible with radix cache unless `SGLANG_ENABLE_SPEC_V2=1` and `--mamba-scheduler-strategy extra_buffer` are both set.
2. The MTP `commandRule` set neither, and instead passed `--disable-radix-cache`, dropping radix cache entirely.
3. On B200 the default MHA backend is `flashinfer`, whose per-step `plan()` host-sync serializes the spec-v2 overlap scheduler.
4. `commandRule` received only its value, not the selected hardware, so no B200-only backend override was possible.

## Fix
Thread the per-card UI `state` into `commandRule`, then for the MTP path: prefix `SGLANG_ENABLE_SPEC_V2=1`, replace `--disable-radix-cache` with `--mamba-scheduler-strategy extra_buffer` so radix cache stays on under spec decode, and append `--attention-backend trtllm_mha` only when `state.hardware === 'b200'`. H200 defaults to `fa3`, which has no `plan()` host-sync, so it needs no override.

## Verification
- **Manual:** In the rendered snippet, the B200 MTP command carries the `SGLANG_ENABLE_SPEC_V2=1` prefix plus the `trtllm_mha` override; the H200 command carries neither override nor `--disable-radix-cache`.

## Review Focus
- Scrutinize the `state.hardware === 'b200'` guard in `commandRule`: confirm the override is emitted for B200 only, never H200.
- Verify the `commandRule(values[key], values)` call site passes full state without altering the non-MTP rules.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26915081259](https://github.com/sgl-project/sglang/actions/runs/26915081259)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26915081161](https://github.com/sgl-project/sglang/actions/runs/26915081161)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->