### PR TITLE
fix: close MiniMax M2 streaming tool-call blocks

### DIFF
--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -264,6 +264,15 @@ class MinimaxM2Detector(BaseFormatDetector):
 
             # We're in a tool call, try to parse function name if not sent yet
             if not self._function_name_sent:
+                end_pos = self._buf.find(self.tool_call_end_token)
+                next_function_pos = self._buf.find(self.tool_call_prefix)
+                if end_pos != -1 and (
+                    next_function_pos == -1 or end_pos < next_function_pos
+                ):
+                    self._buf = self._buf[end_pos + len(self.tool_call_end_token) :]
+                    self._reset_streaming_state(False)
+                    continue
+
                 # Look for function name pattern: <invoke name=name>
                 function_match = re.search(r"<invoke name=\"([^>]+)\">", self._buf)
                 if function_match:

--- a/test/registered/unit/function_call/test_minimax_m2_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m2_detector.py
@@ -1,0 +1,89 @@
+"""Unit tests for the MiniMax M2 function-call detector."""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMinimaxM2Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="lookup",
+                    parameters={
+                        "type": "object",
+                        "properties": {"item": {"type": "string"}},
+                    },
+                ),
+            ),
+        ]
+
+    def test_streaming_closes_tool_call_before_normal_text(self):
+        detector = MinimaxM2Detector()
+
+        first = detector.parse_streaming_increment(
+            'before <minimax:tool_call><invoke name="search">'
+            '<parameter name="query">cats</parameter></invoke>',
+            self.tools,
+        )
+        self.assertEqual(first.normal_text, "before ")
+        self.assertEqual(
+            [(call.tool_index, call.name, call.parameters) for call in first.calls],
+            [(0, "search", ""), (0, None, '{"query": "cats"'), (0, None, "}")],
+        )
+
+        second = detector.parse_streaming_increment(
+            "</minimax:tool_call> after", self.tools
+        )
+        self.assertEqual(second.normal_text, " after")
+        self.assertEqual(second.calls, [])
+        self.assertEqual(detector._buf, "")
+        self.assertFalse(detector._in_tool_call)
+
+    def test_streaming_preserves_multi_invoke_tool_call_block(self):
+        detector = MinimaxM2Detector()
+
+        first = detector.parse_streaming_increment(
+            'before <minimax:tool_call><invoke name="search">'
+            '<parameter name="query">cats</parameter></invoke><in',
+            self.tools,
+        )
+        self.assertEqual(first.normal_text, "before ")
+        self.assertEqual(
+            [(call.tool_index, call.name, call.parameters) for call in first.calls],
+            [(0, "search", ""), (0, None, '{"query": "cats"'), (0, None, "}")],
+        )
+
+        second = detector.parse_streaming_increment(
+            'voke name="lookup"><parameter name="item">dogs</parameter></invoke>'
+            "</minimax:tool_call> after",
+            self.tools,
+        )
+        self.assertEqual(second.normal_text, " after")
+        self.assertEqual(
+            [(call.tool_index, call.name, call.parameters) for call in second.calls],
+            [(1, "lookup", ""), (1, None, '{"item": "dogs"'), (1, None, "}")],
+        )
+        self.assertEqual(detector._buf, "")
+        self.assertFalse(detector._in_tool_call)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Consume `</minimax:tool_call>` in `MinimaxM2Detector.parse_streaming_increment` when the block close marker arrives before another `<invoke ...>` block.
- Reset streaming state back to normal text mode after the MiniMax tool-call block is closed.
- Add a focused regression test where `</minimax:tool_call>` and trailing normal text arrive in the chunk after `</invoke>`.

## Motivation

After streaming a complete MiniMax M2 `<invoke ...>...</invoke>` block, the detector reset its per-function state with `still_in_tool_call=True`. If the remaining buffer only contained `</minimax:tool_call>` followed by normal text, the parser kept waiting for another `<invoke ...>` and never consumed the block close marker. As a result, trailing normal text stayed buffered and was not emitted on later streaming increments.

The fix handles the closing MiniMax tool-call marker before searching for the next function invocation. If another `<invoke ...>` appears before the close marker, existing multi-invoke behavior is preserved.

Refs #20865.

## Test Plan

```bash
PYTHONPATH=python pytest \
  test/registered/unit/function_call/test_minimax_m2_detector.py \
  test/registered/unit/function_call/test_unknown_tool_name.py -q
```

Result:

```text
3 passed, 1 warning in 2.32s
```

Additional checks:

```bash
python -m py_compile \
  python/sglang/srt/function_call/minimax_m2.py \
  test/registered/unit/function_call/test_minimax_m2_detector.py

ruff format --check \
  python/sglang/srt/function_call/minimax_m2.py \
  test/registered/unit/function_call/test_minimax_m2_detector.py

ruff check \
  python/sglang/srt/function_call/minimax_m2.py \
  test/registered/unit/function_call/test_minimax_m2_detector.py
```























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27080659943](https://github.com/sgl-project/sglang/actions/runs/27080659943)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27080659872](https://github.com/sgl-project/sglang/actions/runs/27080659872)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->