### PR TITLE
Fix GPT-OSS MXFP4 hidden size reshape on SM10X

### DIFF
--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -208,6 +208,7 @@ class GptOssSparseMoeBlock(nn.Module):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
         self.layer_id = layer_id
+        self.hidden_size = config.hidden_size
         self.activation = config.hidden_act
         self.gemm1_alpha = getattr(config, "hidden_act_alpha", 1.702)
         self.gemm1_clamp_limit = config.swiglu_limit
@@ -291,7 +292,7 @@ class GptOssSparseMoeBlock(nn.Module):
         # is then trimmed back to the unpadded width so postprocess_layer
         # can pair it with the (M, hidden_dim_unpadded) residual.
         num_tokens = hidden_states.shape[0]
-        hidden_dim_unpadded = self.experts.hidden_size
+        hidden_dim_unpadded = self.hidden_size
         is_prepadded = hidden_states.shape[-1] != hidden_dim_unpadded
         if is_prepadded:
             router_input = hidden_states[..., :hidden_dim_unpadded]


### PR DESCRIPTION
## Summary

Fix a regression from #27063 where GPT-OSS used the backend-internal expert hidden size for the final MoE reshape.

On SM10X with FlashInfer MXFP4, `self.experts.hidden_size` is padded from `2880` to `3072`, while `config.hidden_size` remains `2880`, causing warmup to fail:

```text
RuntimeError: shape '[4096, 3072]' is invalid for input of size 11796480
```

I also checked H200, where serving succeeds because it uses `moe_runner_backend='triton_kernel'` and does not pad the expert hidden size to `3072`.

## Test Plan

### Before

On one GPU from a single GB300 node, GPT-OSS 20B failed during server warmup before this fix:

```bash
CUDA_VISIBLE_DEVICES=0 sglang serve \
  --model-path openai/gpt-oss-20b \
  --kv-cache-dtype fp8_e4m3 \
  --reasoning-parser gpt-oss \
  --tool-call-parser gpt-oss \
  --trust-remote-code
```

Failure:

```text
RuntimeError: shape '[4096, 3072]' is invalid for input of size 11796480
```

### After

With this fix, the same server command succeeds, and GPQA eval completes:

```bash
python -m gpt_oss.evals \
  --model openai/gpt-oss-20b \
  --eval gpqa \
  --n-threads 512 \
  --reasoning-effort low \
  --base-url http://127.0.0.1:30000/v1 \
  --sampler chat_completions
```

Result:

```text
100%|...| 1584/1584 [00:29<00:00, 53.63it/s]
score: 0.5593434343434344
```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27116872906](https://github.com/sgl-project/sglang/actions/runs/27116872906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27116872875](https://github.com/sgl-project/sglang/actions/runs/27116872875)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->