### PR TITLE
ci: show partition fit window as a date range in the step summary

### DIFF
--- a/scripts/ci/update_est_time.py
+++ b/scripts/ci/update_est_time.py
@@ -166,8 +166,8 @@ def main():
 
     print(f"Fetching {args.model_url}", file=sys.stderr)
     model = fetch_model(args.model_url)
-    # `data_as_of` fallback covers snapshots predating the sglang-ci-stats
-    # rename to `fit_window_start` (drop once that rename is deployed).
+    # `data_as_of` fallback covers pre-rename sglang-ci-stats snapshots
+    # (drop once the `fit_window_start` rename is deployed).
     window_start = model.get("fit_window_start") or model.get("data_as_of")
     print(
         f"  model fit_window_start={window_start} "

--- a/scripts/ci/update_est_time.py
+++ b/scripts/ci/update_est_time.py
@@ -166,8 +166,12 @@ def main():
 
     print(f"Fetching {args.model_url}", file=sys.stderr)
     model = fetch_model(args.model_url)
+    # `data_as_of` fallback covers snapshots predating the sglang-ci-stats
+    # rename to `fit_window_start` (drop once that rename is deployed).
+    window_start = model.get("fit_window_start") or model.get("data_as_of")
     print(
-        f"  model data_as_of={model.get('data_as_of')} "
+        f"  model fit_window_start={window_start} "
+        f"fit_window_days={model.get('fit_window_days')} "
         f"n_runs={model.get('n_runs')} "
         f"n_suites={len(model.get('est', {}))}",
         file=sys.stderr,

--- a/scripts/ci/update_est_time.py
+++ b/scripts/ci/update_est_time.py
@@ -166,11 +166,8 @@ def main():
 
     print(f"Fetching {args.model_url}", file=sys.stderr)
     model = fetch_model(args.model_url)
-    # `data_as_of` fallback covers pre-rename sglang-ci-stats snapshots
-    # (drop once the `fit_window_start` rename is deployed).
-    window_start = model.get("fit_window_start") or model.get("data_as_of")
     print(
-        f"  model fit_window_start={window_start} "
+        f"  model fit_window_start={model.get('fit_window_start')} "
         f"fit_window_days={model.get('fit_window_days')} "
         f"n_runs={model.get('n_runs')} "
         f"n_suites={len(model.get('est', {}))}",

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -184,10 +184,8 @@ def format_fit_window(model: dict) -> str:
     """Render the model's fit window as `[start, end)` for the step summary.
 
     Surfacing the whole span keeps the lower-bound date from reading as a
-    staleness marker (it trails today by fit_window_days). Falls back to the
-    legacy `data_as_of` key for pre-rename sglang-ci-stats snapshots (drop
-    once the `fit_window_start` rename is deployed)."""
-    start = model.get("fit_window_start") or model.get("data_as_of")
+    staleness marker (it trails today by fit_window_days)."""
+    start = model.get("fit_window_start")
     days = model.get("fit_window_days")
     if not start or not isinstance(days, int):
         return f"fit_window_start={start}"

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -12,6 +12,7 @@ import json
 import math
 import os
 from collections import defaultdict
+from datetime import datetime, timedelta
 
 import yaml  # PyYAML; preinstalled on ubuntu-latest GHA runners.
 
@@ -179,6 +180,24 @@ def compute_partitions(
     return result
 
 
+def format_fit_window(model: dict) -> str:
+    """Render the model's fit window as `[start, end)` for the step summary.
+
+    `fit_window_start` is the inclusive lower bound (UTC midnight, today -
+    fit_window_days); end = start + fit_window_days. Surfacing the whole
+    span avoids reading the single lower-bound date as a staleness marker.
+    Falls back to the legacy `data_as_of` key for snapshots predating the
+    sglang-ci-stats rename (drop once that rename is deployed)."""
+    start = model.get("fit_window_start") or model.get("data_as_of")
+    days = model.get("fit_window_days")
+    if not start or not isinstance(days, int):
+        return f"fit_window_start={start}"
+    end = (datetime.strptime(start[:10], "%Y-%m-%d") + timedelta(days=days)).strftime(
+        "%Y-%m-%d"
+    )
+    return f"fit over [{start[:10]}, {end}) ({days}d window)"
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", default=REPO_ROOT)
@@ -234,7 +253,7 @@ def main():
                 src_note = "no live model -- static est_time + (coeff=1, bias=0)"
             else:
                 src_note = (
-                    f"live model `data_as_of={partition_model.get('data_as_of')}`, "
+                    f"live model: {format_fit_window(partition_model)}, "
                     f"`n_runs={partition_model.get('n_runs')}`"
                 )
             f.write(

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -183,11 +183,10 @@ def compute_partitions(
 def format_fit_window(model: dict) -> str:
     """Render the model's fit window as `[start, end)` for the step summary.
 
-    `fit_window_start` is the inclusive lower bound (UTC midnight, today -
-    fit_window_days); end = start + fit_window_days. Surfacing the whole
-    span avoids reading the single lower-bound date as a staleness marker.
-    Falls back to the legacy `data_as_of` key for snapshots predating the
-    sglang-ci-stats rename (drop once that rename is deployed)."""
+    Surfacing the whole span keeps the lower-bound date from reading as a
+    staleness marker (it trails today by fit_window_days). Falls back to the
+    legacy `data_as_of` key for pre-rename sglang-ci-stats snapshots (drop
+    once the `fit_window_start` rename is deployed)."""
     start = model.get("fit_window_start") or model.get("data_as_of")
     days = model.get("fit_window_days")
     if not start or not isinstance(days, int):


### PR DESCRIPTION
## Summary
- The partition step summary printed the live model's lower-bound date as `data_as_of=2026-05-30...`, which reads as stale — it's the fit window's **start** (trails today by `fit_window_days`), not the data's freshness.
- Render the full window `[start, end)` instead, derived from `fit_window_start` + `fit_window_days`.

## Rendered `check-changes` step summary
Before:
```
full_parallel=false (size//3 throttle is lifted when true); live model data_as_of=2026-05-30T00:00:00Z, n_runs=18
```
After:
```
full_parallel=false (size//3 throttle is lifted when true); live model: fit over [2026-05-30, 2026-06-06) (7d window), n_runs=18
```

## Changes
- `compute_partitions.py`: add `format_fit_window()`; the `## Partitions` summary shows the window range.
- `update_est_time.py`: stderr diagnostic prints `fit_window_start` + `fit_window_days`.
- Reads the `fit_window_start` key introduced in sgl-project/sglang-ci-stats#5 (the lower-bound date renamed from `data_as_of` to reflect it's the window start, not a freshness marker).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27074467846](https://github.com/sgl-project/sglang/actions/runs/27074467846)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27074467779](https://github.com/sgl-project/sglang/actions/runs/27074467779)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
