### PR TITLE
[AMD] fix(ci): run partition 3 of stage-c-test-large-8-gpu-amd

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -970,7 +970,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        part: [0, 1, 2]
+        part: [0, 1, 2, 3]
     runs-on: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || 'mi325') }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

`stage-c-test-large-8-gpu-amd` in `pr-test-amd.yml` runs with `--auto-partition-size 4`, but its job matrix only scheduled `part: [0, 1, 2]`. As a result **partition 3 was never dispatched** and ~1/4 of the 8-GPU stage-c suite was silently skipped on the ROCm 7.0 PR test.

The deterministic LPT partitioner puts these files in partition 3 (so they were never run on ROCm 7.0):
- `test/registered/ops/test_aiter_allreduce_fusion_amd.py`
- `test/registered/ops/test_aiter_allgather_amd.py`
- `test/registered/amd/test_deepseek_v3_mtp.py`
- `test/registered/amd/test_deepseek_v3_basic.py`

This regressed in #24762, which bumped `--auto-partition-size 3 -> 4` and correctly updated the matrix to `[0, 1, 2, 3]` in `pr-test-amd-rocm720.yml`, but missed the same matrix update in `pr-test-amd.yml`. This PR aligns the matrix with the partition size.

```diff
       matrix:
-        part: [0, 1, 2]
+        part: [0, 1, 2, 3]
```

## Test plan

- [ ] `PR Test (AMD)` now dispatches 4 jobs for `stage-c-test-large-8-gpu-amd` (`..., 0` through `..., 3`).
- [ ] Heads-up: these aiter tests currently fail on the ROCm 7.2 schedule (residual-accuracy divergence in the fused all-reduce path, and missing `aiter` ops in all-gather). Restoring coverage on ROCm 7.0 may surface real failures there too — to be triaged separately.

Made with [Cursor](https://cursor.com)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27000139504](https://github.com/sgl-project/sglang/actions/runs/27000139504)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27000139459](https://github.com/sgl-project/sglang/actions/runs/27000139459)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->