### PR TITLE
[HiSparse  PD & PP]Fix HiSparse compatibility with PP decode

### DIFF
--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1392,6 +1392,9 @@ class SchedulerPPMixin:
             released_reqs = self.disagg_decode_transfer_queue.pop_transferred(
                 release_rids
             )
+            if self.enable_hisparse:
+                for req in released_reqs:
+                    self.hisparse_coordinator.admit_request_direct(req)
             self.waiting_queue.extend(released_reqs)
             return [req.rid for req in released_reqs]
         return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In the non-PP decode path, after KV transfer finishes, each request is passed through hisparse_coordinator.admit_request_direct(req) before entering waiting_queue. This initializes the HiSparse device buffer metadata required by decode-time swap-in.

The PP decode path uses a separate release flow in process_decode_transfer_queue(). It popped transferred requests and moved them directly to waiting_queue, but skipped admit_request_direct(req). As a result, requests could start decode with host KV ready but without initialized HiSparse device buffer metadata.

This breaks HiSparse swap-in under enable_hisparse + direct-to-host + decode pp_size > 1. In practice, GPU cache usage stayed at the baseline reserved amount instead of growing with active requests, which caused incorrect outputs.

The fix makes the PP release path match the non-PP path by calling admit_request_direct(req) before adding released requests to waiting_queue.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
Config:
Mooncake + DSV4 HiSparse
Prefill: tp=2, pp=2
Decode:  tp=2, pp=2
GSM8K: 200 questions, 20-shot
CUDA graph: enabled

Before fix:
Score: 0.715

After fix:
Score: 0.965

```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26940220748](https://github.com/sgl-project/sglang/actions/runs/26940220748)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26940220742](https://github.com/sgl-project/sglang/actions/runs/26940220742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->