### PR TITLE
[diffusion] doc: add ernie Image diffusion

### DIFF
--- a/docs/diffusion/performance/deployment_cookbook.md
+++ b/docs/diffusion/performance/deployment_cookbook.md
@@ -64,6 +64,41 @@ sglang generate \
 
 In this example, `auto` will not re-enable FSDP. The same applies to parallelism; for example, `--enable-cfg-parallel false` keeps CFG parallelism disabled.
 
+## ERNIE Image
+
+`baidu/ERNIE-Image` and `baidu/ERNIE-Image-Turbo` use the native ERNIE Image text-to-image pipeline. Start with `--performance-mode auto`; switch to `speed` only when the full pipeline fits comfortably on the selected GPU(s), or to `memory` when you need lower peak GPU memory.
+
+Regular checkpoint:
+
+```bash
+sglang generate \
+  --model-path baidu/ERNIE-Image \
+  --prompt "A cinematic photo of a quiet lakeside cabin at sunrise" \
+  --performance-mode auto \
+  --save-output
+```
+
+Turbo checkpoint:
+
+```bash
+sglang generate \
+  --model-path baidu/ERNIE-Image-Turbo \
+  --prompt "A cinematic photo of a quiet lakeside cabin at sunrise" \
+  --performance-mode auto \
+  --save-output
+```
+
+Persistent server:
+
+```bash
+sglang serve \
+  --model-path baidu/ERNIE-Image-Turbo \
+  --performance-mode auto \
+  --port 30010
+```
+
+Treat FSDP, SP/Ulysses/Ring, and TP as explicit benchmark knobs for ERNIE Image. Do not assume they are faster than the default path until you have measured the target resolution, step count, and GPU type. If the checkpoint includes a PE component, the pipeline loads it automatically from `model_index.json`.
+
 ## Interpreting The Levers
 
 **No offload** keeps model components resident on GPU. It is usually fastest when memory is sufficient.

--- a/docs/diffusion/performance/deployment_cookbook.md
+++ b/docs/diffusion/performance/deployment_cookbook.md
@@ -64,41 +64,6 @@ sglang generate \
 
 In this example, `auto` will not re-enable FSDP. The same applies to parallelism; for example, `--enable-cfg-parallel false` keeps CFG parallelism disabled.
 
-## ERNIE Image
-
-`baidu/ERNIE-Image` and `baidu/ERNIE-Image-Turbo` use the native ERNIE Image text-to-image pipeline. Start with `--performance-mode auto`; switch to `speed` only when the full pipeline fits comfortably on the selected GPU(s), or to `memory` when you need lower peak GPU memory.
-
-Regular checkpoint:
-
-```bash
-sglang generate \
-  --model-path baidu/ERNIE-Image \
-  --prompt "A cinematic photo of a quiet lakeside cabin at sunrise" \
-  --performance-mode auto \
-  --save-output
-```
-
-Turbo checkpoint:
-
-```bash
-sglang generate \
-  --model-path baidu/ERNIE-Image-Turbo \
-  --prompt "A cinematic photo of a quiet lakeside cabin at sunrise" \
-  --performance-mode auto \
-  --save-output
-```
-
-Persistent server:
-
-```bash
-sglang serve \
-  --model-path baidu/ERNIE-Image-Turbo \
-  --performance-mode auto \
-  --port 30010
-```
-
-Treat FSDP, SP/Ulysses/Ring, and TP as explicit benchmark knobs for ERNIE Image. Do not assume they are faster than the default path until you have measured the target resolution, step count, and GPU type. If the checkpoint includes a PE component, the pipeline loads it automatically from `model_index.json`.
-
 ## Interpreting The Levers
 
 **No offload** keeps model components resident on GPU. It is usually fastest when memory is sufficient.

--- a/docs_new/cookbook/diffusion/Ernie-Image/Ernie-Image.mdx
+++ b/docs_new/cookbook/diffusion/Ernie-Image/Ernie-Image.mdx
@@ -1,0 +1,77 @@
+---
+title: ERNIE-Image
+metatags:
+    description: "Deploy ERNIE-Image and ERNIE-Image-Turbo with SGLang Diffusion."
+---
+
+## 1. Model introduction
+
+[ERNIE-Image](https://huggingface.co/baidu/ERNIE-Image) is Baidu's text-to-image diffusion model family. SGLang Diffusion supports both the regular and Turbo checkpoints with the native `ErnieImagePipeline`.
+
+| Model | Hugging Face model ID | Notes |
+| --- | --- | --- |
+| ERNIE-Image | `baidu/ERNIE-Image` | Regular text-to-image checkpoint |
+| ERNIE-Image-Turbo | `baidu/ERNIE-Image-Turbo` | Turbo text-to-image checkpoint |
+
+## 2. Installation
+
+Install SGLang with the diffusion dependencies:
+
+```bash Command
+pip install -e "python[diffusion]"
+```
+
+For full installation options, see the [SGLang Diffusion installation guide](/docs/sglang-diffusion/installation).
+
+## 3. Serve the model
+
+The commands below target a single supported NVIDIA CUDA or AMD ROCm GPU. Start with `--performance-mode auto`; use `speed` only when the full pipeline fits comfortably on the selected GPU(s), and use `memory` when you need lower peak GPU memory.
+
+Serve ERNIE-Image:
+
+```bash Command
+sglang serve \
+  --model-path baidu/ERNIE-Image \
+  --num-gpus 1 \
+  --performance-mode auto \
+  --port 30010
+```
+
+Serve ERNIE-Image-Turbo:
+
+```bash Command
+sglang serve \
+  --model-path baidu/ERNIE-Image-Turbo \
+  --num-gpus 1 \
+  --performance-mode auto \
+  --port 30010
+```
+
+## 4. Generate an image
+
+Use the OpenAI-compatible image generation API after the server starts:
+
+```python Python
+import base64
+from openai import OpenAI
+
+client = OpenAI(api_key="EMPTY", base_url="http://127.0.0.1:30010/v1")
+
+response = client.images.generate(
+    model="baidu/ERNIE-Image-Turbo",
+    prompt="A cinematic photo of a quiet lakeside cabin at sunrise",
+    n=1,
+    response_format="b64_json",
+)
+
+image_bytes = base64.b64decode(response.data[0].b64_json)
+with open("ernie_image.png", "wb") as f:
+    f.write(image_bytes)
+```
+
+## 5. Configuration tips
+
+- ERNIE-Image is a text-to-image pipeline; do not pass `--image-path`.
+- `--performance-mode auto` keeps conservative defaults while preserving explicit user flags.
+- If the checkpoint includes a PE component, SGLang loads it automatically from `model_index.json`.
+- Treat FSDP, SP/Ulysses/Ring, and TP as explicit benchmark knobs. Measure the target resolution, step count, and GPU type before making them production defaults.

--- a/docs_new/cookbook/diffusion/README.mdx
+++ b/docs_new/cookbook/diffusion/README.mdx
@@ -45,6 +45,8 @@ sgl-cookbook/docs/diffusion/
 │   └── Wan2.2.md
 ├── Z-Image/               # Z-Image series models docs
 │   └── Z-Image-Turbo.md
+├── Ernie-Image/           # ERNIE-Image series models docs
+│   └── Ernie-Image.md
 └── ...
 ```
 

--- a/docs_new/cookbook/diffusion/intro.mdx
+++ b/docs_new/cookbook/diffusion/intro.mdx
@@ -48,6 +48,12 @@ Offline models generate each image or video request as a bounded denoising job. 
     img="/cards/logos/zimage.png"
   />
   <Card
+    title="ERNIE-Image"
+    mode="card"
+    href="/cookbook/diffusion/Ernie-Image/Ernie-Image"
+    img="/cards/logos/ernie.png"
+  />
+  <Card
     title="MOVA"
     mode="card"
     href="/cookbook/diffusion/MOVA/MOVA"

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1140,6 +1140,12 @@
                     ]
                   },
                   {
+                    "group": "ERNIE-Image",
+                    "pages": [
+                      "cookbook/diffusion/Ernie-Image/Ernie-Image"
+                    ]
+                  },
+                  {
                     "group": "MOVA",
                     "pages": [
                       "cookbook/diffusion/MOVA/MOVA"


### PR DESCRIPTION
## Summary
- Add a docs_new diffusion cookbook page for `baidu/ERNIE-Image` and `baidu/ERNIE-Image-Turbo`.
- Link the ERNIE-Image page from the diffusion cookbook overview, README, and docs navigation.

## Validation
- Not run; documentation-only change and local SGLang Diffusion instructions avoid local validation runs.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26922441813](https://github.com/sgl-project/sglang/actions/runs/26922441813)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26922441651](https://github.com/sgl-project/sglang/actions/runs/26922441651)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->