### PR TITLE
[diffusion] Send lossless realtime RGB without delta packing

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_output_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_output_adapter.py
@@ -451,8 +451,6 @@ class RawRGBRealtimeOutputAdapter:
         content_type = result.raw_frame_content_type
         if result.raw_frame_batches is None:
             return empty_frame_send_stats(content_type)
-        if batch.block_idx == 0:
-            self.reset()
 
         frame_metadata = (
             result.raw_frame_metadata or _raw_rgb_frame_metadata(batch)

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_output_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_output_adapter.py
@@ -324,7 +324,7 @@ def _should_build_payload_off_loop(
 ) -> bool:
     if content_type != RAW_RGB_CONTENT_TYPE or not transport_frames:
         return False
-    return output_format in ENCODED_PREVIEW_FORMATS
+    return output_format in ENCODED_PREVIEW_FORMATS or output_format is None
 
 
 def _is_encoded_preview_transport(

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_output_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/realtime/realtime_output_adapter.py
@@ -324,7 +324,7 @@ def _should_build_payload_off_loop(
 ) -> bool:
     if content_type != RAW_RGB_CONTENT_TYPE or not transport_frames:
         return False
-    return output_format in ENCODED_PREVIEW_FORMATS or output_format is None
+    return output_format in ENCODED_PREVIEW_FORMATS
 
 
 def _is_encoded_preview_transport(


### PR DESCRIPTION
## Summary

Use direct raw RGB payloads for the default lossless realtime transport instead of building delta-gzip payloads.

This keeps the realtime output lossless and avoids CPU-side delta packing on the hot path. Large payloads are sent as the already-supported `frame_batch_header` + raw bytes wire format, which also avoids copying 10-14 MiB frame payloads into msgpack. Encoded preview transports such as webp/jpeg keep the existing behavior.

Relation to existing realtime transport optimizations: #27236 keeps the delta-gzip helper inexpensive by using gzip level 0, but this PR removes delta-gzip from the default raw RGB hot path. The endpoint comparison below should be read as replacing the default delta-gzip transport with direct raw RGB plus separate large-payload writes, not as an additive gain on top of delta-gzip compression.

Current head `4e804c661d` preserves the same default raw RGB off-loop payload build behavior as the measured patch `d900b1f59`; the later commits are lint and test-behavior alignment follow-ups.

## Experiments

Unit:

```bash
python3 -m pytest -q python/sglang/multimodal_gen/test/unit/realtime/test_realtime_output_transport.py
# 13 passed
```

Latest head `4e804c661d` was rechecked with the same unit file: `13 passed`.

Correctness:

```bash
python3 python/sglang/multimodal_gen/test/run_suite.py --suite 1-gpu --total-partitions 2 --partition-id 0 -k lingbot_world_realtime_plastic_beach
# 1 passed
# CLIP/SSIM: 1.0000
# PSNR: inf
# mean_abs_diff: 0.0000
```

4xH200 same-env LingBot realtime A/B, SGLD only. The patch changes transport payload building / packing only; scheduler time is expected to stay flat. I use chunks 2/3 as the stable request window because some runs had a chunk1 cold-start residual.

| Run | Variant | chunks 2/3 chunk_total | chunks 2/3 scheduler | chunks 2/3 raw_payload_build | chunks 2/3 header_pack |
| --- | --- | ---: | ---: | ---: | ---: |
| 1 | main `9e2ad6054` | 1491 ms | 1420 ms | 39 ms | 13.6 ms |
| 1 | patch `d900b1f59` | 1426 ms | 1409 ms | 2 ms | 0.02 ms |
| 2 | main `9e2ad6054` | 1487 ms | 1414 ms | 43 ms | 14.6 ms |
| 2 | patch `d900b1f59` | 1438 ms | 1421 ms | 4 ms | 0.02 ms |

Averages:

| Metric | main | patch | Change |
| --- | ---: | ---: | ---: |
| chunks 2/3 chunk_total | 1489.0 ms | 1432.0 ms | 3.8% faster |
| chunks 2/3 raw_payload_build | 41.0 ms | 3.0 ms | 92.7% faster |
| chunks 2/3 header_pack | 14.1 ms | 0.02 ms | 99.9% faster |
| chunks 2/3 scheduler | 1417.0 ms | 1415.0 ms | flat |

Chunk1 is intentionally excluded from the main comparison: main run1 and patch run2 each had a cold-start residual around 3.1-3.2s, while main run2 and patch run1 did not. Chunks 2/3 are stable across all four runs.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27003246524](https://github.com/sgl-project/sglang/actions/runs/27003246524)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27003246491](https://github.com/sgl-project/sglang/actions/runs/27003246491)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

