### PR TITLE
Fix TRTLLM target verify query metadata

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -484,7 +484,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ]
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
             self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
-            metadata.max_seq_len_q = self.speculative_num_draft_tokens
         elif forward_mode.is_draft_extend(include_v2=True):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)


### PR DESCRIPTION
## Summary
- Remove incorrect `max_seq_len_q` override in target verify path of `TRTLLMHAAttnBackend`
- Re-land of #27473 which was reverted in #27494

## Test plan
- CI pass on `lint.yml` and `pr-test.yml`

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27089084453](https://github.com/sgl-project/sglang/actions/runs/27089084453)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27089085734](https://github.com/sgl-project/sglang/actions/runs/27089085734)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->