### PR TITLE
[MUSA] bump torchada version to 0.1.59 and workaround PCG limitation.

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -123,7 +123,7 @@ srt_musa = [
   "sglang[runtime_common]",
   "torch",
   "torch_musa",
-  "torchada>=0.1.57",
+  "torchada>=0.1.59",
   "mthreads-ml-py",
   "mate>=0.2.0",
   "deep-gemm>=0.1.3",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -120,7 +120,7 @@ srt_musa = [
   "sglang[runtime_common]",
   "torch",
   "torch_musa",
-  "torchada>=0.1.57",
+  "torchada>=0.1.59",
   "mthreads-ml-py",
   "mate>=0.2.0",
   "deep-gemm>=0.1.3",

--- a/sgl-kernel/pyproject_musa.toml
+++ b/sgl-kernel/pyproject_musa.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=75.0",
   "scikit-build-core>=0.10",
   "torch",
-  "torchada>=0.1.57",
+  "torchada>=0.1.59",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION

## Motivation

Upgrade `torchada` to `0.1.59` to pick up the MUSA CUDA Graph executable rotation fix for the long-standing PCG issue.

SGLang’s piecewise CUDA Graph path can instantiate a large number of MUSA graph executables for deep models. On MUSA, the driver has a per-process limit of roughly 2048 live `musaGraphExec_t` objects, which can cause graph capture failures when PCG is enabled.

`torchada 0.1.59` includes a transparent LRU rotation mechanism for MUSA CUDA Graph executables. It keeps graph templates alive, caps only live executables, and lazily re-instantiates evicted executables before replay.


## Modifications

- Bump `torchada` dependency to `0.1.59`.


## Testing Done

Tested in a clean torch_musa container.

<details>
<summary><===Click to expand log details===></summary>

```sh

python3 -m sglang.launch_server \
    --model-path /home/dist/Qwen3-30B-A3B-FP8/ \
    --served-model-name base-model \
    --trust-remote-code \
    --disable-radix-cache \
    --host 0.0.0.0 \
    --port 31000 \
    --tp-size 2 \
    --pp-size 1 \
    --attention-backend fa3 \
    --cuda-graph-max-bs 10 \

[2026-06-08 07:20:16] Available plugins for group vllm.platform_plugins:
[2026-06-08 07:20:16] - musa -> vllm_musa:register
[2026-06-08 07:20:16] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-06-08 07:20:16] Available plugins for group vllm.platform_plugins:
[2026-06-08 07:20:16] - musa -> vllm_musa:register
[2026-06-08 07:20:16] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-06-08 07:20:16] Platform plugin musa is activated
[2026-06-08 07:20:16] No platform detected, vLLM is running on UnspecifiedPlatform
[2026-06-08 07:20:16] /home/dist/yafeng/code/opensource/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-06-08 07:20:17] server_args=ServerArgs(model_path='/home/dist/Qwen3-30B-A3B-FP8/', tokenizer_path='/home/dist/Qwen3-30B-A3B-FP8/', tokenizer_mode='auto', tokenizer_backend='huggingface', tokenizer_worker_num=1, detokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, prefill_only_disable_kv_cache=False, enable_multimodal=None, revision=None, model_impl='auto', model_config_parser='auto', host='0.0.0.0', port=31000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.835, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=64, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, prefill_delayer_queue_min_ratio=None, prefill_delayer_max_delay_ms=None, device='musa', tp_size=2, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, batch_notify_size=16, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=533291389, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, load_snapshot_publish_interval=15, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, grpc_http_sidecar_port=None, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_forward_pass_metrics=False, forward_pass_metrics_worker_id='', forward_pass_metrics_ipc_name=None, enable_trace=False, trace_modules='request', otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, stat_loggers=None, api_key=None, admin_api_key=None, served_model_name='base-model', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, strip_thinking_cache=False, enable_strict_thinking=False, tool_call_parser=None, tool_server=None, sampling_defaults='model', asr_max_buffer_seconds=60, asr_max_concurrent_sessions=32, dp_size=1, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, lora_use_virtual_experts=False, lora_strict_loading=False, lora_drain_wait_threshold=0.0, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', radix_cache_backend=None, mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', dsa_prefill_backend=None, dsa_decode_backend=None, dsa_topk_backend='sgl-kernel', disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_dflash_block_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_draft_window_size=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_skip_dp_mlp_sync=False, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, speculative_adaptive=False, speculative_adaptive_config=None, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='auto', deepep_dispatcher_output_dtype='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, enable_deepep_waterfill=False, elastic_ep_rejoin=False, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='timeout', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, lmcache_config_file=None, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', enable_mis=False, disable_radix_cache=True, cuda_graph_max_bs=10, cuda_graph_bs=[1, 2, 4, 8, 10], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_breakable_cuda_graph=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, debug_cuda_graph=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_attention_local_control_broadcast=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=False, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, enforce_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, enable_return_indexer_topk=False, enable_deepseek_v4_fp4_indexer=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, disable_attn_tp_gather=False, gc_threshold=None, kv_canary='none', kv_canary_real_data='none', kv_canary_sweep_interval=0, enable_dsa_prefill_context_parallel=False, dsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device=None, disaggregation_decode_enable_radix_cache=False, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, optimistic_prefill_retries=0, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, weight_loader_prefetch_checkpoints=False, weight_loader_prefetch_num_threads=4, weight_loader_drop_cache_after_load=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None, enable_quant_communications=False, msprobe_dump_config=None)
[2026-06-08 07:20:18] Using default HuggingFace chat template with detected content format: string
[2026-06-08 07:20:18] Auto-detected template features: reasoning_config=ReasoningToggleConfig(toggle_param='enable_thinking', default_enabled=True, special_case=None), reasoning_parser=qwen3, tool_call_parser=qwen
2026-06-08 07:20:25 | __init__ | 140299849062208 | INFO : Available plugins for group vllm.platform_plugins:
2026-06-08 07:20:25 | __init__ | 140299849062208 | INFO : - musa -> vllm_musa:register
2026-06-08 07:20:25 | __init__ | 140299849062208 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-06-08 07:20:25 | __init__ | 140299849062208 | INFO : Available plugins for group vllm.platform_plugins:
2026-06-08 07:20:25 | __init__ | 140299849062208 | INFO : - musa -> vllm_musa:register
2026-06-08 07:20:25 | __init__ | 140299849062208 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-06-08 07:20:25 | __init__ | 140299849062208 | INFO : Platform plugin musa is activated
2026-06-08 07:20:25 | __init__ | 139625113900864 | INFO : Available plugins for group vllm.platform_plugins:
2026-06-08 07:20:25 | __init__ | 139625113900864 | INFO : - musa -> vllm_musa:register
2026-06-08 07:20:25 | __init__ | 139625113900864 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-06-08 07:20:25 | __init__ | 139625113900864 | INFO : Available plugins for group vllm.platform_plugins:
2026-06-08 07:20:25 | __init__ | 139625113900864 | INFO : - musa -> vllm_musa:register
2026-06-08 07:20:25 | __init__ | 139625113900864 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-06-08 07:20:25 | __init__ | 139625113900864 | INFO : Platform plugin musa is activated
2026-06-08 07:20:25 | __init__ | 140420107425600 | INFO : Available plugins for group vllm.platform_plugins:
2026-06-08 07:20:25 | __init__ | 140420107425600 | INFO : - musa -> vllm_musa:register
2026-06-08 07:20:25 | __init__ | 140420107425600 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-06-08 07:20:25 | __init__ | 140420107425600 | INFO : Available plugins for group vllm.platform_plugins:
2026-06-08 07:20:25 | __init__ | 140420107425600 | INFO : - musa -> vllm_musa:register
2026-06-08 07:20:25 | __init__ | 140420107425600 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-06-08 07:20:25 | __init__ | 140420107425600 | INFO : Platform plugin musa is activated
2026-06-08 07:20:26 | __init__ | 140299849062208 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-06-08 07:20:26 | common | 140299849062208 | WARNING : /home/dist/yafeng/code/opensource/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-06-08 07:20:26 | __init__ | 139625113900864 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-06-08 07:20:26 | common | 139625113900864 | WARNING : /home/dist/yafeng/code/opensource/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-06-08 07:20:26 | __init__ | 140420107425600 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-06-08 07:20:26 | common | 140420107425600 | WARNING : /home/dist/yafeng/code/opensource/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-06-08 07:20:26 TP1] Process 3715388 gpu_id 1 is running on CPUs: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
[2026-06-08 07:20:26 TP0] Process 3715387 gpu_id 0 is running on CPUs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
[2026-06-08 07:20:27 TP1] Init torch distributed begin.
[2026-06-08 07:20:28 TP0] Init torch distributed begin.
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-06-08 07:20:30 TP0] sglang is using nccl==2.11.4
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-06-08 07:20:31 TP0] Init torch distributed ends. elapsed=3.60 s, mem usage=0.77 GB
[2026-06-08 07:20:31 TP1] Init torch distributed ends. elapsed=3.96 s, mem usage=0.81 GB
[2026-06-08 07:20:33 TP1] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-06-08 07:20:33 TP0] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-06-08 07:20:35 TP1] Load weight begin. avail mem=78.39 GB
[2026-06-08 07:20:35 TP0] Load weight begin. avail mem=78.31 GB
[2026-06-08 07:20:35 TP0] Detected fp8 checkpoint.
Multi-thread loading shards:  86% Completed | 6/7 [00:14<00:02,  2.29s/it][2026-06-08 07:20:52 TP1] Load weight end. elapsed=17.48 s, type=Qwen3MoeForCausalLM, quant=fp8, fmt=e4m3, avail mem=63.65 GB, mem usage=14.73 GB.
Multi-thread loading shards: 100% Completed | 7/7 [00:15<00:00,  2.18s/it]
[2026-06-08 07:20:53 TP0] Load weight end. elapsed=18.03 s, type=Qwen3MoeForCausalLM, quant=fp8, fmt=e4m3, avail mem=63.58 GB, mem usage=14.73 GB.
[2026-06-08 07:20:53 TP0] Max concurrent requests (per dp worker) from the finalized token capacity: max_num_reqs=4096.
[2026-06-08 07:20:53 TP1] Max concurrent requests (per dp worker) from the finalized token capacity: max_num_reqs=4096.
[2026-06-08 07:20:53 TP1] KV Cache is allocated. dtype: torch.bfloat16, #tokens: 1106304, K size: 25.32 GB, V size: 25.32 GB
[2026-06-08 07:20:53 TP1] Memory pool end. avail mem=12.12 GB
[2026-06-08 07:20:53 TP0] KV Cache is allocated. dtype: torch.bfloat16, #tokens: 1106304, K size: 25.32 GB, V size: 25.32 GB
[2026-06-08 07:20:53 TP0] Memory pool end. avail mem=12.05 GB
[2026-06-08 07:20:54 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=12.07 GB
[2026-06-08 07:20:54 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=11.99 GB
[2026-06-08 07:20:54 TP0] Capture cuda graph bs [1, 2, 4, 8, 10]
Capturing batches (bs=10 avail_mem=11.99 GB):   0%|                                                                                                                                                                             | 0/5 [00:00<?, ?it/s][2026-06-08 07:21:05 TP1] Using MoE kernel config from /root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=128,N=384,device_name=MTT_S5000,dtype=fp8_w8a8,block_shape=[128, 128].json.
[2026-06-08 07:21:05 TP1] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=128,N=384,device_name=MTT_S5000,dtype=fp8_w8a8,block_shape=[128, 128]_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2026-06-08 07:21:05 TP0] Using MoE kernel config from /root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=128,N=384,device_name=MTT_S5000,dtype=fp8_w8a8,block_shape=[128, 128].json.
[2026-06-08 07:21:05 TP0] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=128,N=384,device_name=MTT_S5000,dtype=fp8_w8a8,block_shape=[128, 128]_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
Capturing batches (bs=1 avail_mem=11.13 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:56<00:00, 11.23s/it]
[2026-06-08 07:21:50 TP0] Registering 485 cuda graph addresses
[2026-06-08 07:21:51 TP1] Capture cuda graph end. Time elapsed: 56.96 s. mem usage=0.87 GB. avail mem=11.20 GB.
[2026-06-08 07:21:51 TP1] Capture piecewise CUDA graph begin. avail mem=11.20 GB
[2026-06-08 07:21:51 TP0] Capture cuda graph end. Time elapsed: 57.01 s. mem usage=0.87 GB. avail mem=11.12 GB.
[2026-06-08 07:21:51 TP0] Capture piecewise CUDA graph begin. avail mem=11.12 GB
[2026-06-08 07:21:51 TP0] Capture cuda graph num tokens [4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192]
Compiling num tokens (num_tokens=8192):   0%|                                                                                                                                                                                  | 0/58 [00:00<?, ?it/s][2026-06-08 07:22:08 TP0] Compiling a graph for dynamic shape takes 2.49 s
[2026-06-08 07:22:09 TP1] Compiling a graph for dynamic shape takes 2.49 s
Compiling num tokens (num_tokens=4): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 58/58 [02:04<00:00,  2.15s/it]
Capturing num tokens (num_tokens=224 avail_mem=2.75 GB):  66%|███████████████████████████████████████████████████████████████████████████████████████████████████▌                                                    | 38/58 [04:59<02:40,  8.01s/it][2026-06-08 07:29:00 TP1] torchada graph-exec rotation engaged (cap=1900): live CUDA-graph executables exceeded the cap; rotating via re-instantiation.
[2026-06-08 07:29:02 TP0] torchada graph-exec rotation engaged (cap=1900): live CUDA-graph executables exceeded the cap; rotating via re-instantiation.
Capturing num tokens (num_tokens=4 avail_mem=2.61 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 58/58 [07:38<00:00,  7.90s/it]
[2026-06-08 07:31:35 TP0] Registering 5626 cuda graph addresses
[2026-06-08 07:31:35 TP1] Capture piecewise CUDA graph end. Time elapsed: 584.12 s. mem usage=8.51 GB. avail mem=2.69 GB.
[2026-06-08 07:31:35 TP0] Capture piecewise CUDA graph end. Time elapsed: 584.06 s. mem usage=8.51 GB. avail mem=2.61 GB.
[2026-06-08 07:31:36 TP0] max_total_num_tokens=1106304, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=40960, available_gpu_mem=2.61 GB
[2026-06-08 07:31:36 TP1] Tree cache initialized: source=default impl=ChunkCache hybrid_swa=False hybrid_ssm=False hierarchical=False streaming_wrapped=False
[2026-06-08 07:31:36 TP0] Tree cache initialized: source=default impl=ChunkCache hybrid_swa=False hybrid_ssm=False hierarchical=False streaming_wrapped=False
[2026-06-08 07:31:37] INFO:     Started server process [3711159]
[2026-06-08 07:31:37] INFO:     Waiting for application startup.
[2026-06-08 07:31:37] Using default chat sampling params from model generation config: {'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-06-08 07:31:37] INFO:     Application startup complete.
[2026-06-08 07:31:37] INFO:     Uvicorn running on http://0.0.0.0:31000 (Press CTRL+C to quit)
[2026-06-08 07:31:38] INFO:     127.0.0.1:44138 - "GET /model_info HTTP/1.1" 200 OK
[2026-06-08 07:31:38 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, musa graph: True, input throughput (token/s): 36.96
[2026-06-08 07:31:38] INFO:     127.0.0.1:44142 - "POST /generate HTTP/1.1" 200 OK
[2026-06-08 07:31:38] The server is fired up and ready to roll!
[2026-06-08 07:32:05 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, musa graph: True, input throughput (token/s): 2.35
[2026-06-08 07:32:06 TP0] Decode batch, #running-req: 1, #token: 64, token usage: 0.00, musa graph: True, gen throughput (token/s): 1.36, #queue-req: 0
[2026-06-08 07:32:06] INFO:     127.0.0.1:59040 - "POST /v1/chat/completions HTTP/1.1" 200 OK

```
</details>

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27122844035](https://github.com/sgl-project/sglang/actions/runs/27122844035)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27122843815](https://github.com/sgl-project/sglang/actions/runs/27122843815)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->