### PR TITLE
[gemma4] Compute RMSNorm in fp32 to fix deep-layer hidden-state divergence vs HF

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -209,6 +209,7 @@ class RMSNorm(MultiPlatformOp):
         weight_dtype: Optional = None,
         override_orig_dtype: Optional = None,
         x_pad_to_multiple: int = 0,
+        force_fp32: bool = False,
     ) -> None:
         super().__init__()
         self.has_weight = has_weight
@@ -244,6 +245,16 @@ class RMSNorm(MultiPlatformOp):
                 except ImportError:
                     self._fused_pad_kernel = None
             self._forward_method = self.forward_aiter
+
+        # Accuracy: force the fp32 PyTorch path. The fused CUDA rmsnorm reduces the
+        # variance in the input (bf16) dtype; when a few outlier "massive-activation"
+        # dims dominate the sum-of-squares this loses precision, and the per-layer
+        # error compounds across deep layers. forward_native upcasts to fp32 and
+        # matches HF. (See gemma-4-31B: deep hidden states collapse to cos≈0.51 vs HF
+        # with the fused kernel, but stay ≥0.998 with forward_native.)
+        self.force_fp32 = force_fp32
+        if force_fp32:
+            self._forward_method = self.forward_native
 
     def forward_cuda(
         self,

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -564,15 +564,20 @@ class Gemma4DecoderLayer(nn.Module):
             prefix=add_prefix("mlp", prefix),
         )
 
-        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # force_fp32: gemma-4's deep layers grow massive-activation outlier dims; the
+        # fused bf16 rmsnorm loses precision there and the per-layer error compounds,
+        # collapsing deep hidden states vs HF (cos≈0.51 by L58). fp32 RMSNorm matches HF.
+        self.input_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
+        )
         self.post_attention_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
+            config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
         )
         self.pre_feedforward_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
+            config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
         )
         self.post_feedforward_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
+            config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
         )
 
         # Per-Layer Embedding (PLE) components — present in each decoder layer
@@ -618,13 +623,13 @@ class Gemma4DecoderLayer(nn.Module):
             )
 
             self.post_feedforward_layernorm_1 = RMSNorm(
-                config.hidden_size, eps=config.rms_norm_eps
+                config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
             )
             self.post_feedforward_layernorm_2 = RMSNorm(
-                config.hidden_size, eps=config.rms_norm_eps
+                config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
             )
             self.pre_feedforward_layernorm_2 = RMSNorm(
-                config.hidden_size, eps=config.rms_norm_eps
+                config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
             )
         else:
             self.router = None
@@ -834,6 +839,7 @@ class Gemma4TextModel(PreTrainedModel):
             self.per_layer_projection_norm = RMSNorm(
                 self.hidden_size_per_layer_input,
                 config.rms_norm_eps,
+                force_fp32=True,
             )
             self.per_layer_input_scale = torch.rsqrt(torch.tensor(2.0))
             self.per_layer_projection_scale = torch.tensor(
@@ -860,7 +866,9 @@ class Gemma4TextModel(PreTrainedModel):
         )
 
         if self.pp_group.is_last_rank:
-            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.norm = RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps, force_fp32=True
+            )
         else:
             self.norm = PPMissingLayer()
         self.layers_to_capture = []


### PR DESCRIPTION
## Summary

gemma-4 (e.g. `google/gemma-4-31B-it`) produces hidden states that diverge from HuggingFace **only in the deep decoder layers**, collapsing to cosine ≈ 0.51 by layer 58 (same weights, bf16). Root cause: the fused CUDA `RMSNorm` reduces the variance in the **input (bf16) dtype**. gemma-4's deep layers grow massive-activation outlier dims, so the bf16 sum-of-squares loses precision; the per-layer error compounds across the 60-layer stack and collapses the deep hidden states.

This PR routes gemma-4's `RMSNorm`s through the fp32 `forward_native` path via a new `force_fp32` flag.

## Evidence (text GSM8K, cosine vs HF eager)

| layer | default (fused CUDA RMSNorm) | this PR (`force_fp32`) |
|------:|:--:|:--:|
| 52 | 0.913 | **0.999** |
| 57 | **0.744** | **0.999** |
| 58 | **0.513** | **0.999** |

A/B on the same engine isolates it precisely: forcing **only** the generic `RMSNorm` (sandwich + final norms; the q/k/v `Gemma4RMSNorm` left fused) onto `forward_native` recovers the deep cosine to ≥0.998. Cross-checks: a third engine (**vLLM**) matches HF ≥0.998 → SGLang-specific; **Qwen3.5** (which uses `GemmaRMSNorm`, not the generic `RMSNorm`) is unaffected; the vision encoder agrees ≥0.95 for all engines.

**Regression window:** introduced when the fp32 `forward_native` fallback was dropped from `RMSNorm.forward_cuda` — works at `692979a8d`, broken by `v0.5.12.post1` (`5a15cde`).

## Change

- `layers/layernorm.py`: add `force_fp32: bool = False` to `RMSNorm`; when set, dispatch to `forward_native` (fp32 variance reduction).
- `models/gemma4_causal.py`: pass `force_fp32=True` for gemma-4's RMSNorms.

## Notes

The deeper fix is to accumulate the variance in fp32 inside the fused `rmsnorm` / `fused_add_rmsnorm` kernels; this PR is a targeted, low-risk model-level fix (correctness ≫ a few % RMSNorm throughput on gemma-4). Marked **draft** pending maintainer CI / a GPU run — the numbers above are from an A/B that forces the same code path at runtime on the same engine.

## Scope note

The regression is in the **module-routed** norms: gemma-4's `input_layernorm`, `post_attention_layernorm`, `pre_feedforward_layernorm` and the final `norm` are called as `RMSNorm` modules, so `force_fp32` routes them to `forward_native` (fp32) — these are what the A/B fixes. The dense `post_feedforward_layernorm` (and the MoE branch) are instead computed via the separate `gemma_rmsnorm_residual_scalar` / `gemma_dual_rmsnorm_residual_scalar` Triton kernels, which are **not** part of this regression (unchanged across `692979a8d`→`v0.5.12`) and were verified not to be the cause. `force_fp32` on those modules still applies to their non-fused fallback branches; making those Triton kernels accumulate variance in fp32 can be a follow-up if full parity is wanted.
