### PR TITLE
[BugFix] Correct cell_size calculation for DSA models with FP8 KV cache

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -137,6 +137,13 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 * num_layers
                 * kv_size
             )
+
+            # For DSA models with FP8 KV cache, the nope part is stored in FP8 with
+            # per-block scales, and the rope part is stored in BF16 (not FP8).
+            # calculate_mla_kv_cache_dim() correctly accounts for this layout.
+            if is_deepseek_dsa(model_config.hf_config) and kv_cache_dtype == torch.float8_e4m3fn:
+                kv_cache_dim = mr.calculate_mla_kv_cache_dim()
+                cell_size = kv_cache_dim * num_layers
             if is_float4_e2m1fn_x2(kv_cache_dtype):
                 # kv_scale_buffer
                 scale_block_size = 16

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -143,7 +143,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             # calculate_mla_kv_cache_dim() correctly accounts for this layout.
             if (
                 is_deepseek_dsa(model_config.hf_config)
-                and kv_cache_dtype == torch.float8_e4m3fn
+                and kv_cache_dtype in [torch.float8_e4m3fn, torch.float8_e4m3fnuz]
             ):
                 kv_cache_dim = mr.calculate_mla_kv_cache_dim()
                 cell_size = kv_cache_dim * num_layers

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -141,7 +141,10 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             # For DSA models with FP8 KV cache, the nope part is stored in FP8 with
             # per-block scales, and the rope part is stored in BF16 (not FP8).
             # calculate_mla_kv_cache_dim() correctly accounts for this layout.
-            if is_deepseek_dsa(model_config.hf_config) and kv_cache_dtype == torch.float8_e4m3fn:
+            if (
+                is_deepseek_dsa(model_config.hf_config)
+                and kv_cache_dtype == torch.float8_e4m3fn
+            ):
                 kv_cache_dim = mr.calculate_mla_kv_cache_dim()
                 cell_size = kv_cache_dim * num_layers
             if is_float4_e2m1fn_x2(kv_cache_dtype):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Modifications

`_compute_cell_size` for DSA+FP8 underestimates cell_size by ~12%.

For DSA models with FP8 KV cache, nope is stored in FP8 with per-block scales and rope is stored in BF16, but cell_size treated both as FP8 and missed scale storage. This causes over-allocation of tokens and potential OOM at runtime.

Fix: use calculate_mla_kv_cache_dim() which correctly accounts for the FP8+scale layout for nope and BF16 layout for rope.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27001249438](https://github.com/sgl-project/sglang/actions/runs/27001249438)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27001249384](https://github.com/sgl-project/sglang/actions/runs/27001249384)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->