### PR TITLE
Add zx3xyy to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1420,6 +1420,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "zx3xyy": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "zyksir": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Add `zx3xyy` to `.github/CI_PERMISSIONS.json` (sorted alphabetically) with:

- `can_tag_run_ci_label: true`
- `can_rerun_failed_ci: true`
- `can_rerun_stage: true`
- `cooldown_interval_minutes: 60`
- `reason: custom override`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26930168946](https://github.com/sgl-project/sglang/actions/runs/26930168946)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26930168798](https://github.com/sgl-project/sglang/actions/runs/26930168798)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->