### PR TITLE
[Spec] Clamp multimodal pad sentinels in spec-v2 draft prefill embedding

### DIFF
--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -201,7 +201,12 @@ class MiMoV2ModelNextN(nn.Module):
         input_embeds: torch.Tensor = None,
     ) -> torch.Tensor:
         if input_embeds is None:
-            hidden_states = self.embed_tokens(input_ids)
+            # Multimodal pad sentinels (MM_PAD_SHIFT_VALUE + hash) sit out of vocab;
+            # clamp to avoid an OOB gather. The draft gets visual semantics from target
+            # hidden_states, so the embedding at these positions is unused anyway.
+            hidden_states = self.embed_tokens(
+                input_ids.clamp(min=0, max=self.vocab_size - 1)
+            )
         else:
             hidden_states = input_embeds
         if hidden_states.shape[0] > 0:

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -389,7 +389,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         maybe_detect_oob(
             next_token_ids,
             0,
-            self.draft_runner_list[0].model_config.vocab_size,
+            self.model_config.vocab_size,
             "draft_extend_for_prefill: next_token_ids before draft embed",
         )
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -383,6 +383,16 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
             target_hidden_states: Hidden states from the target model forward
             next_token_ids: Next token ids generated from the target forward.
         """
+        # The draft embed clamps unconditionally (to tolerate multimodal pad
+        # sentinels), so probe next_token_ids here first -- otherwise a corrupted id
+        # would be clamped away instead of surfacing.
+        maybe_detect_oob(
+            next_token_ids,
+            0,
+            self.draft_runner_list[0].model_config.vocab_size,
+            "draft_extend_for_prefill: next_token_ids before draft embed",
+        )
+
         # Construct spec_info
         next_draft_input = EagleDraftInput(
             hidden_states=target_hidden_states,


### PR DESCRIPTION
## Summary
- Spec-v2 draft prefill fed out-of-vocab multimodal pad sentinels straight into the draft `embed_tokens`, causing an out-of-bounds embedding gather.
- Clamp the ids in the draft embed (like the main model already does), and probe `next_token_ids` so a genuinely corrupted id still surfaces.

## Root cause
- Multimodal placeholder positions in `input_ids` are filled with pad sentinels (`MM_PAD_SHIFT_VALUE + hash`, intentionally out of vocab so per-image RadixAttention prefixes don't collide).
- The main model handles them in `general_mm_embed_routine`: `clamp(0, vocab - 1)` before the gather, then scatter vision features over those positions.
- The spec-v2 draft (`_draft_extend_for_prefill` -> `MiMoV2ModelNextN.forward`) does neither and gathers the raw sentinel. At `tp=1` (no vocab-parallel masking) this is a real OOB read / crash; at `tp>1` the embedding mask hides it as a zero embedding. Any VLM with multi-layer EAGLE hits it on the first image request (server warmup is the first one).

## Fix
- `mimo_v2_nextn.py`: `embed_tokens(input_ids.clamp(min=0, max=vocab_size - 1))`. The draft gets visual semantics from the target hidden states, so the embedding at sentinel positions is unused regardless.
- `multi_layer_eagle_worker_v2.py`: probe `next_token_ids` with `maybe_detect_oob` before the clamp — the clamp would otherwise silently swallow a corrupted/uninitialized id, so this keeps OOB detection where the "must be a valid vocab id" invariant genuinely holds.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27108653732](https://github.com/sgl-project/sglang/actions/runs/27108653732)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27108653633](https://github.com/sgl-project/sglang/actions/runs/27108653633)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
