### PR TITLE
[fix]NPU spec decode fixes

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -266,6 +266,7 @@ class AscendHybridLinearAttnBackend(HybridLinearAttnBackend):
             dst_indices_tensor,
             src_indices_tensor,
             last_steps,
+            h_block_size=1,
         )
 
         draft_token_num = intermediate_state_cache.shape[2]

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
@@ -77,21 +77,53 @@ class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
             out = run_once_fn()
         return out
 
+    def _is_dense_mha(self):
+        # Only dense MHA models have a per-layer context_lens updatable op in the
+        # captured draft graph (so the replay update must be expanded per layer).
+        # MLA and hybrid (mamba/linear-attention) models keep the original single
+        # actual_seq_lengths_kv update that covers all layers.
+        mc = self.model_runner.model_config
+        return (
+            mc.attention_arch == AttentionArch.MHA
+            and getattr(self.model_runner, "mambaish_config", None) is None
+        )
+
     def _get_update_attr_name(self):
-        return self.attr_name[AttentionArch.MLA]
+        arch = AttentionArch.MHA if self._is_dense_mha() else AttentionArch.MLA
+        return self.attr_name[arch]
 
     def _get_update_attr_type(self):
-        return self.attr_type[AttentionArch.MLA]
+        arch = AttentionArch.MHA if self._is_dense_mha() else AttentionArch.MLA
+        return self.attr_type[arch]
 
     def _replay_update(self, seq_lens_list):
-        if isinstance(self.update_attr_type, torch.Tensor):
-            seq_lens = torch.from_numpy(np.array(seq_lens_list).astype(np.int32))
+        # The captured draft graph records one seq-len updatable op per executed
+        # full-attention layer per draft step. That count isn't reliably derivable
+        # from the (base) model config (a full-size duplicate draft has one per
+        # layer; a 1-layer MTP module has one; MLA layers may build two attn
+        # submodules but execute one), so read the exact number straight from the
+        # graph's recorded ops. Records are in step-outer / layer-inner order, so
+        # repeat each step's seq_lens `per_step` times.
+        #
+        # graph_dispatch_mode / graph_dispatch_records are torch_npu internals;
+        # access them defensively and fall back to one update per step (the
+        # single-shared-op case) if a future torch_npu version changes them.
+        steps = len(seq_lens_list)
+        per_step = 1
+        if steps:
+            dispatch_mode = getattr(self.graphs[self.bs], "graph_dispatch_mode", None)
+            records = getattr(dispatch_mode, "graph_dispatch_records", None)
+            if records is not None:
+                per_step = max(1, len(records) // steps)
 
-        self.graphs[self.bs].update(
-            cpu_update_input=[
-                {self.update_attr_name: seq_lens} for seq_lens in seq_lens_list
-            ]
-        )
+        cpu_update_input = []
+        for seq_lens in seq_lens_list:
+            if isinstance(self.update_attr_type, torch.Tensor):
+                seq_lens = torch.from_numpy(np.array(seq_lens).astype(np.int32))
+            for _ in range(per_step):
+                cpu_update_input.append({self.update_attr_name: seq_lens})
+
+        self.graphs[self.bs].update(cpu_update_input=cpu_update_input)
 
     def _replay(self, forward_batch: ForwardBatch):
         self.update_attr_name = self._get_update_attr_name()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Two independent NPU speculative-decoding correctness/stability fixes, found while bringing
up MTP (EAGLE/NEXTN) on Ascend NPU. 

### 1. EAGLE draft NPU graph crashes on non-MLA models

The EAGLE/NEXTN draft full-graph NPU runner replayed its captured graph with a hardcoded,
MLA-only `cpu_update_input` (one `actual_seq_lengths_kv` entry per draft step). On any
other draft the number of seq-len updatable operators in the captured graph doesn't match,
so `NPUGraph.update` aborts on the first request (N = 72 for dense MHA Qwen3-8B, 54 for
dense MLA DeepSeek-V2-Lite, 2 for the 1-layer Qwen3.5 MTP module).

<details>
<summary>Error log (DeepSeek-V2-Lite, N=54)</summary>

```
Exception in thread Thread-8 (_replay_update):
Traceback (most recent call last):
  File ".../threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File ".../hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py", line 90, in _replay_update
    self.graphs[self.bs].update(
  File ".../torch_npu/npu/graphs.py", line 395, in update
    self.graph_dispatch_mode.update_capture_record(cpu_update_input)
  File ".../torch_npu/npu/graphs.py", line 282, in update_capture_record
    raise RuntimeError(
RuntimeError: ('Currently, there are 54 operators that need to be updated by capture, and there are only 2 elements in the incoming cpu_update_input list', '... ERR00001 PTA invalid parameter')
```
</details>

### 2. Triton UB overflow when updating mamba state after MTP verify

`update_mamba_state_after_mtp_verify` launches the Triton kernel
`move_cache_dynamic_last_kernel_h_block` via `move_intermediate_cache`. With the default
`h_block_size`, the kernel's tiling basic block exceeds the NPU Unified Buffer — BiShengIR
fails to compile with `ub overflow, requires 2097152 bits while 1572864 bits available` —
so the scheduler crashes during verify on hybrid linear-attention (mamba/GDN) models.

<details>
<summary>Error log (Triton/BiShengIR UB overflow in move_intermediate_cache)</summary>

```
[TP1] Scheduler hit an exception: Traceback (most recent call last):
  ...
  File ".../speculative/eagle_worker_v2.py", line 1230, in verify
    self._mamba_verify_update(...)
  File ".../speculative/eagle_worker_v2.py", line 1334, in _mamba_verify_update
    self.target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify(...)
  File ".../hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py", line 263, in update_mamba_state_after_mtp_verify
    move_intermediate_cache(...)
  File ".../sgl_kernel_npu/mamba/mamba_state_update_triton.py", line 126, in move_intermediate_cache
    move_cache_dynamic_last_kernel_h_block[grid](...)
  ...
triton.compiler.errors.MLIRCompilationError:
///------------------[ERROR][Triton][BEG]------------------
[ConvertLinalgRToBinary] encounters error:
loc(".../sgl_kernel_npu/mamba/mamba_state_update_triton.py":21:0): error: Failed to run BiShengHIR pipeline
loc(".../sgl_kernel_npu/mamba/mamba_state_update_triton.py":21:0): error: ub overflow, requires 2097152 bits while 1572864 bits available! (possible reason: tiling basic block is too large or block number is more than what user expect due to multi-buffer feature is enabled and some ops need extra local buffer.)
... (repeated)
[ERROR] Failed to run BiShengIR pipeline
///------------------[ERROR][Triton][END]------------------
```
</details>

## Modifications

**1. `eagle_draft_npu_graph_runner.py` — make the replay update generic.**
The captured draft graph records one seq-len updatable op per executed full-attention
layer per draft step; that count is not derivable from the (base) model config (a
full-size duplicate draft has one per layer; a 1-layer MTP module has one). Instead of
guessing, read the exact count straight from the graph
(`graph_dispatch_mode.graph_dispatch_records`) and build the update list step-outer /
layer-inner. Select the kwarg name/dtype from the attention arch: `context_lens` +
int32 tensor for dense MHA, `actual_seq_lengths_kv` + list for MLA/hybrid.These are torch_npu internals, so they are accessed defensively via getattr, falling back to one update per step if a future torch_npu version changes/removes them (no AttributeError).

**2. `ascend_hybrid_linear_attn_backend.py` — pass `h_block_size=1`** to
`move_intermediate_cache` in `update_mamba_state_after_mtp_verify`. This shrinks the
`move_cache_dynamic_last_kernel_h_block` per-block tile so it fits the NPU Unified Buffer,
fixing the BiShengIR UB-overflow compilation failure above.

## Accuracy Tests

Validated on NPU (Ascend), TP=2, with NEXTN/EAGLE speculative decoding
(`--speculative-num-steps 3`):
- **Qwen3-8B** (dense MHA) — no longer crashes; correct output.
- **DeepSeek-V2-Lite** (dense MLA) — no longer crashes; correct output.
- **Qwen3.5-9B** (hybrid linear-attention) — no UB overflow during verify; correct output.
Each matches its non-speculative baseline.

## Speed Tests and Profiling

No perf-relevant change; these are correctness/stability fixes that unblock the NPU draft
CUDA graph replay path and the mamba MTP-verify state update.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests. *(NPU-only path; covered by manual accuracy validation above)*
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27049946098](https://github.com/sgl-project/sglang/actions/runs/27049946098)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27049946038](https://github.com/sgl-project/sglang/actions/runs/27049946038)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->