### PR TITLE
[RL] convert DeepSeek V4 APE layout through weight loader

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -382,19 +382,23 @@ class Compressor(nn.Module):
 
         self.ape_converted = False
 
-    def load_ape_weight(self, param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
-        assert param is self.ape
-        if self.overlap:
-            loaded_weight = torch.chunk(loaded_weight, 2, dim=-1)
-            loaded_weight = torch.cat([loaded_weight[0], loaded_weight[1]], dim=0)
-            loaded_weight = loaded_weight.view(self.ratio, -1)
-        assert loaded_weight.shape == param.shape
-        param.data.copy_(loaded_weight)
+    def _apply_ape_hotfix(self):
         self.ape_converted = True
+
+        if self.overlap:
+            ape = torch.chunk(self.ape.data, 2, dim=-1)
+            ape = torch.cat([ape[0], ape[1]], dim=0)
+            self.ape.data.copy_(ape.view(self.ratio, -1))
 
     def apply_ape_hotfix(self):
         assert not self.ape_converted
-        self.load_ape_weight(self.ape, self.ape.data)
+        self._apply_ape_hotfix()
+
+    def load_ape_weight(self, param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        assert param is self.ape
+        assert loaded_weight.shape == param.shape
+        param.data.copy_(loaded_weight)
+        self._apply_ape_hotfix()
 
     def get_state_pool(self, attn_backend: AttentionBackend) -> CompressStatePool:
         token_to_kv_pool = attn_backend.token_to_kv_pool

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -28,7 +28,7 @@ from sglang.srt.mem_cache.deepseek_v4_compress_state import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.models.deepseek_v2 import _is_hip
-from sglang.srt.utils import add_prefix, get_bool_env_var
+from sglang.srt.utils import add_prefix, get_bool_env_var, set_weight_attrs
 
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _tgemm = None
@@ -364,6 +364,7 @@ class Compressor(nn.Module):
         self.ape = nn.Parameter(
             torch.empty(self.ratio, coff * self.head_dim, dtype=torch.float32)
         )
+        set_weight_attrs(self.ape, {"weight_loader": self.load_ape_weight})
         wkv_gate_dtype = torch.bfloat16
         self.wkv_gate = ReplicatedLinear(
             self.dim,
@@ -381,14 +382,19 @@ class Compressor(nn.Module):
 
         self.ape_converted = False
 
-    def apply_ape_hotfix(self):
-        assert not self.ape_converted
+    def load_ape_weight(self, param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        assert param is self.ape
+        if self.overlap:
+            loaded_weight = torch.chunk(loaded_weight, 2, dim=-1)
+            loaded_weight = torch.cat([loaded_weight[0], loaded_weight[1]], dim=0)
+            loaded_weight = loaded_weight.view(self.ratio, -1)
+        assert loaded_weight.shape == param.shape
+        param.data.copy_(loaded_weight)
         self.ape_converted = True
 
-        if self.overlap:
-            ape = torch.chunk(self.ape.data, 2, dim=-1)
-            ape = torch.cat([ape[0], ape[1]], dim=0)
-            self.ape.data.copy_(ape.view(self.ratio, -1))
+    def apply_ape_hotfix(self):
+        assert not self.ape_converted
+        self.load_ape_weight(self.ape, self.ape.data)
 
     def get_state_pool(self, attn_backend: AttentionBackend) -> CompressStatePool:
         token_to_kv_pool = attn_backend.token_to_kv_pool


### PR DESCRIPTION
Use the weight loader to do ape hotfix, to allow ape conversion during RL weight update through weight loader













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27041772098](https://github.com/sgl-project/sglang/actions/runs/27041772098)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27041771955](https://github.com/sgl-project/sglang/actions/runs/27041771955)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->