### PR TITLE
Add all_to_all_single to GroupCoordinator

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -196,6 +196,17 @@ def reg_reduce_scatter_tensor(
     group._reduce_scatter_tensor(output, input)
 
 
+@register_custom_op(mutates_args=["output"])
+def reg_all_to_all_single(
+    output: torch.Tensor, input: torch.Tensor, group_name: str
+) -> None:
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    group._all_to_all_single(output, input)
+
+
 class GroupCoordinator:
     """
     PyTorch ProcessGroup wrapper for a group of processes.
@@ -775,6 +786,15 @@ class GroupCoordinator:
             self._reduce_scatter_tensor(output, input)
         else:
             reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
+
+    def _all_to_all_single(self, output: torch.Tensor, input: torch.Tensor) -> None:
+        torch.distributed.all_to_all_single(output, input, group=self.device_group)
+
+    def all_to_all_single(self, output: torch.Tensor, input: torch.Tensor):
+        if self.world_size == 1:
+            output.copy_(input)
+            return
+        reg_all_to_all_single(output, input, group_name=self.unique_name)
 
     def reduce_scatter(
         self,


### PR DESCRIPTION
## Summary

- Add `all_to_all_single` method to `GroupCoordinator` with a `reg_all_to_all_single` custom op wrapper, following the same pattern as existing `reduce_scatter_tensor`.
- This enables all-to-all sequence parallelism support for models that manage SP at the model level.

## Original commits

- `51821cb7a`

## Test plan

- [ ] Verify `all_to_all_single` works correctly in multi-GPU setup with sequence parallelism enabled







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27088316393](https://github.com/sgl-project/sglang/actions/runs/27088316393)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27088316331](https://github.com/sgl-project/sglang/actions/runs/27088316331)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->