### PR TITLE
fix: add missing clamp_limit for CompressedTensorsWNA16MoE

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -423,6 +423,7 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
             num_bits=self.num_bits,
             is_k_full=self.is_k_full,
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
+            clamp_limit=self.moe_runner_config.swiglu_limit,
             workspace=layer.workspace,
         )
         return StandardCombineInput(hidden_states=output)


### PR DESCRIPTION
## Motivation

When deploying DeepSeek V4 W4A16 quantized model, the fused_marlin_moe call in CompressedTensorsWNA16MoE was missing the clamp_limit parameter, causing incorrect outputs.

## Modifications

Pass clamp_limit=self.moe_runner_config.swiglu_limit to the fused_marlin_moe call.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26991731789](https://github.com/sgl-project/sglang/actions/runs/26991731789)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26992163929](https://github.com/sgl-project/sglang/actions/runs/26992163929)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->