### PR TITLE
Fix Gemma3 mixed multimodal attention masks

### DIFF
--- a/python/sglang/srt/models/gemma3_mm.py
+++ b/python/sglang/srt/models/gemma3_mm.py
@@ -243,19 +243,20 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
 
                 # Consider bidirectional attention between image tokens
                 mm_inputs = forward_batch.mm_inputs[i]
-                for mm_item in mm_inputs.mm_items:
-                    if mm_item.is_image():
-                        for im_begin, im_end in mm_item.offsets:
-                            if (
-                                im_begin >= forward_batch.extend_prefix_lens[i]
-                            ):  # compatible with radix cache
-                                bidirectional_attn_mask[
-                                    im_begin
-                                    - forward_batch.extend_prefix_lens[i] : im_end
-                                    + 1
-                                    - forward_batch.extend_prefix_lens[i],
-                                    im_begin : im_end + 1,
-                                ] = 1
+                if mm_inputs is not None:
+                    for mm_item in mm_inputs.mm_items:
+                        if mm_item.is_image():
+                            for im_begin, im_end in mm_item.offsets:
+                                if (
+                                    im_begin >= forward_batch.extend_prefix_lens[i]
+                                ):  # compatible with radix cache
+                                    bidirectional_attn_mask[
+                                        im_begin
+                                        - forward_batch.extend_prefix_lens[i] : im_end
+                                        + 1
+                                        - forward_batch.extend_prefix_lens[i],
+                                        im_begin : im_end + 1,
+                                    ] = 1
                 bidirectional_attn_masks_list.append(bidirectional_attn_mask.flatten())
                 bidirectional_attn_mask_indptr[i + 1] = (
                     bidirectional_attn_mask_indptr[i]

--- a/test/registered/unit/models/test_gemma3_mm.py
+++ b/test/registered/unit/models/test_gemma3_mm.py
@@ -1,0 +1,65 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.models import gemma3_mm
+from sglang.srt.models.gemma3_mm import Gemma3ForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class FakeTritonAttnBackend(gemma3_mm.TritonAttnBackend):
+    def __init__(self):
+        self.forward_metadata = SimpleNamespace()
+
+
+class FakeImageItem:
+    offsets = [(1, 2)]
+
+    def is_image(self):
+        return True
+
+
+class TestGemma3ForConditionalGeneration(CustomTestCase):
+    @patch("sglang.srt.models.gemma3_mm.get_attn_backend")
+    def test_prepare_attn_masks_skips_text_only_rows_in_mixed_batch(
+        self, mock_get_attn_backend
+    ):
+        backend = FakeTritonAttnBackend()
+        mock_get_attn_backend.return_value = backend
+
+        model = object.__new__(Gemma3ForConditionalGeneration)
+        forward_batch = SimpleNamespace(
+            batch_size=2,
+            forward_mode=ForwardMode.EXTEND,
+            extend_seq_lens=[4, 3],
+            extend_prefix_lens=[0, 0],
+            mm_inputs=[
+                SimpleNamespace(mm_items=[FakeImageItem()]),
+                None,
+            ],
+        )
+
+        model.prepare_attn_masks(
+            forward_batch,
+            input_ids=torch.arange(7),
+            mask_dtype=torch.bool,
+        )
+
+        expected_mask_size = 4 * 4 + 3 * 3
+        self.assertEqual(
+            backend.forward_metadata.custom_mask.numel(), expected_mask_size
+        )
+        self.assertEqual(
+            backend.forward_metadata.mask_indptr.tolist(),
+            [0, 16, expected_mask_size],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #26503.

This PR skips Gemma3 bidirectional image-token mask handling for text-only rows in mixed multimodal batches. The batch-level `contains_image_inputs()` path can include rows whose `mm_inputs` is `None`, so Gemma3 should match the guarded behavior used by Gemma4 and leave those rows on the causal mask.

## Changes
- Guard `Gemma3ForConditionalGeneration.prepare_attn_masks()` when a batch row has no multimodal inputs.
- Add a CPU unit test for a mixed image/text batch with `mm_inputs=[image_inputs, None]`.

## Testing
- `pre-commit run isort --files python/sglang/srt/models/gemma3_mm.py test/registered/unit/models/test_gemma3_mm.py`
- `pre-commit run ruff --files python/sglang/srt/models/gemma3_mm.py test/registered/unit/models/test_gemma3_mm.py`
- `pre-commit run black-jupyter --files python/sglang/srt/models/gemma3_mm.py test/registered/unit/models/test_gemma3_mm.py`
- `python scripts/ci/check_registered_tests.py`
- `python scripts/ci/check_no_docs_changes.py`
- read-only syntax compile check for changed files

Full unit test execution was not available in this local Windows environment because the installed Python environment is missing project dependencies such as `torch`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27094671277](https://github.com/sgl-project/sglang/actions/runs/27094671277)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27094671216](https://github.com/sgl-project/sglang/actions/runs/27094671216)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->