### PR TITLE
[Bug Fix] Fix NPU pools get_cpu_copy/load_cpu_copy missing mamba_indices param

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -221,7 +221,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
     # NPUMHATokenToKVPool stores buffers as
     #   (num_pages, page_size, head_num, head_dim)            # use_fia=False
     #   (num_pages*page_size, 1, head_num, head_dim)          # use_fia=True
-    def get_cpu_copy(self, indices):
+    def get_cpu_copy(self, indices, mamba_indices=None):
         torch.npu.synchronize()
         buf_of_layers = []
         for local_layer_id in range(self.layer_num):
@@ -236,7 +236,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
         torch.npu.synchronize()
         return kv_cache_cpu
 
-    def load_cpu_copy(self, kv_cache_cpu, indices):
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
         torch.npu.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         for local_layer_id in range(self.layer_num):
@@ -480,7 +480,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
             out.append(layer_chunks)
         return out
 
-    def get_cpu_copy(self, indices):
+    def get_cpu_copy(self, indices, mamba_indices=None):
         torch.npu.synchronize()
         buf_of_layers = []
         has_ik = self.index_head_dim is not None
@@ -498,7 +498,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
         torch.npu.synchronize()
         return kv_cache_cpu
 
-    def load_cpu_copy(self, kv_cache_cpu, indices):
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
         torch.npu.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         has_ik = self.index_head_dim is not None


### PR DESCRIPTION
## Motivation

`NPUMHATokenToKVPool` and `NPUMLATokenToKVPool` override `get_cpu_copy` / `load_cpu_copy` with the signature `(self, indices)`, but the paged/token allocator unconditionally forwards `mamba_indices=mamba_indices` (even when `None`) to the underlying pool:

```python
# mem_cache/allocator/paged.py
def get_cpu_copy(self, indices, mamba_indices=None):
    return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
```

As a result, offloading the KV cache during retraction on NPU raises:

```
TypeError: get_cpu_copy() got an unexpected keyword argument 'mamba_indices'
```

This was introduced when the allocator changed from `**kwargs` forwarding to an explicit, unconditional `mamba_indices=` keyword. The base `KVCache` and the CUDA pools already accept `mamba_indices=None`; the NPU overrides were missed.

## Modifications

Align the NPU `get_cpu_copy` / `load_cpu_copy` overrides with the base signature by accepting `mamba_indices=None`. These pools carry no mamba state, so the argument is accepted and ignored.

This mirrors the NSA/DSA fix in #25833 for the same allocator change.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26933491378](https://github.com/sgl-project/sglang/actions/runs/26933491378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26933491308](https://github.com/sgl-project/sglang/actions/runs/26933491308)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->