### PR TITLE
Classify malformed-multimodal rejects as invalid_request

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -726,7 +726,21 @@ async def generate_request(obj: GenerateReqInput, request: Request):
                 ):
                     yield b"data: " + dumps_json(out) + b"\n\n"
             except ValueError as e:
-                out = {"error": {"message": str(e)}}
+                # A client disconnect also surfaces here. It's a client-side
+                # cancellation, not a server error or bad input -- log it and
+                # stop (the request was already aborted upstream) instead of
+                # emitting a 400.
+                if request is not None and await request.is_disconnected():
+                    logger.info(f"[http_server] Client disconnected: {e}")
+                    return
+                out = {
+                    "error": {
+                        "message": str(e),
+                        "type": "invalid_request_error",
+                        "code": 400,
+                        "retryable": False,
+                    }
+                }
                 logger.error(f"[http_server] Error: {e}")
                 yield b"data: " + dumps_json(out) + b"\n\n"
             yield b"data: [DONE]\n\n"

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -551,9 +551,15 @@ class BaseMultimodalProcessor(ABC):
 
         except ValueError as e:
             # Bad input (e.g. invalid base64) -> 400, not 500.
-            raise ValueError(f"Error while loading data {data}: {e}") from e
+            data_str = str(data)
+            if len(data_str) > 100:
+                data_str = data_str[:100] + "..."
+            raise ValueError(f"Error while loading data {data_str}: {e}") from e
         except Exception as e:
-            raise RuntimeError(f"Error while loading data {data}: {e}") from e
+            data_str = str(data)
+            if len(data_str) > 100:
+                data_str = data_str[:100] + "..."
+            raise RuntimeError(f"Error while loading data {data_str}: {e}") from e
 
     @staticmethod
     def _get_preprocessed_input_format(data):

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -549,8 +549,11 @@ class BaseMultimodalProcessor(ABC):
             elif modality == Modality.AUDIO:
                 return load_audio(data, audio_sample_rate)
 
+        except ValueError as e:
+            # Bad input (e.g. invalid base64) -> 400, not 500.
+            raise ValueError(f"Error while loading data {data}: {e}") from e
         except Exception as e:
-            raise RuntimeError(f"Error while loading data {data}: {e}")
+            raise RuntimeError(f"Error while loading data {data}: {e}") from e
 
     @staticmethod
     def _get_preprocessed_input_format(data):


### PR DESCRIPTION
## Summary

- When a multimodal request fails validation (e.g. bad base64), return a structured error with `type=invalid_request_error` and `code=400` instead of a bare error message.
- Detect client disconnects in the streaming path and exit cleanly instead of emitting a 400.
- In the multimodal base processor, re-raise `ValueError` separately from `RuntimeError` so callers can distinguish bad input (4xx) from internal failures (5xx), and chain the original exception via `from e`.

## Original commits

- `1bce350b1`

## Test plan

- Send a streaming request with a malformed base64 image and verify the SSE error event contains `"type": "invalid_request_error"` and `"code": 400`.
- Send a streaming multimodal request and disconnect the client mid-flight; verify the server logs an info-level disconnect message and does not emit a 400 error event.
- Send a valid multimodal request and confirm it still succeeds end-to-end.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27066493925](https://github.com/sgl-project/sglang/actions/runs/27066493925)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27066493871](https://github.com/sgl-project/sglang/actions/runs/27066493871)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->