### PR TITLE
fix(fla/layernorm_gated): handle CPU device in _get_sm_count (#27456)

### DIFF
--- a/python/sglang/srt/layers/attention/fla/layernorm_gated.py
+++ b/python/sglang/srt/layers/attention/fla/layernorm_gated.py
@@ -183,6 +183,11 @@ def _get_sm_count(device: torch.device) -> int:
     if device.type == "xpu":
         assert torch.xpu.is_available(), "XPU device is not available"
         return torch.xpu.get_device_properties(device).gpu_subslice_count
+    if device.type == "cpu":
+        # CPU has no streaming multiprocessors; use the intra-op thread count
+        # as the parallelism proxy so calc_rows_per_block stays well-defined
+        # instead of crashing in torch.cuda.get_device_properties.
+        return max(torch.get_num_threads(), 1)
     props = torch.cuda.get_device_properties(device)
     return props.multi_processor_count
 


### PR DESCRIPTION
## Motivation

Closes #27456.

`_get_sm_count()` in `python/sglang/srt/layers/attention/fla/layernorm_gated.py` handles `xpu` and then unconditionally calls `torch.cuda.get_device_properties(device)`. On a CPU-only build (e.g. the `docker/xeon.Dockerfile` image with CPU PyTorch wheels), the server starts up fine but crashes on the **first inference request** that hits a gated layer-norm (any model using `linear_attn`):

```
File ".../sglang/srt/layers/attention/fla/layernorm_gated.py", line 186, in _get_sm_count
    props = torch.cuda.get_device_properties(device)
AssertionError: Torch not compiled with CUDA enabled
```

## Modification

Add a `cpu` branch to `_get_sm_count()` that returns `max(torch.get_num_threads(), 1)`. CPUs have no streaming multiprocessors, so the intra-op thread count is used as the parallelism proxy. `_get_sm_count` only feeds `calc_rows_per_block` via `cdiv(M, 2 * sm_count)` (result clamped to `MAX_ROWS_PER_BLOCK`), so any positive value keeps block sizing well-defined — the goal here is simply to stop crashing on CPU. The CUDA path is unchanged.

## Checklist

- [x] Minimal, targeted change (1 file, +5/-0); CUDA/XPU paths untouched.
- [x] Mirrors the existing per-device branching style in the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27082463953](https://github.com/sgl-project/sglang/actions/runs/27082463953)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27082463879](https://github.com/sgl-project/sglang/actions/runs/27082463879)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->