### PR TITLE
fix: skip radix inserts for positional embeds

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -950,7 +950,10 @@ class Req(ReqDllmMixin):
         self.bootstrap_host: str = bootstrap_host
         self.bootstrap_port: Optional[int] = bootstrap_port
         self.bootstrap_room: Optional[int] = bootstrap_room
-        self.skip_radix_cache_insert = bootstrap_host == FAKE_BOOTSTRAP_HOST
+        self.skip_radix_cache_insert = (
+            bootstrap_host == FAKE_BOOTSTRAP_HOST
+            or positional_embed_overrides is not None
+        )
         self.disagg_kv_sender: Optional[BaseKVSender] = None
 
         self.routed_dp_rank: Optional[int] = routed_dp_rank

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -162,5 +162,24 @@ class TestStashGatePreservesPrefixIndices(CustomTestCase):
         self.assertIsNone(s.chunked_req)
 
 
+class TestPositionalEmbedOverridesSkipRadixInsert(CustomTestCase):
+    def test_positional_embed_overrides_do_not_populate_radix_cache(self):
+        from sglang.srt.managers.embed_types import PositionalEmbeds
+        from sglang.srt.sampling.sampling_params import SamplingParams
+
+        req = Req(
+            rid="override-req",
+            origin_input_text="",
+            origin_input_ids=array("q", [1, 2, 3]),
+            sampling_params=SamplingParams(),
+            positional_embed_overrides=PositionalEmbeds(
+                embeds=torch.ones((1, 4)),
+                positions=[0],
+            ),
+        )
+
+        self.assertTrue(req.skip_radix_cache_insert)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- mark requests with `positional_embed_overrides` as ineligible for radix cache insertion
- keep the existing lookup bypass and prevent the finished KV from being published under the normal token key
- add a small regression test around `Req` initialization

Fixes #27472.

## Why

`positional_embed_overrides` changes the embeddings used for a token sequence. The scheduler already avoids prefix lookup for those requests by matching an empty token id array, but the completed request could still be inserted into the radix cache with the ordinary token ids and `extra_key`.

That means a later request without overrides could reuse KV computed from injected embeddings. The safe behavior is to treat these requests like other non-insertable cache paths.

## Validation

- `python -m py_compile python\sglang\srt\managers\schedule_batch.py test\registered\unit\managers\test_scheduler_chunked_req_gate.py`
- `git diff --check`

I also tried the targeted pytest paths locally:

- `PYTHONPATH=python python -m pytest test\registered\unit\managers\test_scheduler_chunked_req_gate.py -q`
- `PYTHONPATH=python python -m pytest test\registered\prefill_only\test_embed_overrides.py -q`

On this Windows environment they fail during collection before reaching the tests because `sglang.srt.utils.common` imports Unix/GPU-only modules that are not available locally (`resource`, then `triton` after stubbing `resource`).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27081823276](https://github.com/sgl-project/sglang/actions/runs/27081823276)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27081823253](https://github.com/sgl-project/sglang/actions/runs/27081823253)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->