### PR TITLE
[srt] add sglang:weight_load_duration_seconds gauge for per-rank weight-update tail latency

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1581,6 +1581,7 @@ class Scheduler(
             memory_saver_adapter=self.memory_saver_adapter,
             flush_cache=self.flush_cache,
             is_fully_idle=self.is_fully_idle,
+            metrics_collector=self.metrics_collector if self.enable_metrics else None,
         )
 
     def init_lora_drainer(self) -> None:

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import time
 import traceback
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple
 
 import torch
 
@@ -75,8 +77,28 @@ class SchedulerWeightUpdaterManager:
     memory_saver_adapter: Any
     flush_cache: Callable[..., bool]
     is_fully_idle: Callable[..., bool]
+    # Optional: when provided, time each update_weights_from_* call and
+    # publish the duration to sglang:weight_load_duration_seconds via the
+    # collector's observe_weight_load(). The collector is responsible for
+    # multiproc-safe gauge updates.
+    metrics_collector: Optional[Any] = None
     offload_tags: set = field(default_factory=set)
     stashed_model_static_state: Any = None
+
+    @contextmanager
+    def _observe_weight_load(self, source: str) -> Iterator[None]:
+        # Edge-trigger weight_load_duration_seconds at the end of each
+        # update_weights_from_* call. Engine is paused during the update so
+        # the periodic report_stats path can't carry this.
+        # `source` distinguishes disk vs distributed vs tensor vs ipc.
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            if self.metrics_collector is not None:
+                self.metrics_collector.observe_weight_load(
+                    time.perf_counter() - t0, source
+                )
 
     def flush_cache_after_weight_update(self, recv_req) -> None:
         if recv_req.flush_cache:
@@ -87,15 +109,16 @@ class SchedulerWeightUpdaterManager:
 
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
         """In-place update of the weights from disk."""
-        success, message = self.tp_worker.update_weights_from_disk(recv_req)
-        tp_success = success
-        if success and self.draft_worker is not None:
-            success, message = self.draft_worker.update_weights_from_disk(recv_req)
-        if tp_success:
-            self.flush_cache_after_weight_update(recv_req)
-        if not success:
-            logger.error(message)
-        return UpdateWeightFromDiskReqOutput(success, message, 0)
+        with self._observe_weight_load("disk"):
+            success, message = self.tp_worker.update_weights_from_disk(recv_req)
+            tp_success = success
+            if success and self.draft_worker is not None:
+                success, message = self.draft_worker.update_weights_from_disk(recv_req)
+            if tp_success:
+                self.flush_cache_after_weight_update(recv_req)
+            if not success:
+                logger.error(message)
+            return UpdateWeightFromDiskReqOutput(success, message, 0)
 
     def init_weights_update_group(self, recv_req: InitWeightsUpdateGroupReqInput):
         """Initialize the online model parameter update group."""
@@ -115,39 +138,42 @@ class SchedulerWeightUpdaterManager:
         recv_req: UpdateWeightsFromDistributedReqInput,
     ) -> Tuple[bool, str]:
         """Update the online model parameter."""
-        success, message = self.tp_worker.update_weights_from_distributed(recv_req)
-        if success:
-            self.flush_cache_after_weight_update(recv_req)
-        else:
-            logger.error(message)
-        return UpdateWeightsFromDistributedReqOutput(success, message)
+        with self._observe_weight_load("distributed"):
+            success, message = self.tp_worker.update_weights_from_distributed(recv_req)
+            if success:
+                self.flush_cache_after_weight_update(recv_req)
+            else:
+                logger.error(message)
+            return UpdateWeightsFromDistributedReqOutput(success, message)
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
         """Update the online model parameter from tensors."""
-        if recv_req.disable_draft_model:
-            worker = self.tp_worker
-        else:
-            worker = self.draft_worker or self.tp_worker
-        success, message = worker.update_weights_from_tensor(recv_req)
-        if success:
-            self.flush_cache_after_weight_update(recv_req)
-        else:
-            logger.error(message)
-        torch.distributed.barrier(group=self.tp_cpu_group)
-        return UpdateWeightsFromTensorReqOutput(success, message)
+        with self._observe_weight_load("tensor"):
+            if recv_req.disable_draft_model:
+                worker = self.tp_worker
+            else:
+                worker = self.draft_worker or self.tp_worker
+            success, message = worker.update_weights_from_tensor(recv_req)
+            if success:
+                self.flush_cache_after_weight_update(recv_req)
+            else:
+                logger.error(message)
+            torch.distributed.barrier(group=self.tp_cpu_group)
+            return UpdateWeightsFromTensorReqOutput(success, message)
 
     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
         """Update the online model parameter from IPC for checkpoint-engine integration."""
-        success, message = self.tp_worker.update_weights_from_ipc(recv_req)
-        tp_success = success
-        if success and self.draft_worker is not None:
-            success, message = self.draft_worker.update_weights_from_ipc(recv_req)
-        if tp_success:
-            self.flush_cache_after_weight_update(recv_req)
-        if not success:
-            logger.error(message)
-        torch.distributed.barrier(group=self.tp_cpu_group)
-        return UpdateWeightsFromIPCReqOutput(success, message)
+        with self._observe_weight_load("ipc"):
+            success, message = self.tp_worker.update_weights_from_ipc(recv_req)
+            tp_success = success
+            if success and self.draft_worker is not None:
+                success, message = self.draft_worker.update_weights_from_ipc(recv_req)
+            if tp_success:
+                self.flush_cache_after_weight_update(recv_req)
+            if not success:
+                logger.error(message)
+            torch.distributed.barrier(group=self.tp_cpu_group)
+            return UpdateWeightsFromIPCReqOutput(success, message)
 
     def get_weights_by_name(self, recv_req: GetWeightsByNameReqInput):
         parameter = self.tp_worker.get_weights_by_name(recv_req)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -451,6 +451,17 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             documentation="The number of paused requests by async weight sync.",
             labelnames=labels.keys(),
         )
+        self.weight_load_duration_seconds = Gauge(
+            name="sglang:weight_load_duration_seconds",
+            documentation=(
+                "Wall time of the most recent update_weights_from_<source> call on "
+                "this scheduler rank (seconds). `source` label is one of: disk, "
+                "distributed, tensor, ipc. Detect events via "
+                "changes(...[<range>]) > 0 — no separate counter needed."
+            ),
+            labelnames=[*labels.keys(), "source"],
+            multiprocess_mode="mostrecent",
+        )
 
         # =================================================================
         # PD disaggregation
@@ -1071,6 +1082,14 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
     def _log_gauge(self, gauge: Gauge, data: Union[int, float]) -> None:
         # Convenience function for logging a scalar to gauge.
         gauge.labels(**self.labels).set(data)
+
+    def observe_weight_load(self, duration_seconds: float, source: str) -> None:
+        # Edge-triggered: engine is paused during the update, so report_stats
+        # won't fire — write the gauge inline at end of update_weights_from_*.
+        # `source` is "disk" | "distributed" | "tensor" | "ipc".
+        self.weight_load_duration_seconds.labels(**self.labels, source=source).set(
+            duration_seconds
+        )
 
     def _log_gauge_queue_count(self, gauge: Gauge, data: QueueCount) -> None:
         # Log a QueueCount to gauge: total under default labels, per-priority breakdown under priority="<int>".


### PR DESCRIPTION
## Summary
Adds a Gauge metric on \`SchedulerMetricsCollector\` that records the wall time of the most recent \`update_weights_from_<source>\` call per scheduler rank.

The existing \`engine_load_weights_time\` gauge is hardcoded to 0.0 in \`emit_constants\` and never updated; this replaces that signal with one that actually fires on each hot-reload.

## Changes

- **New metric**: \`sglang:weight_load_duration_seconds\` (Gauge, \`multiprocess_mode='mostrecent'\`) with a \`source\` label of one of: \`disk\`, \`distributed\`, \`tensor\`, \`ipc\`. Event detection via PromQL \`changes(...[<range>]) > 0\` — no separate counter needed.

- **\`SchedulerWeightUpdaterManager\`** gains an optional \`metrics_collector\` field and an \`_observe_weight_load(source)\` contextmanager that times the body and writes the gauge at the end. The four \`update_weights_from_{disk,distributed,tensor,ipc}\` methods are wrapped.

- **\`Scheduler.init_weight_updater\`** passes \`metrics_collector=self.metrics_collector\` when \`enable_metrics\` is set (None otherwise → observe is a no-op; preserves the existing default-off behavior).

## Why
Useful for dashboards that surface long weight-load tail latency on a per-rank basis, e.g. RL hot-reload setups where the engine is paused during the update and the periodic \`report_stats\` path can't carry this. The \`source\` label lets you distinguish disk-load vs IB-transfer vs IPC-transfer paths.

## Test plan

- [ ] Launch SGL with \`--enable-metrics\` and trigger an \`/update_weights_from_disk\` request; confirm \`curl host:30000/metrics | grep sglang:weight_load_duration_seconds\` shows a non-zero value with \`source="disk"\`.
- [ ] Confirm distributed / tensor / ipc paths also emit with their respective \`source\` labels.
- [ ] Confirm \`enable_metrics=False\` is a no-op (no measurable overhead added to the update path).

## Background

Ported from a TML-internal mixin variant at \`iterationlab/monorepo#51754\` (also written by me). The OSS layout uses the \`SchedulerWeightUpdaterManager\` dataclass instead of a mixin, so the wiring is via an optional dataclass field rather than \`self.metrics_collector\` direct access.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26989093202](https://github.com/sgl-project/sglang/actions/runs/26989093202)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26989093074](https://github.com/sgl-project/sglang/actions/runs/26989093074)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->