### PR TITLE
Avoid scattered assignment of Req.extend_input_len and extend_fill_len and consolidate them into Req.extend_range

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -371,9 +371,8 @@ def prepare_inputs_for_correctness_test(bench_args, tokenizer, custom_prompts):
             origin_input_ids=array("q", tmp_input_ids),
             sampling_params=sampling_params,
         )
-        req.extend_fill_len = len(req.origin_input_ids)
         req.logprob_start_len = -1
-        req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
+        req.set_extend_range(len(req.prefix_indices), len(req.origin_input_ids))
         reqs.append(req)
 
     return input_ids, reqs
@@ -387,14 +386,13 @@ def prepare_extend_inputs_for_correctness_test(
         req.origin_input_ids = req.origin_input_ids + array(
             "q", input_ids[i][bench_args.cut_len :]
         )
-        req.extend_fill_len = len(req.origin_input_ids)
         if model_runner is not None:
             # Use req.req_pool_idx instead of i to handle slot 0 padding correctly
             req.prefix_indices = model_runner.req_to_token_pool.req_to_token[
                 req.req_pool_idx, : bench_args.cut_len
             ].to(req.prefix_indices.dtype)
             req.logprob_start_len = -1
-            req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
+        req.set_extend_range(len(req.prefix_indices), len(req.origin_input_ids))
     return reqs
 
 
@@ -419,9 +417,8 @@ def prepare_synthetic_inputs_for_latency_test(
             origin_input_ids=array("q", input_ids[i]),
             sampling_params=sampling_params,
         )
-        req.extend_fill_len = len(req.origin_input_ids)
         req.logprob_start_len = -1
-        req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
+        req.set_extend_range(len(req.prefix_indices), len(req.origin_input_ids))
         reqs.append(req)
 
     return reqs

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1857,9 +1857,7 @@ class SchedulerDisaggregationDecodeMixin:
                 # only sees committed KV (full array includes one uncommitted
                 # token because init_next_round_input rebuilt it as full).
                 if req.kv_committed_len is not None:
-                    req.set_extend_range(
-                        len(req.prefix_indices), req.kv_committed_len
-                    )
+                    req.set_extend_range(len(req.prefix_indices), req.kv_committed_len)
             else:
                 waiting_queue.append(req)
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1386,10 +1386,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_loc,
         )
 
-        # Truncate extend_fill_len to kv_committed_len so cache_unfinished_req only
-        # inserts committed KV into the radix tree. The last output token
-        # hasn't had KV committed yet (output_ids is 1 ahead).
-        req.extend_fill_len = req.kv_committed_len
         # Set prefix_indices so downstream consumers (init_next_round_input,
         # prepare_for_extend) see the correct prefix length. In the agg path
         # this is done inside init_next_round_input, but decode-disagg needs
@@ -1397,7 +1393,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         req.prefix_indices = (
             prefix_indices if prefix_len > 0 else torch.empty((0,), dtype=torch.int64)
         )
-        req.set_extend_input_len(req.extend_fill_len - total_prefix_len)
+        # Truncate the extend end to kv_committed_len so cache_unfinished_req only
+        # inserts committed KV into the radix tree (output_ids is 1 ahead, so the
+        # last output token has no committed KV yet). The extend start is the full
+        # committed prefix (L1+L2+L3) total_prefix_len, NOT len(prefix_indices):
+        # the [prefix_len, total_prefix_len) host/storage portion is loaded back
+        # later, so the freshly-ingested span is [total_prefix_len, kv_committed_len).
+        req.set_extend_range(total_prefix_len, req.kv_committed_len)
 
         # Return the transfer destination indices:
         if self.scheduler.enable_hisparse:
@@ -1851,13 +1853,12 @@ class SchedulerDisaggregationDecodeMixin:
                 else:
                     tree_cache = self.tree_cache
                 req.init_next_round_input(tree_cache)
-                # Truncate extend_fill_len to kv_committed_len so cache_unfinished_req
+                # Truncate the extend end to kv_committed_len so cache_unfinished_req
                 # only sees committed KV (full array includes one uncommitted
                 # token because init_next_round_input rebuilt it as full).
                 if req.kv_committed_len is not None:
-                    req.extend_fill_len = req.kv_committed_len
-                    req.set_extend_input_len(
-                        req.extend_fill_len - len(req.prefix_indices)
+                    req.set_extend_range(
+                        len(req.prefix_indices), req.kv_committed_len
                     )
             else:
                 waiting_queue.append(req)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1055,7 +1055,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
     @property
     def num_tokens_pre_allocated(self):
         return sum(
-            decode_req.req.extend_fill_len for decode_req in self.transfer_queue.queue
+            decode_req.req.extend_range.end for decode_req in self.transfer_queue.queue
         )
 
     def _need_space_for_single_req(
@@ -1393,12 +1393,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         req.prefix_indices = (
             prefix_indices if prefix_len > 0 else torch.empty((0,), dtype=torch.int64)
         )
-        # Truncate the extend end to kv_committed_len so cache_unfinished_req only
-        # inserts committed KV into the radix tree (output_ids is 1 ahead, so the
-        # last output token has no committed KV yet). The extend start is the full
-        # committed prefix (L1+L2+L3) total_prefix_len, NOT len(prefix_indices):
-        # the [prefix_len, total_prefix_len) host/storage portion is loaded back
-        # later, so the freshly-ingested span is [total_prefix_len, kv_committed_len).
         req.set_extend_range(total_prefix_len, req.kv_committed_len)
 
         # Return the transfer destination indices:
@@ -1853,9 +1847,6 @@ class SchedulerDisaggregationDecodeMixin:
                 else:
                     tree_cache = self.tree_cache
                 req.init_next_round_input(tree_cache)
-                # Truncate the extend end to kv_committed_len so cache_unfinished_req
-                # only sees committed KV (full array includes one uncommitted
-                # token because init_next_round_input rebuilt it as full).
                 if req.kv_committed_len is not None:
                     req.set_extend_range(len(req.prefix_indices), req.kv_committed_len)
             else:

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -36,7 +36,7 @@ class ScheduleBatchDisaggregationDecodeMixin:
         req_pool_indices = []
 
         # Pre-calculate total size
-        total_size = sum(req.extend_input_len for req in reqs)
+        total_size = sum(req.extend_range.length for req in reqs)
         out_cache_loc = torch.empty(total_size, dtype=torch.int64, device=self.device)
 
         # Fill the tensor in one pass
@@ -46,20 +46,20 @@ class ScheduleBatchDisaggregationDecodeMixin:
             pre_len = len(req.prefix_indices)
 
             chunk = self.req_to_token_pool.req_to_token[req.req_pool_idx][
-                pre_len : pre_len + req.extend_input_len
+                pre_len : pre_len + req.extend_range.length
             ]
             assert (
-                offset + req.extend_input_len <= total_size
-            ), f"Exceeds total size: offset={offset}, req.extend_input_len={req.extend_input_len}, total_size={total_size}"
-            out_cache_loc[offset : offset + req.extend_input_len] = chunk
-            offset += req.extend_input_len
+                offset + req.extend_range.length <= total_size
+            ), f"Exceeds total size: offset={offset}, req.extend_range.length={req.extend_range.length}, total_size={total_size}"
+            out_cache_loc[offset : offset + req.extend_range.length] = chunk
+            offset += req.extend_range.length
 
             seq_len = len(req.origin_input_ids) + max(0, len(req.output_ids) - 1)
             seq_lens.append(seq_len)
             if len(req.output_ids) == 0:
                 assert (
-                    seq_len - pre_len == req.extend_input_len
-                ), f"seq_len={seq_len}, pre_len={pre_len}, req.extend_input_len={req.extend_input_len}"
+                    seq_len - pre_len == req.extend_range.length
+                ), f"seq_len={seq_len}, pre_len={pre_len}, req.extend_range.length={req.extend_range.length}"
 
             if not req.retracted_stain:
                 # Clamp to avoid double-counting: already_computed is seeded from
@@ -98,7 +98,7 @@ class ScheduleBatchDisaggregationDecodeMixin:
 
         self.extend_num_tokens = extend_num_tokens
         self.prefix_lens = [len(r.prefix_indices) for r in reqs]
-        self.extend_lens = [r.extend_input_len for r in reqs]
+        self.extend_lens = [r.extend_range.length for r in reqs]
         self.extend_logprob_start_lens = [r.extend_logprob_start_len for r in reqs]
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
         self.multimodal_inputs = [r.multimodal_inputs for r in reqs]

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -882,7 +882,7 @@ class SchedulerDisaggregationPrefillMixin:
             elif self.enable_overlap:
                 # Delay KV transfer to process_batch_result_disagg_prefill when overlap is enabled to ensure results are resolved
                 self.chunked_req.tmp_end_idx = min(
-                    self.chunked_req.extend_fill_len,
+                    self.chunked_req.extend_range.end,
                     len(self.chunked_req.origin_input_ids),
                 )
             else:
@@ -918,7 +918,7 @@ class SchedulerDisaggregationPrefillMixin:
         end_idx = (
             end_idx
             if end_idx is not None
-            else min(req.extend_fill_len, len(req.origin_input_ids))
+            else min(req.extend_range.end, len(req.origin_input_ids))
         )
 
         if not last_chunk:
@@ -949,7 +949,7 @@ class SchedulerDisaggregationPrefillMixin:
             # length here avoids emitting an extra state page when the sampled
             # token crosses a page boundary, which mismatched src/dst lengths in
             # group_concurrent_contiguous.
-            seq_len = min(req.extend_fill_len, len(req.origin_input_ids))
+            seq_len = min(req.extend_range.end, len(req.origin_input_ids))
 
             def _mamba_payload():
                 return [

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -58,10 +58,10 @@ class ReqDllmMixin:
     def _init_fill_ids_for_dllm(self: Req):
         self.dllm_block_offset = (
             0
-            if self.extend_fill_len is None
+            if not self.dllm_initialized
             else self.dllm_block_offset + self.dllm_config.block_size
         )
-        self.extend_fill_len = self.get_full_untruncated_fill_len()
+        self.dllm_initialized = True
 
     def _update_block_offset_for_dllm(self):
         prefix_len = len(self.prefix_indices)

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -207,7 +207,7 @@ class HiSparseCoordinator:
         req.hisparse_staging = True
 
         full_kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, : req.extend_fill_len
+            req.req_pool_idx, : req.extend_range.end
         ].to(dtype=torch.int64, copy=True)
         device_indices = (
             self.mem_pool_device.translate_loc_from_full_to_hisparse_device(
@@ -298,7 +298,7 @@ class HiSparseCoordinator:
 
     def alloc_device_buffer(self, req: Req) -> None:
         if self.is_dsv4_hisparse:
-            allocated_len = req.extend_fill_len
+            allocated_len = req.extend_range.end
             alloc_size = self.padded_buffer_size
         else:
             allocated_len = req.kv_allocated_len
@@ -707,7 +707,7 @@ class HiSparseCoordinator:
         # Wait for any in-flight staging DMA to complete before freeing
         self.write_staging_stream.synchronize()
 
-        prefill_len = req.extend_fill_len
+        prefill_len = req.extend_range.end
         allocated_locs = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, :prefill_len
         ]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils.common import (
+    Range,
     ceil_align,
     flatten_arrays_to_pinned_cpu,
     is_pin_memory_available,
@@ -640,27 +641,6 @@ class ReqLogprob:
     output_token_ids_logprobs_idx: Optional[list] = None
 
 
-class ExtendRange(NamedTuple):
-    """The half-open token range ``[start, end)`` filled by one extend pass.
-
-    ``start`` is the absolute boundary (index into ``full_untruncated_fill_ids``)
-    of the already-committed prefix that this extend does NOT reprocess; ``end``
-    is the absolute fill end. ``length`` (the number of tokens processed this
-    extend) is derived, never stored, so it can never drift from its anchor.
-
-    ``start`` is NOT always ``len(prefix_indices)``: in disagg decode it is the
-    full (L1+L2+L3) ``total_prefix_len`` whose host/storage portion is loaded
-    back later, and in a mixed batch's running reqs it is the decoded length.
-    """
-
-    start: int
-    end: int
-
-    @property
-    def length(self) -> int:
-        return self.end - self.start
-
-
 class Req(ReqDllmMixin):
     """The input and output status of a request."""
 
@@ -717,10 +697,7 @@ class Req(ReqDllmMixin):
         )  # Before image padding
         # Each decode stage's output ids
         self.output_ids = array("q")
-        # The token range [start, end) filled by the current extend pass. None
-        # outside an extend (e.g. during decode) — an invalid-state sentinel.
-        self.extend_range: Optional[ExtendRange] = None
-        # Whether _init_fill_ids_for_dllm has run at least once (dllm only).
+        self.extend_range: Optional[Range] = None
         self.dllm_initialized: bool = False
 
         self.session = session
@@ -1100,27 +1077,12 @@ class Req(ReqDllmMixin):
             length += self.dllm_config.block_size
         return length
 
-    @property
-    def extend_fill_len(self) -> Optional[int]:
-        # Absolute fill end of the current extend pass; None outside an extend.
-        return self.extend_range.end if self.extend_range is not None else None
-
-    @property
-    def extend_input_len(self) -> int:
-        # Number of tokens processed by the current extend pass; 0 outside one.
-        return self.extend_range.length if self.extend_range is not None else 0
-
     def set_extend_range(self, start: int, end: int) -> None:
-        self.extend_range = ExtendRange(start, end)
+        self.extend_range = Range(start, end)
         self._recompute_extend_logprob_start_len()
 
-    def get_uncommitted_extend_len(self) -> int:
-        # The untruncated extend length a not-yet-admitted req wants to run,
-        # relative to its currently materialized device prefix.
-        return self.get_full_untruncated_fill_len() - len(self.prefix_indices)
-
     def get_fill_ids(self) -> array:
-        return self.get_full_untruncated_fill_ids()[: self.extend_fill_len]
+        return self.get_full_untruncated_fill_ids()[: self.extend_range.end]
 
     def init_next_round_input(
         self,
@@ -1212,10 +1174,6 @@ class Req(ReqDllmMixin):
                     self.multimodal_inputs.mrope_positions, len(self.output_ids)
                 )
             )
-
-        # The committed extend range is set later by the PrefillAdder (or the
-        # disagg/mixed paths). Until then get_uncommitted_extend_len() serves
-        # the not-yet-truncated candidate length.
 
     def _compute_max_prefix_len(self, input_len: int) -> int:
         # NOTE: the matched length is at most 1 less than the input length to enable logprob computation
@@ -1487,7 +1445,7 @@ class Req(ReqDllmMixin):
             logprob_start_len = max(self.logprob_start_len, len(self.prefix_indices))
         self.extend_logprob_start_len = min(
             logprob_start_len - len(self.prefix_indices),
-            self.extend_input_len,
+            self.extend_range.length,
         )
 
     def set_finish_with_abort(self, error_msg: str):
@@ -1605,7 +1563,7 @@ def _compute_chunked_req_next_prompt_token(
 ) -> Optional[int]:
     if chunked_req is None:
         return None
-    extend_fill_len = chunked_req.extend_fill_len
+    extend_fill_len = chunked_req.extend_range.end
     if extend_fill_len >= len(chunked_req.origin_input_ids):
         return None
     return int(chunked_req.origin_input_ids[extend_fill_len])
@@ -1862,17 +1820,17 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 input_ids[i] = input_ids[i][encoder_len:]
                 encoder_out_cache_loc.append(self.out_cache_loc[pt : pt + encoder_len])
                 decoder_out_cache_loc.append(
-                    self.out_cache_loc[pt + encoder_len : pt + req.extend_input_len]
+                    self.out_cache_loc[pt + encoder_len : pt + req.extend_range.length]
                 )
                 self.extend_lens[i] -= encoder_len
                 self.extend_num_tokens -= encoder_len
             else:
                 decoder_out_cache_loc.append(
-                    self.out_cache_loc[pt : pt + req.extend_input_len]
+                    self.out_cache_loc[pt : pt + req.extend_range.length]
                 )
                 self.prefix_lens[i] -= encoder_len
 
-            pt += req.extend_input_len
+            pt += req.extend_range.length
 
         # Reassign: ED stripping rebuilds prefill_input_ids_cpu (CPU pinned);
         # resolve_forward_inputs will H2D this on forward stream. self.input_ids
@@ -1907,7 +1865,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             for i, req in enumerate(self.reqs):
                 encoder_len = self.encoder_lens_cpu[i]
                 old_start_len = self.extend_logprob_start_lens[i]
-                old_contribution = req.extend_input_len - old_start_len
+                old_contribution = req.extend_range.length - old_start_len
 
                 if len(req.prefix_indices) < encoder_len:
                     tokens_to_strip = max(0, encoder_len - old_start_len)
@@ -1938,11 +1896,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             if encoder_len == 0:
                 continue
             if len(req.prefix_indices) < encoder_len:
-                # The encoder span is processed as a whole, so an uncached
-                # encoder implies an empty device prefix.
                 assert len(req.prefix_indices) == 0
-                # Advance the extend start past the encoder tokens (which the
-                # encoder path handles), shrinking the decoder extend length.
                 req.extend_range = req.extend_range._replace(
                     start=req.extend_range.start + encoder_len
                 )
@@ -1962,10 +1916,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         reqs = self.reqs
         input_ids = [r.get_fill_ids()[len(r.prefix_indices) :] for r in reqs]
         extend_num_tokens = sum(len(ids) for ids in input_ids)
-        seq_lens = [r.extend_fill_len for r in reqs]
-        orig_seq_lens = [max(r.extend_fill_len, len(r.origin_input_ids)) for r in reqs]
+        seq_lens = [r.extend_range.end for r in reqs]
+        orig_seq_lens = [max(r.extend_range.end, len(r.origin_input_ids)) for r in reqs]
         prefix_lens = [len(r.prefix_indices) for r in reqs]
-        extend_lens = [r.extend_input_len for r in reqs]
+        extend_lens = [r.extend_range.length for r in reqs]
 
         _pin = is_pin_memory_available(self.device)
         # Stay on pinned CPU; H2D is deferred to forward stream via
@@ -2005,7 +1959,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         mamba_track_seqlens_cpu = []
 
         for i, (req, seq_len, pre_len) in enumerate(zip(reqs, seq_lens, prefix_lens)):
-            assert seq_len - pre_len == req.extend_input_len
+            assert seq_len - pre_len == req.extend_range.length
 
             req.extend_batch_idx += 1
 
@@ -2018,7 +1972,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # Slice to match extend_input_len — PrefillAdder truncates
                 # extend_fill_len/extend_input_len on chunk overflow but not input_embeds.
                 input_embeds.extend(
-                    req.input_embeds[pre_len : pre_len + req.extend_input_len]
+                    req.input_embeds[pre_len : pre_len + req.extend_range.length]
                 )
 
             if req.positional_embed_overrides is not None:
@@ -2030,7 +1984,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     req.positional_embed_overrides.positions
                 ):
                     extend_pos = pos - pre_len
-                    if extend_pos < 0 or extend_pos >= req.extend_input_len:
+                    if extend_pos < 0 or extend_pos >= req.extend_range.length:
                         continue  # Outside current extend chunk, skip
                     embeds_to_add.append((embed_idx, input_id_pointer + extend_pos))
                 if embeds_to_add:
@@ -2099,7 +2053,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # extend_input_logprob_token_id = [4, 0]
                 global_start_idx, global_end_idx = (
                     len(req.prefix_indices),
-                    req.extend_fill_len,
+                    req.extend_range.end,
                 )
                 if req.logprob_start_len == -1:
                     logprob_start_len = len(req.origin_input_ids)
@@ -2119,7 +2073,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 extend_input_logprob_token_ids.extend(
                     [0]
                     * (
-                        req.extend_input_len
+                        req.extend_range.length
                         - req.extend_logprob_start_len
                         - len(logprob_token_ids)
                     )
@@ -2229,7 +2183,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # to force the math calculation to retrieve the correct mamba state from h.
             return i + 1
 
-        mask = req.extend_input_len >= mamba_cache_chunk_size
+        mask = req.extend_range.length >= mamba_cache_chunk_size
         track_index = req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx].item()
         mamba_track_seqlen = -1
         if mask:
@@ -2240,13 +2194,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # otherwise retrieved from h (i.e. unaligned).
             # We need to pass the non-aligned seqlen to the calculation. Even though
             # we pass in mamba_track_seqlen, the actual tracked seqlen is mamba_last_track_seqlen.
-            mamba_track_seqlen = len(req.prefix_indices) + req.extend_input_len
+            mamba_track_seqlen = len(req.prefix_indices) + req.extend_range.length
 
             # mamba_track_seqlen_aligned/mamba_last_track_seqlen is actual tracked seqlen. Used to pass to
             # mamba radix cache to track which seqlen this mamba state should store at.
             mamba_track_seqlen_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_input_len // mamba_cache_chunk_size)
+                + (req.extend_range.length // mamba_cache_chunk_size)
                 * mamba_cache_chunk_size
             )
 
@@ -2256,7 +2210,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # by _force_track_h()
             mamba_track_fla_chunk_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_input_len // mamba_cache_chunk_size)
+                + (req.extend_range.length // mamba_cache_chunk_size)
                 * mamba_cache_chunk_size
             )
             if mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned:
@@ -2329,8 +2283,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         running_bs = running_batch.batch_size()
 
         for req in running_batch.reqs:
-            # A mixed-in running req contributes a single decode token, so its
-            # extend start is the full sequence minus that one token.
             full_len = req.get_full_untruncated_fill_len()
             req.set_extend_range(full_len - 1, full_len)
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -640,6 +640,27 @@ class ReqLogprob:
     output_token_ids_logprobs_idx: Optional[list] = None
 
 
+class ExtendRange(NamedTuple):
+    """The half-open token range ``[start, end)`` filled by one extend pass.
+
+    ``start`` is the absolute boundary (index into ``full_untruncated_fill_ids``)
+    of the already-committed prefix that this extend does NOT reprocess; ``end``
+    is the absolute fill end. ``length`` (the number of tokens processed this
+    extend) is derived, never stored, so it can never drift from its anchor.
+
+    ``start`` is NOT always ``len(prefix_indices)``: in disagg decode it is the
+    full (L1+L2+L3) ``total_prefix_len`` whose host/storage portion is loaded
+    back later, and in a mixed batch's running reqs it is the decoded length.
+    """
+
+    start: int
+    end: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+
 class Req(ReqDllmMixin):
     """The input and output status of a request."""
 
@@ -696,7 +717,11 @@ class Req(ReqDllmMixin):
         )  # Before image padding
         # Each decode stage's output ids
         self.output_ids = array("q")
-        self.extend_fill_len: Optional[int] = None
+        # The token range [start, end) filled by the current extend pass. None
+        # outside an extend (e.g. during decode) — an invalid-state sentinel.
+        self.extend_range: Optional[ExtendRange] = None
+        # Whether _init_fill_ids_for_dllm has run at least once (dllm only).
+        self.dllm_initialized: bool = False
 
         self.session = session
         self.input_embeds = input_embeds
@@ -807,8 +832,6 @@ class Req(ReqDllmMixin):
         # Prefix info
         # The indices to kv cache for the shared prefix.
         self.prefix_indices: torch.Tensor = torch.empty((0,), dtype=torch.int64)
-        # Number of tokens to run prefill.
-        self.extend_input_len = 0
         # The relative logprob_start_len in an extend batch
         self.extend_logprob_start_len = 0
         # TODO(ispobock): rename to last_device_node
@@ -1077,6 +1100,25 @@ class Req(ReqDllmMixin):
             length += self.dllm_config.block_size
         return length
 
+    @property
+    def extend_fill_len(self) -> Optional[int]:
+        # Absolute fill end of the current extend pass; None outside an extend.
+        return self.extend_range.end if self.extend_range is not None else None
+
+    @property
+    def extend_input_len(self) -> int:
+        # Number of tokens processed by the current extend pass; 0 outside one.
+        return self.extend_range.length if self.extend_range is not None else 0
+
+    def set_extend_range(self, start: int, end: int) -> None:
+        self.extend_range = ExtendRange(start, end)
+        self._recompute_extend_logprob_start_len()
+
+    def get_uncommitted_extend_len(self) -> int:
+        # The untruncated extend length a not-yet-admitted req wants to run,
+        # relative to its currently materialized device prefix.
+        return self.get_full_untruncated_fill_len() - len(self.prefix_indices)
+
     def get_fill_ids(self) -> array:
         return self.get_full_untruncated_fill_ids()[: self.extend_fill_len]
 
@@ -1171,7 +1213,9 @@ class Req(ReqDllmMixin):
                 )
             )
 
-        self.set_extend_input_len(input_len - len(self.prefix_indices))
+        # The committed extend range is set later by the PrefillAdder (or the
+        # disagg/mixed paths). Until then get_uncommitted_extend_len() serves
+        # the not-yet-truncated candidate length.
 
     def _compute_max_prefix_len(self, input_len: int) -> int:
         # NOTE: the matched length is at most 1 less than the input length to enable logprob computation
@@ -1356,7 +1400,8 @@ class Req(ReqDllmMixin):
         self.num_matched_prefix_tokens = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False
-        self.extend_input_len = 0
+        self.extend_range = None
+        self.dllm_initialized = False
         self.is_retracted = True
         self.retracted_stain = True
         self.input_token_logprobs = None
@@ -1379,7 +1424,6 @@ class Req(ReqDllmMixin):
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
-        self.extend_fill_len = None
 
         # When using input_embeds, we cannot easily mix the original input embeddings
         # with the newly generated output token IDs during re-prefill of retracted request.
@@ -1429,14 +1473,13 @@ class Req(ReqDllmMixin):
         logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
         self.has_log_time_stats = True
 
-    def set_extend_input_len(self, extend_input_len: int):
-        # Setting extend_input_len and computing the relative logprob_start_len in an extend batch
+    def _recompute_extend_logprob_start_len(self):
+        # Recompute the relative logprob start within the current extend batch.
         #
         # Key variables:
         # - logprob_start_len: Absolute position in full sequence where logprob computation begins
         # - extend_logprob_start_len: Relative position within current extend batch where logprob computation begins
         # - extend_input_len: Number of tokens that need to be processed in this extend batch
-        self.extend_input_len = extend_input_len
         if self.logprob_start_len == -1:
             logprob_start_len = self.get_full_untruncated_fill_len()
         else:
@@ -1895,7 +1938,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             if encoder_len == 0:
                 continue
             if len(req.prefix_indices) < encoder_len:
-                req.extend_input_len -= encoder_len
+                # The encoder span is processed as a whole, so an uncached
+                # encoder implies an empty device prefix.
+                assert len(req.prefix_indices) == 0
+                # Advance the extend start past the encoder tokens (which the
+                # encoder path handles), shrinking the decoder extend length.
+                req.extend_range = req.extend_range._replace(
+                    start=req.extend_range.start + encoder_len
+                )
                 req.extend_logprob_start_len = max(
                     0, req.extend_logprob_start_len - encoder_len
                 )
@@ -2279,8 +2329,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         running_bs = running_batch.batch_size()
 
         for req in running_batch.reqs:
-            req.extend_fill_len = req.get_full_untruncated_fill_len()
-            req.set_extend_input_len(1)
+            # A mixed-in running req contributes a single decode token, so its
+            # extend start is the full sequence minus that one token.
+            full_len = req.get_full_untruncated_fill_len()
+            req.set_extend_range(full_len - 1, full_len)
 
         # Decode tokens of the running portion live in future_map.output_tokens_buf.
         self.input_ids = None
@@ -2506,7 +2558,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.forward_mode = ForwardMode.DECODE
         bs = len(self.reqs)
         for req in self.reqs:
-            req.extend_fill_len = None
+            req.extend_range = None
         # Decode embeds the last output token via embed_tokens; clear the stale
         # prefill-time tensor so it doesn't leak into ForwardBatch.
         self.input_embeds = None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -678,7 +678,7 @@ class PrefillAdder:
             return AddReqResult.NO_TOKEN
 
         # Truncate input length to available tokens and update request metadata
-        cand_len = req.get_uncommitted_extend_len()
+        cand_len = req.get_full_untruncated_fill_len() - len(req.prefix_indices)
         truncated = cand_len > _rem_tokens
         new_len = min(cand_len, _rem_tokens)
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
@@ -691,7 +691,7 @@ class PrefillAdder:
             else 0
         )
         self._update_prefill_budget(
-            0, req.extend_input_len, max_new_tokens, req.retracted_stain
+            0, req.extend_range.length, max_new_tokens, req.retracted_stain
         )
 
         # Return based on remaining token availability
@@ -719,14 +719,14 @@ class PrefillAdder:
                     return req
                 _rem_tokens = self.rem_chunk_tokens
 
-        cand_len = req.get_uncommitted_extend_len()
+        cand_len = req.get_full_untruncated_fill_len() - len(req.prefix_indices)
         truncated = cand_len > _rem_tokens
         new_len = min(cand_len, _rem_tokens)
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
         self._update_prefill_budget(
             0,
-            req.extend_input_len,
+            req.extend_range.length,
             (
                 min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
                 if not truncated
@@ -756,7 +756,7 @@ class PrefillAdder:
                 self.tree_cache.dec_lock_ref(last_node)
 
     def add_one_req_ignore_eos(self, req: Req):
-        cand_len = req.get_uncommitted_extend_len()
+        cand_len = req.get_full_untruncated_fill_len() - len(req.prefix_indices)
         paged_input = self.ceil_paged_tokens(cand_len)
         if paged_input > min(self.cur_rem_tokens, self.rem_total_tokens):
             return AddReqResult.NO_TOKEN
@@ -834,7 +834,7 @@ class PrefillAdder:
             self.can_run_list.append(req)
             self._update_prefill_budget(
                 0,
-                req.extend_input_len,
+                req.extend_range.length,
                 min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS),
                 req.retracted_stain,
             )
@@ -889,7 +889,7 @@ class PrefillAdder:
             max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
             CLIP_MAX_NEW_TOKENS,
         )
-        cand_len = req.get_uncommitted_extend_len()
+        cand_len = req.get_full_untruncated_fill_len() - len(req.prefix_indices)
         total_tokens = cand_len + max_new + self.page_size
 
         # adjusting the input_tokens based on host_hit_length and page_size
@@ -941,9 +941,9 @@ class PrefillAdder:
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
 
-            # Recompute the candidate against the (possibly host-loaded-back)
-            # prefix length, which may have grown just above.
-            input_tokens = self.ceil_paged_tokens(req.get_uncommitted_extend_len())
+            input_tokens = self.ceil_paged_tokens(
+                req.get_full_untruncated_fill_len() - len(req.prefix_indices)
+            )
 
             if (
                 self.rem_chunk_tokens is None
@@ -1052,7 +1052,8 @@ class PrefillAdder:
 
         preemptible_reqs = []
         min_tokens_to_remove = (
-            req.get_uncommitted_extend_len()
+            req.get_full_untruncated_fill_len()
+            - len(req.prefix_indices)
             + min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
             - self.rem_total_tokens
         )

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -659,8 +659,7 @@ class PrefillAdder:
             * self.page_size
         )
 
-        req.extend_input_len = trunc_len
-        req.extend_fill_len = prefix_len + trunc_len
+        req.set_extend_range(prefix_len, prefix_len + trunc_len)
 
         self.can_run_list.append(req)
 
@@ -679,9 +678,10 @@ class PrefillAdder:
             return AddReqResult.NO_TOKEN
 
         # Truncate input length to available tokens and update request metadata
-        truncated = req.extend_input_len > _rem_tokens
-        req.extend_input_len = min(req.extend_input_len, _rem_tokens)
-        req.extend_fill_len = len(req.prefix_indices) + req.extend_input_len
+        cand_len = req.get_uncommitted_extend_len()
+        truncated = cand_len > _rem_tokens
+        new_len = min(cand_len, _rem_tokens)
+        req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
 
         # Update budget: reserve max_new_tokens only if not truncated
@@ -719,9 +719,10 @@ class PrefillAdder:
                     return req
                 _rem_tokens = self.rem_chunk_tokens
 
-        truncated = req.extend_input_len > _rem_tokens
-        req.set_extend_input_len(min(req.extend_input_len, _rem_tokens))
-        req.extend_fill_len = len(req.prefix_indices) + req.extend_input_len
+        cand_len = req.get_uncommitted_extend_len()
+        truncated = cand_len > _rem_tokens
+        new_len = min(cand_len, _rem_tokens)
+        req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
         self._update_prefill_budget(
             0,
@@ -755,11 +756,12 @@ class PrefillAdder:
                 self.tree_cache.dec_lock_ref(last_node)
 
     def add_one_req_ignore_eos(self, req: Req):
-        paged_input = self.ceil_paged_tokens(req.extend_input_len)
+        cand_len = req.get_uncommitted_extend_len()
+        paged_input = self.ceil_paged_tokens(cand_len)
         if paged_input > min(self.cur_rem_tokens, self.rem_total_tokens):
             return AddReqResult.NO_TOKEN
         if self.is_hybrid_swa:
-            if self._swa_budget_for_req(req.extend_input_len) > self.rem_swa_tokens:
+            if self._swa_budget_for_req(cand_len) > self.rem_swa_tokens:
                 return AddReqResult.NO_TOKEN
 
         def add_req_state(r, insert_sort=False):
@@ -798,9 +800,7 @@ class PrefillAdder:
         if not self.is_hybrid_swa:
             # Skip this logic for swa. The SWA has different memory management, and
             # this mechanism is underestimating the memory usage.
-            cur_rem_tokens = self.cur_rem_tokens - self.ceil_paged_tokens(
-                req.extend_input_len
-            )
+            cur_rem_tokens = self.cur_rem_tokens - self.ceil_paged_tokens(cand_len)
             tokens_freed = 0
             for i, (tokens_left, tokens_occupied) in enumerate(self.req_states):
                 # tokens_left gives a reservative calculation as the last token is not stored
@@ -825,13 +825,12 @@ class PrefillAdder:
             self._add_dllm_req(req, 0)
         elif (
             self.rem_chunk_tokens is None  # chunked prefill is disabled
-            or req.extend_input_len <= self.rem_chunk_tokens  # it is the last chunk
+            or cand_len <= self.rem_chunk_tokens  # it is the last chunk
         ):
             # Non-chunked prefill — the whole sequence is committed this iter.
-            req.extend_fill_len = req.get_full_untruncated_fill_len()
-            assert (
-                req.extend_fill_len == len(req.prefix_indices) + req.extend_input_len
-            ), f"{req.extend_fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
+            req.set_extend_range(
+                len(req.prefix_indices), req.get_full_untruncated_fill_len()
+            )
             self.can_run_list.append(req)
             self._update_prefill_budget(
                 0,
@@ -846,9 +845,10 @@ class PrefillAdder:
             # Chunked prefill
             trunc_len = self.rem_chunk_tokens
 
-            req.set_extend_input_len(trunc_len)
             assert len(req.prefix_indices) == 0
-            req.extend_fill_len = len(req.prefix_indices) + trunc_len
+            req.set_extend_range(
+                len(req.prefix_indices), len(req.prefix_indices) + trunc_len
+            )
             self.can_run_list.append(req)
             self.new_chunked_req = req
             self._update_prefill_budget(0, trunc_len, 0, req.retracted_stain)
@@ -889,10 +889,11 @@ class PrefillAdder:
             max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
             CLIP_MAX_NEW_TOKENS,
         )
-        total_tokens = req.extend_input_len + max_new + self.page_size
+        cand_len = req.get_uncommitted_extend_len()
+        total_tokens = cand_len + max_new + self.page_size
 
         # adjusting the input_tokens based on host_hit_length and page_size
-        real_input_tokens = req.extend_input_len - req.host_hit_length
+        real_input_tokens = cand_len - req.host_hit_length
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
 
@@ -901,7 +902,7 @@ class PrefillAdder:
 
         if self.is_hybrid_swa:
             swa_needed = self._swa_budget_for_req(
-                req.extend_input_len, swa_host_hit_length=req.swa_host_hit_length
+                cand_len, swa_host_hit_length=req.swa_host_hit_length
             )
             if swa_needed >= self.rem_swa_tokens:
                 return AddReqResult.NO_TOKEN
@@ -923,7 +924,7 @@ class PrefillAdder:
 
             if self.is_hybrid_swa:
                 swa_needed = self._swa_budget_for_req(
-                    req.extend_input_len, swa_host_hit_length=req.swa_host_hit_length
+                    cand_len, swa_host_hit_length=req.swa_host_hit_length
                 )
                 if swa_needed >= self.rem_swa_tokens:
                     return AddReqResult.NO_TOKEN
@@ -937,13 +938,12 @@ class PrefillAdder:
                     )
                 )
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
-                req.set_extend_input_len(
-                    req.get_full_untruncated_fill_len() - len(req.prefix_indices)
-                )
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
 
-            input_tokens = self.ceil_paged_tokens(req.extend_input_len)
+            # Recompute the candidate against the (possibly host-loaded-back)
+            # prefix length, which may have grown just above.
+            input_tokens = self.ceil_paged_tokens(req.get_uncommitted_extend_len())
 
             if (
                 self.rem_chunk_tokens is None
@@ -967,11 +967,9 @@ class PrefillAdder:
                 self._req_inc_lock_ref(req)
             elif self.rem_chunk_tokens is None or input_tokens <= self.rem_chunk_tokens:
                 # Non-chunked prefill — the whole sequence is committed this iter.
-                req.extend_fill_len = req.get_full_untruncated_fill_len()
-                assert (
-                    req.extend_fill_len
-                    == len(req.prefix_indices) + req.extend_input_len
-                ), f"{req.extend_fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
+                req.set_extend_range(
+                    len(req.prefix_indices), req.get_full_untruncated_fill_len()
+                )
                 self.can_run_list.append(req)
 
                 self._req_inc_lock_ref(req)
@@ -1010,8 +1008,9 @@ class PrefillAdder:
                     return AddReqResult.OTHER
 
                 # Chunked prefill
-                req.set_extend_input_len(trunc_len)
-                req.extend_fill_len = len(req.prefix_indices) + trunc_len
+                req.set_extend_range(
+                    len(req.prefix_indices), len(req.prefix_indices) + trunc_len
+                )
 
                 self.can_run_list.append(req)
                 self.new_chunked_req = req
@@ -1053,7 +1052,7 @@ class PrefillAdder:
 
         preemptible_reqs = []
         min_tokens_to_remove = (
-            req.extend_input_len
+            req.get_uncommitted_extend_len()
             + min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
             - self.rem_total_tokens
         )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1227,7 +1227,7 @@ class Scheduler(
             request_lengths = []
             for req in batch.reqs:
                 start = len(req.prefix_indices)
-                end = start + req.extend_input_len
+                end = start + req.extend_range.length
                 fill_ids = req.origin_input_ids + req.output_ids
                 if start == 0:
                     tokens = fill_ids[start:end]
@@ -2438,7 +2438,7 @@ class Scheduler(
             # beyond what is already cached. A parked chunk (add_chunked_req
             # hybrid-SWA early-return) leaves extend_fill_len == len(prefix_indices),
             # so there is nothing new to cache and stashing would be a no-op.
-            if self.chunked_req.extend_fill_len > len(self.chunked_req.prefix_indices):
+            if self.chunked_req.extend_range.end > len(self.chunked_req.prefix_indices):
                 self.stash_chunked_request(self.chunked_req)
 
         # HiSparse has its own prefill-to-decode transition; skip last_batch merge.
@@ -2777,7 +2777,7 @@ class Scheduler(
             self.enable_priority_scheduling,
             num_pending_tokens=self.load_inquirer._get_num_pending_tokens(
                 chunk_deduct=(
-                    self.chunked_req.extend_input_len
+                    self.chunked_req.extend_range.length
                     if self.chunked_req is not None
                     else 0
                 ),
@@ -3105,7 +3105,7 @@ class Scheduler(
             # we can use the correct values in output processing.
             if batch.return_logprob:
                 batch_result.extend_input_len_per_req = [
-                    req.extend_input_len for req in batch.reqs
+                    req.extend_range.length for req in batch.reqs
                 ]
                 batch_result.extend_logprob_start_len_per_req = [
                     req.extend_logprob_start_len for req in batch.reqs

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -622,7 +622,7 @@ class SchedulerPPMixin:
                     self.spec_algorithm,
                 )
 
-                current_seq_len = req.extend_fill_len
+                current_seq_len = req.extend_range.end
 
                 if is_dp_attention_enabled():
                     # For profiling, we only have one request on PP0
@@ -686,7 +686,7 @@ class SchedulerPPMixin:
                 # Release KV cache
                 if req.req_pool_idx is not None:
                     kv_indices = self.req_to_token_pool.req_to_token[
-                        req.req_pool_idx, : req.extend_fill_len
+                        req.req_pool_idx, : req.extend_range.end
                     ]
                     self.token_to_kv_pool_allocator.free(kv_indices)
                     self.req_to_token_pool.free(req)

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -606,9 +606,10 @@ class SchedulerPPMixin:
                     origin_input_ids=input_ids,
                     sampling_params=sampling_params,
                 )
-                req.extend_fill_len = req.get_full_untruncated_fill_len()
                 req.logprob_start_len = -1
-                req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
+                req.set_extend_range(
+                    len(req.prefix_indices), req.get_full_untruncated_fill_len()
+                )
 
                 # Prepare batch
                 batch = ScheduleBatch.init_new(

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -86,8 +86,8 @@ class ChunkCache(BasePrefixCache):
 
     def cache_unfinished_req(self, req: Req, chunked=False):
         assert (
-            req.extend_fill_len == req.kv_committed_len
-        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+            req.extend_range.end == req.kv_committed_len
+        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : req.kv_committed_len
         ]

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -611,8 +611,8 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
 
         def _skip_cache_unfinished_req(req: Req) -> None:
             assert (
-                req.extend_fill_len == req.kv_committed_len
-            ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+                req.extend_range.end == req.kv_committed_len
+            ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
             kv_indices = self.req_to_token_pool.req_to_token[
                 req.req_pool_idx, : req.kv_committed_len
             ]
@@ -622,8 +622,8 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             return
 
         assert (
-            req.extend_fill_len == req.kv_committed_len
-        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+            req.extend_range.end == req.kv_committed_len
+        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
         token_ids = req.get_full_untruncated_fill_ids()[: req.kv_committed_len]
         cache_len = (
             req.mamba_last_track_seqlen

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -467,8 +467,8 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             return
 
         assert (
-            req.extend_fill_len == req.kv_committed_len
-        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+            req.extend_range.end == req.kv_committed_len
+        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
         token_ids = req.get_full_untruncated_fill_ids()[: req.kv_committed_len]
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(token_ids)

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -211,8 +211,8 @@ class RadixCacheCpp(BasePrefixCache):
         """Cache request when it is unfinished."""
         assert req.req_pool_idx is not None
         assert (
-            req.extend_fill_len == req.kv_committed_len
-        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+            req.extend_range.end == req.kv_committed_len
+        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
         token_ids = req.get_full_untruncated_fill_ids()[: req.kv_committed_len]
         prefill_len = len(token_ids)  # prefill only (maybe chunked)
         kv_indices = self.req_to_token_pool.req_to_token[

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -488,8 +488,8 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         """Cache request when it is unfinished."""
         if self.disable:
             assert (
-                req.extend_fill_len == req.kv_committed_len
-            ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+                req.extend_range.end == req.kv_committed_len
+            ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
             kv_indices = self.req_to_token_pool.req_to_token[
                 req.req_pool_idx, : req.kv_committed_len
             ]
@@ -499,8 +499,8 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             return
 
         assert (
-            req.extend_fill_len == req.kv_committed_len
-        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+            req.extend_range.end == req.kv_committed_len
+        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
         token_ids = req.get_full_untruncated_fill_ids()[: req.kv_committed_len]
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(token_ids)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -723,8 +723,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             return
 
         assert (
-            req.extend_fill_len == req.kv_committed_len
-        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_fill_len=} {req.kv_committed_len=}"
+            req.extend_range.end == req.kv_committed_len
+        ), f"Sanity check since migrating extend_fill_len to kv_committed_len: {req.extend_range.end=} {req.kv_committed_len=}"
         token_ids = req.get_full_untruncated_fill_ids()[: req.kv_committed_len]
 
         if self.disable:

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -353,7 +353,7 @@ class StreamingSession(BasePrefixCache):
             return False
         if chunked:
             kv_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, : req.extend_fill_len
+                req.req_pool_idx, : req.extend_range.end
             ]
             req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
             return True

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -64,6 +64,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    NamedTuple,
     Optional,
     Protocol,
     Sequence,
@@ -102,6 +103,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 torch_release = pkg_version.parse(torch.__version__).release
+
+
+class Range(NamedTuple):
+    start: int
+    end: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
 
 
 def flatten_arrays_to_pinned_cpu(parts: List[array[int]], pin: bool) -> torch.Tensor:

--- a/test/manual/test_forward_split_prefill.py
+++ b/test/manual/test_forward_split_prefill.py
@@ -95,9 +95,10 @@ class TestForwardSplitPrefill(CustomTestCase):
                 origin_input_ids=array("q", input_ids[i]),
                 sampling_params=sampling_params,
             )
-            req.extend_fill_len = req.get_full_untruncated_fill_len()
             req.logprob_start_len = -1
-            req.set_extend_input_len(req.extend_fill_len - len(req.prefix_indices))
+            req.set_extend_range(
+                len(req.prefix_indices), req.get_full_untruncated_fill_len()
+            )
             reqs.append(req)
 
         # Create dummy tree_cache for tests (no prefix caching, just allocation)

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 import torch
 
 from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
+from sglang.srt.utils.common import Range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
@@ -57,8 +58,7 @@ def _make_req(rid="test-req-0", origin_input_ids=None, output_ids=None):
     req.finished = lambda: req.finished_reason is not None
 
     def _set_extend_range(start, end):
-        req.extend_input_len = end - start
-        req.extend_fill_len = end
+        req.extend_range = Range(start, end)
 
     req.set_extend_range = _set_extend_range
     return req
@@ -213,7 +213,7 @@ class TestHiSparseUnit(unittest.TestCase):
         self.req_to_token_pool.write((req.req_pool_idx, slice(0, len(kv_loc))), kv_loc)
         req.kv_allocated_len = fill_len
         req.kv_committed_len = fill_len
-        req.extend_fill_len = fill_len
+        req.extend_range = Range(0, fill_len)
         return kv_loc
 
     # ==================================================================
@@ -682,7 +682,7 @@ class TestHiSparseUnit(unittest.TestCase):
         )
         self.assertEqual(req.kv_allocated_len, fill_len)
         self.assertEqual(req.kv_committed_len, fill_len)
-        self.assertEqual(req.extend_input_len, fill_len)
+        self.assertEqual(req.extend_range.length, fill_len)
 
         rounded_len = (fill_len + self.page_size - 1) // self.page_size * self.page_size
         self.assertEqual(

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -55,9 +55,12 @@ def _make_req(rid="test-req-0", origin_input_ids=None, output_ids=None):
         inflight_middle_chunks=0,
     )
     req.finished = lambda: req.finished_reason is not None
-    req.set_extend_input_len = lambda extend_input_len: setattr(
-        req, "extend_input_len", extend_input_len
-    )
+
+    def _set_extend_range(start, end):
+        req.extend_input_len = end - start
+        req.extend_fill_len = end
+
+    req.set_extend_range = _set_extend_range
     return req
 
 

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -77,6 +77,7 @@ class TestPrefillAdder(CustomTestCase):
         req.rid = str(rid)
         req.priority = priority
         req.extend_input_len = 0
+        req.get_uncommitted_extend_len.return_value = 0
         req.extend_logprob_start_len = 0
         req.output_ids = [0] * output_len
         req.sampling_params = SimpleNamespace(max_new_tokens=max_new_tokens)
@@ -387,6 +388,7 @@ class TestPrefillAdder(CustomTestCase):
         req1.host_hit_length = 0
         req1.prefix_indices = []
         req1.get_full_untruncated_fill_len.return_value = 56
+        req1.get_uncommitted_extend_len.return_value = 56
         req1.extend_fill_len = 56
         req1.last_node = MagicMock()
         req1.sampling_params.ignore_eos = False
@@ -422,6 +424,7 @@ class TestPrefillAdder(CustomTestCase):
         req2.host_hit_length = 0
         req2.prefix_indices = []
         req2.get_full_untruncated_fill_len.return_value = 56
+        req2.get_uncommitted_extend_len.return_value = 56
         req2.extend_fill_len = 56
         req2.last_node = MagicMock()
         req2.sampling_params.ignore_eos = False
@@ -440,6 +443,7 @@ class TestPrefillAdder(CustomTestCase):
         req3.host_hit_length = 0
         req3.prefix_indices = []
         req3.get_full_untruncated_fill_len.return_value = 3
+        req3.get_uncommitted_extend_len.return_value = 3
         req3.extend_fill_len = 3
         req3.last_node = MagicMock()
         req3.sampling_params.ignore_eos = False
@@ -477,8 +481,9 @@ class TestPrefillAdder(CustomTestCase):
         req.extend_input_len = extend_input_len
         req.prefix_indices = []
         req.get_full_untruncated_fill_len.return_value = extend_input_len
+        req.get_uncommitted_extend_len.return_value = extend_input_len
         req.extend_fill_len = extend_input_len
-        req.set_extend_input_len = MagicMock()
+        req.set_extend_range = MagicMock()
         return adder, req
 
     def test_add_chunked_req_hybrid_swa_reserves_page_for_alloc_extend(self):
@@ -495,8 +500,9 @@ class TestPrefillAdder(CustomTestCase):
         result = adder.add_chunked_req(req)
 
         self.assertIs(result, req)  # truncated → chunked prefill continues
-        req.set_extend_input_len.assert_called_once()
-        new_len = req.set_extend_input_len.call_args.args[0]
+        req.set_extend_range.assert_called_once()
+        start, end = req.set_extend_range.call_args.args
+        new_len = end - start
         self.assertLessEqual(new_len + PAGE_SIZE, REM_SWA)
         self.assertEqual(new_len, REM_SWA - PAGE_SIZE)
 
@@ -513,7 +519,7 @@ class TestPrefillAdder(CustomTestCase):
         result = adder.add_chunked_req(req)
 
         self.assertIs(result, req)
-        req.set_extend_input_len.assert_not_called()
+        req.set_extend_range.assert_not_called()
         self.assertEqual(req.extend_input_len, original_len)
         self.assertEqual(len(adder.can_run_list), 0)
 
@@ -552,7 +558,7 @@ class TestPrefillAdder(CustomTestCase):
 
         result = adder.add_chunked_req(req)
         self.assertIsNone(result)
-        req.set_extend_input_len.assert_called_once_with(200)
+        req.set_extend_range.assert_called_once_with(0, 200)
         self.assertIn(req, adder.can_run_list)
 
 

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -76,8 +76,8 @@ class TestPrefillAdder(CustomTestCase):
         req = MagicMock(spec=Req)
         req.rid = str(rid)
         req.priority = priority
-        req.extend_input_len = 0
-        req.get_uncommitted_extend_len.return_value = 0
+        req.prefix_indices = []
+        req.get_full_untruncated_fill_len.return_value = 0
         req.extend_logprob_start_len = 0
         req.output_ids = [0] * output_len
         req.sampling_params = SimpleNamespace(max_new_tokens=max_new_tokens)
@@ -384,12 +384,9 @@ class TestPrefillAdder(CustomTestCase):
 
         # Add a prefill that exactly consumes the chunk budget
         req1 = self.create_mock_req("req1", priority=0, max_new_tokens=64)
-        req1.extend_input_len = 56
         req1.host_hit_length = 0
         req1.prefix_indices = []
         req1.get_full_untruncated_fill_len.return_value = 56
-        req1.get_uncommitted_extend_len.return_value = 56
-        req1.extend_fill_len = 56
         req1.last_node = MagicMock()
         req1.sampling_params.ignore_eos = False
 
@@ -420,12 +417,9 @@ class TestPrefillAdder(CustomTestCase):
 
         # Same prefill no longer exhausts the chunk budget
         req2 = self.create_mock_req("req2", priority=0, max_new_tokens=64)
-        req2.extend_input_len = 56
         req2.host_hit_length = 0
         req2.prefix_indices = []
         req2.get_full_untruncated_fill_len.return_value = 56
-        req2.get_uncommitted_extend_len.return_value = 56
-        req2.extend_fill_len = 56
         req2.last_node = MagicMock()
         req2.sampling_params.ignore_eos = False
 
@@ -439,12 +433,9 @@ class TestPrefillAdder(CustomTestCase):
 
         # Fit last small prefill request
         req3 = self.create_mock_req("req3", priority=0, max_new_tokens=16)
-        req3.extend_input_len = 3
         req3.host_hit_length = 0
         req3.prefix_indices = []
         req3.get_full_untruncated_fill_len.return_value = 3
-        req3.get_uncommitted_extend_len.return_value = 3
-        req3.extend_fill_len = 3
         req3.last_node = MagicMock()
         req3.sampling_params.ignore_eos = False
 
@@ -478,11 +469,8 @@ class TestPrefillAdder(CustomTestCase):
         adder.is_hybrid_swa = is_hybrid_swa
 
         req = self.create_mock_req("chunked", priority=0, max_new_tokens=128)
-        req.extend_input_len = extend_input_len
         req.prefix_indices = []
         req.get_full_untruncated_fill_len.return_value = extend_input_len
-        req.get_uncommitted_extend_len.return_value = extend_input_len
-        req.extend_fill_len = extend_input_len
         req.set_extend_range = MagicMock()
         return adder, req
 
@@ -514,13 +502,11 @@ class TestPrefillAdder(CustomTestCase):
         adder, req = self._build_hybrid_swa_chunked_req(
             page_size=PAGE_SIZE, rem_swa=PAGE_SIZE
         )
-        original_len = req.extend_input_len
 
         result = adder.add_chunked_req(req)
 
         self.assertIs(result, req)
         req.set_extend_range.assert_not_called()
-        self.assertEqual(req.extend_input_len, original_len)
         self.assertEqual(len(adder.can_run_list), 0)
 
     def test_swa_budget_for_req(self):

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -12,7 +12,7 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_batch import ExtendRange, Req
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.mem_cache.chunk_cache import ChunkCache
 
@@ -32,10 +32,9 @@ def _make_req(
     req.dllm_config = None
     req.origin_input_ids = array("q", fill_ids)
     req.output_ids = array("q")
-    req.extend_fill_len = fill_len
     req.prefix_indices = prefix_indices
     req.req_pool_idx = req_pool_idx
-    req.extend_input_len = extend_input_len
+    req.extend_range = ExtendRange(fill_len - extend_input_len, fill_len)
     req.inflight_middle_chunks = 0
     req.host_hit_length = 0
     req.cache_protected_len = 0

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -12,9 +12,10 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.schedule_batch import ExtendRange, Req
+from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.mem_cache.chunk_cache import ChunkCache
+from sglang.srt.utils.common import Range
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
@@ -34,7 +35,7 @@ def _make_req(
     req.output_ids = array("q")
     req.prefix_indices = prefix_indices
     req.req_pool_idx = req_pool_idx
-    req.extend_range = ExtendRange(fill_len - extend_input_len, fill_len)
+    req.extend_range = Range(fill_len - extend_input_len, fill_len)
     req.inflight_middle_chunks = 0
     req.host_hit_length = 0
     req.cache_protected_len = 0

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -38,6 +38,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+from sglang.srt.utils.common import Range
 
 
 def _make_cache_with_pools(page_size=1):
@@ -68,7 +69,7 @@ class MockReq:
 
     def __init__(self, fill_ids, req_pool_idx=0, cache_protected_len=0, last_node=None):
         self.full_untruncated_fill_ids = array("q", fill_ids)
-        self.extend_fill_len = len(self.full_untruncated_fill_ids)
+        self.extend_range = Range(0, len(self.full_untruncated_fill_ids))
         self.origin_input_ids = array(
             "q", fill_ids[:-1] if len(fill_ids) > 1 else fill_ids
         )
@@ -84,7 +85,7 @@ class MockReq:
         self.kv_committed_freed = False
 
     def get_fill_ids(self):
-        return self.full_untruncated_fill_ids[: self.extend_fill_len]
+        return self.full_untruncated_fill_ids[: self.extend_range.end]
 
     def pop_committed_kv_cache(self):
         self.kv_committed_freed = True

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_bench.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_bench.py
@@ -637,7 +637,7 @@ def bench_cache_finished(
         req = env.make_req()
         req.origin_input_ids = array("q", seq)
         req.output_ids = array("q")
-        req.extend_fill_len = req.get_full_untruncated_fill_len()
+        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
         req.last_node = node
         req.cache_protected_len = matched_len
         req.kv_committed_len = len(seq)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_bench.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_bench.py
@@ -637,7 +637,9 @@ def bench_cache_finished(
         req = env.make_req()
         req.origin_input_ids = array("q", seq)
         req.output_ids = array("q")
-        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
+        req.set_extend_range(
+            len(req.prefix_indices), req.get_full_untruncated_fill_len()
+        )
         req.last_node = node
         req.cache_protected_len = matched_len
         req.kv_committed_len = len(seq)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -798,7 +798,7 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.extend_fill_len = req.get_full_untruncated_fill_len()
+        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
         if self.cfg.has_mamba:
             req.mamba_last_track_seqlen = kv_len
 
@@ -821,7 +821,7 @@ class UnifiedRadixCacheSuite:
         output_ids = self._make_seq(2000, 7)
         req.origin_input_ids = array("q", prompt_ids)
         req.output_ids = array("q", output_ids)
-        req.extend_fill_len = req.get_full_untruncated_fill_len()
+        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
         kv_len = req.extend_fill_len
         kv_indices = self._alloc(allocator, kv_len)
         req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
@@ -875,7 +875,7 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.extend_fill_len = req.get_full_untruncated_fill_len()
+        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
 
         avail_before = allocator.available_size()
         tree.cache_finished_req(req, is_insert=False)
@@ -892,7 +892,7 @@ class UnifiedRadixCacheSuite:
         tokens = self._make_seq(1, 3)
         req.origin_input_ids = array("q", tokens)
         req.output_ids = array("q")
-        req.extend_fill_len = req.get_full_untruncated_fill_len()
+        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
         kv_len = len(tokens)
         kv_indices = self._alloc(allocator, kv_len)
         req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
@@ -1026,7 +1026,7 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.extend_fill_len = req.get_full_untruncated_fill_len()
+        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
         if self.cfg.has_mamba:
             req.mamba_last_track_seqlen = kv_len
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -798,7 +798,9 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
+        req.set_extend_range(
+            len(req.prefix_indices), req.get_full_untruncated_fill_len()
+        )
         if self.cfg.has_mamba:
             req.mamba_last_track_seqlen = kv_len
 
@@ -821,7 +823,9 @@ class UnifiedRadixCacheSuite:
         output_ids = self._make_seq(2000, 7)
         req.origin_input_ids = array("q", prompt_ids)
         req.output_ids = array("q", output_ids)
-        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
+        req.set_extend_range(
+            len(req.prefix_indices), req.get_full_untruncated_fill_len()
+        )
         kv_len = req.extend_fill_len
         kv_indices = self._alloc(allocator, kv_len)
         req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
@@ -875,7 +879,9 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
+        req.set_extend_range(
+            len(req.prefix_indices), req.get_full_untruncated_fill_len()
+        )
 
         avail_before = allocator.available_size()
         tree.cache_finished_req(req, is_insert=False)
@@ -892,7 +898,9 @@ class UnifiedRadixCacheSuite:
         tokens = self._make_seq(1, 3)
         req.origin_input_ids = array("q", tokens)
         req.output_ids = array("q")
-        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
+        req.set_extend_range(
+            len(req.prefix_indices), req.get_full_untruncated_fill_len()
+        )
         kv_len = len(tokens)
         kv_indices = self._alloc(allocator, kv_len)
         req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
@@ -1026,7 +1034,9 @@ class UnifiedRadixCacheSuite:
         req.cache_protected_len = 0
         req.swa_uuid_for_lock = None
         req.extra_key = None
-        req.set_extend_range(len(req.prefix_indices), req.get_full_untruncated_fill_len())
+        req.set_extend_range(
+            len(req.prefix_indices), req.get_full_untruncated_fill_len()
+        )
         if self.cfg.has_mamba:
             req.mamba_last_track_seqlen = kv_len
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -826,7 +826,7 @@ class UnifiedRadixCacheSuite:
         req.set_extend_range(
             len(req.prefix_indices), req.get_full_untruncated_fill_len()
         )
-        kv_len = req.extend_fill_len
+        kv_len = req.extend_range.end
         kv_indices = self._alloc(allocator, kv_len)
         req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
         req.kv_committed_len = kv_len


### PR DESCRIPTION
## Motivation

An extend pass fills a half-open token range over `full_untruncated_fill_ids`, but it was stored as two independently-writable `Req` fields:

- `extend_fill_len` — the absolute **end** of the range
- `extend_input_len` — the **length**

The range **start** was never stored. Every place that reconstructs an absolute position did `len(prefix_indices) + extend_input_len`, implicitly using `len(prefix_indices)` as the anchor. That anchor is wrong in two by-design cases, so `extend_input_len` was genuinely **not** derivable from `extend_fill_len` and `prefix_indices`:

1. **Disagg decode + HiCache** — the committed prefix is `total_prefix_len` (L1+L2+L3); `len(prefix_indices)` only covers the device-resident L1 part, and the `[prefix_len, total_prefix_len)` host/storage gap is loaded back later. `extend_input_len` is set from `total_prefix_len`, not `len(prefix_indices)`.
2. **Mixed-batch running reqs** — a decode step's KV is never folded into `prefix_indices` (`we don't cache each decode step`), so the true start is `full_len - 1`, not `len(prefix_indices)`.

A bare length with an unstored, sometimes-wrong anchor is the underlying smell.

## Change

Introduce `ExtendRange(start, end)`, an immutable `NamedTuple` with a derived `length = end - start`, stored as the single `Req.extend_range: Optional[ExtendRange]`. This:

- makes the range **start** an explicit first-class value, set correctly per path;
- makes **length** a pure derivation that can never drift from its anchor;
- makes the illegal "only one endpoint written" state **unrepresentable**.

`extend_input_len` and `extend_fill_len` are retained as **read-only properties** (`extend_range.length` / `extend_range.end`, or `0`/`None` when `extend_range is None`), so the ~150 read sites are untouched and this stays a focused diff.

Writers now go through `set_extend_range(start, end)` (which also recomputes `extend_logprob_start_len`, the old `set_extend_input_len` side effect). The not-yet-admitted candidate length, previously stored eagerly in `init_next_round_input`, is computed on demand via `get_uncommitted_extend_len()` so the only stored state is the committed range. The encoder-decoder strip becomes an explicit start advance past the encoder span (with an added `assert len(prefix_indices) == 0`, which already held implicitly). DLLM first-round detection moves from the `extend_fill_len is None` sentinel to an explicit `dllm_initialized` flag.

## Behavior preservation

Each writer sets `start = end - old_length`, so both property views evaluate exactly as before. One intentional, minor refinement: the two DLLM truncation writers (`_add_dllm_req`, `add_dllm_staging_req`) now recompute `extend_logprob_start_len` against the truncated length rather than the full candidate — this only differs for dllm chunked prefill with cross-chunk input logprobs, and the new value (clamped to the tokens actually processed) is the more correct one.

No tests run (per request); changed modules `py_compile` clean and `pre-commit` (black/isort/ruff) applied.

Stacked on #27575.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27173896554](https://github.com/sgl-project/sglang/actions/runs/27173896554)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27173896431](https://github.com/sgl-project/sglang/actions/runs/27173896431)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->