### PR TITLE
Revert "Fix TRTLLM target verify query metadata (#27473)"

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -484,6 +484,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ]
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
             self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
+            metadata.max_seq_len_q = self.speculative_num_draft_tokens
         elif forward_mode.is_draft_extend(include_v2=True):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)


### PR DESCRIPTION
## Summary
- Reverts #27473 which was force-merged prematurely before CI completed
- Will re-open a new PR with the same changes to go through proper CI

## Test plan
- This is a clean revert, no new logic







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27089074140](https://github.com/sgl-project/sglang/actions/runs/27089074140)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27089074088](https://github.com/sgl-project/sglang/actions/runs/27089074088)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->