### PR TITLE
support DDTree speculative decode

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -110,6 +110,8 @@ def handle_speculative_decoding(server_args: "ServerArgs") -> None:
 
     if server_args.speculative_algorithm == "DFLASH":
         _handle_dflash(server_args)
+    elif server_args.speculative_algorithm == "DDTREE":
+        _handle_ddtree(server_args)
     elif server_args.speculative_algorithm == "FROZEN_KV_MTP":
         _handle_frozen_kv_mtp(server_args)
     elif server_args.speculative_algorithm in ("EAGLE", "EAGLE3", "STANDALONE"):
@@ -247,6 +249,159 @@ def _handle_dflash(server_args: "ServerArgs") -> None:
         logger.warning(
             "Mixed chunked prefill is disabled because of using dflash speculative decoding."
         )
+
+
+def _handle_ddtree(server_args: "ServerArgs") -> None:
+    """Validate and set defaults for DDTREE speculative decoding.
+
+    DDTREE extends DFLASH (DDTreeWorker inherits from DFlashWorker) and
+    shares most of the DFLASH validation.  The key difference is that
+    DDTREE adds a tree-budget parameter that controls how many tree nodes
+    are verified per round; ``max_tree_nodes = ddtree_budget + 1``, which
+    is *not* the same as ``speculative_num_draft_tokens`` (the draft model's
+    verify-window / block_size).
+    """
+
+    # --- Common validation (shared with DFLASH) ---
+    if server_args.enable_dp_attention:
+        raise ValueError(
+            "Currently DDTREE speculative decoding does not support dp attention."
+        )
+
+    if server_args.pp_size != 1:
+        raise ValueError(
+            "Currently DDTREE speculative decoding only supports pp_size == 1."
+        )
+
+    if server_args.speculative_draft_model_path is None:
+        raise ValueError(
+            "DDTREE speculative decoding requires setting --speculative-draft-model-path."
+        )
+
+    # DDTREE does not use EAGLE-style num_steps/topk; force them to 1
+    # so generic scheduler/KV-cache accounting behaves correctly.
+    if server_args.speculative_num_steps is None:
+        server_args.speculative_num_steps = 1
+    elif int(server_args.speculative_num_steps) != 1:
+        logger.warning(
+            "DDTREE only supports speculative_num_steps == 1; "
+            "overriding speculative_num_steps=%s to 1.",
+            server_args.speculative_num_steps,
+        )
+        server_args.speculative_num_steps = 1
+
+    if server_args.speculative_eagle_topk is None:
+        server_args.speculative_eagle_topk = 1
+    elif int(server_args.speculative_eagle_topk) != 1:
+        logger.warning(
+            "DDTREE only supports speculative_eagle_topk == 1; "
+            "overriding speculative_eagle_topk=%s to 1.",
+            server_args.speculative_eagle_topk,
+        )
+        server_args.speculative_eagle_topk = 1
+
+    # --- Infer speculative_num_draft_tokens (block_size) ---
+    # DDTREE requires this to match the draft model's verify-window.
+    # It is NOT the same as max_tree_nodes (ddtree_budget + 1).
+    if server_args.speculative_dflash_block_size is not None:
+        logger.warning(
+            "--speculative-dflash-block-size has no effect with "
+            "speculative_algorithm=DDTREE (use --speculative-ddtree-budget instead)."
+        )
+
+    if server_args.speculative_num_draft_tokens is None:
+        from sglang.srt.speculative.dflash_utils import (
+            parse_dflash_draft_config,
+        )
+
+        model_override_args = json.loads(server_args.json_model_override_args)
+        inferred_block_size = None
+        try:
+            from sglang.srt.utils.hf_transformers_utils import get_config
+
+            draft_hf_config = get_config(
+                server_args.speculative_draft_model_path,
+                trust_remote_code=server_args.trust_remote_code,
+                revision=server_args.speculative_draft_model_revision,
+                model_override_args=model_override_args,
+            )
+            inferred_block_size = parse_dflash_draft_config(
+                draft_hf_config=draft_hf_config
+            ).resolve_block_size(default=None)
+        except Exception as e:
+            logger.warning(
+                "Failed to infer DDTREE block_size from draft model config; "
+                "defaulting speculative_num_draft_tokens to 16. Error: %s",
+                e,
+            )
+
+        if inferred_block_size is None:
+            inferred_block_size = 16
+            logger.warning(
+                "speculative_num_draft_tokens is not set; defaulting to %d for DDTREE.",
+                inferred_block_size,
+            )
+        server_args.speculative_num_draft_tokens = inferred_block_size
+        logger.info(
+            "Inferred speculative_num_draft_tokens=%d (block_size) "
+            "from draft model config for DDTREE.",
+            server_args.speculative_num_draft_tokens,
+        )
+
+    # --- DDTREE-specific: handle tree budget ---
+    if server_args.speculative_ddtree_budget is None:
+        # Default: budget = block_size - 1, matching DDTreeWorker fallback.
+        server_args.speculative_ddtree_budget = (
+            server_args.speculative_num_draft_tokens - 1
+        )
+        logger.info(
+            "Inferred speculative_ddtree_budget=%d from "
+            "speculative_num_draft_tokens=%d for DDTREE.",
+            server_args.speculative_ddtree_budget,
+            server_args.speculative_num_draft_tokens,
+        )
+    elif server_args.speculative_ddtree_budget < 1:
+        raise ValueError(
+            "--speculative-ddtree-budget must be >= 1, got "
+            f"{server_args.speculative_ddtree_budget}."
+        )
+
+    if server_args.max_running_requests is None:
+        server_args.max_running_requests = 48
+        logger.warning(
+            "Max running requests is reset to 48 for DDTREE speculative decoding. "
+            "You can override this by explicitly setting --max-running-requests."
+        )
+
+    server_args.disable_overlap_schedule = True
+    logger.warning(
+        "Overlap scheduler is disabled when using DDTREE speculative decoding "
+        "(spec v2 is not supported yet)."
+    )
+
+    if server_args.enable_mixed_chunk:
+        server_args.enable_mixed_chunk = False
+        logger.warning(
+            "Mixed chunked prefill is disabled because of using "
+            "DDTREE speculative decoding."
+        )
+
+    # DDTREE uses large verify token counts (max_tree_nodes = budget + 1).
+    # Piecewise CUDA graph compilation pre-allocates workspace sized to
+    # ``piecewise_cuda_graph_max_tokens`` and easily OOMs on mid-range GPUs
+    # when budget is large.  Disable it only when budget > block_size-1
+    # (branching mode); spine mode has the same verify size as DFLASH.
+    if not server_args.disable_piecewise_cuda_graph:
+        _ddtree_block_size = server_args.speculative_num_draft_tokens
+        if server_args.speculative_ddtree_budget > _ddtree_block_size - 1:
+            server_args.disable_piecewise_cuda_graph = True
+            logger.warning(
+                "Piecewise CUDA graph is disabled when using DDTREE speculative "
+                "decoding with budget=%d > block_size-1=%d (large verify-token "
+                "counts may OOM during compilation).",
+                server_args.speculative_ddtree_budget,
+                _ddtree_block_size - 1,
+            )
 
 
 def _handle_frozen_kv_mtp(server_args: "ServerArgs") -> None:

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -189,7 +189,8 @@ class NPUGraphRunner(CudaGraphRunner):
             self.buffers.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
             self.buffers.positions[: self.raw_num_token].copy_(forward_batch.positions)
             if (
-                self.model_runner.spec_algorithm.is_dflash()
+                (self.model_runner.spec_algorithm.is_dflash()
+                 or self.model_runner.spec_algorithm.is_ddtree())
                 and self.model_runner.is_draft_worker
                 and forward_batch.input_embeds is not None
             ):

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -497,19 +497,29 @@ class FlashAttentionBackend(AttentionBackend):
                 and forward_batch.spec_algorithm is not None
                 and forward_batch.spec_algorithm.is_ddtree()
             )
-            if self.topk <= 1 and not is_ddtree:
+            # Spine DDTree trees use the same linear metadata as DFLASH
+            _ddtree_spine = is_ddtree and getattr(
+                forward_batch.spec_info, "tree_is_spine", False
+            )
+            # Use spec_info.draft_token_num for spine DDTree (may differ from block_size)
+            _num_draft = (
+                forward_batch.spec_info.draft_token_num
+                if _ddtree_spine and forward_batch.spec_info is not None
+                else self.speculative_num_draft_tokens
+            )
+            if self.topk <= 1 and (not is_ddtree or _ddtree_spine):
                 metadata.cache_seqlens_int32 = (
-                    forward_batch.seq_lens + self.speculative_num_draft_tokens
+                    forward_batch.seq_lens + _num_draft
                 ).to(torch.int32)
-                metadata.max_seq_len_q = self.speculative_num_draft_tokens
+                metadata.max_seq_len_q = _num_draft
                 metadata.max_seq_len_k = (
                     forward_batch.seq_lens_cpu.max().item()
-                    + self.speculative_num_draft_tokens
+                    + _num_draft
                 )
                 metadata.cu_seqlens_q = torch.arange(
                     0,
-                    batch_size * self.speculative_num_draft_tokens + 1,
-                    self.speculative_num_draft_tokens,
+                    batch_size * _num_draft + 1,
+                    _num_draft,
                     dtype=torch.int32,
                     device=device,
                 )
@@ -853,9 +863,14 @@ class FlashAttentionBackend(AttentionBackend):
         )
 
         # We do cascade attention for Target Verify with topk > 1
+        # We skip cascade for DDTree spine trees (no branching → causal is fine).
         # We don't use cascade attention for Sliding Window Attention:
         # - Different window sizes should be passed in for each q in the first stage of cascade attention, but FA3 interface doesn't support pass in a list of window sizes.
         # - The overhead of duplicated computation of the common prefix part is small for sliding window layers (seq_len <= window_size), so we can just expand it.
+        _ddtree_is_spine = (
+            forward_batch.spec_info is not None
+            and getattr(forward_batch.spec_info, "tree_is_spine", False)
+        )
         use_cascade_attn = (
             forward_batch.forward_mode.is_target_verify()
             and (
@@ -864,6 +879,7 @@ class FlashAttentionBackend(AttentionBackend):
                     hasattr(forward_batch, "spec_algorithm")
                     and forward_batch.spec_algorithm is not None
                     and forward_batch.spec_algorithm.is_ddtree()
+                    and not _ddtree_is_spine
                 )
             )
             and not is_swa_layer

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -311,7 +311,13 @@ class FlashAttentionBackend(AttentionBackend):
                 )
                 return
 
-            if forward_mode.is_target_verify() and self.topk > 1:
+            if forward_mode.is_target_verify() and (
+                self.topk > 1
+                or (
+                    spec_info is not None
+                    and hasattr(spec_info, "tree_budget")
+                )
+            ):
                 # topk>1 target verify: replay needs spec_info.positions and .custom_mask
                 # which are not populated at capture time.
                 self.forward_metadata = self.target_verify_metadata_topk_normal[bs]
@@ -486,7 +492,12 @@ class FlashAttentionBackend(AttentionBackend):
             # TODO: we need to test this part for llama 4 eagle case
             self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
         elif forward_batch.forward_mode.is_target_verify():
-            if self.topk <= 1:
+            is_ddtree = (
+                hasattr(forward_batch, "spec_algorithm")
+                and forward_batch.spec_algorithm is not None
+                and forward_batch.spec_algorithm.is_ddtree()
+            )
+            if self.topk <= 1 and not is_ddtree:
                 metadata.cache_seqlens_int32 = (
                     forward_batch.seq_lens + self.speculative_num_draft_tokens
                 ).to(torch.int32)
@@ -514,13 +525,18 @@ class FlashAttentionBackend(AttentionBackend):
 
                 self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
             else:
+                num_draft_tokens = (
+                    forward_batch.spec_info.draft_token_num
+                    if is_ddtree and forward_batch.spec_info is not None
+                    else self.speculative_num_draft_tokens
+                )
                 metadata.cache_seqlens_int32 = forward_batch.seq_lens.to(torch.int32)
-                metadata.max_seq_len_q = self.speculative_num_draft_tokens
+                metadata.max_seq_len_q = num_draft_tokens
                 metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
                 metadata.cu_seqlens_q = torch.arange(
                     0,
-                    batch_size * self.speculative_num_draft_tokens + 1,
-                    step=self.speculative_num_draft_tokens,
+                    batch_size * num_draft_tokens + 1,
+                    step=num_draft_tokens,
                     dtype=torch.int32,
                     device=device,
                 )
@@ -539,7 +555,7 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata_expand.max_seq_len_q = 1
                 metadata_expand.cu_seqlens_q = torch.arange(
                     0,
-                    forward_batch.seq_lens.numel() * self.speculative_num_draft_tokens
+                    forward_batch.seq_lens.numel() * num_draft_tokens
                     + 1,
                     dtype=torch.int32,
                     device=device,
@@ -547,47 +563,38 @@ class FlashAttentionBackend(AttentionBackend):
 
                 # create expand page table
                 offsets = torch.arange(
-                    self.speculative_num_draft_tokens, device=device
+                    num_draft_tokens, device=device
                 ).unsqueeze(
                     0
-                )  # shape: (1, self.speculative_num_draft_tokens)
+                )  # shape: (1, num_draft_tokens)
                 cols = offsets.expand(
                     forward_batch.seq_lens.numel(), -1
                 ) + forward_batch.seq_lens.unsqueeze(1)
                 cum_len = torch.nn.functional.pad(
                     torch.cumsum(
                         (
-                            forward_batch.seq_lens + self.speculative_num_draft_tokens
-                        ).repeat_interleave(self.speculative_num_draft_tokens),
+                            forward_batch.seq_lens + num_draft_tokens
+                        ).repeat_interleave(num_draft_tokens),
                         dim=0,
                     ),
                     (1, 0),
                 )[:-1]
                 mask_extraction_indices = (
-                    cols.repeat_interleave(self.speculative_num_draft_tokens, dim=0)
+                    cols.repeat_interleave(num_draft_tokens, dim=0)
                     + cum_len[:, None]
                 ).view(1, -1)
                 mask = forward_batch.spec_info.custom_mask[
                     mask_extraction_indices
                 ].view(
-                    -1, self.speculative_num_draft_tokens
+                    -1, num_draft_tokens
                 )  # (bsz * draft_num, draft_num)
 
                 # shift table indices to avoid padding
-                # non_masked_page_table [[8, 9, 10],   mask (display with int format) [[1, 0, 0],
-                #                        [8, 9, 10],                                   [1, 1, 0],
-                #                        [8, 9, 10]]                                   [1, 0, 1]]
-                # if masked with padding [[8, 0, 0],   our mask without padding       [[8, 9, 10],
-                #                        [8, 9, 0],                                    [8, 9, 10],
-                #                        [8, 0, 10]]                                   [8, 10, 9]]
-                # note here cache_seqlens_int32 is [1, 2, 2] so extra page indices will be ignored in each row
                 col_indices = offsets.expand(
-                    mask.shape[0], self.speculative_num_draft_tokens
+                    mask.shape[0], num_draft_tokens
                 )
-                # Build keys: if an entry is valid (mask==True), keep its original index;
-                # if not, add self.speculative_num_draft_tokens so that it sorts after all valid entries.
                 keys = torch.where(
-                    mask, col_indices, col_indices + self.speculative_num_draft_tokens
+                    mask, col_indices, col_indices + num_draft_tokens
                 )
                 _, sort_order = torch.sort(keys, dim=1)
                 non_masked_page_table = (
@@ -595,7 +602,7 @@ class FlashAttentionBackend(AttentionBackend):
                         forward_batch.req_pool_indices, :
                     ]
                     .gather(1, cols)
-                    .repeat_interleave(self.speculative_num_draft_tokens, dim=0)
+                    .repeat_interleave(num_draft_tokens, dim=0)
                 )  # (bsz, draft_num)
                 metadata_expand.page_table = non_masked_page_table.gather(1, sort_order)
                 metadata_expand.cache_seqlens_int32 = mask.sum(dim=1).to(torch.int32)
@@ -851,7 +858,14 @@ class FlashAttentionBackend(AttentionBackend):
         # - The overhead of duplicated computation of the common prefix part is small for sliding window layers (seq_len <= window_size), so we can just expand it.
         use_cascade_attn = (
             forward_batch.forward_mode.is_target_verify()
-            and self.topk > 1
+            and (
+                self.topk > 1
+                or (
+                    hasattr(forward_batch, "spec_algorithm")
+                    and forward_batch.spec_algorithm is not None
+                    and forward_batch.spec_algorithm.is_ddtree()
+                )
+            )
             and not is_swa_layer
         )
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -355,6 +355,14 @@ class TritonAttnBackend(AttentionBackend):
             )
         return kv_indptr, window_kv_indptr, window_kv_lens
 
+    def _resolve_target_verify_num_draft_tokens(self, spec_info) -> int:
+        if spec_info is not None and hasattr(spec_info, "draft_token_num"):
+            from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+            if hasattr(spec_info, "tree_budget"):
+                return int(spec_info.draft_token_num)
+        return self.num_draft_tokens
+
     def _update_target_verify_buffers(
         self,
         bs: int,
@@ -368,11 +376,12 @@ class TritonAttnBackend(AttentionBackend):
         ``(qo_indptr, kv_indptr, custom_mask, mask_indptr,
           window_kv_indptr, window_kv_indices, window_num_kv_splits, window_kv_offsets)``
         """
+        num_draft_tokens = self._resolve_target_verify_num_draft_tokens(spec_info)
         qo_indptr = self.qo_indptr[: bs + 1]
         qo_indptr[: bs + 1] = torch.arange(
             0,
-            (1 + bs) * self.num_draft_tokens,
-            step=self.num_draft_tokens,
+            (1 + bs) * num_draft_tokens,
+            step=num_draft_tokens,
             dtype=torch.int32,
             device=self.device,
         )
@@ -407,7 +416,7 @@ class TritonAttnBackend(AttentionBackend):
             custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
         else:
             custom_mask = None
-        seq_mask_len = self.num_draft_tokens * (seq_lens + self.num_draft_tokens)
+        seq_mask_len = num_draft_tokens * (seq_lens + num_draft_tokens)
         mask_indptr = self.mask_indptr[: bs + 1]
         mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
         return (
@@ -606,10 +615,11 @@ class TritonAttnBackend(AttentionBackend):
             max_extend_len = None
         elif forward_batch.forward_mode.is_target_verify():
             bs = len(forward_batch.req_pool_indices)
+            num_draft_tokens = self._resolve_target_verify_num_draft_tokens(spec_info)
             qo_indptr = torch.arange(
                 0,
-                (1 + bs) * self.num_draft_tokens,
-                step=self.num_draft_tokens,
+                (1 + bs) * num_draft_tokens,
+                step=num_draft_tokens,
                 dtype=torch.int32,
                 device=self.device,
             )
@@ -647,13 +657,13 @@ class TritonAttnBackend(AttentionBackend):
                 )
 
             custom_mask = spec_info.custom_mask
-            seq_mask_len = self.num_draft_tokens * (
-                forward_batch.seq_lens + self.num_draft_tokens
+            seq_mask_len = num_draft_tokens * (
+                forward_batch.seq_lens + num_draft_tokens
             )
             mask_indptr = self.mask_indptr
             mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
             mask_indptr = mask_indptr[: bs + 1]
-            max_extend_len = self.num_draft_tokens
+            max_extend_len = num_draft_tokens
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
@@ -867,6 +877,7 @@ class TritonAttnBackend(AttentionBackend):
                 swa_attn_logits=self.cuda_graph_swa_attn_logits,
             )
         elif forward_mode.is_target_verify():
+            num_draft_tokens = self._resolve_target_verify_num_draft_tokens(spec_info)
             custom_mask = (
                 self.cuda_graph_custom_mask
                 if spec_info is not None
@@ -876,7 +887,7 @@ class TritonAttnBackend(AttentionBackend):
             return ForwardMetadata(
                 attn_logits=None,
                 attn_lse=None,
-                max_extend_len=self.num_draft_tokens,
+                max_extend_len=num_draft_tokens,
                 num_kv_splits=None,
                 kv_indptr=self.kv_indptr[: bs + 1],
                 kv_indices=self.cuda_graph_kv_indices,

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -455,6 +455,7 @@ def _fwd_kernel(
                 mask=(mask_m[:, None] & mask_n[None, :]),
                 other=0,
             )
+            custom_mask = custom_mask.to(tl.int1)
             custom_mask &= mask_m[:, None] & mask_n[None, :]
             final_mask &= custom_mask
         elif IS_CAUSAL:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2261,7 +2261,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         server_args = get_global_server_args()
         len_per_topk = server_args.speculative_num_steps or 1
         spec_topk = server_args.speculative_eagle_topk or 1
-        spec_tokens = server_args.speculative_num_draft_tokens
+        spec_tokens = server_args.speculative_num_draft_tokens or 1
+
+        # DDTREE: the per-step token count is max_tree_nodes = ddtree_budget + 1,
+        # which may differ from speculative_num_draft_tokens (the draft model's
+        # verify-window / block_size).
+        if (
+            server_args.speculative_algorithm == "DDTREE"
+            and server_args.speculative_ddtree_budget is not None
+        ):
+            spec_tokens = server_args.speculative_ddtree_budget + 1
 
         if page_size > 1 and spec_topk > 1:
             # last partial page and ceil alignment

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2038,7 +2038,7 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
-        if self.spec_algorithm.is_dflash():
+        if self.spec_algorithm.is_dflash() or self.spec_algorithm.is_ddtree():
             error_msg = validate_dflash_request(req)
             if error_msg is not None:
                 req.set_finish_with_abort(error_msg)

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -648,6 +648,7 @@ class CudaGraphRunner:
                 if self.model_runner.spec_algorithm.is_eagle()
                 or self.model_runner.spec_algorithm.is_standalone()
                 or self.model_runner.spec_algorithm.is_dflash()
+                or self.model_runner.spec_algorithm.is_ddtree()
                 else max(forward_batch.global_num_tokens_cpu)
             )
         else:
@@ -1012,7 +1013,10 @@ class CudaGraphRunner:
                         {k: v.clone() for k, v in pp_proxy_tensors.tensors.items()}
                     )
                 if (
-                    self.model_runner.spec_algorithm.is_dflash()
+                    (
+                        self.model_runner.spec_algorithm.is_dflash()
+                        or self.model_runner.spec_algorithm.is_ddtree()
+                    )
                     and self.model_runner.is_draft_worker
                     and "input_embeds" in inspect.signature(forward).parameters
                 ):
@@ -1102,6 +1106,7 @@ class CudaGraphRunner:
                 if self.model_runner.spec_algorithm.is_eagle()
                 or self.model_runner.spec_algorithm.is_standalone()
                 or self.model_runner.spec_algorithm.is_dflash()
+                or self.model_runner.spec_algorithm.is_ddtree()
                 else max_num_tokens
             )
             index = bisect.bisect_left(self.capture_bs, max_batch_size)
@@ -1119,7 +1124,8 @@ class CudaGraphRunner:
         )
 
         if (
-            self.model_runner.spec_algorithm.is_dflash()
+            (self.model_runner.spec_algorithm.is_dflash()
+             or self.model_runner.spec_algorithm.is_ddtree())
             and self.model_runner.is_draft_worker
             and forward_batch.input_embeds is not None
         ):
@@ -1175,7 +1181,8 @@ class CudaGraphRunner:
             self.buffers.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
             self.buffers.positions[: self.raw_num_token].copy_(forward_batch.positions)
             if (
-                self.model_runner.spec_algorithm.is_dflash()
+                (self.model_runner.spec_algorithm.is_dflash()
+                 or self.model_runner.spec_algorithm.is_ddtree())
                 and self.model_runner.is_draft_worker
                 and forward_batch.input_embeds is not None
             ):
@@ -1289,6 +1296,23 @@ class CudaGraphRunner:
                     if self.model_runner.is_draft_worker
                     else CaptureHiddenMode.FULL
                 ),
+            )
+
+        elif self.model_runner.spec_algorithm.is_ddtree():
+            from sglang.srt.speculative.ddtree_info import DDTreeVerifyInput
+
+            tree_budget = getattr(
+                self.model_runner.server_args, "speculative_ddtree_budget", None
+            )
+            if tree_budget is None:
+                tree_budget = self.model_runner.server_args.speculative_num_draft_tokens - 1
+            draft_token_num = tree_budget + 1
+            spec_info = DDTreeVerifyInput(
+                draft_token=None,
+                positions=None,
+                draft_token_num=draft_token_num,
+                tree_budget=tree_budget,
+                custom_mask=self.buffers.custom_mask,
             )
 
         elif self.model_runner.spec_algorithm.is_ngram():

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -1299,21 +1299,48 @@ class CudaGraphRunner:
             )
 
         elif self.model_runner.spec_algorithm.is_ddtree():
-            from sglang.srt.speculative.ddtree_info import DDTreeVerifyInput
-
             tree_budget = getattr(
                 self.model_runner.server_args, "speculative_ddtree_budget", None
             )
             if tree_budget is None:
                 tree_budget = self.model_runner.server_args.speculative_num_draft_tokens - 1
             draft_token_num = tree_budget + 1
-            spec_info = DDTreeVerifyInput(
-                draft_token=None,
-                positions=None,
-                draft_token_num=draft_token_num,
-                tree_budget=tree_budget,
-                custom_mask=self.buffers.custom_mask,
-            )
+
+            # Spine mode (budget <= block_size-1) uses DFLASH verify for CUDA-graph
+            # compatibility.  Full-tree mode uses DDTree verify.
+            if tree_budget <= self.model_runner.server_args.speculative_num_draft_tokens - 1:
+                from sglang.srt.speculative.dflash_info import DFlashVerifyInput
+                from sglang.srt.speculative.dflash_utils import (
+                    resolve_dflash_verify_mask_policy,
+                )
+                _, build_custom_mask = resolve_dflash_verify_mask_policy(
+                    self.model_runner.attn_backend
+                )
+                spec_info = DFlashVerifyInput(
+                    draft_token=None,
+                    positions=None,
+                    draft_token_num=draft_token_num,
+                    custom_mask=(
+                        None
+                        if (self.model_runner.is_draft_worker or not build_custom_mask)
+                        else self.buffers.custom_mask
+                    ),
+                    capture_hidden_mode=(
+                        CaptureHiddenMode.NULL
+                        if self.model_runner.is_draft_worker
+                        else CaptureHiddenMode.FULL
+                    ),
+                )
+            else:
+                from sglang.srt.speculative.ddtree_info import DDTreeVerifyInput
+
+                spec_info = DDTreeVerifyInput(
+                    draft_token=None,
+                    positions=None,
+                    draft_token_num=draft_token_num,
+                    tree_budget=tree_budget,
+                    custom_mask=self.buffers.custom_mask,
+                )
 
         elif self.model_runner.spec_algorithm.is_ngram():
             from sglang.srt.speculative.ngram_info import NgramVerifyInput

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -470,7 +470,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 # if there is no aux layer, set to None
                 self.eagle_aux_hidden_state_layer_ids = None
 
-        if self.spec_algorithm.is_dflash() and not self.is_draft_worker:
+        if (self.spec_algorithm.is_dflash() or self.spec_algorithm.is_ddtree()) and not self.is_draft_worker:
             from sglang.srt.speculative.dflash_utils import (
                 parse_dflash_draft_config,
             )
@@ -2716,6 +2716,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                         if self.is_draft_worker
                         else CaptureHiddenMode.FULL
                     ),
+                )
+
+            elif self.spec_algorithm.is_ddtree():
+                from sglang.srt.speculative.ddtree_info import DDTreeVerifyInput
+
+                tree_budget = getattr(self.server_args, "speculative_ddtree_budget", None)
+                if tree_budget is None:
+                    tree_budget = self.server_args.speculative_num_draft_tokens - 1
+                draft_token_num = tree_budget + 1
+                spec_info = DDTreeVerifyInput(
+                    draft_token=torch.empty(
+                        (self.max_total_num_tokens,), dtype=torch.long, device=self.device
+                    ),
+                    positions=torch.empty(
+                        (self.max_total_num_tokens,), dtype=torch.int64, device=self.device
+                    ),
+                    draft_token_num=draft_token_num,
+                    tree_budget=tree_budget,
                 )
 
             elif self.spec_algorithm.is_ngram():

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -104,8 +104,8 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
 
         self._cell_size = self._compute_cell_size(mr, num_layers)
 
-        # DFLASH: scale cell_size to account for draft model KV cache
-        if mr.spec_algorithm.is_dflash() and not mr.is_draft_worker:
+        # DFLASH/DDTREE: scale cell_size to account for draft model KV cache
+        if (mr.spec_algorithm.is_dflash() or mr.spec_algorithm.is_ddtree()) and not mr.is_draft_worker:
             from sglang.srt.speculative.dflash_utils import (
                 scale_kv_cell_size_per_token_for_dflash,
             )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -607,6 +607,7 @@ class ServerArgs:
     speculative_eagle_topk: Optional[int] = None
     speculative_num_draft_tokens: Optional[int] = None
     speculative_dflash_block_size: Optional[int] = None
+    speculative_ddtree_budget: Optional[int] = None
     speculative_accept_threshold_single: float = 1.0
     speculative_accept_threshold_acc: float = 1.0
     speculative_token_map: Optional[str] = None
@@ -5830,6 +5831,12 @@ class ServerArgs:
             type=int,
             help="DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
             default=ServerArgs.speculative_dflash_block_size,
+        )
+        parser.add_argument(
+            "--speculative-ddtree-budget",
+            type=int,
+            help="DDTREE only. Tree node budget B. Controls how many tree nodes are verified per round (excluding root). Defaults to speculative_num_draft_tokens - 1.",
+            default=ServerArgs.speculative_ddtree_budget,
         )
         parser.add_argument(
             "--speculative-accept-threshold-single",

--- a/python/sglang/srt/speculative/ddtree_info.py
+++ b/python/sglang/srt/speculative/ddtree_info.py
@@ -1,0 +1,170 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import torch
+
+from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+
+
+@dataclass
+class DDTreeVerifyInput(SpecInput):
+    draft_token: torch.Tensor
+    positions: torch.Tensor
+    draft_token_num: int
+    tree_budget: int
+
+    child_maps: List[Dict[int, Dict[int, int]]] = field(default_factory=list)
+    actual_tree_sizes: Optional[torch.Tensor] = None
+
+    custom_mask: Optional[torch.Tensor] = None
+    topk: int = 1
+
+    accepted_indices: List[List[int]] = field(default_factory=list)
+    next_tokens: Optional[torch.Tensor] = None
+
+    def __post_init__(self):
+        super().__init__(spec_input_type=SpecInputType.DDTREE_VERIFY)
+
+    def get_spec_adjust_token_coefficient(self):
+        return (self.draft_token_num, self.draft_token_num)
+
+    def prepare_for_verify(self, batch, page_size):
+        bs = len(batch.reqs)
+        q_len = self.draft_token_num
+
+        allocator = batch.token_to_kv_pool_allocator
+        out_cache_loc = allocator.alloc(bs * q_len)
+
+        for i, req in enumerate(batch.reqs):
+            start_idx = i * q_len
+            batch.req_to_token_pool.req_to_token[
+                req.req_pool_idx, batch.seq_lens[i]:batch.seq_lens[i] + q_len
+            ] = out_cache_loc[start_idx:start_idx + q_len]
+
+        batch.out_cache_loc = out_cache_loc
+
+    def generate_attn_arg_prefill(
+        self,
+        req_pool_indices: torch.Tensor,
+        paged_kernel_lens: torch.Tensor,
+        paged_kernel_lens_sum: int,
+        req_to_token: torch.Tensor,
+    ):
+        from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
+
+        device = req_pool_indices.device
+        bs = len(req_pool_indices)
+
+        qo_indptr = torch.arange(
+            0,
+            (bs + 1) * self.draft_token_num,
+            step=self.draft_token_num,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        cum_kv_seq_len = torch.zeros((bs + 1,), dtype=torch.int32, device=device)
+        paged_kernel_lens = paged_kernel_lens + self.draft_token_num
+        cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
+
+        kv_indices = torch.empty(
+            paged_kernel_lens_sum + self.draft_token_num * bs,
+            dtype=torch.int32,
+            device=device,
+        )
+        create_flashinfer_kv_indices_triton[(bs,)](
+            req_to_token,
+            req_pool_indices,
+            paged_kernel_lens,
+            cum_kv_seq_len,
+            None,
+            kv_indices,
+            req_to_token.size(1),
+        )
+        mask = self.custom_mask
+        if mask is not None:
+            mask_numel = (
+                paged_kernel_lens_sum * self.draft_token_num
+                + (self.draft_token_num**2) * bs
+            )
+            if mask.numel() < mask_numel:
+                mask = torch.cat(
+                    [
+                        mask,
+                        torch.full(
+                            (mask_numel - mask.numel(),),
+                            True,
+                            dtype=torch.bool,
+                            device=device,
+                        ),
+                    ],
+                    dim=0,
+                )
+                self.custom_mask = mask
+        return kv_indices, cum_kv_seq_len, qo_indptr, mask
+
+    def verify(self, *, batch, logits_output, page_size):
+        from sglang.srt.speculative.ddtree_utils import (
+            follow_verified_tree,
+            compact_ddtree_kv_cache,
+        )
+
+        bs = len(batch.reqs)
+
+        target_predict = torch.argmax(logits_output.next_token_logits, dim=-1)
+        target_predict = target_predict.reshape(bs, self.draft_token_num)
+
+        self.accepted_indices, self.next_tokens = follow_verified_tree(
+            self.child_maps, target_predict
+        )
+
+        commit_lens = []
+        num_correct_drafts_per_req = []
+        for i, req in enumerate(batch.reqs):
+            accepted = self.accepted_indices[i]
+            num_accepted = len(accepted) - 1
+
+            for idx in accepted[1:]:
+                token_id = int(self.draft_token[i * self.draft_token_num + idx])
+                req.output_ids.append(token_id)
+                req.check_finished()
+                if req.finished():
+                    break
+
+            if not req.finished():
+                bonus = int(self.next_tokens[i].item())
+                req.output_ids.append(bonus)
+                req.check_finished()
+
+            commit_lens.append(len(accepted))
+            num_correct_drafts_per_req.append(num_accepted)
+
+        commit_lens_tensor = torch.tensor(commit_lens, dtype=torch.long, device=batch.device)
+        past_lengths = batch.seq_lens.clone()
+
+        batch.seq_lens += commit_lens_tensor
+
+        for layer in batch.model_runner.model.layers:
+            attn_layer = layer.self_attn.attn
+            compact_ddtree_kv_cache(
+                batch.token_to_kv_pool,
+                attn_layer,
+                batch.out_cache_loc.view(bs, self.draft_token_num),
+                self.accepted_indices,
+                past_lengths,
+                self.actual_tree_sizes,
+            )
+
+        hidden = logits_output.hidden_states
+        if hidden is not None:
+            hidden = hidden.view(bs, self.draft_token_num, -1)
+            segments = []
+            for i, n in enumerate(commit_lens):
+                segments.append(hidden[i, :n, :])
+            next_target_hidden = torch.cat(segments, dim=0)
+        else:
+            next_target_hidden = None
+
+        num_correct_drafts_cpu = num_correct_drafts_per_req
+
+        return self.next_tokens, commit_lens_tensor, next_target_hidden, num_correct_drafts_cpu

--- a/python/sglang/srt/speculative/ddtree_info.py
+++ b/python/sglang/srt/speculative/ddtree_info.py
@@ -3,7 +3,13 @@ from typing import Dict, List, Optional
 
 import torch
 
+from sglang.srt.mem_cache.common import (
+    alloc_token_slots,
+    get_last_loc,
+)
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
 
 
 @dataclass
@@ -12,6 +18,7 @@ class DDTreeVerifyInput(SpecInput):
     positions: torch.Tensor
     draft_token_num: int
     tree_budget: int
+    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
     child_maps: List[Dict[int, Dict[int, int]]] = field(default_factory=list)
     actual_tree_sizes: Optional[torch.Tensor] = None
@@ -21,6 +28,11 @@ class DDTreeVerifyInput(SpecInput):
 
     accepted_indices: List[List[int]] = field(default_factory=list)
     next_tokens: Optional[torch.Tensor] = None
+
+    # When True, the tree is a pure linear chain (no branching siblings).
+    # In this mode, cascade attention is unnecessary and a standard causal
+    # mask suffices, matching DFLASH's verify pattern exactly.
+    tree_is_spine: bool = False
 
     def __post_init__(self):
         super().__init__(spec_input_type=SpecInputType.DDTREE_VERIFY)
@@ -32,16 +44,45 @@ class DDTreeVerifyInput(SpecInput):
         bs = len(batch.reqs)
         q_len = self.draft_token_num
 
-        allocator = batch.token_to_kv_pool_allocator
-        out_cache_loc = allocator.alloc(bs * q_len)
+        batch.input_ids = self.draft_token
 
-        for i, req in enumerate(batch.reqs):
-            start_idx = i * q_len
-            batch.req_to_token_pool.req_to_token[
-                req.req_pool_idx, batch.seq_lens[i]:batch.seq_lens[i] + q_len
-            ] = out_cache_loc[start_idx:start_idx + q_len]
+        if page_size == 1:
+            batch.out_cache_loc = alloc_token_slots(
+                batch.tree_cache, len(batch.input_ids)
+            )
+            end_offset = batch.seq_lens + q_len
+        else:
+            prefix_lens = batch.seq_lens
+            prefix_lens_cpu = batch.seq_lens_cpu
+            end_offset_cpu = [pl + q_len for pl in prefix_lens_cpu.tolist()]
+            from sglang.srt.mem_cache.common import (
+                alloc_paged_token_slots_extend,
+            )
 
-        batch.out_cache_loc = out_cache_loc
+            last_loc = get_last_loc(
+                batch.req_to_token_pool.req_to_token,
+                batch.req_pool_indices,
+                prefix_lens,
+            )
+            batch.out_cache_loc = alloc_paged_token_slots_extend(
+                batch.tree_cache,
+                prefix_lens_cpu.tolist(),
+                end_offset_cpu,
+                last_loc,
+                len(batch.input_ids),
+            )
+            end_offset = torch.tensor(
+                end_offset_cpu, dtype=prefix_lens.dtype, device=prefix_lens.device
+            )
+
+        assign_req_to_token_pool_func(
+            batch.req_pool_indices,
+            batch.req_to_token_pool.req_to_token,
+            batch.seq_lens,
+            end_offset,
+            batch.out_cache_loc,
+            bs,
+        )
 
     def generate_attn_arg_prefill(
         self,
@@ -103,57 +144,184 @@ class DDTreeVerifyInput(SpecInput):
                 self.custom_mask = mask
         return kv_indices, cum_kv_seq_len, qo_indptr, mask
 
-    def verify(self, *, batch, logits_output, page_size):
+    def verify(self, *, batch, logits_output, page_size, model_runner=None):
         from sglang.srt.speculative.ddtree_utils import (
             follow_verified_tree,
-            compact_ddtree_kv_cache,
+        )
+        from sglang.srt.speculative.dflash_utils import (
+            is_dflash_sampling_verify_available,
         )
 
         bs = len(batch.reqs)
+        device = batch.device
+
+        sampling_info = batch.sampling_info
+        use_sampling = (
+            sampling_info is not None
+            and not sampling_info.is_all_greedy
+            and is_dflash_sampling_verify_available()
+        )
 
         target_predict = torch.argmax(logits_output.next_token_logits, dim=-1)
         target_predict = target_predict.reshape(bs, self.draft_token_num)
 
-        self.accepted_indices, self.next_tokens = follow_verified_tree(
-            self.child_maps, target_predict
+        # --- 1) Acceptance ---
+        if self.tree_is_spine:
+            if use_sampling:
+                # Chain-based sampling verification via sgl_kernel.
+                # candidates must include ALL N tokens (bonus + drafts).
+                from sglang.srt.speculative.dflash_utils import (
+                    compute_dflash_sampling_correct_drafts_and_bonus,
+                )
+                candidates = self.draft_token.view(bs, self.draft_token_num)
+                correct_len, bonus = (
+                    compute_dflash_sampling_correct_drafts_and_bonus(
+                        candidates=candidates,
+                        next_token_logits=logits_output.next_token_logits,
+                        sampling_info=sampling_info,
+                    )
+                )
+                # correct_len = number of accepted candidates (includes bonus at pos 0).
+                # commit_len = correct_len + 1 (includes the final bonus token).
+                commit_lens = (correct_len + 1).tolist()
+                num_correct_drafts_per_req = [max(0, cl - 1) for cl in commit_lens]
+                self.accepted_indices = [
+                    list(range(cl)) for cl in (correct_len + 1).tolist()
+                ]
+                self.next_tokens = bonus
+            else:
+                # Spine greedy: chain comparison on GPU.
+                candidates = target_predict[:, :-1]
+                targets = target_predict[:, 1:]
+                matches = (candidates == targets).to(torch.int32)
+                correct = matches.cumprod(dim=1).sum(dim=1)
+                commit_lens = (correct + 1).tolist()
+                num_correct_drafts_per_req = [max(0, cl - 1) for cl in commit_lens]
+                self.accepted_indices = [list(range(cl)) for cl in commit_lens]
+                next_tokens_list = [
+                    int(target_predict[b_i, cl - 1]) if cl > 0
+                    else int(target_predict[b_i, 0])
+                    for b_i, cl in enumerate(commit_lens)
+                ]
+                self.next_tokens = torch.tensor(
+                    next_tokens_list, dtype=torch.long, device=device
+                )
+        else:
+            # Full tree path: greedy-only for now (tree sampling requires
+            # sgl_kernel tree topology which is expensive to build per-step).
+            self.accepted_indices, self.next_tokens = follow_verified_tree(
+                self.child_maps, target_predict
+            )
+            commit_lens = []
+            num_correct_drafts_per_req = []
+            for i, req in enumerate(batch.reqs):
+                accepted = self.accepted_indices[i]
+                appended = 0
+                for idx in accepted[1:]:
+                    token_id = int(self.draft_token[i * self.draft_token_num + idx])
+                    req.output_ids.append(token_id)
+                    appended += 1
+                    req.update_finish_state()
+                    if req.finished():
+                        break
+                if not req.finished():
+                    bonus = int(self.next_tokens[i].item())
+                    req.output_ids.append(bonus)
+                    appended += 1
+                    req.update_finish_state()
+                commit_lens.append(appended)
+                num_correct_drafts_per_req.append(max(0, appended - 1))
+                req.spec_verify_ct += 1
+                req.spec_num_correct_drafts += max(0, appended - 1)
+
+        # --- 2) Commit tokens to output ---
+        if self.tree_is_spine:
+            for i, req in enumerate(batch.reqs):
+                for idx in range(1, commit_lens[i]):
+                    token_id = int(self.draft_token[i * self.draft_token_num + idx])
+                    req.output_ids.append(token_id)
+                    req.update_finish_state()
+                    if req.finished():
+                        break
+                else:
+                    bonus = int(self.next_tokens[i].item())
+                    req.output_ids.append(bonus)
+                    req.update_finish_state()
+                req.spec_verify_ct += 1
+                req.spec_num_correct_drafts += num_correct_drafts_per_req[i]
+
+        commit_lens_tensor = torch.tensor(
+            commit_lens, dtype=torch.long, device=device
         )
 
-        commit_lens = []
-        num_correct_drafts_per_req = []
-        for i, req in enumerate(batch.reqs):
-            accepted = self.accepted_indices[i]
-            num_accepted = len(accepted) - 1
-
-            for idx in accepted[1:]:
-                token_id = int(self.draft_token[i * self.draft_token_num + idx])
-                req.output_ids.append(token_id)
-                req.check_finished()
-                if req.finished():
+        # --- KV cache compaction (skip entirely if all paths are contiguous) ---
+        if model_runner is not None:
+            # Fast check: if every accepted path is contiguous from 0, no compaction needed.
+            need_compaction = False
+            for accepted in self.accepted_indices:
+                if accepted != list(range(len(accepted))):
+                    need_compaction = True
                     break
 
-            if not req.finished():
-                bonus = int(self.next_tokens[i].item())
-                req.output_ids.append(bonus)
-                req.check_finished()
+            if need_compaction:
+                model = model_runner.model
+                model_layers = getattr(model, "model", model)
+                model_layers = getattr(model_layers, "layers", None)
+                if model_layers is None:
+                    model_layers = []
 
-            commit_lens.append(len(accepted))
-            num_correct_drafts_per_req.append(num_accepted)
+                from sglang.srt.speculative.ddtree_utils import compact_ddtree_kv_cache
+                token_to_kv_pool = model_runner.token_to_kv_pool
+                past_lengths = batch.seq_lens.clone()
 
-        commit_lens_tensor = torch.tensor(commit_lens, dtype=torch.long, device=batch.device)
-        past_lengths = batch.seq_lens.clone()
+                for layer in model_layers:
+                    attn_layer = layer.self_attn.attn
+                    compact_ddtree_kv_cache(
+                        token_to_kv_pool,
+                        attn_layer,
+                        batch.out_cache_loc.view(bs, self.draft_token_num),
+                        self.accepted_indices,
+                        past_lengths,
+                        self.actual_tree_sizes,
+                    )
 
-        batch.seq_lens += commit_lens_tensor
+            # Free uncommitted KV cache slots.
+            if page_size == 1:
+                out_cache_loc = batch.out_cache_loc.view(bs, self.draft_token_num)
+                keep_mask = (
+                    torch.arange(self.draft_token_num, device=device)[None, :]
+                    < commit_lens_tensor[:, None]
+                )
+                batch.token_to_kv_pool_allocator.free(out_cache_loc[~keep_mask])
+                batch.out_cache_loc = out_cache_loc[keep_mask]
 
-        for layer in batch.model_runner.model.layers:
-            attn_layer = layer.self_attn.attn
-            compact_ddtree_kv_cache(
-                batch.token_to_kv_pool,
-                attn_layer,
-                batch.out_cache_loc.view(bs, self.draft_token_num),
-                self.accepted_indices,
-                past_lengths,
-                self.actual_tree_sizes,
+            # Update req-level KV cache accounting.
+            for req, commit_len in zip(batch.reqs, commit_lens, strict=True):
+                req.kv_committed_len += commit_len
+                req.kv_allocated_len = req.kv_committed_len
+
+            # Update req_to_token pool mapping for newly committed tokens.
+            end_offset = batch.seq_lens + commit_lens_tensor.to(batch.seq_lens.dtype)
+            assign_req_to_token_pool_func(
+                batch.req_pool_indices,
+                batch.req_to_token_pool.req_to_token,
+                batch.seq_lens,
+                end_offset,
+                batch.out_cache_loc,
+                bs,
             )
+
+            # Update batch seq lens.
+            batch.seq_lens.add_(commit_lens_tensor.to(batch.seq_lens.dtype))
+            batch.seq_lens_cpu.add_(
+                torch.tensor(
+                    [int(c) for c in commit_lens], dtype=batch.seq_lens_cpu.dtype
+                )
+            )
+            batch.seq_lens_sum += sum(commit_lens)
+        else:
+            # Fallback path
+            batch.seq_lens += commit_lens_tensor
 
         hidden = logits_output.hidden_states
         if hidden is not None:

--- a/python/sglang/srt/speculative/ddtree_utils.py
+++ b/python/sglang/srt/speculative/ddtree_utils.py
@@ -1,19 +1,105 @@
 import heapq
+import math
 from typing import Dict, List, Tuple
 
 import numpy as np
 import torch
 
 
+# Dynamic early-stop margin for tree building.
+# When the heap top's log-prob falls below (root_log_prob - log(budget) - margin),
+# we stop expanding the tree — remaining candidates are too unlikely to contribute.
+_DDTREE_EARLY_STOP_MARGIN: float = 1.0
+
+# Depth bonus: added to child log-probs to encourage deeper tree exploration
+# over clustering siblings at shallow depths.  Kept small (0.2) to allow
+# some sibling exploration when budget exceeds draft depth.
+_DDTREE_DEPTH_BONUS: float = 0.2
+
+
 def build_ddtree_tree(
     draft_logits: torch.Tensor,  # [bs, L, vocab_size]
-    tree_budget: int,            # 鑺傜偣棰勭畻 B
+    tree_budget: int,            # 节点预算 B
     device: torch.device,
+    _out_node_token_ids: torch.Tensor | None = None,
+    _out_node_depths: torch.Tensor | None = None,
+    _out_parents: torch.Tensor | None = None,
+    _out_visibility: torch.Tensor | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[Dict[int, Dict[int, int]]], torch.Tensor]:
     bs, L, V = draft_logits.shape
-    topk = min(tree_budget, V)
+    max_nodes = tree_budget + 1
 
     logits = draft_logits.float()
+
+    # --- Spine fast path: when budget equals L, the beam search only ever
+    # picks spine nodes (one per depth).  No siblings can be chosen because
+    # the spine consumes the entire budget.  This holds for any depth_bonus >= 0
+    # since child_push always happens before sibling_push in the loop.
+    if tree_budget == L:
+        _, top_token_ids = torch.topk(logits, k=1, dim=-1)  # [bs, L, 1]
+        top_token_ids = top_token_ids.squeeze(-1)  # [bs, L]
+        spine_nodes = tree_budget  # all non-root nodes
+
+        if _out_node_token_ids is None or _out_node_token_ids.shape[0] < bs:
+            padded_node_token_ids = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
+        else:
+            padded_node_token_ids = _out_node_token_ids[:bs]
+            padded_node_token_ids.zero_()
+        padded_node_token_ids[:, :spine_nodes] = top_token_ids[:, :spine_nodes]
+
+        if _out_node_depths is None or _out_node_depths.shape[0] < bs:
+            padded_node_depths = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
+        else:
+            padded_node_depths = _out_node_depths[:bs]
+            padded_node_depths.zero_()
+        padded_node_depths[:, :spine_nodes] = torch.arange(
+            1, spine_nodes + 1, device=device
+        ).unsqueeze(0)
+
+        if _out_parents is None or _out_parents.shape[0] < bs:
+            padded_parents = torch.full((bs, max_nodes), -1, dtype=torch.long, device=device)
+        else:
+            padded_parents = _out_parents[:bs]
+            padded_parents.fill_(-1)
+        padded_parents[:, 1 : spine_nodes + 1] = torch.arange(
+            spine_nodes, device=device
+        ).unsqueeze(0)
+
+        # Lower-triangular visibility (ancestral: node i sees nodes 0..i)
+        if _out_visibility is None or _out_visibility.shape[0] < bs:
+            padded_visibility = torch.zeros(bs, max_nodes, max_nodes, dtype=torch.bool, device=device)
+        else:
+            padded_visibility = _out_visibility[:bs]
+            padded_visibility.zero_()
+        actual = spine_nodes + 1
+        padded_visibility[:, :actual, :actual] = torch.tril(
+            torch.ones(actual, actual, dtype=torch.bool, device=device)
+        ).unsqueeze(0)
+
+        actual_tree_sizes_t = torch.full((bs,), actual, dtype=torch.long, device=device)
+
+        # Build per-batch child_maps (chain: node i → {token: i+1})
+        top_ids_cpu = top_token_ids[:, :spine_nodes].to(device="cpu", dtype=torch.long)
+        all_child_maps = []
+        for b in range(bs):
+            cm: Dict[int, Dict[int, int]] = {0: {}}
+            for i in range(spine_nodes):
+                tok = int(top_ids_cpu[b, i])
+                cm[i][tok] = i + 1
+                cm[i + 1] = {}
+            all_child_maps.append(cm)
+
+        return (
+            padded_node_token_ids,
+            padded_node_depths,
+            padded_parents,
+            all_child_maps,
+            padded_visibility,
+            actual_tree_sizes_t,
+        )
+
+    # --- Full tree path (budget > L): beam search with branching ---
+    topk = min(max(tree_budget // max(L, 1) + 1, 2), V, 6)
     top_logits, top_token_ids = torch.topk(logits, k=topk, dim=-1)
     log_z = torch.logsumexp(logits, dim=-1, keepdim=True)
     top_log_probs = (top_logits - log_z).to(device="cpu", dtype=torch.float32)
@@ -37,11 +123,30 @@ def build_ddtree_tree(
         all_visibility.append(vis)
         actual_sizes.append(actual)
 
-    max_nodes = tree_budget + 1
-    padded_node_token_ids = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
-    padded_node_depths = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
-    padded_parents = torch.full((bs, max_nodes), -1, dtype=torch.long, device=device)
-    padded_visibility = torch.zeros(bs, max_nodes, max_nodes, dtype=torch.bool, device=device)
+    # Reuse or allocate padded output buffers.
+    if _out_node_token_ids is None or _out_node_token_ids.shape[0] < bs:
+        padded_node_token_ids = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
+    else:
+        padded_node_token_ids = _out_node_token_ids[:bs]
+        padded_node_token_ids.zero_()
+
+    if _out_node_depths is None or _out_node_depths.shape[0] < bs:
+        padded_node_depths = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
+    else:
+        padded_node_depths = _out_node_depths[:bs]
+        padded_node_depths.zero_()
+
+    if _out_parents is None or _out_parents.shape[0] < bs:
+        padded_parents = torch.full((bs, max_nodes), -1, dtype=torch.long, device=device)
+    else:
+        padded_parents = _out_parents[:bs]
+        padded_parents.fill_(-1)
+
+    if _out_visibility is None or _out_visibility.shape[0] < bs:
+        padded_visibility = torch.zeros(bs, max_nodes, max_nodes, dtype=torch.bool, device=device)
+    else:
+        padded_visibility = _out_visibility[:bs]
+        padded_visibility.zero_()
 
     for b in range(bs):
         n = actual_sizes[b] - 1
@@ -50,14 +155,18 @@ def build_ddtree_tree(
             padded_node_depths[b, :n] = torch.from_numpy(all_node_depths[b]).to(device)
         padded_parents[b, :actual_sizes[b]] = torch.from_numpy(all_parents[b]).to(device)
         vis = all_visibility[b]
-        padded_visibility[b, :actual_sizes[b], :actual_sizes[b]] = torch.from_numpy(vis).to(device)
+        padded_visibility[b, :actual_sizes[b], :actual_sizes[b]] = (
+            torch.from_numpy(vis).to(device=device, dtype=torch.bool)
+        )
 
+    actual_tree_sizes_t = torch.tensor(actual_sizes, dtype=torch.long, device=device)
     return (
         padded_node_token_ids,
         padded_node_depths,
         padded_parents,
         all_child_maps,
         padded_visibility,
+        actual_tree_sizes_t,
     )
 
 
@@ -79,9 +188,17 @@ def _build_single_tree(
     first_logw = float(log_probs_np[0, 0])
     heap = [(-first_logw, (0,), 0, 1, 0, first_logw)]
 
+    # Dynamic early-stop: skip candidates whose log-prob is more than
+    # log(budget) + margin below the root log-prob.
+    _stop_threshold = first_logw - math.log(max(budget, 1)) - _DDTREE_EARLY_STOP_MARGIN
+
     node_count = 0
     while heap and node_count < budget:
         _, ranks, parent_idx, depth, rank, logw = heapq.heappop(heap)
+
+        # Early stop: remaining candidates' log-prob is too low to matter.
+        if logw < _stop_threshold:
+            break
 
         token_id = int(token_ids_np[depth - 1, rank])
         current_idx = node_count + 1
@@ -106,7 +223,7 @@ def _build_single_tree(
             )
 
         if depth < depth_limit:
-            child_logw = logw + float(log_probs_np[depth, 0])
+            child_logw = logw + float(log_probs_np[depth, 0]) + _DDTREE_DEPTH_BONUS
             child_ranks = ranks + (0,)
             heapq.heappush(
                 heap,
@@ -139,16 +256,12 @@ def compile_ddtree_tree(
     start_positions: torch.Tensor,
     past_lengths: torch.Tensor,
     tree_budget: int,
+    actual_tree_sizes: torch.Tensor,
     dtype: torch.dtype,
     device: torch.device,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     bs = root_token_ids.shape[0]
     max_nodes = tree_budget + 1
-
-    actual_tree_sizes = torch.zeros(bs, dtype=torch.long, device=device)
-    for b in range(bs):
-        non_zero = (node_token_ids[b] != 0).sum().item()
-        actual_tree_sizes[b] = non_zero + 1
 
     verify_input_ids = torch.zeros(bs, max_nodes, dtype=torch.long, device=device)
     verify_input_ids[:, 0] = root_token_ids
@@ -161,24 +274,41 @@ def compile_ddtree_tree(
     max_past = int(past_lengths.max().item())
     total_kv_len = max_past + max_nodes
 
+    # The Triton attention kernel interprets `custom_mask` values as:
+    #   0.0 (→ tl.int1: False)  → masked  (Q-K pair SKIPPED)
+    #   ≠0.0 (→ tl.int1: True)  → allowed (Q-K pair COMPUTED)
+    #
+    # We initialise the whole mask to 0.0 (= all masked) and then set allowed
+    # positions to 1.0.
     tree_attention_mask = torch.zeros(bs, max_nodes, total_kv_len, dtype=dtype, device=device)
 
+    # --- Prefix portion (vectorized broadcast) ---
+    # All actual tree nodes may attend to their full prefix.
+    # Build a mask of shape [bs, max_nodes, total_kv_len] where
+    # mask[b, q, k] = 1.0 if k < past_lengths[b] and q < actual_tree_sizes[b]
+    past_lens_t = past_lengths.to(device=device)  # [bs]
+    actual_t = actual_tree_sizes.to(device=device)  # [bs]
+    kv_range = torch.arange(total_kv_len, device=device)  # [total_kv_len]
+    q_range = torch.arange(max_nodes, device=device)  # [max_nodes]
+    # [bs, 1, total_kv_len]: True where k < past_len
+    prefix_visible = kv_range.unsqueeze(0).unsqueeze(0) < past_lens_t.unsqueeze(1).unsqueeze(2)
+    # [bs, max_nodes, 1]: True where q < actual_size
+    actual_query_mask = q_range.unsqueeze(0).unsqueeze(2) < actual_t.unsqueeze(1).unsqueeze(2)
+    tree_attention_mask.copy_(prefix_visible.logical_and(actual_query_mask).to(dtype=dtype))
+
+    # --- Tree portion (per-batch, visibility shapes differ) ---
+    # Within the tree portion, only ancestor-visible pairs are allowed.
     for b in range(bs):
-        past_len = int(past_lengths[b].item())
+        past_len_i = int(past_lengths[b].item())
         actual_size = int(actual_tree_sizes[b].item())
 
-        tree_attention_mask[b, :actual_size, :past_len] = 0.0
-
         vis = visibility[b, :actual_size, :actual_size]
-        neg_inf = torch.finfo(dtype).min
-        tree_attention_mask[b, :actual_size, past_len:past_len + actual_size] = torch.where(
-            vis,
-            torch.tensor(0.0, dtype=dtype, device=device),
-            torch.tensor(neg_inf, dtype=dtype, device=device),
+        tree_attention_mask[b, :actual_size, past_len_i:past_len_i + actual_size] = (
+            vis.to(dtype=dtype, device=device)
         )
 
-        if actual_size < max_nodes:
-            tree_attention_mask[b, actual_size:, :] = neg_inf
+        # Padding nodes that are not part of the actual tree stay at 0.0
+        # (fully masked).
 
     return verify_input_ids, verify_position_ids, tree_attention_mask, actual_tree_sizes
 
@@ -218,6 +348,17 @@ def compact_ddtree_kv_cache(
     past_lengths: torch.Tensor,
     actual_tree_sizes: torch.Tensor,
 ):
+    """Compact KV cache by moving kept slots to the front.
+
+    Uses batched index_select + index_copy_ to replace per-element
+    set_kv_buffer kernel launches with 2 launches per layer.
+    """
+    k_buffer, v_buffer = kv_cache_pool.get_kv_buffer(layer.layer_id)
+    device = cache_locs.device
+
+    src_list: List[torch.Tensor] = []
+    tgt_list: List[torch.Tensor] = []
+
     for b in range(len(keep_indices)):
         keep = keep_indices[b]
         actual = int(actual_tree_sizes[b].item())
@@ -225,16 +366,32 @@ def compact_ddtree_kv_cache(
         if len(keep) == actual:
             continue
 
-        all_locs = cache_locs[b, :actual]
-        keep_locs = all_locs[keep]
+        # Safety: clamp keep indices to valid range [0, actual).
+        keep = [idx for idx in keep if 0 <= idx < actual]
+        if not keep or len(keep) == actual:
+            continue
 
-        for i, (src_loc, tgt_loc) in enumerate(zip(keep_locs, all_locs[:len(keep)])):
-            if src_loc == tgt_loc:
-                continue
-            k_buffer, v_buffer = kv_cache_pool.get_kv_buffer(layer)
-            kv_cache_pool.set_kv_buffer(
-                layer,
-                tgt_loc.unsqueeze(0),
-                k_buffer[src_loc:src_loc + 1],
-                v_buffer[src_loc:src_loc + 1],
-            )
+        # Fast path: if kept indices are contiguous from 0, no compaction needed.
+        if keep == list(range(len(keep))):
+            continue
+
+        all_locs = cache_locs[b, :actual]
+        keep_t = torch.tensor(keep, dtype=torch.long, device=device)
+        keep_locs = all_locs[keep_t]
+        tgt_locs = all_locs[: len(keep)]
+
+        mask = keep_locs != tgt_locs
+        if mask.any():
+            src_list.append(keep_locs[mask])
+            tgt_list.append(tgt_locs[mask])
+
+    if not src_list:
+        return
+
+    src_idx = torch.cat(src_list)
+    tgt_idx = torch.cat(tgt_list)
+
+    k_selected = k_buffer.index_select(0, src_idx)
+    v_selected = v_buffer.index_select(0, src_idx)
+    k_buffer.index_copy_(0, tgt_idx, k_selected)
+    v_buffer.index_copy_(0, tgt_idx, v_selected)

--- a/python/sglang/srt/speculative/ddtree_utils.py
+++ b/python/sglang/srt/speculative/ddtree_utils.py
@@ -1,0 +1,240 @@
+import heapq
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+
+
+def build_ddtree_tree(
+    draft_logits: torch.Tensor,  # [bs, L, vocab_size]
+    tree_budget: int,            # 鑺傜偣棰勭畻 B
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[Dict[int, Dict[int, int]]], torch.Tensor]:
+    bs, L, V = draft_logits.shape
+    topk = min(tree_budget, V)
+
+    logits = draft_logits.float()
+    top_logits, top_token_ids = torch.topk(logits, k=topk, dim=-1)
+    log_z = torch.logsumexp(logits, dim=-1, keepdim=True)
+    top_log_probs = (top_logits - log_z).to(device="cpu", dtype=torch.float32)
+    top_token_ids_cpu = top_token_ids.to(device="cpu", dtype=torch.long)
+
+    all_node_token_ids = []
+    all_node_depths = []
+    all_parents = []
+    all_child_maps = []
+    all_visibility = []
+    actual_sizes = []
+
+    for b in range(bs):
+        node_ids, depths, parents, child_map, vis, actual = _build_single_tree(
+            top_log_probs[b], top_token_ids_cpu[b], topk, L, tree_budget
+        )
+        all_node_token_ids.append(node_ids)
+        all_node_depths.append(depths)
+        all_parents.append(parents)
+        all_child_maps.append(child_map)
+        all_visibility.append(vis)
+        actual_sizes.append(actual)
+
+    max_nodes = tree_budget + 1
+    padded_node_token_ids = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
+    padded_node_depths = torch.zeros(bs, tree_budget, dtype=torch.long, device=device)
+    padded_parents = torch.full((bs, max_nodes), -1, dtype=torch.long, device=device)
+    padded_visibility = torch.zeros(bs, max_nodes, max_nodes, dtype=torch.bool, device=device)
+
+    for b in range(bs):
+        n = actual_sizes[b] - 1
+        if n > 0:
+            padded_node_token_ids[b, :n] = torch.from_numpy(all_node_token_ids[b]).to(device)
+            padded_node_depths[b, :n] = torch.from_numpy(all_node_depths[b]).to(device)
+        padded_parents[b, :actual_sizes[b]] = torch.from_numpy(all_parents[b]).to(device)
+        vis = all_visibility[b]
+        padded_visibility[b, :actual_sizes[b], :actual_sizes[b]] = torch.from_numpy(vis).to(device)
+
+    return (
+        padded_node_token_ids,
+        padded_node_depths,
+        padded_parents,
+        all_child_maps,
+        padded_visibility,
+    )
+
+
+def _build_single_tree(
+    top_log_probs: torch.Tensor,
+    top_token_ids: torch.Tensor,
+    topk: int,
+    depth_limit: int,
+    budget: int,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Dict[int, Dict[int, int]], np.ndarray, int]:
+    log_probs_np = top_log_probs.numpy().astype(np.float64)
+    token_ids_np = top_token_ids.numpy().astype(np.int64)
+
+    node_token_ids = np.zeros(budget, dtype=np.int64)
+    node_depths = np.zeros(budget, dtype=np.int32)
+    parents = np.full(budget + 1, -1, dtype=np.int32)
+    child_maps: Dict[int, Dict[int, int]] = {0: {}}
+
+    first_logw = float(log_probs_np[0, 0])
+    heap = [(-first_logw, (0,), 0, 1, 0, first_logw)]
+
+    node_count = 0
+    while heap and node_count < budget:
+        _, ranks, parent_idx, depth, rank, logw = heapq.heappop(heap)
+
+        token_id = int(token_ids_np[depth - 1, rank])
+        current_idx = node_count + 1
+
+        node_token_ids[node_count] = token_id
+        node_depths[node_count] = depth
+        parents[current_idx] = parent_idx
+        child_maps.setdefault(parent_idx, {})[token_id] = current_idx
+        child_maps.setdefault(current_idx, {})
+        node_count += 1
+
+        if rank + 1 < topk:
+            sibling_logw = (
+                logw
+                - float(log_probs_np[depth - 1, rank])
+                + float(log_probs_np[depth - 1, rank + 1])
+            )
+            sibling_ranks = ranks[:-1] + (rank + 1,)
+            heapq.heappush(
+                heap,
+                (-sibling_logw, sibling_ranks, parent_idx, depth, rank + 1, sibling_logw),
+            )
+
+        if depth < depth_limit:
+            child_logw = logw + float(log_probs_np[depth, 0])
+            child_ranks = ranks + (0,)
+            heapq.heappush(
+                heap,
+                (-child_logw, child_ranks, current_idx, depth + 1, 0, child_logw),
+            )
+
+    current_length = node_count + 1
+    visibility = np.zeros((current_length, current_length), dtype=bool)
+    visibility[0, 0] = True
+    for idx in range(1, current_length):
+        p = int(parents[idx])
+        visibility[idx, :idx] = visibility[p, :idx]
+        visibility[idx, idx] = True
+
+    return (
+        node_token_ids[:node_count],
+        node_depths[:node_count],
+        parents[:current_length],
+        child_maps,
+        visibility,
+        current_length,
+    )
+
+
+def compile_ddtree_tree(
+    root_token_ids: torch.Tensor,
+    node_token_ids: torch.Tensor,
+    node_depths: torch.Tensor,
+    visibility: torch.Tensor,
+    start_positions: torch.Tensor,
+    past_lengths: torch.Tensor,
+    tree_budget: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    bs = root_token_ids.shape[0]
+    max_nodes = tree_budget + 1
+
+    actual_tree_sizes = torch.zeros(bs, dtype=torch.long, device=device)
+    for b in range(bs):
+        non_zero = (node_token_ids[b] != 0).sum().item()
+        actual_tree_sizes[b] = non_zero + 1
+
+    verify_input_ids = torch.zeros(bs, max_nodes, dtype=torch.long, device=device)
+    verify_input_ids[:, 0] = root_token_ids
+    verify_input_ids[:, 1:] = node_token_ids
+
+    verify_position_ids = torch.zeros(bs, max_nodes, dtype=torch.long, device=device)
+    verify_position_ids[:, 0] = start_positions
+    verify_position_ids[:, 1:] = start_positions.unsqueeze(1) + node_depths
+
+    max_past = int(past_lengths.max().item())
+    total_kv_len = max_past + max_nodes
+
+    tree_attention_mask = torch.zeros(bs, max_nodes, total_kv_len, dtype=dtype, device=device)
+
+    for b in range(bs):
+        past_len = int(past_lengths[b].item())
+        actual_size = int(actual_tree_sizes[b].item())
+
+        tree_attention_mask[b, :actual_size, :past_len] = 0.0
+
+        vis = visibility[b, :actual_size, :actual_size]
+        neg_inf = torch.finfo(dtype).min
+        tree_attention_mask[b, :actual_size, past_len:past_len + actual_size] = torch.where(
+            vis,
+            torch.tensor(0.0, dtype=dtype, device=device),
+            torch.tensor(neg_inf, dtype=dtype, device=device),
+        )
+
+        if actual_size < max_nodes:
+            tree_attention_mask[b, actual_size:, :] = neg_inf
+
+    return verify_input_ids, verify_position_ids, tree_attention_mask, actual_tree_sizes
+
+
+def follow_verified_tree(
+    child_maps: List[Dict[int, Dict[int, int]]],
+    posterior_tokens: torch.Tensor,
+) -> Tuple[List[List[int]], torch.Tensor]:
+    bs = len(child_maps)
+    accepted_indices = []
+    next_tokens_list = []
+
+    for b in range(bs):
+        posterior = posterior_tokens[b].tolist()
+        accepted = [0]
+        current_idx = 0
+        next_token = posterior[0]
+
+        cmap = child_maps[b]
+        while next_token in cmap.get(current_idx, {}):
+            current_idx = cmap[current_idx][next_token]
+            accepted.append(current_idx)
+            next_token = posterior[current_idx]
+
+        accepted_indices.append(accepted)
+        next_tokens_list.append(next_token)
+
+    next_tokens = torch.tensor(next_tokens_list, dtype=torch.long, device=posterior_tokens.device)
+    return accepted_indices, next_tokens
+
+
+def compact_ddtree_kv_cache(
+    kv_cache_pool,
+    layer,
+    cache_locs: torch.Tensor,
+    keep_indices: List[List[int]],
+    past_lengths: torch.Tensor,
+    actual_tree_sizes: torch.Tensor,
+):
+    for b in range(len(keep_indices)):
+        keep = keep_indices[b]
+        actual = int(actual_tree_sizes[b].item())
+
+        if len(keep) == actual:
+            continue
+
+        all_locs = cache_locs[b, :actual]
+        keep_locs = all_locs[keep]
+
+        for i, (src_loc, tgt_loc) in enumerate(zip(keep_locs, all_locs[:len(keep)])):
+            if src_loc == tgt_loc:
+                continue
+            k_buffer, v_buffer = kv_cache_pool.get_kv_buffer(layer)
+            kv_cache_pool.set_kv_buffer(
+                layer,
+                tgt_loc.unsqueeze(0),
+                k_buffer[src_loc:src_loc + 1],
+                v_buffer[src_loc:src_loc + 1],
+            )

--- a/python/sglang/srt/speculative/ddtree_worker.py
+++ b/python/sglang/srt/speculative/ddtree_worker.py
@@ -4,11 +4,10 @@ from typing import Optional
 import torch
 
 from sglang.srt.distributed import get_tp_group
-from sglang.srt.managers.schedule_batch import GenerationBatchResult, ScheduleBatch
-from sglang.srt.mem_cache.common import get_last_loc
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
-    ForwardBatch,
     ForwardMode,
 )
 from sglang.srt.speculative.ddtree_info import DDTreeVerifyInput
@@ -16,10 +15,8 @@ from sglang.srt.speculative.ddtree_utils import (
     build_ddtree_tree,
     compile_ddtree_tree,
 )
-from sglang.srt.speculative.dflash_info import DFlashDraftInput
+from sglang.srt.speculative.dflash_info import DFlashDraftInput, DFlashVerifyInput
 from sglang.srt.speculative.dflash_worker import DFlashWorker
-from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +52,24 @@ class DDTreeWorker(DFlashWorker):
 
         self.max_tree_nodes = self.tree_budget + 1
 
+        # Pre-allocated tree-build output buffers (reused across steps).
+        _max_bs = getattr(server_args, "cuda_graph_max_bs", None) or 64
+        _budget = self.tree_budget
+        _mn = self.max_tree_nodes
+        dev = self.device
+        self._tree_node_token_ids_buf: torch.Tensor = torch.zeros(
+            _max_bs, _budget, dtype=torch.long, device=dev
+        )
+        self._tree_node_depths_buf: torch.Tensor = torch.zeros(
+            _max_bs, _budget, dtype=torch.long, device=dev
+        )
+        self._tree_parents_buf: torch.Tensor = torch.full(
+            (_max_bs, _mn), -1, dtype=torch.long, device=dev
+        )
+        self._tree_visibility_buf: torch.Tensor = torch.zeros(
+            _max_bs, _mn, _mn, dtype=torch.bool, device=dev
+        )
+
         if self.tp_rank == 0:
             logger.info(
                 "Initialized DDTree worker. block_size=%s, tree_budget=%s, max_tree_nodes=%s",
@@ -76,10 +91,10 @@ class DDTreeWorker(DFlashWorker):
 
         bs = batch.batch_size()
 
+        # --- 1) Append target hidden to draft KV cache.
         self._append_target_hidden_to_draft_kv(batch, draft_input)
 
         target_model = self.target_worker.model_runner.model
-        embed_module = target_model.get_input_embeddings()
         lm_head = getattr(target_model, "lm_head", None)
         if (
             lm_head is None
@@ -91,104 +106,57 @@ class DDTreeWorker(DFlashWorker):
                 "`shard_indices` attributes."
             )
 
-        self._ensure_draft_block_buffers(bs)
-        assert self._draft_block_ids_buf is not None
-        assert self._draft_block_positions_buf is not None
-        assert self._draft_block_tokens_buf is not None
-        assert self._draft_block_end_buf is not None
-        assert self._draft_seq_lens_cpu_buf is not None
-
-        block_ids = self._draft_block_ids_buf[:bs]
-        block_ids.fill_(int(self._mask_token_id))
-        block_ids[:, 0].copy_(draft_input.bonus_tokens.to(torch.long))
-
-        noise_embedding = embed_module(block_ids)
-        input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
-
-        target_prefix_lens = batch.seq_lens
-        draft_prefix_lens = draft_input.draft_seq_lens
-        if draft_prefix_lens.dtype != torch.int32:
-            draft_prefix_lens = draft_prefix_lens.to(torch.int32)
-        if draft_prefix_lens.device != self.device:
-            draft_prefix_lens = draft_prefix_lens.to(self.device, non_blocking=True)
-
-        positions_2d = self._draft_block_positions_buf[:bs]
-        torch.add(
-            target_prefix_lens.unsqueeze(1), self._block_pos_offsets, out=positions_2d
+        # --- 2) Draft a non-causal block (reuse parent's shared implementation).
+        draft_hidden, positions_2d, block_ids = self._run_draft_forward(
+            batch, draft_input
         )
-        positions = positions_2d.reshape(-1)
 
-        block_start = draft_prefix_lens
-        block_end = self._draft_block_end_buf[:bs]
-        torch.add(block_start, int(self.block_size), out=block_end)
+        # --- 3) Spine-mode fast path: delegate to DFLASH verify. ---
+        if self.tree_budget <= self.block_size - 1:
+            # Spine mode: linear chain, identical to DFLASH.  Skip all DDTree
+            # overhead (tree building, child_maps, custom masks) and reuse
+            # DFLASH's battle-tested verify path with CUDA graph support.
+            from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 
-        seq_lens_cpu = self._draft_seq_lens_cpu_buf[:bs]
-        seq_lens_cpu.copy_(draft_prefix_lens.to(device="cpu", dtype=torch.int32))
-        allocator = self.draft_model_runner.token_to_kv_pool_allocator
-        token_to_kv_pool_state_backup = allocator.backup_state()
-        try:
-            if self.page_size == 1:
-                block_cache_loc = allocator.alloc(bs * self.block_size)
-            else:
-                block_end_cpu = seq_lens_cpu + int(self.block_size)
-                last_loc = get_last_loc(
-                    self.draft_model_runner.req_to_token_pool.req_to_token,
-                    batch.req_pool_indices,
-                    block_start,
-                )
-                block_cache_loc = allocator.alloc_extend(
-                    block_start,
-                    seq_lens_cpu,
-                    block_end,
-                    block_end_cpu,
-                    last_loc,
-                    bs * self.block_size,
-                )
-            if block_cache_loc is None:
-                raise RuntimeError(
-                    f"DDTREE draft OOM when allocating {bs * self.block_size} block tokens."
-                )
+            draft_tokens = self._greedy_sample_draft_tokens(
+                hidden_states=draft_hidden[:, 1:, :].reshape(-1, draft_hidden.shape[-1]),
+                lm_head=lm_head,
+            ).view(bs, self.block_size - 1)
 
-            assign_req_to_token_pool_func(
-                batch.req_pool_indices,
-                self.draft_model_runner.req_to_token_pool.req_to_token,
-                block_start,
-                block_end,
-                block_cache_loc,
-                bs,
+            # Build verify IDs: [bonus, draft_0, ..., draft_{budget-1}]
+            draft_ids = torch.zeros(
+                bs, self.max_tree_nodes, dtype=torch.long, device=batch.device
+            )
+            draft_ids[:, 0] = draft_input.bonus_tokens
+            draft_ids[:, 1:] = draft_tokens[:, : self.tree_budget]
+
+            positions = torch.zeros(
+                bs, self.max_tree_nodes, dtype=torch.long, device=batch.device
+            )
+            positions[:, 0] = batch.seq_lens
+            positions[:, 1:] = (
+                batch.seq_lens.unsqueeze(1)
+                + torch.arange(1, self.tree_budget + 1, device=batch.device)
             )
 
-            draft_spec_info = self._draft_block_spec_info
-            seq_lens = draft_prefix_lens
-            seq_lens_sum = int(draft_prefix_lens.sum().item())
-            forward_batch = ForwardBatch(
-                forward_mode=ForwardMode.TARGET_VERIFY,
-                batch_size=bs,
-                input_ids=block_ids.flatten(),
-                req_pool_indices=batch.req_pool_indices,
-                seq_lens=seq_lens,
-                out_cache_loc=block_cache_loc,
-                seq_lens_sum=seq_lens_sum,
-                seq_lens_cpu=seq_lens_cpu,
-                positions=positions,
-                input_embeds=input_embeds,
-                spec_algorithm=SpeculativeAlgorithm.DDTREE,
-                spec_info=draft_spec_info,
-                capture_hidden_mode=CaptureHiddenMode.NULL,
+            verify_input = DFlashVerifyInput(
+                draft_token=draft_ids.reshape(-1),
+                positions=positions.reshape(-1),
+                draft_token_num=self.max_tree_nodes,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
             )
+            verify_input.prepare_for_verify(batch, self.page_size)
 
-            with torch.inference_mode():
-                draft_logits_output = self.draft_model_runner.forward(
-                    forward_batch
-                ).logits_output
-        finally:
-            allocator.restore_state(token_to_kv_pool_state_backup)
+            batch.forward_mode = (
+                ForwardMode.TARGET_VERIFY
+                if not batch.forward_mode.is_idle()
+                else ForwardMode.IDLE
+            )
+            batch.spec_info = verify_input
+            batch.return_hidden_states = False
+            return
 
-        draft_hidden = draft_logits_output.hidden_states
-        if draft_hidden is None:
-            raise RuntimeError("DDTREE draft model returned no hidden states.")
-        draft_hidden = draft_hidden.view(bs, self.block_size, -1)
-
+        # --- 4) Full tree path (budget > L): compute logits, beam search, compile mask. ---
         draft_logits = self._compute_draft_logits(
             hidden_states=draft_hidden[:, 1:, :].reshape(-1, draft_hidden.shape[-1]),
             lm_head=lm_head,
@@ -200,10 +168,15 @@ class DDTreeWorker(DFlashWorker):
             parents,
             child_maps,
             visibility,
+            actual_tree_sizes,
         ) = build_ddtree_tree(
             draft_logits=draft_logits,
             tree_budget=self.tree_budget,
             device=batch.device,
+            _out_node_token_ids=self._tree_node_token_ids_buf,
+            _out_node_depths=self._tree_node_depths_buf,
+            _out_parents=self._tree_parents_buf,
+            _out_visibility=self._tree_visibility_buf,
         )
 
         (
@@ -219,8 +192,14 @@ class DDTreeWorker(DFlashWorker):
             start_positions=batch.seq_lens,
             past_lengths=batch.seq_lens,
             tree_budget=self.tree_budget,
+            actual_tree_sizes=actual_tree_sizes,
             dtype=torch.bfloat16,
             device=batch.device,
+        )
+
+        tree_is_spine = all(
+            all(len(children) <= 1 for children in cm.values())
+            for cm in child_maps
         )
 
         verify_input = DDTreeVerifyInput(
@@ -231,6 +210,7 @@ class DDTreeWorker(DFlashWorker):
             child_maps=child_maps,
             actual_tree_sizes=actual_tree_sizes,
             custom_mask=tree_attention_mask,
+            tree_is_spine=tree_is_spine,
         )
         verify_input.prepare_for_verify(batch, self.page_size)
 
@@ -309,7 +289,11 @@ class DDTreeWorker(DFlashWorker):
 
         assert batch.forward_mode.is_target_verify()
         verify_input = batch.spec_info
-        assert isinstance(verify_input, DDTreeVerifyInput)
+
+        # Copy CUDA graph state from target worker BEFORE forward
+        self.target_worker.capture_mode = getattr(
+            self.target_worker.model_runner, "capture_mode", False
+        )
 
         batch_result = self.target_worker.forward_batch_generation(
             batch, is_verify=True, **kwargs
@@ -319,6 +303,45 @@ class DDTreeWorker(DFlashWorker):
             batch_result.can_run_cuda_graph,
         )
 
+        # Spine path: delegate to DFLASH verify (CUDA-graph compatible, handles
+        # KV, seq_lens, hidden states, etc. in one call).
+        if isinstance(verify_input, DFlashVerifyInput):
+            (
+                new_bonus_tokens,
+                commit_lens,
+                next_target_hidden,
+                num_correct_drafts_per_req_cpu,
+            ) = verify_input.verify(
+                batch=batch,
+                logits_output=logits_output,
+                page_size=self.page_size,
+            )
+
+            draft_input.bonus_tokens = new_bonus_tokens
+            draft_input.target_hidden = next_target_hidden
+            draft_input.ctx_lens = commit_lens
+            self._append_target_hidden_to_draft_kv(batch, draft_input)
+            batch.spec_info = draft_input
+            batch.forward_mode = ForwardMode.DECODE
+
+            num_correct_drafts = sum(num_correct_drafts_per_req_cpu)
+            if not self._logged_first_verify and self.tp_rank == 0:
+                logger.info(
+                    "DDTREE spine verify completed. num_correct_drafts_per_req=%s",
+                    num_correct_drafts_per_req_cpu,
+                )
+                self._logged_first_verify = True
+
+            return GenerationBatchResult(
+                logits_output=logits_output,
+                next_token_ids=new_bonus_tokens,
+                num_correct_drafts=num_correct_drafts,
+                num_correct_drafts_per_req_cpu=num_correct_drafts_per_req_cpu,
+                can_run_cuda_graph=can_run_cuda_graph,
+            )
+
+        # Full tree path: use DDTree verify.
+        assert isinstance(verify_input, DDTreeVerifyInput)
         (
             new_bonus_tokens,
             commit_lens,
@@ -328,6 +351,7 @@ class DDTreeWorker(DFlashWorker):
             batch=batch,
             logits_output=logits_output,
             page_size=self.page_size,
+            model_runner=self.target_worker.model_runner,
         )
 
         draft_input.bonus_tokens = new_bonus_tokens
@@ -353,23 +377,16 @@ class DDTreeWorker(DFlashWorker):
             can_run_cuda_graph=can_run_cuda_graph,
         )
 
-    def _compute_draft_logits(
+    def _greedy_sample_draft_tokens(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor,  # [total_tokens, hidden]
         lm_head,
     ) -> torch.Tensor:
+        """Return argmax token IDs (long).  Used by spine fast path."""
         tp_group = get_tp_group()
         tp_size = int(tp_group.world_size)
-
-        shard = lm_head.shard_indices
         weight = lm_head.weight
         weight_dtype = weight.dtype
-
-        num_org = int(shard.num_org_elements)
-        num_org_padded = int(shard.num_org_elements_padded)
-        num_added = int(shard.num_added_elements)
-        org_vocab_start = int(shard.org_vocab_start_index)
-        added_vocab_start = int(shard.added_vocab_start_index)
 
         if hidden_states.dtype != weight_dtype:
             hidden_states = hidden_states.to(weight_dtype)
@@ -377,11 +394,69 @@ class DDTreeWorker(DFlashWorker):
         local_logits = torch.mm(hidden_states, weight.t())
 
         if tp_size == 1:
+            return local_logits.argmax(dim=-1)
+
+        # TP > 1: per-rank argmax + all-gather of max/argmax
+        shard = lm_head.shard_indices
+        local_max, local_argmax = local_logits.max(dim=-1)
+
+        gathered_max = torch.empty(
+            tp_size, hidden_states.shape[0],
+            dtype=local_max.dtype, device=local_max.device,
+        )
+        tp_group.all_gather_into_tensor(gathered_max, local_max)
+        global_max_idx = gathered_max.argmax(dim=0)
+
+        gathered_argmax = torch.empty(
+            tp_size, hidden_states.shape[0],
+            dtype=local_argmax.dtype, device=local_argmax.device,
+        )
+        tp_group.all_gather_into_tensor(gathered_argmax, local_argmax)
+        global_argmax = gathered_argmax[
+            global_max_idx, torch.arange(hidden_states.shape[0], device=hidden_states.device)
+        ]
+
+        # Adjust for per-rank vocab shard offset
+        num_org = int(shard.num_org_elements)
+        return torch.where(
+            global_argmax < num_org,
+            global_argmax + int(shard.padding_offset),
+            global_argmax - num_org + int(shard.org_vocab_start_index),
+        )
+
+    def _compute_draft_logits(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head,
+    ) -> torch.Tensor:
+        """Compute global draft logits (raw, not log-softmax).
+
+        Returns raw float logits.  build_ddtree_tree will compute log-probs
+        itself via logsumexp, so we skip the exp→log chain here.
+        """
+        tp_group = get_tp_group()
+        tp_size = int(tp_group.world_size)
+
+        shard = lm_head.shard_indices
+        weight = lm_head.weight
+        weight_dtype = weight.dtype
+
+        if hidden_states.dtype != weight_dtype:
+            hidden_states = hidden_states.to(weight_dtype)
+
+        local_logits = torch.mm(hidden_states, weight.t())
+
+        # Fast path: single-GPU — return raw logits directly.
+        if tp_size == 1:
             return local_logits.float()
 
-        local_max = local_logits.amax(dim=-1, keepdim=True)
-        local_shifted = local_logits - local_max
+        # TP > 1: compute global log-probs (the exp→log path is needed
+        # here because vocab shard sizes may differ across ranks).
+        num_org = int(shard.num_org_elements)
+        num_org_padded = int(shard.num_org_elements_padded)
+        num_added = int(shard.num_added_elements)
 
+        local_max = local_logits.amax(dim=-1, keepdim=True)
         gathered_max = torch.empty(
             tp_size, hidden_states.shape[0], dtype=local_max.dtype, device=local_max.device
         )

--- a/python/sglang/srt/speculative/ddtree_worker.py
+++ b/python/sglang/srt/speculative/ddtree_worker.py
@@ -1,0 +1,405 @@
+import logging
+from typing import Optional
+
+import torch
+
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.managers.schedule_batch import GenerationBatchResult, ScheduleBatch
+from sglang.srt.mem_cache.common import get_last_loc
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sglang.srt.speculative.ddtree_info import DDTreeVerifyInput
+from sglang.srt.speculative.ddtree_utils import (
+    build_ddtree_tree,
+    compile_ddtree_tree,
+)
+from sglang.srt.speculative.dflash_info import DFlashDraftInput
+from sglang.srt.speculative.dflash_worker import DFlashWorker
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
+
+logger = logging.getLogger(__name__)
+
+
+class DDTreeWorker(DFlashWorker):
+    def __init__(
+        self,
+        server_args,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        attn_cp_rank: int,
+        moe_dp_rank: int,
+        nccl_port: int,
+        target_worker,
+    ):
+        super().__init__(
+            server_args,
+            gpu_id,
+            tp_rank,
+            dp_rank,
+            moe_ep_rank,
+            attn_cp_rank,
+            moe_dp_rank,
+            nccl_port,
+            target_worker,
+        )
+
+        self.tree_budget = getattr(server_args, "speculative_ddtree_budget", None)
+        if self.tree_budget is None:
+            self.tree_budget = self.block_size - 1
+
+        self.max_tree_nodes = self.tree_budget + 1
+
+        if self.tp_rank == 0:
+            logger.info(
+                "Initialized DDTree worker. block_size=%s, tree_budget=%s, max_tree_nodes=%s",
+                self.block_size,
+                self.tree_budget,
+                self.max_tree_nodes,
+            )
+
+    def _prepare_for_speculative_decoding(
+        self, batch: ScheduleBatch, draft_input: DFlashDraftInput
+    ):
+        if batch.forward_mode.is_extend() or batch.forward_mode.is_idle():
+            return
+
+        if batch.has_grammar:
+            raise RuntimeError(
+                "DDTREE batch has grammar constraints, but scheduler should have rejected this request."
+            )
+
+        bs = batch.batch_size()
+
+        self._append_target_hidden_to_draft_kv(batch, draft_input)
+
+        target_model = self.target_worker.model_runner.model
+        embed_module = target_model.get_input_embeddings()
+        lm_head = getattr(target_model, "lm_head", None)
+        if (
+            lm_head is None
+            or not hasattr(lm_head, "weight")
+            or not hasattr(lm_head, "shard_indices")
+        ):
+            raise RuntimeError(
+                "DDTREE requires the target model to expose a vocab-parallel `lm_head` with `weight` and "
+                "`shard_indices` attributes."
+            )
+
+        self._ensure_draft_block_buffers(bs)
+        assert self._draft_block_ids_buf is not None
+        assert self._draft_block_positions_buf is not None
+        assert self._draft_block_tokens_buf is not None
+        assert self._draft_block_end_buf is not None
+        assert self._draft_seq_lens_cpu_buf is not None
+
+        block_ids = self._draft_block_ids_buf[:bs]
+        block_ids.fill_(int(self._mask_token_id))
+        block_ids[:, 0].copy_(draft_input.bonus_tokens.to(torch.long))
+
+        noise_embedding = embed_module(block_ids)
+        input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
+
+        target_prefix_lens = batch.seq_lens
+        draft_prefix_lens = draft_input.draft_seq_lens
+        if draft_prefix_lens.dtype != torch.int32:
+            draft_prefix_lens = draft_prefix_lens.to(torch.int32)
+        if draft_prefix_lens.device != self.device:
+            draft_prefix_lens = draft_prefix_lens.to(self.device, non_blocking=True)
+
+        positions_2d = self._draft_block_positions_buf[:bs]
+        torch.add(
+            target_prefix_lens.unsqueeze(1), self._block_pos_offsets, out=positions_2d
+        )
+        positions = positions_2d.reshape(-1)
+
+        block_start = draft_prefix_lens
+        block_end = self._draft_block_end_buf[:bs]
+        torch.add(block_start, int(self.block_size), out=block_end)
+
+        seq_lens_cpu = self._draft_seq_lens_cpu_buf[:bs]
+        seq_lens_cpu.copy_(draft_prefix_lens.to(device="cpu", dtype=torch.int32))
+        allocator = self.draft_model_runner.token_to_kv_pool_allocator
+        token_to_kv_pool_state_backup = allocator.backup_state()
+        try:
+            if self.page_size == 1:
+                block_cache_loc = allocator.alloc(bs * self.block_size)
+            else:
+                block_end_cpu = seq_lens_cpu + int(self.block_size)
+                last_loc = get_last_loc(
+                    self.draft_model_runner.req_to_token_pool.req_to_token,
+                    batch.req_pool_indices,
+                    block_start,
+                )
+                block_cache_loc = allocator.alloc_extend(
+                    block_start,
+                    seq_lens_cpu,
+                    block_end,
+                    block_end_cpu,
+                    last_loc,
+                    bs * self.block_size,
+                )
+            if block_cache_loc is None:
+                raise RuntimeError(
+                    f"DDTREE draft OOM when allocating {bs * self.block_size} block tokens."
+                )
+
+            assign_req_to_token_pool_func(
+                batch.req_pool_indices,
+                self.draft_model_runner.req_to_token_pool.req_to_token,
+                block_start,
+                block_end,
+                block_cache_loc,
+                bs,
+            )
+
+            draft_spec_info = self._draft_block_spec_info
+            seq_lens = draft_prefix_lens
+            seq_lens_sum = int(draft_prefix_lens.sum().item())
+            forward_batch = ForwardBatch(
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                batch_size=bs,
+                input_ids=block_ids.flatten(),
+                req_pool_indices=batch.req_pool_indices,
+                seq_lens=seq_lens,
+                out_cache_loc=block_cache_loc,
+                seq_lens_sum=seq_lens_sum,
+                seq_lens_cpu=seq_lens_cpu,
+                positions=positions,
+                input_embeds=input_embeds,
+                spec_algorithm=SpeculativeAlgorithm.DDTREE,
+                spec_info=draft_spec_info,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+            )
+
+            with torch.inference_mode():
+                draft_logits_output = self.draft_model_runner.forward(
+                    forward_batch
+                ).logits_output
+        finally:
+            allocator.restore_state(token_to_kv_pool_state_backup)
+
+        draft_hidden = draft_logits_output.hidden_states
+        if draft_hidden is None:
+            raise RuntimeError("DDTREE draft model returned no hidden states.")
+        draft_hidden = draft_hidden.view(bs, self.block_size, -1)
+
+        draft_logits = self._compute_draft_logits(
+            hidden_states=draft_hidden[:, 1:, :].reshape(-1, draft_hidden.shape[-1]),
+            lm_head=lm_head,
+        ).view(bs, self.block_size - 1, -1)
+
+        (
+            node_token_ids,
+            node_depths,
+            parents,
+            child_maps,
+            visibility,
+        ) = build_ddtree_tree(
+            draft_logits=draft_logits,
+            tree_budget=self.tree_budget,
+            device=batch.device,
+        )
+
+        (
+            verify_input_ids,
+            verify_position_ids,
+            tree_attention_mask,
+            actual_tree_sizes,
+        ) = compile_ddtree_tree(
+            root_token_ids=draft_input.bonus_tokens,
+            node_token_ids=node_token_ids,
+            node_depths=node_depths,
+            visibility=visibility,
+            start_positions=batch.seq_lens,
+            past_lengths=batch.seq_lens,
+            tree_budget=self.tree_budget,
+            dtype=torch.bfloat16,
+            device=batch.device,
+        )
+
+        verify_input = DDTreeVerifyInput(
+            draft_token=verify_input_ids.reshape(-1),
+            positions=verify_position_ids.reshape(-1),
+            draft_token_num=self.max_tree_nodes,
+            tree_budget=self.tree_budget,
+            child_maps=child_maps,
+            actual_tree_sizes=actual_tree_sizes,
+            custom_mask=tree_attention_mask,
+        )
+        verify_input.prepare_for_verify(batch, self.page_size)
+
+        batch.forward_mode = (
+            ForwardMode.TARGET_VERIFY
+            if not batch.forward_mode.is_idle()
+            else ForwardMode.IDLE
+        )
+        batch.spec_info = verify_input
+        batch.return_hidden_states = False
+
+    def forward_batch_generation(
+        self, batch: ScheduleBatch, **kwargs
+    ) -> GenerationBatchResult:
+        if getattr(batch, "return_logprob", False):
+            raise RuntimeError(
+                "DDTREE batch requested return_logprob, but scheduler should have rejected this request."
+            )
+
+        if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
+            batch.capture_hidden_mode = CaptureHiddenMode.FULL
+            batch_result = self.target_worker.forward_batch_generation(batch, **kwargs)
+            logits_output, next_token_ids = (
+                batch_result.logits_output,
+                batch_result.next_token_ids,
+            )
+            if logits_output.hidden_states is None:
+                raise RuntimeError(
+                    "DDTREE requires target aux hidden capture for prefill, but got None. "
+                    "Make sure the target model has DFlash layers-to-capture configured."
+                )
+
+            if batch.extend_lens is None or batch.prefix_lens is None:
+                raise RuntimeError(
+                    "DDTREE expected extend_lens / prefix_lens to be populated in extend mode, but got None."
+                )
+
+            device = next_token_ids.device
+
+            def _to_int32_device_tensor(x, *, device=device):
+                if isinstance(x, torch.Tensor):
+                    if x.device != device:
+                        x = x.to(device, non_blocking=True)
+                    return x if x.dtype == torch.int32 else x.to(torch.int32)
+                return torch.tensor(x, dtype=torch.int32, device=device)
+
+            extend_seq_lens = _to_int32_device_tensor(batch.extend_lens)
+            draft_input = DFlashDraftInput(
+                bonus_tokens=next_token_ids.to(torch.int64),
+                target_hidden=logits_output.hidden_states,
+                ctx_lens=extend_seq_lens,
+                draft_seq_lens=(
+                    torch.zeros_like(extend_seq_lens)
+                    if self.use_compact_draft_cache
+                    else _to_int32_device_tensor(batch.prefix_lens)
+                ),
+            )
+            self._append_target_hidden_to_draft_kv(batch, draft_input)
+            batch.spec_info = draft_input
+
+            return GenerationBatchResult(
+                logits_output=logits_output,
+                next_token_ids=next_token_ids,
+                num_correct_drafts=0,
+                can_run_cuda_graph=batch_result.can_run_cuda_graph,
+            )
+
+        draft_input = batch.spec_info
+        if not isinstance(draft_input, DFlashDraftInput):
+            raise RuntimeError(
+                "DDTREE decode requires DFlashDraftInput state on the running batch. "
+                "This usually means the request did not complete the prefill stage."
+            )
+
+        self._prepare_for_speculative_decoding(batch, draft_input)
+
+        assert batch.forward_mode.is_target_verify()
+        verify_input = batch.spec_info
+        assert isinstance(verify_input, DDTreeVerifyInput)
+
+        batch_result = self.target_worker.forward_batch_generation(
+            batch, is_verify=True, **kwargs
+        )
+        logits_output, can_run_cuda_graph = (
+            batch_result.logits_output,
+            batch_result.can_run_cuda_graph,
+        )
+
+        (
+            new_bonus_tokens,
+            commit_lens,
+            next_target_hidden,
+            num_correct_drafts_per_req_cpu,
+        ) = verify_input.verify(
+            batch=batch,
+            logits_output=logits_output,
+            page_size=self.page_size,
+        )
+
+        draft_input.bonus_tokens = new_bonus_tokens
+        draft_input.target_hidden = next_target_hidden
+        draft_input.ctx_lens = commit_lens
+        self._append_target_hidden_to_draft_kv(batch, draft_input)
+        batch.spec_info = draft_input
+        batch.forward_mode = ForwardMode.DECODE
+
+        num_correct_drafts = sum(num_correct_drafts_per_req_cpu)
+        if not self._logged_first_verify and self.tp_rank == 0:
+            logger.info(
+                "DDTREE verify completed. num_correct_drafts_per_req=%s",
+                num_correct_drafts_per_req_cpu,
+            )
+            self._logged_first_verify = True
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=new_bonus_tokens,
+            num_correct_drafts=num_correct_drafts,
+            num_correct_drafts_per_req_cpu=num_correct_drafts_per_req_cpu,
+            can_run_cuda_graph=can_run_cuda_graph,
+        )
+
+    def _compute_draft_logits(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head,
+    ) -> torch.Tensor:
+        tp_group = get_tp_group()
+        tp_size = int(tp_group.world_size)
+
+        shard = lm_head.shard_indices
+        weight = lm_head.weight
+        weight_dtype = weight.dtype
+
+        num_org = int(shard.num_org_elements)
+        num_org_padded = int(shard.num_org_elements_padded)
+        num_added = int(shard.num_added_elements)
+        org_vocab_start = int(shard.org_vocab_start_index)
+        added_vocab_start = int(shard.added_vocab_start_index)
+
+        if hidden_states.dtype != weight_dtype:
+            hidden_states = hidden_states.to(weight_dtype)
+
+        local_logits = torch.mm(hidden_states, weight.t())
+
+        if tp_size == 1:
+            return local_logits.float()
+
+        local_max = local_logits.amax(dim=-1, keepdim=True)
+        local_shifted = local_logits - local_max
+
+        gathered_max = torch.empty(
+            tp_size, hidden_states.shape[0], dtype=local_max.dtype, device=local_max.device
+        )
+        tp_group.all_gather_into_tensor(gathered_max, local_max.squeeze(-1))
+        global_max = gathered_max.amax(dim=0, keepdim=True)
+
+        local_exp = torch.exp(local_logits - global_max.unsqueeze(-1))
+
+        gathered_exp = torch.empty(
+            tp_size, hidden_states.shape[0], local_logits.shape[-1],
+            dtype=local_exp.dtype, device=local_exp.device,
+        )
+        tp_group.all_gather_into_tensor(gathered_exp, local_exp)
+        global_sum = gathered_exp.sum(dim=(0, 2), keepdim=True)
+
+        global_logits = torch.cat(
+            [gathered_exp[i] for i in range(tp_size)], dim=-1
+        )
+        global_log_probs = torch.log(global_logits / global_sum.unsqueeze(-1))
+
+        return global_log_probs.float()

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -522,53 +522,27 @@ class DFlashWorker:
 
         return int(resolved_id)
 
-    def _prepare_for_speculative_decoding(
+    def _run_draft_forward(
         self, batch: ScheduleBatch, draft_input: DFlashDraftInput
-    ):
-        if batch.forward_mode.is_extend() or batch.forward_mode.is_idle():
-            return
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run the draft model forward for a single block.
 
-        if batch.has_grammar:
-            raise RuntimeError(
-                "Invariant broken: DFLASH batch has grammar constraints, but scheduler should have rejected this request."
-            )
-        if batch.sampling_info is not None and not batch.sampling_info.is_all_greedy:
-            if (
-                not is_dflash_sampling_verify_available()
-                and not self._warned_sampling_fallback
-                and self.tp_rank == 0
-            ):
-                logger.warning(
-                    "DFLASH non-greedy verification is unavailable on this build/device; "
-                    "falling back to greedy argmax verification."
-                )
-                self._warned_sampling_fallback = True
-
+        Returns:
+            draft_hidden: [bs, block_size, hidden_size]  draft hidden states.
+            positions_2d: [bs, block_size]               RoPE positions.
+            block_ids:    [bs, block_size]               input token ids.
+        """
         bs = batch.batch_size()
 
-        # --- 1) Append any newly committed tokens into the draft KV cache.
-        self._append_target_hidden_to_draft_kv(batch, draft_input)
-
-        target_model = self.target_worker.model_runner.model
-        embed_module = target_model.get_input_embeddings()
-        lm_head = getattr(target_model, "lm_head", None)
-        if (
-            lm_head is None
-            or not hasattr(lm_head, "weight")
-            or not hasattr(lm_head, "shard_indices")
-        ):
-            raise RuntimeError(
-                "DFLASH requires the target model to expose a vocab-parallel `lm_head` with `weight` and "
-                "`shard_indices` attributes."
-            )
-
-        # --- 2) Draft a non-causal block with the draft model.
         self._ensure_draft_block_buffers(bs)
         assert self._draft_block_ids_buf is not None
         assert self._draft_block_positions_buf is not None
         assert self._draft_block_tokens_buf is not None
         assert self._draft_block_end_buf is not None
         assert self._draft_seq_lens_cpu_buf is not None
+
+        target_model = self.target_worker.model_runner.model
+        embed_module = target_model.get_input_embeddings()
 
         block_ids = self._draft_block_ids_buf[:bs]
         block_ids.fill_(int(self._mask_token_id))
@@ -577,10 +551,7 @@ class DFlashWorker:
         noise_embedding = embed_module(block_ids)
         input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
 
-        # For spec-v1, the draft KV cache is always materialized before drafting the
-        # next block. `target_prefix_lens` stay absolute for RoPE; `draft_prefix_lens`
-        # are the logical resident lengths in the draft-local cache.
-        target_prefix_lens = batch.seq_lens  # int32, device
+        target_prefix_lens = batch.seq_lens
         draft_prefix_lens = draft_input.draft_seq_lens
         if draft_prefix_lens.dtype != torch.int32:
             draft_prefix_lens = draft_prefix_lens.to(torch.int32)
@@ -633,9 +604,6 @@ class DFlashWorker:
                 bs,
             )
 
-            # Use TARGET_VERIFY mode (cuda-graphable) to run a fixed-size draft block.
-            # In this mode, `seq_lens` stores the prefix lengths; attention backends
-            # derive kv_len by adding `draft_token_num`.
             draft_spec_info = self._draft_block_spec_info
             seq_lens = draft_prefix_lens
             seq_lens_sum = int(draft_prefix_lens.sum().item())
@@ -660,13 +628,59 @@ class DFlashWorker:
                     forward_batch
                 ).logits_output
         finally:
-            # Drop the speculative block from the shared allocator (EAGLE3-style).
             allocator.restore_state(token_to_kv_pool_state_backup)
 
         draft_hidden = draft_logits_output.hidden_states
         if draft_hidden is None:
             raise RuntimeError("DFLASH draft model returned no hidden states.")
         draft_hidden = draft_hidden.view(bs, self.block_size, -1)
+
+        return draft_hidden, positions_2d, block_ids
+
+    def _prepare_for_speculative_decoding(
+        self, batch: ScheduleBatch, draft_input: DFlashDraftInput
+    ):
+        if batch.forward_mode.is_extend() or batch.forward_mode.is_idle():
+            return
+
+        if batch.has_grammar:
+            raise RuntimeError(
+                "Invariant broken: DFLASH batch has grammar constraints, but scheduler should have rejected this request."
+            )
+        if batch.sampling_info is not None and not batch.sampling_info.is_all_greedy:
+            if (
+                not is_dflash_sampling_verify_available()
+                and not self._warned_sampling_fallback
+                and self.tp_rank == 0
+            ):
+                logger.warning(
+                    "DFLASH non-greedy verification is unavailable on this build/device; "
+                    "falling back to greedy argmax verification."
+                )
+                self._warned_sampling_fallback = True
+
+        bs = batch.batch_size()
+
+        # --- 1) Append any newly committed tokens into the draft KV cache.
+        self._append_target_hidden_to_draft_kv(batch, draft_input)
+
+        target_model = self.target_worker.model_runner.model
+        lm_head = getattr(target_model, "lm_head", None)
+        if (
+            lm_head is None
+            or not hasattr(lm_head, "weight")
+            or not hasattr(lm_head, "shard_indices")
+        ):
+            raise RuntimeError(
+                "DFLASH requires the target model to expose a vocab-parallel `lm_head` with `weight` and "
+                "`shard_indices` attributes."
+            )
+
+        # --- 2) Draft a non-causal block with the draft model.
+        draft_hidden, positions_2d, block_ids = self._run_draft_forward(
+            batch, draft_input
+        )
+
         draft_next = self._greedy_sample_from_vocab_parallel_head(
             hidden_states=draft_hidden[:, 1:, :].reshape(-1, draft_hidden.shape[-1]),
             lm_head=lm_head,

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -33,6 +33,7 @@ class SpeculativeAlgorithm(Enum):
     """
 
     DFLASH = auto()
+    DDTREE = auto()
     EAGLE = auto()
     EAGLE3 = auto()
     FROZEN_KV_MTP = auto()
@@ -109,6 +110,9 @@ class SpeculativeAlgorithm(Enum):
     def is_dflash(self) -> bool:
         return self == SpeculativeAlgorithm.DFLASH
 
+    def is_ddtree(self) -> bool:
+        return self == SpeculativeAlgorithm.DDTREE
+
     def is_standalone(self) -> bool:
         return self == SpeculativeAlgorithm.STANDALONE
 
@@ -116,7 +120,7 @@ class SpeculativeAlgorithm(Enum):
         return self == SpeculativeAlgorithm.NGRAM
 
     def supports_target_verify_for_draft(self) -> bool:
-        return self.is_dflash()
+        return self.is_dflash() or self.is_ddtree()
 
     def create_future_map(
         self,
@@ -175,6 +179,15 @@ class SpeculativeAlgorithm(Enum):
             from sglang.srt.speculative.dflash_worker import DFlashWorker
 
             return DFlashWorker
+
+        if self.is_ddtree():
+            if enable_overlap:
+                raise ValueError(
+                    "DDTREE does not support overlap scheduling (spec v2)."
+                )
+            from sglang.srt.speculative.ddtree_worker import DDTreeWorker
+
+            return DDTreeWorker
 
         if self.is_frozen_kv_mtp():
             if enable_overlap:
@@ -248,6 +261,7 @@ class SpecInputType(IntEnum):
     FROZEN_KV_MTP_VERIFY = auto()
     DFLASH_DRAFT = auto()
     DFLASH_VERIFY = auto()
+    DDTREE_VERIFY = auto()
     NGRAM_VERIFY = auto()
 
 
@@ -273,6 +287,7 @@ class SpecInput(ABC):
             SpecInputType.EAGLE_VERIFY,
             SpecInputType.FROZEN_KV_MTP_VERIFY,
             SpecInputType.DFLASH_VERIFY,
+            SpecInputType.DDTREE_VERIFY,
             SpecInputType.NGRAM_VERIFY,
         }
 


### PR DESCRIPTION
## Motivation

Add **DDTree (Draft-Tree)** speculative decoding, a new spec algorithm that improves draft acceptance rates by constructing a dynamic tree over draft tokens instead of verifying them in a fixed linear sequence. By searching the top-k draft logit paths with a priority-queue beam builder, DDTree verifies multiple branching hypotheses in parallel and follows the longest verified path, yielding more accepted tokens per round than block-wise approaches.

## Modifications

**New files:**
- `python/sglang/srt/speculative/ddtree_info.py` — `DDTreeVerifyInput` dataclass: KV allocation, tree attention mask generation, and target verify logic (path-following + KV compaction).
- `python/sglang/srt/speculative/ddtree_utils.py` — Tree builder (`build_ddtree_tree`) using log-probability beam search to select B tree nodes; tree compiler (`compile_ddtree_tree`) producing verify input ids, position ids, and tree-structured attention mask; verified-path follower and KV compaction helpers.
- `python/sglang/srt/speculative/ddtree_worker.py` — `DDTreeWorker` extending `DFlashWorker`: draft model forward with vocab-parallel logit computation, tree construction from draft logits, and verify-round orchestration.

**Integration across 9 existing files:**
- `spec_info.py` — Register `DDTREE` in `SpeculativeAlgorithm` enum, `SpecInputType.DDTREE_VERIFY`, and worker dispatch.
- `scheduler.py` — Route DDTREE requests through existing DFLASH validation.
- `model_runner.py` — Instantiate `DDTreeVerifyInput` on target model runner.
- `cuda_graph_runner.py` / `npu_graph_runner.py` — Support DDTREE verify capture with correct draft-token count derived from tree budget.
- `flashattention_backend.py` / `triton_backend.py` — Handle DDTree's variable draft-token count and tree-structured custom mask in target-verify attention, using `draft_token_num` from spec_info instead of hardcoded `speculative_num_draft_tokens`.
- `pool_configurator.py` — Scale KV cell size for DDTREE draft model cache (same scaling as DFLASH).
- `server_args.py` — Add `--speculative-ddtree-budget` (tree node budget B, defaults to `speculative_num_draft_tokens - 1`).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->