### PR TITLE
fix(sgl-kernel/rocm): honor explicit AMDGPU_TARGET over auto-detection

### DIFF
--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -64,21 +64,40 @@ libraries = ["hiprtc", "amdhip64", "c10", "torch", "torch_python"]
 extra_link_args = ["-Wl,-rpath,$ORIGIN/../../torch/lib", f"-L/usr/lib/{arch}-linux-gnu"]
 
 default_target = "gfx942"
-amdgpu_target = os.environ.get("AMDGPU_TARGET", default_target)
+# An explicit AMDGPU_TARGET always wins over auto-detection. This is the
+# documented escape hatch for cross-compilation and for building on
+# experimental/unsupported architectures; previously it was read here but then
+# silently overwritten by the torch.cuda detection below whenever a GPU was
+# visible, so the override never took effect on a build host with a GPU.
+explicit_target = os.environ.get("AMDGPU_TARGET")
+amdgpu_target = explicit_target or default_target
 
-if torch.cuda.is_available():
-    try:
-        amdgpu_target = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
-    except Exception as e:
-        print(f"Warning: Failed to detect GPU properties: {e}")
-else:
-    print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
+if explicit_target is None:
+    if torch.cuda.is_available():
+        try:
+            props = torch.cuda.get_device_properties(0)
+            amdgpu_target = props.gcnArchName.split(":")[0]
+        except Exception as e:
+            print(f"Warning: Failed to detect GPU properties: {e}")
+    else:
+        print(
+            f"Warning: torch.cuda not available. Using default target: {amdgpu_target}"
+        )
 
 if amdgpu_target not in ["gfx942", "gfx950"]:
     print(
         f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
     )
-    sys.exit(1)
+    # Only abort for an auto-detected architecture. If the user explicitly set
+    # AMDGPU_TARGET they have opted in to building for an unsupported arch
+    # (e.g. RDNA3 gfx1101), so honor it with a warning instead of aborting.
+    if explicit_target is None:
+        sys.exit(1)
+    print(
+        f"Warning: AMDGPU_TARGET='{explicit_target}' was set explicitly; "
+        "continuing with an unsupported architecture. This configuration is "
+        "untested upstream — use at your own risk."
+    )
 
 fp8_macro = (
     "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"


### PR DESCRIPTION
## Motivation

Closes #27519.

`sgl-kernel/setup_rocm.py` reads `AMDGPU_TARGET` from the environment:

```python
amdgpu_target = os.environ.get("AMDGPU_TARGET", default_target)
```

but then **unconditionally overwrites** it with the auto-detected arch whenever a GPU is visible:

```python
if torch.cuda.is_available():
    amdgpu_target = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
```

So on any build host that has a ROCm GPU attached, an explicitly-set `AMDGPU_TARGET` is silently ignored — the documented override is dead exactly when someone would use it (cross-compiling, or deliberately targeting an arch other than the locally-installed one). There is also no way to opt into building for an unsupported arch: the gate hard-`sys.exit(1)`s for anything outside `gfx942`/`gfx950`, even when the user asked for it on purpose.

## Modifications

- An explicit `AMDGPU_TARGET` now **wins over auto-detection** (standard cross-compile semantics). Auto-detection only runs when the env var is unset, so the default path on MI300/MI350 is unchanged.
- The unsupported-arch gate now only aborts for an **auto-detected** architecture. If the user set `AMDGPU_TARGET` explicitly, that is treated as opt-in: it continues with a clear "untested upstream — use at your own risk" warning instead of exiting.

This is a minimal, low-risk change: when `AMDGPU_TARGET` is not set, behavior is byte-for-byte identical to before. It only changes what happens when a user explicitly sets the variable — which previously did nothing useful.

It also unblocks the experimental RDNA3 (gfx1101) build path from #27519 without the project having to claim or CI official support for that arch.

## Accuracy Tests

No functional kernel change — this only affects build-target selection in `setup_rocm.py`. Verified `python -m black --check` is clean and the module parses. The default (no `AMDGPU_TARGET`) detection + abort behavior is preserved; the new branch is reached only on an explicit override.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27121937111](https://github.com/sgl-project/sglang/actions/runs/27121937111)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27121936965](https://github.com/sgl-project/sglang/actions/runs/27121936965)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->