### PR TITLE
Use torchcodec instead of decord2/av on aarch64

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "cuda-python>=13.0",
-  "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "datasets",
   "distro",
   "einops",
@@ -71,8 +70,7 @@ dependencies = [
   "torch==2.11.0",
   "torchao==0.17.0",
   "torchaudio==2.11.0",
-  "torchcodec==0.11.1 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec 0.11.1 for torch 2.11.x (0.10 is ABI-incompatible: references the pre-2.11 c10::MessageLogger ctor signature). Not available on Linux ARM.
-  "av ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
+  "torchcodec==0.11.1", # torchcodec 0.11.1 for torch 2.11.x (0.10 is ABI-incompatible: references the pre-2.11 c10::MessageLogger ctor signature).
   "torchvision",
   "tqdm",
   "mistral_common>=1.11.0",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

`decord2` and `av` were only still used because `torchcodec` didn't have an `aarch64` build, but `torchcodec` now has `aarch64` builds: https://pypi.org/project/torchcodec/0.11.1/#files (since version `0.11.0`).

## Modifications

<!-- Detail the changes made in this pull request. -->

Removes `decord2` and `av` from package requirements and enables `torchcodec` instead on `Linux aarch64` platforms.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A as non-`aarch64` platforms already use `torchcodec`.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A as non-`aarch64` platforms already use `torchcodec`.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26992664059](https://github.com/sgl-project/sglang/actions/runs/26992664059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26992664011](https://github.com/sgl-project/sglang/actions/runs/26992664011)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->