### PR TITLE
[diffusion] Add dual realtime recording controls

### DIFF
--- a/python/sglang/multimodal_gen/apps/realtime_webui/app.js
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/app.js
@@ -233,6 +233,10 @@ let recordingEncoderReady = null;
 let recordingEncoderConfig = null;
 let recordingFrameIndex = 0;
 let recordingFps = DEFAULT_TARGET_FPS;
+let recordingMode = "smooth";
+let recordingStartedAt = 0;
+let recordingLastTimestampUs = -1;
+let recordingLastDurationUs = 0;
 let recordingTimer = 0;
 let recordingSaving = false;
 let recordingEncodeChain = Promise.resolve();
@@ -493,20 +497,41 @@ function closeFrames(items) {
 
 function recordingFileName() {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  return `sglang-realtime-${stamp}.mp4`;
+  return `sglang-realtime-${recordingMode}-${stamp}.mp4`;
 }
 
 function updateRecordButton() {
-  const button = $("recordBtn");
-  button.classList.toggle("is-recording", recordingActive);
-  button.classList.toggle("is-saving", recordingSaving);
-  button.disabled = recordingSaving;
-  button.setAttribute("aria-pressed", recordingActive ? "true" : "false");
-  $("recordLabel").textContent = recordingSaving
+  const smoothButton = $("recordSmoothBtn");
+  const realtimeButton = $("recordRealtimeBtn");
+  const smoothActive = recordingActive && recordingMode === "smooth";
+  const realtimeActive = recordingActive && recordingMode === "realtime";
+  document.querySelector(".record-actions")?.classList.toggle("is-recording", recordingActive);
+  smoothButton.classList.toggle("is-recording", smoothActive);
+  realtimeButton.classList.toggle("is-recording", realtimeActive);
+  smoothButton.classList.toggle("is-saving", recordingSaving && recordingMode === "smooth");
+  realtimeButton.classList.toggle("is-saving", recordingSaving && recordingMode === "realtime");
+  smoothButton.disabled = recordingSaving || (recordingActive && recordingMode !== "smooth");
+  realtimeButton.disabled = recordingSaving || (recordingActive && recordingMode !== "realtime");
+  smoothButton.setAttribute("aria-pressed", smoothActive ? "true" : "false");
+  realtimeButton.setAttribute("aria-pressed", realtimeActive ? "true" : "false");
+  $("recordSmoothLabel").textContent = recordingSaving && recordingMode === "smooth"
     ? "Saving"
-    : recordingActive ? "Stop" : "Record";
-  const elapsedMs = recordingActive ? recordingFrameIndex / Math.max(1, recordingFps) * 1000 : 0;
+    : smoothActive ? "Stop" : "Smooth";
+  $("recordRealtimeLabel").textContent = recordingSaving && recordingMode === "realtime"
+    ? "Saving"
+    : realtimeActive ? "Stop" : "Server";
+  const elapsedMs = recordingActive || recordingSaving ? recordingElapsedMs() : 0;
   $("recordDuration").textContent = formatRecordingDuration(elapsedMs);
+}
+
+function recordingElapsedMs() {
+  if (recordingMode === "realtime" && recordingLastTimestampUs >= 0) {
+    return (recordingLastTimestampUs + recordingLastDurationUs) / 1000;
+  }
+  if (recordingFrameIndex > 0) {
+    return recordingFrameIndex / Math.max(1, recordingFps) * 1000;
+  }
+  return recordingStartedAt ? performance.now() - recordingStartedAt : 0;
 }
 
 function formatRecordingDuration(elapsedMs) {
@@ -516,13 +541,14 @@ function formatRecordingDuration(elapsedMs) {
   return `${String(minutes).padStart(2, "0")}:${String(rest).padStart(2, "0")}`;
 }
 
-function startRecording() {
+function startRecording(mode = "smooth") {
   if (recordingActive || recordingSaving) return;
   if (!window.VideoEncoder || !window.VideoFrame) {
     setStatus("MP4 unsupported", "error");
     addHistory("MP4 recording requires WebCodecs H.264 support");
     return;
   }
+  recordingMode = mode;
   recordingActive = true;
   recordingSamples = [];
   recordingEncoder = null;
@@ -530,10 +556,13 @@ function startRecording() {
   recordingEncoderConfig = null;
   recordingFrameIndex = 0;
   recordingFps = Math.max(1, previewPlaybackTargetFps());
+  recordingStartedAt = performance.now();
+  recordingLastTimestampUs = -1;
+  recordingLastDurationUs = 0;
   recordingEncodeChain = Promise.resolve();
   recordingTimer = window.setInterval(updateRecordButton, 250);
   updateRecordButton();
-  addHistory("recording started");
+  addHistory(`${recordingMode === "realtime" ? "server-paced" : "smooth"} recording started`);
 }
 
 async function stopRecording() {
@@ -583,24 +612,40 @@ async function stopRecording() {
     recordingEncoderReady = null;
     recordingSaving = false;
     recordingSamples = [];
+    recordingFrameIndex = 0;
+    recordingStartedAt = 0;
+    recordingLastTimestampUs = -1;
+    recordingLastDurationUs = 0;
     updateRecordButton();
   }
 }
 
-function recordDecodedFrameBatch(decodedFrames) {
+function recordDecodedFrameBatch(decodedFrames, header = {}) {
   if (!recordingActive || recordingSaving) return;
-  for (const item of decodedFrames) {
-    if (!recordingActive) break;
-    recordDecodedFrame(item.image);
+  let duration = Math.round(1_000_000 / Math.max(1, recordingFps));
+  if (recordingMode === "realtime") {
+    const chunkDurationMs =
+      Number(header.chunk_total_ms || 0) || playbackController.snapshot().latestChunkDurationMs || 0;
+    if (chunkDurationMs > 0 && decodedFrames.length) {
+      duration = Math.max(1, Math.round(chunkDurationMs * 1000 / decodedFrames.length));
+    }
+    for (let i = 0; i < decodedFrames.length; i++) {
+      if (!recordingActive) break;
+      const timestamp = recordingLastTimestampUs < 0 ? 0 : recordingLastTimestampUs + duration;
+      recordDecodedFrame(decodedFrames[i].image, timestamp, duration);
+    }
+  } else {
+    for (const item of decodedFrames) {
+      if (!recordingActive) break;
+      recordDecodedFrame(item.image, recordingFrameIndex * duration, duration);
+    }
   }
   updateRecordButton();
 }
 
-function recordDecodedFrame(image) {
+function recordDecodedFrame(image, timestamp, duration) {
   if (!recordingActive || recordingSaving) return;
   const frameIndex = recordingFrameIndex;
-  const duration = Math.round(1_000_000 / Math.max(1, recordingFps));
-  const timestamp = frameIndex * duration;
   let frame;
   try {
     frame = createRecordingFrame(image, timestamp, duration);
@@ -611,6 +656,8 @@ function recordDecodedFrame(image) {
     return;
   }
   recordingFrameIndex += 1;
+  recordingLastTimestampUs = timestamp;
+  recordingLastDurationUs = duration;
   recordingEncodeChain = recordingEncodeChain
     .then(async () => {
       await ensureRecordingEncoder(frame.displayWidth, frame.displayHeight);
@@ -1558,7 +1605,7 @@ async function decodeAndEnqueueFrameBatch(header, data, epoch) {
   }
   const now = performance.now();
   // record source frames before preview playback can hold or drop for latency
-  recordDecodedFrameBatch(decodedFrames);
+  recordDecodedFrameBatch(decodedFrames, header);
   const enqueueResult = playbackController.enqueueDecodedFrames(header, decodedFrames, now);
   closeFrames(enqueueResult.droppedFrames);
   if (enqueueResult.cutover?.latencyMs) {
@@ -2058,11 +2105,18 @@ $("connectBtn").onclick = connect;
 $("stopBtn").onclick = () => closeSession();
 $("sendPromptBtn").onclick = () => sendEvent("prompt", $("prompt").value);
 $("enhanceBtn").onclick = enhancePrompt;
-$("recordBtn").onclick = () => {
-  if (recordingActive) {
+$("recordSmoothBtn").onclick = () => {
+  if (recordingActive && recordingMode === "smooth") {
     stopRecording();
   } else {
-    startRecording();
+    startRecording("smooth");
+  }
+};
+$("recordRealtimeBtn").onclick = () => {
+  if (recordingActive && recordingMode === "realtime") {
+    stopRecording();
+  } else {
+    startRecording("realtime");
   }
 };
 $("firstFrame").onchange = () => drawReferencePreview($("firstFrame").files[0]);

--- a/python/sglang/multimodal_gen/apps/realtime_webui/index.html
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>sglang-diffusion Realtime Studio</title>
-    <link rel="stylesheet" href="./styles.css?v=realtime-record-v49" />
+    <link rel="stylesheet" href="./styles.css?v=realtime-record-dual-v1" />
   </head>
   <body>
     <main class="shell">
@@ -87,11 +87,6 @@
             <span id="statusDot" class="dot"></span>
             <span id="statusText">Idle</span>
             <span id="chunkText">chunk -</span>
-            <button id="recordBtn" class="record-button" type="button" aria-pressed="false" title="Record preview">
-              <span class="record-button-icon" aria-hidden="true"></span>
-              <span id="recordLabel">Record</span>
-              <span id="recordDuration" class="record-button-duration">00:00</span>
-            </button>
             <span class="topbar-spacer"></span>
             <label class="preview-scale-control">Preview
               <input id="previewScale" type="range" min="80" max="170" value="120" />
@@ -133,9 +128,22 @@
             </div>
           </div>
           <div class="timeline">
-            <span id="queueText">queue 0</span>
-            <span id="frameText">frames 0</span>
-            <span id="byteText">0 MB</span>
+            <div class="record-actions" aria-label="Recording">
+              <button id="recordSmoothBtn" class="record-button" type="button" aria-pressed="false" title="Record a smooth target-FPS MP4">
+                <span class="record-button-icon" aria-hidden="true"></span>
+                <span id="recordSmoothLabel">Smooth</span>
+              </button>
+              <button id="recordRealtimeBtn" class="record-button" type="button" aria-pressed="false" title="Record an MP4 paced by received source frames">
+                <span class="record-button-icon" aria-hidden="true"></span>
+                <span id="recordRealtimeLabel">Server</span>
+              </button>
+              <span id="recordDuration" class="record-button-duration">00:00</span>
+            </div>
+            <div class="timeline-stats">
+              <span id="queueText">queue 0</span>
+              <span id="frameText">frames 0</span>
+              <span id="byteText">0 MB</span>
+            </div>
           </div>
           <div class="telemetry stage-telemetry">
             <span>Payload<b id="payloadMode">webp</b></span>
@@ -163,6 +171,6 @@
       </section>
     </main>
   <script src="./playback_controller.js?v=realtime-playback-v13"></script>
-  <script src="./app.js?v=realtime-record-v73"></script>
+  <script src="./app.js?v=realtime-record-dual-v1"></script>
 </body>
 </html>

--- a/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
+++ b/python/sglang/multimodal_gen/apps/realtime_webui/styles.css
@@ -295,13 +295,20 @@ button:focus-visible {
 }
 
 .topbar-spacer { flex: 1; }
+.record-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-width: 0;
+}
 .record-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
-  flex: 0 0 118px;
-  width: 118px;
+  flex: 0 0 86px;
+  width: 86px;
   min-height: 28px;
   height: 28px;
   padding: 0 9px;
@@ -331,9 +338,11 @@ button:focus-visible {
   cursor: wait;
   opacity: 0.76;
 }
-#recordLabel {
-  flex: 0 0 36px;
-  text-align: left;
+.record-button > span:last-child {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .record-button-icon {
   flex: 0 0 9px;
@@ -351,12 +360,12 @@ button:focus-visible {
 }
 .record-button-duration {
   display: inline-block;
-  flex: 0 0 34px;
-  min-width: 34px;
+  flex: 0 0 38px;
+  min-width: 38px;
   text-align: right;
   color: rgba(232, 234, 223, 0.7);
 }
-.record-button.is-recording .record-button-duration {
+.record-actions.is-recording .record-button-duration {
   color: rgba(255, 253, 247, 0.86);
 }
 .preview-scale-control {
@@ -429,7 +438,25 @@ button:focus-visible {
   #stageLatencyText { min-width: 108px; }
 }
 
-.timeline { justify-content: flex-end; border-top: 1px solid rgba(232, 234, 223, 0.12); }
+.timeline {
+  justify-content: space-between;
+  border-top: 1px solid rgba(232, 234, 223, 0.12);
+}
+.timeline-stats {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+.timeline-stats span {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted); }
 .dot.live { background: #8ecf9d; box-shadow: 0 0 0 4px rgba(142, 207, 157, 0.14); }
 .dot.error { background: var(--accent); }
@@ -707,6 +734,16 @@ button:focus-visible {
   .topbar { flex-wrap: wrap; height: auto; min-height: 44px; padding: 10px 14px; }
   .topbar-spacer { display: none; }
   .preview-scale-control { min-width: 160px; }
+  .timeline {
+    flex-wrap: wrap;
+    height: auto;
+    min-height: 44px;
+    padding: 8px 14px;
+  }
+  .timeline-stats {
+    justify-content: flex-start;
+    flex-basis: 100%;
+  }
 }
 
 @keyframes previewProgressSpin {


### PR DESCRIPTION
## Summary
- Move realtime WebUI recording controls out of the crowded top bar.
- Add separate Smooth and Server recording buttons.
- Make Server recording pace MP4 timestamps from source chunk throughput instead of preview rendering.

## Notes
- Smooth recording keeps fixed target-FPS output.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26952864240](https://github.com/sgl-project/sglang/actions/runs/26952864240)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #26952864089](https://github.com/sgl-project/sglang/actions/runs/26952864089)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->