### PR TITLE
Fix flaky test_self_e2e_pd_perturb

### DIFF
--- a/python/sglang/test/kv_canary/pd_fixture.py
+++ b/python/sglang/test/kv_canary/pd_fixture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import ClassVar, Literal, Optional
 
 from sglang.srt.kv_canary.config import CanaryMode
@@ -61,10 +62,19 @@ class CanaryPDFixture(CanaryViolationAssertMixin, PDDisaggregationServerBase):
         assert_all_success: bool = True,
         max_new_tokens: int = 100,
         timeout: float = 60.0,
+        distinct_prompts: bool = False,
     ) -> list[dict]:
+        if distinct_prompts:
+            # Diverge at the very first token (request index before the per-call
+            # nonce) so requests share no radix-dedupable prefix beyond a
+            # tokenizer-added BOS, and retries never hit earlier attempts' cache.
+            nonce = uuid.uuid4().hex[:8]
+            prompts = [f"{i} {nonce} {_SHORT_PROMPT_BODY}" for i in range(n)]
+        else:
+            prompts = [_SHORT_PROMPT_BODY] * n
         results = post_parallel_generate(
             url=self.lb_url + "/generate",
-            prompts=[_SHORT_PROMPT_BODY] * n,
+            prompts=prompts,
             max_new_tokens=max_new_tokens,
             timeout=timeout,
         )

--- a/test/registered/kv_canary/test_self_e2e_pd_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pd_perturb.py
@@ -13,6 +13,18 @@ register_cuda_ci(est_time=180, stage="extra-a", runner_config="2-gpu-large")
 class _PDPerturbBase(CanaryPDFixture):
     target_group: ClassVar[TargetGroupKind]
 
+    # The parallel requests share one prompt, and P-side radix caching rewrites
+    # each request's req_to_token row to the first-inserted (canonical) copy's
+    # slots in cache_unfinished_req BEFORE send_kv_chunk snapshots the indices.
+    # A flip on a non-canonical duplicate slot is then freed without ever being
+    # transferred or re-verified, so the asserted D-side violation flakes away.
+    # Disable the radix cache so every request transfers exactly the slots the
+    # post-forward perturb can hit.
+    extra_server_args: ClassVar[tuple[str, ...]] = (
+        *CanaryPDFixture.extra_server_args,
+        "--disable-radix-cache",
+    )
+
     @classmethod
     def setUpClass(cls) -> None:
         if cls is _PDPerturbBase:

--- a/test/registered/kv_canary/test_self_e2e_pd_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pd_perturb.py
@@ -13,18 +13,6 @@ register_cuda_ci(est_time=180, stage="extra-a", runner_config="2-gpu-large")
 class _PDPerturbBase(CanaryPDFixture):
     target_group: ClassVar[TargetGroupKind]
 
-    # The parallel requests share one prompt, and P-side radix caching rewrites
-    # each request's req_to_token row to the first-inserted (canonical) copy's
-    # slots in cache_unfinished_req BEFORE send_kv_chunk snapshots the indices.
-    # A flip on a non-canonical duplicate slot is then freed without ever being
-    # transferred or re-verified, so the asserted D-side violation flakes away.
-    # Disable the radix cache so every request transfers exactly the slots the
-    # post-forward perturb can hit.
-    extra_server_args: ClassVar[tuple[str, ...]] = (
-        *CanaryPDFixture.extra_server_args,
-        "--disable-radix-cache",
-    )
-
     @classmethod
     def setUpClass(cls) -> None:
         if cls is _PDPerturbBase:
@@ -49,7 +37,14 @@ class _PDPerturbBase(CanaryPDFixture):
     ) -> None:
         # send_parallel_short_requests defaults to max_new_tokens=100 so D-side runs
         # decode forwards that exercise canary verify on the transferred prefix.
-        self.send_parallel_short_requests(n=4)
+        #
+        # distinct_prompts is required for the violation to surface reliably:
+        # with a shared prompt, P-side radix caching rewrites each request's
+        # req_to_token row to the first-inserted (canonical) copy's slots in
+        # cache_unfinished_req BEFORE send_kv_chunk snapshots the indices, so a
+        # flip on a deduped duplicate slot is freed untransferred and never
+        # re-verified on either side.
+        self.send_parallel_short_requests(n=4, distinct_prompts=True)
         # D-side: first decode forward re-verifies the transferred prefix slots,
         # so the flip MUST surface as real_kv_hash violation.
         self.assert_per_forward_violation_reported(

--- a/test/registered/kv_canary/test_self_e2e_pd_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pd_perturb.py
@@ -7,12 +7,7 @@ from sglang.srt.kv_canary.perturb.config import TargetGroupKind
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kv_canary.pd_fixture import CanaryPDFixture
 
-register_cuda_ci(
-    est_time=180,
-    stage="extra-a",
-    runner_config="2-gpu-large",
-    disabled="Temporarily disabled",
-)
+register_cuda_ci(est_time=180, stage="extra-a", runner_config="2-gpu-large")
 
 
 class _PDPerturbBase(CanaryPDFixture):

--- a/test/registered/kv_canary/test_self_e2e_pd_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pd_perturb.py
@@ -7,7 +7,12 @@ from sglang.srt.kv_canary.perturb.config import TargetGroupKind
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kv_canary.pd_fixture import CanaryPDFixture
 
-register_cuda_ci(est_time=180, stage="extra-a", runner_config="2-gpu-large")
+register_cuda_ci(
+    est_time=180,
+    stage="extra-a",
+    runner_config="2-gpu-large",
+    disabled="Temporarily disabled",
+)
 
 
 class _PDPerturbBase(CanaryPDFixture):


### PR DESCRIPTION
## Motivation

`test_self_e2e_pd_perturb.py` flaked in CI (e.g. https://github.com/sgl-project/sglang/actions/runs/27040516652/job/79815267923): the P-side perturb fired, but neither side ever reported the asserted `verify_real_kv_hash` violation (decode-side canary stats showed `violations=0` throughout, including the in-test retry). The test was temporarily disabled in #27425; this PR re-enables it with the flake fixed.

## Root cause

The parallel test requests share one prompt. On the prefill server, `process_batch_result_disagg_prefill` calls `maybe_cache_unfinished_req` **before** `send_kv_chunk`. `RadixCache.cache_unfinished_req` dedups the shared prefix against the first-inserted (canonical) copy: it frees the duplicate KV slots and rewrites the request's `req_to_token` row to the canonical slots. `send_kv_chunk` then snapshots the rewritten row, so every request transfers the canonical copy's slots — confirmed by temporarily logging the per-request transfer indices: all 4 requests sent the identical slot range even though the batch computed each request's KV separately.

The `real_kv_post_forward` perturb flips a byte in a slot picked from the prefill forward's `out_cache_loc`. When the flip lands on a non-canonical duplicate, the corrupted slot is freed without ever being transferred or re-verified, so neither side reports a violation. Whether the test passed was a race on batch shape:

- the common 1+3 batch split always corrupts the canonical copy first → pass
- a 4-request single batch (the failing CI run) passes only with p=1/4
- the radix-warm in-test retry always fails (the freshly recomputed last token is deduped on insert)

## Fix

Make the parallel requests use distinct prompts: each prompt starts with the request index followed by a per-call nonce, so requests share no radix-dedupable prefix beyond a tokenizer-added BOS, and method retries never hit earlier attempts' cache. `cache_unfinished_req` then has nothing to dedup, `send_kv_chunk` transfers each request's own slots, and any post-forward flip stays observable on the decode side — while the radix cache stays enabled like in production.

(An earlier commit in this PR deflaked by disabling the radix cache instead; it was superseded by the distinct-prompts approach to keep the radix-enabled PD transfer path covered. `test_self_e2e_pd_baseline.py` still uses identical prompts, so the canonical-dedup radix-sharing path also stays covered there.)

## Validation

- Before the fix: reproduced the exact CI failure signature (perturb fires, both sides silent) on fresh 2-GPU servers in ~1/4 of runs.
- After the fix, fresh-server loops on 2-GPU H200: **15/15 full-file runs + 30/30 `TestPDPerturbSwaFull`-only runs, all green**.
- CI cross-check via `/rerun-test test_self_e2e_pd_perturb.py` on this PR (2-gpu-h100 runners, the original flake environment): **4/5 runs green**; the one failure is an unrelated infra race — the decode server hit `[Errno 98] address already in use` while the file relaunches servers between its two test classes, before any canary assertion ran (`TestPDPerturbMhaFull` in that same run passed with violations firing). That server-relaunch port race is a pre-existing fixture issue independent of this fix.
