### PR TITLE
[Diffusion] Avoid GPU syncs in UniPC scheduler

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_unipc_multistep.py
+++ b/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_unipc_multistep.py
@@ -853,8 +853,8 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             rks.append(rk)
             D1s.append((mi - m0) / rk)
 
-        rks.append(1.0)
-        rks = torch.tensor(rks, device=device)
+        rks.append(torch.ones((), dtype=h.dtype, device=h.device))
+        rks = torch.stack(rks).to(device=device)
 
         R = []
         b = []
@@ -879,7 +879,7 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             h_phi_k = h_phi_k / hh - 1 / factorial_i
 
         R = torch.stack(R)
-        b = torch.tensor(b, device=device)
+        b = torch.stack(b).to(device=device)
 
         if len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)  # (B, K)
@@ -991,8 +991,8 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             rks.append(rk)
             D1s.append((mi - m0) / rk)
 
-        rks.append(1.0)
-        rks = torch.tensor(rks, device=device)
+        rks.append(torch.ones((), dtype=h.dtype, device=h.device))
+        rks = torch.stack(rks).to(device=device)
 
         R = []
         b = []
@@ -1017,7 +1017,7 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             h_phi_k = h_phi_k / hh - 1 / factorial_i
 
         R = torch.stack(R)
-        b = torch.tensor(b, device=device)
+        b = torch.stack(b).to(device=device)
 
         if len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)


### PR DESCRIPTION
## Summary

- Replace `torch.tensor(list_of_gpu_scalars)` with `torch.stack(...)` in the UniPC multistep predictor and corrector paths.
- Keep the coefficient assembly on-device to avoid implicit GPU-to-CPU synchronization.

## Motivation

A Cosmos3 H200 denoising profile showed repeated `aten::item` / `_local_scalar_dense` / `cudaStreamSynchronize` overhead from constructing tensors out of GPU scalar tensors in the UniPC scheduler. Stacking the already-device-resident scalars preserves the same tensor values without forcing a CPU sync.

## Benchmark

H200, `nvidia/Cosmos3-Nano`, 1280x720, 81 frames, 35 steps, seed 42, warmup excluded, native SGLang diffusion backend:

| Metric | Before | After |
| --- | ---: | ---: |
| Total duration | 57457.98 ms | 56509.18 ms |
| Denoising stage | 53571.69 ms | 52634.58 ms |
| Peak reserved memory | 43792 MB | 43792 MB |

## Validation

- `git diff --check`
- H200: `PYTHONPATH=/tmp/sglang_pr_unipc_sync/python pytest -q python/sglang/multimodal_gen/test/unit/test_cosmos3.py`
  - `37 passed, 20 warnings, 6 subtests passed in 15.86s`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27060366823](https://github.com/sgl-project/sglang/actions/runs/27060366823)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27060366780](https://github.com/sgl-project/sglang/actions/runs/27060366780)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->