### PR TITLE
[diffusion] model: fix Wan2.2 graph breaks

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -416,8 +416,9 @@ def fuse_scale_shift_kernel(
         else:
             sh_sb = sh_sl = sh_sc = 0
 
-        # If both scalars and both zero, copy fast-path
-        if need_scale_scalar and need_shift_scalar:
+        # If both scalars and both zero, copy fast-path (skip under torch.compile
+        # to avoid a data-dependent graph break)
+        if not torch.compiler.is_compiling() and need_scale_scalar and need_shift_scalar:
             if not (
                 scale_blc.any().to("cpu", non_blocking=True)
                 or shift_blc.any().to("cpu", non_blocking=True)

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/mrope.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/mrope.py
@@ -253,6 +253,10 @@ class OneDRotaryEmbedding(torch.nn.Module):
         This method converts the input tensor to a hashable representation
         and calls a cached helper method to perform the computation.
         """
+        if torch.compiler.is_compiling():
+            # Skip lru_cache path under torch.compile to avoid graph break
+            # from Tensor.tolist() on non-integer tensor
+            return self.build_freqs_outer(pos, pos.device)
         pos_tuple = tuple(pos.tolist())
         device_str = str(pos.device)
         return self._forward_cached(pos_tuple, device_str)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes two small graph breaks still present for Wan2.2 models.
While the gain from fixing these is minor, it's good to fix them so future checks won't have to inspect them again.

## Modifications

<!-- Detail the changes made in this pull request. -->

 1. scale_shift.py-- Data-dependent branching
 The `fuse_scale_shift_kernel` has an eager-mode fast-path that checks if both scale and shift are zero scalars, and if so, copies input directly to output instead of launching the Triton kernel. This uses `.any().to("cpu")` which forces a GPU-to-CPU sync and creates a data-dependent branch that dynamo cannot trace.
 Fix: Guard the fast-path with `torch.compiler.is_compiling()`  so it's skipped during tracing, 

 3. mrope.py -- Tensor.tolist() on non-integer tensor
The 1D RoPE `forward()` method converts position tensors to Python tuples via `pos.tolist()` to use them as `functools.lru_cache` keys, avoiding redundant RoPE recomputation across denoising steps. Dynamo cannot trace `tolist()` on float tensors since the values become opaque Python scalars.
 Fix: Skip the `lru_cache` entirely when compiling and call `build_freqs_outer()` directly.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
No difference in output quality.

**Before:**
https://github.com/user-attachments/assets/f00a109b-e8cb-44b1-85a1-a475bc68b10c

**After:**
https://github.com/user-attachments/assets/41ee578f-db33-48e4-8676-d64e08a16c63

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 60871.11 ms | 60450.24 ms | **-420.87 ms (-0.7%)** | ⚪️ |
| **Throughput** | 0.02 req/s | 0.02 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 4.57 | 4.40 | -0.17 | -3.6% | ⚪️ |
| TextEncodingStage | 448.83 | 456.40 | +7.57 | +1.7% | ⚪️ |
| ImageVAEEncodingStage | 748.10 | 739.82 | -8.28 | -1.1% | ⚪️ |
| LatentPreparationStage | 0.15 | 0.18 | +0.03 | +20.5% | ⚪️ |
| TimestepPreparationStage | 8.05 | 0.34 | -7.71 | -95.7% | ⚪️ |
| DenoisingStage | 55199.29 | 54811.89 | -387.40 | -0.7% | ⚪️ |
| DecodingStage | 4458.95 | 4433.97 | -24.98 | -0.6% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.04 | 0.04 | +0.00 | +4.7% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.01 | 0.01 | -0.00 | -30.8% | ⚪️ |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27141470833](https://github.com/sgl-project/sglang/actions/runs/27141470833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27141470407](https://github.com/sgl-project/sglang/actions/runs/27141470407)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->