### PR TITLE
[ROCm] dsv4: remove the redundant fp8 scale transpose-copy on decode

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -65,6 +65,7 @@ from sglang.srt.layers.moe import (
     should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
+from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 from sglang.srt.layers.utils.cp_utils import (
     is_mla_prefill_cp_enabled,
     mla_use_prefill_cp,
@@ -82,7 +83,6 @@ from sglang.srt.utils import (
     is_sm90_supported,
     is_sm100_supported,
 )
-from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 
 _is_cuda = is_cuda()
 _is_flashinfer_available = is_flashinfer_available()

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -108,6 +108,8 @@ elif _is_npu:
     from sglang.srt.hardware_backend.npu.cmo import prepare_weight_cache
 
 
+from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
+
 def _fused_rmsnorm_fp8_per_token_quant(
     hidden_states: torch.Tensor,
     weight: torch.Tensor,
@@ -572,6 +574,7 @@ class LayerCommunicator:
                             dtype_quant=torch.float8_e4m3fn,
                             res1=None,
                             output_unquantized_inp1=_dsa_needs_bf16,
+                            transpose_scale=_use_aiter_bpreshuffle_gfx95,
                         )
                         if _dsa_needs_bf16:
                             hidden_states = (
@@ -617,6 +620,7 @@ class LayerCommunicator:
                                 dtype_quant=torch.float8_e4m3fn,
                                 res1=residual,
                                 output_unquantized_inp1=_dsa_needs_bf16,
+                                transpose_scale=_use_aiter_bpreshuffle_gfx95,
                             )
                         )
                         if _dsa_needs_bf16:

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -82,6 +82,7 @@ from sglang.srt.utils import (
     is_sm90_supported,
     is_sm100_supported,
 )
+from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 
 _is_cuda = is_cuda()
 _is_flashinfer_available = is_flashinfer_available()
@@ -107,8 +108,6 @@ if _use_aiter:
 elif _is_npu:
     from sglang.srt.hardware_backend.npu.cmo import prepare_weight_cache
 
-
-from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 
 def _fused_rmsnorm_fp8_per_token_quant(
     hidden_states: torch.Tensor,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -786,10 +786,8 @@ def aiter_w8a8_block_fp8_linear(
     if input_scale is not None:
         q_input = input_2d
         x_scale = input_scale
-        # Producers emit the scale transposed only when bpreshuffle is the backend
-        # (>= ROCm 7.2). The triton GEMM reads a_scale by stride, so re-stride it back
-        # to row-major for free; bpreshuffle keeps the transposed layout it wants, and
-        # on ROCm 7.0 the scale is already row-major for the CK / triton GEMMs.
+        # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
+        # Triton needs a row-major view, so adjust strides only. No copy.
         if use_triton and _use_aiter_bpreshuffle_gfx95:
             x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -786,8 +786,12 @@ def aiter_w8a8_block_fp8_linear(
     if input_scale is not None:
         q_input = input_2d
         x_scale = input_scale
-        if _use_aiter_bpreshuffle_gfx95 and not use_triton:
-            x_scale = x_scale.transpose(-1, -2).contiguous().view(*x_scale.shape)
+        # Producers emit the scale transposed only when bpreshuffle is the backend
+        # (>= ROCm 7.2). The triton GEMM reads a_scale by stride, so re-stride it back
+        # to row-major for free; bpreshuffle keeps the transposed layout it wants, and
+        # on ROCm 7.0 the scale is already row-major for the CK / triton GEMMs.
+        if use_triton and _use_aiter_bpreshuffle_gfx95:
+            x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:
         q_input, x_scale = aiter_per1x128_quant(
             input_2d,

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -19,6 +19,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_musa,
     _is_npu,
+    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -44,8 +45,6 @@ if _use_aiter_gfx95:
     from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
     from sglang.srt.layers.quantization.rocm_mxfp4_utils import fused_rms_mxfp4_quant
 
-
-from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 
 def _resolve_attn_backend(forward_batch: ForwardBatch):
     backend = get_attn_backend()

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -45,6 +45,8 @@ if _use_aiter_gfx95:
     from sglang.srt.layers.quantization.rocm_mxfp4_utils import fused_rms_mxfp4_quant
 
 
+from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
+
 def _resolve_attn_backend(forward_batch: ForwardBatch):
     backend = get_attn_backend()
     if isinstance(backend, TboAttnBackend):
@@ -152,6 +154,7 @@ class DeepseekMHAForwardMixin:
                         dtype_quant=torch.float8_e4m3fn,
                         res1=None,
                         output_unquantized_inp1=True,
+                        transpose_scale=_use_aiter_bpreshuffle_gfx95,
                     )
                     q = self.q_b_proj(q_quanted)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
@@ -193,6 +196,7 @@ class DeepseekMHAForwardMixin:
                     dtype_quant=torch.float8_e4m3fn,
                     res1=None,
                     output_unquantized_inp1=False,
+                    transpose_scale=_use_aiter_bpreshuffle_gfx95,
                 )
                 q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
             else:
@@ -222,6 +226,7 @@ class DeepseekMHAForwardMixin:
                 dtype_quant=torch.float8_e4m3fn,
                 res1=None,
                 output_unquantized_inp1=True,  # return unqaunt kv_a
+                transpose_scale=_use_aiter_bpreshuffle_gfx95,
             )
 
         else:

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -131,6 +131,8 @@ if _use_aiter_gfx95:
     from sglang.srt.layers.rocm_linear_utils import fused_qk_rope_cat_and_cache_mla
 
 
+from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
+
 class DeepseekMLAForwardMixin:
     def init_mla_forward(self: DeepseekV2AttentionMLA):
         self.flashinfer_mla_disable_ragged = (
@@ -197,6 +199,7 @@ class DeepseekMLAForwardMixin:
                                 dtype_quant=torch.float8_e4m3fn,
                                 res1=None,
                                 output_unquantized_inp1=True,
+                                transpose_scale=_use_aiter_bpreshuffle_gfx95,
                             )
                             q = q_quanted
                         else:
@@ -211,6 +214,7 @@ class DeepseekMLAForwardMixin:
                                 dtype_quant=torch.float8_e4m3fn,
                                 res1=None,
                                 output_unquantized_inp1=False,
+                                transpose_scale=_use_aiter_bpreshuffle_gfx95,
                             )
 
                     elif _use_aiter:

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -38,6 +38,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_musa,
     _use_aiter,
+    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -130,8 +131,6 @@ if _use_aiter_gfx95:
     )
     from sglang.srt.layers.rocm_linear_utils import fused_qk_rope_cat_and_cache_mla
 
-
-from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 
 class DeepseekMLAForwardMixin:
     def init_mla_forward(self: DeepseekV2AttentionMLA):

--- a/python/sglang/srt/models/deepseek_common/utils.py
+++ b/python/sglang/srt/models/deepseek_common/utils.py
@@ -25,6 +25,7 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
     get_device_sm,
+    get_hip_version,
     is_cpu,
     is_cuda,
     is_gfx95_supported,
@@ -47,6 +48,7 @@ _is_xpu = is_xpu()
 _device_sm = get_device_sm()
 _is_gfx95_supported = is_gfx95_supported()
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
+_use_aiter_bpreshuffle_gfx95 = _use_aiter_gfx95 and get_hip_version() >= (7, 2, 0)
 
 
 _is_cublas_ge_129 = is_nvidia_cublas_version_ge_12_9()

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -162,6 +162,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_npu,
     _is_xpu,
     _use_aiter,
+    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -207,8 +208,6 @@ else:
 
 logger = logging.getLogger(__name__)
 
-
-from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 
 class DeepseekV2MLP(nn.Module):
     def __init__(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -208,6 +208,8 @@ else:
 logger = logging.getLogger(__name__)
 
 
+from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
+
 class DeepseekV2MLP(nn.Module):
     def __init__(
         self,
@@ -376,7 +378,7 @@ class DeepseekV2MLP(nn.Module):
                     swiglu_limit=self.swiglu_limit,
                     activation="silu",
                     dtype_quant=dtypes.fp8,
-                    transpose_scale=False,
+                    transpose_scale=_use_aiter_bpreshuffle_gfx95,
                 )
                 x = (x_fp8, x_scale)
             else:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -121,6 +121,8 @@ _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
 
 
+from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
+
 def _is_fused_mhc_post_pre_enabled() -> bool:
     # The fused path directly reuses TileLang mhc_post/mhc_pre kernels and their
     # tensor layout assumptions, so keep it disabled when either dependency is off.
@@ -151,6 +153,7 @@ def _fused_rmsnorm_fp8_quant(hidden_states, weight, eps):
         dtype_quant=torch.float8_e4m3fn,
         res1=None,
         output_unquantized_inp1=True,
+        transpose_scale=_use_aiter_bpreshuffle_gfx95,
     )
     return x_quant, x_bf16
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -97,8 +97,8 @@ from sglang.srt.models.dbrx import ReplicatedLinear
 from sglang.srt.models.deepseek_common.amd.deepseek_v4_fused_mhc import (
     try_fused_hc_post_pre,
 )
-from sglang.srt.models.deepseek_v2 import ParallelLMHead, _is_cuda, _is_hip, _is_npu
 from sglang.srt.models.deepseek_common.utils import _use_aiter_bpreshuffle_gfx95
+from sglang.srt.models.deepseek_v2 import ParallelLMHead, _is_cuda, _is_hip, _is_npu
 
 if not _is_hip:
     from sglang.srt.layers.utils.cp_utils import (

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -98,6 +98,7 @@ from sglang.srt.models.deepseek_common.amd.deepseek_v4_fused_mhc import (
     try_fused_hc_post_pre,
 )
 from sglang.srt.models.deepseek_v2 import ParallelLMHead, _is_cuda, _is_hip, _is_npu
+from sglang.srt.models.deepseek_common.utils import _use_aiter_bpreshuffle_gfx95
 
 if not _is_hip:
     from sglang.srt.layers.utils.cp_utils import (
@@ -120,8 +121,6 @@ logger = logging.getLogger(__name__)
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
 
-
-from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
 
 def _is_fused_mhc_post_pre_enabled() -> bool:
     # The fused path directly reuses TileLang mhc_post/mhc_pre kernels and their


### PR DESCRIPTION
## TL;DR

On ROCm MI355X DSv4-Pro decode, every fp8 quant was followed by a small copy whose only job was transposing the per-128 block-scale tensor into the layout the aiter bpreshuffle GEMM wants — 183 copies per decode step, ~3% of decode GPU. This PR has the quant producers emit the scale in the layout the *active* GEMM backend expects, so the copy is gone. Median TPOT improves ~2% across concurrencies; the data entering the GEMM is bit-identical.

## Motivation

In a decode profile for DSv4-Pro TP=8 on MI355X, one small copy kernel appeared right after every FP8 quantization:

```bash
python -m sglang.bench_serving --host localhost --port 30000 \
  --dataset-name random --random-input 1024 --random-output 1024 --random-range-ratio 1.0 \
  --num-prompt 16 --max-concurrency 4 \
  --profile --profile-num-steps 5 --profile-by-stage
```

`--profile-by-stage` writes a separate decode trace per rank: `*-TP-0-DECODE.trace.json.gz`.

<img width="1660" height="176" alt="image" src="https://github.com/user-attachments/assets/44925b64-7c8b-488d-a5dd-e238c5b0ec12" />
<img width="1294" height="142" alt="image" src="https://github.com/user-attachments/assets/92fd39ec-b7b9-4692-b419-c894a55d4548" />

Counting kernels by name shows 183 such `elementwise_kernel_manual_unroll` copies per decode step (122 after `fused_rms_fp8_group_quant`, 61 after `fused_clamp_silu_mul`). The copy does no quantization — it only materializes the block-scale relayout from `.transpose().contiguous()`.

## Root cause

`aiter_w8a8_block_fp8_linear` receives an already-quantized input and its block scale. The bpreshuffle GEMM wants the scale column-major, so the code transposes it:

```python
x_scale = x_scale.transpose(-1, -2).contiguous().view(*x_scale.shape)
```

`.transpose()` is free (just strides); `.contiguous()` is the real copy.

## Change

The quant kernels already support `transpose_scale=True`. This PR enables it only when the selected GEMM backend needs that layout.

On ROCm 7.2+ with bpreshuffle, producers write the FP8 block scale directly in bpreshuffle's expected layout. bpreshuffle can consume it as-is.

If the Triton GEMM is used on that path, it does not need a real transpose back to row-major. It can read the same buffer with adjusted strides:

```python
if use_triton and _use_aiter_bpreshuffle_gfx95:
    x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
```
**ROCm 7.0 (CK/Triton):** producers still emit row-major scales, so these GEMMs consume them directly.

All changed call sites are under `_use_aiter` / gfx95 ROCm guards; CUDA paths are untouched.

## Validation

MI355X (gfx950) x8, DSv4-Pro, TP=8, --attention-backend dsv4.

### Correctness

The GEMM receives the same scale values as before, so model output should stay the same.

| test | main | this PR |
|---|---:|---:|
| GSM8K | 0.942 | 0.944 |

### Decode profile

The redundant scale-layout copy is removed from the decode trace.

| metric | main | this PR |
|---|---:|---:|
| Extra direct_copy after quant / clamp per decode step | 122 + 61 = 183 | 0 + 0 = 0 |
| Decode GPU busy, TP0 main compute stream | 23289 us | 22566 us, -3.1% |
| Median TPOT | 18.49 ms | 18.10 ms, -2.2% |

### End-to-end sweep

Random benchmark, --random-range-ratio 0.8, --num-prompts CONC*10, 1k in / 1k out.

Output throughput, tokens/s

| CONC | main | this PR | change |
|---:|---:|---:|---:|
| 4 | 198.6 | 205.9 | +3.6% |
| 8 | 365.5 | 373.1 | +2.1% |
| 16 | 617.9 | 633.5 | +2.5% |
| 32 | 1032.4 | 1052.2 | +1.9% |
| 64 | 1040.4 | 1042.3 | +0.2% |

Mean TPOT, ms, lower is better

| CONC | main | this PR | change |
|---:|---:|---:|---:|
| 4 | 19.07 | 18.66 | -2.2% |
| 8 | 20.70 | 20.24 | -2.2% |
| 16 | 24.77 | 24.14 | -2.5% |
| 32 | 29.92 | 29.35 | -1.9% |
| 64 | 59.97 | 59.86 | -0.2% |







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27116170423](https://github.com/sgl-project/sglang/actions/runs/27116170423)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27122269010](https://github.com/sgl-project/sglang/actions/runs/27122269010)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->