### PR TITLE
[Fix] Fix DSV4 DP attention incorrect output in MoE scatter path

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1436,6 +1436,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                 hidden_states,
             )
             if _use_dp_reduce_scatterv:
+                hidden_states.fill_(0)
                 get_tp_group().reduce_scatterv(
                     global_hidden_states,
                     output=hidden_states,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -59,6 +59,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_dp_size,
     get_attention_tp_rank,
     get_attention_tp_size,
+    get_dp_global_num_tokens,
     get_global_dp_buffer,
     get_local_dp_buffer,
     is_dp_attention_enabled,
@@ -67,7 +68,7 @@ from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.mhc import mhc_fused_post_pre
-from sglang.srt.layers.moe import get_moe_a2a_backend
+from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
@@ -1390,6 +1391,9 @@ class DeepseekV4DecoderLayer(nn.Module):
             and get_attention_dp_size() > 1
             and get_moe_a2a_backend().is_none()
         )
+        _use_dp_reduce_scatterv = (
+            _use_tp_moe_gather and should_use_dp_reduce_scatterv()
+        )
         _use_tp_attn_a2a_scatter = (
             not _use_cp
             and envs.SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER.get()
@@ -1431,7 +1435,14 @@ class DeepseekV4DecoderLayer(nn.Module):
                 get_local_dp_buffer(get_tp_group()),
                 hidden_states,
             )
-            dp_scatter(hidden_states, global_hidden_states, forward_batch)
+            if _use_dp_reduce_scatterv:
+                get_tp_group().reduce_scatterv(
+                    global_hidden_states,
+                    output=hidden_states,
+                    sizes=get_dp_global_num_tokens(),
+                )
+            else:
+                dp_scatter(hidden_states, global_hidden_states, forward_batch)
         if _use_tp_attn_a2a_scatter:
             assert _a2a_scatter_chunks is not None
             gathered = [torch.empty_like(t) for t in _a2a_scatter_chunks]


### PR DESCRIPTION
## Summary
- Fix incorrect output when using DP attention with DeepSeek V4 in the MoE scatter path
- Use `reduce_scatterv` instead of `dp_scatter` when `should_use_dp_reduce_scatterv()` is true, ensuring correct token distribution across DP ranks

## Problem
When DP attention is enabled with DeepSeek V4, the MoE scatter path unconditionally used `dp_scatter`, which doesn't handle the reduce+scatter semantics needed for TP MoE gather scenarios, resulting in incorrect output.

## Test plan
- [x] Verified correct output with DeepSeek V4 + DP attention (8 GPU, DP=2, TP=4)
- [x] No regression with DP attention disabled



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26938895586](https://github.com/sgl-project/sglang/actions/runs/26938895586)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #26938895263](https://github.com/sgl-project/sglang/actions/runs/26938895263)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->