### PR TITLE
[AMD] Enable fused GDN QKV split Triton kernel on HIP

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -18,7 +18,7 @@ from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.utils import is_cpu, is_cuda, is_npu
+from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_npu
 from sglang.srt.utils.common import rank0_log
 
 if not is_cpu():
@@ -26,7 +26,7 @@ if not is_cpu():
         CHUNK_SIZE as FLA_CHUNK_SIZE,
     )
 
-if is_cuda():
+if is_cuda() or is_hip():
     from sglang.jit_kernel.triton.gdn_fused_proj import fused_qkv_split_gdn_prefill
 
 MAX_FUSED_QKV_SPLIT_DIM = 8192
@@ -451,7 +451,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
 
         actual_seq_len = mixed_qkv.shape[0]
         qkv_dim = layer.q_dim + layer.k_dim + layer.v_dim
-        if is_cuda() and qkv_dim <= MAX_FUSED_QKV_SPLIT_DIM:
+        if (is_cuda() or is_hip()) and qkv_dim <= MAX_FUSED_QKV_SPLIT_DIM:
             query, key, value = fused_qkv_split_gdn_prefill(
                 mixed_qkv,
                 layer.num_q_heads,


### PR DESCRIPTION
## Motivation

The `fused_qkv_split_gdn_prefill` Triton kernel fuses the split of packed GDN (Gated Delta Net) QKV output into separate contiguous Q/K/V tensors in a single kernel launch. This kernel was gated behind `is_cuda()`, so on HIP/ROCm the code fell back to `torch.split()` + `.view()`, which triggers **3 separate elementwise copy kernels** due to strided memory from the causal conv1d output.

Since `fused_qkv_split_gdn_prefill_kernel` is a `@triton.jit` kernel, it works natively on ROCm/HIP without any modifications.

## Modifications

**`python/sglang/srt/layers/attention/linear/gdn_backend.py`** (3 lines changed):
- Add `is_hip` to the import from `sglang.srt.utils`
- Change the import guard from `if is_cuda():` to `if is_cuda() or is_hip():` for `fused_qkv_split_gdn_prefill`
- Change the dispatch guard from `if is_cuda() and ...` to `if (is_cuda() or is_hip()) and ...`

## Accuracy Tests

| Test | Score | Threshold | Status |
|------|-------|-----------|--------|
| GSM8K (Qwen3.5-397B-A17B-MXFP4, TP=2, 200 questions, 5-shot) | 0.915 | 0.88 | PASS |

## Benchmarking

### Kernel-level: QKV split region per GDN layer (prefill, ISL=8192)

| Kernel | Before (MI355) | After (MI355) | B200 (reference) |
|--------|:-:|:-:|:-:|
| `elementwise_kernel_manual_unroll` (copy q) | 23.3 us | — | — |
| `elementwise_kernel_manual_unroll` (copy k) | 20.6 us | — | — |
| `elementwise_kernel_manual_unroll` (copy v) | 66.4 us | — | — |
| `fused_qkv_split_gdn_prefill_kernel` | — | 85.8 us | 79.8 us |
| **Subtotal (QKV split)** | **110.3 us (3 kernels)** | **85.8 us (1 kernel)** | **79.8 us (1 kernel)** |
| **Savings** | — | **24.5 us/layer** | — |

Total estimated savings: 24.5 us/layer x 45 GDN layers = ~1,103 us per prefill iteration.

### E2E benchmark (Qwen3.5-397B-A17B-MXFP4, TP=2, ISL=8192, OSL=1024, concurrency=4)

| Metric | Before | After | Delta |
|--------|:------:|:-----:|:-----:|
| Total throughput (tok/s) | 2916.17 | 2920.61 | +0.15% |
| Output throughput (tok/s) | 324.40 | 324.89 | +0.15% |
| Median TTFT (ms) | 393.75 | 392.89 | -0.22% |
| Median ITL (ms) | 10.60 | 10.59 | -0.09% |
| Median TPOT (ms) | 11.70 | 11.66 | -0.34% |
| Median E2E Latency (ms) | 11014.78 | 11003.49 | -0.10% |

E2E impact is neutral as expected — the kernel savings (~1.1 ms per prefill) is ~0.28% of TTFT (~393 ms), within benchmark noise. The change reduces kernel launch count (3 → 1) for parity with the B200 CUDA path.

## Checklist
- [x] Format: `pre-commit run --all-files`
- [x] No new dependencies
- [x] CUDA path unchanged (common path byte-identical when `is_hip()` is False)