### PR TITLE
[core] Probe `set_kv_buffer` / `set_mla_kv_buffer` slot ids for OOB

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1174,6 +1174,9 @@ class MHATokenToKVPool(KVCache):
         v_scale: Optional[float] = None,
         layer_id_override: Optional[int] = None,
     ):
+        # Catch stale slot ids here instead of as illegal-addr / silent KV
+        # corruption in the store_kvcache write (gated on SGLANG_ENABLE_ASYNC_ASSERT).
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MHA)")
         if layer_id_override is not None:
             layer_id = layer_id_override
         else:
@@ -1470,6 +1473,7 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         v_scale: Optional[float] = None,
         layer_id_override: Optional[int] = None,
     ):
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MHA-FP4)")
         from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 
         if layer_id_override is not None:
@@ -1860,6 +1864,7 @@ class MLATokenToKVPool(KVCache):
         cache_k: torch.Tensor,
         cache_v: torch.Tensor,
     ):
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MLA)")
         layer_id = layer.layer_id
         assert not self.dsa_kv_cache_store_fp8
         if cache_k.dtype != self.dtype:
@@ -1879,6 +1884,7 @@ class MLATokenToKVPool(KVCache):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ):
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_mla_kv_buffer (MLA)")
         layer_id = layer.layer_id
 
         if _is_hip and self.use_dsa and self.dtype == fp8_dtype:
@@ -2052,6 +2058,7 @@ class MLATokenToKVPoolFP4(MLATokenToKVPool):
         cache_k: torch.Tensor,
         cache_v: torch.Tensor,
     ):
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MLA-FP4)")
         layer_id = layer.layer_id
         assert not self.dsa_kv_cache_store_fp8
         if cache_k.dtype != self.dtype:
@@ -2076,6 +2083,9 @@ class MLATokenToKVPoolFP4(MLATokenToKVPool):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ):
+        maybe_detect_oob(
+            loc, 0, self.size + self.page_size, "set_mla_kv_buffer (MLA-FP4)"
+        )
         layer_id = layer.layer_id
 
         if self.dsa_kv_cache_store_fp8:


### PR DESCRIPTION
## Summary
- Add an async OOB probe on the KV-cache write path: `set_kv_buffer` / `set_mla_kv_buffer` now call `maybe_detect_oob(loc, 0, self.size + self.page_size)` before the store, across every writing pool (`MHATokenToKVPool`, `MHATokenToKVPoolFP4`, `MLATokenToKVPool`, `MLATokenToKVPoolFP4`).

## Background
- `move_kv_cache` already probes its `tgt_loc` / `src_loc` the same way, but the much hotter `set_kv_buffer` write path had no value check on `loc` — a stale slot id there either walks off the pool as an illegal-address crash or silently corrupts neighboring KV (surfacing far from the culprit).
- Bound is `self.size + self.page_size` (the physical buffer height, the same range `move_kv_cache` uses). This is a slot-index value check, not a buffer-width one, so no `topk` / `num_steps` factor applies. The `+ page_size` keeps the reserved padding tail and the zero-padded cuda-graph rows in-bounds, so there is no false positive on padding.

## Notes
- Gated on `SGLANG_ENABLE_ASYNC_ASSERT` (default off): an early return makes it free in prod, and it is already enabled in the spec CI fixtures, so a bad slot id surfaces as a clear assert at the next sync point instead of a displaced crash.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27075032092](https://github.com/sgl-project/sglang/actions/runs/27075032092)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27075032016](https://github.com/sgl-project/sglang/actions/runs/27075032016)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
