### PR TITLE
[AMD][CI] Remove per-job transformers pin from GLM-5.x nightly jobs

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -253,7 +253,6 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test MI35x ROCm 7.2 (2-GPU GLM-5.1-MXFP4 GSM8K)
         timeout-minutes: 120
@@ -1559,7 +1558,6 @@ jobs:
       - name: Install dependencies
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test ROCm 7.2 (8-GPU GLM-5.1 DSA)
         timeout-minutes: 120
@@ -1606,7 +1604,6 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test MI35x ROCm 7.2 (8-GPU GLM-5.1 DSA)
         timeout-minutes: 180
@@ -1656,7 +1653,6 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test MI35x ROCm 7.2 (8-GPU GLM-5-MXFP4)
         timeout-minutes: 180

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -255,7 +255,6 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test MI35x (2-GPU GLM-5.1-MXFP4 GSM8K)
         timeout-minutes: 120
@@ -1490,7 +1489,6 @@ jobs:
       - name: Install dependencies
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test (8-GPU GLM-5.1 DSA)
         timeout-minutes: 120
@@ -1537,7 +1535,6 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test MI35x (8-GPU GLM-5.1 DSA)
         timeout-minutes: 180
@@ -1587,7 +1584,6 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
 
       - name: Accuracy Test MI35x (8-GPU GLM-5-MXFP4)
         timeout-minutes: 180


### PR DESCRIPTION
## Motivation

The GLM-5.x AMD nightly jobs were the **only** jobs that pinned `transformers` to a specific old commit (`96f807a33b75`, ~`5.4.0.dev0`), downgrading from the image's default `transformers`. This per-job version skew is an anti-pattern, and it had a concrete cost:

Because these were the only jobs running on an old `transformers` (where `PreTrainedConfig` is not yet a dataclass), they were the **only** jobs to hit the import-time `StrictDataclassDefinitionError` from the `@strict Cohere2MoeConfig` added in #26106 — every non-GLM nightly job (on the image-default `transformers`, where `PreTrainedConfig` is a dataclass) imported fine. The GLM matrix was collateral damage purely because of this pin.

Verified that GLM-5.1 no longer needs the downgrade: with the pin removed, the GLM-5.1-MXFP4 GSM8K accuracy job passes on the image-default `transformers` on both ROCm 7 and ROCm 7.2.

## Modifications

Remove the `pip install git+https://github.com/huggingface/transformers.git@96f807a33b75` step from all 8 GLM-5.x jobs in:
- `.github/workflows/nightly-test-amd.yml`
- `.github/workflows/nightly-test-amd-rocm720.yml`

No other changes; the jobs now use the image-default `transformers` like every other model in the matrix.

## Accuracy / Test results

Dispatched the GLM-5.1-MXFP4 job on this branch (pin removed) with `continue_on_error=false` so the result is a real pass/fail:

| Lane | Job | Run | Result |
|---|---|---|---|
| ROCm 7 | `nightly-2-gpu-mi35x-glm51-mxfp4` | https://github.com/sgl-project/sglang/actions/runs/26932118585 | ✅ success |
| ROCm 7.2 | `nightly-2-gpu-mi35x-glm51-mxfp4-rocm720` | https://github.com/sgl-project/sglang/actions/runs/26932119590 | ✅ success |

The sibling GLM jobs (`nightly-8-gpu-glm51`, `nightly-8-gpu-mi35x-glm51`, `nightly-8-gpu-mi35x-glm5-mxfp4`, and their `-rocm720` counterparts) get the identical change and the same default `transformers`.

> Note: the underlying `@strict Cohere2MoeConfig` import crash from #26106 is being addressed separately in `python/sglang/srt/configs/cohere2_moe.py`; this PR independently removes the version skew that singled out the GLM matrix.

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26933837304](https://github.com/sgl-project/sglang/actions/runs/26933837304)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26933837185](https://github.com/sgl-project/sglang/actions/runs/26933837185)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->