### PR TITLE
[debug] Register #27338 EAGLE draft kv_indices revert in pr_fix_toggle

### DIFF
--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -66,6 +66,17 @@ patches:
 """
 
 
+_PR_REVERT_YAML_27338 = """
+patches:
+  - target: sglang.srt.layers.attention.flashinfer_backend.FlashInferMultiStepDraftBackend.init_cuda_graph_state
+    edits:
+      - match: |
+          (self.speculative_num_steps, max_bs * self.topk * self.max_context_len),
+        replacement: |
+          (self.speculative_num_steps, max_bs * self.max_context_len),
+"""
+
+
 _PR_REVERT_YAML_27360 = """
 patches:
   - target: sglang.srt.layers.attention.flashattention_backend.FlashAttentionBackend._apply_cuda_graph_metadata
@@ -79,6 +90,7 @@ patches:
 _PR_FIX_REVERT_YAML: Dict[int, str] = {
     25015: _PR_REVERT_YAML_25015,
     26329: _PR_REVERT_YAML_26329,
+    27338: _PR_REVERT_YAML_27338,
     27360: _PR_REVERT_YAML_27360,
 }
 


### PR DESCRIPTION
`pr_fix_toggle` lets `SGLANG_DEBUG_REVERT_PR=<n>` reverse-apply a merged PR's fix for regression A/B testing. #27338 (EAGLE draft cuda-graph `kv_indices` topk under-allocation) wasn't registered. This adds it: reverting drops the `* self.topk` from the buffer alloc, so the always-on size invariant #27338 added in `common_template` trips deterministically.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27056231459](https://github.com/sgl-project/sglang/actions/runs/27056231459)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27056231414](https://github.com/sgl-project/sglang/actions/runs/27056231414)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->