### PR TITLE
[Bugfix] Forward EPD-disaggregation and background fields in GenerateReqInput.__getitem__

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -724,6 +724,14 @@ class GenerateReqInput(BaseReq):
                 if self.multi_item_delimiter_indices is not None
                 else None
             ),
+            # EPD-disaggregation fields (issue #27217)
+            need_wait_for_mm_inputs=self.need_wait_for_mm_inputs,
+            num_items_assigned=self.num_items_assigned,
+            mm_data_mooncake=(
+                self.mm_data_mooncake[i] if self.mm_data_mooncake is not None else None
+            ),
+            # Responses API background flag (issue #27231)
+            background=self.background,
         )
         cache[i] = sub
         return sub


### PR DESCRIPTION
## Motivation

`GenerateReqInput.__getitem__` is responsible for slicing a batched request into individual per-sample sub-requests. However, several fields were never forwarded in this method, causing them to silently fall back to their default values for every sliced sub-request in a batch.

This PR fixes two related issues:

**EPD-disaggregation fields (fixes #27217):**
`need_wait_for_mm_inputs`, `num_items_assigned`, and `mm_data_mooncake` are used in the EPD-disaggregated inference path. When a batched request is sliced, these fields were reset to `None`, breaking disaggregated multimodal inference silently.

**Responses API background flag (fixes #27231):**
`background` is set from the OpenAI Responses API (`background=request.background`) and is read in `tokenizer_manager.py` to decide whether to abort a request on client disconnect. With `background` always falling back to `False` on sliced sub-requests, a background job whose client had disconnected was being aborted instead of continuing to run in the background — directly contradicting the intended semantics of background responses.

## Modifications

Added the following fields to `GenerateReqInput.__getitem__` in `python/sglang/srt/managers/io_struct.py`:

- `need_wait_for_mm_inputs=self.need_wait_for_mm_inputs` — request-global scalar, forwarded as-is
- `num_items_assigned=self.num_items_assigned` — request-global scalar, forwarded as-is
- `mm_data_mooncake=self.mm_data_mooncake[i] if self.mm_data_mooncake is not None else None` — per-sample list, indexed correctly
- `background=self.background` — request-global scalar, forwarded as-is

## Accuracy Tests

No model output changes. This is a pure request-routing fix with no impact on model forward passes or sampling logic.

## Speed Tests and Profiling

No performance impact. The changes are limited to object construction in `__getitem__` and do not affect any hot paths.

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27077572967](https://github.com/sgl-project/sglang/actions/runs/27077572967)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27077572931](https://github.com/sgl-project/sglang/actions/runs/27077572931)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->