### PR TITLE
docs(cookbook): add Docker install option for Gemma 4

### DIFF
--- a/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
+++ b/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
@@ -77,6 +77,26 @@ pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 pip install 'git+https://github.com/huggingface/transformers.git@1423d22f7a3b62e8c70ad67b58ec25cd9b675897'
 ```
 
+### Docker (prebuilt dev image)
+
+Prebuilt development images bundle SGLang together with the matching transformers commit preinstalled, so no manual install is needed. All tags are multi-arch (`amd64` + `arm64`):
+
+| Tag | CUDA | Hardware |
+| --- | --- | --- |
+| `lmsysorg/sglang:dev-gemma-4-12B` | 13.0 | Default — amd64 (H200 / B200) + arm64 (GB200 / GB300) |
+| `lmsysorg/sglang:dev-cu13-gemma-4-12B` | 13.0 | Alias of the default tag |
+| `lmsysorg/sglang:dev-cu12-gemma-4-12B` | 12.9 | CUDA 12.x hosts |
+
+```bash Command
+docker run --gpus all --ipc=host --shm-size 32g \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -p 30000:30000 \
+  lmsysorg/sglang:dev-gemma-4-12B \
+  sglang serve --model-path google/gemma-4-12B-it \
+    --reasoning-parser gemma4 --tool-call-parser gemma4 \
+    --host 0.0.0.0 --port 30000
+```
+
 For other installation methods, please refer to the [official SGLang installation guide](../../../docs/get-started/install).
 
 ## 3. Model Deployment

--- a/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
+++ b/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
@@ -67,14 +67,11 @@ Gemma 4 is Google's next-generation family of open models, building on the Gemma
 
 ## 2. SGLang Installation
 
-Gemma 4 (including the encoder-free unified 12B, [sgl-project/sglang#27167](https://github.com/sgl-project/sglang/pull/27167)) is supported on SGLang main. Install it together with the matching transformers commit:
+Gemma 4 (including the encoder-free unified 12B, [sgl-project/sglang#27167](https://github.com/sgl-project/sglang/pull/27167)) is supported on SGLang main:
 
 ```bash Command
 # Install SGLang from main
 pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
-
-# Install transformers with Gemma 4 support (encoder-free unified family included)
-pip install 'git+https://github.com/huggingface/transformers.git@1423d22f7a3b62e8c70ad67b58ec25cd9b675897'
 ```
 
 ### Docker (prebuilt dev image)


### PR DESCRIPTION
## What

Adds a **Docker (prebuilt dev image)** quickstart to the Gemma 4 cookbook's installation section (`docs_new/cookbook/autoregressive/Google/Gemma4.mdx`, §2), and drops the stale transformers commit pin from the existing pip-install instructions.

The dev images bundle SGLang + a matching transformers preinstalled, so users can `docker run` instead of building from source.

Published tags (all multi-arch `amd64` + `arm64`):

| Tag | CUDA |
| --- | --- |
| `lmsysorg/sglang:dev-gemma-4-12B` | 13.0 (default) |
| `lmsysorg/sglang:dev-cu13-gemma-4-12B` | 13.0 (alias) |
| `lmsysorg/sglang:dev-cu12-gemma-4-12B` | 12.9 |

## Changes

1. **New Docker section** in §2 — `docker run … sglang serve` quickstart matching the cookbook's existing `bash Command` fence + `--reasoning-parser gemma4 --tool-call-parser gemma4` invocation.
2. **Removed the stale transformers pin** (`pip install 'git+…transformers.git@1423d22…'`) — that commit is outdated; the pip path now relies on SGLang's own dependency resolution for transformers.

## Notes

- The Docker table uses Markdown rather than the HTML-table styling used elsewhere in this file — happy to convert it to match the house style if preferred.
- Docs-only change; no code paths touched.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26970610779](https://github.com/sgl-project/sglang/actions/runs/26970610779)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26970610713](https://github.com/sgl-project/sglang/actions/runs/26970610713)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->