### PR TITLE
[Diffusion] Enable Cosmos3 denoising profiling

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -41,6 +41,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
 from sglang.srt.utils.common import get_compiler_backend
 
 logger = init_logger(__name__)
@@ -484,6 +485,11 @@ class Cosmos3DenoisingStage(PipelineStage):
         result.add_check("timesteps", batch.timesteps, V.is_tensor)
         return result
 
+    def step_profile(self):
+        profiler = SGLDiffusionProfiler.get_instance()
+        if profiler:
+            profiler.step_denoising_step()
+
     def _run_transformer(
         self,
         latents: torch.Tensor,
@@ -699,6 +705,9 @@ class Cosmos3DenoisingStage(PipelineStage):
 
             if image_latent is not None:
                 latents[:, :, 0:1, :, :] = image_latent
+
+            if batch.profile and not batch.is_warmup:
+                self.step_profile()
 
         batch.latents = latents
         self.log_info("Denoising complete")


### PR DESCRIPTION
## Summary

- Add per-timestep profiler stepping to the custom Cosmos3 denoising loop.
- Keep profiler stepping disabled for warmup and non-profile requests.

## Motivation

Cosmos3 uses a model-specific denoising loop instead of the generic denoising stage. As a result, `--profile --num-profiled-timesteps ...` could start the profiler but never advance the denoising schedule, producing traces without the requested timestep coverage.

## Validation

- `git diff --check`
- H200: `PYTHONPATH=/tmp/sglang_pr_cosmos3_profiler/python pytest -q python/sglang/multimodal_gen/test/unit/test_cosmos3.py`
  - `37 passed, 20 warnings, 6 subtests passed in 15.46s`





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27060582251](https://github.com/sgl-project/sglang/actions/runs/27060582251)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27060582130](https://github.com/sgl-project/sglang/actions/runs/27060582130)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
