### PR TITLE
Add the get_cpu_copy() and get_cpu_copy() functions for deepseekv4 wh…

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.attention.dsv4.index_buf_accessor import NopeFp8RopeBf16P
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
+from sglang.srt.platforms import current_platform
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import ceil_div, is_hip
 
@@ -164,6 +165,35 @@ class DeepSeekV4SingleKVPool(KVCache):
 
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError("Use get_key_buffer instead.")
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        page_indices = torch.unique_consecutive(indices // self.page_size)
+        kv_cache_cpu = []
+        chunk_size = max(1, self.cpu_offloading_chunk_size // self.page_size)
+        for layer_id in range(self.layer_num):
+            kv_cache_cpu.append([])
+            for i in range(0, len(page_indices), chunk_size):
+                chunk_page_indices = page_indices[i : i + chunk_size]
+                kv_cpu = self.kv_buffer[layer_id][chunk_page_indices].to(
+                    "cpu", non_blocking=True
+                )
+                kv_cache_cpu[-1].append(kv_cpu)
+        current_platform.synchronize()
+        return kv_cache_cpu
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        page_indices = torch.unique_consecutive(indices // self.page_size)
+        chunk_size = max(1, self.cpu_offloading_chunk_size // self.page_size)
+        for layer_id in range(self.layer_num):
+            for i in range(0, len(page_indices), chunk_size):
+                chunk_page_indices = page_indices[i : i + chunk_size]
+                kv_cpu = kv_cache_cpu[layer_id][i // chunk_size]
+                assert kv_cpu.shape[0] == len(chunk_page_indices)
+                kv_chunk = kv_cpu.to(self.kv_buffer[0].device, non_blocking=True)
+                self.kv_buffer[layer_id][chunk_page_indices] = kv_chunk
+        current_platform.synchronize()
 
 
 class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
@@ -378,6 +408,37 @@ class DeepSeekV4IndexerPool(KVCache):
             loc=loc,
             page_size=self.page_size,
         )
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        page_indices = torch.unique_consecutive(indices // self.page_size)
+        index_k_cpu = []
+        chunk_size = max(1, self.cpu_offloading_chunk_size // self.page_size)
+        for layer_id in range(self.layer_num):
+            index_k_cpu.append([])
+            for i in range(0, len(page_indices), chunk_size):
+                chunk_page_indices = page_indices[i : i + chunk_size]
+                idx_cpu = self.index_k_with_scale_buffer[layer_id][
+                    chunk_page_indices
+                ].to("cpu", non_blocking=True)
+                index_k_cpu[-1].append(idx_cpu)
+        current_platform.synchronize()
+        return index_k_cpu
+
+    def load_cpu_copy(self, index_k_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        page_indices = torch.unique_consecutive(indices // self.page_size)
+        chunk_size = max(1, self.cpu_offloading_chunk_size // self.page_size)
+        for layer_id in range(self.layer_num):
+            for i in range(0, len(page_indices), chunk_size):
+                chunk_page_indices = page_indices[i : i + chunk_size]
+                idx_cpu = index_k_cpu[layer_id][i // chunk_size]
+                assert idx_cpu.shape[0] == len(chunk_page_indices)
+                idx_chunk = idx_cpu.to(
+                    self.index_k_with_scale_buffer[0].device, non_blocking=True
+                )
+                self.index_k_with_scale_buffer[layer_id][chunk_page_indices] = idx_chunk
+        current_platform.synchronize()
 
 
 class DeepSeekV4LayerItem(NamedTuple):
@@ -1089,6 +1150,136 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
         self.c4_indexer_kv_pool.set_index_k_scale_buffer(
             compress_layer_id, loc, index_k, index_k_scale
+        )
+
+    def _compressed_indices_from_full(
+        self, indices: torch.Tensor, ratio: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        mask = (indices + 1) % ratio == 0
+        return indices[mask] // ratio, mask
+
+    def _get_state_cpu_copy(
+        self, state_pools: List[Optional[CompressStatePool]], swa_indices: torch.Tensor
+    ):
+        if swa_indices is None or swa_indices.numel() == 0:
+            return None
+
+        current_platform.synchronize()
+        state_cpu = []
+        for pool in state_pools:
+            if pool is None:
+                state_cpu.append(None)
+                continue
+            state_locs = pool.translate_from_swa_loc_to_state_loc(swa_indices)
+            state_cpu.append(
+                pool.kv_score_buffer.kv_score[state_locs].to("cpu", non_blocking=True)
+            )
+        current_platform.synchronize()
+        return state_cpu
+
+    def _load_state_cpu_copy(
+        self,
+        state_pools: List[Optional[CompressStatePool]],
+        state_cpu,
+        swa_indices: torch.Tensor,
+    ) -> None:
+        if state_cpu is None or swa_indices is None or swa_indices.numel() == 0:
+            return
+
+        current_platform.synchronize()
+        for pool, cpu_tensor in zip(state_pools, state_cpu):
+            if pool is None or cpu_tensor is None:
+                continue
+            state_locs = pool.translate_from_swa_loc_to_state_loc(swa_indices)
+            assert cpu_tensor.shape[0] == len(state_locs)
+            state_chunk = cpu_tensor.to(
+                pool.kv_score_buffer.kv_score.device, non_blocking=True
+            )
+            pool.kv_score_buffer.kv_score[state_locs] = state_chunk
+            pool.kv_score_buffer[-1].clear()
+        current_platform.synchronize()
+
+    def _filter_state_cpu_copy(self, state_cpu, row_mask: torch.Tensor):
+        if state_cpu is None:
+            return None
+        return [None if x is None else x[row_mask] for x in state_cpu]
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        c4_indices, _ = self._compressed_indices_from_full(indices, 4)
+        c128_indices, _ = self._compressed_indices_from_full(indices, 128)
+
+        swa_mask = None
+        swa_indices = None
+        full_to_swa_index_mapping = getattr(self, "full_to_swa_index_mapping", None)
+        if full_to_swa_index_mapping is not None:
+            mapped_swa_indices = full_to_swa_index_mapping[indices]
+            swa_mask = mapped_swa_indices > 0
+            if torch.any(swa_mask):
+                swa_indices = mapped_swa_indices[swa_mask]
+                swa_cpu = self.swa_kv_pool.get_cpu_copy(swa_indices)
+                swa_mask = swa_mask.cpu()
+            else:
+                swa_cpu = None
+        else:
+            swa_cpu = None
+
+        c4_cpu = self.c4_kv_pool.get_cpu_copy(c4_indices)
+        c4_indexer_cpu = self.c4_indexer_kv_pool.get_cpu_copy(c4_indices)
+        c128_cpu = self.c128_kv_pool.get_cpu_copy(c128_indices)
+
+        return {
+            "swa": swa_cpu,
+            "swa_mask": swa_mask,
+            "c4": c4_cpu,
+            "c4_indexer": c4_indexer_cpu,
+            "c128": c128_cpu,
+            "attention_state": self._get_state_cpu_copy(
+                self.compress_state_pools, swa_indices
+            ),
+            "indexer_state": self._get_state_cpu_copy(
+                self.indexer_compress_state_pools, swa_indices
+            ),
+        }
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        c4_indices, _ = self._compressed_indices_from_full(indices, 4)
+        c128_indices, _ = self._compressed_indices_from_full(indices, 128)
+
+        c4_cpu = kv_cache_cpu.get("c4")
+        if c4_cpu is not None:
+            self.c4_kv_pool.load_cpu_copy(c4_cpu, c4_indices)
+        self.c4_indexer_kv_pool.load_cpu_copy(kv_cache_cpu["c4_indexer"], c4_indices)
+        self.c128_kv_pool.load_cpu_copy(kv_cache_cpu["c128"], c128_indices)
+
+        swa_cpu = kv_cache_cpu.get("swa")
+        full_to_swa_index_mapping = getattr(self, "full_to_swa_index_mapping", None)
+        if swa_cpu is None or full_to_swa_index_mapping is None:
+            return
+
+        mapped_swa_indices = full_to_swa_index_mapping[indices]
+        new_swa_mask = mapped_swa_indices > 0
+        old_swa_mask = kv_cache_cpu.get("swa_mask")
+        if old_swa_mask is not None:
+            old_swa_mask = old_swa_mask.to(indices.device)
+            row_mask = new_swa_mask[old_swa_mask].cpu()
+            swa_indices = mapped_swa_indices[old_swa_mask][row_mask.to(indices.device)]
+        else:
+            row_mask = new_swa_mask.cpu()
+            swa_indices = mapped_swa_indices[new_swa_mask]
+
+        if swa_indices.numel() == 0:
+            return
+
+        self.swa_kv_pool.load_cpu_copy(swa_cpu, swa_indices)
+        self._load_state_cpu_copy(
+            self.compress_state_pools,
+            self._filter_state_cpu_copy(kv_cache_cpu.get("attention_state"), row_mask),
+            swa_indices,
+        )
+        self._load_state_cpu_copy(
+            self.indexer_compress_state_pools,
+            self._filter_state_cpu_copy(kv_cache_cpu.get("indexer_state"), row_mask),
+            swa_indices,
         )
 
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -1204,6 +1204,45 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             return None
         return [None if x is None else x[row_mask] for x in state_cpu]
 
+    def _filter_swa_cpu_copy(
+        self,
+        swa_cpu,
+        old_swa_indices: torch.Tensor,
+        row_mask: torch.Tensor,
+    ):
+        if swa_cpu is None:
+            return None
+        if row_mask is None or bool(torch.all(row_mask).item()):
+            return swa_cpu
+
+        old_swa_indices = old_swa_indices.to(row_mask.device)
+        old_page_indices = torch.unique_consecutive(
+            old_swa_indices // self.swa_kv_pool.page_size
+        )
+        kept_page_indices = torch.unique_consecutive(
+            old_swa_indices[row_mask] // self.swa_kv_pool.page_size
+        )
+        page_mask = torch.isin(old_page_indices, kept_page_indices)
+
+        chunk_size = max(
+            1,
+            self.swa_kv_pool.cpu_offloading_chunk_size // self.swa_kv_pool.page_size,
+        )
+        filtered = []
+        for layer_chunks in swa_cpu:
+            if len(layer_chunks) == 0:
+                filtered.append([])
+                continue
+
+            layer_cpu = torch.cat(layer_chunks, dim=0)
+            layer_cpu = layer_cpu[page_mask]
+
+            filtered_layer = []
+            for i in range(0, len(layer_cpu), chunk_size):
+                filtered_layer.append(layer_cpu[i : i + chunk_size])
+            filtered.append(filtered_layer)
+        return filtered
+
     def get_cpu_copy(self, indices, mamba_indices=None):
         c4_indices, _ = self._compressed_indices_from_full(indices, 4)
         c128_indices, _ = self._compressed_indices_from_full(indices, 128)
@@ -1230,6 +1269,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         return {
             "swa": swa_cpu,
             "swa_mask": swa_mask,
+            "swa_indices": None if swa_indices is None else swa_indices.cpu(),
             "c4": c4_cpu,
             "c4_indexer": c4_indexer_cpu,
             "c128": c128_cpu,
@@ -1270,6 +1310,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         if swa_indices.numel() == 0:
             return
 
+        swa_cpu = self._filter_swa_cpu_copy(
+            swa_cpu, kv_cache_cpu.get("swa_indices"), row_mask
+        )
         self.swa_kv_pool.load_cpu_copy(swa_cpu, swa_indices)
         self._load_state_cpu_copy(
             self.compress_state_pools,

--- a/test/manual/dsv4/test_dsv4_cpu_copy_roundtrip.py
+++ b/test/manual/dsv4/test_dsv4_cpu_copy_roundtrip.py
@@ -1,0 +1,254 @@
+"""Round-trip test for DeepSeek V4 request-level CPU KV copy.
+
+This test exercises DeepSeekV4TokenToKVPool.get_cpu_copy/load_cpu_copy without
+starting an SGLang server or loading a model. It constructs minimal pool objects
+via __new__ and fills their backing tensors with deterministic byte patterns.
+
+Run on an environment with SGLang Python dependencies installed:
+    PYTHONPATH=python python -m pytest test/manual/dsv4/test_dsv4_cpu_copy_roundtrip.py -v
+
+The test intentionally assumes HiSparse is disabled: c4_kv_pool is a normal
+DeepSeekV4SingleKVPool-like object, not HiSparseC4DevicePool.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.mem_cache.deepseek_v4_compress_state import KVAndScore
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+    DeepSeekV4IndexerPool,
+    DeepSeekV4SingleKVPool,
+    DeepSeekV4TokenToKVPool,
+)
+
+
+def _make_single_pool(
+    *, num_layers: int, num_pages: int, page_size: int, row_bytes: int
+):
+    pool = DeepSeekV4SingleKVPool.__new__(DeepSeekV4SingleKVPool)
+    pool.page_size = page_size
+    pool.layer_num = num_layers
+    pool.cpu_offloading_chunk_size = 17  # deliberately not page-aligned
+    pool.kv_buffer = [
+        torch.zeros((num_pages, row_bytes), dtype=torch.uint8, device="cpu")
+        for _ in range(num_layers)
+    ]
+    return pool
+
+
+def _make_indexer_pool(
+    *, num_layers: int, num_pages: int, page_size: int, row_bytes: int
+):
+    pool = DeepSeekV4IndexerPool.__new__(DeepSeekV4IndexerPool)
+    pool.page_size = page_size
+    pool.layer_num = num_layers
+    pool.cpu_offloading_chunk_size = 19
+    pool.index_k_with_scale_buffer = [
+        torch.zeros((num_pages, row_bytes), dtype=torch.uint8, device="cpu")
+        for _ in range(num_layers)
+    ]
+    return pool
+
+
+def _make_state_pool(
+    *, num_rows: int, row_dim: int, ring_size: int, swa_page_size: int
+):
+    class _StatePool:
+        pass
+
+    pool = _StatePool()
+    pool.ring_size = ring_size
+    pool.swa_page_size = swa_page_size
+    pool.kv_score_buffer = KVAndScore(
+        torch.zeros((num_rows, row_dim), dtype=torch.float32, device="cpu")
+    )
+
+    def translate_from_swa_loc_to_state_loc(swa_loc: torch.Tensor) -> torch.Tensor:
+        swa_pages = swa_loc // pool.swa_page_size
+        state_loc = swa_pages * pool.ring_size + (swa_loc % pool.ring_size)
+        minus_one = torch.tensor(-1, dtype=state_loc.dtype, device=state_loc.device)
+        return torch.where(swa_loc < 0, minus_one, state_loc)
+
+    pool.translate_from_swa_loc_to_state_loc = translate_from_swa_loc_to_state_loc
+    return pool
+
+
+def _fill_page_pool(pool, base: int):
+    for layer_id, buf in enumerate(pool.kv_buffer):
+        values = torch.arange(buf.numel(), dtype=torch.int64).reshape(buf.shape)
+        buf.copy_(((values + base + layer_id * 37) % 251).to(torch.uint8))
+
+
+def _fill_indexer_pool(pool, base: int):
+    for layer_id, buf in enumerate(pool.index_k_with_scale_buffer):
+        values = torch.arange(buf.numel(), dtype=torch.int64).reshape(buf.shape)
+        buf.copy_(((values + base + layer_id * 41) % 251).to(torch.uint8))
+
+
+def _fill_state_pool(pool, base: float):
+    values = torch.arange(pool.kv_score_buffer.kv_score.numel(), dtype=torch.float32)
+    pool.kv_score_buffer.kv_score.copy_(
+        values.reshape(pool.kv_score_buffer.kv_score.shape) + base
+    )
+
+
+def _page_indices(indices: torch.Tensor, page_size: int) -> torch.Tensor:
+    return torch.unique_consecutive(indices // page_size)
+
+
+def _snapshot_pages(pool, indices):
+    pages = _page_indices(indices, pool.page_size)
+    return [buf[pages].clone() for buf in pool.kv_buffer]
+
+
+def _snapshot_indexer_pages(pool, indices):
+    pages = _page_indices(indices, pool.page_size)
+    return [buf[pages].clone() for buf in pool.index_k_with_scale_buffer]
+
+
+def _assert_pages_equal(dst_pool, dst_indices, expected_by_layer, *, label: str):
+    dst_pages = _page_indices(dst_indices, dst_pool.page_size)
+    for layer_id, expected in enumerate(expected_by_layer):
+        actual = dst_pool.kv_buffer[layer_id][dst_pages]
+        assert torch.equal(actual, expected), f"{label} layer {layer_id} mismatch"
+
+
+def _assert_indexer_pages_equal(
+    dst_pool, dst_indices, expected_by_layer, *, label: str
+):
+    dst_pages = _page_indices(dst_indices, dst_pool.page_size)
+    for layer_id, expected in enumerate(expected_by_layer):
+        actual = dst_pool.index_k_with_scale_buffer[layer_id][dst_pages]
+        assert torch.equal(actual, expected), f"{label} layer {layer_id} mismatch"
+
+
+def test_dsv4_cpu_copy_roundtrip_non_hisparse():
+    # Full-token locations before and after retract. The new allocation uses
+    # different pages, so this catches accidental in-place assumptions.
+    old_full = torch.arange(1, 257, dtype=torch.int64)
+    new_full = torch.arange(513, 769, dtype=torch.int64)
+
+    c4_old = old_full[(old_full + 1) % 4 == 0] // 4
+    c4_new = new_full[(new_full + 1) % 4 == 0] // 4
+    c128_old = old_full[(old_full + 1) % 128 == 0] // 128
+    c128_new = new_full[(new_full + 1) % 128 == 0] // 128
+
+    # Tail-only SWA mapping: only the last 64 full tokens have SWA slots.
+    old_swa = torch.arange(17, 81, dtype=torch.int64)
+    new_swa = torch.arange(217, 281, dtype=torch.int64)
+    old_mapping = torch.zeros(900, dtype=torch.int64)
+    new_mapping = torch.zeros(900, dtype=torch.int64)
+    old_mapping[old_full[-64:]] = old_swa
+    new_mapping[new_full[-64:]] = new_swa
+
+    token_pool = DeepSeekV4TokenToKVPool.__new__(DeepSeekV4TokenToKVPool)
+    token_pool.swa_kv_pool = _make_single_pool(
+        num_layers=2, num_pages=128, page_size=8, row_bytes=13
+    )
+    token_pool.c4_kv_pool = _make_single_pool(
+        num_layers=3, num_pages=256, page_size=4, row_bytes=11
+    )
+    token_pool.c128_kv_pool = _make_single_pool(
+        num_layers=2, num_pages=32, page_size=1, row_bytes=7
+    )
+    token_pool.c4_indexer_kv_pool = _make_indexer_pool(
+        num_layers=3, num_pages=256, page_size=4, row_bytes=17
+    )
+    token_pool.compress_state_pools = [
+        _make_state_pool(num_rows=512, row_dim=10, ring_size=8, swa_page_size=8),
+        None,
+        _make_state_pool(num_rows=512, row_dim=12, ring_size=8, swa_page_size=8),
+    ]
+    token_pool.indexer_compress_state_pools = [
+        _make_state_pool(num_rows=512, row_dim=14, ring_size=8, swa_page_size=8),
+        None,
+        None,
+    ]
+    token_pool.full_to_swa_index_mapping = old_mapping
+
+    _fill_page_pool(token_pool.swa_kv_pool, 3)
+    _fill_page_pool(token_pool.c4_kv_pool, 11)
+    _fill_page_pool(token_pool.c128_kv_pool, 19)
+    _fill_indexer_pool(token_pool.c4_indexer_kv_pool, 29)
+    for i, state_pool in enumerate(token_pool.compress_state_pools):
+        if state_pool is not None:
+            _fill_state_pool(state_pool, 1000.0 + i * 100)
+    for i, state_pool in enumerate(token_pool.indexer_compress_state_pools):
+        if state_pool is not None:
+            _fill_state_pool(state_pool, 2000.0 + i * 100)
+
+    expected_swa = _snapshot_pages(token_pool.swa_kv_pool, old_swa)
+    expected_c4 = _snapshot_pages(token_pool.c4_kv_pool, c4_old)
+    expected_c128 = _snapshot_pages(token_pool.c128_kv_pool, c128_old)
+    expected_indexer = _snapshot_indexer_pages(token_pool.c4_indexer_kv_pool, c4_old)
+
+    expected_attention_state = []
+    expected_indexer_state = []
+    for state_pool in token_pool.compress_state_pools:
+        if state_pool is None:
+            expected_attention_state.append(None)
+        else:
+            loc = state_pool.translate_from_swa_loc_to_state_loc(old_swa)
+            expected_attention_state.append(
+                state_pool.kv_score_buffer.kv_score[loc].clone()
+            )
+    for state_pool in token_pool.indexer_compress_state_pools:
+        if state_pool is None:
+            expected_indexer_state.append(None)
+        else:
+            loc = state_pool.translate_from_swa_loc_to_state_loc(old_swa)
+            expected_indexer_state.append(
+                state_pool.kv_score_buffer.kv_score[loc].clone()
+            )
+
+    cpu_copy = token_pool.get_cpu_copy(old_full)
+
+    # Destroy device-side data to prove load_cpu_copy really restores it.
+    for pool in [
+        token_pool.swa_kv_pool,
+        token_pool.c4_kv_pool,
+        token_pool.c128_kv_pool,
+    ]:
+        for buf in pool.kv_buffer:
+            buf.fill_(0)
+    for buf in token_pool.c4_indexer_kv_pool.index_k_with_scale_buffer:
+        buf.fill_(0)
+    for state_pool in (
+        token_pool.compress_state_pools + token_pool.indexer_compress_state_pools
+    ):
+        if state_pool is not None:
+            state_pool.kv_score_buffer.kv_score.fill_(-999.0)
+
+    token_pool.full_to_swa_index_mapping = new_mapping
+    token_pool.load_cpu_copy(cpu_copy, new_full)
+
+    _assert_pages_equal(token_pool.swa_kv_pool, new_swa, expected_swa, label="swa")
+    _assert_pages_equal(token_pool.c4_kv_pool, c4_new, expected_c4, label="c4")
+    _assert_pages_equal(token_pool.c128_kv_pool, c128_new, expected_c128, label="c128")
+    _assert_indexer_pages_equal(
+        token_pool.c4_indexer_kv_pool, c4_new, expected_indexer, label="c4_indexer"
+    )
+
+    for state_pool, expected in zip(
+        token_pool.compress_state_pools, expected_attention_state
+    ):
+        if state_pool is None:
+            assert expected is None
+            continue
+        loc = state_pool.translate_from_swa_loc_to_state_loc(new_swa)
+        assert torch.equal(state_pool.kv_score_buffer.kv_score[loc], expected)
+
+    for state_pool, expected in zip(
+        token_pool.indexer_compress_state_pools, expected_indexer_state
+    ):
+        if state_pool is None:
+            assert expected is None
+            continue
+        loc = state_pool.translate_from_swa_loc_to_state_loc(new_swa)
+        assert torch.equal(state_pool.kv_score_buffer.kv_score[loc], expected)
+
+
+if __name__ == "__main__":
+    test_dsv4_cpu_copy_roundtrip_non_hisparse()
+    print("dsv4 cpu copy roundtrip ok")


### PR DESCRIPTION
## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When I deployed deepseekv4 using 1p1d for extreme load testing, retraction occurred. However, since the current deepseekv4 does not support the relevant functions yet, it will report the error as shown in the following figure.
<img width="1686" height="954" alt="image" src="https://github.com/user-attachments/assets/7340cdec-aeea-4c8a-9b1a-57b18c29f4f4" />

## accuracy test
### server command
prefill:
```
GLOO_SOCKET_IFNAME=eth1 \
    NCCL_SOCKET_IFNAME=eth1 \
    NVSHMEM_IB_GID_INDEX=3 \
    NVSHMEM_IB_TRAFFIC_CLASS=184 \
    NVSHMEM_IB_ENABLE_IBGDA=true \
    MC_SLICE_SIZE=262144 \
    MC_TE_METRIC=1 \
    SGLANG_SET_CPU_AFFINITY=1 \
    SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT=1 \
    SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1 \
    SGLANG_OPT_FIX_MEGA_MOE_MEMORY=1 \
    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=0 \
    SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW=1 \
    SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1 \
    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320 \
    SGLANG_TEST_RETRACT=1 \
    SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY=1 \
    sglang serve \
    --trust-remote-code \
    --model-path /deepseek-ai/DeepSeek-V4-Pro \
    --tp 8 \
    --dp 8 \
    --enable-dp-attention \
    --enable-dp-lm-head \
    --disaggregation-mode prefill \
    --disaggregation-transfer-backend mooncake \
    --disaggregation-ib-device /configs/mooncake_gpu_nic_map_2rail.json \
    --dist-init-addr $p0:5757 \
    --moe-a2a-backend megamoe \
    --swa-full-tokens-ratio 0.1 \
    --mem-fraction-static 0.9 \
    --chunked-prefill-size 65536 \
    --enable-prefill-delayer \
    --deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
    --host 0.0.0.0 \
    --port 30001
```
decode:
```
GLOO_SOCKET_IFNAME=eth1 \
    NCCL_SOCKET_IFNAME=eth1 \
    NVSHMEM_IB_GID_INDEX=3 \
    NVSHMEM_IB_TRAFFIC_CLASS=184 \
    NVSHMEM_IB_ENABLE_IBGDA=true \
    MC_SLICE_SIZE=262144 \
    MC_TE_METRIC=1 \
    SGLANG_SET_CPU_AFFINITY=1 \
    SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT=1 \
    SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1 \
    SGLANG_OPT_USE_FAST_MASK_EP=1 \
    SGLANG_OPT_FIX_MEGA_MOE_MEMORY=1 \
    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=0 \
    SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW=1 \
    SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1 \
    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320 \
    SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY=1 \
    SGLANG_TEST_RETRACT=1 \
    sglang serve \
    --trust-remote-code \
    --model-path /deepseek-ai/DeepSeek-V4-Pro \
    --tp 8 \
    --dp 8 \
    --enable-dp-attention \
    --enable-dp-lm-head \
    --disaggregation-mode decode \
    --disaggregation-ib-device /configs/mooncake_gpu_nic_map_2rail.json \
    --dist-init-addr $d0:5757 \
    --moe-a2a-backend megamoe \
    --mem-fraction-static 0.94 \
    --max-running-requests 1024 \
    --swa-full-tokens-ratio 0.09 \
    --deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
    --load-balance-method round_robin \
    --host 0.0.0.0 \
    --port 30001
```
router:
```
python -m sglang_router.launch_router \
    --pd-disaggregation \
    --prefill-policy round_robin \
    --decode-policy round_robin \
    --prefill http://prefill-ip:30001 \
    --decode http://decode-ip:30001 \
    --host 192.168.170.100 \
    --disable-circuit-breaker \
    --port 8008 
```

### test1:
```
python3 sglang/test/manual/dsv4/test_dsv4_cpu_copy_roundtrip.py
```
test1 result:
<img width="1890" height="80" alt="image" src="https://github.com/user-attachments/assets/065992ff-9b75-4cb4-b664-3134c13b14ae" />

### gsm8k-test2:
```
python3 -m sglang.test.few_shot_gsm8k --num-questions 200 --port 30001
```
not retract result:
<img width="770" height="122" alt="image" src="https://github.com/user-attachments/assets/db5845d7-5c19-4c1a-b2cb-2f8485d49f4b" />

retract result:
<img width="572" height="124" alt="image" src="https://github.com/user-attachments/assets/4a1503a6-f467-4d0f-8a83-38d89e2be8af" />















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28691727285](https://github.com/sgl-project/sglang/actions/runs/28691727285)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28691727222](https://github.com/sgl-project/sglang/actions/runs/28691727222)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->