### PR TITLE
Complete server warmup before scripted runtime scripts start

### DIFF
--- a/python/sglang/test/scripted_runtime/http_server.py
+++ b/python/sglang/test/scripted_runtime/http_server.py
@@ -151,12 +151,13 @@ class ScriptedHttpServer:
         # _reset_engine_state, which POSTs to this server's own HTTP port, so
         # block until the port is bound and routing before any script can run.
         #
-        # Wait for *any* HTTP response, not status 200: in scripted mode the
-        # scheduler is driven by the script, so normal warmup never completes
-        # and /health stays 503 (server_status == Starting) for the whole run.
-        # A 503 still proves the socket is bound and routes are registered,
-        # which is all the control POSTs need.
-        url = f"{self._base_url}/health"
+        # Poll /model_info rather than /health: once the server reports Up,
+        # /health runs the generation-based health check (a real probe request
+        # through the scheduler), which cannot complete while the scheduler
+        # waits for scripts between RunScript commands. Any /model_info
+        # response proves the socket is bound and routes are registered, which
+        # is all the control POSTs need.
+        url = f"{self._base_url}/model_info"
         deadline = time.monotonic() + HTTP_READY_TIMEOUT_S
         while time.monotonic() < deadline:
             if not self._server_process.is_alive():

--- a/python/sglang/test/scripted_runtime/scheduler_hook.py
+++ b/python/sglang/test/scripted_runtime/scheduler_hook.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +37,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 RESET_DRAIN_MAX_STEPS: int = 200
+# Below the test-side LISTENER_ACCEPT_TIMEOUT_S so a stuck warmup surfaces as
+# this specific error instead of a generic handshake timeout.
+WARMUP_DRIVE_TIMEOUT_S: float = 120.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +49,39 @@ class ScriptedBatchRecord:
     rids: Tuple[str, ...]
     extend_rids: Tuple[str, ...]
     chunked_rid: Optional[str]
+
+
+def _drive_engine_through_warmup(ctx: ScriptedContext) -> Generator:
+    """Run the engine until the server warmup request has been received and
+    fully processed, so scripts never observe foreign warmup traffic."""
+    scheduler = ctx.scheduler
+    if scheduler.server_args.skip_server_warmup:
+        return
+
+    # is_fully_idle() can transiently report idle while a PP microbatch result
+    # is still in flight, so require it to hold for two full microbatch
+    # rotations after the warmup request was observed on the recv socket.
+    server_args = scheduler.server_args
+    quiesce_iters = 2 * (server_args.pp_size + server_args.pp_async_batch_depth)
+    proxy = ctx._tokenizer_recv_proxy
+    deadline = time.monotonic() + WARMUP_DRIVE_TIMEOUT_S
+
+    idle_streak = 0
+    while proxy.work_reqs_seen == 0 or idle_streak < quiesce_iters:
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                "scripted_runtime: server warmup did not complete within "
+                f"{WARMUP_DRIVE_TIMEOUT_S}s "
+                f"(work_reqs_seen={proxy.work_reqs_seen}, "
+                f"idle_streak={idle_streak})"
+            )
+        yield
+        if proxy.work_reqs_seen == 0:
+            idle_streak = 0
+        elif scheduler.is_fully_idle():
+            idle_streak += 1
+        else:
+            idle_streak = 0
 
 
 def _reset_engine_state(ctx: ScriptedContext) -> Generator:
@@ -106,6 +143,7 @@ class ScriptedSchedulerHook:
         ctx_zmq = zmq.Context()
         socket = get_zmq_socket(ctx_zmq, zmq.PAIR, endpoint, bind=False)
         try:
+            yield from _drive_engine_through_warmup(self._context)
             socket.send_pyobj(HookReady())
             while True:
                 msg = socket.recv_pyobj()

--- a/python/sglang/test/scripted_runtime/scheduler_hook.py
+++ b/python/sglang/test/scripted_runtime/scheduler_hook.py
@@ -55,13 +55,13 @@ def _drive_engine_through_warmup(ctx: ScriptedContext) -> Generator:
     """Run the engine until the server warmup request has been received and
     fully processed, so scripts never observe foreign warmup traffic."""
     scheduler = ctx.scheduler
-    if scheduler.server_args.skip_server_warmup:
+    server_args = scheduler.server_args
+    if server_args.skip_server_warmup:
         return
 
     # is_fully_idle() can transiently report idle while a PP microbatch result
     # is still in flight, so require it to hold for two full microbatch
     # rotations after the warmup request was observed on the recv socket.
-    server_args = scheduler.server_args
     quiesce_iters = 2 * (server_args.pp_size + server_args.pp_async_batch_depth)
     proxy = ctx._tokenizer_recv_proxy
     deadline = time.monotonic() + WARMUP_DRIVE_TIMEOUT_S

--- a/python/sglang/test/scripted_runtime/scheduler_hook.py
+++ b/python/sglang/test/scripted_runtime/scheduler_hook.py
@@ -67,7 +67,7 @@ def _drive_engine_through_warmup(ctx: ScriptedContext) -> Generator:
     deadline = time.monotonic() + WARMUP_DRIVE_TIMEOUT_S
 
     idle_streak = 0
-    while proxy.work_reqs_seen == 0 or idle_streak < quiesce_iters:
+    while idle_streak < quiesce_iters:
         if time.monotonic() >= deadline:
             raise RuntimeError(
                 "scripted_runtime: server warmup did not complete within "
@@ -76,9 +76,7 @@ def _drive_engine_through_warmup(ctx: ScriptedContext) -> Generator:
                 f"idle_streak={idle_streak})"
             )
         yield
-        if proxy.work_reqs_seen == 0:
-            idle_streak = 0
-        elif scheduler.is_fully_idle():
+        if proxy.work_reqs_seen > 0 and scheduler.is_fully_idle():
             idle_streak += 1
         else:
             idle_streak = 0

--- a/python/sglang/test/scripted_runtime/scheduler_hook.py
+++ b/python/sglang/test/scripted_runtime/scheduler_hook.py
@@ -57,14 +57,18 @@ def _drive_engine_through_warmup(ctx: ScriptedContext) -> Generator:
     scheduler = ctx.scheduler
     server_args = scheduler.server_args
     if server_args.skip_server_warmup:
+        logger.info("scripted_runtime: skip_server_warmup set, not driving warmup")
         return
+
+    logger.info("scripted_runtime: driving engine until server warmup completes")
+    start_time = time.monotonic()
 
     # is_fully_idle() can transiently report idle while a PP microbatch result
     # is still in flight, so require it to hold for two full microbatch
     # rotations after the warmup request was observed on the recv socket.
     quiesce_iters = 2 * (server_args.pp_size + server_args.pp_async_batch_depth)
     proxy = ctx._tokenizer_recv_proxy
-    deadline = time.monotonic() + WARMUP_DRIVE_TIMEOUT_S
+    deadline = start_time + WARMUP_DRIVE_TIMEOUT_S
 
     idle_streak = 0
     while idle_streak < quiesce_iters:
@@ -80,6 +84,12 @@ def _drive_engine_through_warmup(ctx: ScriptedContext) -> Generator:
             idle_streak += 1
         else:
             idle_streak = 0
+
+    logger.info(
+        "scripted_runtime: server warmup drained in %.1fs (work_reqs_seen=%d)",
+        time.monotonic() - start_time,
+        proxy.work_reqs_seen,
+    )
 
 
 def _reset_engine_state(ctx: ScriptedContext) -> Generator:

--- a/python/sglang/test/scripted_runtime/tokenizer_recv_proxy.py
+++ b/python/sglang/test/scripted_runtime/tokenizer_recv_proxy.py
@@ -6,12 +6,27 @@ from typing import Any, Callable
 
 import zmq
 
+from sglang.srt.managers.io_struct import (
+    BatchTokenizedEmbeddingReqInput,
+    BatchTokenizedGenerateReqInput,
+    TokenizedEmbeddingReqInput,
+    TokenizedGenerateReqInput,
+)
+
+_WORK_REQ_TYPES = (
+    TokenizedGenerateReqInput,
+    TokenizedEmbeddingReqInput,
+    BatchTokenizedGenerateReqInput,
+    BatchTokenizedEmbeddingReqInput,
+)
+
 
 class ScriptedTokenizerRecvProxy:
 
     def __init__(self, *, underlying: zmq.Socket) -> None:
         self._underlying = underlying
         self._buffer: deque = deque()
+        self.work_reqs_seen: int = 0
 
     def recv_pyobj(self, flags: int = 0) -> Any:
         self._drain_underlying()
@@ -52,4 +67,6 @@ class ScriptedTokenizerRecvProxy:
                 req = self._underlying.recv_pyobj(zmq.NOBLOCK)
             except zmq.ZMQError:
                 break
+            if isinstance(req, _WORK_REQ_TYPES):
+                self.work_reqs_seen += 1
             self._buffer.append(req)


### PR DESCRIPTION
## Motivation

This is PR 1 of 2 extracted from the investigation of the flaky `test/registered/chunked_prefill/test_scripted_core_4gpu.py` ([example CI failure](https://github.com/sgl-project/sglang/actions/runs/27060252626/job/79871858168)); PR 2 (based on this branch) fixes the actual scheduler bug.

The scripted runtime promises scripts a deterministic, script-driven scheduler, but the server it launches still runs the standard `launch_server` warmup thread. Since the scheduler loop freezes between `RunScript` commands, the warmup could never complete on its own; instead:

- the warmup thread's `/generate` ("The capital city of France is") landed in the scheduler queues at an **arbitrary point during the first scripts** as foreign traffic, perturbing queue contents, batch compositions and reset drains (one of the amplifiers behind the flaky CI failure above, and directly observed blocking a reproduction experiment with `Cache not flushed ... #queue-req: 1`);
- the warmup thread kept polling `GET /model_info` once per second in the background;
- `/health` stayed 503 (`server_status == Starting`) for the whole run.

## Modifications

- **Drive the engine through warmup before accepting scripts** (`scheduler_hook.py`, `tokenizer_recv_proxy.py`): the hook now advances the real scheduler loop until the warmup request has been observed on the recv socket (the proxy counts inbound tokenized work requests) and the scheduler then stays fully idle for two microbatch rotations, and only then sends `HookReady`. Scripts start with the server warmed up, `Up`, and quiesced, with no ambient traffic left. The two-rotation quiesce guard is needed because `is_fully_idle()` can transiently report idle while a PP microbatch result is still in flight (the scheduler-side bug fixed in PR 2). Honors `skip_server_warmup=True` by skipping the drive. Bounded by a 120s wall-clock timeout that fails loudly.
- **Poll `/model_info` instead of `/health` for readiness** (`http_server.py`): with the server now genuinely reaching `Up`, `/health` runs the generation-based health check (a real probe through the scheduler), which cannot complete while the scheduler waits for scripts between commands — the old readiness poll would hang. `/model_info` is pure metadata and proves the same thing (socket bound, routes registered).

A side benefit: the first KV-canary sweeps (triggered after each rank's first forward, ~100ms each, cascading across PP ranks) now also happen during the warmup drive instead of racing the first script.

Scope note: the warmup-completion detection targets the current scripted-runtime scope (no disaggregation, text models); PD-disagg/VLM warmups have different shapes and should be revisited if the scripted runtime grows there.

## Accuracy Tests

N/A (test harness only).

## Speed Tests and Profiling

N/A.











































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27064732059](https://github.com/sgl-project/sglang/actions/runs/27064732059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27065446238](https://github.com/sgl-project/sglang/actions/runs/27065446238)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->