### PR TITLE
[diffusion] V2 Transport Modules of SGLang Diffusion Disaggregation

### DIFF
--- a/python/sglang/multimodal_gen/runtime/disaggregation/transport/allocator.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/transport/allocator.py
@@ -11,6 +11,29 @@ from functools import lru_cache
 logger = logging.getLogger(__name__)
 
 
+@lru_cache(maxsize=None)
+def next_power_of_2(n: int) -> int:
+    if n <= 0:
+        return 1
+    n -= 1
+    n |= n >> 1
+    n |= n >> 2
+    n |= n >> 4
+    n |= n >> 8
+    n |= n >> 16
+    n |= n >> 32
+    return n + 1
+
+
+def round_allocation_size(size: int, min_block_size: int = 1 << 20) -> int:
+    """Return the actual buddy block size needed for a requested allocation."""
+    if size <= 0:
+        raise ValueError(f"Allocation size must be positive, got {size}")
+    if min_block_size <= 0 or (min_block_size & (min_block_size - 1)) != 0:
+        raise ValueError(f"min_block_size must be a power of 2, got {min_block_size}")
+    return max(next_power_of_2(size), min_block_size)
+
+
 @dataclass
 class Block:
     offset: int  # byte offset from pool start
@@ -29,7 +52,7 @@ class BuddyAllocator:
             )
 
         self._min_block_size = min_block_size
-        self._pool_size = self._next_power_of_2(max(pool_size, min_block_size))
+        self._pool_size = next_power_of_2(max(pool_size, min_block_size))
         self._lock = threading.Lock()
 
         # Free lists indexed by order: order 0 = min_block_size, order 1 = 2*min_block_size, ...
@@ -49,12 +72,31 @@ class BuddyAllocator:
     def pool_size(self) -> int:
         return self._pool_size
 
+    @property
+    def min_block_size(self) -> int:
+        return self._min_block_size
+
+    @property
+    def allocated_bytes(self) -> int:
+        with self._lock:
+            return self._allocated_bytes
+
+    @property
+    def free_bytes(self) -> int:
+        with self._lock:
+            return self._pool_size - self._allocated_bytes
+
+    @property
+    def num_allocations(self) -> int:
+        with self._lock:
+            return self._num_allocations
+
     def allocate(self, size: int, request_id: str | None = None) -> int | None:
         """Allocate a block of at least `size` bytes. Returns offset or None."""
         if size <= 0:
             raise ValueError(f"Allocation size must be positive, got {size}")
 
-        alloc_size = max(self._next_power_of_2(size), self._min_block_size)
+        alloc_size = round_allocation_size(size, self._min_block_size)
         target_order = self._size_to_order(alloc_size)
 
         if target_order > self._max_order:
@@ -93,11 +135,25 @@ class BuddyAllocator:
                 "free_blocks_by_size": free_blocks_by_order,
             }
 
+    def can_allocate(self, size: int) -> bool:
+        if size <= 0:
+            return False
+        alloc_size = round_allocation_size(size, self._min_block_size)
+        target_order = self._size_to_order(alloc_size)
+        if target_order > self._max_order:
+            return False
+
+        with self._lock:
+            for order in range(target_order, self._max_order + 1):
+                if self._free_lists[order]:
+                    return True
+            return False
+
     def count_free_slots(self, slot_size: int) -> int:
         """Count how many allocations of the given size can fit."""
         if slot_size <= 0:
             return 0
-        alloc_size = max(self._next_power_of_2(slot_size), self._min_block_size)
+        alloc_size = round_allocation_size(slot_size, self._min_block_size)
 
         with self._lock:
             count = 0
@@ -186,15 +242,5 @@ class BuddyAllocator:
         return order
 
     @staticmethod
-    @lru_cache(maxsize=256)
     def _next_power_of_2(n: int) -> int:
-        if n <= 0:
-            return 1
-        n -= 1
-        n |= n >> 1
-        n |= n >> 2
-        n |= n >> 4
-        n |= n >> 8
-        n |= n >> 16
-        n |= n >> 32
-        return n + 1
+        return next_power_of_2(n)

--- a/python/sglang/multimodal_gen/runtime/disaggregation/transport/codec.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/transport/codec.py
@@ -53,10 +53,13 @@ class TensorWrapper:
         if not tensor.is_contiguous():
             tensor = tensor.contiguous()
         self.tensor = tensor
-        data_ptr = tensor.data_ptr()
-        total_bytes = tensor.numel() * tensor.element_size()
-        self._c_buf = (ctypes.c_char * total_bytes).from_address(data_ptr)
-        self._view = memoryview(self._c_buf)
+
+    def __buffer__(self, flags=0):
+        data_ptr = self.tensor.data_ptr()
+        total_bytes = self.tensor.numel() * self.tensor.element_size()
+        c_obj = (ctypes.c_char * total_bytes).from_address(data_ptr)
+        c_obj._keep_alive_ref = self  # prevent GC while ZMQ holds the buffer
+        return memoryview(c_obj)
 
 
 @dataclass
@@ -144,8 +147,8 @@ def send_tensors(
     """Send tensors over ZMQ using multipart with zero-copy."""
     metadata_bytes, buffers = pack_tensors(tensor_fields, scalar_fields)
     parts: list = [metadata_bytes]
-    parts.extend(w._view if isinstance(w, TensorWrapper) else w for w in buffers)
-    socket.send_multipart(parts, flags=flags, copy=True)
+    parts.extend(buffers)
+    socket.send_multipart(parts, flags=flags, copy=False)
 
 
 def unpack_tensors(
@@ -183,9 +186,11 @@ def unpack_tensors(
 
     for i, desc in enumerate(descriptors):
         frame = parts[i + 1]
-        buf = frame.buffer if hasattr(frame, "buffer") else bytes(frame)
+        raw_buf = frame.buffer if hasattr(frame, "buffer") else bytes(frame)
+        # torch.frombuffer warns on read-only buffers; make a writable view first,
+        # then clone so the tensor lifetime is decoupled from the ZMQ frame.
+        buf = bytearray(raw_buf)
         dtype = str_to_dtype(desc.dtype)
-        # clone() to own the memory (decouple from ZMQ buffer lifetime)
         tensor = torch.frombuffer(buf, dtype=dtype).reshape(desc.shape).clone()
         if device != "cpu" and device != torch.device("cpu"):
             tensor = tensor.to(device)

--- a/python/sglang/multimodal_gen/runtime/disaggregation/transport/engine.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/transport/engine.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Transfer engine abstraction for tensor transfer between role instances."""
 
+import ipaddress
 import logging
+import threading
 from abc import ABC, abstractmethod
+from typing import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +24,41 @@ def _check_mooncake() -> bool:
         except ImportError:
             _MOONCAKE_AVAILABLE = False
     return _MOONCAKE_AVAILABLE
+
+
+def is_mooncake_available() -> bool:
+    return _check_mooncake()
+
+
+def _is_loopback_hostname(hostname: str) -> bool:
+    normalized = (hostname or "").strip().lower()
+    if normalized in {"", "127.0.0.1", "localhost", "::1", "[::1]", "0.0.0.0"}:
+        return True
+
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def resolve_transfer_backend(
+    configured_backend: Literal["auto", "mock", "mooncake"] = "auto",
+    *,
+    hostname: str = "127.0.0.1",
+    ib_device: str | None = None,
+) -> Literal["mock", "mooncake"]:
+    if configured_backend == "mock":
+        return "mock"
+    if configured_backend == "mooncake":
+        return "mooncake"
+    if ib_device:
+        return "mooncake"
+    if _is_loopback_hostname(hostname):
+        return "mock"
+    return "mooncake"
 
 
 class BaseTransferEngine(ABC):
@@ -110,17 +148,101 @@ class MooncakeDiffusionEngine(BaseTransferEngine):
         )
 
 
+class MockTransferEngine(BaseTransferEngine):
+    """Local/test fallback that simulates transfer with ctypes memmove.
+
+    Production cross-host deployments should use Mooncake/RDMA. The mock
+    backend keeps unit tests and same-host development usable when Mooncake is
+    not installed.
+    """
+
+    # Shared registry so mock instances can "see" each other's buffers
+    _registry: dict[str, dict[int, tuple[object, int]]] = {}
+    _lock = threading.Lock()
+    _counter = 0
+
+    def __init__(self, session_id: str | None = None):
+        with MockTransferEngine._lock:
+            if session_id is None:
+                MockTransferEngine._counter += 1
+                session_id = f"mock-session-{MockTransferEngine._counter}"
+            self._session_id = session_id
+            MockTransferEngine._registry[session_id] = {}
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    def register_buffer(self, ptr: int, length: int) -> None:
+        with MockTransferEngine._lock:
+            self._registry[self._session_id][ptr] = (None, length)
+
+    def deregister_buffer(self, ptr: int) -> None:
+        with MockTransferEngine._lock:
+            self._registry[self._session_id].pop(ptr, None)
+
+    def transfer_sync(
+        self, dst_session_id: str, src_addr: int, dst_addr: int, length: int
+    ) -> int:
+        import ctypes
+
+        try:
+            ctypes.memmove(dst_addr, src_addr, length)
+            return 0
+        except Exception as e:
+            logger.error("MockTransferEngine transfer failed: %s", e)
+            return -1
+
+    def batch_transfer_sync(
+        self,
+        dst_session_id: str,
+        src_addrs: list[int],
+        dst_addrs: list[int],
+        lengths: list[int],
+    ) -> int:
+        for src, dst, length in zip(src_addrs, dst_addrs, lengths):
+            ret = self.transfer_sync(dst_session_id, src, dst, length)
+            if ret != 0:
+                return ret
+        return 0
+
+    @classmethod
+    def reset(cls):
+        """Reset global registry (for test cleanup)."""
+        with cls._lock:
+            cls._registry.clear()
+            cls._counter = 0
+
+
 def create_transfer_engine(
     hostname: str = "127.0.0.1",
     gpu_id: int = 0,
     ib_device: str | None = None,
+    backend: Literal["auto", "mock", "mooncake"] = "auto",
+    force_mock: bool = False,
 ) -> BaseTransferEngine:
-    """Factory: returns MooncakeDiffusionEngine if mooncake is available."""
-    if not _check_mooncake():
-        raise RuntimeError(
-            "Mooncake transfer engine is required for disaggregated diffusion "
-            "but is not installed. Please install mooncake first."
+    """Factory: returns MooncakeDiffusionEngine if available, else MockTransferEngine."""
+    resolved_backend = (
+        "mock"
+        if force_mock
+        else resolve_transfer_backend(
+            backend,
+            hostname=hostname,
+            ib_device=ib_device,
         )
-    return MooncakeDiffusionEngine(
-        hostname=hostname, gpu_id=gpu_id, ib_device=ib_device
     )
+    if resolved_backend == "mooncake":
+        if not _check_mooncake():
+            raise RuntimeError(
+                "Mooncake transfer backend was requested but mooncake-transfer-engine "
+                "is not available in this environment."
+            )
+        return MooncakeDiffusionEngine(
+            hostname=hostname, gpu_id=gpu_id, ib_device=ib_device
+        )
+    logger.info(
+        "Using MockTransferEngine (backend=%s, force_mock=%s)",
+        resolved_backend,
+        force_mock,
+    )
+    return MockTransferEngine()

--- a/python/sglang/multimodal_gen/runtime/disaggregation/transport/pinned_memory.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/transport/pinned_memory.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA host-registration helpers for shared-memory transfer buffers."""
+
+from __future__ import annotations
+
+import logging
+import mmap
+from dataclasses import dataclass
+
+import torch
+
+from sglang.multimodal_gen.runtime.disaggregation.transport.utils import warn_or_raise
+
+logger = logging.getLogger(__name__)
+
+
+def _cuda_status_code(result) -> int:
+    if isinstance(result, tuple):
+        result = result[0]
+    if hasattr(result, "value"):
+        return int(result.value)
+    if result is None:
+        return 0
+    return int(result)
+
+
+def _align_host_region(ptr: int, size: int) -> tuple[int, int]:
+    page_size = mmap.PAGESIZE
+    aligned_ptr = ptr - (ptr % page_size)
+    end = ptr + size
+    aligned_end = ((end + page_size - 1) // page_size) * page_size
+    return aligned_ptr, aligned_end - aligned_ptr
+
+
+@dataclass
+class PinnedHostMemoryRegistration:
+    """Tracks a cudaHostRegister registration for one process-local mapping."""
+
+    ptr: int
+    size: int
+    aligned_ptr: int
+    aligned_size: int
+    registered: bool = False
+    status: str = "disabled"
+    error: str | None = None
+
+    def unregister(self) -> None:
+        if not self.registered:
+            return
+        try:
+            result = torch.cuda.cudart().cudaHostUnregister(self.aligned_ptr)
+            status_code = _cuda_status_code(result)
+            if status_code != 0:
+                logger.warning(
+                    "cudaHostUnregister failed for ptr=%s size=%s: cuda error %s",
+                    self.aligned_ptr,
+                    self.aligned_size,
+                    status_code,
+                )
+        except Exception:
+            logger.exception(
+                "cudaHostUnregister raised for ptr=%s size=%s",
+                self.aligned_ptr,
+                self.aligned_size,
+            )
+        finally:
+            self.registered = False
+            self.status = "unregistered"
+
+
+def register_pinned_host_memory(
+    ptr: int,
+    size: int,
+    *,
+    enabled: bool,
+    strict: bool = False,
+) -> PinnedHostMemoryRegistration:
+    """Register a process-local host memory mapping as CUDA pinned memory.
+
+    `multiprocessing.shared_memory` gives each process its own virtual address
+    mapping, so cudaHostRegister must be called in every process that wants CUDA
+    H2D/D2H copies to treat the mapping as page-locked.
+    """
+
+    aligned_ptr, aligned_size = _align_host_region(int(ptr), int(size))
+    registration = PinnedHostMemoryRegistration(
+        ptr=int(ptr),
+        size=int(size),
+        aligned_ptr=aligned_ptr,
+        aligned_size=aligned_size,
+    )
+    if not enabled:
+        return registration
+    if size <= 0:
+        registration.status = "skipped_empty"
+        return registration
+    if not torch.cuda.is_available():
+        registration.status = "cuda_unavailable"
+        registration.error = "CUDA is not available"
+        warn_or_raise(
+            logger,
+            strict,
+            "CUDA host registration requested but CUDA is unavailable; using unpinned shared-memory buffer.",
+        )
+        return registration
+
+    try:
+        cudart = torch.cuda.cudart()
+        flags = getattr(cudart, "cudaHostRegisterPortable", 1)
+        result = cudart.cudaHostRegister(aligned_ptr, aligned_size, flags)
+        status_code = _cuda_status_code(result)
+        if status_code == 0:
+            registration.registered = True
+            registration.status = "pinned"
+            return registration
+        registration.status = "failed"
+        registration.error = f"cudaHostRegister returned cuda error {status_code}"
+    except Exception as exc:
+        registration.status = "failed"
+        registration.error = str(exc)
+
+    if strict:
+        warn_or_raise(
+            logger,
+            True,
+            "Failed to pin shared-memory transfer buffer: %s",
+            registration.error or registration.status,
+        )
+    logger.warning(
+        "Failed to pin shared-memory transfer buffer; using unpinned memory: %s",
+        registration.error or registration.status,
+    )
+    return registration

--- a/python/sglang/multimodal_gen/runtime/disaggregation/transport/shared_memory.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/transport/shared_memory.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared-memory helpers for diffusion transfer buffers."""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import uuid
+from dataclasses import dataclass
+from multiprocessing import shared_memory
+
+import numpy as np
+import torch
+
+from sglang.multimodal_gen.runtime.disaggregation.transport.pinned_memory import (
+    PinnedHostMemoryRegistration,
+    register_pinned_host_memory,
+)
+
+
+@dataclass
+class SharedMemoryAttachment:
+    shm: shared_memory.SharedMemory
+    np_array: np.ndarray
+
+    @property
+    def data_ptr(self) -> int:
+        return int(self.np_array.ctypes.data)
+
+    def close(self, logger: logging.Logger | None = None) -> None:
+        try:
+            self.shm.close()
+        except FileNotFoundError:
+            if logger is not None:
+                logger.debug("Shared memory attachment already closed")
+
+
+class SharedMemoryRegion:
+    """Process-local mapping that may also be CUDA host-registered."""
+
+    def __init__(
+        self,
+        role_name: str,
+        tag: str,
+        size: int,
+        *,
+        pin_memory: bool = False,
+        pin_memory_strict: bool = False,
+    ):
+        self._name = f"sgl_diff_{role_name}_{tag}_{uuid.uuid4().hex}"
+        self._shm = shared_memory.SharedMemory(name=self._name, create=True, size=size)
+        self._np_array = np.ndarray((size,), dtype=np.uint8, buffer=self._shm.buf)
+        self._tensor = torch.from_numpy(self._np_array)
+        self._pin_registration: PinnedHostMemoryRegistration | None = None
+        if pin_memory:
+            try:
+                self._pin_registration = register_pinned_host_memory(
+                    int(self._np_array.ctypes.data),
+                    size,
+                    enabled=True,
+                    strict=pin_memory_strict,
+                )
+            except Exception:
+                self.cleanup()
+                raise
+
+    @property
+    def tensor(self) -> torch.Tensor:
+        return self._tensor
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def is_pinned(self) -> bool:
+        return bool(self._pin_registration and self._pin_registration.registered)
+
+    @property
+    def pin_memory_status(self) -> str:
+        if self._pin_registration is None:
+            return "disabled"
+        return self._pin_registration.status
+
+    @property
+    def pin_memory_error(self) -> str | None:
+        if self._pin_registration is None:
+            return None
+        return self._pin_registration.error
+
+    def cleanup(self, logger: logging.Logger | None = None) -> None:
+        if self._pin_registration is not None:
+            self._pin_registration.unregister()
+            self._pin_registration = None
+        try:
+            self._shm.close()
+        except FileNotFoundError:
+            if logger is not None:
+                logger.debug("Shared memory region %s was already closed", self._name)
+        try:
+            self._shm.unlink()
+        except FileNotFoundError:
+            if logger is not None:
+                logger.debug("Shared memory region %s was already unlinked", self._name)
+
+
+def get_shared_memory_attachment(
+    name: str,
+    attachments: dict[str, SharedMemoryAttachment],
+) -> SharedMemoryAttachment:
+    attachment = attachments.get(name)
+    if attachment is not None:
+        return attachment
+
+    shm = shared_memory.SharedMemory(name=name)
+    np_array = np.ndarray((shm.size,), dtype=np.uint8, buffer=shm.buf)
+    attachment = SharedMemoryAttachment(shm=shm, np_array=np_array)
+    attachments[name] = attachment
+    return attachment
+
+
+def copy_to_shared_memory(
+    *,
+    src_addr: int,
+    dst_shm_name: str | None,
+    dst_shm_offset: int,
+    length: int,
+    attachments: dict[str, SharedMemoryAttachment],
+    logger: logging.Logger,
+) -> bool:
+    """Copy into a peer's same-host shared-memory mapping when available."""
+    if not dst_shm_name or length <= 0:
+        return True
+    try:
+        attachment = get_shared_memory_attachment(dst_shm_name, attachments)
+        ctypes.memmove(attachment.data_ptr + int(dst_shm_offset), src_addr, int(length))
+        return True
+    except Exception:
+        logger.exception(
+            "TransferManager local shared-memory copy failed: shm=%s offset=%s length=%s",
+            dst_shm_name,
+            dst_shm_offset,
+            length,
+        )
+        return False

--- a/python/sglang/multimodal_gen/runtime/disaggregation/transport/utils.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/transport/utils.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small helpers shared by diffusion transfer components."""
+
+from __future__ import annotations
+
+import logging
+from typing import TypeVar
+
+import torch
+
+_ExcT = TypeVar("_ExcT", bound=Exception)
+
+
+def warn_or_raise(
+    logger: logging.Logger,
+    strict: bool,
+    message: str,
+    *args,
+    exc_type: type[_ExcT] = RuntimeError,
+) -> str:
+    text = message % args if args else message
+    if strict:
+        raise exc_type(text)
+    logger.warning(text)
+    return text
+
+
+def require_request_id(
+    msg: dict,
+    *,
+    context: str,
+    logger: logging.Logger,
+    strict: bool = False,
+) -> str | None:
+    request_id = str(msg.get("request_id", "") or "")
+    if request_id:
+        return request_id
+    warn_or_raise(
+        logger,
+        strict,
+        "%s missing request_id; dropping message: %s",
+        context,
+        msg,
+        exc_type=ValueError,
+    )
+    return None
+
+
+def tensor_fields_need_device_event(
+    tensor_fields: dict[str, torch.Tensor | list[torch.Tensor] | None],
+) -> bool:
+    for value in tensor_fields.values():
+        tensors = value if isinstance(value, list) else [value]
+        for tensor in tensors:
+            if isinstance(tensor, torch.Tensor) and tensor.device.type != "cpu":
+                return True
+    return False
+
+
+def record_device_event_if_needed(
+    *,
+    enabled: bool,
+    stream: torch.Stream | None = None,
+):
+    if not enabled:
+        return None
+    device_module = torch.get_device_module()
+    if stream is not None:
+        event = device_module.Event()
+        event.record(stream)
+        return event
+    if device_module.is_available():
+        event = device_module.Event()
+        event.record(device_module.current_stream())
+        return event
+    return None
+
+
+def record_load_event(device: torch.device | str, stream: torch.Stream | None = None):
+    device_type = (
+        device.type
+        if isinstance(device, torch.device)
+        else str(device).split(":", 1)[0]
+    )
+    return record_device_event_if_needed(
+        enabled=device_type != "cpu",
+        stream=stream,
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## [diffusion] Add transport foundation helpers

### Summary

This PR adds the low-level foundation used by the later diffusion transport v2 stack. It keeps the changes intentionally below the manager layer: allocator behavior, tensor wire codec helpers, backend selection, optional pinned host memory, shared-memory copy support, and small cross-cutting utility functions. Later PRs build the buffer/protocol contracts and manager lifecycle on top of these primitives.

### Files, Classes, And Key Functions

- `python/sglang/multimodal_gen/runtime/disaggregation/transport/allocator.py`
  - `Block` and `BuddyAllocator` implement pool-offset allocation.
  - Core functions: `allocate`, `free`, `_split_block`, `_try_coalesce`, `get_block_info`, `get_stats`, `count_free_slots`.
  - Code logic: the allocator tracks request ownership by offset, splits larger free blocks for allocations, coalesces buddies on free, and exposes stats for warning/debug output.

- `python/sglang/multimodal_gen/runtime/disaggregation/transport/codec.py`
  - `TensorDescriptor`, `TensorWrapper`, `pack_tensors`, and `unpack_tensors` keep the existing ZMQ multipart tensor format.
  - Core functions: `dtype_to_str`, `str_to_dtype`, `pack_tensors`, `unpack_tensors`.
  - Compatibility note: host-copy handling keeps the main/V2 platform compatibility update by treating both CUDA and NPU tensors as device tensors that need host staging before socket serialization.

- `python/sglang/multimodal_gen/runtime/disaggregation/transport/engine.py`
  - `BaseTransferEngine` defines the common transfer interface.
  - `MooncakeDiffusionEngine` wraps the production Mooncake/RDMA backend.
  - `MockTransferEngine` provides local/test transfer through `ctypes.memmove`.
  - Core functions: `resolve_transfer_backend`, `create_transfer_engine`, `is_mooncake_available`, `transfer_sync`, `batch_transfer_sync`.
  - Code logic: loopback defaults to mock, explicit mock stays mock, and non-loopback or explicit Mooncake selection raises if Mooncake is unavailable instead of silently falling back.

- `python/sglang/multimodal_gen/runtime/disaggregation/transport/pinned_memory.py`
  - `PinnedHostMemoryRegistration` records optional host-memory pinning state.
  - Core function: `register_pinned_host_memory`.
  - Code logic: compatible pinning failures can warn and continue with unpinned memory, while strict mode raises a clear error.

- `python/sglang/multimodal_gen/runtime/disaggregation/transport/shared_memory.py`
  - `SharedMemoryRegion` owns same-host shared-memory-backed tensors.
  - `SharedMemoryAttachment` attaches to peer shared-memory regions.
  - Core functions: `get_shared_memory_attachment`, `copy_to_shared_memory`, `cleanup`, `close`.
  - Code logic: this gives later buffer/manager code a same-host fast path while centralizing close/unlink logging and best-effort cleanup.

- `python/sglang/multimodal_gen/runtime/disaggregation/transport/utils.py`
  - Small shared helpers used by later PRs.
  - Core functions: `warn_or_raise`, `require_request_id`, `tensor_fields_need_device_event`, `record_device_event_if_needed`, `record_load_event`.
  - Code logic: fault handling is centralized so compatible cases warn and continue, while strict/fatal paths raise with useful context.

### Coding Focus

- Backend selection should not hide unavailable Mooncake in production-like paths.
- Shared-memory and pinned-memory helpers should be safe to clean up repeatedly.
- Device-event helpers should preserve main/V2 platform abstraction via `torch.get_device_module()` instead of CUDA-only calls.

### Dependency Note

This PR has no dependency on the follow-up branches. It is the first foundation PR and should target `main`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27517553459](https://github.com/sgl-project/sglang/actions/runs/27517553459)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27517553422](https://github.com/sgl-project/sglang/actions/runs/27517553422)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->