### PR TITLE
Initialize NIXL disaggregation before pinning HiCache host buffer

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -444,6 +444,7 @@ class Scheduler(
             ps=self.ps,
             tp_group=self.tp_group,
             enable_hierarchical_cache=self.enable_hierarchical_cache,
+            on_device_pools_ready=self._init_prefill_disaggregation_before_hicache,
         )
         self.is_hybrid_swa = result.is_hybrid_swa
         self.is_hybrid_ssm = result.is_hybrid_ssm
@@ -519,8 +520,12 @@ class Scheduler(
         # Init profiler
         self.init_profiler()
 
-        # Init prefill-decodedisaggregation
-        self.init_disaggregation()
+        # Init prefill-decode disaggregation. Prefill is brought up earlier, via
+        # the build_kv_cache on_device_pools_ready callback, so its libfabric
+        # buffer registration precedes the HiCache host-buffer pin. Decode and
+        # the non-disaggregated case are initialized here.
+        if self.server_args.disaggregation_mode != "prefill":
+            self.init_disaggregation()
 
         # Init overlap schedule
         self.init_overlap()
@@ -1030,6 +1035,22 @@ class Scheduler(
         # Configure GC logger
         if envs.SGLANG_LOG_GC.get():
             configure_gc_logger()
+
+    def _init_prefill_disaggregation_before_hicache(
+        self, req_to_token_pool, token_to_kv_pool_allocator
+    ):
+        # Invoked by build_kv_cache after the device KV buffers are allocated
+        # but before the host KV buffer is pinned. NIXL registers the device
+        # buffers with libfabric during disaggregation init; running it after
+        # the HiCache host pin (cudaHostRegister) can OOM libfabric, which needs
+        # contiguous physical memory for completion queues and other structures.
+        # The prefill bootstrap queue needs only the device pool, not the radix
+        # tree, so it is safe to initialize here. Decode keeps its init in
+        # __init__ since its queues require the tree cache.
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        if self.server_args.disaggregation_mode == "prefill":
+            self.init_disaggregation()
 
     def init_disaggregation(self):
         self.disaggregation_mode = DisaggregationMode(

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -5,7 +5,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Optional
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -143,6 +143,7 @@ def build_kv_cache(
     ps: "ParallelState",
     tp_group: "GroupCoordinator",
     enable_hierarchical_cache: bool,
+    on_device_pools_ready: Optional[Callable[[object, object], None]] = None,
 ) -> "KVCacheBuildResult":
     sliding_window_size: Optional[int] = None
     full_tokens_per_layer: Optional[int] = None
@@ -171,6 +172,15 @@ def build_kv_cache(
         )
 
     req_to_token_pool, token_to_kv_pool_allocator = tp_worker.get_memory_pool()
+
+    # Hook for setup that must observe the freshly-allocated device KV buffers
+    # but must run before the host KV buffer is allocated below. NIXL
+    # disaggregation registers the device buffers with libfabric during this
+    # step; if it runs after HiCache pins (cudaHostRegister) its large host
+    # buffer, libfabric can fail to allocate the contiguous physical memory it
+    # needs for completion queues and other structures.
+    if on_device_pools_ready is not None:
+        on_device_pools_ready(req_to_token_pool, token_to_kv_pool_allocator)
 
     disable_radix_cache = server_args.disable_radix_cache or (
         model_config.is_multimodal and uses_transformers_backend


### PR DESCRIPTION
NIXL's libfabric backend can OOM if it is initialized after HiCache pages are pinned, because there is insufficient contiguous physical space for completion queues and other libfabric structures. This brings up prefill NIXL disaggregation (which registers the device KV buffers with libfabric) before the HiCache host buffer is pinned.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26977290555](https://github.com/sgl-project/sglang/actions/runs/26977290555)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26977290495](https://github.com/sgl-project/sglang/actions/runs/26977290495)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->