### PR TITLE
[SMG] Fix load imbalance issue of cache_aware when decode is faster than prefill

### DIFF
--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -328,7 +328,7 @@ impl CacheAwarePolicy {
         // Use shortest queue when imbalanced
         let min_load_idx = healthy_indices
             .iter()
-            .min_by_key(|&&idx| workers[idx].load())
+            .min_by_key(|&&idx| (workers[idx].load(), workers[idx].processed_requests(), idx))
             .copied()?;
 
         // Even in imbalanced mode, update the tree to maintain cache state
@@ -368,6 +368,13 @@ impl CacheAwarePolicy {
         workers[min_load_idx].increment_processed();
 
         Some(min_load_idx)
+    }
+
+    fn tenant_tree_size(tree: &Tree, worker: &dyn Worker) -> usize {
+        tree.tenant_char_count
+            .get(worker.url())
+            .map(|count| *count)
+            .unwrap_or(0)
     }
 }
 
@@ -438,10 +445,19 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
                     .position(|w| w.url() == tenant_url)
                     .filter(|&idx| workers[idx].is_healthy())
             } else {
-                // Low cache match: use worker with minimum load
+                // Low cache match: use worker with minimum load, then smallest
+                // approximate tree size so cold traffic does not always pick the
+                // first equally idle worker.
                 healthy_indices
                     .iter()
-                    .min_by_key(|&&idx| workers[idx].load())
+                    .min_by_key(|&&idx| {
+                        (
+                            workers[idx].load(),
+                            Self::tenant_tree_size(&tree, workers[idx].as_ref()),
+                            workers[idx].processed_requests(),
+                            idx,
+                        )
+                    })
                     .copied()
             };
 

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -369,13 +369,6 @@ impl CacheAwarePolicy {
 
         Some(min_load_idx)
     }
-
-    fn tenant_tree_size(tree: &Tree, worker: &dyn Worker) -> usize {
-        tree.tenant_char_count
-            .get(worker.url())
-            .map(|count| *count)
-            .unwrap_or(0)
-    }
 }
 
 #[async_trait]
@@ -451,12 +444,7 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
                 healthy_indices
                     .iter()
                     .min_by_key(|&&idx| {
-                        (
-                            workers[idx].load(),
-                            Self::tenant_tree_size(&tree, workers[idx].as_ref()),
-                            workers[idx].processed_requests(),
-                            idx,
-                        )
+                        (workers[idx].load(), workers[idx].processed_requests(), idx)
                     })
                     .copied()
             };

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -446,8 +446,8 @@ impl PDRouter {
         &self,
         res: reqwest::Response,
         context: &PDRequestContext<'_>,
-        prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
+        load_guards: Vec<WorkerLoadGuard>,
     ) -> Response {
         let status = res.status();
 
@@ -490,8 +490,8 @@ impl PDRouter {
                 None,
                 context.return_logprob,
                 Some(response_headers),
-                prefill,
                 decode,
+                load_guards,
             )
         } else {
             // Handle non-streaming error response
@@ -575,12 +575,10 @@ impl PDRouter {
         decode: Arc<dyn Worker>,
         _start_time: Instant,
     ) -> Response {
-        // For non-streaming: use guard for automatic load management
-        // For streaming: load will be managed in create_streaming_response
-        let _prefill_guard =
-            (!context.is_stream).then(|| WorkerLoadGuard::new(prefill.clone(), headers));
-        let _decode_guard =
-            (!context.is_stream).then(|| WorkerLoadGuard::new(decode.clone(), headers));
+        let load_guards = vec![
+            WorkerLoadGuard::new(prefill.clone(), headers),
+            WorkerLoadGuard::new(decode.clone(), headers),
+        ];
 
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
         inject_trace_context_http(&mut headers_with_trace);
@@ -660,7 +658,7 @@ impl PDRouter {
                     }
 
                     let mut response = self
-                        .handle_decode_error_response(res, &context, prefill, decode)
+                        .handle_decode_error_response(res, &context, decode, load_guards)
                         .await;
                     response.extensions_mut().insert(BreakerOutcomesRecorded);
                     return response;
@@ -711,8 +709,8 @@ impl PDRouter {
                         prefill_logprobs,
                         context.return_logprob,
                         Some(response_headers),
-                        prefill,
                         decode,
+                        load_guards,
                     )
                 } else {
                     // Non-streaming response
@@ -929,8 +927,8 @@ impl PDRouter {
         prefill_logprobs: Option<Value>,
         return_logprob: bool,
         headers: Option<HeaderMap>,
-        prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
+        load_guards: Vec<WorkerLoadGuard>,
     ) -> Response {
         use crate::core::AttachedBody;
 
@@ -1019,11 +1017,6 @@ impl PDRouter {
         let stream = UnboundedReceiverStream::new(rx);
         let body = Body::from_stream(stream);
 
-        let guards = vec![
-            WorkerLoadGuard::new(prefill, headers.as_ref()),
-            WorkerLoadGuard::new(decode, headers.as_ref()),
-        ];
-
         let mut response = Response::new(body);
         *response.status_mut() = status;
 
@@ -1031,7 +1024,7 @@ impl PDRouter {
         response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
         *response.headers_mut() = response_headers;
 
-        AttachedBody::wrap_response(response, guards)
+        AttachedBody::wrap_response(response, load_guards)
     }
 
     // Helper to process non-streaming decode response with logprob merging
@@ -1680,14 +1673,22 @@ mod tests {
         let stream = UnboundedReceiverStream::new(rx);
 
         {
+            let guards = vec![
+                WorkerLoadGuard::new(prefill_ref.clone(), None),
+                WorkerLoadGuard::new(decode_ref.clone(), None),
+            ];
+
+            assert_eq!(prefill_ref.load(), 1);
+            assert_eq!(decode_ref.load(), 1);
+
             let response = router.create_streaming_response(
                 stream.map(Ok),
                 StatusCode::OK,
                 None,
                 false,
                 None,
-                prefill_ref.clone(),
                 decode_ref.clone(),
+                guards,
             );
 
             // Guards are now attached to response body, so load should be 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In some extreme scenarios, default cache_aware policy will lead to severe load imbalance problem. 

For example, 32k input and output only 1 token. In such case, all the requests will be routed to the same prefill worker and others are always left unused.

The reason is that in the `select_worker` of CacheAwarePolicy, only `workers[idx].load()` is used for sorting. After the worker is selected, worker.load() will only be updated till `create_streaming_response` is called (after stream response is returned from decode worker to the router). If prefill is very slow and decode is very fast, then at most of the time, worker.load() will be the same for all prefill workers. Then pd-router will always select the first prefill worker.

## Modifications

1. Create `WorkerLoadGuard` before request is sent to the worker for inference.
2. In select_worker, sort the workers according to (load, processed_requests, idx), instead of solely depending on load.

## Accuracy Tests

1. Unit test test_streaming_load_tracking Passed
`cd ./sglang/sgl-model-gateway && TMPDIR=/private/tmp cargo test --lib test_streaming_load_tracking`

<img width="694" height="71" alt="image" src="https://github.com/user-attachments/assets/84d5bc9c-76ba-42df-a5dc-a50f4ba5799e" />

2. bench_serving
benching random dataset with 32k input and 1 token output, all the prefill workers have requests received.
<img width="1336" height="261" alt="image" src="https://github.com/user-attachments/assets/d293930f-0f96-4583-a1b2-da25812dab0d" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
6. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27662944256](https://github.com/sgl-project/sglang/actions/runs/27662944256)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27662944148](https://github.com/sgl-project/sglang/actions/runs/27662944148)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->