### PR TITLE
Temporarily disable test_self_e2e_pd_perturb in CI

### DIFF
--- a/test/registered/kv_canary/test_self_e2e_pd_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pd_perturb.py
@@ -7,7 +7,12 @@ from sglang.srt.kv_canary.perturb.config import TargetGroupKind
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kv_canary.pd_fixture import CanaryPDFixture
 
-register_cuda_ci(est_time=180, stage="extra-a", runner_config="2-gpu-large")
+register_cuda_ci(
+    est_time=180,
+    stage="extra-a",
+    runner_config="2-gpu-large",
+    disabled="Temporarily disabled",
+)
 
 
 class _PDPerturbBase(CanaryPDFixture):


### PR DESCRIPTION
next: https://github.com/sgl-project/sglang/pull/27426









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27055871062](https://github.com/sgl-project/sglang/actions/runs/27055871062)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27055870994](https://github.com/sgl-project/sglang/actions/runs/27055870994)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->