### PR TITLE
Fix require_reasoning and routing_key dropped in GenerateReqInput.__getitem__

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -676,6 +676,13 @@ class GenerateReqInput(BaseReq):
             return_routed_experts=self.return_routed_experts,
             routed_experts_start_len=self.routed_experts_start_len,
             return_indexer_topk=self.return_indexer_topk,
+            # NOTE: this constructor is an explicit allowlist, so any request-scoped
+            # field not listed here is silently dropped when an n>1 batch is sliced.
+            # Other fields still affected by this are tracked in #27216 (multimodal
+            # tiling), #27217 (EPD/disaggregation), #27218 (session_params), and
+            # #27231 (background).
+            require_reasoning=self.require_reasoning,
+            routing_key=self.routing_key,
             modalities=self.modalities[i] if self.modalities else None,
             session_params=self.session_params,
             lora_path=self.lora_path[i] if self.lora_path is not None else None,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -917,6 +917,12 @@ class GenerateReqInput:
             ),
             routed_dp_rank=self.routed_dp_rank,
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
+            # NOTE: this constructor is an explicit allowlist, so any request-scoped
+            # field not listed here is silently dropped when an n>1 batch is sliced.
+            # Other fields still affected by this are tracked in #27216 (multimodal
+            # tiling), #27217 (EPD/disaggregation), #27218 (session_params), and
+            # #27231 (background).
+            routing_key=self.routing_key,
             conversation_id=self.conversation_id,
             http_worker_ipc=self.http_worker_ipc,
             require_reasoning=self.require_reasoning,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -518,6 +518,8 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             lora_path=["path1", "path2"],
             custom_logit_processor=["processor1", "processor2"],
             return_hidden_states=True,
+            require_reasoning=True,
+            routing_key="rk-1",
         )
         req.normalize_batch_and_arguments()
 
@@ -538,6 +540,95 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.lora_path, "path1")
         self.assertEqual(item0.custom_logit_processor, "processor1")
         self.assertEqual(item0.return_hidden_states, True)
+        # request-scoped reasoning metadata must survive slicing for every sample
+        self.assertEqual(item0.require_reasoning, True)
+        self.assertEqual(item0.routing_key, "rk-1")
+        item1 = req[1]
+        self.assertEqual(item1.require_reasoning, True)
+        self.assertEqual(item1.routing_key, "rk-1")
+
+    def test_getitem_preserves_require_reasoning_parallel_sampling(self):
+        """require_reasoning must survive __getitem__ for parallel sampling (n>1).
+
+        This is the exact shape from the original report: a single prompt with
+        sampling_params={"n": 2}. normalize_batch_and_arguments expands it into a
+        non-single batch and every parallel sample is produced via __getitem__, so
+        each one must retain require_reasoning. Without the fix the slice resets it
+        to the default False, constrained decoding is applied before </think>, and
+        message.content comes back None.
+        """
+        # require_reasoning=True is propagated to every parallel sample
+        req = GenerateReqInput(text="What is 2+2?", sampling_params={"n": 2})
+        req.require_reasoning = True
+        req.routing_key = "rk-1"
+        req.normalize_batch_and_arguments()
+        self.assertFalse(req.is_single)
+        for i in range(len(req.text)):
+            self.assertTrue(
+                req[i].require_reasoning,
+                f"require_reasoning dropped for parallel sample {i}",
+            )
+            self.assertEqual(req[i].routing_key, "rk-1")
+
+        # The default (False / None) is propagated as-is, not hard-coded
+        req_default = GenerateReqInput(text="What is 2+2?", sampling_params={"n": 2})
+        req_default.normalize_batch_and_arguments()
+        for i in range(len(req_default.text)):
+            self.assertFalse(req_default[i].require_reasoning)
+            self.assertIsNone(req_default[i].routing_key)
+
+    def test_getitem_propagates_all_request_scoped_fields(self):
+        """__getitem__ must propagate every declared field except a known set.
+
+        This guards the whole class of "scalar request field silently dropped when
+        slicing an n>1 batch" bug (the root cause behind require_reasoning /
+        routing_key loss) instead of rediscovering it one field at a time. When a
+        new field is added to GenerateReqInput, either propagate it in __getitem__
+        or add it to KNOWN_UNPROPAGATED below with a reason.
+        """
+        import ast
+        import dataclasses
+        import inspect
+        import textwrap
+
+        declared = {f.name for f in dataclasses.fields(GenerateReqInput)}
+
+        source = textwrap.dedent(inspect.getsource(GenerateReqInput.__getitem__))
+        construction = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "GenerateReqInput"
+        )
+        propagated = {kw.arg for kw in construction.keywords if kw.arg}
+
+        # Fields intentionally not forwarded by __getitem__. Each is tracked as a
+        # follow-up issue; do not silently extend this set.
+        KNOWN_UNPROPAGATED = {
+            # deprecated; normalize() migrates it into routed_dp_rank (propagated)
+            "data_parallel_rank",
+            # background-generation disconnect handling (#27231)
+            "background",
+            # multimodal dynamic tiling / audio, dropped on n>1 multimodal (#27216)
+            "max_dynamic_patch",
+            "min_dynamic_patch",
+            "image_max_dynamic_patch",
+            "video_max_dynamic_patch",
+            "use_audio_in_video",
+            "mm_hashes",
+            # EPD/disaggregation fields populated after tokenization (#27217)
+            "need_wait_for_mm_inputs",
+            "num_items_assigned",
+            "mm_data_mooncake",
+        }
+
+        dropped = declared - propagated - KNOWN_UNPROPAGATED
+        self.assertEqual(
+            dropped,
+            set(),
+            f"__getitem__ drops request-scoped fields {sorted(dropped)}; "
+            "propagate them in __getitem__ or add to KNOWN_UNPROPAGATED with a reason.",
+        )
 
     def test_regenerate_rid(self):
         """Test the regenerate_rid method."""

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1027,6 +1027,8 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             lora_path=["path1", "path2"],
             custom_logit_processor=["processor1", "processor2"],
             return_hidden_states=[True, "last"],
+            require_reasoning=True,
+            routing_key="rk-1",
         )
         req.normalize_batch_and_arguments()
 
@@ -1047,7 +1049,13 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.lora_path, "path1")
         self.assertEqual(item0.custom_logit_processor, "processor1")
         self.assertEqual(item0.return_hidden_states, True)
-        self.assertEqual(req[1].return_hidden_states, "last")
+        # request-scoped reasoning metadata must survive slicing for every sample
+        self.assertEqual(item0.require_reasoning, True)
+        self.assertEqual(item0.routing_key, "rk-1")
+        item1 = req[1]
+        self.assertEqual(item1.return_hidden_states, "last")
+        self.assertEqual(item1.require_reasoning, True)
+        self.assertEqual(item1.routing_key, "rk-1")
 
     def test_getitem_preserves_return_prompt_token_ids(self):
         """Batch subrequests must keep the prompt-token-id return flag."""
@@ -1061,6 +1069,93 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
         self.assertTrue(req[0].return_prompt_token_ids)
         self.assertTrue(req[1].return_prompt_token_ids)
+
+    def test_getitem_preserves_require_reasoning_parallel_sampling(self):
+        """require_reasoning must survive __getitem__ for parallel sampling (n>1).
+
+        This is the exact shape from the original report: a single prompt with
+        sampling_params={"n": 2}. normalize_batch_and_arguments expands it into a
+        non-single batch and every parallel sample is produced via __getitem__, so
+        each one must retain require_reasoning. Without the fix the slice resets it
+        to the default False, constrained decoding is applied before </think>, and
+        message.content comes back None.
+        """
+        # require_reasoning=True is propagated to every parallel sample
+        req = GenerateReqInput(text="What is 2+2?", sampling_params={"n": 2})
+        req.require_reasoning = True
+        req.routing_key = "rk-1"
+        req.normalize_batch_and_arguments()
+        self.assertFalse(req.is_single)
+        for i in range(len(req.text)):
+            self.assertTrue(
+                req[i].require_reasoning,
+                f"require_reasoning dropped for parallel sample {i}",
+            )
+            self.assertEqual(req[i].routing_key, "rk-1")
+
+        # The default (False / None) is propagated as-is, not hard-coded
+        req_default = GenerateReqInput(text="What is 2+2?", sampling_params={"n": 2})
+        req_default.normalize_batch_and_arguments()
+        for i in range(len(req_default.text)):
+            self.assertFalse(req_default[i].require_reasoning)
+            self.assertIsNone(req_default[i].routing_key)
+
+    def test_getitem_propagates_all_request_scoped_fields(self):
+        """__getitem__ must propagate every declared field except a known set.
+
+        This guards the whole class of "scalar request field silently dropped when
+        slicing an n>1 batch" bug (the root cause behind require_reasoning /
+        routing_key loss) instead of rediscovering it one field at a time. When a
+        new field is added to GenerateReqInput, either propagate it in __getitem__
+        or add it to KNOWN_UNPROPAGATED below with a reason.
+        """
+        import ast
+        import dataclasses
+        import inspect
+        import textwrap
+
+        declared = {f.name for f in dataclasses.fields(GenerateReqInput)}
+
+        source = textwrap.dedent(inspect.getsource(GenerateReqInput.__getitem__))
+        construction = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "GenerateReqInput"
+        )
+        propagated = {kw.arg for kw in construction.keywords if kw.arg}
+
+        # Fields intentionally not forwarded by __getitem__. Each is tracked as a
+        # follow-up issue; do not silently extend this set.
+        KNOWN_UNPROPAGATED = {
+            # deprecated; normalize() migrates it into routed_dp_rank (propagated)
+            "data_parallel_rank",
+            # background-generation disconnect handling (#27231)
+            "background",
+            # multimodal dynamic tiling / audio / per-request processor configs,
+            # dropped on n>1 multimodal (#27216; video_config and images_config were
+            # added upstream later but share the same drop-on-slice failure mode)
+            "max_dynamic_patch",
+            "min_dynamic_patch",
+            "image_max_dynamic_patch",
+            "video_max_dynamic_patch",
+            "use_audio_in_video",
+            "video_config",
+            "images_config",
+            # EPD/disaggregation fields populated after tokenization (#27217;
+            # encoder_urls is a tokenizer-side snapshot tied to num_items_assigned)
+            "need_wait_for_mm_inputs",
+            "num_items_assigned",
+            "encoder_urls",
+        }
+
+        dropped = declared - propagated - KNOWN_UNPROPAGATED
+        self.assertEqual(
+            dropped,
+            set(),
+            f"__getitem__ drops request-scoped fields {sorted(dropped)}; "
+            "propagate them in __getitem__ or add to KNOWN_UNPROPAGATED with a reason.",
+        )
 
     def test_regenerate_rid(self):
         """Test the regenerate_rid method."""


### PR DESCRIPTION
## Problem

When using a reasoning parser (e.g. `--reasoning-parser qwen3`) with a structured output constraint (`response_format={"type":"json_schema",...}`) and `n>1` parallel sampling, `message.content` is always `None` while the structured answer is misrouted into `message.reasoning_content`.

Root cause: `GenerateReqInput.__getitem__` slices a batch into per-sample sub-requests but does **not** propagate `require_reasoning` and `routing_key`. The serving layer sets `require_reasoning=True` on the top-level batch request (`serving_chat.py`), but after slicing each sample loses that flag. Without `require_reasoning=True`, the grammar backend applies the JSON schema constraint from token 0 — before the model emits `</think>` — so all structured output is classified as reasoning and `content` stays empty.

Call chain:

```
serving_chat.py: require_reasoning=True set on parent GenerateReqInput (n>1)
  -> tokenizer_manager: obj[i] for i in range(batch_size)   # __getitem__ slice
       -> require_reasoning DROPPED -> per-sample obj.require_reasoning == False
  -> tokenizer_manager.py reads obj.require_reasoning (False)
  -> grammar applied from token 0, before </think>  -> content=None
```

Observed with `Qwen/Qwen3.5-0.8B` + `--reasoning-parser qwen3` + `response_format=json_schema`: all `n` choices come back `content=None` with the answer in `reasoning_content`.

Related: #22042. This PR is the **unit-level fix + a coverage guard**; the end-to-end server test for the same bug lives in #22043. The two are intentionally kept separate, and this PR folds in the review feedback left on #22043 (fold asserts into `test_getitem_method`, `dataclasses.fields` coverage, follow-up issues for the other dropped fields).

## Fix

Add `require_reasoning=self.require_reasoning` and `routing_key=self.routing_key` to the `GenerateReqInput(...)` construction inside `__getitem__` (both are request-global scalars, propagated as-is). A comment is added at that site noting the constructor is an explicit allowlist and linking the other fields with the same drop-on-slice issue.

```diff
+            # NOTE: this constructor is an explicit allowlist, so any request-scoped
+            # field not listed here is silently dropped when an n>1 batch is sliced.
+            # Other fields still affected by this are tracked in #27216 / #27217 / #27218.
+            require_reasoning=self.require_reasoning,
+            routing_key=self.routing_key,
```

## Tests

All in `test/registered/unit/managers/test_io_struct.py` (CPU-only). Each **fails on current `main` and passes with this fix**:

- `test_getitem_method` (existing comprehensive test) now also asserts `require_reasoning` / `routing_key` survive `__getitem__` for every sample.
- `test_getitem_preserves_require_reasoning_parallel_sampling` — the exact reported shape (single prompt, `sampling_params={"n": 2}`), plus a check that the default (`False`/`None`) is propagated as-is rather than hard-coded.
- `test_getitem_propagates_all_request_scoped_fields` — a guard that enumerates `dataclasses.fields(GenerateReqInput)` and asserts `__getitem__` propagates every field except a documented `KNOWN_UNPROPAGATED` allowlist. This catches the whole class of "request-scoped field silently dropped on `n>1` slicing" bug instead of rediscovering it one field at a time (per the review suggestion on #22043).

## Verification

Ran the affected tests against `main`'s `io_struct.py` (no fix) and with the fix:

```
# WITHOUT fix:  3 failed
test_getitem_method ........................................ FAILED  (require_reasoning: False != True)
test_getitem_preserves_require_reasoning_parallel_sampling . FAILED
test_getitem_propagates_all_request_scoped_fields .......... FAILED
    __getitem__ drops request-scoped fields ['require_reasoning', 'routing_key']

# WITH fix:  all pass
```

The full `TestGenerateReqInputNormalization` class (25 tests) passes with the fix — no existing test regressed.

## Scope & follow-ups

This PR is limited to the reported reasoning regression. The same review found other fields with the same drop-on-slice failure mode, in unrelated subsystems; they are filed as separate issues rather than bundled here, and the guard test lists them in `KNOWN_UNPROPAGATED`:

- #27216 — multimodal tiling / audio (`max_dynamic_patch`, `image/video/min_dynamic_patch`, `use_audio_in_video`, `mm_hashes`).
- #27217 — EPD/disaggregation (`need_wait_for_mm_inputs`, `num_items_assigned`, `mm_data_mooncake`).
- #27218 — `session_params` forwarded whole instead of `session_params[i]` (a wrong-indexing variant, not caught by the presence guard).
- #27231 — `background` flag dropped, so Responses API background jobs can hit spurious disconnect aborts on `n>1`.

`data_parallel_rank` is **not** a bug: `normalize_batch_and_arguments` migrates it into `routed_dp_rank` (propagated) and resets it to `None`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32624807399](https://github.com/sgl-project/sglang/actions/runs/32624807399)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32624807249](https://github.com/sgl-project/sglang/actions/runs/32624807249)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32624807328](https://github.com/sgl-project/sglang/actions/runs/32624807328)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
