### PR TITLE
Route the eager forward path through the CUDA graph input-buffer registry

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -763,6 +763,11 @@ class Envs:
     # CUDA graph
     SGLANG_PREP_IN_CUDA_GRAPH = EnvBool(True)
 
+    # When set, the eager forward path skips copying its FB-shared input tensors
+    # into the CUDA graph buffer registry and instead wraps the ForwardBatch's
+    # own tensors in a fresh view (no per-iter device-to-device copy).
+    SGLANG_EAGER_INPUT_NO_COPY = EnvBool(False)
+
     # Distributed
     SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER = EnvBool(True)
     SGLANG_SHARED_EXPERT_TP1 = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -763,9 +763,8 @@ class Envs:
     # CUDA graph
     SGLANG_PREP_IN_CUDA_GRAPH = EnvBool(True)
 
-    # When set, the eager forward path skips copying its FB-shared input tensors
-    # into the CUDA graph buffer registry and instead wraps the ForwardBatch's
-    # own tensors in a fresh view (no per-iter device-to-device copy).
+    # Eager forward wraps the ForwardBatch's own tensors instead of copying them
+    # into the CUDA graph buffer registry (no per-iter device-to-device copy).
     SGLANG_EAGER_INPUT_NO_COPY = EnvBool(False)
 
     # Distributed

--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -462,31 +462,11 @@ class CudaGraphBufferRegistry:
         padded_num_tokens: int,
         forward_batch_template: "ForwardBatch",
     ) -> "ForwardBatch":
-        """Return a FB view backed by registry slot buffers.
-
-        ``forward_batch_template`` provides the non-slot fields
-        (``forward_mode`` / ``spec_info`` / ``sampling_info`` /
-        ``capture_hidden_mode`` / ``dp_*`` / ``lora_ids`` / ...). Slot
-        fields are replaced with views into the registry buffers via
-        ``dataclasses.replace`` — the template itself is not mutated.
-
-        Consumed by the **eager** forward path (``ModelRunner.forward_decode``
-        et al.), where the FB has already been DP-padded in place so
-        ``raw == padded`` — the slot slice equals the FB value, ``seq_lens_sum``
-        is already correct on the template, and there is no IDLE substitution.
-        The decode **replay** path keeps ``build_replay_fb_view`` instead: it
-        DOES need the padded-vs-raw ``out_cache_loc`` distinction, the
-        ``seq_lens_sum`` padded-tail recompute, and the ``forward_mode`` vs
-        ``actual_forward_mode`` split — none of which apply to eager.
-
-        A plain copy-from-FB slot whose FB field is absent this iter (e.g.
-        ``mrope_positions`` on a non-multimodal batch, ``encoder_lens`` on a
-        decoder-only model) holds only stale / zero-init buffer data —
-        ``fill_from`` skipped it. Such a slot is **carried from the template**
-        (preserving the original ``None``) rather than exposed as a zero
-        buffer, mirroring ``fill_from``'s None-skip. Computed slots
-        (``post_fill`` / ``copy_from_fb=False``) are always exposed: their
-        buffer holds the produced value, not an FB copy.
+        """Return a FB view (``dataclasses.replace`` of ``forward_batch_template``)
+        whose slot fields are buffer views and whose non-slot fields are carried
+        from the template. A plain copy slot whose FB field is ``None`` this iter
+        is carried (not exposed as a stale buffer); computed slots are always
+        exposed.
         """
         import dataclasses
 
@@ -505,8 +485,7 @@ class CudaGraphBufferRegistry:
                 and slot.source_fn is None
                 and getattr(forward_batch_template, slot.name, None) is None
             ):
-                # FB didn't carry this field this iter; fill_from skipped it.
-                # Carry the template's value (None) instead of a stale buffer.
+                # Absent this iter (fill_from skipped it): carry the template.
                 continue
             replace_kwargs[slot.name] = slot.slice_for(padded_bs, padded_num_tokens)
         return dataclasses.replace(forward_batch_template, **replace_kwargs)
@@ -664,17 +643,12 @@ def build_decode_registry(
             )
         )
 
-    # These are computed slots (copy_from_fb=False): the post_fill writes the
-    # gathered (DP) count and ``extract_buffer`` always exposes them. Callers
-    # that have already populated ``global_num_tokens_*`` on the batch (the
-    # eager path, where ``prepare_mlp_sync_batch`` ran before the forward) must
-    # pass ``register_global_num_tokens=False`` so the batch values are carried
-    # through instead of overwritten by a zero buffer.
+    # Computed slots, always exposed by extract_buffer; callers that already set
+    # global_num_tokens_* on the batch pass register_global_num_tokens=False.
     if register_global_num_tokens:
 
         def _global_num_tokens_post_fill(buf, fb, ctx):
-            # Filled with the padded token count on the gathered (DP) path; left
-            # untouched otherwise. Not an FB copy (copy_from_fb=False).
+            # Only the gathered (DP) path writes a value; otherwise left as init.
             if require_gathered_buffer:
                 buf.fill_(ctx.padded_num_tokens)
 
@@ -799,14 +773,9 @@ def build_prefill_registry(
     """Registry mirroring the **token-axis** FB-shared buffers for the
     piecewise / breakable (prefill) cuda-graph runners.
 
-    ``register_input_embeds`` (default ``True``) controls whether the
-    ``input_embeds`` slot is registered for multimodal models. The
-    piecewise / breakable graph paths keep it ``True``: the model writes the
-    embeds into the (reset-only) buffer inside the graph. The **eager** extend
-    path passes ``False``: there ``input_embeds`` is a real *read* input
-    (``forward_extend`` does ``fb.input_embeds.bfloat16()``), not something the
-    model writes, so it must be carried through from the FB by
-    ``extract_buffer`` rather than handed back as a zero buffer.
+    ``register_input_embeds`` (default ``True``) registers the multimodal
+    ``input_embeds`` slot; the eager extend path passes ``False`` so it is
+    carried from the batch (a read input) rather than written in-graph.
 
     Padding policies match the inline copy/zero in
     ``PiecewiseCudaGraphRunner.replay_prepare``: ``input_ids`` / ``positions``

--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -470,12 +470,23 @@ class CudaGraphBufferRegistry:
         fields are replaced with views into the registry buffers via
         ``dataclasses.replace`` — the template itself is not mutated.
 
-        NOTE: currently parked / unused. It is NOT a drop-in for the decode
-        replay path's ``build_replay_fb_view``: it returns the *padded*
-        out_cache_loc slot slice (vs the raw ``fb.out_cache_loc`` that path
-        keeps), does not recompute ``seq_lens_sum`` for the padded tail, and
-        does not split ``forward_mode`` vs ``actual_forward_mode``. Reconcile
-        those before wiring it into any replay path.
+        Consumed by the **eager** forward path (``ModelRunner.forward_decode``
+        et al.), where the FB has already been DP-padded in place so
+        ``raw == padded`` — the slot slice equals the FB value, ``seq_lens_sum``
+        is already correct on the template, and there is no IDLE substitution.
+        The decode **replay** path keeps ``build_replay_fb_view`` instead: it
+        DOES need the padded-vs-raw ``out_cache_loc`` distinction, the
+        ``seq_lens_sum`` padded-tail recompute, and the ``forward_mode`` vs
+        ``actual_forward_mode`` split — none of which apply to eager.
+
+        A plain copy-from-FB slot whose FB field is absent this iter (e.g.
+        ``mrope_positions`` on a non-multimodal batch, ``encoder_lens`` on a
+        decoder-only model) holds only stale / zero-init buffer data —
+        ``fill_from`` skipped it. Such a slot is **carried from the template**
+        (preserving the original ``None``) rather than exposed as a zero
+        buffer, mirroring ``fill_from``'s None-skip. Computed slots
+        (``post_fill`` / ``copy_from_fb=False``) are always exposed: their
+        buffer holds the produced value, not an FB copy.
         """
         import dataclasses
 
@@ -487,6 +498,15 @@ class CudaGraphBufferRegistry:
             # top-level FB attributes — their data is consumed in place off the
             # adopted backing object, not re-attached to the FB view here.
             if "." in slot.name:
+                continue
+            is_computed = slot.post_fill is not None or not slot.copy_from_fb
+            if (
+                not is_computed
+                and slot.source_fn is None
+                and getattr(forward_batch_template, slot.name, None) is None
+            ):
+                # FB didn't carry this field this iter; fill_from skipped it.
+                # Carry the template's value (None) instead of a stale buffer.
                 continue
             replace_kwargs[slot.name] = slot.slice_for(padded_bs, padded_num_tokens)
         return dataclasses.replace(forward_batch_template, **replace_kwargs)
@@ -507,6 +527,7 @@ def build_decode_registry(
     enable_prefill_cp: bool = False,
     require_mlp_tp_gather: bool = False,
     dp_size: int = 1,
+    register_global_num_tokens: bool = True,
     share_pool: bool = True,
     source: Optional[Any] = None,
 ) -> CudaGraphBufferRegistry:
@@ -643,28 +664,39 @@ def build_decode_registry(
             )
         )
 
-    def _global_num_tokens_post_fill(buf, fb, ctx):
-        # Filled with the padded token count on the gathered (DP) path; left
-        # untouched otherwise. Not an FB copy (copy_from_fb=False).
-        if require_gathered_buffer:
-            buf.fill_(ctx.padded_num_tokens)
+    # These are computed slots (copy_from_fb=False): the post_fill writes the
+    # gathered (DP) count and ``extract_buffer`` always exposes them. Callers
+    # that have already populated ``global_num_tokens_*`` on the batch (the
+    # eager path, where ``prepare_mlp_sync_batch`` ran before the forward) must
+    # pass ``register_global_num_tokens=False`` so the batch values are carried
+    # through instead of overwritten by a zero buffer.
+    if register_global_num_tokens:
 
-    _global_shape = (
-        (lambda _bs, _mt: (dp_size,))
-        if require_mlp_tp_gather
-        else (lambda _bs, _mt: (1,))
-    )
-    for _global_name in ("global_num_tokens_gpu", "global_num_tokens_for_logprob_gpu"):
-        slots.append(
-            GraphSlot(
-                _global_name,
-                _global_shape,
-                torch.int32,
-                axis="none",
-                copy_from_fb=False,
-                post_fill=_global_num_tokens_post_fill,
-            )
+        def _global_num_tokens_post_fill(buf, fb, ctx):
+            # Filled with the padded token count on the gathered (DP) path; left
+            # untouched otherwise. Not an FB copy (copy_from_fb=False).
+            if require_gathered_buffer:
+                buf.fill_(ctx.padded_num_tokens)
+
+        _global_shape = (
+            (lambda _bs, _mt: (dp_size,))
+            if require_mlp_tp_gather
+            else (lambda _bs, _mt: (1,))
         )
+        for _global_name in (
+            "global_num_tokens_gpu",
+            "global_num_tokens_for_logprob_gpu",
+        ):
+            slots.append(
+                GraphSlot(
+                    _global_name,
+                    _global_shape,
+                    torch.int32,
+                    axis="none",
+                    copy_from_fb=False,
+                    post_fill=_global_num_tokens_post_fill,
+                )
+            )
 
     for slot in slots:
         bind = None
@@ -760,11 +792,21 @@ def build_prefill_registry(
     hidden_size: int = 0,
     embed_dtype: Optional[torch.dtype] = None,
     enable_mamba_track: bool = False,
+    register_input_embeds: bool = True,
     share_pool: bool = True,
     source: Optional[Any] = None,
 ) -> CudaGraphBufferRegistry:
     """Registry mirroring the **token-axis** FB-shared buffers for the
     piecewise / breakable (prefill) cuda-graph runners.
+
+    ``register_input_embeds`` (default ``True``) controls whether the
+    ``input_embeds`` slot is registered for multimodal models. The
+    piecewise / breakable graph paths keep it ``True``: the model writes the
+    embeds into the (reset-only) buffer inside the graph. The **eager** extend
+    path passes ``False``: there ``input_embeds`` is a real *read* input
+    (``forward_extend`` does ``fb.input_embeds.bfloat16()``), not something the
+    model writes, so it must be carried through from the FB by
+    ``extract_buffer`` rather than handed back as a zero buffer.
 
     Padding policies match the inline copy/zero in
     ``PiecewiseCudaGraphRunner.replay_prepare``: ``input_ids`` / ``positions``
@@ -828,16 +870,17 @@ def build_prefill_registry(
                 slice_fn=lambda buf, n: buf[:, :n],
             )
         )
-        slots.append(
-            GraphSlot(
-                "input_embeds",
-                lambda _bs2, mt: (mt, hidden_size),
-                embed_dtype,
-                axis="tokens",
-                padding_policy=PaddingPolicy.ZERO,
-                copy_from_fb=False,
+        if register_input_embeds:
+            slots.append(
+                GraphSlot(
+                    "input_embeds",
+                    lambda _bs2, mt: (mt, hidden_size),
+                    embed_dtype,
+                    axis="tokens",
+                    padding_policy=PaddingPolicy.ZERO,
+                    copy_from_fb=False,
+                )
             )
-        )
     if enable_mamba_track:
         slots.append(GraphSlot("mamba_track_indices", _bs, torch.int64, axis="bs"))
         slots.append(GraphSlot("mamba_track_mask", _bs, torch.bool, axis="bs"))

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -219,7 +219,7 @@ from sglang.srt.utils import (
     set_cuda_arch,
     slow_rank_detector,
 )
-from sglang.srt.utils.common import ceil_align, require_mlp_sync
+from sglang.srt.utils.common import ceil_align, next_power_of_2, require_mlp_sync
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.offloader import (
@@ -343,6 +343,14 @@ class ModelRunnerOutput:
     indexer_topk_output: Optional[TopkCaptureOutput] = None
 
 
+@dataclass
+class _EagerBufferRegistry:
+    # Lazily-built eager input-buffer registry plus the capacity it was sized to.
+    registry: Optional["CudaGraphBufferRegistry"] = None
+    max_bs: int = 0
+    max_num_tokens: int = 0
+
+
 class ModelRunner(ModelRunnerKVCacheMixin):
     """ModelRunner runs the forward passes of the models."""
 
@@ -419,6 +427,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.enable_elastic_ep = server_args.elastic_ep_backend is not None
         self.forward_pass_id = 0
         self.init_new_workspace = False
+        self._eager_decode_registry = _EagerBufferRegistry()
+        self._eager_prefill_registry = _EagerBufferRegistry()
         self.draft_model_idx = draft_model_idx
         self.enable_hisparse = server_args.enable_hisparse
 
@@ -3084,108 +3094,97 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def update_decode_attn_backend(self, stream_idx: int):
         self.decode_attn_backend = self.decode_attn_backend_group[stream_idx]
 
+    def _ensure_eager_registry(
+        self,
+        cache: _EagerBufferRegistry,
+        raw_bs: int,
+        raw_num_tokens: int,
+        build: Callable[[int, int], "CudaGraphBufferRegistry"],
+    ) -> "CudaGraphBufferRegistry":
+        # Built on first use and grown (next power of two) when a batch exceeds
+        # the current capacity.
+        if (
+            cache.registry is not None
+            and raw_bs <= cache.max_bs
+            and raw_num_tokens <= cache.max_num_tokens
+        ):
+            return cache.registry
+        cache.max_bs = next_power_of_2(max(raw_bs, cache.max_bs))
+        cache.max_num_tokens = next_power_of_2(
+            max(raw_num_tokens, cache.max_num_tokens)
+        )
+        cache.registry = build(cache.max_bs, cache.max_num_tokens)
+        return cache.registry
+
     def _ensure_eager_decode_registry(
         self, raw_bs: int, raw_num_tokens: int
     ) -> "CudaGraphBufferRegistry":
-        reg = getattr(self, "_eager_decode_registry", None)
-        cap_bs, cap_tokens = getattr(self, "_eager_decode_registry_capacity", (0, 0))
-        if reg is not None and raw_bs <= cap_bs and raw_num_tokens <= cap_tokens:
-            return reg
-
-        def _next_pow2(n: int) -> int:
-            return 1 << max(0, n - 1).bit_length() if n > 0 else 1
-
-        new_bs = _next_pow2(max(raw_bs, cap_bs))
-        new_tokens = _next_pow2(max(raw_num_tokens, cap_tokens))
         is_encoder_decoder = self.model_config.is_encoder_decoder
-        reg = build_decode_registry(
-            device=self.device,
-            max_bs=new_bs,
-            max_num_token=new_tokens,
-            # Eager has no padding so this sentinel is never read; 0 avoids the
-            # cuda-graph-only fill-value method that some backends lack.
-            seq_len_fill_value=0,
-            cache_loc_dtype=torch.int64,
-            enable_mamba_track=(
-                self.server_args.enable_mamba_extra_buffer()
-                and self.spec_algorithm.is_none()
+        return self._ensure_eager_registry(
+            self._eager_decode_registry,
+            raw_bs,
+            raw_num_tokens,
+            lambda bs, num_tokens: build_decode_registry(
+                device=self.device,
+                max_bs=bs,
+                max_num_token=num_tokens,
+                # Eager has no padding so this sentinel is never read; 0 avoids the
+                # cuda-graph-only fill-value method that some backends lack.
+                seq_len_fill_value=0,
+                cache_loc_dtype=torch.int64,
+                enable_mamba_track=(
+                    self.server_args.enable_mamba_extra_buffer()
+                    and self.spec_algorithm.is_none()
+                ),
+                is_encoder_decoder=is_encoder_decoder,
+                encoder_len_fill_value=(
+                    getattr(self.model_config.hf_config, "max_source_positions", 0)
+                    if is_encoder_decoder
+                    else 0
+                ),
+                enable_num_token_non_padded=False,
+                register_global_num_tokens=False,
+                require_gathered_buffer=False,
+                require_mlp_tp_gather=False,
+                dp_size=self.server_args.dp_size,
+                share_pool=False,
+                source=None,
             ),
-            is_encoder_decoder=is_encoder_decoder,
-            encoder_len_fill_value=(
-                getattr(self.model_config.hf_config, "max_source_positions", 0)
-                if is_encoder_decoder
-                else 0
-            ),
-            enable_num_token_non_padded=False,
-            register_global_num_tokens=False,
-            require_gathered_buffer=False,
-            require_mlp_tp_gather=False,
-            dp_size=self.server_args.dp_size,
-            share_pool=False,
-            source=None,
-        )
-        self._eager_decode_registry = reg
-        self._eager_decode_registry_capacity = (new_bs, new_tokens)
-        return reg
-
-    def _eager_decode_fb_view(
-        self, forward_batch: ForwardBatch, pp_proxy_tensors=None
-    ) -> ForwardBatch:
-        if envs.SGLANG_EAGER_INPUT_NO_COPY.get():
-            return replace(forward_batch)
-        raw_bs = forward_batch.batch_size
-        raw_num_tokens = forward_batch.input_ids.shape[0]
-        registry = self._ensure_eager_decode_registry(raw_bs, raw_num_tokens)
-        registry.fill_from(
-            forward_batch,
-            raw_bs=raw_bs,
-            padded_bs=raw_bs,
-            raw_num_tokens=raw_num_tokens,
-            padded_num_tokens=raw_num_tokens,
-            pp_proxy_tensors=pp_proxy_tensors,
-        )
-        return registry.extract_buffer(
-            padded_bs=raw_bs,
-            padded_num_tokens=raw_num_tokens,
-            forward_batch_template=forward_batch,
         )
 
     def _ensure_eager_prefill_registry(
         self, raw_bs: int, raw_num_tokens: int
     ) -> "CudaGraphBufferRegistry":
-        reg = getattr(self, "_eager_prefill_registry", None)
-        cap_bs, cap_tokens = getattr(self, "_eager_prefill_registry_capacity", (0, 0))
-        if reg is not None and raw_bs <= cap_bs and raw_num_tokens <= cap_tokens:
-            return reg
-
-        def _next_pow2(n: int) -> int:
-            return 1 << max(0, n - 1).bit_length() if n > 0 else 1
-
-        new_bs = _next_pow2(max(raw_bs, cap_bs))
-        new_tokens = _next_pow2(max(raw_num_tokens, cap_tokens))
-        reg = build_prefill_registry(
-            device=self.device,
-            max_bs=new_bs,
-            max_num_token=new_tokens,
-            cache_loc_dtype=torch.int64,
-            is_multimodal=self.is_multimodal,
-            enable_mamba_track=False,
-            register_input_embeds=False,
-            share_pool=False,
-            source=None,
+        return self._ensure_eager_registry(
+            self._eager_prefill_registry,
+            raw_bs,
+            raw_num_tokens,
+            lambda bs, num_tokens: build_prefill_registry(
+                device=self.device,
+                max_bs=bs,
+                max_num_token=num_tokens,
+                cache_loc_dtype=torch.int64,
+                is_multimodal=self.is_multimodal,
+                enable_mamba_track=False,
+                register_input_embeds=False,
+                share_pool=False,
+                source=None,
+            ),
         )
-        self._eager_prefill_registry = reg
-        self._eager_prefill_registry_capacity = (new_bs, new_tokens)
-        return reg
 
-    def _eager_extend_fb_view(
+    def _eager_fb_view(
         self, forward_batch: ForwardBatch, pp_proxy_tensors=None
     ) -> ForwardBatch:
         if envs.SGLANG_EAGER_INPUT_NO_COPY.get():
             return replace(forward_batch)
         raw_bs = forward_batch.batch_size
         raw_num_tokens = forward_batch.input_ids.shape[0]
-        registry = self._ensure_eager_prefill_registry(raw_bs, raw_num_tokens)
+        ensure = (
+            self._ensure_eager_prefill_registry
+            if forward_batch.forward_mode.is_extend(include_draft_extend_v2=True)
+            else self._ensure_eager_decode_registry
+        )
+        registry = ensure(raw_bs, raw_num_tokens)
         registry.fill_from(
             forward_batch,
             raw_bs=raw_bs,
@@ -3206,7 +3205,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         pp_proxy_tensors=None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
         if not self.server_args.enable_pdmux:
-            forward_batch = self._eager_decode_fb_view(forward_batch, pp_proxy_tensors)
+            forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
         # Set extra arguments
         pdmux_override = False
         if forward_batch.needs_forward_metadata_init():
@@ -3296,7 +3295,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return (ret, can_run_graph)
 
         if not self.server_args.enable_pdmux:
-            forward_batch = self._eager_extend_fb_view(forward_batch, pp_proxy_tensors)
+            forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
 
         # Launch model forward
         if forward_batch.needs_forward_metadata_init():
@@ -3332,9 +3331,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # indices and trigger SWA mapping use-after-free.
         if forward_batch.batch_size > 0:
             if not self.server_args.enable_pdmux:
-                forward_batch = self._eager_decode_fb_view(
-                    forward_batch, pp_proxy_tensors
-                )
+                forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
             self.attn_backend.init_forward_metadata(forward_batch)
         else:
             self.attn_backend.forward_metadata = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -140,6 +140,11 @@ from sglang.srt.model_executor.breakable_cuda_graph_runner import (
     BreakableCudaGraphRunner,
 )
 from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
+from sglang.srt.model_executor.cuda_graph_buffer_registry import (
+    CudaGraphBufferRegistry,
+    build_decode_registry,
+    build_prefill_registry,
+)
 from sglang.srt.model_executor.cuda_graph_runner import (
     CudaGraphRunner,
     _allocate_decode_buffers,
@@ -3079,11 +3084,156 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def update_decode_attn_backend(self, stream_idx: int):
         self.decode_attn_backend = self.decode_attn_backend_group[stream_idx]
 
+    def _ensure_eager_decode_registry(
+        self, raw_bs: int, raw_num_tokens: int
+    ) -> "CudaGraphBufferRegistry":
+        """Lazily build (and grow) the decode buffer registry for the eager path.
+
+        Eager decode batches can exceed the cuda-graph capture buckets, so the
+        graph runner's registry (sized to ``max(capture_bs)``) cannot be reused.
+        Eager has no graph address burn-in, so growing by reallocation is safe:
+        build on first use and grow on demand (next power of two).
+
+        The DP-computed slots (``num_token_non_padded`` / ``global_num_tokens_*``)
+        are not registered — ``prepare_mlp_sync_batch`` already set their values
+        on the batch and ``extract_buffer`` carries them through. ``share_pool``
+        is off so the eager buffers are never aliased with a graph's.
+        """
+        reg = getattr(self, "_eager_decode_registry", None)
+        cap_bs, cap_tokens = getattr(self, "_eager_decode_registry_capacity", (0, 0))
+        if reg is not None and raw_bs <= cap_bs and raw_num_tokens <= cap_tokens:
+            return reg
+
+        def _next_pow2(n: int) -> int:
+            return 1 << max(0, n - 1).bit_length() if n > 0 else 1
+
+        new_bs = _next_pow2(max(raw_bs, cap_bs))
+        new_tokens = _next_pow2(max(raw_num_tokens, cap_tokens))
+        is_encoder_decoder = self.model_config.is_encoder_decoder
+        reg = build_decode_registry(
+            device=self.device,
+            max_bs=new_bs,
+            max_num_token=new_tokens,
+            seq_len_fill_value=self.attn_backend.get_cuda_graph_seq_len_fill_value(),
+            cache_loc_dtype=torch.int64,
+            enable_mamba_track=(
+                self.server_args.enable_mamba_extra_buffer()
+                and self.spec_algorithm.is_none()
+            ),
+            is_encoder_decoder=is_encoder_decoder,
+            encoder_len_fill_value=(
+                getattr(self.model_config.hf_config, "max_source_positions", 0)
+                if is_encoder_decoder
+                else 0
+            ),
+            enable_num_token_non_padded=False,  # eager carries it from the FB
+            register_global_num_tokens=False,  # eager carries these from the FB
+            require_gathered_buffer=False,
+            require_mlp_tp_gather=False,
+            dp_size=self.server_args.dp_size,
+            share_pool=False,
+            source=None,
+        )
+        self._eager_decode_registry = reg
+        self._eager_decode_registry_capacity = (new_bs, new_tokens)
+        return reg
+
+    def _eager_decode_fb_view(
+        self, forward_batch: ForwardBatch, pp_proxy_tensors=None
+    ) -> ForwardBatch:
+        """Return a ForwardBatch view whose shared input tensors are backed by
+        the eager decode buffer registry. The batch is already DP-padded in
+        place by ``_forward_raw``, so ``raw == padded`` (no capture-bucket
+        padding, no idle substitution)."""
+        raw_bs = forward_batch.batch_size
+        raw_num_tokens = forward_batch.input_ids.shape[0]
+        registry = self._ensure_eager_decode_registry(raw_bs, raw_num_tokens)
+        registry.fill_from(
+            forward_batch,
+            raw_bs=raw_bs,
+            padded_bs=raw_bs,
+            raw_num_tokens=raw_num_tokens,
+            padded_num_tokens=raw_num_tokens,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+        return registry.extract_buffer(
+            padded_bs=raw_bs,
+            padded_num_tokens=raw_num_tokens,
+            forward_batch_template=forward_batch,
+        )
+
+    def _ensure_eager_prefill_registry(
+        self, raw_bs: int, raw_num_tokens: int
+    ) -> "CudaGraphBufferRegistry":
+        """Lazily build (and grow) the token-axis prefill buffer registry for
+        the eager ``forward_extend`` path (same grow rationale as the decode
+        registry).
+
+        ``input_embeds`` is not registered (``register_input_embeds=False``):
+        on the eager path it is a read input, carried from the batch rather than
+        written into a reset-only buffer. ``mamba_track_*`` / ``seq_lens`` /
+        ``req_pool_indices`` are carried too; only the token-axis inputs
+        (``input_ids`` / ``positions`` / ``out_cache_loc`` and, for multimodal
+        models, ``mrope_positions``) are buffered."""
+        reg = getattr(self, "_eager_prefill_registry", None)
+        cap_bs, cap_tokens = getattr(self, "_eager_prefill_registry_capacity", (0, 0))
+        if reg is not None and raw_bs <= cap_bs and raw_num_tokens <= cap_tokens:
+            return reg
+
+        def _next_pow2(n: int) -> int:
+            return 1 << max(0, n - 1).bit_length() if n > 0 else 1
+
+        new_bs = _next_pow2(max(raw_bs, cap_bs))
+        new_tokens = _next_pow2(max(raw_num_tokens, cap_tokens))
+        reg = build_prefill_registry(
+            device=self.device,
+            max_bs=new_bs,
+            max_num_token=new_tokens,
+            cache_loc_dtype=torch.int64,
+            is_multimodal=self.is_multimodal,
+            enable_mamba_track=False,  # eager carries mamba_track_* from the FB
+            register_input_embeds=False,  # eager reads input_embeds; carry it
+            share_pool=False,
+            source=None,
+        )
+        self._eager_prefill_registry = reg
+        self._eager_prefill_registry_capacity = (new_bs, new_tokens)
+        return reg
+
+    def _eager_extend_fb_view(
+        self, forward_batch: ForwardBatch, pp_proxy_tensors=None
+    ) -> ForwardBatch:
+        """Return a ForwardBatch view whose token-axis input tensors are backed
+        by the eager prefill buffer registry. ``raw == padded`` (the batch is
+        already DP-padded in place by ``_forward_raw``)."""
+        raw_bs = forward_batch.batch_size
+        raw_num_tokens = forward_batch.input_ids.shape[0]
+        registry = self._ensure_eager_prefill_registry(raw_bs, raw_num_tokens)
+        registry.fill_from(
+            forward_batch,
+            raw_bs=raw_bs,
+            padded_bs=raw_bs,
+            raw_num_tokens=raw_num_tokens,
+            padded_num_tokens=raw_num_tokens,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+        return registry.extract_buffer(
+            padded_bs=raw_bs,
+            padded_num_tokens=raw_num_tokens,
+            forward_batch_template=forward_batch,
+        )
+
     def forward_decode(
         self,
         forward_batch: ForwardBatch,
         pp_proxy_tensors=None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
+        # Route the eager decode input through the buffer registry (the same one
+        # capture/replay use) instead of reading the ForwardBatch directly.
+        # pdmux runs concurrent per-stream decode forwards that would race on
+        # the shared buffers, so it stays on the ForwardBatch.
+        if not self.server_args.enable_pdmux:
+            forward_batch = self._eager_decode_fb_view(forward_batch, pp_proxy_tensors)
         # Set extra arguments
         pdmux_override = False
         if forward_batch.needs_forward_metadata_init():
@@ -3172,6 +3322,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 ret = self.piecewise_cuda_graph_runner.replay(forward_batch, **kwargs)
             return (ret, can_run_graph)
 
+        # Route the eager (non-piecewise) extend input through the prefill
+        # buffer registry. input_embeds / replace_* were already read off the
+        # batch above and are carried through the view. pdmux stays on the
+        # ForwardBatch (per-stream race on shared buffers), as in forward_decode.
+        if not self.server_args.enable_pdmux:
+            forward_batch = self._eager_extend_fb_view(forward_batch, pp_proxy_tensors)
+
         # Launch model forward
         if forward_batch.needs_forward_metadata_init():
             if hasattr(self.model, "prepare_forward_batch"):
@@ -3205,6 +3362,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # called from the idle path can re-read a prior batch's req_pool
         # indices and trigger SWA mapping use-after-free.
         if forward_batch.batch_size > 0:
+            # Padded idle batches go through the buffer registry like
+            # forward_decode. The unpadded case (bs == 0) stays on the empty
+            # ForwardBatch — there is nothing to fill and the
+            # forward_metadata=None reset below must be exact.
+            if not self.server_args.enable_pdmux:
+                forward_batch = self._eager_decode_fb_view(
+                    forward_batch, pp_proxy_tensors
+                )
             self.attn_backend.init_forward_metadata(forward_batch)
         else:
             self.attn_backend.forward_metadata = None
@@ -3231,6 +3396,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         reinit_attn_backend: bool = False,
         forward_count: int = 1,
     ) -> LogitsProcessorOutput:
+        # Not routed through the eager buffer registry (unlike forward_decode /
+        # forward_extend / forward_idle): this path is stateful across calls —
+        # it advances forward_batch.split_index in place and is re-invoked with
+        # the same ForwardBatch — so it must read and mutate the real batch. An
+        # extract_buffer view is a per-call copy whose split_index update would
+        # never reach the caller's batch.
         if forward_batch.split_index == 0 or reinit_attn_backend:
             self.attn_backend.init_forward_metadata(forward_batch)
         next_split_index = min(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3087,18 +3087,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _ensure_eager_decode_registry(
         self, raw_bs: int, raw_num_tokens: int
     ) -> "CudaGraphBufferRegistry":
-        """Lazily build (and grow) the decode buffer registry for the eager path.
-
-        Eager decode batches can exceed the cuda-graph capture buckets, so the
-        graph runner's registry (sized to ``max(capture_bs)``) cannot be reused.
-        Eager has no graph address burn-in, so growing by reallocation is safe:
-        build on first use and grow on demand (next power of two).
-
-        The DP-computed slots (``num_token_non_padded`` / ``global_num_tokens_*``)
-        are not registered — ``prepare_mlp_sync_batch`` already set their values
-        on the batch and ``extract_buffer`` carries them through. ``share_pool``
-        is off so the eager buffers are never aliased with a graph's.
-        """
         reg = getattr(self, "_eager_decode_registry", None)
         cap_bs, cap_tokens = getattr(self, "_eager_decode_registry_capacity", (0, 0))
         if reg is not None and raw_bs <= cap_bs and raw_num_tokens <= cap_tokens:
@@ -3114,11 +3102,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             device=self.device,
             max_bs=new_bs,
             max_num_token=new_tokens,
-            # Eager applies no padding (raw == padded), so the seq_lens
-            # FILL_SENTINEL only initializes the [raw:padded] tail, which is
-            # empty and never read here. Use 0 rather than the backend's
-            # cuda-graph fill value, which non-cuda-graph backends
-            # (torch_native / torch_flex / intel_amx / ...) do not implement.
+            # Eager has no padding so this sentinel is never read; 0 avoids the
+            # cuda-graph-only fill-value method that some backends lack.
             seq_len_fill_value=0,
             cache_loc_dtype=torch.int64,
             enable_mamba_track=(
@@ -3131,8 +3116,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 if is_encoder_decoder
                 else 0
             ),
-            enable_num_token_non_padded=False,  # eager carries it from the FB
-            register_global_num_tokens=False,  # eager carries these from the FB
+            enable_num_token_non_padded=False,
+            register_global_num_tokens=False,
             require_gathered_buffer=False,
             require_mlp_tp_gather=False,
             dp_size=self.server_args.dp_size,
@@ -3146,13 +3131,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _eager_decode_fb_view(
         self, forward_batch: ForwardBatch, pp_proxy_tensors=None
     ) -> ForwardBatch:
-        """Return a ForwardBatch view whose shared input tensors are backed by
-        the eager decode buffer registry. The batch is already DP-padded in
-        place by ``_forward_raw``, so ``raw == padded`` (no capture-bucket
-        padding, no idle substitution).
-
-        With ``SGLANG_EAGER_INPUT_NO_COPY`` set, skip the registry copy and wrap
-        the batch's own tensors in a fresh view instead (no per-iter D2D copy)."""
         if envs.SGLANG_EAGER_INPUT_NO_COPY.get():
             return replace(forward_batch)
         raw_bs = forward_batch.batch_size
@@ -3175,16 +3153,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _ensure_eager_prefill_registry(
         self, raw_bs: int, raw_num_tokens: int
     ) -> "CudaGraphBufferRegistry":
-        """Lazily build (and grow) the token-axis prefill buffer registry for
-        the eager ``forward_extend`` path (same grow rationale as the decode
-        registry).
-
-        ``input_embeds`` is not registered (``register_input_embeds=False``):
-        on the eager path it is a read input, carried from the batch rather than
-        written into a reset-only buffer. ``mamba_track_*`` / ``seq_lens`` /
-        ``req_pool_indices`` are carried too; only the token-axis inputs
-        (``input_ids`` / ``positions`` / ``out_cache_loc`` and, for multimodal
-        models, ``mrope_positions``) are buffered."""
         reg = getattr(self, "_eager_prefill_registry", None)
         cap_bs, cap_tokens = getattr(self, "_eager_prefill_registry_capacity", (0, 0))
         if reg is not None and raw_bs <= cap_bs and raw_num_tokens <= cap_tokens:
@@ -3201,8 +3169,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             max_num_token=new_tokens,
             cache_loc_dtype=torch.int64,
             is_multimodal=self.is_multimodal,
-            enable_mamba_track=False,  # eager carries mamba_track_* from the FB
-            register_input_embeds=False,  # eager reads input_embeds; carry it
+            enable_mamba_track=False,
+            register_input_embeds=False,
             share_pool=False,
             source=None,
         )
@@ -3213,12 +3181,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _eager_extend_fb_view(
         self, forward_batch: ForwardBatch, pp_proxy_tensors=None
     ) -> ForwardBatch:
-        """Return a ForwardBatch view whose token-axis input tensors are backed
-        by the eager prefill buffer registry. ``raw == padded`` (the batch is
-        already DP-padded in place by ``_forward_raw``).
-
-        With ``SGLANG_EAGER_INPUT_NO_COPY`` set, skip the registry copy and wrap
-        the batch's own tensors in a fresh view instead (no per-iter D2D copy)."""
         if envs.SGLANG_EAGER_INPUT_NO_COPY.get():
             return replace(forward_batch)
         raw_bs = forward_batch.batch_size
@@ -3243,10 +3205,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         forward_batch: ForwardBatch,
         pp_proxy_tensors=None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        # Route the eager decode input through the buffer registry (the same one
-        # capture/replay use) instead of reading the ForwardBatch directly.
-        # pdmux runs concurrent per-stream decode forwards that would race on
-        # the shared buffers, so it stays on the ForwardBatch.
         if not self.server_args.enable_pdmux:
             forward_batch = self._eager_decode_fb_view(forward_batch, pp_proxy_tensors)
         # Set extra arguments
@@ -3337,10 +3295,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 ret = self.piecewise_cuda_graph_runner.replay(forward_batch, **kwargs)
             return (ret, can_run_graph)
 
-        # Route the eager (non-piecewise) extend input through the prefill
-        # buffer registry. input_embeds / replace_* were already read off the
-        # batch above and are carried through the view. pdmux stays on the
-        # ForwardBatch (per-stream race on shared buffers), as in forward_decode.
         if not self.server_args.enable_pdmux:
             forward_batch = self._eager_extend_fb_view(forward_batch, pp_proxy_tensors)
 
@@ -3377,10 +3331,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # called from the idle path can re-read a prior batch's req_pool
         # indices and trigger SWA mapping use-after-free.
         if forward_batch.batch_size > 0:
-            # Padded idle batches go through the buffer registry like
-            # forward_decode. The unpadded case (bs == 0) stays on the empty
-            # ForwardBatch — there is nothing to fill and the
-            # forward_metadata=None reset below must be exact.
             if not self.server_args.enable_pdmux:
                 forward_batch = self._eager_decode_fb_view(
                     forward_batch, pp_proxy_tensors
@@ -3411,12 +3361,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         reinit_attn_backend: bool = False,
         forward_count: int = 1,
     ) -> LogitsProcessorOutput:
-        # Not routed through the eager buffer registry (unlike forward_decode /
-        # forward_extend / forward_idle): this path is stateful across calls —
-        # it advances forward_batch.split_index in place and is re-invoked with
-        # the same ForwardBatch — so it must read and mutate the real batch. An
-        # extract_buffer view is a per-call copy whose split_index update would
-        # never reach the caller's batch.
         if forward_batch.split_index == 0 or reinit_attn_backend:
             self.attn_backend.init_forward_metadata(forward_batch)
         next_split_index = min(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3114,7 +3114,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             device=self.device,
             max_bs=new_bs,
             max_num_token=new_tokens,
-            seq_len_fill_value=self.attn_backend.get_cuda_graph_seq_len_fill_value(),
+            # Eager applies no padding (raw == padded), so the seq_lens
+            # FILL_SENTINEL only initializes the [raw:padded] tail, which is
+            # empty and never read here. Use 0 rather than the backend's
+            # cuda-graph fill value, which non-cuda-graph backends
+            # (torch_native / torch_flex / intel_amx / ...) do not implement.
+            seq_len_fill_value=0,
             cache_loc_dtype=torch.int64,
             enable_mamba_track=(
                 self.server_args.enable_mamba_extra_buffer()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -26,7 +26,7 @@ import socket
 import threading
 import time
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
@@ -3144,7 +3144,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         """Return a ForwardBatch view whose shared input tensors are backed by
         the eager decode buffer registry. The batch is already DP-padded in
         place by ``_forward_raw``, so ``raw == padded`` (no capture-bucket
-        padding, no idle substitution)."""
+        padding, no idle substitution).
+
+        With ``SGLANG_EAGER_INPUT_NO_COPY`` set, skip the registry copy and wrap
+        the batch's own tensors in a fresh view instead (no per-iter D2D copy)."""
+        if envs.SGLANG_EAGER_INPUT_NO_COPY.get():
+            return replace(forward_batch)
         raw_bs = forward_batch.batch_size
         raw_num_tokens = forward_batch.input_ids.shape[0]
         registry = self._ensure_eager_decode_registry(raw_bs, raw_num_tokens)
@@ -3205,7 +3210,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     ) -> ForwardBatch:
         """Return a ForwardBatch view whose token-axis input tensors are backed
         by the eager prefill buffer registry. ``raw == padded`` (the batch is
-        already DP-padded in place by ``_forward_raw``)."""
+        already DP-padded in place by ``_forward_raw``).
+
+        With ``SGLANG_EAGER_INPUT_NO_COPY`` set, skip the registry copy and wrap
+        the batch's own tensors in a fresh view instead (no per-iter D2D copy)."""
+        if envs.SGLANG_EAGER_INPUT_NO_COPY.get():
+            return replace(forward_batch)
         raw_bs = forward_batch.batch_size
         raw_num_tokens = forward_batch.input_ids.shape[0]
         registry = self._ensure_eager_prefill_registry(raw_bs, raw_num_tokens)

--- a/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
+++ b/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
@@ -84,10 +84,9 @@ def _make_valued_batch(bs: int) -> ForwardBatch:
 
 
 class TestTboFilterBatchOnRegistryView(CustomTestCase):
-    """The eager forward path hands TBO a ForwardBatch view backed by the
-    CudaGraphBufferRegistry (extract_buffer), not the raw batch. TBO runs one
-    forward on that parent and splits it via filter_batch, so the buffer-backed
-    view must filter into children identically to the raw batch."""
+    """TBO runs one forward on the parent and splits via filter_batch, so an
+    eager registry-backed view must filter into children identically to the raw
+    batch."""
 
     def _registry_view(self, batch: ForwardBatch) -> ForwardBatch:
         from sglang.srt.model_executor.cuda_graph_buffer_registry import (

--- a/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
+++ b/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
@@ -67,5 +67,75 @@ class TestTboFilterBatchMarker(CustomTestCase):
         self.assertFalse(child.forward_metadata_replan_equivalent)
 
 
+def _make_valued_batch(bs: int) -> ForwardBatch:
+    # Distinct per-position values so a filtered slice is unambiguous.
+    return ForwardBatch(
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        batch_size=bs,
+        input_ids=torch.arange(bs, dtype=torch.long),
+        positions=torch.arange(bs, dtype=torch.long),
+        out_cache_loc=torch.arange(bs, dtype=torch.long) + 100,
+        req_pool_indices=torch.arange(bs, dtype=torch.long),
+        seq_lens=torch.arange(1, bs + 1, dtype=torch.int32),
+        seq_lens_cpu=torch.arange(1, bs + 1, dtype=torch.int32),
+        seq_lens_sum=int(torch.arange(1, bs + 1).sum()),
+        spec_info=None,
+    )
+
+
+class TestTboFilterBatchOnRegistryView(CustomTestCase):
+    """The eager forward path hands TBO a ForwardBatch view backed by the
+    CudaGraphBufferRegistry (extract_buffer), not the raw batch. TBO runs one
+    forward on that parent and splits it via filter_batch, so the buffer-backed
+    view must filter into children identically to the raw batch."""
+
+    def _registry_view(self, batch: ForwardBatch) -> ForwardBatch:
+        from sglang.srt.model_executor.cuda_graph_buffer_registry import (
+            build_decode_registry,
+        )
+
+        bs = batch.batch_size
+        reg = build_decode_registry(
+            device=torch.device("cpu"),
+            max_bs=bs,
+            max_num_token=bs,
+            seq_len_fill_value=1,
+            cache_loc_dtype=torch.int64,
+            register_global_num_tokens=False,  # eager decode config
+            share_pool=False,
+            source=None,
+        )
+        reg.fill_from(
+            batch, raw_bs=bs, padded_bs=bs, raw_num_tokens=bs, padded_num_tokens=bs
+        )
+        view = reg.extract_buffer(
+            padded_bs=bs, padded_num_tokens=bs, forward_batch_template=batch
+        )
+        # The buffered fields are registry buffers (distinct storage), same values.
+        self.assertNotEqual(view.input_ids.data_ptr(), batch.input_ids.data_ptr())
+        self.assertTrue(torch.equal(view.input_ids, batch.input_ids))
+        return view
+
+    def test_filter_registry_view_matches_raw_batch(self):
+        raw_child = _filter(_make_valued_batch(8), lo=0, hi=4)
+        view_child = _filter(self._registry_view(_make_valued_batch(8)), lo=0, hi=4)
+
+        self.assertEqual(view_child.batch_size, raw_child.batch_size)
+        for f in (
+            "input_ids",
+            "positions",
+            "out_cache_loc",
+            "seq_lens",
+            "seq_lens_cpu",
+            "req_pool_indices",
+        ):
+            self.assertTrue(
+                torch.equal(getattr(view_child, f), getattr(raw_child, f)),
+                f"{f} differs between raw-batch and registry-view filtering",
+            )
+        # filter_batch still resets the plan marker on the child.
+        self.assertFalse(view_child.forward_metadata_ready)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
+++ b/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
@@ -438,10 +438,8 @@ class TestMissingAndOptionalSlots(unittest.TestCase):
         )
 
     def test_extract_carries_none_for_absent_plain_slot(self):
-        # A plain copy-from-FB slot whose FB field is None this iter (e.g.
-        # mrope_positions on a non-multimodal batch) must be carried from the
-        # template as None, not exposed as the stale/zero slot buffer — handing
-        # the model a zeros tensor in place of None would change its behavior.
+        # A plain copy slot absent this iter (mrope on a non-multimodal batch)
+        # must be carried as None, not exposed as the stale/zero buffer.
         r = _make_registry(max_bs=4, max_num_tokens=8)
         r.register_slot(
             GraphSlot("input_ids", lambda bs, mt: (mt,), torch.int64, axis="tokens")
@@ -471,9 +469,8 @@ class TestMissingAndOptionalSlots(unittest.TestCase):
         self.assertIsNone(fb_view.mrope_positions)
 
     def test_extract_exposes_computed_slot_even_when_fb_field_none(self):
-        # A computed slot (copy_from_fb=False + post_fill) produces its own
-        # value; its buffer must be exposed even though the same-named FB field
-        # is None — the None-skip carry applies only to plain copy slots.
+        # A computed slot (copy_from_fb=False) is always exposed, even when its
+        # FB field is None — the None-skip carry applies only to plain copies.
         def _fill_two(buf, fb, ctx):
             buf.fill_(2)
 
@@ -951,12 +948,9 @@ class TestBuildDecodeRegistry(unittest.TestCase):
         self.assertEqual(int(src.num_token_non_padded.item()), 4)
 
     def test_register_global_num_tokens_false_carries_fb_values(self):
-        # The global_num_tokens_* slots are computed (copy_from_fb=False); with
-        # require_gathered_buffer=False their post_fill is a no-op, so the buffer
-        # stays zero, and extract_buffer always exposes computed slots. The eager
-        # decode path passes register_global_num_tokens=False so the values
-        # prepare_mlp_sync_batch already wrote onto the batch (DP attention)
-        # survive extract_buffer instead of being clobbered by the zero buffer.
+        # register_global_num_tokens=False (eager) excludes the computed
+        # global_num_tokens_* slots so the batch's DP values are carried, not
+        # clobbered by the zero buffer extract_buffer would otherwise expose.
         from sglang.srt.model_executor.cuda_graph_buffer_registry import (
             build_decode_registry,
         )
@@ -1309,10 +1303,8 @@ class TestBuildPrefillRegistry(unittest.TestCase):
         self.assertTrue(torch.all(ids[3:8] == 0))
 
     def test_register_input_embeds_false_keeps_mrope_carries_embeds(self):
-        # The eager extend path passes register_input_embeds=False: mrope is
-        # still registered (multimodal), but input_embeds is NOT — it must be
-        # carried from the FB (a real read input) rather than handed back as a
-        # reset-only zero buffer.
+        # register_input_embeds=False (eager): mrope stays registered but
+        # input_embeds is carried from the FB (a read input), not a zero buffer.
         from sglang.srt.model_executor.cuda_graph_buffer_registry import (
             build_prefill_registry,
         )

--- a/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
+++ b/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
@@ -437,6 +437,68 @@ class TestMissingAndOptionalSlots(unittest.TestCase):
             )
         )
 
+    def test_extract_carries_none_for_absent_plain_slot(self):
+        # A plain copy-from-FB slot whose FB field is None this iter (e.g.
+        # mrope_positions on a non-multimodal batch) must be carried from the
+        # template as None, not exposed as the stale/zero slot buffer — handing
+        # the model a zeros tensor in place of None would change its behavior.
+        r = _make_registry(max_bs=4, max_num_tokens=8)
+        r.register_slot(
+            GraphSlot("input_ids", lambda bs, mt: (mt,), torch.int64, axis="tokens")
+        )
+        r.register_slot(
+            GraphSlot(
+                "mrope_positions",
+                lambda bs, mt: (3, mt),
+                torch.int64,
+                axis="tokens",
+                slice_fn=lambda buf, n: buf[:, :n],
+            )
+        )
+        fb = _MiniForwardBatch(
+            batch_size=2,
+            input_ids=torch.arange(2, dtype=torch.int64),
+            mrope_positions=None,  # non-multimodal: FB doesn't carry it
+        )
+        r.fill_from(fb, raw_bs=2, padded_bs=2, raw_num_tokens=2, padded_num_tokens=2)
+        fb_view = r.extract_buffer(
+            padded_bs=2, padded_num_tokens=2, forward_batch_template=fb
+        )
+        # input_ids was present -> buffer-backed; mrope absent -> carried None.
+        self.assertEqual(
+            fb_view.input_ids.data_ptr(), r.get_slot("input_ids").buffer.data_ptr()
+        )
+        self.assertIsNone(fb_view.mrope_positions)
+
+    def test_extract_exposes_computed_slot_even_when_fb_field_none(self):
+        # A computed slot (copy_from_fb=False + post_fill) produces its own
+        # value; its buffer must be exposed even though the same-named FB field
+        # is None — the None-skip carry applies only to plain copy slots.
+        def _fill_two(buf, fb, ctx):
+            buf.fill_(2)
+
+        r = _make_registry(max_bs=4, max_num_tokens=8)
+        r.register_slot(
+            GraphSlot(
+                "global_num_tokens_gpu",
+                lambda bs, mt: (1,),
+                torch.int32,
+                axis="none",
+                copy_from_fb=False,
+                post_fill=_fill_two,
+            )
+        )
+        fb = _MiniForwardBatch(batch_size=2, global_num_tokens_gpu=None)
+        r.fill_from(fb, raw_bs=2, padded_bs=2, raw_num_tokens=2, padded_num_tokens=2)
+        fb_view = r.extract_buffer(
+            padded_bs=2, padded_num_tokens=2, forward_batch_template=fb
+        )
+        self.assertIsNotNone(fb_view.global_num_tokens_gpu)
+        self.assertEqual(
+            fb_view.global_num_tokens_gpu.data_ptr(),
+            r.get_slot("global_num_tokens_gpu").buffer.data_ptr(),
+        )
+
 
 class TestPostFillHook(unittest.TestCase):
     def test_post_fill_runs_after_copy(self):
@@ -888,6 +950,64 @@ class TestBuildDecodeRegistry(unittest.TestCase):
         # local = clamp(100 - rank*4, 0, 4) = 4  (NOT the raw FB copy of 100).
         self.assertEqual(int(src.num_token_non_padded.item()), 4)
 
+    def test_register_global_num_tokens_false_carries_fb_values(self):
+        # The global_num_tokens_* slots are computed (copy_from_fb=False); with
+        # require_gathered_buffer=False their post_fill is a no-op, so the buffer
+        # stays zero, and extract_buffer always exposes computed slots. The eager
+        # decode path passes register_global_num_tokens=False so the values
+        # prepare_mlp_sync_batch already wrote onto the batch (DP attention)
+        # survive extract_buffer instead of being clobbered by the zero buffer.
+        from sglang.srt.model_executor.cuda_graph_buffer_registry import (
+            build_decode_registry,
+        )
+
+        reg = build_decode_registry(
+            device=torch.device("cpu"),
+            max_bs=4,
+            max_num_token=8,
+            seq_len_fill_value=5,
+            cache_loc_dtype=torch.int64,
+            register_global_num_tokens=False,
+            share_pool=False,
+            source=None,
+        )
+        self.assertFalse(reg.has_slot("global_num_tokens_gpu"))
+        self.assertFalse(reg.has_slot("global_num_tokens_for_logprob_gpu"))
+
+        gnt = torch.tensor([37], dtype=torch.int32)
+        gntlp = torch.tensor([41], dtype=torch.int32)
+        fb = _MiniForwardBatch(
+            batch_size=2,
+            input_ids=torch.arange(2, dtype=torch.int64),
+            positions=torch.arange(2, dtype=torch.int64),
+            out_cache_loc=torch.arange(2, dtype=torch.int64),
+            req_pool_indices=torch.zeros(2, dtype=torch.int64),
+            seq_lens=torch.full((2,), 5, dtype=torch.int32),
+            seq_lens_cpu=torch.full((2,), 5, dtype=torch.int32),
+            global_num_tokens_gpu=gnt,
+            global_num_tokens_for_logprob_gpu=gntlp,
+        )
+        reg.fill_from(fb, raw_bs=2, padded_bs=2, raw_num_tokens=2, padded_num_tokens=2)
+        fb_view = reg.extract_buffer(
+            padded_bs=2, padded_num_tokens=2, forward_batch_template=fb
+        )
+        # Carried from the batch (same tensors), not a zero registry buffer.
+        self.assertIs(fb_view.global_num_tokens_gpu, gnt)
+        self.assertIs(fb_view.global_num_tokens_for_logprob_gpu, gntlp)
+
+        # Default (graph path) still registers the computed slots.
+        reg2 = build_decode_registry(
+            device=torch.device("cpu"),
+            max_bs=4,
+            max_num_token=8,
+            seq_len_fill_value=5,
+            cache_loc_dtype=torch.int64,
+            share_pool=False,
+            source=None,
+        )
+        self.assertTrue(reg2.has_slot("global_num_tokens_gpu"))
+        self.assertTrue(reg2.has_slot("global_num_tokens_for_logprob_gpu"))
+
     def test_source_with_ngram_registers_structured_slots(self):
         from sglang.srt.model_executor.cuda_graph_buffer_registry import (
             build_decode_registry,
@@ -1187,6 +1307,44 @@ class TestBuildPrefillRegistry(unittest.TestCase):
             torch.equal(ids[:3], torch.tensor([1, 2, 3], dtype=torch.int64))
         )
         self.assertTrue(torch.all(ids[3:8] == 0))
+
+    def test_register_input_embeds_false_keeps_mrope_carries_embeds(self):
+        # The eager extend path passes register_input_embeds=False: mrope is
+        # still registered (multimodal), but input_embeds is NOT — it must be
+        # carried from the FB (a real read input) rather than handed back as a
+        # reset-only zero buffer.
+        from sglang.srt.model_executor.cuda_graph_buffer_registry import (
+            build_prefill_registry,
+        )
+
+        reg = build_prefill_registry(
+            device=torch.device("cpu"),
+            max_bs=2,
+            max_num_token=8,
+            cache_loc_dtype=torch.int64,
+            is_multimodal=True,
+            hidden_size=4,
+            embed_dtype=torch.float32,
+            register_input_embeds=False,
+            share_pool=False,
+            source=None,
+        )
+        self.assertTrue(reg.has_slot("mrope_positions"))
+        self.assertFalse(reg.has_slot("input_embeds"))
+        # extract_buffer carries the FB's real input_embeds (not a zero buffer).
+        embeds = torch.randn(3, 4)
+        fb = _MiniForwardBatch(
+            batch_size=1,
+            input_ids=torch.tensor([1, 2, 3], dtype=torch.int64),
+            positions=torch.tensor([0, 1, 2], dtype=torch.int64),
+            out_cache_loc=torch.tensor([7, 8, 9], dtype=torch.int64),
+            input_embeds=embeds,
+        )
+        reg.fill_from(fb, raw_bs=1, padded_bs=1, raw_num_tokens=3, padded_num_tokens=3)
+        fb_view = reg.extract_buffer(
+            padded_bs=1, padded_num_tokens=3, forward_batch_template=fb
+        )
+        self.assertIs(fb_view.input_embeds, embeds)
 
 
 class TestFillOncePolicy(unittest.TestCase):


### PR DESCRIPTION
## Motivation

The CUDA graph capture and replay paths already assemble their forward input tensors through `CudaGraphBufferRegistry` (`fill_from` → registry buffers), but the eager forward path (`forward_decode` / `forward_extend` / `forward_idle`) still reads its tensors straight off the `ForwardBatch`. That leaves two parallel ways to build forward inputs, and the registry's `extract_buffer` API has no caller at all.

This PR routes the eager path through the same registry, so the eager, capture, and replay paths share a single input-buffer path and `extract_buffer` gains a real consumer. The change is behavior-preserving.

## Modifications

**`CudaGraphBufferRegistry`**
- `extract_buffer` now carries an absent `ForwardBatch` field (e.g. `mrope_positions` on a non-multimodal batch, `encoder_lens` on a decoder-only model) through from the template instead of exposing the slot's stale / zero buffer. `fill_from` already skips copying such a field, so its buffer holds no meaningful data, and handing the model a zeros tensor where it expects `None` would change behavior. Computed slots (`post_fill` / `copy_from_fb=False`) are still always exposed. `extract_buffer` previously had no caller, so capture / replay are unaffected.
- `build_prefill_registry` gains a `register_input_embeds` flag (default `True`, unchanged for the piecewise / breakable graph paths, where the model writes the embeds into a reset-only in-graph buffer). The eager extend path passes `False` so `input_embeds` — a real read input there — is carried from the batch.
- `build_decode_registry` gains a `register_global_num_tokens` flag (default `True`). The `global_num_tokens_*` slots are computed (`copy_from_fb=False`) and `extract_buffer` always exposes them; with `require_gathered_buffer=False` their `post_fill` is a no-op and the buffer stays zero. The eager path, where `prepare_mlp_sync_batch` has already populated `global_num_tokens_*` on the batch (DP attention), passes `False` so the batch values are carried instead of overwritten by a zero buffer.

**`ModelRunner`**
- `forward_decode` / `forward_extend` / `forward_idle` build a `ForwardBatch` view backed by the registry and run on it. The registry is built lazily per runner and grown on demand: eager batches can exceed the cuda-graph capture buckets, and eager has no graph address burn-in, so reallocation is safe. Decode / idle use a bs-axis registry; extend uses a token-axis one.
- The batch is already DP-padded in place before these methods run (`raw == padded`); fields that are not buffered (`input_embeds`, `seq_lens`, `global_num_tokens_*`, `spec_info`, …) are carried from the batch unchanged.
- `pdmux` keeps reading the `ForwardBatch` directly — its concurrent per-stream forwards would race on the shared buffers.
- `forward_idle` only routes padded (`bs > 0`) batches; the `bs == 0` case keeps its exact `forward_metadata=None` reset.
- `forward_split_prefill` stays on the `ForwardBatch`: it advances `split_index` across repeated calls, which a per-call view copy cannot propagate back to the caller.
- Two-batch overlap is unaffected: it runs one forward on the parent and splits it via `filter_batch`, so the buffer-backed view filters into children identically to the raw batch.
- **`SGLANG_EAGER_INPUT_NO_COPY`** (default off): an escape hatch from the per-iter `fill_from` copy on the hot decode path. The copy buys a single input path, not cross-stream isolation (`fill_from` does no stream handoff), so when this is set the eager helpers skip the registry and wrap the batch's own tensors in a fresh view (`dataclasses.replace`) instead.

## Accuracy Tests

The eager path reads the same tensor values, now from registry buffers rather than the `ForwardBatch`, so model math is unchanged.

- **Greedy generation is byte-identical to `main`** (deterministic, `temperature=0`, batched prompts) in eager mode (`--disable-cuda-graph`, which routes both decode and extend through the changed paths): `Qwen2.5-0.5B-Instruct`, `Qwen3-4B`, and `Qwen3-VL-2B-Instruct` (multimodal — exercises the `register_input_embeds=False` extend path), plus `Qwen2.5-0.5B-Instruct` with cuda graph **on** (graph decode + eager extend). `SGLANG_EAGER_INPUT_NO_COPY=1` is likewise byte-identical to both the default path and `main`.
- New CPU unit tests: `test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py` (the `extract_buffer` None-carry behavior, `register_input_embeds=False`, and `register_global_num_tokens=False`) and `test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py` (a registry-backed view filters into TBO children identically to the raw batch) — `42 passed`.
- DP-attention end-to-end (`--enable-dp-attention`) — the only condition under which the `global_num_tokens_*` carry matters — should be validated on the GPU CI suites. (Locally, the eager DP prefill path crashes in `memory_pool.set_kv_buffer` (`k.view` vs `.reshape`) on this build; the same crash reproduces on `main`, so it is pre-existing and unrelated to this change.)

## Speed Tests and Profiling

By default the eager path now does one extra device-to-device copy of the shared input tensors per forward (`fill_from`) plus a `dataclasses.replace` to build the view. As this is the latency-sensitive decode path, a TPOT comparison (e.g. `bench_one_batch_server` at small batch sizes) is worth running on GPU; I have not benchmarked it locally. `SGLANG_EAGER_INPUT_NO_COPY=1` removes the copy for deployments that want to avoid it. Steady-state behavior is otherwise unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27073752136](https://github.com/sgl-project/sglang/actions/runs/27073752136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27073843059](https://github.com/sgl-project/sglang/actions/runs/27073843059)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->