### PR TITLE
docs(cookbook): restore Gemma 4 transformers commit pin

### DIFF
--- a/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
+++ b/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
@@ -67,11 +67,14 @@ Gemma 4 is Google's next-generation family of open models, building on the Gemma
 
 ## 2. SGLang Installation
 
-Gemma 4 (including the encoder-free unified 12B, [sgl-project/sglang#27167](https://github.com/sgl-project/sglang/pull/27167)) is supported on SGLang main:
+Gemma 4 (including the encoder-free unified 12B, [sgl-project/sglang#27167](https://github.com/sgl-project/sglang/pull/27167)) is supported on SGLang main. Install it together with the matching transformers commit:
 
 ```bash Command
 # Install SGLang from main
 pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+
+# Install transformers with Gemma 4 support (encoder-free unified family included)
+pip install 'git+https://github.com/huggingface/transformers.git@1423d22f7a3b62e8c70ad67b58ec25cd9b675897'
 ```
 
 ### Docker (prebuilt dev image)


### PR DESCRIPTION
### What

Restores the pinned transformers commit in the Gemma 4 cookbook install instructions (`docs_new/cookbook/autoregressive/Google/Gemma4.mdx`, §2).

### Why

#27287 dropped the transformers pin from the pip-install path (the `pip install 'git+https://github.com/huggingface/transformers.git@1423d22f...'` line). SGLang main needs the encoder-free unified family added in transformers commit `1423d22f`, which is not yet in any released `transformers` build — so the pip path must pin it, otherwise a fresh `pip install transformers` pulls a build that can't load `gemma-4-12B-it`. The Docker path (which bundles the matching commit) is unchanged.

Same one-line change as #27319.

### Checklist

- [x] Docs-only (`.mdx` under `docs_new/`); no code changes, no tests needed







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26988076950](https://github.com/sgl-project/sglang/actions/runs/26988076950)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26988076846](https://github.com/sgl-project/sglang/actions/runs/26988076846)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->