### PR TITLE
[HiCache] Fix startup failure with DeepSeekV4 + PP

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -284,7 +284,6 @@ def build_deepseek_v4_hicache_stack(
     storage_backend_extra_config: Optional[dict] = None,
     enable_storage_metrics: bool = False,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
-    # TODO(hzh0425): Support PP for deepseek v4 with hicache
     transfer_layer_num = kvcache.end_layer - kvcache.start_layer
     full_layer_mapping = {layer_id: layer_id for layer_id in range(transfer_layer_num)}
     swa_layer_mapping = {
@@ -377,7 +376,7 @@ def build_deepseek_v4_hicache_stack(
         c4_state_host_pool = DeepSeekV4StateHostPool(
             pool_name=str(PoolName.DEEPSEEK_V4_C4_STATE),
             state_pools=[
-                kvcache.compress_state_pools[layer_id]
+                kvcache.compress_state_pools[layer_id + kvcache.start_layer]
                 for layer_id in c4_state_global_layers
             ],
             num_host_pages=swa_num_host_pages,
@@ -388,7 +387,7 @@ def build_deepseek_v4_hicache_stack(
         c4_indexer_state_host_pool = DeepSeekV4StateHostPool(
             pool_name=str(PoolName.DEEPSEEK_V4_C4_INDEXER_STATE),
             state_pools=[
-                kvcache.indexer_compress_state_pools[layer_id]
+                kvcache.indexer_compress_state_pools[layer_id + kvcache.start_layer]
                 for layer_id in c4_state_global_layers
             ],
             num_host_pages=swa_num_host_pages,
@@ -439,8 +438,6 @@ def build_deepseek_v4_hicache_stack(
             layout=server_args.hicache_mem_layout,
             allocator_type=server_args.hicache_storage_backend,
         )
-        # C128 state pool is intentionally not registered with hicache.
-        # page_size=256 % 128 == 0, so state pool is not consumed on load.
         entries.extend(
             [
                 build_pool_entry(

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -438,6 +438,8 @@ def build_deepseek_v4_hicache_stack(
             layout=server_args.hicache_mem_layout,
             allocator_type=server_args.hicache_storage_backend,
         )
+        # C128 state pool is intentionally not registered with hicache.
+        # page_size=256 % 128 == 0, so state pool is not consumed on load.
         entries.extend(
             [
                 build_pool_entry(

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
@@ -42,6 +42,8 @@ class TestUnifiedDeepSeekV4FlashHiCache(UnifiedRadixTreeTestMixin, CustomTestCas
     decode_cache_assert = staticmethod(_assert_dsv4_decode_cached_tokens)
     gsm8k_threshold = 0.90
     num_gsm8k_questions = 100
+    tp_size = 4
+    pp_size = 1
 
     @unittest.skipIf(is_in_ci(), "To reduce the CI execution time.")
     def test_multiturn_logprobs_match(self):
@@ -58,7 +60,9 @@ class TestUnifiedDeepSeekV4FlashHiCache(UnifiedRadixTreeTestMixin, CustomTestCas
             other_args=[
                 "--trust-remote-code",
                 "--tp-size",
-                "4",
+                cls.tp_size,
+                "--pp-size",
+                cls.pp_size,
                 "--attention-backend",
                 "compressed",
                 "--page-size",
@@ -103,6 +107,13 @@ class TestUnifiedDeepSeekV4FlashHiCachePageFirstDirect(
 
     hicache_io_backend = "kernel"
     hicache_mem_layout = "layer_first"
+
+
+class TestUnifiedDeepSeekV4FlashHiCachePP(TestUnifiedDeepSeekV4FlashHiCache):
+    """DeepSeek V4 Flash HiCache + PP"""
+
+    tp_size = 1
+    pp_size = 4
 
 
 # ─── DeepSeek V4 Flash + HiCache L3 (file backend) ──────────────────────


### PR DESCRIPTION
## Motivation

This PR fixes startup failure with DeepSeekV4 + PP.

The failure message was:

```
[2026-06-07 01:57:37 PP3] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/managers/scheduler.py", line 4024, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/managers/scheduler.py", line 433, in __init__
    result = kv_cache_builder.build_kv_cache(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/kv_cache_builder.py", line 230, in build_kv_cache
    tree_cache = create_tree_cache(
                 ^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/registry.py", line 180, in create_tree_cache
    cache = default_radix_cache_factory(ctx)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/registry.py", line 118, in default_radix_cache_factory
    cache.init_hicache(server_args, params)
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/unified_radix_cache.py", line 497, in init_hicache
    attach_hybrid_pool_to_unified_cache(
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 1115, in attach_hybrid_pool_to_unified_cache
    result = strategy.build(
             ^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 714, in build
    host_pool_group, cache_controller = build_deepseek_v4_hicache_stack(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 377, in build_deepseek_v4_hicache_stack
    c4_state_host_pool = DeepSeekV4StateHostPool(
                         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang_pp_bug/python/sglang/srt/mem_cache/memory_pool_host.py", line 2238, in __init__
    raise ValueError(f"{pool_name} state_pools must not contain None")
ValueError: deepseek_v4_c4_state state_pools must not contain None
```

I have tested this PR with DeepSeekV4-Flash-FP8.  It is able to start successfully and produce reasonable outputs.

## Modifications

The failure reason is that, in `build_deepseek_v4_hicache_stack`, `kvcache.compress_state_pools` was indexed by global layer No..  So in PP, this should be adjusted by adding `start_layer`.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27259270965](https://github.com/sgl-project/sglang/actions/runs/27259270965)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27259270706](https://github.com/sgl-project/sglang/actions/runs/27259270706)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->