### PR TITLE
Fix TRTLLM target verify query metadata

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -484,7 +484,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ]
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
             self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
-            metadata.max_seq_len_q = self.speculative_num_draft_tokens
         elif forward_mode.is_draft_extend(include_v2=True):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)


### PR DESCRIPTION
## Summary

- Remove a target-verify metadata override that forced the query length to the configured draft token count.
- Let target-verify graph metadata keep the query length derived from the captured request shape.

## Verification

- `python3 -m py_compile python/sglang/srt/layers/attention/trtllm_mha_backend.py`

## Original commits

- `6e73c7a4fc98fa6fc1351c88506e1e48f1a99e79`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27081813112](https://github.com/sgl-project/sglang/actions/runs/27081813112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27081813037](https://github.com/sgl-project/sglang/actions/runs/27081813037)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->