### PR TITLE
Fix MMMU VLM eval max_tokens for CoT prompt

### DIFF
--- a/test/registered/eval/test_vlms_mmmu_eval.py
+++ b/test/registered/eval/test_vlms_mmmu_eval.py
@@ -94,7 +94,7 @@ class TestNightlyVLMMmmuEval(unittest.TestCase):
                         eval_name="mmmu",
                         num_examples=100,
                         num_threads=64,
-                        max_tokens=30,
+                        max_tokens=1024,
                     )
 
                     args.return_latency = True


### PR DESCRIPTION
## Motivation

PR #21841 changed the MMMU eval prompt to use Chain-of-Thought instructions ("Think step by step before answering") but kept `max_tokens=30`. This is too short for models to complete their reasoning before outputting `Answer: X`, causing all VLM models to fail the nightly MMMU accuracy test since April 2.

## Modifications

Increase `max_tokens` from 30 to 1024 in `test/registered/eval/test_vlms_mmmu_eval.py`.

## Verification

Tested on H200 with all models in the nightly VLM MMMU eval:

| Model | Score (max_tokens=30) | Score (max_tokens=1024) | Threshold | Status |
|-------|----------------------|------------------------|-----------|--------|
| Qwen2.5-VL-7B | 0.28 | **0.56** | 0.33 | PASS |
| MiMo-VL-7B-RL | 0.30 | **0.49** | 0.28 | PASS |
| deepseek-vl2-small | 0.28 | **0.48** | 0.32 | PASS |
| Qwen3-VL-30B-A3B | 0.27 | **0.47** | 0.29 | PASS |
| GLM-4.1V-9B-Thinking | 0.29 | **0.47** | 0.28 | PASS |
| GLM-4.5V-FP8 | 0.29 | **0.47** | 0.26 | PASS |
| Qwen2-VL-7B | 0.29 | **0.35** | 0.31 | PASS |
| Janus-Pro-7B | 0.30 | **0.33** | 0.285 | PASS |
| InternVL2_5-2B | 0.29 | **0.30** | 0.30 | PASS |

All models that can launch successfully now pass the accuracy threshold.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26991456983](https://github.com/sgl-project/sglang/actions/runs/26991456983)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26991456867](https://github.com/sgl-project/sglang/actions/runs/26991456867)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->