### PR TITLE
[AMD] fix: handle per-frame 4D shift in native scale-shift kernel

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -363,13 +363,14 @@ def fuse_scale_shift_kernel(
 
         # Compact scale [B, F, 1, C] -> [B*F, C] (per-frame)
         scale_reshaped = scale.squeeze(2).reshape(-1, C).contiguous()
-        if shift.dim() == 4:
-            # shift is per-frame [B, F, 1, C] (e.g. AdaLN output modulation from
-            # causal Wan / LingBot). Broadcast it across each frame's tokens to
-            # per-token [B, L, C] before flattening to [B*L, C], matching the
-            # per-token indexing in _fused_scale_shift_4d_kernel. This mirrors the
-            # CUDA fused path, which accepts [B, F, 1, C] shift and broadcasts it
-            # per-frame.
+        if shift.dim() == 4 and current_platform.is_hip():
+            # ROCm has no fused CUTLASS scale-shift kernel, so this native path
+            # handles the causal Wan / LingBot output AdaLN, which passes a
+            # per-frame shift [B, F, 1, C]. Broadcast it across each frame's
+            # tokens to per-token [B, L, C] before flattening to [B*L, C],
+            # matching the per-token indexing in _fused_scale_shift_4d_kernel
+            # (the CUDA fused path accepts [B, F, 1, C] shift and broadcasts it
+            # per-frame).
             shift_reshaped = (
                 shift.expand(B, num_frames, frame_seqlen, C)
                 .reshape(rows, C)

--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -363,8 +363,21 @@ def fuse_scale_shift_kernel(
 
         # Compact scale [B, F, 1, C] -> [B*F, C] (per-frame)
         scale_reshaped = scale.squeeze(2).reshape(-1, C).contiguous()
-        # shift is per-token [B, L, C] -> [B*L, C]
-        shift_reshaped = shift.reshape(rows, C).contiguous()
+        if shift.dim() == 4:
+            # shift is per-frame [B, F, 1, C] (e.g. AdaLN output modulation from
+            # causal Wan / LingBot). Broadcast it across each frame's tokens to
+            # per-token [B, L, C] before flattening to [B*L, C], matching the
+            # per-token indexing in _fused_scale_shift_4d_kernel. This mirrors the
+            # CUDA fused path, which accepts [B, F, 1, C] shift and broadcasts it
+            # per-frame.
+            shift_reshaped = (
+                shift.expand(B, num_frames, frame_seqlen, C)
+                .reshape(rows, C)
+                .contiguous()
+            )
+        else:
+            # shift is per-token [B, L, C] -> [B*L, C]
+            shift_reshaped = shift.reshape(rows, C).contiguous()
 
         _fused_scale_shift_4d_kernel[grid](
             output_2d,


### PR DESCRIPTION
## Summary

**Broken test:** `test_diffusion_generation[lingbot_world_realtime_plastic_beach]` (job `multimodal-gen-test-1-gpu-amd`)
**Original failing run:** https://github.com/sgl-project/sglang/actions/runs/27141231624/job/80106737785

It fails on the **PR Test (AMD)** job with:

```
[LingBotWorldCausalDMDDenoisingStage] Error during execution: Dynamo failed to run FX node
with fake tensors: call_method reshape(... size=(1, 1, 1, 5120) ..., 4680, 5120):
got RuntimeError("shape '[4680, 5120]' is invalid for input of size 5120")
```

The causal LingBot / Wan output AdaLN builds a **per-frame** modulation `shift`/`scale` of shape `[B, F, 1, C]` (here `(1, 1, 1, 5120)`) and passes it to `LayerNormScaleShift.norm_out` (`lingbot_world.py`, `causal_wanvideo.py`).

- On **CUDA**, `forward_cuda` uses the CUTLASS `fused_norm_scale_shift`, which explicitly accepts `[B, F, 1, D]` shift and broadcasts it per-frame, so it works.
- On **ROCm** (also MUSA/XPU, and under `torch.compile`), `forward_hip` -> `forward_native` -> the native Triton `fuse_scale_shift_kernel`. Its `scale.dim()==4` branch assumed `shift` was per-token `[B, L, C]` and did `shift.reshape(B*L, C)` = `reshape(4680, 5120)` on a 5120-element tensor, which crashes.

This PR broadcasts a 4D per-frame `[B, F, 1, C]` shift across each frame's tokens to per-token `[B, L, C]` before flattening, gated to ROCm via `current_platform.is_hip()` so only the ROCm path (where this native kernel actually runs) changes. The 3D per-token shift path is unchanged, the CUDA path is unaffected, and all other backends keep the original behavior. This also covers `CausalWanTransformer3DModel`, which uses the same output-norm pattern.

## Regression

This is a latent kernel defect surfaced by the LingBot-World model PR:

- **Root cause (latent):** #23109, re-landed as #24180 (`aefd8e257`, 2026-05-08), introduced the native `fuse_scale_shift_kernel`; its 4D branch assumes `shift` is per-token `[B, L, C]`. Harmless for ~3.5 weeks because nothing fed a per-frame `[B, F, 1, C]` shift through the native path.
- **Trigger:** #26954 "[diffusion] model: support lingbot-world" (`2fc548f25`, 2026-06-02) added the causal LingBot model (and the causal `[B, F, 1, C]` output-AdaLN, also added to `causal_wanvideo.py`) plus the `lingbot_world_realtime_plastic_beach` case — the first thing to route a per-frame 4D shift through the native ROCm path. It merged green because CUDA's CUTLASS kernel accepts `[B, F, 1, D]`, so NVIDIA CI stayed green and the AMD-only break went unnoticed.

`multimodal-gen-test-1-gpu-amd` was fully green (all 4 shards) on every scheduled run from 2026-05-31 through 2026-06-01, and began failing on 2026-06-02 — the day #26954 merged — and has been red since.

## Test plan

- Reproduced the exact failure on an AMD Instinct MI355X (ROCm 7.2, torch 2.9.1) with the real `(1, 1, 1, 5120)` shapes: both eager `fuse_scale_shift_kernel` and the `@torch.compile`'d `forward_native` path raised the exact CI error.
- After the fix, both paths succeed and the output is **bitwise-identical** (max abs diff `0.0`) to the already-working 3D per-token path, for `F=1` and `F=3`.
- [x] `PR Test (AMD)` / `multimodal-gen-test-1-gpu-amd` passes on this PR head — [run #27150328377](https://github.com/sgl-project/sglang/actions/runs/27150328377), all 4 partitions green. Partition 0 (the shard that failed in the original run) went from `1 failed, 6 passed` to **`7 passed, 25 deselected`**, with `test_diffusion_generation[lingbot_world_realtime_plastic_beach]` now passing.

Original failing run: https://github.com/sgl-project/sglang/actions/runs/27141231624/job/80106737785
Verification run (this PR head): https://github.com/sgl-project/sglang/actions/runs/27150328377

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27150323139](https://github.com/sgl-project/sglang/actions/runs/27150323139)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27153606895](https://github.com/sgl-project/sglang/actions/runs/27153606895)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

