### PR TITLE
[LoRA] Fix MoE virtual-experts gated gate_up: up half must use up_A shrink

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
@@ -381,6 +381,8 @@ def fused_moe_kernel(
     FUSE_ADD_TO_OUTPUT: tl.constexpr,
     FUSE_SUM_ALL_REDUCE: tl.constexpr,
     ROUTER_TOPK: tl.constexpr,
+    GATED_A_INPUT: tl.constexpr,
+    GATED_A_N_HALF: tl.constexpr,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -465,8 +467,18 @@ def fused_moe_kernel(
         assert use_fp8_w8a8 and group_n > 0 and group_k > 0
         start_offs_m = pid_m * BLOCK_SIZE_M
     else:
+        # Gated gate_up LoRA expand: A holds [gate_shrink | up_shrink] (2*K columns).
+        # Output N tiles in the up half (pid_n past the gate/up boundary) contract the
+        # up-shrink columns [K:2K] instead of [0:K], so a single launch produces the
+        # correct gate (from gate_A) and up (from up_A) deltas. GATED_A_INPUT=False
+        # (the default) leaves the offset at 0 -- identical to the non-gated path.
+        if GATED_A_INPUT:
+            a_k_offset = tl.where(pid_n * BLOCK_SIZE_N >= GATED_A_N_HALF, K, 0)
+        else:
+            a_k_offset = 0
         a_ptrs = a_ptr + (
-            offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
+            offs_token[:, None] // top_k * stride_am
+            + (offs_k[None, :] + a_k_offset) * stride_ak
         )
 
     if b_desc is not None:
@@ -731,9 +743,22 @@ def invoke_fused_moe_kernel(
     router_topk: int = 1,
     fuse_add_to_output: bool = False,
     add_output_mask: Optional[torch.Tensor] = None,
+    gated_a_input: bool = False,
+    gated_a_n_half: int = 0,
 ) -> None:
     assert topk_weights.stride(1) == 1
     assert sorted_token_ids.stride(0) == 1
+    if gated_a_input:
+        # A holds [gate_shrink | up_shrink] = 2*K columns; the kernel selects [0:K]
+        # for the gate output half and [K:2K] for the up half via GATED_A_N_HALF.
+        assert not (
+            use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
+        ), "gated A remap is only supported for unquantized LoRA expand kernels"
+        assert A.shape[1] >= 2 * B.shape[2]
+        assert gated_a_n_half > 0
+        assert (
+            gated_a_n_half % config["BLOCK_SIZE_N"] == 0
+        ), "gated A remap requires the gate/up output boundary to align to BLOCK_SIZE_N"
 
     if use_fp8_w8a8:
         swap_ab = should_enable_swap_ab(config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"])
@@ -926,6 +951,8 @@ def invoke_fused_moe_kernel(
             FUSE_ADD_TO_OUTPUT=fuse_add_to_output,
             FUSE_SUM_ALL_REDUCE=fuse_sum_all_reduce,
             ROUTER_TOPK=router_topk,
+            GATED_A_INPUT=gated_a_input,
+            GATED_A_N_HALF=gated_a_n_half,
             **config,
         )
 

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
@@ -754,6 +754,10 @@ def invoke_fused_moe_kernel(
         assert not (
             use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
         ), "gated A remap is only supported for unquantized LoRA expand kernels"
+        # The A-TMA path (a_desc) loads A in the `a_desc is not None` branch, which
+        # bypasses the GATED_A_INPUT column remap entirely -- it would silently fall
+        # back to reading gate-shrink for the up half. Disallow the combination.
+        assert not a_use_tma, "gated A remap is not supported with A TMA"
         assert A.shape[1] >= 2 * B.shape[2]
         assert gated_a_n_half > 0
         assert (

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -704,6 +704,19 @@ def _merged_experts_fused_moe_lora_add_impl(
     # deltas. This matches the classic path (_add_lora_gate_up_delta) numerically.
     expand_rank = lora_b_virtual.shape[-1]
     is_gated = max_lora_rank > expand_rank
+    gated_a_n_half = (lora_b_virtual.shape[1] // 2) if is_gated else 0
+    expand_config = b_stage_config
+    if is_gated:
+        # The in-kernel gate/up split needs the gate/up output boundary (gated_a_n_half)
+        # to land on a BLOCK_SIZE_N tile boundary, else a tile would straddle the two
+        # halves. Clamp the expand tile to a power-of-2 divisor of n_half (n_half is a
+        # power-of-2-multiple MLP dim, so this terminates) instead of crashing on an
+        # ill-aligned tuned config. BLOCK_SIZE_N only affects this expand's tiling.
+        block_n = b_stage_config["BLOCK_SIZE_N"]
+        while gated_a_n_half % block_n != 0:
+            block_n //= 2
+        if block_n != b_stage_config["BLOCK_SIZE_N"]:
+            expand_config = {**b_stage_config, "BLOCK_SIZE_N": block_n}
     invoke_fused_moe_kernel(
         intermediate.view(-1, max_lora_rank),
         lora_b_virtual,
@@ -719,7 +732,7 @@ def _merged_experts_fused_moe_lora_add_impl(
         num_tokens_post_padded,
         mul_routed_weight,
         1,
-        b_stage_config,
+        expand_config,
         tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
         False,
         False,
@@ -731,7 +744,7 @@ def _merged_experts_fused_moe_lora_add_impl(
         add_output_mask=token_lora_mask,
         router_topk=topk_ids.shape[1],
         gated_a_input=is_gated,
-        gated_a_n_half=(lora_b_virtual.shape[1] // 2) if is_gated else 0,
+        gated_a_n_half=gated_a_n_half,
     )
 
 

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -692,33 +692,60 @@ def _merged_experts_fused_moe_lora_add_impl(
         b_stage_config["BLOCK_SIZE_M"],
     )
 
-    invoke_fused_moe_kernel(
-        intermediate.view(-1, max_lora_rank),
-        lora_b_virtual,
-        None,
-        output,
-        None,
-        None,
-        None,
-        topk_weights,
-        topk_ids,
-        sorted_token_ids,
-        expert_ids,
-        num_tokens_post_padded,
-        mul_routed_weight,
-        1,
-        b_stage_config,
-        tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
-        False,
-        False,
-        False,
-        False,
-        False,
-        None,
-        fuse_add_to_output=True,
-        add_output_mask=token_lora_mask,
-        router_topk=topk_ids.shape[1],
-    )
+    intermediate_2d = intermediate.view(-1, max_lora_rank)
+
+    def _expand(a_2d, b_3d, out):
+        invoke_fused_moe_kernel(
+            a_2d,
+            b_3d,
+            None,
+            out,
+            None,
+            None,
+            None,
+            topk_weights,
+            topk_ids,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            1,
+            b_stage_config,
+            tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
+            False,
+            False,
+            False,
+            False,
+            False,
+            None,
+            fuse_add_to_output=True,
+            add_output_mask=token_lora_mask,
+            router_topk=topk_ids.shape[1],
+        )
+
+    # Gated MLP (gate_up): lora_a stacks gate+up A-weights along the rank dim
+    # (rank = 2r) while lora_b keeps the original rank r. The shrink produces
+    # both gate-shrink [:, 0:r] and up-shrink [:, r:2r], but the expand kernel
+    # contracts only K = lora_b.shape[-1] = r columns. A single call would feed
+    # the gate-shrink [:, 0:r] to BOTH the gate and up output halves, dropping
+    # up_A entirely (up delta computed from gate_A — wrong whenever gate_A !=
+    # up_A, which is the normal independently-trained gate/up LoRA case). Match
+    # the classic-LoRA path (_add_lora_gate_up_delta) by splitting the expand
+    # into gate and up halves, each contracting its own rank slice.
+    expand_rank = lora_b_virtual.shape[-1]
+    if max_lora_rank > expand_rank:
+        n_half = lora_b_virtual.shape[1] // 2
+        # Slice the output's last dim (3D [M, top_k, gate_up_dim]); the kernel
+        # addresses C via stride(-2)/stride(-1), so a strided column slice writes
+        # the right half in-place without a contiguity-forcing .view/.reshape.
+        for half in range(2):
+            _expand(
+                intermediate_2d[:, half * expand_rank : (half + 1) * expand_rank],
+                lora_b_virtual[:, half * n_half : (half + 1) * n_half, :],
+                output[..., half * n_half : (half + 1) * n_half],
+            )
+    else:
+        _expand(intermediate_2d, lora_b_virtual, output)
 
 
 def _merged_experts_fused_moe_lora_add_op(

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -692,60 +692,47 @@ def _merged_experts_fused_moe_lora_add_impl(
         b_stage_config["BLOCK_SIZE_M"],
     )
 
-    intermediate_2d = intermediate.view(-1, max_lora_rank)
-
-    def _expand(a_2d, b_3d, out):
-        invoke_fused_moe_kernel(
-            a_2d,
-            b_3d,
-            None,
-            out,
-            None,
-            None,
-            None,
-            topk_weights,
-            topk_ids,
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            mul_routed_weight,
-            1,
-            b_stage_config,
-            tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
-            False,
-            False,
-            False,
-            False,
-            False,
-            None,
-            fuse_add_to_output=True,
-            add_output_mask=token_lora_mask,
-            router_topk=topk_ids.shape[1],
-        )
-
     # Gated MLP (gate_up): lora_a stacks gate+up A-weights along the rank dim
-    # (rank = 2r) while lora_b keeps the original rank r. The shrink produces
-    # both gate-shrink [:, 0:r] and up-shrink [:, r:2r], but the expand kernel
-    # contracts only K = lora_b.shape[-1] = r columns. A single call would feed
-    # the gate-shrink [:, 0:r] to BOTH the gate and up output halves, dropping
-    # up_A entirely (up delta computed from gate_A — wrong whenever gate_A !=
-    # up_A, which is the normal independently-trained gate/up LoRA case). Match
-    # the classic-LoRA path (_add_lora_gate_up_delta) by splitting the expand
-    # into gate and up halves, each contracting its own rank slice.
+    # (rank = 2r) while lora_b keeps the original rank r. The shrink produces both
+    # gate-shrink [:, 0:r] and up-shrink [:, r:2r], but the expand contracts only
+    # K = lora_b.shape[-1] = r columns of A. Without the gated remap a single call
+    # feeds the gate-shrink [:, 0:r] to BOTH the gate and up output halves, dropping
+    # up_A entirely (up delta computed from gate_A -- wrong whenever gate_A != up_A,
+    # the normal independently-trained gate/up LoRA case). `gated_a_input` makes the
+    # up output tiles read the up-shrink columns [r:2r] IN-KERNEL, so one launch (one
+    # routing pass, weights read once) yields the correct gate (gate_A) and up (up_A)
+    # deltas. This matches the classic path (_add_lora_gate_up_delta) numerically.
     expand_rank = lora_b_virtual.shape[-1]
-    if max_lora_rank > expand_rank:
-        n_half = lora_b_virtual.shape[1] // 2
-        # Slice the output's last dim (3D [M, top_k, gate_up_dim]); the kernel
-        # addresses C via stride(-2)/stride(-1), so a strided column slice writes
-        # the right half in-place without a contiguity-forcing .view/.reshape.
-        for half in range(2):
-            _expand(
-                intermediate_2d[:, half * expand_rank : (half + 1) * expand_rank],
-                lora_b_virtual[:, half * n_half : (half + 1) * n_half, :],
-                output[..., half * n_half : (half + 1) * n_half],
-            )
-    else:
-        _expand(intermediate_2d, lora_b_virtual, output)
+    is_gated = max_lora_rank > expand_rank
+    invoke_fused_moe_kernel(
+        intermediate.view(-1, max_lora_rank),
+        lora_b_virtual,
+        None,
+        output,
+        None,
+        None,
+        None,
+        topk_weights,
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        mul_routed_weight,
+        1,
+        b_stage_config,
+        tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
+        False,
+        False,
+        False,
+        False,
+        False,
+        None,
+        fuse_add_to_output=True,
+        add_output_mask=token_lora_mask,
+        router_topk=topk_ids.shape[1],
+        gated_a_input=is_gated,
+        gated_a_n_half=(lora_b_virtual.shape[1] // 2) if is_gated else 0,
+    )
 
 
 def _merged_experts_fused_moe_lora_add_op(

--- a/test/registered/lora/test_virtual_experts_kernels.py
+++ b/test/registered/lora/test_virtual_experts_kernels.py
@@ -37,6 +37,7 @@ from sglang.srt.lora.triton_ops.virtual_experts import (
     _align_block_size_torch,
     _fused_virtual_topk_ids,
     fused_sanitize_expert_ids,
+    merged_experts_fused_moe_lora_add,
 )
 
 
@@ -274,6 +275,67 @@ class TestAlignBlockSizeJitSentinelBucket(_AlignBlockSizeSentinelBucketBase):
         )
         expert_ids = fused_sanitize_expert_ids(expert_ids, num_experts)
         return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+class TestMergedExpertsGatedGateUpLoRA(CustomTestCase):
+    """Gated gate_up MoE-LoRA expand must use up_A for the up half, gate_A for gate.
+
+    Regression for the bug where the virtual-experts expand contracted only the
+    first `rank` shrink columns (gate_A) and fed them to BOTH output halves, so
+    the up-projection LoRA delta was computed from gate_A and up_A was dropped.
+    Builds independently-initialized gate_A != up_A and checks both output halves
+    against a plain-PyTorch PEFT reference (gate = x@gate_A^T@gate_B^T,
+    up = x@up_A^T@up_B^T).
+    """
+
+    def test_up_half_uses_up_a(self):
+        """Gated gate_up LoRA: gate and up halves each match their own A/B vs PEFT."""
+        torch.manual_seed(0)
+        device, dtype = "cuda", torch.bfloat16
+        E, top_k, K, inter, r, bs = 8, 4, 256, 128, 16, 16
+        gen = torch.Generator(device=device).manual_seed(0)
+
+        def rnd(*shape):
+            return torch.randn(*shape, generator=gen, device=device, dtype=dtype) * 0.1
+
+        gate_a, up_a = rnd(E, r, K), rnd(E, r, K)  # independent: gate_A != up_A
+        gate_b, up_b = rnd(E, inter, r), rnd(E, inter, r)
+        # Stacked buffers as the loader builds them: lora_a rank-dim = 2r, lora_b N = 2*inter.
+        lora_a = torch.empty(1, E, 2 * r, K, device=device, dtype=dtype)
+        lora_a[0, :, 0:r, :], lora_a[0, :, r : 2 * r, :] = gate_a, up_a
+        lora_b = torch.empty(1, E, 2 * inter, r, device=device, dtype=dtype)
+        lora_b[0, :, 0:inter, :], lora_b[0, :, inter : 2 * inter, :] = gate_b, up_b
+
+        hidden = rnd(bs, K)
+        topk_ids = torch.topk(
+            torch.rand(bs, E, generator=gen, device=device), k=top_k, dim=1
+        ).indices.to(torch.int32)
+        topk_weights = torch.ones(bs, top_k, device=device, dtype=torch.float32)
+        tlm = torch.zeros(bs, device=device, dtype=torch.int32)
+
+        output = torch.zeros(bs, top_k, 2 * inter, device=device, dtype=dtype)
+        merged_experts_fused_moe_lora_add(
+            output, hidden, lora_a, lora_b, topk_ids, topk_weights, tlm,
+            False, False, False,
+        )
+
+        xf = hidden.float()
+        gate_a_f, up_a_f = gate_a.float(), up_a.float()
+        gate_b_f, up_b_f = gate_b.float(), up_b.float()
+        for m in range(bs):
+            for k in range(top_k):
+                e = int(topk_ids[m, k].item())
+                gate_ref = (xf[m] @ gate_a_f[e].t()) @ gate_b_f[e].t()
+                up_ref = (xf[m] @ up_a_f[e].t()) @ up_b_f[e].t()
+                got = output[m, k].float()
+                torch.testing.assert_close(
+                    got[:inter], gate_ref, rtol=2e-2, atol=2e-3,
+                    msg=f"gate half mismatch (m={m}, k={k}, e={e})",
+                )
+                torch.testing.assert_close(
+                    got[inter:], up_ref, rtol=2e-2, atol=2e-3,
+                    msg=f"up half mismatch (m={m}, k={k}, e={e}) -- up must use up_A",
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/lora/test_virtual_experts_kernels.py
+++ b/test/registered/lora/test_virtual_experts_kernels.py
@@ -315,8 +315,16 @@ class TestMergedExpertsGatedGateUpLoRA(CustomTestCase):
 
         output = torch.zeros(bs, top_k, 2 * inter, device=device, dtype=dtype)
         merged_experts_fused_moe_lora_add(
-            output, hidden, lora_a, lora_b, topk_ids, topk_weights, tlm,
-            False, False, False,
+            output,
+            hidden,
+            lora_a,
+            lora_b,
+            topk_ids,
+            topk_weights,
+            tlm,
+            False,
+            False,
+            False,
         )
 
         xf = hidden.float()
@@ -329,11 +337,17 @@ class TestMergedExpertsGatedGateUpLoRA(CustomTestCase):
                 up_ref = (xf[m] @ up_a_f[e].t()) @ up_b_f[e].t()
                 got = output[m, k].float()
                 torch.testing.assert_close(
-                    got[:inter], gate_ref, rtol=2e-2, atol=2e-3,
+                    got[:inter],
+                    gate_ref,
+                    rtol=2e-2,
+                    atol=2e-3,
                     msg=f"gate half mismatch (m={m}, k={k}, e={e})",
                 )
                 torch.testing.assert_close(
-                    got[inter:], up_ref, rtol=2e-2, atol=2e-3,
+                    got[inter:],
+                    up_ref,
+                    rtol=2e-2,
+                    atol=2e-3,
                     msg=f"up half mismatch (m={m}, k={k}, e={e}) -- up must use up_A",
                 )
 

--- a/test/registered/lora/test_virtual_experts_kernels.py
+++ b/test/registered/lora/test_virtual_experts_kernels.py
@@ -15,6 +15,10 @@ Covers two regression bugs that surface only with `--lora-use-virtual-experts`
   wrap, or past-end) and don't get assigned to a real expert in the
   consumer-block table.
 
+It also covers the gated gate_up expand math: the up output half must contract
+the up_A shrink slice (`[r:2r]`), not gate_A (`[0:r]`). The pre-fix expand fed
+gate_A's shrink to both halves, dropping up_A entirely.
+
 Both kernels run on CUDA. The fallback is gated on `virtual_num_experts >= 1024`
 in production, but we exercise it directly here at smaller sizes for cheaper
 iteration; one test sticks to the >1024 regime to mirror the production trigger.
@@ -285,20 +289,34 @@ class TestMergedExpertsGatedGateUpLoRA(CustomTestCase):
     the up-projection LoRA delta was computed from gate_A and up_A was dropped.
     Builds independently-initialized gate_A != up_A and checks both output halves
     against a plain-PyTorch PEFT reference (gate = x@gate_A^T@gate_B^T,
-    up = x@up_A^T@up_B^T).
+    up = x@up_A^T@up_B^T), including the EP-dispatch `topk_ids == -1` sentinels and
+    no-LoRA tokens (`token_lora_mapping == -1`) that gate the production trigger.
     """
 
-    def test_up_half_uses_up_a(self):
-        """Gated gate_up LoRA: gate and up halves each match their own A/B vs PEFT."""
-        torch.manual_seed(0)
-        device, dtype = "cuda", torch.bfloat16
-        E, top_k, K, inter, r, bs = 8, 4, 256, 128, 16, 16
-        gen = torch.Generator(device=device).manual_seed(0)
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA required")
+        cls.device = "cuda:0"
+
+    def _run_gated(self, r, E, with_sentinels):
+        """Build a gated gate_up adapter (gate_A != up_A), run the real dispatch,
+        and assert each output half matches its own A/B vs a PEFT reference.
+
+        ``with_sentinels`` injects EP-dropped experts (topk_ids == -1) and a
+        no-LoRA token (token_lora_mapping == -1); both must yield a zero delta.
+        """
+        device, dtype = self.device, torch.bfloat16
+        top_k, K, inter, bs = 4, 256, 128, 16
+        gen = torch.Generator(device=device).manual_seed(r + int(with_sentinels))
 
         def rnd(*shape):
             return torch.randn(*shape, generator=gen, device=device, dtype=dtype) * 0.1
 
         gate_a, up_a = rnd(E, r, K), rnd(E, r, K)  # independent: gate_A != up_A
+        self.assertFalse(
+            torch.equal(gate_a, up_a), "test invariant: gate_A must differ from up_A"
+        )
         gate_b, up_b = rnd(E, inter, r), rnd(E, inter, r)
         # Stacked buffers as the loader builds them: lora_a rank-dim = 2r, lora_b N = 2*inter.
         lora_a = torch.empty(1, E, 2 * r, K, device=device, dtype=dtype)
@@ -312,6 +330,10 @@ class TestMergedExpertsGatedGateUpLoRA(CustomTestCase):
         ).indices.to(torch.int32)
         topk_weights = torch.ones(bs, top_k, device=device, dtype=torch.float32)
         tlm = torch.zeros(bs, device=device, dtype=torch.int32)
+        if with_sentinels:
+            topk_ids[0, 0] = -1  # EP-dropped (non-owned) expert
+            topk_ids[1, :] = -1  # whole token dropped
+            tlm[2] = -1  # no-LoRA token
 
         output = torch.zeros(bs, top_k, 2 * inter, device=device, dtype=dtype)
         merged_experts_fused_moe_lora_add(
@@ -328,27 +350,92 @@ class TestMergedExpertsGatedGateUpLoRA(CustomTestCase):
         )
 
         xf = hidden.float()
-        gate_a_f, up_a_f = gate_a.float(), up_a.float()
-        gate_b_f, up_b_f = gate_b.float(), up_b.float()
+        gate_a_f, up_a_f, gate_b_f, up_b_f = (
+            gate_a.float(),
+            up_a.float(),
+            gate_b.float(),
+            up_b.float(),
+        )
+        zero = torch.zeros(inter, device=device, dtype=torch.float32)
         for m in range(bs):
             for k in range(top_k):
                 e = int(topk_ids[m, k].item())
-                gate_ref = (xf[m] @ gate_a_f[e].t()) @ gate_b_f[e].t()
-                up_ref = (xf[m] @ up_a_f[e].t()) @ up_b_f[e].t()
+                if e < 0 or int(tlm[m].item()) < 0:
+                    gate_ref = up_ref = zero  # sentinel / no-LoRA -> no delta
+                else:
+                    gate_ref = (xf[m] @ gate_a_f[e].t()) @ gate_b_f[e].t()
+                    up_ref = (xf[m] @ up_a_f[e].t()) @ up_b_f[e].t()
                 got = output[m, k].float()
                 torch.testing.assert_close(
                     got[:inter],
                     gate_ref,
                     rtol=2e-2,
                     atol=2e-3,
-                    msg=f"gate half mismatch (m={m}, k={k}, e={e})",
+                    msg=f"gate half mismatch (r={r}, m={m}, k={k}, e={e})",
                 )
                 torch.testing.assert_close(
                     got[inter:],
                     up_ref,
                     rtol=2e-2,
                     atol=2e-3,
-                    msg=f"up half mismatch (m={m}, k={k}, e={e}) -- up must use up_A",
+                    msg=f"up half mismatch (r={r}, m={m}, k={k}, e={e}) -- up must use up_A",
+                )
+
+    def test_up_half_uses_up_a_rank16(self):
+        """Gated gate_up LoRA (rank 16): gate and up halves each match their own A/B."""
+        self._run_gated(r=16, E=8, with_sentinels=False)
+
+    def test_up_half_uses_up_a_rank64(self):
+        """Gated gate_up LoRA (rank 64, production max): up half must use up_A."""
+        self._run_gated(r=64, E=8, with_sentinels=False)
+
+    def test_gated_with_ep_sentinels(self):
+        """Split expand + masked add stays correct under EP -1 sentinels / no-LoRA tokens."""
+        self._run_gated(r=16, E=8, with_sentinels=True)
+
+    def test_non_gated_no_regression(self):
+        """Non-gated (lora_a rank == lora_b rank) keeps the single-expand path correct."""
+        device, dtype = self.device, torch.bfloat16
+        E, top_k, K, N, r, bs = 8, 4, 256, 256, 16, 16
+        gen = torch.Generator(device=device).manual_seed(7)
+
+        def rnd(*shape):
+            return torch.randn(*shape, generator=gen, device=device, dtype=dtype) * 0.1
+
+        a, b = rnd(E, r, K), rnd(E, N, r)  # rank-dim r == lora_b rank -> non-gated
+        lora_a = a.unsqueeze(0).clone()
+        lora_b = b.unsqueeze(0).clone()
+        hidden = rnd(bs, K)
+        topk_ids = torch.topk(
+            torch.rand(bs, E, generator=gen, device=device), k=top_k, dim=1
+        ).indices.to(torch.int32)
+        topk_weights = torch.ones(bs, top_k, device=device, dtype=torch.float32)
+        tlm = torch.zeros(bs, device=device, dtype=torch.int32)
+
+        output = torch.zeros(bs, top_k, N, device=device, dtype=dtype)
+        merged_experts_fused_moe_lora_add(
+            output,
+            hidden,
+            lora_a,
+            lora_b,
+            topk_ids,
+            topk_weights,
+            tlm,
+            False,
+            False,
+            False,
+        )
+        xf, af, bf = hidden.float(), a.float(), b.float()
+        for m in range(bs):
+            for k in range(top_k):
+                e = int(topk_ids[m, k].item())
+                ref = (xf[m] @ af[e].t()) @ bf[e].t()
+                torch.testing.assert_close(
+                    output[m, k].float(),
+                    ref,
+                    rtol=2e-2,
+                    atol=2e-3,
+                    msg=f"non-gated mismatch (m={m}, k={k}, e={e})",
                 )
 
 


### PR DESCRIPTION
## Problem

The MoE virtual-experts gated `gate_up` LoRA expand computed the **up**-projection LoRA delta from `gate_A` instead of `up_A`, silently dropping `up_A` entirely.

The gated `gate_up` LoRA-A stacks gate and up along the rank dim (`lora_a` rank = `2r`), and the shrink produces both `gate_shrink = x @ gate_A^T` (cols `[0:r]`) and `up_shrink = x @ up_A^T` (cols `[r:2r]`). But `lora_b` keeps rank `r`, so the single `invoke_fused_moe_kernel` contracts only `K = r` columns of A — feeding `gate_shrink` to **both** the gate and up output halves. The `up_shrink` slice `[r:2r]` was never read.

Whenever `gate_A != up_A` (the normal case for independently-trained gate/up LoRA), the up half is wrong. On a real Qwen3.5-35B-A3B LoRA adapter, the up-half delta has **>100% relative error** vs a plain-PyTorch PEFT reference (the error exceeds the true signal), while the gate half is correct.

This only affects the `--lora-use-virtual-experts` path. The classic `fused_moe_lora` path (`_add_lora_gate_up_delta`) already splits `lora_a_stacked` into gate/up slices and is correct; the dense `gate_up_lora_b` path is also correct.

## Fix (single kernel, in-kernel A-column remap)

Give the generic `fused_moe_kernel` two constexprs, `GATED_A_INPUT` / `GATED_A_N_HALF`: when set, output N tiles in the up half (`pid_n * BLOCK_SIZE_N >= GATED_A_N_HALF`) contract the up-shrink columns `[r:2r]` of A instead of `[0:r]`. The virtual-experts gated `gate_up` expand sets `gated_a_input=True, gated_a_n_half = N/2`, so a **single launch** (one routing pass, weights read once) produces the correct gate (from `gate_A`) and up (from `up_A`) deltas — no extra kernel launch or routing reload on this latency-bound decode kernel.

`gated_a_input` defaults to `False`, leaving every other `fused_moe_kernel` caller bit-identical. This restores the in-kernel approach that briefly existed upstream (later dropped by the trtllm-lora rewrite).

## Test

Adds `TestMergedExpertsGatedGateUpLoRA` to `test/registered/lora/test_virtual_experts_kernels.py`: builds independently-initialized `gate_A != up_A`, runs the real `merged_experts_fused_moe_lora_add`, and checks **both** output halves against a PyTorch PEFT reference. Covers rank 16 and 64 (production max), an EP-sentinel case (`topk_ids == -1` + no-LoRA token — the production trigger, exercising the masked add), and a non-gated regression smoke. It **fails on the pre-fix code** (up half >100% rel error) and **passes after the fix** (verified on GB200).

The existing virtual-experts tests only covered the routing kernels (topk-id sentinels, align-block-size buckets) and never the gate/up expand math — the blind spot that let this ship.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26956087601](https://github.com/sgl-project/sglang/actions/runs/26956087601)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26956087786](https://github.com/sgl-project/sglang/actions/runs/26956087786)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->