### PR TITLE
Avoid over-general name of Req.fill_len since only used in decode now by renaming to extend_fill_len

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -374,9 +374,9 @@ def prepare_inputs_for_correctness_test(bench_args, tokenizer, custom_prompts):
             origin_input_ids=array("q", tmp_input_ids),
             sampling_params=sampling_params,
         )
-        req.fill_len = len(req.origin_input_ids)
+        req.extend_fill_len = len(req.origin_input_ids)
         req.logprob_start_len = -1
-        req.set_extend_input_len(req.fill_len - len(req.prefix_indices))
+        req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
         reqs.append(req)
 
     return input_ids, reqs
@@ -390,14 +390,14 @@ def prepare_extend_inputs_for_correctness_test(
         req.origin_input_ids = req.origin_input_ids + array(
             "q", input_ids[i][bench_args.cut_len :]
         )
-        req.fill_len = len(req.origin_input_ids)
+        req.extend_fill_len = len(req.origin_input_ids)
         if model_runner is not None:
             # Use req.req_pool_idx instead of i to handle slot 0 padding correctly
             req.prefix_indices = model_runner.req_to_token_pool.req_to_token[
                 req.req_pool_idx, : bench_args.cut_len
             ].to(req.prefix_indices.dtype)
             req.logprob_start_len = -1
-            req.set_extend_input_len(req.fill_len - len(req.prefix_indices))
+            req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
     return reqs
 
 
@@ -422,9 +422,9 @@ def prepare_synthetic_inputs_for_latency_test(
             origin_input_ids=array("q", input_ids[i]),
             sampling_params=sampling_params,
         )
-        req.fill_len = len(req.origin_input_ids)
+        req.extend_fill_len = len(req.origin_input_ids)
         req.logprob_start_len = -1
-        req.set_extend_input_len(req.fill_len - len(req.prefix_indices))
+        req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
         reqs.append(req)
 
     return reqs

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1054,7 +1054,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
     @property
     def num_tokens_pre_allocated(self):
-        return sum(decode_req.req.fill_len for decode_req in self.transfer_queue.queue)
+        return sum(
+            decode_req.req.extend_fill_len for decode_req in self.transfer_queue.queue
+        )
 
     def _need_space_for_single_req(
         self, retractable_tokens: Optional[int] = None
@@ -1384,10 +1386,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_loc,
         )
 
-        # Truncate fill_len to kv_committed_len so cache_unfinished_req only
+        # Truncate extend_fill_len to kv_committed_len so cache_unfinished_req only
         # inserts committed KV into the radix tree. The last output token
         # hasn't had KV committed yet (output_ids is 1 ahead).
-        req.fill_len = req.kv_committed_len
+        req.extend_fill_len = req.kv_committed_len
         # Set prefix_indices so downstream consumers (init_next_round_input,
         # prepare_for_extend) see the correct prefix length. In the agg path
         # this is done inside init_next_round_input, but decode-disagg needs
@@ -1395,7 +1397,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         req.prefix_indices = (
             prefix_indices if prefix_len > 0 else torch.empty((0,), dtype=torch.int64)
         )
-        req.set_extend_input_len(req.fill_len - total_prefix_len)
+        req.set_extend_input_len(req.extend_fill_len - total_prefix_len)
 
         # Return the transfer destination indices:
         if self.scheduler.enable_hisparse:
@@ -1849,12 +1851,14 @@ class SchedulerDisaggregationDecodeMixin:
                 else:
                     tree_cache = self.tree_cache
                 req.init_next_round_input(tree_cache)
-                # Truncate fill_len to kv_committed_len so cache_unfinished_req
+                # Truncate extend_fill_len to kv_committed_len so cache_unfinished_req
                 # only sees committed KV (full array includes one uncommitted
                 # token because init_next_round_input rebuilt it as full).
                 if req.kv_committed_len is not None:
-                    req.fill_len = req.kv_committed_len
-                    req.set_extend_input_len(req.fill_len - len(req.prefix_indices))
+                    req.extend_fill_len = req.kv_committed_len
+                    req.set_extend_input_len(
+                        req.extend_fill_len - len(req.prefix_indices)
+                    )
             else:
                 waiting_queue.append(req)
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -882,7 +882,7 @@ class SchedulerDisaggregationPrefillMixin:
             elif self.enable_overlap:
                 # Delay KV transfer to process_batch_result_disagg_prefill when overlap is enabled to ensure results are resolved
                 self.chunked_req.tmp_end_idx = min(
-                    self.chunked_req.fill_len,
+                    self.chunked_req.extend_fill_len,
                     len(self.chunked_req.origin_input_ids),
                 )
             else:
@@ -918,7 +918,7 @@ class SchedulerDisaggregationPrefillMixin:
         end_idx = (
             end_idx
             if end_idx is not None
-            else min(req.fill_len, len(req.origin_input_ids))
+            else min(req.extend_fill_len, len(req.origin_input_ids))
         )
 
         if not last_chunk:
@@ -949,7 +949,7 @@ class SchedulerDisaggregationPrefillMixin:
             # length here avoids emitting an extra state page when the sampled
             # token crosses a page boundary, which mismatched src/dst lengths in
             # group_concurrent_contiguous.
-            seq_len = min(req.fill_len, len(req.origin_input_ids))
+            seq_len = min(req.extend_fill_len, len(req.origin_input_ids))
 
             def _mamba_payload():
                 return [

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -58,10 +58,10 @@ class ReqDllmMixin:
     def _init_fill_ids_for_dllm(self: Req):
         self.dllm_block_offset = (
             0
-            if self.fill_len == 0
+            if self.extend_fill_len == 0
             else self.dllm_block_offset + self.dllm_config.block_size
         )
-        self.fill_len = self.get_full_untruncated_fill_len()
+        self.extend_fill_len = self.get_full_untruncated_fill_len()
 
     def _update_block_offset_for_dllm(self):
         prefix_len = len(self.prefix_indices)

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -207,7 +207,7 @@ class HiSparseCoordinator:
         req.hisparse_staging = True
 
         full_kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, : req.fill_len
+            req.req_pool_idx, : req.extend_fill_len
         ].to(dtype=torch.int64, copy=True)
         device_indices = (
             self.mem_pool_device.translate_loc_from_full_to_hisparse_device(
@@ -298,7 +298,7 @@ class HiSparseCoordinator:
 
     def alloc_device_buffer(self, req: Req) -> None:
         if self.is_dsv4_hisparse:
-            allocated_len = req.fill_len
+            allocated_len = req.extend_fill_len
             alloc_size = self.padded_buffer_size
         else:
             allocated_len = req.kv_allocated_len
@@ -707,7 +707,7 @@ class HiSparseCoordinator:
         # Wait for any in-flight staging DMA to complete before freeing
         self.write_staging_stream.synchronize()
 
-        prefill_len = req.fill_len
+        prefill_len = req.extend_fill_len
         allocated_locs = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, :prefill_len
         ]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -696,7 +696,7 @@ class Req(ReqDllmMixin):
         )  # Before image padding
         # Each decode stage's output ids
         self.output_ids = array("q")
-        self.fill_len: int = 0
+        self.extend_fill_len: int = 0
 
         self.session = session
         self.input_embeds = input_embeds
@@ -958,8 +958,8 @@ class Req(ReqDllmMixin):
         # the start index of the sent kv cache
         # We want to send it chunk by chunk for chunked prefill.
         # After every chunk forward, we do the following:
-        # kv_send(req.input_ids[req.start_send_idx:req.fill_len])
-        # start_send_idx = req.fill_len
+        # kv_send(req.input_ids[req.start_send_idx:req.extend_fill_len])
+        # start_send_idx = req.extend_fill_len
         self.start_send_idx: int = 0
 
         # For overlap schedule, we delay the kv transfer until `process_batch_result_disagg_prefill` rather than `process_prefill_chunk` in non-overlap
@@ -1078,7 +1078,7 @@ class Req(ReqDllmMixin):
         return length
 
     def get_fill_ids(self) -> array:
-        return self.get_full_untruncated_fill_ids()[: self.fill_len]
+        return self.get_full_untruncated_fill_ids()[: self.extend_fill_len]
 
     def init_next_round_input(
         self,
@@ -1421,7 +1421,7 @@ class Req(ReqDllmMixin):
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
-        self.fill_len = 0
+        self.extend_fill_len = 0
 
         # When using input_embeds, we cannot easily mix the original input embeddings
         # with the newly generated output token IDs during re-prefill of retracted request.
@@ -1604,10 +1604,10 @@ def _compute_chunked_req_next_prompt_token(
 ) -> Optional[int]:
     if chunked_req is None:
         return None
-    fill_len = chunked_req.fill_len
-    if fill_len >= len(chunked_req.origin_input_ids):
+    extend_fill_len = chunked_req.extend_fill_len
+    if extend_fill_len >= len(chunked_req.origin_input_ids):
         return None
-    return int(chunked_req.origin_input_ids[fill_len])
+    return int(chunked_req.origin_input_ids[extend_fill_len])
 
 
 @dataclasses.dataclass
@@ -1955,8 +1955,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         reqs = self.reqs
         input_ids = [r.get_fill_ids()[len(r.prefix_indices) :] for r in reqs]
         extend_num_tokens = sum(len(ids) for ids in input_ids)
-        seq_lens = [r.fill_len for r in reqs]
-        orig_seq_lens = [max(r.fill_len, len(r.origin_input_ids)) for r in reqs]
+        seq_lens = [r.extend_fill_len for r in reqs]
+        orig_seq_lens = [max(r.extend_fill_len, len(r.origin_input_ids)) for r in reqs]
         prefix_lens = [len(r.prefix_indices) for r in reqs]
         extend_lens = [r.extend_input_len for r in reqs]
 
@@ -2009,7 +2009,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # If input_embeds are available, store them
             if req.input_embeds is not None:
                 # Slice to match extend_input_len — PrefillAdder truncates
-                # fill_len/extend_input_len on chunk overflow but not input_embeds.
+                # extend_fill_len/extend_input_len on chunk overflow but not input_embeds.
                 input_embeds.extend(
                     req.input_embeds[pre_len : pre_len + req.extend_input_len]
                 )
@@ -2092,7 +2092,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # extend_input_logprob_token_id = [4, 0]
                 global_start_idx, global_end_idx = (
                     len(req.prefix_indices),
-                    req.fill_len,
+                    req.extend_fill_len,
                 )
                 if req.logprob_start_len == -1:
                     logprob_start_len = len(req.origin_input_ids)
@@ -2322,7 +2322,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         running_bs = running_batch.batch_size()
 
         for req in running_batch.reqs:
-            req.fill_len = req.get_full_untruncated_fill_len()
+            req.extend_fill_len = req.get_full_untruncated_fill_len()
             req.set_extend_input_len(1)
 
         # Decode tokens of the running portion live in future_map.output_tokens_buf.

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -660,7 +660,7 @@ class PrefillAdder:
         )
 
         req.extend_input_len = trunc_len
-        req.fill_len = prefix_len + trunc_len
+        req.extend_fill_len = prefix_len + trunc_len
 
         self.can_run_list.append(req)
 
@@ -681,7 +681,7 @@ class PrefillAdder:
         # Truncate input length to available tokens and update request metadata
         truncated = req.extend_input_len > _rem_tokens
         req.extend_input_len = min(req.extend_input_len, _rem_tokens)
-        req.fill_len = len(req.prefix_indices) + req.extend_input_len
+        req.extend_fill_len = len(req.prefix_indices) + req.extend_input_len
         self.can_run_list.append(req)
 
         # Update budget: reserve max_new_tokens only if not truncated
@@ -721,7 +721,7 @@ class PrefillAdder:
 
         truncated = req.extend_input_len > _rem_tokens
         req.set_extend_input_len(min(req.extend_input_len, _rem_tokens))
-        req.fill_len = len(req.prefix_indices) + req.extend_input_len
+        req.extend_fill_len = len(req.prefix_indices) + req.extend_input_len
         self.can_run_list.append(req)
         self._update_prefill_budget(
             0,
@@ -828,10 +828,10 @@ class PrefillAdder:
             or req.extend_input_len <= self.rem_chunk_tokens  # it is the last chunk
         ):
             # Non-chunked prefill — the whole sequence is committed this iter.
-            req.fill_len = req.get_full_untruncated_fill_len()
+            req.extend_fill_len = req.get_full_untruncated_fill_len()
             assert (
-                req.fill_len == len(req.prefix_indices) + req.extend_input_len
-            ), f"{req.fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
+                req.extend_fill_len == len(req.prefix_indices) + req.extend_input_len
+            ), f"{req.extend_fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
             self.can_run_list.append(req)
             self._update_prefill_budget(
                 0,
@@ -848,7 +848,7 @@ class PrefillAdder:
 
             req.set_extend_input_len(trunc_len)
             assert len(req.prefix_indices) == 0
-            req.fill_len = len(req.prefix_indices) + trunc_len
+            req.extend_fill_len = len(req.prefix_indices) + trunc_len
             self.can_run_list.append(req)
             self.new_chunked_req = req
             self._update_prefill_budget(0, trunc_len, 0, req.retracted_stain)
@@ -967,10 +967,11 @@ class PrefillAdder:
                 self._req_inc_lock_ref(req)
             elif self.rem_chunk_tokens is None or input_tokens <= self.rem_chunk_tokens:
                 # Non-chunked prefill — the whole sequence is committed this iter.
-                req.fill_len = req.get_full_untruncated_fill_len()
+                req.extend_fill_len = req.get_full_untruncated_fill_len()
                 assert (
-                    req.fill_len == len(req.prefix_indices) + req.extend_input_len
-                ), f"{req.fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
+                    req.extend_fill_len
+                    == len(req.prefix_indices) + req.extend_input_len
+                ), f"{req.extend_fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
                 self.can_run_list.append(req)
 
                 self._req_inc_lock_ref(req)
@@ -1010,7 +1011,7 @@ class PrefillAdder:
 
                 # Chunked prefill
                 req.set_extend_input_len(trunc_len)
-                req.fill_len = len(req.prefix_indices) + trunc_len
+                req.extend_fill_len = len(req.prefix_indices) + trunc_len
 
                 self.can_run_list.append(req)
                 self.new_chunked_req = req

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2435,9 +2435,9 @@ class Scheduler(
 
             # Stash (cache) the previous chunk only when it produced new KV
             # beyond what is already cached. A parked chunk (add_chunked_req
-            # hybrid-SWA early-return) leaves fill_len == len(prefix_indices),
+            # hybrid-SWA early-return) leaves extend_fill_len == len(prefix_indices),
             # so there is nothing new to cache and stashing would be a no-op.
-            if self.chunked_req.fill_len > len(self.chunked_req.prefix_indices):
+            if self.chunked_req.extend_fill_len > len(self.chunked_req.prefix_indices):
                 self.stash_chunked_request(self.chunked_req)
 
         # HiSparse has its own prefill-to-decode transition; skip last_batch merge.

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -606,9 +606,9 @@ class SchedulerPPMixin:
                     origin_input_ids=input_ids,
                     sampling_params=sampling_params,
                 )
-                req.fill_len = req.get_full_untruncated_fill_len()
+                req.extend_fill_len = req.get_full_untruncated_fill_len()
                 req.logprob_start_len = -1
-                req.set_extend_input_len(req.fill_len - len(req.prefix_indices))
+                req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
 
                 # Prepare batch
                 batch = ScheduleBatch.init_new(
@@ -621,7 +621,7 @@ class SchedulerPPMixin:
                     self.spec_algorithm,
                 )
 
-                current_seq_len = req.fill_len
+                current_seq_len = req.extend_fill_len
 
                 if is_dp_attention_enabled():
                     # For profiling, we only have one request on PP0
@@ -685,7 +685,7 @@ class SchedulerPPMixin:
                 # Release KV cache
                 if req.req_pool_idx is not None:
                     kv_indices = self.req_to_token_pool.req_to_token[
-                        req.req_pool_idx, : req.fill_len
+                        req.req_pool_idx, : req.extend_fill_len
                     ]
                     self.token_to_kv_pool_allocator.free(kv_indices)
                     self.req_to_token_pool.free(req)

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -86,7 +86,7 @@ class ChunkCache(BasePrefixCache):
 
     def cache_unfinished_req(self, req: Req, chunked=False):
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, : req.fill_len
+            req.req_pool_idx, : req.extend_fill_len
         ]
         # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later
         req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -611,7 +611,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
 
         def _skip_cache_unfinished_req(req: Req) -> None:
             kv_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, : req.fill_len
+                req.req_pool_idx, : req.extend_fill_len
             ]
 
             # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -488,7 +488,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         """Cache request when it is unfinished."""
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, : req.fill_len
+                req.req_pool_idx, : req.extend_fill_len
             ]
 
             # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -353,7 +353,7 @@ class StreamingSession(BasePrefixCache):
             return False
         if chunked:
             kv_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, : req.fill_len
+                req.req_pool_idx, : req.extend_fill_len
             ]
             req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
             return True

--- a/test/manual/test_forward_split_prefill.py
+++ b/test/manual/test_forward_split_prefill.py
@@ -95,9 +95,9 @@ class TestForwardSplitPrefill(CustomTestCase):
                 origin_input_ids=array("q", input_ids[i]),
                 sampling_params=sampling_params,
             )
-            req.fill_len = req.get_full_untruncated_fill_len()
+            req.extend_fill_len = req.get_full_untruncated_fill_len()
             req.logprob_start_len = -1
-            req.set_extend_input_len(req.fill_len - len(req.prefix_indices))
+            req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
             reqs.append(req)
 
         # Create dummy tree_cache for tests (no prefix caching, just allocation)

--- a/test/registered/input_embedding/test_input_embeds_chunked.py
+++ b/test/registered/input_embedding/test_input_embeds_chunked.py
@@ -3,7 +3,7 @@
 Covers two bugs with the same crash signature
 (RuntimeError: shape mismatch in set_kv_buffer) but opposite polarity:
 
-- Chunked prefill truncation (#20376): PrefillAdder shrinks fill_len and
+- Chunked prefill truncation (#20376): PrefillAdder shrinks extend_fill_len and
   extend_input_len on chunk overflow but not input_embeds, so the full array
   flows through while out_cache_loc is sized for the truncated length.
   Polarity: cache_k > loc.

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -210,7 +210,7 @@ class TestHiSparseUnit(unittest.TestCase):
         self.req_to_token_pool.write((req.req_pool_idx, slice(0, len(kv_loc))), kv_loc)
         req.kv_allocated_len = fill_len
         req.kv_committed_len = fill_len
-        req.fill_len = fill_len
+        req.extend_fill_len = fill_len
         return kv_loc
 
     # ==================================================================

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -387,7 +387,7 @@ class TestPrefillAdder(CustomTestCase):
         req1.host_hit_length = 0
         req1.prefix_indices = []
         req1.get_full_untruncated_fill_len.return_value = 56
-        req1.fill_len = 56
+        req1.extend_fill_len = 56
         req1.last_node = MagicMock()
         req1.sampling_params.ignore_eos = False
 
@@ -422,7 +422,7 @@ class TestPrefillAdder(CustomTestCase):
         req2.host_hit_length = 0
         req2.prefix_indices = []
         req2.get_full_untruncated_fill_len.return_value = 56
-        req2.fill_len = 56
+        req2.extend_fill_len = 56
         req2.last_node = MagicMock()
         req2.sampling_params.ignore_eos = False
 
@@ -440,7 +440,7 @@ class TestPrefillAdder(CustomTestCase):
         req3.host_hit_length = 0
         req3.prefix_indices = []
         req3.get_full_untruncated_fill_len.return_value = 3
-        req3.fill_len = 3
+        req3.extend_fill_len = 3
         req3.last_node = MagicMock()
         req3.sampling_params.ignore_eos = False
 
@@ -477,7 +477,7 @@ class TestPrefillAdder(CustomTestCase):
         req.extend_input_len = extend_input_len
         req.prefix_indices = []
         req.get_full_untruncated_fill_len.return_value = extend_input_len
-        req.fill_len = extend_input_len
+        req.extend_fill_len = extend_input_len
         req.set_extend_input_len = MagicMock()
         return adder, req
 

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -32,7 +32,7 @@ def _make_req(
     req.dllm_config = None
     req.origin_input_ids = array("q", fill_ids)
     req.output_ids = array("q")
-    req.fill_len = fill_len
+    req.extend_fill_len = fill_len
     req.prefix_indices = prefix_indices
     req.req_pool_idx = req_pool_idx
     req.extend_input_len = extend_input_len

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -68,7 +68,7 @@ class MockReq:
 
     def __init__(self, fill_ids, req_pool_idx=0, cache_protected_len=0, last_node=None):
         self.full_untruncated_fill_ids = array("q", fill_ids)
-        self.fill_len = len(self.full_untruncated_fill_ids)
+        self.extend_fill_len = len(self.full_untruncated_fill_ids)
         self.origin_input_ids = array(
             "q", fill_ids[:-1] if len(fill_ids) > 1 else fill_ids
         )
@@ -84,7 +84,7 @@ class MockReq:
         self.kv_committed_freed = False
 
     def get_fill_ids(self):
-        return self.full_untruncated_fill_ids[: self.fill_len]
+        return self.full_untruncated_fill_ids[: self.extend_fill_len]
 
     def pop_committed_kv_cache(self):
         self.kv_committed_freed = True

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_bench.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_bench.py
@@ -637,7 +637,7 @@ def bench_cache_finished(
         req = env.make_req()
         req.origin_input_ids = array("q", seq)
         req.output_ids = array("q")
-        req.fill_len = req.get_full_untruncated_fill_len()
+        req.extend_fill_len = req.get_full_untruncated_fill_len()
         req.last_node = node
         req.cache_protected_len = matched_len
         req.kv_committed_len = len(seq)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -798,7 +798,7 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.fill_len = req.get_full_untruncated_fill_len()
+        req.extend_fill_len = req.get_full_untruncated_fill_len()
         if self.cfg.has_mamba:
             req.mamba_last_track_seqlen = kv_len
 
@@ -821,8 +821,8 @@ class UnifiedRadixCacheSuite:
         output_ids = self._make_seq(2000, 7)
         req.origin_input_ids = array("q", prompt_ids)
         req.output_ids = array("q", output_ids)
-        req.fill_len = req.get_full_untruncated_fill_len()
-        kv_len = req.fill_len
+        req.extend_fill_len = req.get_full_untruncated_fill_len()
+        kv_len = req.extend_fill_len
         kv_indices = self._alloc(allocator, kv_len)
         req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
         req.kv_committed_len = kv_len
@@ -875,7 +875,7 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.fill_len = req.get_full_untruncated_fill_len()
+        req.extend_fill_len = req.get_full_untruncated_fill_len()
 
         avail_before = allocator.available_size()
         tree.cache_finished_req(req, is_insert=False)
@@ -892,7 +892,7 @@ class UnifiedRadixCacheSuite:
         tokens = self._make_seq(1, 3)
         req.origin_input_ids = array("q", tokens)
         req.output_ids = array("q")
-        req.fill_len = req.get_full_untruncated_fill_len()
+        req.extend_fill_len = req.get_full_untruncated_fill_len()
         kv_len = len(tokens)
         kv_indices = self._alloc(allocator, kv_len)
         req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
@@ -1026,7 +1026,7 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.fill_len = req.get_full_untruncated_fill_len()
+        req.extend_fill_len = req.get_full_untruncated_fill_len()
         if self.cfg.has_mamba:
             req.mamba_last_track_seqlen = kv_len
 


### PR DESCRIPTION
Stacked on #27571.

## Motivation

`Req.fill_len` is an extend-phase quantity. At every assignment it equals `len(prefix_indices) + extend_input_len` — the total committed fill length for the current extend pass — and it is exactly what `prepare_for_extend` turns into the batch `seq_lens`. The decode loop neither updates nor reads it (and, after #27571, `prepare_for_decode` invalidates it to `None`).

The bare name `fill_len` does not convey this extend-only lifecycle, which is precisely the source of the misuse #27571 guards against. This PR renames the field to `extend_fill_len` so the extend-phase semantics are explicit at every call site, and a decode-time reference reads as obviously suspect.

The `extend_` prefix mirrors the sibling `extend_input_len`. Note the two are **not** the same kind of quantity — `extend_input_len` is the increment beyond the cached prefix, while `extend_fill_len = len(prefix_indices) + extend_input_len` is the absolute end position — but they belong to the same extend pass, and the shared prefix keeps the related fields grouped. The "fill" stem is kept to stay consistent with the existing `get_fill_ids()` / `get_full_untruncated_fill_ids()` family.

## Modifications

Pure mechanical rename of the `Req.fill_len` attribute to `Req.extend_fill_len`. No behavior change.

- Field declaration, both reset-to-`None` sites, and all reads/writes across scheduler, schedule policy, disaggregation, mem_cache backends, hisparse, PP, session, and bench.
- The migration sanity-assert message text (`"... migrating fill_len to kv_committed_len ..."`) and field-referencing comments/docstrings updated to the new name.
- One local variable that mirrors the field (`_compute_chunked_req_next_prompt_token`) renamed for readability.
- Test mocks/fixtures that supply the field updated to `extend_fill_len` (`MagicMock(spec=Req)` in `test_prefill_adder.py`, the `Req.__new__` fixture in `test_scheduler_chunked_req_gate.py`, the standalone `MockReq` in `test_decode_radix_lock_ref.py`, hisparse and unified-radix-cache tests).

Deliberately **not** renamed: unrelated local variables/parameters also named `fill_len` whose semantics differ from the field — the disagg decode allocator (`_required_alloc_tokens(*, fill_len, ...)` and its callers) and the SWA host-pool fill length (`swa_component.py`). `prefill_len` and the `get_full_untruncated_fill_len()` / `get_full_untruncated_fill_ids()` methods are untouched.

## Verification

- `grep -rn "\.fill_len\b"` over `python/` and `test/` returns nothing — no old-name attribute reference survives.
- The rename was applied only to attribute accesses (`\.fill_len\b`), so substrings like `prefill_len` and `get_full_untruncated_fill_len` cannot be corrupted.
- `py_compile` passes on all changed files; pre-commit (black/isort/ruff) is clean.
- Independent self-review confirmed completeness, no collateral damage, and mock/fixture consistency (production now reads `req.extend_fill_len`; every supplying mock provides it).

## Accuracy Tests

N/A (pure rename, no behavioral change).

## Benchmarking and Profiling

N/A.

## Checklist

- [x] Pre-commit passed.





























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27244996890](https://github.com/sgl-project/sglang/actions/runs/27244996890)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27244996837](https://github.com/sgl-project/sglang/actions/runs/27244996837)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->