### PR TITLE
[Spec] Guard async-assert probes against `None` tensor

### DIFF
--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -5,30 +5,38 @@ When the gate is on, a violation surfaces as an assertion at the next CUDA
 sync point instead of as a silent NaN cascade or illegal-address crash.
 """
 
+from typing import Optional
+
 import torch
 
 from sglang.srt.environ import envs
 
 
-def maybe_detect_nan(tensor: torch.Tensor, msg: str = ""):
+def maybe_detect_nan(tensor: Optional[torch.Tensor], msg: str = ""):
     """Async NaN check — no GPU-CPU sync, error surfaces at next sync point."""
     if not envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
+        return
+    # A None tensor means there is nothing to probe, e.g. hidden_states on
+    # capture_hidden_mode=NULL paths (STANDALONE speculative decoding).
+    if tensor is None:
         return
     torch._assert_async(~torch.any(torch.isnan(tensor)), f"NaN detected! {msg}")
 
 
-def maybe_detect_inf(tensor: torch.Tensor, msg: str = ""):
+def maybe_detect_inf(tensor: Optional[torch.Tensor], msg: str = ""):
     """Async Inf check — fp16 overflow surfaces as Inf before NaN."""
     if not envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
+        return
+    if tensor is None:
         return
     torch._assert_async(~torch.any(torch.isinf(tensor)), f"Inf detected! {msg}")
 
 
-def maybe_detect_oob(indices: torch.Tensor, low: int, high: int, msg: str):
+def maybe_detect_oob(indices: Optional[torch.Tensor], low: int, high: int, msg: str):
     """Async OOB check — no GPU-CPU sync, error surfaces at next sync point."""
     if not envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
         return
-    if indices.numel() == 0:
+    if indices is None or indices.numel() == 0:
         return
     torch._assert_async(
         (indices.min() >= low) & (indices.max() < high),
@@ -36,11 +44,13 @@ def maybe_detect_oob(indices: torch.Tensor, low: int, high: int, msg: str):
     )
 
 
-def maybe_detect_page_aligned(indices: torch.Tensor, page_size: int, msg: str):
+def maybe_detect_page_aligned(
+    indices: Optional[torch.Tensor], page_size: int, msg: str
+):
     """Async page-alignment check on slot ids."""
     if not envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
         return
-    if indices.numel() == 0 or page_size <= 1:
+    if indices is None or indices.numel() == 0 or page_size <= 1:
         return
     torch._assert_async(
         (indices % page_size == 0).all(),


### PR DESCRIPTION
## Summary
- Treat a `None` tensor as nothing to check across all `async_probe.py` probes (`maybe_detect_nan` / `maybe_detect_inf` / `maybe_detect_oob` / `maybe_detect_page_aligned`)

## Root cause
- STANDALONE speculative decoding runs the draft model with `capture_hidden_mode=NULL`, so `logits_output.hidden_states` is legitimately `None` (the standalone draft is a full model and does not thread target hidden states between steps)
- With `SGLANG_ENABLE_ASYNC_ASSERT` enabled, `draft_forward` calls `maybe_detect_nan(logits_output.hidden_states, ...)`, which hits `torch.isnan(None)` and crashes the engine during draft CUDA-graph capture (probes added in #26335)
- The real draft path already tolerates `None` (`select_top_k_tokens` guards `hidden_states is None`), so only the probe was affected

## Fix
- Early-return on `None` in every probe; widen type hints to `Optional[torch.Tensor]`
- Fold `indices is None` into the existing `numel() == 0` short-circuit for the OOB / page-alignment probes so `.numel()` never runs on `None`

## Test
- `/rerun-test test_spec_standalone_extra.py test_spec_standalone.py` (STANDALONE spec decoding, the path that reproduced the crash)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27082164563](https://github.com/sgl-project/sglang/actions/runs/27082164563)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27082164471](https://github.com/sgl-project/sglang/actions/runs/27082164471)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
