### PR TITLE
[Fix] Avoid applying cuda graph input-buffer registry on non-cuda devices

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3208,7 +3208,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         forward_batch: ForwardBatch,
         pp_proxy_tensors=None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        if not self.server_args.enable_pdmux:
+        if not self.server_args.enable_pdmux and self.device == 'cuda':
             forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
         # Set extra arguments
         pdmux_override = False
@@ -3298,7 +3298,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 ret = self.piecewise_cuda_graph_runner.replay(forward_batch, **kwargs)
             return (ret, can_run_graph)
 
-        if not self.server_args.enable_pdmux:
+        if not self.server_args.enable_pdmux and self.device == 'cuda':
             forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
 
         # Launch model forward
@@ -3359,7 +3359,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # called from the idle path can re-read a prior batch's req_pool
         # indices and trigger SWA mapping use-after-free.
         if forward_batch.batch_size > 0:
-            if not self.server_args.enable_pdmux:
+            if not self.server_args.enable_pdmux and self.device == 'cuda':
                 forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
             self.attn_backend.init_forward_metadata(forward_batch)
         else:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3208,7 +3208,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         forward_batch: ForwardBatch,
         pp_proxy_tensors=None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        if not self.server_args.enable_pdmux and self.device == 'cuda':
+        if not self.server_args.enable_pdmux and self.device == "cuda":
             forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
         # Set extra arguments
         pdmux_override = False
@@ -3298,7 +3298,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 ret = self.piecewise_cuda_graph_runner.replay(forward_batch, **kwargs)
             return (ret, can_run_graph)
 
-        if not self.server_args.enable_pdmux and self.device == 'cuda':
+        if not self.server_args.enable_pdmux and self.device == "cuda":
             forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
 
         # Launch model forward
@@ -3359,7 +3359,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # called from the idle path can re-read a prior batch's req_pool
         # indices and trigger SWA mapping use-after-free.
         if forward_batch.batch_size > 0:
-            if not self.server_args.enable_pdmux and self.device == 'cuda':
+            if not self.server_args.enable_pdmux and self.device == "cuda":
                 forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
             self.attn_backend.init_forward_metadata(forward_batch)
         else:


### PR DESCRIPTION
## Motivation

The feature introduced in PR #27407 is not compatible with non-CUDA devices (at least not for Xeon CPU). [Xeon CI failure](https://github.com/sgl-project/sglang/actions/runs/27113115257/job/80014685310) is observed after the merging of this PR.

## Modifications

Add gating logics so that the feature can be applied only on cuda device.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27127564313](https://github.com/sgl-project/sglang/actions/runs/27127564313)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27127564042](https://github.com/sgl-project/sglang/actions/runs/27127564042)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->