### PR TITLE
[Fix] phi3_small: use getattr for tie_word_embeddings to support transformers v5

### DIFF
--- a/python/sglang/srt/models/phi3_small.py
+++ b/python/sglang/srt/models/phi3_small.py
@@ -387,7 +387,7 @@ class Phi3SmallForCausalLM(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("lm_head", prefix),
         )
-        if self.config.tie_word_embeddings:
+        if getattr(self.config, "tie_word_embeddings", True):
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(config)
         self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
@@ -465,7 +465,7 @@ class Phi3SmallForCausalLM(nn.Module):
                 continue
             if name.endswith(".bias") and name not in params_dict:
                 continue
-            if self.config.tie_word_embeddings and "lm_head.weight" in name:
+            if getattr(self.config, "tie_word_embeddings", True) and "lm_head.weight" in name:
                 continue
 
             param = params_dict[name]


### PR DESCRIPTION
## Motivation

`Phi3SmallForCausalLM` fails to start with transformers v5:

```
AttributeError: 'Phi3SmallConfig' object has no attribute 'tie_word_embeddings'
```

Transformers v5 removed the implicit `tie_word_embeddings = False` default from `PretrainedConfig`. Direct attribute access (`self.config.tie_word_embeddings`) now raises `AttributeError` for configs that don't declare this field.

## Modifications

Replace bare attribute access with `getattr(..., True)` at both usage sites in `Phi3SmallForCausalLM`:

- `__init__`: weight tying conditional
- `load_weights`: skip `lm_head.weight` from checkpoint when tied

Default is `True` because the Phi-3-small checkpoint stores only `model.embed_tokens.weight` (no separate `lm_head.weight`), matching the model's `_tied_weights_keys = ["lm_head.weight"]` declaration. Using `False` leaves `lm_head` uninitialized, giving 0% accuracy.

## Accuracy Tests

- `microsoft/Phi-3-small-8k-instruct` — gsm8k, 4 examples,  `getattr(..., True)`: **exact_match = 1.0** ✅
- `microsoft/Phi-3-small-8k-instruct` — gsm8k, 4 examples,  `getattr(..., False)`: exact_match = 0.0 ❌

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26935216583](https://github.com/sgl-project/sglang/actions/runs/26935216583)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26935216472](https://github.com/sgl-project/sglang/actions/runs/26935216472)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->