### PR TITLE
Replace skip_attn_backend_init with a batch-carried attention plan marker (+ staleness re-plan)

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -761,6 +761,14 @@ class TboForwardBatchPreparer:
                 token_ids_logprobs=None,
                 next_token_logits_buffer=None,
                 return_hidden_states_before_norm=False,
+                # TBO children start unplanned: each sub-batch's attention
+                # metadata is established by the TBO-aware init flow, so the
+                # plan marker / record must not carry over from the parent
+                # (a stale "ready" would wrongly skip the child's planning).
+                forward_metadata_ready=False,
+                forward_metadata_planned_bs=None,
+                forward_metadata_planned_num_tokens=None,
+                forward_metadata_replan_equivalent=False,
             )
         )
 

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -761,10 +761,8 @@ class TboForwardBatchPreparer:
                 token_ids_logprobs=None,
                 next_token_logits_buffer=None,
                 return_hidden_states_before_norm=False,
-                # TBO children start unplanned: each sub-batch's attention
-                # metadata is established by the TBO-aware init flow, so the
-                # plan marker / record must not carry over from the parent
-                # (a stale "ready" would wrongly skip the child's planning).
+                # TBO children start unplanned — planned by the TBO-aware init
+                # flow; a stale parent "ready" would wrongly skip that.
                 forward_metadata_ready=False,
                 forward_metadata_planned_bs=None,
                 forward_metadata_planned_num_tokens=None,

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -98,7 +98,7 @@ class MlxTpModelWorker(TpModelWorker):
         forward_batch: Optional[ForwardBatch] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
         is_verify: bool = False,
-        skip_attn_backend_init=False,
+        skip_attn_backend_init: Optional[bool] = None,  # deprecated
     ) -> GenerationBatchResult:
         """Override to route through MLX model runner."""
         if batch is not None:

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -180,10 +180,9 @@ class NPUGraphRunner(CudaGraphRunner):
     def replay(
         self,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool = False,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
+        if forward_batch.needs_forward_metadata_init():
             self.replay_prepare(forward_batch, pp_proxy_tensors)
         else:
             # In speculative decoding, these two fields are still needed.

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -183,7 +183,7 @@ class NPUGraphRunner(CudaGraphRunner):
         skip_attn_backend_init: bool = False,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        if not skip_attn_backend_init:
+        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
             self.replay_prepare(forward_batch, pp_proxy_tensors)
         else:
             # In speculative decoding, these two fields are still needed.

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -956,12 +956,9 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             or self.forward_decode_metadata
         )
 
-        # Backstop for stale metadata (batch padded by prepare_mlp_sync_batch
-        # after planning). Equivalent-replan pre-plan sites now opt into
-        # replan_equivalent and get re-planned centrally post-pad; this local
-        # re-plan only still fires for regimes that cannot opt in — wrapper
-        # (multi-step) plans and multi_layer_eagle_worker_v2's
-        # skip-without-pre-plan paths. Remove once those are fixed.
+        # Backstop: re-plan if the batch was padded after planning. Only
+        # fires for regimes that cannot opt into replan_equivalent (wrapper
+        # plans, mlv2's skip-without-pre-plan paths); remove once fixed.
         batch_size = getattr(metadata, "batch_size", None)
         if batch_size is not None and batch_size < forward_batch.batch_size:
             self.init_forward_metadata(forward_batch)
@@ -1061,13 +1058,10 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 or self.forward_decode_metadata
             )
 
-            # Backstop for stale metadata (batch padded by
-            # prepare_mlp_sync_batch after planning). Equivalent-replan
-            # pre-plan sites now opt into replan_equivalent and get
-            # re-planned centrally post-pad; this local re-plan only still
-            # fires for regimes that cannot opt in — wrapper (multi-step)
-            # plans and multi_layer_eagle_worker_v2's skip-without-pre-plan
-            # paths. Remove once those are fixed.
+            # Backstop: re-plan if the batch was padded after planning.
+            # Only fires for regimes that cannot opt into replan_equivalent
+            # (wrapper plans, mlv2's skip-without-pre-plan paths); remove
+            # once fixed.
             batch_size = getattr(metadata, "batch_size", None)
             if batch_size is not None and batch_size < forward_batch.batch_size:
                 self.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -957,8 +957,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         )
 
         # Ensure batch_size is sufficient, the batch size increase due to the padding from the forward batch
-        # FIXME(@rainj-me), refactor the skip_attn_backend_init, init_forward_metadata for attn backends
-        # and padding logic in prepare_mlp_sync_batch to avoid this
+        # FIXME(@rainj-me): metadata went stale because the batch was padded
+        # (prepare_mlp_sync_batch) after a pre-planner marked it
+        # forward_metadata_ready. Replace this defensive re-plan with central
+        # staleness validation on the marker (record planned_bs at mark time,
+        # invalidate when padding changes shapes).
         batch_size = getattr(metadata, "batch_size", None)
         if batch_size is not None and batch_size < forward_batch.batch_size:
             self.init_forward_metadata(forward_batch)
@@ -1059,8 +1062,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             )
 
             # Ensure batch_size is sufficient, the batch size increase due to the padding from the forward batch
-            # FIXME(@rainj-me), refactor the skip_attn_backend_init, init_forward_metadata for attn backends
-            # and padding logic in prepare_mlp_sync_batch to avoid this
+            # FIXME(@rainj-me): metadata went stale because the batch was
+            # padded (prepare_mlp_sync_batch) after a pre-planner marked it
+            # forward_metadata_ready. Replace this defensive re-plan with
+            # central staleness validation on the marker (record planned_bs
+            # at mark time, invalidate when padding changes shapes).
             batch_size = getattr(metadata, "batch_size", None)
             if batch_size is not None and batch_size < forward_batch.batch_size:
                 self.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -956,9 +956,10 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             or self.forward_decode_metadata
         )
 
-        # Backstop: re-plan if the batch was padded after planning. Only
-        # fires for regimes that cannot opt into replan_equivalent (wrapper
-        # plans, mlv2's skip-without-pre-plan paths); remove once fixed.
+        # Backstop: metadata was built pre-pad (marked) and DP padding then
+        # grew the batch. The marker path deliberately does not re-plan
+        # post-pad (DSA can't rebuild on a padded batch, see #27091), so this
+        # local re-plan catches the size mismatch.
         batch_size = getattr(metadata, "batch_size", None)
         if batch_size is not None and batch_size < forward_batch.batch_size:
             self.init_forward_metadata(forward_batch)
@@ -1058,10 +1059,10 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 or self.forward_decode_metadata
             )
 
-            # Backstop: re-plan if the batch was padded after planning.
-            # Only fires for regimes that cannot opt into replan_equivalent
-            # (wrapper plans, mlv2's skip-without-pre-plan paths); remove
-            # once fixed.
+            # Backstop: metadata was built pre-pad (marked) and DP padding
+            # then grew the batch. The marker path deliberately does not
+            # re-plan post-pad (DSA can't rebuild on a padded batch, see
+            # #27091), so this local re-plan catches the size mismatch.
             batch_size = getattr(metadata, "batch_size", None)
             if batch_size is not None and batch_size < forward_batch.batch_size:
                 self.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -956,12 +956,12 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             or self.forward_decode_metadata
         )
 
-        # Ensure batch_size is sufficient, the batch size increase due to the padding from the forward batch
-        # FIXME(@rainj-me): metadata went stale because the batch was padded
-        # (prepare_mlp_sync_batch) after a pre-planner marked it
-        # forward_metadata_ready. Replace this defensive re-plan with central
-        # staleness validation on the marker (record planned_bs at mark time,
-        # invalidate when padding changes shapes).
+        # Backstop for stale metadata (batch padded by prepare_mlp_sync_batch
+        # after planning). Equivalent-replan pre-plan sites now opt into
+        # replan_on_reshape and get re-planned centrally post-pad; this local
+        # re-plan only still fires for regimes that cannot opt in — wrapper
+        # (multi-step) plans and multi_layer_eagle_worker_v2's
+        # skip-without-pre-plan paths. Remove once those are fixed.
         batch_size = getattr(metadata, "batch_size", None)
         if batch_size is not None and batch_size < forward_batch.batch_size:
             self.init_forward_metadata(forward_batch)
@@ -1061,12 +1061,13 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 or self.forward_decode_metadata
             )
 
-            # Ensure batch_size is sufficient, the batch size increase due to the padding from the forward batch
-            # FIXME(@rainj-me): metadata went stale because the batch was
-            # padded (prepare_mlp_sync_batch) after a pre-planner marked it
-            # forward_metadata_ready. Replace this defensive re-plan with
-            # central staleness validation on the marker (record planned_bs
-            # at mark time, invalidate when padding changes shapes).
+            # Backstop for stale metadata (batch padded by
+            # prepare_mlp_sync_batch after planning). Equivalent-replan
+            # pre-plan sites now opt into replan_on_reshape and get
+            # re-planned centrally post-pad; this local re-plan only still
+            # fires for regimes that cannot opt in — wrapper (multi-step)
+            # plans and multi_layer_eagle_worker_v2's skip-without-pre-plan
+            # paths. Remove once those are fixed.
             batch_size = getattr(metadata, "batch_size", None)
             if batch_size is not None and batch_size < forward_batch.batch_size:
                 self.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -958,7 +958,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         # Backstop for stale metadata (batch padded by prepare_mlp_sync_batch
         # after planning). Equivalent-replan pre-plan sites now opt into
-        # replan_on_reshape and get re-planned centrally post-pad; this local
+        # replan_equivalent and get re-planned centrally post-pad; this local
         # re-plan only still fires for regimes that cannot opt in — wrapper
         # (multi-step) plans and multi_layer_eagle_worker_v2's
         # skip-without-pre-plan paths. Remove once those are fixed.
@@ -1063,7 +1063,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
             # Backstop for stale metadata (batch padded by
             # prepare_mlp_sync_batch after planning). Equivalent-replan
-            # pre-plan sites now opt into replan_on_reshape and get
+            # pre-plan sites now opt into replan_equivalent and get
             # re-planned centrally post-pad; this local re-plan only still
             # fires for regimes that cannot opt in — wrapper (multi-step)
             # plans and multi_layer_eagle_worker_v2's skip-without-pre-plan

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -450,11 +450,8 @@ class TpModelWorker(BaseTpWorker):
         forward_batch: Optional[ForwardBatch] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
         is_verify: bool = False,
-        skip_attn_backend_init=False,
+        skip_attn_backend_init: Optional[bool] = None,  # deprecated
     ) -> GenerationBatchResult:
-        # FIXME(lsyin): maybe remove skip_attn_backend_init in forward_batch_generation,
-        #               which requires preparing replay to always be in this function
-
         # Get forward batch from schedule batch
         if batch is not None:
             # update the consumer index of hicache to the running batch
@@ -465,6 +462,9 @@ class TpModelWorker(BaseTpWorker):
             # FIXME(lsyin): unify the interface of forward_batch
             assert forward_batch is not None
 
+        # Deprecated kwarg: pre-planners mark the batch themselves now.
+        forward_batch.apply_deprecated_skip_attn_backend_init(skip_attn_backend_init)
+
         if self.is_dllm():
             return self._forward_batch_generation_dllm(forward_batch)
 
@@ -472,7 +472,6 @@ class TpModelWorker(BaseTpWorker):
             out = self.model_runner.forward(
                 forward_batch,
                 pp_proxy_tensors=pp_proxy_tensors,
-                skip_attn_backend_init=skip_attn_backend_init,
             )
             logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
             batch_result = GenerationBatchResult(
@@ -529,7 +528,6 @@ class TpModelWorker(BaseTpWorker):
             out = self.model_runner.forward(
                 forward_batch,
                 pp_proxy_tensors=pp_proxy_tensors,
-                skip_attn_backend_init=skip_attn_backend_init,
             )
             pp_proxy_tensors, can_run_cuda_graph = out.logits_output, out.can_run_graph
             return GenerationBatchResult(

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -816,7 +816,6 @@ class CPUGraphRunner:
     def replay(
         self,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool = False,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
         assert (

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -1234,7 +1234,7 @@ class CudaGraphRunner:
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
         self.deepep_adapter.replay()
 
-        if not skip_attn_backend_init:
+        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
             self.replay_prepare(forward_batch, pp_proxy_tensors)
         else:
             # In speculative decoding, these two fields are still needed.

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -1229,14 +1229,14 @@ class CudaGraphRunner:
     def replay(
         self,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool = False,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
         self.deepep_adapter.replay()
 
-        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
+        if forward_batch.needs_forward_metadata_init():
             self.replay_prepare(forward_batch, pp_proxy_tensors)
         else:
+            # Pre-planned (plan-stream replay_prepare already ran).
             # In speculative decoding, these two fields are still needed.
             self.buffers.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
             self.buffers.positions[: self.raw_num_token].copy_(forward_batch.positions)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -472,15 +472,37 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # marker is only valid for the planning regime (backend set) it was set
     # under; a fresh batch from init_new always starts unplanned.
     forward_metadata_ready: bool = False
+    # Shapes the batch had when it was marked (plan record). Lets the
+    # judgment predicate detect staleness when DP padding
+    # (prepare_mlp_sync_batch) reshapes the batch after pre-planning.
+    # Deliberately plain ints — no planner object ref on ForwardBatch
+    # (runtime refs were removed from this dataclass on purpose).
+    forward_metadata_planned_bs: Optional[int] = None
+    forward_metadata_planned_num_tokens: Optional[int] = None
+    # Whether the forward path may re-plan this batch when its shapes no
+    # longer match the plan record. Only mark sites where the forward
+    # path's own init_forward_metadata is equivalent to the pre-plan
+    # (same backend object, no special context) may opt in; multi-step
+    # wrapper plans and view-context plans must keep this False — a
+    # forward-path re-plan would clobber their metadata.
+    forward_metadata_replan_on_reshape: bool = False
 
-    def mark_forward_metadata_ready(self):
+    def mark_forward_metadata_ready(self, replan_on_reshape: bool = False):
         """Record that attention metadata was pre-planned for this batch.
 
         Call right next to the out-of-forward planning action
         (e.g. ``draft_attn_backend.init_forward_metadata(fb)`` or
-        ``graph_runner.replay_prepare(fb)``).
+        ``graph_runner.replay_prepare(fb)``). Records the batch shapes so
+        staleness is detectable; pass ``replan_on_reshape=True`` only when
+        a forward-path re-plan is equivalent to the pre-plan (see field
+        docs).
         """
         self.forward_metadata_ready = True
+        self.forward_metadata_planned_bs = self.batch_size
+        self.forward_metadata_planned_num_tokens = (
+            self.input_ids.shape[0] if self.input_ids is not None else 0
+        )
+        self.forward_metadata_replan_on_reshape = replan_on_reshape
 
     def needs_forward_metadata_init(self) -> bool:
         """Single judgment point for whether the forward path must plan.

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -485,15 +485,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # (same backend object, no special context) may opt in; multi-step
     # wrapper plans and view-context plans must keep this False — a
     # forward-path re-plan would clobber their metadata.
-    forward_metadata_replan_on_reshape: bool = False
+    forward_metadata_replan_equivalent: bool = False
 
-    def mark_forward_metadata_ready(self, replan_on_reshape: bool = False):
+    def mark_forward_metadata_ready(self, replan_equivalent: bool = False):
         """Record that attention metadata was pre-planned for this batch.
 
         Call right next to the out-of-forward planning action
         (e.g. ``draft_attn_backend.init_forward_metadata(fb)`` or
         ``graph_runner.replay_prepare(fb)``). Records the batch shapes so
-        staleness is detectable; pass ``replan_on_reshape=True`` only when
+        staleness is detectable; pass ``replan_equivalent=True`` only when
         a forward-path re-plan is equivalent to the pre-plan (see field
         docs).
         """
@@ -502,14 +502,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         self.forward_metadata_planned_num_tokens = (
             self.input_ids.shape[0] if self.input_ids is not None else 0
         )
-        self.forward_metadata_replan_on_reshape = replan_on_reshape
+        self.forward_metadata_replan_equivalent = replan_equivalent
 
     def needs_forward_metadata_init(self) -> bool:
         """Single judgment point for whether the forward path must plan.
 
         A marked batch is treated as stale — and re-planned — when its
         shapes no longer match the plan record AND the mark site declared
-        the re-plan safe (replan_on_reshape). This runs after
+        the re-plan safe (replan_equivalent). This runs after
         prepare_mlp_sync_batch in _forward_raw, so the re-plan sees the
         padded (final) shapes. Sites that cannot opt in (multi-step
         wrapper plans etc.) keep today's behavior: marked stays skipped,
@@ -517,7 +517,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         """
         if not self.forward_metadata_ready:
             return True
-        if not self.forward_metadata_replan_on_reshape:
+        if not self.forward_metadata_replan_equivalent:
             return False
         num_tokens = self.input_ids.shape[0] if self.input_ids is not None else 0
         return (

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -507,11 +507,23 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     def needs_forward_metadata_init(self) -> bool:
         """Single judgment point for whether the forward path must plan.
 
-        Kept as a method (not an inlined attribute read) so the predicate can
-        later grow planner-identity / staleness checks without touching the
-        call sites.
+        A marked batch is treated as stale — and re-planned — when its
+        shapes no longer match the plan record AND the mark site declared
+        the re-plan safe (replan_on_reshape). This runs after
+        prepare_mlp_sync_batch in _forward_raw, so the re-plan sees the
+        padded (final) shapes. Sites that cannot opt in (multi-step
+        wrapper plans etc.) keep today's behavior: marked stays skipped,
+        backends' defensive checks remain the backstop.
         """
-        return not self.forward_metadata_ready
+        if not self.forward_metadata_ready:
+            return True
+        if not self.forward_metadata_replan_on_reshape:
+            return False
+        num_tokens = self.input_ids.shape[0] if self.input_ids is not None else 0
+        return (
+            self.batch_size != self.forward_metadata_planned_bs
+            or num_tokens != self.forward_metadata_planned_num_tokens
+        )
 
     def apply_deprecated_skip_attn_backend_init(
         self, skip_attn_backend_init: Optional[bool]

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -28,6 +28,7 @@ ScheduleBatch -> ForwardBatch
 from __future__ import annotations
 
 import hashlib
+import warnings
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from functools import total_ordering
@@ -71,6 +72,10 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
+
+# Warn-once flag for the deprecated skip_attn_backend_init kwarg; see
+# ForwardBatch.apply_deprecated_skip_attn_backend_init.
+_skip_attn_backend_init_warned = False
 
 _is_npu = is_npu()
 
@@ -485,6 +490,33 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         call sites.
         """
         return not self.forward_metadata_ready
+
+    def apply_deprecated_skip_attn_backend_init(
+        self, skip_attn_backend_init: Optional[bool]
+    ) -> None:
+        """Map the deprecated ``skip_attn_backend_init`` kwarg onto the marker.
+
+        Mapped, not ignored: callers passing True relied on planning being
+        skipped — ignoring the flag would silently re-plan and corrupt
+        pre-planned multi-step draft metadata. Warns once per process (a
+        module flag, not the warnings filter, so the hot decode loop never
+        pays warnings.warn per forward).
+        """
+        if skip_attn_backend_init is None:
+            return
+        global _skip_attn_backend_init_warned
+        if not _skip_attn_backend_init_warned:
+            _skip_attn_backend_init_warned = True
+            warnings.warn(
+                "skip_attn_backend_init is deprecated and will be removed; "
+                "pre-planners should call "
+                "ForwardBatch.mark_forward_metadata_ready() after planning "
+                "instead. The flag is mapped onto the marker for now.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        if skip_attn_backend_init:
+            self.mark_forward_metadata_ready()
 
     @classmethod
     def init_new(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -459,6 +459,33 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     req_all_ids_flat: Optional[torch.Tensor] = None
     req_all_ids_lens: Optional[torch.Tensor] = None
 
+    # Attention planning state. True iff attention metadata for this batch has
+    # already been planned outside ModelRunner.forward (multi-step draft
+    # pre-plan, plan-stream replay_prepare, hand-built spec batches), so the
+    # forward path must not plan again. Only such pre-planners may set this —
+    # ModelRunner / graph runners never mark after their own planning. The
+    # marker is only valid for the planning regime (backend set) it was set
+    # under; a fresh batch from init_new always starts unplanned.
+    forward_metadata_ready: bool = False
+
+    def mark_forward_metadata_ready(self):
+        """Record that attention metadata was pre-planned for this batch.
+
+        Call right next to the out-of-forward planning action
+        (e.g. ``draft_attn_backend.init_forward_metadata(fb)`` or
+        ``graph_runner.replay_prepare(fb)``).
+        """
+        self.forward_metadata_ready = True
+
+    def needs_forward_metadata_init(self) -> bool:
+        """Single judgment point for whether the forward path must plan.
+
+        Kept as a method (not an inlined attribute read) so the predicate can
+        later grow planner-identity / staleness checks without touching the
+        call sites.
+        """
+        return not self.forward_metadata_ready
+
     @classmethod
     def init_new(
         cls,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3061,12 +3061,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def forward_decode(
         self,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool = False,
         pp_proxy_tensors=None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
         # Set extra arguments
         pdmux_override = False
-        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
+        if forward_batch.needs_forward_metadata_init():
             if hasattr(self.model, "prepare_forward_batch"):
                 # Prepare model-specific attention metadata before planning,
                 # e.g. Moss-VL's prefill cross-attention custom mask.
@@ -3110,7 +3109,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def forward_extend(
         self,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool = False,
         pp_proxy_tensors=None,
     ) -> Tuple[
         Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput], bool
@@ -3154,7 +3152,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return (ret, can_run_graph)
 
         # Launch model forward
-        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
+        if forward_batch.needs_forward_metadata_init():
             if hasattr(self.model, "prepare_forward_batch"):
                 # Prepare model-specific attention metadata before planning,
                 # e.g. Moss-VL's prefill cross-attention custom mask.
@@ -3236,11 +3234,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def forward(
         self,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool = False,
+        skip_attn_backend_init: Optional[bool] = None,  # deprecated
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
         reinit_attn_backend: bool = False,
         split_forward_count: int = 1,
     ) -> ModelRunnerOutput:
+        # Deprecated kwarg: pre-planners mark the batch themselves now.
+        forward_batch.apply_deprecated_skip_attn_backend_init(skip_attn_backend_init)
+
         self.forward_pass_id += 1
 
         # Try msprob debugger
@@ -3279,7 +3280,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         ):
             output = self._forward_raw(
                 forward_batch,
-                skip_attn_backend_init,
                 pp_proxy_tensors,
                 reinit_attn_backend,
                 split_forward_count,
@@ -3288,7 +3288,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 output = self._maybe_rebalance_after_rank_fault(
                     output,
                     forward_batch,
-                    skip_attn_backend_init,
                     pp_proxy_tensors,
                     reinit_attn_backend,
                     split_forward_count,
@@ -3330,7 +3329,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _forward_raw(
         self,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool,
         pp_proxy_tensors: Optional[PPProxyTensors],
         reinit_attn_backend: bool = False,
         split_forward_count: int = 1,
@@ -3366,7 +3364,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             if can_run_graph:
                 ret = self.graph_runner.replay(
                     forward_batch,
-                    skip_attn_backend_init=skip_attn_backend_init,
                     pp_proxy_tensors=pp_proxy_tensors,
                 )
                 return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
@@ -3402,7 +3399,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             if forward_batch.forward_mode.is_decode():
                 ret = self.forward_decode(
                     forward_batch,
-                    skip_attn_backend_init=skip_attn_backend_init,
                     pp_proxy_tensors=pp_proxy_tensors,
                 )
             elif forward_batch.forward_mode.is_split_prefill():
@@ -3414,7 +3410,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
                 ret, can_run_graph = self.forward_extend(
                     forward_batch,
-                    skip_attn_backend_init=skip_attn_backend_init,
                     pp_proxy_tensors=pp_proxy_tensors,
                 )
             elif forward_batch.forward_mode.is_idle():
@@ -3575,7 +3570,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self,
         output: ModelRunnerOutput,
         forward_batch: ForwardBatch,
-        skip_attn_backend_init: bool,
         pp_proxy_tensors: Optional[PPProxyTensors],
         reinit_attn_backend: bool,
         split_forward_count: int,
@@ -3593,7 +3587,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     break
             output = self._forward_raw(
                 forward_batch,
-                skip_attn_backend_init,
                 pp_proxy_tensors,
                 reinit_attn_backend,
                 split_forward_count,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3066,7 +3066,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
         # Set extra arguments
         pdmux_override = False
-        if not skip_attn_backend_init:
+        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
             if hasattr(self.model, "prepare_forward_batch"):
                 # Prepare model-specific attention metadata before planning,
                 # e.g. Moss-VL's prefill cross-attention custom mask.
@@ -3154,7 +3154,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return (ret, can_run_graph)
 
         # Launch model forward
-        if not skip_attn_backend_init:
+        if not skip_attn_backend_init and forward_batch.needs_forward_metadata_init():
             if hasattr(self.model, "prepare_forward_batch"):
                 # Prepare model-specific attention metadata before planning,
                 # e.g. Moss-VL's prefill cross-attention custom mask.

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -377,6 +377,9 @@ class EAGLEDraftCudaGraphRunner:
             self.draft_attn_backend.init_forward_metadata_out_graph(
                 forward_batch, in_capture=True
             )
+            # The capture batch is planned here (out-of-forward), so the
+            # per-step forwards inside draft_forward must not re-plan.
+            forward_batch.mark_forward_metadata_ready()
             self.deepep_adapter.capture(is_extend_in_batch=False)
             self._capture_init(run_once)
             out = self._capture_graph(

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -262,7 +262,7 @@ class EagleDraftInputV2Mixin:
             # Planned with the runner's own backend, no special context: a
             # forward-path re-plan is equivalent, so let the judgment
             # re-plan post-pad if DP padding reshapes the batch.
-            forward_batch.mark_forward_metadata_ready(replan_on_reshape=True)
+            forward_batch.mark_forward_metadata_ready(replan_equivalent=True)
         return forward_batch
 
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -259,9 +259,8 @@ class EagleDraftInputV2Mixin:
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         if not batch.forward_mode.is_idle() and not can_cuda_graph:
             draft_model_runner.attn_backend.init_forward_metadata(forward_batch)
-            # Planned with the runner's own backend, no special context: a
-            # forward-path re-plan is equivalent, so let the judgment
-            # re-plan post-pad if DP padding reshapes the batch.
+            # Own-backend plan, no special context -> a forward-path re-plan
+            # is equivalent, so allow post-pad re-plan on DP-padding reshape.
             forward_batch.mark_forward_metadata_ready(replan_equivalent=True)
         return forward_batch
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -259,7 +259,10 @@ class EagleDraftInputV2Mixin:
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         if not batch.forward_mode.is_idle() and not can_cuda_graph:
             draft_model_runner.attn_backend.init_forward_metadata(forward_batch)
-            forward_batch.mark_forward_metadata_ready()
+            # Planned with the runner's own backend, no special context: a
+            # forward-path re-plan is equivalent, so let the judgment
+            # re-plan post-pad if DP padding reshapes the batch.
+            forward_batch.mark_forward_metadata_ready(replan_on_reshape=True)
         return forward_batch
 
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -259,9 +259,12 @@ class EagleDraftInputV2Mixin:
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         if not batch.forward_mode.is_idle() and not can_cuda_graph:
             draft_model_runner.attn_backend.init_forward_metadata(forward_batch)
-            # Own-backend plan, no special context -> a forward-path re-plan
-            # is equivalent, so allow post-pad re-plan on DP-padding reshape.
-            forward_batch.mark_forward_metadata_ready(replan_equivalent=True)
+            # Planned pre-pad; do NOT opt into post-pad re-plan. DSA's indexer
+            # cannot rebuild its deep_gemm schedule_meta on a DP-padded batch
+            # (the `_batch_size == batch_size` assertion, see #27091); the
+            # marked pre-pad metadata is used as-is, matching the proven
+            # skip_attn_backend_init=True behavior.
+            forward_batch.mark_forward_metadata_ready()
         return forward_batch
 
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -259,6 +259,7 @@ class EagleDraftInputV2Mixin:
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         if not batch.forward_mode.is_idle() and not can_cuda_graph:
             draft_model_runner.attn_backend.init_forward_metadata(forward_batch)
+            forward_batch.mark_forward_metadata_ready()
         return forward_batch
 
 
@@ -325,6 +326,7 @@ class EagleVerifyInputV2Mixin:
         )
         if can_run_cuda_graph:
             target_worker.model_runner.graph_runner.replay_prepare(verify_forward_batch)
+            verify_forward_batch.mark_forward_metadata_ready()
         # Non-cuda-graph: defer init to forward_extend, which runs after
         # `_forward_raw -> prepare_mlp_sync_batch` pads the batch. Initing
         # here would use pre-pad shapes and trip DSv4 indexer shape match.

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -898,8 +898,10 @@ class EAGLEWorker(TpModelWorker):
             with forward_context(
                 ForwardContext(attn_backend=self.draft_attn_backend.attn_backends[i])
             ):
+                # forward_metadata_ready (set at the multi-step pre-plan)
+                # keeps the forward path from re-planning per step.
                 logits_output = self.draft_model_runner.forward(
-                    forward_batch, skip_attn_backend_init=True
+                    forward_batch
                 ).logits_output
             maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
             maybe_detect_inf(logits_output.next_token_logits, f"draft_forward step {i}")
@@ -1230,7 +1232,7 @@ class EAGLEWorker(TpModelWorker):
                 ctx_mgr = contextlib.nullcontext()
             with ctx_mgr:
                 logits_output = self.draft_model_runner.forward(
-                    forward_batch, skip_attn_backend_init=True
+                    forward_batch
                 ).logits_output
             # Non-cuda-graph path: compute topk_p / topk_index inline.
             probs = torch.softmax(logits_output.next_token_logits, dim=-1)

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -898,8 +898,6 @@ class EAGLEWorker(TpModelWorker):
             with forward_context(
                 ForwardContext(attn_backend=self.draft_attn_backend.attn_backends[i])
             ):
-                # forward_metadata_ready (set at the multi-step pre-plan)
-                # keeps the forward path from re-planning per step.
                 logits_output = self.draft_model_runner.forward(
                     forward_batch
                 ).logits_output

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -783,6 +783,7 @@ class EAGLEWorker(TpModelWorker):
             ):
                 # Skip attention backend init for idle mode or 1-step draft
                 self.draft_attn_backend.init_forward_metadata(forward_batch)
+                forward_batch.mark_forward_metadata_ready()
             # Run forward steps
             parent_list, top_scores_index, draft_tokens = self.draft_forward(
                 forward_batch
@@ -1220,6 +1221,7 @@ class EAGLEWorker(TpModelWorker):
                     or self.draft_model_runner.attn_backend
                 )
                 attn_backend.init_forward_metadata(forward_batch)
+                forward_batch.mark_forward_metadata_ready()
             # Publish the chosen backend via ForwardContext so model code
             # picks it up for this forward (no runner-attr mutation).
             if attn_backend is not None:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -427,6 +427,7 @@ class EagleDraftWorker(BaseDraftWorker):
                     # Skip attention backend init for 1-step draft,
                     # `draft_forward` only does sample in this case.
                     self.draft_attn_backend.init_forward_metadata(forward_batch)
+                    forward_batch.mark_forward_metadata_ready()
                 parent_list, top_scores_index, draft_tokens = self.draft_forward(
                     forward_batch
                 )

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -560,9 +560,9 @@ class EagleDraftWorker(BaseDraftWorker):
             with forward_context(
                 ForwardContext(attn_backend=self.draft_attn_backend.attn_backends[i])
             ), canary_index_ctx:
-                logits_output = self.draft_runner.forward(
-                    forward_batch, skip_attn_backend_init=True
-                ).logits_output
+                # forward_metadata_ready (set at the multi-step pre-plan)
+                # keeps the forward path from re-planning per step.
+                logits_output = self.draft_runner.forward(forward_batch).logits_output
             maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
             maybe_detect_inf(logits_output.next_token_logits, f"draft_forward step {i}")
             if self.topk == 1 and not _is_hip:
@@ -750,8 +750,9 @@ class EagleDraftWorker(BaseDraftWorker):
                     forward_batch
                 )
             else:
+                # Pre-planned in prepare_draft_extend_after_decode (marker).
                 draft_logits_output = self.draft_runner.forward(
-                    forward_batch, skip_attn_backend_init=True
+                    forward_batch
                 ).logits_output
 
         maybe_detect_nan(
@@ -1182,13 +1183,14 @@ class EAGLEWorkerV2(BaseSpecWorker):
             ).cpu()
 
         # Run target verify batch in the main compute stream (GPU compute).
-        # Only skip metadata init when cuda-graph already ran replay_prepare;
-        # the non-cuda-graph path needs forward_extend's init (post-pad).
+        # Metadata init is skipped iff cuda-graph already ran replay_prepare —
+        # prepare_for_v2_verify marked the batch in exactly that case; the
+        # non-cuda-graph path stays unmarked and gets forward_extend's init
+        # (post-pad).
         forward_batch_output = self.target_worker.forward_batch_generation(
             batch=None,
             forward_batch=verify_forward_batch,
             is_verify=True,
-            skip_attn_backend_init=can_run_cuda_graph,
         )
         logits_output = forward_batch_output.logits_output
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -560,8 +560,6 @@ class EagleDraftWorker(BaseDraftWorker):
             with forward_context(
                 ForwardContext(attn_backend=self.draft_attn_backend.attn_backends[i])
             ), canary_index_ctx:
-                # forward_metadata_ready (set at the multi-step pre-plan)
-                # keeps the forward path from re-planning per step.
                 logits_output = self.draft_runner.forward(forward_batch).logits_output
             maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
             maybe_detect_inf(logits_output.next_token_logits, f"draft_forward step {i}")
@@ -750,7 +748,6 @@ class EagleDraftWorker(BaseDraftWorker):
                     forward_batch
                 )
             else:
-                # Pre-planned in prepare_draft_extend_after_decode (marker).
                 draft_logits_output = self.draft_runner.forward(
                     forward_batch
                 ).logits_output

--- a/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
@@ -280,9 +280,9 @@ class FrozenKVMTPCudaGraphRunner:
             set_is_extend_in_batch(False)
 
             hidden_states_backup = forward_batch.spec_info.hidden_states
-            ret = self.frozen_kv_mtp_worker.draft_forward(
-                forward_batch, skip_attn_backend_init=True
-            )
+            # The capture batch is marked by the capture metadata helper
+            # below, so draft_forward skips its eager plan.
+            ret = self.frozen_kv_mtp_worker.draft_forward(forward_batch)
             forward_batch.spec_info.hidden_states = hidden_states_backup
             return ret
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -634,7 +634,6 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         # Seed + recurrent iters share the same `seq_lens - 1` rope position,
         # so one init covers the loop. Must run even at num_steps == 1.
-        # Pre-planned batches (cuda-graph capture) carry the marker already.
         if forward_batch.needs_forward_metadata_init():
             self._init_frozen_kv_metadata(forward_batch)
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -624,9 +624,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             seq_lens_cpu=batch.seq_lens_cpu,
         )
 
-    def draft_forward(
-        self, forward_batch: ForwardBatch, skip_attn_backend_init: bool = False
-    ):
+    def draft_forward(self, forward_batch: ForwardBatch):
         spec_info = forward_batch.spec_info
         assert isinstance(spec_info, FrozenKVMTPDraftInput)
 
@@ -636,7 +634,8 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         # Seed + recurrent iters share the same `seq_lens - 1` rope position,
         # so one init covers the loop. Must run even at num_steps == 1.
-        if not skip_attn_backend_init:
+        # Pre-planned batches (cuda-graph capture) carry the marker already.
+        if forward_batch.needs_forward_metadata_init():
             self._init_frozen_kv_metadata(forward_batch)
 
         # Seed iter: assistant forward on (bonus_token, target_h) to produce
@@ -659,9 +658,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             self._target_kv_pool_view(forward_batch),
             forward_context(ForwardContext(attn_backend=self.draft_attn_backend)),
         ):
-            seed_output = self.draft_model_runner.forward(
-                forward_batch, skip_attn_backend_init=True
-            ).logits_output
+            seed_output = self.draft_model_runner.forward(forward_batch).logits_output
 
         maybe_detect_nan(
             seed_output.next_token_logits, "frozen_kv_mtp_draft: seed iter"
@@ -705,7 +702,7 @@ class FrozenKVMTPWorker(TpModelWorker):
                 forward_context(ForwardContext(attn_backend=self.draft_attn_backend)),
             ):
                 logits_output = self.draft_model_runner.forward(
-                    forward_batch, skip_attn_backend_init=True
+                    forward_batch
                 ).logits_output
 
             maybe_detect_nan(

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -283,6 +283,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             forward_batch.seq_lens_sum = torch.sum(forward_batch.seq_lens).item()
         with self._frozen_kv_target_view(forward_batch):
             self.draft_attn_backend.init_forward_metadata(forward_batch)
+        forward_batch.mark_forward_metadata_ready()
 
     def _init_frozen_kv_metadata_capture_cuda_graph(
         self, forward_batch: ForwardBatch
@@ -291,6 +292,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             self.draft_attn_backend.init_forward_metadata_out_graph(
                 forward_batch, in_capture=True
             )
+        forward_batch.mark_forward_metadata_ready()
 
     def _init_frozen_kv_metadata_replay_cuda_graph(
         self, forward_batch: ForwardBatch, bs: int, seq_lens_sum: int

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -769,7 +769,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                     # post-pad re-plan if DP padding reshapes the batch.
                     # The per-step re-mark re-records padded shapes, so
                     # later steps don't re-plan again.
-                    forward_batch.mark_forward_metadata_ready(replan_on_reshape=True)
+                    forward_batch.mark_forward_metadata_ready(replan_equivalent=True)
                 logits_output = (
                     self.mtp_model_runner(step).forward(forward_batch).logits_output
                 )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -766,9 +766,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                     )
                     forward_batch.mark_forward_metadata_ready()
                 logits_output = (
-                    self.mtp_model_runner(step)
-                    .forward(forward_batch, skip_attn_backend_init=True)
-                    .logits_output
+                    self.mtp_model_runner(step).forward(forward_batch).logits_output
                 )
 
             maybe_detect_nan(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -764,6 +764,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                     self.mtp_model_runner(step).attn_backend.init_forward_metadata(
                         forward_batch
                     )
+                    forward_batch.mark_forward_metadata_ready()
                 logits_output = (
                     self.mtp_model_runner(step)
                     .forward(forward_batch, skip_attn_backend_init=True)

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -764,10 +764,10 @@ class MultiLayerEagleWorker(TpModelWorker):
                     self.mtp_model_runner(step).attn_backend.init_forward_metadata(
                         forward_batch
                     )
-                    # Own-backend plan -> re-plan equivalent; allow post-pad
-                    # re-plan. The per-step re-mark re-records padded shapes,
-                    # so later steps skip.
-                    forward_batch.mark_forward_metadata_ready(replan_equivalent=True)
+                    # Planned pre-pad; do NOT opt into post-pad re-plan — a
+                    # DP-padded re-plan breaks DSA's indexer schedule_meta
+                    # (see #27091). Use the marked pre-pad metadata as-is.
+                    forward_batch.mark_forward_metadata_ready()
                 logits_output = (
                     self.mtp_model_runner(step).forward(forward_batch).logits_output
                 )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -764,11 +764,9 @@ class MultiLayerEagleWorker(TpModelWorker):
                     self.mtp_model_runner(step).attn_backend.init_forward_metadata(
                         forward_batch
                     )
-                    # Planned with this step runner's own backend: a
-                    # forward-path re-plan is equivalent, so allow a
-                    # post-pad re-plan if DP padding reshapes the batch.
-                    # The per-step re-mark re-records padded shapes, so
-                    # later steps don't re-plan again.
+                    # Own-backend plan -> re-plan equivalent; allow post-pad
+                    # re-plan. The per-step re-mark re-records padded shapes,
+                    # so later steps skip.
                     forward_batch.mark_forward_metadata_ready(replan_equivalent=True)
                 logits_output = (
                     self.mtp_model_runner(step).forward(forward_batch).logits_output

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -764,7 +764,12 @@ class MultiLayerEagleWorker(TpModelWorker):
                     self.mtp_model_runner(step).attn_backend.init_forward_metadata(
                         forward_batch
                     )
-                    forward_batch.mark_forward_metadata_ready()
+                    # Planned with this step runner's own backend: a
+                    # forward-path re-plan is equivalent, so allow a
+                    # post-pad re-plan if DP padding reshapes the batch.
+                    # The per-step re-mark re-records padded shapes, so
+                    # later steps don't re-plan again.
+                    forward_batch.mark_forward_metadata_ready(replan_on_reshape=True)
                 logits_output = (
                     self.mtp_model_runner(step).forward(forward_batch).logits_output
                 )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -535,8 +535,10 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
                     draft_logits_output.topk_index,
                 )
             else:
+                # Skip relies on the unconditional mark above (pre-existing
+                # no-pre-plan behavior preserved verbatim).
                 draft_logits_output = self.draft_runner_list[step].forward(
-                    forward_batch, skip_attn_backend_init=True
+                    forward_batch
                 )
                 probs = torch.softmax(
                     draft_logits_output.logits_output.next_token_logits[select_index],
@@ -783,7 +785,6 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             batch=None,
             forward_batch=verify_forward_batch,
             is_verify=True,
-            skip_attn_backend_init=True,
         )
         logits_output = forward_batch_output.logits_output
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -516,6 +516,11 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
                 + batch_result.accept_lens
                 - 1
             )
+            # NOTE: this non-graph path runs the per-step forwards without any
+            # pre-plan (see warning above). Mark the batch so the forward path
+            # keeps skipping metadata init — preserves the pre-existing
+            # behavior; the latent issue is tracked by the warning.
+            forward_batch.mark_forward_metadata_ready()
 
         for step in range(self.speculative_num_steps):
             # log_info_on_rank0(logger, f"step: {step}, forward_batch.input_ids: {forward_batch.input_ids}")
@@ -768,6 +773,11 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                     else None
                 ),
             )
+        # NOTE: metadata init is skipped here unconditionally, although
+        # prepare_for_v2_verify only plans when cuda-graph replay_prepare ran.
+        # eagle_worker_v2 re-inits the non-graph path instead (post-pad); this
+        # worker has not adopted that fix, so preserve its behavior verbatim.
+        verify_forward_batch.mark_forward_metadata_ready()
         # Run target verify batch in the main compute stream
         forward_batch_output = self.target_worker.forward_batch_generation(
             batch=None,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -390,9 +390,7 @@ def _run_eagle_draft_eager(
         init_eager_metadata(worker, batch, settings)
     else:
         worker.draft_attn_backend.init_forward_metadata(batch)
-    # Mirror the production workers: the pre-plan marks the batch so the
-    # per-step forwards inside draft_forward don't re-plan.
-    batch.mark_forward_metadata_ready()
+    batch.mark_forward_metadata_ready()  # mirror production: pre-plan marks
     return worker.draft_forward(batch)
 
 
@@ -592,10 +590,6 @@ class _DenseEagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
-        # Draft-loop forwards must arrive pre-planned: the production
-        # ModelRunner.forward would otherwise re-plan via the single-backend
-        # entry and clobber the per-step metadata. Mocks stand in for the
-        # runner forward, so assert the contract the real judgment enforces.
         assert (
             forward_batch.forward_metadata_ready
         ), "draft-loop forward reached the runner without a pre-planned batch"
@@ -635,10 +629,6 @@ class _FrozenKVMTPDenseDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
-        # Draft-loop forwards must arrive pre-planned: the production
-        # ModelRunner.forward would otherwise re-plan via the single-backend
-        # entry and clobber the per-step metadata. Mocks stand in for the
-        # runner forward, so assert the contract the real judgment enforces.
         assert (
             forward_batch.forward_metadata_ready
         ), "draft-loop forward reached the runner without a pre-planned batch"
@@ -1028,10 +1018,6 @@ class _MLAEagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
-        # Draft-loop forwards must arrive pre-planned: the production
-        # ModelRunner.forward would otherwise re-plan via the single-backend
-        # entry and clobber the per-step metadata. Mocks stand in for the
-        # runner forward, so assert the contract the real judgment enforces.
         assert (
             forward_batch.forward_metadata_ready
         ), "draft-loop forward reached the runner without a pre-planned batch"
@@ -1290,10 +1276,6 @@ class _DSV4EagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
-        # Draft-loop forwards must arrive pre-planned: the production
-        # ModelRunner.forward would otherwise re-plan via the single-backend
-        # entry and clobber the per-step metadata. Mocks stand in for the
-        # runner forward, so assert the contract the real judgment enforces.
         assert (
             forward_batch.forward_metadata_ready
         ), "draft-loop forward reached the runner without a pre-planned batch"
@@ -1596,10 +1578,6 @@ class _DSAEagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
-        # Draft-loop forwards must arrive pre-planned: the production
-        # ModelRunner.forward would otherwise re-plan via the single-backend
-        # entry and clobber the per-step metadata. Mocks stand in for the
-        # runner forward, so assert the contract the real judgment enforces.
         assert (
             forward_batch.forward_metadata_ready
         ), "draft-loop forward reached the runner without a pre-planned batch"

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -397,7 +397,7 @@ def _run_frozen_kv_mtp_eager(
     worker: _FrozenKVMTPWorkerHarness,
     batch: ForwardBatch,
 ):
-    return worker.draft_forward(batch, skip_attn_backend_init=False)
+    return worker.draft_forward(batch)
 
 
 def _capture_eagle_draft_graph_runner(
@@ -588,7 +588,9 @@ class _DenseEagleDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool):
+    def __call__(
+        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
+    ):
         del skip_attn_backend_init
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
@@ -625,7 +627,9 @@ class _FrozenKVMTPDenseDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool):
+    def __call__(
+        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
+    ):
         del skip_attn_backend_init
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
@@ -1012,7 +1016,9 @@ class _MLAEagleDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool):
+    def __call__(
+        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
+    ):
         del skip_attn_backend_init
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
@@ -1268,7 +1274,9 @@ class _DSV4EagleDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool):
+    def __call__(
+        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
+    ):
         del skip_attn_backend_init
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
@@ -1568,7 +1576,9 @@ class _DSAEagleDraftForward:
             torch.full_like(indices, -1),
         )
 
-    def __call__(self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool):
+    def __call__(
+        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
+    ):
         del skip_attn_backend_init
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -588,10 +588,7 @@ class _DenseEagleDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(
-        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
-    ):
-        del skip_attn_backend_init
+    def __call__(self, forward_batch: ForwardBatch):
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -627,10 +624,7 @@ class _FrozenKVMTPDenseDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(
-        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
-    ):
-        del skip_attn_backend_init
+    def __call__(self, forward_batch: ForwardBatch):
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -1016,10 +1010,7 @@ class _MLAEagleDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(
-        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
-    ):
-        del skip_attn_backend_init
+    def __call__(self, forward_batch: ForwardBatch):
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -1274,10 +1265,7 @@ class _DSV4EagleDraftForward:
             hidden_size, vocab_size, bias=False, dtype=dtype, device=device
         )
 
-    def __call__(
-        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
-    ):
-        del skip_attn_backend_init
+    def __call__(self, forward_batch: ForwardBatch):
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -1576,10 +1564,7 @@ class _DSAEagleDraftForward:
             torch.full_like(indices, -1),
         )
 
-    def __call__(
-        self, forward_batch: ForwardBatch, *, skip_attn_backend_init: bool = False
-    ):
-        del skip_attn_backend_init
+    def __call__(self, forward_batch: ForwardBatch):
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -390,6 +390,9 @@ def _run_eagle_draft_eager(
         init_eager_metadata(worker, batch, settings)
     else:
         worker.draft_attn_backend.init_forward_metadata(batch)
+    # Mirror the production workers: the pre-plan marks the batch so the
+    # per-step forwards inside draft_forward don't re-plan.
+    batch.mark_forward_metadata_ready()
     return worker.draft_forward(batch)
 
 
@@ -589,6 +592,13 @@ class _DenseEagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
+        # Draft-loop forwards must arrive pre-planned: the production
+        # ModelRunner.forward would otherwise re-plan via the single-backend
+        # entry and clobber the per-step metadata. Mocks stand in for the
+        # runner forward, so assert the contract the real judgment enforces.
+        assert (
+            forward_batch.forward_metadata_ready
+        ), "draft-loop forward reached the runner without a pre-planned batch"
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -625,6 +635,13 @@ class _FrozenKVMTPDenseDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
+        # Draft-loop forwards must arrive pre-planned: the production
+        # ModelRunner.forward would otherwise re-plan via the single-backend
+        # entry and clobber the per-step metadata. Mocks stand in for the
+        # runner forward, so assert the contract the real judgment enforces.
+        assert (
+            forward_batch.forward_metadata_ready
+        ), "draft-loop forward reached the runner without a pre-planned batch"
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -1011,6 +1028,13 @@ class _MLAEagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
+        # Draft-loop forwards must arrive pre-planned: the production
+        # ModelRunner.forward would otherwise re-plan via the single-backend
+        # entry and clobber the per-step metadata. Mocks stand in for the
+        # runner forward, so assert the contract the real judgment enforces.
+        assert (
+            forward_batch.forward_metadata_ready
+        ), "draft-loop forward reached the runner without a pre-planned batch"
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -1266,6 +1290,13 @@ class _DSV4EagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
+        # Draft-loop forwards must arrive pre-planned: the production
+        # ModelRunner.forward would otherwise re-plan via the single-backend
+        # entry and clobber the per-step metadata. Mocks stand in for the
+        # runner forward, so assert the contract the real judgment enforces.
+        assert (
+            forward_batch.forward_metadata_ready
+        ), "draft-loop forward reached the runner without a pre-planned batch"
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:
@@ -1565,6 +1596,13 @@ class _DSAEagleDraftForward:
         )
 
     def __call__(self, forward_batch: ForwardBatch):
+        # Draft-loop forwards must arrive pre-planned: the production
+        # ModelRunner.forward would otherwise re-plan via the single-backend
+        # entry and clobber the per-step metadata. Mocks stand in for the
+        # runner forward, so assert the contract the real judgment enforces.
+        assert (
+            forward_batch.forward_metadata_ready
+        ), "draft-loop forward reached the runner without a pre-planned batch"
         spec_info = forward_batch.spec_info
         hidden_states = spec_info.hidden_states
         if hidden_states is None:

--- a/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
+++ b/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
@@ -1,15 +1,8 @@
-"""Regression: TBO filter_batch must handle ForwardBatch's attention plan
-marker fields.
+"""Regression: TBO filter_batch resets the attention plan marker on children.
 
-`TboForwardBatchPreparer.filter_batch` ends with a completeness guard that
-raises for any ForwardBatch field that is non-None but absent from the child
-``output_dict``. The plan marker added by the skip_attn_backend_init refactor
-(`forward_metadata_ready` etc.) defaults to ``False`` — non-None — so an
-unhandled marker crashes TBO cuda-graph capture (DP + spec + TBO).
-The children must be reset to "unplanned" so each sub-batch is planned by the
-TBO-aware init flow.
-
-Pure dataclass logic — CPU only.
+filter_batch's completeness guard raises for any non-None ForwardBatch field
+missing from the child dict; the plan marker defaults to False (non-None) and
+crashed TBO cuda-graph capture until reset. CPU-only.
 """
 
 import unittest
@@ -59,8 +52,6 @@ def _filter(batch: ForwardBatch, *, lo: int, hi: int) -> ForwardBatch:
 
 class TestTboFilterBatchMarker(CustomTestCase):
     def test_filter_batch_resets_plan_marker_on_children(self):
-        # Default marker (forward_metadata_ready=False) is non-None and would
-        # trip the completeness guard if unhandled.
         child = _filter(_make_target_verify_batch(8), lo=0, hi=4)
         self.assertEqual(child.batch_size, 4)
         self.assertFalse(child.forward_metadata_ready)
@@ -69,8 +60,6 @@ class TestTboFilterBatchMarker(CustomTestCase):
         self.assertFalse(child.forward_metadata_replan_equivalent)
 
     def test_pre_planned_parent_does_not_leak_ready_into_children(self):
-        # Even if the parent was marked, children must start unplanned — a
-        # stale "ready" would wrongly skip the child's own planning.
         parent = _make_target_verify_batch(8)
         parent.mark_forward_metadata_ready(replan_equivalent=True)
         child = _filter(parent, lo=0, hi=4)

--- a/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
+++ b/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
@@ -1,0 +1,82 @@
+"""Regression: TBO filter_batch must handle ForwardBatch's attention plan
+marker fields.
+
+`TboForwardBatchPreparer.filter_batch` ends with a completeness guard that
+raises for any ForwardBatch field that is non-None but absent from the child
+``output_dict``. The plan marker added by the skip_attn_backend_init refactor
+(`forward_metadata_ready` etc.) defaults to ``False`` — non-None — so an
+unhandled marker crashes TBO cuda-graph capture (DP + spec + TBO).
+The children must be reset to "unplanned" so each sub-batch is planned by the
+TBO-aware init flow.
+
+Pure dataclass logic — CPU only.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.batch_overlap.two_batch_overlap as tbo
+from sglang.srt.batch_overlap.two_batch_overlap import TboForwardBatchPreparer
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_target_verify_batch(bs: int) -> ForwardBatch:
+    return ForwardBatch(
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        batch_size=bs,
+        input_ids=torch.zeros(bs, dtype=torch.long),
+        positions=torch.zeros(bs, dtype=torch.long),
+        out_cache_loc=torch.zeros(bs, dtype=torch.long),
+        req_pool_indices=torch.zeros(bs, dtype=torch.long),
+        seq_lens=torch.ones(bs, dtype=torch.int32),
+        seq_lens_cpu=torch.ones(bs, dtype=torch.int32),
+        seq_lens_sum=bs,
+        spec_info=None,
+    )
+
+
+def _filter(batch: ForwardBatch, *, lo: int, hi: int) -> ForwardBatch:
+    fake_args = SimpleNamespace(moe_dense_tp_size=None, attention_backend="fa3")
+    with patch.object(tbo, "get_attention_tp_size", lambda: 1), patch.object(
+        tbo, "get_global_server_args", lambda: fake_args
+    ):
+        return TboForwardBatchPreparer.filter_batch(
+            batch,
+            start_token_index=lo,
+            end_token_index=hi,
+            start_seq_index=lo,
+            end_seq_index=hi,
+            out_num_token_non_padded=torch.tensor(hi - lo),
+        )
+
+
+class TestTboFilterBatchMarker(CustomTestCase):
+    def test_filter_batch_resets_plan_marker_on_children(self):
+        # Default marker (forward_metadata_ready=False) is non-None and would
+        # trip the completeness guard if unhandled.
+        child = _filter(_make_target_verify_batch(8), lo=0, hi=4)
+        self.assertEqual(child.batch_size, 4)
+        self.assertFalse(child.forward_metadata_ready)
+        self.assertIsNone(child.forward_metadata_planned_bs)
+        self.assertIsNone(child.forward_metadata_planned_num_tokens)
+        self.assertFalse(child.forward_metadata_replan_equivalent)
+
+    def test_pre_planned_parent_does_not_leak_ready_into_children(self):
+        # Even if the parent was marked, children must start unplanned — a
+        # stale "ready" would wrongly skip the child's own planning.
+        parent = _make_target_verify_batch(8)
+        parent.mark_forward_metadata_ready(replan_equivalent=True)
+        child = _filter(parent, lo=0, hi=4)
+        self.assertFalse(child.forward_metadata_ready)
+        self.assertFalse(child.forward_metadata_replan_equivalent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
+++ b/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
@@ -50,8 +50,7 @@ class TestForwardMetadataPlanRecord(CustomTestCase):
         self.assertEqual(fb.forward_metadata_planned_num_tokens, 7)
 
     def test_reshape_without_opt_in_keeps_skipping(self):
-        # Multi-step wrapper regimes must never be auto-re-planned: a
-        # forward-path re-plan would clobber their per-step metadata.
+        # Wrapper regimes must never auto-re-plan (would clobber per-step metadata).
         fb = _make_batch(bs=2)
         fb.mark_forward_metadata_ready()
         fb.batch_size = 4  # DP padding reshapes the batch
@@ -70,8 +69,7 @@ class TestForwardMetadataPlanRecord(CustomTestCase):
         self.assertTrue(fb.needs_forward_metadata_init())
 
     def test_remark_re_records_padded_shapes(self):
-        # Per-step loops re-mark after each plan; the second mark must
-        # snapshot the padded shapes so later steps skip again.
+        # Per-step loops re-mark each plan; the re-mark must snapshot padded shapes.
         fb = _make_batch(bs=2)
         fb.mark_forward_metadata_ready(replan_equivalent=True)
         fb.batch_size = 4
@@ -97,8 +95,7 @@ class TestDeprecatedSkipKwargShim(CustomTestCase):
         self.assertTrue(fb.needs_forward_metadata_init())
 
     def test_true_maps_onto_marker_and_warns(self):
-        # Mapped, not ignored: True-callers relied on planning being
-        # skipped; a no-op would silently re-plan multi-step metadata.
+        # Mapped, not ignored: a no-op would silently re-plan multi-step metadata.
         fb = _make_batch()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -116,8 +113,7 @@ class TestDeprecatedSkipKwargShim(CustomTestCase):
         self.assertEqual(len(caught), 1)
 
     def test_warns_once_per_process(self):
-        # Hot-loop guard: external callers passing the kwarg every
-        # forward must not pay warnings.warn repeatedly.
+        # Hot-loop guard: per-forward callers must not pay warnings.warn repeatedly.
         fb = _make_batch()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")

--- a/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
+++ b/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
@@ -4,7 +4,7 @@ Covers the contract behind ``skip_attn_backend_init`` deprecation:
   * fresh batches need planning; marked batches don't
   * the plan record (planned bs / num tokens) snapshots mark-time shapes
   * reshape after marking triggers a re-plan only for sites that opted
-    into ``replan_on_reshape``; re-marking re-records the new shapes
+    into ``replan_equivalent``; re-marking re-records the new shapes
   * the deprecated kwarg shim maps explicit values onto the marker
     (mapped, not ignored) and warns once per process
 
@@ -59,7 +59,7 @@ class TestForwardMetadataPlanRecord(CustomTestCase):
 
     def test_reshape_with_opt_in_replans(self):
         fb = _make_batch(bs=2, num_tokens=2)
-        fb.mark_forward_metadata_ready(replan_on_reshape=True)
+        fb.mark_forward_metadata_ready(replan_equivalent=True)
         self.assertFalse(fb.needs_forward_metadata_init())
 
         fb.batch_size = 4  # bs drift (prepare_mlp_sync_batch decode pad)
@@ -73,10 +73,10 @@ class TestForwardMetadataPlanRecord(CustomTestCase):
         # Per-step loops re-mark after each plan; the second mark must
         # snapshot the padded shapes so later steps skip again.
         fb = _make_batch(bs=2)
-        fb.mark_forward_metadata_ready(replan_on_reshape=True)
+        fb.mark_forward_metadata_ready(replan_equivalent=True)
         fb.batch_size = 4
         self.assertTrue(fb.needs_forward_metadata_init())
-        fb.mark_forward_metadata_ready(replan_on_reshape=True)
+        fb.mark_forward_metadata_ready(replan_equivalent=True)
         self.assertFalse(fb.needs_forward_metadata_init())
         self.assertEqual(fb.forward_metadata_planned_bs, 4)
 

--- a/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
+++ b/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
@@ -1,0 +1,131 @@
+"""Unit tests for the ForwardBatch attention plan marker / plan record.
+
+Covers the contract behind ``skip_attn_backend_init`` deprecation:
+  * fresh batches need planning; marked batches don't
+  * the plan record (planned bs / num tokens) snapshots mark-time shapes
+  * reshape after marking triggers a re-plan only for sites that opted
+    into ``replan_on_reshape``; re-marking re-records the new shapes
+  * the deprecated kwarg shim maps explicit values onto the marker
+    (mapped, not ignored) and warns once per process
+
+Pure dataclass logic — CPU only.
+"""
+
+import unittest
+import warnings
+
+import torch
+
+import sglang.srt.model_executor.forward_batch_info as fbi
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_batch(bs: int = 2, num_tokens: int = 2) -> ForwardBatch:
+    return ForwardBatch(
+        forward_mode=ForwardMode.DECODE,
+        batch_size=bs,
+        input_ids=torch.zeros(num_tokens, dtype=torch.long),
+        req_pool_indices=torch.zeros(bs, dtype=torch.long),
+        seq_lens=torch.ones(bs, dtype=torch.long),
+        out_cache_loc=torch.zeros(bs, dtype=torch.long),
+        seq_lens_sum=bs,
+    )
+
+
+class TestForwardMetadataPlanRecord(CustomTestCase):
+    def test_fresh_batch_needs_planning(self):
+        fb = _make_batch()
+        self.assertTrue(fb.needs_forward_metadata_init())
+        self.assertFalse(fb.forward_metadata_ready)
+
+    def test_mark_records_shapes_and_skips_planning(self):
+        fb = _make_batch(bs=3, num_tokens=7)
+        fb.mark_forward_metadata_ready()
+        self.assertFalse(fb.needs_forward_metadata_init())
+        self.assertEqual(fb.forward_metadata_planned_bs, 3)
+        self.assertEqual(fb.forward_metadata_planned_num_tokens, 7)
+
+    def test_reshape_without_opt_in_keeps_skipping(self):
+        # Multi-step wrapper regimes must never be auto-re-planned: a
+        # forward-path re-plan would clobber their per-step metadata.
+        fb = _make_batch(bs=2)
+        fb.mark_forward_metadata_ready()
+        fb.batch_size = 4  # DP padding reshapes the batch
+        self.assertFalse(fb.needs_forward_metadata_init())
+
+    def test_reshape_with_opt_in_replans(self):
+        fb = _make_batch(bs=2, num_tokens=2)
+        fb.mark_forward_metadata_ready(replan_on_reshape=True)
+        self.assertFalse(fb.needs_forward_metadata_init())
+
+        fb.batch_size = 4  # bs drift (prepare_mlp_sync_batch decode pad)
+        self.assertTrue(fb.needs_forward_metadata_init())
+
+        fb.batch_size = 2
+        fb.input_ids = torch.zeros(6, dtype=torch.long)  # token drift
+        self.assertTrue(fb.needs_forward_metadata_init())
+
+    def test_remark_re_records_padded_shapes(self):
+        # Per-step loops re-mark after each plan; the second mark must
+        # snapshot the padded shapes so later steps skip again.
+        fb = _make_batch(bs=2)
+        fb.mark_forward_metadata_ready(replan_on_reshape=True)
+        fb.batch_size = 4
+        self.assertTrue(fb.needs_forward_metadata_init())
+        fb.mark_forward_metadata_ready(replan_on_reshape=True)
+        self.assertFalse(fb.needs_forward_metadata_init())
+        self.assertEqual(fb.forward_metadata_planned_bs, 4)
+
+
+class TestDeprecatedSkipKwargShim(CustomTestCase):
+    def setUp(self):
+        self._saved_warned = fbi._skip_attn_backend_init_warned
+        fbi._skip_attn_backend_init_warned = False
+
+    def tearDown(self):
+        fbi._skip_attn_backend_init_warned = self._saved_warned
+
+    def test_none_is_a_silent_no_op(self):
+        fb = _make_batch()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            fb.apply_deprecated_skip_attn_backend_init(None)
+        self.assertTrue(fb.needs_forward_metadata_init())
+
+    def test_true_maps_onto_marker_and_warns(self):
+        # Mapped, not ignored: True-callers relied on planning being
+        # skipped; a no-op would silently re-plan multi-step metadata.
+        fb = _make_batch()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fb.apply_deprecated_skip_attn_backend_init(True)
+        self.assertFalse(fb.needs_forward_metadata_init())
+        self.assertEqual(len(caught), 1)
+        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
+
+    def test_false_warns_but_does_not_mark(self):
+        fb = _make_batch()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fb.apply_deprecated_skip_attn_backend_init(False)
+        self.assertTrue(fb.needs_forward_metadata_init())
+        self.assertEqual(len(caught), 1)
+
+    def test_warns_once_per_process(self):
+        # Hot-loop guard: external callers passing the kwarg every
+        # forward must not pay warnings.warn repeatedly.
+        fb = _make_batch()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fb.apply_deprecated_skip_attn_backend_init(True)
+            fb.apply_deprecated_skip_attn_backend_init(True)
+            _make_batch().apply_deprecated_skip_attn_backend_init(False)
+        self.assertEqual(len(caught), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`skip_attn_backend_init` is a control-coupling boolean threaded through ~6 layers (`TpModelWorker.forward_batch_generation` → `ModelRunner.forward` → `_forward_raw` → `forward_decode` / `forward_extend` / graph-runner `replay`, plus the NPU/CPU/MLX mirrors). It means *"the attention metadata for this batch was already planned elsewhere — don't plan again"*, but the protocol has three structural problems:

1. **Unverifiable caller assertion.** Nothing checks that the caller actually pre-planned. A missed flag silently re-plans inside a multi-step draft loop and clobbers the per-step metadata (wrong output, not a crash); a wrongly-passed flag silently runs on stale metadata.
2. **Two meanings under one name.** On the eager path it means "skip `init_forward_metadata`"; on the cuda-graph path it means "skip `replay_prepare` *but still refresh the per-iter input buffers*".
3. **Every new forward path must remember to thread it.** There is a standing `FIXME(lsyin)` in `tp_worker.py` asking to remove it from `forward_batch_generation`.

This PR replaces the caller-asserted flag with **batch-carried planning state**: the pre-planner records the fact on the `ForwardBatch` right next to the planning action, and the forward path consults the batch instead of trusting a bool passed from six layers away. It then builds one step further — turning the marker into a small **plan record** so a batch reshaped by DP padding after planning is detected and re-planned centrally, retiring the per-backend defensive re-plan that motivated `FIXME(@rainj-me)`.

The two parts are separable and reviewable as such (see commit groups below); they are bundled into one PR only to share a CI run.

## Modifications

### Part 1 — deprecate the kwarg in favor of the marker

- **`ForwardBatch.forward_metadata_ready`** with `mark_forward_metadata_ready()` (called by pre-planners only — `ModelRunner` / graph runners never mark after their own planning, so re-forward paths such as the elastic-EP retry replan exactly as today) and `needs_forward_metadata_init()` (a method, not an inlined attribute read, so the predicate can grow staleness checks without call-site churn).
- **Pre-plan sites mark the batch**: the multi-step draft pre-plans (EAGLE v1/v2, multi-layer v1), the plan-stream `replay_prepare` for spec-v2 verify, the draft-extend non-graph plan, the frozen-KV MTP plan helpers, and the EAGLE draft cuda-graph capture (the last one was the source of a capture-path bug caught in review — see below).
- **Judgment points consult the marker**: `forward_decode`, `forward_extend`, and cuda/NPU graph-runner `replay`. Branch bodies are untouched — the cuda-graph else-branch still refreshes per-iter inputs (the marker covers metadata planning, not input fill).
- **Callers stop passing the kwarg**; the internal plumbing drops the parameter entirely. **Public entries keep a deprecation shim** (`ModelRunner.forward`, `TpModelWorker.forward_batch_generation`, MLX mirror): an explicitly passed value is **mapped onto the marker, not ignored** — callers passing `True` relied on planning being skipped, and a no-op would silently corrupt pre-planned multi-step metadata — with a process-wide warn-once (module flag, so a hot decode loop never pays `warnings.warn` per forward). The kwarg is removed entirely after a deprecation window.
- Resolves the `FIXME(lsyin)` in `tp_worker.py`.

### Part 2 — plan record + staleness validation

- **The marker records the shapes it was planned with** (`forward_metadata_planned_bs`, `forward_metadata_planned_num_tokens`; plain ints, no runtime object ref on `ForwardBatch`). `needs_forward_metadata_init()` now re-plans a marked batch whose shapes drifted from the record — but only when the mark site declared the re-plan safe via `replan_equivalent=True`. The judgment runs after `prepare_mlp_sync_batch`, so the re-plan sees post-pad shapes, with **zero coupling to the padding code** (the predicate self-checks; no invalidate hook).
- **Only "re-plan equivalent" sites opt in** — where the forward path's own `init_forward_metadata` (same backend object, no special context) is equivalent to the pre-plan: the draft-extend non-graph plan and the multi-layer v1 per-step plan. Multi-step wrapper plans, view-context plans (frozen-KV), and the plan-stream replay path keep the default `False` and are never auto-re-planned.
- **trtllm-MLA's defensive re-plan is narrowed to a documented backstop**: it now only fires for the regimes that cannot opt in (wrapper plans, mlv2's non-graph draft-extend loop) and carries a removal condition, instead of being an open `FIXME` design question.

### Preserved behavior / scope notes

- Two pre-existing skip-without-pre-plan paths in `multi_layer_eagle_worker_v2` are preserved **verbatim** with NOTE comments (one already carries a `warning_once` about correctness); fixes are intentionally not smuggled into this refactor.
- The branch is **30 atomic commits**, each minimal — the marker field, per-file mark sites, dual-read judgment, per-file caller flips, the entry shim, internal-plumbing removal, then the plan-record field, the predicate staleness check, the two opt-in sites, and the trtllm backstop narrowing. Commit-by-commit review is recommended; the two Part-2 opt-in commits are isolated so they can be reverted independently if needed (see below).

## Accuracy Tests

Run with `PYTHONPATH` pointed at the worktree so the changes are actually exercised:

- `test/registered/attention/unittests/dense/{test_fa3,test_triton}.py` spec/draft/frozen-KV runner-mode subsets — **15 passed, 42 subtests passed** (multi-step draft loops, draft-extend, frozen-KV MTP, spec verify, and their cuda-graph runners).
- `test/registered/attention/unittests/dense/test_extend_init_contract.py` — **5 passed**.
- `test/registered/unit/model_executor/test_forward_metadata_plan_record.py` (new) — **9 passed** (marker contract, no-replan-without-opt-in safety, opt-in reshape re-planning with per-step re-marking, deprecated-kwarg shim mapped-not-ignored + warn-once).
- `grep -rn skip_attn_backend_init python/` now matches only the deprecation-shim surface.

> ⚠️ **Reviewer note — please run the DP + spec suites.** The local kit tests do not exercise DP padding, which is the only condition under which the Part-2 opt-in re-plan fires. [#27091](https://github.com/sgl-project/sglang/pull/27091) records that a prior attempt to feed NSA/DSA a post-pad batch state tripped a deep_gemm schedule-meta mismatch on the DSv3.2 `--dp 8 --enable-dp-attention` EAGLE test and the deepep 4×B200 DSV4-Flash path. Those suites are exactly what validates (or refutes) the two `replan_equivalent` opt-in commits here; if they regress, reverting just those two commits leaves the inert plan-record groundwork intact.

## Speed Tests and Profiling

No GPU-side change in Part 1 (the judgment flips from a kwarg read to a batch-attribute read; planning happens exactly as often as before). Part 2 adds at most one extra plan per forward, and only on the opt-in sites when DP padding actually reshaped the batch — replacing the per-backend defensive re-plan that already did this work lazily. Steady-state, non-DP performance is expected to be byte-identical; the runner-mode suites above also guard against accidental re-planning in draft loops (which would surface as failures, not just slowdowns).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26974853587](https://github.com/sgl-project/sglang/actions/runs/26974853587)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26974853178](https://github.com/sgl-project/sglang/actions/runs/26974853178)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->