### PR TITLE
[Bugfix] Fall back to max_running_requests for sglang:utilization in OSS codepath

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -974,13 +974,21 @@ class SchedulerMetricsReporter:
         if self.scheduler.disaggregation_mode == DisaggregationMode.PREFILL:
             self.stats.utilization = -1
         else:
-            # TODO: max_running_requests_under_SLO has no setter — sglang:utilization stuck at 0 (regressed #22713).
+            # Prefer the SLO-aware capacity if it has been populated (non-OSS
+            # or future OSS paths). Fall back to max_running_requests so that
+            # sglang:utilization reflects real load in the OSS codepath.
+            # See: https://github.com/sgl-project/sglang/issues/22713
             max_under_slo = getattr(
                 self.scheduler, "max_running_requests_under_SLO", None
             )
-            if max_under_slo is not None and max_under_slo > 0:
+            capacity = (
+                max_under_slo
+                if (max_under_slo is not None and max_under_slo > 0)
+                else getattr(self.scheduler, "max_running_requests", None)
+            )
+            if capacity is not None and capacity > 0:
                 self.stats.utilization = max(
-                    self.stats.num_running_reqs.total / max_under_slo,
+                    self.stats.num_running_reqs.total / capacity,
                     self.stats.token_usage / 0.9,
                 )
 


### PR DESCRIPTION
## Summary

Fixes #22713

## Problem

`sglang:utilization` is permanently stuck at `0.0` in all open-source SGLang deployments. The utilization calculation is gated on `max_running_requests_under_SLO` being set and greater than zero, but this field is never assigned anywhere in the OSS codebase — it is defined but has no setter.

## Fix

Fall back to `max_running_requests` (which is always populated on the scheduler) when `max_running_requests_under_SLO` is not set. The SLO-aware path is preserved for non-OSS or future OSS implementations.

```python
# Before: utilization always stuck at 0.0 in OSS
if max_under_slo is not None and max_under_slo > 0:
    self.stats.utilization = max(...)

# After: falls back to max_running_requests when SLO capacity not set
capacity = (
    max_under_slo
    if (max_under_slo is not None and max_under_slo > 0)
    else getattr(self.scheduler, "max_running_requests", None)
)
if capacity is not None and capacity > 0:
    self.stats.utilization = max(...)
```

## Testing

No GPU needed. The fix is a pure Python change to the metrics calculation path. Can be verified by starting a server with `--enable-metrics` and confirming `sglang:utilization` now reflects running request count relative to `max_running_requests`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27077290327](https://github.com/sgl-project/sglang/actions/runs/27077290327)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27077290297](https://github.com/sgl-project/sglang/actions/runs/27077290297)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->