### PR TITLE
Add ForcedSequenceLogitProcessor (teacher-forcing custom logit processor)

### DIFF
--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -200,3 +200,31 @@ class DeepseekOCRNoRepeatNGramLogitProcessor(CustomLogitProcessor):
             logits[batch_idx, indices] = -float("inf")
 
         return logits
+
+
+class ForcedSequenceLogitProcessor(CustomLogitProcessor):
+    """Teacher-forcing: pin each decode step to a per-request recorded token sequence.
+
+    Per-request custom_params: {"forced_output_ids": [int, ...]}. At decode step t
+    (t = tokens already generated for the req), forces the next token to
+    forced_output_ids[t] by masking every other logit; past the end of the list it
+    samples normally. Useful for running two server configurations on a byte-identical
+    decode workload (so the only variable is the config under test) and for
+    reproducible / replayed decoding.
+    """
+
+    def __call__(self, logits, custom_param_list=None):
+        if not custom_param_list:
+            return logits
+        for i, params in enumerate(custom_param_list):
+            if not params:
+                continue
+            forced = params.get("forced_output_ids")
+            if not forced:
+                continue
+            req = params.get("__req__")
+            t = len(req.output_ids) if req is not None else 0
+            if t < len(forced):
+                logits[i, :] = float("-inf")
+                logits[i, forced[t]] = 0.0
+        return logits


### PR DESCRIPTION
## What

Adds a general-purpose `ForcedSequenceLogitProcessor`. Per request, pass `custom_params={"forced_output_ids": [int, ...]}`; at decode step *t* it forces the next token to `forced_output_ids[t]` by masking all other logits, then samples normally past the end of the list.

## Why

Lets two server configurations run a byte-identical decode workload so the only variable is the configuration under test (a sampling/caching flag, a kernel, a quantization mode), and supports reproducible / replayed decoding. It's a natural sibling of the existing `ThinkingBudgetLogitProcessor`, `DisallowedTokensLogitsProcessor`, and `DeepseekOCRNoRepeatNGramLogitProcessor` in the same file.

## Usage

- Launch the server with `--enable-custom-logit-processor`.
- Per request (`/generate` or `/v1/chat/completions`):
  - `custom_logit_processor = ForcedSequenceLogitProcessor.to_str()`
  - `sampling_params.custom_params = {"forced_output_ids": [...]}`
  - `max_new_tokens = len(forced_output_ids)`

Standalone; no dependency on other changes.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27029002283](https://github.com/sgl-project/sglang/actions/runs/27029002283)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27029002112](https://github.com/sgl-project/sglang/actions/runs/27029002112)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->