### PR TITLE
[AMD] Fix missing enable_deepseek_v4_fp4_indexer on DSV4 HIP radix backend

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -374,6 +374,9 @@ class DeepseekV4HipRadixBackend(
             model_runner.model_config.hf_text_config, "index_topk", C4_TOPK
         )
 
+        self.enable_deepseek_v4_fp4_indexer: bool = (
+            model_runner.server_args.enable_deepseek_v4_fp4_indexer
+        )
         self.topk = model_runner.server_args.speculative_eagle_topk or 0
         assert self.topk in [0, 1], "MTP Topk > 1 not supported for DeepSeek V4"
         self.mtp_enabled = self.topk > 0


### PR DESCRIPTION
## Summary

The FP4 Indexer feature (#26209) added `self.enable_deepseek_v4_fp4_indexer` to `DeepseekV4AttnBackend` but did **not** add it to `DeepseekV4HipRadixBackend`. Both backends share the same `CompressorBackendMixin`, whose `forward_unified` (and the V1 `compressor.py` path) reads `self.enable_deepseek_v4_fp4_indexer`. On HIP the fast path is gated on `_is_hip and not SGLANG_OPT_USE_JIT_NORM`, and `SGLANG_OPT_USE_JIT_NORM` defaults to `True`, so the HIP backend falls into the branch that reads the attribute and crashes at CUDA graph capture:

```
AttributeError: 'DeepseekV4HipRadixBackend' object has no attribute 'enable_deepseek_v4_fp4_indexer'
```

This is **not** FP4-specific: the attribute is read as part of `compressor.is_in_indexer and self.enable_deepseek_v4_fp4_indexer`, so it fails even with the flag at its default `False`, taking down the AMD nightly DeepSeek-V4 jobs (`nightly-8-gpu-mi35x-deepseek-v4-pro` and `-flash`) at server startup.

## Fix

Set `self.enable_deepseek_v4_fp4_indexer` from `server_args` in `DeepseekV4HipRadixBackend.__init__`, mirroring `DeepseekV4AttnBackend`.

## Test

Dispatched the DeepSeek-V4-Flash AMD ROCm 7.2 nightly job on this branch:

https://github.com/sgl-project/sglang/actions/runs/26961514923

Made with [Cursor](https://cursor.com)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26961557392](https://github.com/sgl-project/sglang/actions/runs/26961557392)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26961557620](https://github.com/sgl-project/sglang/actions/runs/26961557620)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->