### PR TITLE
[Spec] Apply custom logit processor in EAGLE-v2 verify path

### DIFF
--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -12,6 +12,7 @@ from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.sampler import apply_custom_logit_processor
 from sglang.srt.managers.schedule_batch import (
     ScheduleBatch,
     set_mamba_track_indices_from_reqs,
@@ -351,6 +352,16 @@ class EagleVerifyInputV2Mixin:
         bs = len(batch.seq_lens)
         sampling_info = batch.sampling_info
         next_token_logits = logits_output.next_token_logits
+
+        # Apply the custom logit processors if registered in the sampling info.
+        # Without this, custom logit processors are silently bypassed when
+        # speculative decoding runs through the v2 verify path (see #26330).
+        if sampling_info.has_custom_logit_processor:
+            apply_custom_logit_processor(
+                next_token_logits,
+                sampling_info,
+                num_tokens_in_batch=self.draft_token_num,
+            )
 
         # Apply penalty
         # This is a relaxed version of penalties for speculative decoding.

--- a/test/registered/unit/spec/test_eagle_v2_custom_logit_processor.py
+++ b/test/registered/unit/spec/test_eagle_v2_custom_logit_processor.py
@@ -1,0 +1,75 @@
+"""Regression test for #26330.
+
+The EAGLE-v2 / SPEC_V2 verify path (``EagleVerifyInputV2Mixin.sample``) must
+apply custom logit processors, matching the v1 path (``eagle_info.py``). Before
+the fix, the v2 ``sample`` skipped ``apply_custom_logit_processor`` entirely, so
+custom processors (e.g. a ``thinking_budget`` limiter) were silently ignored
+whenever speculative decoding ran through the v2 path — which is the default
+(``SGLANG_ENABLE_SPEC_V2`` defaults to ``True``).
+
+This drives ``sample()`` with a spy custom logit processor and asserts it is
+invoked on the verify logits. The processor short-circuits by raising, so the
+test never reaches the spec-sampling CUDA kernel and stays CPU-only.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
+from sglang.srt.speculative.eagle_info_v2 import EagleVerifyInputV2Mixin
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class _ProcessorApplied(Exception):
+    """Raised by the spy processor to prove it was invoked."""
+
+
+class _SpyLogitProcessor(CustomLogitProcessor):
+    def __call__(self, logits, custom_param_list=None):
+        raise _ProcessorApplied()
+
+
+class _FakeSamplingInfo:
+    """Minimal SamplingBatchInfo stand-in carrying one custom logit processor."""
+
+    def __init__(self, bs: int):
+        self._bs = bs
+        self.has_custom_logit_processor = True
+        self.custom_logit_processor = {
+            "spy": (_SpyLogitProcessor(), torch.ones(bs, dtype=torch.bool))
+        }
+        self.custom_params = [{} for _ in range(bs)]
+
+    def __len__(self) -> int:
+        return self._bs
+
+
+class TestEagleV2AppliesCustomLogitProcessor(unittest.TestCase):
+    def test_v2_verify_applies_custom_logit_processor(self):
+        bs, draft_token_num, vocab = 2, 3, 16
+
+        batch = SimpleNamespace(
+            device="cpu",
+            forward_mode=SimpleNamespace(is_idle=lambda: False),
+            seq_lens=torch.zeros(bs),
+            sampling_info=_FakeSamplingInfo(bs),
+        )
+        logits_output = SimpleNamespace(
+            # v2 verify logits shape: (bs * draft_token_num, vocab)
+            next_token_logits=torch.randn(bs * draft_token_num, vocab),
+        )
+        verify_input = SimpleNamespace(draft_token_num=draft_token_num)
+
+        # With the fix, sample() applies the custom logit processor (which raises
+        # to signal it ran). Without the fix, the processor is never called and
+        # this assertion fails.
+        with self.assertRaises(_ProcessorApplied):
+            EagleVerifyInputV2Mixin.sample(verify_input, batch, logits_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When speculative decoding runs through the **v2 / SPEC_V2** verify path — which is the **default**, since `SGLANG_ENABLE_SPEC_V2` defaults to `True` — custom logit processors registered via `--enable-custom-logit-processor` are **silently bypassed**. For example, a `thinking_budget` limiter correctly caps reasoning tokens *without* speculative decoding, but has no effect *with* it.

Fixes #26330. (#21724 earlier reported the same root cause for the EAGLE-v2 path.)

## Root cause

`apply_custom_logit_processor` is applied in the v1 verify path (`eagle_info.py`), as well as in `dflash_info.py` and `ngram_info.py`. But `EagleVerifyInputV2Mixin.sample` (`eagle_info_v2.py`) applied penalties, grammar masks, and sampling **without ever calling it** — so the processor is dropped for every spec algorithm that routes through the v2 verify path.

## Modifications

- **`eagle_info_v2.py`**: apply the custom logit processor on the verify logits before penalties/sampling, mirroring the v1 path (`num_tokens_in_batch=self.draft_token_num`).
- **`test/registered/unit/spec/test_eagle_v2_custom_logit_processor.py`**: CPU regression test that drives `EagleVerifyInputV2Mixin.sample()` with a spy custom logit processor and asserts it is invoked on the verify logits.

## Test plan

The regression test passes **with** the fix and fails **without** it (verified on an RTX 4090):

```
WITH fix    (apply_custom_logit_processor present):  1 passed
WITHOUT fix (line reverted):                         1 failed
```

I also confirmed the call's batch-shape contract directly: `apply_custom_logit_processor` applied to a `(bs * draft_token_num, vocab)` tensor with `num_tokens_in_batch=draft_token_num` passes its internal shape assertion and modifies the expected rows.

I did not run a full server-mode end-to-end budget-enforcement test — happy to add one if preferred.

## Checklist

- [x] Format with pre-commit (isort, ruff, black, codespell all pass)
- [x] Unit test added (passes with the fix, fails without it)
- [ ] Accuracy / speed benchmarks — N/A (correctness fix; no kernel or model-forward change)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26968569993](https://github.com/sgl-project/sglang/actions/runs/26968569993)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26968569850](https://github.com/sgl-project/sglang/actions/runs/26968569850)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->