### PR TITLE
[OpenAI] Accept standard tools in the Responses API

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1694,12 +1694,11 @@ async def v1_score_request(request: ScoringRequest, raw_request: Request):
 
 
 @app.post("/v1/responses", dependencies=[Depends(validate_json_request)])
-async def v1_responses_request(request: dict, raw_request: Request):
+async def v1_responses_request(request: ResponsesRequest, raw_request: Request):
     """Endpoint for the responses API with reasoning support."""
 
-    request_obj = ResponsesRequest(**request)
     result = await raw_request.app.state.openai_serving_responses.create_responses(
-        request_obj, raw_request
+        request, raw_request
     )
 
     # Handle streaming responses

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -42,7 +42,6 @@ from openai.types.responses import (
     ResponseReasoningItem,
 )
 from openai.types.responses.response import ToolChoice
-from openai.types.responses.tool import Tool
 from openai.types.responses.tool import Tool as OpenAIResponsesToolType
 from pydantic import (
     BaseModel,
@@ -567,7 +566,9 @@ class ChatCompletionMessageGenericParam(BaseModel):
     name: Optional[str] = None
     reasoning_content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
-    tools: Optional[List[Tool]] = Field(default=None, examples=[None])
+    tools: Optional[List[OpenAIResponsesToolType]] = Field(
+        default=None, examples=[None]
+    )
 
     @field_validator("role", mode="before")
     @classmethod

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -43,6 +43,7 @@ from openai.types.responses import (
 )
 from openai.types.responses.response import ToolChoice
 from openai.types.responses.tool import Tool
+from openai.types.responses.tool import Tool as OpenAIResponsesToolType
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -1286,12 +1287,7 @@ class ResponseReasoningParam(BaseModel):
     )
 
 
-class ResponseTool(BaseModel):
-    """Tool definition for responses."""
-
-    type: Literal["web_search_preview", "code_interpreter"] = Field(
-        description="Type of tool to enable"
-    )
+ResponseTool: TypeAlias = OpenAIResponsesToolType
 
 
 ResponseInputOutputItem: TypeAlias = Union[

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -27,6 +27,7 @@ from sglang.srt.entrypoints.openai.protocol import (
     Function,
     ModelCard,
     ModelList,
+    ResponsesRequest,
     Tool,
     UsageInfo,
 )
@@ -524,6 +525,42 @@ class TestParsedResponseFieldsProtocol(unittest.TestCase):
             reasoning_content = None
 
         self.assertIsInstance(MockFields(), ParsedResponseFields)
+
+
+class TestResponsesRequest(unittest.TestCase):
+    """Test Responses API protocol model"""
+
+    def test_responses_request_accepts_function_tool(self):
+        """Responses API accepts OpenAI function tool schemas."""
+        request = ResponsesRequest(
+            input="hello",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get weather for a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                }
+            ],
+        )
+
+        self.assertEqual(request.tools[0].type, "function")
+        self.assertEqual(request.tools[0].name, "get_weather")
+
+    def test_responses_request_accepts_web_search_tool(self):
+        """Responses API accepts OpenAI web search tool schemas."""
+        request = ResponsesRequest(input="hello", tools=[{"type": "web_search"}])
+
+        self.assertEqual(request.tools[0].type, "web_search")
+
+    def test_responses_request_rejects_non_openai_tool_type(self):
+        """Responses API rejects tool types outside OpenAI's schema."""
+        with self.assertRaises(ValidationError):
+            ResponsesRequest(input="hello", tools=[{"type": "namespace"}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
`/v1/responses` defined `ResponseTool` with a narrow schema
(`web_search_preview` / `code_interpreter` only), so requests carrying
OpenAI `function` or `web_search` tools failed Pydantic validation and
returned **500** — before reaching inference. `/v1/chat/completions`
was unaffected. The downstream harmony path (`get_developer_message`)
already handles `function` tools, so only the request schema was the gate.

## Fix
- Align `ResponseTool` with `openai.types.responses.tool.Tool` (matches vLLM).
- Bind `ResponsesRequest` directly at the `/v1/responses` endpoint, so
  malformed bodies return a clean **422** instead of a **500** raised
  inside the handler.

## Tests
Adds protocol tests: function tool, web_search tool, and rejection of
non-OpenAI tool types.

## Verification
Verified live on a DeepSeek-V4 deployment: `function` and `web_search`
tools now return 200 (previously 500); invalid tool types return 4xx.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27252070223](https://github.com/sgl-project/sglang/actions/runs/27252070223)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27252070124](https://github.com/sgl-project/sglang/actions/runs/27252070124)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->