### PR TITLE
[OpenAI] Avoid encode/decode round-trip and id-space splice in jinja path

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -760,10 +760,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     return_dict=False,
                     **extra_template_kwargs,
                 )
-                prompt_ids = self.tokenizer_manager.tokenizer.encode(
-                    rendered_prompt, **encode_kwargs
-                )
-            except Exception as e:
+            except Exception:
                 # If the first attempt fails, try with flat function-only format.
                 # Some templates (e.g. Mistral) expect tools without the OpenAI wrapper.
                 tools = (
@@ -782,23 +779,21 @@ class OpenAIServingChat(OpenAIServingBase):
                             **extra_template_kwargs,
                         )
                     )
-                    prompt_ids = self.tokenizer_manager.tokenizer.encode(
-                        rendered_prompt, **encode_kwargs
-                    )
                 except (jinja2.TemplateError, TypeError) as template_error:
                     # Template errors (e.g., from raise_exception in Jinja templates)
                     # and TypeError (e.g., tojson filter on Jinja2 Undefined variables)
                     # should be treated as client errors (400 BadRequest)
                     raise ValueError(str(template_error)) from template_error
 
-            # Append assistant prefix if continue_final_message is enabled
-            if assistant_prefix:
-                prompt_ids = self._append_assistant_prefix_to_prompt_ids(
-                    prompt_ids, assistant_prefix
-                )
-
+            full_prompt = rendered_prompt + (assistant_prefix or "")
             if is_multimodal:
-                prompt = self.tokenizer_manager.tokenizer.decode(prompt_ids)
+                # MM processor re-encodes the prompt string downstream.
+                prompt = full_prompt
+                prompt_ids = []
+            else:
+                prompt_ids = self.tokenizer_manager.tokenizer.encode(
+                    full_prompt, **encode_kwargs
+                )
 
         stop = request.stop
         image_data = image_data if image_data else None

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -151,6 +151,10 @@ class ServingChatTestCase(unittest.TestCase):
         """Ensure Jinja chat templates receive OpenAI-shaped tools by default."""
         self.template_manager.chat_template_name = None
         self.template_manager.jinja_template_content_format = "string"
+        # apply_chat_template(tokenize=False) returns a string in production.
+        # Set an explicit return value so the string-concat path doesn't TypeError
+        # on the default Mock return.
+        self.tm.tokenizer.apply_chat_template.return_value = "USER: 2+2?\nASSISTANT:"
 
         req = ChatCompletionRequest(
             model="x",
@@ -209,7 +213,7 @@ class ServingChatTestCase(unittest.TestCase):
 
         self.tm.tokenizer.apply_chat_template.side_effect = [
             RuntimeError("template expects flat tools format"),
-            [1, 2, 3],
+            "USER: What is 2+2?\nASSISTANT:",
         ]
 
         self.chat._process_messages(req, is_multimodal=False)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

OpenAIServingChat._apply_jinja_template used to encode the rendered chat template, splice the assistant_prefix in id-space (with a strip-leading-BOS heuristic), then decode back to a string for the MM processor on multimodal requests. Replace with one string-level concat:

```python
  full_prompt = rendered_prompt + (assistant_prefix or "")
  if is_multimodal:
      prompt = full_prompt
      prompt_ids = []
  else:
      prompt_ids = tokenizer.encode(full_prompt, **encode_kwargs)
```

The legacy _apply_conversation_template path in the same file already does this for multimodal; this brings the jinja path in line.

Two effects:

* Faster. Drops 1 encode + 1 decode per multimodal request and 1 encode per text-only + assistant_prefix request. (need to verify)

* More faithful prompt. The old decode roundtrip was lossy on SentencePiece tokenizers (decode normalizes U+2581 "▁" to plain space, the next encode then drops inter-word spaces — observed on DeepSeek-V3.1 and Phi-3.5-vision). The id-space splice inserted phantom-space tokens at the boundary on word-start-marking tokenizers (LLaVA-1.5). Sweep of 13 tokenizers x 4 (is_multimodal, assistant_prefix) combos: 45 byte-identical, 7 cases where the new path matches the chat template's literal output, 0 regressions.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Existing 52 unit tests pass. Two of them had mocks for apply_chat_template(tokenize=False) returning non-strings (a list, a default Mock); they now return strings to match the actual transformers API contract.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26973794844](https://github.com/sgl-project/sglang/actions/runs/26973794844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26973794270](https://github.com/sgl-project/sglang/actions/runs/26973794270)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->