### PR TITLE
fix: preserve background flag when slicing requests

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -716,6 +716,7 @@ class GenerateReqInput(BaseReq):
             return_bytes=self.return_bytes,
             return_entropy=self.return_entropy,
             return_prompt_token_ids=self.return_prompt_token_ids,
+            background=self.background,
             external_trace_header=self.external_trace_header,
             http_worker_ipc=self.http_worker_ipc,
             received_time=self.received_time,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -552,6 +552,19 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertTrue(req[0].return_prompt_token_ids)
         self.assertTrue(req[1].return_prompt_token_ids)
 
+    def test_getitem_preserves_background(self):
+        """Batch subrequests must keep the background response flag."""
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            background=True,
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertTrue(req[0].background)
+        self.assertTrue(req[1].background)
+
     def test_regenerate_rid(self):
         """Test the regenerate_rid method."""
         req = GenerateReqInput(text="Hello")


### PR DESCRIPTION
Fixes #27231.

## Summary
- keep the request-level `background` flag when `GenerateReqInput.__getitem__` slices an `n > 1` batch into per-sample requests
- add a regression test so Responses API background jobs do not silently fall back to foreground disconnect handling after slicing

## To verify
- `python -m py_compile python\sglang\srt\managers\io_struct.py test\registered\unit\managers\test_io_struct.py`
- `python -m ruff check python\sglang\srt\managers\io_struct.py test\registered\unit\managers\test_io_struct.py`
- `git diff --check`

I also attempted the targeted pytest on Windows:

`PYTHONPATH=python python -m pytest test\registered\unit\managers\test_io_struct.py::TestGenerateReqInputNormalization::test_getitem_preserves_background -q`

That collection is blocked locally by Linux/GPU-oriented imports (`resource`, then `triton`).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26940118880](https://github.com/sgl-project/sglang/actions/runs/26940118880)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26940118634](https://github.com/sgl-project/sglang/actions/runs/26940118634)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->