### PR TITLE
Fix TP deadlock in unified radix cache writing_check / loading_check

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2258,9 +2258,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 assert len(self.ongoing_write_through) == 0
             return
 
-        if len(self.ongoing_write_through) == 0:
-            return
-
+        # Every rank must enter the all_reduce below; ongoing_write_through can
+        # diverge across ranks (e.g. write_backup returning 0 on a subset).
         finish_count = 0
         if self.pp_rank == 0:
             for _, finish_event, ack_list in cc.ack_write_queue:
@@ -2283,8 +2282,10 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
     def loading_check(self) -> None:
         """Poll load-back completions."""
         cc = self.cache_controller
-        if cc is None or not self.ongoing_load_back:
+        if cc is None:
             return
+        # Every rank must enter the all_reduce below; ongoing_load_back can
+        # diverge across ranks.
         finish_count = 0
         if self.pp_rank == 0:
             for _, finish_event, ack_list in cc.ack_load_queue:


### PR DESCRIPTION
## Motivation

A permanent TP deadlock has been observed in `UnifiedRadixCache.writing_check` after a long run with HiCache enabled. py-spy fingerprint:

- TP0: `all_reduce → writing_check → check_hicache_events → get_new_batch_prefill_raw → event_loop_overlap`
- TP1-3: `broadcast → broadcast_pyobj → recv_requests → event_loop_overlap` (next iteration)

TP0 entered the all_reduce in `writing_check` while TP1-3 took the early-return path on empty `ongoing_write_through` and advanced to the next event-loop iteration's `recv_requests` broadcast. Mismatched collectives → 300s watchdog → process kill.

`loading_check` has the same anti-pattern (early-return on empty `ongoing_load_back` before an all_reduce) and is fixed alongside.

## Fix

Always enter the all_reduce regardless of local queue state. An empty local queue contributes 0 to the MIN-reduce; the `while finish_count > 0` loop becomes a no-op. Cheap and collective-safe.

## Tradeoff

Removing the early-return does not address the underlying source of cross-rank `ongoing_write_through` divergence (e.g. `write_backup` returning 0 on a subset of ranks when host-pool alloc or aux-pool alloc fails). With this fix the process no longer deadlocks, but the divergent entries can be left undrained — manifesting as slow host-pool / lock-ref leak rather than a hard hang. A follow-up will make `write_backup` enqueue decisions themselves collective-consistent.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27088062621](https://github.com/sgl-project/sglang/actions/runs/27088062621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27088062560](https://github.com/sgl-project/sglang/actions/runs/27088062560)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->