### PR TITLE
Add torchembed as optional RoPE backend

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -133,6 +133,7 @@ http2 = [
 fastokens = [
   "fastokens>=0.1.1,<0.2.0",
 ]
+torchembed = ["torchembed>=0.1.0"]
 
 test = [
   "accelerate",

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -37,6 +37,12 @@ _is_mps = is_mps()
 
 if _is_cuda:
     from sglang.jit_kernel.rope import apply_rope_with_cos_sin_cache_inplace
+    try:
+        from torchembed._triton import fused_rope_forward as _torchembed_rope_forward
+
+        _torchembed_available = True
+    except ImportError:
+        _torchembed_available = False
 
 if _is_npu:
     import torch_npu
@@ -345,6 +351,33 @@ class RotaryEmbedding(MultiPlatformOp):
         offsets: Optional[torch.Tensor] = None,
         fused_set_kv_buffer_arg: Optional[Union[FusedSetKVBufferArg, dict]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if _torchembed_available:
+            if offsets is not None:
+                positions = positions + offsets
+            positions = positions.flatten()
+            batch_size = positions.size(0)
+            cos_sin = self.cos_sin_cache.index_select(0, positions)
+            cos, sin = cos_sin.chunk(2, dim=-1)
+
+            q_rope = query.view(batch_size, -1, self.head_size)
+            k_rope = key.view(batch_size, -1, self.head_size)
+
+            if self.head_size != self.rotary_dim:
+                q_rot = q_rope[..., : self.rotary_dim]
+                k_rot = k_rope[..., : self.rotary_dim]
+            else:
+                q_rot = q_rope
+                k_rot = k_rope
+
+            q_t = q_rot.transpose(0, 1).contiguous()
+            k_t = k_rot.transpose(0, 1).contiguous()
+
+            q_out_rot, k_out_rot = _torchembed_rope_forward(q_t, k_t, cos, sin)
+
+            q_rot.copy_(q_out_rot.transpose(0, 1))
+            k_rot.copy_(k_out_rot.transpose(0, 1))
+            return query, key
+
         if not self.use_fallback_kernel:
             batch_size = positions.size(0)
             q_rope = query.view(batch_size, -1, self.head_size)

--- a/test/registered/rotary/test_rope_torchembed.py
+++ b/test/registered/rotary/test_rope_torchembed.py
@@ -1,0 +1,105 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.rotary_embedding import RotaryEmbedding
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(0)
+
+try:
+    from torchembed._triton import fused_rope_forward  # noqa: F401
+
+    _torchembed_available = True
+except ImportError:
+    _torchembed_available = False
+
+_CASES = [
+    (64, 64, 32, 8000, True, torch.bfloat16, 32, 32, 1, 1),
+    (128, 128, 4096, 10000, True, torch.bfloat16, 2, 512, 4, 2),
+    (128, 128, 2048, 10000, True, torch.bfloat16, 2, 512, 32, 8),
+    (128, 128, 2048, 10000, False, torch.bfloat16, 2, 512, 32, 8),
+    (256, 128, 4096, 10000, True, torch.bfloat16, 3, 39, 4, 2),
+    (128, 64, 2048, 10000, True, torch.bfloat16, 2, 512, 16, 4),
+]
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available() or not _torchembed_available,
+    reason="requires CUDA and torchembed",
+)
+class TestRotaryEmbeddingTorchembed(CustomTestCase):
+    def _run_case(
+        self,
+        head_size: int,
+        rotary_dim: int,
+        max_pos: int,
+        base: int,
+        is_neox: bool,
+        dtype: torch.dtype,
+        batch_size: int,
+        seq_len: int,
+        num_q: int,
+        num_kv: int,
+    ) -> None:
+        rope = RotaryEmbedding(
+            head_size, rotary_dim, max_pos, base, is_neox, dtype
+        ).to("cuda")
+
+        pos_ids = torch.arange(seq_len, device="cuda").repeat(batch_size)
+        query = torch.randn(
+            batch_size * seq_len, num_q * head_size, dtype=dtype, device="cuda"
+        )
+        key = torch.randn(
+            batch_size * seq_len, num_kv * head_size, dtype=dtype, device="cuda"
+        )
+
+        q_ref, k_ref = rope.forward_native(pos_ids, query.clone(), key.clone())
+        q_cuda, k_cuda = rope.forward_cuda(pos_ids, query.clone(), key.clone())
+
+        torch.testing.assert_close(q_ref, q_cuda, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(k_ref, k_cuda, atol=1e-2, rtol=1e-2)
+
+    def test_all_cases(self) -> None:
+        for case in _CASES:
+            with self.subTest(case=case):
+                self._run_case(*case)
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available() or not _torchembed_available,
+    reason="requires CUDA and torchembed",
+)
+class TestRotaryEmbeddingGrad(CustomTestCase):
+    def test_gradient_flow(self):
+        head_size, rotary_dim, max_pos = 64, 64, 128
+        batch_size, seq_len = 2, 16
+        num_q, num_kv = 4, 2
+        dtype = torch.float32
+
+        rope = RotaryEmbedding(
+            head_size, rotary_dim, max_pos, 10000, True, dtype
+        ).to("cuda")
+
+        pos_ids = torch.arange(seq_len, device="cuda").repeat(batch_size)
+        q = torch.randn(
+            batch_size * seq_len, num_q * head_size, dtype=dtype, device="cuda",
+            requires_grad=True,
+        )
+        k = torch.randn(
+            batch_size * seq_len, num_kv * head_size, dtype=dtype, device="cuda",
+            requires_grad=True,
+        )
+
+        q_out, k_out = rope.forward_cuda(pos_ids, q, k)
+        loss = q_out.sum() + k_out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertFalse(torch.isnan(q.grad).any())
+        self.assertFalse(torch.isnan(k.grad).any())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add [torchembed](https://github.com/liodon-ai/torchembed) as an optional accelerated RoPE backend for the rotary embedding layer. When `torchembed>=0.1.0` is installed, `forward_cuda` automatically dispatches to the fused Triton kernel for improved performance.

## Changes

1. **`python/sglang/srt/layers/rotary_embedding/base.py`**: Try-import `torchembed._triton.fused_rope_forward` at module level (CUDA-only). In `forward_cuda`, short-circuit to the torchembed kernel when available -- follows the same early-dispatch pattern used by the existing JIT kernel.

2. **`python/pyproject.toml`**: Add optional dependency `torchembed = ["torchembed>=0.1.0"]`.

3. **`test/registered/rotary/test_rope_torchembed.py`**: New test file with 7 parametrized cases covering:
   - Numerical correctness vs `forward_native` across head sizes 64, 128, 256 and varying batch/seq parameters
   - Gradient flow check (requires `requires_grad` on inputs, no NaN grads)

All tests gated on CUDA + torchembed availability.

## Testing

```
pytest test/registered/rotary/test_rope_torchembed.py -v
```

## Related

- torchembed: https://github.com/liodon-ai/torchembed
- transformers PR: https://github.com/huggingface/transformers/pull/46479
- vLLM PR: https://github.com/vllm-project/vllm/pull/44810







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27108349222](https://github.com/sgl-project/sglang/actions/runs/27108349222)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27108349132](https://github.com/sgl-project/sglang/actions/runs/27108349132)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->