### PR TITLE
fix(triton): handle asymmetric KV dims in MLA grouped decode attention

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -337,6 +337,8 @@ def _fwd_grouped_kernel_stage1(
         base_offs_kpe = cur_kv_head * stride_buf_kh + offs_dpe[:, None]
     if not HAS_MLA:
         base_offs_v = cur_kv_head * stride_buf_vh + offs_dv[None, :]
+    if HAS_MLA and BLOCK_DV < BLOCK_DMODEL:
+        base_offs_v_mla = cur_kv_head * stride_buf_kh + offs_dv[None, :]
 
     if split_kv_end > split_kv_start:
         q = tl.load(Q + offs_q, mask=(mask_h[:, None]) & (mask_d[None, :]), other=0.0)
@@ -379,7 +381,22 @@ def _fwd_grouped_kernel_stage1(
                 mask_h[:, None] & (offs_n[None, :] < split_kv_end), qk, float("-inf")
             )
             if HAS_MLA:
-                v = tl.trans(k)
+                # MLA stores K and V in the same buffer.  When the key
+                # dimension (BLOCK_DMODEL) equals the value dimension
+                # (BLOCK_DV) a simple transpose suffices.  When they
+                # differ (e.g. Mistral-Large-3 / Mistral-Small-4 where
+                # K = kv_lora_rank + rope_dim but V = kv_lora_rank) we
+                # reload the first Lv elements from the KV buffer to
+                # avoid a shape mismatch in the subsequent ``tl.dot``.
+                if BLOCK_DV < BLOCK_DMODEL:
+                    offs_buf_v_mla = kv_loc[:, None] * stride_buf_kbs + base_offs_v_mla
+                    v = tl.load(
+                        K_Buffer + offs_buf_v_mla,
+                        mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+                        other=0.0,
+                    )
+                else:
+                    v = tl.trans(k)
             else:
                 offs_buf_v = kv_loc[:, None] * stride_buf_vbs + base_offs_v
                 v = tl.load(


### PR DESCRIPTION
## Summary

Fixes the Triton compilation crash in `_fwd_grouped_kernel_stage1` when EAGLE speculative decoding is used with MLA models that have asymmetric key/value dimensions (`BLOCK_DV != BLOCK_DMODEL`).

Fixes #27367

## Problem

```
triton.compiler.errors.CompilationError:
ValueError('Cannot make_shape_compatible: incompatible dimensions at index 1: 256 and 512')
```

Line 382: `v = tl.trans(k)` transposes K of shape `[BLOCK_DMODEL, BLOCK_N]` to `[BLOCK_N, BLOCK_DMODEL]`, but `acc` has shape `[BLOCK_H, BLOCK_DV]`. When `BLOCK_DMODEL != BLOCK_DV` (MLA models with rope dimensions in K but not V), the subsequent `tl.dot(p, v)` fails.

**Affected models:** Mistral-Small-4 (119B MoE), Mistral-Large-3, and any MLA model where `kv_lora_rank + qk_rope_head_dim != kv_lora_rank`.

For Mistral Small 4:
- `Lk = kv_lora_rank + qk_rope_head_dim = 256 + 64 = 320` -> `BLOCK_DMODEL = 512`
- `Lv = kv_lora_rank = 256` -> `BLOCK_DV = 256`

## Fix

When `BLOCK_DV < BLOCK_DMODEL`, reload V from the first `Lv` elements of the KV buffer instead of transposing K. When dimensions match, the original zero-cost `tl.trans(k)` path is preserved -- no regression for symmetric models (DeepSeek-V2/V3).

## Test plan

- [x] Tested on NVIDIA DGX Spark (GB10, SM121, 128GB unified memory)
- [x] Mistral-Small-4-119B NVFP4 + EAGLE: **34.6 tok/s**, 46-63% acceptance rate
- [x] CUDA graphs: working
- [x] No regression on symmetric MLA (BLOCK_DV == BLOCK_DMODEL path unchanged)
- [ ] Need upstream CI validation

## Performance note

The `BLOCK_DV < BLOCK_DMODEL` path incurs an extra `tl.load` vs the original `tl.trans(k)` (which reuses K already in registers). A more optimal approach would load K truncated to `Lv` dims upfront, but that would require restructuring the QK computation. This fix prioritizes correctness and minimal diff.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27013351026](https://github.com/sgl-project/sglang/actions/runs/27013351026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27013350834](https://github.com/sgl-project/sglang/actions/runs/27013350834)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->