### PR TITLE
[AMD] Guard aiter greedy_sample OOB token id (fixes VLM MMMU CI)

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -46,6 +46,13 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
 if _use_aiter:
     from aiter import greedy_sample as _aiter_greedy_sample
 
+# The aiter greedy_sample kernel can return an out-of-range token id (== vocab_size,
+# e.g. 151666 for MiniCPM-V) for all-NaN / all -inf logit rows on ROCm, which decodes
+# to an empty string and breaks downstream consumers. Set this to 1 to fall back to
+# torch.argmax (which always returns a valid index). Default off so behavior is
+# unchanged elsewhere.
+_disable_aiter_greedy_sample = get_bool_env_var("SGLANG_DISABLE_AITER_GREEDY_SAMPLE")
+
 if is_npu():
     import torch_npu
 
@@ -110,7 +117,7 @@ class Sampler(nn.Module):
         logits = self._preprocess_logits(logits, sampling_info)
 
         if sampling_info.is_all_greedy:
-            if _use_aiter:
+            if _use_aiter and not _disable_aiter_greedy_sample:
                 batch_next_token_ids = torch.empty(
                     logits.shape[0], device=logits.device, dtype=torch.int32
                 )

--- a/test/registered/models/test_vlm_models.py
+++ b/test/registered/models/test_vlm_models.py
@@ -8,7 +8,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.mmmu_vlm_kit import (
     MMMUMultiModelTestBase,
 )
-from sglang.test.test_utils import is_in_ci
+from sglang.test.test_utils import is_in_amd_ci, is_in_ci
 
 # VLM (Vision Language Model) tests
 
@@ -41,7 +41,14 @@ class TestVLMModels(MMMUMultiModelTestBase):
             with tempfile.TemporaryDirectory(
                 prefix=f"test_vlm_mmmu_{model.model.replace('/', '_')}_"
             ) as temp_dir:
-                self._run_vlm_mmmu_test(model, temp_dir)
+                # On AMD CI, the aiter greedy_sample kernel returns an out-of-range
+                # token id (== vocab_size) for degenerate (all-NaN / all -inf) logit
+                # rows, producing empty completions that crash the MMMU eval. Disable
+                # it there so greedy sampling falls back to torch.argmax.
+                custom_env = None
+                if is_in_amd_ci():
+                    custom_env = {"SGLANG_DISABLE_AITER_GREEDY_SAMPLE": "1"}
+                self._run_vlm_mmmu_test(model, temp_dir, custom_env=custom_env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Motivation
On AMD CI, test/registered/models/test_vlm_models.py::test_vlm_mmmu_benchmark (MiniCPM-V-2.6, MMMU) intermittently fails with lmms-eval "IndexError: list index out of range" ("No JSON result files found").
Root cause: the aiter greedy_sample kernel - used for greedy decoding when SGLANG_USE_AITER=1 on HIP (introduced in #26383) - returns an out-of-range token id equal to vocab_size (151666 for MiniCPM-V-2.6, whose valid ids are
0-151665) for any logits row that has no valid finite maximum, i.e. an all-NaN or all -inf row. 
torch.argmax returns a valid index (0) for the same rows.
151666 is not a real token, so it decodes to an empty string -> the OpenAI-compatible server returns content=None -> lmms-eval's take_first filter does r[0] on an empty list -> IndexError -> no result JSON -> the test fails.
When it happens (all must hold):
1. ROCm/HIP with SGLANG_USE_AITER=1 (i.e. AMD CI), so the aiter greedy path is active.
2. Greedy sampling (temperature 0), which MMMU uses.
3. At least one request whose final logits row is degenerate (all NaN or all -inf).

On the affected build this happens for ~8% of MMMU inputs.  With torch.argmax such rows still yield a valid (if wrong) token, so the eval survives; only the aiter kernel turns them into a hard out-of-vocab failure.
Isolated repro (aiter vs torch), V = vocab_size = 151666:
```
    import torch, aiter
    V = 151666
    g = torch.randn(8, V, device="cuda")
    g[1, :] = float("nan")    # all-NaN row
    g[3, :] = float("-inf")   # all -inf row
    out = torch.empty(8, device="cuda", dtype=torch.int32)
    aiter.greedy_sample(out, g)
    # out[1] == 151666 (OOB), out[3] == 151666 (OOB)   <-- bug
    # torch.argmax(g, -1)[1] == 0, [3] == 0            <-- correct
```
## Modifications
- sampler.py: add SGLANG_DISABLE_AITER_GREEDY_SAMPLE (default off -> no behavior
  change anywhere). When set, the greedy path falls back to torch.argmax, which
  is correct (logits are already sliced to vocab_size) at negligible cost.
- test/registered/models/test_vlm_models.py: set that env var for the MMMU VLM
  test only on AMD CI via is_in_amd_ci().

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26938510378](https://github.com/sgl-project/sglang/actions/runs/26938510378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26938522468](https://github.com/sgl-project/sglang/actions/runs/26938522468)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->