### PR TITLE
Fix HiRadix host cache load_back crash and internal-node eviction

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -478,10 +478,30 @@ class HiRadixCache(RadixCache):
         # After controller threads are fully stopped, it's safe to force-release any
         # leftover pending ops (e.g., async prefetch/backup that didn't get a revoke/ack).
         self._force_release_pending_storage_ops()
+        # The storage backend is gone, so no node's pages can be recovered from
+        # it anymore. Clear storage_backed so internal host nodes are no longer
+        # treated as host-evictable (which would orphan their subtrees).
+        self._invalidate_storage_backing()
 
         self.enable_storage = False
         self.enable_storage_metrics = False
         return True, "Detached HiCache storage backend successfully."
+
+    def _invalidate_storage_backing(self):
+        """Clear storage_backed across the tree and refresh host-leaf status.
+
+        Used when the storage backend is detached or cleared: pages that were
+        previously confirmed in storage are no longer recoverable, so internal
+        nodes must not be host-evicted (only true leaves may be).
+        """
+        stack = [self.root_node]
+        self.evictable_host_leaves.clear()
+        while stack:
+            node = stack.pop()
+            node.storage_backed = False
+            stack.extend(node.children.values())
+            if node != self.root_node:
+                self._update_host_leaf_status(node)
 
     def _force_release_pending_storage_ops(self):
         """Force release any leftover pending prefetch/backup bookkeeping.
@@ -589,7 +609,13 @@ class HiRadixCache(RadixCache):
                 ack_id = operation.id
                 entry = self.ongoing_backup.pop(ack_id, None)
                 if entry is not None:
+                    # A fully-completed backup confirms the node's pages are now
+                    # recoverable from storage, so the internal node may later
+                    # shed its host pages without orphaning its subtree.
+                    if operation.completed_tokens >= len(entry.key):
+                        entry.storage_backed = True
                     entry.release_host()
+                    self._update_host_leaf_status(entry)
                 if log_metrics and self.enable_storage_metrics:
                     self.storage_metrics_collector.log_backuped_tokens(
                         operation.completed_tokens
@@ -740,6 +766,7 @@ class HiRadixCache(RadixCache):
                 # Check if the storage backend has a clear method (for nixl backends)
                 if hasattr(self.cache_controller.storage_backend, "clear"):
                     self.cache_controller.storage_backend.clear()
+                    self._invalidate_storage_backing()
                     logger.info(
                         "Hierarchical cache storage backend cleared successfully!"
                     )
@@ -858,6 +885,7 @@ class HiRadixCache(RadixCache):
         )
         self.ongoing_backup[operation_id] = node
         node.protect_host()
+        self._update_host_leaf_status(node)
 
     def _concat_split_chain(self, node: TreeNode, backup_len: int):
         """Recover enqueue-time key/hash/host by walking the split chain."""
@@ -1015,17 +1043,27 @@ class HiRadixCache(RadixCache):
             node = node.parent
         return DecLockRefResult(delta=delta)
 
+    def _is_host_evictable(self, node: TreeNode):
+        if (
+            node == self.root_node
+            or not node.evicted
+            or not node.backuped
+            or node.lock_ref > 0
+            or node.host_ref_counter > 0
+        ):
+            return False
+        # Leaves are removed from the tree entirely. Internal nodes must keep
+        # their radix subtree reachable, so they may only shed their host pages
+        # when the pages are confirmed recoverable from the storage backend.
+        return len(node.children) == 0 or (
+            getattr(self, "enable_storage", False) and node.storage_backed
+        )
+
     def _update_host_leaf_status(self, node: TreeNode):
-        if not node.evicted or node.lock_ref > 0:
+        if not self._is_host_evictable(node):
             if node in self.evictable_host_leaves:
                 self.evictable_host_leaves.remove(node)
             return
-
-        for child in node.children.values():
-            if child.backuped:
-                if node in self.evictable_host_leaves:
-                    self.evictable_host_leaves.remove(node)
-                return
 
         if node not in self.evictable_host_leaves:
             self.evictable_host_leaves.add(node)
@@ -1115,6 +1153,8 @@ class HiRadixCache(RadixCache):
             _priority, x = heapq.heappop(eviction_heap)
             if x == self.root_node:
                 break
+            if x not in self.evictable_host_leaves:
+                continue
             # only evict the host value of evicted nodes
             if not x.evicted:
                 continue
@@ -1122,21 +1162,36 @@ class HiRadixCache(RadixCache):
             if x.host_ref_counter > 0:
                 continue
 
-            # Block deleted entirely (GPU already evicted, now CPU freed) --
-            # emit remove(CPU) so the router drops the host-tier entry.
-            self._record_remove_event(x, medium=StorageMedium.CPU)
+            # Re-check eviction eligibility: heap entries can go stale as the
+            # tree mutates between heapify and pop (e.g. an internal node gained
+            # a non-evictable child, or its storage backing was invalidated).
+            if not self._is_host_evictable(x):
+                self.evictable_host_leaves.discard(x)
+                continue
+
             num_evicted += self.cache_controller.evict_host(x.host_value)
+            x.host_value = None
+            self.evictable_host_leaves.discard(x)
 
-            key = x.key.child_key(self.page_size)
-            v = x.parent.children.pop(key, None)
-            assert v == x, f"parent does not have child key, {key}"
-            if x in self.evictable_host_leaves:
-                self.evictable_host_leaves.remove(x)
-            self._update_host_leaf_status(x.parent)
+            if len(x.children) == 0:
+                # Leaf: GPU already evicted, host now freed -> the block is gone.
+                # Emit remove(CPU) so the router drops the host-tier entry and
+                # detach the node from the tree.
+                self._record_remove_event(x, medium=StorageMedium.CPU)
+                key = x.key.child_key(self.page_size)
+                v = x.parent.children.pop(key, None)
+                assert v == x, f"parent does not have child key, {key}"
+                self._update_host_leaf_status(x.parent)
 
-            if len(x.parent.children) == 0 and x.parent.evicted:
-                new_priority = self.eviction_strategy.get_priority(x.parent)
-                heapq.heappush(eviction_heap, (new_priority, x.parent))
+                if len(x.parent.children) == 0 and x.parent.evicted:
+                    new_priority = self.eviction_strategy.get_priority(x.parent)
+                    heapq.heappush(eviction_heap, (new_priority, x.parent))
+            else:
+                # Internal node: only shed the host pages, keep the radix
+                # subtree reachable so it can be restored from storage later.
+                # The host pages were confirmed storage-backed by
+                # _is_host_evictable, so no BlockRemoved is emitted.
+                self._update_host_leaf_status(x)
 
     def load_back(
         self, node: TreeNode, mem_quota: Optional[int] = None
@@ -1145,70 +1200,109 @@ class HiRadixCache(RadixCache):
         start_time = time.perf_counter()
         last_hit_node = node
         nodes_to_load = []
-        while node.evicted:
-            assert (
-                node.backuped
-            ), "No backup available on evicted nodes, should not happen"
-            nodes_to_load.insert(0, node)
-            node = node.parent
-        else:
-            ancester_node = node
+        protected_host_nodes = []
+        ancester_node = None
+        ancestor_locked = False
 
-        # protect the ancestor nodes from eviction
-        result = self.inc_lock_ref(ancester_node)
-        delta = result.delta
+        try:
+            # Protect each evicted node's host pages for the duration of the
+            # load. inc_lock_ref only guards device eviction; host eviction is
+            # gated on host_ref_counter, so without protect_host() a concurrent
+            # evict_host() can free host_value mid-load and the subsequent
+            # len()/cat() crashes the scheduler.
+            while node.evicted:
+                node.protect_host()
+                protected_host_nodes.append(node)
+                self.evictable_host_leaves.discard(node)
+                if not node.backuped:
+                    logger.warning(
+                        "load_back: skip evicted node %d without host backup "
+                        "(last_hit_node=%d)",
+                        node.id,
+                        last_hit_node.id,
+                    )
+                    return None
+                nodes_to_load.insert(0, node)
+                node = node.parent
+            else:
+                ancester_node = node
 
-        # load it all or not at all
-        host_indices = torch.cat([n.host_value for n in nodes_to_load])
-        if len(host_indices) < self.load_back_threshold or (
-            len(host_indices) > mem_quota + delta if mem_quota is not None else False
-        ):
-            # skip loading back if the total size is too small or exceeding the memory quota
-            self.dec_lock_ref(ancester_node)
-            return None
+            # protect the ancestor nodes from device eviction
+            result = self.inc_lock_ref(ancester_node)
+            ancestor_locked = True
+            delta = result.delta
 
-        device_indices = self.cache_controller.load(
-            host_indices=host_indices,
-            node_id=last_hit_node.id,
-            **self._get_extra_pools(),
-        )
-        if device_indices is None:
-            self.evict(EvictParams(num_tokens=len(host_indices)))
+            # Snapshot host segment lengths now while protect_host() guarantees
+            # the host pages are still present; later code must not re-read
+            # node.host_value lengths (they may be freed once unprotected).
+            host_values = [n.host_value for n in nodes_to_load]
+            if any(v is None for v in host_values):
+                logger.warning(
+                    "load_back: host backup disappeared while protecting node %d",
+                    last_hit_node.id,
+                )
+                return None
+            host_lengths = [len(v) for v in host_values]
+
+            # load it all or not at all
+            host_indices = torch.cat(host_values)
+            if len(host_indices) < self.load_back_threshold or (
+                len(host_indices) > mem_quota + delta
+                if mem_quota is not None
+                else False
+            ):
+                # skip loading back if the total size is too small or exceeding the memory quota
+                return None
+
             device_indices = self.cache_controller.load(
                 host_indices=host_indices,
                 node_id=last_hit_node.id,
                 **self._get_extra_pools(),
             )
-        self.dec_lock_ref(ancester_node)
-        if device_indices is None:
-            # no sufficient GPU memory to load back KV caches
-            logger.warning(
-                "load_back: FAILED to load %d tokens for node %d "
-                "even after eviction (evictable_size=%d)",
-                len(host_indices),
-                last_hit_node.id,
-                self.evictable_size_,
-            )
-            return None
+            if device_indices is None:
+                self.evict(EvictParams(num_tokens=len(host_indices)))
+                device_indices = self.cache_controller.load(
+                    host_indices=host_indices,
+                    node_id=last_hit_node.id,
+                    **self._get_extra_pools(),
+                )
+            if device_indices is None:
+                # no sufficient GPU memory to load back KV caches
+                logger.warning(
+                    "load_back: FAILED to load %d tokens for node %d "
+                    "even after eviction (evictable_size=%d)",
+                    len(host_indices),
+                    last_hit_node.id,
+                    self.evictable_size_,
+                )
+                return None
 
-        self.ongoing_load_back[last_hit_node.id] = last_hit_node
-        offset = 0
-        for node in nodes_to_load:
-            node.value = device_indices[offset : offset + len(node.host_value)].clone()
-            offset += len(node.host_value)
-            # Block promoted from host to GPU -- emit store(GPU) so downstream
-            # indexers see it as device-local again.
-            self._record_store_event(node, medium=StorageMedium.GPU)
-        self.evictable_size_ += len(device_indices)
-        self.inc_lock_ref(last_hit_node)
+            self.ongoing_load_back[last_hit_node.id] = last_hit_node
+            offset = 0
+            for node, node_len in zip(nodes_to_load, host_lengths):
+                node.value = device_indices[offset : offset + node_len].clone()
+                offset += node_len
+                # Block promoted from host to GPU -- emit store(GPU) so downstream
+                # indexers see it as device-local again.
+                self._record_store_event(node, medium=StorageMedium.GPU)
+            self.evictable_size_ += len(device_indices)
+            self.inc_lock_ref(last_hit_node)
 
-        if self.metrics_collector is not None:
-            self.metrics_collector.observe_load_back_duration(
-                time.perf_counter() - start_time
-            )
-            self.metrics_collector.increment_load_back_num_tokens(len(device_indices))
+            if self.metrics_collector is not None:
+                self.metrics_collector.observe_load_back_duration(
+                    time.perf_counter() - start_time
+                )
+                self.metrics_collector.increment_load_back_num_tokens(
+                    len(device_indices)
+                )
 
-        return device_indices
+            return device_indices
+        finally:
+            if ancestor_locked:
+                self.dec_lock_ref(ancester_node)
+            for protected_node in protected_host_nodes:
+                protected_node.release_host()
+                self._update_host_leaf_status(protected_node)
 
     def init_load_back(
         self,
@@ -1387,14 +1481,22 @@ class HiRadixCache(RadixCache):
         min_completed_tokens = completed_tokens_tensor.item()
         fetched_key = prefetch_key[:min_completed_tokens]
         written_indices = host_indices[:min_completed_tokens]
-        matched_length = self._insert_helper_host(
-            last_host_node,
-            fetched_key,
-            written_indices,
-            hash_value[: min_completed_tokens // self.page_size],
+        matched_prefix_length, matched_length, extra_matched_host_values = (
+            self._insert_helper_host(
+                last_host_node,
+                fetched_key,
+                written_indices,
+                hash_value[: min_completed_tokens // self.page_size],
+            )
         )
 
-        self.cache_controller.mem_pool_host.free(host_indices[:matched_length])
+        self.cache_controller.mem_pool_host.free(
+            host_indices[:matched_prefix_length]
+        )
+        if extra_matched_host_values:
+            self.cache_controller.mem_pool_host.free(
+                torch.cat(extra_matched_host_values)
+            )
         self.cache_controller.append_host_mem_release(
             host_indices[min_completed_tokens:completed_tokens]
         )
@@ -1444,13 +1546,28 @@ class HiRadixCache(RadixCache):
         else:
             value = self._empty_match_result.device_indices
 
+        # Collect the evicted suffix (deepest -> shallowest).
+        host_path = []
+        while last_node.evicted:
+            host_path.append(last_node)
+            last_node = last_node.parent
+
+        # Walk from the shallowest evicted node downward and stop at the first
+        # host gap. Internal host eviction can leave a parent with host_value=None
+        # while a deeper child still has host pages; those deeper pages are not a
+        # contiguous, loadable prefix, so they must not be counted as host hits.
         host_hit_length = 0
         last_host_node = last_node
-        while last_node.evicted:
-            host_hit_length += len(last_node.host_value)
-            last_node = last_node.parent
-        while not last_host_node.backuped:
-            last_host_node = last_host_node.parent
+        for node in reversed(host_path):
+            if not node.backuped:
+                self.evictable_host_leaves.discard(node)
+                break
+            host_hit_length += len(node.host_value)
+            last_host_node = node
+
+        if host_hit_length == 0:
+            while last_host_node != self.root_node and not last_host_node.backuped:
+                last_host_node = last_host_node.parent
 
         return MatchResult(
             device_indices=value,
@@ -1525,23 +1642,48 @@ class HiRadixCache(RadixCache):
     ):
         node.last_access_time = time.monotonic()
         if len(key) == 0:
-            return 0
+            return 0, 0, []
 
         child_key = key.child_key(self.page_size)
 
+        # matched_prefix_length: leading host pages that already exist on
+        #   contiguous backed nodes -> the freshly written copy can be freed.
+        # matched_length: total tokens already host-resident (used for metrics).
+        # extra_matched_host_values: host pages that duplicate already-backed
+        #   nodes *after* a gap, so they aren't a simple leading prefix and must
+        #   be freed separately to avoid leaking host memory.
+        matched_prefix_length = 0
         matched_length = 0
+        consumed_length = 0
+        extra_matched_host_values = []
         while len(key) > 0 and child_key in node.children.keys():
             node = node.children[child_key]
             node.last_access_time = time.monotonic()
             prefix_len = node.key.match(key, page_size=self.page_size)
-            key = key[prefix_len:]
-            host_value = host_value[prefix_len:]
-            hash_value = hash_value[prefix_len // self.page_size :]
-            matched_length += prefix_len
 
             if prefix_len < len(node.key):
                 new_node = self._split_node(node.key, node, prefix_len)
                 node = new_node
+
+            if node.backuped:
+                matched_length += prefix_len
+                if consumed_length == matched_prefix_length:
+                    matched_prefix_length += prefix_len
+                else:
+                    extra_matched_host_values.append(host_value[:prefix_len])
+            else:
+                # Internal node previously shed its host pages; restore them
+                # from this freshly prefetched copy and re-mark it storage-backed.
+                node.host_value = host_value[:prefix_len].clone()
+                if node.hash_value is None:
+                    node.hash_value = hash_value[: prefix_len // self.page_size]
+                node.storage_backed = True
+                self._update_host_leaf_status(node)
+
+            consumed_length += prefix_len
+            key = key[prefix_len:]
+            host_value = host_value[prefix_len:]
+            hash_value = hash_value[prefix_len // self.page_size :]
 
             if len(key):
                 child_key = key.child_key(self.page_size)
@@ -1553,6 +1695,7 @@ class HiRadixCache(RadixCache):
             new_node.value = None
             new_node.host_value = host_value.clone()
             new_node.hash_value = hash_value
+            new_node.storage_backed = True
             node.children[child_key] = new_node
             self._update_host_leaf_status(new_node)
             self._update_leaf_status(node)
@@ -1561,7 +1704,7 @@ class HiRadixCache(RadixCache):
             # cache indexers can resolve descendants that extend this L2-only prefix.
             self._record_store_event(new_node, medium=StorageMedium.CPU)
 
-        return matched_length
+        return matched_prefix_length, matched_length, extra_matched_host_values
 
     def _match_prefix_helper(self, node: TreeNode, key: RadixKey):
         node.last_access_time = time.monotonic()
@@ -1607,6 +1750,9 @@ class HiRadixCache(RadixCache):
         if child.backuped:
             new_node.host_value = child.host_value[:split_len].clone()
             child.host_value = child.host_value[split_len:].clone()
+        # The prefix half inherits the child's storage backing: if the child's
+        # pages were confirmed in storage, the split prefix is too.
+        new_node.storage_backed = child.storage_backed
 
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -220,6 +220,8 @@ class TreeNode:
         self.write_through_pending_id: Optional[int] = None
         # store hash values of each pages
         self.hash_value: Optional[List[str]] = None
+        # Whether this node's pages are confirmed present in the storage backend.
+        self.storage_backed = False
         # priority for priority-aware eviction
         self.priority = priority
 

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -38,7 +38,9 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     EvictResult,
     InsertParams,
     MatchPrefixParams,
+    MatchResult,
 )
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
 from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 
@@ -894,6 +896,331 @@ class TestRadixCache(unittest.TestCase):
 
         print(cache.available_and_evictable_str())
         print(available_and_evictable_str(cache))
+
+
+class TestHiRadixCacheHostState(unittest.TestCase):
+    """HiRadix host-cache eviction invariants, exercised without GPU pools.
+
+    These tests build a minimal HiRadixCache shell via object.__new__ and only
+    populate the radix-tree state the host-eviction / load-back paths touch, so
+    they run on a plain CPU runner. They cover the invariants that previously
+    let load_back() crash on a freed host_value and let internal host eviction
+    orphan a radix subtree.
+    """
+
+    def _new_hiradix_shell(self):
+        cache = object.__new__(HiRadixCache)
+        cache.disable = False
+        cache.page_size = 1
+        cache.device = torch.device("cpu")
+        cache.load_back_threshold = 0
+        cache.enable_storage = True
+        cache.evictable_size_ = 0
+        cache.protected_size_ = 0
+        cache.evictable_leaves = set()
+        cache.evictable_host_leaves = set()
+        cache.ongoing_load_back = {}
+        cache.ongoing_backup = {}
+        cache.metrics_collector = None
+        cache.is_eagle = False
+        cache._record_remove_event = lambda node, medium=None: None
+        cache._record_store_event = lambda node, medium=None: None
+        cache._get_extra_pools = lambda: {}
+
+        root = TreeNode(priority=-1)
+        root.key = RadixKey([])
+        root.value = torch.empty((0,), dtype=torch.int64)
+        root.host_value = torch.empty((0,), dtype=torch.int64)
+        root.lock_ref = 1
+        root.hash_value = []
+        cache.root_node = root
+        cache._empty_match_result = MatchResult(
+            device_indices=torch.empty((0,), dtype=torch.int64, device=cache.device),
+            last_device_node=root,
+            last_host_node=root,
+            best_match_node=root,
+        )
+        return cache
+
+    def _install_host_evict_controller(self, cache):
+        class HostController:
+            def __init__(self):
+                self.evicted = []
+
+            def evict_host(self, host_value):
+                self.evicted.append(host_value.clone())
+                return len(host_value)
+
+        class EvictionStrategy:
+            def get_priority(self, node):
+                return 0
+
+        controller = HostController()
+        cache.cache_controller = controller
+        cache.eviction_strategy = EvictionStrategy()
+        return controller
+
+    def test_host_candidate_requires_leaf_or_storage_backed_internal(self):
+        """Host eviction candidates must be safe to delete or recover."""
+        cache = self._new_hiradix_shell()
+        parent = TreeNode()
+        child = TreeNode()
+        parent.parent = cache.root_node
+        parent.key = RadixKey([1])
+        parent.value = None
+        parent.host_value = torch.tensor([1])
+        child.parent = parent
+        child.key = RadixKey([2])
+        child.value = torch.tensor([2])
+        parent.children[child.key.child_key(cache.page_size)] = child
+
+        # Internal node without storage backing must not be host-evictable.
+        cache._update_host_leaf_status(parent)
+        self.assertNotIn(parent, cache.evictable_host_leaves)
+
+        # Once it becomes a leaf it can be host-evicted (the block is deleted).
+        parent.children.clear()
+        cache._update_host_leaf_status(parent)
+        self.assertIn(parent, cache.evictable_host_leaves)
+
+        # Without host pages there is nothing to evict.
+        parent.host_value = None
+        cache._update_host_leaf_status(parent)
+        self.assertNotIn(parent, cache.evictable_host_leaves)
+
+    def test_internal_storage_backed_host_value_can_be_evicted(self):
+        """Internal host eviction frees host pages without deleting the subtree."""
+        cache = self._new_hiradix_shell()
+        controller = self._install_host_evict_controller(cache)
+        removed = []
+        cache._record_remove_event = lambda node, medium=None: removed.append(node)
+
+        parent = TreeNode()
+        parent.parent = cache.root_node
+        parent.key = RadixKey([1, 2, 3])
+        parent.value = None
+        parent.host_value = torch.tensor([1, 2, 3])
+        parent.storage_backed = True
+        cache.root_node.children[parent.key.child_key(cache.page_size)] = parent
+
+        child = TreeNode()
+        child.parent = parent
+        child.key = RadixKey([4])
+        child.value = None
+        child.host_value = torch.tensor([4])
+        child.storage_backed = True
+        parent.children[child.key.child_key(cache.page_size)] = child
+
+        cache._update_host_leaf_status(parent)
+        self.assertIn(parent, cache.evictable_host_leaves)
+
+        cache.evict_host(3)
+
+        # Subtree stays reachable; only host pages were shed; no BlockRemoved.
+        self.assertIs(
+            cache.root_node.children[parent.key.child_key(cache.page_size)], parent
+        )
+        self.assertIs(parent.children[child.key.child_key(cache.page_size)], child)
+        self.assertIsNone(parent.host_value)
+        self.assertEqual(len(controller.evicted), 1)
+        self.assertEqual(removed, [])
+
+    def test_internal_host_value_eviction_requires_storage_backing(self):
+        """Internal host pages are not dropped unless L3 can recover them."""
+        cache = self._new_hiradix_shell()
+        controller = self._install_host_evict_controller(cache)
+
+        parent = TreeNode()
+        parent.parent = cache.root_node
+        parent.key = RadixKey([1, 2, 3])
+        parent.value = None
+        parent.host_value = torch.tensor([1, 2, 3])
+        cache.root_node.children[parent.key.child_key(cache.page_size)] = parent
+
+        child = TreeNode()
+        child.parent = parent
+        child.key = RadixKey([4])
+        parent.children[child.key.child_key(cache.page_size)] = child
+
+        cache._update_host_leaf_status(parent)
+        self.assertNotIn(parent, cache.evictable_host_leaves)
+
+        cache.evict_host(3)
+
+        self.assertIsNotNone(parent.host_value)
+        self.assertEqual(controller.evicted, [])
+
+    def test_clear_storage_backend_invalidates_internal_storage_backing(self):
+        """Clearing L3 makes internal host pages non-recoverable from storage."""
+        cache = self._new_hiradix_shell()
+        controller = self._install_host_evict_controller(cache)
+
+        class StorageBackend:
+            def __init__(self):
+                self.cleared = False
+
+            def clear(self):
+                self.cleared = True
+
+        storage_backend = StorageBackend()
+        controller.storage_backend = storage_backend
+
+        parent = TreeNode()
+        parent.parent = cache.root_node
+        parent.key = RadixKey([1, 2, 3])
+        parent.value = None
+        parent.host_value = torch.tensor([1, 2, 3])
+        parent.storage_backed = True
+        cache.root_node.children[parent.key.child_key(cache.page_size)] = parent
+
+        child = TreeNode()
+        child.parent = parent
+        child.key = RadixKey([4])
+        parent.children[child.key.child_key(cache.page_size)] = child
+
+        cache._update_host_leaf_status(parent)
+        self.assertIn(parent, cache.evictable_host_leaves)
+
+        self.assertTrue(cache.clear_storage_backend())
+
+        self.assertTrue(storage_backend.cleared)
+        self.assertFalse(parent.storage_backed)
+        self.assertNotIn(parent, cache.evictable_host_leaves)
+
+        cache.evict_host(3)
+        self.assertIsNotNone(parent.host_value)
+        self.assertEqual(controller.evicted, [])
+
+    def test_match_prefix_does_not_skip_host_gap(self):
+        """Child host hits are unusable when an ancestor host value is gone."""
+        cache = self._new_hiradix_shell()
+
+        parent = TreeNode()
+        parent.parent = cache.root_node
+        parent.key = RadixKey([1, 2])
+        parent.value = None
+        parent.host_value = None
+        parent.storage_backed = True
+        cache.root_node.children[parent.key.child_key(cache.page_size)] = parent
+
+        child = TreeNode()
+        child.parent = parent
+        child.key = RadixKey([3, 4])
+        child.value = None
+        child.host_value = torch.tensor([3, 4])
+        child.storage_backed = True
+        parent.children[child.key.child_key(cache.page_size)] = child
+
+        result = cache.match_prefix(MatchPrefixParams(key=RadixKey([1, 2, 3, 4])))
+
+        self.assertEqual(result.host_hit_length, 0)
+        self.assertIs(result.last_host_node, cache.root_node)
+
+    def test_insert_helper_host_restores_existing_storage_node(self):
+        """L3 reads must refill existing storage-only radix nodes."""
+        cache = self._new_hiradix_shell()
+
+        node = TreeNode()
+        node.parent = cache.root_node
+        node.key = RadixKey([1, 2])
+        node.value = None
+        node.host_value = None
+        node.hash_value = ["h1", "h2"]
+        node.storage_backed = True
+        cache.root_node.children[node.key.child_key(cache.page_size)] = node
+
+        matched_prefix, matched, extra_matched_host_values = cache._insert_helper_host(
+            cache.root_node,
+            RadixKey([1, 2]),
+            torch.tensor([10, 11]),
+            ["h1", "h2"],
+        )
+
+        # First insert refills the storage-only node; nothing to free.
+        self.assertEqual(matched_prefix, 0)
+        self.assertEqual(matched, 0)
+        self.assertEqual(extra_matched_host_values, [])
+        self.assertTrue(torch.equal(node.host_value, torch.tensor([10, 11])))
+
+        matched_prefix, matched, extra_matched_host_values = cache._insert_helper_host(
+            cache.root_node,
+            RadixKey([1, 2]),
+            torch.tensor([12, 13]),
+            ["h1", "h2"],
+        )
+
+        # Second insert is a pure prefix hit; the freshly written copy is freed.
+        self.assertEqual(matched_prefix, 2)
+        self.assertEqual(matched, 2)
+        self.assertEqual(extra_matched_host_values, [])
+        self.assertTrue(torch.equal(node.host_value, torch.tensor([10, 11])))
+
+    def test_insert_helper_host_reports_non_prefix_duplicate_host_pages(self):
+        """Duplicate host pages after a storage gap must be released separately."""
+        cache = self._new_hiradix_shell()
+
+        parent = TreeNode()
+        parent.parent = cache.root_node
+        parent.key = RadixKey([1, 2])
+        parent.value = None
+        parent.host_value = None
+        parent.hash_value = ["h1", "h2"]
+        parent.storage_backed = True
+        cache.root_node.children[parent.key.child_key(cache.page_size)] = parent
+
+        child = TreeNode()
+        child.parent = parent
+        child.key = RadixKey([3, 4])
+        child.value = None
+        child.host_value = torch.tensor([30, 31])
+        child.hash_value = ["h3", "h4"]
+        child.storage_backed = True
+        parent.children[child.key.child_key(cache.page_size)] = child
+
+        matched_prefix, matched, extra_matched_host_values = cache._insert_helper_host(
+            cache.root_node,
+            RadixKey([1, 2, 3, 4]),
+            torch.tensor([10, 11, 20, 21]),
+            ["h1", "h2", "h3", "h4"],
+        )
+
+        # parent (gap) is refilled; child already backed -> its duplicate copy
+        # ([20, 21]) is reported as an extra value to free, not a leading prefix.
+        self.assertEqual(matched_prefix, 0)
+        self.assertEqual(matched, 2)
+        self.assertEqual(len(extra_matched_host_values), 1)
+        self.assertTrue(
+            torch.equal(extra_matched_host_values[0], torch.tensor([20, 21]))
+        )
+        self.assertTrue(torch.equal(parent.host_value, torch.tensor([10, 11])))
+        self.assertTrue(torch.equal(child.host_value, torch.tensor([30, 31])))
+
+    def test_load_back_protects_host_value_until_device_restore(self):
+        """Concurrent host eviction must not clear host_value during load_back."""
+        cache = self._new_hiradix_shell()
+        node = TreeNode()
+        node.parent = cache.root_node
+        node.key = RadixKey(list(range(12)))
+        node.value = None
+        node.host_value = torch.arange(12, dtype=torch.int64)
+        cache.root_node.children[node.key.child_key(cache.page_size)] = node
+
+        class RaceController:
+            def load(self, host_indices, node_id):
+                # Simulate a concurrent host eviction: it would clear host_value
+                # if the node were not protected. protect_host() must prevent it.
+                if node.host_ref_counter == 0:
+                    node.host_value = None
+                return host_indices + 100
+
+        cache.cache_controller = RaceController()
+
+        restored = cache.load_back(node)
+
+        self.assertTrue(torch.equal(restored, torch.arange(100, 112)))
+        self.assertTrue(torch.equal(node.value, torch.arange(100, 112)))
+        self.assertEqual(node.host_ref_counter, 0)
+        self.assertIsNotNone(node.host_value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

HiRadix host-cache load-back can crash when an evicted node is still treated as host-recoverable after its `host_value` has been freed by host eviction. In that state `load_back()` may call `len()` or `torch.cat()` on `None`, terminating the scheduler.

The same host eviction path also detached internal radix nodes when freeing host pages, which could orphan their child subtree even though the internal node was still needed as a prefix anchor.

## Modifications

- Protect every evicted node's host pages during `load_back()` and snapshot host segment lengths before restoring device pages.
- Add `TreeNode.storage_backed` to distinguish internal host nodes that can safely shed host pages because they are recoverable from L3 storage.
- Preserve radix subtrees when evicting host pages from storage-backed internal nodes; only true leaves are removed from the tree.
- Maintain storage-backed state on backup completion, L3 prefetch insertion, node split, storage clear, and backend detach.
- Stop host-prefix matching at the first host gap so descendant host pages are not counted as a contiguous loadable prefix.

Internal node host-page shedding does not emit `BlockRemoved(CPU)` because the block is not deleted from the radix tree; the subtree stays reachable and a host gap will trigger L3 recovery instead of router removal.

## Accuracy

The new tests cover host-evictable predicates, internal storage-backed host eviction, storage clear invalidation, host-gap matching, L3 prefetch insertion into storage-only nodes, duplicate host-page accounting after a host gap, and host protection during `load_back()`.

## Tests

- `python3 -m py_compile python/sglang/srt/mem_cache/hiradix_cache.py python/sglang/srt/mem_cache/radix_cache.py test/registered/unit/mem_cache/test_radix_cache_unit.py`
- `git diff --check upstream/main..HEAD`

Target unittest is expected to run in CI: `test/registered/unit/mem_cache/test_radix_cache_unit.py::TestHiRadixCacheHostState`.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27137270652](https://github.com/sgl-project/sglang/actions/runs/27137270652)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27137270371](https://github.com/sgl-project/sglang/actions/runs/27137270371)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->