### PR TITLE
docs(cookbook): restore Gemma 4 transformers commit pin

### DIFF
--- a/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
+++ b/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
@@ -67,11 +67,14 @@ Gemma 4 is Google's next-generation family of open models, building on the Gemma
 
 ## 2. SGLang Installation
 
-Gemma 4 (including the encoder-free unified 12B, [sgl-project/sglang#27167](https://github.com/sgl-project/sglang/pull/27167)) is supported on SGLang main:
+Gemma 4 (including the encoder-free unified 12B, [sgl-project/sglang#27167](https://github.com/sgl-project/sglang/pull/27167)) is supported on SGLang main. Install it together with the matching transformers commit:
 
 ```bash Command
 # Install SGLang from main
 pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+
+# Install transformers with Gemma 4 support (encoder-free unified family included)
+pip install 'git+https://github.com/huggingface/transformers.git@1423d22f7a3b62e8c70ad67b58ec25cd9b675897'
 ```
 
 ### Docker (prebuilt dev image)


### PR DESCRIPTION
## What

Restores the pinned transformers commit in the Gemma 4 cookbook install instructions (`docs_new/cookbook/autoregressive/Google/Gemma4.mdx`, §2).

[#27287](https://github.com/sgl-project/sglang/pull/27287) dropped the transformers pin (`pip install 'git+…transformers.git@1423d22…'`) on the assumption it was stale, but that pin is required and correct for Gemma 4 support. This brings it back.

## Changes

- Restore the `pip install 'git+https://github.com/huggingface/transformers.git@1423d22f7a3b62e8c70ad67b58ec25cd9b675897'` step in the pip-install fence.
- Restore the intro line wording (`…is supported on SGLang main. Install it together with the matching transformers commit:`).
- **Keep** the Docker (prebuilt dev image) section that #27287 added — only the pin removal is reverted.

## Notes

- Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26987685272](https://github.com/sgl-project/sglang/actions/runs/26987685272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26987685164](https://github.com/sgl-project/sglang/actions/runs/26987685164)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->