### PR TITLE
ci: open the LMSYS blog-sync PR with the repo sglang-bot

### DIFF
--- a/.github/workflows/sync-lmsys-sglang-blogs.yml
+++ b/.github/workflows/sync-lmsys-sglang-blogs.yml
@@ -28,8 +28,12 @@ jobs:
         run: python docs_new/scripts/update_lmsys_sglang_blogs.py
 
       - name: Open or update pull request
+        # `main` is protected, so propose the change via a PR. Use the repo's PAT
+        # (the convention shared with the other bot-* workflows) rather than
+        # GITHUB_TOKEN: a GITHUB_TOKEN-authored PR is blocked by org policy and
+        # would not trigger the required status checks.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_PULL_REQUEST }}
         run: |
           set -euo pipefail
 
@@ -38,9 +42,9 @@ jobs:
             exit 0
           fi
 
-          BRANCH="auto/lmsys-blog-cards"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="bot/lmsys-blog-cards"
+          git config user.name "sglang-bot"
+          git config user.email "sglang-bot@users.noreply.github.com"
 
           # Recreate the bot branch as "current main + card diff" and overwrite
           # any previous state, so the PR always shows a clean single-commit diff.
@@ -56,5 +60,5 @@ jobs:
               --base main \
               --head "$BRANCH" \
               --title "docs: sync LMSYS SGLang blog cards" \
-              --body 'Automated sync of the LMSYS SGLang blog cards in `docs_new/index.mdx`, opened by the `Sync LMSYS SGLang blogs` workflow.'
+              --body $'Automated sync of the LMSYS SGLang blog cards in `docs_new/index.mdx`.\n\n🤖 Generated with GitHub Actions'
           fi

--- a/.github/workflows/sync-lmsys-sglang-blogs.yml
+++ b/.github/workflows/sync-lmsys-sglang-blogs.yml
@@ -28,10 +28,6 @@ jobs:
         run: python docs_new/scripts/update_lmsys_sglang_blogs.py
 
       - name: Open or update pull request
-        # `main` is protected, so propose the change via a PR. Use the repo's PAT
-        # (the convention shared with the other bot-* workflows) rather than
-        # GITHUB_TOKEN: a GITHUB_TOKEN-authored PR is blocked by org policy and
-        # would not trigger the required status checks.
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_PULL_REQUEST }}
         run: |


### PR DESCRIPTION
## Background

#27179 made the `Sync LMSYS SGLang blogs` workflow propose its card updates through a pull request (since `main` is protected) instead of pushing directly. It opened that PR with `GITHUB_TOKEN`, which has two problems:

1. A `GITHUB_TOKEN`-created PR is blocked by the org's **"Allow GitHub Actions to create and approve pull requests"** setting, so the run fails at `gh pr create`.
2. Even if allowed, a `GITHUB_TOKEN`-authored PR does **not** trigger the required status checks (events from `GITHUB_TOKEN` don't spawn new workflow runs), so the PR can't pass CI on its own.

## Fix

Use the repo's existing **`GH_PAT_FOR_PULL_REQUEST`** secret for the PR step — the same convention already used by `bot-bump-sglang-version`, `bot-bump-kernel-version`, `bot-bump-flashinfer-version`, `weekly-update-est-time`, and `bot-cherry-pick`.

- The branch is still pushed with `GITHUB_TOKEN`; only the `gh pr create` call uses the PAT. The PR is therefore opened as a real user, which both satisfies the org policy and triggers CI normally.
- Aligned with the sibling bot workflows: `sglang-bot` committer identity and a `bot/` branch prefix.
- Unchanged: the `if: github.repository == 'sgl-project/sglang' && github.ref == 'refs/heads/main'` guard (keeps it off forks / non-main), and the single-branch + dedup + force-push logic (one self-updating PR, never duplicates).

The closest analog is `weekly-update-est-time.yml` (scheduled bot → updates a file → opens a PR via `GH_PAT_FOR_PULL_REQUEST`); this change makes the blog sync follow the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26987739202](https://github.com/sgl-project/sglang/actions/runs/26987739202)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26987739102](https://github.com/sgl-project/sglang/actions/runs/26987739102)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->