### PR TITLE
Fix DeepSeek V4 DP reduce scatter when use attention DP + MoE TP

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -59,6 +59,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_dp_size,
     get_attention_tp_rank,
     get_attention_tp_size,
+    get_dp_global_num_tokens,
     get_global_dp_buffer,
     get_local_dp_buffer,
     is_dp_attention_enabled,
@@ -67,7 +68,7 @@ from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.mhc import mhc_fused_post_pre
-from sglang.srt.layers.moe import get_moe_a2a_backend
+from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
@@ -1430,7 +1431,14 @@ class DeepseekV4DecoderLayer(nn.Module):
                 get_local_dp_buffer(get_tp_group()),
                 hidden_states,
             )
-            dp_scatter(hidden_states, global_hidden_states, forward_batch)
+            if should_use_dp_reduce_scatterv():
+                get_tp_group().reduce_scatterv(
+                    global_hidden_states,
+                    output=hidden_states,
+                    sizes=get_dp_global_num_tokens(),
+                )
+            else:
+                dp_scatter(hidden_states, global_hidden_states, forward_batch)
         if _use_tp_attn_a2a_scatter:
             assert _a2a_scatter_chunks is not None
             gathered = [torch.empty_like(t) for t in _a2a_scatter_chunks]


### PR DESCRIPTION
## Summary

- Use `reduce_scatterv` for DeepSeek V4's TP-MoE gather return path when DP reduce-scatter is enabled.
- Keep the existing `dp_scatter` path for configurations that do not use DP reduce-scatter.

## Root Cause

DeepSeek V4 has a hand-written `_use_tp_moe_gather` path. In DP attention with TP MoE, the MLP output can be TP-partial. When `should_use_dp_reduce_scatterv()` is true, scattering that partial tensor directly leaves the local hidden state unreduced before the following HC post block.

The generic communicator already uses `reduce_scatterv` for this mode. This change makes the DeepSeek V4 custom path match that behavior.

## Trigger Conditions

This can trigger when DeepSeek V4 runs with DP attention, `attention_dp_size > 1`, no MoE A2A backend, and expert parallel world size equal to the attention DP size. The Miles DeepSeek V4 4-layer reproduction used `--sglang-enable-dp-attention`, `--sglang-tp-size 8`, `--sglang-dp-size 8`, and `--sglang-ep-size 8`.

## Validation

- `python3 -m py_compile python/sglang/srt/models/deepseek_v4.py`
- `pre-commit run --files python/sglang/srt/models/deepseek_v4.py`





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26916891279](https://github.com/sgl-project/sglang/actions/runs/26916891279)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26916891116](https://github.com/sgl-project/sglang/actions/runs/26916891116)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->