### PR TITLE
[Attn] Fix aiter MLA verify `kv_indices` under-alloc + shared `assert_buffer_fits` guard

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1450,7 +1450,15 @@ class AiterAttnBackend(AttentionBackend):
             # metadata sites + paged_attention_ragged call site + FP8 KV
             # coordination, after which this allocation can revert to
             # per-page (gated on use_mla).
-            buffer_numel = max_bs * max_num_blocks_per_seq * self.page_size
+            # MLA target_verify writes kv_lens = seq_len + num_draft_tokens per
+            # row (see _apply_cuda_graph_metadata); reserve that slack here.
+            # create_flashinfer_kv_indices_triton bounds writes only per-row
+            # (req_to_token stride), not against this buffer, so without the slack
+            # a near-full sequence silently overflows. Mirrors dsa / flashmla.
+            draft_slack = self.num_draft_tokens or 0
+            buffer_numel = max_bs * (
+                max_num_blocks_per_seq * self.page_size + draft_slack
+            )
             self.cuda_graph_kv_indices = torch.zeros(
                 (buffer_numel,),
                 dtype=torch.int32,
@@ -1691,6 +1699,20 @@ class AiterAttnBackend(AttentionBackend):
             kv_indptr = self.kv_indptr[: bs + 1]
             kv_indptr[1 : bs + 1] = torch.cumsum(kv_lens, dim=0)
             kv_indices = self.cuda_graph_kv_indices
+            # Fail fast on an undersized buffer: the kernel bounds writes only
+            # per-row (req_to_token stride), not against kv_indices, so an
+            # overflow would silently corrupt memory. seq_lens_sum is None during
+            # capture (dummy seq_lens, no overflow); check on replay.
+            if seq_lens_sum is not None:
+                kv_indices_used = seq_lens_sum + (
+                    self.num_draft_tokens * bs if self.use_mla else 0
+                )
+                assert kv_indices_used <= kv_indices.numel(), (
+                    f"aiter target_verify kv_indices too small: need "
+                    f"{kv_indices_used} > {kv_indices.numel()} (bs={bs}, "
+                    f"seq_lens_sum={seq_lens_sum}, "
+                    f"num_draft_tokens={self.num_draft_tokens}, use_mla={self.use_mla})."
+                )
             create_flashinfer_kv_indices_triton[(bs,)](
                 self.req_to_token,
                 req_pool_indices,

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1452,9 +1452,8 @@ class AiterAttnBackend(AttentionBackend):
             # coordination, after which this allocation can revert to
             # per-page (gated on use_mla).
             # Reserve draft slack: MLA target_verify writes seq_len +
-            # num_draft_tokens per row and the kernel doesn't bound writes to
-            # this buffer, so a near-full sequence would silently overflow.
-            # Mirrors dsa / flashmla.
+            # num_draft_tokens per row; without it a near-full sequence
+            # overflows the buffer. Mirrors dsa / flashmla.
             draft_slack = self.num_draft_tokens or 0
             buffer_numel = max_bs * (
                 max_num_blocks_per_seq * self.page_size + draft_slack
@@ -1699,9 +1698,7 @@ class AiterAttnBackend(AttentionBackend):
             kv_indptr = self.kv_indptr[: bs + 1]
             kv_indptr[1 : bs + 1] = torch.cumsum(kv_lens, dim=0)
             kv_indices = self.cuda_graph_kv_indices
-            # Safety guard: fail fast on an undersized buffer (silent overflow
-            # otherwise). seq_lens_sum is None at capture (dummy seq_lens); only
-            # check on replay.
+            # seq_lens_sum is None at capture (dummy seq_lens); only check on replay.
             if seq_lens_sum is not None:
                 kv_indices_used = seq_lens_sum + (
                     self.num_draft_tokens * bs if self.use_mla else 0
@@ -1712,8 +1709,6 @@ class AiterAttnBackend(AttentionBackend):
                     "aiter target_verify kv_indices",
                     bs=bs,
                     seq_lens_sum=seq_lens_sum,
-                    num_draft_tokens=self.num_draft_tokens,
-                    use_mla=self.use_mla,
                 )
             create_flashinfer_kv_indices_triton[(bs,)](
                 self.req_to_token,

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1450,11 +1450,10 @@ class AiterAttnBackend(AttentionBackend):
             # metadata sites + paged_attention_ragged call site + FP8 KV
             # coordination, after which this allocation can revert to
             # per-page (gated on use_mla).
-            # MLA target_verify writes kv_lens = seq_len + num_draft_tokens per
-            # row (see _apply_cuda_graph_metadata); reserve that slack here.
-            # create_flashinfer_kv_indices_triton bounds writes only per-row
-            # (req_to_token stride), not against this buffer, so without the slack
-            # a near-full sequence silently overflows. Mirrors dsa / flashmla.
+            # Reserve draft slack: MLA target_verify writes seq_len +
+            # num_draft_tokens per row and the kernel doesn't bound writes to
+            # this buffer, so a near-full sequence would silently overflow.
+            # Mirrors dsa / flashmla.
             draft_slack = self.num_draft_tokens or 0
             buffer_numel = max_bs * (
                 max_num_blocks_per_seq * self.page_size + draft_slack
@@ -1699,10 +1698,9 @@ class AiterAttnBackend(AttentionBackend):
             kv_indptr = self.kv_indptr[: bs + 1]
             kv_indptr[1 : bs + 1] = torch.cumsum(kv_lens, dim=0)
             kv_indices = self.cuda_graph_kv_indices
-            # Fail fast on an undersized buffer: the kernel bounds writes only
-            # per-row (req_to_token stride), not against kv_indices, so an
-            # overflow would silently corrupt memory. seq_lens_sum is None during
-            # capture (dummy seq_lens, no overflow); check on replay.
+            # Safety guard: fail fast on an undersized buffer (silent overflow
+            # otherwise). seq_lens_sum is None at capture (dummy seq_lens); only
+            # check on replay.
             if seq_lens_sum is not None:
                 kv_indices_used = seq_lens_sum + (
                     self.num_draft_tokens * bs if self.use_mla else 0

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -18,6 +18,7 @@ from sglang.srt.layers.attention.triton_ops.aiter_unified_attention import (
     scatter_req_to_token_to_page_table_kernel,
 )
 from sglang.srt.layers.attention.utils import (
+    assert_buffer_fits,
     create_flashinfer_kv_indices_triton,
     create_flashmla_kv_indices_triton,
     get_num_kv_index_blocks_flashmla,
@@ -1705,11 +1706,14 @@ class AiterAttnBackend(AttentionBackend):
                 kv_indices_used = seq_lens_sum + (
                     self.num_draft_tokens * bs if self.use_mla else 0
                 )
-                assert kv_indices_used <= kv_indices.numel(), (
-                    f"aiter target_verify kv_indices too small: need "
-                    f"{kv_indices_used} > {kv_indices.numel()} (bs={bs}, "
-                    f"seq_lens_sum={seq_lens_sum}, "
-                    f"num_draft_tokens={self.num_draft_tokens}, use_mla={self.use_mla})."
+                assert_buffer_fits(
+                    kv_indices_used,
+                    kv_indices.numel(),
+                    "aiter target_verify kv_indices",
+                    bs=bs,
+                    seq_lens_sum=seq_lens_sum,
+                    num_draft_tokens=self.num_draft_tokens,
+                    use_mla=self.use_mla,
                 )
             create_flashinfer_kv_indices_triton[(bs,)](
                 self.req_to_token,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -12,6 +12,7 @@ from sglang.srt.layers.attention.triton_ops.metadata import (
     normal_decode_set_metadata,
     prepare_swa_spec_page_table_triton,
 )
+from sglang.srt.layers.attention.utils import assert_buffer_fits
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.layers.utils.cp_utils import (
     cp_allgather_and_save_kv_cache,
@@ -2107,14 +2108,13 @@ class FlashAttentionBackend(AttentionBackend):
                         # most decode_length of the (decode_length + 1) expand page_table
                         # columns -- without this the extra distinct pages overflow the row.
                         cache_loc = cache_loc[:, :decode_length]
-                        assert (
-                            cache_loc.shape[1] <= metadata_expand.page_table.shape[1]
-                        ), (
-                            f"draft expand page_table too narrow: cache_loc width "
-                            f"{cache_loc.shape[1]} > "
-                            f"{metadata_expand.page_table.shape[1]} columns "
-                            f"(decode_length + 1); page_size={self.page_size}, "
-                            f"topk={self.topk}, num_steps={self.speculative_num_steps}"
+                        assert_buffer_fits(
+                            cache_loc.shape[1],
+                            metadata_expand.page_table.shape[1],
+                            "draft expand page_table (width decode_length + 1)",
+                            page_size=self.page_size,
+                            topk=self.topk,
+                            num_steps=self.speculative_num_steps,
                         )
                         draft_decode_set_expand_metadata(
                             cache_seqlens_int32=metadata_expand.cache_seqlens_int32,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2112,9 +2112,6 @@ class FlashAttentionBackend(AttentionBackend):
                             cache_loc.shape[1],
                             metadata_expand.page_table.shape[1],
                             "draft expand page_table (width decode_length + 1)",
-                            page_size=self.page_size,
-                            topk=self.topk,
-                            num_steps=self.speculative_num_steps,
                         )
                         draft_decode_set_expand_metadata(
                             cache_seqlens_int32=metadata_expand.cache_seqlens_int32,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2051,6 +2051,11 @@ class FlashAttentionBackend(AttentionBackend):
                         metadata.max_seq_len_k + self.page_size - 1
                     ) // self.page_size
 
+                    assert_buffer_fits(
+                        max_seq_pages,
+                        metadata.page_table.shape[1],
+                        "FA3 draft-decode page_table",
+                    )
                     normal_decode_set_metadata(
                         metadata.cache_seqlens_int32,
                         metadata.cu_seqlens_k,
@@ -2135,6 +2140,11 @@ class FlashAttentionBackend(AttentionBackend):
                 max_seq_pages = (max_len + self.page_size - 1) // self.page_size
                 metadata.max_seq_len_k = max_len
 
+                assert_buffer_fits(
+                    max_seq_pages,
+                    metadata.page_table.shape[1],
+                    "FA3 decode page_table",
+                )
                 normal_decode_set_metadata(
                     metadata.cache_seqlens_int32,
                     metadata.cu_seqlens_k,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2644,6 +2644,11 @@ class FlashAttentionBackend(AttentionBackend):
             if metadata_swa is None
             else metadata_swa.page_table
         )
+        assert_buffer_fits(
+            metadata.max_seq_len_k + metadata_expand.page_table.shape[1],
+            page_table.shape[1],
+            "FA3 swa-spec page_table",
+        )
 
         page_table_a = metadata.page_table
         page_table_b = metadata_expand.page_table

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1590,8 +1590,6 @@ class FlashInferMultiStepDraftBackend:
         bs = self.topk * num_seqs
         seq_lens_sum = forward_batch.seq_lens_sum
 
-        # Fail fast on an undersized kv_indices row: the kernel would otherwise write
-        # OOB and *silently* corrupt memory, only sometimes surfacing as a crash.
         required_kv_indices_len = draft_kv_indices_used_len(
             seq_lens_sum, self.topk, bs, self.speculative_num_steps
         )
@@ -1599,10 +1597,8 @@ class FlashInferMultiStepDraftBackend:
             required_kv_indices_len,
             kv_indices_buffer.shape[1],
             "EAGLE draft kv_indices row (size max_bs * topk * max_context_len)",
-            topk=self.topk,
-            num_seqs=num_seqs,
+            bs=bs,
             seq_lens_sum=seq_lens_sum,
-            num_steps=self.speculative_num_steps,
         )
 
         self.generate_draft_decode_kv_indices[

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -21,7 +21,10 @@ from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cud
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.layers.attention.utils import (
+    assert_buffer_fits,
+    create_flashinfer_kv_indices_triton,
+)
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
@@ -1592,12 +1595,14 @@ class FlashInferMultiStepDraftBackend:
         required_kv_indices_len = draft_kv_indices_used_len(
             seq_lens_sum, self.topk, bs, self.speculative_num_steps
         )
-        assert required_kv_indices_len <= kv_indices_buffer.shape[1], (
-            f"EAGLE draft kv_indices row too small: need {required_kv_indices_len} "
-            f"but row width is {kv_indices_buffer.shape[1]} (topk={self.topk}, "
-            f"num_seqs={num_seqs}, seq_lens_sum={seq_lens_sum}, "
-            f"num_steps={self.speculative_num_steps}); the buffer must be sized "
-            f"max_bs * topk * max_context_len."
+        assert_buffer_fits(
+            required_kv_indices_len,
+            kv_indices_buffer.shape[1],
+            "EAGLE draft kv_indices row (size max_bs * topk * max_context_len)",
+            topk=self.topk,
+            num_seqs=num_seqs,
+            seq_lens_sum=seq_lens_sum,
+            num_steps=self.speculative_num_steps,
         )
 
         self.generate_draft_decode_kv_indices[

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.flashinfer_backend import (
     create_flashinfer_kv_indices_triton,
 )
+from sglang.srt.layers.attention.utils import assert_buffer_fits
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args
@@ -951,12 +952,14 @@ class FlashInferMLAMultiStepDraftBackend:
         required_kv_indices_len = draft_kv_indices_used_len(
             seq_lens_sum, self.topk, bs, self.speculative_num_steps
         )
-        assert required_kv_indices_len <= kv_indices_buffer.shape[1], (
-            f"EAGLE draft kv_indices row too small: need {required_kv_indices_len} "
-            f"but row width is {kv_indices_buffer.shape[1]} (topk={self.topk}, "
-            f"num_seqs={num_seqs}, seq_lens_sum={seq_lens_sum}, "
-            f"num_steps={self.speculative_num_steps}); the buffer must be sized "
-            f"max_bs * topk * max_context_len."
+        assert_buffer_fits(
+            required_kv_indices_len,
+            kv_indices_buffer.shape[1],
+            "EAGLE draft kv_indices row (size max_bs * topk * max_context_len)",
+            topk=self.topk,
+            num_seqs=num_seqs,
+            seq_lens_sum=seq_lens_sum,
+            num_steps=self.speculative_num_steps,
         )
 
         self.generate_draft_decode_kv_indices[

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -947,8 +947,6 @@ class FlashInferMLAMultiStepDraftBackend:
         bs = self.topk * num_seqs
         seq_lens_sum = forward_batch.seq_lens_sum
 
-        # Fail fast on an undersized kv_indices row: the kernel would otherwise
-        # write OOB and silently corrupt memory.
         required_kv_indices_len = draft_kv_indices_used_len(
             seq_lens_sum, self.topk, bs, self.speculative_num_steps
         )
@@ -956,10 +954,8 @@ class FlashInferMLAMultiStepDraftBackend:
             required_kv_indices_len,
             kv_indices_buffer.shape[1],
             "EAGLE draft kv_indices row (size max_bs * topk * max_context_len)",
-            topk=self.topk,
-            num_seqs=num_seqs,
+            bs=bs,
             seq_lens_sum=seq_lens_sum,
-            num_steps=self.speculative_num_steps,
         )
 
         self.generate_draft_decode_kv_indices[

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -184,6 +184,6 @@ def assert_buffer_fits(used: int, capacity: int, what: str, **context) -> None:
     into the adjacent row. Fail fast on the host-known extent instead. All args
     are host ints, so this is always-on (no device sync, unlike async probes).
     """
-    assert used <= capacity, f"{what}: need {used} > capacity {capacity}" + (
+    assert used <= capacity, f"{what}: used {used} > capacity {capacity}" + (
         f" ({', '.join(f'{k}={v}' for k, v in context.items())})" if context else ""
     )

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -174,3 +174,16 @@ def concat_mla_absorb_q_general(q_nope, q_rope):
         return concat_mla_absorb_q(q_nope, q_rope)
     else:
         return torch.cat([q_nope, q_rope], dim=-1)
+
+
+def assert_buffer_fits(used: int, capacity: int, what: str, **context) -> None:
+    """Safety guard: a preallocated cuda-graph buffer must hold the runtime write.
+
+    The kv_indices / page_table scatter kernels bound writes only per-row, not
+    against the destination buffer, so an undersized buffer silently overflows
+    into the adjacent row. Fail fast on the host-known extent instead. All args
+    are host ints, so this is always-on (no device sync, unlike async probes).
+    """
+    assert used <= capacity, f"{what}: need {used} > capacity {capacity}" + (
+        f" ({', '.join(f'{k}={v}' for k, v in context.items())})" if context else ""
+    )


### PR DESCRIPTION
## Fix (behavior change)

aiter MLA `target_verify` writes `kv_lens = seq_len + num_draft_tokens` per row into the cuda-graph `cuda_graph_kv_indices` buffer, but the buffer was sized only for `seq_len` (no draft slack, unlike `dsa` / `flashmla` / `trtllm_mha`). `create_flashinfer_kv_indices_triton` bounds writes only per-row (`req_to_token` stride), not against the buffer, so a near-full sequence silently overflows into adjacent memory. Reserve the `num_draft_tokens` slack at alloc + add an always-on replay-side fail-fast assert. Sibling of #27338 / #27460.

## Shared capacity guard

Extract one always-on host-side helper `assert_buffer_fits(used, capacity, what, **context)` in `layers/attention/utils.py` for the "preallocated cuda-graph buffer + runtime-shaped scatter overflows the adjacent row" pattern, and route the existing hand-written guards through it:

- aiter `target_verify` `kv_indices` (this PR)
- flashinfer / flashinfer_mla draft `kv_indices` (#27338 / #27460)
- FA3 draft expand `page_table` (#27360)

## New defensive guards (FA3 `page_table`)

The FA3 `page_table` writes filled by `normal_decode_set_metadata` / `prepare_swa_spec_page_table_triton` mask by the runtime width (`max_seq_pages` / `total_len`), not the static buffer width -- an undersized buffer would silently overflow. Add the same host-side guard there:

- normal-decode + draft-decode (topk=1) `page_table`
- swa-spec `page_table`

These were safe only via the upstream `seq_len <= context_len` cap; the asserts turn a future cap violation into a clear error instead of silent corruption. (The `page_table[:, :max_seq_pages].copy_` sites already fail loud on a shape mismatch, so they need no guard.)

Behavior-preserving -- every assert fires only on a real sizing bug. The named helper is also a single grep target for catching future unguarded cuda-graph buffer writes.

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27088565410](https://github.com/sgl-project/sglang/actions/runs/27088565410)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27108887129](https://github.com/sgl-project/sglang/actions/runs/27108887129)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
