### PR TITLE
[Fix] mamba: add XPU support for causal_conv1d kernel dispatch

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -35,10 +35,11 @@ from sglang.srt.utils import (
     is_cpu,
     is_cuda,
     is_npu,
+    is_xpu,
     set_weight_attrs,
 )
 
-if is_cuda():
+if is_cuda() or is_xpu():
     from sglang.srt.layers.attention.mamba.causal_conv1d import (
         causal_conv1d_fn,
         causal_conv1d_update,


### PR DESCRIPTION
## Problem

Mamba-hybrid models (Falcon-H1, Nemotron-H, GraniteMoeHybrid) crash with `NameError` on first forward pass when running on Intel XPU:

```
NameError: name 'causal_conv1d_fn' is not defined
  File "sglang/srt/layers/attention/mamba/mamba.py", line 532, in forward
```

**Root cause:** The module-level import guard in `mamba.py` was `if is_cuda()` only. On XPU, neither `causal_conv1d_fn` nor `causal_conv1d_update` were ever imported, leaving those names undefined at call time.

The existing `causal_conv1d.py` wrapper already handles non-CUDA gracefully — it tries to load `sgl_kernel` (CUDA-only), sets `_HAS_SGL_KERNEL = False` when unavailable, and falls back to the Triton implementation automatically. LFM2 models already import from this wrapper directly and work on XPU for this reason.

## Fix

Extend the guard from `if is_cuda():` to `if is_cuda() or is_xpu():` so XPU shares the same import path as CUDA:

```python
# Before
if is_cuda():
    from sglang.srt.layers.attention.mamba.causal_conv1d import (
        causal_conv1d_fn,
        causal_conv1d_update,
    )

# After
if is_cuda() or is_xpu():
    from sglang.srt.layers.attention.mamba.causal_conv1d import (
        causal_conv1d_fn,
        causal_conv1d_update,
    )
```

On XPU, `causal_conv1d.py` resolves to the Triton implementation (`_HAS_SGL_KERNEL = False`), which is already supported on Intel XPU via the Intel Triton backend. No new logic is needed.

## Verification

Tested locally on Intel BMG XPU with 5-sample `gsm8k` eval and `--disable-radix-cache`:

| Model | Before | After |
|-------|--------|-------|
| `tiiuae/Falcon-H1-1.5B-Instruct` | `NameError: causal_conv1d_fn` | ✅ `exact_match = 0.8` |
| `nvidia/Nemotron-H-4B-Instruct-128K` | `NameError: causal_conv1d_fn` | ✅ `exact_match = 0.8` |

**No regression risk:** the CUDA and NPU branches are unchanged. The fix only adds XPU to the existing CUDA import path, which was already device-agnostic via `causal_conv1d.py`'s Triton fallback.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27124899453](https://github.com/sgl-project/sglang/actions/runs/27124899453)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27124899437](https://github.com/sgl-project/sglang/actions/runs/27124899437)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->