### PR TITLE
Fix DeepSeek V4 DP reduce scatter

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -52,6 +52,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_dp_size,
     get_attention_tp_rank,
     get_attention_tp_size,
+    get_dp_global_num_tokens,
     get_global_dp_buffer,
     get_local_dp_buffer,
     is_dp_attention_enabled,
@@ -59,7 +60,7 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.moe import get_moe_a2a_backend
+from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
@@ -864,7 +865,14 @@ class DeepseekV4DecoderLayer(nn.Module):
                 get_local_dp_buffer(get_tp_group()),
                 hidden_states,
             )
-            dp_scatter(hidden_states, global_hidden_states, forward_batch)
+            if should_use_dp_reduce_scatterv():
+                get_tp_group().reduce_scatterv(
+                    global_hidden_states,
+                    output=hidden_states,
+                    sizes=get_dp_global_num_tokens(),
+                )
+            else:
+                dp_scatter(hidden_states, global_hidden_states, forward_batch)
         if _use_tp_attn_a2a_scatter:
             assert _a2a_scatter_chunks is not None
             gathered = [torch.empty_like(t) for t in _a2a_scatter_chunks]


### PR DESCRIPTION
## Summary

- Use `reduce_scatterv` for DeepSeek V4's TP-MoE gather return path when DP reduce-scatter is enabled.
- Keep the existing `dp_scatter` path for configurations that do not use DP reduce-scatter.

## Root Cause

DeepSeek V4 has a hand-written `_use_tp_moe_gather` path. In DP attention with TP MoE, the MLP output can be TP-partial. When `should_use_dp_reduce_scatterv()` is true, scattering that partial tensor directly leaves the local hidden state unreduced before the following HC post block.

The generic communicator already uses `reduce_scatterv` for this mode. This change makes the DeepSeek V4 custom path match that behavior.

## Validation

- `python3 -m py_compile python/sglang/srt/models/deepseek_v4.py`
- `pre-commit run --files python/sglang/srt/models/deepseek_v4.py`
- Miles 4-layer manual run with this patch reduced the train/rollout logprob mismatch from ~12.4 to ~0.085 before the Miles-side CI logprob checker threshold stopped the run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->