### PR TITLE
[AMD] WIP - Fix DSV4 C4/C128 v2 compress dtype mismatch on HIP+AITER

### DIFF
--- a/python/sglang/jit_kernel/dsv4/compress.py
+++ b/python/sglang/jit_kernel/dsv4/compress.py
@@ -313,6 +313,13 @@ def compress_forward(
     out: Optional[torch.Tensor] = None,
     is_online: bool = False,
 ) -> torch.Tensor:
+    if not is_online and kv_score_input.dtype != kv_score_buffer.dtype:
+        # The C4/C128 v2 kernel templates a single dtype for the state buffer,
+        # ragged input and ape, and derives it from the input. The DSV4 state
+        # buffer (and ape) are always fp32, but on the HIP+AITER path the input
+        # arrives as bf16 (compute_kv_score skips the fp32 cast), so align the
+        # input to the buffer dtype to satisfy the kernel's TensorMatcher.
+        kv_score_input = kv_score_input.to(kv_score_buffer.dtype)
     if out is None:
         num_q_tokens = plan[1].shape[0]  # NOTE: decode = bs, prefill = dynamic
         out = kv_score_input.new_empty((num_q_tokens, head_dim))

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -114,6 +114,7 @@ class DSV4AttnMetadata:
     c4_topk_lengths_clamp1: Optional[torch.Tensor] = None
     c4_sparse_topk_lengths: torch.Tensor = field(init=False)
     c4_sparse_page_indices: torch.Tensor = field(init=False)
+    c4_sparse_raw_indices: Optional[torch.Tensor] = field(init=False, default=None)
 
     c128_out_loc: Optional[torch.Tensor] = None
     c128_page_indices: Optional[torch.Tensor] = None


### PR DESCRIPTION

https://github.com/sgl-project/sglang/actions/runs/27116638452

## Motivation
AMD nightly DSV4-Flash (mi35x/ROCm) crashes in the C4 indexer compressor:
```
tvm.error.InternalError: Tensor match failed for Tensor<..., dtype=float32, device=rocm>
Root cause: Dtype value [float32] not in the allowed options: [bfloat16]
```
#26914 made `compute_kv_score` return **bf16** on the HIP+AITER path (dropping the fp32 cast). But the C4/C128 v2 JIT kernel templates a **single** dtype for the state buffer, ragged input and ape, deriving it from the input. The DSV4 state buffer and ape are always **fp32**, so a bf16 input no longer matches and `TensorMatcher` rejects the fp32 buffer.
## Modifications
- In `compress_forward`, align `kv_score_input` to the state buffer dtype before launching the kernel (non-online path only).
- CUDA is unaffected (input is already fp32 → cast is a no-op); the online c128 path is excluded. Restores the pre-#26914 fp32 behavior on the v2 JIT path.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27116613516](https://github.com/sgl-project/sglang/actions/runs/27116613516)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27116613430](https://github.com/sgl-project/sglang/actions/runs/27116613430)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->