### PR TITLE
[Fix] Gemma3 RoPE KeyError and Gemma3n initialization failures

### DIFF
--- a/python/sglang/srt/models/gemma3_causal.py
+++ b/python/sglang/srt/models/gemma3_causal.py
@@ -580,9 +580,8 @@ class Gemma3TextModel(PreTrainedModel):
 
         global_config = copy.deepcopy(config)
         global_config.rope_parameters = {
+            **rope_params["full_attention"],
             "rope_theta": global_theta,
-            "factor": config.rope_parameters["full_attention"]["factor"],
-            "rope_type": "linear",
         }
         self.rotary_emb = Gemma3RotaryEmbedding(config=global_config)
         self.gradient_checkpointing = False

--- a/python/sglang/srt/models/gemma3n_causal.py
+++ b/python/sglang/srt/models/gemma3n_causal.py
@@ -389,16 +389,17 @@ class Gemma3nAttention(nn.Module):
                 self.head_dim,
                 rotary_dim=self.head_dim,
                 max_position=config.max_position_embeddings,
-                base=config.rope_local_base_freq,
+                base=config.rope_parameters.get("sliding_attention", {}).get("rope_theta", 10000.0),
                 rope_scaling={"rope_type": "default"},
             )
         else:
+            full_attn_rope = config.rope_parameters.get("full_attention", {})
             self.rotary_emb = get_rope(
                 self.head_dim,
                 rotary_dim=self.head_dim,
                 max_position=config.max_position_embeddings,
-                base=config.rope_parameters["rope_theta"],
-                rope_scaling=config.rope_parameters,
+                base=full_attn_rope.get("rope_theta", 1000000.0),
+                rope_scaling=full_attn_rope if full_attn_rope else {"rope_type": "default"},
             )
 
         self.sliding_window = config.sliding_window if self.is_sliding else None

--- a/python/sglang/srt/models/gemma3n_mm.py
+++ b/python/sglang/srt/models/gemma3n_mm.py
@@ -445,8 +445,8 @@ class Gemma3nForConditionalGeneration(PreTrainedModel):
             input_ids, hidden_states, self.language_model.embed_tokens, forward_batch
         )
 
-    def tie_weights(self):
-        return self.language_model.tie_weights()
+    def tie_weights(self, **kwargs):
+        return self.language_model.tie_weights(**kwargs)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [


### PR DESCRIPTION
## Problem

Three model initialization bugs causing server crashes on `gemma-3-1b-it` and `gemma-3n-E2B-it`/`E4B-it`.

### 1. `gemma3_causal.py` — `KeyError: 'factor'` for `gemma-3-1b-it`

`rope_parameters["full_attention"]` for the 1B model has `rope_type=default` and no `factor` key. The old code unconditionally accessed `["factor"]` and hardcoded `"rope_type": "linear"`, which is wrong for models that use default RoPE.

**Root cause:** Only `Gemma3TextConfig` (used by 1B) has the nested `rope_parameters` format. `Gemma3Config` (4B/12B/27B) doesn't have this attribute and goes through the `else` branch — those models are unaffected.

### 2. `gemma3n_causal.py` — `AttributeError: rope_local_base_freq` + `KeyError: rope_theta`

`Gemma3nTextConfig` uses nested `rope_parameters: {"sliding_attention": {...}, "full_attention": {...}}`. The code read non-existent `config.rope_local_base_freq` (sliding branch) and the flat `config.rope_parameters["rope_theta"]` (full-attention branch, doesn't exist in the nested format). Both branches crash during layer initialization.

### 3. `gemma3n_mm.py` — `TypeError: tie_weights() unexpected kwarg 'recompute_mapping'`

`transformers >= 5.8.1` calls `tie_weights(recompute_mapping=False)` from `init_weights()`, but `Gemma3nForConditionalGeneration.tie_weights()` had no `**kwargs`. `language_model` is `Gemma3nTextModel(PreTrainedModel)` which inherits the updated `PreTrainedModel.tie_weights()` signature, so forwarding `**kwargs` is safe.

## Fix

**`gemma3_causal.py`:** Spread the `full_attention` dict directly and override `rope_theta`, preserving all rope params as-is. Works correctly for any `rope_type` (`default`, `linear`, `llama3`, etc.).

**`gemma3n_causal.py`:** Read theta from `rope_parameters["sliding_attention"]["rope_theta"]` and `rope_parameters["full_attention"]["rope_theta"]` with `.get()` fallbacks. Pass `full_attention` dict as `rope_scaling` (has the correct `rope_type` key) instead of the entire nested dict.

**`gemma3n_mm.py`:** Add `**kwargs` to `tie_weights()` and forward to `language_model.tie_weights(**kwargs)`.

## Verification

Tested on Intel BMG XPU with `gemma-3-1b-it` and `gemma-3n-E2B-it`:
- Server startup: no crashes
- `mmmu_val` eval (4 samples): completes successfully
- `gemma-3-4b-it`, `gemma-3-12b-it`, `gemma-3-27b-it`: unaffected (use `Gemma3Config` without `rope_parameters`, go through the `else` branch)

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26997689922](https://github.com/sgl-project/sglang/actions/runs/26997689922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26997689815](https://github.com/sgl-project/sglang/actions/runs/26997689815)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->