### PR TITLE
Update CUDA memory allocation methods for compatibility

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
@@ -6,12 +6,7 @@ import traceback
 from contextlib import nullcontext
 
 import torch
-from torch.cuda.memory import (
-    CUDAPluggableAllocator,
-    _cuda_beginAllocateCurrentThreadToPool,
-    _cuda_endAllocateToPool,
-    _cuda_releasePool,
-)
+from torch.cuda.memory import CUDAPluggableAllocator
 
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.environ import envs
@@ -279,7 +274,12 @@ class SymmetricMemoryContext:
                     _cur_device, _graph_pool_id
                 )
 
-        _cuda_beginAllocateCurrentThreadToPool(self._device_index, self._pool_id)
+        if after_2_8_0:
+            torch._C._cuda_beginAllocateCurrentThreadToPool(
+                self._device_index, self._pool_id
+            )
+        else:
+            torch._C._cuda_beginAllocateToPool(self._device_index, self._pool_id)
 
         global _active_symmetric_memory_context
         _active_symmetric_memory_context = self
@@ -287,8 +287,13 @@ class SymmetricMemoryContext:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        _cuda_endAllocateToPool(self._device_index, self._pool_id)
-        _cuda_releasePool(self._device_index, self._pool_id)
+        if after_2_8_0:
+            torch._C._cuda_endAllocateToPool(self._device_index, self._pool_id)
+        else:
+            torch._C._cuda_endAllocateCurrentStreamToPool(
+                self._device_index, self._pool_id
+            )
+        torch._C._cuda_releasePool(self._device_index, self._pool_id)
         # Register all unregistered segments
         # with the current comm
         self._register_segments_for_comm()


### PR DESCRIPTION
## Motivation
 
PyTorch 2.8.0 renamed several private CUDA memory pool allocation APIs, breaking the pynccl symmetric allocator context manager on `torch >= 2.8.0`. The old Python wrappers in `torch.cuda.memory` no longer map to the correct underlying symbols.
 
Specifically, the affected APIs:
 
| Operation | `< 2.8.0` | `>= 2.8.0` |
|-----------|-----------|------------|
| begin pool alloc | `_cuda_beginAllocateToPool` | `_cuda_beginAllocateCurrentThreadToPool` |
| end pool alloc | `_cuda_endAllocateCurrentStreamToPool` | `_cuda_endAllocateToPool` |
| release pool | `_cuda_releasePool` | `_cuda_releasePool` (unchanged) |
 
## Modifications
 
- **`pynccl_allocator.py`**: Replaced `torch.cuda.memory` wrapper imports with direct `torch._C._cuda_*` calls, gated on `after_2_8_0` version check.
  - `__enter__`: calls `_cuda_beginAllocateCurrentThreadToPool` (>= 2.8.0) or `_cuda_beginAllocateToPool` (< 2.8.0)
  - `__exit__`: calls `_cuda_endAllocateToPool` (>= 2.8.0) or `_cuda_endAllocateCurrentStreamToPool` (< 2.8.0)
  - `_cuda_releasePool` unified to `torch._C._cuda_releasePool` across both paths (symbol unchanged in 2.8.0)

## Accuracy Tests

No model output changes — this patch only affects CUDA memory pool lifecycle management for pynccl symmetric allocations. Functional behavior is preserved.

## Speed Tests and Profiling

No performance impact expected. The version branch is evaluated once at context entry/exit, not in any hot path.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27151689377](https://github.com/sgl-project/sglang/actions/runs/27151689377)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27151689153](https://github.com/sgl-project/sglang/actions/runs/27151689153)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->