### PR TITLE
[AMD] Pin VLM encoder-DP nightly to InternVL2_5-8B on ROCm

### DIFF
--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from types import SimpleNamespace
 
+from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.mmmu_vlm_kit import MMMUMultiModelTestBase
 from sglang.test.test_utils import is_in_ci
@@ -16,6 +17,13 @@ MODELS = [
     SimpleNamespace(model="OpenGVLab/InternVL2_5-8B", mmmu_accuracy=0.52),
     SimpleNamespace(model="zai-org/GLM-4.1V-9B-Thinking", mmmu_accuracy=0.68),
 ]
+
+# On ROCm the Qwen2.5-VL / Qwen3-VL / GLM-4.1V models hit a GPU "write access to
+# a read-only page" memory fault during warmup in the rope_2d DP vision-encoder
+# gather path, so the server is killed (-9) before it becomes ready. Only
+# InternVL2_5-8B (which uses the separate DP-sharded vision path) runs reliably
+# there, so pin to it instead of a random pick to keep the nightly deterministic.
+AMD_PASSING_MODEL = "OpenGVLab/InternVL2_5-8B"
 
 
 class TestVLMEncoderDP(MMMUMultiModelTestBase):
@@ -31,7 +39,14 @@ class TestVLMEncoderDP(MMMUMultiModelTestBase):
         models_to_test = MODELS
 
         if is_in_ci():
-            models_to_test = [random.choice(MODELS)]
+            if is_hip():
+                # Deterministically use the only model that passes on ROCm
+                # rather than a random pick (avoids the DP-encoder memory fault).
+                models_to_test = [
+                    next(m for m in MODELS if m.model == AMD_PASSING_MODEL)
+                ]
+            else:
+                models_to_test = [random.choice(MODELS)]
 
         for model in models_to_test:
             # Per-model temp dir avoids cross-test cached results.


### PR DESCRIPTION
## Summary

`test/registered/vlm/test_encoder_dp.py` randomly picks one of four VLMs per CI run (`random.choice(MODELS)`). On ROCm (MI325, `nightly-4-gpu`) three of the four models **deterministically crash during server warmup**, so the nightly flaps green/red purely based on which model is drawn.

This pins the **ROCm** run to the only model that reliably passes — `OpenGVLab/InternVL2_5-8B` — instead of a random pick. **CUDA behavior is unchanged** (still rotates randomly across all four).

## Root cause

For `Qwen/Qwen2.5-VL-72B-Instruct`, `Qwen/Qwen3-VL-32B-Instruct`, and `zai-org/GLM-4.1V-9B-Thinking`, the server starts, captures CUDA graphs, prints `Uvicorn running`, and then the first multimodal forward (warmup) hits:

```
Memory access fault by GPU node-2 ... Reason: Write access to a read-only page.
```

The scheduler dies, `/health_generate` returns 503, the warmup request times out after 600s, and the process is killed (`Server process exited with code -9`). All three failing models go through the `--mm-enable-dp-encoder` mrope vision path (`run_dp_sharded_mrope_vision_model`); `InternVL2_5-8B` uses the separate `run_dp_sharded_vision_model` path and is unaffected. The crash is ROCm-only (HSA "read-only page" fault), so the fix is scoped with `is_hip()`. This is a latent bug from the encoder-DP feature (#13126), exposed on AMD CI by #20294; it is **not** the LM or KV cache.

## History — AMD `nightly-4-gpu` (model selected vs. result)

| Date | Run (nightly-4-gpu) | Model selected | Result |
|---|---|---|---|
| Jun 7 | [80040799521](https://github.com/sgl-project/sglang/actions/runs/27100228380/job/80040799521) | Qwen2.5-VL-72B | ❌ fault → -9 |
| Jun 6 | [79896282822](https://github.com/sgl-project/sglang/actions/runs/27069575829/job/79896282822) | InternVL2_5-8B | ✅ pass (acc 0.5267) |
| Jun 5 | [79785978573](https://github.com/sgl-project/sglang/actions/runs/27031869358/job/79785978573) | InternVL2_5-8B | ✅ pass |
| Jun 4 | [79585286680](https://github.com/sgl-project/sglang/actions/runs/26970821370/job/79585286680) | Qwen3-VL-32B (1st, clean GPU) | ❌ fault → -9 |
| Jun 3 | [79370094025](https://github.com/sgl-project/sglang/actions/runs/26905752888/job/79370094025) | Qwen2.5-VL-72B | ❌ fault → -9 |
| May 31 | [78745072458](https://github.com/sgl-project/sglang/actions/runs/26719940447/job/78745072458) | 72B fault → InternVL2_5-8B | ✅ pass (via retry) |
| May 30 | [78666659505](https://github.com/sgl-project/sglang/actions/runs/26690774939/job/78666659505) | Qwen2.5-VL-72B | ❌ fault → -9 |
| May 29 | [78561429947](https://github.com/sgl-project/sglang/actions/runs/26654604433/job/78561429947) | InternVL2_5-8B | ✅ pass |
| May 27 | [78144240451](https://github.com/sgl-project/sglang/actions/runs/26530117755/job/78144240451) | GLM-4.1V-9B (1st, clean GPU) | ❌ fault → -9 |
| May 26 | [77928967706](https://github.com/sgl-project/sglang/actions/runs/26466739564/job/77928967706) | 72B fault → InternVL2_5-8B | ✅ pass (via retry) |
| May 25 | [77753167043](https://github.com/sgl-project/sglang/actions/runs/26413604860/job/77753167043) | GLM-4.1V-9B | ❌ fault → -9 |
| May 24 | [77616144738](https://github.com/sgl-project/sglang/actions/runs/26368427819/job/77616144738) | Qwen2.5-VL-72B + GLM-4.1V | ❌ fault → -9 |

Per-model tally (whenever the model actually ran on MI325):

| Model | pass / fault |
|---|---|
| `OpenGVLab/InternVL2_5-8B` | ✅ 5 / 0 |
| `Qwen/Qwen2.5-VL-72B-Instruct` | ❌ 0 / 6 |
| `Qwen/Qwen3-VL-32B-Instruct` | ❌ 0 / 1 |
| `zai-org/GLM-4.1V-9B-Thinking` | ❌ 0 / 3 |

(Qwen3-VL-32B on Jun 4 and GLM-4.1V-9B on May 27 each faulted as the **first** attempt on a freshly-cleared GPU, ruling out GPU poisoning from a prior attempt.)

## Verified

Dispatched the `nightly-4-gpu` job (`nightly-test-amd.yml` `workflow_dispatch`) against this change rebased on latest `main`:

[**Run 27150305490**](https://github.com/sgl-project/sglang/actions/runs/27150305490/job/80139242557) → **success**

```
Testing model: OpenGVLab/InternVL2_5-8B
Model OpenGVLab/InternVL2_5-8B achieved accuracy: 0.5311
Test Summary: 1/1 passed
PASSED: test/registered/vlm/test_encoder_dp.py (elapsed 370s)
```

No `Memory access fault` in the run.

## Notes

- This stabilizes the nightly; the underlying ROCm DP-encoder memory fault for the Qwen-VL / GLM-4.1V family is a separate bug that should be tracked and fixed, after which these models can be re-enabled on ROCm.

## Test plan

- [x] AMD `nightly-4-gpu` runs `test_vlm_mmmu_benchmark` against `InternVL2_5-8B` and passes deterministically ([run 27150305490](https://github.com/sgl-project/sglang/actions/runs/27150305490/job/80139242557)).
- [x] CUDA `nightly-4-gpu` selection is unchanged (random across all four models).