### PR TITLE
[AMD] Fix AttributeError in GeneratedSharedPrefixDataset.from_args for in-process callers

### DIFF
--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -55,8 +55,8 @@ class GeneratedSharedPrefixDataset(BaseDataset):
     @classmethod
     def from_args(cls, args: Namespace) -> "GeneratedSharedPrefixDataset":
         assert not getattr(args, "tokenize_prompt", False)
-        group_distribution = args.gsp_group_distribution
-        zipf_alpha = args.gsp_zipf_alpha
+        group_distribution = getattr(args, "gsp_group_distribution", "uniform")
+        zipf_alpha = getattr(args, "gsp_zipf_alpha", None)
 
         # Defensive validation for in-process callers that construct a
         # Namespace by hand and bypass the argparse boundary in


### PR DESCRIPTION
> **Restore-only fix — no new logic and no behavior change.** It reverts two fields back to the pre-existing `getattr(args, ..., default)` convention used everywhere else in this file; see Modifications.

## Motivation

The 1-GPU nightly tests fail in `test/registered/bench_fn/test_bench_serving_functionality.py::test_gsp_multi_turn` with:

```
File ".../sglang/benchmark/datasets/generated_shared_prefix.py", line 58, in from_args
    group_distribution = args.gsp_group_distribution
AttributeError: 'types.SimpleNamespace' object has no attribute 'gsp_group_distribution'
```

`GeneratedSharedPrefixDataset.from_args` reads `args.gsp_group_distribution` and `args.gsp_zipf_alpha` via **direct attribute access**. These options have argparse defaults (`"uniform"` / `None`) on the `bench_serving.py` CLI, but in-process callers that build a `SimpleNamespace` through `get_benchmark_args` (e.g. `test_gsp_multi_turn`) never set them, so the access raises before the method's own defensive validation can run. Every other optional `gsp_*` field in `from_args` already uses `getattr(args, ..., default)`, and the method's comment states it is meant to tolerate hand-built Namespaces.

This is shared benchmark-client code and the test is registered for **both** suites (`register_cuda_ci` + `register_amd_ci`), so it breaks both 1-GPU nightlies:

| Nightly suite | Job | Failing run | Result |
|---|---|---|---|
| Nightly Test (AMD) | `nightly-test-1-gpu-unit` | https://github.com/sgl-project/sglang/actions/runs/27100228380/job/80040799251 | 9/10 ✗ |
| Nightly Test (Nvidia) | `nightly-test-general-1-gpu-h100` | https://github.com/sgl-project/sglang/actions/runs/27110545438/job/80007477055 | 19/20 ✗ |

### Regression

Introduced by #26378 (commit f838adb7d, merged 2026-05-28), which added the `gsp_group_distribution` / `gsp_zipf_alpha` feature. That PR added the argparse options (with defaults) and the hard attribute access in `from_args`, but did not update `get_benchmark_args` in `python/sglang/test/test_utils.py`. Because `test_gsp_multi_turn` is registered **nightly-only**, it does not run in pre-merge PR CI, so the break only surfaced in the scheduled nightlies after the merge. cc @Jiminator

## Modifications

**Restore-only — not a new code change.** This puts the two GSP fields back on the `getattr(args, ..., default)` convention that the rest of `from_args` (and #19363, "remove args dependency") already use. #26378 was the only place that deviated to direct attribute access; this reverts that one deviation:

```diff
-        group_distribution = args.gsp_group_distribution
-        zipf_alpha = args.gsp_zipf_alpha
+        group_distribution = getattr(args, "gsp_group_distribution", "uniform")
+        zipf_alpha = getattr(args, "gsp_zipf_alpha", None)
```

No behavior change for existing usage: the CLI/argparse path always supplies these attributes, so `getattr` returns exactly the same values, and the defaults (`"uniform"` / `None`) match both the argparse defaults and the feature's own test helper (`make_args`). The only difference is that an in-process `Namespace` that omits the fields now defaults (as the sibling fields already do) instead of raising `AttributeError`.

## Accuracy Tests

N/A — does not affect model outputs (benchmark-client arg handling only).

## Speed Tests and Profiling

N/A — pure arg-handling bugfix.

## Verification

- **Local repro** with the exact `SimpleNamespace` that `test_gsp_multi_turn` builds via `get_benchmark_args(...)`: before → `AttributeError: ... 'gsp_group_distribution'`; after → `GeneratedSharedPrefixDataset(..., group_distribution='uniform', zipf_alpha=None)`.
- **AMD CI dispatch on this branch** (`nightly-test-amd.yml`, `nightly-test-1-gpu-unit`): https://github.com/sgl-project/sglang/actions/runs/27150321984/job/80139313149 → **10/10 passed** (`test_bench_serving_functionality.py` now passes; previously 9/10).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27149657199](https://github.com/sgl-project/sglang/actions/runs/27149657199)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27153205907](https://github.com/sgl-project/sglang/actions/runs/27153205907)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->