### PR TITLE
test: add CPU unit tests for function_call/utils helpers (#20865)

### DIFF
--- a/test/registered/unit/function_call/test_function_call_utils.py
+++ b/test/registered/unit/function_call/test_function_call_utils.py
@@ -1,0 +1,127 @@
+"""Unit tests for function_call/utils.py helpers — pure functions, no GPU/server."""
+
+from partial_json_parser.core.options import Allow
+
+from sglang.srt.function_call.utils import (
+    _partial_json_loads,
+    infer_type_from_json_schema,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestInferTypeFromJsonSchema(CustomTestCase):
+    def test_direct_type(self):
+        self.assertEqual(infer_type_from_json_schema({"type": "string"}), "string")
+        self.assertEqual(infer_type_from_json_schema({"type": "integer"}), "integer")
+
+    def test_type_array_filters_null(self):
+        self.assertEqual(
+            infer_type_from_json_schema({"type": ["null", "integer"]}), "integer"
+        )
+        # only null -> defaults to string
+        self.assertEqual(infer_type_from_json_schema({"type": ["null"]}), "string")
+
+    def test_any_of(self):
+        # all the same -> that type
+        self.assertEqual(
+            infer_type_from_json_schema(
+                {"anyOf": [{"type": "integer"}, {"type": "integer"}]}
+            ),
+            "integer",
+        )
+        # mixed -> string preferred
+        self.assertEqual(
+            infer_type_from_json_schema(
+                {"anyOf": [{"type": "integer"}, {"type": "string"}]}
+            ),
+            "string",
+        )
+        # oneOf treated like anyOf
+        self.assertEqual(
+            infer_type_from_json_schema(
+                {"oneOf": [{"type": "number"}, {"type": "number"}]}
+            ),
+            "number",
+        )
+
+    def test_enum_value_type_inference(self):
+        self.assertEqual(infer_type_from_json_schema({"enum": [1, 2, 3]}), "integer")
+        self.assertEqual(infer_type_from_json_schema({"enum": ["a", "b"]}), "string")
+        # bool must be detected before int (bool is a subclass of int)
+        self.assertEqual(
+            infer_type_from_json_schema({"enum": [True, False]}), "boolean"
+        )
+        # mixed enum -> string
+        self.assertEqual(infer_type_from_json_schema({"enum": [1, "a"]}), "string")
+        # empty enum -> string
+        self.assertEqual(infer_type_from_json_schema({"enum": []}), "string")
+
+    def test_all_of(self):
+        # first non-string type wins
+        self.assertEqual(
+            infer_type_from_json_schema(
+                {"allOf": [{"type": "string"}, {"type": "object"}]}
+            ),
+            "object",
+        )
+        # all string -> string
+        self.assertEqual(
+            infer_type_from_json_schema({"allOf": [{"type": "string"}]}),
+            "string",
+        )
+
+    def test_properties_and_items(self):
+        self.assertEqual(
+            infer_type_from_json_schema({"properties": {"a": {"type": "string"}}}),
+            "object",
+        )
+        self.assertEqual(
+            infer_type_from_json_schema({"items": {"type": "integer"}}), "array"
+        )
+
+    def test_non_dict_and_empty(self):
+        self.assertIsNone(infer_type_from_json_schema("not a dict"))
+        self.assertIsNone(infer_type_from_json_schema({}))
+
+    def test_priority_type_over_enum(self):
+        # explicit type field takes priority over enum value inference
+        self.assertEqual(
+            infer_type_from_json_schema({"type": "string", "enum": [1, 2]}),
+            "string",
+        )
+
+
+class TestPartialJsonLoads(CustomTestCase):
+    def test_complete_object_consumes_all(self):
+        obj, end = _partial_json_loads('{"a": 1, "b": 2}', Allow.ALL)
+        self.assertEqual(obj, {"a": 1, "b": 2})
+        self.assertEqual(end, len('{"a": 1, "b": 2}'))
+
+    def test_extra_data_falls_back_to_raw_decode(self):
+        # trailing junk after a complete object -> raw_decode returns consumed < len
+        s = '{"a": 1} trailing junk'
+        obj, end = _partial_json_loads(s, Allow.ALL)
+        self.assertEqual(obj, {"a": 1})
+        self.assertEqual(end, len('{"a": 1}'))
+        self.assertLess(end, len(s))
+
+    def test_partial_object(self):
+        # an incomplete object is tolerated under Allow.ALL
+        obj, end = _partial_json_loads('{"a": 1, "b":', Allow.ALL)
+        self.assertIsInstance(obj, dict)
+        self.assertEqual(obj.get("a"), 1)
+
+    def test_leading_whitespace_with_extra_data(self):
+        s = '   {"x": 5} more'
+        obj, end = _partial_json_loads(s, Allow.ALL)
+        self.assertEqual(obj, {"x": 5})
+        self.assertLess(end, len(s))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
### What

Adds CPU-only unit tests for two previously-uncovered pure helpers in
`python/sglang/srt/function_call/utils.py`. Their siblings
(`get_json_schema_constraint` / `_get_tool_schema_defs`) are already tested, so this
fills the precise gap. Part of #20865.

### Coverage (12 tests)

`infer_type_from_json_schema()` — all 6 priority branches:
- direct `type` (incl. `type` arrays with `null` filtered out, and the only-`null` → `string` default)
- `anyOf`/`oneOf` unification (all-same vs mixed → `string` preferred)
- `enum` value-type inference, including the **bool-before-int** subtlety (`[True, False]` → `boolean`, not `integer`), mixed enum → `string`, empty enum → `string`
- `allOf` (first non-string type wins)
- `properties` → `object`, `items` → `array`
- explicit `type` takes priority over `enum`; non-dict / `{}` → `None`

`_partial_json_loads()` — complete parse (consumes all), the **"Extra data"** raw-decode fallback (returns consumed length < input), partial object under `Allow.ALL`, and leading-whitespace handling.

### Testing done

All 12 pass against the real functions; `ruff` clean.

```
Ran 12 tests in 0.000s
OK
```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26979662257](https://github.com/sgl-project/sglang/actions/runs/26979662257)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26979662066](https://github.com/sgl-project/sglang/actions/runs/26979662066)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->