### PR TITLE
[spec] Dedup draft `kv_indices` sizing into `spec_utils` helpers

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -27,7 +27,11 @@ from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
+from sglang.srt.speculative.spec_utils import (
+    draft_kv_indices_buffer_width,
+    draft_kv_indices_used_len,
+    generate_draft_decode_kv_indices,
+)
 from sglang.srt.utils import is_gfx95_supported
 
 if TYPE_CHECKING:
@@ -2837,7 +2841,7 @@ class AiterMultiStepDraftBackend:
         for i in range(self.speculative_num_steps - 1):
             forward_batch.spec_info.kv_indptr = self.kv_indptr[i, : bs + 1]
             forward_batch.spec_info.kv_indices = kv_indices_buffer[i][
-                : seq_lens_sum * self.topk + bs * (i + 1)
+                : draft_kv_indices_used_len(seq_lens_sum, self.topk, bs, i + 1)
             ]
             call_fn(i, forward_batch)
 
@@ -2845,7 +2849,9 @@ class AiterMultiStepDraftBackend:
         kv_indices = torch.empty(
             (
                 self.speculative_num_steps,
-                forward_batch.batch_size * self.topk * self.max_context_len,
+                draft_kv_indices_buffer_width(
+                    forward_batch.batch_size, self.topk, self.max_context_len
+                ),
             ),
             dtype=torch.int32,
             device=self.device,
@@ -2864,7 +2870,10 @@ class AiterMultiStepDraftBackend:
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.cuda_graph_kv_indices = torch.zeros(
-            (self.speculative_num_steps, max_num_tokens * self.max_context_len),
+            (
+                self.speculative_num_steps,
+                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
+            ),
             dtype=torch.int32,
             device=self.device,
         )

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2846,13 +2846,11 @@ class AiterMultiStepDraftBackend:
             call_fn(i, forward_batch)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
+        kv_indices_width = draft_kv_indices_buffer_width(
+            forward_batch.batch_size, self.topk, self.max_context_len
+        )
         kv_indices = torch.empty(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(
-                    forward_batch.batch_size, self.topk, self.max_context_len
-                ),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int32,
             device=self.device,
         )
@@ -2869,11 +2867,11 @@ class AiterMultiStepDraftBackend:
         self.common_template(forward_batch, kv_indices, call_fn)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+        kv_indices_width = draft_kv_indices_buffer_width(
+            max_bs, self.topk, self.max_context_len
+        )
         self.cuda_graph_kv_indices = torch.zeros(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int32,
             device=self.device,
         )

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1636,13 +1636,11 @@ class FlashInferMultiStepDraftBackend:
         global_override_indptr_cpu = None
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
+        kv_indices_width = draft_kv_indices_buffer_width(
+            forward_batch.batch_size, self.topk, self.max_context_len
+        )
         kv_indices = torch.empty(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(
-                    forward_batch.batch_size, self.topk, self.max_context_len
-                ),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int32,
             device="cuda",
         )
@@ -1662,11 +1660,11 @@ class FlashInferMultiStepDraftBackend:
         # generate_draft_decode_kv_indices packs topk per-branch sequences per row,
         # so the row needs the topk factor -- same as the eager init_forward_metadata
         # (batch_size * topk * max_context_len). Dropping it overflows the buffer.
+        kv_indices_width = draft_kv_indices_buffer_width(
+            max_bs, self.topk, self.max_context_len
+        )
         self.cuda_graph_kv_indices = torch.zeros(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int32,
             device="cuda",
         )

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -27,7 +27,11 @@ from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
-from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
+from sglang.srt.speculative.spec_utils import (
+    draft_kv_indices_buffer_width,
+    draft_kv_indices_used_len,
+    generate_draft_decode_kv_indices,
+)
 from sglang.srt.utils import (
     get_int_env_var,
     is_flashinfer_available,
@@ -1585,8 +1589,8 @@ class FlashInferMultiStepDraftBackend:
 
         # Fail fast on an undersized kv_indices row: the kernel would otherwise write
         # OOB and *silently* corrupt memory, only sometimes surfacing as a crash.
-        required_kv_indices_len = (
-            seq_lens_sum * self.topk + bs * self.speculative_num_steps
+        required_kv_indices_len = draft_kv_indices_used_len(
+            seq_lens_sum, self.topk, bs, self.speculative_num_steps
         )
         assert required_kv_indices_len <= kv_indices_buffer.shape[1], (
             f"EAGLE draft kv_indices row too small: need {required_kv_indices_len} "
@@ -1624,7 +1628,7 @@ class FlashInferMultiStepDraftBackend:
         for i in range(self.speculative_num_steps - 1):
             forward_batch.spec_info.kv_indptr = self.kv_indptr[i, : bs + 1]
             forward_batch.spec_info.kv_indices = kv_indices_buffer[i][
-                : seq_lens_sum * self.topk + bs * (i + 1)
+                : draft_kv_indices_used_len(seq_lens_sum, self.topk, bs, i + 1)
             ]
             global_override_indptr_cpu = indptr_cpu_whole[i]
             call_fn(i, forward_batch)
@@ -1635,7 +1639,9 @@ class FlashInferMultiStepDraftBackend:
         kv_indices = torch.empty(
             (
                 self.speculative_num_steps,
-                forward_batch.batch_size * self.topk * self.max_context_len,
+                draft_kv_indices_buffer_width(
+                    forward_batch.batch_size, self.topk, self.max_context_len
+                ),
             ),
             dtype=torch.int32,
             device="cuda",
@@ -1657,7 +1663,10 @@ class FlashInferMultiStepDraftBackend:
         # so the row needs the topk factor -- same as the eager init_forward_metadata
         # (batch_size * topk * max_context_len). Dropping it overflows the buffer.
         self.cuda_graph_kv_indices = torch.zeros(
-            (self.speculative_num_steps, max_bs * self.topk * self.max_context_len),
+            (
+                self.speculative_num_steps,
+                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
+            ),
             dtype=torch.int32,
             device="cuda",
         )

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -25,7 +25,11 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput
-from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
+from sglang.srt.speculative.spec_utils import (
+    draft_kv_indices_buffer_width,
+    draft_kv_indices_used_len,
+    generate_draft_decode_kv_indices,
+)
 from sglang.srt.utils import (
     is_flashinfer_available,
     is_sm100_supported,
@@ -944,8 +948,8 @@ class FlashInferMLAMultiStepDraftBackend:
 
         # Fail fast on an undersized kv_indices row: the kernel would otherwise
         # write OOB and silently corrupt memory.
-        required_kv_indices_len = (
-            seq_lens_sum * self.topk + bs * self.speculative_num_steps
+        required_kv_indices_len = draft_kv_indices_used_len(
+            seq_lens_sum, self.topk, bs, self.speculative_num_steps
         )
         assert required_kv_indices_len <= kv_indices_buffer.shape[1], (
             f"EAGLE draft kv_indices row too small: need {required_kv_indices_len} "
@@ -979,7 +983,7 @@ class FlashInferMLAMultiStepDraftBackend:
         for i in range(self.speculative_num_steps - 1):
             forward_batch.spec_info.kv_indptr = self.kv_indptr[i, : bs + 1]
             forward_batch.spec_info.kv_indices = kv_indices_buffer[i][
-                : seq_lens_sum * self.topk + bs * (i + 1)
+                : draft_kv_indices_used_len(seq_lens_sum, self.topk, bs, i + 1)
             ]
             call_fn(i, forward_batch)
 
@@ -987,7 +991,9 @@ class FlashInferMLAMultiStepDraftBackend:
         kv_indices = torch.zeros(
             (
                 self.speculative_num_steps,
-                forward_batch.batch_size * self.topk * self.max_context_len,
+                draft_kv_indices_buffer_width(
+                    forward_batch.batch_size, self.topk, self.max_context_len
+                ),
             ),
             dtype=torch.int32,
             device="cuda",
@@ -1008,7 +1014,10 @@ class FlashInferMLAMultiStepDraftBackend:
         # Row holds topk per-branch sequences (generate_draft_decode_kv_indices), so
         # it needs the topk factor, matching the eager init_forward_metadata.
         self.cuda_graph_kv_indices = torch.zeros(
-            (self.speculative_num_steps, max_bs * self.topk * self.max_context_len),
+            (
+                self.speculative_num_steps,
+                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
+            ),
             dtype=torch.int32,
             device="cuda",
         )

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -988,13 +988,11 @@ class FlashInferMLAMultiStepDraftBackend:
             call_fn(i, forward_batch)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
+        kv_indices_width = draft_kv_indices_buffer_width(
+            forward_batch.batch_size, self.topk, self.max_context_len
+        )
         kv_indices = torch.zeros(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(
-                    forward_batch.batch_size, self.topk, self.max_context_len
-                ),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int32,
             device="cuda",
         )
@@ -1013,11 +1011,11 @@ class FlashInferMLAMultiStepDraftBackend:
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         # Row holds topk per-branch sequences (generate_draft_decode_kv_indices), so
         # it needs the topk factor, matching the eager init_forward_metadata.
+        kv_indices_width = draft_kv_indices_buffer_width(
+            max_bs, self.topk, self.max_context_len
+        )
         self.cuda_graph_kv_indices = torch.zeros(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int32,
             device="cuda",
         )

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1402,13 +1402,11 @@ class TritonMultiStepDraftBackend:
             call_fn(i, forward_batch)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
+        kv_indices_width = draft_kv_indices_buffer_width(
+            forward_batch.batch_size, self.topk, self.max_context_len
+        )
         kv_indices = torch.empty(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(
-                    forward_batch.batch_size, self.topk, self.max_context_len
-                ),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int64,
             device=self.device,
         )
@@ -1425,11 +1423,11 @@ class TritonMultiStepDraftBackend:
         self.common_template(forward_batch, kv_indices, call_fn)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+        kv_indices_width = draft_kv_indices_buffer_width(
+            max_bs, self.topk, self.max_context_len
+        )
         self.cuda_graph_kv_indices = torch.zeros(
-            (
-                self.speculative_num_steps,
-                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
-            ),
+            (self.speculative_num_steps, kv_indices_width),
             dtype=torch.int64,
             device=self.device,
         )

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -16,7 +16,11 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
+from sglang.srt.speculative.spec_utils import (
+    draft_kv_indices_buffer_width,
+    draft_kv_indices_used_len,
+    generate_draft_decode_kv_indices,
+)
 from sglang.srt.utils import (
     get_bool_env_var,
     get_device_core_count,
@@ -1393,7 +1397,7 @@ class TritonMultiStepDraftBackend:
         for i in range(self.speculative_num_steps - 1):
             forward_batch.spec_info.kv_indptr = self.kv_indptr[i, : bs + 1]
             forward_batch.spec_info.kv_indices = kv_indices_buffer[i][
-                : seq_lens_sum * self.topk + bs * (i + 1)
+                : draft_kv_indices_used_len(seq_lens_sum, self.topk, bs, i + 1)
             ]
             call_fn(i, forward_batch)
 
@@ -1401,7 +1405,9 @@ class TritonMultiStepDraftBackend:
         kv_indices = torch.empty(
             (
                 self.speculative_num_steps,
-                forward_batch.batch_size * self.topk * self.max_context_len,
+                draft_kv_indices_buffer_width(
+                    forward_batch.batch_size, self.topk, self.max_context_len
+                ),
             ),
             dtype=torch.int64,
             device=self.device,
@@ -1420,7 +1426,10 @@ class TritonMultiStepDraftBackend:
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.cuda_graph_kv_indices = torch.zeros(
-            (self.speculative_num_steps, max_num_tokens * self.max_context_len),
+            (
+                self.speculative_num_steps,
+                draft_kv_indices_buffer_width(max_bs, self.topk, self.max_context_len),
+            ),
             dtype=torch.int64,
             device=self.device,
         )

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -83,9 +83,8 @@ def draft_kv_indices_buffer_width(
 ) -> int:
     """Per-step row width of the EAGLE draft-decode kv_indices buffer.
 
-    Each of the num_seqs * topk draft branches attends to up to max_context_len
-    KV slots, so the row holds num_seqs * topk * max_context_len indices. The topk
-    factor is mandatory: dropping it under-allocates and overflows the row (#27338, #27460).
+    num_seqs * topk branches each attend up to max_context_len KV slots; the topk
+    factor is mandatory -- dropping it under-allocates and overflows the row (#27338, #27460).
     """
     return num_seqs * topk * max_context_len
 
@@ -93,11 +92,10 @@ def draft_kv_indices_buffer_width(
 def draft_kv_indices_used_len(
     seq_lens_sum: int, topk: int, bs: int, num_steps: int
 ) -> int:
-    """kv_indices length actually used through num_steps draft-decode steps.
+    """kv_indices length used through num_steps draft-decode steps.
 
-    bs = topk * num_seqs branches; each step appends one index per branch. Used both
-    to slice the per-step kv_indices view (num_steps = i + 1) and to assert the row is
-    wide enough (num_steps = speculative_num_steps).
+    bs = topk * num_seqs branches, one index appended per branch per step. Called with
+    num_steps = i + 1 (per-step slice) and speculative_num_steps (capacity assert).
     """
     return seq_lens_sum * topk + bs * num_steps
 

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -78,6 +78,30 @@ TREE_SPEC_KERNEL_AVAILABLE = (
 )  # This kernel is only available for CUDA and MUSA now
 
 
+def draft_kv_indices_buffer_width(
+    num_seqs: int, topk: int, max_context_len: int
+) -> int:
+    """Per-step row width of the EAGLE draft-decode kv_indices buffer.
+
+    Each of the num_seqs * topk draft branches attends to up to max_context_len
+    KV slots, so the row holds num_seqs * topk * max_context_len indices. The topk
+    factor is mandatory: dropping it under-allocates and overflows the row (#27338, #27460).
+    """
+    return num_seqs * topk * max_context_len
+
+
+def draft_kv_indices_used_len(
+    seq_lens_sum: int, topk: int, bs: int, num_steps: int
+) -> int:
+    """kv_indices length actually used through num_steps draft-decode steps.
+
+    bs = topk * num_seqs branches; each step appends one index per branch. Used both
+    to slice the per-step kv_indices view (num_steps = i + 1) and to assert the row is
+    wide enough (num_steps = speculative_num_steps).
+    """
+    return seq_lens_sum * topk + bs * num_steps
+
+
 def record_stream_each(tensors, stream):
     """Call record_stream(stream) on each cuda tensor in `tensors`, skipping
     non-tensor / non-cuda entries. Tells the caching allocator that the


### PR DESCRIPTION
## Summary

Extract the two `kv_indices` sizing formulas that the EAGLE draft-decode backends duplicate inline into shared helpers in `python/sglang/srt/speculative/spec_utils.py`:

- `draft_kv_indices_buffer_width(num_seqs, topk, max_context_len)` = `num_seqs * topk * max_context_len` (per-step row width of the draft `kv_indices` buffer).
- `draft_kv_indices_used_len(seq_lens_sum, topk, bs, num_steps)` = `seq_lens_sum * topk + bs * num_steps` (length actually consumed through `num_steps` draft steps).

The four draft backends (`flashinfer`, `flashinfer_mla`, `triton`, `aiter`) import both helpers from `spec_utils` alongside `generate_draft_decode_kv_indices` and use them at the 14 call sites (8 buffer-width allocations + 6 used-length assert/slice sites). Centralizing the `* topk` factor in one place makes the under-allocation bug class (#27338, #27460) structurally impossible for a new backend to reintroduce, and keeps the per-step slice and the capacity assert in sync.

Follows #27484, which made `spec_utils` module-importable from the attention backends (so the helpers can be imported there directly, no local-import workaround).

## Behavior-preserving

Pure refactor; every numeric result is identical:

- Each helper returns exactly the previous inline expression.
- triton/aiter cuda-graph sites: old expression was `max_num_tokens * max_context_len`. In the draft cuda-graph runner `max_num_tokens == max_bs * topk` (`num_tokens_per_bs = topk`), so the new `draft_kv_indices_buffer_width(max_bs, topk, max_context_len)` is exact.
- `dtype` (int32 vs int64), device (`"cuda"` vs `self.device`), and `torch.empty` vs `torch.zeros` are preserved unchanged at every site.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27086358664](https://github.com/sgl-project/sglang/actions/runs/27086358664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27086358613](https://github.com/sgl-project/sglang/actions/runs/27086358613)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
