### PR TITLE
[deepseek] Enable DP attention + TBO + shared experts fusion

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -673,14 +673,6 @@ class TboForwardBatchPreparer:
                 output_dict[key] = None
                 continue
             elif key == "rids" and len(old_value) != num_seqs:
-                # Under DP attention MAX_LEN padding, `prepare_mlp_sync_batch`
-                # pads `batch_size` (= num_seqs) and the device tensors of a
-                # sub-max rank up to the global max token count, but `rids` is
-                # a per-request host list (one entry per real request) that is
-                # not padded -- so it can be shorter than num_seqs here (e.g. a
-                # rank with 4 real reqs padded to batch_size=5 has len(rids)=4).
-                # Padding rows have no request to attribute, so slice with a
-                # clamped end instead of asserting equality.
                 output_dict[key] = old_value[
                     start_seq_index : min(end_seq_index, len(old_value))
                 ]

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -672,6 +672,19 @@ class TboForwardBatchPreparer:
             ):
                 output_dict[key] = None
                 continue
+            elif key == "rids" and len(old_value) != num_seqs:
+                # Under DP attention MAX_LEN padding, `prepare_mlp_sync_batch`
+                # pads `batch_size` (= num_seqs) and the device tensors of a
+                # sub-max rank up to the global max token count, but `rids` is
+                # a per-request host list (one entry per real request) that is
+                # not padded -- so it can be shorter than num_seqs here (e.g. a
+                # rank with 4 real reqs padded to batch_size=5 has len(rids)=4).
+                # Padding rows have no request to attribute, so slice with a
+                # clamped end instead of asserting equality.
+                output_dict[key] = old_value[
+                    start_seq_index : min(end_seq_index, len(old_value))
+                ]
+                continue
             assert (
                 len(old_value) == num_seqs
             ), f"{key=} {old_value=} {num_seqs=} {batch=}"

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1333,9 +1333,14 @@ class DeepseekV2MoE(nn.Module):
             return None
 
     def op_gate(self, state):
-        if is_non_idle_and_non_empty(
-            state.forward_batch.forward_mode, state.hidden_states_mlp_input
-        ):
+        # Gate on `shape[0] > 0` (not is_non_idle_and_non_empty) to match the
+        # non-TBO `forward_deepep` path: a padded IDLE batch (dummy rows added
+        # by prepare_mlp_sync_batch under MAX_LEN DP-padding) still carries
+        # N>0 rows that must be routed, or topk_output stays 0-row while
+        # hidden_states is N-row and DeepEP dispatch asserts
+        # `x.size(0) == topk_idx.size(0)`. num_token_non_padded masks the dummy
+        # rows' expert ids to -1 downstream, so the routing is a no-op.
+        if state.hidden_states_mlp_input.shape[0] > 0:
             # router_logits: (num_tokens, n_experts)
             state.router_logits = self.gate(state.hidden_states_mlp_input)
         else:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1333,13 +1333,6 @@ class DeepseekV2MoE(nn.Module):
             return None
 
     def op_gate(self, state):
-        # Gate on `shape[0] > 0` (not is_non_idle_and_non_empty) to match the
-        # non-TBO `forward_deepep` path: a padded IDLE batch (dummy rows added
-        # by prepare_mlp_sync_batch under MAX_LEN DP-padding) still carries
-        # N>0 rows that must be routed, or topk_output stays 0-row while
-        # hidden_states is N-row and DeepEP dispatch asserts
-        # `x.size(0) == topk_idx.size(0)`. num_token_non_padded masks the dummy
-        # rows' expert ids to -1 downstream, so the routing is a no-op.
         if state.hidden_states_mlp_input.shape[0] > 0:
             # router_logits: (num_tokens, n_experts)
             state.router_logits = self.gate(state.hidden_states_mlp_input)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7492,11 +7492,6 @@ class ServerArgs:
                 "When enabling two batch overlap, moe_a2a_backend cannot be 'none'."
             )
 
-        if self.enable_two_batch_overlap and self.enforce_shared_experts_fusion:
-            raise ValueError(
-                "--enable-two-batch-overlap and --enforce-shared-experts-fusion cannot be used together."
-            )
-
         # Check communications compression
         if self.enable_quant_communications and self.tp_size == 1:
             raise ValueError(

--- a/test/registered/ep/test_deepep_small.py
+++ b/test/registered/ep/test_deepep_small.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=600, stage="base-c", runner_config="deepep-4-gpu-h100")
+register_cuda_ci(est_time=478, stage="base-c", runner_config="deepep-4-gpu-h100")
 
 
 class TestPureDP(CustomTestCase):
@@ -225,58 +225,6 @@ class TestTBO(CustomTestCase):
                 "--enable-two-batch-overlap",
                 "--cuda-graph-max-bs",
                 "128",
-                "--max-running-requests",
-                "512",
-            ],
-            env={
-                **os.environ,
-                "SGLANG_TBO_DEBUG": "1",
-            },
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-    def test_gsm8k(self):
-        args = SimpleNamespace(
-            base_url=self.base_url,
-            model=self.model,
-            eval_name="gsm8k",
-            api="completion",
-            max_tokens=512,
-            num_examples=200,
-            num_threads=128,
-        )
-        metrics = run_eval(args)
-        print(metrics)
-
-        self.assertGreater(metrics["score"], 0.60)
-
-
-class TestTBOWithSharedExpertsFusion(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--trust-remote-code",
-                "--tp",
-                "4",
-                "--enable-dp-attention",
-                "--dp",
-                "4",
-                "--moe-dense-tp-size",
-                "1",
-                "--moe-a2a-backend",
-                "deepep",
-                "--enable-two-batch-overlap",
-                "--enforce-shared-experts-fusion",
-                "--disable-cuda-graph",
                 "--max-running-requests",
                 "512",
             ],

--- a/test/registered/ep/test_deepep_small.py
+++ b/test/registered/ep/test_deepep_small.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=478, stage="base-c", runner_config="deepep-4-gpu-h100")
+register_cuda_ci(est_time=600, stage="base-c", runner_config="deepep-4-gpu-h100")
 
 
 class TestPureDP(CustomTestCase):
@@ -225,6 +225,73 @@ class TestTBO(CustomTestCase):
                 "--enable-two-batch-overlap",
                 "--cuda-graph-max-bs",
                 "128",
+                "--max-running-requests",
+                "512",
+            ],
+            env={
+                **os.environ,
+                "SGLANG_TBO_DEBUG": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(metrics)
+
+        self.assertGreater(metrics["score"], 0.60)
+
+
+class TestTBOWithSharedExpertsFusion(CustomTestCase):
+    """TBO + shared-experts fusion on DeepSeek (issue #24690).
+
+    Runs in eager mode (--disable-cuda-graph) on purpose: the bugs this guards
+    (the filter_batch rids assert and the op_gate / DeepEP
+    `x.size(0) == topk_idx.size(0)` mismatch on padded sub-max / idle DP ranks)
+    only surface on the eager forward path. With CUDA graph on, IDLE batches
+    replay through compute_split_indices_for_cuda_graph_replay and never hit
+    these code paths, so a graph-on test would not regression-guard the fix.
+
+    Note: verify the CI model actually engages fusion -- the log should print
+    "Shared experts fusion optimization enabled" at load. --enforce-shared-
+    experts-fusion bypasses the config checks but the weight loader still
+    requires num_fused_shared_experts == 1 (n_shared_experts == 1).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--enable-dp-attention",
+                "--dp",
+                "4",
+                "--moe-dense-tp-size",
+                "1",
+                "--moe-a2a-backend",
+                "deepep",
+                "--enable-two-batch-overlap",
+                "--enforce-shared-experts-fusion",
+                "--disable-cuda-graph",
                 "--max-running-requests",
                 "512",
             ],

--- a/test/registered/ep/test_deepep_small.py
+++ b/test/registered/ep/test_deepep_small.py
@@ -255,21 +255,6 @@ class TestTBO(CustomTestCase):
 
 
 class TestTBOWithSharedExpertsFusion(CustomTestCase):
-    """TBO + shared-experts fusion on DeepSeek (issue #24690).
-
-    Runs in eager mode (--disable-cuda-graph) on purpose: the bugs this guards
-    (the filter_batch rids assert and the op_gate / DeepEP
-    `x.size(0) == topk_idx.size(0)` mismatch on padded sub-max / idle DP ranks)
-    only surface on the eager forward path. With CUDA graph on, IDLE batches
-    replay through compute_split_indices_for_cuda_graph_replay and never hit
-    these code paths, so a graph-on test would not regression-guard the fix.
-
-    Note: verify the CI model actually engages fusion -- the log should print
-    "Shared experts fusion optimization enabled" at load. --enforce-shared-
-    experts-fusion bypasses the config checks but the weight loader still
-    requires num_fused_shared_experts == 1 (n_shared_experts == 1).
-    """
-
     @classmethod
     def setUpClass(cls):
         cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA

--- a/test/registered/ep/test_tbo_shared_experts_fusion.py
+++ b/test/registered/ep/test_tbo_shared_experts_fusion.py
@@ -1,0 +1,79 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+# Label-gated extra CI (run-ci + run-ci-extra) on the 8x H200 DeepEP runner.
+# Shared-experts fusion only supports n_shared_experts == 1, so this uses the
+# real DeepSeek-V3-Base (n_shared_experts=1) rather than the small CI MLA proxy
+# model (n_shared_experts != 1, which cannot fuse and trips
+# `assert num_fused_shared_experts == 1` in deepseek_weight_loader.py). The
+# 671B FP8 weights need all 8 GPUs.
+register_cuda_ci(est_time=900, stage="extra-b", runner_config="deepep-8-gpu-h200")
+
+DEEPSEEK_V3_BASE_MODEL_PATH = "deepseek-ai/DeepSeek-V3-Base"
+
+
+class TestTBOWithSharedExpertsFusion(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_BASE_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "8",
+                "--enable-dp-attention",
+                "--dp",
+                "8",
+                "--moe-dense-tp-size",
+                "1",
+                "--moe-a2a-backend",
+                "deepep",
+                "--enable-two-batch-overlap",
+                "--enforce-shared-experts-fusion",
+                "--disable-cuda-graph",
+                "--max-running-requests",
+                "512",
+            ],
+            env={
+                **os.environ,
+                "SGLANG_TBO_DEBUG": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(metrics)
+
+        self.assertGreater(metrics["score"], 0.60)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ep/test_tbo_shared_experts_fusion.py
+++ b/test/registered/ep/test_tbo_shared_experts_fusion.py
@@ -14,13 +14,13 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=900, stage="extra-b", runner_config="deepep-8-gpu-h200")
 
-DEEPSEEK_V3_BASE_MODEL_PATH = "deepseek-ai/DeepSeek-V3-Base"
+DEEPSEEK_V3_MODEL_PATH = "deepseek-ai/DeepSeek-V3-0324"
 
 
 class TestTBOWithSharedExpertsFusion(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = DEEPSEEK_V3_BASE_MODEL_PATH
+        cls.model = DEEPSEEK_V3_MODEL_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
             cls.model,

--- a/test/registered/ep/test_tbo_shared_experts_fusion.py
+++ b/test/registered/ep/test_tbo_shared_experts_fusion.py
@@ -12,12 +12,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-# Label-gated extra CI (run-ci + run-ci-extra) on the 8x H200 DeepEP runner.
-# Shared-experts fusion only supports n_shared_experts == 1, so this uses the
-# real DeepSeek-V3-Base (n_shared_experts=1) rather than the small CI MLA proxy
-# model (n_shared_experts != 1, which cannot fuse and trips
-# `assert num_fused_shared_experts == 1` in deepseek_weight_loader.py). The
-# 671B FP8 weights need all 8 GPUs.
 register_cuda_ci(est_time=900, stage="extra-b", runner_config="deepep-8-gpu-h200")
 
 DEEPSEEK_V3_BASE_MODEL_PATH = "deepseek-ai/DeepSeek-V3-Base"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR enables DP attention, TBO, and shared-experts fusion simultaneously.

Closes #24690

## Modifications
* Change 1: `python/sglang/srt/server_args.py`
  *  Remove the guard that rejected `--enable-two-batch-overlap` together with `--enforce-shared-experts-fusion`, so the two flags can now be enabled together. 

Run the test and get error https://github.com/sgl-project/sglang/pull/27510#discussion_r3370366772:
* [launch_server.sh](https://gist.github.com/kevin85421/ee051b535583501c7ffce8df6c34c375)
* [run_load.sh](https://gist.github.com/kevin85421/c99e901f1445a569c7bbf68bf1924833)
```
# Step 1: Launch server
./launch_server.sh
# Step 2: Submit requests
./run_load.sh
```

* Change 2: `two_batch_overlap.py`
  * `prepare_mlp_sync_batch` -> `_pad_inputs_to_size`
    * Each DP attention rank has a different `global_num_tokens_cpu[i]`, so every DP attention rank will be padded to `max(global_num_tokens_cpu)`. However, `_pad_inputs_to_size` doesn't pad rids. Therefore, the assertion `len(old_value) == num_seqs` will fail, because `num_seqs` changes after padding but `rids` does not.

Run the test again and get error https://github.com/sgl-project/sglang/pull/27510#discussion_r3370368321.

* Change 3: `python/sglang/srt/models/deepseek_v2.py`
  * Currently `op_gate` leaves `state.router_logits = None` for an `IDLE` batch, even when DP-attention MAX_LEN padding has padded it to N > 0 dummy rows.. `op_select_experts` then takes the else branch and sets `state.topk_output = self.topk.empty_topk_output(...)`, which is 0-row. Since hidden_states still has the N padded rows, `op_dispatch_a` hands DeepEP an N-row `x` against a 0-row `topk_idx`, and `low_latency_dispatch` fails the assert `x.size(0) == topk_idx.size(0)` (N ≠ 0).

Run the test again:

<img width="1984" height="691" alt="Screenshot 2026-06-07 at 5 23 10 PM" src="https://github.com/user-attachments/assets/7c44fd06-e1a7-43c4-9593-0ac02e4a54c3" />

## Accuracy Tests

### GSM8K
* [launch_server.sh](https://gist.github.com/kevin85421/ee051b535583501c7ffce8df6c34c375)
* [run_gsm8k.sh](https://gist.github.com/kevin85421/d187809166622922aa885320de0ae316)
```
# Step 1: Launch server
./launch_server.sh
# Step 2: Run GSM8K
./run_gsm8k.sh
# Score: 0.940
```
<img width="1983" height="438" alt="image" src="https://github.com/user-attachments/assets/f7ae6331-194f-4a65-91b6-3204f665d7bc" />

### CI

```sh
python -m pytest   test/registered/ep/test_tbo_shared_experts_fusion.py -s -v
```

* DeepSeek-V3-Base
  <img width="2388" height="778" alt="Screenshot 2026-06-09 at 1 51 30 PM" src="https://github.com/user-attachments/assets/59094e55-ed02-4cc1-aa79-3b36b666d6f0" />

* DeepSeek-V3-0324
  <img width="1650" height="845" alt="image" src="https://github.com/user-attachments/assets/62eab0e1-1960-40c5-804d-6fca0b8c46c8" />


## Speed Tests and Profiling

* Benchmark A: this branch + TBO only 
* Benchmark B: this branch + TBO + shared experts fusion

* [bench_one.sh](https://gist.github.com/kevin85421/70b60b7f9656416a8506b051ffe98dc6)

```sh
# Step 1: Launch server with TBO
# remove `--enforce-shared-experts-fusion` from `launch_server.sh`.
./launch_server.sh

# Step 2: Submit requests
./bench_one.sh A_nofusion

# bench_A_nofusion.result
Successful requests:                     256       
Benchmark duration (s):                  135.23    
Request throughput (req/s):              1.89      
Input token throughput (tok/s):          734.28    
Output token throughput (tok/s):         179.66    
Total token throughput (tok/s):          913.93    
Mean TTFT (ms):                          961.83    
Median TTFT (ms):                        773.61    
P99 TTFT (ms):                           1872.63   
Mean ITL (ms):                           301.23    
Median ITL (ms):                         282.89    
P99 ITL (ms):                            604.07    


# Step 3: Kill the server and add `--enforce-shared-experts-fusion` back to `launch_server.sh` to launch a server with both TBO and shared experts fusion.
./launch_server.sh

# Step 4: Submit requests
./bench_one.sh B_fusion

# bench_B_nofusion.result
Successful requests:                     256       
Benchmark duration (s):                  131.98    
Request throughput (req/s):              1.94      
Input token throughput (tok/s):          752.33    
Output token throughput (tok/s):         184.07    
Total token throughput (tok/s):          936.40    
Mean TTFT (ms):                          936.71    
Median TTFT (ms):                        748.05    
P99 TTFT (ms):                           1868.32   
Mean ITL (ms):                           293.44    
Median ITL (ms):                         279.20    
P99 ITL (ms):                            615.40    
```

| Metric | TBO only | TBO + fusion | Δ |
|---|---|---|---|
| Output throughput (tok/s) | 179.66 | 184.07 | **+2.5%** |
| Total throughput (tok/s) | 913.93 | 936.40 | **+2.5%** |
| Request throughput (req/s) | 1.89 | 1.94 | **+2.6%** |
| Benchmark duration (s) | 135.23 | 131.98 | **−2.4%** |
| Mean TTFT (ms) | 961.83 | 936.71 | **−2.6%** |
| Median TTFT (ms) | 773.61 | 748.05 | **−3.3%** |
| P99 TTFT (ms) | 1872.63 | 1868.32 | −0.2% |
| Mean ITL (ms) | 301.23 | 293.44 | **−2.6%** |
| Median ITL (ms) | 282.89 | 279.20 | **−1.3%** |
| P99 ITL (ms) | 604.07 | 615.40 | +1.9% |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27255262645](https://github.com/sgl-project/sglang/actions/runs/27255262645)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27255262541](https://github.com/sgl-project/sglang/actions/runs/27255262541)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->