### PR TITLE
Fix DBRX config loading with integer moe_jitter_eps

### DIFF
--- a/python/sglang/srt/configs/dbrx.py
+++ b/python/sglang/srt/configs/dbrx.py
@@ -118,6 +118,8 @@ class DbrxFFNConfig(PretrainedConfig):
         super().__init__()
         if ffn_act_fn is None:
             ffn_act_fn = {"name": "silu"}
+        if isinstance(moe_jitter_eps, int) and not isinstance(moe_jitter_eps, bool):
+            moe_jitter_eps = float(moe_jitter_eps)
         self.ffn_act_fn = ffn_act_fn
         self.ffn_hidden_size = ffn_hidden_size
         self.moe_num_experts = moe_num_experts

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -140,7 +140,7 @@ except ImportError:
 
 for name, cls in _CONFIG_REGISTRY.items():
     try:
-        AutoConfig.register(name, cls)
+        AutoConfig.register(name, cls, exist_ok=(name == "dbrx"))
     except ValueError as e:
         err = str(e).lower()
         if "already registered" not in err and "already used" not in err:

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -4,13 +4,17 @@ Tests cover the pure utility functions (compat patches, config helpers,
 context length, GGUF detection, etc.) that don't require actual model files.
 """
 
+import json
 import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from transformers import PretrainedConfig
 
+from sglang.srt.configs.dbrx import DbrxConfig
 from sglang.srt.utils.hf_transformers.common import (
+    AutoConfig,
     _is_deepseek_ocr2_model,
     _is_deepseek_ocr_model,
     _override_v_head_dim_if_zero,
@@ -25,6 +29,45 @@ from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_comp
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+# ---------------------------------------------------------------------------
+# DBRX config compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestDbrxConfigCompat(unittest.TestCase):
+    def test_autoconfig_accepts_integer_moe_jitter_eps(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "config.json").write_text(
+                json.dumps(
+                    {
+                        "architectures": ["DbrxForCausalLM"],
+                        "attn_config": {
+                            "clip_qkv": 8,
+                            "kv_n_heads": 8,
+                            "model_type": "",
+                            "rope_theta": 500000,
+                        },
+                        "ffn_config": {
+                            "ffn_act_fn": {"name": "silu"},
+                            "ffn_hidden_size": 10752,
+                            "model_type": "",
+                            "moe_jitter_eps": 0,
+                            "moe_loss_weight": 0.05,
+                            "moe_num_experts": 16,
+                            "moe_top_k": 4,
+                        },
+                        "model_type": "dbrx",
+                    }
+                )
+            )
+
+            config = AutoConfig.from_pretrained(tmpdir)
+
+        self.assertIsInstance(config, DbrxConfig)
+        self.assertEqual(config.ffn_config.moe_jitter_eps, 0.0)
+        self.assertIsInstance(config.ffn_config.moe_jitter_eps, float)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

 Fixes DBRX config loading for configs that encode `ffn_config.moe_jitter_eps` as the JSON integer `0`.

 With `transformers==5.8.1`, upstream DBRX config validation rejects this value because the field is typed
as `float | None`. SGLang already carries a local DBRX config, but the AutoConfig registration did not override
the upstream DBRX registration, so startup still hit the upstream strict validator.

This change:
  - lets SGLang override the DBRX AutoConfig registration
  - normalizes integer `moe_jitter_eps` values to float in
the local DBRX FFN config
  - adds regression coverage for DBRX configs with integer
`moe_jitter_eps`

Fixes #26674.

  ## Test plan

  - Reproduced the original failure with the real
ModelScope DBRX config:
    - `StrictDataclassFieldValidationError` on
`moe_jitter_eps: 0 int`
  - Verified the fixed load path with the same config:
    - `post-fix load succeeds: DbrxConfig`
    - `post-fix moe_jitter_eps: 0.0 float`
  - `PYTHONPATH=python uv run --with 'transformers==5.8.1'
--with 'huggingface-hub' python test/registered/unit/
utils/test_hf_transformers.py -f`
    - `Ran 60 tests`
    - `OK`
  - `git diff --check`
  - `python3 -m py_compile python/sglang/srt/utils/
hf_transformers/common.py python/sglang/srt/configs/
dbrx.py test/registered/unit/utils/
test_hf_transformers.py`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27113475885](https://github.com/sgl-project/sglang/actions/runs/27113475885)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27113475818](https://github.com/sgl-project/sglang/actions/runs/27113475818)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->