### PR TITLE
Fix Req token ID normalization for gRPC inputs

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -688,12 +688,22 @@ class Req(ReqDllmMixin):
     ):
         # Input and output info
         self.rid = rid
-        self.origin_input_ids = origin_input_ids
-        self.origin_input_ids_unpadded = (
-            origin_input_ids_unpadded
-            if origin_input_ids_unpadded
-            else self.origin_input_ids
-        )  # Before image padding
+        # Keep Req token-id storage homogeneous even when non-tokenizer ingress
+        # paths (e.g. gRPC bridge) pass Python lists.
+        self.origin_input_ids = (
+            origin_input_ids
+            if isinstance(origin_input_ids, array)
+            else array("q", origin_input_ids)
+        )
+        if origin_input_ids_unpadded:
+            self.origin_input_ids_unpadded = (
+                origin_input_ids_unpadded
+                if isinstance(origin_input_ids_unpadded, array)
+                else array("q", origin_input_ids_unpadded)
+            )
+        else:
+            self.origin_input_ids_unpadded = self.origin_input_ids
+        # Before image padding
         # Each decode stage's output ids
         self.output_ids = array("q")
         # fill_ids = origin_input_ids + output_ids. Updated if chunked.

--- a/test/registered/unit/managers/test_req_token_ids.py
+++ b/test/registered/unit/managers/test_req_token_ids.py
@@ -1,0 +1,41 @@
+from array import array
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestReqTokenIds(CustomTestCase):
+    def test_list_origin_input_ids_are_normalized_for_fill_ids(self):
+        req = Req(
+            rid="req-list-origin",
+            origin_input_text="",
+            origin_input_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_new_tokens=8),
+        )
+        req.output_ids.extend([4, 5])
+
+        req.init_next_round_input()
+
+        self.assertIsInstance(req.origin_input_ids, array)
+        self.assertIsInstance(req.output_ids, array)
+        self.assertIsInstance(req.fill_ids, array)
+        self.assertEqual(list(req.fill_ids), [1, 2, 3, 4, 5])
+
+    def test_list_origin_input_ids_unpadded_are_normalized(self):
+        req = Req(
+            rid="req-list-unpadded",
+            origin_input_text="",
+            origin_input_ids=array("q", [10, 11]),
+            origin_input_ids_unpadded=[10],
+            sampling_params=SamplingParams(max_new_tokens=8),
+        )
+
+        self.assertIsInstance(req.origin_input_ids_unpadded, array)
+        self.assertEqual(list(req.origin_input_ids_unpadded), [10])


### PR DESCRIPTION
## Summary

PR #26182 moved token ID array conversion to callers, but the SMG/gRPC bridge can still pass `input_ids` into Python as plain lists. That leaves `Req.origin_input_ids` as a list while `Req.output_ids` is an `array("q")`, causing scheduler concat paths like `origin_input_ids + output_ids` to fail after generated tokens exist.

This restores the scheduler invariant in `Req.__init__` by normalizing list token IDs to `array("q")` once, while avoiding extra copies when callers already pass arrays.

This preserves the caller-array contract for normal paths, but adds a no-copy guard at the `Req` boundary for non-tokenizer ingress paths such as the Rust gRPC bridge, where JSON arrays become Python lists.

cc @Jialin @merrymercy

## Tests

- `pytest -q test/registered/unit/managers/test_req_token_ids.py`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27107343493](https://github.com/sgl-project/sglang/actions/runs/27107343493)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27107343436](https://github.com/sgl-project/sglang/actions/runs/27107343436)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->