### PR TITLE
fix(hicache): migrate captured indexer-topk on host-tier cache hits

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -59,6 +59,7 @@ class PoolName(str, Enum):
     MAMBA = "mamba"
     SWA = "swa"
     INDEXER = "indexer"
+    INDEXER_TOPK = "indexer_topk"
     # TODO(hzh0425): Current DeepSeek V4 pool naming is verbose; will be normalized to
     # 'COMPRESSED_KV / COMPRESSED_INDEXER / COMPRESSED_STATE' in the next PR.
     DEEPSEEK_V4_C4 = "deepseek_v4_c4"

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -36,6 +36,7 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
 from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
+    _indexer_topk_sidecar_enabled,
     attach_hybrid_dsa_pool_to_hiradix_cache,
 )
 from sglang.srt.mem_cache.memory_pool import (
@@ -653,12 +654,24 @@ class HiRadixCache(RadixCache):
         if not isinstance(self.cache_controller, HybridCacheController):
             return {}
         if isinstance(self.kv_cache, DSATokenToKVPool):
-            pool = PoolTransfer(
-                name=PoolName.INDEXER,
-                hit_policy=PoolHitPolicy.ALL_PAGES,
-                indices_from_pool=PoolName.KV,
-            )
-            return {"extra_pools": [pool]}
+            from sglang.srt.server_args import get_global_server_args
+
+            pools = [
+                PoolTransfer(
+                    name=PoolName.INDEXER,
+                    hit_policy=PoolHitPolicy.ALL_PAGES,
+                    indices_from_pool=PoolName.KV,
+                )
+            ]
+            if _indexer_topk_sidecar_enabled(get_global_server_args()):
+                pools.append(
+                    PoolTransfer(
+                        name=PoolName.INDEXER_TOPK,
+                        hit_policy=PoolHitPolicy.ALL_PAGES,
+                        indices_from_pool=PoolName.KV,
+                    )
+                )
+            return {"extra_pools": pools}
         else:
             return {}
 

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -16,6 +16,7 @@ from sglang.srt.mem_cache.memory_pool_host import (
     DeepSeekV4PagedHostPool,
     DeepSeekV4StateHostPool,
     DSAIndexerPoolHost,
+    DSAIndexerTopkPoolHost,
     HostPoolGroup,
     LogicalHostPool,
     MambaPoolHost,
@@ -35,6 +36,17 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
+
+
+def _indexer_topk_sidecar_enabled(server_args: "ServerArgs") -> bool:
+    """Gate sidecar on the capturer existing, not just the flag: it only has
+    data to migrate when the capturer was actually built (DSA+CUDA)."""
+    from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
+
+    return (
+        server_args.enable_return_indexer_topk
+        and get_global_indexer_capturer() is not None
+    )
 
 
 def _make_layer_mapper(
@@ -599,6 +611,7 @@ def build_anchor_sidecar_stack(
     pp_rank: int = 0,
     pp_size: int = 1,
     enable_storage_metrics: bool = False,
+    extra_sidecar_pools: Optional[list[tuple[PoolName, Callable[[Any], Any]]]] = None,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = len(full_layer_mapping)
     kv_host_pool = build_kv_host_pool(
@@ -626,6 +639,17 @@ def build_anchor_sidecar_stack(
             transfer_layer_num=transfer_layer_num,
         ),
     ]
+    if extra_sidecar_pools:
+        for pool_name, host_pool_factory in extra_sidecar_pools:
+            entries.append(
+                build_pool_entry(
+                    name=pool_name,
+                    host_pool=host_pool_factory(kv_host_pool),
+                    device_pool=kv_pool,
+                    layer_mapping=full_layer_mapping,
+                    transfer_layer_num=transfer_layer_num,
+                )
+            )
     host_pool_group = HostPoolGroup(entries)
     cache_controller = HybridCacheController(
         params.token_to_kv_pool_allocator,
@@ -942,6 +966,7 @@ class _DsaStrategy(StackStrategy):
         full_kv_pool = kvcache
         use_mla = isinstance(kvcache, MLATokenToKVPool)
         full_layer_mapping = {i: i for i in range(full_kv_pool.layer_num)}
+        enable_indexer_topk_sidecar = _indexer_topk_sidecar_enabled(server_args)
         host_pool_group, cache_controller = build_anchor_sidecar_stack(
             params=params,
             server_args=server_args,
@@ -968,6 +993,37 @@ class _DsaStrategy(StackStrategy):
             pp_rank=params.pp_rank,
             pp_size=params.pp_size,
             enable_storage_metrics=enable_storage_metrics,
+            extra_sidecar_pools=(
+                [
+                    (
+                        PoolName.INDEXER_TOPK,
+                        lambda kv_host_pool: DSAIndexerTopkPoolHost(
+                            full_kv_pool,
+                            kv_host_pool,
+                            server_args.hicache_mem_layout,
+                            allocator_type=server_args.hicache_storage_backend,
+                        ),
+                    ),
+                ]
+                if enable_indexer_topk_sidecar
+                else None
+            ),
+        )
+        sidecars = [
+            SidecarPoolSpec(
+                pool_name=PoolName.INDEXER,
+                indices_from_pool=PoolName.KV,
+            ),
+        ]
+        if enable_indexer_topk_sidecar:
+            sidecars.append(
+                SidecarPoolSpec(
+                    pool_name=PoolName.INDEXER_TOPK,
+                    indices_from_pool=PoolName.KV,
+                )
+            )
+        pools_desc = "KV + INDEXER" + (
+            " + INDEXER_TOPK" if enable_indexer_topk_sidecar else ""
         )
         return StackBuildResult(
             host_pool_group=host_pool_group,
@@ -975,14 +1031,9 @@ class _DsaStrategy(StackStrategy):
             component_host_pools={
                 ComponentType.FULL: host_pool_group.get_pool(PoolName.KV),
             },
-            sidecars=[
-                SidecarPoolSpec(
-                    pool_name=PoolName.INDEXER,
-                    indices_from_pool=PoolName.KV,
-                ),
-            ],
+            sidecars=sidecars,
             transfer_layer_num=len(full_layer_mapping),
-            pools_desc="KV + INDEXER",
+            pools_desc=pools_desc,
         )
 
 
@@ -1167,6 +1218,7 @@ def attach_hybrid_dsa_pool_to_hiradix_cache(
     try:
         kv = radix_cache.kv_cache
         layer_mapping = {layer_id: layer_id for layer_id in range(kv.layer_num)}
+        enable_indexer_topk_sidecar = _indexer_topk_sidecar_enabled(server_args)
         host_pool_group, cache_controller = build_anchor_sidecar_stack(
             params=params,
             server_args=server_args,
@@ -1193,13 +1245,29 @@ def attach_hybrid_dsa_pool_to_hiradix_cache(
             pp_rank=radix_cache.pp_rank,
             pp_size=radix_cache.pp_size,
             enable_storage_metrics=enable_storage_metrics,
+            extra_sidecar_pools=(
+                [
+                    (
+                        PoolName.INDEXER_TOPK,
+                        lambda kv_host_pool: DSAIndexerTopkPoolHost(
+                            kv,
+                            kv_host_pool,
+                            server_args.hicache_mem_layout,
+                            allocator_type=server_args.hicache_storage_backend,
+                        ),
+                    ),
+                ]
+                if enable_indexer_topk_sidecar
+                else None
+            ),
         )
         radix_cache.full_kv_pool_host = host_pool_group.get_pool(PoolName.KV)
         radix_cache.token_to_kv_pool_host = host_pool_group
         radix_cache.cache_controller = cache_controller
         logger.info(
-            "Attached hybrid DSA pool stack to HiRadixCache: pools=KV + INDEXER, "
+            "Attached hybrid DSA pool stack to HiRadixCache: pools=KV + INDEXER%s, "
             "transfer_layer_num=%s",
+            " + INDEXER_TOPK" if enable_indexer_topk_sidecar else "",
             len(layer_mapping),
         )
     except Exception:

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2962,3 +2962,145 @@ class DSAIndexerPoolHost(HostKVCache):
             page_index = int(indices[i]) // self.page_size
             ptr_list.append(base_ptr + page_index * page_stride_bytes)
         return ptr_list, [page_stride_bytes] * len(ptr_list)
+
+
+class DSAIndexerTopkPoolHost(HostKVCache):
+    """Host sidecar for the DSA indexer-topk capture buffer; slot layout matches
+    the anchor MLA host pool.
+
+    Travels with KV (``indices_from_pool=KV``) so a HiCache load_back migrates the
+    capturer's topk rows to the new device slots too. All copies are CPU<->CPU
+    (the capturer buffer is already pinned), so ``device_pool`` and ``io_backend``
+    are ignored.
+    """
+
+    def __init__(
+        self,
+        device_pool,
+        anchor_host,
+        layout: str,
+        pin_memory: bool = True,
+        device: str = "cpu",
+        allocator_type: str = "default",
+    ):
+        from sglang.srt.state_capturer.indexer_topk import (
+            get_global_indexer_capturer,
+        )
+
+        self.device_pool = device_pool
+        self.page_size = anchor_host.page_size
+        self.layout = layout  # stored for parity; CPU<->CPU transfer ignores it
+        self.pin_memory = pin_memory
+        self.device = device
+        self.allocator = get_allocator_from_storage(allocator_type)
+        self.size = anchor_host.size
+        self.page_num = anchor_host.page_num
+
+        cap = get_global_indexer_capturer()
+        if cap is None:
+            raise ValueError(
+                "INDEXER_TOPK host pool requires the indexer capturer to be "
+                "initialized (enable-return-indexer-topk)."
+            )
+        self._capturer = cap
+        self._cap_buffer = cap.host_cache.buffer
+        self.num_layers = cap.num_layers
+        self.topk_size = cap.topk_size
+
+        requested_bytes = self.size * self.num_layers * self.topk_size * 4
+        host_mem = psutil.virtual_memory()
+        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        if requested_bytes > available_bytes:
+            raise ValueError(
+                f"Not enough host memory for the indexer-topk hierarchical cache "
+                f"sidecar. Requesting {requested_bytes / 1e9:.2f} GB but only have "
+                f"{available_bytes / 1e9:.2f} GB free. Please reduce the size of "
+                f"the hierarchical cache or max-total-tokens."
+            )
+        logger.info(
+            "Allocating %.2f GB host memory for indexer-topk sidecar "
+            "(size=%d, num_layers=%d, topk_size=%d).",
+            requested_bytes / 1e9,
+            self.size,
+            self.num_layers,
+            self.topk_size,
+        )
+
+        self.init_kv_buffer()
+        self.lock = threading.RLock()
+        self.clear()
+
+    def get_size_per_token(self):
+        return self.num_layers * self.topk_size * 4
+
+    def get_ksize_per_token(self):
+        # Storage backends call this during host-pool registration (not on base).
+        return self.get_size_per_token()
+
+    def init_kv_buffer(self):
+        self.buffer = torch.zeros(
+            (self.size, self.num_layers, self.topk_size),
+            dtype=torch.int32,
+            device=self.device,
+            pin_memory=self.pin_memory,
+        )
+
+    def get_hybrid_pool_buffer(self):
+        return [self.buffer]
+
+    def _capturer_buffer(self) -> torch.Tensor:
+        return self._cap_buffer
+
+    def backup_from_device_all_layer(
+        self, device_pool, host_indices, device_indices, io_backend
+    ) -> None:
+        # device_indices index the capturer (KV slots); host_indices index this pool.
+        if host_indices.numel() == 0:
+            return
+        self.buffer[host_indices] = self._capturer_buffer()[device_indices]
+
+    def load_to_device_per_layer(
+        self, device_pool, host_indices, device_indices, layer_id, io_backend
+    ) -> None:
+        # Inverse of backup, one layer at a time (per-layer load contract).
+        if host_indices.numel() == 0:
+            return
+        self._capturer_buffer()[device_indices, layer_id, :] = self.buffer[
+            host_indices, layer_id, :
+        ]
+
+    def get_data_page(self, index, flat: bool = True) -> torch.Tensor:
+        page_idx = int(index) // self.page_size
+        start = page_idx * self.page_size
+        data_page = self.buffer[start : start + self.page_size]
+        if flat:
+            data_page = data_page.flatten()
+        return data_page
+
+    def get_dummy_flat_data_page(self) -> torch.Tensor:
+        return torch.zeros(
+            (self.page_size, self.num_layers, self.topk_size),
+            dtype=torch.int32,
+            device=self.device,
+            pin_memory=self.pin_memory,
+        ).flatten()
+
+    def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:
+        page_idx = int(index) // self.page_size
+        start = page_idx * self.page_size
+        self.buffer[start : start + self.page_size] = data_page.reshape(
+            self.page_size, self.num_layers, self.topk_size
+        )
+
+    def get_page_buffer_meta(self, indices):
+        """Meta data for zero-copy storage I/O. Buffer is page-contiguous:
+        a page occupies ``page_size`` rows of ``(num_layers, topk_size)`` int32."""
+        assert len(indices) % self.page_size == 0
+        ptr_list = []
+        indices = indices.tolist()
+        page_stride_bytes = self.page_size * self.num_layers * self.topk_size * 4
+        base_ptr = self.buffer.data_ptr()
+        for i in range(0, len(indices), self.page_size):
+            page_index = int(indices[i]) // self.page_size
+            ptr_list.append(base_ptr + page_index * page_stride_bytes)
+        return ptr_list, [page_stride_bytes] * len(ptr_list)

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -685,6 +685,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 ]
         elif pool_name in (
             PoolName.INDEXER,
+            PoolName.INDEXER_TOPK,
             PoolName.DEEPSEEK_V4_C4,
             PoolName.DEEPSEEK_V4_C4_INDEXER,
             PoolName.DEEPSEEK_V4_C128,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4133,6 +4133,13 @@ class ServerArgs:
                 "and cannot be used at the same time. Please use only one of them."
             )
 
+        if self.enable_hierarchical_cache and self.enable_return_routed_experts:
+            raise ValueError(
+                "enable-hierarchical-cache is incompatible with enable-return-routed-experts: "
+                "captured expert routing data is not migrated on host-tier cache hits "
+                "(see issue #26975)."
+            )
+
         if self.disaggregation_decode_enable_offload_kvcache:
             if self.disaggregation_mode != "decode":
                 raise ValueError(

--- a/test/registered/8-gpu-models/test_hicache_return_indexer_topk.py
+++ b/test/registered/8-gpu-models/test_hicache_return_indexer_topk.py
@@ -1,0 +1,297 @@
+import asyncio
+import logging
+import unittest
+
+import aiohttp
+import numpy as np
+
+from sglang.srt.state_capturer.indexer_topk import (
+    extract_indexer_topk_from_meta_info,
+)
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=420, stage="extra-b", runner_config="8-gpu-h200")
+
+DEEPSEEK_V32_MODEL_PATH = "deepseek-ai/DeepSeek-V3.2"
+
+# V3.2 config — hardcoded for response decoding (mirrors test_return_indexer_topk.py).
+NUM_INDEXER_LAYERS = 61
+INDEX_TOPK = 2048
+INDEX_TOPK_FREQ = 2
+
+# Topology / eviction tuning. IndexerTopkCapturer requires attn_tp_size == 1, so
+# dp_size must equal tp_size (=> dp 8 on 8 GPUs). KV pools are PER-RANK, and the
+# default load balancer is round_robin, so a request and its identical re-send do
+# NOT land on the same rank. We therefore:
+#   - keep the per-rank device pool tiny so a modest filler burst evicts req_A to
+#     the host tier on whichever rank served it, and
+#   - probe req_B up to DP_SIZE times: round_robin visits each rank exactly once
+#     per DP_SIZE consecutive sends, so the single probe that lands on req_A's
+#     rank is the one that triggers load_back -> INDEXER_TOPK sidecar restore.
+# A host-tier hit (cached_tokens_details["host"] > 0) is ONLY possible on req_A's
+# rank, since no other rank ever held the shared prompt's KV — so host > 0 both
+# proves the restore path ran and pins us to the correct rank.
+DP_SIZE = 8
+MAX_TOTAL_TOKENS = 4096  # per-rank device KV pool; small enough to force eviction.
+CHUNKED_PREFILL_SIZE = 2048  # must be <= MAX_TOTAL_TOKENS on a tiny pool.
+NUM_FILLERS = 64  # ~8 per rank, each ~MAX_TOTAL_TOKENS-worth, evicts req_A.
+SETTLE_SECONDS = 5  # let the async HiCache write_backup flush before probing.
+MAX_PROBES = DP_SIZE  # round_robin guarantees req_A's rank is visited within DP_SIZE.
+
+logger = logging.getLogger(__name__)
+
+
+class TestHiCacheReturnIndexerTopk(CustomTestCase):
+    """HiCache + indexer-topk correctness e2e test for DSv3.2 (DSA) — issue #26975.
+
+    Boots a server with BOTH `--enable-hierarchical-cache` and
+    `--enable-return-indexer-topk`. This combination used to be rejected at
+    startup; the INDEXER_TOPK sidecar host pool now migrates the captured topk
+    alongside KV on host-tier cache hits.
+
+    Flow:
+      1. req_A: a long prompt -> collect its indexer-topk (the reference, produced
+         by the original forward pass) and the rank that served it.
+      2. A burst of distinct long filler prompts to evict req_A's KV from every
+         rank's device pool down to the host tier (write_backup).
+      3. req_B: the SAME prompt as req_A, re-sent until a probe reports a
+         host-tier cache hit (load_back -> INDEXER_TOPK sidecar restore). Only
+         req_A's rank can produce a host hit for this prompt.
+      4. Assert req_B's restored prefix equals req_A's element-wise. A regression
+         (sidecar not migrated) surfaces as all -1 (unrestored) or mismatched
+         (stale slots) on the restored rows — and is no longer maskable by a
+         silent recompute, because we require an actual host hit.
+
+    Also keeps the shape / value-range / skip_topk(freq=2) invariants from
+    test_return_indexer_topk.py.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.other_args = [
+            "--trust-remote-code",
+            "--tp",
+            "8",
+            "--dp",
+            "8",
+            "--enable-dp-attention",
+            "--enable-return-indexer-topk",
+            # The fix under test: HiCache must coexist with indexer-topk capture.
+            "--enable-hierarchical-cache",
+            # Pin the balancer so the probe-until-host-hit logic below holds.
+            "--load-balance-method",
+            "round_robin",
+            # Tiny per-rank KV pool so the filler burst forces host-tier eviction
+            # quickly, and so the indexer-topk pinned buffer stays bounded.
+            "--max-total-tokens",
+            str(MAX_TOTAL_TOKENS),
+            "--chunked-prefill-size",
+            str(CHUNKED_PREFILL_SIZE),
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true, "num_threads": 64}',
+            "--json-model-override-args",
+            f'{{"index_topk_freq": {INDEX_TOPK_FREQ}}}',
+        ]
+        cls.sampling_args = {"temperature": 0, "max_new_tokens": 8}
+
+        # A long prompt that spans several KV pages so eviction + restore is
+        # meaningfully exercised across pages.
+        base = (
+            "Describe in detail the history, geography, economy, and culture of a "
+            "fictional country, covering its founding, major cities, rivers, "
+            "mountains, trade routes, and notable historical figures. "
+        )
+        cls.shared_prompt = base * 12
+
+        # Distinct long fillers (no shared prefix with shared_prompt) to push the
+        # shared prompt's KV out of every rank's device pool into the host tier.
+        cls.fillers = [
+            f"Filler request number {i}. " + (base * 12) for i in range(NUM_FILLERS)
+        ]
+
+        cls.process = popen_launch_server(
+            DEEPSEEK_V32_MODEL_PATH,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.other_args,
+        )
+        try:
+            (
+                cls.topk_a,
+                cls.topk_b,
+                cls.cached_len_b,
+                cls.rank_a,
+                cls.rank_b,
+                cls.probes,
+            ) = asyncio.run(cls._collect_async())
+        except Exception:
+            kill_process_tree(cls.process.pid)
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    @classmethod
+    async def _collect_async(cls):
+        async with aiohttp.ClientSession() as session:
+            url = f"{DEFAULT_URL_FOR_TEST}/generate"
+
+            # Phase 1: reference request (original forward pass, must be a cold
+            # miss so the captured topk is genuinely produced by forward).
+            res_a = await _generate(session, url, cls.shared_prompt, cls.sampling_args)
+            if _cached_tokens(res_a) != 0:
+                raise AssertionError(
+                    "reference req_A was a cache hit "
+                    f"(cached_tokens={_cached_tokens(res_a)}); expected a cold miss"
+                )
+            topk_a = _decode_topk(res_a)
+            rank_a = _dp_rank(res_a)
+
+            # Phase 2: evict req_A's KV to the host tier on every rank.
+            await asyncio.gather(
+                *[
+                    _generate(session, url, f, cls.sampling_args, capture=False)
+                    for f in cls.fillers
+                ]
+            )
+            # Let the async HiCache write_backup flush before we probe.
+            await asyncio.sleep(SETTLE_SECONDS)
+
+            # Phase 3: re-send the identical prompt until a probe reports a
+            # host-tier hit. Only req_A's rank holds this prompt's backed-up KV,
+            # so host > 0 both confirms the restore ran and pins us to that rank.
+            res_b = None
+            probes = []
+            for _ in range(MAX_PROBES):
+                r = await _generate(session, url, cls.shared_prompt, cls.sampling_args)
+                probes.append((_dp_rank(r), _cached_tokens(r), _host_cached(r)))
+                if _host_cached(r) > 0:
+                    res_b = r
+                    break
+
+            if res_b is None:
+                raise AssertionError(
+                    "no host-tier cache hit observed across "
+                    f"{MAX_PROBES} probes (rank_a={rank_a}; "
+                    f"probes[(rank, cached, host)]={probes}). req_A was likely not "
+                    "evicted to the host tier — increase NUM_FILLERS / SETTLE_SECONDS "
+                    "or lower MAX_TOTAL_TOKENS."
+                )
+
+            topk_b = _decode_topk(res_b)
+            return (
+                topk_a,
+                topk_b,
+                _cached_tokens(res_b),
+                rank_a,
+                _dp_rank(res_b),
+                probes,
+            )
+
+    def test_shape_and_range(self):
+        for topk in (self.topk_a, self.topk_b):
+            self.assertEqual(topk.ndim, 3)
+            seqlen_minus_1, num_layers, topk_size = topk.shape
+            self.assertGreater(seqlen_minus_1, 0)
+            self.assertEqual(num_layers, NUM_INDEXER_LAYERS)
+            self.assertEqual(topk_size, INDEX_TOPK)
+            self.assertTrue((topk >= -1).all(), f"min index {topk.min()} < -1")
+
+    def test_skip_topk_equality(self):
+        for topk in (self.topk_a, self.topk_b):
+            for L in range(2, NUM_INDEXER_LAYERS, 2):
+                np.testing.assert_array_equal(
+                    topk[:, L, :],
+                    topk[:, L - 1, :],
+                    err_msg=f"layer {L} should reuse layer {L - 1}'s topk",
+                )
+
+    def test_hicache_restore_matches_reference(self):
+        """The core #26975 regression check.
+
+        req_B's prefix is reconstructed from the INDEXER_TOPK sidecar after a
+        host-tier cache hit (guaranteed: setUpClass only accepts a probe with
+        host > 0). The restored prefix rows must byte-equal req_A's reference at
+        the same positions. We compare ONLY the cache-served prefix region: the
+        recomputed tail goes through the extend path rather than full prefill and
+        can differ in the last index of a near-tie, so comparing it would be
+        flaky and is not what #26975 is about.
+
+        A mismatch (or a prefix of the -1 padding sentinel) means the captured
+        topk was not migrated on load_back.
+        """
+        # Host-tier hit actually happened (this is what makes the test able to
+        # detect the regression at all — a silent recompute would pass trivially).
+        host = self.probes[-1][2]
+        self.assertGreater(
+            host, 0, f"req_B did not hit the host tier; probes={self.probes}"
+        )
+        if self.rank_a is not None and self.rank_b is not None:
+            self.assertEqual(
+                self.rank_b,
+                self.rank_a,
+                "host hit must be on req_A's rank (only it holds the prompt's KV)",
+            )
+
+        # Compare the cache-served prefix region row-for-row.
+        n = min(self.cached_len_b, self.topk_a.shape[0], self.topk_b.shape[0])
+        self.assertGreater(n, 0, "no cached prefix rows to compare on req_B")
+        prefix_a = self.topk_a[:n]
+        prefix_b = self.topk_b[:n]
+
+        # Guard against the trivial all-padding failure mode on the restored side.
+        self.assertTrue(
+            (prefix_b != -1).any(),
+            "req_B restored prefix is entirely the -1 padding sentinel: "
+            "sidecar not restored",
+        )
+        np.testing.assert_array_equal(
+            prefix_b,
+            prefix_a,
+            err_msg=(
+                "HiCache-restored indexer-topk differs from the original forward "
+                "pass — captured topk was not migrated on host-tier cache hit "
+                "(issue #26975)."
+            ),
+        )
+
+
+def _decode_topk(res) -> np.ndarray:
+    return extract_indexer_topk_from_meta_info(res).reshape(
+        -1, NUM_INDEXER_LAYERS, INDEX_TOPK
+    )
+
+
+def _cached_tokens(res) -> int:
+    return int(res["meta_info"].get("cached_tokens", 0))
+
+
+def _host_cached(res) -> int:
+    details = res["meta_info"].get("cached_tokens_details") or {}
+    return int(details.get("host", 0))
+
+
+def _dp_rank(res):
+    return res["meta_info"].get("dp_rank")
+
+
+async def _generate(session, url, text, sampling_params, capture: bool = True):
+    payload = {
+        "text": text,
+        "sampling_params": sampling_params,
+        "return_indexer_topk": capture,
+    }
+    async with session.post(url=url, json=payload) as response:
+        return await response.json()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_indexer_topk_guard.py
+++ b/test/registered/unit/mem_cache/test_hicache_indexer_topk_guard.py
@@ -1,0 +1,56 @@
+"""Guard-compatibility tests for HiCache + capture flags (#26975).
+
+INDEXER_TOPK is now allowed with --enable-hierarchical-cache (sidecar pool);
+--enable-return-routed-experts stays guarded. Pure CPU arg-validation against a
+stub -- no model load, no GPU.
+"""
+
+import types
+import unittest
+
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_args(**overrides) -> types.SimpleNamespace:
+    """A stub carrying exactly the attributes _handle_cache_compatibility reads."""
+    defaults = dict(
+        enable_hierarchical_cache=False,
+        disable_radix_cache=False,
+        enable_return_routed_experts=False,
+        enable_return_indexer_topk=False,
+        disaggregation_decode_enable_offload_kvcache=False,
+        disaggregation_mode="null",
+        hicache_storage_backend=None,
+        swa_full_tokens_ratio=1.0,
+    )
+    defaults.update(overrides)
+    return types.SimpleNamespace(**defaults)
+
+
+class TestHiCacheCaptureGuards(unittest.TestCase):
+    def _run(self, **overrides):
+        ServerArgs._handle_cache_compatibility(_make_args(**overrides))
+
+    def test_indexer_topk_allowed_with_hicache(self):
+        # The fix: this combination must no longer raise.
+        self._run(enable_hierarchical_cache=True, enable_return_indexer_topk=True)
+
+    def test_routed_experts_still_guarded(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._run(enable_hierarchical_cache=True, enable_return_routed_experts=True)
+        self.assertIn("return-routed-experts", str(ctx.exception))
+
+    def test_routed_experts_alone_ok(self):
+        # Without hierarchical cache, routed-experts is fine.
+        self._run(enable_hierarchical_cache=False, enable_return_routed_experts=True)
+
+    def test_disable_radix_still_guarded(self):
+        with self.assertRaises(ValueError):
+            self._run(enable_hierarchical_cache=True, disable_radix_cache=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_indexer_topk_pool.py
+++ b/test/registered/unit/mem_cache/test_hicache_indexer_topk_pool.py
@@ -1,0 +1,177 @@
+"""CPU-only round-trip tests for the INDEXER_TOPK HiCache sidecar pool (#26975).
+
+Exercise DSAIndexerTopkPoolHost in isolation: the host<->host backup/load path
+and the L3 flat-page serialization path, using lightweight fakes for the
+capturer and anchor host pool. No GPU required.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool_host import DSAIndexerTopkPoolHost
+from sglang.srt.state_capturer.indexer_topk import (
+    get_global_indexer_capturer,
+    set_global_indexer_capturer,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeHostCache:
+    """Stand-in for BaseHostCache: a plain (non-pinned) CPU buffer."""
+
+    def __init__(self, num_tokens, num_layers, topk_size):
+        self.buffer = torch.zeros(
+            (num_tokens, num_layers, topk_size), dtype=torch.int32
+        )
+
+
+class _FakeCapturer:
+    """Duck-typed IndexerTopkCapturer: exposes num_layers/topk_size/host_cache."""
+
+    def __init__(self, num_tokens, num_layers, topk_size):
+        self.num_layers = num_layers
+        self.topk_size = topk_size
+        self.host_cache = _FakeHostCache(num_tokens, num_layers, topk_size)
+
+
+class _FakeAnchorHost:
+    def __init__(self, size, page_size, page_num):
+        self.size = size
+        self.page_size = page_size
+        self.page_num = page_num
+
+
+class TestDSAIndexerTopkPool(unittest.TestCase):
+    PAGE_SIZE = 4
+    NUM_LAYERS = 3
+    TOPK_SIZE = 5
+    # capturer index space (KV slots) and pool slots are independent ranges.
+    CAP_TOKENS = 64
+    POOL_SIZE = 64  # multiple of page_size
+
+    def setUp(self):
+        self._prev_capturer = get_global_indexer_capturer()
+        self.capturer = _FakeCapturer(self.CAP_TOKENS, self.NUM_LAYERS, self.TOPK_SIZE)
+        set_global_indexer_capturer(self.capturer)
+        anchor = _FakeAnchorHost(
+            size=self.POOL_SIZE,
+            page_size=self.PAGE_SIZE,
+            page_num=self.POOL_SIZE // self.PAGE_SIZE,
+        )
+        # pin_memory=False keeps this CPU-only (pinned alloc needs CUDA).
+        self.pool = DSAIndexerTopkPoolHost(
+            device_pool=None,
+            anchor_host=anchor,
+            layout="layer_first",
+            pin_memory=False,
+            device="cpu",
+            allocator_type="default",
+        )
+
+    def tearDown(self):
+        set_global_indexer_capturer(self._prev_capturer)
+
+    def _fill_capturer(self, slots):
+        """Write deterministic, slot-unique topk data into the capturer buffer."""
+        buf = self.capturer.host_cache.buffer
+        for i, s in enumerate(slots.tolist()):
+            base = (s + 1) * 1000
+            buf[s] = (
+                torch.arange(
+                    self.NUM_LAYERS * self.TOPK_SIZE, dtype=torch.int32
+                ).reshape(self.NUM_LAYERS, self.TOPK_SIZE)
+                + base
+            )
+
+    def test_l2_round_trip_to_new_slots(self):
+        """capturer[old] -> backup -> pool; pool -> per-layer load -> capturer[new]."""
+        old_slots = torch.tensor([8, 9, 10, 11], dtype=torch.int64)  # one page
+        host_slots = torch.tensor([0, 1, 2, 3], dtype=torch.int64)  # pool page 0
+        new_slots = torch.tensor([20, 21, 22, 23], dtype=torch.int64)
+
+        self._fill_capturer(old_slots)
+        expected = self.capturer.host_cache.buffer[old_slots].clone()
+
+        # backup: capturer[old_slots] -> pool[host_slots]
+        self.pool.backup_from_device_all_layer(
+            None, host_slots, old_slots, io_backend="direct"
+        )
+        self.assertTrue(torch.equal(self.pool.buffer[host_slots], expected))
+
+        # simulate slot recycling: capturer rows wiped
+        self.capturer.host_cache.buffer[old_slots] = 0
+
+        # load: pool[host_slots] -> capturer[new_slots], one layer at a time
+        for layer_id in range(self.NUM_LAYERS):
+            self.pool.load_to_device_per_layer(
+                None, host_slots, new_slots, layer_id, io_backend="direct"
+            )
+
+        self.assertTrue(
+            torch.equal(self.capturer.host_cache.buffer[new_slots], expected),
+            "restored capturer rows at new slots must equal the original topk",
+        )
+
+    def test_empty_indices_noop(self):
+        empty = torch.tensor([], dtype=torch.int64)
+        # Must not raise and must not touch buffers.
+        self.pool.backup_from_device_all_layer(None, empty, empty, io_backend="direct")
+        self.pool.load_to_device_per_layer(None, empty, empty, 0, io_backend="direct")
+
+    def test_flat_data_page_round_trip(self):
+        """L3 path: get_data_page(flat) -> set_from_flat_data_page restores bytes."""
+        # Fill pool page 1 directly with known data.
+        page_idx = 1
+        start = page_idx * self.PAGE_SIZE
+        src = (
+            torch.arange(
+                self.PAGE_SIZE * self.NUM_LAYERS * self.TOPK_SIZE, dtype=torch.int32
+            ).reshape(self.PAGE_SIZE, self.NUM_LAYERS, self.TOPK_SIZE)
+            + 777
+        )
+        self.pool.buffer[start : start + self.PAGE_SIZE] = src
+
+        flat = self.pool.get_data_page(start, flat=True)
+        self.assertEqual(
+            flat.numel(), self.PAGE_SIZE * self.NUM_LAYERS * self.TOPK_SIZE
+        )
+
+        # get_data_page may return a view; clone before mutating the underlying
+        # buffer so the flat snapshot survives the wipe.
+        flat = flat.clone()
+
+        # Wipe and restore from the flat page.
+        self.pool.buffer[start : start + self.PAGE_SIZE] = 0
+        self.pool.set_from_flat_data_page(start, flat)
+        self.assertTrue(
+            torch.equal(self.pool.buffer[start : start + self.PAGE_SIZE], src)
+        )
+
+    def test_dummy_flat_data_page_shape(self):
+        dummy = self.pool.get_dummy_flat_data_page()
+        self.assertEqual(
+            dummy.numel(), self.PAGE_SIZE * self.NUM_LAYERS * self.TOPK_SIZE
+        )
+        self.assertTrue(torch.equal(dummy, torch.zeros_like(dummy)))
+
+    def test_page_buffer_meta_strides(self):
+        indices = torch.tensor([0, 1, 2, 3, 8, 9, 10, 11], dtype=torch.int64)
+        ptrs, sizes = self.pool.get_page_buffer_meta(indices)
+        page_bytes = self.PAGE_SIZE * self.NUM_LAYERS * self.TOPK_SIZE * 4
+        self.assertEqual(sizes, [page_bytes, page_bytes])
+        self.assertEqual(ptrs[1] - ptrs[0], 2 * page_bytes)  # page 0 vs page 2
+
+    def test_size_per_token(self):
+        self.assertEqual(
+            self.pool.get_size_per_token(), self.NUM_LAYERS * self.TOPK_SIZE * 4
+        )
+        self.assertEqual(
+            self.pool.get_ksize_per_token(), self.pool.get_size_per_token()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #26975.

## Problem

`state_capturer/` indexes per-token indexer/expert routing data by **device KV slot**. With hierarchical cache enabled, a host-tier cache hit makes `HiRadixCache.load_back()` relocate KV to new device slots, but the capture buffers are not migrated — so `get_topk()` / `meta_info.routed_experts` read stale slots. Output tokens are unaffected; the corruption only hits captured RL-training data.

Previously this combination was hard-rejected at startup.

## Fix

Add an `INDEXER_TOPK` sidecar host pool that travels with KV (`indices_from_pool=KV`). On backup it copies the capturer's topk rows for evicted slots into a slot-indexed host buffer; on `load_back` it restores them into the capturer at the new slots. All copies are CPU↔CPU (the capturer buffer is already pinned), so no GPU DMA is involved.

- `--enable-hierarchical-cache` + `--enable-return-indexer-topk` is now **supported** (DSA path).
- `--enable-return-routed-experts` with HiCache remains **guarded** — MHA/MoE has no sidecar infrastructure yet.

## Changes

- `memory_pool_host.py`: `DSAIndexerTopkPoolHost` sidecar host pool (backup/load + L3 flat-page serialization).
- `hybrid_pool_assembler.py`: wire the sidecar into both DSA stack-build paths, gated on the capturer actually existing.
- `hiradix_cache.py`: request the `INDEXER_TOPK` transfer on `load_back` under the same gate.
- `server_args.py`: keep the startup guard for routed-experts only.
- `hicache_storage.py` / `mooncake_store.py`: register the new pool name.

## Tests

- CPU unit tests: sidecar host↔host round-trip + L3 flat-page serialization; capture-flag guard validation.
- e2e: boots a server with hierarchical cache + indexer-topk capture, evicts a prompt's KV to the host tier, re-requests the identical prompt, and asserts the host-restored topk matches the original forward pass element-wise.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26991456248](https://github.com/sgl-project/sglang/actions/runs/26991456248)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26991456150](https://github.com/sgl-project/sglang/actions/runs/26991456150)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->