### PR TITLE
[Fix] Emulate PDEATHSIG on macOS to prevent orphaned worker processes

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/parent_watchdog.py
+++ b/python/sglang/srt/hardware_backend/mlx/parent_watchdog.py
@@ -1,0 +1,60 @@
+"""Parent-death watchdog for MLX workers on Apple Silicon.
+
+macOS has no ``PR_SET_PDEATHSIG`` equivalent, so the kernel will not signal a
+worker process when its parent dies; the worker would be reparented to PID 1
+and leak (holding GPU/host memory and ports). This module emulates PDEATHSIG
+with a daemon thread that watches the parent PID via kqueue and SIGKILLs the
+current process once it gets orphaned.
+"""
+
+import os
+import select
+import signal
+import threading
+
+
+def start_parent_death_watcher() -> None:
+    """SIGKILL this process once its current parent exits (macOS only).
+
+    kqueue with an ``EVFILT_PROC`` / ``NOTE_EXIT`` filter is the native,
+    event-driven mechanism on macOS (exposed via ``select.kqueue`` /
+    ``select.kevent``), so the watcher thread blocks until the parent actually
+    exits instead of waking up to poll.
+
+    ``SIGKILL`` is sent from this watcher thread and is uncatchable /
+    unblockable, so it works even when the main thread is stuck inside a
+    blocking native call (e.g. an MLX/Metal ``mx.eval`` / ``.tolist()``).
+    """
+    original_ppid = os.getppid()
+
+    def _watch_parent():
+        kq = select.kqueue()
+        kev = select.kevent(
+            original_ppid,
+            filter=select.KQ_FILTER_PROC,
+            flags=select.KQ_EV_ADD,
+            fflags=select.KQ_NOTE_EXIT,
+        )
+        try:
+            # Register the EVFILT_PROC / NOTE_EXIT watch on the parent PID.
+            kq.control([kev], 0, None)
+        except (ProcessLookupError, OSError):
+            # The parent already exited before we could register the watch
+            # (ESRCH); we are already orphaned.
+            os.kill(os.getpid(), signal.SIGKILL)
+            return
+        # Guard against the race where the parent exits between reading
+        # original_ppid and registering the watch above.
+        if os.getppid() != original_ppid:
+            os.kill(os.getpid(), signal.SIGKILL)
+            return
+        # Block until the parent exits, then terminate ourselves.
+        kq.control(None, 1, None)
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    watcher = threading.Thread(
+        target=_watch_parent,
+        name="parent-death-watcher",
+        daemon=True,
+    )
+    watcher.start()

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2538,55 +2538,13 @@ def kill_itself_when_parent_died():
         libc = ctypes.CDLL("libc.so.6")
         libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL)
     elif sys.platform == "darwin":
-        # macOS has no PR_SET_PDEATHSIG equivalent, so the
-        # kernel will not signal this process when the parent dies; the worker
-        # would be reparented to PID 1 and leak (holding GPU/host memory and
-        # ports). Emulate PDEATHSIG with a daemon thread that watches the parent
-        # PID via kqueue and SIGKILLs *this* process once it gets orphaned.
-        #
-        # kqueue with an EVFILT_PROC / NOTE_EXIT filter is the native,
-        # event-driven mechanism on macOS (exposed via select.kqueue /
-        # select.kevent), so the watcher thread blocks until the parent actually
-        # exits instead of waking up to poll.
-        #
-        # SIGKILL is sent from this watcher thread and is uncatchable /
-        # unblockable, so it works even when the main thread is stuck inside a
-        # blocking native call (e.g. an MLX/Metal `mx.eval` / `.tolist()`).
-        import select
-
-        original_ppid = os.getppid()
-
-        def _watch_parent():
-            kq = select.kqueue()
-            kev = select.kevent(
-                original_ppid,
-                filter=select.KQ_FILTER_PROC,
-                flags=select.KQ_EV_ADD,
-                fflags=select.KQ_NOTE_EXIT,
-            )
-            try:
-                # Register the EVFILT_PROC / NOTE_EXIT watch on the parent PID.
-                kq.control([kev], 0, None)
-            except (ProcessLookupError, OSError):
-                # The parent already exited before we could register the watch
-                # (ESRCH); we are already orphaned.
-                os.kill(os.getpid(), signal.SIGKILL)
-                return
-            # Guard against the race where the parent exits between reading
-            # original_ppid and registering the watch above.
-            if os.getppid() != original_ppid:
-                os.kill(os.getpid(), signal.SIGKILL)
-                return
-            # Block until the parent exits, then terminate ourselves.
-            kq.control(None, 1, None)
-            os.kill(os.getpid(), signal.SIGKILL)
-
-        watcher = threading.Thread(
-            target=_watch_parent,
-            name="parent-death-watcher",
-            daemon=True,
+        # macOS has no PR_SET_PDEATHSIG equivalent; the MLX backend provides a
+        # kqueue-based watchdog that SIGKILLs this worker once it is orphaned.
+        from sglang.srt.hardware_backend.mlx.parent_watchdog import (
+            start_parent_death_watcher,
         )
-        watcher.start()
+
+        start_parent_death_watcher()
     else:
         logger.warning(
             "kill_itself_when_parent_died is only supported on linux and macOS."

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2541,21 +2541,45 @@ def kill_itself_when_parent_died():
         # macOS has no PR_SET_PDEATHSIG equivalent, so the
         # kernel will not signal this process when the parent dies; the worker
         # would be reparented to PID 1 and leak (holding GPU/host memory and
-        # ports). Emulate PDEATHSIG with a daemon thread that polls the parent
-        # PID and SIGKILLs *this* process once it gets orphaned.
+        # ports). Emulate PDEATHSIG with a daemon thread that watches the parent
+        # PID via kqueue and SIGKILLs *this* process once it gets orphaned.
+        #
+        # kqueue with an EVFILT_PROC / NOTE_EXIT filter is the native,
+        # event-driven mechanism on macOS (exposed via select.kqueue /
+        # select.kevent), so the watcher thread blocks until the parent actually
+        # exits instead of waking up to poll.
         #
         # SIGKILL is sent from this watcher thread and is uncatchable /
         # unblockable, so it works even when the main thread is stuck inside a
         # blocking native call (e.g. an MLX/Metal `mx.eval` / `.tolist()`).
+        import select
+
         original_ppid = os.getppid()
 
         def _watch_parent():
-            while True:
-                # getppid() returns 1 (reparented to init/launchd) once the
-                # original parent has exited.
-                if os.getppid() != original_ppid:
-                    os.kill(os.getpid(), signal.SIGKILL)
-                time.sleep(1.0)
+            kq = select.kqueue()
+            kev = select.kevent(
+                original_ppid,
+                filter=select.KQ_FILTER_PROC,
+                flags=select.KQ_EV_ADD,
+                fflags=select.KQ_NOTE_EXIT,
+            )
+            try:
+                # Register the EVFILT_PROC / NOTE_EXIT watch on the parent PID.
+                kq.control([kev], 0, None)
+            except (ProcessLookupError, OSError):
+                # The parent already exited before we could register the watch
+                # (ESRCH); we are already orphaned.
+                os.kill(os.getpid(), signal.SIGKILL)
+                return
+            # Guard against the race where the parent exits between reading
+            # original_ppid and registering the watch above.
+            if os.getppid() != original_ppid:
+                os.kill(os.getpid(), signal.SIGKILL)
+                return
+            # Block until the parent exits, then terminate ourselves.
+            kq.control(None, 1, None)
+            os.kill(os.getpid(), signal.SIGKILL)
 
         watcher = threading.Thread(
             target=_watch_parent,

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2537,8 +2537,8 @@ def kill_itself_when_parent_died():
         PR_SET_PDEATHSIG = 1
         libc = ctypes.CDLL("libc.so.6")
         libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL)
-    else:
-        # macOS / other platforms have no PR_SET_PDEATHSIG equivalent, so the
+    elif sys.platform == "darwin":
+        # macOS has no PR_SET_PDEATHSIG equivalent, so the
         # kernel will not signal this process when the parent dies; the worker
         # would be reparented to PID 1 and leak (holding GPU/host memory and
         # ports). Emulate PDEATHSIG with a daemon thread that polls the parent
@@ -2563,6 +2563,10 @@ def kill_itself_when_parent_died():
             daemon=True,
         )
         watcher.start()
+    else:
+        logger.warning(
+            "kill_itself_when_parent_died is only supported on linux and macOS."
+        )
 
 
 class UvicornAccessLogFilter(logging.Filter):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2538,7 +2538,31 @@ def kill_itself_when_parent_died():
         libc = ctypes.CDLL("libc.so.6")
         libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL)
     else:
-        logger.warning("kill_itself_when_parent_died is only supported in linux.")
+        # macOS / other platforms have no PR_SET_PDEATHSIG equivalent, so the
+        # kernel will not signal this process when the parent dies; the worker
+        # would be reparented to PID 1 and leak (holding GPU/host memory and
+        # ports). Emulate PDEATHSIG with a daemon thread that polls the parent
+        # PID and SIGKILLs *this* process once it gets orphaned.
+        #
+        # SIGKILL is sent from this watcher thread and is uncatchable /
+        # unblockable, so it works even when the main thread is stuck inside a
+        # blocking native call (e.g. an MLX/Metal `mx.eval` / `.tolist()`).
+        original_ppid = os.getppid()
+
+        def _watch_parent():
+            while True:
+                # getppid() returns 1 (reparented to init/launchd) once the
+                # original parent has exited.
+                if os.getppid() != original_ppid:
+                    os.kill(os.getpid(), signal.SIGKILL)
+                time.sleep(1.0)
+
+        watcher = threading.Thread(
+            target=_watch_parent,
+            name="parent-death-watcher",
+            daemon=True,
+        )
+        watcher.start()
 
 
 class UvicornAccessLogFilter(logging.Filter):


### PR DESCRIPTION
## Motivation

On Linux, `kill_itself_when_parent_died()` calls
`prctl(PR_SET_PDEATHSIG, SIGKILL)` so that the scheduler / detokenizer /
DP-controller / tokenizer-router subprocesses are killed by the kernel
when their parent dies. On macOS (and any non-Linux platform) the
function currently only logs a warning and does nothing.

As a result, on macOS — e.g. running the MLX backend with
`SGLANG_USE_MLX=1` — whenever the parent engine process exits abnormally
(or a test/REPL session that launched a server simply goes away), the
`sglang::scheduler` workers are reparented to PID 1 and survive, holding
host memory and their ports. Across a few restarts these orphans pile up
(I observed 5 leftover `sglang::scheduler` processes holding ~27 GB
combined), which then leads to:

- port conflicts on the next launch,
- tokenizer / scheduler startup errors because a stale worker still owns
  the socket/port,
- eventually host OOM and `forkpty: Device not configured`.

This is the macOS instance of the well-known orphan-process problem
tracked broadly in #23627 (previously patched for specific Linux paths
in #7995, #16756, #21180, #18582). #23627 explicitly notes the
non-Linux path is not covered.

Related to #23627

## Modifications

> **Note (edited after merge):** this section originally described a polling
> implementation — a daemon thread waking up to compare `os.getppid()` against
> the original parent PID. That was the approach in the first revision; during
> review it was replaced with an event-driven kqueue watcher, which is what
> actually merged. The description is updated here so it matches the code rather
> than the first draft. The rest of the discussion is in the review thread below.

`python/sglang/srt/hardware_backend/mlx/parent_watchdog.py` (new) —
`start_parent_death_watcher()`:

- Registers an `EVFILT_PROC` / `NOTE_EXIT` watch on the current parent PID
  through `select.kqueue()` / `select.kevent()`. This is the native macOS
  mechanism for "tell me when that process exits", so the watcher thread
  **blocks until the parent actually exits** rather than waking up on a timer.
  Compared to polling this removes both the periodic wakeups and the detection
  window between two polls.
- Handles the parent dying *before* the watch is registered: `kq.control()`
  raises `ProcessLookupError`/`OSError` (ESRCH) in that case, which means we are
  already orphaned, so the process `SIGKILL`s itself immediately.
- Guards the reparenting race explicitly: the parent can exit between reading
  `os.getppid()` and registering the watch, in which case the watch would be
  registered against a PID that is already gone (or, worse, reused). After
  registering, the watcher re-reads `os.getppid()` and terminates if it no
  longer matches.
- `SIGKILL` is raised from the watcher thread and is uncatchable/unblockable, so
  it reliably terminates the worker even when the main thread is blocked inside
  a native call (e.g. an MLX/Metal `mx.eval` / `.tolist()` that never returns to
  the Python signal-handling layer).
- The thread is a daemon, so it is torn down automatically on normal interpreter
  exit and adds nothing to the shutdown path.

`python/sglang/srt/utils/common.py` — `kill_itself_when_parent_died()`:

- Linux path is unchanged (`prctl(PR_SET_PDEATHSIG, SIGKILL)`).
- The non-Linux branch now starts the watcher above instead of only logging a
  warning.

All four worker entry points already call this single helper, so the fix covers
scheduler, detokenizer, DP controller and tokenizer router at once.

## Tests

SGLang's CI runners are GPU/Linux-only, and this branch of the function is
macOS-specific (the Linux branch is already covered at the kernel level via
`PR_SET_PDEATHSIG`), so there is no CI runner that exercises this path. I
verified it manually on macOS (Apple Silicon) with a controlled A/B
reproduction: a parent spawns a child, the child installs the watcher (or not)
and then busy-loops on its main thread, the parent `_exit`s, and an outside
observer polls the child's PID.

| | child state after the parent exits |
|---|---|
| Before (current `else` branch) | **still alive** after 8 s — leaks, matches the bug |
| After (this PR) | **gone in 11–13 ms** across 6 runs |

The 11–13 ms is bounded by the observer's 10 ms polling interval, not by the
watcher: `kqueue` returns as soon as the kernel posts `NOTE_EXIT`, so the real
detection latency is below what this harness can resolve. The point of the
measurement is the difference in kind — leaked indefinitely versus reaped
immediately — rather than the millisecond figure.

The child keeps its main thread in a tight loop with no syscalls, mimicking a
scheduler stuck inside a native MLX/Metal call, and is still reliably killed —
exactly the case the `SIGKILL`-from-watcher-thread approach is designed for.

Environment: macOS 26.3.1, arm64, CPython 3.13.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27222964093](https://github.com/sgl-project/sglang/actions/runs/27222964093)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27222963866](https://github.com/sgl-project/sglang/actions/runs/27222963866)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

