### PR TITLE
Add startup self-benchmarking for ForwardPassMetrics

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2081,9 +2081,12 @@ class SchedulerDisaggregationDecodeMixin:
         """A normal scheduler loop for decode worker in disaggregation mode."""
 
         while True:
-            # Receive requests
-            recv_reqs = self.request_receiver.recv_requests()
-            self.process_input_requests(recv_reqs)
+            if self.self_benchmark is not None and self.self_benchmark.active:
+                self.self_benchmark.maybe_schedule_next()
+            else:
+                # Receive requests
+                recv_reqs = self.request_receiver.recv_requests()
+                self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
             self.process_decode_queue()
@@ -2120,9 +2123,12 @@ class SchedulerDisaggregationDecodeMixin:
             self.process_batch_result(tmp_batch, tmp_result)
 
         while True:
-            # Receive requests
-            recv_reqs = self.request_receiver.recv_requests()
-            self.process_input_requests(recv_reqs)
+            if self.self_benchmark is not None and self.self_benchmark.active:
+                self.self_benchmark.maybe_schedule_next()
+            else:
+                # Receive requests
+                recv_reqs = self.request_receiver.recv_requests()
+                self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
             self.process_decode_queue()

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2081,9 +2081,7 @@ class SchedulerDisaggregationDecodeMixin:
         """A normal scheduler loop for decode worker in disaggregation mode."""
 
         while True:
-            if self.self_benchmark is not None and self.self_benchmark.active:
-                self.self_benchmark.maybe_schedule_next()
-            else:
+            if not self._maybe_run_self_benchmark_step():
                 # Receive requests
                 recv_reqs = self.request_receiver.recv_requests()
                 self.process_input_requests(recv_reqs)
@@ -2123,9 +2121,7 @@ class SchedulerDisaggregationDecodeMixin:
             self.process_batch_result(tmp_batch, tmp_result)
 
         while True:
-            if self.self_benchmark is not None and self.self_benchmark.active:
-                self.self_benchmark.maybe_schedule_next()
-            else:
+            if not self._maybe_run_self_benchmark_step():
                 # Receive requests
                 recv_reqs = self.request_receiver.recv_requests()
                 self.process_input_requests(recv_reqs)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -553,9 +553,12 @@ class SchedulerDisaggregationPrefillMixin:
     def event_loop_normal_disagg_prefill(self: Scheduler) -> None:
         """A normal scheduler loop for prefill worker in disaggregation mode."""
         while True:
-            # Receive requests
-            recv_reqs = self.request_receiver.recv_requests()
-            self.process_input_requests(recv_reqs)
+            if self.self_benchmark is not None and self.self_benchmark.active:
+                self.self_benchmark.maybe_schedule_next()
+            else:
+                # Receive requests
+                recv_reqs = self.request_receiver.recv_requests()
+                self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
             self.waiting_queue.extend(
@@ -592,9 +595,12 @@ class SchedulerDisaggregationPrefillMixin:
         self.result_queue = deque()
 
         while True:
-            # Receive requests
-            recv_reqs = self.request_receiver.recv_requests()
-            self.process_input_requests(recv_reqs)
+            if self.self_benchmark is not None and self.self_benchmark.active:
+                self.self_benchmark.maybe_schedule_next()
+            else:
+                # Receive requests
+                recv_reqs = self.request_receiver.recv_requests()
+                self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
             self.waiting_queue.extend(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -553,9 +553,7 @@ class SchedulerDisaggregationPrefillMixin:
     def event_loop_normal_disagg_prefill(self: Scheduler) -> None:
         """A normal scheduler loop for prefill worker in disaggregation mode."""
         while True:
-            if self.self_benchmark is not None and self.self_benchmark.active:
-                self.self_benchmark.maybe_schedule_next()
-            else:
+            if not self._maybe_run_self_benchmark_step():
                 # Receive requests
                 recv_reqs = self.request_receiver.recv_requests()
                 self.process_input_requests(recv_reqs)
@@ -595,9 +593,7 @@ class SchedulerDisaggregationPrefillMixin:
         self.result_queue = deque()
 
         while True:
-            if self.self_benchmark is not None and self.self_benchmark.active:
-                self.self_benchmark.maybe_schedule_next()
-            else:
+            if not self._maybe_run_self_benchmark_step():
                 # Receive requests
                 recv_reqs = self.request_receiver.recv_requests()
                 self.process_input_requests(recv_reqs)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -855,6 +855,10 @@ class Req(ReqDllmMixin):
         self.finished_len = None
         # Whether this request has finished output
         self.finished_output = None
+        # When True, the request's outputs are not streamed to the tokenizer.
+        # Used by synthetic self-benchmark requests (see SelfBenchmark) so their
+        # dummy outputs never reach the detokenizer.
+        self.suppress_output = False
         # If we want to abort the request in the middle of the event loop,
         # set to_finish instead of directly setting finished_reason.
         # Note: We should never set finished_reason in the middle, the req will get filtered and never respond

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -615,15 +615,13 @@ class Scheduler(
 
         self.init_batch_result_processor()
 
-        self.init_init_info_sender()
+        self.init_startup_readiness_sender()
 
         self.maybe_init_self_benchmark()
 
-        maybe_revert_pr_fix()
-
         self.is_initializing = False
 
-    def init_init_info_sender(self) -> None:
+    def init_startup_readiness_sender(self) -> None:
         self._init_info_pipe_writer = None
         self._init_info_sent = False
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -617,55 +617,13 @@ class Scheduler(
 
         self.init_startup_readiness_sender()
 
-        self.maybe_init_self_benchmark()
+        self.self_benchmark = SelfBenchmark.create_if_enabled(self)
 
         self.is_initializing = False
 
     def init_startup_readiness_sender(self) -> None:
         self._init_info_pipe_writer = None
         self._init_info_sent = False
-
-    def maybe_init_self_benchmark(self) -> None:
-        self.self_benchmark = None
-        if self.server_args.benchmark_mode is None:
-            return
-
-        if self.ps.pp_size > 1:
-            raise ValueError(
-                "--benchmark-mode is not supported with pipeline parallelism"
-            )
-        if self.enable_pdmux:
-            raise ValueError("--benchmark-mode is not supported with PD multiplexing")
-        if self.enable_overlap_mlx:
-            raise ValueError("--benchmark-mode is not supported with MLX overlap")
-        if not self.is_generation:
-            # Non-generation (embedding/reward) models would leak synthetic
-            # prefill outputs to the tokenizer (suppress_output is only honored
-            # on the generation streaming path).
-            raise ValueError("--benchmark-mode is only supported for generative models")
-        if not self.spec_algorithm.is_none():
-            # The synthetic decode path is incompatible with speculative
-            # decoding, and the synthetic prefill path is not guarded for it.
-            raise ValueError(
-                "--benchmark-mode is not supported with speculative decoding"
-            )
-        if self.model_config.is_encoder_decoder:
-            raise ValueError(
-                "--benchmark-mode is not supported with encoder-decoder models"
-            )
-        if self.model_config.is_multimodal:
-            # Synthetic requests carry no multimodal inputs.
-            raise ValueError("--benchmark-mode is not supported with multimodal models")
-        if self.enable_lora:
-            raise ValueError("--benchmark-mode is not supported with LoRA")
-        if self.server_args.load_format == "dummy":
-            # Dummy weights produce meaningless benchmark results.
-            raise ValueError(
-                "--benchmark-mode is not supported with dummy weights "
-                "(--load-format dummy)"
-            )
-
-        self.self_benchmark = SelfBenchmark(self)
 
     def init_zbal_on_npu(self):
         if _is_npu:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -366,6 +366,7 @@ class Scheduler(
 
         # Parse args
         self.server_args = server_args
+        self.instance_id = port_args.instance_id
         self.nccl_port = port_args.nccl_port
         self.schedule_policy = server_args.schedule_policy
         self.enable_priority_scheduling = server_args.enable_priority_scheduling
@@ -3725,8 +3726,8 @@ class Scheduler(
         if self.enable_fpm:
             fpm = self.metrics_reporter._emit_forward_pass_metrics(batch, result)
 
-        if self.self_benchmark is not None:
-            self.self_benchmark.observe_forward_pass(batch, fpm)
+            if self.self_benchmark is not None:
+                self.self_benchmark.observe_forward_pass(batch, fpm)
 
         self._maybe_clear_mm_inputs(batch)
         self.maybe_send_health_check_signal()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -221,6 +221,7 @@ from sglang.srt.managers.scheduler_components.recv_skipper import (
 from sglang.srt.managers.scheduler_components.request_receiver import (
     SchedulerRequestReceiver,
 )
+from sglang.srt.managers.scheduler_components.self_benchmark import SelfBenchmark
 from sglang.srt.managers.scheduler_components.weight_updater import (
     SchedulerWeightUpdaterManager,
 )
@@ -612,6 +613,12 @@ class Scheduler(
         self.init_output_streamer()
 
         self.init_batch_result_processor()
+
+        self.self_benchmark = (
+            SelfBenchmark(self) if self.server_args.benchmark_mode is not None else None
+        )
+
+        maybe_revert_pr_fix()
 
         self.is_initializing = False
 
@@ -1583,9 +1590,12 @@ class Scheduler(
             if self.gracefully_exit:
                 break
 
-            # Receive requests
-            recv_reqs = self.request_receiver.recv_requests()
-            self.process_input_requests(recv_reqs)
+            if self.self_benchmark is not None and self.self_benchmark.active:
+                self.self_benchmark.maybe_schedule_next()
+            else:
+                # Receive requests
+                recv_reqs = self.request_receiver.recv_requests()
+                self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
 
@@ -1626,9 +1636,12 @@ class Scheduler(
             if self.gracefully_exit:
                 break
 
-            # Receive requests
-            recv_reqs = self.request_receiver.recv_requests()
-            self.process_input_requests(recv_reqs)
+            if self.self_benchmark is not None and self.self_benchmark.active:
+                self.self_benchmark.maybe_schedule_next()
+            else:
+                # Receive requests
+                recv_reqs = self.request_receiver.recv_requests()
+                self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
 
@@ -3671,8 +3684,12 @@ class Scheduler(
         self.metrics_reporter.log_batch_result_stats(batch, result)
 
         # Emit forward pass metrics (every iteration when enabled)
+        fpm = None
         if self.enable_fpm:
-            self.metrics_reporter._emit_forward_pass_metrics(batch, result)
+            fpm = self.metrics_reporter._emit_forward_pass_metrics(batch, result)
+
+        if self.self_benchmark is not None:
+            self.self_benchmark.observe_forward_pass(batch, fpm)
 
         self._maybe_clear_mm_inputs(batch)
         self.maybe_send_health_check_signal()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -638,6 +638,32 @@ class Scheduler(
             raise ValueError("--benchmark-mode is not supported with PD multiplexing")
         if self.enable_overlap_mlx:
             raise ValueError("--benchmark-mode is not supported with MLX overlap")
+        if not self.is_generation:
+            # Non-generation (embedding/reward) models would leak synthetic
+            # prefill outputs to the tokenizer (suppress_output is only honored
+            # on the generation streaming path).
+            raise ValueError("--benchmark-mode is only supported for generative models")
+        if not self.spec_algorithm.is_none():
+            # The synthetic decode path is incompatible with speculative
+            # decoding, and the synthetic prefill path is not guarded for it.
+            raise ValueError(
+                "--benchmark-mode is not supported with speculative decoding"
+            )
+        if self.model_config.is_encoder_decoder:
+            raise ValueError(
+                "--benchmark-mode is not supported with encoder-decoder models"
+            )
+        if self.model_config.is_multimodal:
+            # Synthetic requests carry no multimodal inputs.
+            raise ValueError("--benchmark-mode is not supported with multimodal models")
+        if self.enable_lora:
+            raise ValueError("--benchmark-mode is not supported with LoRA")
+        if self.server_args.load_format == "dummy":
+            # Dummy weights produce meaningless benchmark results.
+            raise ValueError(
+                "--benchmark-mode is not supported with dummy weights "
+                "(--load-format dummy)"
+            )
 
         self.self_benchmark = SelfBenchmark(self)
 
@@ -1560,6 +1586,19 @@ class Scheduler(
     def on_self_benchmark_finished(self) -> None:
         self.send_init_info_once()
 
+    def _maybe_run_self_benchmark_step(self) -> bool:
+        """Run one self-benchmark scheduling step in place of request intake.
+
+        Returns True if the self-benchmark handled this iteration's input step
+        (so the caller should skip the normal request receive/process), False
+        otherwise. Replaces the duplicated event-loop guard across the normal
+        and disaggregated loops.
+        """
+        if self.self_benchmark is not None and self.self_benchmark.active:
+            self.self_benchmark.maybe_schedule_next()
+            return True
+        return False
+
     def release_host_resources(self) -> None:
         # Release pinned host buffers in userspace on graceful shutdown; see
         # HostKVCache.destroy. Called from run_scheduler_process's finally.
@@ -1626,9 +1665,7 @@ class Scheduler(
             if self.gracefully_exit:
                 break
 
-            if self.self_benchmark is not None and self.self_benchmark.active:
-                self.self_benchmark.maybe_schedule_next()
-            else:
+            if not self._maybe_run_self_benchmark_step():
                 # Receive requests
                 recv_reqs = self.request_receiver.recv_requests()
                 self.process_input_requests(recv_reqs)
@@ -1672,9 +1709,7 @@ class Scheduler(
             if self.gracefully_exit:
                 break
 
-            if self.self_benchmark is not None and self.self_benchmark.active:
-                self.self_benchmark.maybe_schedule_next()
-            else:
+            if not self._maybe_run_self_benchmark_step():
                 # Receive requests
                 recv_reqs = self.request_receiver.recv_requests()
                 self.process_input_requests(recv_reqs)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -614,13 +614,33 @@ class Scheduler(
 
         self.init_batch_result_processor()
 
-        self.self_benchmark = (
-            SelfBenchmark(self) if self.server_args.benchmark_mode is not None else None
-        )
+        self.init_init_info_sender()
+
+        self.maybe_init_self_benchmark()
 
         maybe_revert_pr_fix()
 
         self.is_initializing = False
+
+    def init_init_info_sender(self) -> None:
+        self._init_info_pipe_writer = None
+        self._init_info_sent = False
+
+    def maybe_init_self_benchmark(self) -> None:
+        self.self_benchmark = None
+        if self.server_args.benchmark_mode is None:
+            return
+
+        if self.ps.pp_size > 1:
+            raise ValueError(
+                "--benchmark-mode is not supported with pipeline parallelism"
+            )
+        if self.enable_pdmux:
+            raise ValueError("--benchmark-mode is not supported with PD multiplexing")
+        if self.enable_overlap_mlx:
+            raise ValueError("--benchmark-mode is not supported with MLX overlap")
+
+        self.self_benchmark = SelfBenchmark(self)
 
     def init_zbal_on_npu(self):
         if _is_npu:
@@ -1523,6 +1543,23 @@ class Scheduler(
         }
 
         return result_dict
+
+    def register_init_info_pipe_writer(self, pipe_writer) -> None:
+        self._init_info_pipe_writer = pipe_writer
+
+    def should_defer_init_info(self) -> bool:
+        return self.self_benchmark is not None and self.self_benchmark.active
+
+    def send_init_info_once(self) -> None:
+        if self._init_info_sent:
+            return
+        if self._init_info_pipe_writer is None:
+            raise RuntimeError("Scheduler init-info pipe writer is not registered")
+        self._init_info_pipe_writer.send(self.get_init_info())
+        self._init_info_sent = True
+
+    def on_self_benchmark_finished(self) -> None:
+        self.send_init_info_once()
 
     def release_host_resources(self) -> None:
         # Release pinned host buffers in userspace on graceful shutdown; see
@@ -4772,8 +4809,12 @@ def run_scheduler_process(
             dp_rank,
         )
 
-        # Send initialization info back to the parent process
-        pipe_writer.send(scheduler.get_init_info())
+        # Send initialization info back to the parent process. Startup
+        # self-benchmarking is a readiness gate, so benchmark mode defers this
+        # until the sweep has completed and results are written.
+        scheduler.register_init_info_pipe_writer(pipe_writer)
+        if not scheduler.should_defer_init_info():
+            scheduler.send_init_info_once()
 
         # Run the event loop (blocks until a ShutdownReq sets gracefully_exit)
         scheduler.run_event_loop()

--- a/python/sglang/srt/managers/scheduler_components/benchmark_points.py
+++ b/python/sglang/srt/managers/scheduler_components/benchmark_points.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class _PointCandidate(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    batch_size: int = Field(gt=0)
+
+
+class PrefillPointCandidate(_PointCandidate):
+    total_prefill_tokens: int = Field(gt=0)
+    total_kv_read_tokens: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_totals(self) -> PrefillPointCandidate:
+        if self.total_prefill_tokens < self.batch_size:
+            raise ValueError("total_prefill_tokens must be at least batch_size")
+        if 0 < self.total_kv_read_tokens < self.batch_size:
+            raise ValueError("total_kv_read_tokens must be zero or at least batch_size")
+        return self
+
+
+class DecodePointCandidate(_PointCandidate):
+    total_kv_read_tokens: int = Field(gt=0)
+
+    @model_validator(mode="after")
+    def validate_totals(self) -> DecodePointCandidate:
+        if self.total_kv_read_tokens < self.batch_size:
+            raise ValueError("total_kv_read_tokens must be at least batch_size")
+        return self
+
+
+class BenchmarkPoints(BaseModel):
+    """Versioned, ordered startup self-benchmark point manifest."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schema_version: int = Field(strict=True, ge=1, le=1)
+    prefill: list[PrefillPointCandidate]
+    decode: list[DecodePointCandidate]
+
+
+def load_benchmark_points_file(path: str) -> BenchmarkPoints:
+    try:
+        return BenchmarkPoints.model_validate_json(Path(path).read_bytes())
+    except Exception as error:
+        raise ValueError(f"--benchmark-points-file {path!r}: {error}") from error

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -189,7 +189,7 @@ class SchedulerMetricsReporter:
     def _init_fpm(self):
         """Initialize Forward Pass Metrics (FPM) publisher if configured.
 
-        Normally FPM is published only by the real FPM rank (attn_tp_rank == 0 on
+        Normally FPM is published only by the real FPM rank (attention TP0/CP0 on
         the last pp_rank). The self-benchmark, however, drives its sweep off
         observe_forward_pass, which only fires when enable_fpm is True. Since the
         benchmark is built and advances on EVERY rank, we force FPM on for the
@@ -201,6 +201,7 @@ class SchedulerMetricsReporter:
         is_fpm_rank = (
             self.scheduler.server_args.enable_forward_pass_metrics
             and self.scheduler.ps.attn_tp_rank == 0
+            and self.scheduler.ps.attn_cp_rank == 0
             and self.scheduler.ps.pp_rank == self.scheduler.ps.pp_size - 1
         )
         benchmark_forces_fpm = (

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -968,7 +968,7 @@ class SchedulerMetricsReporter:
         Falls back to monotonic clock when DeviceTimer is not enabled.
         """
         if not self.scheduler.enable_fpm:
-            return
+            return None
 
         from sglang.srt.observability.forward_pass_metrics import (
             ForwardPassMetrics,
@@ -979,7 +979,7 @@ class SchedulerMetricsReporter:
             wall_time = self.scheduler._fpm_gpu_time_acc
             self.scheduler._fpm_gpu_time_acc = 0.0
             if wall_time == 0.0:
-                return
+                return None
         else:
             wall_time = max(0.0, time.monotonic() - batch.fpm_start_time)
 
@@ -991,6 +991,7 @@ class SchedulerMetricsReporter:
             queued_requests=self._build_queued_request_metrics(),
         )
         self.scheduler._fpm_publisher.publish(fpm)
+        return fpm
 
     def _shutdown_fpm(self):
         """Shut down the FPM publisher thread."""

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -184,24 +184,34 @@ class SchedulerMetricsReporter:
     def _install_device_timer_on_runners(self):
         if self.forward_pass_device_timer is None:
             return
-        timer = self.forward_pass_device_timer
-        self.scheduler.tp_worker.model_runner.device_timer = timer
-        if self.scheduler.draft_worker is not None:
-            dw = getattr(self.scheduler.draft_worker, "draft_worker", None)
-            if dw is not None:
-                if hasattr(dw, "draft_runner"):
-                    dw.draft_runner.device_timer = timer
-                for r in getattr(dw, "draft_runner_list", []):
-                    r.device_timer = timer
+        self._install_device_timer_on_runners_value(self.forward_pass_device_timer)
 
     def _init_fpm(self):
-        """Initialize Forward Pass Metrics (FPM) publisher if configured."""
+        """Initialize Forward Pass Metrics (FPM) publisher if configured.
+
+        Normally FPM is published only by the real FPM rank (attn_tp_rank == 0 on
+        the last pp_rank). The self-benchmark, however, drives its sweep off
+        observe_forward_pass, which only fires when enable_fpm is True. Since the
+        benchmark is built and advances on EVERY rank, we force FPM on for the
+        benchmark's duration on the ranks that would otherwise have it disabled
+        so every rank advances the sweep in lockstep and sends its deferred
+        init-info. SelfBenchmark._finish() restores the original state.
+        """
         self.scheduler.enable_fpm = False
-        if (
+        is_fpm_rank = (
             self.scheduler.server_args.enable_forward_pass_metrics
             and self.scheduler.ps.attn_tp_rank == 0
             and self.scheduler.ps.pp_rank == self.scheduler.ps.pp_size - 1
-        ):
+        )
+        benchmark_forces_fpm = (
+            self.scheduler.server_args.benchmark_mode is not None and not is_fpm_rank
+        )
+        # Distinguish a real FPM rank from a benchmark-forced one: only the real
+        # rank writes its JSON output and keeps publishing after the sweep.
+        self.scheduler._fpm_is_real_rank = is_fpm_rank
+        self.scheduler._fpm_benchmark_forced = benchmark_forces_fpm
+
+        if is_fpm_rank or benchmark_forces_fpm:
             from sglang.srt.observability.forward_pass_metrics import (
                 _FpmPublisherThread,
             )
@@ -214,15 +224,23 @@ class SchedulerMetricsReporter:
             self.scheduler._fpm_worker_id = (
                 self.scheduler.server_args.forward_pass_metrics_worker_id
             )
-            base_endpoint = self.scheduler.server_args.forward_pass_metrics_ipc_name
-            if base_endpoint is None:
+            if benchmark_forces_fpm:
+                # A benchmark-forced rank's published stream is never consumed.
+                # Use a process-unique endpoint: the shared
+                # {base}.{dp_rank} endpoint would collide across the multiple TP
+                # ranks that share a dp_rank, causing a ZMQ bind error.
                 ipc_path = tempfile.NamedTemporaryFile(delete=False).name
-                base_endpoint = f"ipc://{ipc_path}"
-                self.scheduler.server_args.override(
-                    "metrics_reporter.ipc_endpoint",
-                    forward_pass_metrics_ipc_name=base_endpoint,
-                )
-            endpoint = f"{base_endpoint}.{self.scheduler._fpm_dp_rank}"
+                endpoint = f"ipc://{ipc_path}"
+            else:
+                base_endpoint = self.scheduler.server_args.forward_pass_metrics_ipc_name
+                if base_endpoint is None:
+                    ipc_path = tempfile.NamedTemporaryFile(delete=False).name
+                    base_endpoint = f"ipc://{ipc_path}"
+                    self.scheduler.server_args.override(
+                        "metrics_reporter.ipc_endpoint",
+                        forward_pass_metrics_ipc_name=base_endpoint,
+                    )
+                endpoint = f"{base_endpoint}.{self.scheduler._fpm_dp_rank}"
             self.scheduler._fpm_publisher = _FpmPublisherThread(
                 endpoint,
                 worker_id=self.scheduler._fpm_worker_id,
@@ -233,19 +251,26 @@ class SchedulerMetricsReporter:
             def _fpm_device_timer_reporter(t, **_kwargs):
                 self.scheduler._fpm_gpu_time_acc += t
 
+            # Track the reporter + whether we own a freshly created timer so a
+            # benchmark-forced rank can fully tear the timer down afterwards.
+            self._fpm_device_timer_reporter = _fpm_device_timer_reporter
             if self.forward_pass_device_timer is not None:
+                self._fpm_owns_device_timer = False
                 self.forward_pass_device_timer.add_reporter(_fpm_device_timer_reporter)
             else:
+                self._fpm_owns_device_timer = True
                 self.forward_pass_device_timer = DeviceTimer(
                     reporter=_fpm_device_timer_reporter,
                 )
             self.scheduler._fpm_uses_device_timer = True
             self.scheduler.enable_fpm = True
             logger.info(
-                "FPM: ZMQ PUB bound on %s (dp_rank=%d, device_timer=%s)",
+                "FPM: ZMQ PUB bound on %s (dp_rank=%d, device_timer=%s, "
+                "benchmark_forced=%s)",
                 endpoint,
                 self.scheduler._fpm_dp_rank,
                 self.scheduler._fpm_uses_device_timer,
+                benchmark_forces_fpm,
             )
 
     def _build_scheduled_request_metrics(self, batch: ScheduleBatch):
@@ -997,6 +1022,43 @@ class SchedulerMetricsReporter:
         """Shut down the FPM publisher thread."""
         if self.scheduler.enable_fpm:
             self.scheduler._fpm_publisher.shutdown()
+
+    def shutdown_benchmark_forced_fpm(self):
+        """Tear down FPM machinery that was only forced on for the self-benchmark.
+
+        Called by SelfBenchmark._finish() on ranks where FPM was benchmark-forced
+        (not a real FPM rank). Shuts down the forced publisher and stops the
+        device-timer reporter so production is unaffected. Must run BEFORE the
+        caller flips enable_fpm back to False, since the publisher only exists
+        while FPM is active on this rank.
+        """
+        if not getattr(self.scheduler, "_fpm_benchmark_forced", False):
+            return
+        self.scheduler._fpm_publisher.shutdown()
+        # Stop feeding the FPM device-timer accumulator.
+        reporter = getattr(self, "_fpm_device_timer_reporter", None)
+        if reporter is not None and self.forward_pass_device_timer is not None:
+            if getattr(self, "_fpm_owns_device_timer", False):
+                # We created this timer solely for forced FPM; drop it entirely.
+                self.forward_pass_device_timer = None
+                self._install_device_timer_on_runners_value(None)
+            else:
+                self.forward_pass_device_timer.remove_reporter(reporter)
+        self.scheduler._fpm_uses_device_timer = False
+        self._fpm_device_timer_reporter = None
+        # Forced ranks never write output and have nothing left to publish.
+        self.scheduler._fpm_benchmark_forced = False
+
+    def _install_device_timer_on_runners_value(self, timer):
+        """Set (or clear) the device timer reference on the model runners."""
+        self.scheduler.tp_worker.model_runner.device_timer = timer
+        if self.scheduler.draft_worker is not None:
+            dw = getattr(self.scheduler.draft_worker, "draft_worker", None)
+            if dw is not None:
+                if hasattr(dw, "draft_runner"):
+                    dw.draft_runner.device_timer = timer
+                for r in getattr(dw, "draft_runner_list", []):
+                    r.device_timer = timer
 
     def _log_hicache_stats(self):
         """Populate HiCache host-tier stats on self.stats.

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -334,6 +334,13 @@ class _GenerationStreamAccumulator:
             self.output_token_sampling_logprobs = []
 
     def accept(self, *, req: Req) -> None:
+        if getattr(req, "suppress_output", False):
+            if req.finished():
+                req.finished_output = True
+                if req.finished_len is None:
+                    req.finished_len = len(req.output_ids)
+            return
+
         if req.finished():
             assert not req.finished_output
             req.finished_output = True

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -736,6 +736,9 @@ class SelfBenchmark:
             metrics_collector=None,
             extra_key=extra_key or rid,
         )
+        # Synthetic requests bypass Scheduler.handle_generate_request, which
+        # disables input logprob computation when return_logprob is false.
+        req.logprob_start_len = -1
         req.tokenizer = self.scheduler.tokenizer
         req.suppress_output = True
         return req

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from array import array
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Optional
+
+import msgspec
+import numpy as np
+
+from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.utils import validate_input_length
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.managers.scheduler import Scheduler
+    from sglang.srt.observability.forward_pass_metrics import ForwardPassMetrics
+
+
+logger = logging.getLogger(__name__)
+
+SELF_BENCHMARK_REQ_PREFIX = "__sgl_bench_"
+
+
+@dataclass
+class SelfBenchmarkConfig:
+    mode: str
+    prefill_isl_granularity: int = 16
+    decode_length_granularity: int = 6
+    decode_batch_size_granularity: int = 6
+    warmup_iterations: int = 5
+    output_path: str = "/tmp/benchmark_results.json"
+    timeout: int = 300
+
+
+@dataclass
+class BenchmarkPoint:
+    point_type: str
+    isl: int = 0
+    context_length: int = 0
+    batch_size: int = 0
+
+
+@dataclass
+class BenchmarkPointResult:
+    point: BenchmarkPoint
+    fpms: list = field(default_factory=list)
+
+
+class BenchmarkPhase(Enum):
+    WARMUP = "warmup"
+    SWEEP = "sweep"
+    DONE = "done"
+
+
+class SelfBenchmark:
+    """Scheduler-local self benchmark that reuses normal SGLang request paths."""
+
+    def __init__(self, scheduler: Scheduler):
+        self.scheduler = scheduler
+        self.config = SelfBenchmarkConfig(
+            mode=scheduler.server_args.benchmark_mode,
+            prefill_isl_granularity=scheduler.server_args.benchmark_prefill_granularity,
+            decode_length_granularity=(
+                scheduler.server_args.benchmark_decode_length_granularity
+            ),
+            decode_batch_size_granularity=(
+                scheduler.server_args.benchmark_decode_batch_granularity
+            ),
+            warmup_iterations=scheduler.server_args.benchmark_warmup_iterations,
+            output_path=scheduler.server_args.benchmark_output_path,
+            timeout=scheduler.server_args.benchmark_timeout,
+        )
+        self.phase = BenchmarkPhase.WARMUP
+        self._grid: list[BenchmarkPoint] = []
+        self._results: list[BenchmarkPointResult] = []
+        self._current: Optional[BenchmarkPointResult] = None
+        self._seq = 0
+        self._warmup_remaining = max(0, self.config.warmup_iterations)
+        self._grid_index = 0
+        self._write_results = bool(getattr(scheduler, "enable_fpm", False))
+        self._build_grid()
+        if self._warmup_remaining == 0:
+            self.phase = BenchmarkPhase.SWEEP
+        logger.info("Self-benchmark enabled: %s", self.config)
+
+    @property
+    def active(self) -> bool:
+        return self.phase != BenchmarkPhase.DONE
+
+    def maybe_schedule_next(self) -> None:
+        if not self.active or self._current is not None or self._has_inflight_work():
+            return
+
+        if self.phase == BenchmarkPhase.WARMUP:
+            if (
+                self._inject_prefill(
+                    prompt_len=min(256, self._max_prefill_isl()), max_tokens=0
+                )
+                == 0
+            ):
+                self.phase = BenchmarkPhase.SWEEP
+            return
+
+        if self._grid_index >= len(self._grid):
+            self._finish()
+            return
+
+        point = self._grid[self._grid_index]
+        self._current = BenchmarkPointResult(point=point)
+        if point.point_type == "prefill":
+            injected = self._inject_prefill(prompt_len=point.isl, max_tokens=0)
+        else:
+            injected = self._inject_decode(
+                context_length=point.context_length, batch_size=point.batch_size
+            )
+
+        if injected == 0:
+            logger.warning("Skipping benchmark point with no valid requests: %s", point)
+            self._current = None
+            self._grid_index += 1
+
+    def observe_forward_pass(
+        self, batch: ScheduleBatch, fpm: Optional[ForwardPassMetrics]
+    ) -> None:
+        if not self.active:
+            return
+        if getattr(batch.forward_mode, "is_prebuilt", lambda: False)():
+            return
+
+        point_type = self._scheduled_point_type(batch, fpm)
+        if point_type is None:
+            return
+
+        if self.phase == BenchmarkPhase.WARMUP:
+            self._warmup_remaining -= 1
+            if self._warmup_remaining <= 0:
+                self.phase = BenchmarkPhase.SWEEP
+            return
+
+        if self._current is None:
+            return
+
+        current_type = self._current.point.point_type
+        if current_type == "decode" and point_type == "prefill":
+            return
+        if point_type != current_type:
+            return
+
+        if fpm is not None:
+            self._current.fpms.append(msgspec.to_builtins(fpm))
+        self._results.append(self._current)
+        self._current = None
+        self._grid_index += 1
+
+    def _build_grid(self) -> None:
+        if self.config.mode in ("prefill", "agg"):
+            self._build_prefill_grid()
+        if self.config.mode in ("decode", "agg"):
+            self._build_decode_grid()
+        logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
+
+    def _build_prefill_grid(self) -> None:
+        n = max(1, self.config.prefill_isl_granularity)
+        max_isl = self._max_prefill_isl()
+        if max_isl < 1:
+            return
+        min_isl = min(10, max_isl)
+        for isl in np.unique(np.linspace(min_isl, max_isl, n, dtype=int)):
+            self._grid.append(BenchmarkPoint(point_type="prefill", isl=int(isl)))
+
+    def _build_decode_grid(self) -> None:
+        n_len = max(1, self.config.decode_length_granularity)
+        n_bs = max(1, self.config.decode_batch_size_granularity)
+        max_ctx = max(1, self.scheduler.max_req_input_len)
+        ctx_lens = np.unique(np.linspace(1, max_ctx, n_len, dtype=int))
+        for ctx_len_raw in ctx_lens:
+            ctx_len = int(ctx_len_raw)
+            max_bs = self._max_batch_size_for_context(ctx_len)
+            if max_bs < 1:
+                continue
+            for bs in np.unique(np.linspace(1, max_bs, n_bs, dtype=int)):
+                self._grid.append(
+                    BenchmarkPoint(
+                        point_type="decode",
+                        context_length=ctx_len,
+                        batch_size=int(bs),
+                    )
+                )
+
+    def _max_prefill_isl(self) -> int:
+        return max(
+            1,
+            min(
+                self.scheduler.max_req_input_len,
+                self.scheduler.max_total_num_tokens - 2,
+            ),
+        )
+
+    def _max_batch_size_for_context(self, context_length: int) -> int:
+        max_running = max(1, getattr(self.scheduler, "max_running_requests", 1))
+        max_tokens = max(1, getattr(self.scheduler, "max_total_num_tokens", 1))
+        token_capped = max(1, max_tokens // max(1, context_length + 2))
+        return min(max_running, token_capped)
+
+    def _inject_prefill(self, prompt_len: int, max_tokens: int) -> int:
+        return self._inject_requests(prompt_len=prompt_len, max_tokens=max_tokens, n=1)
+
+    def _inject_decode(self, context_length: int, batch_size: int) -> int:
+        # In normal aggregated serving this performs prefill then one decode step.
+        # In disaggregated decode mode the fake bootstrap path skips real transfer.
+        return self._inject_requests(
+            prompt_len=context_length, max_tokens=2, n=batch_size
+        )
+
+    def _inject_requests(self, prompt_len: int, max_tokens: int, n: int) -> int:
+        prompt_len = max(1, min(prompt_len, self.scheduler.max_req_input_len))
+        token_id = self._dummy_token_id()
+        injected = 0
+        for _ in range(n):
+            rid = f"{SELF_BENCHMARK_REQ_PREFIX}{self._seq}"
+            self._seq += 1
+            req = Req(
+                rid=rid,
+                origin_input_text="",
+                origin_input_ids=array("q", [token_id] * prompt_len),
+                sampling_params=SamplingParams(
+                    max_new_tokens=max_tokens,
+                    temperature=0.0,
+                    ignore_eos=True,
+                ),
+                return_logprob=False,
+                top_logprobs_num=0,
+                token_ids_logprob=[],
+                stream=False,
+                eos_token_ids=self.scheduler.model_config.hf_eos_token_id,
+                bootstrap_host=FAKE_BOOTSTRAP_HOST,
+                bootstrap_port=self.scheduler.server_args.disaggregation_bootstrap_port,
+                bootstrap_room=self._seq,
+                disagg_mode=self.scheduler.disaggregation_mode,
+                vocab_size=self.scheduler.model_config.vocab_size,
+                metrics_collector=None,
+                extra_key=rid,
+            )
+            req.tokenizer = self.scheduler.tokenizer
+            req.suppress_output = True
+            self.scheduler.init_req_max_new_tokens(req)
+            error_msg = validate_input_length(
+                req,
+                self.scheduler.max_req_input_len,
+                self.scheduler.server_args.allow_auto_truncate,
+            )
+            if error_msg:
+                logger.warning("Skipping invalid benchmark request: %s", error_msg)
+                continue
+            self.scheduler._add_request_to_queue(req)
+            injected += 1
+        return injected
+
+    def _dummy_token_id(self) -> int:
+        vocab_size = getattr(self.scheduler.model_config, "vocab_size", None) or 1
+        return 0 if vocab_size > 0 else 0
+
+    def _has_inflight_work(self) -> bool:
+        result_queue = getattr(self.scheduler, "result_queue", None)
+        if result_queue:
+            return True
+        if getattr(self.scheduler, "waiting_queue", None):
+            return True
+        for queue_name in (
+            "disagg_prefill_bootstrap_queue",
+            "disagg_prefill_inflight_queue",
+            "disagg_decode_prealloc_queue",
+            "disagg_decode_transfer_queue",
+        ):
+            queue_owner = getattr(self.scheduler, queue_name, None)
+            if queue_owner is None:
+                continue
+            queue = getattr(queue_owner, "queue", None)
+            if queue:
+                return True
+        running = getattr(self.scheduler, "running_batch", None)
+        if running is not None and not running.is_empty():
+            return True
+        return False
+
+    def _scheduled_point_type(
+        self, batch: ScheduleBatch, fpm: Optional[ForwardPassMetrics]
+    ) -> Optional[str]:
+        if fpm is not None:
+            scheduled = fpm.scheduled_requests
+            if scheduled.num_decode_requests > 0:
+                return "decode"
+            if scheduled.num_prefill_requests > 0:
+                return "prefill"
+            return None
+        if batch.forward_mode.is_decode():
+            return "decode"
+        if batch.forward_mode.is_extend():
+            return "prefill"
+        return None
+
+    def _finish(self) -> None:
+        if self._write_results:
+            self._write_output()
+        self.phase = BenchmarkPhase.DONE
+        logger.info("Self-benchmark completed")
+
+    def _write_output(self) -> None:
+        output_path = self._rank_output_path(self.config.output_path)
+        output = {
+            "config": asdict(self.config),
+            "limits": {
+                "max_num_scheduled_tokens": getattr(
+                    self.scheduler, "max_prefill_tokens", None
+                ),
+                "max_num_running_reqs": getattr(
+                    self.scheduler, "max_running_requests", None
+                ),
+                "max_model_len": getattr(self.scheduler, "max_req_len", None),
+                "block_size": getattr(self.scheduler, "page_size", None),
+                "num_gpu_blocks": getattr(self.scheduler, "max_total_num_tokens", None),
+            },
+            "results": [
+                {"point": asdict(result.point), "fpms": result.fpms}
+                for result in self._results
+            ],
+        }
+        tmp = output_path + ".tmp"
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        with open(tmp, "w") as f:
+            json.dump(output, f, indent=2)
+        os.replace(tmp, output_path)
+        logger.info(
+            "Self-benchmark results written to %s (%d point(s))",
+            output_path,
+            len(self._results),
+        )
+
+    def _rank_output_path(self, base_path: str) -> str:
+        dp_rank = (
+            self.scheduler.ps.dp_rank if self.scheduler.ps.dp_rank is not None else 0
+        )
+        if dp_rank == 0:
+            return base_path
+        stem, ext = os.path.splitext(base_path)
+        return f"{stem}_dp{dp_rank}{ext}"

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -87,6 +87,7 @@ class SelfBenchmark:
         self._grid: list[BenchmarkPoint] = []
         self._results: list[BenchmarkPointResult] = []
         self._current: Optional[BenchmarkPointResult] = None
+        self._active_reqs: list[Req] = []
         self._seq = 0
         self._warmup_remaining = max(0, self.config.warmup_iterations)
         self._grid_index = 0
@@ -115,6 +116,7 @@ class SelfBenchmark:
 
         point = self._grid[self._grid_index]
         self._current = BenchmarkPointResult(point=point)
+        self._active_reqs = []
         if point.point_type == "prefill":
             injected = self._inject_prefill(prompt_len=point.isl, max_tokens=0)
         else:
@@ -125,6 +127,7 @@ class SelfBenchmark:
         if injected == 0:
             logger.warning("Skipping benchmark point with no valid requests: %s", point)
             self._current = None
+            self._active_reqs = []
             self._grid_index += 1
 
     def observe_forward_pass(
@@ -143,6 +146,7 @@ class SelfBenchmark:
             self._warmup_remaining -= 1
             if self._warmup_remaining <= 0:
                 self.phase = BenchmarkPhase.SWEEP
+                self._active_reqs = []
             return
 
         if self._current is None:
@@ -156,8 +160,21 @@ class SelfBenchmark:
 
         if fpm is not None:
             self._current.fpms.append(msgspec.to_builtins(fpm))
+        if not self._current_point_finished():
+            return
+        self._save_current_point()
+
+    def _current_point_finished(self) -> bool:
+        if not self._active_reqs:
+            return True
+        return all(req.finished() for req in self._active_reqs)
+
+    def _save_current_point(self) -> None:
+        if self._current is None:
+            return
         self._results.append(self._current)
         self._current = None
+        self._active_reqs = []
         self._grid_index += 1
 
     def _build_grid(self) -> None:
@@ -227,16 +244,10 @@ class SelfBenchmark:
                 )
 
     def _max_prefill_isl(self) -> int:
-        chunked_prefill_size = getattr(
-            self.scheduler.server_args, "chunked_prefill_size", None
-        )
-        if chunked_prefill_size is None or chunked_prefill_size <= 0:
-            chunked_prefill_size = self._max_valid_input_len()
         return max(
             0,
             min(
                 self._max_valid_input_len(),
-                chunked_prefill_size,
                 self.scheduler.max_total_num_tokens - 2,
             ),
         )
@@ -351,6 +362,7 @@ class SelfBenchmark:
             return 0
 
         self.scheduler.running_batch = batch
+        self._active_reqs = reqs
         return len(reqs)
 
     def _inject_requests(self, prompt_len: int, max_tokens: int, n: int) -> int:
@@ -380,6 +392,7 @@ class SelfBenchmark:
                 logger.warning("Skipping invalid benchmark request: %s", error_msg)
                 continue
             self.scheduler._add_request_to_queue(req)
+            self._active_reqs.append(req)
             injected += 1
         return injected
 
@@ -523,6 +536,8 @@ class SelfBenchmark:
     def _has_inflight_work(self) -> bool:
         result_queue = getattr(self.scheduler, "result_queue", None)
         if result_queue:
+            return True
+        if getattr(self.scheduler, "chunked_req", None) is not None:
             return True
         if getattr(self.scheduler, "waiting_queue", None):
             return True

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -12,7 +12,7 @@ import msgspec
 import numpy as np
 import torch
 
-from sglang.srt.disaggregation.utils import DisaggregationMode, FAKE_BOOTSTRAP_HOST
+from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import validate_input_length
 from sglang.srt.mem_cache.common import (
@@ -21,8 +21,8 @@ from sglang.srt.mem_cache.common import (
     alloc_token_slots,
     release_kv_cache,
 )
-from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sglang.srt.sampling.sampling_params import SamplingParams
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 import time
+import uuid
 from array import array
 from dataclasses import asdict, dataclass, field
 from enum import Enum
@@ -48,7 +50,6 @@ class SelfBenchmarkConfig:
     decode_batch_size_granularity: int = 6
     warmup_iterations: int = 5
     output_path: str = "/tmp/benchmark_results.json"
-    timeout: int = 300
 
 
 @dataclass
@@ -91,7 +92,6 @@ class SelfBenchmark:
             ),
             warmup_iterations=scheduler.server_args.benchmark_warmup_iterations,
             output_path=scheduler.server_args.benchmark_output_path,
-            timeout=scheduler.server_args.benchmark_timeout,
         )
         self.phase = BenchmarkPhase.WARMUP
         self._grid: list[BenchmarkPoint] = []
@@ -102,10 +102,13 @@ class SelfBenchmark:
         self._warmup_remaining = max(0, self.config.warmup_iterations)
         self._grid_index = 0
         self._write_results = bool(getattr(scheduler, "enable_fpm", False))
+        self._run_id = self._make_run_id()
+        self._identity = self._build_output_identity()
+        self._output_path = self._rank_output_path(self.config.output_path)
+        if self._write_results:
+            self._invalidate_output()
         self._pending_seed_point: Optional[BenchmarkPoint] = None
         self._pending_seed_extra_key: Optional[str] = None
-        self._timed_out = False
-        self._deadline_monotonic = self._init_deadline_monotonic()
         self._build_grid()
         if self._warmup_remaining == 0:
             self.phase = BenchmarkPhase.SWEEP
@@ -118,9 +121,9 @@ class SelfBenchmark:
     def maybe_schedule_next(self) -> None:
         if not self.active:
             return
-        if self._has_timed_out():
-            self._finish(timed_out=True)
-            return
+
+        # Synthetic requests are owned by normal scheduler/result processing after
+        # injection, so do not advance or advertise readiness until that state drains.
         if self._current is not None or self._has_inflight_work():
             return
 
@@ -210,17 +213,6 @@ class SelfBenchmark:
         self._current = None
         self._active_reqs = []
         self._grid_index += 1
-
-    def _init_deadline_monotonic(self) -> Optional[float]:
-        if self.config.timeout <= 0:
-            return None
-        return time.monotonic() + self.config.timeout
-
-    def _has_timed_out(self) -> bool:
-        return (
-            self._deadline_monotonic is not None
-            and time.monotonic() >= self._deadline_monotonic
-        )
 
     def _build_grid(self) -> None:
         mode = self.config.mode
@@ -320,6 +312,7 @@ class SelfBenchmark:
             0,
             min(
                 self._max_valid_input_len(),
+                self._max_prefill_forward_tokens(),
                 self.scheduler.max_total_num_tokens - 2,
             ),
         )
@@ -327,6 +320,12 @@ class SelfBenchmark:
     def _max_valid_input_len(self) -> int:
         # validate_input_length rejects requests with len >= max_req_input_len.
         return max(0, self.scheduler.max_req_input_len - 1)
+
+    def _max_prefill_forward_tokens(self) -> int:
+        # max_total_num_tokens is KV capacity, not transient forward/logits
+        # headroom. Keep optional startup benchmarking within the scheduler's
+        # normal prefill-forward token budget.
+        return max(0, getattr(self.scheduler, "max_prefill_tokens", 0))
 
     def _max_decode_context_len(self) -> int:
         page_size = max(1, self.scheduler.page_size)
@@ -444,9 +443,9 @@ class SelfBenchmark:
 
         reqs = []
         for _ in range(batch_size):
-            req = self._new_synthetic_req(prompt_len=context_length, max_tokens=1)
+            req = self._new_synthetic_req(prompt_len=context_length, max_tokens=2)
             self.scheduler.init_req_max_new_tokens(req)
-            if req.sampling_params.max_new_tokens < 1:
+            if req.sampling_params.max_new_tokens < 2:
                 logger.warning(
                     "Skipping decode benchmark request after max_new_tokens clamp: "
                     "rid=%s context_length=%d max_new_tokens=%d",
@@ -464,7 +463,10 @@ class SelfBenchmark:
                 logger.warning("Skipping invalid benchmark request: %s", error_msg)
                 continue
             req.skip_radix_cache_insert = True
-            req.fill_ids = req.origin_input_ids
+            # Model the normal post-prefill boundary: prefill has produced one
+            # output token, but decode has not yet allocated KV for that token.
+            req.output_ids.append(SELF_BENCHMARK_DUMMY_TOKEN_ID)
+            req.fill_ids = req.origin_input_ids + req.output_ids
             req.kv_committed_len = context_length
             req.kv_allocated_len = context_length
             req.already_computed = context_length
@@ -627,12 +629,12 @@ class SelfBenchmark:
             batch, self.scheduler.model_config.vocab_size
         )
 
-        last_tokens = torch.tensor(
-            [req.origin_input_ids[-1] for req in reqs],
+        prefill_output_tokens = torch.tensor(
+            [req.output_ids[-1] for req in reqs],
             dtype=torch.int64,
             device=batch.device,
         )
-        self.scheduler.future_map.stash(batch.req_pool_indices, last_tokens)
+        self.scheduler.future_map.stash(batch.req_pool_indices, prefill_output_tokens)
         batch.input_ids = None
         return batch
 
@@ -737,21 +739,9 @@ class SelfBenchmark:
             return "prefill"
         return None
 
-    def _finish(self, timed_out: bool = False) -> None:
+    def _finish(self) -> None:
         if self.phase == BenchmarkPhase.DONE:
             return
-        if timed_out:
-            self._timed_out = True
-            self._current = None
-            self._active_reqs = []
-            self._pending_seed_point = None
-            self._pending_seed_extra_key = None
-            logger.warning(
-                "Self-benchmark timed out after %d seconds; writing %d completed "
-                "point(s) and continuing startup",
-                self.config.timeout,
-                len(self._results),
-            )
         if self._write_results:
             self._write_output()
         self.phase = BenchmarkPhase.DONE
@@ -761,10 +751,16 @@ class SelfBenchmark:
         logger.info("Self-benchmark completed")
 
     def _write_output(self) -> None:
-        output_path = self._rank_output_path(self.config.output_path)
         output = {
+            "schema_version": 1,
+            "scope": "local_diagnostics",
+            "status": "complete",
+            "valid": True,
+            "run_id": self._run_id,
+            "completed_at_unix": time.time(),
+            "identity": self._identity,
+            "output_path": self._output_path,
             "config": asdict(self.config),
-            "timed_out": self._timed_out,
             "limits": {
                 "max_num_scheduled_tokens": getattr(
                     self.scheduler, "max_prefill_tokens", None
@@ -781,22 +777,106 @@ class SelfBenchmark:
                 for result in self._results
             ],
         }
-        tmp = output_path + ".tmp"
-        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-        with open(tmp, "w") as f:
-            json.dump(output, f, indent=2)
-        os.replace(tmp, output_path)
+        self._atomic_write_json(self._output_path, output)
         logger.info(
             "Self-benchmark results written to %s (%d point(s))",
-            output_path,
+            self._output_path,
             len(self._results),
         )
 
-    def _rank_output_path(self, base_path: str) -> str:
-        dp_rank = (
-            self.scheduler.ps.dp_rank if self.scheduler.ps.dp_rank is not None else 0
+    def _invalidate_output(self) -> None:
+        output_dir = os.path.dirname(self._output_path) or "."
+        os.makedirs(output_dir, exist_ok=True)
+        try:
+            os.unlink(self._output_path)
+        except FileNotFoundError:
+            pass
+        output = {
+            "schema_version": 1,
+            "scope": "local_diagnostics",
+            "status": "running",
+            "valid": False,
+            "run_id": self._run_id,
+            "started_at_unix": time.time(),
+            "identity": self._identity,
+            "output_path": self._output_path,
+            "message": "Self-benchmark is running; previous results are invalid.",
+        }
+        self._atomic_write_json(self._output_path, output)
+
+    def _atomic_write_json(self, output_path: str, output: dict) -> None:
+        output_dir = os.path.dirname(output_path) or "."
+        os.makedirs(output_dir, exist_ok=True)
+        basename = os.path.basename(output_path)
+        fd, tmp = tempfile.mkstemp(
+            prefix=f".{basename}.{os.getpid()}.",
+            suffix=".tmp",
+            dir=output_dir,
+            text=True,
         )
-        if dp_rank == 0:
-            return base_path
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(output, f, indent=2)
+                f.write("\n")
+            os.replace(tmp, output_path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def _make_run_id(self) -> str:
+        return getattr(self.scheduler, "instance_id", None) or uuid.uuid4().hex[:12]
+
+    def _build_output_identity(self) -> dict:
+        server_args = self.scheduler.server_args
+        ps = self.scheduler.ps
+        return {
+            "model_path": getattr(server_args, "model_path", None),
+            "served_model_name": getattr(server_args, "served_model_name", None),
+            "benchmark_mode": self.config.mode,
+            "disaggregation_mode": self._role_name(),
+            "node_rank": getattr(server_args, "node_rank", None),
+            "nnodes": getattr(server_args, "nnodes", None),
+            "dp_rank": self._rank_value("dp_rank", default=0),
+            "dp_size": getattr(ps, "dp_size", None),
+            "tp_rank": self._rank_value("tp_rank", default=0),
+            "tp_size": getattr(ps, "tp_size", None),
+            "attn_tp_rank": self._rank_value("attn_tp_rank", default=0),
+            "attn_tp_size": getattr(ps, "attn_tp_size", None),
+            "attn_cp_rank": self._rank_value("attn_cp_rank", default=0),
+            "attn_cp_size": getattr(ps, "attn_cp_size", None),
+            "pid": os.getpid(),
+        }
+
+    def _rank_output_path(self, base_path: str) -> str:
         stem, ext = os.path.splitext(base_path)
-        return f"{stem}_dp{dp_rank}{ext}"
+        return f"{stem}_{self._output_path_suffix()}{ext}"
+
+    def _output_path_suffix(self) -> str:
+        parts = [
+            ("role", self._role_name()),
+            ("node", getattr(self.scheduler.server_args, "node_rank", 0)),
+            ("dp", self._rank_value("dp_rank", default=0)),
+            ("tp", self._rank_value("tp_rank", default=0)),
+            ("atp", self._rank_value("attn_tp_rank", default=0)),
+            ("acp", self._rank_value("attn_cp_rank", default=0)),
+        ]
+        return "_".join(
+            f"{name}-{self._sanitize_path_part(value)}" for name, value in parts
+        )
+
+    def _role_name(self) -> str:
+        role = getattr(self.scheduler, "disaggregation_mode", DisaggregationMode.NULL)
+        return str(getattr(role, "value", role))
+
+    def _rank_value(self, name: str, *, default: int) -> int:
+        value = getattr(self.scheduler.ps, name, default)
+        return default if value is None else value
+
+    @staticmethod
+    def _sanitize_path_part(value) -> str:
+        return "".join(
+            ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in str(value)
+        )

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -34,6 +34,7 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
     from sglang.srt.observability.forward_pass_metrics import ForwardPassMetrics
+    from sglang.srt.server_args import ServerArgs
 
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,12 @@ class BenchmarkPointResult:
     fpms: list = field(default_factory=list)
 
 
+@dataclass
+class SkippedBenchmarkPoint:
+    point: BenchmarkPoint
+    reason: str
+
+
 class BenchmarkPhase(Enum):
     WARMUP = "warmup"
     SWEEP = "sweep"
@@ -90,6 +97,100 @@ class SelfBenchmark:
     only on homogeneous state.
     """
 
+    MAX_AXIS_GRANULARITY = 1024
+    MAX_GRID_POINTS = 4096
+
+    @classmethod
+    def create_if_enabled(cls, scheduler: Scheduler) -> Optional[SelfBenchmark]:
+        """Validate runtime compatibility and create an enabled benchmark."""
+        if scheduler.server_args.benchmark_mode is None:
+            return None
+
+        if scheduler.ps.pp_size > 1:
+            raise ValueError(
+                "--benchmark-mode is not supported with pipeline parallelism"
+            )
+        if scheduler.enable_pdmux:
+            raise ValueError("--benchmark-mode is not supported with PD multiplexing")
+        if scheduler.enable_overlap_mlx:
+            raise ValueError("--benchmark-mode is not supported with MLX overlap")
+        if not scheduler.is_generation:
+            # Non-generation (embedding/reward) models would leak synthetic
+            # prefill outputs to the tokenizer (suppress_output is only honored
+            # on the generation streaming path).
+            raise ValueError("--benchmark-mode is only supported for generative models")
+        if not scheduler.spec_algorithm.is_none():
+            # The synthetic decode path is incompatible with speculative
+            # decoding, and the synthetic prefill path is not guarded for it.
+            raise ValueError(
+                "--benchmark-mode is not supported with speculative decoding"
+            )
+        if scheduler.model_config.is_encoder_decoder:
+            raise ValueError(
+                "--benchmark-mode is not supported with encoder-decoder models"
+            )
+        if scheduler.model_config.is_multimodal:
+            # Synthetic requests carry no multimodal inputs.
+            raise ValueError("--benchmark-mode is not supported with multimodal models")
+        if scheduler.enable_lora:
+            raise ValueError("--benchmark-mode is not supported with LoRA")
+        if scheduler.server_args.load_format == "dummy":
+            # Dummy weights produce meaningless benchmark results.
+            raise ValueError(
+                "--benchmark-mode is not supported with dummy weights "
+                "(--load-format dummy)"
+            )
+
+        return cls(scheduler)
+
+    @classmethod
+    def validate_args(cls, server_args: ServerArgs) -> None:
+        """Validate self-benchmark-specific server arguments."""
+        if server_args.benchmark_mode is None:
+            return
+
+        # Non-positive values collapse an axis to one point, while very large
+        # values can exhaust host memory before the event loop starts.
+        for name in (
+            "benchmark_prefill_granularity",
+            "benchmark_prefill_kv_read_granularity",
+            "benchmark_decode_length_granularity",
+            "benchmark_decode_batch_granularity",
+        ):
+            value = getattr(server_args, name)
+            flag = f"--{name.replace('_', '-')}"
+            if value < 1:
+                raise ValueError(f"{flag} must be >= 1 when --benchmark-mode is set.")
+            if value > cls.MAX_AXIS_GRANULARITY:
+                raise ValueError(
+                    f"{flag} must be <= {cls.MAX_AXIS_GRANULARITY} "
+                    "when --benchmark-mode is set."
+                )
+
+        grid_points = {
+            "prefill": server_args.benchmark_prefill_granularity
+            * server_args.benchmark_prefill_kv_read_granularity,
+            "decode": server_args.benchmark_decode_length_granularity
+            * server_args.benchmark_decode_batch_granularity,
+        }
+        requested_grid_points = (
+            sum(grid_points.values())
+            if server_args.benchmark_mode == "agg"
+            else grid_points[server_args.benchmark_mode]
+        )
+        if requested_grid_points > cls.MAX_GRID_POINTS:
+            raise ValueError(
+                f"--benchmark-mode {server_args.benchmark_mode} requests "
+                f"{requested_grid_points} grid points; the maximum is "
+                f"{cls.MAX_GRID_POINTS}."
+            )
+
+        if server_args.benchmark_warmup_iterations < 0:
+            raise ValueError(
+                "--benchmark-warmup-iterations must be >= 0 when "
+                "--benchmark-mode is set."
+            )
+
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
         self.config = SelfBenchmarkConfig(
@@ -110,6 +211,7 @@ class SelfBenchmark:
         self.phase = BenchmarkPhase.WARMUP
         self._grid: list[BenchmarkPoint] = []
         self._results: list[BenchmarkPointResult] = []
+        self._skipped_points: list[SkippedBenchmarkPoint] = []
         self._current: Optional[BenchmarkPointResult] = None
         self._active_reqs: list[Req] = []
         self._seq = 0
@@ -186,7 +288,7 @@ class SelfBenchmark:
             if injected > 0:
                 return
             logger.warning("Skipping benchmark point with no valid seed: %s", point)
-            self._advance_grid_point()
+            self._skip_grid_point(point, "seed_injection_failed")
             return
 
         self._current = BenchmarkPointResult(point=point)
@@ -200,7 +302,7 @@ class SelfBenchmark:
 
         if injected == 0:
             logger.warning("Skipping benchmark point with no valid requests: %s", point)
-            self._advance_grid_point()
+            self._skip_grid_point(point, "request_injection_failed")
 
     def observe_forward_pass(
         self, batch: ScheduleBatch, fpm: Optional[ForwardPassMetrics]
@@ -246,7 +348,16 @@ class SelfBenchmark:
     def _save_current_point(self) -> None:
         if self._current is None:
             return
+        if not self._current.fpms:
+            point = self._current.point
+            logger.warning("Skipping benchmark point with no metrics: %s", point)
+            self._skip_grid_point(point, "no_forward_pass_metrics")
+            return
         self._results.append(self._current)
+        self._advance_grid_point()
+
+    def _skip_grid_point(self, point: BenchmarkPoint, reason: str) -> None:
+        self._skipped_points.append(SkippedBenchmarkPoint(point=point, reason=reason))
         self._advance_grid_point()
 
     def _advance_grid_point(self) -> None:
@@ -388,7 +499,23 @@ class SelfBenchmark:
         paged_context = ((context_length + page_size - 1) // page_size) * page_size
         tokens_per_req = paged_context + page_size
         token_capped = max(1, max_tokens // max(1, tokens_per_req))
-        return min(max_running, token_capped)
+        return min(max_running, token_capped, self._max_decode_forward_batch_size())
+
+    def _max_decode_forward_batch_size(self) -> int:
+        """Return the configured decode-forward batch ceiling.
+
+        KV capacity and request slots do not account for transient full-vocabulary
+        logits. The decode graph limit is SGLang's existing memory-tuned forward
+        ceiling; keeping startup diagnostics within it avoids eager-only batches
+        whose logits can exceed the remaining device headroom.
+        """
+        max_bs = self.scheduler.server_args.cuda_graph_config.decode.max_bs
+        if max_bs is None:
+            raise RuntimeError(
+                "Decode CUDA graph max batch size must be resolved before "
+                "self-benchmark initialization"
+            )
+        return max(1, int(max_bs))
 
     def _inject_warmup(self) -> int:
         if self._supports_decode_points() and self._should_use_decode_warmup():
@@ -458,7 +585,7 @@ class SelfBenchmark:
                 point.kv_read_tokens,
                 actual_kv_read_tokens,
             )
-            self._advance_grid_point()
+            self._skip_grid_point(point, "seed_cache_validation_failed")
             return
 
         self._current = BenchmarkPointResult(point=point)
@@ -466,7 +593,7 @@ class SelfBenchmark:
         injected = self._inject_prefill(point=point, extra_key=extra_key)
         if injected == 0:
             logger.warning("Skipping benchmark point with no valid requests: %s", point)
-            self._advance_grid_point()
+            self._skip_grid_point(point, "request_injection_failed")
 
     def _inject_synthetic_decode(self, context_length: int, batch_size: int) -> int:
         if not self._synthetic_decode_supported():
@@ -517,17 +644,15 @@ class SelfBenchmark:
 
         try:
             batch = self._build_synthetic_decode_batch(reqs, context_length)
-        except Exception as exc:
-            # Any failure between KV/req-slot allocation and publish (KV OOM, a
-            # stash/payload error, etc.) must free the pre-allocated context KV +
-            # req slots and skip the point, never crash the scheduler.
-            logger.warning(
-                "Skipping decode benchmark point due to synthetic batch build "
-                "failure: %s",
-                exc,
-            )
-            self._free_synthetic_decode_reqs(reqs)
-            return 0
+        except Exception:
+            # A rank-local skip would let successful peers publish running_batch
+            # and enter model collectives alone. Clean up what we can, then let the
+            # scheduler wrapper fail startup and tear down every rank.
+            try:
+                self._free_synthetic_decode_reqs(reqs)
+            except Exception:
+                logger.exception("Failed to clean up a synthetic decode batch")
+            raise
 
         self.scheduler.running_batch = batch
         self._active_reqs = reqs
@@ -829,11 +954,14 @@ class SelfBenchmark:
             self.scheduler.enable_fpm = self._restore_enable_fpm
 
     def _write_output(self) -> None:
+        expected_points = len(self._grid)
+        completed_points = len(self._results)
+        skipped_count = len(self._skipped_points)
         output = {
             "schema_version": 1,
             "scope": "local_diagnostics",
             "status": "complete",
-            "valid": True,
+            "valid": completed_points == expected_points and skipped_count == 0,
             "run_id": self._run_id,
             "completed_at_unix": time.time(),
             "identity": self._identity,
@@ -849,17 +977,30 @@ class SelfBenchmark:
                 "max_model_len": getattr(self.scheduler, "max_req_len", None),
                 "block_size": getattr(self.scheduler, "page_size", None),
                 "num_gpu_blocks": getattr(self.scheduler, "max_total_num_tokens", None),
+                "max_decode_forward_batch_size": (
+                    self._max_decode_forward_batch_size()
+                ),
+            },
+            "coverage": {
+                "expected_points": expected_points,
+                "completed_points": completed_points,
+                "skipped_points": skipped_count,
             },
             "results": [
                 {"point": asdict(result.point), "fpms": result.fpms}
                 for result in self._results
             ],
+            "skipped_points": [
+                asdict(skipped_point) for skipped_point in self._skipped_points
+            ],
         }
         self._atomic_write_json(self._output_path, output)
         logger.info(
-            "Self-benchmark results written to %s (%d point(s))",
+            "Self-benchmark results written to %s (%d/%d point(s), %d skipped)",
             self._output_path,
-            len(self._results),
+            completed_points,
+            expected_points,
+            skipped_count,
         )
 
     def _invalidate_output(self) -> None:

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -13,14 +13,17 @@ import numpy as np
 import torch
 
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import validate_input_length
+from sglang.srt.mem_cache.base_prefix_cache import MatchPrefixParams
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_req_slots,
     alloc_token_slots,
     release_kv_cache,
 )
+from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
 
@@ -38,6 +41,7 @@ SELF_BENCHMARK_REQ_PREFIX = "__sgl_bench_"
 class SelfBenchmarkConfig:
     mode: str
     prefill_isl_granularity: int = 16
+    prefill_kv_read_granularity: int = 1
     decode_length_granularity: int = 6
     decode_batch_size_granularity: int = 6
     warmup_iterations: int = 5
@@ -49,6 +53,7 @@ class SelfBenchmarkConfig:
 class BenchmarkPoint:
     point_type: str
     isl: int = 0
+    kv_read_tokens: int = 0
     context_length: int = 0
     batch_size: int = 0
 
@@ -73,6 +78,9 @@ class SelfBenchmark:
         self.config = SelfBenchmarkConfig(
             mode=scheduler.server_args.benchmark_mode,
             prefill_isl_granularity=scheduler.server_args.benchmark_prefill_granularity,
+            prefill_kv_read_granularity=(
+                scheduler.server_args.benchmark_prefill_kv_read_granularity
+            ),
             decode_length_granularity=(
                 scheduler.server_args.benchmark_decode_length_granularity
             ),
@@ -92,6 +100,8 @@ class SelfBenchmark:
         self._warmup_remaining = max(0, self.config.warmup_iterations)
         self._grid_index = 0
         self._write_results = bool(getattr(scheduler, "enable_fpm", False))
+        self._pending_seed_point: Optional[BenchmarkPoint] = None
+        self._pending_seed_extra_key: Optional[str] = None
         self._build_grid()
         if self._warmup_remaining == 0:
             self.phase = BenchmarkPhase.SWEEP
@@ -110,15 +120,27 @@ class SelfBenchmark:
                 self.phase = BenchmarkPhase.SWEEP
             return
 
+        if self._pending_seed_point is not None:
+            self._inject_pending_seeded_prefill()
+            return
+
         if self._grid_index >= len(self._grid):
             self._finish()
             return
 
         point = self._grid[self._grid_index]
+        if point.point_type == "prefill" and point.kv_read_tokens > 0:
+            injected = self._inject_prefill_seed(point)
+            if injected > 0:
+                return
+            logger.warning("Skipping benchmark point with no valid seed: %s", point)
+            self._grid_index += 1
+            return
+
         self._current = BenchmarkPointResult(point=point)
         self._active_reqs = []
         if point.point_type == "prefill":
-            injected = self._inject_prefill(prompt_len=point.isl, max_tokens=0)
+            injected = self._inject_prefill(point=point)
         else:
             injected = self._inject_decode(
                 context_length=point.context_length, batch_size=point.batch_size
@@ -153,9 +175,11 @@ class SelfBenchmark:
             return
 
         current_type = self._current.point.point_type
-        if current_type == "decode" and point_type == "prefill":
+        if current_type == "prefill" and point_type == "decode":
+            if self._current_point_finished():
+                self._save_current_point()
             return
-        if point_type != current_type:
+        elif point_type != current_type:
             return
 
         if fpm is not None:
@@ -220,7 +244,34 @@ class SelfBenchmark:
             return
         min_isl = min(10, max_isl)
         for isl in np.unique(np.linspace(min_isl, max_isl, n, dtype=int)):
-            self._grid.append(BenchmarkPoint(point_type="prefill", isl=int(isl)))
+            isl = int(isl)
+            for kv_read_tokens in self._prefill_kv_read_points(isl):
+                self._grid.append(
+                    BenchmarkPoint(
+                        point_type="prefill",
+                        isl=isl,
+                        kv_read_tokens=kv_read_tokens,
+                    )
+                )
+
+    def _prefill_kv_read_points(self, isl: int) -> list[int]:
+        n = max(1, self.config.prefill_kv_read_granularity)
+        if n == 1:
+            return [0]
+        max_kv_read_tokens = self._align_prefill_kv_read_tokens(isl - 1)
+        if max_kv_read_tokens < 1:
+            return [0]
+        raw_points = np.unique(np.linspace(0, max_kv_read_tokens, n, dtype=int))
+        points = {
+            self._align_prefill_kv_read_tokens(int(kv_read_tokens))
+            for kv_read_tokens in raw_points
+        }
+        return sorted(points)
+
+    def _align_prefill_kv_read_tokens(self, kv_read_tokens: int) -> int:
+        page_size = max(1, self.scheduler.page_size)
+        kv_read_tokens = max(0, kv_read_tokens)
+        return kv_read_tokens // page_size * page_size
 
     def _build_decode_grid(self) -> None:
         n_len = max(1, self.config.decode_length_granularity)
@@ -287,7 +338,10 @@ class SelfBenchmark:
             )
         if self._supports_prefill_points() and self.config.mode in ("prefill", "agg"):
             return self._inject_prefill(
-                prompt_len=min(256, self._max_prefill_isl()), max_tokens=0
+                point=BenchmarkPoint(
+                    point_type="prefill",
+                    isl=min(256, self._max_prefill_isl()),
+                )
             )
         return 0
 
@@ -297,8 +351,64 @@ class SelfBenchmark:
             and self.scheduler.disaggregation_mode == DisaggregationMode.DECODE
         )
 
-    def _inject_prefill(self, prompt_len: int, max_tokens: int) -> int:
-        return self._inject_requests(prompt_len=prompt_len, max_tokens=max_tokens, n=1)
+    def _inject_prefill(self, point: BenchmarkPoint) -> int:
+        # Chunked prefill requests need a decode step to reach the normal request
+        # finished/release path. The benchmark still records only prefill FPMs.
+        return self._inject_requests(
+            prompt_len=point.isl,
+            max_tokens=1,
+            n=1,
+            extra_key=self._pending_seed_extra_key,
+            track_active=True,
+        )
+
+    def _inject_prefill_seed(self, point: BenchmarkPoint) -> int:
+        if point.kv_read_tokens <= 0:
+            return 0
+        extra_key = self._seed_extra_key()
+        injected = self._inject_requests(
+            prompt_len=point.kv_read_tokens,
+            max_tokens=0,
+            n=1,
+            extra_key=extra_key,
+            track_active=False,
+        )
+        if injected == 0:
+            return 0
+        self._pending_seed_point = point
+        self._pending_seed_extra_key = extra_key
+        return injected
+
+    def _inject_pending_seeded_prefill(self) -> None:
+        point = self._pending_seed_point
+        extra_key = self._pending_seed_extra_key
+        self._pending_seed_point = None
+        self._pending_seed_extra_key = None
+        if point is None or extra_key is None:
+            return
+
+        actual_kv_read_tokens = self._cached_kv_read_tokens_for_point(point, extra_key)
+        if actual_kv_read_tokens != point.kv_read_tokens:
+            logger.warning(
+                "Skipping benchmark point after seed cache validation failed: "
+                "point=%s expected_kv_read_tokens=%d actual_kv_read_tokens=%d",
+                point,
+                point.kv_read_tokens,
+                actual_kv_read_tokens,
+            )
+            self._grid_index += 1
+            return
+
+        self._pending_seed_extra_key = extra_key
+        self._current = BenchmarkPointResult(point=point)
+        self._active_reqs = []
+        injected = self._inject_prefill(point=point)
+        self._pending_seed_extra_key = None
+        if injected == 0:
+            logger.warning("Skipping benchmark point with no valid requests: %s", point)
+            self._current = None
+            self._active_reqs = []
+            self._grid_index += 1
 
     def _inject_decode(self, context_length: int, batch_size: int) -> int:
         return self._inject_synthetic_decode(
@@ -365,14 +475,25 @@ class SelfBenchmark:
         self._active_reqs = reqs
         return len(reqs)
 
-    def _inject_requests(self, prompt_len: int, max_tokens: int, n: int) -> int:
+    def _inject_requests(
+        self,
+        prompt_len: int,
+        max_tokens: int,
+        n: int,
+        extra_key: Optional[str] = None,
+        track_active: bool = True,
+    ) -> int:
         max_prompt_len = self._max_valid_input_len()
         if max_prompt_len < 1:
             return 0
         prompt_len = max(1, min(prompt_len, max_prompt_len))
         injected = 0
         for _ in range(n):
-            req = self._new_synthetic_req(prompt_len=prompt_len, max_tokens=max_tokens)
+            req = self._new_synthetic_req(
+                prompt_len=prompt_len,
+                max_tokens=max_tokens,
+                extra_key=extra_key,
+            )
             self.scheduler.init_req_max_new_tokens(req)
             if max_tokens > 0 and req.sampling_params.max_new_tokens < max_tokens:
                 logger.warning(
@@ -391,12 +512,20 @@ class SelfBenchmark:
             if error_msg:
                 logger.warning("Skipping invalid benchmark request: %s", error_msg)
                 continue
+            # Synthetic requests use FAKE_BOOTSTRAP_HOST to avoid real disagg
+            # transfer, which makes Req default to skipping cache insert. Chunked
+            # prefill still needs unfinished-request cache bookkeeping so that
+            # prefix_indices advance between chunks.
+            req.skip_radix_cache_insert = False
             self.scheduler._add_request_to_queue(req)
-            self._active_reqs.append(req)
+            if track_active:
+                self._active_reqs.append(req)
             injected += 1
         return injected
 
-    def _new_synthetic_req(self, prompt_len: int, max_tokens: int) -> Req:
+    def _new_synthetic_req(
+        self, prompt_len: int, max_tokens: int, extra_key: Optional[str] = None
+    ) -> Req:
         token_id = self._dummy_token_id()
         rid = f"{SELF_BENCHMARK_REQ_PREFIX}{self._seq}"
         self._seq += 1
@@ -422,11 +551,34 @@ class SelfBenchmark:
             disagg_mode=self.scheduler.disaggregation_mode,
             vocab_size=self.scheduler.model_config.vocab_size,
             metrics_collector=None,
-            extra_key=rid,
+            extra_key=extra_key or rid,
         )
         req.tokenizer = self.scheduler.tokenizer
         req.suppress_output = True
         return req
+
+    def _cached_kv_read_tokens_for_point(
+        self, point: BenchmarkPoint, extra_key: str
+    ) -> int:
+        if envs.SGLANG_RADIX_FORCE_MISS.get():
+            return 0
+        if getattr(self.scheduler.tree_cache, "disable", True):
+            return 0
+        token_id = self._dummy_token_id()
+        token_ids = array("q", [token_id] * point.isl)
+        max_prefix_len = max(point.isl - 1, 0)
+        match_result = self.scheduler.tree_cache.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(
+                    token_ids=token_ids[:max_prefix_len],
+                    extra_key=extra_key,
+                )
+            )
+        )
+        return len(match_result.device_indices)
+
+    def _seed_extra_key(self) -> str:
+        return f"{SELF_BENCHMARK_REQ_PREFIX}kv_seed_{self._grid_index}"
 
     def _synthetic_decode_supported(self) -> bool:
         if not self.scheduler.is_generation:

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -10,14 +10,21 @@ from typing import TYPE_CHECKING, Optional
 
 import msgspec
 import numpy as np
+import torch
 
-from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
-from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.disaggregation.utils import DisaggregationMode, FAKE_BOOTSTRAP_HOST
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import validate_input_length
+from sglang.srt.mem_cache.common import (
+    alloc_paged_token_slots_extend,
+    alloc_req_slots,
+    alloc_token_slots,
+    release_kv_cache,
+)
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 
 if TYPE_CHECKING:
-    from sglang.srt.managers.schedule_batch import ScheduleBatch
     from sglang.srt.managers.scheduler import Scheduler
     from sglang.srt.observability.forward_pass_metrics import ForwardPassMetrics
 
@@ -59,7 +66,7 @@ class BenchmarkPhase(Enum):
 
 
 class SelfBenchmark:
-    """Scheduler-local self benchmark that reuses normal SGLang request paths."""
+    """Scheduler-local self benchmark."""
 
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
@@ -98,12 +105,7 @@ class SelfBenchmark:
             return
 
         if self.phase == BenchmarkPhase.WARMUP:
-            if (
-                self._inject_prefill(
-                    prompt_len=min(256, self._max_prefill_isl()), max_tokens=0
-                )
-                == 0
-            ):
+            if self._inject_warmup() == 0:
                 self.phase = BenchmarkPhase.SWEEP
             return
 
@@ -159,11 +161,40 @@ class SelfBenchmark:
         self._grid_index += 1
 
     def _build_grid(self) -> None:
-        if self.config.mode in ("prefill", "agg"):
+        mode = self.config.mode
+        disaggregation_mode = self.scheduler.disaggregation_mode
+
+        if disaggregation_mode == DisaggregationMode.PREFILL:
+            if self._supports_prefill_points() and mode in ("prefill", "agg"):
+                self._build_prefill_grid()
+            else:
+                logger.warning(
+                    "Skipping decode self-benchmark grid on disaggregated prefill worker"
+                )
+            logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
+            return
+
+        if disaggregation_mode == DisaggregationMode.DECODE:
+            if self._supports_decode_points() and mode in ("decode", "agg"):
+                self._build_decode_grid()
+            else:
+                logger.warning(
+                    "Skipping prefill self-benchmark grid on disaggregated decode worker"
+                )
+            logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
+            return
+
+        if mode in ("prefill", "agg"):
             self._build_prefill_grid()
-        if self.config.mode in ("decode", "agg"):
+        if mode in ("decode", "agg"):
             self._build_decode_grid()
         logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
+
+    def _supports_prefill_points(self) -> bool:
+        return self.scheduler.disaggregation_mode != DisaggregationMode.DECODE
+
+    def _supports_decode_points(self) -> bool:
+        return self.scheduler.disaggregation_mode != DisaggregationMode.PREFILL
 
     def _build_prefill_grid(self) -> None:
         n = max(1, self.config.prefill_isl_granularity)
@@ -177,7 +208,9 @@ class SelfBenchmark:
     def _build_decode_grid(self) -> None:
         n_len = max(1, self.config.decode_length_granularity)
         n_bs = max(1, self.config.decode_batch_size_granularity)
-        max_ctx = max(1, self.scheduler.max_req_input_len)
+        max_ctx = self._max_decode_context_len()
+        if max_ctx < 1:
+            return
         ctx_lens = np.unique(np.linspace(1, max_ctx, n_len, dtype=int))
         for ctx_len_raw in ctx_lens:
             ctx_len = int(ctx_len_raw)
@@ -194,62 +227,150 @@ class SelfBenchmark:
                 )
 
     def _max_prefill_isl(self) -> int:
+        chunked_prefill_size = getattr(
+            self.scheduler.server_args, "chunked_prefill_size", None
+        )
+        if chunked_prefill_size is None or chunked_prefill_size <= 0:
+            chunked_prefill_size = self._max_valid_input_len()
         return max(
-            1,
+            0,
             min(
-                self.scheduler.max_req_input_len,
+                self._max_valid_input_len(),
+                chunked_prefill_size,
                 self.scheduler.max_total_num_tokens - 2,
+            ),
+        )
+
+    def _max_valid_input_len(self) -> int:
+        # validate_input_length rejects requests with len >= max_req_input_len.
+        return max(0, self.scheduler.max_req_input_len - 1)
+
+    def _max_decode_context_len(self) -> int:
+        page_size = max(1, self.scheduler.page_size)
+        max_total_budget = self.scheduler.max_total_num_tokens - page_size - 2
+        max_total_for_one_decode = (max_total_budget // page_size) * page_size
+        max_req_for_one_decode = self.scheduler.max_req_len - 2
+        return max(
+            0,
+            min(
+                self._max_valid_input_len(),
+                max_req_for_one_decode,
+                max_total_for_one_decode,
             ),
         )
 
     def _max_batch_size_for_context(self, context_length: int) -> int:
         max_running = max(1, getattr(self.scheduler, "max_running_requests", 1))
         max_tokens = max(1, getattr(self.scheduler, "max_total_num_tokens", 1))
-        token_capped = max(1, max_tokens // max(1, context_length + 2))
+        page_size = max(1, self.scheduler.page_size)
+        paged_context = ((context_length + page_size - 1) // page_size) * page_size
+        tokens_per_req = paged_context + page_size
+        token_capped = max(1, max_tokens // max(1, tokens_per_req))
         return min(max_running, token_capped)
+
+    def _inject_warmup(self) -> int:
+        if self._supports_decode_points() and self._should_use_decode_warmup():
+            return self._inject_decode(
+                context_length=min(256, self._max_decode_context_len()),
+                batch_size=1,
+            )
+        if self._supports_prefill_points() and self.config.mode in ("prefill", "agg"):
+            return self._inject_prefill(
+                prompt_len=min(256, self._max_prefill_isl()), max_tokens=0
+            )
+        return 0
+
+    def _should_use_decode_warmup(self) -> bool:
+        return self.config.mode == "decode" or (
+            self.config.mode == "agg"
+            and self.scheduler.disaggregation_mode == DisaggregationMode.DECODE
+        )
 
     def _inject_prefill(self, prompt_len: int, max_tokens: int) -> int:
         return self._inject_requests(prompt_len=prompt_len, max_tokens=max_tokens, n=1)
 
     def _inject_decode(self, context_length: int, batch_size: int) -> int:
-        # In normal aggregated serving this performs prefill then one decode step.
-        # In disaggregated decode mode the fake bootstrap path skips real transfer.
-        return self._inject_requests(
-            prompt_len=context_length, max_tokens=2, n=batch_size
+        return self._inject_synthetic_decode(
+            context_length=context_length,
+            batch_size=batch_size,
         )
 
+    def _inject_synthetic_decode(self, context_length: int, batch_size: int) -> int:
+        if not self._synthetic_decode_supported():
+            return 0
+
+        max_context = self._max_decode_context_len()
+        if max_context < 1:
+            return 0
+        context_length = max(1, min(context_length, max_context))
+        batch_size = max(1, batch_size)
+
+        if not self.scheduler.running_batch.is_empty():
+            return 0
+
+        reqs = []
+        for _ in range(batch_size):
+            req = self._new_synthetic_req(prompt_len=context_length, max_tokens=1)
+            self.scheduler.init_req_max_new_tokens(req)
+            if req.sampling_params.max_new_tokens < 1:
+                logger.warning(
+                    "Skipping decode benchmark request after max_new_tokens clamp: "
+                    "rid=%s context_length=%d max_new_tokens=%d",
+                    req.rid,
+                    context_length,
+                    req.sampling_params.max_new_tokens,
+                )
+                continue
+            error_msg = validate_input_length(
+                req,
+                self.scheduler.max_req_input_len,
+                self.scheduler.server_args.allow_auto_truncate,
+            )
+            if error_msg:
+                logger.warning("Skipping invalid benchmark request: %s", error_msg)
+                continue
+            req.skip_radix_cache_insert = True
+            req.fill_ids = req.origin_input_ids
+            req.kv_committed_len = context_length
+            req.kv_allocated_len = context_length
+            req.already_computed = context_length
+            reqs.append(req)
+
+        if not reqs:
+            return 0
+
+        try:
+            batch = self._build_synthetic_decode_batch(reqs, context_length)
+        except RuntimeError as exc:
+            logger.warning(
+                "Skipping decode benchmark point due to synthetic KV allocation "
+                "failure: %s",
+                exc,
+            )
+            self._free_synthetic_decode_reqs(reqs)
+            return 0
+
+        self.scheduler.running_batch = batch
+        return len(reqs)
+
     def _inject_requests(self, prompt_len: int, max_tokens: int, n: int) -> int:
-        prompt_len = max(1, min(prompt_len, self.scheduler.max_req_input_len))
-        token_id = self._dummy_token_id()
+        max_prompt_len = self._max_valid_input_len()
+        if max_prompt_len < 1:
+            return 0
+        prompt_len = max(1, min(prompt_len, max_prompt_len))
         injected = 0
         for _ in range(n):
-            rid = f"{SELF_BENCHMARK_REQ_PREFIX}{self._seq}"
-            self._seq += 1
-            req = Req(
-                rid=rid,
-                origin_input_text="",
-                origin_input_ids=array("q", [token_id] * prompt_len),
-                sampling_params=SamplingParams(
-                    max_new_tokens=max_tokens,
-                    temperature=0.0,
-                    ignore_eos=True,
-                ),
-                return_logprob=False,
-                top_logprobs_num=0,
-                token_ids_logprob=[],
-                stream=False,
-                eos_token_ids=self.scheduler.model_config.hf_eos_token_id,
-                bootstrap_host=FAKE_BOOTSTRAP_HOST,
-                bootstrap_port=self.scheduler.server_args.disaggregation_bootstrap_port,
-                bootstrap_room=self._seq,
-                disagg_mode=self.scheduler.disaggregation_mode,
-                vocab_size=self.scheduler.model_config.vocab_size,
-                metrics_collector=None,
-                extra_key=rid,
-            )
-            req.tokenizer = self.scheduler.tokenizer
-            req.suppress_output = True
+            req = self._new_synthetic_req(prompt_len=prompt_len, max_tokens=max_tokens)
             self.scheduler.init_req_max_new_tokens(req)
+            if max_tokens > 0 and req.sampling_params.max_new_tokens < max_tokens:
+                logger.warning(
+                    "Skipping benchmark request after max_new_tokens clamp: "
+                    "rid=%s requested=%d actual=%d",
+                    req.rid,
+                    max_tokens,
+                    req.sampling_params.max_new_tokens,
+                )
+                continue
             error_msg = validate_input_length(
                 req,
                 self.scheduler.max_req_input_len,
@@ -261,6 +382,139 @@ class SelfBenchmark:
             self.scheduler._add_request_to_queue(req)
             injected += 1
         return injected
+
+    def _new_synthetic_req(self, prompt_len: int, max_tokens: int) -> Req:
+        token_id = self._dummy_token_id()
+        rid = f"{SELF_BENCHMARK_REQ_PREFIX}{self._seq}"
+        self._seq += 1
+        req = Req(
+            rid=rid,
+            origin_input_text="",
+            origin_input_ids=array("q", [token_id] * prompt_len),
+            sampling_params=SamplingParams(
+                max_new_tokens=max_tokens,
+                stop=[],
+                stop_regex=[],
+                temperature=0.0,
+                ignore_eos=True,
+            ),
+            return_logprob=False,
+            top_logprobs_num=0,
+            token_ids_logprob=[],
+            stream=False,
+            eos_token_ids=self.scheduler.model_config.hf_eos_token_id,
+            bootstrap_host=FAKE_BOOTSTRAP_HOST,
+            bootstrap_port=self.scheduler.server_args.disaggregation_bootstrap_port,
+            bootstrap_room=self._seq,
+            disagg_mode=self.scheduler.disaggregation_mode,
+            vocab_size=self.scheduler.model_config.vocab_size,
+            metrics_collector=None,
+            extra_key=rid,
+        )
+        req.tokenizer = self.scheduler.tokenizer
+        req.suppress_output = True
+        return req
+
+    def _synthetic_decode_supported(self) -> bool:
+        if not self.scheduler.is_generation:
+            return False
+        if self.scheduler.model_config.is_encoder_decoder:
+            logger.warning(
+                "Synthetic decode self-benchmark does not support encoder-decoder models"
+            )
+            return False
+        if not self.scheduler.spec_algorithm.is_none():
+            logger.warning(
+                "Synthetic decode self-benchmark does not support speculative decoding"
+            )
+            return False
+        return True
+
+    def _build_synthetic_decode_batch(
+        self, reqs: list[Req], context_length: int
+    ) -> ScheduleBatch:
+        batch = ScheduleBatch.init_new(
+            reqs=reqs,
+            req_to_token_pool=self.scheduler.req_to_token_pool,
+            token_to_kv_pool_allocator=self.scheduler.token_to_kv_pool_allocator,
+            tree_cache=self.scheduler.tree_cache,
+            model_config=self.scheduler.model_config,
+            enable_overlap=self.scheduler.enable_overlap,
+            spec_algorithm=self.scheduler.spec_algorithm,
+            dllm_config=self.scheduler.dllm_config,
+        )
+        if getattr(self.scheduler, "enable_hisparse", False):
+            batch.hisparse_coordinator = self.scheduler.hisparse_coordinator
+
+        self._place_synthetic_context_cache(batch, context_length)
+        batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
+            batch, self.scheduler.model_config.vocab_size
+        )
+
+        last_tokens = torch.tensor(
+            [req.origin_input_ids[-1] for req in reqs],
+            dtype=torch.int64,
+            device=batch.device,
+        )
+        self.scheduler.future_map.stash(batch.req_pool_indices, last_tokens)
+        batch.input_ids = None
+        return batch
+
+    def _place_synthetic_context_cache(
+        self, batch: ScheduleBatch, context_length: int
+    ) -> None:
+        reqs = batch.reqs
+        req_pool_indices = alloc_req_slots(
+            batch.req_to_token_pool, reqs, batch.tree_cache
+        )
+        req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+        batch.req_pool_indices_cpu = req_pool_indices_cpu
+        batch.req_pool_indices = req_pool_indices_cpu.to(
+            batch.device, non_blocking=True
+        )
+
+        seq_lens_cpu = torch.full((len(reqs),), context_length, dtype=torch.int64)
+        batch.seq_lens_cpu = seq_lens_cpu
+        batch.seq_lens = seq_lens_cpu.to(batch.device, non_blocking=True)
+        batch.orig_seq_lens = torch.full(
+            (len(reqs),), context_length, dtype=torch.int32, device=batch.device
+        )
+        batch.seq_lens_sum = context_length * len(reqs)
+
+        total_context_tokens = context_length * len(reqs)
+        if batch.tree_cache.page_size == 1:
+            context_locs = alloc_token_slots(batch.tree_cache, total_context_tokens)
+        else:
+            prefix_lens_cpu = torch.zeros((len(reqs),), dtype=torch.int64)
+            prefix_lens = prefix_lens_cpu.to(batch.device, non_blocking=True)
+            last_loc = torch.full(
+                (len(reqs),), -1, dtype=torch.int64, device=batch.device
+            )
+            context_locs = alloc_paged_token_slots_extend(
+                tree_cache=batch.tree_cache,
+                prefix_lens=prefix_lens,
+                prefix_lens_cpu=prefix_lens_cpu,
+                seq_lens=batch.seq_lens,
+                seq_lens_cpu=batch.seq_lens_cpu,
+                last_loc=last_loc,
+                extend_num_tokens=total_context_tokens,
+            )
+
+        for i, req in enumerate(reqs):
+            start = i * context_length
+            end = start + context_length
+            batch.req_to_token_pool.write(
+                (req.req_pool_idx, slice(0, context_length)),
+                context_locs[start:end].to(torch.int32),
+            )
+            req.synthetic_benchmark_kv_placed = True
+
+    def _free_synthetic_decode_reqs(self, reqs: list[Req]) -> None:
+        for req in reqs:
+            if getattr(req, "synthetic_benchmark_kv_placed", False):
+                release_kv_cache(req, self.scheduler.tree_cache, is_insert=False)
+            elif req.req_pool_idx is not None:
+                self.scheduler.req_to_token_pool.free(req)
 
     def _dummy_token_id(self) -> int:
         vocab_size = getattr(self.scheduler.model_config, "vocab_size", None) or 1

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -702,6 +702,10 @@ class SelfBenchmark:
             queue_owner = getattr(self.scheduler, queue_name, None)
             if queue_owner is None:
                 continue
+            if isinstance(queue_owner, list):
+                if queue_owner:
+                    return True
+                continue
             queue = getattr(queue_owner, "queue", None)
             if queue:
                 return True
@@ -730,6 +734,9 @@ class SelfBenchmark:
         if self._write_results:
             self._write_output()
         self.phase = BenchmarkPhase.DONE
+        on_finish = getattr(self.scheduler, "on_self_benchmark_finished", None)
+        if on_finish is not None:
+            on_finish()
         logger.info("Self-benchmark completed")
 
     def _write_output(self) -> None:

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -17,6 +17,7 @@ import torch
 
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.environ import envs
+from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import validate_input_length
 from sglang.srt.mem_cache.base_prefix_cache import MatchPrefixParams
@@ -74,7 +75,20 @@ class BenchmarkPhase(Enum):
 
 
 class SelfBenchmark:
-    """Scheduler-local self benchmark."""
+    """Scheduler-local self benchmark.
+
+    Multi-rank lockstep assumption: the benchmark is constructed and advanced on
+    every scheduler rank, and FPM is forced on for all ranks during the sweep
+    (see metrics_reporter._init_fpm) so observe_forward_pass fires everywhere and
+    every rank advances WARMUP->SWEEP->DONE together. The grid (_build_grid) and
+    synthetic allocations are deterministic functions of the server args and the
+    homogeneous per-rank limits (max_total_num_tokens, page_size, max_req_len,
+    etc.), so each iteration runs an identical synthetic batch in the same
+    collective across ranks. There is intentionally no cross-rank barrier: any
+    per-rank, data-dependent skip in maybe_schedule_next / observe_forward_pass
+    would desync the collectives, so all skip/advance decisions here must depend
+    only on homogeneous state.
+    """
 
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
@@ -101,7 +115,23 @@ class SelfBenchmark:
         self._seq = 0
         self._warmup_remaining = max(0, self.config.warmup_iterations)
         self._grid_index = 0
-        self._write_results = bool(getattr(scheduler, "enable_fpm", False))
+        # Keep output writing keyed to whether THIS rank is a real FPM rank, not
+        # to the (possibly benchmark-forced) enable_fpm flag. Otherwise every TP
+        # rank forced into FPM for the sweep would write a redundant JSON file.
+        # _fpm_is_real_rank is set in metrics_reporter._init_fpm; fall back to
+        # enable_fpm for fake schedulers in tests that don't set it.
+        self._write_results = bool(
+            getattr(
+                scheduler,
+                "_fpm_is_real_rank",
+                getattr(scheduler, "enable_fpm", False),
+            )
+        )
+        # Original per-rank enable_fpm, restored when the sweep finishes so a
+        # benchmark-forced rank stops publishing afterwards.
+        self._restore_enable_fpm = bool(getattr(scheduler, "enable_fpm", False)) and (
+            not bool(getattr(scheduler, "_fpm_benchmark_forced", False))
+        )
         self._run_id = self._make_run_id()
         self._identity = self._build_output_identity()
         self._output_path = self._rank_output_path(self.config.output_path)
@@ -477,9 +507,12 @@ class SelfBenchmark:
 
         try:
             batch = self._build_synthetic_decode_batch(reqs, context_length)
-        except RuntimeError as exc:
+        except Exception as exc:
+            # Any failure between KV/req-slot allocation and publish (KV OOM, a
+            # stash/payload error, etc.) must free the pre-allocated context KV +
+            # req slots and skip the point, never crash the scheduler.
             logger.warning(
-                "Skipping decode benchmark point due to synthetic KV allocation "
+                "Skipping decode benchmark point due to synthetic batch build "
                 "failure: %s",
                 exc,
             )
@@ -634,7 +667,12 @@ class SelfBenchmark:
             dtype=torch.int64,
             device=batch.device,
         )
-        self.scheduler.future_map.stash(batch.req_pool_indices, prefill_output_tokens)
+        # FutureMap.stash expects a RelayPayload, not a raw tensor; non-spec only
+        # fills bonus_tokens (which the synthetic decode batch reads back next iter).
+        self.scheduler.future_map.stash(
+            batch.req_pool_indices,
+            RelayPayload(bonus_tokens=prefill_output_tokens),
+        )
         batch.input_ids = None
         return batch
 
@@ -702,6 +740,12 @@ class SelfBenchmark:
             return True
         if getattr(self.scheduler, "waiting_queue", None):
             return True
+        # Requests waiting on grammar compilation are not yet in waiting_queue.
+        grammar_manager = getattr(self.scheduler, "grammar_manager", None)
+        if grammar_manager is not None and getattr(
+            grammar_manager, "grammar_queue", None
+        ):
+            return True
         for queue_name in (
             "disagg_prefill_bootstrap_queue",
             "disagg_prefill_inflight_queue",
@@ -717,6 +761,12 @@ class SelfBenchmark:
                 continue
             queue = getattr(queue_owner, "queue", None)
             if queue:
+                return True
+            # The decode prealloc queue also holds retracted and not-yet-resolved
+            # requests outside its main `queue`.
+            if getattr(queue_owner, "retracted_queue", None):
+                return True
+            if getattr(queue_owner, "pending_reqs", None):
                 return True
         running = getattr(self.scheduler, "running_batch", None)
         if running is not None and not running.is_empty():
@@ -745,10 +795,28 @@ class SelfBenchmark:
         if self._write_results:
             self._write_output()
         self.phase = BenchmarkPhase.DONE
+        self._restore_fpm_state()
         on_finish = getattr(self.scheduler, "on_self_benchmark_finished", None)
         if on_finish is not None:
             on_finish()
         logger.info("Self-benchmark completed")
+
+    def _restore_fpm_state(self) -> None:
+        """Restore FPM to its prior per-rank state after the sweep.
+
+        FPM was turned on for every rank for the sweep's duration (so each rank
+        advances WARMUP->SWEEP->DONE in lockstep). On ranks where FPM was
+        benchmark-forced, tear the forced publisher/timer down and disable FPM;
+        on the real FPM rank, leave production publishing intact.
+        """
+        reporter = getattr(self.scheduler, "metrics_reporter", None)
+        # Shut down the forced publisher BEFORE flipping enable_fpm: the forced
+        # teardown does not depend on enable_fpm, but flipping it first would
+        # leave the publisher thread running on benchmark-forced ranks.
+        if reporter is not None and hasattr(reporter, "shutdown_benchmark_forced_fpm"):
+            reporter.shutdown_benchmark_forced_fpm()
+        if hasattr(self.scheduler, "enable_fpm"):
+            self.scheduler.enable_fpm = self._restore_enable_fpm
 
     def _write_output(self) -> None:
         output = {

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -153,8 +153,18 @@ class SelfBenchmark:
             return
 
         # Synthetic requests are owned by normal scheduler/result processing after
-        # injection, so do not advance or advertise readiness until that state drains.
-        if self._current is not None or self._has_inflight_work():
+        # injection. Record a completed current point as soon as its tracked
+        # requests finish, but do not inject more work or advertise readiness
+        # until all scheduler-owned state drains.
+        if self._current is not None:
+            # Disaggregated prefill can mark a synthetic request finished after
+            # observe_forward_pass() has already checked it. Re-check here so a
+            # point completed by post-forward transfer processing can advance.
+            if self._current_point_finished():
+                self._save_current_point()
+            else:
+                return
+        if self._has_inflight_work():
             return
 
         if self.phase == BenchmarkPhase.WARMUP:

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SELF_BENCHMARK_REQ_PREFIX = "__sgl_bench_"
+SELF_BENCHMARK_DUMMY_TOKEN_ID = 0
 
 
 @dataclass
@@ -134,7 +135,7 @@ class SelfBenchmark:
             if injected > 0:
                 return
             logger.warning("Skipping benchmark point with no valid seed: %s", point)
-            self._grid_index += 1
+            self._advance_grid_point()
             return
 
         self._current = BenchmarkPointResult(point=point)
@@ -142,15 +143,13 @@ class SelfBenchmark:
         if point.point_type == "prefill":
             injected = self._inject_prefill(point=point)
         else:
-            injected = self._inject_decode(
+            injected = self._inject_synthetic_decode(
                 context_length=point.context_length, batch_size=point.batch_size
             )
 
         if injected == 0:
             logger.warning("Skipping benchmark point with no valid requests: %s", point)
-            self._current = None
-            self._active_reqs = []
-            self._grid_index += 1
+            self._advance_grid_point()
 
     def observe_forward_pass(
         self, batch: ScheduleBatch, fpm: Optional[ForwardPassMetrics]
@@ -197,6 +196,9 @@ class SelfBenchmark:
         if self._current is None:
             return
         self._results.append(self._current)
+        self._advance_grid_point()
+
+    def _advance_grid_point(self) -> None:
         self._current = None
         self._active_reqs = []
         self._grid_index += 1
@@ -332,7 +334,7 @@ class SelfBenchmark:
 
     def _inject_warmup(self) -> int:
         if self._supports_decode_points() and self._should_use_decode_warmup():
-            return self._inject_decode(
+            return self._inject_synthetic_decode(
                 context_length=min(256, self._max_decode_context_len()),
                 batch_size=1,
             )
@@ -351,14 +353,16 @@ class SelfBenchmark:
             and self.scheduler.disaggregation_mode == DisaggregationMode.DECODE
         )
 
-    def _inject_prefill(self, point: BenchmarkPoint) -> int:
+    def _inject_prefill(
+        self, point: BenchmarkPoint, extra_key: Optional[str] = None
+    ) -> int:
         # Chunked prefill requests need a decode step to reach the normal request
         # finished/release path. The benchmark still records only prefill FPMs.
         return self._inject_requests(
             prompt_len=point.isl,
             max_tokens=1,
             n=1,
-            extra_key=self._pending_seed_extra_key,
+            extra_key=extra_key,
             track_active=True,
         )
 
@@ -396,25 +400,15 @@ class SelfBenchmark:
                 point.kv_read_tokens,
                 actual_kv_read_tokens,
             )
-            self._grid_index += 1
+            self._advance_grid_point()
             return
 
-        self._pending_seed_extra_key = extra_key
         self._current = BenchmarkPointResult(point=point)
         self._active_reqs = []
-        injected = self._inject_prefill(point=point)
-        self._pending_seed_extra_key = None
+        injected = self._inject_prefill(point=point, extra_key=extra_key)
         if injected == 0:
             logger.warning("Skipping benchmark point with no valid requests: %s", point)
-            self._current = None
-            self._active_reqs = []
-            self._grid_index += 1
-
-    def _inject_decode(self, context_length: int, batch_size: int) -> int:
-        return self._inject_synthetic_decode(
-            context_length=context_length,
-            batch_size=batch_size,
-        )
+            self._advance_grid_point()
 
     def _inject_synthetic_decode(self, context_length: int, batch_size: int) -> int:
         if not self._synthetic_decode_supported():
@@ -526,13 +520,12 @@ class SelfBenchmark:
     def _new_synthetic_req(
         self, prompt_len: int, max_tokens: int, extra_key: Optional[str] = None
     ) -> Req:
-        token_id = self._dummy_token_id()
         rid = f"{SELF_BENCHMARK_REQ_PREFIX}{self._seq}"
         self._seq += 1
         req = Req(
             rid=rid,
             origin_input_text="",
-            origin_input_ids=array("q", [token_id] * prompt_len),
+            origin_input_ids=array("q", [SELF_BENCHMARK_DUMMY_TOKEN_ID] * prompt_len),
             sampling_params=SamplingParams(
                 max_new_tokens=max_tokens,
                 stop=[],
@@ -564,8 +557,7 @@ class SelfBenchmark:
             return 0
         if getattr(self.scheduler.tree_cache, "disable", True):
             return 0
-        token_id = self._dummy_token_id()
-        token_ids = array("q", [token_id] * point.isl)
+        token_ids = array("q", [SELF_BENCHMARK_DUMMY_TOKEN_ID] * point.isl)
         max_prefix_len = max(point.isl - 1, 0)
         match_result = self.scheduler.tree_cache.match_prefix(
             MatchPrefixParams(
@@ -680,10 +672,6 @@ class SelfBenchmark:
                 release_kv_cache(req, self.scheduler.tree_cache, is_insert=False)
             elif req.req_pool_idx is not None:
                 self.scheduler.req_to_token_pool.free(req)
-
-    def _dummy_token_id(self) -> int:
-        vocab_size = getattr(self.scheduler.model_config, "vocab_size", None) or 1
-        return 0 if vocab_size > 0 else 0
 
     def _has_inflight_work(self) -> bool:
         result_queue = getattr(self.scheduler, "result_queue", None)

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -919,21 +919,19 @@ class SelfBenchmark:
         }
 
     def _rank_output_path(self, base_path: str) -> str:
+        # The consumer addresses rank files by DP rank only: dp_rank 0 writes the
+        # caller-assigned base path, dp_rank N writes the "_dpN" sibling. We keep
+        # the filename to exactly that contract and carry the full
+        # role/rank/run identity inside the file (see _build_output_identity), so
+        # a consumer validates provenance from contents rather than parsing a
+        # brittle path suffix. Co-located workers (e.g. disagg prefill/decode)
+        # are kept distinct by the caller assigning a unique base path per
+        # worker, not by namespacing the filename here.
+        dp_rank = self._rank_value("dp_rank", default=0)
+        if dp_rank == 0:
+            return base_path
         stem, ext = os.path.splitext(base_path)
-        return f"{stem}_{self._output_path_suffix()}{ext}"
-
-    def _output_path_suffix(self) -> str:
-        parts = [
-            ("role", self._role_name()),
-            ("node", getattr(self.scheduler.server_args, "node_rank", 0)),
-            ("dp", self._rank_value("dp_rank", default=0)),
-            ("tp", self._rank_value("tp_rank", default=0)),
-            ("atp", self._rank_value("attn_tp_rank", default=0)),
-            ("acp", self._rank_value("attn_cp_rank", default=0)),
-        ]
-        return "_".join(
-            f"{name}-{self._sanitize_path_part(value)}" for name, value in parts
-        )
+        return f"{stem}_dp{dp_rank}{ext}"
 
     def _role_name(self) -> str:
         role = getattr(self.scheduler, "disaggregation_mode", DisaggregationMode.NULL)
@@ -942,9 +940,3 @@ class SelfBenchmark:
     def _rank_value(self, name: str, *, default: int) -> int:
         value = getattr(self.scheduler.ps, name, default)
         return default if value is None else value
-
-    @staticmethod
-    def _sanitize_path_part(value) -> str:
-        return "".join(
-            ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in str(value)
-        )

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -13,22 +13,16 @@ from typing import TYPE_CHECKING, Optional
 
 import msgspec
 import numpy as np
-import torch
 
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.managers.scheduler_components.self_benchmark_decode import (
+    SyntheticDecodeBatchBuilder,
+)
 from sglang.srt.managers.utils import validate_input_length
 from sglang.srt.mem_cache.base_prefix_cache import MatchPrefixParams
-from sglang.srt.mem_cache.common import (
-    alloc_paged_token_slots_extend,
-    alloc_req_slots,
-    alloc_token_slots,
-    release_kv_cache,
-)
 from sglang.srt.mem_cache.radix_cache import RadixKey
-from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 if TYPE_CHECKING:
@@ -114,6 +108,12 @@ class SelfBenchmark:
             raise ValueError("--benchmark-mode is not supported with PD multiplexing")
         if scheduler.enable_overlap_mlx:
             raise ValueError("--benchmark-mode is not supported with MLX overlap")
+        if scheduler.dllm_config is not None:
+            raise ValueError("--benchmark-mode is not supported with diffusion LLMs")
+        if hasattr(scheduler.token_to_kv_pool_allocator, "c4_attn_allocator"):
+            raise ValueError(
+                "--benchmark-mode is not supported with DeepSeek V4 on NPU"
+            )
         if not scheduler.is_generation:
             # Non-generation (embedding/reward) models would leak synthetic
             # prefill outputs to the tokenizer (suppress_output is only honored
@@ -193,6 +193,7 @@ class SelfBenchmark:
 
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
+        self._decode_batch_builder = SyntheticDecodeBatchBuilder(scheduler)
         self.config = SelfBenchmarkConfig(
             mode=scheduler.server_args.benchmark_mode,
             prefill_isl_granularity=scheduler.server_args.benchmark_prefill_granularity,
@@ -643,13 +644,13 @@ class SelfBenchmark:
             return 0
 
         try:
-            batch = self._build_synthetic_decode_batch(reqs, context_length)
+            batch = self._decode_batch_builder.build(reqs, context_length)
         except Exception:
             # A rank-local skip would let successful peers publish running_batch
             # and enter model collectives alone. Clean up what we can, then let the
             # scheduler wrapper fail startup and tear down every rank.
             try:
-                self._free_synthetic_decode_reqs(reqs)
+                self._decode_batch_builder.cleanup(reqs)
             except Exception:
                 logger.exception("Failed to clean up a synthetic decode batch")
             raise
@@ -775,97 +776,6 @@ class SelfBenchmark:
             )
             return False
         return True
-
-    def _build_synthetic_decode_batch(
-        self, reqs: list[Req], context_length: int
-    ) -> ScheduleBatch:
-        batch = ScheduleBatch.init_new(
-            reqs=reqs,
-            req_to_token_pool=self.scheduler.req_to_token_pool,
-            token_to_kv_pool_allocator=self.scheduler.token_to_kv_pool_allocator,
-            tree_cache=self.scheduler.tree_cache,
-            model_config=self.scheduler.model_config,
-            enable_overlap=self.scheduler.enable_overlap,
-            spec_algorithm=self.scheduler.spec_algorithm,
-            dllm_config=self.scheduler.dllm_config,
-        )
-        if getattr(self.scheduler, "enable_hisparse", False):
-            batch.hisparse_coordinator = self.scheduler.hisparse_coordinator
-
-        self._place_synthetic_context_cache(batch, context_length)
-        batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
-            batch, self.scheduler.model_config.vocab_size
-        )
-
-        prefill_output_tokens = torch.tensor(
-            [req.output_ids[-1] for req in reqs],
-            dtype=torch.int64,
-            device=batch.device,
-        )
-        # FutureMap.stash expects a RelayPayload, not a raw tensor; non-spec only
-        # fills bonus_tokens (which the synthetic decode batch reads back next iter).
-        self.scheduler.future_map.stash(
-            batch.req_pool_indices,
-            RelayPayload(bonus_tokens=prefill_output_tokens),
-        )
-        batch.input_ids = None
-        return batch
-
-    def _place_synthetic_context_cache(
-        self, batch: ScheduleBatch, context_length: int
-    ) -> None:
-        reqs = batch.reqs
-        req_pool_indices = alloc_req_slots(
-            batch.req_to_token_pool, reqs, batch.tree_cache
-        )
-        req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
-        batch.req_pool_indices_cpu = req_pool_indices_cpu
-        batch.req_pool_indices = req_pool_indices_cpu.to(
-            batch.device, non_blocking=True
-        )
-
-        seq_lens_cpu = torch.full((len(reqs),), context_length, dtype=torch.int64)
-        batch.seq_lens_cpu = seq_lens_cpu
-        batch.seq_lens = seq_lens_cpu.to(batch.device, non_blocking=True)
-        batch.orig_seq_lens = torch.full(
-            (len(reqs),), context_length, dtype=torch.int32, device=batch.device
-        )
-        batch.seq_lens_sum = context_length * len(reqs)
-
-        total_context_tokens = context_length * len(reqs)
-        if batch.tree_cache.page_size == 1:
-            context_locs = alloc_token_slots(batch.tree_cache, total_context_tokens)
-        else:
-            prefix_lens_cpu = torch.zeros((len(reqs),), dtype=torch.int64)
-            prefix_lens = prefix_lens_cpu.to(batch.device, non_blocking=True)
-            last_loc = torch.full(
-                (len(reqs),), -1, dtype=torch.int64, device=batch.device
-            )
-            context_locs = alloc_paged_token_slots_extend(
-                tree_cache=batch.tree_cache,
-                prefix_lens=prefix_lens,
-                prefix_lens_cpu=prefix_lens_cpu,
-                seq_lens=batch.seq_lens,
-                seq_lens_cpu=batch.seq_lens_cpu,
-                last_loc=last_loc,
-                extend_num_tokens=total_context_tokens,
-            )
-
-        for i, req in enumerate(reqs):
-            start = i * context_length
-            end = start + context_length
-            batch.req_to_token_pool.write(
-                (req.req_pool_idx, slice(0, context_length)),
-                context_locs[start:end].to(torch.int32),
-            )
-            req.synthetic_benchmark_kv_placed = True
-
-    def _free_synthetic_decode_reqs(self, reqs: list[Req]) -> None:
-        for req in reqs:
-            if getattr(req, "synthetic_benchmark_kv_placed", False):
-                release_kv_cache(req, self.scheduler.tree_cache, is_insert=False)
-            elif req.req_pool_idx is not None:
-                self.scheduler.req_to_token_pool.free(req)
 
     def _has_inflight_work(self) -> bool:
         result_queue = getattr(self.scheduler, "result_queue", None)

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from array import array
 from dataclasses import asdict, dataclass, field
 from enum import Enum
@@ -103,6 +104,8 @@ class SelfBenchmark:
         self._write_results = bool(getattr(scheduler, "enable_fpm", False))
         self._pending_seed_point: Optional[BenchmarkPoint] = None
         self._pending_seed_extra_key: Optional[str] = None
+        self._timed_out = False
+        self._deadline_monotonic = self._init_deadline_monotonic()
         self._build_grid()
         if self._warmup_remaining == 0:
             self.phase = BenchmarkPhase.SWEEP
@@ -113,7 +116,12 @@ class SelfBenchmark:
         return self.phase != BenchmarkPhase.DONE
 
     def maybe_schedule_next(self) -> None:
-        if not self.active or self._current is not None or self._has_inflight_work():
+        if not self.active:
+            return
+        if self._has_timed_out():
+            self._finish(timed_out=True)
+            return
+        if self._current is not None or self._has_inflight_work():
             return
 
         if self.phase == BenchmarkPhase.WARMUP:
@@ -202,6 +210,17 @@ class SelfBenchmark:
         self._current = None
         self._active_reqs = []
         self._grid_index += 1
+
+    def _init_deadline_monotonic(self) -> Optional[float]:
+        if self.config.timeout <= 0:
+            return None
+        return time.monotonic() + self.config.timeout
+
+    def _has_timed_out(self) -> bool:
+        return (
+            self._deadline_monotonic is not None
+            and time.monotonic() >= self._deadline_monotonic
+        )
 
     def _build_grid(self) -> None:
         mode = self.config.mode
@@ -718,7 +737,21 @@ class SelfBenchmark:
             return "prefill"
         return None
 
-    def _finish(self) -> None:
+    def _finish(self, timed_out: bool = False) -> None:
+        if self.phase == BenchmarkPhase.DONE:
+            return
+        if timed_out:
+            self._timed_out = True
+            self._current = None
+            self._active_reqs = []
+            self._pending_seed_point = None
+            self._pending_seed_extra_key = None
+            logger.warning(
+                "Self-benchmark timed out after %d seconds; writing %d completed "
+                "point(s) and continuing startup",
+                self.config.timeout,
+                len(self._results),
+            )
         if self._write_results:
             self._write_output()
         self.phase = BenchmarkPhase.DONE
@@ -731,6 +764,7 @@ class SelfBenchmark:
         output_path = self._rank_output_path(self.config.output_path)
         output = {
             "config": asdict(self.config),
+            "timed_out": self._timed_out,
             "limits": {
                 "max_num_scheduled_tokens": getattr(
                     self.scheduler, "max_prefill_tokens", None

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -795,15 +795,24 @@ class SelfBenchmark:
             new_lengths, kv_lengths, prompt_lengths = self._prefill_lengths(point)
         except ValueError:
             return False
+        page_size = max(1, self.scheduler.page_size)
+        scheduled_new_lengths = [
+            ((length + page_size - 1) // page_size) * page_size
+            for length in new_lengths
+        ]
+        # PrefillAdder accounts the page-aligned token total against one shared
+        # chunk budget. A point that changes shape during admission cannot yield
+        # the single exact FPM required by self-benchmarking.
+        if sum(scheduled_new_lengths) != point.total_prefill_tokens:
+            return False
         chunk_size = getattr(self.scheduler.server_args, "chunked_prefill_size", None)
         if chunk_size is not None and chunk_size > 0:
-            if any(length > chunk_size for length in new_lengths):
+            if sum(scheduled_new_lengths) > chunk_size:
                 return False
         if any(
             prompt_len > self._max_valid_input_len() for prompt_len in prompt_lengths
         ):
             return False
-        page_size = max(1, self.scheduler.page_size)
         required = sum(
             ((prompt_len + 1 + page_size - 1) // page_size) * page_size
             for prompt_len in prompt_lengths
@@ -989,7 +998,11 @@ class SelfBenchmark:
         # max_total_num_tokens is KV capacity, not transient forward/logits
         # headroom. Keep optional startup benchmarking within the scheduler's
         # normal prefill-forward token budget.
-        return max(0, getattr(self.scheduler, "max_prefill_tokens", 0))
+        limit = max(0, getattr(self.scheduler, "max_prefill_tokens", 0))
+        chunk_size = getattr(self.scheduler.server_args, "chunked_prefill_size", None)
+        if chunk_size is not None and chunk_size > 0:
+            limit = min(limit, int(chunk_size))
+        return limit
 
     def _max_generated_prefill_tokens(self) -> int:
         """Return the largest schedulable generated-grid prefill total.

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -9,14 +10,19 @@ import uuid
 from array import array
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Sequence
 
 import msgspec
-import numpy as np
 
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.managers.schedule_batch import Req, ReqKvInfo, ScheduleBatch
+from sglang.srt.managers.scheduler_components.benchmark_points import (
+    BenchmarkPoints,
+    DecodePointCandidate,
+    PrefillPointCandidate,
+    load_benchmark_points_file,
+)
 from sglang.srt.managers.scheduler_components.self_benchmark_decode import (
     SyntheticDecodeBatchBuilder,
 )
@@ -37,24 +43,146 @@ SELF_BENCHMARK_REQ_PREFIX = "__sgl_bench_"
 SELF_BENCHMARK_DUMMY_TOKEN_ID = 0
 
 
+def _balanced_partition(
+    total: int, count: int, *, unit: int = 1, minimum_units: int = 0
+) -> list[int]:
+    if count < 1 or unit < 1:
+        raise ValueError("count and unit must be positive")
+    if total < 0 or total % unit != 0:
+        raise ValueError("total must be a non-negative multiple of unit")
+    total_units = total // unit
+    required_units = count * minimum_units
+    if total_units < required_units:
+        raise ValueError("total is too small for the requested minimum")
+    quotient, remainder = divmod(total_units - required_units, count)
+    return [
+        (minimum_units + quotient + int(index < remainder)) * unit
+        for index in range(count)
+    ]
+
+
+def _powers_of_two_up_to(limit: int) -> list[int]:
+    values: list[int] = []
+    value = 1
+    while value <= limit:
+        values.append(value)
+        value *= 2
+    return values
+
+
+def _uniformly_limit_axis(values: Sequence[int], max_samples: int) -> list[int]:
+    if max_samples < 2:
+        raise ValueError("uniform axis sample limits must be at least 2")
+    if len(values) <= max_samples:
+        return list(values)
+    last_index = len(values) - 1
+    intervals = max_samples - 1
+    return [
+        values[(sample * last_index + intervals // 2) // intervals]
+        for sample in range(max_samples)
+    ]
+
+
+def _limit_cudagraph_axis(
+    values: Sequence[int], capture_sizes: Sequence[int], max_samples: int
+) -> list[int]:
+    candidates = list(values)
+    if len(candidates) <= max_samples:
+        return candidates
+    captures = [int(size) for size in capture_sizes if int(size) >= 1]
+    if not captures:
+        return _uniformly_limit_axis(candidates, max_samples)
+    max_capture = max(captures)
+    graph_points = [value for value in candidates if value <= max_capture]
+    eager_tail = [value for value in candidates if value > max_capture]
+    protect_tail = bool(eager_tail) and len(eager_tail) * 5 <= len(candidates)
+    graph_budget = max_samples - len(eager_tail)
+    if not protect_tail or not graph_points or graph_budget < 1:
+        return _uniformly_limit_axis(candidates, max_samples)
+    limited_graph = (
+        [graph_points[0]]
+        if graph_budget == 1
+        else _uniformly_limit_axis(graph_points, graph_budget)
+    )
+    return limited_graph + eager_tail
+
+
+def _cudagraph_axis_points(capture_sizes: Sequence[int], limit: int) -> list[int]:
+    if limit < 1:
+        return []
+    configured = sorted({int(size) for size in capture_sizes if int(size) >= 1})
+    if not configured:
+        return sorted(set(_powers_of_two_up_to(limit) + [limit]))
+    points: set[int] = set()
+    for capture_size in (size for size in configured if size <= limit):
+        points.add(capture_size)
+        if capture_size < limit:
+            points.add(capture_size + 1)
+    if configured[-1] <= limit:
+        value = configured[-1] * 2
+        while value < limit:
+            points.add(value)
+            value *= 2
+    points.add(limit)
+    return sorted(points)
+
+
 @dataclass
 class SelfBenchmarkConfig:
     mode: str
     prefill_isl_granularity: int = 16
     prefill_kv_read_granularity: int = 1
+    prefill_batch_size_granularity: int = 3
     decode_length_granularity: int = 6
     decode_batch_size_granularity: int = 6
     warmup_iterations: int = 5
     output_path: str = "/tmp/benchmark_results.json"
+    points_file: Optional[str] = None
 
 
 @dataclass
 class BenchmarkPoint:
     point_type: str
+    benchmark_id: int = 0
+    total_prefill_tokens: int = 0
+    total_kv_read_tokens: int = 0
+    batch_size: int = 0
+    expected_cudagraph_mode: str = "NONE"
+    expected_capture_size: Optional[int] = None
+    padding_tokens: Optional[int] = None
+    sample_reasons: list[str] = field(default_factory=list)
+
+    # Compatibility coordinates retained for existing result consumers.
     isl: int = 0
     kv_read_tokens: int = 0
     context_length: int = 0
-    batch_size: int = 0
+
+    def __post_init__(self) -> None:
+        if self.point_type == "prefill":
+            if self.batch_size == 0:
+                self.batch_size = 1
+            if self.total_kv_read_tokens == 0 and self.kv_read_tokens:
+                self.total_kv_read_tokens = self.kv_read_tokens
+            if self.total_prefill_tokens == 0 and self.isl:
+                self.total_prefill_tokens = max(
+                    self.batch_size, self.isl - self.total_kv_read_tokens
+                )
+            if self.isl == 0 and self.batch_size == 1:
+                self.isl = self.total_prefill_tokens + self.total_kv_read_tokens
+            if self.kv_read_tokens == 0 and self.batch_size == 1:
+                self.kv_read_tokens = self.total_kv_read_tokens
+        elif self.point_type == "decode":
+            if self.batch_size == 0:
+                self.batch_size = 1
+            if self.total_kv_read_tokens == 0 and self.context_length:
+                self.total_kv_read_tokens = (self.context_length + 1) * self.batch_size
+            if (
+                self.context_length == 0
+                and self.total_kv_read_tokens % self.batch_size == 0
+            ):
+                self.context_length = max(
+                    0, self.total_kv_read_tokens // self.batch_size - 1
+                )
 
 
 @dataclass
@@ -147,43 +275,56 @@ class SelfBenchmark:
     def validate_args(cls, server_args: ServerArgs) -> None:
         """Validate self-benchmark-specific server arguments."""
         if server_args.benchmark_mode is None:
+            if server_args.benchmark_points_file is not None:
+                raise ValueError("--benchmark-points-file requires --benchmark-mode")
             return
 
-        # Non-positive values collapse an axis to one point, while very large
-        # values can exhaust host memory before the event loop starts.
-        for name in (
-            "benchmark_prefill_granularity",
-            "benchmark_prefill_kv_read_granularity",
-            "benchmark_decode_length_granularity",
-            "benchmark_decode_batch_granularity",
-        ):
-            value = getattr(server_args, name)
-            flag = f"--{name.replace('_', '-')}"
-            if value < 1:
-                raise ValueError(f"{flag} must be >= 1 when --benchmark-mode is set.")
-            if value > cls.MAX_AXIS_GRANULARITY:
-                raise ValueError(
-                    f"{flag} must be <= {cls.MAX_AXIS_GRANULARITY} "
-                    "when --benchmark-mode is set."
-                )
-
-        grid_points = {
-            "prefill": server_args.benchmark_prefill_granularity
-            * server_args.benchmark_prefill_kv_read_granularity,
-            "decode": server_args.benchmark_decode_length_granularity
-            * server_args.benchmark_decode_batch_granularity,
-        }
-        requested_grid_points = (
-            sum(grid_points.values())
-            if server_args.benchmark_mode == "agg"
-            else grid_points[server_args.benchmark_mode]
-        )
-        if requested_grid_points > cls.MAX_GRID_POINTS:
-            raise ValueError(
-                f"--benchmark-mode {server_args.benchmark_mode} requests "
-                f"{requested_grid_points} grid points; the maximum is "
-                f"{cls.MAX_GRID_POINTS}."
+        explicit_points = None
+        if server_args.benchmark_points_file is not None:
+            explicit_points = load_benchmark_points_file(
+                server_args.benchmark_points_file
             )
+
+        if explicit_points is None:
+            # Non-positive values collapse an axis to one point, while very large
+            # values can exhaust host memory before the event loop starts.
+            for name in (
+                "benchmark_prefill_granularity",
+                "benchmark_prefill_kv_read_granularity",
+                "benchmark_prefill_batch_granularity",
+                "benchmark_decode_length_granularity",
+                "benchmark_decode_batch_granularity",
+            ):
+                value = getattr(server_args, name)
+                flag = f"--{name.replace('_', '-')}"
+                if value < 1:
+                    raise ValueError(
+                        f"{flag} must be >= 1 when --benchmark-mode is set."
+                    )
+                if value > cls.MAX_AXIS_GRANULARITY:
+                    raise ValueError(
+                        f"{flag} must be <= {cls.MAX_AXIS_GRANULARITY} "
+                        "when --benchmark-mode is set."
+                    )
+
+            grid_points = {
+                "prefill": server_args.benchmark_prefill_granularity
+                * server_args.benchmark_prefill_kv_read_granularity
+                * server_args.benchmark_prefill_batch_granularity,
+                "decode": server_args.benchmark_decode_length_granularity
+                * server_args.benchmark_decode_batch_granularity,
+            }
+            requested_grid_points = (
+                sum(grid_points.values())
+                if server_args.benchmark_mode == "agg"
+                else grid_points[server_args.benchmark_mode]
+            )
+            if requested_grid_points > cls.MAX_GRID_POINTS:
+                raise ValueError(
+                    f"--benchmark-mode {server_args.benchmark_mode} requests "
+                    f"{requested_grid_points} grid points; the maximum is "
+                    f"{cls.MAX_GRID_POINTS}."
+                )
 
         if server_args.benchmark_warmup_iterations < 0:
             raise ValueError(
@@ -200,6 +341,9 @@ class SelfBenchmark:
             prefill_kv_read_granularity=(
                 scheduler.server_args.benchmark_prefill_kv_read_granularity
             ),
+            prefill_batch_size_granularity=(
+                scheduler.server_args.benchmark_prefill_batch_granularity
+            ),
             decode_length_granularity=(
                 scheduler.server_args.benchmark_decode_length_granularity
             ),
@@ -208,6 +352,12 @@ class SelfBenchmark:
             ),
             warmup_iterations=scheduler.server_args.benchmark_warmup_iterations,
             output_path=scheduler.server_args.benchmark_output_path,
+            points_file=scheduler.server_args.benchmark_points_file,
+        )
+        self._explicit_points = (
+            load_benchmark_points_file(self.config.points_file)
+            if self.config.points_file is not None
+            else None
         )
         self.phase = BenchmarkPhase.WARMUP
         self._grid: list[BenchmarkPoint] = []
@@ -241,7 +391,9 @@ class SelfBenchmark:
         if self._write_results:
             self._invalidate_output()
         self._pending_seed_point: Optional[BenchmarkPoint] = None
-        self._pending_seed_extra_key: Optional[str] = None
+        self._pending_seed_extra_keys: Optional[list[str]] = None
+        self._max_generated_prefill_tokens_cache: Optional[int] = None
+        self._max_feasible_decode_batch_size_cache: Optional[int] = None
         self._build_grid()
         if self._warmup_remaining == 0:
             self.phase = BenchmarkPhase.SWEEP
@@ -284,7 +436,7 @@ class SelfBenchmark:
             return
 
         point = self._grid[self._grid_index]
-        if point.point_type == "prefill" and point.kv_read_tokens > 0:
+        if point.point_type == "prefill" and point.total_kv_read_tokens > 0:
             injected = self._inject_prefill_seed(point)
             if injected > 0:
                 return
@@ -298,7 +450,7 @@ class SelfBenchmark:
             injected = self._inject_prefill(point=point)
         else:
             injected = self._inject_synthetic_decode(
-                context_length=point.context_length, batch_size=point.batch_size
+                context_lengths=self._decode_context_lengths(point)
             )
 
         if injected == 0:
@@ -349,15 +501,52 @@ class SelfBenchmark:
     def _save_current_point(self) -> None:
         if self._current is None:
             return
+        point = self._current.point
         if not self._current.fpms:
-            point = self._current.point
             logger.warning("Skipping benchmark point with no metrics: %s", point)
             self._skip_grid_point(point, "no_forward_pass_metrics")
             return
+        if point.benchmark_id > 0 and len(self._current.fpms) != 1:
+            self._skip_grid_point(point, "expected_exactly_one_forward_pass_metric")
+            return
+        if point.benchmark_id > 0:
+            failure = self._fpm_validation_failure(point, self._current.fpms[0])
+            if failure is not None:
+                self._skip_grid_point(point, failure)
+                return
         self._results.append(self._current)
         self._advance_grid_point()
 
+    @staticmethod
+    def _fpm_validation_failure(point: BenchmarkPoint, fpm: dict) -> Optional[str]:
+        scheduled = fpm.get("scheduled_requests", {})
+        if point.point_type == "prefill":
+            expected = {
+                "num_prefill_requests": point.batch_size,
+                "sum_prefill_tokens": point.total_prefill_tokens,
+                "sum_prefill_kv_tokens": point.total_kv_read_tokens,
+                "num_decode_requests": 0,
+                "sum_decode_kv_tokens": 0,
+            }
+        else:
+            expected = {
+                "num_prefill_requests": 0,
+                "sum_prefill_tokens": 0,
+                "sum_prefill_kv_tokens": 0,
+                "num_decode_requests": point.batch_size,
+                "sum_decode_kv_tokens": point.total_kv_read_tokens,
+            }
+        actual = {name: scheduled.get(name, 0) for name in expected}
+        if actual != expected:
+            return f"measured_shape_mismatch expected={expected} actual={actual}"
+        return None
+
     def _skip_grid_point(self, point: BenchmarkPoint, reason: str) -> None:
+        if "explicit" in point.sample_reasons:
+            raise RuntimeError(
+                f"explicit benchmark point benchmark_id={point.benchmark_id} "
+                f"failed at runtime: {reason}"
+            )
         self._skipped_points.append(SkippedBenchmarkPoint(point=point, reason=reason))
         self._advance_grid_point()
 
@@ -368,33 +557,83 @@ class SelfBenchmark:
 
     def _build_grid(self) -> None:
         mode = self.config.mode
-        disaggregation_mode = self.scheduler.disaggregation_mode
+        prefill_enabled = self._supports_prefill_points() and mode in ("prefill", "agg")
+        decode_enabled = self._supports_decode_points() and mode in ("decode", "agg")
 
-        if disaggregation_mode == DisaggregationMode.PREFILL:
-            if self._supports_prefill_points() and mode in ("prefill", "agg"):
+        if self._explicit_points is not None:
+            self._build_explicit_grid(
+                self._explicit_points,
+                prefill_enabled=prefill_enabled,
+                decode_enabled=decode_enabled,
+            )
+        else:
+            if prefill_enabled:
                 self._build_prefill_grid()
-            else:
-                logger.warning(
-                    "Skipping decode self-benchmark grid on disaggregated prefill worker"
-                )
-            logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
-            return
-
-        if disaggregation_mode == DisaggregationMode.DECODE:
-            if self._supports_decode_points() and mode in ("decode", "agg"):
+            if decode_enabled:
                 self._build_decode_grid()
-            else:
-                logger.warning(
-                    "Skipping prefill self-benchmark grid on disaggregated decode worker"
-                )
-            logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
-            return
 
-        if mode in ("prefill", "agg"):
-            self._build_prefill_grid()
-        if mode in ("decode", "agg"):
-            self._build_decode_grid()
-        logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
+        for benchmark_id, point in enumerate(self._grid, start=1):
+            point.benchmark_id = benchmark_id
+        payload = json.dumps(
+            [asdict(point) for point in self._grid],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        self._grid_digest = hashlib.sha256(payload).hexdigest()
+        logger.info(
+            "Self-benchmark grid: %d point(s), digest=%s",
+            len(self._grid),
+            self._grid_digest,
+        )
+
+    def _build_explicit_grid(
+        self,
+        points: BenchmarkPoints,
+        *,
+        prefill_enabled: bool,
+        decode_enabled: bool,
+    ) -> None:
+        if prefill_enabled:
+            self._grid.extend(
+                self._materialize_prefill_candidate(candidate, f"prefill[{index}]")
+                for index, candidate in enumerate(points.prefill)
+            )
+        if decode_enabled:
+            self._grid.extend(
+                self._materialize_decode_candidate(candidate, f"decode[{index}]")
+                for index, candidate in enumerate(points.decode)
+            )
+
+    def _materialize_prefill_candidate(
+        self, candidate: PrefillPointCandidate, path: str
+    ) -> BenchmarkPoint:
+        point = self._prefill_point(
+            candidate.total_prefill_tokens,
+            candidate.total_kv_read_tokens,
+            candidate.batch_size,
+            sample_reasons=["explicit"],
+        )
+        if not self._prefill_point_feasible(point):
+            self._raise_explicit_infeasible(path, candidate)
+        return point
+
+    def _materialize_decode_candidate(
+        self, candidate: DecodePointCandidate, path: str
+    ) -> BenchmarkPoint:
+        point = self._decode_point(
+            candidate.total_kv_read_tokens,
+            candidate.batch_size,
+            sample_reasons=["explicit"],
+        )
+        if not self._decode_point_feasible(point):
+            self._raise_explicit_infeasible(path, candidate)
+        return point
+
+    def _raise_explicit_infeasible(self, path: str, candidate: object) -> None:
+        raise ValueError(
+            f"{path}: explicit benchmark point is infeasible: "
+            f"point={candidate.model_dump()} limits={self._benchmark_limits()}"
+        )
 
     def _supports_prefill_points(self) -> bool:
         return self.scheduler.disaggregation_mode != DisaggregationMode.DECODE
@@ -403,61 +642,334 @@ class SelfBenchmark:
         return self.scheduler.disaggregation_mode != DisaggregationMode.PREFILL
 
     def _build_prefill_grid(self) -> None:
-        n = max(1, self.config.prefill_isl_granularity)
-        max_isl = self._max_prefill_isl()
-        if max_isl < 1:
-            return
-        min_isl = min(10, max_isl)
-        for isl in np.unique(np.linspace(min_isl, max_isl, n, dtype=int)):
-            isl = int(isl)
-            for kv_read_tokens in self._prefill_kv_read_points(isl):
-                self._grid.append(
-                    BenchmarkPoint(
-                        point_type="prefill",
-                        isl=isl,
-                        kv_read_tokens=kv_read_tokens,
+        max_tokens = self._max_generated_prefill_tokens()
+        capture_sizes = self._prefill_capture_sizes()
+        totals = _limit_cudagraph_axis(
+            _cudagraph_axis_points(capture_sizes, max_tokens),
+            capture_sizes,
+            max(2, self.config.prefill_isl_granularity),
+        )
+        points: list[BenchmarkPoint] = []
+        for total_prefill_tokens in totals:
+            for batch_size in self._prefill_batch_sizes(total_prefill_tokens):
+                for total_kv_read_tokens in self._prefill_kv_read_points(
+                    total_prefill_tokens, batch_size
+                ):
+                    point = self._prefill_point(
+                        total_prefill_tokens,
+                        total_kv_read_tokens,
+                        batch_size,
                     )
-                )
+                    if self._prefill_point_feasible(point):
+                        points.append(point)
+        self._grid.extend(
+            sorted(
+                points,
+                key=lambda point: (
+                    point.total_prefill_tokens,
+                    point.batch_size,
+                    point.total_kv_read_tokens,
+                ),
+                reverse=True,
+            )
+        )
 
-    def _prefill_kv_read_points(self, isl: int) -> list[int]:
-        n = max(1, self.config.prefill_kv_read_granularity)
-        if n == 1:
-            return [0]
-        max_kv_read_tokens = self._align_prefill_kv_read_tokens(isl - 1)
-        if max_kv_read_tokens < 1:
-            return [0]
-        raw_points = np.unique(np.linspace(0, max_kv_read_tokens, n, dtype=int))
-        points = {
-            self._align_prefill_kv_read_tokens(int(kv_read_tokens))
-            for kv_read_tokens in raw_points
-        }
-        return sorted(points)
+    def _prefill_point(
+        self,
+        total_prefill_tokens: int,
+        total_kv_read_tokens: int,
+        batch_size: int,
+        *,
+        sample_reasons: Optional[list[str]] = None,
+    ) -> BenchmarkPoint:
+        capture_size, padding_tokens, reasons = self._cudagraph_metadata(
+            total_prefill_tokens,
+            self._prefill_capture_sizes(),
+            self._max_generated_prefill_tokens(),
+        )
+        return BenchmarkPoint(
+            point_type="prefill",
+            total_prefill_tokens=total_prefill_tokens,
+            total_kv_read_tokens=total_kv_read_tokens,
+            batch_size=batch_size,
+            expected_cudagraph_mode=(
+                self._prefill_cudagraph_mode() if capture_size is not None else "NONE"
+            ),
+            expected_capture_size=capture_size,
+            padding_tokens=padding_tokens,
+            sample_reasons=[*(sample_reasons or []), *reasons],
+        )
 
-    def _align_prefill_kv_read_tokens(self, kv_read_tokens: int) -> int:
+    def _prefill_batch_sizes(self, total_prefill_tokens: int) -> list[int]:
+        upper_bound = min(
+            total_prefill_tokens,
+            self._available_req_slots(),
+            max(1, getattr(self.scheduler, "max_running_requests", 1)),
+        )
+        legal = [
+            batch_size
+            for batch_size in range(1, upper_bound + 1)
+            if self._prefill_point_feasible(
+                self._prefill_point(total_prefill_tokens, 0, batch_size)
+            )
+        ]
+        if not legal:
+            return []
+        maximum = legal[-1]
+        presets = _powers_of_two_up_to(maximum) + [maximum]
+        return sorted(set(presets))[: self.config.prefill_batch_size_granularity]
+
+    def _prefill_kv_read_points(
+        self, total_prefill_tokens: int, batch_size: int
+    ) -> list[int]:
+        if self.config.prefill_kv_read_granularity == 1:
+            return [0]
         page_size = max(1, self.scheduler.page_size)
-        kv_read_tokens = max(0, kv_read_tokens)
-        return kv_read_tokens // page_size * page_size
+        max_total = self._max_prefill_kv_read_tokens(total_prefill_tokens, batch_size)
+        max_blocks = max_total // page_size
+        if max_blocks < batch_size:
+            return [0]
+        block_totals = [batch_size]
+        block_totals.extend(
+            value for value in _powers_of_two_up_to(max_blocks) if value >= batch_size
+        )
+        block_totals.append(max_blocks)
+        candidates = [0, *(value * page_size for value in sorted(set(block_totals)))]
+        return _uniformly_limit_axis(
+            candidates,
+            max(2, self.config.prefill_kv_read_granularity),
+        )
+
+    def _max_prefill_kv_read_tokens(
+        self, total_prefill_tokens: int, batch_size: int
+    ) -> int:
+        page_size = max(1, self.scheduler.page_size)
+        high = max(0, self._available_kv_tokens() // page_size)
+        low = batch_size
+        best = 0
+        while low <= high:
+            mid = (low + high) // 2
+            point = self._prefill_point(
+                total_prefill_tokens, mid * page_size, batch_size
+            )
+            if self._prefill_point_feasible(point):
+                best = mid * page_size
+                low = mid + 1
+            else:
+                high = mid - 1
+        return best
+
+    def _prefill_lengths(
+        self, point: BenchmarkPoint
+    ) -> tuple[list[int], list[int], list[int]]:
+        new_lengths = _balanced_partition(
+            point.total_prefill_tokens,
+            point.batch_size,
+            minimum_units=1,
+        )
+        if point.total_kv_read_tokens == 0:
+            kv_lengths = [0] * point.batch_size
+        else:
+            kv_lengths = _balanced_partition(
+                point.total_kv_read_tokens,
+                point.batch_size,
+                unit=max(1, self.scheduler.page_size),
+                minimum_units=1,
+            )
+        prompt_lengths = [
+            new_tokens + kv_tokens
+            for new_tokens, kv_tokens in zip(new_lengths, kv_lengths)
+        ]
+        return new_lengths, kv_lengths, prompt_lengths
+
+    def _prefill_point_feasible(self, point: BenchmarkPoint) -> bool:
+        if (
+            point.total_prefill_tokens < point.batch_size
+            or point.total_prefill_tokens > self._max_prefill_forward_tokens()
+            or point.batch_size < 1
+            or point.batch_size > self._available_req_slots()
+            or point.batch_size > getattr(self.scheduler, "max_running_requests", 1)
+        ):
+            return False
+        try:
+            new_lengths, kv_lengths, prompt_lengths = self._prefill_lengths(point)
+        except ValueError:
+            return False
+        chunk_size = getattr(self.scheduler.server_args, "chunked_prefill_size", None)
+        if chunk_size is not None and chunk_size > 0:
+            if any(length > chunk_size for length in new_lengths):
+                return False
+        if any(
+            prompt_len > self._max_valid_input_len() for prompt_len in prompt_lengths
+        ):
+            return False
+        page_size = max(1, self.scheduler.page_size)
+        required = sum(
+            ((prompt_len + 1 + page_size - 1) // page_size) * page_size
+            for prompt_len in prompt_lengths
+        )
+        seed_required = sum(
+            ((kv_len + page_size - 1) // page_size) * page_size for kv_len in kv_lengths
+        )
+        return max(required, seed_required) <= self._available_kv_tokens()
 
     def _build_decode_grid(self) -> None:
-        n_len = max(1, self.config.decode_length_granularity)
-        n_bs = max(1, self.config.decode_batch_size_granularity)
-        max_ctx = self._max_decode_context_len()
-        if max_ctx < 1:
+        max_batch_size = self._max_feasible_decode_batch_size()
+        if max_batch_size < 1:
             return
-        ctx_lens = np.unique(np.linspace(1, max_ctx, n_len, dtype=int))
-        for ctx_len_raw in ctx_lens:
-            ctx_len = int(ctx_len_raw)
-            max_bs = self._max_batch_size_for_context(ctx_len)
-            if max_bs < 1:
+        capture_sizes = self._decode_capture_sizes()
+        batch_sizes = _limit_cudagraph_axis(
+            _cudagraph_axis_points(capture_sizes, max_batch_size),
+            capture_sizes,
+            max(2, self.config.decode_batch_size_granularity),
+        )
+        for batch_size in batch_sizes:
+            max_total = self._max_decode_kv_read_tokens(batch_size)
+            minimum_total = batch_size * 2
+            if max_total < minimum_total:
                 continue
-            for bs in np.unique(np.linspace(1, max_bs, n_bs, dtype=int)):
-                self._grid.append(
-                    BenchmarkPoint(
-                        point_type="decode",
-                        context_length=ctx_len,
-                        batch_size=int(bs),
-                    )
-                )
+            totals = [minimum_total]
+            totals.extend(
+                value
+                for value in _powers_of_two_up_to(max_total)
+                if value >= minimum_total
+            )
+            totals.append(max_total)
+            for total_kv_read_tokens in _uniformly_limit_axis(
+                sorted(set(totals)),
+                max(2, self.config.decode_length_granularity),
+            ):
+                point = self._decode_point(total_kv_read_tokens, batch_size)
+                if self._decode_point_feasible(point):
+                    self._grid.append(point)
+
+    def _decode_point(
+        self,
+        total_kv_read_tokens: int,
+        batch_size: int,
+        *,
+        sample_reasons: Optional[list[str]] = None,
+    ) -> BenchmarkPoint:
+        capture_size, padding_tokens, reasons = self._cudagraph_metadata(
+            batch_size,
+            self._decode_capture_sizes(),
+            self._max_feasible_decode_batch_size(),
+        )
+        return BenchmarkPoint(
+            point_type="decode",
+            total_kv_read_tokens=total_kv_read_tokens,
+            batch_size=batch_size,
+            expected_cudagraph_mode=(
+                self._decode_cudagraph_mode() if capture_size is not None else "NONE"
+            ),
+            expected_capture_size=capture_size,
+            padding_tokens=padding_tokens,
+            sample_reasons=[*(sample_reasons or []), *reasons],
+        )
+
+    def _decode_context_lengths(self, point: BenchmarkPoint) -> list[int]:
+        # SGLang's decode FPM includes the current decode input token in each
+        # request's KV-read length. Preload one fewer token per request so the
+        # measured sum equals the canonical total_kv_read_tokens coordinate.
+        measured_lengths = _balanced_partition(
+            point.total_kv_read_tokens,
+            point.batch_size,
+            minimum_units=2,
+        )
+        return [length - 1 for length in measured_lengths]
+
+    def _decode_point_feasible(self, point: BenchmarkPoint) -> bool:
+        if (
+            point.batch_size < 1
+            or point.batch_size > self._available_req_slots()
+            or point.batch_size > getattr(self.scheduler, "max_running_requests", 1)
+            or point.batch_size > self._max_decode_forward_batch_size()
+        ):
+            return False
+        try:
+            context_lengths = self._decode_context_lengths(point)
+        except ValueError:
+            return False
+        if any(
+            context_length > self._max_decode_context_len()
+            for context_length in context_lengths
+        ):
+            return False
+        page_size = max(1, self.scheduler.page_size)
+        required = sum(
+            ((context_length + 1 + page_size - 1) // page_size) * page_size
+            for context_length in context_lengths
+        )
+        return required <= self._available_kv_tokens()
+
+    def _max_decode_kv_read_tokens(self, batch_size: int) -> int:
+        low = batch_size * 2
+        high = batch_size * (self._max_decode_context_len() + 1)
+        best = 0
+        while low <= high:
+            mid = (low + high) // 2
+            if self._decode_point_feasible(self._decode_point(mid, batch_size)):
+                best = mid
+                low = mid + 1
+            else:
+                high = mid - 1
+        return best
+
+    def _available_req_slots(self) -> int:
+        pool = getattr(self.scheduler, "req_to_token_pool", None)
+        available = getattr(pool, "available_size", None)
+        if callable(available):
+            return max(0, int(available()))
+        return max(1, getattr(self.scheduler, "max_running_requests", 1))
+
+    def _available_kv_tokens(self) -> int:
+        allocator = getattr(self.scheduler, "token_to_kv_pool_allocator", None)
+        available = getattr(allocator, "available_size", None)
+        if callable(available):
+            return max(0, int(available()))
+        return max(0, getattr(self.scheduler, "max_total_num_tokens", 0))
+
+    def _prefill_capture_sizes(self) -> list[int]:
+        config = getattr(self.scheduler.server_args.cuda_graph_config, "prefill", None)
+        return list(getattr(config, "bs", None) or [])
+
+    def _decode_capture_sizes(self) -> list[int]:
+        config = self.scheduler.server_args.cuda_graph_config.decode
+        return list(getattr(config, "bs", None) or [])
+
+    def _prefill_cudagraph_mode(self) -> str:
+        config = getattr(self.scheduler.server_args.cuda_graph_config, "prefill", None)
+        backend = getattr(config, "backend", None)
+        return str(getattr(backend, "value", backend) or "NONE").upper()
+
+    def _decode_cudagraph_mode(self) -> str:
+        config = self.scheduler.server_args.cuda_graph_config.decode
+        backend = getattr(config, "backend", None)
+        return str(getattr(backend, "value", backend) or "FULL").upper()
+
+    @staticmethod
+    def _cudagraph_metadata(
+        num_tokens: int, capture_sizes: Sequence[int], axis_limit: int
+    ) -> tuple[Optional[int], Optional[int], list[str]]:
+        captures = sorted({int(size) for size in capture_sizes if int(size) > 0})
+        capture_size = next((size for size in captures if size >= num_tokens), None)
+        reasons: list[str] = []
+        if num_tokens in captures:
+            reasons.append("capture")
+        if num_tokens > 1 and num_tokens - 1 in captures:
+            reasons.append("post_capture")
+        if not captures:
+            reasons.append("cudagraph_disabled")
+            if num_tokens != axis_limit:
+                reasons.append("geometric_axis")
+        elif num_tokens > captures[-1]:
+            reasons.append("eager_tail")
+            if num_tokens != axis_limit:
+                reasons.append("geometric_tail")
+        if num_tokens == axis_limit:
+            reasons.append("engine_limit")
+        padding_tokens = capture_size - num_tokens if capture_size is not None else None
+        return capture_size, padding_tokens, reasons
 
     def _max_prefill_isl(self) -> int:
         return max(
@@ -478,6 +990,47 @@ class SelfBenchmark:
         # headroom. Keep optional startup benchmarking within the scheduler's
         # normal prefill-forward token budget.
         return max(0, getattr(self.scheduler, "max_prefill_tokens", 0))
+
+    def _max_generated_prefill_tokens(self) -> int:
+        """Return the largest schedulable generated-grid prefill total.
+
+        The forward-token ceiling can be larger than any legal request shape,
+        for example when the per-request input limit is smaller than an even
+        partition of that ceiling. Keep the generated axis endpoint feasible so
+        limiting the axis never discards every large prefill sample.
+        """
+        if self._max_generated_prefill_tokens_cache is not None:
+            return self._max_generated_prefill_tokens_cache
+
+        upper_bound = min(
+            self._max_prefill_forward_tokens(),
+            self._available_req_slots() * self._max_valid_input_len(),
+            max(1, getattr(self.scheduler, "max_running_requests", 1))
+            * self._max_valid_input_len(),
+            max(0, self._available_kv_tokens() - max(1, self.scheduler.page_size)),
+        )
+        maximum = 0
+        for total_prefill_tokens in range(upper_bound, 0, -1):
+            max_batch_size = min(
+                total_prefill_tokens,
+                self._available_req_slots(),
+                max(1, getattr(self.scheduler, "max_running_requests", 1)),
+            )
+            for batch_size in range(1, max_batch_size + 1):
+                candidate = BenchmarkPoint(
+                    point_type="prefill",
+                    total_prefill_tokens=total_prefill_tokens,
+                    total_kv_read_tokens=0,
+                    batch_size=batch_size,
+                )
+                if self._prefill_point_feasible(candidate):
+                    maximum = total_prefill_tokens
+                    break
+            if maximum:
+                break
+
+        self._max_generated_prefill_tokens_cache = maximum
+        return maximum
 
     def _max_decode_context_len(self) -> int:
         page_size = max(1, self.scheduler.page_size)
@@ -501,6 +1054,28 @@ class SelfBenchmark:
         tokens_per_req = paged_context + page_size
         token_capped = max(1, max_tokens // max(1, tokens_per_req))
         return min(max_running, token_capped, self._max_decode_forward_batch_size())
+
+    def _max_feasible_decode_batch_size(self) -> int:
+        if self._max_feasible_decode_batch_size_cache is not None:
+            return self._max_feasible_decode_batch_size_cache
+
+        upper_bound = min(
+            self._available_req_slots(),
+            max(1, getattr(self.scheduler, "max_running_requests", 1)),
+            self._max_decode_forward_batch_size(),
+        )
+        maximum = 0
+        for batch_size in range(upper_bound, 0, -1):
+            candidate = BenchmarkPoint(
+                point_type="decode",
+                total_kv_read_tokens=batch_size * 2,
+                batch_size=batch_size,
+            )
+            if self._decode_point_feasible(candidate):
+                maximum = batch_size
+                break
+        self._max_feasible_decode_batch_size_cache = maximum
+        return maximum
 
     def _max_decode_forward_batch_size(self) -> int:
         """Return the configured decode-forward batch ceiling.
@@ -540,50 +1115,52 @@ class SelfBenchmark:
         )
 
     def _inject_prefill(
-        self, point: BenchmarkPoint, extra_key: Optional[str] = None
+        self, point: BenchmarkPoint, extra_keys: Optional[Sequence[str]] = None
     ) -> int:
-        # Chunked prefill requests need a decode step to reach the normal request
-        # finished/release path. The benchmark still records only prefill FPMs.
+        _, _, prompt_lengths = self._prefill_lengths(point)
         return self._inject_requests(
-            prompt_len=point.isl,
+            prompt_lens=prompt_lengths,
             max_tokens=1,
-            n=1,
-            extra_key=extra_key,
+            extra_keys=extra_keys,
             track_active=True,
         )
 
     def _inject_prefill_seed(self, point: BenchmarkPoint) -> int:
-        if point.kv_read_tokens <= 0:
+        if point.total_kv_read_tokens <= 0:
             return 0
-        extra_key = self._seed_extra_key()
+        _, kv_lengths, _ = self._prefill_lengths(point)
+        extra_keys = [self._seed_extra_key(index) for index in range(point.batch_size)]
         injected = self._inject_requests(
-            prompt_len=point.kv_read_tokens,
+            prompt_lens=kv_lengths,
             max_tokens=0,
-            n=1,
-            extra_key=extra_key,
+            extra_keys=extra_keys,
             track_active=False,
         )
-        if injected == 0:
+        if injected != point.batch_size:
             return 0
         self._pending_seed_point = point
-        self._pending_seed_extra_key = extra_key
+        self._pending_seed_extra_keys = extra_keys
         return injected
 
     def _inject_pending_seeded_prefill(self) -> None:
         point = self._pending_seed_point
-        extra_key = self._pending_seed_extra_key
+        extra_keys = self._pending_seed_extra_keys
         self._pending_seed_point = None
-        self._pending_seed_extra_key = None
-        if point is None or extra_key is None:
+        self._pending_seed_extra_keys = None
+        if point is None or extra_keys is None:
             return
 
-        actual_kv_read_tokens = self._cached_kv_read_tokens_for_point(point, extra_key)
-        if actual_kv_read_tokens != point.kv_read_tokens:
+        _, kv_lengths, prompt_lengths = self._prefill_lengths(point)
+        actual_kv_read_tokens = [
+            self._cached_kv_read_tokens(prompt_len, extra_key)
+            for prompt_len, extra_key in zip(prompt_lengths, extra_keys)
+        ]
+        if actual_kv_read_tokens != kv_lengths:
             logger.warning(
                 "Skipping benchmark point after seed cache validation failed: "
-                "point=%s expected_kv_read_tokens=%d actual_kv_read_tokens=%d",
+                "point=%s expected_kv_read_tokens=%s actual_kv_read_tokens=%s",
                 point,
-                point.kv_read_tokens,
+                kv_lengths,
                 actual_kv_read_tokens,
             )
             self._skip_grid_point(point, "seed_cache_validation_failed")
@@ -591,34 +1168,47 @@ class SelfBenchmark:
 
         self._current = BenchmarkPointResult(point=point)
         self._active_reqs = []
-        injected = self._inject_prefill(point=point, extra_key=extra_key)
-        if injected == 0:
+        injected = self._inject_prefill(point=point, extra_keys=extra_keys)
+        if injected != point.batch_size:
             logger.warning("Skipping benchmark point with no valid requests: %s", point)
             self._skip_grid_point(point, "request_injection_failed")
 
-    def _inject_synthetic_decode(self, context_length: int, batch_size: int) -> int:
+    def _inject_synthetic_decode(
+        self,
+        context_length: Optional[int] = None,
+        batch_size: Optional[int] = None,
+        *,
+        context_lengths: Optional[Sequence[int]] = None,
+    ) -> int:
         if not self._synthetic_decode_supported():
             return 0
 
-        max_context = self._max_decode_context_len()
-        if max_context < 1:
-            return 0
-        context_length = max(1, min(context_length, max_context))
-        batch_size = max(1, batch_size)
-
-        if not self.scheduler.running_batch.is_empty():
+        if context_lengths is None:
+            if context_length is None or batch_size is None:
+                raise ValueError("decode injection requires context lengths")
+            max_context = self._max_decode_context_len()
+            if max_context < 1:
+                return 0
+            context_lengths = [max(1, min(context_length, max_context))] * max(
+                1, batch_size
+            )
+        else:
+            context_lengths = list(context_lengths)
+        if not context_lengths or not self.scheduler.running_batch.is_empty():
             return 0
 
         reqs = []
-        for _ in range(batch_size):
-            req = self._new_synthetic_req(prompt_len=context_length, max_tokens=2)
+        for request_context_length in context_lengths:
+            req = self._new_synthetic_req(
+                prompt_len=request_context_length, max_tokens=2
+            )
             self.scheduler.init_req_max_new_tokens(req)
             if req.sampling_params.max_new_tokens < 2:
                 logger.warning(
                     "Skipping decode benchmark request after max_new_tokens clamp: "
                     "rid=%s context_length=%d max_new_tokens=%d",
                     req.rid,
-                    context_length,
+                    request_context_length,
                     req.sampling_params.max_new_tokens,
                 )
                 continue
@@ -631,24 +1221,22 @@ class SelfBenchmark:
                 logger.warning("Skipping invalid benchmark request: %s", error_msg)
                 continue
             req.skip_radix_cache_insert = True
-            # Model the normal post-prefill boundary: prefill has produced one
-            # output token, but decode has not yet allocated KV for that token.
             req.output_ids.append(SELF_BENCHMARK_DUMMY_TOKEN_ID)
             req.fill_ids = req.origin_input_ids + req.output_ids
-            req.kv_committed_len = context_length
-            req.kv_allocated_len = context_length
-            req.already_computed = context_length
+            req.kv_committed_len = request_context_length
+            req.kv = ReqKvInfo(
+                kv_allocated_len=request_context_length,
+                swa_evicted_seqlen=0,
+            )
+            req.already_computed = request_context_length
             reqs.append(req)
 
-        if not reqs:
+        if len(reqs) != len(context_lengths):
             return 0
 
         try:
-            batch = self._decode_batch_builder.build(reqs, context_length)
+            batch = self._decode_batch_builder.build(reqs, context_lengths)
         except Exception:
-            # A rank-local skip would let successful peers publish running_batch
-            # and enter model collectives alone. Clean up what we can, then let the
-            # scheduler wrapper fail startup and tear down every rank.
             try:
                 self._decode_batch_builder.cleanup(reqs)
             except Exception:
@@ -661,22 +1249,37 @@ class SelfBenchmark:
 
     def _inject_requests(
         self,
-        prompt_len: int,
-        max_tokens: int,
-        n: int,
-        extra_key: Optional[str] = None,
+        prompt_lens: Optional[Sequence[int]] = None,
+        max_tokens: int = 0,
+        extra_keys: Optional[Sequence[str]] = None,
         track_active: bool = True,
+        *,
+        prompt_len: Optional[int] = None,
+        n: Optional[int] = None,
+        extra_key: Optional[str] = None,
     ) -> int:
+        # Keep the scalar form for callers/tests from the first implementation.
+        if prompt_lens is None:
+            if prompt_len is None:
+                raise ValueError("prompt_lens is required")
+            prompt_lens = [prompt_len] * (n or 1)
+        prompt_lens = list(prompt_lens)
+        if extra_keys is None and extra_key is not None:
+            extra_keys = [extra_key] * len(prompt_lens)
+        if extra_keys is not None and len(extra_keys) != len(prompt_lens):
+            raise ValueError("extra_keys must match prompt_lens")
+
         max_prompt_len = self._max_valid_input_len()
         if max_prompt_len < 1:
             return 0
-        prompt_len = max(1, min(prompt_len, max_prompt_len))
-        injected = 0
-        for _ in range(n):
+        requests: list[Req] = []
+        for index, requested_prompt_len in enumerate(prompt_lens):
+            if requested_prompt_len < 1 or requested_prompt_len > max_prompt_len:
+                return 0
             req = self._new_synthetic_req(
-                prompt_len=prompt_len,
+                prompt_len=requested_prompt_len,
                 max_tokens=max_tokens,
-                extra_key=extra_key,
+                extra_key=extra_keys[index] if extra_keys is not None else None,
             )
             self.scheduler.init_req_max_new_tokens(req)
             if max_tokens > 0 and req.sampling_params.max_new_tokens < max_tokens:
@@ -687,7 +1290,7 @@ class SelfBenchmark:
                     max_tokens,
                     req.sampling_params.max_new_tokens,
                 )
-                continue
+                return 0
             error_msg = validate_input_length(
                 req,
                 self.scheduler.max_req_input_len,
@@ -695,17 +1298,15 @@ class SelfBenchmark:
             )
             if error_msg:
                 logger.warning("Skipping invalid benchmark request: %s", error_msg)
-                continue
-            # Synthetic requests use FAKE_BOOTSTRAP_HOST to avoid real disagg
-            # transfer, which makes Req default to skipping cache insert. Chunked
-            # prefill still needs unfinished-request cache bookkeeping so that
-            # prefix_indices advance between chunks.
+                return 0
             req.skip_radix_cache_insert = False
+            requests.append(req)
+
+        for req in requests:
             self.scheduler._add_request_to_queue(req)
-            if track_active:
-                self._active_reqs.append(req)
-            injected += 1
-        return injected
+        if track_active:
+            self._active_reqs.extend(requests)
+        return len(requests)
 
     def _new_synthetic_req(
         self, prompt_len: int, max_tokens: int, extra_key: Optional[str] = None
@@ -743,27 +1344,26 @@ class SelfBenchmark:
         req.suppress_output = True
         return req
 
-    def _cached_kv_read_tokens_for_point(
-        self, point: BenchmarkPoint, extra_key: str
-    ) -> int:
+    def _cached_kv_read_tokens(self, prompt_len: int, extra_key: str) -> int:
         if envs.SGLANG_RADIX_FORCE_MISS.get():
             return 0
         if getattr(self.scheduler.tree_cache, "disable", True):
             return 0
-        token_ids = array("q", [SELF_BENCHMARK_DUMMY_TOKEN_ID] * point.isl)
-        max_prefix_len = max(point.isl - 1, 0)
+        token_ids = array("q", [SELF_BENCHMARK_DUMMY_TOKEN_ID] * prompt_len)
         match_result = self.scheduler.tree_cache.match_prefix(
             MatchPrefixParams(
                 key=RadixKey(
-                    token_ids=token_ids[:max_prefix_len],
+                    token_ids=token_ids[: max(prompt_len - 1, 0)],
                     extra_key=extra_key,
                 )
             )
         )
         return len(match_result.device_indices)
 
-    def _seed_extra_key(self) -> str:
-        return f"{SELF_BENCHMARK_REQ_PREFIX}kv_seed_{self._grid_index}"
+    def _seed_extra_key(self, request_index: int = 0) -> str:
+        return (
+            f"{SELF_BENCHMARK_REQ_PREFIX}kv_seed_" f"{self._grid_index}_{request_index}"
+        )
 
     def _synthetic_decode_supported(self) -> bool:
         if not self.scheduler.is_generation:
@@ -866,34 +1466,39 @@ class SelfBenchmark:
         if hasattr(self.scheduler, "enable_fpm"):
             self.scheduler.enable_fpm = self._restore_enable_fpm
 
+    def _benchmark_limits(self) -> dict:
+        return {
+            "max_num_scheduled_tokens": getattr(
+                self.scheduler, "max_prefill_tokens", None
+            ),
+            "max_num_running_reqs": getattr(
+                self.scheduler, "max_running_requests", None
+            ),
+            "max_model_len": getattr(self.scheduler, "max_req_len", None),
+            "block_size": getattr(self.scheduler, "page_size", None),
+            "kv_capacity_tokens": getattr(self.scheduler, "max_total_num_tokens", None),
+            "available_kv_tokens": self._available_kv_tokens(),
+            "available_request_slots": self._available_req_slots(),
+            "max_decode_forward_batch_size": (self._max_decode_forward_batch_size()),
+        }
+
     def _write_output(self) -> None:
         expected_points = len(self._grid)
         completed_points = len(self._results)
         skipped_count = len(self._skipped_points)
         output = {
-            "schema_version": 1,
+            "schema_version": 2,
             "scope": "local_diagnostics",
             "status": "complete",
             "valid": completed_points == expected_points and skipped_count == 0,
+            "usable": completed_points > 0 or expected_points == 0,
+            "grid_digest": self._grid_digest,
             "run_id": self._run_id,
             "completed_at_unix": time.time(),
             "identity": self._identity,
             "output_path": self._output_path,
             "config": asdict(self.config),
-            "limits": {
-                "max_num_scheduled_tokens": getattr(
-                    self.scheduler, "max_prefill_tokens", None
-                ),
-                "max_num_running_reqs": getattr(
-                    self.scheduler, "max_running_requests", None
-                ),
-                "max_model_len": getattr(self.scheduler, "max_req_len", None),
-                "block_size": getattr(self.scheduler, "page_size", None),
-                "num_gpu_blocks": getattr(self.scheduler, "max_total_num_tokens", None),
-                "max_decode_forward_batch_size": (
-                    self._max_decode_forward_batch_size()
-                ),
-            },
+            "limits": self._benchmark_limits(),
             "coverage": {
                 "expected_points": expected_points,
                 "completed_points": completed_points,

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark_decode.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark_decode.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.managers.overlap_utils import RelayPayload
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.mem_cache.common import alloc_for_extend, release_kv_cache
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.scheduler import Scheduler
+
+
+class SyntheticDecodeBatchBuilder:
+    """Build and clean up decode-ready batches for the self-benchmark."""
+
+    def __init__(self, scheduler: Scheduler):
+        self.scheduler = scheduler
+
+    def build(self, reqs: list[Req], context_length: int) -> ScheduleBatch:
+        batch = ScheduleBatch.init_new(
+            reqs=reqs,
+            req_to_token_pool=self.scheduler.req_to_token_pool,
+            token_to_kv_pool_allocator=self.scheduler.token_to_kv_pool_allocator,
+            tree_cache=self.scheduler.tree_cache,
+            model_config=self.scheduler.model_config,
+            enable_overlap=self.scheduler.enable_overlap,
+            spec_algorithm=self.scheduler.spec_algorithm,
+            dllm_config=self.scheduler.dllm_config,
+        )
+        if getattr(self.scheduler, "enable_hisparse", False):
+            batch.hisparse_coordinator = self.scheduler.hisparse_coordinator
+
+        self._place_context_cache(batch, context_length)
+        batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
+            batch, self.scheduler.model_config.vocab_size
+        )
+
+        prefill_output_tokens = torch.tensor(
+            [req.output_ids[-1] for req in reqs],
+            dtype=torch.int64,
+            device=batch.device,
+        )
+        self.scheduler.future_map.stash(
+            batch.req_pool_indices,
+            RelayPayload(bonus_tokens=prefill_output_tokens),
+        )
+        batch.input_ids = None
+        return batch
+
+    def _place_context_cache(self, batch: ScheduleBatch, context_length: int) -> None:
+        """Allocate synthetic context through the scheduler's canonical path."""
+        batch_size = len(batch.reqs)
+        total_context_tokens = context_length * batch_size
+        batch.forward_mode = ForwardMode.EXTEND
+        batch.prefix_lens = [0] * batch_size
+        batch.extend_lens = [context_length] * batch_size
+        batch.extend_num_tokens = total_context_tokens
+        root_node = getattr(batch.tree_cache, "root_node", None)
+        if root_node is not None:
+            for req in batch.reqs:
+                req.last_node = root_node
+                req.last_host_node = root_node
+                req.best_match_node = root_node
+        batch.seq_lens_cpu = torch.full(
+            (batch_size,), context_length, dtype=torch.int64
+        )
+        batch.seq_lens = batch.seq_lens_cpu.to(batch.device, non_blocking=True)
+        batch.orig_seq_lens = torch.full(
+            (batch_size,), context_length, dtype=torch.int32, device=batch.device
+        )
+        batch.seq_lens_sum = total_context_tokens
+        (
+            batch.out_cache_loc,
+            batch.req_pool_indices,
+            batch.req_pool_indices_cpu,
+        ) = alloc_for_extend(batch)
+
+        for req in batch.reqs:
+            req.synthetic_benchmark_kv_placed = True
+
+    def cleanup(self, reqs: list[Req]) -> None:
+        for req in reqs:
+            if getattr(req, "synthetic_benchmark_kv_placed", False):
+                release_kv_cache(req, self.scheduler.tree_cache, is_insert=False)
+            elif req.req_pool_idx is not None:
+                self.scheduler.req_to_token_pool.free(req)

--- a/python/sglang/srt/managers/scheduler_components/self_benchmark_decode.py
+++ b/python/sglang/srt/managers/scheduler_components/self_benchmark_decode.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 import torch
 
 from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
-from sglang.srt.mem_cache.common import alloc_for_extend, release_kv_cache
+from sglang.srt.mem_cache.allocation import alloc_for_extend
+from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 
@@ -20,7 +21,19 @@ class SyntheticDecodeBatchBuilder:
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
 
-    def build(self, reqs: list[Req], context_length: int) -> ScheduleBatch:
+    def build(
+        self,
+        reqs: list[Req],
+        context_lengths: int | Sequence[int] | None = None,
+        *,
+        context_length: int | None = None,
+    ) -> ScheduleBatch:
+        if context_lengths is None:
+            if context_length is None:
+                raise TypeError("context_lengths is required")
+            context_lengths = context_length
+        elif context_length is not None:
+            raise TypeError("pass only one of context_lengths and context_length")
         batch = ScheduleBatch.init_new(
             reqs=reqs,
             req_to_token_pool=self.scheduler.req_to_token_pool,
@@ -34,7 +47,7 @@ class SyntheticDecodeBatchBuilder:
         if getattr(self.scheduler, "enable_hisparse", False):
             batch.hisparse_coordinator = self.scheduler.hisparse_coordinator
 
-        self._place_context_cache(batch, context_length)
+        self._place_context_cache(batch, context_lengths)
         batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
             batch, self.scheduler.model_config.vocab_size
         )
@@ -51,13 +64,21 @@ class SyntheticDecodeBatchBuilder:
         batch.input_ids = None
         return batch
 
-    def _place_context_cache(self, batch: ScheduleBatch, context_length: int) -> None:
+    def _place_context_cache(
+        self, batch: ScheduleBatch, context_lengths: int | Sequence[int]
+    ) -> None:
         """Allocate synthetic context through the scheduler's canonical path."""
         batch_size = len(batch.reqs)
-        total_context_tokens = context_length * batch_size
+        if isinstance(context_lengths, int):
+            context_lengths = [context_lengths] * batch_size
+        else:
+            context_lengths = list(context_lengths)
+        if len(context_lengths) != batch_size:
+            raise ValueError("context_lengths must match the decode batch size")
+        total_context_tokens = sum(context_lengths)
         batch.forward_mode = ForwardMode.EXTEND
         batch.prefix_lens = [0] * batch_size
-        batch.extend_lens = [context_length] * batch_size
+        batch.extend_lens = list(context_lengths)
         batch.extend_num_tokens = total_context_tokens
         root_node = getattr(batch.tree_cache, "root_node", None)
         if root_node is not None:
@@ -65,12 +86,10 @@ class SyntheticDecodeBatchBuilder:
                 req.last_node = root_node
                 req.last_host_node = root_node
                 req.best_match_node = root_node
-        batch.seq_lens_cpu = torch.full(
-            (batch_size,), context_length, dtype=torch.int64
-        )
+        batch.seq_lens_cpu = torch.tensor(context_lengths, dtype=torch.int64)
         batch.seq_lens = batch.seq_lens_cpu.to(batch.device, non_blocking=True)
-        batch.orig_seq_lens = torch.full(
-            (batch_size,), context_length, dtype=torch.int32, device=batch.device
+        batch.orig_seq_lens = torch.tensor(
+            context_lengths, dtype=torch.int32, device=batch.device
         )
         batch.seq_lens_sum = total_context_tokens
         (

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -234,8 +234,19 @@ class RayEngine(Engine):
         if "log_level" not in kwargs:
             kwargs["log_level"] = "error"
         server_args = ServerArgs(**kwargs)
+        self._validate_self_benchmark_not_enabled(server_args)
         server_args.override("ray.placement_group", placement_group=placement_group)
         super().__init__(server_args=server_args)
+
+    @staticmethod
+    def _validate_self_benchmark_not_enabled(server_args: ServerArgs) -> None:
+        if server_args.benchmark_mode is None:
+            return
+        # Ray calls SchedulerActor.get_info() before run_event_loop(), while
+        # self-benchmarking is driven by the event loop. Keep readiness
+        # launcher-owned by rejecting Ray until it has an explicit benchmark
+        # completion wait path.
+        raise ValueError("--benchmark-mode is not supported with RayEngine")
 
     def shutdown(self):
         """Shutdown the engine — kill Ray scheduler actors then local processes."""
@@ -259,6 +270,8 @@ class RayEngine(Engine):
             Tuple of (RaySchedulerInitResult, None).
             scheduler_procs is None since Ray uses actors instead of mp.Process.
         """
+        cls._validate_self_benchmark_not_enabled(server_args)
+
         pg = server_args.placement_group or ray.util.get_current_placement_group()
         if pg is None:
             from ray.util.placement_group import (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7888,24 +7888,11 @@ class ServerArgs:
                 "--benchmark-mode requires --enable-forward-pass-metrics so "
                 "ForwardPassMetrics publication is enabled explicitly."
             )
-        # Guard the sweep granularity args: 0/negative would silently
-        # collapse the grid to a single point instead of failing fast.
-        for name in (
-            "benchmark_prefill_granularity",
-            "benchmark_prefill_kv_read_granularity",
-            "benchmark_decode_length_granularity",
-            "benchmark_decode_batch_granularity",
-        ):
-            if getattr(self, name) < 1:
-                raise ValueError(
-                    f"--{name.replace('_', '-')} must be >= 1 when "
-                    "--benchmark-mode is set."
-                )
-        if self.benchmark_warmup_iterations < 0:
-            raise ValueError(
-                "--benchmark-warmup-iterations must be >= 0 when "
-                "--benchmark-mode is set."
-            )
+        from sglang.srt.managers.scheduler_components.self_benchmark import (
+            SelfBenchmark,
+        )
+
+        SelfBenchmark.validate_args(self)
         if self.use_ray:
             # Ray reports scheduler readiness by calling SchedulerActor.get_info()
             # before the scheduler event loop starts. Self-benchmarking currently

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1569,6 +1569,44 @@ class ServerArgs:
     forward_pass_metrics_ipc_name: A[
         Optional[str], Arg(help=argparse.SUPPRESS), NS("observability")
     ] = None
+    benchmark_mode: A[
+        Optional[Literal["prefill", "decode", "agg"]],
+        Arg(
+            help="Run a scheduler-local self-benchmark on startup and write ForwardPassMetrics results to --benchmark-output-path.",
+            choices=["prefill", "decode", "agg"],
+        ),
+        NS("observability"),
+    ] = None
+    benchmark_prefill_granularity: A[
+        int,
+        "Number of ISL sample points for self-benchmark prefill sweep.",
+        NS("observability"),
+    ] = 16
+    benchmark_decode_length_granularity: A[
+        int,
+        "Number of context length sample points for self-benchmark decode sweep.",
+        NS("observability"),
+    ] = 6
+    benchmark_decode_batch_granularity: A[
+        int,
+        "Number of batch size sample points per decode context length.",
+        NS("observability"),
+    ] = 6
+    benchmark_warmup_iterations: A[
+        int,
+        "Number of warmup forward passes before collecting benchmark data.",
+        NS("observability"),
+    ] = 5
+    benchmark_output_path: A[
+        str,
+        "Path to write self-benchmark results JSON.",
+        NS("observability"),
+    ] = "/tmp/benchmark_results.json"
+    benchmark_timeout: A[
+        int,
+        "Timeout in seconds for external callers waiting on benchmark output.",
+        NS("observability"),
+    ] = 300
     enable_trace: A[bool, "Enable opentelemetry trace", NS("observability")] = False
     trace_modules: A[
         str,
@@ -4046,6 +4084,11 @@ class ServerArgs:
             self.random_seed = random.randint(0, 1 << 30)
         if self.mm_process_config is None:
             self.mm_process_config = {}
+
+        # Self-benchmark publishes its results through the forward-pass-metrics
+        # pipeline, so benchmark mode implies the metrics are enabled.
+        if self.benchmark_mode is not None:
+            self.enable_forward_pass_metrics = True
 
         # Handle ModelScope model downloads
         if envs.SGLANG_USE_MODELSCOPE.get():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7888,6 +7888,24 @@ class ServerArgs:
                 "--benchmark-mode requires --enable-forward-pass-metrics so "
                 "ForwardPassMetrics publication is enabled explicitly."
             )
+        # Guard the sweep granularity args: 0/negative would silently
+        # collapse the grid to a single point instead of failing fast.
+        for name in (
+            "benchmark_prefill_granularity",
+            "benchmark_prefill_kv_read_granularity",
+            "benchmark_decode_length_granularity",
+            "benchmark_decode_batch_granularity",
+        ):
+            if getattr(self, name) < 1:
+                raise ValueError(
+                    f"--{name.replace('_', '-')} must be >= 1 when "
+                    "--benchmark-mode is set."
+                )
+        if self.benchmark_warmup_iterations < 0:
+            raise ValueError(
+                "--benchmark-warmup-iterations must be >= 0 when "
+                "--benchmark-mode is set."
+            )
         if self.use_ray:
             # Ray reports scheduler readiness by calling SchedulerActor.get_info()
             # before the scheduler event loop starts. Self-benchmarking currently

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1582,6 +1582,10 @@ class ServerArgs:
         "Number of ISL sample points for self-benchmark prefill sweep.",
         NS("observability"),
     ] = 16
+    benchmark_prefill_kv_read_granularity: A[
+        int,
+        "Number of KV-read sample points per ISL for self-benchmark prefill sweep. The default keeps the existing miss-only sweep.",
+    ] = 1
     benchmark_decode_length_granularity: A[
         int,
         "Number of context length sample points for self-benchmark decode sweep.",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1577,6 +1577,11 @@ class ServerArgs:
         ),
         NS("observability"),
     ] = None
+    benchmark_points_file: A[
+        Optional[str],
+        "JSON file containing explicit pure prefill/decode self-benchmark points. Explicit points replace the generated grid.",
+        NS("observability"),
+    ] = None
     benchmark_prefill_granularity: A[
         int,
         "Number of ISL sample points for self-benchmark prefill sweep.",
@@ -1587,6 +1592,11 @@ class ServerArgs:
         "Number of KV-read sample points per ISL for self-benchmark prefill sweep. The default keeps the existing miss-only sweep.",
         NS("observability"),
     ] = 1
+    benchmark_prefill_batch_granularity: A[
+        int,
+        "Maximum number of generated prefill request-batch-size samples for each token point.",
+        NS("observability"),
+    ] = 3
     benchmark_decode_length_granularity: A[
         int,
         "Number of context length sample points for self-benchmark decode sweep.",
@@ -3445,6 +3455,10 @@ class ServerArgs:
         # _handle_model_specific_adjustments never runs.
         self._resolved_overrides = []
 
+        # Startup self-benchmark flags are model-independent and must also be
+        # validated for dummy model paths used by config/CLI tests.
+        self._handle_self_benchmark_validation()
+
         if self.model_path.lower() in ["none", "dummy"]:
             return
 
@@ -3463,9 +3477,6 @@ class ServerArgs:
             raise ValueError(
                 "--default-chat-template-kwargs must decode to a JSON object"
             )
-
-        # Validate self-benchmark flags.
-        self._handle_self_benchmark_validation()
 
         # Handle deprecated arguments.
         self._handle_deprecated_args()
@@ -7882,6 +7893,8 @@ class ServerArgs:
     def _handle_self_benchmark_validation(self):
         """Validate startup self-benchmark flags."""
         if self.benchmark_mode is None:
+            if self.benchmark_points_file is not None:
+                raise ValueError("--benchmark-points-file requires --benchmark-mode")
             return
         if not self.enable_forward_pass_metrics:
             raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1585,6 +1585,7 @@ class ServerArgs:
     benchmark_prefill_kv_read_granularity: A[
         int,
         "Number of KV-read sample points per ISL for self-benchmark prefill sweep. The default keeps the existing miss-only sweep.",
+        NS("observability"),
     ] = 1
     benchmark_decode_length_granularity: A[
         int,
@@ -1606,11 +1607,6 @@ class ServerArgs:
         "Path to write self-benchmark results JSON.",
         NS("observability"),
     ] = "/tmp/benchmark_results.json"
-    benchmark_timeout: A[
-        int,
-        "Timeout in seconds for external callers waiting on benchmark output.",
-        NS("observability"),
-    ] = 300
     enable_trace: A[bool, "Enable opentelemetry trace", NS("observability")] = False
     trace_modules: A[
         str,
@@ -3468,6 +3464,9 @@ class ServerArgs:
                 "--default-chat-template-kwargs must decode to a JSON object"
             )
 
+        # Validate self-benchmark flags.
+        self._handle_self_benchmark_validation()
+
         # Handle deprecated arguments.
         self._handle_deprecated_args()
 
@@ -4088,11 +4087,6 @@ class ServerArgs:
             self.random_seed = random.randint(0, 1 << 30)
         if self.mm_process_config is None:
             self.mm_process_config = {}
-
-        # Self-benchmark publishes its results through the forward-pass-metrics
-        # pipeline, so benchmark mode implies the metrics are enabled.
-        if self.benchmark_mode is not None:
-            self.enable_forward_pass_metrics = True
 
         # Handle ModelScope model downloads
         if envs.SGLANG_USE_MODELSCOPE.get():
@@ -7884,6 +7878,21 @@ class ServerArgs:
                 f"--asr-max-concurrent-sessions must be positive "
                 f"(got {self.asr_max_concurrent_sessions})."
             )
+
+    def _handle_self_benchmark_validation(self):
+        """Validate startup self-benchmark flags."""
+        if self.benchmark_mode is None:
+            return
+        if not self.enable_forward_pass_metrics:
+            raise ValueError(
+                "--benchmark-mode requires --enable-forward-pass-metrics so "
+                "ForwardPassMetrics publication is enabled explicitly."
+            )
+        if self.use_ray:
+            # Ray reports scheduler readiness by calling SchedulerActor.get_info()
+            # before the scheduler event loop starts. Self-benchmarking currently
+            # runs inside that event loop, so Ray needs a separate readiness path.
+            raise ValueError("--benchmark-mode is not supported with --use-ray")
 
     def _handle_other_validations(self):
         from sglang.srt.arg_groups.overrides import resolved_view

--- a/python/sglang/srt/utils/device_timer.py
+++ b/python/sglang/srt/utils/device_timer.py
@@ -26,6 +26,14 @@ class DeviceTimer:
     def add_reporter(self, reporter: Callable):
         self._reporters.append(reporter)
 
+    def remove_reporter(self, reporter: Callable) -> bool:
+        """Remove a previously added reporter. Returns True if it was present."""
+        try:
+            self._reporters.remove(reporter)
+            return True
+        except ValueError:
+            return False
+
     @contextmanager
     def wrap(self, metadata: Dict):
         # Not re-entrant: a nested wrap would end the wrong interval and leave

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -24,6 +24,22 @@ def _make_ps(**overrides) -> ParallelState:
     return ParallelState.trivial(**defaults)
 
 
+def _make_server_args(**overrides):
+    defaults = dict(
+        benchmark_mode=None,
+        enable_forward_pass_metrics=False,
+        forward_pass_metrics_worker_id="",
+        forward_pass_metrics_ipc_name=None,
+        enable_metrics=False,
+        enable_metrics_for_all_schedulers=False,
+        kv_events_config=None,
+        enable_mfu_metrics=False,
+        extra_metric_labels=None,
+    )
+    defaults.update(overrides)
+    return _fake_server_args(**defaults)
+
+
 class _FakeReq:
     def __init__(
         self,
@@ -85,13 +101,7 @@ def _fake_server_args(**fields):
 
 def _make_reporter(scheduler) -> SchedulerMetricsReporter:
     if not hasattr(scheduler, "server_args"):
-        scheduler.server_args = _fake_server_args(
-            enable_metrics=False,
-            enable_metrics_for_all_schedulers=False,
-            kv_events_config=None,
-            enable_mfu_metrics=False,
-            enable_forward_pass_metrics=False,
-        )
+        scheduler.server_args = _make_server_args()
     if not hasattr(scheduler, "ps"):
         scheduler.ps = ParallelState.trivial()
     if not hasattr(scheduler, "kv_events_publisher"):
@@ -275,14 +285,9 @@ class TestForwardPassMetrics(unittest.TestCase):
 
     def test_init_metrics_uses_server_worker_id(self):
         scheduler = types.SimpleNamespace()
-        scheduler.server_args = _fake_server_args(
-            enable_metrics=False,
-            enable_metrics_for_all_schedulers=False,
-            extra_metric_labels=None,
+        scheduler.server_args = _make_server_args(
             enable_forward_pass_metrics=True,
             forward_pass_metrics_worker_id="endpoint-42",
-            forward_pass_metrics_ipc_name=None,
-            kv_events_config=None,
         )
         scheduler.ps = _make_ps(attn_tp_rank=0, dp_rank=2, pp_rank=0, pp_size=1)
         scheduler.enable_kv_cache_events = False
@@ -291,7 +296,7 @@ class TestForwardPassMetrics(unittest.TestCase):
             "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
             _DummyPublisherThread,
         ):
-            reporter = _make_reporter(scheduler)
+            _make_reporter(scheduler)
 
         self.assertTrue(scheduler.enable_fpm)
         self.assertEqual(scheduler._fpm_worker_id, "endpoint-42")
@@ -303,14 +308,9 @@ class TestForwardPassMetrics(unittest.TestCase):
 
     def test_init_fpm_disabled_on_non_last_pp_rank(self):
         scheduler = types.SimpleNamespace()
-        scheduler.server_args = _fake_server_args(
-            enable_metrics=False,
-            enable_metrics_for_all_schedulers=False,
-            extra_metric_labels=None,
+        scheduler.server_args = _make_server_args(
             enable_forward_pass_metrics=True,
             forward_pass_metrics_worker_id="endpoint-42",
-            forward_pass_metrics_ipc_name=None,
-            kv_events_config=None,
         )
         scheduler.ps = _make_ps(attn_tp_rank=0, dp_rank=0, pp_rank=0, pp_size=2)
         scheduler.enable_kv_cache_events = False
@@ -319,9 +319,27 @@ class TestForwardPassMetrics(unittest.TestCase):
             "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
             _DummyPublisherThread,
         ):
-            reporter = _make_reporter(scheduler)
+            _make_reporter(scheduler)
 
         self.assertFalse(scheduler.enable_fpm)
+
+    def test_init_fpm_forced_on_for_benchmark_rank(self):
+        scheduler = types.SimpleNamespace()
+        scheduler.server_args = _make_server_args(benchmark_mode="agg")
+        scheduler.ps = _make_ps(attn_tp_rank=1, attn_tp_size=2)
+        scheduler.enable_kv_cache_events = False
+
+        with patch(
+            "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
+            _DummyPublisherThread,
+        ):
+            reporter = _make_reporter(scheduler)
+
+        self.assertTrue(scheduler.enable_fpm)
+        self.assertFalse(scheduler._fpm_is_real_rank)
+        self.assertTrue(scheduler._fpm_benchmark_forced)
+        reporter.shutdown_benchmark_forced_fpm()
+        self.assertFalse(scheduler._fpm_benchmark_forced)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -173,10 +173,11 @@ class TestForwardPassMetrics(unittest.TestCase):
             "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
             return_value=104.5,
         ):
-            self.reporter._emit_forward_pass_metrics(batch)
+            emitted = self.reporter._emit_forward_pass_metrics(batch)
 
         self.assertEqual(len(self.scheduler._fpm_publisher.metrics), 1)
         metrics = self.scheduler._fpm_publisher.metrics[0]
+        self.assertIs(emitted, metrics)
         self.assertEqual(metrics.worker_id, "worker-7")
         self.assertEqual(metrics.dp_rank, 3)
         self.assertEqual(metrics.wall_time, 4.5)

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -324,22 +324,30 @@ class TestForwardPassMetrics(unittest.TestCase):
         self.assertFalse(scheduler.enable_fpm)
 
     def test_init_fpm_forced_on_for_benchmark_rank(self):
-        scheduler = types.SimpleNamespace()
-        scheduler.server_args = _make_server_args(benchmark_mode="agg")
-        scheduler.ps = _make_ps(attn_tp_rank=1, attn_tp_size=2)
-        scheduler.enable_kv_cache_events = False
+        rank_cases = (
+            {"attn_tp_rank": 1, "attn_tp_size": 2},
+            {"attn_cp_rank": 1, "attn_cp_size": 2},
+        )
+        for rank_overrides in rank_cases:
+            with self.subTest(rank_overrides=rank_overrides):
+                scheduler = types.SimpleNamespace(
+                    server_args=_make_server_args(
+                        benchmark_mode="agg", enable_forward_pass_metrics=True
+                    ),
+                    ps=_make_ps(**rank_overrides),
+                    enable_kv_cache_events=False,
+                )
+                with patch(
+                    "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
+                    _DummyPublisherThread,
+                ):
+                    reporter = _make_reporter(scheduler)
 
-        with patch(
-            "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
-            _DummyPublisherThread,
-        ):
-            reporter = _make_reporter(scheduler)
-
-        self.assertTrue(scheduler.enable_fpm)
-        self.assertFalse(scheduler._fpm_is_real_rank)
-        self.assertTrue(scheduler._fpm_benchmark_forced)
-        reporter.shutdown_benchmark_forced_fpm()
-        self.assertFalse(scheduler._fpm_benchmark_forced)
+                self.assertTrue(scheduler.enable_fpm)
+                self.assertFalse(scheduler._fpm_is_real_rank)
+                self.assertTrue(scheduler._fpm_benchmark_forced)
+                reporter.shutdown_benchmark_forced_fpm()
+                self.assertFalse(scheduler._fpm_benchmark_forced)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -19,6 +19,7 @@ from sglang.srt.observability.forward_pass_metrics import (
     ForwardPassMetrics,
     ScheduledRequestMetrics,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
 class _FakeForwardMode:
@@ -41,6 +42,7 @@ def _make_scheduler(output_path: str):
         server_args=types.SimpleNamespace(
             benchmark_mode="agg",
             benchmark_prefill_granularity=2,
+            benchmark_prefill_kv_read_granularity=1,
             benchmark_decode_length_granularity=2,
             benchmark_decode_batch_granularity=2,
             benchmark_warmup_iterations=0,
@@ -61,6 +63,7 @@ def _make_scheduler(output_path: str):
         waiting_queue=[],
         running_batch=None,
         chunked_req=None,
+        tree_cache=types.SimpleNamespace(disable=True),
     )
 
 
@@ -72,7 +75,7 @@ class _FakeReq:
         return self._finished
 
 
-class TestSelfBenchmark(unittest.TestCase):
+class TestSelfBenchmark(CustomTestCase):
     def test_prefill_point_collects_fpm_and_writes_output(self):
         with TemporaryDirectory() as tmpdir:
             output_path = f"{tmpdir}/benchmark.json"
@@ -228,6 +231,106 @@ class TestSelfBenchmark(unittest.TestCase):
         prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
         self.assertGreater(len(prefill_points), 0)
         self.assertEqual(max(p.isl for p in prefill_points), 62)
+        self.assertTrue(all(p.kv_read_tokens == 0 for p in prefill_points))
+
+    def test_prefill_kv_read_grid_crosses_with_isl(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.server_args.benchmark_prefill_kv_read_granularity = 3
+
+        benchmark = SelfBenchmark(scheduler)
+
+        prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
+        self.assertEqual(
+            [(p.isl, p.kv_read_tokens) for p in prefill_points],
+            [
+                (10, 0),
+                (10, 4),
+                (10, 9),
+                (15, 0),
+                (15, 7),
+                (15, 14),
+            ],
+        )
+
+    def test_prefill_kv_read_grid_aligns_to_page_size(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.page_size = 8
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.server_args.benchmark_prefill_kv_read_granularity = 4
+        scheduler.max_req_input_len = 40
+
+        benchmark = SelfBenchmark(scheduler)
+
+        prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
+        self.assertTrue(all(p.kv_read_tokens % 8 == 0 for p in prefill_points))
+        self.assertTrue(all(p.kv_read_tokens <= p.isl - 1 for p in prefill_points))
+        self.assertIn(
+            BenchmarkPoint(point_type="prefill", isl=39, kv_read_tokens=32),
+            prefill_points,
+        )
+
+    def test_prefill_kv_read_point_seeds_then_measures_with_same_extra_key(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.server_args.benchmark_mode = "prefill"
+        benchmark = SelfBenchmark(scheduler)
+        point = BenchmarkPoint(point_type="prefill", isl=16, kv_read_tokens=8)
+        calls = []
+
+        def fake_inject_requests(**kwargs):
+            calls.append(kwargs)
+            return 1
+
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid = [point]
+        benchmark._grid_index = 0
+        benchmark._inject_requests = fake_inject_requests
+        benchmark._cached_kv_read_tokens_for_point = (
+            lambda cached_point, _extra_key: cached_point.kv_read_tokens
+        )
+
+        benchmark.maybe_schedule_next()
+
+        self.assertIsNone(benchmark._current)
+        self.assertIs(benchmark._pending_seed_point, point)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["prompt_len"], 8)
+        self.assertEqual(calls[0]["max_tokens"], 0)
+        self.assertFalse(calls[0]["track_active"])
+
+        benchmark.maybe_schedule_next()
+
+        self.assertIsNotNone(benchmark._current)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1]["prompt_len"], 16)
+        self.assertEqual(calls[1]["max_tokens"], 1)
+        self.assertTrue(calls[1]["track_active"])
+        self.assertEqual(calls[0]["extra_key"], calls[1]["extra_key"])
+
+    def test_prefill_kv_read_point_skips_when_seed_validation_misses(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.server_args.benchmark_mode = "prefill"
+        benchmark = SelfBenchmark(scheduler)
+        point = BenchmarkPoint(point_type="prefill", isl=16, kv_read_tokens=8)
+        calls = []
+
+        def fake_inject_requests(**kwargs):
+            calls.append(kwargs)
+            return 1
+
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid = [point]
+        benchmark._grid_index = 0
+        benchmark._inject_requests = fake_inject_requests
+        benchmark._cached_kv_read_tokens_for_point = lambda _point, _extra_key: 0
+
+        benchmark.maybe_schedule_next()
+        benchmark.maybe_schedule_next()
+
+        self.assertIsNone(benchmark._current)
+        self.assertIsNone(benchmark._pending_seed_point)
+        self.assertEqual(benchmark._grid_index, 1)
+        self.assertEqual(len(calls), 1)
 
     def test_chunked_prefill_request_counts_as_inflight_work(self):
         scheduler = _make_scheduler("/tmp/unused.json")

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -179,39 +179,49 @@ class TestSelfBenchmark(CustomTestCase):
 
     def test_output_invalidation_replaces_stale_result_for_worker_path(self):
         with TemporaryDirectory() as tmpdir:
+            # dp_rank 0 writes the caller-assigned base path; a stale prior-run
+            # result there must be invalidated at init.
             output_path = f"{tmpdir}/benchmark.json"
-            stale_path = (
-                f"{tmpdir}/benchmark_role-null_node-0_dp-0_tp-0_atp-0_acp-0.json"
-            )
-            with open(stale_path, "w") as f:
+            with open(output_path, "w") as f:
                 json.dump({"valid": True, "run_id": "old-run"}, f)
 
             scheduler = _make_scheduler(output_path)
             scheduler.instance_id = "new-run"
             benchmark = SelfBenchmark(scheduler)
 
-            self.assertEqual(benchmark._output_path, stale_path)
+            self.assertEqual(benchmark._output_path, output_path)
             with open(benchmark._output_path) as f:
                 output = json.load(f)
             self.assertFalse(output["valid"])
             self.assertEqual(output["status"], "running")
             self.assertEqual(output["run_id"], "new-run")
 
-    def test_output_path_is_role_and_rank_qualified(self):
+    def test_output_path_follows_dp_rank_contract(self):
         with TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/benchmark.json"
+            # dp_rank 0 -> caller-assigned base path, unchanged.
+            dp0 = SelfBenchmark(_make_scheduler(output_path))
+            self.assertEqual(dp0._output_path, output_path)
+
+            # dp_rank N -> the "_dpN" sibling the consumer addresses.
+            dp1_scheduler = _make_scheduler(output_path)
+            dp1_scheduler.ps.dp_rank = 1
+            dp1 = SelfBenchmark(dp1_scheduler)
+            self.assertEqual(dp1._output_path, f"{tmpdir}/benchmark_dp1.json")
+
+    def test_role_recorded_in_contents_not_path(self):
+        with TemporaryDirectory() as tmpdir:
+            # Role/run/rank identity lives in the file contents, not the
+            # filename; co-located workers are kept distinct by the caller
+            # assigning a unique base path, not by namespacing the filename.
             output_path = f"{tmpdir}/benchmark.json"
             prefill_scheduler = _make_scheduler(output_path)
             prefill_scheduler.disaggregation_mode = DisaggregationMode.PREFILL
-            decode_scheduler = _make_scheduler(output_path)
-            decode_scheduler.disaggregation_mode = DisaggregationMode.DECODE
-
             prefill_benchmark = SelfBenchmark(prefill_scheduler)
-            decode_benchmark = SelfBenchmark(decode_scheduler)
 
-            self.assertIn("role-prefill", prefill_benchmark._output_path)
-            self.assertIn("role-decode", decode_benchmark._output_path)
-            self.assertNotEqual(
-                prefill_benchmark._output_path, decode_benchmark._output_path
+            self.assertEqual(prefill_benchmark._output_path, output_path)
+            self.assertEqual(
+                prefill_benchmark._identity["disaggregation_mode"], "prefill"
             )
 
     def test_finish_waits_for_inflight_scheduler_state(self):

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -131,6 +131,32 @@ class TestSelfBenchmark(CustomTestCase):
                 output = json.load(f)
             self.assertIn("results", output)
 
+    def test_timeout_finishes_even_with_unfinished_current_point(self):
+        with TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/benchmark.json"
+            scheduler = _make_scheduler(output_path)
+            calls = []
+            scheduler.on_self_benchmark_finished = lambda: calls.append("done")
+            benchmark = SelfBenchmark(scheduler)
+            point = BenchmarkPoint(point_type="prefill", isl=10)
+            benchmark.phase = BenchmarkPhase.SWEEP
+            benchmark._grid = [point]
+            benchmark._grid_index = 0
+            benchmark._current = BenchmarkPointResult(point=point)
+            benchmark._active_reqs = [_FakeReq(finished=False)]
+            benchmark._deadline_monotonic = 0
+
+            benchmark.maybe_schedule_next()
+
+            self.assertEqual(calls, ["done"])
+            self.assertFalse(benchmark.active)
+            self.assertIsNone(benchmark._current)
+            self.assertEqual(benchmark._active_reqs, [])
+            with open(output_path) as f:
+                output = json.load(f)
+            self.assertTrue(output["timed_out"])
+            self.assertEqual(output["results"], [])
+
     def test_decode_point_ignores_setup_prefill_until_decode_pass(self):
         benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
         point = BenchmarkPoint(point_type="decode", context_length=8, batch_size=2)

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -113,6 +113,24 @@ class TestSelfBenchmark(CustomTestCase):
                 1,
             )
 
+    def test_finish_notifies_scheduler_after_writing_output(self):
+        with TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/benchmark.json"
+            scheduler = _make_scheduler(output_path)
+            calls = []
+            scheduler.on_self_benchmark_finished = lambda: calls.append("done")
+            benchmark = SelfBenchmark(scheduler)
+            benchmark.phase = BenchmarkPhase.SWEEP
+            benchmark._grid_index = len(benchmark._grid)
+
+            benchmark.maybe_schedule_next()
+
+            self.assertEqual(calls, ["done"])
+            self.assertFalse(benchmark.active)
+            with open(output_path) as f:
+                output = json.load(f)
+            self.assertIn("results", output)
+
     def test_decode_point_ignores_setup_prefill_until_decode_pass(self):
         benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
         point = BenchmarkPoint(point_type="decode", context_length=8, batch_size=2)
@@ -338,6 +356,15 @@ class TestSelfBenchmark(CustomTestCase):
 
         self.assertFalse(benchmark._has_inflight_work())
         scheduler.chunked_req = object()
+        self.assertTrue(benchmark._has_inflight_work())
+
+    def test_disagg_prefill_inflight_list_counts_as_inflight_work(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.disagg_prefill_inflight_queue = []
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertFalse(benchmark._has_inflight_work())
+        scheduler.disagg_prefill_inflight_queue.append(object())
         self.assertTrue(benchmark._has_inflight_work())
 
     def test_disaggregated_workers_only_build_supported_grid(self):

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -1,0 +1,135 @@
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import json
+import types
+import unittest
+from collections import deque
+from tempfile import TemporaryDirectory
+
+from sglang.srt.managers.scheduler_components.self_benchmark import (
+    BenchmarkPhase,
+    BenchmarkPoint,
+    BenchmarkPointResult,
+    SelfBenchmark,
+)
+from sglang.srt.observability.forward_pass_metrics import (
+    ForwardPassMetrics,
+    ScheduledRequestMetrics,
+)
+
+
+class _FakeForwardMode:
+    def __init__(self, *, is_decode: bool = False, is_extend: bool = False):
+        self._is_decode = is_decode
+        self._is_extend = is_extend
+
+    def is_prebuilt(self):
+        return False
+
+    def is_decode(self):
+        return self._is_decode
+
+    def is_extend(self):
+        return self._is_extend
+
+
+def _make_scheduler(output_path: str):
+    return types.SimpleNamespace(
+        server_args=types.SimpleNamespace(
+            benchmark_mode="agg",
+            benchmark_prefill_granularity=2,
+            benchmark_decode_length_granularity=2,
+            benchmark_decode_batch_granularity=2,
+            benchmark_warmup_iterations=0,
+            benchmark_output_path=output_path,
+            benchmark_timeout=300,
+        ),
+        enable_fpm=True,
+        max_req_input_len=16,
+        max_total_num_tokens=64,
+        max_running_requests=4,
+        max_req_len=32,
+        max_prefill_tokens=64,
+        page_size=1,
+        ps=types.SimpleNamespace(dp_rank=0),
+        result_queue=deque(),
+        waiting_queue=[],
+        running_batch=None,
+    )
+
+
+class TestSelfBenchmark(unittest.TestCase):
+    def test_prefill_point_collects_fpm_and_writes_output(self):
+        with TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/benchmark.json"
+            benchmark = SelfBenchmark(_make_scheduler(output_path))
+            point = BenchmarkPoint(point_type="prefill", isl=10)
+            benchmark.phase = BenchmarkPhase.SWEEP
+            benchmark._grid = [point]
+            benchmark._grid_index = 0
+            benchmark._current = BenchmarkPointResult(point=point)
+
+            fpm = ForwardPassMetrics(
+                worker_id="worker-1",
+                scheduled_requests=ScheduledRequestMetrics(
+                    num_prefill_requests=1,
+                    sum_prefill_tokens=10,
+                    sum_prefill_kv_tokens=10,
+                ),
+            )
+            batch = types.SimpleNamespace(
+                forward_mode=_FakeForwardMode(is_extend=True),
+            )
+
+            benchmark.observe_forward_pass(batch, fpm)
+            benchmark.maybe_schedule_next()
+
+            self.assertFalse(benchmark.active)
+            with open(output_path) as f:
+                output = json.load(f)
+            self.assertEqual(output["config"]["mode"], "agg")
+            self.assertEqual(output["results"][0]["point"]["point_type"], "prefill")
+            self.assertEqual(
+                output["results"][0]["fpms"][0]["scheduled_requests"][
+                    "num_prefill_requests"
+                ],
+                1,
+            )
+
+    def test_decode_point_ignores_setup_prefill_until_decode_pass(self):
+        benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
+        point = BenchmarkPoint(point_type="decode", context_length=8, batch_size=2)
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid = [point]
+        benchmark._current = BenchmarkPointResult(point=point)
+
+        prefill_fpm = ForwardPassMetrics(
+            scheduled_requests=ScheduledRequestMetrics(num_prefill_requests=2)
+        )
+        decode_fpm = ForwardPassMetrics(
+            scheduled_requests=ScheduledRequestMetrics(num_decode_requests=2)
+        )
+
+        benchmark.observe_forward_pass(
+            types.SimpleNamespace(forward_mode=_FakeForwardMode(is_extend=True)),
+            prefill_fpm,
+        )
+        self.assertIsNotNone(benchmark._current)
+        self.assertEqual(len(benchmark._results), 0)
+
+        benchmark.observe_forward_pass(
+            types.SimpleNamespace(forward_mode=_FakeForwardMode(is_decode=True)),
+            decode_fpm,
+        )
+        self.assertIsNone(benchmark._current)
+        self.assertEqual(len(benchmark._results), 1)
+        self.assertEqual(
+            benchmark._results[0].fpms[0]["scheduled_requests"]["num_decode_requests"],
+            2,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -10,7 +10,7 @@ from collections import deque
 from tempfile import TemporaryDirectory
 from unittest import mock
 
-import sglang.srt.managers.scheduler_components.self_benchmark as self_benchmark_module
+import sglang.srt.managers.scheduler_components.self_benchmark_decode as self_benchmark_decode_module
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.scheduler_components.self_benchmark import (
     SELF_BENCHMARK_DUMMY_TOKEN_ID,
@@ -492,7 +492,7 @@ class TestSelfBenchmark(CustomTestCase):
             captured["context_length"] = context_length
             return fake_batch
 
-        benchmark._build_synthetic_decode_batch = fake_build_synthetic_decode_batch
+        benchmark._decode_batch_builder.build = fake_build_synthetic_decode_batch
 
         injected = benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
 
@@ -524,7 +524,7 @@ class TestSelfBenchmark(CustomTestCase):
         def fail_build_synthetic_decode_batch(_reqs, _context_length):
             raise AssertionError("synthetic decode batch should not be built")
 
-        benchmark._build_synthetic_decode_batch = fail_build_synthetic_decode_batch
+        benchmark._decode_batch_builder.build = fail_build_synthetic_decode_batch
 
         injected = benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
 
@@ -683,23 +683,15 @@ class TestSelfBenchmark(CustomTestCase):
 
         self.assertTrue(all(p.point_type == "decode" for p in benchmark._grid))
 
-    def test_build_synthetic_decode_batch_stashes_relay_payload(self):
-        # P0-1 regression guard: _build_synthetic_decode_batch must hand
-        # FutureMap.stash a RelayPayload, never a raw tensor. We exercise the
-        # REAL _build_synthetic_decode_batch (only the memory allocation and
-        # sampling-info construction are stubbed) so the stash call is covered.
+    def test_decode_batch_builder_uses_canonical_allocation_and_relay_payload(self):
         scheduler = _prepare_decode_scheduler(self._scheduler())
-
         captured = {}
 
         class _FakeFutureMap:
             def stash(self, future_indices, payload):
                 captured["future_indices"] = future_indices
                 captured["payload"] = payload
-                # Mirror FutureMap.stash's real access pattern: a raw tensor
-                # would raise AttributeError here.
                 assert type(payload).__name__ == "RelayPayload"
-                assert hasattr(payload, "bonus_tokens")
                 _ = payload.bonus_tokens.to
 
         scheduler.future_map = _FakeFutureMap()
@@ -708,40 +700,55 @@ class TestSelfBenchmark(CustomTestCase):
         scheduler.enable_overlap = False
         scheduler.dllm_config = None
         scheduler.enable_hisparse = False
+        root_node = object()
+        scheduler.tree_cache.root_node = root_node
 
         benchmark = SelfBenchmark(scheduler)
-
-        # Stub the GPU-memory allocation + sampling-info construction; keep the
-        # real stash path. _place_synthetic_context_cache normally fills
-        # req_pool_indices, so the stub sets it.
-        def fake_place(batch, context_length):
-            batch.req_pool_indices = list(range(len(batch.reqs)))
-
-        benchmark._place_synthetic_context_cache = fake_place
 
         class _FakeBatch:
             def __init__(self, **kwargs):
                 self.reqs = kwargs.get("reqs", [])
+                self.tree_cache = kwargs["tree_cache"]
                 self.device = "cpu"
-                self.req_pool_indices = None
-                self.sampling_info = None
                 self.input_ids = "sentinel"
 
-        # mock.patch.object correctly saves/restores the classmethod descriptors.
+        out_cache_loc = object()
+        req_pool_indices = [0]
+        req_pool_indices_cpu = [0]
+        alloc_for_extend = mock.Mock(
+            return_value=(out_cache_loc, req_pool_indices, req_pool_indices_cpu)
+        )
         with mock.patch.object(
-            self_benchmark_module.ScheduleBatch,
+            self_benchmark_decode_module.ScheduleBatch,
             "init_new",
             staticmethod(lambda **kwargs: _FakeBatch(**kwargs)),
         ), mock.patch.object(
-            self_benchmark_module.SamplingBatchInfo,
+            self_benchmark_decode_module.SamplingBatchInfo,
             "from_schedule_batch",
             staticmethod(lambda batch, vocab_size: object()),
+        ), mock.patch.object(
+            self_benchmark_decode_module, "alloc_for_extend", alloc_for_extend
         ):
             reqs = [benchmark._new_synthetic_req(prompt_len=8, max_tokens=2)]
             reqs[0].output_ids.append(SELF_BENCHMARK_DUMMY_TOKEN_ID)
-            batch = benchmark._build_synthetic_decode_batch(reqs, context_length=8)
+            batch = benchmark._decode_batch_builder.build(reqs, context_length=8)
 
-        self.assertIn("payload", captured)
+        alloc_for_extend.assert_called_once_with(batch)
+        self.assertIs(batch.out_cache_loc, out_cache_loc)
+        self.assertIs(batch.req_pool_indices, req_pool_indices)
+        self.assertIs(batch.req_pool_indices_cpu, req_pool_indices_cpu)
+        self.assertEqual(batch.prefix_lens, [0])
+        self.assertEqual(batch.extend_lens, [8])
+        self.assertEqual(batch.extend_num_tokens, 8)
+        self.assertEqual(batch.seq_lens_cpu.tolist(), [8])
+        self.assertEqual(batch.seq_lens.tolist(), [8])
+        self.assertEqual(batch.orig_seq_lens.tolist(), [8])
+        self.assertEqual(batch.seq_lens_sum, 8)
+        self.assertTrue(batch.forward_mode.is_extend())
+        self.assertTrue(reqs[0].synthetic_benchmark_kv_placed)
+        self.assertIs(reqs[0].last_node, root_node)
+        self.assertIs(reqs[0].last_host_node, root_node)
+        self.assertIs(reqs[0].best_match_node, root_node)
         self.assertEqual(type(captured["payload"]).__name__, "RelayPayload")
         self.assertEqual(captured["payload"].bonus_tokens.tolist(), [0])
         self.assertIsNone(batch.input_ids)
@@ -754,10 +761,10 @@ class TestSelfBenchmark(CustomTestCase):
                 benchmark = SelfBenchmark(scheduler)
                 build_error = AttributeError("synthetic build failed")
                 cleanup = mock.Mock(side_effect=cleanup_error)
-                benchmark._build_synthetic_decode_batch = mock.Mock(
+                benchmark._decode_batch_builder.build = mock.Mock(
                     side_effect=build_error
                 )
-                benchmark._free_synthetic_decode_reqs = cleanup
+                benchmark._decode_batch_builder.cleanup = cleanup
 
                 with self.assertRaises(AttributeError) as raised:
                     benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
@@ -767,6 +774,24 @@ class TestSelfBenchmark(CustomTestCase):
                 self.assertEqual(len(cleanup.call_args.args[0]), 2)
                 self.assertIs(scheduler.running_batch, original_batch)
                 self.assertEqual(benchmark._active_reqs, [])
+
+    def test_decode_batch_builder_cleanup_handles_partial_allocation(self):
+        scheduler = self._scheduler()
+        scheduler.req_to_token_pool = types.SimpleNamespace(free=mock.Mock())
+        placed = types.SimpleNamespace(
+            synthetic_benchmark_kv_placed=True, req_pool_idx=1
+        )
+        slot_only = types.SimpleNamespace(req_pool_idx=2)
+        unallocated = types.SimpleNamespace(req_pool_idx=None)
+
+        with mock.patch.object(
+            self_benchmark_decode_module, "release_kv_cache"
+        ) as release:
+            benchmark = SelfBenchmark(scheduler)
+            benchmark._decode_batch_builder.cleanup([placed, slot_only, unallocated])
+
+        release.assert_called_once_with(placed, scheduler.tree_cache, is_insert=False)
+        scheduler.req_to_token_pool.free.assert_called_once_with(slot_only)
 
     def test_partial_sweep_records_skipped_point_and_is_invalid(self):
         benchmark = SelfBenchmark(self._scheduler())
@@ -878,6 +903,8 @@ def _make_rejection_scheduler():
         ps=types.SimpleNamespace(pp_size=1, tp_size=2, dp_size=2),
         enable_pdmux=False,
         enable_overlap_mlx=False,
+        dllm_config=None,
+        token_to_kv_pool_allocator=object(),
         is_generation=True,
         spec_algorithm=types.SimpleNamespace(is_none=lambda: True),
         model_config=types.SimpleNamespace(
@@ -920,6 +947,10 @@ class TestSelfBenchmarkFactory(CustomTestCase):
                 lambda scheduler: setattr(scheduler, "enable_overlap_mlx", True),
             ),
             (
+                "diffusion LLM",
+                lambda scheduler: setattr(scheduler, "dllm_config", object()),
+            ),
+            (
                 "only supported for generative",
                 lambda scheduler: setattr(scheduler, "is_generation", False),
             ),
@@ -955,6 +986,17 @@ class TestSelfBenchmarkFactory(CustomTestCase):
                 fake = _make_rejection_scheduler()
                 mutate(fake)
                 with self.assertRaisesRegex(ValueError, message):
+                    self._run(fake)
+
+    def test_rejects_deepseek_v4_npu_for_all_modes(self):
+        for mode in ("prefill", "decode", "agg"):
+            with self.subTest(mode=mode):
+                fake = _make_rejection_scheduler()
+                fake.server_args.benchmark_mode = mode
+                fake.token_to_kv_pool_allocator = types.SimpleNamespace(
+                    c4_attn_allocator=object()
+                )
+                with self.assertRaisesRegex(ValueError, "DeepSeek V4 on NPU"):
                     self._run(fake)
 
     def test_does_not_reject_multi_rank_tp(self):

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -360,6 +360,37 @@ class TestSelfBenchmark(CustomTestCase):
             16,
         )
 
+    def test_maybe_schedule_next_advances_current_point_finished_after_observe(self):
+        benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
+        point = BenchmarkPoint(point_type="prefill", isl=32)
+        req = _FakeReq(finished=False)
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid = [point]
+        benchmark._grid_index = 0
+        benchmark._current = BenchmarkPointResult(point=point)
+        benchmark._active_reqs = [req]
+
+        fpm = ForwardPassMetrics(
+            scheduled_requests=ScheduledRequestMetrics(
+                num_prefill_requests=1,
+                sum_prefill_tokens=32,
+                sum_prefill_kv_tokens=0,
+            )
+        )
+        batch = types.SimpleNamespace(forward_mode=_FakeForwardMode(is_extend=True))
+
+        benchmark.observe_forward_pass(batch, fpm)
+        self.assertIsNotNone(benchmark._current)
+        self.assertEqual(len(benchmark._results), 0)
+
+        req._finished = True
+        benchmark.maybe_schedule_next()
+
+        self.assertIsNone(benchmark._current)
+        self.assertEqual(benchmark._grid_index, 1)
+        self.assertEqual(len(benchmark._results), 1)
+        self.assertEqual(len(benchmark._results[0].fpms), 1)
+
     def test_decode_grid_preserves_room_for_one_decode_token(self):
         scheduler = _make_scheduler("/tmp/unused.json")
         scheduler.max_req_input_len = 16

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -3,11 +3,14 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import json
+import os
 import types
 import unittest
 from collections import deque
 from tempfile import TemporaryDirectory
+from unittest import mock
 
+import sglang.srt.managers.scheduler_components.self_benchmark as self_benchmark_module
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.scheduler_components.self_benchmark import (
     SELF_BENCHMARK_DUMMY_TOKEN_ID,
@@ -591,6 +594,295 @@ class TestSelfBenchmark(CustomTestCase):
         benchmark = SelfBenchmark(scheduler)
 
         self.assertTrue(all(p.point_type == "decode" for p in benchmark._grid))
+
+    def test_build_synthetic_decode_batch_stashes_relay_payload(self):
+        # P0-1 regression guard: _build_synthetic_decode_batch must hand
+        # FutureMap.stash a RelayPayload, never a raw tensor. We exercise the
+        # REAL _build_synthetic_decode_batch (only the memory allocation and
+        # sampling-info construction are stubbed) so the stash call is covered.
+        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
+
+        captured = {}
+
+        class _FakeFutureMap:
+            def stash(self, future_indices, payload):
+                captured["future_indices"] = future_indices
+                captured["payload"] = payload
+                # Mirror FutureMap.stash's real access pattern: a raw tensor
+                # would raise AttributeError here.
+                assert type(payload).__name__ == "RelayPayload"
+                assert hasattr(payload, "bonus_tokens")
+                _ = payload.bonus_tokens.to
+
+        scheduler.future_map = _FakeFutureMap()
+        scheduler.req_to_token_pool = object()
+        scheduler.token_to_kv_pool_allocator = object()
+        scheduler.enable_overlap = False
+        scheduler.dllm_config = None
+        scheduler.enable_hisparse = False
+
+        benchmark = SelfBenchmark(scheduler)
+
+        # Stub the GPU-memory allocation + sampling-info construction; keep the
+        # real stash path. _place_synthetic_context_cache normally fills
+        # req_pool_indices, so the stub sets it.
+        def fake_place(batch, context_length):
+            batch.req_pool_indices = list(range(len(batch.reqs)))
+
+        benchmark._place_synthetic_context_cache = fake_place
+
+        class _FakeBatch:
+            def __init__(self, **kwargs):
+                self.reqs = kwargs.get("reqs", [])
+                self.device = "cpu"
+                self.req_pool_indices = None
+                self.sampling_info = None
+                self.input_ids = "sentinel"
+
+        # mock.patch.object correctly saves/restores the classmethod descriptors.
+        with mock.patch.object(
+            self_benchmark_module.ScheduleBatch,
+            "init_new",
+            staticmethod(lambda **kwargs: _FakeBatch(**kwargs)),
+        ), mock.patch.object(
+            self_benchmark_module.SamplingBatchInfo,
+            "from_schedule_batch",
+            staticmethod(lambda batch, vocab_size: object()),
+        ):
+            reqs = [benchmark._new_synthetic_req(prompt_len=8, max_tokens=2)]
+            reqs[0].output_ids.append(SELF_BENCHMARK_DUMMY_TOKEN_ID)
+            batch = benchmark._build_synthetic_decode_batch(reqs, context_length=8)
+
+        self.assertIn("payload", captured)
+        self.assertEqual(type(captured["payload"]).__name__, "RelayPayload")
+        self.assertEqual(captured["payload"].bonus_tokens.tolist(), [0])
+        self.assertIsNone(batch.input_ids)
+
+    def test_synthetic_decode_build_failure_frees_reqs_and_skips(self):
+        # P0-1: any failure in _build_synthetic_decode_batch (now caught as
+        # Exception, not just RuntimeError) must free the pre-allocated reqs and
+        # skip the point, never crash the scheduler.
+        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
+        freed = {}
+        benchmark = SelfBenchmark(scheduler)
+
+        def raising_build(_reqs, _ctx):
+            raise AttributeError("simulated stash on raw tensor")
+
+        def fake_free(reqs):
+            freed["reqs"] = reqs
+
+        benchmark._build_synthetic_decode_batch = raising_build
+        benchmark._free_synthetic_decode_reqs = fake_free
+
+        injected = benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
+
+        self.assertEqual(injected, 0)
+        self.assertEqual(benchmark._active_reqs, [])
+        self.assertIn("reqs", freed)
+        self.assertEqual(len(freed["reqs"]), 2)
+
+    def test_benchmark_forced_fpm_rank_advances_then_restores(self):
+        # P0-2: a rank where the real gate gives enable_fpm=False, but with
+        # benchmark_mode set, has FPM force-enabled for the sweep. The sweep must
+        # advance WARMUP->SWEEP->DONE off observe_forward_pass and restore FPM
+        # afterwards (and not write the redundant JSON).
+        with TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/benchmark.json"
+            scheduler = _make_scheduler(output_path)
+            # Simulate metrics_reporter._init_fpm forcing FPM on a non-FPM rank.
+            scheduler.enable_fpm = True
+            scheduler._fpm_is_real_rank = False
+            scheduler._fpm_benchmark_forced = True
+
+            shutdown_calls = []
+            scheduler.metrics_reporter = types.SimpleNamespace(
+                shutdown_benchmark_forced_fpm=lambda: shutdown_calls.append("shutdown")
+            )
+            finished_calls = []
+            scheduler.on_self_benchmark_finished = lambda: finished_calls.append("done")
+
+            benchmark = SelfBenchmark(scheduler)
+            # Forced rank must not be marked as an output writer.
+            self.assertFalse(benchmark._write_results)
+            # FPM stays on for the duration of the sweep.
+            self.assertTrue(scheduler.enable_fpm)
+
+            point = BenchmarkPoint(point_type="prefill", isl=10)
+            benchmark.phase = BenchmarkPhase.SWEEP
+            benchmark._grid = [point]
+            benchmark._grid_index = 0
+            benchmark._current = BenchmarkPointResult(point=point)
+
+            fpm = ForwardPassMetrics(
+                scheduled_requests=ScheduledRequestMetrics(num_prefill_requests=1),
+            )
+            batch = types.SimpleNamespace(
+                forward_mode=_FakeForwardMode(is_extend=True),
+            )
+
+            # observe_forward_pass must fire and advance the phase.
+            benchmark.observe_forward_pass(batch, fpm)
+            benchmark.maybe_schedule_next()
+
+            self.assertFalse(benchmark.active)
+            self.assertEqual(benchmark.phase, BenchmarkPhase.DONE)
+            self.assertEqual(finished_calls, ["done"])
+            # Forced publisher torn down and FPM restored to the prior off state.
+            self.assertEqual(shutdown_calls, ["shutdown"])
+            self.assertFalse(scheduler.enable_fpm)
+            # No JSON written on the forced rank.
+            self.assertFalse(
+                os.path.exists(benchmark._output_path),
+                "benchmark-forced rank must not write output JSON",
+            )
+
+    def test_real_fpm_rank_keeps_fpm_enabled_after_sweep(self):
+        # P0-2: the real FPM rank's production behavior is unchanged after the
+        # sweep -- enable_fpm stays True and no forced teardown happens.
+        with TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/benchmark.json"
+            scheduler = _make_scheduler(output_path)
+            scheduler.enable_fpm = True
+            scheduler._fpm_is_real_rank = True
+            scheduler._fpm_benchmark_forced = False
+
+            # Faithful stub: the real helper early-returns for a non-forced rank.
+            shutdown_calls = []
+
+            def fake_shutdown():
+                if getattr(scheduler, "_fpm_benchmark_forced", False):
+                    shutdown_calls.append("shutdown")
+
+            scheduler.metrics_reporter = types.SimpleNamespace(
+                shutdown_benchmark_forced_fpm=fake_shutdown
+            )
+
+            benchmark = SelfBenchmark(scheduler)
+            self.assertTrue(benchmark._write_results)
+
+            benchmark.phase = BenchmarkPhase.SWEEP
+            benchmark._grid_index = len(benchmark._grid)
+            benchmark.maybe_schedule_next()
+
+            self.assertFalse(benchmark.active)
+            # Real rank keeps publishing; forced-teardown is a no-op for it.
+            self.assertEqual(shutdown_calls, [])
+            self.assertTrue(scheduler.enable_fpm)
+
+    def test_grammar_queue_counts_as_inflight_work(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.grammar_manager = types.SimpleNamespace(grammar_queue=[])
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertFalse(benchmark._has_inflight_work())
+        scheduler.grammar_manager.grammar_queue.append(object())
+        self.assertTrue(benchmark._has_inflight_work())
+
+    def test_decode_prealloc_retracted_and_pending_count_as_inflight_work(self):
+        for attr in ("retracted_queue", "pending_reqs"):
+            with self.subTest(attr=attr):
+                scheduler = _make_scheduler("/tmp/unused.json")
+                queue_owner = types.SimpleNamespace(
+                    queue=[], retracted_queue=[], pending_reqs=[]
+                )
+                scheduler.disagg_decode_prealloc_queue = queue_owner
+                benchmark = SelfBenchmark(scheduler)
+
+                self.assertFalse(benchmark._has_inflight_work())
+                getattr(queue_owner, attr).append(object())
+                self.assertTrue(benchmark._has_inflight_work())
+
+
+def _make_rejection_scheduler():
+    """Fake `self` for invoking Scheduler.maybe_init_self_benchmark unbound.
+
+    Defaults to a configuration that would PASS all rejections; each test flips
+    one attribute to trigger a specific ValueError. The success path constructs
+    a real SelfBenchmark, so tests only assert the rejection branches.
+    """
+    return types.SimpleNamespace(
+        self_benchmark=None,
+        server_args=types.SimpleNamespace(benchmark_mode="agg", load_format="auto"),
+        ps=types.SimpleNamespace(pp_size=1),
+        enable_pdmux=False,
+        enable_overlap_mlx=False,
+        is_generation=True,
+        spec_algorithm=types.SimpleNamespace(is_none=lambda: True),
+        model_config=types.SimpleNamespace(
+            is_encoder_decoder=False, is_multimodal=False
+        ),
+        enable_lora=False,
+    )
+
+
+class TestSelfBenchmarkSchedulerRejections(CustomTestCase):
+    """Scheduler-side fast-fail rejections in maybe_init_self_benchmark.
+
+    These cannot live in the server_args tests because the validations run in
+    the Scheduler (they need is_generation / spec_algorithm / model_config /
+    enable_lora / load_format resolved). We invoke the method unbound on a fake
+    `self` so we don't have to construct a full Scheduler.
+    """
+
+    @staticmethod
+    def _run(fake_self):
+        from sglang.srt.managers.scheduler import Scheduler
+
+        Scheduler.maybe_init_self_benchmark(fake_self)
+
+    def test_rejects_non_generation_model(self):
+        fake = _make_rejection_scheduler()
+        fake.is_generation = False
+        with self.assertRaisesRegex(ValueError, "only supported for generative"):
+            self._run(fake)
+
+    def test_rejects_speculative_decoding(self):
+        fake = _make_rejection_scheduler()
+        fake.spec_algorithm = types.SimpleNamespace(is_none=lambda: False)
+        with self.assertRaisesRegex(ValueError, "speculative decoding"):
+            self._run(fake)
+
+    def test_rejects_encoder_decoder(self):
+        fake = _make_rejection_scheduler()
+        fake.model_config.is_encoder_decoder = True
+        with self.assertRaisesRegex(ValueError, "encoder-decoder"):
+            self._run(fake)
+
+    def test_rejects_multimodal(self):
+        fake = _make_rejection_scheduler()
+        fake.model_config.is_multimodal = True
+        with self.assertRaisesRegex(ValueError, "multimodal"):
+            self._run(fake)
+
+    def test_rejects_lora(self):
+        fake = _make_rejection_scheduler()
+        fake.enable_lora = True
+        with self.assertRaisesRegex(ValueError, "LoRA"):
+            self._run(fake)
+
+    def test_rejects_dummy_weights(self):
+        fake = _make_rejection_scheduler()
+        fake.server_args.load_format = "dummy"
+        with self.assertRaisesRegex(ValueError, "dummy weights"):
+            self._run(fake)
+
+    def test_does_not_reject_multi_rank_tp(self):
+        # MUST NOT reject tp_size>1 / dp_size>1. The fake `self` has no tp_size
+        # gate; maybe_init_self_benchmark only rejects pp_size>1. Confirm a
+        # passing config reaches SelfBenchmark construction (which then fails on
+        # the incomplete fake), proving none of the rejections fired.
+        fake = _make_rejection_scheduler()
+        # Reaching SelfBenchmark(self) means all rejections passed. SelfBenchmark
+        # construction will raise (fake lacks the full surface) -- anything but a
+        # benchmark-mode ValueError proves we got past the guards.
+        try:
+            self._run(fake)
+        except ValueError as exc:  # pragma: no cover - defensive
+            self.assertNotIn("--benchmark-mode is not supported", str(exc))
+            self.assertNotIn("only supported for generative", str(exc))
+        except Exception:
+            pass
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -55,6 +55,9 @@ def _make_scheduler(output_path: str):
             benchmark_warmup_iterations=0,
             benchmark_output_path=output_path,
             chunked_prefill_size=None,
+            cuda_graph_config=types.SimpleNamespace(
+                decode=types.SimpleNamespace(max_bs=4)
+            ),
             node_rank=0,
             nnodes=1,
         ),
@@ -109,120 +112,135 @@ def _prepare_decode_scheduler(scheduler):
 
 
 class TestSelfBenchmark(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.output_path = os.path.join(self._tmpdir.name, "benchmark.json")
+
+    def _scheduler(self):
+        return _make_scheduler(self.output_path)
+
+    @staticmethod
+    def _read_output(benchmark):
+        with open(benchmark._output_path) as f:
+            return json.load(f)
+
+    @staticmethod
+    def _start_point(benchmark, point, *, active_reqs=()):
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid = [point]
+        benchmark._grid_index = 0
+        benchmark._current = BenchmarkPointResult(point=point)
+        benchmark._active_reqs = list(active_reqs)
+
+    @staticmethod
+    def _fpm(**scheduled_fields):
+        return ForwardPassMetrics(
+            scheduled_requests=ScheduledRequestMetrics(**scheduled_fields)
+        )
+
     def test_prefill_point_collects_fpm_and_writes_output(self):
-        with TemporaryDirectory() as tmpdir:
-            output_path = f"{tmpdir}/benchmark.json"
-            benchmark = SelfBenchmark(_make_scheduler(output_path))
-            with open(benchmark._output_path) as f:
-                running_output = json.load(f)
-            self.assertEqual(running_output["scope"], "local_diagnostics")
-            self.assertEqual(running_output["status"], "running")
-            self.assertFalse(running_output["valid"])
-            self.assertEqual(running_output["run_id"], "test-run")
+        benchmark = SelfBenchmark(self._scheduler())
+        running_output = self._read_output(benchmark)
+        self.assertEqual(running_output["scope"], "local_diagnostics")
+        self.assertEqual(running_output["status"], "running")
+        self.assertFalse(running_output["valid"])
+        self.assertEqual(running_output["run_id"], "test-run")
 
-            point = BenchmarkPoint(point_type="prefill", isl=10)
-            benchmark.phase = BenchmarkPhase.SWEEP
-            benchmark._grid = [point]
-            benchmark._grid_index = 0
-            benchmark._current = BenchmarkPointResult(point=point)
+        point = BenchmarkPoint(point_type="prefill", isl=10)
+        self._start_point(benchmark, point)
 
-            fpm = ForwardPassMetrics(
-                worker_id="worker-1",
-                scheduled_requests=ScheduledRequestMetrics(
-                    num_prefill_requests=1,
-                    sum_prefill_tokens=10,
-                    sum_prefill_kv_tokens=10,
-                ),
-            )
-            batch = types.SimpleNamespace(
-                forward_mode=_FakeForwardMode(is_extend=True),
-            )
+        fpm = ForwardPassMetrics(
+            worker_id="worker-1",
+            scheduled_requests=ScheduledRequestMetrics(
+                num_prefill_requests=1,
+                sum_prefill_tokens=10,
+                sum_prefill_kv_tokens=10,
+            ),
+        )
+        batch = types.SimpleNamespace(
+            forward_mode=_FakeForwardMode(is_extend=True),
+        )
 
-            benchmark.observe_forward_pass(batch, fpm)
-            benchmark.maybe_schedule_next()
+        benchmark.observe_forward_pass(batch, fpm)
+        benchmark.maybe_schedule_next()
 
-            self.assertFalse(benchmark.active)
-            with open(benchmark._output_path) as f:
-                output = json.load(f)
-            self.assertEqual(output["scope"], "local_diagnostics")
-            self.assertEqual(output["status"], "complete")
-            self.assertTrue(output["valid"])
-            self.assertEqual(output["run_id"], "test-run")
-            self.assertEqual(output["identity"]["model_path"], "test-model")
-            self.assertEqual(output["identity"]["disaggregation_mode"], "null")
-            self.assertEqual(output["config"]["mode"], "agg")
-            self.assertEqual(output["results"][0]["point"]["point_type"], "prefill")
-            self.assertEqual(
-                output["results"][0]["fpms"][0]["scheduled_requests"][
-                    "num_prefill_requests"
-                ],
-                1,
-            )
+        self.assertFalse(benchmark.active)
+        output = self._read_output(benchmark)
+        self.assertEqual(output["scope"], "local_diagnostics")
+        self.assertEqual(output["status"], "complete")
+        self.assertTrue(output["valid"])
+        self.assertEqual(
+            output["coverage"],
+            {"expected_points": 1, "completed_points": 1, "skipped_points": 0},
+        )
+        self.assertEqual(output["skipped_points"], [])
+        self.assertEqual(output["run_id"], "test-run")
+        self.assertEqual(output["identity"]["model_path"], "test-model")
+        self.assertEqual(output["identity"]["disaggregation_mode"], "null")
+        self.assertEqual(output["config"]["mode"], "agg")
+        self.assertEqual(output["results"][0]["point"]["point_type"], "prefill")
+        self.assertEqual(
+            output["results"][0]["fpms"][0]["scheduled_requests"][
+                "num_prefill_requests"
+            ],
+            1,
+        )
 
     def test_finish_notifies_scheduler_after_writing_output(self):
-        with TemporaryDirectory() as tmpdir:
-            output_path = f"{tmpdir}/benchmark.json"
-            scheduler = _make_scheduler(output_path)
-            calls = []
-            scheduler.on_self_benchmark_finished = lambda: calls.append("done")
-            benchmark = SelfBenchmark(scheduler)
-            benchmark.phase = BenchmarkPhase.SWEEP
-            benchmark._grid_index = len(benchmark._grid)
+        scheduler = self._scheduler()
+        calls = []
+        scheduler.on_self_benchmark_finished = lambda: calls.append("done")
+        benchmark = SelfBenchmark(scheduler)
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid_index = len(benchmark._grid)
 
-            benchmark.maybe_schedule_next()
+        benchmark.maybe_schedule_next()
 
-            self.assertEqual(calls, ["done"])
-            self.assertFalse(benchmark.active)
-            with open(benchmark._output_path) as f:
-                output = json.load(f)
-            self.assertIn("results", output)
+        self.assertEqual(calls, ["done"])
+        self.assertFalse(benchmark.active)
+        self.assertIn("results", self._read_output(benchmark))
 
     def test_output_invalidation_replaces_stale_result_for_worker_path(self):
-        with TemporaryDirectory() as tmpdir:
-            # dp_rank 0 writes the caller-assigned base path; a stale prior-run
-            # result there must be invalidated at init.
-            output_path = f"{tmpdir}/benchmark.json"
-            with open(output_path, "w") as f:
-                json.dump({"valid": True, "run_id": "old-run"}, f)
+        # dp_rank 0 writes the caller-assigned base path; a stale prior-run
+        # result there must be invalidated at init.
+        with open(self.output_path, "w") as f:
+            json.dump({"valid": True, "run_id": "old-run"}, f)
 
-            scheduler = _make_scheduler(output_path)
-            scheduler.instance_id = "new-run"
-            benchmark = SelfBenchmark(scheduler)
+        scheduler = self._scheduler()
+        scheduler.instance_id = "new-run"
+        benchmark = SelfBenchmark(scheduler)
 
-            self.assertEqual(benchmark._output_path, output_path)
-            with open(benchmark._output_path) as f:
-                output = json.load(f)
-            self.assertFalse(output["valid"])
-            self.assertEqual(output["status"], "running")
-            self.assertEqual(output["run_id"], "new-run")
+        self.assertEqual(benchmark._output_path, self.output_path)
+        output = self._read_output(benchmark)
+        self.assertFalse(output["valid"])
+        self.assertEqual(output["status"], "running")
+        self.assertEqual(output["run_id"], "new-run")
 
     def test_output_path_follows_dp_rank_contract(self):
-        with TemporaryDirectory() as tmpdir:
-            output_path = f"{tmpdir}/benchmark.json"
-            # dp_rank 0 -> caller-assigned base path, unchanged.
-            dp0 = SelfBenchmark(_make_scheduler(output_path))
-            self.assertEqual(dp0._output_path, output_path)
+        # dp_rank 0 -> caller-assigned base path, unchanged.
+        dp0 = SelfBenchmark(self._scheduler())
+        self.assertEqual(dp0._output_path, self.output_path)
 
-            # dp_rank N -> the "_dpN" sibling the consumer addresses.
-            dp1_scheduler = _make_scheduler(output_path)
-            dp1_scheduler.ps.dp_rank = 1
-            dp1 = SelfBenchmark(dp1_scheduler)
-            self.assertEqual(dp1._output_path, f"{tmpdir}/benchmark_dp1.json")
+        # dp_rank N -> the "_dpN" sibling the consumer addresses.
+        dp1_scheduler = self._scheduler()
+        dp1_scheduler.ps.dp_rank = 1
+        dp1 = SelfBenchmark(dp1_scheduler)
+        self.assertEqual(
+            dp1._output_path,
+            os.path.join(self._tmpdir.name, "benchmark_dp1.json"),
+        )
 
     def test_role_recorded_in_contents_not_path(self):
-        with TemporaryDirectory() as tmpdir:
-            # Role/run/rank identity lives in the file contents, not the
-            # filename; co-located workers are kept distinct by the caller
-            # assigning a unique base path, not by namespacing the filename.
-            output_path = f"{tmpdir}/benchmark.json"
-            prefill_scheduler = _make_scheduler(output_path)
-            prefill_scheduler.disaggregation_mode = DisaggregationMode.PREFILL
-            prefill_benchmark = SelfBenchmark(prefill_scheduler)
+        # Role/run/rank identity lives in the file contents, not the filename;
+        # co-located workers are kept distinct by caller-assigned base paths.
+        prefill_scheduler = self._scheduler()
+        prefill_scheduler.disaggregation_mode = DisaggregationMode.PREFILL
+        prefill_benchmark = SelfBenchmark(prefill_scheduler)
 
-            self.assertEqual(prefill_benchmark._output_path, output_path)
-            self.assertEqual(
-                prefill_benchmark._identity["disaggregation_mode"], "prefill"
-            )
+        self.assertEqual(prefill_benchmark._output_path, self.output_path)
+        self.assertEqual(prefill_benchmark._identity["disaggregation_mode"], "prefill")
 
     def test_finish_waits_for_inflight_scheduler_state(self):
         cases = [
@@ -265,11 +283,39 @@ class TestSelfBenchmark(CustomTestCase):
                     types.SimpleNamespace(queue=[object()]),
                 ),
             ),
+            (
+                "grammar_queue",
+                lambda s: setattr(
+                    s,
+                    "grammar_manager",
+                    types.SimpleNamespace(grammar_queue=[object()]),
+                ),
+            ),
+            (
+                "disagg_decode_retracted_queue",
+                lambda s: setattr(
+                    s,
+                    "disagg_decode_prealloc_queue",
+                    types.SimpleNamespace(
+                        queue=[], retracted_queue=[object()], pending_reqs=[]
+                    ),
+                ),
+            ),
+            (
+                "disagg_decode_pending_reqs",
+                lambda s: setattr(
+                    s,
+                    "disagg_decode_prealloc_queue",
+                    types.SimpleNamespace(
+                        queue=[], retracted_queue=[], pending_reqs=[object()]
+                    ),
+                ),
+            ),
         ]
 
         for name, mark_inflight in cases:
             with self.subTest(name=name):
-                scheduler = _make_scheduler("/tmp/unused.json")
+                scheduler = self._scheduler()
                 calls = []
                 scheduler.on_self_benchmark_finished = lambda: calls.append("done")
                 mark_inflight(scheduler)
@@ -284,19 +330,28 @@ class TestSelfBenchmark(CustomTestCase):
                 self.assertEqual(calls, [])
                 self.assertTrue(benchmark.active)
 
-    def test_decode_point_ignores_setup_prefill_until_decode_pass(self):
-        benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
-        point = BenchmarkPoint(point_type="decode", context_length=8, batch_size=2)
-        benchmark.phase = BenchmarkPhase.SWEEP
-        benchmark._grid = [point]
-        benchmark._current = BenchmarkPointResult(point=point)
+    def test_empty_optional_queues_are_not_inflight(self):
+        empty_queues = (
+            ("disagg_prefill_inflight_queue", []),
+            ("grammar_manager", types.SimpleNamespace(grammar_queue=[])),
+            (
+                "disagg_decode_prealloc_queue",
+                types.SimpleNamespace(queue=[], retracted_queue=[], pending_reqs=[]),
+            ),
+        )
+        for name, value in empty_queues:
+            with self.subTest(name=name):
+                scheduler = self._scheduler()
+                setattr(scheduler, name, value)
+                self.assertFalse(SelfBenchmark(scheduler)._has_inflight_work())
 
-        prefill_fpm = ForwardPassMetrics(
-            scheduled_requests=ScheduledRequestMetrics(num_prefill_requests=2)
-        )
-        decode_fpm = ForwardPassMetrics(
-            scheduled_requests=ScheduledRequestMetrics(num_decode_requests=2)
-        )
+    def test_decode_point_ignores_setup_prefill_until_decode_pass(self):
+        benchmark = SelfBenchmark(self._scheduler())
+        point = BenchmarkPoint(point_type="decode", context_length=8, batch_size=2)
+        self._start_point(benchmark, point)
+
+        prefill_fpm = self._fpm(num_prefill_requests=2)
+        decode_fpm = self._fpm(num_decode_requests=2)
 
         benchmark.observe_forward_pass(
             types.SimpleNamespace(forward_mode=_FakeForwardMode(is_extend=True)),
@@ -317,13 +372,10 @@ class TestSelfBenchmark(CustomTestCase):
         )
 
     def test_prefill_point_accumulates_fpms_until_request_finishes(self):
-        benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
+        benchmark = SelfBenchmark(self._scheduler())
         point = BenchmarkPoint(point_type="prefill", isl=32)
         req = _FakeReq(finished=False)
-        benchmark.phase = BenchmarkPhase.SWEEP
-        benchmark._grid = [point]
-        benchmark._current = BenchmarkPointResult(point=point)
-        benchmark._active_reqs = [req]
+        self._start_point(benchmark, point, active_reqs=[req])
 
         first_chunk = ForwardPassMetrics(
             scheduled_requests=ScheduledRequestMetrics(
@@ -361,14 +413,10 @@ class TestSelfBenchmark(CustomTestCase):
         )
 
     def test_maybe_schedule_next_advances_current_point_finished_after_observe(self):
-        benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
+        benchmark = SelfBenchmark(self._scheduler())
         point = BenchmarkPoint(point_type="prefill", isl=32)
         req = _FakeReq(finished=False)
-        benchmark.phase = BenchmarkPhase.SWEEP
-        benchmark._grid = [point]
-        benchmark._grid_index = 0
-        benchmark._current = BenchmarkPointResult(point=point)
-        benchmark._active_reqs = [req]
+        self._start_point(benchmark, point, active_reqs=[req])
 
         fpm = ForwardPassMetrics(
             scheduled_requests=ScheduledRequestMetrics(
@@ -392,7 +440,7 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(len(benchmark._results[0].fpms), 1)
 
     def test_decode_grid_preserves_room_for_one_decode_token(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.max_req_input_len = 16
         scheduler.max_req_len = 12
         scheduler.max_total_num_tokens = 64
@@ -406,7 +454,7 @@ class TestSelfBenchmark(CustomTestCase):
             10,
         )
 
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.max_req_input_len = 128
         scheduler.max_req_len = 128
         scheduler.max_total_num_tokens = 100
@@ -421,8 +469,20 @@ class TestSelfBenchmark(CustomTestCase):
             80,
         )
 
+    def test_decode_grid_is_capped_by_forward_batch_limit(self):
+        scheduler = self._scheduler()
+        scheduler.server_args.benchmark_mode = "decode"
+        scheduler.server_args.cuda_graph_config.decode.max_bs = 7
+        scheduler.max_running_requests = 4096
+        scheduler.max_total_num_tokens = 8192
+
+        benchmark = SelfBenchmark(scheduler)
+
+        decode_points = [p for p in benchmark._grid if p.point_type == "decode"]
+        self.assertEqual(max(p.batch_size for p in decode_points), 7)
+
     def test_synthetic_decode_models_prefill_to_decode_boundary(self):
-        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
+        scheduler = _prepare_decode_scheduler(self._scheduler())
         benchmark = SelfBenchmark(scheduler)
         captured = {}
         fake_batch = object()
@@ -455,7 +515,7 @@ class TestSelfBenchmark(CustomTestCase):
             self.assertFalse(req.finished())
 
     def test_synthetic_decode_skips_if_two_tokens_cannot_be_generated(self):
-        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
+        scheduler = _prepare_decode_scheduler(self._scheduler())
         scheduler.init_req_max_new_tokens = lambda req: setattr(
             req.sampling_params, "max_new_tokens", 1
         )
@@ -472,7 +532,7 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(benchmark._active_reqs, [])
 
     def test_prefill_grid_is_not_capped_at_chunked_prefill_size(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.server_args.chunked_prefill_size = 8
         scheduler.max_req_input_len = 128
@@ -486,7 +546,7 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertTrue(all(p.kv_read_tokens == 0 for p in prefill_points))
 
     def test_prefill_grid_is_capped_by_forward_token_budget(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.max_req_input_len = 40960
         scheduler.max_total_num_tokens = 40960
@@ -502,7 +562,7 @@ class TestSelfBenchmark(CustomTestCase):
         )
 
     def test_prefill_kv_read_grid_crosses_with_isl(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.server_args.benchmark_prefill_kv_read_granularity = 3
 
@@ -522,7 +582,7 @@ class TestSelfBenchmark(CustomTestCase):
         )
 
     def test_prefill_kv_read_grid_aligns_to_page_size(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.page_size = 8
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.server_args.benchmark_prefill_kv_read_granularity = 4
@@ -539,7 +599,7 @@ class TestSelfBenchmark(CustomTestCase):
         )
 
     def test_prefill_kv_read_point_seeds_then_measures_with_same_extra_key(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         benchmark = SelfBenchmark(scheduler)
         point = BenchmarkPoint(point_type="prefill", isl=16, kv_read_tokens=8)
@@ -577,7 +637,7 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertIsNone(benchmark._pending_seed_extra_key)
 
     def test_prefill_kv_read_point_skips_when_seed_validation_misses(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         benchmark = SelfBenchmark(scheduler)
         point = BenchmarkPoint(point_type="prefill", isl=16, kv_read_tokens=8)
@@ -600,26 +660,13 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertIsNone(benchmark._pending_seed_point)
         self.assertEqual(benchmark._grid_index, 1)
         self.assertEqual(len(calls), 1)
-
-    def test_chunked_prefill_request_counts_as_inflight_work(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
-        benchmark = SelfBenchmark(scheduler)
-
-        self.assertFalse(benchmark._has_inflight_work())
-        scheduler.chunked_req = object()
-        self.assertTrue(benchmark._has_inflight_work())
-
-    def test_disagg_prefill_inflight_list_counts_as_inflight_work(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
-        scheduler.disagg_prefill_inflight_queue = []
-        benchmark = SelfBenchmark(scheduler)
-
-        self.assertFalse(benchmark._has_inflight_work())
-        scheduler.disagg_prefill_inflight_queue.append(object())
-        self.assertTrue(benchmark._has_inflight_work())
+        self.assertEqual(len(benchmark._skipped_points), 1)
+        self.assertEqual(
+            benchmark._skipped_points[0].reason, "seed_cache_validation_failed"
+        )
 
     def test_disaggregated_workers_only_build_supported_grid(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "decode"
         scheduler.disaggregation_mode = DisaggregationMode.PREFILL
 
@@ -628,7 +675,7 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(benchmark._grid, [])
         self.assertEqual(benchmark._inject_warmup(), 0)
 
-        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "agg"
         scheduler.disaggregation_mode = DisaggregationMode.DECODE
 
@@ -641,7 +688,7 @@ class TestSelfBenchmark(CustomTestCase):
         # FutureMap.stash a RelayPayload, never a raw tensor. We exercise the
         # REAL _build_synthetic_decode_batch (only the memory allocation and
         # sampling-info construction are stubbed) so the stash call is covered.
-        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
+        scheduler = _prepare_decode_scheduler(self._scheduler())
 
         captured = {}
 
@@ -699,153 +746,136 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(captured["payload"].bonus_tokens.tolist(), [0])
         self.assertIsNone(batch.input_ids)
 
-    def test_synthetic_decode_build_failure_frees_reqs_and_skips(self):
-        # P0-1: any failure in _build_synthetic_decode_batch (now caught as
-        # Exception, not just RuntimeError) must free the pre-allocated reqs and
-        # skip the point, never crash the scheduler.
-        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
-        freed = {}
-        benchmark = SelfBenchmark(scheduler)
+    def test_synthetic_decode_build_failure_cleans_up_and_reraises(self):
+        for cleanup_error in (None, RuntimeError("cleanup failed")):
+            with self.subTest(cleanup_error=cleanup_error):
+                scheduler = _prepare_decode_scheduler(self._scheduler())
+                original_batch = scheduler.running_batch
+                benchmark = SelfBenchmark(scheduler)
+                build_error = AttributeError("synthetic build failed")
+                cleanup = mock.Mock(side_effect=cleanup_error)
+                benchmark._build_synthetic_decode_batch = mock.Mock(
+                    side_effect=build_error
+                )
+                benchmark._free_synthetic_decode_reqs = cleanup
 
-        def raising_build(_reqs, _ctx):
-            raise AttributeError("simulated stash on raw tensor")
+                with self.assertRaises(AttributeError) as raised:
+                    benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
 
-        def fake_free(reqs):
-            freed["reqs"] = reqs
+                self.assertIs(raised.exception, build_error)
+                cleanup.assert_called_once()
+                self.assertEqual(len(cleanup.call_args.args[0]), 2)
+                self.assertIs(scheduler.running_batch, original_batch)
+                self.assertEqual(benchmark._active_reqs, [])
 
-        benchmark._build_synthetic_decode_batch = raising_build
-        benchmark._free_synthetic_decode_reqs = fake_free
+    def test_partial_sweep_records_skipped_point_and_is_invalid(self):
+        benchmark = SelfBenchmark(self._scheduler())
+        completed = BenchmarkPoint(point_type="prefill", isl=10)
+        skipped = BenchmarkPoint(point_type="decode", context_length=1, batch_size=1)
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid = [completed, skipped]
+        benchmark._grid_index = 1
+        benchmark._results = [
+            BenchmarkPointResult(point=completed, fpms=[{"wall_time": 0.1}])
+        ]
+        benchmark._inject_synthetic_decode = lambda **_kwargs: 0
 
-        injected = benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
+        benchmark.maybe_schedule_next()
+        benchmark.maybe_schedule_next()
 
-        self.assertEqual(injected, 0)
-        self.assertEqual(benchmark._active_reqs, [])
-        self.assertIn("reqs", freed)
-        self.assertEqual(len(freed["reqs"]), 2)
+        output = self._read_output(benchmark)
+        self.assertEqual(output["status"], "complete")
+        self.assertFalse(output["valid"])
+        self.assertEqual(
+            output["coverage"],
+            {"expected_points": 2, "completed_points": 1, "skipped_points": 1},
+        )
+        self.assertEqual(len(output["results"]), 1)
+        [skipped_output] = output["skipped_points"]
+        self.assertEqual(skipped_output["point"], vars(skipped))
+        self.assertEqual(skipped_output["reason"], "request_injection_failed")
+
+    def test_completed_point_without_metrics_is_skipped(self):
+        benchmark = SelfBenchmark(self._scheduler())
+        point = BenchmarkPoint(point_type="prefill", isl=10)
+        self._start_point(benchmark, point)
+
+        benchmark._save_current_point()
+
+        self.assertEqual(benchmark._results, [])
+        self.assertEqual(benchmark._skipped_points[0].reason, "no_forward_pass_metrics")
 
     def test_benchmark_forced_fpm_rank_advances_then_restores(self):
-        # P0-2: a rank where the real gate gives enable_fpm=False, but with
-        # benchmark_mode set, has FPM force-enabled for the sweep. The sweep must
-        # advance WARMUP->SWEEP->DONE off observe_forward_pass and restore FPM
-        # afterwards (and not write the redundant JSON).
-        with TemporaryDirectory() as tmpdir:
-            output_path = f"{tmpdir}/benchmark.json"
-            scheduler = _make_scheduler(output_path)
-            # Simulate metrics_reporter._init_fpm forcing FPM on a non-FPM rank.
-            scheduler.enable_fpm = True
-            scheduler._fpm_is_real_rank = False
-            scheduler._fpm_benchmark_forced = True
+        scheduler = self._scheduler()
+        # Simulate metrics_reporter._init_fpm forcing FPM on a non-FPM rank.
+        scheduler.enable_fpm = True
+        scheduler._fpm_is_real_rank = False
+        scheduler._fpm_benchmark_forced = True
 
-            shutdown_calls = []
-            scheduler.metrics_reporter = types.SimpleNamespace(
-                shutdown_benchmark_forced_fpm=lambda: shutdown_calls.append("shutdown")
-            )
-            finished_calls = []
-            scheduler.on_self_benchmark_finished = lambda: finished_calls.append("done")
+        shutdown_calls = []
+        scheduler.metrics_reporter = types.SimpleNamespace(
+            shutdown_benchmark_forced_fpm=lambda: shutdown_calls.append("shutdown")
+        )
+        finished_calls = []
+        scheduler.on_self_benchmark_finished = lambda: finished_calls.append("done")
 
-            benchmark = SelfBenchmark(scheduler)
-            # Forced rank must not be marked as an output writer.
-            self.assertFalse(benchmark._write_results)
-            # FPM stays on for the duration of the sweep.
-            self.assertTrue(scheduler.enable_fpm)
+        benchmark = SelfBenchmark(scheduler)
+        self.assertFalse(benchmark._write_results)
+        self.assertTrue(scheduler.enable_fpm)
 
-            point = BenchmarkPoint(point_type="prefill", isl=10)
-            benchmark.phase = BenchmarkPhase.SWEEP
-            benchmark._grid = [point]
-            benchmark._grid_index = 0
-            benchmark._current = BenchmarkPointResult(point=point)
+        point = BenchmarkPoint(point_type="prefill", isl=10)
+        self._start_point(benchmark, point)
+        batch = types.SimpleNamespace(forward_mode=_FakeForwardMode(is_extend=True))
 
-            fpm = ForwardPassMetrics(
-                scheduled_requests=ScheduledRequestMetrics(num_prefill_requests=1),
-            )
-            batch = types.SimpleNamespace(
-                forward_mode=_FakeForwardMode(is_extend=True),
-            )
+        benchmark.observe_forward_pass(batch, self._fpm(num_prefill_requests=1))
+        benchmark.maybe_schedule_next()
 
-            # observe_forward_pass must fire and advance the phase.
-            benchmark.observe_forward_pass(batch, fpm)
-            benchmark.maybe_schedule_next()
-
-            self.assertFalse(benchmark.active)
-            self.assertEqual(benchmark.phase, BenchmarkPhase.DONE)
-            self.assertEqual(finished_calls, ["done"])
-            # Forced publisher torn down and FPM restored to the prior off state.
-            self.assertEqual(shutdown_calls, ["shutdown"])
-            self.assertFalse(scheduler.enable_fpm)
-            # No JSON written on the forced rank.
-            self.assertFalse(
-                os.path.exists(benchmark._output_path),
-                "benchmark-forced rank must not write output JSON",
-            )
+        self.assertFalse(benchmark.active)
+        self.assertEqual(benchmark.phase, BenchmarkPhase.DONE)
+        self.assertEqual(finished_calls, ["done"])
+        self.assertEqual(shutdown_calls, ["shutdown"])
+        self.assertFalse(scheduler.enable_fpm)
+        self.assertFalse(
+            os.path.exists(benchmark._output_path),
+            "benchmark-forced rank must not write output JSON",
+        )
 
     def test_real_fpm_rank_keeps_fpm_enabled_after_sweep(self):
-        # P0-2: the real FPM rank's production behavior is unchanged after the
-        # sweep -- enable_fpm stays True and no forced teardown happens.
-        with TemporaryDirectory() as tmpdir:
-            output_path = f"{tmpdir}/benchmark.json"
-            scheduler = _make_scheduler(output_path)
-            scheduler.enable_fpm = True
-            scheduler._fpm_is_real_rank = True
-            scheduler._fpm_benchmark_forced = False
+        scheduler = self._scheduler()
+        scheduler.enable_fpm = True
+        scheduler._fpm_is_real_rank = True
+        scheduler._fpm_benchmark_forced = False
+        shutdown_calls = []
 
-            # Faithful stub: the real helper early-returns for a non-forced rank.
-            shutdown_calls = []
+        def fake_shutdown():
+            if getattr(scheduler, "_fpm_benchmark_forced", False):
+                shutdown_calls.append("shutdown")
 
-            def fake_shutdown():
-                if getattr(scheduler, "_fpm_benchmark_forced", False):
-                    shutdown_calls.append("shutdown")
+        scheduler.metrics_reporter = types.SimpleNamespace(
+            shutdown_benchmark_forced_fpm=fake_shutdown
+        )
 
-            scheduler.metrics_reporter = types.SimpleNamespace(
-                shutdown_benchmark_forced_fpm=fake_shutdown
-            )
-
-            benchmark = SelfBenchmark(scheduler)
-            self.assertTrue(benchmark._write_results)
-
-            benchmark.phase = BenchmarkPhase.SWEEP
-            benchmark._grid_index = len(benchmark._grid)
-            benchmark.maybe_schedule_next()
-
-            self.assertFalse(benchmark.active)
-            # Real rank keeps publishing; forced-teardown is a no-op for it.
-            self.assertEqual(shutdown_calls, [])
-            self.assertTrue(scheduler.enable_fpm)
-
-    def test_grammar_queue_counts_as_inflight_work(self):
-        scheduler = _make_scheduler("/tmp/unused.json")
-        scheduler.grammar_manager = types.SimpleNamespace(grammar_queue=[])
         benchmark = SelfBenchmark(scheduler)
+        self.assertTrue(benchmark._write_results)
 
-        self.assertFalse(benchmark._has_inflight_work())
-        scheduler.grammar_manager.grammar_queue.append(object())
-        self.assertTrue(benchmark._has_inflight_work())
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid_index = len(benchmark._grid)
+        benchmark.maybe_schedule_next()
 
-    def test_decode_prealloc_retracted_and_pending_count_as_inflight_work(self):
-        for attr in ("retracted_queue", "pending_reqs"):
-            with self.subTest(attr=attr):
-                scheduler = _make_scheduler("/tmp/unused.json")
-                queue_owner = types.SimpleNamespace(
-                    queue=[], retracted_queue=[], pending_reqs=[]
-                )
-                scheduler.disagg_decode_prealloc_queue = queue_owner
-                benchmark = SelfBenchmark(scheduler)
-
-                self.assertFalse(benchmark._has_inflight_work())
-                getattr(queue_owner, attr).append(object())
-                self.assertTrue(benchmark._has_inflight_work())
+        self.assertFalse(benchmark.active)
+        self.assertEqual(shutdown_calls, [])
+        self.assertTrue(scheduler.enable_fpm)
 
 
 def _make_rejection_scheduler():
-    """Fake `self` for invoking Scheduler.maybe_init_self_benchmark unbound.
+    """Fake scheduler for exercising SelfBenchmark.create_if_enabled.
 
-    Defaults to a configuration that would PASS all rejections; each test flips
-    one attribute to trigger a specific ValueError. The success path constructs
-    a real SelfBenchmark, so tests only assert the rejection branches.
+    Defaults to a configuration that passes every compatibility check; tests
+    mutate one attribute at a time to exercise each rejection.
     """
     return types.SimpleNamespace(
-        self_benchmark=None,
         server_args=types.SimpleNamespace(benchmark_mode="agg", load_format="auto"),
-        ps=types.SimpleNamespace(pp_size=1),
+        ps=types.SimpleNamespace(pp_size=1, tp_size=2, dp_size=2),
         enable_pdmux=False,
         enable_overlap_mlx=False,
         is_generation=True,
@@ -857,73 +887,83 @@ def _make_rejection_scheduler():
     )
 
 
-class TestSelfBenchmarkSchedulerRejections(CustomTestCase):
-    """Scheduler-side fast-fail rejections in maybe_init_self_benchmark.
+class TestSelfBenchmarkFactory(CustomTestCase):
+    """Runtime fast-fail rejections in SelfBenchmark.create_if_enabled.
 
     These cannot live in the server_args tests because the validations run in
-    the Scheduler (they need is_generation / spec_algorithm / model_config /
-    enable_lora / load_format resolved). We invoke the method unbound on a fake
-    `self` so we don't have to construct a full Scheduler.
+    the scheduler process (they need is_generation / spec_algorithm /
+    model_config / enable_lora / load_format resolved).
     """
 
     @staticmethod
-    def _run(fake_self):
-        from sglang.srt.managers.scheduler import Scheduler
+    def _run(fake_scheduler):
+        return SelfBenchmark.create_if_enabled(fake_scheduler)
 
-        Scheduler.maybe_init_self_benchmark(fake_self)
+    def test_disabled_returns_none(self):
+        fake = types.SimpleNamespace(
+            server_args=types.SimpleNamespace(benchmark_mode=None)
+        )
+        self.assertIsNone(self._run(fake))
 
-    def test_rejects_non_generation_model(self):
-        fake = _make_rejection_scheduler()
-        fake.is_generation = False
-        with self.assertRaisesRegex(ValueError, "only supported for generative"):
-            self._run(fake)
+    def test_rejects_unsupported_runtime_configurations(self):
+        cases = (
+            (
+                "pipeline parallelism",
+                lambda scheduler: setattr(scheduler.ps, "pp_size", 2),
+            ),
+            (
+                "PD multiplexing",
+                lambda scheduler: setattr(scheduler, "enable_pdmux", True),
+            ),
+            (
+                "MLX overlap",
+                lambda scheduler: setattr(scheduler, "enable_overlap_mlx", True),
+            ),
+            (
+                "only supported for generative",
+                lambda scheduler: setattr(scheduler, "is_generation", False),
+            ),
+            (
+                "speculative decoding",
+                lambda scheduler: setattr(
+                    scheduler.spec_algorithm, "is_none", lambda: False
+                ),
+            ),
+            (
+                "encoder-decoder",
+                lambda scheduler: setattr(
+                    scheduler.model_config, "is_encoder_decoder", True
+                ),
+            ),
+            (
+                "multimodal",
+                lambda scheduler: setattr(
+                    scheduler.model_config, "is_multimodal", True
+                ),
+            ),
+            ("LoRA", lambda scheduler: setattr(scheduler, "enable_lora", True)),
+            (
+                "dummy weights",
+                lambda scheduler: setattr(
+                    scheduler.server_args, "load_format", "dummy"
+                ),
+            ),
+        )
 
-    def test_rejects_speculative_decoding(self):
-        fake = _make_rejection_scheduler()
-        fake.spec_algorithm = types.SimpleNamespace(is_none=lambda: False)
-        with self.assertRaisesRegex(ValueError, "speculative decoding"):
-            self._run(fake)
-
-    def test_rejects_encoder_decoder(self):
-        fake = _make_rejection_scheduler()
-        fake.model_config.is_encoder_decoder = True
-        with self.assertRaisesRegex(ValueError, "encoder-decoder"):
-            self._run(fake)
-
-    def test_rejects_multimodal(self):
-        fake = _make_rejection_scheduler()
-        fake.model_config.is_multimodal = True
-        with self.assertRaisesRegex(ValueError, "multimodal"):
-            self._run(fake)
-
-    def test_rejects_lora(self):
-        fake = _make_rejection_scheduler()
-        fake.enable_lora = True
-        with self.assertRaisesRegex(ValueError, "LoRA"):
-            self._run(fake)
-
-    def test_rejects_dummy_weights(self):
-        fake = _make_rejection_scheduler()
-        fake.server_args.load_format = "dummy"
-        with self.assertRaisesRegex(ValueError, "dummy weights"):
-            self._run(fake)
+        for message, mutate in cases:
+            with self.subTest(message=message):
+                fake = _make_rejection_scheduler()
+                mutate(fake)
+                with self.assertRaisesRegex(ValueError, message):
+                    self._run(fake)
 
     def test_does_not_reject_multi_rank_tp(self):
-        # MUST NOT reject tp_size>1 / dp_size>1. The fake `self` has no tp_size
-        # gate; maybe_init_self_benchmark only rejects pp_size>1. Confirm a
-        # passing config reaches SelfBenchmark construction (which then fails on
-        # the incomplete fake), proving none of the rejections fired.
         fake = _make_rejection_scheduler()
-        # Reaching SelfBenchmark(self) means all rejections passed. SelfBenchmark
-        # construction will raise (fake lacks the full surface) -- anything but a
-        # benchmark-mode ValueError proves we got past the guards.
-        try:
-            self._run(fake)
-        except ValueError as exc:  # pragma: no cover - defensive
-            self.assertNotIn("--benchmark-mode is not supported", str(exc))
-            self.assertNotIn("only supported for generative", str(exc))
-        except Exception:
-            pass
+        with mock.patch.object(SelfBenchmark, "__init__", return_value=None) as init:
+            benchmark = self._run(fake)
+
+        init.assert_called_once_with(fake)
+        self.assertIsInstance(benchmark, SelfBenchmark)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -8,6 +8,7 @@ import unittest
 from collections import deque
 from tempfile import TemporaryDirectory
 
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.scheduler_components.self_benchmark import (
     BenchmarkPhase,
     BenchmarkPoint,
@@ -53,6 +54,7 @@ def _make_scheduler(output_path: str):
         max_req_len=32,
         max_prefill_tokens=64,
         page_size=1,
+        disaggregation_mode=DisaggregationMode.NULL,
         ps=types.SimpleNamespace(dp_rank=0),
         result_queue=deque(),
         waiting_queue=[],
@@ -129,6 +131,54 @@ class TestSelfBenchmark(unittest.TestCase):
             benchmark._results[0].fpms[0]["scheduled_requests"]["num_decode_requests"],
             2,
         )
+
+    def test_decode_grid_preserves_room_for_one_decode_token(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.max_req_input_len = 16
+        scheduler.max_req_len = 12
+        scheduler.max_total_num_tokens = 64
+
+        benchmark = SelfBenchmark(scheduler)
+
+        decode_points = [p for p in benchmark._grid if p.point_type == "decode"]
+        self.assertGreater(len(decode_points), 0)
+        self.assertLessEqual(
+            max(p.context_length for p in decode_points),
+            10,
+        )
+
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.max_req_input_len = 128
+        scheduler.max_req_len = 128
+        scheduler.max_total_num_tokens = 100
+        scheduler.page_size = 16
+
+        benchmark = SelfBenchmark(scheduler)
+
+        decode_points = [p for p in benchmark._grid if p.point_type == "decode"]
+        self.assertGreater(len(decode_points), 0)
+        self.assertLessEqual(
+            max(p.context_length for p in decode_points),
+            80,
+        )
+
+    def test_disaggregated_workers_only_build_supported_grid(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.server_args.benchmark_mode = "decode"
+        scheduler.disaggregation_mode = DisaggregationMode.PREFILL
+
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertEqual(benchmark._grid, [])
+        self.assertEqual(benchmark._inject_warmup(), 0)
+
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.server_args.benchmark_mode = "agg"
+        scheduler.disaggregation_mode = DisaggregationMode.DECODE
+
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertTrue(all(p.point_type == "decode" for p in benchmark._grid))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -12,6 +12,7 @@ from unittest import mock
 
 import sglang.srt.managers.scheduler_components.self_benchmark_decode as self_benchmark_decode_module
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.schedule_batch import compute_extend_logprob_start_len
 from sglang.srt.managers.scheduler_components.self_benchmark import (
     SELF_BENCHMARK_DUMMY_TOKEN_ID,
     BenchmarkPhase,
@@ -752,6 +753,23 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(type(captured["payload"]).__name__, "RelayPayload")
         self.assertEqual(captured["payload"].bonus_tokens.tolist(), [0])
         self.assertIsNone(batch.input_ids)
+
+    def test_synthetic_req_matches_dp_attention_logprob_accounting(self):
+        scheduler = _prepare_decode_scheduler(self._scheduler())
+        benchmark = SelfBenchmark(scheduler)
+        prompt_len = 8
+
+        req = benchmark._new_synthetic_req(prompt_len=prompt_len, max_tokens=2)
+        logprob_start_len = compute_extend_logprob_start_len(
+            logprob_start_len=req.logprob_start_len,
+            prefix_len=0,
+            extend_len=prompt_len,
+            full_untruncated_fill_len=prompt_len,
+        )
+        num_tokens_for_logprob = max(prompt_len - logprob_start_len, 1)
+
+        self.assertFalse(req.return_logprob)
+        self.assertEqual(num_tokens_for_logprob, 1)
 
     def test_synthetic_decode_build_failure_cleans_up_and_reraises(self):
         for cleanup_error in (None, RuntimeError("cleanup failed")):

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -46,6 +46,7 @@ def _make_scheduler(output_path: str):
             benchmark_warmup_iterations=0,
             benchmark_output_path=output_path,
             benchmark_timeout=300,
+            chunked_prefill_size=None,
         ),
         enable_fpm=True,
         max_req_input_len=16,
@@ -59,7 +60,16 @@ def _make_scheduler(output_path: str):
         result_queue=deque(),
         waiting_queue=[],
         running_batch=None,
+        chunked_req=None,
     )
+
+
+class _FakeReq:
+    def __init__(self, finished: bool = False):
+        self._finished = finished
+
+    def finished(self):
+        return self._finished
 
 
 class TestSelfBenchmark(unittest.TestCase):
@@ -132,6 +142,50 @@ class TestSelfBenchmark(unittest.TestCase):
             2,
         )
 
+    def test_prefill_point_accumulates_fpms_until_request_finishes(self):
+        benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
+        point = BenchmarkPoint(point_type="prefill", isl=32)
+        req = _FakeReq(finished=False)
+        benchmark.phase = BenchmarkPhase.SWEEP
+        benchmark._grid = [point]
+        benchmark._current = BenchmarkPointResult(point=point)
+        benchmark._active_reqs = [req]
+
+        first_chunk = ForwardPassMetrics(
+            scheduled_requests=ScheduledRequestMetrics(
+                num_prefill_requests=1,
+                sum_prefill_tokens=16,
+                sum_prefill_kv_tokens=0,
+            )
+        )
+        final_chunk = ForwardPassMetrics(
+            scheduled_requests=ScheduledRequestMetrics(
+                num_prefill_requests=1,
+                sum_prefill_tokens=16,
+                sum_prefill_kv_tokens=16,
+            )
+        )
+        batch = types.SimpleNamespace(forward_mode=_FakeForwardMode(is_extend=True))
+
+        benchmark.observe_forward_pass(batch, first_chunk)
+
+        self.assertIsNotNone(benchmark._current)
+        self.assertEqual(len(benchmark._results), 0)
+        self.assertEqual(len(benchmark._current.fpms), 1)
+
+        req._finished = True
+        benchmark.observe_forward_pass(batch, final_chunk)
+
+        self.assertIsNone(benchmark._current)
+        self.assertEqual(len(benchmark._results), 1)
+        self.assertEqual(len(benchmark._results[0].fpms), 2)
+        self.assertEqual(
+            benchmark._results[0].fpms[1]["scheduled_requests"][
+                "sum_prefill_kv_tokens"
+            ],
+            16,
+        )
+
     def test_decode_grid_preserves_room_for_one_decode_token(self):
         scheduler = _make_scheduler("/tmp/unused.json")
         scheduler.max_req_input_len = 16
@@ -161,6 +215,27 @@ class TestSelfBenchmark(unittest.TestCase):
             max(p.context_length for p in decode_points),
             80,
         )
+
+    def test_prefill_grid_is_not_capped_at_chunked_prefill_size(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.server_args.chunked_prefill_size = 8
+        scheduler.max_req_input_len = 128
+        scheduler.max_total_num_tokens = 64
+
+        benchmark = SelfBenchmark(scheduler)
+
+        prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
+        self.assertGreater(len(prefill_points), 0)
+        self.assertEqual(max(p.isl for p in prefill_points), 62)
+
+    def test_chunked_prefill_request_counts_as_inflight_work(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertFalse(benchmark._has_inflight_work())
+        scheduler.chunked_req = object()
+        self.assertTrue(benchmark._has_inflight_work())
 
     def test_disaggregated_workers_only_build_supported_grid(self):
         scheduler = _make_scheduler("/tmp/unused.json")

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryDirectory
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.scheduler_components.self_benchmark import (
+    SELF_BENCHMARK_DUMMY_TOKEN_ID,
     BenchmarkPhase,
     BenchmarkPoint,
     BenchmarkPointResult,
@@ -39,7 +40,10 @@ class _FakeForwardMode:
 
 def _make_scheduler(output_path: str):
     return types.SimpleNamespace(
+        instance_id="test-run",
         server_args=types.SimpleNamespace(
+            model_path="test-model",
+            served_model_name=None,
             benchmark_mode="agg",
             benchmark_prefill_granularity=2,
             benchmark_prefill_kv_read_granularity=1,
@@ -47,8 +51,9 @@ def _make_scheduler(output_path: str):
             benchmark_decode_batch_granularity=2,
             benchmark_warmup_iterations=0,
             benchmark_output_path=output_path,
-            benchmark_timeout=300,
             chunked_prefill_size=None,
+            node_rank=0,
+            nnodes=1,
         ),
         enable_fpm=True,
         max_req_input_len=16,
@@ -58,7 +63,16 @@ def _make_scheduler(output_path: str):
         max_prefill_tokens=64,
         page_size=1,
         disaggregation_mode=DisaggregationMode.NULL,
-        ps=types.SimpleNamespace(dp_rank=0),
+        ps=types.SimpleNamespace(
+            dp_rank=0,
+            dp_size=1,
+            tp_rank=0,
+            tp_size=1,
+            attn_tp_rank=0,
+            attn_tp_size=1,
+            attn_cp_rank=0,
+            attn_cp_size=1,
+        ),
         result_queue=deque(),
         waiting_queue=[],
         running_batch=None,
@@ -75,11 +89,34 @@ class _FakeReq:
         return self._finished
 
 
+def _prepare_decode_scheduler(scheduler):
+    scheduler.is_generation = True
+    scheduler.model_config = types.SimpleNamespace(
+        is_encoder_decoder=False,
+        hf_eos_token_id=None,
+        vocab_size=32000,
+    )
+    scheduler.spec_algorithm = types.SimpleNamespace(is_none=lambda: True)
+    scheduler.server_args.allow_auto_truncate = False
+    scheduler.server_args.disaggregation_bootstrap_port = None
+    scheduler.tokenizer = None
+    scheduler.running_batch = types.SimpleNamespace(is_empty=lambda: True)
+    scheduler.init_req_max_new_tokens = lambda req: None
+    return scheduler
+
+
 class TestSelfBenchmark(CustomTestCase):
     def test_prefill_point_collects_fpm_and_writes_output(self):
         with TemporaryDirectory() as tmpdir:
             output_path = f"{tmpdir}/benchmark.json"
             benchmark = SelfBenchmark(_make_scheduler(output_path))
+            with open(benchmark._output_path) as f:
+                running_output = json.load(f)
+            self.assertEqual(running_output["scope"], "local_diagnostics")
+            self.assertEqual(running_output["status"], "running")
+            self.assertFalse(running_output["valid"])
+            self.assertEqual(running_output["run_id"], "test-run")
+
             point = BenchmarkPoint(point_type="prefill", isl=10)
             benchmark.phase = BenchmarkPhase.SWEEP
             benchmark._grid = [point]
@@ -102,8 +139,14 @@ class TestSelfBenchmark(CustomTestCase):
             benchmark.maybe_schedule_next()
 
             self.assertFalse(benchmark.active)
-            with open(output_path) as f:
+            with open(benchmark._output_path) as f:
                 output = json.load(f)
+            self.assertEqual(output["scope"], "local_diagnostics")
+            self.assertEqual(output["status"], "complete")
+            self.assertTrue(output["valid"])
+            self.assertEqual(output["run_id"], "test-run")
+            self.assertEqual(output["identity"]["model_path"], "test-model")
+            self.assertEqual(output["identity"]["disaggregation_mode"], "null")
             self.assertEqual(output["config"]["mode"], "agg")
             self.assertEqual(output["results"][0]["point"]["point_type"], "prefill")
             self.assertEqual(
@@ -127,35 +170,106 @@ class TestSelfBenchmark(CustomTestCase):
 
             self.assertEqual(calls, ["done"])
             self.assertFalse(benchmark.active)
-            with open(output_path) as f:
+            with open(benchmark._output_path) as f:
                 output = json.load(f)
             self.assertIn("results", output)
 
-    def test_timeout_finishes_even_with_unfinished_current_point(self):
+    def test_output_invalidation_replaces_stale_result_for_worker_path(self):
         with TemporaryDirectory() as tmpdir:
             output_path = f"{tmpdir}/benchmark.json"
+            stale_path = (
+                f"{tmpdir}/benchmark_role-null_node-0_dp-0_tp-0_atp-0_acp-0.json"
+            )
+            with open(stale_path, "w") as f:
+                json.dump({"valid": True, "run_id": "old-run"}, f)
+
             scheduler = _make_scheduler(output_path)
-            calls = []
-            scheduler.on_self_benchmark_finished = lambda: calls.append("done")
+            scheduler.instance_id = "new-run"
             benchmark = SelfBenchmark(scheduler)
-            point = BenchmarkPoint(point_type="prefill", isl=10)
-            benchmark.phase = BenchmarkPhase.SWEEP
-            benchmark._grid = [point]
-            benchmark._grid_index = 0
-            benchmark._current = BenchmarkPointResult(point=point)
-            benchmark._active_reqs = [_FakeReq(finished=False)]
-            benchmark._deadline_monotonic = 0
 
-            benchmark.maybe_schedule_next()
-
-            self.assertEqual(calls, ["done"])
-            self.assertFalse(benchmark.active)
-            self.assertIsNone(benchmark._current)
-            self.assertEqual(benchmark._active_reqs, [])
-            with open(output_path) as f:
+            self.assertEqual(benchmark._output_path, stale_path)
+            with open(benchmark._output_path) as f:
                 output = json.load(f)
-            self.assertTrue(output["timed_out"])
-            self.assertEqual(output["results"], [])
+            self.assertFalse(output["valid"])
+            self.assertEqual(output["status"], "running")
+            self.assertEqual(output["run_id"], "new-run")
+
+    def test_output_path_is_role_and_rank_qualified(self):
+        with TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/benchmark.json"
+            prefill_scheduler = _make_scheduler(output_path)
+            prefill_scheduler.disaggregation_mode = DisaggregationMode.PREFILL
+            decode_scheduler = _make_scheduler(output_path)
+            decode_scheduler.disaggregation_mode = DisaggregationMode.DECODE
+
+            prefill_benchmark = SelfBenchmark(prefill_scheduler)
+            decode_benchmark = SelfBenchmark(decode_scheduler)
+
+            self.assertIn("role-prefill", prefill_benchmark._output_path)
+            self.assertIn("role-decode", decode_benchmark._output_path)
+            self.assertNotEqual(
+                prefill_benchmark._output_path, decode_benchmark._output_path
+            )
+
+    def test_finish_waits_for_inflight_scheduler_state(self):
+        cases = [
+            ("result_queue", lambda s: s.result_queue.append(object())),
+            ("waiting_queue", lambda s: s.waiting_queue.append(object())),
+            ("chunked_req", lambda s: setattr(s, "chunked_req", object())),
+            (
+                "running_batch",
+                lambda s: setattr(
+                    s,
+                    "running_batch",
+                    types.SimpleNamespace(is_empty=lambda: False),
+                ),
+            ),
+            (
+                "disagg_prefill_bootstrap_queue",
+                lambda s: setattr(
+                    s,
+                    "disagg_prefill_bootstrap_queue",
+                    types.SimpleNamespace(queue=[object()]),
+                ),
+            ),
+            (
+                "disagg_prefill_inflight_queue",
+                lambda s: setattr(s, "disagg_prefill_inflight_queue", [object()]),
+            ),
+            (
+                "disagg_decode_prealloc_queue",
+                lambda s: setattr(
+                    s,
+                    "disagg_decode_prealloc_queue",
+                    types.SimpleNamespace(queue=[object()]),
+                ),
+            ),
+            (
+                "disagg_decode_transfer_queue",
+                lambda s: setattr(
+                    s,
+                    "disagg_decode_transfer_queue",
+                    types.SimpleNamespace(queue=[object()]),
+                ),
+            ),
+        ]
+
+        for name, mark_inflight in cases:
+            with self.subTest(name=name):
+                scheduler = _make_scheduler("/tmp/unused.json")
+                calls = []
+                scheduler.on_self_benchmark_finished = lambda: calls.append("done")
+                mark_inflight(scheduler)
+                benchmark = SelfBenchmark(scheduler)
+                benchmark.phase = BenchmarkPhase.SWEEP
+                benchmark._grid = []
+                benchmark._grid_index = 0
+                benchmark._write_results = False
+
+                benchmark.maybe_schedule_next()
+
+                self.assertEqual(calls, [])
+                self.assertTrue(benchmark.active)
 
     def test_decode_point_ignores_setup_prefill_until_decode_pass(self):
         benchmark = SelfBenchmark(_make_scheduler("/tmp/unused.json"))
@@ -263,6 +377,56 @@ class TestSelfBenchmark(CustomTestCase):
             80,
         )
 
+    def test_synthetic_decode_models_prefill_to_decode_boundary(self):
+        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
+        benchmark = SelfBenchmark(scheduler)
+        captured = {}
+        fake_batch = object()
+
+        def fake_build_synthetic_decode_batch(reqs, context_length):
+            captured["reqs"] = reqs
+            captured["context_length"] = context_length
+            return fake_batch
+
+        benchmark._build_synthetic_decode_batch = fake_build_synthetic_decode_batch
+
+        injected = benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
+
+        self.assertEqual(injected, 2)
+        self.assertIs(scheduler.running_batch, fake_batch)
+        self.assertEqual(captured["context_length"], 8)
+        self.assertEqual(benchmark._active_reqs, captured["reqs"])
+
+        for req in captured["reqs"]:
+            self.assertEqual(req.sampling_params.max_new_tokens, 2)
+            self.assertEqual(list(req.output_ids), [SELF_BENCHMARK_DUMMY_TOKEN_ID])
+            self.assertEqual(
+                list(req.fill_ids),
+                list(req.origin_input_ids) + [SELF_BENCHMARK_DUMMY_TOKEN_ID],
+            )
+            self.assertEqual(req.seqlen, 9)
+            self.assertEqual(req.kv_committed_len, 8)
+            self.assertEqual(req.kv_allocated_len, 8)
+            self.assertEqual(req.already_computed, 8)
+            self.assertFalse(req.finished())
+
+    def test_synthetic_decode_skips_if_two_tokens_cannot_be_generated(self):
+        scheduler = _prepare_decode_scheduler(_make_scheduler("/tmp/unused.json"))
+        scheduler.init_req_max_new_tokens = lambda req: setattr(
+            req.sampling_params, "max_new_tokens", 1
+        )
+        benchmark = SelfBenchmark(scheduler)
+
+        def fail_build_synthetic_decode_batch(_reqs, _context_length):
+            raise AssertionError("synthetic decode batch should not be built")
+
+        benchmark._build_synthetic_decode_batch = fail_build_synthetic_decode_batch
+
+        injected = benchmark._inject_synthetic_decode(context_length=8, batch_size=2)
+
+        self.assertEqual(injected, 0)
+        self.assertEqual(benchmark._active_reqs, [])
+
     def test_prefill_grid_is_not_capped_at_chunked_prefill_size(self):
         scheduler = _make_scheduler("/tmp/unused.json")
         scheduler.server_args.benchmark_mode = "prefill"
@@ -276,6 +440,22 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertGreater(len(prefill_points), 0)
         self.assertEqual(max(p.isl for p in prefill_points), 62)
         self.assertTrue(all(p.kv_read_tokens == 0 for p in prefill_points))
+
+    def test_prefill_grid_is_capped_by_forward_token_budget(self):
+        scheduler = _make_scheduler("/tmp/unused.json")
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.max_req_input_len = 40960
+        scheduler.max_total_num_tokens = 40960
+        scheduler.max_prefill_tokens = 1024
+
+        benchmark = SelfBenchmark(scheduler)
+
+        prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
+        self.assertGreater(len(prefill_points), 0)
+        self.assertEqual(max(p.isl for p in prefill_points), 1024)
+        self.assertTrue(
+            all(p.isl <= scheduler.max_prefill_tokens for p in prefill_points)
+        )
 
     def test_prefill_kv_read_grid_crosses_with_isl(self):
         scheduler = _make_scheduler("/tmp/unused.json")

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -324,6 +324,7 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(calls[1]["max_tokens"], 1)
         self.assertTrue(calls[1]["track_active"])
         self.assertEqual(calls[0]["extra_key"], calls[1]["extra_key"])
+        self.assertIsNone(benchmark._pending_seed_extra_key)
 
     def test_prefill_kv_read_point_skips_when_seed_validation_misses(self):
         scheduler = _make_scheduler("/tmp/unused.json")

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -583,7 +583,7 @@ class TestSelfBenchmark(CustomTestCase):
             all("engine_limit" in p.sample_reasons for p in max_batch_points)
         )
 
-    def test_prefill_grid_respects_chunked_prefill_per_request(self):
+    def test_prefill_grid_respects_shared_chunked_prefill_budget(self):
         scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.server_args.chunked_prefill_size = 8
@@ -594,12 +594,47 @@ class TestSelfBenchmark(CustomTestCase):
 
         prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
         self.assertGreater(len(prefill_points), 0)
-        self.assertEqual(max(p.total_prefill_tokens for p in prefill_points), 32)
+        self.assertEqual(max(p.total_prefill_tokens for p in prefill_points), 8)
         self.assertTrue(any(p.batch_size > 1 for p in prefill_points))
         self.assertTrue(all(p.total_kv_read_tokens == 0 for p in prefill_points))
         for point in prefill_points:
-            new_lengths, _, _ = benchmark._prefill_lengths(point)
-            self.assertTrue(all(length <= 8 for length in new_lengths))
+            self.assertLessEqual(point.total_prefill_tokens, 8)
+
+    def test_prefill_feasibility_requires_exact_page_aligned_shape(self):
+        scheduler = self._scheduler()
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.server_args.chunked_prefill_size = 64
+        scheduler.page_size = 16
+        scheduler.max_req_input_len = 128
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertFalse(
+            benchmark._prefill_point_feasible(
+                BenchmarkPoint(
+                    point_type="prefill",
+                    total_prefill_tokens=4,
+                    batch_size=1,
+                )
+            )
+        )
+        self.assertTrue(
+            benchmark._prefill_point_feasible(
+                BenchmarkPoint(
+                    point_type="prefill",
+                    total_prefill_tokens=32,
+                    batch_size=2,
+                )
+            )
+        )
+        self.assertFalse(
+            benchmark._prefill_point_feasible(
+                BenchmarkPoint(
+                    point_type="prefill",
+                    total_prefill_tokens=64,
+                    batch_size=3,
+                )
+            )
+        )
 
     def test_prefill_grid_is_capped_by_forward_token_budget(self):
         scheduler = self._scheduler()
@@ -641,7 +676,8 @@ class TestSelfBenchmark(CustomTestCase):
         scheduler.page_size = 8
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.server_args.benchmark_prefill_kv_read_granularity = 4
-        scheduler.max_req_input_len = 40
+        scheduler.max_req_input_len = 128
+        scheduler.max_total_num_tokens = 256
 
         benchmark = SelfBenchmark(scheduler)
 

--- a/test/registered/unit/observability/test_self_benchmark.py
+++ b/test/registered/unit/observability/test_self_benchmark.py
@@ -19,6 +19,8 @@ from sglang.srt.managers.scheduler_components.self_benchmark import (
     BenchmarkPoint,
     BenchmarkPointResult,
     SelfBenchmark,
+    _cudagraph_axis_points,
+    _limit_cudagraph_axis,
 )
 from sglang.srt.observability.forward_pass_metrics import (
     ForwardPassMetrics,
@@ -49,15 +51,18 @@ def _make_scheduler(output_path: str):
             model_path="test-model",
             served_model_name=None,
             benchmark_mode="agg",
+            benchmark_points_file=None,
             benchmark_prefill_granularity=2,
             benchmark_prefill_kv_read_granularity=1,
+            benchmark_prefill_batch_granularity=3,
             benchmark_decode_length_granularity=2,
             benchmark_decode_batch_granularity=2,
             benchmark_warmup_iterations=0,
             benchmark_output_path=output_path,
             chunked_prefill_size=None,
             cuda_graph_config=types.SimpleNamespace(
-                decode=types.SimpleNamespace(max_bs=4)
+                prefill=types.SimpleNamespace(bs=[]),
+                decode=types.SimpleNamespace(max_bs=4, bs=[1, 2, 4]),
             ),
             node_rank=0,
             nnodes=1,
@@ -499,7 +504,7 @@ class TestSelfBenchmark(CustomTestCase):
 
         self.assertEqual(injected, 2)
         self.assertIs(scheduler.running_batch, fake_batch)
-        self.assertEqual(captured["context_length"], 8)
+        self.assertEqual(captured["context_length"], [8, 8])
         self.assertEqual(benchmark._active_reqs, captured["reqs"])
 
         for req in captured["reqs"]:
@@ -511,7 +516,7 @@ class TestSelfBenchmark(CustomTestCase):
             )
             self.assertEqual(req.seqlen, 9)
             self.assertEqual(req.kv_committed_len, 8)
-            self.assertEqual(req.kv_allocated_len, 8)
+            self.assertEqual(req.kv.kv_allocated_len, 8)
             self.assertEqual(req.already_computed, 8)
             self.assertFalse(req.finished())
 
@@ -532,7 +537,53 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(injected, 0)
         self.assertEqual(benchmark._active_reqs, [])
 
-    def test_prefill_grid_is_not_capped_at_chunked_prefill_size(self):
+    def test_cudagraph_axis_includes_capture_boundaries_and_eager_tail(self):
+        points = _cudagraph_axis_points([8, 16], 64)
+
+        self.assertEqual(points, [8, 9, 16, 17, 32, 64])
+        self.assertEqual(
+            _limit_cudagraph_axis(points, [8, 16], len(points)),
+            points,
+        )
+
+    def test_prefill_grid_records_graph_metadata(self):
+        scheduler = self._scheduler()
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.server_args.benchmark_prefill_granularity = 16
+        scheduler.server_args.benchmark_prefill_batch_granularity = 1
+        scheduler.server_args.cuda_graph_config.prefill = types.SimpleNamespace(
+            backend="full", bs=[8, 16]
+        )
+        scheduler.max_req_input_len = 128
+        scheduler.max_total_num_tokens = 128
+        scheduler.max_prefill_tokens = 64
+
+        benchmark = SelfBenchmark(scheduler)
+        points = {p.total_prefill_tokens: p for p in benchmark._grid}
+
+        self.assertEqual(points[9].expected_capture_size, 16)
+        self.assertEqual(points[9].padding_tokens, 7)
+        self.assertEqual(points[9].sample_reasons, ["post_capture"])
+        self.assertIsNone(points[32].expected_capture_size)
+        self.assertEqual(points[32].sample_reasons, ["eager_tail", "geometric_tail"])
+        self.assertEqual(points[64].sample_reasons, ["eager_tail", "engine_limit"])
+
+    def test_decode_axis_uses_largest_feasible_batch(self):
+        scheduler = self._scheduler()
+        scheduler.server_args.benchmark_mode = "decode"
+        scheduler.max_total_num_tokens = 6
+
+        benchmark = SelfBenchmark(scheduler)
+        decode_points = [p for p in benchmark._grid if p.point_type == "decode"]
+
+        self.assertEqual(benchmark._max_feasible_decode_batch_size(), 3)
+        self.assertEqual(max(p.batch_size for p in decode_points), 3)
+        max_batch_points = [p for p in decode_points if p.batch_size == 3]
+        self.assertTrue(
+            all("engine_limit" in p.sample_reasons for p in max_batch_points)
+        )
+
+    def test_prefill_grid_respects_chunked_prefill_per_request(self):
         scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.server_args.chunked_prefill_size = 8
@@ -543,8 +594,12 @@ class TestSelfBenchmark(CustomTestCase):
 
         prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
         self.assertGreater(len(prefill_points), 0)
-        self.assertEqual(max(p.isl for p in prefill_points), 62)
-        self.assertTrue(all(p.kv_read_tokens == 0 for p in prefill_points))
+        self.assertEqual(max(p.total_prefill_tokens for p in prefill_points), 32)
+        self.assertTrue(any(p.batch_size > 1 for p in prefill_points))
+        self.assertTrue(all(p.total_kv_read_tokens == 0 for p in prefill_points))
+        for point in prefill_points:
+            new_lengths, _, _ = benchmark._prefill_lengths(point)
+            self.assertTrue(all(length <= 8 for length in new_lengths))
 
     def test_prefill_grid_is_capped_by_forward_token_budget(self):
         scheduler = self._scheduler()
@@ -557,12 +612,15 @@ class TestSelfBenchmark(CustomTestCase):
 
         prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
         self.assertGreater(len(prefill_points), 0)
-        self.assertEqual(max(p.isl for p in prefill_points), 1024)
+        self.assertEqual(max(p.total_prefill_tokens for p in prefill_points), 1024)
         self.assertTrue(
-            all(p.isl <= scheduler.max_prefill_tokens for p in prefill_points)
+            all(
+                p.total_prefill_tokens <= scheduler.max_prefill_tokens
+                for p in prefill_points
+            )
         )
 
-    def test_prefill_kv_read_grid_crosses_with_isl(self):
+    def test_prefill_kv_read_grid_crosses_token_and_batch_axes(self):
         scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         scheduler.server_args.benchmark_prefill_kv_read_granularity = 3
@@ -571,15 +629,11 @@ class TestSelfBenchmark(CustomTestCase):
 
         prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
         self.assertEqual(
-            [(p.isl, p.kv_read_tokens) for p in prefill_points],
             [
-                (10, 0),
-                (10, 4),
-                (10, 9),
-                (15, 0),
-                (15, 7),
-                (15, 14),
+                (p.total_prefill_tokens, p.total_kv_read_tokens, p.batch_size)
+                for p in prefill_points
             ],
+            [(60, 0, 4), (1, 14, 1), (1, 4, 1), (1, 0, 1)],
         )
 
     def test_prefill_kv_read_grid_aligns_to_page_size(self):
@@ -592,38 +646,43 @@ class TestSelfBenchmark(CustomTestCase):
         benchmark = SelfBenchmark(scheduler)
 
         prefill_points = [p for p in benchmark._grid if p.point_type == "prefill"]
-        self.assertTrue(all(p.kv_read_tokens % 8 == 0 for p in prefill_points))
-        self.assertTrue(all(p.kv_read_tokens <= p.isl - 1 for p in prefill_points))
-        self.assertIn(
-            BenchmarkPoint(point_type="prefill", isl=39, kv_read_tokens=32),
-            prefill_points,
-        )
+        self.assertTrue(all(p.total_kv_read_tokens % 8 == 0 for p in prefill_points))
+        self.assertTrue(any(p.total_kv_read_tokens == 32 for p in prefill_points))
+        for point in prefill_points:
+            _, kv_lengths, prompt_lengths = benchmark._prefill_lengths(point)
+            self.assertTrue(all(length % 8 == 0 for length in kv_lengths))
+            self.assertTrue(
+                all(length < scheduler.max_req_input_len for length in prompt_lengths)
+            )
 
     def test_prefill_kv_read_point_seeds_then_measures_with_same_extra_key(self):
         scheduler = self._scheduler()
         scheduler.server_args.benchmark_mode = "prefill"
         benchmark = SelfBenchmark(scheduler)
-        point = BenchmarkPoint(point_type="prefill", isl=16, kv_read_tokens=8)
+        point = BenchmarkPoint(
+            point_type="prefill",
+            total_prefill_tokens=4,
+            total_kv_read_tokens=4,
+            batch_size=2,
+        )
         calls = []
 
         def fake_inject_requests(**kwargs):
             calls.append(kwargs)
-            return 1
+            return len(kwargs["prompt_lens"])
 
         benchmark.phase = BenchmarkPhase.SWEEP
         benchmark._grid = [point]
         benchmark._grid_index = 0
         benchmark._inject_requests = fake_inject_requests
-        benchmark._cached_kv_read_tokens_for_point = (
-            lambda cached_point, _extra_key: cached_point.kv_read_tokens
-        )
+        benchmark._cached_kv_read_tokens = lambda _prompt_len, _extra_key: 2
 
         benchmark.maybe_schedule_next()
 
         self.assertIsNone(benchmark._current)
         self.assertIs(benchmark._pending_seed_point, point)
         self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0]["prompt_len"], 8)
+        self.assertEqual(calls[0]["prompt_lens"], [2, 2])
         self.assertEqual(calls[0]["max_tokens"], 0)
         self.assertFalse(calls[0]["track_active"])
 
@@ -631,11 +690,12 @@ class TestSelfBenchmark(CustomTestCase):
 
         self.assertIsNotNone(benchmark._current)
         self.assertEqual(len(calls), 2)
-        self.assertEqual(calls[1]["prompt_len"], 16)
+        self.assertEqual(calls[1]["prompt_lens"], [4, 4])
         self.assertEqual(calls[1]["max_tokens"], 1)
         self.assertTrue(calls[1]["track_active"])
-        self.assertEqual(calls[0]["extra_key"], calls[1]["extra_key"])
-        self.assertIsNone(benchmark._pending_seed_extra_key)
+        self.assertEqual(calls[0]["extra_keys"], calls[1]["extra_keys"])
+        self.assertEqual(len(set(calls[0]["extra_keys"])), 2)
+        self.assertIsNone(benchmark._pending_seed_extra_keys)
 
     def test_prefill_kv_read_point_skips_when_seed_validation_misses(self):
         scheduler = self._scheduler()
@@ -652,7 +712,7 @@ class TestSelfBenchmark(CustomTestCase):
         benchmark._grid = [point]
         benchmark._grid_index = 0
         benchmark._inject_requests = fake_inject_requests
-        benchmark._cached_kv_read_tokens_for_point = lambda _point, _extra_key: 0
+        benchmark._cached_kv_read_tokens = lambda _prompt_len, _extra_key: 0
 
         benchmark.maybe_schedule_next()
         benchmark.maybe_schedule_next()
@@ -665,6 +725,129 @@ class TestSelfBenchmark(CustomTestCase):
         self.assertEqual(
             benchmark._skipped_points[0].reason, "seed_cache_validation_failed"
         )
+
+    def test_explicit_points_replace_generated_grid_and_preserve_order(self):
+        points_path = os.path.join(self._tmpdir.name, "points.json")
+        with open(points_path, "w") as f:
+            json.dump(
+                {
+                    "schema_version": 1,
+                    "prefill": [
+                        {
+                            "total_prefill_tokens": 4,
+                            "total_kv_read_tokens": 0,
+                            "batch_size": 2,
+                        },
+                        {
+                            "total_prefill_tokens": 2,
+                            "total_kv_read_tokens": 2,
+                            "batch_size": 2,
+                        },
+                    ],
+                    "decode": [
+                        {"total_kv_read_tokens": 8, "batch_size": 2},
+                    ],
+                },
+                f,
+            )
+        scheduler = self._scheduler()
+        scheduler.server_args.benchmark_points_file = points_path
+
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertEqual(
+            [
+                (
+                    p.point_type,
+                    p.total_prefill_tokens,
+                    p.total_kv_read_tokens,
+                    p.batch_size,
+                )
+                for p in benchmark._grid
+            ],
+            [
+                ("prefill", 4, 0, 2),
+                ("prefill", 2, 2, 2),
+                ("decode", 0, 8, 2),
+            ],
+        )
+        self.assertEqual([p.benchmark_id for p in benchmark._grid], [1, 2, 3])
+        self.assertTrue(all("explicit" in p.sample_reasons for p in benchmark._grid))
+        self.assertEqual(len(benchmark._grid_digest), 64)
+
+    def test_explicit_points_filter_by_mode_and_allow_empty_grid(self):
+        points_path = os.path.join(self._tmpdir.name, "decode-only.json")
+        with open(points_path, "w") as f:
+            json.dump(
+                {
+                    "schema_version": 1,
+                    "prefill": [],
+                    "decode": [
+                        {"total_kv_read_tokens": 8, "batch_size": 2},
+                    ],
+                },
+                f,
+            )
+        scheduler = self._scheduler()
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.server_args.benchmark_points_file = points_path
+
+        benchmark = SelfBenchmark(scheduler)
+
+        self.assertEqual(benchmark._grid, [])
+        benchmark.maybe_schedule_next()
+        self.assertFalse(benchmark.active)
+
+    def test_explicit_infeasible_point_reports_section_index(self):
+        points_path = os.path.join(self._tmpdir.name, "infeasible.json")
+        with open(points_path, "w") as f:
+            json.dump(
+                {
+                    "schema_version": 1,
+                    "prefill": [
+                        {
+                            "total_prefill_tokens": 2,
+                            "total_kv_read_tokens": 0,
+                            "batch_size": 1,
+                        },
+                        {
+                            "total_prefill_tokens": 64,
+                            "total_kv_read_tokens": 0,
+                            "batch_size": 1,
+                        },
+                    ],
+                    "decode": [],
+                },
+                f,
+            )
+        scheduler = self._scheduler()
+        scheduler.server_args.benchmark_mode = "prefill"
+        scheduler.server_args.benchmark_points_file = points_path
+
+        with self.assertRaisesRegex(ValueError, r"prefill\[1\].*infeasible"):
+            SelfBenchmark(scheduler)
+
+    def test_explicit_point_runtime_failure_is_fatal(self):
+        benchmark = SelfBenchmark(self._scheduler())
+        point = BenchmarkPoint(
+            point_type="decode",
+            benchmark_id=1,
+            total_kv_read_tokens=8,
+            batch_size=2,
+            sample_reasons=["explicit"],
+        )
+        benchmark._current = BenchmarkPointResult(point=point)
+        benchmark._current.fpms = [
+            {
+                "scheduled_requests": {
+                    "num_decode_requests": 1,
+                    "sum_decode_kv_tokens": 8,
+                }
+            }
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "explicit benchmark point"):
+            benchmark._save_current_point()
 
     def test_disaggregated_workers_only_build_supported_grid(self):
         scheduler = self._scheduler()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -689,6 +689,34 @@ class TestContextParallelServerArgs(CustomTestCase):
                 )
 
 
+class TestBenchmarkArgs(unittest.TestCase):
+    def test_benchmark_mode_requires_forward_pass_metrics(self):
+        with self.assertRaisesRegex(
+            ValueError, "--benchmark-mode requires --enable-forward-pass-metrics"
+        ):
+            ServerArgs(model_path="dummy", benchmark_mode="agg")
+
+    def test_benchmark_mode_accepts_explicit_forward_pass_metrics(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            benchmark_mode="agg",
+            enable_forward_pass_metrics=True,
+        )
+
+        self.assertTrue(server_args.enable_forward_pass_metrics)
+
+    def test_benchmark_mode_rejects_ray(self):
+        with self.assertRaisesRegex(
+            ValueError, "--benchmark-mode is not supported with --use-ray"
+        ):
+            ServerArgs(
+                model_path="dummy",
+                benchmark_mode="agg",
+                enable_forward_pass_metrics=True,
+                use_ray=True,
+            )
+
+
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")
     def test_init_new_standard_case(self, mock_temp_file):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -694,6 +694,7 @@ class TestBenchmarkArgs(unittest.TestCase):
         "prefill": (
             "benchmark_prefill_granularity",
             "benchmark_prefill_kv_read_granularity",
+            "benchmark_prefill_batch_granularity",
         ),
         "decode": (
             "benchmark_decode_length_granularity",
@@ -758,6 +759,7 @@ class TestBenchmarkArgs(unittest.TestCase):
                 dict(
                     benchmark_prefill_granularity=64,
                     benchmark_prefill_kv_read_granularity=64,
+                    benchmark_prefill_batch_granularity=1,
                 ),
                 dict(benchmark_prefill_granularity=65),
             ),
@@ -774,6 +776,7 @@ class TestBenchmarkArgs(unittest.TestCase):
                 dict(
                     benchmark_prefill_granularity=32,
                     benchmark_prefill_kv_read_granularity=64,
+                    benchmark_prefill_batch_granularity=1,
                     benchmark_decode_length_granularity=32,
                     benchmark_decode_batch_granularity=64,
                 ),
@@ -789,6 +792,58 @@ class TestBenchmarkArgs(unittest.TestCase):
                     ValueError, rf"--benchmark-mode {mode} requests .* maximum is 4096"
                 ):
                     self._make_args(benchmark_mode=mode, **overflow_args)
+
+    @staticmethod
+    def _write_benchmark_points(payload):
+        file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+        with file:
+            json.dump(payload, file)
+        return file.name
+
+    def test_benchmark_points_file_requires_mode(self):
+        path = self._write_benchmark_points(
+            {"schema_version": 1, "prefill": [], "decode": []}
+        )
+        self.addCleanup(lambda: os.unlink(path))
+
+        with self.assertRaisesRegex(
+            ValueError, "--benchmark-points-file requires --benchmark-mode"
+        ):
+            ServerArgs(model_path="dummy", benchmark_points_file=path)
+
+    def test_benchmark_points_file_is_strict(self):
+        path = self._write_benchmark_points(
+            {
+                "schema_version": 1,
+                "prefill": [
+                    {
+                        "total_prefill_tokens": "4",
+                        "total_kv_read_tokens": 0,
+                        "batch_size": 1,
+                    }
+                ],
+                "decode": [],
+            }
+        )
+        self.addCleanup(lambda: os.unlink(path))
+
+        with self.assertRaisesRegex(ValueError, "--benchmark-points-file"):
+            self._make_args(benchmark_points_file=path)
+
+    def test_explicit_points_bypass_generated_axis_validation(self):
+        path = self._write_benchmark_points(
+            {"schema_version": 1, "prefill": [], "decode": []}
+        )
+        self.addCleanup(lambda: os.unlink(path))
+
+        server_args = self._make_args(
+            benchmark_points_file=path,
+            benchmark_prefill_granularity=0,
+            benchmark_prefill_batch_granularity=1025,
+            benchmark_decode_length_granularity=0,
+        )
+
+        self.assertEqual(server_args.benchmark_points_file, path)
 
     def test_benchmark_warmup_iterations_negative_rejected(self):
         with self.assertRaisesRegex(ValueError, "must be >= 0"):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -690,6 +690,27 @@ class TestContextParallelServerArgs(CustomTestCase):
 
 
 class TestBenchmarkArgs(unittest.TestCase):
+    _GRID_AXES = {
+        "prefill": (
+            "benchmark_prefill_granularity",
+            "benchmark_prefill_kv_read_granularity",
+        ),
+        "decode": (
+            "benchmark_decode_length_granularity",
+            "benchmark_decode_batch_granularity",
+        ),
+    }
+
+    @staticmethod
+    def _make_args(**overrides):
+        kwargs = dict(
+            model_path="dummy",
+            benchmark_mode="agg",
+            enable_forward_pass_metrics=True,
+        )
+        kwargs.update(overrides)
+        return ServerArgs(**kwargs)
+
     def test_benchmark_mode_requires_forward_pass_metrics(self):
         with self.assertRaisesRegex(
             ValueError, "--benchmark-mode requires --enable-forward-pass-metrics"
@@ -697,11 +718,7 @@ class TestBenchmarkArgs(unittest.TestCase):
             ServerArgs(model_path="dummy", benchmark_mode="agg")
 
     def test_benchmark_mode_accepts_explicit_forward_pass_metrics(self):
-        server_args = ServerArgs(
-            model_path="dummy",
-            benchmark_mode="agg",
-            enable_forward_pass_metrics=True,
-        )
+        server_args = self._make_args()
 
         self.assertTrue(server_args.enable_forward_pass_metrics)
 
@@ -709,56 +726,87 @@ class TestBenchmarkArgs(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "--benchmark-mode is not supported with --use-ray"
         ):
-            ServerArgs(
-                model_path="dummy",
-                benchmark_mode="agg",
-                enable_forward_pass_metrics=True,
-                use_ray=True,
-            )
+            self._make_args(use_ray=True)
 
-    def test_benchmark_granularity_below_one_rejected(self):
-        for arg in (
-            "benchmark_prefill_granularity",
-            "benchmark_prefill_kv_read_granularity",
-            "benchmark_decode_length_granularity",
-            "benchmark_decode_batch_granularity",
-        ):
-            for bad_value in (0, -1):
-                with self.subTest(arg=arg, value=bad_value):
-                    with self.assertRaisesRegex(ValueError, "must be >= 1"):
-                        ServerArgs(
-                            model_path="dummy",
-                            benchmark_mode="agg",
-                            enable_forward_pass_metrics=True,
-                            **{arg: bad_value},
-                        )
+    def test_benchmark_granularity_out_of_range_rejected(self):
+        invalid_values = (
+            (0, "must be >= 1"),
+            (-1, "must be >= 1"),
+            (1025, "must be <= 1024"),
+        )
+        for axes in self._GRID_AXES.values():
+            for arg in axes:
+                for value, error in invalid_values:
+                    with self.subTest(arg=arg, value=value):
+                        with self.assertRaisesRegex(ValueError, error):
+                            self._make_args(**{arg: value})
+
+    def test_benchmark_granularity_limit_allowed(self):
+        # A non-active grid does not contribute to the requested point total.
+        for mode, inactive_mode in (("prefill", "decode"), ("decode", "prefill")):
+            overrides = {arg: 1024 for arg in self._GRID_AXES[inactive_mode]}
+            with self.subTest(mode=mode):
+                self._make_args(benchmark_mode=mode, **overrides)
+
+        # This value is used by the documented high-granularity prefill example.
+        self._make_args(benchmark_mode="prefill", benchmark_prefill_granularity=512)
+
+    def test_benchmark_grid_point_limit(self):
+        cases = (
+            (
+                "prefill",
+                dict(
+                    benchmark_prefill_granularity=64,
+                    benchmark_prefill_kv_read_granularity=64,
+                ),
+                dict(benchmark_prefill_granularity=65),
+            ),
+            (
+                "decode",
+                dict(
+                    benchmark_decode_length_granularity=64,
+                    benchmark_decode_batch_granularity=64,
+                ),
+                dict(benchmark_decode_length_granularity=65),
+            ),
+            (
+                "agg",
+                dict(
+                    benchmark_prefill_granularity=32,
+                    benchmark_prefill_kv_read_granularity=64,
+                    benchmark_decode_length_granularity=32,
+                    benchmark_decode_batch_granularity=64,
+                ),
+                dict(benchmark_decode_length_granularity=33),
+            ),
+        )
+        for mode, boundary, overflow in cases:
+            with self.subTest(mode=mode, case="boundary"):
+                self._make_args(benchmark_mode=mode, **boundary)
+            with self.subTest(mode=mode, case="overflow"):
+                overflow_args = {**boundary, **overflow}
+                with self.assertRaisesRegex(
+                    ValueError, rf"--benchmark-mode {mode} requests .* maximum is 4096"
+                ):
+                    self._make_args(benchmark_mode=mode, **overflow_args)
 
     def test_benchmark_warmup_iterations_negative_rejected(self):
         with self.assertRaisesRegex(ValueError, "must be >= 0"):
-            ServerArgs(
-                model_path="dummy",
-                benchmark_mode="agg",
-                enable_forward_pass_metrics=True,
-                benchmark_warmup_iterations=-1,
-            )
+            self._make_args(benchmark_warmup_iterations=-1)
 
     def test_benchmark_warmup_iterations_zero_allowed(self):
-        server_args = ServerArgs(
-            model_path="dummy",
-            benchmark_mode="agg",
-            enable_forward_pass_metrics=True,
-            benchmark_warmup_iterations=0,
-        )
+        server_args = self._make_args(benchmark_warmup_iterations=0)
         self.assertEqual(server_args.benchmark_warmup_iterations, 0)
 
-    def test_benchmark_granularity_not_validated_without_benchmark_mode(self):
-        # Without --benchmark-mode the granularity guards must not fire.
+    def test_benchmark_values_not_validated_without_benchmark_mode(self):
         server_args = ServerArgs(
             model_path="dummy",
             benchmark_prefill_granularity=0,
+            benchmark_prefill_kv_read_granularity=1025,
             benchmark_warmup_iterations=-5,
         )
         self.assertEqual(server_args.benchmark_prefill_granularity, 0)
+        self.assertEqual(server_args.benchmark_prefill_kv_read_granularity, 1025)
 
 
 class TestPortArgs(unittest.TestCase):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -716,6 +716,50 @@ class TestBenchmarkArgs(unittest.TestCase):
                 use_ray=True,
             )
 
+    def test_benchmark_granularity_below_one_rejected(self):
+        for arg in (
+            "benchmark_prefill_granularity",
+            "benchmark_prefill_kv_read_granularity",
+            "benchmark_decode_length_granularity",
+            "benchmark_decode_batch_granularity",
+        ):
+            for bad_value in (0, -1):
+                with self.subTest(arg=arg, value=bad_value):
+                    with self.assertRaisesRegex(ValueError, "must be >= 1"):
+                        ServerArgs(
+                            model_path="dummy",
+                            benchmark_mode="agg",
+                            enable_forward_pass_metrics=True,
+                            **{arg: bad_value},
+                        )
+
+    def test_benchmark_warmup_iterations_negative_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be >= 0"):
+            ServerArgs(
+                model_path="dummy",
+                benchmark_mode="agg",
+                enable_forward_pass_metrics=True,
+                benchmark_warmup_iterations=-1,
+            )
+
+    def test_benchmark_warmup_iterations_zero_allowed(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            benchmark_mode="agg",
+            enable_forward_pass_metrics=True,
+            benchmark_warmup_iterations=0,
+        )
+        self.assertEqual(server_args.benchmark_warmup_iterations, 0)
+
+    def test_benchmark_granularity_not_validated_without_benchmark_mode(self):
+        # Without --benchmark-mode the granularity guards must not fire.
+        server_args = ServerArgs(
+            model_path="dummy",
+            benchmark_prefill_granularity=0,
+            benchmark_warmup_iterations=-5,
+        )
+        self.assertEqual(server_args.benchmark_prefill_granularity, 0)
+
 
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -82,6 +82,18 @@ _OWNER_SITES = {
         "alloc_for_decode_prealloc_hisparse",
         "kv_allocated_len",
     ): 1,
+    # startup self-benchmark: synthetic decode reqs start at the post-prefill
+    # boundary, so their KV clocks are seeded to the synthetic context length.
+    (
+        "managers/scheduler_components/self_benchmark.py",
+        "SelfBenchmark._inject_synthetic_decode",
+        "kv_committed_len",
+    ): 1,
+    (
+        "managers/scheduler_components/self_benchmark.py",
+        "SelfBenchmark._inject_synthetic_decode",
+        "kv_allocated_len",
+    ): 1,
     # streaming session slot save/restore and tail trimming
     (_SS, "SessionSlot.save_from_req", "kv_committed_len"): 1,
     (_SS, "SessionSlot.restore_to_req", "kv_committed_len"): 1,


### PR DESCRIPTION
# Add startup self-benchmarking for ForwardPassMetrics

## Motivation

In pursuit of intelligent LLM inference autoscaling that can maximize goodput for some SLAs such as max `TTFT`, `TPOT` - Autoscalers like Dynamo Planner aim to make predictions about how a LLM inference server would perform under different deployment configurations and traffic conditions.  

By emitting `ForwardPassMetrics` one can observe the actual wall clock latency for the model worker forward at every iteration of the scheduler.  

The goal of Self-benchmarking is to collect `ForwardPassMetrics` on server start - this will allow downstream consumers like Dynamo Planner to bootstrap performance prediction models with real data and ultimately make more accurate predictions and therefore better scaling decisions.

What makes this feature valuable when implemented in the inference engines themselves, is that we can gather more data a given benchmarking time budget, by skipping actual prefill during decode benchmarking.  We can still measure how decode performs for a given ISL *by using synthetic kv cache block placement*.  Based on our tests, this still gives us an accurate estimate of what decode would look like if prefill had actually run (falling within 3% of FPMs observed with real prefill).

**Callout**: While this is can be considered an 'invasive' change as we mutate some scheduler state, this is gated by the self-benchmarking flags which default to off.

## More on how it works

The benchmark sweeps a configurable grid of operating points:

- Prefill: input sequence lengths / ISLs.
- Decode: context lengths and batch sizes.

## Modifications

Most of the new logic is implemented in `self_benchmark.py`.

This module:

- Builds the benchmark grid from the new server startup args.
- Injects synthetic benchmark requests into the scheduler.
- Collects ForwardPassMetrics for each benchmark point.
- Writes benchmark results to a JSON output file for external consumers.

For prefill benchmark points, self-benchmarking injects synthetic prefill requests with the target input length.

For decode benchmark points, self-benchmarking uses synthetic KV-cache placement instead of running an actual prefill pass. It allocates request slots, KV blocks, and request-token mappings so the measured forward pass is decode-only work.

Scheduler integration is intentionally small:

- `scheduler.py` runs self-benchmark work before scheduling real requests when benchmark mode is enabled.
- `disaggregation/prefill.py` and `disaggregation/decode.py` do the same for disaggregated prefill/decode workers.
- Pipeline-parallel scheduler paths are left out of scope.

## Example

Example server args for decode self-benchmarking:

```bash
python -m sglang.launch_server \
  --model-path /model-store/hub/models--Qwen--Qwen3-32B \
  --benchmark-mode decode \
  --benchmark-decode-length-granularity 8 \
  --benchmark-decode-batch-granularity 8 \
  --benchmark-warmup-iterations 2 \
  --benchmark-output-path /tmp/benchmark_results.json
Example startup logs:

Self-benchmark enabled
Self-benchmark results written to /tmp/benchmark_results.json
Self-benchmark completed
Example decode benchmark output:

{
  "config": {
    "mode": "decode",
    "decode_length_granularity": 8,
    "decode_batch_size_granularity": 8,
    "warmup_iterations": 2,
    "output_path": "/tmp/benchmark_results.json"
  },
  "results": [
    {
      "point": {
        "kind": "decode",
        "context_len": 2,
        "batch_size": 1
      },
      "fpms": {
        "num_prefill_requests": 0,
        "num_decode_requests": 1,
        "sum_decode_kv_tokens": 2
      }
    }
  ]
}
The decode result shows that the benchmark measured decode-only work: no prefill request was counted, and decode KV tokens were present.

Example prefill benchmark output:

{
  "config": {
    "mode": "prefill",
    "prefill_isl_granularity": 512,
    "warmup_iterations": 2,
    "output_path": "/tmp/benchmark_results.json"
  },
  "results": [
    {
      "point": {
        "kind": "prefill",
        "isl": 512,
        "batch_size": 1
      },
      "fpms": {
        "num_prefill_requests": 1,
        "num_decode_requests": 0,
        "sum_prefill_tokens": 512
      }
    }
  ]
}
```

## Testing

We tested multiple different configuration scenarios on an EKS K8s wit P5 nodes.

# Self-Benchmark Test Summary

| Test | Config | Result |
|---|---|---|
| 01 | Agg TP1 | Succeeded. 52 benchmark points collected: 16 prefill, 36 decode. |
| 02 | Agg TP2 | Succeeded. 52 benchmark points collected: 16 prefill, 36 decode. |
| 03 | Agg TP4 | Succeeded. 52 benchmark points collected: 16 prefill, 36 decode. |
| 05 | Agg TP4 no-overlap | Succeeded. 52 benchmark points collected: 16 prefill, 36 decode. |
| 06 | Disaggregated TP1 | Succeeded after the self-benchmark scheduler patch. Decode collected 36 points, and patched prefill collected the full 16-point prefill sweep. |


Accuracy Tests
We did not make changes that affect model outputs or numerical accuracy. Self-benchmarking uses synthetic startup work to collect scheduler/forward-pass metrics and suppresses request output.

Speed Tests and Profiling
These changes only affect startup when self-benchmarking is enabled.
















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->