### PR TITLE
Don't write crash dump on graceful exit

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2592,7 +2592,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             if remain_num_req > 0:
                 await asyncio.sleep(5)
             else:
-                self.dump_requests_before_crash()
                 break
 
         kill_process_tree(os.getpid(), include_parent=True)


### PR DESCRIPTION
## Problem

On a graceful shutdown (SIGTERM), `TokenizerManager.sigterm_watchdog()` drains in-flight requests and then, once they all finish (`remain_num_req == 0`), unconditionally called `dump_requests_before_crash()`. This wrote a `crash_dump_*.pkl` on **every clean shutdown**, even though a graceful exit is not a crash.

## Fix

Skip the dump on the drained-exit path — just `break` and exit cleanly, mirroring the existing `SGL_FORCE_SHUTDOWN` branch right above it which already exits without dumping.

```python
            if remain_num_req > 0:
                await asyncio.sleep(5)
            else:
                # All requests drained: this is a clean, graceful exit, so we
                # must not write a crash dump.
                break
```









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27046159177](https://github.com/sgl-project/sglang/actions/runs/27046159177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27046159094](https://github.com/sgl-project/sglang/actions/runs/27046159094)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->