### PR TITLE
[diffusion] Fix LingBot-World crash on camera control with ulysses>1

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/lingbot_world.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/lingbot_world.py
@@ -89,6 +89,18 @@ from sglang.srt.utils import add_prefix
 logger = init_logger(__name__)
 _is_cuda = current_platform.is_cuda()
 
+
+def _safe_tensor_version(tensor: torch.Tensor) -> int:
+    """Return ``tensor._version``, or ``0`` for inference-mode tensors.
+
+    Tensors created under ``torch.inference_mode`` do not track a version
+    counter, so reading ``tensor._version`` raises ``RuntimeError``. The value
+    is only used as a cache-invalidation hint for the camera conditioner, so a
+    constant fallback is safe for such tensors.
+    """
+    return 0 if tensor.is_inference() else tensor._version
+
+
 if _use_aiter:
     from aiter.ops.rope import rope_cached_2c_fwd_inplace
 
@@ -977,7 +989,7 @@ class CausalLingBotWorldTransformerBlock(CausalWanTransformerBlock):
             c2ws_plucker_emb.dtype,
             c2ws_plucker_emb.device.type,
             c2ws_plucker_emb.device.index,
-            c2ws_plucker_emb._version,
+            _safe_tensor_version(c2ws_plucker_emb),
         )
         if cache.get("source_key") != source_key:
             cache.clear()
@@ -1400,7 +1412,7 @@ class CausalLingBotWorldTransformer3DModel(CausalWanTransformer3DModel):
             c2ws_plucker_emb.dtype,
             c2ws_plucker_emb.device.type,
             c2ws_plucker_emb.device.index,
-            c2ws_plucker_emb._version,
+            _safe_tensor_version(c2ws_plucker_emb),
         )
         if cache.get("source_key") != source_key:
             cache.clear()


### PR DESCRIPTION
### Motivation

Serving LingBot-World (`robbyant/lingbot-world-fast-diffusers`, `LingBotWorldCausalDMDPipeline`) with the documented realtime config — camera control + `--ulysses-degree 4` — crashes on **every** generated chunk:

```
File ".../models/dits/lingbot_world.py", line 1403, in _prepare_cam_conditioner_scale_shifts
    c2ws_plucker_emb._version,
RuntimeError: Inference tensors do not track version counter.
```

The causal transformer caches the camera-conditioner scale/shift keyed on the c2ws plucker embedding's version counter (`_prepare_cam_conditioner_scale_shifts` and `_cam_conditioner_scale_shift`). On the realtime causal path the embedding is an **inference-mode tensor**, and reading `tensor._version` on such tensors raises. The cached cam-conditioner path is only taken when `enable_sequence_shard` + `ulysses_degree > 1`, and warmup doesn't exercise it, so the failure only surfaces at serving time under the recommended 4-GPU layout.

### Modifications

Add a small `_safe_tensor_version()` helper that returns `0` for inference-mode tensors (the version is only used as a cache-invalidation hint, so a constant fallback is safe) and use it at both cache-key sites.

### Accuracy / Test

Reproduced on 8×B200. Before: every chunk fails with the error above. After the fix: realtime generation with camera actions (`{"mode":"state","transitions":[{"actions":["w"]}]}`) runs end-to-end across ulysses=1/2/4, ~562 ms/chunk warm forward at 832×480 on 4×B200, no errors over 20+ chunks.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27059713469](https://github.com/sgl-project/sglang/actions/runs/27059713469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27059713433](https://github.com/sgl-project/sglang/actions/runs/27059713433)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->