### PR TITLE
[Fix] lightonocr: extract rope_theta from rope_parameters for transformers v5

### DIFF
--- a/python/sglang/srt/models/lightonocr.py
+++ b/python/sglang/srt/models/lightonocr.py
@@ -82,10 +82,13 @@ class LightOnOCRForConditionalGeneration(nn.Module):
 
         # Build VisionEncoderArgs from config
         vision_config = config.vision_config
+        config_dict = vision_config.to_dict()
+        if config_dict.get("rope_parameters"):  # transformers v5 compatibility
+            config_dict["rope_theta"] = config_dict["rope_parameters"].get("rope_theta")
         dataclass_fields = {field.name for field in fields(VisionEncoderArgs)}
         vision_args = {
             key: value
-            for key, value in vision_config.to_dict().items()
+            for key, value in config_dict.items()
             if key in dataclass_fields
         }
         # LightOnOCR stores these at the top-level config


### PR DESCRIPTION
## Motivation

`LightOnOCRForConditionalGeneration` fails to start with transformers v5:

```
TypeError: VisionEncoderArgs.__init__() missing 1 required positional argument: 'rope_theta'
```

In transformers v5, `PixtralVisionConfig` moved `rope_theta` from a flat field into a nested dict:
- v4: `rope_theta: 10000`
- v5: `rope_parameters: {'rope_theta': 10000, 'rope_type': 'default'}`

`lightonocr.py` builds `VisionEncoderArgs` by filtering `vision_config.to_dict()` for known dataclass fields. With v5, `rope_theta` no longer appears as a top-level key, so `VisionEncoderArgs(**vision_args)` raises `TypeError`.

## Modifications

Extract `rope_theta` from `rope_parameters` before filtering, following the same pattern already used in `pixtral.py`:

```python
config_dict = vision_config.to_dict()
if config_dict.get("rope_parameters"):  # transformers v5 compatibility
    config_dict["rope_theta"] = config_dict["rope_parameters"].get("rope_theta")
```

## Accuracy Tests

- `lightonai/LightOnOCR-1B-1025` — server starts and processes requests cleanly

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26935959696](https://github.com/sgl-project/sglang/actions/runs/26935959696)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26935959568](https://github.com/sgl-project/sglang/actions/runs/26935959568)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->