### PR TITLE
Fix bench script for large batch sizes and add all-to-all collective

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -196,6 +196,17 @@ def reg_reduce_scatter_tensor(
     group._reduce_scatter_tensor(output, input)
 
 
+@register_custom_op(mutates_args=["output"])
+def reg_all_to_all_single(
+    output: torch.Tensor, input: torch.Tensor, group_name: str
+) -> None:
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    group._all_to_all_single(output, input)
+
+
 class GroupCoordinator:
     """
     PyTorch ProcessGroup wrapper for a group of processes.
@@ -775,6 +786,15 @@ class GroupCoordinator:
             self._reduce_scatter_tensor(output, input)
         else:
             reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
+
+    def _all_to_all_single(self, output: torch.Tensor, input: torch.Tensor) -> None:
+        torch.distributed.all_to_all_single(output, input, group=self.device_group)
+
+    def all_to_all_single(self, output: torch.Tensor, input: torch.Tensor):
+        if self.world_size == 1:
+            output.copy_(input)
+            return
+        reg_all_to_all_single(output, input, group_name=self.unique_name)
 
     def reduce_scatter(
         self,

--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -586,13 +586,17 @@ def run_one_case(
         else:
             json_schema = None
 
+        reduce_sse = batch_size > 256
+        effective_stream_interval = (
+            max(stream_interval, output_len) if reduce_sse else stream_interval
+        )
         payload = {
             "sampling_params": {
                 "temperature": temperature,
                 "max_new_tokens": output_len,
                 "ignore_eos": True,
                 "json_schema": json_schema,
-                "stream_interval": stream_interval,
+                "stream_interval": effective_stream_interval,
             },
             "return_logprob": return_logprob,
             "stream": True,
@@ -709,9 +713,6 @@ def run_one_case(
 
     # Compute metrics
     latency = time.perf_counter() - tic
-    input_throughput = batch_size * input_len / last_ttft
-    output_throughput = batch_size * output_len / (latency - last_ttft)
-    overall_throughput = batch_size * (input_len + output_len) / latency
 
     if backend == "vllm":
         # vLLM does not expose these metrics via API
@@ -724,6 +725,15 @@ def run_one_case(
         internal_state = server_info.get("internal_states", [{}])
         last_gen_throughput = internal_state[0].get("last_gen_throughput", None) or -1
         acc_length = internal_state[0].get("avg_spec_accept_length", None) or -1
+
+    if reduce_sse and last_gen_throughput > 0:
+        dp_size = server_info.get("dp_size", 1)
+        decode_time = batch_size * output_len / (last_gen_throughput * dp_size)
+        last_ttft = latency - decode_time
+
+    input_throughput = batch_size * input_len / last_ttft
+    output_throughput = batch_size * output_len / (latency - last_ttft)
+    overall_throughput = batch_size * (input_len + output_len) / latency
 
     # Calculate cache hit rate from before/after metrics delta
     metrics_after = get_cache_tokens_from_metrics(url)


### PR DESCRIPTION
## Summary

- **Bench script**: Fix inaccurate TTFT/throughput metrics at large batch sizes (>256) by reducing SSE overhead (increasing `stream_interval`) and recomputing TTFT from server-reported generation throughput when SSE reduction is active.
- **Distributed**: Add `all_to_all_single` to `GroupCoordinator` with a `reg_all_to_all_single` custom op wrapper, following the same pattern as `reduce_scatter_tensor`. This enables all-to-all sequence parallelism support.

## Original commits

- `80589c8a4`
- `51821cb7a`

## Test plan

- [ ] Verify bench script produces correct metrics at batch sizes > 256
- [ ] Verify `all_to_all_single` works correctly in multi-GPU setup







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27088213040](https://github.com/sgl-project/sglang/actions/runs/27088213040)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27088212929](https://github.com/sgl-project/sglang/actions/runs/27088212929)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->