### PR TITLE
Fix qwen3 coder parameter end parsing

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -26,6 +26,8 @@ class Qwen3CoderDetector(BaseFormatDetector):
         self.function_end_token: str = "</function>"
         self.parameter_prefix: str = "<parameter="
         self.parameter_end_token: str = "</parameter>"
+        self.parameter_end_prefix: str = "</parameter"
+        self.parameter_end_regex = re.compile(r"</parameter[^<>]*>?")
 
         # Regex for non-streaming fallback
         self.tool_call_regex = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
@@ -33,7 +35,7 @@ class Qwen3CoderDetector(BaseFormatDetector):
             r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL
         )
         self.tool_call_parameter_regex = re.compile(
-            r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
+            r"<parameter=(.*?)(?:</parameter\d*/?>|(?=<parameter=)|(?=</function>)|$)",
             re.DOTALL,
         )
 
@@ -56,6 +58,20 @@ class Qwen3CoderDetector(BaseFormatDetector):
 
     def has_tool_call(self, text: str) -> bool:
         return self.tool_call_start_token in text
+
+    def _strip_parameter_end_tokens(self, value: str) -> str:
+        """Remove leaked parameter end tags from the end of a parsed value."""
+        while True:
+            stripped = value.rstrip()
+            match = self.parameter_end_regex.search(stripped)
+            if match and match.end() == len(stripped):
+                value = stripped[: match.start()].rstrip()
+                continue
+            malformed_match = re.search(r"</parameter[^<>]*$", stripped)
+            if malformed_match:
+                value = stripped[: malformed_match.start()].rstrip()
+                continue
+            return value
 
     def _get_arguments_config(
         self, func_name: str, tools: Optional[list[Tool]]
@@ -211,6 +227,7 @@ class Qwen3CoderDetector(BaseFormatDetector):
                             p_val = p_val[1:]
                         if p_val.endswith("\n"):
                             p_val = p_val[:-1]
+                        p_val = self._strip_parameter_end_tokens(p_val)
 
                         parsed_params[p_name] = self._convert_param_value(
                             p_val, p_name, param_config, func_name
@@ -310,14 +327,14 @@ class Qwen3CoderDetector(BaseFormatDetector):
                     # 2. [Abnormal] Encounter next <parameter=
                     # 3. [Abnormal] Encounter </function>
                     # So we need to find the smallest one as the parameter end position.
-                    cand_end_param = rest_of_slice.find(self.parameter_end_token)
                     cand_next_param = rest_of_slice.find(self.parameter_prefix)
                     cand_end_func = rest_of_slice.find(self.function_end_token)
 
                     candidates = []
-                    if cand_end_param != -1:
+                    end_match = self.parameter_end_regex.search(rest_of_slice)
+                    if end_match is not None:
                         candidates.append(
-                            (cand_end_param, len(self.parameter_end_token))
+                            (end_match.start(), end_match.end() - end_match.start())
                         )
                     if cand_next_param != -1:
                         candidates.append((cand_next_param, 0))
@@ -339,6 +356,7 @@ class Qwen3CoderDetector(BaseFormatDetector):
                             raw_value = raw_value[1:]
                         if raw_value.endswith("\n"):
                             raw_value = raw_value[:-1]
+                        raw_value = self._strip_parameter_end_tokens(raw_value)
 
                         # JSON Construction
                         if not self.json_started:
@@ -431,7 +449,7 @@ class Qwen3CoderDetector(BaseFormatDetector):
                     self.tool_call_prefix,
                     self.function_end_token,
                     self.parameter_prefix,
-                    self.parameter_end_token,
+                    self.parameter_end_prefix,
                 ]
 
                 is_potential_tag = False

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2323,6 +2323,34 @@ class TestQwen3CoderDetector(unittest.TestCase):
         self.assertEqual(params["unit"], "celsius")
         self.assertEqual(params["days"], 3)
 
+    def test_parameter_end_tag_variants(self):
+        """
+        Test malformed parameter end markers emitted by qwen3_coder structural tags.
+        """
+        cases = [
+            "</parameter/>",
+            "</parameter1>",
+            "</parameter",
+            "</parameter_function>",
+            "</parameterfunction>",
+        ]
+
+        for end_tag in cases:
+            with self.subTest(end_tag=end_tag):
+                text = f"""<tool_call>
+<function=get_current_weather>
+<parameter=location>
+上海
+{end_tag}
+</function>
+</tool_call>"""
+                result = self.detector.detect_and_parse(text, self.tools)
+
+                self.assertEqual(len(result.calls), 1)
+                self.assertEqual(result.calls[0].name, "get_current_weather")
+                params = json.loads(result.calls[0].parameters)
+                self.assertEqual(params["location"], "上海")
+
     def test_single_tool_call_with_text_prefix(self):
         """
         Test parsing of tool call with preceding text.
@@ -2413,6 +2441,32 @@ class TestQwen3CoderDetector(unittest.TestCase):
             params = json.loads(collected_params)
             self.assertEqual(params["location"], "Boston")
             self.assertEqual(params["unit"], "celsius")
+
+    def test_streaming_self_closing_parameter_end(self):
+        """
+        Test streaming parsing when the parameter end marker is </parameter/>.
+        """
+        chunks = [
+            "<tool_call>",
+            "<function=get_current_weather>",
+            "<parameter=location>",
+            "上海\n",
+            "</parameter/>",
+            "</function>",
+            "</tool_call>",
+        ]
+
+        detector = Qwen3CoderDetector()
+        collected_params = ""
+
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            for call in result.calls:
+                if call.parameters:
+                    collected_params += call.parameters
+
+        params = json.loads(collected_params)
+        self.assertEqual(params["location"], "上海")
 
     def test_streaming_with_text_and_tool(self):
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix bug #27336
## Modifications

- Make `Qwen3CoderDetector` tolerate malformed parameter end markers emitted by Qwen3.6 / qwen3_coder tool calls.
- Support variants such as `</parameter/>`, `</parameter1>`, truncated `</parameter`, and fused forms like `</parameter_function>` / `</parameterfunction>`.
- Strip leaked parameter end markers from parsed argument values so OpenAI tool call arguments are returned cleanly, e.g. `{"city": "上海"}` instead of `{"city": "上海\n</parameter..."}`.
- Add regression coverage for malformed qwen3_coder parameter end tags in non-streaming and streaming parsing paths.

## Accuracy Tests

- Added unit tests for `Qwen3CoderDetector` covering malformed parameter end marker variants.
- Verified syntax with:

```bash
python3 -m py_compile python/sglang/srt/function_call/qwen3_coder_detector.py test/registered/unit/function_call/test_function_call_parser.py
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26994322882](https://github.com/sgl-project/sglang/actions/runs/26994322882)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26994322790](https://github.com/sgl-project/sglang/actions/runs/26994322790)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->