### PR TITLE
[SPEC] feat: adaptive spec anti-oscillation

### DIFF
--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -23,15 +23,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_ADAPTIVE_CONFIG: dict[str, dict] = {
     "1": {
         "candidate_steps": [1, 3, 7],
-        "up_hysteresis": 0.0,
+        "up_hysteresis": 0.4,
         "down_hysteresis": -0.25,
         "ceiling_coeff": 0,
+        "failed_upshift_backoff_window": 64,
     },
     "8": {
         "candidate_steps": [1, 3],
-        "up_hysteresis": 0.0,
-        "down_hysteresis": 0.0,
+        "up_hysteresis": 0.4,
+        "down_hysteresis": -0.25,
         "ceiling_coeff": 0,
+        "failed_upshift_backoff_window": 128,
     },
     "32": {
         "candidate_steps": [1],
@@ -145,11 +147,9 @@ class AdaptiveStepSlot:
     The core idea: if drafts are consistently accepted, try more steps;
     if drafts are consistently rejected early, reduce steps to avoid waste.
 
-    Formula: target_steps = clamp(round(ema_accept_len) + 1, min_steps, max_steps)
-    - Probes one step beyond observed acceptance
-    - EMA smoothing prevents oscillation
-    - Only updates every `update_interval` batches for stability
-    - num_steps can be selected from different candidate sets on different batch_sizes
+    EMA, interval gating, hysteresis, adjacent upshift, and failed-upshift backoff
+    damp oscillation while preserving fast downshift when acceptance collapses.
+    num_steps can be selected from different candidate sets on different batch_sizes.
     """
 
     def __init__(self, initial_steps: int, cfg: dict):
@@ -164,6 +164,11 @@ class AdaptiveStepSlot:
         self.up_hysteresis = cfg.get("up_hysteresis", 0.0)
         self.ceiling_coeff = cfg.get("ceiling_coeff", 0)
 
+        self.failed_upshift_backoff_window = cfg.get("failed_upshift_backoff_window", 0)
+        assert (
+            self.failed_upshift_backoff_window >= 0
+        ), "failed_upshift_backoff_window must be >= 0"
+
         if initial_steps in self.candidate_steps:
             self.current_steps = initial_steps
         else:
@@ -172,6 +177,10 @@ class AdaptiveStepSlot:
         # Initialize EMA at current steps - 1 (neutral starting point)
         self.ema_accept_len = float(self.current_steps - 1)
         self._batch_count = 0
+
+        self._last_switch_direction = 0
+        self._blocked_upshift_target: int | None = None
+        self._upshift_backoff_remaining = 0
 
     def update(self, num_correct_drafts_per_req: list[int]) -> bool:
         """Update EMA with observed accept lengths. Returns True if params changed.
@@ -201,22 +210,21 @@ class AdaptiveStepSlot:
         old_steps = self.current_steps
         current_idx = self.candidate_steps.index(old_steps)
 
-        # TODO: Consider limiting step changes to avoid overshooting.
+        downshifted = False
         while current_idx > 0:
             prev_step = self.candidate_steps[current_idx - 1]
             drop_threshold = prev_step - 0.5 + self.down_hysteresis
             if self.ema_accept_len <= drop_threshold:
                 current_idx -= 1
+                downshifted = True
             else:
                 break
 
-        while current_idx < len(self.candidate_steps) - 1:
+        if not downshifted and current_idx < len(self.candidate_steps) - 1:
             current_step = self.candidate_steps[current_idx]
             rise_threshold = current_step - 0.5 + self.up_hysteresis
             if self.ema_accept_len > rise_threshold:
                 current_idx += 1
-            else:
-                break
 
         target = self.candidate_steps[current_idx]
         # EMA ceiling: only caps downward — never blocks step-ups, so the
@@ -228,15 +236,40 @@ class AdaptiveStepSlot:
                     current_idx -= 1
                 target = self.candidate_steps[current_idx]
 
-        if target != old_steps:
-            self.current_steps = target
-            log_info_on_rank0(
-                logger,
-                f"Adaptive spec params updated: steps {old_steps} -> {target} "
-                f"(ema_accept_len={self.ema_accept_len:.2f})",
-            )
-            return True
-        return False
+        direction = (target > old_steps) - (target < old_steps)  # sign(target-old)
+
+        if direction == 0:
+            if self._upshift_backoff_remaining > 0:
+                self._upshift_backoff_remaining -= 1
+            return False
+
+        if (
+            direction > 0
+            and self._upshift_backoff_remaining > 0
+            and self._blocked_upshift_target is not None
+            and target >= self._blocked_upshift_target
+        ):
+            self._upshift_backoff_remaining -= 1
+            return False
+
+        self.current_steps = target
+        if direction < 0 and self._last_switch_direction > 0:
+            self._blocked_upshift_target = old_steps
+            self._upshift_backoff_remaining = self.failed_upshift_backoff_window
+        elif direction > 0:
+            if (
+                self._blocked_upshift_target is None
+                or target >= self._blocked_upshift_target
+            ):
+                self._blocked_upshift_target = None
+                self._upshift_backoff_remaining = 0
+        self._last_switch_direction = direction
+        log_info_on_rank0(
+            logger,
+            f"Adaptive spec params updated: steps {old_steps} -> {target} "
+            f"(ema_accept_len={self.ema_accept_len:.2f})",
+        )
+        return True
 
 
 class AdaptiveSpeculativeParams:

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -5,6 +5,7 @@ import unittest
 from sglang.srt.speculative.adaptive_spec_params import (
     AdaptiveSpeculativeParams,
     AdaptiveStepSlot,
+    DEFAULT_ADAPTIVE_CONFIG,
     resolve_candidate_steps_from_config,
     validate_adaptive_initial_steps,
 )
@@ -221,6 +222,55 @@ class TestAdaptiveStepSlot(unittest.TestCase):
         self.assertEqual(params.ceiling_coeff, 0)
 
 
+class TestAntiOscillation(unittest.TestCase):
+    def _slot(self, initial_steps, **cfg):
+        cfg.setdefault("candidate_steps", [1, 3, 7])
+        cfg.setdefault("ema_alpha", 1.0)
+        cfg.setdefault("warmup_batches", 0)
+        cfg.setdefault("update_interval", 1)
+        return AdaptiveStepSlot(initial_steps=initial_steps, cfg=cfg)
+
+    @staticmethod
+    def _count_switches(slot, sequence):
+        return sum(1 for v in sequence if slot.update([v]))
+
+    def test_failed_upshift_backs_off_pingpong(self):
+        sequence = [3, 1] * 12
+        baseline = self._slot(
+            3,
+            candidate_steps=[1, 3, 7],
+            failed_upshift_backoff_window=0,
+            up_hysteresis=0.0,
+            down_hysteresis=0.0,
+        )
+        guarded = self._slot(
+            3,
+            candidate_steps=[1, 3, 7],
+            failed_upshift_backoff_window=16,
+            up_hysteresis=0.0,
+            down_hysteresis=0.0,
+        )
+
+        baseline_switches = self._count_switches(baseline, sequence)
+        guarded_switches = self._count_switches(guarded, sequence)
+
+        self.assertGreaterEqual(baseline_switches, 20)
+        self.assertLessEqual(guarded_switches, 4)
+        self.assertEqual(guarded.current_steps, 3)
+
+    def test_default_bs1_uses_uniform_down_hysteresis_for_7_to_3(self):
+        cfg = {
+            **DEFAULT_ADAPTIVE_CONFIG["1"],
+            "ema_alpha": 1.0,
+            "warmup_batches": 0,
+            "update_interval": 1,
+        }
+        slot = AdaptiveStepSlot(initial_steps=7, cfg=cfg)
+
+        self.assertFalse(slot.update([3, 3]))
+        self.assertEqual(slot.current_steps, 7)
+
+
 class TestAdaptiveSpeculativeParams(unittest.TestCase):
     def test_default_config_loads(self):
         params = AdaptiveSpeculativeParams(initial_steps=3)
@@ -228,6 +278,9 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
         self.assertEqual(params._slots[1].candidate_steps, [1, 3, 7])
         self.assertEqual(params._slots[8].candidate_steps, [1, 3])
         self.assertEqual(params._slots[32].candidate_steps, [1])
+        self.assertEqual(params._slots[1].up_hysteresis, 0.4)
+        self.assertEqual(params._slots[8].down_hysteresis, -0.25)
+        self.assertEqual(params._slots[1].failed_upshift_backoff_window, 64)
 
     def test_config_file(self):
         with tempfile.NamedTemporaryFile("w", suffix=".json") as f:

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -3,9 +3,9 @@ import tempfile
 import unittest
 
 from sglang.srt.speculative.adaptive_spec_params import (
+    DEFAULT_ADAPTIVE_CONFIG,
     AdaptiveSpeculativeParams,
     AdaptiveStepSlot,
-    DEFAULT_ADAPTIVE_CONFIG,
     resolve_candidate_steps_from_config,
     validate_adaptive_initial_steps,
 )


### PR DESCRIPTION
## Summary

This PR adds a small anti-oscillation guard for adaptive speculative decoding and simplifies the policy:

- add failed-upshift backoff after a failed 3 -> 7 probe
- restrict upshift to the next candidate step
- use one uniform `down_hysteresis` instead of step-specific `down_hysteresis_by_step`
- reduce bs=1 backoff window from 192 to 64 to be closer to throughput-optimal behavior
- add focused unit coverage for ping-pong backoff and uniform down-hysteresis behavior

## E2E Validation

Setup:
- `Qwen/Qwen3.6-27B`, MTP/NEXTN, topk=1
- TP=4 on GPUs 0-3
- default adaptive config vs same config with only `failed_upshift_backoff_window=0`
- each workload ran 3 times; table uses averages

### Anti-oscillation

| config | total switches | 3 -> 7 | 7 -> 3 | avg switches / run |
|---|---:|---:|---:|---:|
| with anti-oscillation | 22 | 11 | 11 | 7.3 |
| no backoff | 94 | 47 | 47 | 31.3 |

Result: anti-oscillation reduces adaptive step switching by about 77%.

### Performance

| workload | with anti-oscillation tok/s | no backoff tok/s | delta |
|---|---:|---:|---:|
| high_c1 | 331.0 | 340.8 | -2.9% |
| high_c8 | 2001.3 | 1962.1 | +2.0% |
| low_c8 | 1554.5 | 1572.4 | -1.1% |
| transition_c8 | 1777.9 | 1790.0 | -0.7% |
| long_low_c4 | 933.7 | 929.9 | +0.4% |

Result: switch churn is much lower. Performance stays close on the mixed suite; the remaining tradeoff is a small hit on pure single-concurrency high-acceptance traffic, where probing 7 more aggressively can help.

## Tests

- `PYTHONPATH=python python -m pytest test/registered/unit/spec/test_adaptive_spec_params.py -q`
- `git diff --check`













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27593230304](https://github.com/sgl-project/sglang/actions/runs/27593230304)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27593230179](https://github.com/sgl-project/sglang/actions/runs/27593230179)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->