### PR TITLE
 Fix DSV4 FP8 E4M3 dtype selection on ROCm gfx94x

### DIFF
--- a/python/sglang/jit_kernel/dsv4/elementwise.py
+++ b/python/sglang/jit_kernel/dsv4/elementwise.py
@@ -8,7 +8,7 @@ from sglang.jit_kernel.utils import (
     load_jit,
     make_cpp_args,
 )
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import get_fp8_e4m3_dtype, is_hip
 
 from .utils import make_name
 
@@ -141,7 +141,9 @@ def fused_q_indexer_rope_hadamard_quant(
     positions: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
-    q_fp8 = torch.empty(q_input.shape, dtype=torch.float8_e4m3fn, device=q_input.device)
+    q_fp8 = torch.empty(
+        q_input.shape, dtype=get_fp8_e4m3_dtype(q_input.device), device=q_input.device
+    )
     weights_out = torch.empty(
         (*q_input.shape[:-1], 1), dtype=torch.float32, device=q_input.device
     )

--- a/python/sglang/jit_kernel/tests/deepseek_v4/test_fp4_indexer.py
+++ b/python/sglang/jit_kernel/tests/deepseek_v4/test_fp4_indexer.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.dsv4 import (
     CompressorDecodePlan,
     compress_norm_rope_store,
     fused_q_indexer_rope_hadamard_fp4_quant,
+    fused_q_indexer_rope_hadamard_quant,
 )
 from sglang.jit_kernel.hadamard import hadamard_transform
 from sglang.srt.layers.attention.dsv4.fp4_indexer import (
@@ -19,6 +20,7 @@ from sglang.srt.layers.deepseek_v4_rope import (
     apply_rotary_emb_triton,
     precompute_freqs_cis,
 )
+from sglang.srt.utils import get_fp8_e4m3_dtype
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=60, suite="base-b-kernel-unit-1-gpu-large")
@@ -92,6 +94,29 @@ def _ref_store_fp4_index_cache(
             (x_sf[token_id] >> sf_shifts) & 0xFF
         ).to(torch.uint8)
     return expected
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, 17])
+def test_fp8_fused_q_indexer_rope_hadamard_quant_dtype(batch_size: int) -> None:
+    torch.manual_seed(batch_size + 150)
+    num_heads = 16
+    rope_dim = 64
+    weight_scale = HEAD_DIM**-0.5 * num_heads**-0.5
+    q = torch.randn(
+        batch_size, num_heads, HEAD_DIM, device="cuda", dtype=torch.bfloat16
+    )
+    weight = torch.randn(batch_size, num_heads, device="cuda", dtype=torch.bfloat16)
+    positions = (torch.arange(batch_size, device="cuda", dtype=torch.int32) * 7) % 63
+    freqs_cis = precompute_freqs_cis(rope_dim, 64, 0, 10000, 1, 32, 1).to("cuda")
+
+    q_fp8, weights_out = fused_q_indexer_rope_hadamard_quant(
+        q, weight, weight_scale, freqs_cis, positions
+    )
+
+    assert q_fp8.dtype == get_fp8_e4m3_dtype(q.device)
+    assert q_fp8.shape == q.shape
+    assert weights_out.shape == (batch_size, num_heads, 1)
+    assert torch.isfinite(weights_out).all()
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 96])

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -24,7 +24,7 @@ from sglang.srt.layers.attention.dsa.utils import (
 )
 from sglang.srt.layers.dp_attention import attn_tp_all_gather_into_tensor
 from sglang.srt.layers.layernorm import LayerNorm
-from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
+from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.state_capturer.indexer_topk import (
     maybe_capture_indexer_topk,
@@ -34,6 +34,7 @@ from sglang.srt.utils import (
     ceil_align,
     get_bool_env_var,
     is_cuda,
+    is_fp8_fnuz,
     is_gfx95_supported,
     is_hip,
     is_npu,

--- a/python/sglang/srt/layers/attention/dsa/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/dsa/index_buf_accessor.py
@@ -5,11 +5,13 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-from sglang.srt.utils import get_bool_env_var, is_hip
+from sglang.srt.utils import (
+    get_bool_env_var,
+    get_fp8_e4m3_dtype,
+    is_hip,
+)
 
 _is_hip = is_hip()
-_is_fp8_fnuz = is_fp8_fnuz()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 # aiter cp_gather kernel with preshuffle=True is only valid when the indexer
 # uses the page_size=64 preshuffle layout (i.e. when the matching MQA gluon path
@@ -190,12 +192,11 @@ class GetKAndS:
         seq_len_sum: int,
         max_seq_len: int,
     ):
-        from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
-
         page_size = pool.page_size
         index_head_dim = pool.index_head_dim
         quant_block_size = pool.quant_block_size
         scale_elems = index_head_dim // quant_block_size
+        fp8_dtype = get_fp8_e4m3_dtype(buf.device)
 
         kv_cache = buf.view(-1, page_size, index_head_dim + scale_elems * 4).view(
             fp8_dtype
@@ -437,10 +438,8 @@ def _set_k_and_s_triton(
 
     assert buf.dtype == torch.uint8
     assert loc.dtype == torch.int64, f"{loc.dtype=}"  # can be int32
-    if _is_fp8_fnuz:
-        assert index_k.dtype == torch.float8_e4m3fnuz
-    else:
-        assert index_k.dtype == torch.float8_e4m3fn
+    fp8_dtype = get_fp8_e4m3_dtype(index_k.device)
+    assert index_k.dtype == fp8_dtype
     assert index_k_scale.dtype == torch.float32
 
     assert buf.is_contiguous()
@@ -448,10 +447,7 @@ def _set_k_and_s_triton(
     assert index_k.is_contiguous()
     assert index_k_scale.is_contiguous()
 
-    if _is_fp8_fnuz:
-        buf_fp8 = buf.view(torch.float8_e4m3fnuz)
-    else:
-        buf_fp8 = buf.view(torch.float8_e4m3fn)
+    buf_fp8 = buf.view(fp8_dtype)
     buf_fp32 = buf.view(torch.float32)
 
     _set_k_and_s_triton_kernel[(num_tokens_to_write,)](

--- a/python/sglang/srt/layers/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/srt/layers/attention/dsa/tilelang_kernel.py
@@ -6,8 +6,13 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.srt.utils import (
+    get_fp8_e4m3_dtype,
+    get_fp8_e4m3_dtype_name,
+    is_fp8_fnuz,
+    is_gfx95_supported,
+    is_hip,
+)
 
 tilelang.set_log_level("WARNING")
 
@@ -48,8 +53,8 @@ _is_gfx95_supported = is_gfx95_supported()
 _is_fp8_fnuz = is_fp8_fnuz()
 
 BF16 = "bfloat16"
-FP8 = "float8_e4m3fnuz" if _is_fp8_fnuz else "float8_e4m3fn"
-FP8_DTYPE = torch.float8_e4m3fnuz if _is_fp8_fnuz else torch.float8_e4m3fn
+FP8 = get_fp8_e4m3_dtype_name()
+FP8_DTYPE = get_fp8_e4m3_dtype()
 FP32 = "float32"
 INT32 = "int32"
 UINT8 = "uint8"

--- a/python/sglang/srt/layers/attention/dsv4/dequant_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsv4/dequant_k_cache.py
@@ -4,9 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.srt.utils import get_fp8_e4m3_dtype
 
-fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+fp8_dtype = get_fp8_e4m3_dtype()
 
 # v4 KV cache layout (see dsv4.index_buf_accessor._set_k_and_s_triton_kernel):
 #   per-token: 448 fp8 nope + 64 bf16 rope (= 576 contiguous bytes) +

--- a/python/sglang/srt/layers/attention/dsv4/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/dsv4/index_buf_accessor.py
@@ -7,9 +7,9 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.srt.utils import get_fp8_e4m3_dtype
 
-fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+fp8_dtype = get_fp8_e4m3_dtype()
 
 
 @dataclass

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -20,7 +20,7 @@ from sglang.srt.layers.attention.dsv4.compressor import Compressor
 from sglang.srt.layers.attention.dsv4.metadata import PagedIndexerMetadata
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
-from sglang.srt.utils import add_prefix, is_hip
+from sglang.srt.utils import add_prefix, get_fp8_e4m3_dtype
 from sglang.srt.utils.common import is_sm120_supported
 
 if TYPE_CHECKING:
@@ -33,12 +33,8 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
-if is_hip():
-    FP8_DTYPE = torch.float8_e4m3fnuz
-    FP8_MAX = torch.finfo(FP8_DTYPE).max
-else:
-    FP8_DTYPE = torch.float8_e4m3fn
-    FP8_MAX = torch.finfo(FP8_DTYPE).max
+FP8_DTYPE = get_fp8_e4m3_dtype()
+FP8_MAX = torch.finfo(FP8_DTYPE).max
 
 IndexerQuery: TypeAlias = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 

--- a/python/sglang/srt/layers/attention/dsv4/quant_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsv4/quant_k_cache.py
@@ -3,9 +3,9 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.attention.dsv4.index_buf_accessor import NopeFp8RopeBf16Pack
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.srt.utils import get_fp8_e4m3_dtype
 
-fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+fp8_dtype = get_fp8_e4m3_dtype()
 
 
 @triton.jit

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -16,7 +16,6 @@ import functools
 import json
 import logging
 import os
-from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
@@ -34,8 +33,10 @@ from sglang.srt.utils import (
     get_bool_env_var,
     get_device_core_count,
     get_device_name,
+    get_fp8_e4m3_dtype,
     is_cpu,
     is_cuda,
+    is_fp8_fnuz,
     is_hip,
     is_musa,
     is_sm100_supported,
@@ -115,19 +116,10 @@ if _is_musa:
 logger = logging.getLogger(__name__)
 
 
-@lru_cache()
-def is_fp8_fnuz() -> bool:
-    if _is_hip:
-        # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
-    return False
-
-
+fp8_dtype = get_fp8_e4m3_dtype()
 if is_fp8_fnuz():
-    fp8_dtype = torch.float8_e4m3fnuz
     fp8_max = 224.0
 else:
-    fp8_dtype = torch.float8_e4m3fn
     fp8_max = torch.finfo(fp8_dtype).max
 fp8_min = -fp8_max
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3652,6 +3652,54 @@ def is_gfx942_supported():
         return False
 
 
+def _normalize_cuda_device_index(
+    device: Optional[Union[int, str, torch.device]],
+) -> int:
+    if device is None:
+        return torch.cuda.current_device()
+    if isinstance(device, int):
+        return device
+
+    torch_device = torch.device(device)
+    if torch_device.type != "cuda" or torch_device.index is None:
+        return torch.cuda.current_device()
+    return torch_device.index
+
+
+@lru_cache(maxsize=None)
+def _is_fp8_fnuz_device(device_index: int) -> bool:
+    if not torch.version.hip:
+        return False
+    gcn_arch = torch.cuda.get_device_properties(device_index).gcnArchName
+    return any(
+        gcn_arch.startswith(gfx_arch) for gfx_arch in ("gfx940", "gfx941", "gfx942")
+    )
+
+
+def is_fp8_fnuz(device: Optional[Union[int, str, torch.device]] = None) -> bool:
+    """
+    Returns whether the current FP8 E4M3 format is FNUZ.
+
+    ROCm gfx940/gfx941/gfx942 platforms use E4M3FNUZ, while CUDA and
+    newer ROCm platforms use E4M3FN.
+    """
+    if not torch.version.hip:
+        return False
+    return _is_fp8_fnuz_device(_normalize_cuda_device_index(device))
+
+
+def get_fp8_e4m3_dtype(
+    device: Optional[Union[int, str, torch.device]] = None,
+) -> torch.dtype:
+    return torch.float8_e4m3fnuz if is_fp8_fnuz(device) else torch.float8_e4m3fn
+
+
+def get_fp8_e4m3_dtype_name(
+    device: Optional[Union[int, str, torch.device]] = None,
+) -> str:
+    return "float8_e4m3fnuz" if is_fp8_fnuz(device) else "float8_e4m3fn"
+
+
 def get_hip_version():
     if torch.version.hip:
         return tuple(map(int, torch.version.hip.split("-")[0].split(".")))


### PR DESCRIPTION
## Motivation

Fixes #27124.
## Summary

  This PR addresses #27124 by centralizing FP8 E4M3 dtype selection and using the same dtype decision across the DSV4/DSA indexer paths.

  On ROCm gfx94x platforms, FP8 E4M3 should use `torch.float8_e4m3fnuz`; on CUDA and newer ROCm platforms, it should use
  `torch.float8_e4m3fn`. Previously, the DSV4 fused Q indexer and TileLang consumer paths could disagree on this dtype, which caused a dtype
  mismatch on MI300.

  The change adds shared helpers in `sglang.srt.utils`:

  - `is_fp8_fnuz()`
  - `get_fp8_e4m3_dtype()`
  - `get_fp8_e4m3_dtype_name()`

  The FNUZ path is guarded by an explicit ROCm gfx94x whitelist: `gfx940`, `gfx941`, and `gfx942`.

  ## Changes

  - Use the shared FP8 E4M3 dtype helper in DSV4 fused Q indexer.
  - Use the same helper in DSA/DSV4 TileLang and KV cache paths.
  - Keep CUDA behavior unchanged: CUDA continues to use `torch.float8_e4m3fn`.
  - Add a regression assertion for the DSV4 fused Q indexer output dtype.

  ## Validation

  Validated manually on MI300X / `gfx942:sramecc+:xnack-` with ROCm 7.2.

  ```bash
  python3 -m pytest python/sglang/jit_kernel/tests/deepseek_v4/test_fp4_indexer.py \
    -k fp8_fused_q_indexer_rope_hadamard_quant_dtype -q
```

## Speed Tests and Profiling

Not run; this patch only changes the FP8 tensor dtype selected for the DSV4 indexer output on gfx94 and does not change kernel math or launch parameters.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable for this dtype mismatch fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27061561034](https://github.com/sgl-project/sglang/actions/runs/27061561034)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27061560985](https://github.com/sgl-project/sglang/actions/runs/27061560985)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->