### PR TITLE
Fix DeepSeek V4 C128 HiCache sidecar

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -299,7 +299,6 @@ def build_deepseek_v4_hicache_stack(
     c4_layer_mapping = {}
     c128_layer_mapping = {}
     c4_state_global_layers = []
-    c128_state_global_layers = []
     for layer_id, layer_item in enumerate(
         kvcache.layer_mapping[kvcache.start_layer : kvcache.end_layer]
     ):
@@ -308,13 +307,9 @@ def build_deepseek_v4_hicache_stack(
             c4_state_global_layers.append(layer_id)
         elif layer_item.compress_ratio == 128:
             c128_layer_mapping[layer_id] = layer_item.compress_layer_id
-            c128_state_global_layers.append(layer_id)
 
     c4_state_mapping = {
         layer_id: local_id for local_id, layer_id in enumerate(c4_state_global_layers)
-    }
-    c128_state_mapping = {
-        layer_id: local_id for local_id, layer_id in enumerate(c128_state_global_layers)
     }
     num_host_pages, swa_num_host_pages = _deepseek_v4_num_host_pages(
         params=params,
@@ -444,17 +439,9 @@ def build_deepseek_v4_hicache_stack(
             layout=server_args.hicache_mem_layout,
             allocator_type=server_args.hicache_storage_backend,
         )
-        c128_state_host_pool = DeepSeekV4StateHostPool(
-            pool_name=str(PoolName.DEEPSEEK_V4_C128_STATE),
-            state_pools=[
-                kvcache.compress_state_pools[layer_id]
-                for layer_id in c128_state_global_layers
-            ],
-            num_host_pages=swa_num_host_pages,
-            swa_page_size=kvcache.swa_page_size,
-            layout=server_args.hicache_mem_layout,
-            allocator_type=server_args.hicache_storage_backend,
-        )
+        # C128 offline state only represents an in-progress 128-token chunk.
+        # DeepSeek V4 HiCache nodes are 256-token page aligned, so matched
+        # prefixes always end at a C128 boundary and only need C128 KV pages.
         entries.extend(
             [
                 build_pool_entry(
@@ -462,13 +449,6 @@ def build_deepseek_v4_hicache_stack(
                     host_pool=c128_host_pool,
                     device_pool=kvcache.c128_kv_pool,
                     layer_mapping=c128_layer_mapping,
-                    transfer_layer_num=transfer_layer_num,
-                ),
-                build_pool_entry(
-                    name=PoolName.DEEPSEEK_V4_C128_STATE,
-                    host_pool=c128_state_host_pool,
-                    device_pool=None,
-                    layer_mapping=c128_state_mapping,
                     transfer_layer_num=transfer_layer_num,
                 ),
             ]
@@ -756,7 +736,6 @@ class _DeepSeekV4Strategy(StackStrategy):
                 (PoolName.DEEPSEEK_V4_C128, PoolName.KV),
                 (PoolName.DEEPSEEK_V4_C4_STATE, PoolName.SWA),
                 (PoolName.DEEPSEEK_V4_C4_INDEXER_STATE, PoolName.SWA),
-                (PoolName.DEEPSEEK_V4_C128_STATE, PoolName.SWA),
             )
             if name in host_pool_group.entry_map
         ]

--- a/test/registered/unit/mem_cache/test_unified_radix_hicache_dispatch.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_hicache_dispatch.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from sglang.srt.mem_cache.hicache_storage import PoolName, SidecarPoolSpec
 from sglang.srt.mem_cache.hybrid_cache import hybrid_pool_assembler
@@ -46,6 +46,43 @@ class TestUnifiedRadixHiCacheDispatch(unittest.TestCase):
         kvcache = _mock_kvcache(DeepSeekV4TokenToKVPool)
         strategy = _select_strategy(kvcache, {FULL, SWA})
         self.assertIsInstance(strategy, _DeepSeekV4Strategy)
+
+    def test_deepseek_v4_skips_c128_state_sidecar(self):
+        entry_names = (
+            PoolName.DEEPSEEK_V4_C4,
+            PoolName.DEEPSEEK_V4_C4_INDEXER,
+            PoolName.DEEPSEEK_V4_C128,
+            PoolName.DEEPSEEK_V4_C4_STATE,
+            PoolName.DEEPSEEK_V4_C4_INDEXER_STATE,
+            PoolName.DEEPSEEK_V4_C128_STATE,
+        )
+        host_pool_group = MagicMock()
+        host_pool_group.entry_map = {name: MagicMock() for name in entry_names}
+        host_pool_group.get_pool.return_value = MagicMock()
+
+        cache = MagicMock(page_size=256)
+        params = MagicMock()
+        params.pp_rank = 0
+        params.pp_size = 1
+        kvcache = MagicMock(start_layer=0, end_layer=31)
+
+        with patch.object(
+            hybrid_pool_assembler,
+            "build_deepseek_v4_hicache_stack",
+            return_value=(host_pool_group, MagicMock()),
+        ):
+            result = _DeepSeekV4Strategy().build(
+                cache=cache,
+                kvcache=kvcache,
+                params=params,
+                server_args=MagicMock(),
+                load_cache_event=MagicMock(),
+            )
+
+        sidecar_names = {sidecar.pool_name for sidecar in result.sidecars}
+        self.assertIn(PoolName.DEEPSEEK_V4_C128, sidecar_names)
+        self.assertIn(PoolName.DEEPSEEK_V4_C4_STATE, sidecar_names)
+        self.assertNotIn(PoolName.DEEPSEEK_V4_C128_STATE, sidecar_names)
 
     def test_mamba(self):
         from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool


### PR DESCRIPTION
## Summary
- stop registering/transferring DeepSeek V4 C128 compression state as a HiCache sidecar
- keep C128 compressed KV pages in the HiCache sidecar stack
- add a unit test to lock the C128 state sidecar exclusion

C128 offline state only tracks the in-progress 128-token chunk. DeepSeek V4 HiCache nodes are 256-token page aligned, so matched prefixes end at C128 chunk boundaries and only need the completed C128 KV pages.






<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26970362268](https://github.com/sgl-project/sglang/actions/runs/26970362268)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26970362113](https://github.com/sgl-project/sglang/actions/runs/26970362113)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->