### PR TITLE
[Spec v2] FA3 attn full overlap (needs_cpu_seq_lens=False)

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -104,6 +104,10 @@ class FlashAttentionBackend(AttentionBackend):
     - For each forward batch, init_replay_cuda_graph will be called first and then replay the graph.
     """
 
+    # CUDA-graph replay and eager init derive max_seq_len_k from GPU tensors
+    # via _replay_max_len / _max_seq_len; no host seq_lens mirror needed.
+    needs_cpu_seq_lens: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -369,6 +373,12 @@ class FlashAttentionBackend(AttentionBackend):
                 out_cache_loc=out_cache_loc,
             )
 
+    def _max_seq_len(self, forward_batch: ForwardBatch) -> int:
+        """Sync-free max of seq_lens; falls back to GPU .max() if CPU mirror absent."""
+        if forward_batch.seq_lens_cpu is not None:
+            return forward_batch.seq_lens_cpu.max().item()
+        return int(forward_batch.seq_lens.max())
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize forward metadata hence all layers in the forward pass can reuse it."""
         metadata = FlashAttentionMetadata()
@@ -383,7 +393,7 @@ class FlashAttentionBackend(AttentionBackend):
                     metadata.cache_seqlens_int32 = (
                         seqlens_in_batch + (self.speculative_step_id + 1)
                     ).to(torch.int32)
-                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
+                    metadata.max_seq_len_k = self._max_seq_len(forward_batch) + (
                         self.speculative_step_id + 1
                     )
                     metadata.cu_seqlens_q = torch.arange(
@@ -402,7 +412,7 @@ class FlashAttentionBackend(AttentionBackend):
                     # Draft-extend's idle batch (padded for DP MLP-sync) has no
                     # tree; build plain metadata (padded output is discarded).
                     metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                    metadata.max_seq_len_k = self._max_seq_len(forward_batch)
                     metadata.cu_seqlens_q = torch.arange(
                         0, batch_size + 1, dtype=torch.int32, device=device
                     )
@@ -415,7 +425,7 @@ class FlashAttentionBackend(AttentionBackend):
                 else:
                     metadata.cache_seqlens_int32 = (seqlens_in_batch).to(torch.int32)
                     metadata.max_seq_len_q = self.topk
-                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                    metadata.max_seq_len_k = self._max_seq_len(forward_batch)
                     metadata.cu_seqlens_q = torch.arange(
                         0,
                         batch_size * self.topk + 1,
@@ -465,7 +475,7 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 # Normal Decode
                 metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = self._max_seq_len(forward_batch)
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -492,8 +502,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ).to(torch.int32)
                 metadata.max_seq_len_q = self.speculative_num_draft_tokens
                 metadata.max_seq_len_k = (
-                    forward_batch.seq_lens_cpu.max().item()
-                    + self.speculative_num_draft_tokens
+                    self._max_seq_len(forward_batch) + self.speculative_num_draft_tokens
                 )
                 metadata.cu_seqlens_q = torch.arange(
                     0,
@@ -516,7 +525,7 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 metadata.cache_seqlens_int32 = forward_batch.seq_lens.to(torch.int32)
                 metadata.max_seq_len_q = self.speculative_num_draft_tokens
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = self._max_seq_len(forward_batch)
                 metadata.cu_seqlens_q = torch.arange(
                     0,
                     batch_size * self.speculative_num_draft_tokens + 1,
@@ -616,7 +625,7 @@ class FlashAttentionBackend(AttentionBackend):
             include_draft_extend_v2=True
         ):
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = self._max_seq_len(forward_batch)
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
             )
@@ -631,10 +640,15 @@ class FlashAttentionBackend(AttentionBackend):
                 self.attn_cp_size > 1
                 and forward_batch.global_num_tokens_cpu is not None
                 and forward_batch.extend_num_tokens is not None
-                and forward_batch.extend_seq_lens_cpu is not None
+                and forward_batch.extend_seq_lens is not None
             ):
                 padded_extend = int(forward_batch.extend_num_tokens)
-                real_extend = int(sum(forward_batch.extend_seq_lens_cpu))
+                # Prefer the CPU mirror; fall back to the GPU tensor when the
+                # opt-out path leaves seq_lens_cpu / extend_seq_lens_cpu unset.
+                if forward_batch.extend_seq_lens_cpu is not None:
+                    real_extend = int(sum(forward_batch.extend_seq_lens_cpu))
+                else:
+                    real_extend = int(forward_batch.extend_seq_lens.sum())
                 pad_delta = padded_extend - real_extend
                 if pad_delta > 0:
                     metadata.max_seq_len_k += pad_delta
@@ -643,11 +657,16 @@ class FlashAttentionBackend(AttentionBackend):
                 forward_batch.req_pool_indices, : metadata.max_seq_len_k
             ]
 
-            if any(
-                forward_batch.extend_prefix_lens_cpu
-            ) or forward_batch.forward_mode.is_draft_extend(include_v2=True):
+            has_prefix = (
+                forward_batch.extend_prefix_lens_cpu is not None
+                and any(forward_batch.extend_prefix_lens_cpu)
+            ) or forward_batch.forward_mode.is_draft_extend(include_v2=True)
+            if has_prefix:
                 extend_seq_lens = forward_batch.extend_seq_lens
-                metadata.max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
+                if forward_batch.extend_seq_lens_cpu is not None:
+                    metadata.max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
+                else:
+                    metadata.max_seq_len_q = int(extend_seq_lens.max())
                 metadata.cu_seqlens_q = torch.nn.functional.pad(
                     torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
                 )
@@ -2012,6 +2031,14 @@ class FlashAttentionBackend(AttentionBackend):
 
         return metadata, metadata_expand
 
+    def _replay_max_len(
+        self, seq_lens: torch.Tensor, seq_lens_cpu: Optional[torch.Tensor]
+    ) -> int:
+        """Max seq_len for CG replay page-table sizing; GPU fallback if CPU absent."""
+        if seq_lens_cpu is not None:
+            return seq_lens_cpu.max().item()
+        return int(seq_lens.max())
+
     def _apply_cuda_graph_metadata(
         self,
         bs: int,
@@ -2032,7 +2059,8 @@ class FlashAttentionBackend(AttentionBackend):
         are gone.
         """
         seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
+        if seq_lens_cpu is not None:
+            seq_lens_cpu = seq_lens_cpu[:bs]
         req_pool_indices = req_pool_indices[:bs]
         device = seq_lens.device
         metadata = None
@@ -2044,7 +2072,7 @@ class FlashAttentionBackend(AttentionBackend):
                 if self.topk <= 1:
                     # When topk = 1, we use the normal decode metadata
                     metadata = self.decode_cuda_graph_metadata[bs]
-                    max_len = seq_lens_cpu.max().item()
+                    max_len = self._replay_max_len(seq_lens, seq_lens_cpu)
                     metadata.max_seq_len_k = max_len + self.speculative_step_id + 1
                     max_seq_pages = (
                         metadata.max_seq_len_k + self.page_size - 1
@@ -2082,7 +2110,9 @@ class FlashAttentionBackend(AttentionBackend):
                     # metadata.cu_seqlens_q already set in capture
                     # metadata.cu_seqlens_k is not needed
 
-                    metadata.max_seq_len_k = seq_lens_cpu.max().item()
+                    metadata.max_seq_len_k = self._replay_max_len(
+                        seq_lens, seq_lens_cpu
+                    )
                     max_seq_pages = (
                         metadata.max_seq_len_k + self.page_size - 1
                     ) // self.page_size
@@ -2120,7 +2150,7 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
+                max_len = self._replay_max_len(seq_lens, seq_lens_cpu)
                 max_seq_pages = (max_len + self.page_size - 1) // self.page_size
                 metadata.max_seq_len_k = max_len
 
@@ -2168,7 +2198,8 @@ class FlashAttentionBackend(AttentionBackend):
                 )
 
                 metadata.max_seq_len_k = (
-                    seq_lens_cpu.max().item() + self.speculative_num_draft_tokens
+                    self._replay_max_len(seq_lens, seq_lens_cpu)
+                    + self.speculative_num_draft_tokens
                 )
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
@@ -2200,7 +2231,7 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata = self.target_verify_metadata_topk_normal[bs]
                 metadata.cache_seqlens_int32.copy_(seq_lens)
                 # metadata.max_seq_len_q = self.speculative_num_draft_tokens, already set in capture
-                metadata.max_seq_len_k = seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = self._replay_max_len(seq_lens, seq_lens_cpu)
                 # metadata.cu_seqlens_q already set in capture
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
@@ -2286,7 +2317,7 @@ class FlashAttentionBackend(AttentionBackend):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = self._replay_max_len(seq_lens, seq_lens_cpu)
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -2320,7 +2351,7 @@ class FlashAttentionBackend(AttentionBackend):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = self._replay_max_len(seq_lens, seq_lens_cpu)
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -2658,6 +2689,12 @@ class FlashAttentionBackend(AttentionBackend):
 
 
 class FlashAttentionMultiStepBackend:
+
+    # Wraps per-step FlashAttentionBackend instances, all of which derive
+    # max_seq_len_k from GPU tensors; opt out so decide_needs_cpu_seq_lens'
+    # OR over the spec_v2 backends stays False on an all-FA3 path.
+    needs_cpu_seq_lens: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,


### PR DESCRIPTION
## Motivation

PR #26128 added a per-backend `needs_cpu_seq_lens` capability flag on `AttentionBackend`. When every attention backend touched by a spec_v2 forward sets it to `False`, the overlap scheduler skips the per-iteration `seq_lens_cpu` D2H copy + `int(sum())` host sync and takes a GPU-only path, removing a CPU sync from the EAGLE3 decode hot path.

Backends are being ported one at a time (#23005 roadmap bullet, parent #11762): Triton (#26128), trtllm_mla (#26824), trtllm_mha (#27177). This PR does the same for the **FA3 / FlashAttention** backend, following the #27177 pattern.

## Modifications

`python/sglang/srt/layers/attention/flashattention_backend.py` only:

- Set `needs_cpu_seq_lens = False` on `FlashAttentionBackend` and `FlashAttentionMultiStepBackend` (the multi-step draft wrapper is what `decide_needs_cpu_seq_lens` OR-s over for the all-FA3 EAGLE3 path).
- Add two helpers mirroring #27177:
  - `_max_seq_len(forward_batch)` — sync-free max of `seq_lens`; uses `forward_batch.seq_lens_cpu.max().item()` when present, else `int(forward_batch.seq_lens.max())`.
  - `_replay_max_len(seq_lens, seq_lens_cpu)` — cuda-graph-replay page-table sizing; uses `seq_lens_cpu.max().item()` when present, else `int(seq_lens.max())`.
- Route every eager (`init_forward_metadata`) and cuda-graph-replay (`init_forward_metadata_replay_cuda_graph`) `max_seq_len_k` derivation through the helpers (normal/draft decode, target-verify topk≤1 and topk>1, draft-extend v1/v2).
- Guard the remaining `seq_lens_cpu` / `extend_seq_lens_cpu` reads against `None` with a GPU-tensor fallback: the replay `[:bs]` slice, the CP-pad `real_extend` (`int(extend_seq_lens.sum())`), and the `has_prefix` `max_seq_len_q` (`int(extend_seq_lens.max())`).

When `seq_lens_cpu` **is** present every path is a no-op vs. today; the GPU fallback only activates on the opt-out path.

## Accuracy Tests

A prior FA3 overlap attempt (#12128) was closed for an accuracy regression, so the key check is that the refactor is value-exact.

**1. End-to-end output parity (all-FA3 path).** Qwen3-30B-A3B, H200, `--attention-backend fa3 --disable-piecewise-cuda-graph`, greedy decode, 10 fixed prompts × 128 new tokens. Compared `needs_cpu_seq_lens=True` (before) vs `=False` (after):

```
10 prompts compared; 0 mismatches; 10 byte-identical (and identical completion_tokens)
RESULT: PARITY OK (all outputs byte-identical)
```

**2. GPU-fallback equality (the opt-out branch).** Directly exercised `_max_seq_len` / `_replay_max_len` with `seq_lens_cpu` present vs `None`, on CUDA tensors, across 7 batch sizes × 5 length ranges (up to 40960):

```
70 comparisons; 0 mismatches
RESULT: FALLBACK EQUALITY OK (gpu == cpu == seq_lens.max() in every case)
```

> Note: the available host could not run a downloaded EAGLE3 weight pair, so the E2E parity run is the non-spec all-FA3 overlap path (which exercises the helpers with `seq_lens_cpu` present — the no-regression property). The `seq_lens_cpu=None` fallback branch is covered by check (2). An EAGLE3 acceptance-length parity run on the all-FA3 spec_v2 path is still recommended before merge.

## Benchmarking

Qwen3-30B-A3B, single H200, FA3, `--disable-piecewise-cuda-graph`, `bench_serving` random in=128/out=512, 200 prompts, concurrency=64, mean of 3 warm runs:

| Metric | Before (`needs_cpu=True`) | After (`needs_cpu=False`) |
| --- | --- | --- |
| Output throughput | 2325.4 tok/s | 2312.5 tok/s |
| Median TPOT | 24.42 ms | 24.63 ms |

No regression on the non-spec path (within run-to-run noise, ~0.5%) — expected, since `seq_lens_cpu` is present there so the helpers take the same CPU branch. The sync-removal **gain** lands on the spec_v2 / EAGLE3 path (where `FutureMap` sets `seq_lens_cpu=None`), via the same mechanism already demonstrated for Triton (#26128) and trtllm_mha (#27177); measuring that delta needs an all-FA3 EAGLE3 run on a spec_v2-capable host.

Continues the per-backend opt-out from #26128 and the #23005 roadmap bullet, following #26824 (trtllm_mla) and #27177 (trtllm_mha).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
