### PR TITLE
fix(pd): clear stale bootstrap_room when freeing metadata buffer slot

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1676,6 +1676,9 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 )
             idx = self.queue[i].metadata_buffer_index
             assert idx != -1
+            # Reset so the next owner sees actual_room == 0 ("not yet written")
+            # instead of the stale value, avoiding a false-positive mismatch.
+            self.metadata_buffers.bootstrap_room[idx] = 0
             self.req_to_metadata_buffer_idx_allocator.free(idx)
 
         self.queue = [


### PR DESCRIPTION
## Problem

`_commit_transfer_to_req()` uses `actual_room == 0` as a sentinel
meaning "prefill has not written metadata yet — keep waiting (Case 1)".
However, `free()` never zeroed the slot, so the `bootstrap_room` value
written by the previous request persisted in the buffer.

When a new request reuses the same slot and polls before the prefill
side has written the new `bootstrap_room`, `_commit_transfer_to_req()`
reads the stale non-zero room value, finds `actual_room != expected_room`,
and incorrectly aborts the request with:

```
Metadata corruption detected - bootstrap_room mismatch
```

This is a false positive: no real corruption occurred; prefill simply
had not yet written the new value when decode first polled.

With TCP-based KV-cache transport (`MC_FORCE_TCP=1`), the prefill-side
write is significantly slower than RDMA, making the race window much
wider. Under high concurrency (32+ parallel requests) this causes
roughly ~3% of requests to be incorrectly aborted. Under RDMA the
window is too small to observe in practice.

## Root Cause

PR #17430 (fixing #17259) added `bootstrap_room` validation as a
sentinel-based detection mechanism. It correctly introduced the check
but did not clear the slot on `free()`, making the sentinel assumption
(`actual_room == 0` means "not yet written") invalid after the first
reuse of a slot.

## Fix

Zero out `metadata_buffers.bootstrap_room[idx]` before returning the
slot to the free list, so every new owner starts from the sentinel state.

## Related

- Fixes the regression introduced by #17430
- Related to #17259







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27008816302](https://github.com/sgl-project/sglang/actions/runs/27008816302)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27008816082](https://github.com/sgl-project/sglang/actions/runs/27008816082)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->