### PR TITLE
[AMD][WA] force to use gate_mode interleaved to fix tp2/tp4/tp8 acc issue

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -899,10 +899,12 @@ class AiterAttnBackend(AttentionBackend):
                     )
 
                     if self.use_sliding_window_kv_pool:
+                        # AITER attention kernels require int32 page indices;
+                        # full_to_swa_index_mapping is stored as int64.
                         swa_page_table = (
                             self.token_to_kv_pool.translate_loc_from_full_to_swa(
                                 kv_indices
-                            )
+                            ).to(torch.int32)
                         )
 
                         kv_indices = self._transform_table_1_to_real(kv_indices)
@@ -1378,10 +1380,13 @@ class AiterAttnBackend(AttentionBackend):
                 )
 
                 if self.use_sliding_window_kv_pool:
+                    # AITER attention kernels (e.g. mha_batch_prefill_func)
+                    # require int32 page indices; full_to_swa_index_mapping is
+                    # stored as int64.
                     swa_page_table = (
                         self.token_to_kv_pool.translate_loc_from_full_to_swa(
                             self.indices_updater_prefill.kv_indices
-                        )
+                        ).to(torch.int32)
                     )
 
                 self.forward_metadata = ForwardMetadata(
@@ -1577,10 +1582,12 @@ class AiterAttnBackend(AttentionBackend):
                         ]
 
                         if self.use_sliding_window_kv_pool:
+                            # AITER attention kernels require int32 page indices;
+                            # full_to_swa_index_mapping is stored as int64.
                             swa_page_indices = (
                                 self.token_to_kv_pool.translate_loc_from_full_to_swa(
                                     page_indices
-                                )
+                                ).to(torch.int32)
                             )
 
                             page_indices = self._transform_table_1_to_real(page_indices)

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -28,11 +28,11 @@ from torch.nn.parameter import Parameter
 # cutlass_fused_moe. Its C++ logger reads TLLM_LOG_LEVEL on first kernel launch;
 # setdefault preserves any explicit user override.
 os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
-
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
+from sglang.srt.environ import envs
 from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
@@ -154,6 +154,7 @@ if _is_hip:
     # import aiter
     try:
         from aiter.ops.shuffle import (
+            shuffle_scale,
             shuffle_scale_a16w4,
             shuffle_weight,
             shuffle_weight_a16w4,
@@ -795,20 +796,46 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 .contiguous()
                 .view(e, n, -1)
             )
-
-            layer.w13_weight.data = shuffle_weight_a16w4(layer.w13_weight, 16, True)
-            shuffled_w13_scale = shuffle_scale_a16w4(
-                layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
-                self.num_experts,
-                True,
+            layer.w13_weight_bias.data = (
+                layer.w13_weight_bias.data.view(-1, n // 2, 2)
+                .permute(0, 2, 1)
+                .contiguous()
+                .view(-1, n)
             )
 
-            layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
-            shuffled_w2_scale = shuffle_scale_a16w4(
-                layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
-                self.num_experts,
-                False,
-            )
+            if envs.SGLANG_USE_AITER_MOE_GU_ITLV.get():
+                layer.w13_weight.data = shuffle_weight_a16w4(layer.w13_weight, 16, True)
+                shuffled_w13_scale = shuffle_scale_a16w4(
+                    layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
+                    self.num_experts,
+                    True,
+                )
+
+                layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
+                shuffled_w2_scale = shuffle_scale_a16w4(
+                    layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
+                    self.num_experts,
+                    False,
+                )
+            else:
+                layer.w13_weight.data = shuffle_weight(
+                    layer.w13_weight, is_guinterleave=False, gate_up=True
+                )
+                shuffled_w13_scale = shuffle_scale(
+                    layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
+                    experts_cnt=self.num_experts,
+                    is_guinterleave=False,
+                    gate_up=True,
+                )
+                layer.w2_weight.data = shuffle_weight(
+                    layer.w2_weight, is_guinterleave=False, gate_up=False
+                )
+                shuffled_w2_scale = shuffle_scale(
+                    layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
+                    experts_cnt=self.num_experts,
+                    is_guinterleave=False,
+                    gate_up=False,
+                )
 
             # shuffle_weight_a16w4(gate_up=True) above preshuffles w13 into aiter's
             # preshuffle + gate/up-interleaved layout. Tag the Parameter so apply()
@@ -816,13 +843,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             # fused_moe selects the preshuffle_on kernel family.
             layer.w13_weight.is_shuffled = True
             layer.w2_weight.is_shuffled = True
-
-            layer.w13_weight_bias.data = (
-                layer.w13_weight_bias.data.view(-1, n // 2, 2)
-                .permute(0, 2, 1)
-                .contiguous()
-                .view(-1, n)
-            )
 
             layer.w13_weight_scale = torch.nn.Parameter(
                 shuffled_w13_scale, requires_grad=False

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -154,8 +154,9 @@ if _is_hip:
     # import aiter
     try:
         from aiter.ops.shuffle import (
-            shuffle_scale,
+            shuffle_scale_a16w4,
             shuffle_weight,
+            shuffle_weight_a16w4,
         )
         from aiter.ops.triton.quant import dynamic_mxfp4_quant
         from aiter.utility.fp4_utils import e8m0_shuffle
@@ -773,7 +774,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
             return
         if _use_aiter:
-            # Bias must be fp32 for the AITER kernels.
             if layer.w13_weight_bias is not None:
                 layer.w13_weight_bias.data = layer.w13_weight_bias.data.to(
                     torch.float32
@@ -781,12 +781,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             if layer.w2_weight_bias is not None:
                 layer.w2_weight_bias.data = layer.w2_weight_bias.data.to(torch.float32)
 
-            # HF GPT-OSS stores w13 as gate/up *interleaved* row pairs
-            # [(g0, u0), (g1, u1), ...]. The AITER MXFP4 fused MoE kernels
-            # (FlyDSL `gate_mode="separated"` and CK `preshuffle_on`) expect
-            # the *separated* layout [gate_0..gate_{N-1}, up_0..up_{N-1}].
-            # De-interleave weights, scales, and bias before the tile shuffle
-            # so the post-shuffle bytes land in the layout the kernel reads.
             e, n, k = layer.w13_weight.shape
             layer.w13_weight.view(torch.uint8).copy_(
                 layer.w13_weight.data.view(torch.uint8)
@@ -801,38 +795,33 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 .contiguous()
                 .view(e, n, -1)
             )
+
+            layer.w13_weight.data = shuffle_weight_a16w4(layer.w13_weight, 16, True)
+            shuffled_w13_scale = shuffle_scale_a16w4(
+                layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
+                self.num_experts,
+                True,
+            )
+
+            layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
+            shuffled_w2_scale = shuffle_scale_a16w4(
+                layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
+                self.num_experts,
+                False,
+            )
+
+            # shuffle_weight_a16w4(gate_up=True) above preshuffles w13 into aiter's
+            # preshuffle + gate/up-interleaved layout. Tag the Parameter so apply()
+            # can carry the metadata across .view(float4_e2m1fn_x2) and aiter's
+            # fused_moe selects the preshuffle_on kernel family.
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+
             layer.w13_weight_bias.data = (
                 layer.w13_weight_bias.data.view(-1, n // 2, 2)
                 .permute(0, 2, 1)
                 .contiguous()
                 .view(-1, n)
-            )
-
-            # ATOM-aligned MXFP4 preshuffle (is_guinterleave=False). Both
-            # `gptoss_fp4_tuned_fmoe.csv` flydsl entries (e.g.
-            # flydsl_moe1_afp4_wfp4_bf16_t32x128x256_w2) and the CK
-            # `module_moe_ck2stages_*_preshuffle_on_*` fallback use the
-            # standard (16,16) tile layout produced here. The previous
-            # shuffle_weight_a16w4 path produced a gate/up-interleaved tile
-            # layout that does not match the separated-gate kernels and
-            # caused silent accuracy loss.
-            layer.w13_weight.data = shuffle_weight(
-                layer.w13_weight, is_guinterleave=False, gate_up=True
-            )
-            shuffled_w13_scale = shuffle_scale(
-                layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
-                experts_cnt=self.num_experts,
-                is_guinterleave=False,
-                gate_up=True,
-            )
-            layer.w2_weight.data = shuffle_weight(
-                layer.w2_weight, is_guinterleave=False, gate_up=False
-            )
-            shuffled_w2_scale = shuffle_scale(
-                layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
-                experts_cnt=self.num_experts,
-                is_guinterleave=False,
-                gate_up=False,
             )
 
             layer.w13_weight_scale = torch.nn.Parameter(
@@ -841,14 +830,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight_scale = torch.nn.Parameter(
                 shuffled_w2_scale, requires_grad=False
             )
-
-            # Tell aiter.fused_moe these weights are already preshuffled so it
-            # picks the preshuffle_on CK / FlyDSL kernels (which match the
-            # actual layout) instead of falling back to preshuffle_off kernels
-            # that interpret the shuffled bytes as a non-shuffled tensor and
-            # produce garbage / OOB accesses.
-            layer.w13_weight.is_shuffled = True
-            layer.w2_weight.is_shuffled = True
 
             return
 
@@ -1281,7 +1262,17 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 doweight_stage1=self.moe_runner_config.apply_router_weight_on_input,
                 hidden_pad=self.hidden_pad,
                 intermediate_pad=self.intermediate_pad,
-                swiglu_limit=self.moe_runner_config.swiglu_limit or 0.0,
+                # Triggers aiter's INTERLEAVE gate_mode dispatch (required for our
+                # preshuffled gate/up-interleaved weight layout) and applies the
+                # model's swiglu clamp. Models populate the same scalar under
+                # different MoeRunnerConfig fields: gpt-oss uses `gemm1_clamp_limit`
+                # (renamed in `models/gpt_oss.py` from `config.swiglu_limit`); DSv4
+                # / FP8 uses `swiglu_limit` directly. Accept either.
+                swiglu_limit=(
+                    self.moe_runner_config.gemm1_clamp_limit
+                    or self.moe_runner_config.swiglu_limit
+                    or 0.0
+                ),
             )
             return self.runner.run(
                 dispatch_output._replace(hidden_states=x_padded), quant_info

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2179,13 +2179,13 @@ class ServerArgs:
                     logger.warning(
                         "Detected ROCm and MXFP4 quantization format for GPT-OSS model, enabling aiter MXFP4 MOE kernel."
                     )
-                    # The AITER MXFP4 fused-MoE path for GPT-OSS expects the
-                    # SEPARATED gate/up tile layout (matches the
-                    # `gptoss_fp4_tuned_fmoe.csv` flydsl entries and the
-                    # Mxfp4MoEMethod weight shuffle). Other AITER MXFP4
-                    # callers default to INTERLEAVE; opt this path out
-                    # unless the user explicitly overrode it.
-                    envs.SGLANG_USE_AITER_MOE_GU_ITLV.set(False)
+                    ## The AITER MXFP4 fused-MoE path for GPT-OSS expects the
+                    ## SEPARATED gate/up tile layout (matches the
+                    ## `gptoss_fp4_tuned_fmoe.csv` flydsl entries and the
+                    ## Mxfp4MoEMethod weight shuffle). Other AITER MXFP4
+                    ## callers default to INTERLEAVE; opt this path out
+                    ## unless the user explicitly overrode it.
+                    # envs.SGLANG_USE_AITER_MOE_GU_ITLV.set(False)
                 elif is_hip() and envs.SGLANG_USE_AITER.get():
                     # For GPT-OSS bf16 on ROCm with aiter, use triton backend
                     # because aiter CK kernel doesn't support all GEMM dimensions

--- a/test/registered/amd/accuracy/mi35x/test_gpt_oss_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_gpt_oss_eval_mi35x.py
@@ -76,7 +76,7 @@ MI35X_GPT_OSS_MODELS = [
         # to INTERLEAVE, so opt out explicitly here.
         env_vars={
             "SGLANG_USE_AITER": "1",
-            "SGLANG_USE_AITER_MOE_GU_ITLV": "0",
+            "SGLANG_USE_AITER_MOE_GU_ITLV": "1",
         },
     ),
     ModelConfig(
@@ -97,7 +97,7 @@ MI35X_GPT_OSS_MODELS = [
         ],
         env_vars={
             "SGLANG_USE_AITER": "1",
-            "SGLANG_USE_AITER_MOE_GU_ITLV": "0",
+            "SGLANG_USE_AITER_MOE_GU_ITLV": "1",
         },
     ),
 ]


### PR DESCRIPTION
## Motivation

`gpt-oss-120b` GSM8K accuracy collapses to ~0.04 (flexible-extract) on
TP=2/4/8 when the AITER backend is enabled.  Investigation shows the
breakage is isolated to the **SEPARATED gate_mode + fp4x2 FlyDSL prefill
kernel** path: when `GPTOSS_SWIGLU_MXFP4_BF16_BOUND=99999` is set (forcing
all batch sizes to use the bf16 kernel), accuracy fully recovers to ~0.90.

Root cause: the FlyDSL `flydsl_moe1_afp4_wfp4_bf16_t*_fp4` kernel is
incorrect when used with SEPARATED layout at TP≥2.  The bug affects both
eager and graph-mode decode; it is not a CUDA-graph capture issue.

This PR works around the kernel bug by switching from the SEPARATED path
(de-interleave + `shuffle_weight(is_guinterleave=False)`) to the
**INTERLEAVE path** (`shuffle_weight_a16w4`), which uses the bf16 MoE
kernel exclusively on ROCm/MI300 (`get_gfx() != "gfx950"` ⇒ bf16 for
all M) and avoids the broken fp4x2 code path entirely.

This PR also fixes a runtime regression introduced by
[#27091](https://github.com/sgl-project/sglang/pull/27091) (`c9ca56d`):
`translate_loc_from_full_to_swa` returns an int64 tensor, but the AITER
attention kernels (`mha_batch_prefill_func`, etc.) expect int32 page
indices. Three call sites in `aiter_backend.py` were missing the
`.to(torch.int32)` cast, causing type errors on models with sliding-window
attention (gpt-oss, Kimi-K2, …) when SWA+AITER is used together.

## Modifications

### `python/sglang/srt/layers/quantization/mxfp4.py`

- Import `shuffle_weight_a16w4` / `shuffle_scale_a16w4` from
  `aiter.ops.shuffle`.
- Replace the SEPARATED preshuffle path
  (`shuffle_weight(is_guinterleave=False, gate_up=True)`) with the INTERLEAVE
  preshuffle path (`shuffle_weight_a16w4`). The weight de-interleave step
  (gate/up row permute) is kept so the data layout entering the shuffle
  matches what `shuffle_weight_a16w4` expects.
- Tag `layer.w13_weight.is_shuffled = True` so `apply()` propagates the
  marker across the `.view(float4_e2m1fn_x2)` call and aiter selects the
  `preshuffle_on` kernel family.

### `python/sglang/srt/layers/attention/aiter_backend.py`

- Add `.to(torch.int32)` at the three `translate_loc_from_full_to_swa` call
  sites (decode graph replay, prefill-eager, and prefill graph-capture paths)
  to fix the int64→int32 type mismatch introduced by #27091.

### `python/sglang/srt/server_args.py` / test

- Minor: keep `SGLANG_USE_AITER_MOE_GU_ITLV` wiring consistent with the
  new INTERLEAVE default.

## Accuracy Tests

lm_eval 5-shot GSM8K (chat template, `num_concurrent=128`,
`max_gen_toks=2048`), gpt-oss-120b, MI300, TP=2, graph mode,
`--kv-cache-dtype fp8_e4m3 --page-size 16 --disable-radix-cache
--max-running-requests 128`:

| Variant | flexible-extract | strict-match |
|---|---:|---:|
| Before (SEPARATED, broken) | 0.041 | 0.016 |
| **This PR (INTERLEAVE, WA)** | **0.904** | **0.693** |
| ATOM TP=2 (reference) | 0.849 | 0.537 |
| `GPTOSS_SWIGLU_MXFP4_BF16_BOUND=99999` (root-cause verify) | 0.904 | 0.692 |

TP=1 (unaffected path) baseline held: flexible 0.887 / strict 0.339.

## Speed Tests and Profiling

Performance impact of switching INTERLEAVE vs SEPARATED on gpt-oss TP=1
(the only TP where SEPARATED was previously working and for which we have
sweep data) is minimal: at 8K/1K c=128, TPOT changes by < 1 % between
the two paths since both fall into the bf16 default kernel for decode
M < 256.

TP=2 / TP=4 / TP=8 benchmarks are unblocked by this fix.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [x] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26989921580](https://github.com/sgl-project/sglang/actions/runs/26989921580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26989921555](https://github.com/sgl-project/sglang/actions/runs/26989921555)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->