### PR TITLE
[EPD] Dynamic encoder registration cleanup

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -152,10 +152,10 @@ class EncoderBootstrapServer:
     # ------------------------------------------------------------------ #
     def register(self, url: str) -> bool:
         """Add *url* if not already present.  Returns True if added."""
+        self._consecutive_failures.pop(url, None)
         with self._lock:
             if url not in self._urls:
                 self._urls.append(url)
-                self._consecutive_failures.pop(url, None)
                 logger.info(f"Registered encoder URL: {url}")
                 return True
             logger.debug(f"Encoder URL already registered: {url}")
@@ -166,6 +166,7 @@ class EncoderBootstrapServer:
         with self._lock:
             if url in self._urls:
                 self._urls.remove(url)
+                self._consecutive_failures.pop(url, None)
                 logger.info(f"Unregistered encoder URL: {url}")
                 return True
             return False

--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -152,8 +152,8 @@ class EncoderBootstrapServer:
     # ------------------------------------------------------------------ #
     def register(self, url: str) -> bool:
         """Add *url* if not already present.  Returns True if added."""
-        self._consecutive_failures.pop(url, None)
         with self._lock:
+            self._consecutive_failures.pop(url, None)
             if url not in self._urls:
                 self._urls.append(url)
                 logger.info(f"Registered encoder URL: {url}")

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -3201,6 +3201,37 @@ def _register_encoder_url_with_bootstrap(server_args: ServerArgs):
     ).start()
 
 
+def _unregister_encoder_url_from_bootstrap(server_args: ServerArgs):
+    """Best-effort deregistration of this encoder from all bootstrap servers.
+
+    Called via ``atexit`` so that graceful shutdown removes stale URLs
+    immediately instead of waiting for health-check eviction.
+    """
+    encoder_url = _encoder_url_for_registration(server_args)
+    payload = {"url": encoder_url}
+    timeout = 5.0
+
+    for bootstrap_url in server_args.encoder_register_urls:
+        try:
+            resp = http_requests.delete(
+                f"{bootstrap_url}/unregister_encoder_url",
+                json=payload,
+                timeout=timeout,
+            )
+            if resp.status_code == 200:
+                logger.info(
+                    f"Unregistered encoder URL '{encoder_url}' from "
+                    f"bootstrap at {bootstrap_url}"
+                )
+            else:
+                logger.warning(
+                    f"Bootstrap {bootstrap_url} returned "
+                    f"{resp.status_code} on unregister: {resp.text}"
+                )
+        except Exception as e:
+            logger.debug(f"Unregister from {bootstrap_url} failed: {e}")
+
+
 def launch_server(server_args: ServerArgs):
     configure_logger(server_args, prefix=" encode_server")
     if server_args.dp_size > 1:

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 
 import aiohttp
 import numpy as np
-import requests as http_requests
+import requests
 import torch
 import uvicorn
 import zmq
@@ -3141,7 +3141,11 @@ def _register_encoder_url_with_bootstrap(server_args: ServerArgs):
     instead of serialising sleeps in a single thread.
     """
 
-    encoder_url = server_args.url()
+    host = server_args.host
+    if not host or host in ("0.0.0.0", "::"):
+        host = get_local_ip_auto(server_args.host)
+    scheme = "https" if server_args.ssl_certfile else "http"
+    encoder_url = NetworkAddress(host, server_args.port).to_url(scheme)
     payload = {"url": encoder_url}
     bootstrap_urls = list(server_args.encoder_register_urls)
     if not bootstrap_urls:
@@ -3153,7 +3157,7 @@ def _register_encoder_url_with_bootstrap(server_args: ServerArgs):
 
     def _try_register_once(bootstrap_url: str) -> bool:
         try:
-            resp = http_requests.post(
+            resp = requests.post(
                 f"{bootstrap_url}/register_encoder_url",
                 json=payload,
                 timeout=request_timeout,

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -3233,7 +3233,9 @@ def launch_server(server_args: ServerArgs):
 
     # Register this encoder's URL with prefill server(s) if configured.
     if server_args.encoder_register_urls:
+        import atexit
         _register_encoder_url_with_bootstrap(server_args)
+        atexit.register(_unregister_encoder_url_from_bootstrap, server_args)
 
     uvicorn.run(app, host=server_args.host, port=server_args.port)
 
@@ -3309,7 +3311,9 @@ def _launch_server_dp(server_args: ServerArgs):
 
     # Register this encoder's URL with prefill server(s) if configured.
     if server_args.encoder_register_urls:
+        import atexit
         _register_encoder_url_with_bootstrap(server_args)
+        atexit.register(_unregister_encoder_url_from_bootstrap, server_args)
 
     uvicorn.run(app, host=server_args.host, port=server_args.port)
 

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 
 import aiohttp
 import numpy as np
-import requests
+import requests as http_requests
 import torch
 import uvicorn
 import zmq
@@ -3157,7 +3157,7 @@ def _register_encoder_url_with_bootstrap(server_args: ServerArgs):
 
     def _try_register_once(bootstrap_url: str) -> bool:
         try:
-            resp = requests.post(
+            resp = http_requests.post(
                 f"{bootstrap_url}/register_encoder_url",
                 json=payload,
                 timeout=request_timeout,

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -3202,21 +3202,19 @@ def _register_encoder_url_with_bootstrap(server_args: ServerArgs):
 
 
 def _unregister_encoder_url_from_bootstrap(server_args: ServerArgs):
-    """Best-effort deregistration of this encoder from all bootstrap servers.
-
-    Called via ``atexit`` so that graceful shutdown removes stale URLs
-    immediately instead of waiting for health-check eviction.
-    """
-    encoder_url = _encoder_url_for_registration(server_args)
+    host = server_args.host
+    if not host or host in ("0.0.0.0", "::"):
+        host = get_local_ip_auto(server_args.host)
+    scheme = "https" if server_args.ssl_certfile else "http"
+    encoder_url = NetworkAddress(host, server_args.port).to_url(scheme)
     payload = {"url": encoder_url}
-    timeout = 5.0
 
     for bootstrap_url in server_args.encoder_register_urls:
         try:
             resp = http_requests.delete(
                 f"{bootstrap_url}/unregister_encoder_url",
                 json=payload,
-                timeout=timeout,
+                timeout=2.0,
             )
             if resp.status_code == 200:
                 logger.info(

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -3234,6 +3234,7 @@ def launch_server(server_args: ServerArgs):
     # Register this encoder's URL with prefill server(s) if configured.
     if server_args.encoder_register_urls:
         import atexit
+
         _register_encoder_url_with_bootstrap(server_args)
         atexit.register(_unregister_encoder_url_from_bootstrap, server_args)
 
@@ -3312,6 +3313,7 @@ def _launch_server_dp(server_args: ServerArgs):
     # Register this encoder's URL with prefill server(s) if configured.
     if server_args.encoder_register_urls:
         import atexit
+
         _register_encoder_url_with_bootstrap(server_args)
         atexit.register(_unregister_encoder_url_from_bootstrap, server_args)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
  - Fix _consecutive_failures counter placement in register() to always clear on re-registration (prevents stale failure counts from causing immediate re-eviction of a restarted encoder)
  - Add _consecutive_failures cleanup in unregister() to prevent stale counters from persisting
  - Fix encoder URL construction in _register_encoder_url_with_bootstrap — replace server_args.url() (which maps 0.0.0.0 → 127.0.0.1) with get_local_ip_auto() + NetworkAddress.to_url() for correct cross-machine registration
  - Add atexit handler to gracefully deregister encoder URLs on shutdown in both single-worker and DP launch paths
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Fix #22253:

  1. Loopback URL bug: server_args.url() resolves wildcard hosts to loopback (127.0.0.1/::1), making registered URLs unreachable from other machines in disaggregated deployments.
  2. Race on restart: When an encoder restarts, the failure counter from the previous instance could persist, causing the health-check loop to immediately evict the newly re-registered URL.
  3. No graceful deregistration: Encoder shutdown left stale URLs in the bootstrap server until health-check eviction kicked in (up to max_consecutive_failures × health_check_interval seconds of wasted dispatch attempts).

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





























































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27129532845](https://github.com/sgl-project/sglang/actions/runs/27129532845)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27129532462](https://github.com/sgl-project/sglang/actions/runs/27129532462)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->