### PR TITLE
Use level-1 (quiet) busy memory check in chunked-prefill and streaming tests

### DIFF
--- a/python/sglang/test/server_fixtures/streaming_session_fixture.py
+++ b/python/sglang/test/server_fixtures/streaming_session_fixture.py
@@ -402,7 +402,7 @@ class StreamingSessionServerBase(CustomTestCase):
     - `env_overrides`: list of `(env_attr_name, value)` tuples; each is
       pushed onto the `setUpClass` context stack so the env override is
       live during `popen_launch_server` and torn down on
-      `tearDownClass`-time. `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY=2`
+      `tearDownClass`-time. `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY=1`
       is always applied on top of these.
     """
 
@@ -417,7 +417,7 @@ class StreamingSessionServerBase(CustomTestCase):
 
         with contextlib.ExitStack() as stack:
             stack.enter_context(
-                envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(2)
+                envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1)
             )
             for name, val in cls.env_overrides:
                 stack.enter_context(getattr(envs, name).override(val))

--- a/test/registered/scheduler/test_mixed_chunked_prefill.py
+++ b/test/registered/scheduler/test_mixed_chunked_prefill.py
@@ -29,7 +29,7 @@ class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(2):
+        with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1):
             cls.process = popen_launch_server(
                 cls.model,
                 cls.base_url,


### PR DESCRIPTION
Switch these two fixtures from `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY=2` (verbose: logs the pool accounting every decode step) to `=1` (quiet: buffers recent messages and dumps them only on a leak). Same per-step leak assertion, far less CI log spam.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26979188667](https://github.com/sgl-project/sglang/actions/runs/26979188667)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26979188335](https://github.com/sgl-project/sglang/actions/runs/26979188335)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->