### PR TITLE
fix(router): accept string bool stream flag

### DIFF
--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -12,8 +12,8 @@ use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderName, HeaderValue, Response};
 use bytes::Bytes;
-use serde::de::IgnoredAny;
-use serde::Deserialize;
+use serde::de::{self, IgnoredAny};
+use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -60,7 +60,7 @@ pub const MAX_CHAT_BODY_BYTES: usize = 1 << 20;
 /// full request schema.
 #[derive(Debug, Deserialize)]
 struct RequestProbe {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_bool")]
     stream: Option<bool>,
     #[serde(default)]
     model: Option<String>,
@@ -563,6 +563,29 @@ fn parse_probe(body: &Bytes) -> Result<RequestProbe, ApiError> {
     Ok(probe)
 }
 
+fn deserialize_optional_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrString {
+        Bool(bool),
+        String(String),
+    }
+
+    match Option::<BoolOrString>::deserialize(deserializer)? {
+        Some(BoolOrString::Bool(value)) => Ok(Some(value)),
+        Some(BoolOrString::String(value)) if value.eq_ignore_ascii_case("true") => Ok(Some(true)),
+        Some(BoolOrString::String(value)) if value.eq_ignore_ascii_case("false") => Ok(Some(false)),
+        Some(BoolOrString::String(value)) => Err(de::Error::invalid_value(
+            de::Unexpected::Str(&value),
+            &"a boolean or a string boolean",
+        )),
+        None => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -609,6 +632,14 @@ mod tests {
         let b = Bytes::from_static(br#"{"stream": true, "model": "tiny"}"#);
         assert_eq!(parse_probe(&b).unwrap().stream, Some(true));
         let b = Bytes::from_static(br#"{"stream": false, "model": "tiny"}"#);
+        assert_eq!(parse_probe(&b).unwrap().stream, Some(false));
+    }
+
+    #[test]
+    fn parse_probe_reads_stream_string_bool_from_object() {
+        let b = Bytes::from_static(br#"{"stream": "True", "model": "tiny"}"#);
+        assert_eq!(parse_probe(&b).unwrap().stream, Some(true));
+        let b = Bytes::from_static(br#"{"stream": "FALSE", "model": "tiny"}"#);
         assert_eq!(parse_probe(&b).unwrap().stream, Some(false));
     }
 

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -168,6 +168,37 @@ async fn streaming_chunks_pass_through() {
 }
 
 #[tokio::test]
+async fn streaming_string_true_passes_through() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start(chunks).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "tiny",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": "True"
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers().get("content-type").unwrap().to_str().unwrap(),
+        "text/event-stream"
+    );
+}
+
+#[tokio::test]
 async fn streaming_first_chunk_before_completion() {
     let chunks: Vec<&'static str> = vec![
         "data: {\"choices\":[{\"delta\":{\"content\":\"first\"}}]}\n\n",


### PR DESCRIPTION
## Summary
- accept string boolean values such as `"True"` / `"FALSE"` in the router's lightweight `stream` probe
- keep ordinary JSON booleans and absent `stream` behavior unchanged
- add unit and proxy coverage for the router path

Fixes #27357.

## To verify
- `cargo fmt -- src\server\routes\chat.rs tests\proxy\chat_routing.rs`
- `cargo test parse_probe_reads_stream --lib`
- `cargo check --lib`
- `git diff --check`

Not run locally on Windows:
- `cargo test --test proxy streaming_string_true_passes_through` currently fails before reaching this test because the existing binary imports `tokio::signal::unix` from `src/main.rs`, which is not available on Windows.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27069206676](https://github.com/sgl-project/sglang/actions/runs/27069206676)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27069206585](https://github.com/sgl-project/sglang/actions/runs/27069206585)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->