### PR TITLE
[AMD] ci: reinstall MoRI if Different from Dockerfile-pinned commit during install_dependency

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -180,6 +180,37 @@ EOF
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache accelerate || echo "accelerate installation failed"
 fi
 
+# -----------------------
+# MORI
+# The CI image bakes MORI at the docker/rocm.Dockerfile-pinned commit; when a PR
+# bumps MORI_COMMIT the image is not rebuilt, so reinstall MORI here the same way
+# the Dockerfile does. Only ENABLE_MORI=1 images ship /sgl-workspace/mori.
+if docker exec ci_sglang test -d /sgl-workspace/mori; then
+  MORI_REPO=$(grep -E '^[[:space:]]*ARG[[:space:]]+MORI_REPO=' docker/rocm.Dockerfile | head -n1 | sed 's/.*MORI_REPO="\([^"]*\)".*/\1/')
+  MORI_COMMIT=$(grep -E '^[[:space:]]*ARG[[:space:]]+MORI_COMMIT=' docker/rocm.Dockerfile | head -n1 | sed 's/.*MORI_COMMIT="\([^"]*\)".*/\1/')
+
+  if [[ "${GPU_ARCH}" == "mi35x" ]]; then
+    MORI_GPU_ARCHS="gfx950"
+  else
+    MORI_GPU_ARCHS="gfx942"
+  fi
+
+  echo "[MORI] Reinstalling MORI ${MORI_COMMIT} (MORI_GPU_ARCHS=${MORI_GPU_ARCHS})"
+  docker exec ci_sglang bash -c "
+    set -euo pipefail
+    export MORI_GPU_ARCHS='${MORI_GPU_ARCHS}'
+    rm -rf /sgl-workspace/mori
+    git clone '${MORI_REPO}' /sgl-workspace/mori
+    cd /sgl-workspace/mori
+    git checkout '${MORI_COMMIT}'
+    git submodule update --init --recursive
+    python3 setup.py develop
+    python3 -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))' > /etc/ld.so.conf.d/torch.conf
+    ldconfig
+  "
+  echo "[MORI] Done."
+fi
+
 if [[ -n "${SKIP_AITER_BUILD}" ]]; then
   exit 0
 fi


### PR DESCRIPTION
## Summary
- The AMD CI image bakes MoRI at the commit pinned in `docker/rocm.Dockerfile` (`MORI_COMMIT`). When a PR bumps `MORI_COMMIT` ahead of the published image, the image is not rebuilt per-PR, so `stage-b-test-large-8-gpu-mi35x-disaggregation-amd` runs against a stale MoRI (e.g. missing newer `IOEngine` APIs such as `wait_all`).
- Add a step to `scripts/ci/amd/amd_ci_install_dependency.sh` that reinstalls MoRI inside the running `ci_sglang` container from the repo/commit pinned in `rocm.Dockerfile`, mirroring the image's build steps — so the container matches the Dockerfile **without rebuilding/republishing the image**.
- Guarded on `/sgl-workspace/mori`, so non-MoRI images (every other suite) skip it.

## Test plan
- [ ] On the mi35x disaggregation suite, the *Install dependencies* step logs `[MORI] Reinstalling MORI <commit> ...` / `[MORI] Done.`, and the disaggregation e2e test runs against the Dockerfile-pinned MoRI.
- Validated together with #26922 (which bumps `MORI_COMMIT` to `d87651c`) on branch `bingxche/mori-ci-reinstall-26922`: https://github.com/sgl-project/sglang/actions/runs/27115280593

Made with [Cursor](https://cursor.com)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27122910680](https://github.com/sgl-project/sglang/actions/runs/27122910680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27122910447](https://github.com/sgl-project/sglang/actions/runs/27122910447)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->