### PR TITLE
Pcg npu merge

### DIFF
--- a/python/sglang/srt/compilation/compile.py
+++ b/python/sglang/srt/compilation/compile.py
@@ -171,6 +171,39 @@ def install_torch_compiled(
                 if val is not None:
                     _mark_dynamic_on_value(val, dims)
 
+        # The annotation-based dyn_map only marks dim 0 of top-level Tensor params,
+        # but the real token dimension isn't always dim 0 (e.g. mrope `positions` is
+        # [3, num_tokens] -> token dim is index 1) and tensors reached via
+        # forward_batch.<field> (input_ids/positions/out_cache_loc/...) aren't covered
+        # at all. Left unmarked they get specialized to the first captured bucket size,
+        # so a later bucket triggers a runtime dynamo recompile -> the piecewise graph
+        # re-captures on a live request, which on NPU corrupts order-sensitive
+        # mamba/linear recurrence (garbled spec-decoding output). Mark EVERY dim whose
+        # size == num_tokens dynamic, on both the top-level tensor args and the
+        # ForwardBatch tensor fields, so one dynamic graph covers all buckets and the
+        # init-captured graph is reused at runtime.
+        _ntok = None
+        _fb = None
+        for _v in ba.arguments.values():
+            if type(_v).__name__ == "ForwardBatch":
+                _fb = _v
+                _ref = getattr(_v, "input_ids", None)
+                if isinstance(_ref, torch.Tensor) and _ref.dim() >= 1:
+                    _ntok = _ref.shape[0]
+                break
+
+        def _mark_token_dims(_t):
+            if isinstance(_t, torch.Tensor) and _ntok is not None:
+                for _d in range(_t.dim()):
+                    if _t.shape[_d] == _ntok:
+                        torch._dynamo.maybe_mark_dynamic(_t, _d)
+
+        if _ntok is not None:
+            for _v in ba.arguments.values():
+                _mark_token_dims(_v)
+            for _t in vars(_fb).values():
+                _mark_token_dims(_t)
+
         # Avoid cross-instance cache reuse
         torch._dynamo.eval_frame.remove_from_cache(unbound_fwd.__code__)
 

--- a/python/sglang/srt/compilation/npu_piecewise_backend.py
+++ b/python/sglang/srt/compilation/npu_piecewise_backend.py
@@ -11,6 +11,10 @@ from sglang.srt.compilation.cuda_piecewise_backend import (
     CUDAPiecewiseBackend,
     weak_ref_tensors,
 )
+from sglang.srt.compilation.piecewise_context_manager import (
+    get_pcg_capture_stream,
+    is_in_pcg_torch_compile,
+)
 
 
 class NPUPiecewiseBackend(CUDAPiecewiseBackend):
@@ -39,9 +43,14 @@ class NPUPiecewiseBackend(CUDAPiecewiseBackend):
         )
 
     def __call__(self, *args):
+        if is_in_pcg_torch_compile():
+            return self.compiled_graph_for_general_shape(*args)
+
+        if len(self.sym_shape_indices) == 0:
+            return self.compiled_graph_for_general_shape(*args)
+
         runtime_shape = args[self.sym_shape_indices[0]]
         if runtime_shape not in self.concrete_size_entries:
-            # we don't need to do anything for this shape
             return self.compiled_graph_for_general_shape(*args)
 
         entry = self.concrete_size_entries[runtime_shape]
@@ -73,7 +82,12 @@ class NPUPiecewiseBackend(CUDAPiecewiseBackend):
                     stack.enter_context(patch("torch.npu.empty_cache", lambda: None))
 
                 # mind-exploding: carefully manage the reference and memory.
-                with torch.npu.graph(npugraph, pool=self.graph_pool):
+                with torch.npu.graph(
+                    npugraph,
+                    pool=self.graph_pool,
+                    stream=get_pcg_capture_stream(),
+                    auto_dispatch_capture=True,
+                ):
                     # `output` is managed by pytorch's cudagraph pool
                     output = entry.runnable(*args)
                     if self.is_last_graph:

--- a/python/sglang/srt/compilation/weak_ref_tensor.py
+++ b/python/sglang/srt/compilation/weak_ref_tensor.py
@@ -22,7 +22,11 @@ def weak_ref_tensors(
     if isinstance(tensors, torch.Tensor):
         return weak_ref_tensor(tensors)
     if isinstance(tensors, list):
-        return [weak_ref_tensor(t) for t in tensors]
+        return [
+            weak_ref_tensor(t) if isinstance(t, torch.Tensor) else t for t in tensors
+        ]
     if isinstance(tensors, tuple):
-        return tuple(weak_ref_tensor(t) for t in tensors)
+        return tuple(
+            weak_ref_tensor(t) if isinstance(t, torch.Tensor) else t for t in tensors
+        )
     raise ValueError("Invalid type for tensors")

--- a/python/sglang/srt/hardware_backend/npu/cmo.py
+++ b/python/sglang/srt/hardware_backend/npu/cmo.py
@@ -1,4 +1,8 @@
+from typing import List
+
 import torch
+
+from sglang.srt.utils.custom_op import register_custom_op
 
 cmo_stream = None
 share_stream = None
@@ -19,12 +23,10 @@ def set_cmo_stream(stream):
     cmo_stream = stream
 
 
-def prepare_weight_cache(handle, cache, PREFETCH_MAX_SIZE=1000000000):
-    """
-    PREFETCH_MAX_SIZE: maximum size (bytes) for each prefetch operation.
-    This affects the time spent in prefetch:
-        time ≈ PREFETCH_MAX_SIZE / system_bandwidth
-    """
+@register_custom_op()
+def _prepare_weight_cache_list(
+    handle: torch.Tensor, cache: List[torch.Tensor], max_size: int
+) -> None:
     import torch_npu
 
     stream = get_cmo_stream()
@@ -33,22 +35,39 @@ def prepare_weight_cache(handle, cache, PREFETCH_MAX_SIZE=1000000000):
         set_cmo_stream(stream)
     stream.wait_stream(torch.npu.current_stream())
     with torch.npu.stream(stream):
-        if isinstance(cache, list):
-            for weight in cache:
-                torch_npu.npu_prefetch(
-                    weight,
-                    handle,
-                    PREFETCH_MAX_SIZE,
-                )
-        else:
-            torch_npu.npu_prefetch(
-                cache,
-                handle,
-                PREFETCH_MAX_SIZE,
-            )
+        for weight in cache:
+            torch_npu.npu_prefetch(weight, handle, max_size)
 
 
-def wait_cmo_stream():
+@register_custom_op()
+def _prepare_weight_cache_single(
+    handle: torch.Tensor, cache: torch.Tensor, max_size: int
+) -> None:
+    import torch_npu
+
+    stream = get_cmo_stream()
+    if stream is None:
+        stream = torch.npu.Stream()
+        set_cmo_stream(stream)
+    stream.wait_stream(torch.npu.current_stream())
+    with torch.npu.stream(stream):
+        torch_npu.npu_prefetch(cache, handle, max_size)
+
+
+def prepare_weight_cache(handle, cache, PREFETCH_MAX_SIZE=1000000000):
+    """
+    PREFETCH_MAX_SIZE: maximum size (bytes) for each prefetch operation.
+    This affects the time spent in prefetch:
+        time ≈ PREFETCH_MAX_SIZE / system_bandwidth
+    """
+    if isinstance(cache, list):
+        _prepare_weight_cache_list(handle, cache, PREFETCH_MAX_SIZE)
+    else:
+        _prepare_weight_cache_single(handle, cache, PREFETCH_MAX_SIZE)
+
+
+@register_custom_op()
+def wait_cmo_stream(dummy: torch.Tensor) -> None:
     stream = get_cmo_stream()
     if stream is not None:
         cur_stream = torch.npu.current_stream()
@@ -65,7 +84,8 @@ def set_share_stream(stream):
     share_stream = stream
 
 
-def wait_share_stream():
+@register_custom_op()
+def wait_share_stream(dummy: torch.Tensor) -> None:
     stream = get_share_stream()
     if stream is not None:
         cur_stream = torch.npu.current_stream()
@@ -73,6 +93,11 @@ def wait_share_stream():
 
 
 def shared_expert_on_independent_stream(hidden_states, forward_func):
+    import torch.compiler
+
+    if torch.compiler.is_compiling():
+        return forward_func(hidden_states)
+
     stream = get_share_stream()
     if stream is None:
         stream = torch.npu.Stream()

--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -1,7 +1,16 @@
 from typing import TYPE_CHECKING, Optional
 
 import torch
-from sgl_kernel_npu.norm.l1_norm import l1_norm
+
+from sglang.srt.utils.custom_op import register_custom_op
+
+
+@register_custom_op(out_shape=0)
+def _l1_norm(x: torch.Tensor) -> torch.Tensor:
+    from sgl_kernel_npu.norm.l1_norm import l1_norm
+
+    return l1_norm(x)
+
 
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location_dispatch import topk_ids_logical_to_physical
@@ -34,7 +43,7 @@ def fused_topk_npu(
         )
 
         if renormalize:
-            topk_weights = l1_norm(
+            topk_weights = _l1_norm(
                 topk_weights
                 if topk_config.num_fused_shared_experts == 0
                 else topk_weights[:, :-1]

--- a/python/sglang/srt/layers/attention/fla/layernorm_gated.py
+++ b/python/sglang/srt/layers/attention/fla/layernorm_gated.py
@@ -7,6 +7,7 @@
 
 
 from functools import lru_cache
+from typing import Optional
 
 import torch
 import torch.nn.functional as F
@@ -23,6 +24,7 @@ from sglang.srt.utils import (
     is_npu,
     next_power_of_2,
 )
+from sglang.srt.utils.custom_op import register_custom_op
 
 _is_npu = is_npu()
 _use_cpu = is_cpu() and cpu_has_amx_support()
@@ -271,7 +273,70 @@ def _layer_norm_fwd(
 
 
 if _is_npu:
-    from sgl_kernel_npu.fla.layernorm_gated import layer_norm_fwd_npu as _layer_norm_fwd
+    from sgl_kernel_npu.fla.layernorm_gated import (
+        layer_norm_fwd_npu as _layer_norm_fwd_npu_raw,
+    )
+
+    @register_custom_op(out_shape="x", mutates_args=["out"])
+    def _layer_norm_fwd_custom(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        eps: float,
+        z: Optional[torch.Tensor],
+        out: Optional[torch.Tensor],
+        group_size: Optional[int],
+        norm_before_gate: bool,
+        is_rms_norm: bool,
+        activation: Optional[str],
+    ) -> torch.Tensor:
+        _out, _mean, _rstd = _layer_norm_fwd_npu_raw(
+            x=x,
+            weight=weight,
+            bias=bias,
+            eps=eps,
+            z=z,
+            out=out,
+            group_size=group_size,
+            norm_before_gate=norm_before_gate,
+            is_rms_norm=is_rms_norm,
+            activation=activation,
+        )
+        return _out
+
+    def _layer_norm_fwd(
+        x,
+        weight,
+        bias,
+        eps,
+        z=None,
+        out=None,
+        group_size=None,
+        norm_before_gate=True,
+        is_rms_norm=False,
+        activation=None,
+    ):
+        if group_size is None:
+            group_size = x.shape[-1]
+        if out is not None:
+            assert out.shape == x.shape
+        else:
+            out = torch.empty_like(x)
+        y = _layer_norm_fwd_custom(
+            x=x,
+            weight=weight,
+            bias=bias,
+            eps=eps,
+            z=z,
+            out=out,
+            group_size=group_size,
+            norm_before_gate=norm_before_gate,
+            is_rms_norm=is_rms_norm,
+            activation=activation,
+        )
+        # mean/rstd are unused by all callers on the NPU path (rms_norm_gated
+        # discards them); return None to keep the (y, mean, rstd) unpack contract.
+        return y, None, None
 
 
 def rms_norm_gated(
@@ -318,7 +383,6 @@ def rms_norm_gated(
 
 
 class LayerNormFn(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -362,7 +426,6 @@ def layernorm_fn(
 
 
 class LayerNorm(torch.nn.Module):
-
     def __init__(
         self,
         hidden_size,
@@ -404,7 +467,6 @@ class LayerNorm(torch.nn.Module):
 
 
 class RMSNorm(torch.nn.Module):
-
     def __init__(
         self,
         hidden_size,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2956,8 +2956,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 if hasattr(layer.self_attn, "attn"):
                     attn_layer = layer.self_attn.attn
                 elif hasattr(layer.self_attn, "attn_mqa"):
-                    # For DeepSeek model
-                    attn_layer = layer.self_attn.attn_mqa
+                    # For DeepSeek model.
+                    # On NPU non-DSA extend, dispatch goes through MHA_NPU →
+                    # forward_mha_core_npu → attn_mha, so store attn_mha.
+                    # DSA extend uses DSA_NPU → forward_dsa_core_npu → attn_mqa,
+                    # so keep attn_mqa for layers with an indexer.
+                    # Other platforms always use attn_mqa (MLA absorb path).
+                    if (
+                        _is_npu
+                        and hasattr(layer.self_attn, "attn_mha")
+                        and not hasattr(layer.self_attn, "indexer")
+                    ):
+                        attn_layer = layer.self_attn.attn_mha
+                    else:
+                        attn_layer = layer.self_attn.attn_mqa
             # For hybrid model
             elif hasattr(layer, "attn"):
                 attn_layer = layer.attn

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -138,6 +138,20 @@ def set_torch_compile_config():
     if hasattr(torch._dynamo.config, "cache_size_limit"):
         torch._dynamo.config.cache_size_limit = 1024
 
+    # torch_npu patches os.getenv to record every seen env-var key in a global set
+    # (_seen) for once-logging. Dynamo guards on that global, and it keeps growing as
+    # more env vars are read -> spurious runtime recompiles of the piecewise graph
+    # (which then re-capture on a live request and corrupt order-sensitive mamba
+    # recurrence). Neutralize the once-logging so the global stops mutating and dynamo
+    # no longer guards on it.
+    if is_npu():
+        try:
+            from torch_npu.utils import patch_getenv
+
+            patch_getenv._log_once = lambda *a, **k: None
+        except Exception:
+            pass
+
     if _is_musa:
         from sglang.srt.hardware_backend.musa.utils.patch_torch import (
             patch_fx_custom_device,
@@ -218,17 +232,15 @@ class PiecewiseCudaGraphRunner:
         if model_runner.server_args.enable_return_hidden_states:
             self.capture_hidden_mode = CaptureHiddenMode.FULL
 
-        # For hybrid linear-attention (mamba/GDN) models, do NOT make the speculative
-        # prefill hit PCG. The mamba/linear recurrence is order-sensitive and the
-        # request that triggers NPU graph capture computes a wrong recurrent state
-        # (garbled output). Leaving capture_hidden_mode at the default (NULL) makes
-        # the spec prefill (FULL/LAST) miss can_run() -> it runs eager (correct),
-        # while verify/draft/decode still use their own (full) cuda graphs. Non-mamba
-        # models keep the spec-aware capture_hidden_mode so their prefill uses PCG.
-        is_mambaish = getattr(model_runner, "mambaish_config", None) is not None
+        # Speculative (EAGLE/MTP) prefill needs hidden states, so the PCG graphs must
+        # be captured with the matching capture_hidden_mode (FULL on the target, LAST
+        # on the draft) for can_run() to admit the spec prefill. This lets the spec
+        # prefill use the piecewise graph. (Correctness for hybrid linear-attention/
+        # mamba models relies on the dynamic-shape marking in compile.py so the live
+        # request reuses the init-captured graph instead of re-capturing on a live
+        # request — see _mark_token_dims there.)
         if (
-            not is_mambaish
-            and model_runner.spec_algorithm is not None
+            model_runner.spec_algorithm is not None
             and model_runner.spec_algorithm.is_eagle()
         ):
             if model_runner.is_draft_worker:

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import bisect
+import dataclasses
 import gc
 import logging
 import warnings
@@ -217,6 +218,24 @@ class PiecewiseCudaGraphRunner:
         if model_runner.server_args.enable_return_hidden_states:
             self.capture_hidden_mode = CaptureHiddenMode.FULL
 
+        # For hybrid linear-attention (mamba/GDN) models, do NOT make the speculative
+        # prefill hit PCG. The mamba/linear recurrence is order-sensitive and the
+        # request that triggers NPU graph capture computes a wrong recurrent state
+        # (garbled output). Leaving capture_hidden_mode at the default (NULL) makes
+        # the spec prefill (FULL/LAST) miss can_run() -> it runs eager (correct),
+        # while verify/draft/decode still use their own (full) cuda graphs. Non-mamba
+        # models keep the spec-aware capture_hidden_mode so their prefill uses PCG.
+        is_mambaish = getattr(model_runner, "mambaish_config", None) is not None
+        if (
+            not is_mambaish
+            and model_runner.spec_algorithm is not None
+            and model_runner.spec_algorithm.is_eagle()
+        ):
+            if model_runner.is_draft_worker:
+                self.capture_hidden_mode = CaptureHiddenMode.LAST
+            else:
+                self.capture_hidden_mode = CaptureHiddenMode.FULL
+
         self.max_num_tokens = (
             max(self.capture_num_tokens) if self.capture_num_tokens else 8192
         )
@@ -301,7 +320,30 @@ class PiecewiseCudaGraphRunner:
                 # Capture
                 self.capture()
 
+        # PCG warmup/capture runs the linear-attention (mamba/GDN) recurrence on
+        # dummy (zero) inputs over the full padded length, using req_pool_index 0
+        # which maps to the mamba *dummy slot 0*. A long (e.g. 128-step) recurrence
+        # on garbage input writes diverging/non-zero state into that shared slot.
+        # During real serving, decode/verify reads slot 0 for padding positions, so
+        # the poisoned state corrupts MTP verify (garbled output; the state then
+        # explodes to ~1e19 over decode steps). Capture runs before any real
+        # request, so restore the pristine all-zero mamba state here.
+        self._reset_mamba_state_after_capture()
+
         self.raw_num_tokens = 0
+
+    def _reset_mamba_state_after_capture(self) -> None:
+        mamba_pool = getattr(self.model_runner.req_to_token_pool, "mamba_pool", None)
+        if mamba_pool is None:
+            return
+        cache = mamba_pool.mamba_cache
+        if not dataclasses.is_dataclass(cache):
+            return
+        for f in dataclasses.fields(cache):
+            v = getattr(cache, f.name)
+            for t in v if isinstance(v, (list, tuple)) else [v]:
+                if isinstance(t, torch.Tensor):
+                    t.zero_()
 
     def warmup_compile(self, num_tokens: int):
         """Warmup the model with a simple forward pass before CUDA graph capture."""
@@ -366,7 +408,7 @@ class PiecewiseCudaGraphRunner:
                 mrope_positions=mrope_positions,
                 spec_algorithm=None,
                 spec_info=None,
-                capture_hidden_mode=CaptureHiddenMode.NULL,
+                capture_hidden_mode=self.capture_hidden_mode,
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
@@ -424,9 +466,7 @@ class PiecewiseCudaGraphRunner:
             ):
                 if start_len is not None and start_len < seq_len:
                     return False
-        if num_tokens <= self.max_num_tokens:
-            return True
-        return False
+        return num_tokens <= self.max_num_tokens
 
     def capture(self) -> None:
         # Trigger CUDA graph capture for specific shapes.
@@ -537,7 +577,7 @@ class PiecewiseCudaGraphRunner:
                 mrope_positions=mrope_positions,
                 spec_algorithm=None,
                 spec_info=None,
-                capture_hidden_mode=CaptureHiddenMode.NULL,
+                capture_hidden_mode=self.capture_hidden_mode,
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
@@ -752,6 +792,7 @@ class PiecewiseCudaGraphRunner:
                         and output.mm_input_embeds is not None
                     ):
                         mm_input_embeds = output.mm_input_embeds[: self.raw_num_tokens]
+
                     return LogitsProcessorOutput(
                         next_token_logits=output.next_token_logits[
                             : self.raw_num_tokens

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -445,7 +445,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             topk_output=topk_output,
         )
         if enable_dual_stream:
-            wait_share_stream()
+            wait_share_stream(hidden_states)
 
         if shared_output is not None:
             final_hidden_states.add_(shared_output)

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -425,8 +425,8 @@ class Qwen3DecoderLayer(nn.Module):
             ),
         )
         hidden_states = self.mlp(hidden_states, forward_batch=forward_batch)
-        if _is_npu and get_cmo_stream():
-            wait_cmo_stream()
+        if _is_npu and get_cmo_stream() is not None:
+            wait_cmo_stream(hidden_states)
         hidden_states, residual = self.layer_communicator.postprocess_layer(
             hidden_states, residual, forward_batch
         )

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -15,6 +15,7 @@
 """Inference-only Qwen3.5 model and Qwen3.5 MoE model compatible with HuggingFace weights."""
 
 import logging
+from contextlib import nullcontext
 from functools import lru_cache
 from typing import Iterable, Optional, Set, Tuple, Union
 
@@ -1170,9 +1171,14 @@ class Qwen3_5ForCausalLM(nn.Module):
         # Pass through decoder layers
         for layer_idx in range(self.start_layer, self.end_layer):
             layer = self.layers[layer_idx]
-            with get_global_expert_distribution_recorder().with_current_layer(
-                layer_idx
-            ):
+            ctx = (
+                nullcontext()
+                if not get_global_server_args().disable_piecewise_cuda_graph
+                else get_global_expert_distribution_recorder().with_current_layer(
+                    layer_idx
+                )
+            )
+            with ctx:
                 hidden_states, residual = layer(
                     positions=positions,
                     hidden_states=hidden_states,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1355,7 +1355,7 @@ class ServerArgs:
         if self.pp_size > 1:
             self.disable_piecewise_cuda_graph = True
         # 5. Non-CUDA hardware (AMD, NPU, CPU, MPS, XPU, etc.)
-        if is_hip() or is_npu() or is_cpu() or is_mps() or is_xpu():
+        if is_hip() or is_cpu() or is_mps() or is_xpu():
             self.disable_piecewise_cuda_graph = True
         # 5b. OOT platforms that don't support piecewise cuda graph
         if current_platform.is_out_of_tree():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Piecewise CUDA Graph (PCG) was force-disabled on NPU, so NPU deployments fell back to
fully-eager forward. This PR enables PCG on NPU and makes it work correctly together with
**MoE**, **MTP (EAGLE/NEXTN) speculative decoding**, and **hybrid linear-attention
(mamba/GDN) models** (validated on Qwen3.5, NPU, TP=2, ascend backend).

The hard part is hybrid linear-attention + MTP: the mamba/GDN layers keep a single
**order-sensitive recurrent state** (the prefill-saved final state is the only bridge
`verify` continues from). When a *live* request triggers NPU graph **capture**, that
capture mis-computes the recurrence and corrupts the saved state, producing garbled
(`!!!!`) output. This PR fixes that while keeping prefill on PCG.

## Modifications

Four module-scoped commits:

**1. `[NPU]` Wrap NPU stream/prefetch/l1_norm ops as custom ops for torch.compile.**
NPU helper ops do stream sync / `npu_prefetch` / external-kernel work and runtime
`isinstance` branching that Dynamo cannot trace under `fullgraph=True`. Register them as
**opaque custom ops** so they survive the PCG FX trace:
- `cmo.py`: register `wait_cmo_stream` / `wait_share_stream`; split `prepare_weight_cache`
  into `_prepare_weight_cache_{list,single}`; short-circuit
  `shared_expert_on_independent_stream` to serial forward when compiling.
- `moe/topk.py`: wrap `l1_norm` as `my_l1_norm`.
- Custom-op schemas need a tensor arg, so call sites (`qwen2_moe`, `qwen3`) pass `hidden_states`.

**2. `[NPU]` FLA layernorm-gated custom op for torch.compile.**
Register the NPU `layer_norm_fwd` as a custom op with `mutates_args=["out"]` (correctly
declaring only the in-place-mutated output buffer), so torch.compile's aliasing analysis
is sound.

**3. `[PCG]` Enable piecewise CUDA graph on NPU (MoE + MTP).**
- `server_args`: stop force-disabling PCG on NPU.
- `npu_piecewise_backend`: capture on the dedicated PCG capture stream with
  `auto_dispatch_capture=True`; bypass to eager during the torch.compile trace phase
  (`is_in_pcg_torch_compile`) so the eager split-ops between captured pieces stay correct.
- `weak_ref_tensor`: tolerate non-tensor items in list/tuple outputs.
- `qwen3_5`: skip the expert-distribution-recorder per-layer context under PCG.
- MTP: make spec-aware `capture_hidden_mode` (FULL target / LAST draft) and the static
  prefill buffers MTP-aware; init `attn_backend.init_forward_metadata` before replay;
  register `attn_mha` (not `attn_mqa`) on NPU non-DSA extend.
- Hybrid-mamba: `_reset_mamba_state_after_capture` zeros the mamba pool after init capture
  (the dummy-input recurrence dirties the shared mamba dummy slot 0 that decode padding reads).

**4. `[PCG]` Run hybrid-mamba MTP prefill through PCG correctly (reuse init-captured graph).**
Make the live request **reuse the graph captured at init** so capture only ever happens at
init (dummy batch) — the mamba recurrence is never mis-computed under capture. Done by
removing the runtime dynamo-recompile triggers:
- `compile.py`: mark **every dim whose size == num_tokens** dynamic, on both top-level
  tensor args and the `ForwardBatch` tensor fields (the annotation-based map only marked
  dim 0 of top-level params; the real token dim isn't always dim 0, e.g. mrope `positions`
  is `[3, num_tokens]`). One dynamic graph then covers all token buckets.
- `piecewise_cuda_graph_runner`: neutralize torch_npu's `os.getenv` once-logging on NPU
  (its growing global set was guarded by Dynamo → spurious recompiles).
- Drop the mambaish `capture_hidden_mode` gate so mamba MTP prefill also runs through PCG.

## Accuracy Tests

Validated on Qwen3.5-9B (hybrid linear-attention + MTP), NPU, TP=2, ascend backend:
- **Before:** garbled output (`!!!!`) with PCG + MTP on the mamba model.
- **After:** correct output across token counts 100 / 200 / 333 (buckets 128 / 256 / 512),
  matching the non-PCG (eager) baseline; 111 tokens × 5 requests stable.
- With `TORCH_LOGS=recompiles`: **zero post-ready recompiles**; prefill stays
  `npu graph: True`; dynamic-dim marking happens once at init (largest bucket) and only
  genuine token dims are marked.

## Speed Tests and Profiling

N.A.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests. *(NPU-only path; covered by manual accuracy validation above)*
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27050982335](https://github.com/sgl-project/sglang/actions/runs/27050982335)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27050982299](https://github.com/sgl-project/sglang/actions/runs/27050982299)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->