### PR TITLE
Add SWA HiCache load-back host lock regression test

### DIFF
--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -3271,8 +3271,8 @@ class UnifiedRadixCacheSuite:
             swa_comp.commit_hicache_transfer(
                 chain[-1], CacheTransferPhase.LOAD_BACK, transfers=transfers
             )
-            tree.dec_host_lock_ref(chain[-1], host_lock.to_dec_params())
             released = True
+            tree.dec_host_lock_ref(chain[-1], host_lock.to_dec_params())
 
             offset = 0
             for n in loaded_nodes:

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -3227,6 +3227,69 @@ class UnifiedRadixCacheSuite:
             n_swa,
         )
 
+    def test_hicache_swa_load_back_host_lock_protects_pending_nodes(self):
+        """SWA LOAD_BACK must keep selected host chunks alive until commit.
+
+        PoolTransfer records nodes_to_load before the H2D transfer commits. If a
+        selected host-only SWA node stays evictable in that window, host eviction
+        can clear its host_value and LOAD_BACK commit later hits len(None).
+        """
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA")
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only path keeps the chain construction simple")
+
+        tree, allocator, _, chain, window_pages = self._swa_finalize_setup()
+        loaded_nodes = chain[-window_pages:]
+        for n in loaded_nodes:
+            self._set_aux_host_tombstone(tree, n, ComponentType.SWA)
+
+        swa_comp = tree.components[ComponentType.SWA]
+        transfers = swa_comp.build_hicache_transfers(
+            chain[-1], CacheTransferPhase.LOAD_BACK
+        )
+        self.assertIsNotNone(transfers)
+        xfer = transfers[0]
+        self.assertEqual(xfer.nodes_to_load, loaded_nodes)
+        n_swa = int(xfer.host_indices.numel())
+
+        host_lock = tree.inc_host_lock_ref(chain[-1])
+        released = False
+        try:
+            for n in loaded_nodes:
+                cd = n.component_data[ComponentType.SWA]
+                self.assertGreater(cd.host_lock_ref, 0)
+                self.assertFalse(tree.host_lru_lists[ComponentType.SWA].in_list(n))
+
+            tree.evict_host(n_swa * 2, ComponentType.SWA)
+            for n in loaded_nodes:
+                self.assertIsNotNone(n.component_data[ComponentType.SWA].host_value)
+
+            new_swa = allocator.swa_attn_allocator.alloc(n_swa)
+            self.assertIsNotNone(new_swa)
+            xfer.device_indices = new_swa
+            swa_comp.commit_hicache_transfer(
+                chain[-1], CacheTransferPhase.LOAD_BACK, transfers=transfers
+            )
+            tree.dec_host_lock_ref(chain[-1], host_lock.to_dec_params())
+            released = True
+
+            offset = 0
+            for n in loaded_nodes:
+                cd = n.component_data[ComponentType.SWA]
+                self.assertIsNotNone(cd.value)
+                self.assertEqual(cd.host_lock_ref, 0)
+                chunk_len = int(cd.value.numel())
+                self.assertEqual(
+                    cd.value.tolist(),
+                    new_swa[offset : offset + chunk_len].tolist(),
+                )
+                offset += chunk_len
+            self.assertEqual(offset, n_swa)
+        finally:
+            if not released:
+                tree.dec_host_lock_ref(chain[-1], host_lock.to_dec_params())
+
     def _swa_anchor_chain_tokens(self, num_pages: int) -> list[int]:
         """Reproduce the token sequence used by _build_chain_pages."""
         tokens: list[int] = []


### PR DESCRIPTION
## What

Add regression coverage for the SWA HiCache `LOAD_BACK` host-lock behavior and document the failure mode it prevents.

A `LOAD_BACK` transfer records `nodes_to_load` before the H2D transfer commits. Any SWA host chunk selected by that transfer must stay alive until `commit_hicache_transfer()` consumes it. If the selected host-only chunk remains evictable, host eviction can clear `cd.host_value`, and commit later crashes when it reaches `len(cd_n.host_value)`.

## Runtime Fix Covered

Current `main` already contains the runtime host-side SWA lock path that this PR covers. The contract is:

- `inc_host_lock_ref(..., lock_host=True)` protects SWA host-only chunks selected for the trailing sliding window.
- Protected SWA host chunks are removed from the SWA host LRU while `host_lock_ref > 0`.
- `dec_host_lock_ref(..., lock_host=True)` releases the host lock and reinserts host-only chunks into the SWA host LRU when safe.

This PR adds the focused unit regression test for that behavior. No extra runtime diff is needed on top of current `main` because the runtime path is already present there.

## Failure Signature

The crash shape seen before the host lock protection is:

```text
Scheduler hit an exception: Traceback (most recent call last):
TypeError: object of type 'NoneType' has no len()
```

The failing path is the SWA `LOAD_BACK` commit path where `cd_n.host_value` was cleared after the transfer selected the node but before commit consumed it.

Debug instrumentation on the failing path showed the selected SWA node was unprotected at commit time:

```text
[SGLANG_DEBUG_SWA_LOADBACK_HOST_VALUE_NONE] ... host_lock_ref=0 device_value_present=False
```

## Regression Test

The new test constructs a SWA chain with host-only tombstoned chunks in the trailing window, builds the same `LOAD_BACK` transfer shape used by runtime, acquires the host lock, forces host eviction pressure, and verifies:

- selected SWA host chunks have `host_lock_ref > 0`;
- selected chunks are removed from the SWA host LRU while locked;
- host eviction cannot clear selected `host_value` before commit;
- `commit_hicache_transfer()` restores SWA device values and rebuilds the loaded chunk mapping;
- host locks are released exactly once in cleanup.

## Stress Validation

Sanitized distributed stress validation was run against the same workload shape with and without the host-lock protection:

| Case | Result |
|---|---|
| no host-lock fix, natural c540 | failed with `TypeError: object of type 'NoneType' has no len()` |
| no host-lock fix, natural c640 | failed with the same `NoneType` error |
| no host-lock fix, debug delay0 | failed; debug marker showed `host_lock_ref=0` and `device_value_present=False` |
| no host-lock fix, debug delay100 | failed; same debug marker before the `NoneType` crash |
| with host-lock fix, natural c540 | completed with no server exception |
| with host-lock fix, natural c640 | completed with no server exception |
| with host-lock fix, debug delay100 | completed with no server exception while logging expected `LOAD_BACK_DELAY` events |

The stress configuration intentionally increased host-cache churn to make the race easier to reproduce, so its latency numbers should not be used as the performance baseline for the fix.

Healthy A/B performance runs showed no meaningful overhead from the host-lock fix:

| Case | Cache hit | Server output TPS | TTFT p50 / p95 / p99 |
|---|---:|---:|---|
| no host-lock fix, SWA ratio 0.05 | 96.5% | 10090.3 | 2.570 / 7.764 / 11.038s |
| with host-lock fix, SWA ratio 0.05 | 96.5% | 10168.9 | 2.321 / 8.030 / 10.806s |
| no host-lock fix, SWA ratio 0.10 | 96.5% | 9703.4 | 3.282 / 9.810 / 13.982s |
| with host-lock fix, SWA ratio 0.10 | 96.6% | 9979.6 | 3.144 / 9.166 / 13.241s |

## Testing

Previously run in a GPU dev environment:

```text
python3 -m pytest test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py -k hicache_swa_load_back_host_lock_protects_pending_nodes -q
8 passed, 11 skipped, 1608 deselected

python3 -m pytest test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py -k "hicache_swa and (load_back or host_lock or commit_load_back)" -q
28 passed, 67 skipped, 1532 deselected
```

After the cleanup-order update in this PR, I also ran a syntax check:

```text
python3 -m py_compile test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
```

A non-container local pytest attempt could not collect because `torch` was not installed in that environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27086283946](https://github.com/sgl-project/sglang/actions/runs/27086283946)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27086283896](https://github.com/sgl-project/sglang/actions/runs/27086283896)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->