### PR TITLE
lora: native loading for PEFT 0.18+ batched-MoE adapters

### DIFF
--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -201,6 +201,10 @@ class LoRAAdapter(nn.Module):
 
     def _normalize_weights(self):
         for layer in self.layers:
+            # Convert PEFT 0.18+ ParamWrapper batched-MoE-expert LoRAs into
+            # SGLang's 3D-per-expert layout (must run before the others so
+            # downstream normalizers see the canonical `experts.<leaf>` names).
+            self._normalize_peft_paramwrapper_moe(layer.weights)
             weight_names = list(layer.weights.keys())
             self.normalize_qkv_proj(weight_names, layer.weights)
             self._rename_expert_w_to_proj(layer.weights)
@@ -212,6 +216,137 @@ class LoRAAdapter(nn.Module):
             self.normalize_gate_up_proj(weight_names, layer.weights)
             weight_names = list(layer.weights.keys())
             self.normalize_fused_qkv_a_proj(weight_names, layer.weights)
+
+    # PEFT 0.18+ `target_parameters` save paths for batched-MoE-expert LoRA:
+    #   <parent>.experts.lora_<A|B>(.<adapter>).weight              (outer wrap)
+    #   <parent>.experts.base_layer.lora_<A|B>(.<adapter>).weight   (inner wrap)
+    # `<parent>` varies by model (LFM2 → `feed_forward`, DeepSeek → `mlp`,
+    # Mixtral → `block_sparse_moe`) so we don't anchor on it. Mixtral-style
+    # adapters that save per-expert (`...experts.<N>.<module>.lora_*`) don't
+    # match here and take SGLang's existing per-expert load path.
+    _PEFT_EXPERTS_PARAMWRAPPER_RE = re.compile(
+        r"(?P<prefix>.+?)\.experts(?P<base_layer>\.base_layer)?\.lora_(?P<ab>[AB])"
+        r"(?:\.[^.]+)?\.weight$"
+    )
+
+    # Stacked-shard count per target — for fused targets like gate_up_proj
+    # SGLang stores LoRA A with rank tiled c× along the rank dim.
+    _PEFT_LORA_STACKED_MULTIPLY = {"gate_up_proj": 2, "down_proj": 1}
+
+    def _normalize_peft_paramwrapper_moe(self, weights: Dict[str, torch.Tensor]):
+        """Rewrite PEFT 0.18+ batched-MoE-expert LoRAs into SGLang's 3D-per-expert form.
+
+        PEFT 0.18 added ``target_parameters`` for LoRA-training arbitrary
+        ``nn.Parameter`` tensors — including the batched 3D MoE expert weights
+        used by HF transformers >= 5.8 (Mixtral, DeepSeek-V2, LFM2-MoE via
+        ``@use_experts_implementation``). PEFT saves these via ``ParamWrapper``
+        as flat 2D tensors (A: ``(E*r, in)`` with experts outer; B:
+        ``(out, r*E)`` with experts inner) under names that don't match the
+        standard ``experts.<leaf>.lora_*`` convention SGLang's MoE-LoRA path
+        expects.
+
+        With two ``target_parameters``, PEFT nests the wrappers around the
+        parent module — but the inner/outer slot is set by the order PEFT
+        walks the parent's attributes (= ``__init__`` definition order in the
+        HF module class), NOT the order the user lists them in
+        ``target_parameters``. Both common MoE classes define
+        ``gate_up_proj`` before ``down_proj``, so ``gate_up_proj`` ends up
+        inner and ``down_proj`` outer regardless of config order. We
+        disambiguate by the tensor's input/output dims against
+        ``hidden_size`` / ``moe_intermediate_size`` instead of trusting the
+        list index, reshape A to ``(E, c*r, in)`` (c-tiled for stacked
+        targets like ``gate_up_proj``) and B to ``(E, out, r)``, and rename
+        the key to ``...experts.<leaf>.lora_*.weight`` so the existing 3D
+        MoE load path picks it up natively.
+        """
+        target_parameters = self.config.hf_config.get("target_parameters") or []
+        if not target_parameters:
+            return
+        if len(target_parameters) > 2:
+            raise ValueError(
+                "PEFT ParamWrapper compatibility supports at most 2 "
+                f"target_parameters per parent module, got: {target_parameters}"
+            )
+
+        cfg = self.base_hf_config
+        if hasattr(cfg, "get_text_config"):
+            cfg = cfg.get_text_config()
+        num_experts = (
+            getattr(cfg, "num_experts", None)
+            or getattr(cfg, "num_local_experts", None)
+            or getattr(cfg, "n_routed_experts", None)
+        )
+        if num_experts is None:
+            raise ValueError(
+                "Cannot determine num_experts from base model config; needed to "
+                "reshape PEFT ParamWrapper MoE LoRA weights."
+            )
+        rank = self.config.r
+
+        # Identify which target_parameter leaf this weight belongs to by
+        # its input dim. PEFT's inner/outer slot is HF-class-traversal-order,
+        # not target_parameters-order, so we can't index by list position.
+        leaves_in_config = {tp.rsplit(".", 1)[-1] for tp in target_parameters}
+        moe_inter = (
+            getattr(cfg, "moe_intermediate_size", None) or cfg.intermediate_size
+        )
+        # in_features per known MoE leaf:
+        #   gate_up_proj: in=hidden                 (column-parallel, fused gate+up)
+        #   down_proj:    in=moe_intermediate_size  (row-parallel)
+        in_to_leaf = {
+            cfg.hidden_size: "gate_up_proj",
+            moe_inter: "down_proj",
+        }
+        if cfg.hidden_size == moe_inter:
+            raise ValueError(
+                "Cannot distinguish PEFT ParamWrapper MoE LoRA leaves: "
+                f"hidden_size == moe_intermediate_size ({cfg.hidden_size}). "
+                "Shape-based disambiguation requires distinct dims."
+            )
+
+        # Pre-resolve leaf per matching key from the *initial* weights dict:
+        # we use the sibling lora_A's in_features to disambiguate, and we
+        # pop+rename during the main loop, so the A sibling won't be visible
+        # to a deferred B lookup. Snapshot first.
+        peft_keys = {}  # name -> (re.Match, leaf)
+        for name in list(weights.keys()):
+            m = self._PEFT_EXPERTS_PARAMWRAPPER_RE.match(name)
+            if m is None:
+                continue
+            ab = m.group("ab")
+            a_name = name if ab == "A" else name.replace(".lora_B", ".lora_A", 1)
+            a_w = weights.get(a_name)
+            if a_w is None or a_w.dim() != 2:
+                continue
+            leaf = in_to_leaf.get(a_w.shape[1])
+            if leaf is None or leaf not in leaves_in_config:
+                continue
+            peft_keys[name] = (m, leaf)
+
+        for name, (m, leaf) in peft_keys.items():
+            is_lora_A = m.group("ab") == "A"
+
+            w = weights.pop(name)
+            if is_lora_A:
+                # PEFT layout (E*r, in_features) → (E, r, in)
+                in_features = w.shape[1]
+                w = w.reshape(num_experts, rank, in_features).contiguous()
+                c = self._PEFT_LORA_STACKED_MULTIPLY.get(leaf, 1)
+                if c > 1:
+                    # SGLang's stacked-LoRA A holds [shard_0; shard_1; ...].
+                    # PEFT's fused-parameter LoRA is equivalent to stacked-LoRA
+                    # with identical A across shards — tile along the rank dim.
+                    w = w.repeat(1, c, 1).contiguous()
+            else:
+                # PEFT layout (out_features, r*E) → (E, out, r)
+                out_features = w.shape[0]
+                w = (
+                    w.reshape(out_features, rank, num_experts)
+                    .permute(2, 0, 1)
+                    .contiguous()
+                )
+            new_name = f"{m.group('prefix')}.experts.{leaf}.lora_{m.group('ab')}.weight"
+            weights[new_name] = w
 
     def normalize_qkv_proj(
         self, weight_names: List[str], weights: Dict[str, torch.Tensor]

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -519,9 +519,19 @@ class LoRAMemoryPool:
             if hasattr(cfg, "get_text_config"):
                 cfg = cfg.get_text_config()
             has_shared_experts = (
-                hasattr(cfg, "shared_expert_intermediate_size")
-                and cfg.shared_expert_intermediate_size > 0
-            ) or (getattr(cfg, "n_shared_experts", 0) or 0) > 0
+                # DeepSeek-style shared experts.
+                (
+                    hasattr(cfg, "shared_expert_intermediate_size")
+                    and cfg.shared_expert_intermediate_size > 0
+                )
+                or (getattr(cfg, "n_shared_experts", 0) or 0) > 0
+                # Hybrid-layer MoE models (e.g. LFM2-MoE `num_dense_layers`,
+                # DeepSeek `first_k_dense_replace`) use the standard
+                # `gate_up_proj` / `down_proj` names on their dense MLP layers,
+                # so they also need a non-MoE 3D buffer in addition to `*_moe`.
+                or (getattr(cfg, "num_dense_layers", 0) or 0) > 0
+                or (getattr(cfg, "first_k_dense_replace", 0) or 0) > 0
+            )
             has_moe = self._has_moe_module(base_model)
 
             # Shape functions automatically handle both 3D (standard) and 4D (MoE)

--- a/test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
+++ b/test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
@@ -1,0 +1,318 @@
+"""Unit tests for ``LoRAAdapter._normalize_peft_paramwrapper_moe``.
+
+Covers PEFT 0.18+ ``target_parameters`` (``ParamWrapper``) → SGLang 3D-per-expert
+rewrite: shape-based slot resolution (PEFT's inner/outer mapping comes from the
+HF module class's attribute-definition order, NOT the user's
+``target_parameters`` list order), reshape semantics (c=1 and c=2 stacking,
+B-axis layout per PEFT source), gating against non-PEFT-ParamWrapper adapters.
+
+Usage:
+    python test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
+"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+# CPU-only unit test; no CUDA needed.
+register_cuda_ci(est_time=5, suite="stage-b-test-1-gpu-small")
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt.lora.lora import LoRAAdapter
+
+
+# Standard LFM2-MoE-style adapter_config target_parameters (in user order).
+_TPARAMS = ["experts.gate_up_proj", "experts.down_proj"]
+
+
+def _make_adapter(
+    target_parameters,
+    *,
+    rank: int = 8,
+    num_experts: int = 32,
+    hidden_size: int = 2048,
+    moe_intermediate_size: int = 1792,
+    intermediate_size: int = 7168,
+):
+    """Build a bare LoRAAdapter-like stub with just the fields the normalizer reads.
+
+    We bypass ``__init__`` so the test doesn't need to stand up a base model
+    or a real LoRAConfig instance — both are heavy. The normalizer only reads
+    ``self.config.hf_config["target_parameters"]``, ``self.config.r``, and
+    the MoE dims off ``self.base_hf_config``.
+    """
+    adapter = LoRAAdapter.__new__(LoRAAdapter)
+    adapter.config = types.SimpleNamespace(
+        hf_config={"target_parameters": target_parameters},
+        r=rank,
+    )
+    adapter.base_hf_config = types.SimpleNamespace(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        moe_intermediate_size=moe_intermediate_size,
+        intermediate_size=intermediate_size,
+    )
+    return adapter
+
+
+def _ab_pair(prefix: str, *, inner: bool, rank: int, num_experts: int, in_dim: int, out_dim: int):
+    """Build {A_name: tensor, B_name: tensor} in PEFT's saved layout for one
+    wrapper slot — inner uses ``base_layer``, outer doesn't."""
+    middle = "base_layer." if inner else ""
+    a_name = f"{prefix}.experts.{middle}lora_A.weight"
+    b_name = f"{prefix}.experts.{middle}lora_B.weight"
+    return {
+        a_name: torch.zeros(num_experts * rank, in_dim, dtype=torch.bfloat16),
+        b_name: torch.zeros(out_dim, rank * num_experts, dtype=torch.bfloat16),
+    }
+
+
+class TestPeftParamWrapperRename(unittest.TestCase):
+    """Slot → leaf resolution is shape-based, NOT user-order-based."""
+
+    HIDDEN = 2048
+    MOE_INTER = 1792
+    NUM_EXPERTS = 32
+    RANK = 8
+
+    def test_inner_with_hidden_in_dim_maps_to_gate_up_proj(self):
+        """Inner ``base_layer`` slot with A-in == hidden → gate_up_proj
+        (matches both LFM2-MoE and Qwen3-MoE PEFT save layouts)."""
+        adapter = _make_adapter(_TPARAMS)
+        weights = _ab_pair(
+            "x",
+            inner=True,
+            rank=self.RANK,
+            num_experts=self.NUM_EXPERTS,
+            in_dim=self.HIDDEN,
+            out_dim=2 * self.MOE_INTER,
+        )
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        keys = set(weights.keys())
+        self.assertIn("x.experts.gate_up_proj.lora_A.weight", keys)
+        self.assertIn("x.experts.gate_up_proj.lora_B.weight", keys)
+
+    def test_outer_with_moe_intermediate_in_dim_maps_to_down_proj(self):
+        """Outer slot with A-in == moe_intermediate_size → down_proj."""
+        adapter = _make_adapter(_TPARAMS)
+        weights = _ab_pair(
+            "x",
+            inner=False,
+            rank=self.RANK,
+            num_experts=self.NUM_EXPERTS,
+            in_dim=self.MOE_INTER,
+            out_dim=self.HIDDEN,
+        )
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        keys = set(weights.keys())
+        self.assertIn("x.experts.down_proj.lora_A.weight", keys)
+        self.assertIn("x.experts.down_proj.lora_B.weight", keys)
+
+    def test_user_supplied_order_does_not_affect_mapping(self):
+        """Regression: PEFT writes inner=gate_up_proj / outer=down_proj
+        regardless of the user's ``target_parameters`` list order — both LFM2
+        (``[gate_up, down]``) and Qwen3 (``[down, gate_up]``) demo adapters
+        ship with the same on-disk slot layout. We must resolve by shape, not
+        by index, so the same adapter loads the same way under either order.
+        """
+        weights_a = {}
+        weights_a.update(
+            _ab_pair(
+                "x",
+                inner=True,
+                rank=self.RANK,
+                num_experts=self.NUM_EXPERTS,
+                in_dim=self.HIDDEN,
+                out_dim=2 * self.MOE_INTER,
+            )
+        )
+        weights_a.update(
+            _ab_pair(
+                "x",
+                inner=False,
+                rank=self.RANK,
+                num_experts=self.NUM_EXPERTS,
+                in_dim=self.MOE_INTER,
+                out_dim=self.HIDDEN,
+            )
+        )
+        weights_b = {k: v.clone() for k, v in weights_a.items()}
+
+        adapter_lfm = _make_adapter(_TPARAMS)
+        adapter_qwen = _make_adapter(list(reversed(_TPARAMS)))
+        adapter_lfm._normalize_peft_paramwrapper_moe(weights_a)
+        adapter_qwen._normalize_peft_paramwrapper_moe(weights_b)
+
+        self.assertEqual(set(weights_a.keys()), set(weights_b.keys()))
+        self.assertIn("x.experts.gate_up_proj.lora_A.weight", weights_a)
+        self.assertIn("x.experts.down_proj.lora_A.weight", weights_a)
+
+
+class TestPeftParamWrapperReshape(unittest.TestCase):
+    """Reshape semantics — flat 2D → 3D-per-expert with c-tiling for stacked targets."""
+
+    NUM_EXPERTS = 32
+    RANK = 8
+    HIDDEN = 2048
+    MOE_INTERMEDIATE = 1792
+
+    def test_gate_up_proj_lora_A_tiles_for_stacked_c2(self):
+        adapter = _make_adapter(_TPARAMS)
+        weights = _ab_pair(
+            "x",
+            inner=True,
+            rank=self.RANK,
+            num_experts=self.NUM_EXPERTS,
+            in_dim=self.HIDDEN,
+            out_dim=2 * self.MOE_INTERMEDIATE,
+        )
+        a_in = next(
+            v
+            for k, v in weights.items()
+            if k.endswith(".base_layer.lora_A.weight")
+        )
+        # Replace with randn so the tile-equality check is meaningful.
+        a_in.copy_(torch.randn_like(a_in))
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        out = weights["x.experts.gate_up_proj.lora_A.weight"]
+        # c=2 → rank dim doubled; the two halves identical (PEFT's
+        # fused-parameter LoRA shared across gate/up shards).
+        self.assertEqual(
+            tuple(out.shape), (self.NUM_EXPERTS, 2 * self.RANK, self.HIDDEN)
+        )
+        self.assertTrue(torch.equal(out[:, : self.RANK, :], out[:, self.RANK :, :]))
+
+    def test_down_proj_lora_A_unchanged_for_c1(self):
+        adapter = _make_adapter(_TPARAMS)
+        weights = _ab_pair(
+            "x",
+            inner=False,
+            rank=self.RANK,
+            num_experts=self.NUM_EXPERTS,
+            in_dim=self.MOE_INTERMEDIATE,
+            out_dim=self.HIDDEN,
+        )
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        out = weights["x.experts.down_proj.lora_A.weight"]
+        self.assertEqual(
+            tuple(out.shape),
+            (self.NUM_EXPERTS, self.RANK, self.MOE_INTERMEDIATE),
+        )
+
+    def test_lora_B_reshape_and_permute_preserves_per_expert(self):
+        """Round-trip B: build PEFT's layout (experts FAST-varying inside r*E
+        per ``B.reshape(out, rank, num_experts)`` in peft/tuners/lora/layer.py)
+        then verify the reshape recovers each expert's per-expert ``(out, r)``.
+
+        We pair the B with a matching A (with in_dim == moe_intermediate to
+        select the down_proj branch).
+        """
+        adapter = _make_adapter(
+            _TPARAMS,
+            rank=4,
+            num_experts=5,
+            hidden_size=64,
+            moe_intermediate_size=37,
+            intermediate_size=128,
+        )
+        out_dim, rank, E = 64, 4, 5
+        per_expert = [
+            torch.full((out_dim, rank), float(i + 1), dtype=torch.bfloat16)
+            for i in range(E)
+        ]
+        # Experts FAST-varying — matches PEFT's saved layout.
+        flat = torch.stack(per_expert, dim=2).reshape(out_dim, rank * E)
+        a_in_dim = 37  # moe_intermediate_size → down_proj branch
+        weights = {
+            "x.experts.lora_A.weight": torch.zeros(
+                E * rank, a_in_dim, dtype=torch.bfloat16
+            ),
+            "x.experts.lora_B.weight": flat,
+        }
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        out = weights["x.experts.down_proj.lora_B.weight"]
+        self.assertEqual(tuple(out.shape), (E, out_dim, rank))
+        for i in range(E):
+            self.assertTrue(torch.equal(out[i], per_expert[i]))
+
+
+class TestPeftParamWrapperGating(unittest.TestCase):
+    """The normalizer must be inert for non-PEFT-ParamWrapper adapters."""
+
+    def test_no_target_parameters_is_noop(self):
+        adapter = _make_adapter([])
+        weights = {
+            "x.q_proj.lora_A.weight": torch.zeros(8, 2048),
+            "x.experts.0.gate_proj.lora_A.weight": torch.zeros(8, 2048),
+        }
+        snap = {k: v.clone() for k, v in weights.items()}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertEqual(set(weights.keys()), set(snap.keys()))
+        for k, v in snap.items():
+            self.assertTrue(torch.equal(weights[k], v))
+
+    def test_target_parameters_none_is_noop(self):
+        """Older PEFT writes ``"target_parameters": null`` — should be a no-op."""
+        adapter = LoRAAdapter.__new__(LoRAAdapter)
+        adapter.config = types.SimpleNamespace(
+            hf_config={"target_parameters": None}, r=8
+        )
+        adapter.base_hf_config = types.SimpleNamespace(
+            num_experts=32,
+            hidden_size=2048,
+            moe_intermediate_size=1792,
+            intermediate_size=7168,
+        )
+        weights = {"x.q_proj.lora_A.weight": torch.zeros(8, 2048)}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertIn("x.q_proj.lora_A.weight", weights)
+
+    def test_per_expert_names_not_renamed(self):
+        """Mixtral-classic per-expert names (``experts.0.gate_proj.lora_A.weight``)
+        must NOT match the regex — they take SGLang's existing per-expert path."""
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.layers.5.block_sparse_moe.experts.0.gate_proj.lora_A.weight"
+        weights = {name: torch.zeros(8, 2048)}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertIn(name, weights)
+
+    def test_already_converted_3d_names_not_renamed(self):
+        """Already-converted names (``experts.gate_up_proj.lora_A.weight``)
+        must NOT match (no ``base_layer`` slot, and a leaf module between
+        ``experts.`` and ``lora_``)."""
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.experts.gate_up_proj.lora_A.weight"
+        weights = {name: torch.zeros(32, 8, 2048)}  # already 3D
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertIn(name, weights)
+
+    def test_non_moe_names_untouched(self):
+        adapter = _make_adapter(_TPARAMS)
+        weights = {
+            "x.q_proj.lora_A.weight": torch.zeros(8, 2048),
+            "x.gate_up_proj.lora_B.weight": torch.zeros(2048, 8),
+        }
+        snap = {k: v.clone() for k, v in weights.items()}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertEqual(set(weights.keys()), set(snap.keys()))
+
+    def test_more_than_two_target_parameters_rejected(self):
+        adapter = _make_adapter(_TPARAMS + ["experts.gate"])
+        weights = {"x.experts.base_layer.lora_A.weight": torch.zeros(32 * 8, 2048)}
+        with self.assertRaises(ValueError):
+            adapter._normalize_peft_paramwrapper_moe(weights)
+
+    def test_orphan_lora_B_without_matching_A_skipped(self):
+        """If lora_B has no sibling lora_A (shape-resolve cannot run),
+        leave the key alone for the loader to flag."""
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.experts.lora_B.weight"
+        weights = {name: torch.zeros(2048, 8 * 32, dtype=torch.bfloat16)}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertIn(name, weights)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Split out of #25528 (loader only — model-specific wiring follows in separate PRs) per @yushengsu-thu's review.

## Bug

Adapters trained with PEFT 0.18+ `target_parameters` against the batched 3D MoE expert tensors (HF transformers ≥ 5.8: Qwen3MoE, Mixtral, DeepSeek-V2, LFM2-MoE, …) ship under names like `...mlp.experts.base_layer.lora_*` and `...mlp.experts.lora_*`. SGLang's existing per-expert resolver can't match those keys, so the expert weights are silently dropped (default) or hard-fail under `--lora-strict-loading`.

## Fix

- `lora/lora.py` — `_normalize_peft_paramwrapper_moe` rewrites the PEFT keys into SGLang's existing 3D-per-expert layout (`...experts.<leaf>.lora_*`, A `(E, c·r, in)`, B `(E, out, r)`). After this pass they flow through the existing MoE 4D-buffer load path unchanged.
- `lora/mem_pool.py` — `has_shared_experts` extended for hybrid-layer MoEs (DeepSeek's `first_k_dense_replace` etc.) so they get the standard 3D buffer alongside the 4D `*_moe` one.

No model-specific changes; per-model wiring follows as separate PRs.

## Repro (manual)

Demo adapter: [`tugot17/qwen3-30b-a3b-peft18-moe-lora-demo`](https://huggingface.co/tugot17/qwen3-30b-a3b-peft18-moe-lora-demo) — Qwen3-30B-A3B + 192 expert keys via `target_parameters` (training script bundled with the adapter).

```bash
python -m sglang.launch_server \
    --model-path Qwen/Qwen3-30B-A3B-Instruct-2507 \
    --enable-lora --max-lora-rank 8 \
    --lora-paths "qwen3demo=tugot17/qwen3-30b-a3b-peft18-moe-lora-demo" \
    --lora-target-modules q_proj k_proj v_proj o_proj gate_up_proj down_proj \
    --lora-strict-loading
```

**Before** (`main`): server refuses to start —

```
ValueError: LoRA adapter '<uid>': 192 weight(s) skipped because they did not
match any target module in ['down_proj', 'gate_up_proj', 'o_proj', 'qkv_proj'].
Skipped weights: [...experts.base_layer.lora_A.weight, ...experts.lora_B.weight, ...]
```

**After** (this PR): server starts, all targets load, base vs LoRA outputs diverge from the first token under greedy decoding (verified on H100).

## Note on slot resolution

PEFT picks the inner (`base_layer`) vs outer slot by the parent module's HF attribute-definition order, **not** by `target_parameters` list order — so two adapters with reversed list orders produce the same on-disk layout. The loader resolves leaves by tensor shape (A's input dim vs `hidden_size` / `moe_intermediate_size`), not by index. A unit test asserts both list orders normalize identically.

## Tests

13 CPU-only unit tests in `test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py` — name resolution (incl. the reversed-order regression), reshape semantics (c=1 / c=2, B-axis layout), and inertness on non-PEFT-`ParamWrapper` adapters.

E2E was done manually against the demo adapter above (output divergence on the same prompt, both `--lora-strict-loading` and default modes). An E2E test in-tree will land alongside the first per-model wiring PR — happy to add one here too if reviewers prefer.
