### PR TITLE
Fix DeepSeek V4 APE weight update layout

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -26,7 +26,7 @@ from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
-from sglang.srt.utils import add_prefix
+from sglang.srt.utils import add_prefix, set_weight_attrs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.deepseek_v4_backend import DeepseekV4AttnBackend
@@ -309,6 +309,7 @@ class Compressor(nn.Module):
         self.ape = nn.Parameter(
             torch.empty(self.ratio, coff * self.head_dim, dtype=torch.float32)
         )
+        set_weight_attrs(self.ape, {"weight_loader": self.load_ape_weight})
         wkv_gate_dtype = torch.bfloat16
         self.wkv_gate = ReplicatedLinear(
             self.dim,
@@ -325,14 +326,19 @@ class Compressor(nn.Module):
 
         self.ape_converted = False
 
-    def apply_ape_hotfix(self):
-        assert not self.ape_converted
+    def load_ape_weight(self, param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        assert param is self.ape
+        if self.overlap:
+            loaded_weight = torch.chunk(loaded_weight, 2, dim=-1)
+            loaded_weight = torch.cat([loaded_weight[0], loaded_weight[1]], dim=0)
+            loaded_weight = loaded_weight.view(self.ratio, -1)
+        assert loaded_weight.shape == param.shape
+        param.data.copy_(loaded_weight)
         self.ape_converted = True
 
-        if self.overlap:
-            ape = torch.chunk(self.ape.data, 2, dim=-1)
-            ape = torch.cat([ape[0], ape[1]], dim=0)
-            self.ape.data.copy_(ape.view(self.ratio, -1))
+    def apply_ape_hotfix(self):
+        assert not self.ape_converted
+        self.load_ape_weight(self.ape, self.ape.data)
 
     # NOTE: used by v2 compressor backend
     def get_state_pool(self, forward_batch: ForwardBatch) -> CompressStatePool:


### PR DESCRIPTION
## Summary
- load DeepSeek V4 compressor APE through a parameter-specific weight loader
- keep APE in SGLang runtime/kernel layout for normal online update and P2P CPU replica update
- reuse the same loader from apply_ape_hotfix

## Validation
- python -m py_compile python/sglang/srt/layers/attention/dsv4/compressor.py
- pre-commit run --files python/sglang/srt/layers/attention/dsv4/compressor.py

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->