### PR TITLE
[diffusion] Speed up lossless realtime RGB transport

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/realtime_video.py
+++ b/python/sglang/multimodal_gen/runtime/utils/realtime_video.py
@@ -27,6 +27,7 @@ WEBP_FRAME_CONTENT_TYPE = "image/webp"
 JPEG_FRAME_CONTENT_TYPE = "image/jpeg"
 RAW_RGB_CHANNELS = 3
 RAW_RGBA_CHANNELS = 4
+_RAW_RGB_DELTA_GZIP_LEVEL = 0
 
 
 def build_delta_gzip_raw_rgb_payload(
@@ -46,7 +47,10 @@ def build_delta_gzip_raw_rgb_payload(
         if reference_frame is not None
         else None
     )
-    compressor = zlib.compressobj(level=1, method=zlib.DEFLATED, wbits=31)
+    # keep gzip framing for lossless transport without spending realtime budget on compression
+    compressor = zlib.compressobj(
+        level=_RAW_RGB_DELTA_GZIP_LEVEL, method=zlib.DEFLATED, wbits=31
+    )
     compressed_chunks = []
     for frame in frames:
         if len(frame) != frame_size:


### PR DESCRIPTION
## Summary

- use store-only gzip for realtime raw RGB delta transport while keeping the same delta-gzip wire format and exact frame reconstruction
- avoid spending realtime CPU budget compressing already lossless frame payloads

## Measurements

Same 4x H200 environment, `robbyant/lingbot-world-fast-diffusers`, Plastic Beach realtime case, 4 chunks:

- steady chunks 1-3 `chunk_total` sum: 2596 ms -> 2015 ms, 22.4% faster
- `raw_payload_build` per steady chunk: about 254/213/212 ms -> 21/20/19 ms
- `scheduler_forward` sum: 1899 ms -> 1902 ms, unchanged
- payload per 12-frame chunk: about 6.8-8.3 MiB -> 13.7 MiB, still under the existing 16 MiB realtime payload guard

## Correctness

- `python3 -m pytest -q python/sglang/multimodal_gen/test/unit/realtime/test_realtime_output_transport.py -k "delta_gzip or lossless_compressed or previous_frame_reference"`: 3 passed
- `python3 python/sglang/multimodal_gen/test/run_suite.py --suite 1-gpu --total-partitions 2 --partition-id 0 -k lingbot_world_realtime_plastic_beach`: 1 passed; CLIP/SSIM 1.0000, PSNR inf, mean_abs_diff 0.0000













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26935446660](https://github.com/sgl-project/sglang/actions/runs/26935446660)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26935456352](https://github.com/sgl-project/sglang/actions/runs/26935456352)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->