### PR TITLE
[Fix] afmoe: import fused_moe function directly from its module

### DIFF
--- a/python/sglang/srt/models/afmoe.py
+++ b/python/sglang/srt/models/afmoe.py
@@ -47,7 +47,7 @@ from sglang.srt.layers.linear import (
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.triton_utils import fused_moe
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention


### PR DESCRIPTION
## Problem

`AfmoeMoE.forward()` crashes with `TypeError: 'module' object is not callable` on every inference pass.

**Root cause — module shadowing:**

`triton_utils` is a package whose `__init__.py` does **not** re-export `fused_moe`. When Python evaluates:
```python
from sglang.srt.layers.moe.moe_runner.triton_utils import fused_moe
```
it finds no `fused_moe` name in `__init__.py`, falls back to looking for a **submodule**, and finds `triton_utils/fused_moe.py` — importing the entire file as a module object instead of the function inside it.

At runtime, `fused_moe(hidden_states, w1=..., w2=..., ...)` then raises:
```
TypeError: 'module' object is not callable
```

## Fix

Import `fused_moe` directly from the module that defines it, matching the pattern already used by every other model file that calls this function (`deepseek.py`, `xverse_moe.py`, `dbrx.py`, `bitsandbytes.py`):

```python
# Before
from sglang.srt.layers.moe.moe_runner.triton_utils import fused_moe
# After
from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
```

The NPU conditional override (`fused_moe_npu as fused_moe`) at module scope is unaffected — it rebinds the name after the initial import regardless of how it was first resolved.

## Verification

Tested locally on Intel BMG XPU (`arcee-ai/Trinity-Nano-Base`, `AfmoeForCausalLM` architecture):
- **Before fix:** `TypeError: 'module' object is not callable` on first forward pass
- **After fix:** server starts, `gsm8k` 4-sample eval completes with `exact_match=0.75`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26998575475](https://github.com/sgl-project/sglang/actions/runs/26998575475)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26998575404](https://github.com/sgl-project/sglang/actions/runs/26998575404)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->