### PR TITLE
fix: slice session params per request item

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -680,7 +680,11 @@ class GenerateReqInput(BaseReq):
             routed_experts_start_len=self.routed_experts_start_len,
             return_indexer_topk=self.return_indexer_topk,
             modalities=self.modalities[i] if self.modalities else None,
-            session_params=self.session_params,
+            session_params=(
+                self.session_params[i % len(self.session_params)]
+                if isinstance(self.session_params, list)
+                else self.session_params
+            ),
             lora_path=self.lora_path[i] if self.lora_path is not None else None,
             lora_id=self.lora_id[i] if self.lora_id is not None else None,
             custom_logit_processor=(

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -500,6 +500,46 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req.session_params, [{"id": "session1"}, {"id": "session2"}])
 
+    def test_getitem_slices_list_session_params(self):
+        """Batch subrequests should receive only their own session params."""
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            session_params=[{"id": "session1"}, {"id": "session2"}],
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].session_params, {"id": "session1"})
+        self.assertEqual(req[1].session_params, {"id": "session2"})
+
+    def test_getitem_slices_list_session_params_after_parallel_expand(self):
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params={"n": 2},
+            rid=["id1", "id2"],
+            session_params=[{"id": "session1"}, {"id": "session2"}],
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].session_params, {"id": "session1"})
+        self.assertEqual(req[1].session_params, {"id": "session2"})
+        self.assertEqual(req[2].session_params, {"id": "session1"})
+        self.assertEqual(req[3].session_params, {"id": "session2"})
+
+    def test_getitem_keeps_dict_session_params(self):
+        """A dict session_params value is request-scoped and shared."""
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            session_params={"id": "session1", "offset": 10},
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].session_params, {"id": "session1", "offset": 10})
+        self.assertEqual(req[1].session_params, {"id": "session1", "offset": 10})
+
     def test_getitem_method(self):
         """Test the __getitem__ method."""
         req = GenerateReqInput(


### PR DESCRIPTION
Fixes #27218.

## Summary
- slice list-valued `session_params` in `GenerateReqInput.__getitem__` so each sub-request receives its own dict
- keep dict-valued `session_params` shared as the existing request-scoped form
- add regression coverage for both list and dict forms

## To verify
- `python -m py_compile python\sglang\srt\managers\io_struct.py test\registered\unit\managers\test_io_struct.py`
- `python -m ruff check python\sglang\srt\managers\io_struct.py test\registered\unit\managers\test_io_struct.py`
- `git diff --check`

The targeted pytest for `test_io_struct.py` is blocked in this Windows checkout by Linux/GPU-oriented imports (`resource`, then `triton`) during collection.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26950178868](https://github.com/sgl-project/sglang/actions/runs/26950178868)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26950178471](https://github.com/sgl-project/sglang/actions/runs/26950178471)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->