### PR TITLE
[diffusion] Support Wan multi-output prompt conditioning

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -144,6 +144,41 @@ def pad_text_embeddings_with_mask(
     return TextConditioningOutput(prompt_embeds, prompt_embeds_mask, seq_lens)
 
 
+def expand_cond_to_batch(
+    cond: "list[torch.Tensor] | torch.Tensor | None",
+    target_batch_size: int,
+) -> "list[torch.Tensor] | torch.Tensor | None":
+    """Broadcast a conditioning tensor (or list/None) along the batch dim.
+
+    When ``num_outputs_per_prompt > 1`` the sample batch is expanded to
+    ``target_batch_size`` while the text-conditioning tensors still carry the
+    original per-prompt batch dim. This repeats each prompt's conditioning
+    ``target_batch_size // current`` times via ``repeat_interleave``, so row
+    ``p`` maps to output rows ``[p*k : (p+1)*k]`` -- matching how the latent
+    sample batch is expanded for multi-output generation.
+
+    No-op when the batch dim already equals ``target_batch_size`` (the common
+    ``num_outputs_per_prompt == 1`` case), in which case the input is returned
+    unchanged. Raises ``ValueError`` when the current batch size does not
+    divide ``target_batch_size``.
+    """
+    if cond is None:
+        return None
+    if isinstance(cond, list):
+        return [expand_cond_to_batch(t, target_batch_size) for t in cond]
+
+    current_batch_size = cond.shape[0]
+    if current_batch_size == target_batch_size:
+        return cond
+    if current_batch_size == 0 or target_batch_size % current_batch_size != 0:
+        raise ValueError(
+            f"conditioning batch size ({current_batch_size}) must divide "
+            f"target batch size ({target_batch_size})."
+        )
+    repeat_factor = target_batch_size // current_batch_size
+    return cond.repeat_interleave(repeat_factor, dim=0).contiguous()
+
+
 def shard_rotary_emb_for_sp(emb):
     """
     Shard rotary embeddings [S, D] along sequence for SP.
@@ -671,10 +706,10 @@ class PipelineConfig:
         return safetensors_list
 
     def get_pos_prompt_embeds(self, batch):
-        return batch.prompt_embeds
+        return expand_cond_to_batch(batch.prompt_embeds, batch.batch_size)
 
     def get_neg_prompt_embeds(self, batch):
-        return batch.negative_prompt_embeds
+        return expand_cond_to_batch(batch.negative_prompt_embeds, batch.batch_size)
 
     def post_denoising_loop(self, latents, batch):
         latents = maybe_unpad_latents(latents, batch)

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -88,6 +88,49 @@ class WanT2V480PConfig(PipelineConfig):
     vae_precision: str = "fp32"
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("fp32",))
 
+    @staticmethod
+    def _expand_cond_tensor_batch(
+        tensor: torch.Tensor, target_batch_size: int, cond_name: str
+    ) -> torch.Tensor:
+        current_batch_size = tensor.shape[0]
+        if current_batch_size == target_batch_size:
+            return tensor
+
+        if target_batch_size % current_batch_size != 0:
+            raise ValueError(
+                f"Wan expects `{cond_name}` batch size ({current_batch_size}) "
+                f"to divide target batch size ({target_batch_size})."
+            )
+
+        repeat_factor = target_batch_size // current_batch_size
+        return tensor.repeat_interleave(repeat_factor, dim=0).contiguous()
+
+    @classmethod
+    def _expand_cond_batch(
+        cls,
+        cond: list[torch.Tensor] | torch.Tensor | None,
+        batch,
+        cond_name: str,
+    ) -> list[torch.Tensor] | torch.Tensor | None:
+        if cond is None:
+            return None
+
+        target_batch_size = batch.batch_size
+        if isinstance(cond, list):
+            return [
+                cls._expand_cond_tensor_batch(tensor, target_batch_size, cond_name)
+                for tensor in cond
+            ]
+        return cls._expand_cond_tensor_batch(cond, target_batch_size, cond_name)
+
+    def get_pos_prompt_embeds(self, batch):
+        return self._expand_cond_batch(batch.prompt_embeds, batch, "prompt_embeds")
+
+    def get_neg_prompt_embeds(self, batch):
+        return self._expand_cond_batch(
+            batch.negative_prompt_embeds, batch, "negative_prompt_embeds"
+        )
+
     def __post_init__(self):
         self.vae_config.load_encoder = False
         self.vae_config.load_decoder = True

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -88,48 +88,9 @@ class WanT2V480PConfig(PipelineConfig):
     vae_precision: str = "fp32"
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("fp32",))
 
-    @staticmethod
-    def _expand_cond_tensor_batch(
-        tensor: torch.Tensor, target_batch_size: int, cond_name: str
-    ) -> torch.Tensor:
-        current_batch_size = tensor.shape[0]
-        if current_batch_size == target_batch_size:
-            return tensor
-
-        if target_batch_size % current_batch_size != 0:
-            raise ValueError(
-                f"Wan expects `{cond_name}` batch size ({current_batch_size}) "
-                f"to divide target batch size ({target_batch_size})."
-            )
-
-        repeat_factor = target_batch_size // current_batch_size
-        return tensor.repeat_interleave(repeat_factor, dim=0).contiguous()
-
-    @classmethod
-    def _expand_cond_batch(
-        cls,
-        cond: list[torch.Tensor] | torch.Tensor | None,
-        batch,
-        cond_name: str,
-    ) -> list[torch.Tensor] | torch.Tensor | None:
-        if cond is None:
-            return None
-
-        target_batch_size = batch.batch_size
-        if isinstance(cond, list):
-            return [
-                cls._expand_cond_tensor_batch(tensor, target_batch_size, cond_name)
-                for tensor in cond
-            ]
-        return cls._expand_cond_tensor_batch(cond, target_batch_size, cond_name)
-
-    def get_pos_prompt_embeds(self, batch):
-        return self._expand_cond_batch(batch.prompt_embeds, batch, "prompt_embeds")
-
-    def get_neg_prompt_embeds(self, batch):
-        return self._expand_cond_batch(
-            batch.negative_prompt_embeds, batch, "negative_prompt_embeds"
-        )
+    # Multi-output prompt conditioning (num_outputs_per_prompt > 1) is handled by
+    # the base-class `get_pos/neg_prompt_embeds`, which broadcast the conditioning
+    # batch via `expand_cond_to_batch`.
 
     def __post_init__(self):
         self.vae_config.load_encoder = False


### PR DESCRIPTION
## Motivation

Wan base generation fails when `num_outputs_per_prompt > 1`.

For multi-output generation the sample/latent batch is expanded to
`batch.batch_size` (`= n_prompts * num_outputs_per_prompt`), while the text
conditioning tensors keep their original per-prompt batch dim of `1`. A single
prompt can therefore not drive `N` generations, and denoising hits a batch-size
mismatch.

This is **not** Wan-specific — any model that inherits the default
`get_pos/neg_prompt_embeds` has the same gap. Per the review comment ("could we
make this general for all models"), the fix is generalized into the base class
rather than duplicated per model.

## Modifications

- Add a module-level helper `expand_cond_to_batch(cond, target_batch_size)` in
  `pipeline_configs/base.py` (next to the other conditioning utilities). It
  broadcasts a `Tensor | list[Tensor] | None` along the batch dim via
  `repeat_interleave`, no-ops when the batch dim already matches, and raises a
  clear `ValueError` when the current size does not divide the target.
- `PipelineConfig.get_pos_prompt_embeds` / `get_neg_prompt_embeds` now call it.
- Remove the per-model copy of this logic from `WanT2V480PConfig`; it now
  inherits the base behaviour.

## Why this is safe and correct

**1. No change to any model's existing behaviour.**
`batch.batch_size = n_prompts * num_outputs_per_prompt` and
`prompt_embeds.shape[0] == n_prompts`, so for `num_outputs_per_prompt == 1` the
current batch already equals the target and the input is returned **unchanged**
(identity). Single-output generation is byte-identical before/after.

**2. Models overriding these methods are untouched.**
`flux` / `sana` / `stablediffusion3` / `ltx_2` / `zimage` override
`get_pos/neg_prompt_embeds` and none call `super()`, so they keep their exact
current behaviour.

**3. Randomness is preserved for RL rollout.**
Only the prompt conditioning is broadcast (the same prompt drives all `N`
samples — correct). The per-sample diversity comes from the latent noise, which
is sampled at full `[batch_size, …]` and is untouched by this change.
`repeat_interleave` keeps each prompt's conditioning aligned with its latent
rows (`p -> [p*k:(p+1)*k]`).

## Limitations (out of scope)

- The base helper broadcasts **prompt embeds only**. Models that feed extra
  per-batch conditioning (e.g. Qwen-Image's attention mask / `txt_seq_lens`)
  need to broadcast those too; they can reuse `expand_cond_to_batch`. Not
  changed here, and not regressed.
- Models that override `get_pos/neg_prompt_embeds` don't gain multi-output
  support from this PR; each would call `expand_cond_to_batch` after selecting
  its encoder index.
- The multi-request *grouped* execution path (used by the `sglang generate` CLI
  when it splits `num_outputs` into separate seeded requests) has a separate,
  pre-existing infra gap unrelated to conditioning; that is tracked elsewhere.

## Tests

- Equivalence on the real `WanT2V480PConfig`: refactored
  `get_pos/neg_prompt_embeds` is byte-identical to the previous Wan override for
  `batch_size ∈ {1, 2, 4}`; `bs==1` returns the same object (identity); `bs==N`
  broadcasts with correct `repeat_interleave` order.
- Wan rollout path (single request, `batch_size=2`,
  `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, 1 GPU): denoising runs with the broadcast
  conditioning and **no longer hits the batch-size mismatch** (the original
  failure). Per-sample randomness is unaffected — latent noise is sampled at
  full `[batch_size, …]` (verified row-wise distinct) and is independent of the
  conditioning broadcast.