### PR TITLE
[NPU][EPLB][Fix] Support `--init-expert-location` and pass a .pt hot_map file as input on NPU

### DIFF
--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -600,15 +600,23 @@ def compute_initial_expert_location_metadata(
             # Because pickle serialization embeds NPU-specific deserialization functions, PyTorch's weights_only=True
             # will also reject unknown torch_npu.* global objects due to its security whitelist mechanism during deserialization. 
             # Therefore, modifying the registered safe globals is necessary.
-            import torch_npu.utils.storage
             import torch_npu.npu._format
+            import torch_npu.utils.storage
+
             # Ref: https://docs.pytorch.org/docs/2.12/notes/serialization.html#weights-only-allowlist
             # Context-manager that adds certain globals as safe for weights_only load.
-            with torch.serialization.safe_globals([
-                torch_npu.utils.storage._rebuild_npu_tensor,
-                torch_npu.npu._format.Format,
-            ]):
-                data_dict = torch.load(data, weights_only=True)
+            if hasattr(torch.serialization, "safe_globals"):
+                # This context manager torch.serialization.safe_globals was introduced in PyTorch 2.4
+                with torch.serialization.safe_globals(
+                    [
+                        torch_npu.utils.storage._rebuild_npu_tensor,
+                        torch_npu.npu._format.Format,
+                    ]
+                ):
+                    data_dict = torch.load(data, weights_only=True)
+            else:
+                # Fallback to weights_only=False if it is older PyTorch versions
+                data_dict = torch.load(data, weights_only=False)
     elif data.endswith(".json"):
         data_dict = json.loads(Path(data).read_text())
     else:

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -25,6 +25,7 @@ import torch
 import torch.distributed
 import torch.nn.functional as F
 
+from sglang.srt.utils import is_npu
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.server_args import ServerArgs
@@ -593,7 +594,21 @@ def compute_initial_expert_location_metadata(
 
     # TODO unify with the utils function
     if data.endswith(".pt"):
-        data_dict = torch.load(data, weights_only=True)
+        if not is_npu():
+            data_dict = torch.load(data, weights_only=True)
+        else:
+            # Because pickle serialization embeds NPU-specific deserialization functions, PyTorch's weights_only=True
+            # will also reject unknown torch_npu.* global objects due to its security whitelist mechanism during deserialization. 
+            # Therefore, modifying the registered safe globals is necessary.
+            import torch_npu.utils.storage
+            import torch_npu.npu._format
+            # Ref: https://docs.pytorch.org/docs/2.12/notes/serialization.html#weights-only-allowlist
+            # Context-manager that adds certain globals as safe for weights_only load.
+            with torch.serialization.safe_globals([
+                torch_npu.utils.storage._rebuild_npu_tensor,
+                torch_npu.npu._format.Format,
+            ]):
+                data_dict = torch.load(data, weights_only=True)
     elif data.endswith(".json"):
         data_dict = json.loads(Path(data).read_text())
     else:

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -26,6 +26,7 @@ import torch.distributed
 import torch.nn.functional as F
 
 from sglang.srt.utils import is_npu
+
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.server_args import ServerArgs
@@ -598,7 +599,7 @@ def compute_initial_expert_location_metadata(
             data_dict = torch.load(data, weights_only=True)
         else:
             # Because pickle serialization embeds NPU-specific deserialization functions, PyTorch's weights_only=True
-            # will also reject unknown torch_npu.* global objects due to its security whitelist mechanism during deserialization. 
+            # will also reject unknown torch_npu.* global objects due to its security whitelist mechanism during deserialization.
             # Therefore, modifying the registered safe globals is necessary.
             import torch_npu.npu._format
             import torch_npu.utils.storage


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Support SGLang on NPU platforms to enable `--init-expert-location` and pass a `.pt` hot_map file as input.
Fix issue: [https://github.com/Ascend/sglang/issues/623](https://github.com/Ascend/sglang/issues/623)

## Modifications

In NPU environments, pickle serialization embeds NPU-specific deserialization functions. During deserialization, `torch.load(data, weights_only=True)` rejects unknown `torch_npu.*` global objects due to its security whitelist mechanism, resulting in a `_pickle.UnpicklingError`. Therefore, for the NPU platform, before deserializing `.pt` hot_map files, the context manager `torch.serialization.safe_globals` is used to allow the necessary global functions `torch_npu.utils.storage._rebuild_npu_tensor` and `torch_npu.npu._format.Format`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26940420153](https://github.com/sgl-project/sglang/actions/runs/26940420153)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26940419363](https://github.com/sgl-project/sglang/actions/runs/26940419363)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->