### PR TITLE
[HiCache] Fix HiCacheController.reset() leaking prefetch_io_aux_thread

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -671,8 +671,10 @@ class HiCacheController:
         )
 
     def reset(self):
+        # Core CPU<->GPU transfer path: no long-lived worker threads (it relies on
+        # TransferBuffer + CUDA streams), so pausing via `stop_event` around a drain
+        # of the queues/buffers is sufficient.
         self.stop_event.set()
-        self.storage_stop_event.set()
 
         self.write_queue.clear()
         self.load_queue.clear()
@@ -680,26 +682,21 @@ class HiCacheController:
         self.load_buffer.clear()
         self.ack_write_queue.clear()
         self.ack_load_queue.clear()
-        if self.enable_storage:
-            self.prefetch_thread.join()
-            self.backup_thread.join()
-            self.prefetch_queue.queue.clear()
-            self.backup_queue.queue.clear()
-            self.prefetch_revoke_queue.queue.clear()
-            self.ack_backup_queue.queue.clear()
 
         self.stop_event.clear()
-        self.storage_stop_event.clear()
 
         if self.enable_storage:
-            self.prefetch_thread = threading.Thread(
-                target=self.prefetch_thread_func, daemon=True
-            )
-            self.backup_thread = threading.Thread(
-                target=self.backup_thread_func, daemon=True
-            )
-            self.prefetch_thread.start()
-            self.backup_thread.start()
+            # Reuse the canonical teardown/startup lifecycle rather than a
+            # hand-written join sequence. The old code joined only `prefetch_thread`
+            # and `backup_thread`, missing the `prefetch_io_aux_thread` that
+            # `prefetch_thread_func` spawns internally; that thread could survive the
+            # restart and drain the freshly re-created `prefetch_buffer` alongside the
+            # new aux thread (zombie thread + double consumer).
+            self._stop_storage_threads()
+            # `_stop_storage_threads` deliberately leaves `storage_stop_event` set;
+            # clear it to satisfy the assertion in `_start_storage_threads`.
+            self.storage_stop_event.clear()
+            self._start_storage_threads()
 
     def write(
         self,


### PR DESCRIPTION
## Motivation

`HiCacheController.reset()` hand-rolls its own storage-thread stop/start sequence when `enable_storage=True`. It joins only `prefetch_thread` and `backup_thread`, but **not `prefetch_io_aux_thread`** — that third thread is not created independently, it is spawned *inside* `prefetch_thread_func`, so it is easy to miss in a hand-written teardown.

**The buggy `reset()`** ([cache_controller.py#L673-L702](https://github.com/sgl-project/sglang/blob/a07d813ec8fce31f8a12f3a37f98de5e17ef3c68/python/sglang/srt/managers/cache_controller.py#L673-L702)):

```python
def reset(self):
    self.stop_event.set()
    self.storage_stop_event.set()              # set ...
    # ... drain core transfer queues/buffers ...
    if self.enable_storage:
        self.prefetch_thread.join()            # joins prefetch_thread
        self.backup_thread.join()              # joins backup_thread
        # prefetch_io_aux_thread is NEVER joined
        self.prefetch_queue.queue.clear()
        # ... more queue.clear() ...
    self.stop_event.clear()
    self.storage_stop_event.clear()            # ... cleared microseconds later
    if self.enable_storage:
        self.prefetch_thread = threading.Thread(target=self.prefetch_thread_func, daemon=True)
        self.backup_thread  = threading.Thread(target=self.backup_thread_func,  daemon=True)
        self.prefetch_thread.start()           # restart spawns a NEW aux thread
        self.backup_thread.start()
```

**Root cause — a set/clear race combined with the missing join.** `storage_stop_event.set()` is followed by `storage_stop_event.clear()` only microseconds later. The aux thread's loop ([prefetch_io_aux_func#L1007-L1023](https://github.com/sgl-project/sglang/blob/a07d813ec8fce31f8a12f3a37f98de5e17ef3c68/python/sglang/srt/managers/cache_controller.py#L1007-L1023)):

```python
def prefetch_io_aux_func(self):
    while not self.storage_stop_event.is_set():       # checked once per iteration
        try:
            operation = self.prefetch_buffer.get(block=True, timeout=1)   # blocks up to 1s here
            if operation is None:
                continue
            self._page_transfer(operation)            # real storage IO
            self.append_host_mem_release(operation.host_indices[operation.completed_tokens:])
        except Empty:
            continue
```

When `prefetch_buffer` is empty, the aux thread blocks inside `get(timeout=1)` for up to 1 second and does **not** observe the stop flag during that window. Since `reset()` never joins it, the brief `set()` can fall entirely inside that 1s window; by the time the thread times out and wakes, the flag has already been cleared, so it keeps running and survives the restart.

Meanwhile the restart re-creates the queue and spawns a fresh aux thread ([prefetch_thread_func#L1064-L1071](https://github.com/sgl-project/sglang/blob/a07d813ec8fce31f8a12f3a37f98de5e17ef3c68/python/sglang/srt/managers/cache_controller.py#L1064-L1071)):

```python
def prefetch_thread_func(self):
    self.prefetch_buffer = Queue()                       # NEW queue replaces the old one
    self.prefetch_io_aux_thread = threading.Thread(      # NEW aux thread spawned internally
        target=self.prefetch_io_aux_func, daemon=True
    )
```

**Resulting failure modes:**

- **Zombie thread.** The old aux thread stays alive past the restart, while a new aux thread is spawned on a new `prefetch_buffer`.
- **Two concurrent consumers on one queue.** Both aux threads re-read `self.prefetch_buffer` (now the new queue) every iteration. Since `Queue.get()` is atomic, operations are *split* between the two threads — the zombie steals a share — rather than processed in order by the single consumer the rest of the code assumes.

The repo already has a verified thread-lifecycle pair built for runtime attach/detach — `_stop_storage_threads()` and `_start_storage_threads()`. `_stop_storage_threads()` correctly joins **all three** threads ([#L441-L444](https://github.com/sgl-project/sglang/blob/a07d813ec8fce31f8a12f3a37f98de5e17ef3c68/python/sglang/srt/managers/cache_controller.py#L441-L444)):

```python
if hasattr(self, "prefetch_io_aux_thread"):     # the correct path DOES join aux
    threads.append(self.prefetch_io_aux_thread)
```

So `reset()` is simply the one place that diverges from this verified lifecycle and drops the aux thread. The fix routes `reset()` through the same methods.

## Modifications

Rewrite `HiCacheController.reset()` in `python/sglang/srt/managers/cache_controller.py`:

- Split it into two independent steps: the **core CPU↔GPU transfer reset** (guarded by `stop_event`, which has no long-lived threads — it relies on `TransferBuffer` + CUDA streams) and the **storage background-thread reset** (guarded by `storage_stop_event`).
- For the storage path, replace the hand-written `join()` / `queue.clear()` / thread re-creation with `self._stop_storage_threads()` + `self._start_storage_threads()`. The former joins all three threads **including `prefetch_io_aux_thread`**, eliminating the zombie/double-consumer condition at the source; it also wakes blocked threads via sentinel puts and uses `join(timeout=10)` (fail-fast) instead of an unbounded `join()`.
- Drop the manual `queue.clear()` calls — `_start_storage_threads()` rebuilds the storage queues, yielding fresh empty queues (same end state).
- Add an explicit `storage_stop_event.clear()` between stop and start: `_stop_storage_threads()` deliberately leaves the flag set (so a half-exited thread can't revive and touch released state), while `_start_storage_threads()` asserts `not storage_stop_event.is_set()`. This matches the existing usage in `attach_storage_backend`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27095058806](https://github.com/sgl-project/sglang/actions/runs/27095058806)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27095058754](https://github.com/sgl-project/sglang/actions/runs/27095058754)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->