### PR TITLE
[bench] Reduce SSE overhead for large batch sizes in bench_one_batch_server

### DIFF
--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -586,13 +586,17 @@ def run_one_case(
         else:
             json_schema = None
 
+        reduce_sse = batch_size > 256
+        effective_stream_interval = (
+            max(stream_interval, output_len) if reduce_sse else stream_interval
+        )
         payload = {
             "sampling_params": {
                 "temperature": temperature,
                 "max_new_tokens": output_len,
                 "ignore_eos": True,
                 "json_schema": json_schema,
-                "stream_interval": stream_interval,
+                "stream_interval": effective_stream_interval,
             },
             "return_logprob": return_logprob,
             "stream": True,
@@ -709,9 +713,6 @@ def run_one_case(
 
     # Compute metrics
     latency = time.perf_counter() - tic
-    input_throughput = batch_size * input_len / last_ttft
-    output_throughput = batch_size * output_len / (latency - last_ttft)
-    overall_throughput = batch_size * (input_len + output_len) / latency
 
     if backend == "vllm":
         # vLLM does not expose these metrics via API
@@ -724,6 +725,15 @@ def run_one_case(
         internal_state = server_info.get("internal_states", [{}])
         last_gen_throughput = internal_state[0].get("last_gen_throughput", None) or -1
         acc_length = internal_state[0].get("avg_spec_accept_length", None) or -1
+
+    if reduce_sse and last_gen_throughput > 0:
+        dp_size = server_info.get("dp_size", 1)
+        decode_time = batch_size * output_len / (last_gen_throughput * dp_size)
+        last_ttft = latency - decode_time
+
+    input_throughput = batch_size * input_len / last_ttft
+    output_throughput = batch_size * output_len / (latency - last_ttft)
+    overall_throughput = batch_size * (input_len + output_len) / latency
 
     # Calculate cache hit rate from before/after metrics delta
     metrics_after = get_cache_tokens_from_metrics(url)

--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -586,6 +586,11 @@ def run_one_case(
         else:
             json_schema = None
 
+        # At large batch sizes, per-token SSE streaming events add enough
+        # client-side overhead to skew the measured timing. Raise the effective
+        # stream_interval so the server emits far fewer events; TTFT is then
+        # recovered from the server-reported throughput below instead of from
+        # per-event timestamps.
         reduce_sse = batch_size > 256
         effective_stream_interval = (
             max(stream_interval, output_len) if reduce_sse else stream_interval
@@ -727,6 +732,10 @@ def run_one_case(
         acc_length = internal_state[0].get("avg_spec_accept_length", None) or -1
 
     if reduce_sse and last_gen_throughput > 0:
+        # With SSE suppressed, the per-token last_ttft measured above is
+        # unreliable, so estimate it from total decode time. last_gen_throughput
+        # is per-DP-rank, so scale by dp_size to get aggregate throughput across
+        # all ranks.
         dp_size = server_info.get("dp_size", 1)
         decode_time = batch_size * output_len / (last_gen_throughput * dp_size)
         last_ttft = latency - decode_time


### PR DESCRIPTION
## Summary
- fix large bs benchmark script not showing accurate output throughput due to too many events
- For large batch sizes, per-token SSE streaming events add significant client-side overhead that skews the measured timing. When batch_size > 256, raise the effective stream_interval so the server emits far fewer streaming events, then recover TTFT from the server-reported last_gen_throughput (scaled by dp_size) instead of relying on per-event timestamps.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27076555539](https://github.com/sgl-project/sglang/actions/runs/27076555539)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27076555487](https://github.com/sgl-project/sglang/actions/runs/27076555487)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->