### PR TITLE
Cap SWA compute locks to one window

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -943,6 +943,12 @@ class PrefillAdder:
             # - if the can_run_list is empty, always accept the first prefill request
             return AddReqResult.OTHER
 
+        # Normalize both the current device node and any deeper host node before
+        # admission/load-back locks make structural splits unsafe.
+        self.tree_cache.prepare_swa_compute_lock(req.last_node)
+        if req.needs_host_load_back():
+            self.tree_cache.prepare_swa_compute_lock(req.best_match_node)
+
         with self._lock_node(req.last_node):
             # self.rem_total_tokens may decrease after the lock acquisition
             if total_tokens >= self.rem_total_tokens:

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -263,6 +263,10 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def inc_lock_ref(self, node: Any) -> IncLockRefResult:
         pass
 
+    def prepare_swa_compute_lock(self, node: Any) -> None:
+        """Prepare cache topology for an SWA request compute lock. Default no-op."""
+        pass
+
     @abstractmethod
     def dec_lock_ref(
         self, node: Any, params: Optional[DecLockRefParams] = None

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -282,13 +282,19 @@ class SWAComponent(TreeComponent):
 
         self._maybe_split_leaf_for_swa_lock(node)
 
-    def _maybe_split_leaf_for_swa_lock(self, leaf: UnifiedTreeNode) -> None:
-        """Cap a fresh SWA leaf at one page-aligned window so locking it pins
-        only one window of SWA pool, not the whole (long chunked-prefill) leaf.
+    def _maybe_split_leaf_for_swa_lock(
+        self, leaf: UnifiedTreeNode, *, preserve_lru_position: bool = False
+    ) -> None:
+        """Cap an SWA node at a page-aligned suffix so locking it pins
+        only the needed window, not the whole long chunked-prefill node.
         """
         ct = self.component_type
         cd = leaf.component_data[ct]
-        if leaf is self.cache.root_node or cd.value is None or cd.lock_ref > 0:
+        if (
+            leaf is self.cache.root_node
+            or (cd.value is None and cd.host_value is None)
+            or cd.lock_ref > 0
+        ):
             return
 
         page_size = self.cache.page_size
@@ -301,7 +307,12 @@ class SWAComponent(TreeComponent):
         if page_size > 1 and (split_at % page_size != 0 or leaf_len % page_size != 0):
             return
 
-        self.cache._split_node(leaf.key, leaf, split_at)
+        self.cache._split_node(
+            leaf.key,
+            leaf,
+            split_at,
+            preserve_lru_position=preserve_lru_position,
+        )
 
     def redistribute_on_node_split(
         self, new_parent: UnifiedTreeNode, child: UnifiedTreeNode

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -282,6 +282,10 @@ class SWAComponent(TreeComponent):
 
         self._maybe_split_leaf_for_swa_lock(node)
 
+    def on_became_leaf(self, node: UnifiedTreeNode) -> None:
+        # Re-apply the insert-time one-window cap when a long prefix becomes a leaf.
+        self._maybe_split_leaf_for_swa_lock(node)
+
     def _maybe_split_leaf_for_swa_lock(self, leaf: UnifiedTreeNode) -> None:
         """Cap a fresh SWA leaf at one page-aligned window so locking it pins
         only one window of SWA pool, not the whole (long chunked-prefill) leaf.

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -282,10 +282,6 @@ class SWAComponent(TreeComponent):
 
         self._maybe_split_leaf_for_swa_lock(node)
 
-    def on_became_leaf(self, node: UnifiedTreeNode) -> None:
-        # Re-apply the insert-time one-window cap when a long prefix becomes a leaf.
-        self._maybe_split_leaf_for_swa_lock(node)
-
     def _maybe_split_leaf_for_swa_lock(self, leaf: UnifiedTreeNode) -> None:
         """Cap a fresh SWA leaf at one page-aligned window so locking it pins
         only one window of SWA pool, not the whole (long chunked-prefill) leaf.

--- a/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
@@ -210,6 +210,11 @@ class TreeComponent(ABC):
         is still tombstoned. Default no-op."""
         return None
 
+    def on_became_leaf(self, node: UnifiedTreeNode) -> None:
+        """Called when *node* becomes a device leaf because its only child was
+        deleted. Override to re-apply per-leaf invariants. Default no-op."""
+        return None
+
     def commit_insert_component_data(
         self,
         node: UnifiedTreeNode,

--- a/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
@@ -210,11 +210,6 @@ class TreeComponent(ABC):
         is still tombstoned. Default no-op."""
         return None
 
-    def on_became_leaf(self, node: UnifiedTreeNode) -> None:
-        """Called when *node* becomes a device leaf because its only child was
-        deleted. Override to re-apply per-leaf invariants. Default no-op."""
-        return None
-
     def commit_insert_component_data(
         self,
         node: UnifiedTreeNode,

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1359,6 +1359,10 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             has_host = cur.component_data[ct].host_value is not None
 
             if has_device:
+                # cur just became a device leaf; let components re-apply their
+                # per-leaf invariants (SWA caps a long prefix to one window).
+                for component in self._components_tuple:
+                    component.on_became_leaf(cur)
                 self._update_evictable_leaf_sets(cur)
                 break
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1359,10 +1359,6 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             has_host = cur.component_data[ct].host_value is not None
 
             if has_device:
-                # cur just became a device leaf; let components re-apply their
-                # per-leaf invariants (SWA caps a long prefix to one window).
-                for component in self._components_tuple:
-                    component.on_became_leaf(cur)
                 self._update_evictable_leaf_sets(cur)
                 break
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -8,7 +8,7 @@ from array import array
 from collections import defaultdict
 from functools import partial
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Any, Iterator, NamedTuple, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Iterator, NamedTuple, Optional, TypeVar, cast
 
 import torch
 
@@ -172,6 +172,11 @@ class UnifiedLRUList:
         assert node.id not in self.cache
         self.cache[node.id] = node
         self._add_node(node)
+
+    def insert_after(self, previous: UnifiedTreeNode, node: UnifiedTreeNode) -> None:
+        assert node.id not in self.cache
+        self.cache[node.id] = node
+        self._add_node_after(previous, node)
 
     def remove_node(self, node: UnifiedTreeNode):
         assert node.id in self.cache
@@ -636,6 +641,24 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self._update_evictable_leaf_sets(node)
         return result
 
+    def prepare_swa_compute_lock(self, node: Any) -> None:
+        """Split an SWA node before taking a request compute lock.
+
+        SWA only needs to pin one sliding window, but lock accounting works at
+        node granularity. Cap a long lock node to one page-aligned window. The
+        lock methods do not call this helper implicitly, so short-lived IO locks
+        keep lock_ref as a pure accounting update.
+        """
+        if self.disable or ComponentType.SWA not in self.components:
+            return
+        if not isinstance(node, UnifiedTreeNode) or node is self.root_node:
+            return
+        if self._has_any_lock_ref(node):
+            return
+
+        swa_component = cast(SWAComponent, self.components[ComponentType.SWA])
+        swa_component._maybe_split_leaf_for_swa_lock(node, preserve_lru_position=True)
+
     def dec_lock_ref(
         self,
         node: Any,
@@ -858,6 +881,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             req.last_node,
             DecLockRefParams(swa_uuid_for_lock=getattr(req, "swa_uuid_for_lock", None)),
         )
+        self.prepare_swa_compute_lock(new_last_node)
         lock_result = self.inc_lock_ref(new_last_node)
 
         # Update req fields
@@ -1011,8 +1035,23 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         return result
 
     def _split_node(
-        self, key: RadixKey, child: UnifiedTreeNode, split_len: int
+        self,
+        key: RadixKey,
+        child: UnifiedTreeNode,
+        split_len: int,
+        preserve_lru_position: bool = False,
     ) -> UnifiedTreeNode:
+        original_last_access_time = child.last_access_time
+        preserved_lrus: list[UnifiedLRUList] = []
+        if preserve_lru_position:
+            for lru_dict in (self.lru_lists, self.host_lru_lists):
+                for ct in self.tree_components:
+                    if ct == BASE_COMPONENT_TYPE:
+                        continue
+                    lru = lru_dict[ct]
+                    if lru.in_list(child):
+                        preserved_lrus.append(lru)
+
         new_node = UnifiedTreeNode(self.tree_components, priority=child.priority)
         new_node.children = {key[split_len:].child_key(self.page_size): child}
         new_node.parent = child.parent
@@ -1020,7 +1059,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         new_node.hit_count = child.hit_count
         new_node.creation_time = child.creation_time
 
-        self._for_each_component_lru(child, UnifiedLRUList.remove_node)
+        if not preserve_lru_position:
+            self._for_each_component_lru(child, UnifiedLRUList.remove_node)
 
         child.parent = new_node
         child.key = child.key[split_len:]
@@ -1035,13 +1075,41 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         if child.backuped:
             self._replace_pending_write_through_node(child, [new_node, child])
 
-        self._for_each_component_lru(
-            new_node, UnifiedLRUList.insert_mru, skip_existing=True
-        )
-        self._for_each_component_lru(
-            child, UnifiedLRUList.insert_mru, skip_existing=True
-        )
-        child.last_access_time = get_and_increase_time_counter()
+        if preserve_lru_position:
+            for lru in preserved_lrus:
+                if lru.in_list(new_node):
+                    lru.remove_node(new_node)
+
+                ct = lru.component_type
+                is_host_lru = lru is self.host_lru_lists[ct]
+                cd = new_node.component_data[ct]
+                value = cd.host_value if is_host_lru else cd.value
+                if value is not None:
+                    lru.insert_after(child, new_node)
+
+            for target in (EvictLayer.DEVICE, EvictLayer.HOST):
+                self._for_each_component_lru(
+                    new_node,
+                    UnifiedLRUList.insert_mru,
+                    target=target,
+                    skip_existing=True,
+                )
+                self._for_each_component_lru(
+                    child,
+                    UnifiedLRUList.insert_mru,
+                    target=target,
+                    skip_existing=True,
+                )
+            new_node.last_access_time = original_last_access_time
+            child.last_access_time = original_last_access_time
+        else:
+            self._for_each_component_lru(
+                new_node, UnifiedLRUList.insert_mru, skip_existing=True
+            )
+            self._for_each_component_lru(
+                child, UnifiedLRUList.insert_mru, skip_existing=True
+            )
+            child.last_access_time = get_and_increase_time_counter()
 
         self._update_evictable_leaf_sets(new_node)
         self._update_evictable_leaf_sets(child)
@@ -1460,6 +1528,11 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             self.evictable_host_leaves.add(node)
         else:
             self.evictable_host_leaves.discard(node)
+
+    def _has_any_lock_ref(self, node: UnifiedTreeNode) -> bool:
+        return any(
+            cd.lock_ref > 0 or cd.host_lock_ref > 0 for cd in node.component_data
+        )
 
     def _evict_to_host(
         self, node: UnifiedTreeNode, tracker: Optional[dict[ComponentType, int]] = None

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2333,46 +2333,6 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(tree.swa_evictable_size(), 0)
         tree.sanity_check()
 
-    def test_swa_caps_prefix_when_window_child_deleted(self):
-        # A long internal SWA prefix can turn into a device leaf when its only
-        # child (the one-window suffix) is deleted. on_became_leaf must cap it
-        # to a window in place, just like at insert time — so a device leaf
-        # never holds more than a window of SWA.
-        if not self.cfg.has_swa:
-            self.skipTest("requires SWA component")
-        if self.cfg.has_mamba:
-            self.skipTest("SWA-only path keeps the split setup simple")
-
-        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
-        ps = self.cfg.page_size
-        retain_len = ((self.cfg.sliding_window_size + ps - 1) // ps) * ps
-        # Long sequence (> 2 windows): insert-time cap splits it into a long
-        # prefix parent + a one-window suffix leaf.
-        seq = self._make_seq(1, 2 * (retain_len // ps) + 2)
-        self._insert(tree, allocator, req_to_token_pool, seq)
-        prefix = next(iter(tree.root_node.children.values()))
-        window_leaf = next(iter(prefix.children.values()))
-        self.assertEqual(len(window_leaf.children), 0)
-        self.assertGreater(
-            len(prefix.component_data[ComponentType.SWA].value), retain_len
-        )
-
-        # Delete the window suffix leaf -> prefix would become a long leaf.
-        tracker = {ct: 0 for ct in tree.tree_components}
-        tree._evict_device_leaf(window_leaf, tracker)
-
-        # prefix was capped in place: it is now the one-window suffix leaf under
-        # a freshly split parent, not a long device leaf.
-        new_parent = next(iter(tree.root_node.children.values()))
-        capped_leaf = next(iter(new_parent.children.values()))
-        self.assertIs(capped_leaf, prefix)
-        self.assertEqual(len(capped_leaf.children), 0)
-        self.assertIn(capped_leaf, tree.evictable_device_leaves)
-        self.assertEqual(
-            len(capped_leaf.component_data[ComponentType.SWA].value), retain_len
-        )
-        tree.sanity_check()
-
     def test_evict_d_leaf_set_consistency(self):
         """evictable_device_leaves is consistent after mixed operations."""
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1659,6 +1659,108 @@ class UnifiedRadixCacheSuite:
                 )
                 tree.sanity_check()
 
+    def test_swa_compute_lock_caps_leaf_after_child_deleted(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only path keeps the split setup simple")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        ps = self.cfg.page_size
+        window = self.cfg.sliding_window_size
+        tail_size = ((window + ps - 1) // ps) * ps
+        tail_pages = tail_size // ps
+        seq = self._make_seq(1, 2 * tail_pages + 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+
+        prefix = next(iter(tree.root_node.children.values()))
+        window_leaf = next(iter(prefix.children.values()))
+        prefix_len = len(prefix.key)
+        self.assertGreater(
+            len(prefix.component_data[ComponentType.SWA].value), tail_size
+        )
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_device_leaf(window_leaf, tracker)
+        self.assertEqual(len(prefix.children), 0)
+
+        tree.prepare_swa_compute_lock(prefix)
+        self.assertEqual(len(prefix.component_data[ComponentType.SWA].value), tail_size)
+        self.assertIsNot(prefix.parent, tree.root_node)
+
+        lock_result = tree.inc_lock_ref(prefix)
+        self.assertEqual(tree.swa_protected_size(), tail_size)
+        self.assertEqual(tree.full_protected_size(), prefix_len)
+        tree.dec_lock_ref(prefix, lock_result.to_dec_params())
+        tree.sanity_check()
+
+    def test_swa_compute_lock_split_preserves_lru_position(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only path keeps the split setup simple")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        ps = self.cfg.page_size
+        window = self.cfg.sliding_window_size
+        tail_size = ((window + ps - 1) // ps) * ps
+        tail_pages = tail_size // ps
+        seq = self._make_seq(1, 2 * tail_pages + 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+
+        prefix = next(iter(tree.root_node.children.values()))
+        window_leaf = next(iter(prefix.children.values()))
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_device_leaf(window_leaf, tracker)
+
+        side_seq = self._make_seq(1000, tail_pages)
+        self._insert(tree, allocator, req_to_token_pool, side_seq)
+        pre = self._swa_lru_order(tree)
+        prefix_pos = pre.index(prefix)
+        original_last_access_time = prefix.last_access_time
+
+        tree.prepare_swa_compute_lock(prefix)
+
+        new_parent = prefix.parent
+        post = self._swa_lru_order(tree)
+        self.assertEqual(post[:prefix_pos], pre[:prefix_pos])
+        self.assertEqual(post[prefix_pos : prefix_pos + 2], [prefix, new_parent])
+        self.assertEqual(post[prefix_pos + 2 :], pre[prefix_pos + 1 :])
+        self.assertEqual(prefix.last_access_time, original_last_access_time)
+        self.assertEqual(new_parent.last_access_time, original_last_access_time)
+        tree.sanity_check()
+
+    def test_swa_compute_lock_caps_host_path_before_load_back(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only path keeps the split setup simple")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        ps = self.cfg.page_size
+        window = self.cfg.sliding_window_size
+        tail_size = ((window + ps - 1) // ps) * ps
+        tail_pages = tail_size // ps
+        seq = self._make_seq(1, 2 * tail_pages + 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+
+        host_node = next(iter(tree.root_node.children.values()))
+        swa_cd = host_node.component_data[ComponentType.SWA]
+        self.assertGreater(len(swa_cd.value), tail_size)
+
+        self._simulate_backup(tree, host_node)
+        self._set_aux_host_tombstone(tree, host_node, ComponentType.SWA)
+
+        tree.prepare_swa_compute_lock(host_node)
+        self.assertIsNone(swa_cd.value)
+        self.assertEqual(len(swa_cd.host_value), tail_size)
+        self.assertIsNot(host_node.parent, tree.root_node)
+        self.assertTrue(tree.host_lru_lists[ComponentType.SWA].in_list(host_node))
+        self.assertTrue(
+            tree.host_lru_lists[ComponentType.SWA].in_list(host_node.parent)
+        )
+        tree.sanity_check()
+
     def _swa_lru_order(self, tree):
         lru = tree.lru_lists[ComponentType.SWA]
         pt = lru._pt

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2333,6 +2333,46 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(tree.swa_evictable_size(), 0)
         tree.sanity_check()
 
+    def test_swa_caps_prefix_when_window_child_deleted(self):
+        # A long internal SWA prefix can turn into a device leaf when its only
+        # child (the one-window suffix) is deleted. on_became_leaf must cap it
+        # to a window in place, just like at insert time — so a device leaf
+        # never holds more than a window of SWA.
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only path keeps the split setup simple")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        ps = self.cfg.page_size
+        retain_len = ((self.cfg.sliding_window_size + ps - 1) // ps) * ps
+        # Long sequence (> 2 windows): insert-time cap splits it into a long
+        # prefix parent + a one-window suffix leaf.
+        seq = self._make_seq(1, 2 * (retain_len // ps) + 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        prefix = next(iter(tree.root_node.children.values()))
+        window_leaf = next(iter(prefix.children.values()))
+        self.assertEqual(len(window_leaf.children), 0)
+        self.assertGreater(
+            len(prefix.component_data[ComponentType.SWA].value), retain_len
+        )
+
+        # Delete the window suffix leaf -> prefix would become a long leaf.
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_device_leaf(window_leaf, tracker)
+
+        # prefix was capped in place: it is now the one-window suffix leaf under
+        # a freshly split parent, not a long device leaf.
+        new_parent = next(iter(tree.root_node.children.values()))
+        capped_leaf = next(iter(new_parent.children.values()))
+        self.assertIs(capped_leaf, prefix)
+        self.assertEqual(len(capped_leaf.children), 0)
+        self.assertIn(capped_leaf, tree.evictable_device_leaves)
+        self.assertEqual(
+            len(capped_leaf.component_data[ComponentType.SWA].value), retain_len
+        )
+        tree.sanity_check()
+
     def test_evict_d_leaf_set_consistency(self):
         """evictable_device_leaves is consistent after mixed operations."""
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)


### PR DESCRIPTION
## Summary
SWA only needs one sliding window while a request is locked for compute. Unified radix-cache lock accounting is node-granular, so a compute lock on a long SWA node can otherwise pin the entire node. Insert-time leaf splitting does not cover existing long nodes selected later as device or host-prefix lock endpoints.

## Fix
- Add a typed `prepare_swa_compute_lock` cache hook (default no-op) and override it for the unified hybrid-SWA cache.
- Split the exact device and host-prefix nodes that are about to become compute-lock endpoints at a page-aligned window boundary.
- Prepare host best-match nodes before temporary admission/load-back locks make structural splits unsafe.
- Prepare newly inserted prefix nodes before transferring the request compute lock.
- Preserve auxiliary device/host LRU placement and Full-cache recency when a compute-time split creates a new radix node.
- Keep `inc_lock_ref` unchanged, so short-lived IO/load-back locks remain pure lock accounting.
- Preserve Full-cache lock semantics: Full protects the complete matched prefix, while SWA protects only the required window.
- Leave nodes that already carry a device or host lock unchanged; this change does not migrate existing lock accounting.

## Benchmark
SemiAnalysis AgentX, HiCache disabled, `swa_full_tokens_ratio=0.015`.

Cache-hit results were not stable across fixed-request paired runs. The stable measurement is lower SWA retention: peak SWA token usage changed from `51% -> 40%` and `59% -> 42%` in the two live-response pairs, comparing to only insert cap.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28765025383](https://github.com/sgl-project/sglang/actions/runs/28765025383)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28765025242](https://github.com/sgl-project/sglang/actions/runs/28765025242)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
