### PR TITLE
[HiCache][Observability] Emit cached_tokens even when zero

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1626,28 +1626,23 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
 
         # Report cached tokens with detailed source breakdown
         if cached_tokens > 0:
-            if cached_tokens_details:
-                # Report by cache source (device/host, and storage if L3 enabled)
-                def report_cache_source(source: str, value: int):
-                    if value > 0:
-                        source_labels = {**labels, "cache_source": source}
-                        self.cached_tokens_total.labels(**source_labels).inc(value)
+            # Report by cache source (device/host, and storage if L3 enabled)
+            def report_cache_source(source: str, value: int):
+                source_labels = {**labels, "cache_source": source}
+                self.cached_tokens_total.labels(**source_labels).inc(value)
 
+            if cached_tokens_details:
                 report_cache_source("device", cached_tokens_details.get("device", 0))
                 report_cache_source("host", cached_tokens_details.get("host", 0))
 
                 # Storage fields are only present when L3 storage backend is enabled
                 if "storage" in cached_tokens_details:
-                    storage_tokens = cached_tokens_details.get("storage", 0)
-                    if storage_tokens > 0:
-                        backend = (
-                            cached_tokens_details.get("storage_backend") or "unknown"
-                        )
-                        report_cache_source(f"storage_{backend}", storage_tokens)
+                    storage_tokens = cached_tokens_details["storage"]
+                    backend = cached_tokens_details.get("storage_backend", "unknown")
+                    report_cache_source(f"storage_{backend}", storage_tokens)
             else:
                 # Fallback for backward compatibility
-                labels_total = {**labels, "cache_source": "total"}
-                self.cached_tokens_total.labels(**labels_total).inc(cached_tokens)
+                report_cache_source("total", cached_tokens)
 
         self.num_requests_total.labels(**labels).inc(1)
         if has_grammar:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1637,9 +1637,10 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
 
                 # Storage fields are only present when L3 storage backend is enabled
                 if "storage" in cached_tokens_details:
-                    storage_tokens = cached_tokens_details["storage"]
-                    backend = cached_tokens_details.get("storage_backend", "unknown")
-                    report_cache_source(f"storage_{backend}", storage_tokens)
+                    backend = cached_tokens_details.get("storage_backend") or "unknown"
+                    report_cache_source(
+                        f"storage_{backend}", cached_tokens_details["storage"]
+                    )
             else:
                 # Fallback for backward compatibility
                 report_cache_source("total", cached_tokens)


### PR DESCRIPTION
## Motivation

Fixes an inconsistency where some cached tokens gauges would not be emitted.
In cases such as enabling hierarchical cache with storage plugins, this may lead to confusion: a metric may be missing due to misconfiguration or a zero value.

```
$ curl localhost:30000/metrics -o - | grep cached_tokens
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  113k    0  113k    0     0  11.0M      0 --:--:-- --:--:-- --:--:-- 11.0M
# HELP sglang:cached_tokens_total Number of cached prompt tokens by source (device/host/storage).
# TYPE sglang:cached_tokens_total counter
sglang:cached_tokens_total{cache_source="device",engine_type="unified",model_name="deepseek-ai/DeepSeek-V3"} 5248.0
sglang:cached_tokens_total{cache_source="host",engine_type="unified",model_name="deepseek-ai/DeepSeek-V3"} 0.0
sglang:cached_tokens_total{cache_source="storage_HiCacheNixl",engine_type="unified",model_name="deepseek-ai/DeepSeek-V3"} 52928.0
```

## Modifications

Changed metrics collector logic such that it creates the metrics even when the values are not being incremented.

## Accuracy Tests

This pull request does not affect model outputs.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27142314429](https://github.com/sgl-project/sglang/actions/runs/27142314429)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27142314109](https://github.com/sgl-project/sglang/actions/runs/27142314109)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->