### PR TITLE
fix: preserve multimodal controls when slicing requests

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -646,6 +646,25 @@ class GenerateReqInput(BaseReq):
             return self.positional_embed_overrides
         return self.positional_embed_overrides[i]
 
+    def _get_mm_hashes_item(self, i: int):
+        if self.mm_hashes is None:
+            return None
+        if not self.mm_hashes:
+            return self.mm_hashes
+        if isinstance(self.mm_hashes[0], list):
+            return self.mm_hashes[i]
+
+        item_image_data = self.image_data[i] if self.image_data is not None else None
+        if isinstance(item_image_data, list):
+            if len(item_image_data) == 1 and len(self.mm_hashes) == len(
+                self.image_data
+            ):
+                return [self.mm_hashes[i]]
+            if len(self.mm_hashes) == len(item_image_data):
+                return self.mm_hashes
+
+        return self.mm_hashes
+
     def __getitem__(self, i):
         # Cache sub-objects so that repeated obj[i] calls return the same instance.
         # This avoids subtle bugs where different call sites get divergent objects.
@@ -662,6 +681,8 @@ class GenerateReqInput(BaseReq):
             image_data=self.image_data[i],
             video_data=self.video_data[i],
             audio_data=self.audio_data[i],
+            mm_hashes=self._get_mm_hashes_item(i),
+            use_audio_in_video=self.use_audio_in_video,
             sampling_params=self.sampling_params[i],
             rid=self.rid[i],
             return_logprob=self.return_logprob[i],
@@ -724,6 +745,10 @@ class GenerateReqInput(BaseReq):
                 if self.multi_item_delimiter_indices is not None
                 else None
             ),
+            max_dynamic_patch=self.max_dynamic_patch,
+            min_dynamic_patch=self.min_dynamic_patch,
+            image_max_dynamic_patch=self.image_max_dynamic_patch,
+            video_max_dynamic_patch=self.video_max_dynamic_patch,
         )
         cache[i] = sub
         return sub

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -552,6 +552,53 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertTrue(req[0].return_prompt_token_ids)
         self.assertTrue(req[1].return_prompt_token_ids)
 
+    def test_getitem_preserves_multimodal_scalar_controls(self):
+        """Batch subrequests must keep request-level multimodal controls."""
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            use_audio_in_video=True,
+            max_dynamic_patch=12,
+            min_dynamic_patch=2,
+            image_max_dynamic_patch=10,
+            video_max_dynamic_patch=4,
+        )
+        req.normalize_batch_and_arguments()
+
+        for item in (req[0], req[1]):
+            self.assertTrue(item.use_audio_in_video)
+            self.assertEqual(item.max_dynamic_patch, 12)
+            self.assertEqual(item.min_dynamic_patch, 2)
+            self.assertEqual(item.image_max_dynamic_patch, 10)
+            self.assertEqual(item.video_max_dynamic_patch, 4)
+
+    def test_getitem_slices_flat_mm_hashes_for_batched_images(self):
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            image_data=["image1.jpg", "image2.jpg"],
+            mm_hashes=["hash1", "hash2"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].mm_hashes, ["hash1"])
+        self.assertEqual(req[1].mm_hashes, ["hash2"])
+
+    def test_getitem_preserves_flat_mm_hashes_for_parallel_multi_image(self):
+        req = GenerateReqInput(
+            text="Hello",
+            image_data=["image1.jpg", "image2.jpg"],
+            mm_hashes=["hash1", "hash2"],
+            sampling_params={"n": 2},
+            rid="id1",
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].mm_hashes, ["hash1", "hash2"])
+        self.assertEqual(req[1].mm_hashes, ["hash1", "hash2"])
+
     def test_regenerate_rid(self):
         """Test the regenerate_rid method."""
         req = GenerateReqInput(text="Hello")


### PR DESCRIPTION
Addresses part of #27216.

## Summary
- preserve request-level multimodal scalar controls when `GenerateReqInput.__getitem__` slices a batched request
- covers `use_audio_in_video`, `max_dynamic_patch`, `min_dynamic_patch`, `image_max_dynamic_patch`, and `video_max_dynamic_patch`
- add regression coverage for the scalar fields

I intentionally left `mm_hashes` out of this patch. Its `list[str]` form is ambiguous between "one request with multiple images" and "batch with one image per item", so slicing it safely needs a separate contract decision.

## To verify
- `python -m py_compile python\sglang\srt\managers\io_struct.py test\registered\unit\managers\test_io_struct.py`
- `python -m ruff check python\sglang\srt\managers\io_struct.py test\registered\unit\managers\test_io_struct.py`
- `git diff --check`

The targeted pytest for `test_io_struct.py` is blocked in this Windows checkout by Linux/GPU-oriented imports (`resource`, then `triton`) during collection.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26950751026](https://github.com/sgl-project/sglang/actions/runs/26950751026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26950750470](https://github.com/sgl-project/sglang/actions/runs/26950750470)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->