### PR TITLE
Suffix decoding v2

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -91,6 +91,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [project.optional-dependencies]
+suffix = ["arctic_inference>=0.1.2"]  # SUFFIX speculative decoding (model-free, CPU suffix tree)
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 diffusion = [

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -34,16 +34,18 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
     ], f"{server_args.kv_cache_dtype} is not supported for {model_arch}"
 
     if server_args.speculative_algorithm is not None:
+        # DSv4 supports EAGLE (spec-v2) and SUFFIX (model-free, NGRAMWorker family).
+        _allowed = {"EAGLE", "SUFFIX"}
         assert (
-            server_args.speculative_algorithm == "EAGLE"
-        ), f"Only EAGLE speculative algorithm is supported for {model_arch}"
-        assert (
-            server_args.speculative_eagle_topk == 1
-        ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
-
-        if not envs.SGLANG_ENABLE_SPEC_V2.get():
-            envs.SGLANG_ENABLE_SPEC_V2.set(True)
-            logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
+            server_args.speculative_algorithm in _allowed
+        ), f"Speculative algorithm {server_args.speculative_algorithm} not supported for {model_arch}; allowed: {sorted(_allowed)}"
+        if server_args.speculative_algorithm == "EAGLE":
+            assert (
+                server_args.speculative_eagle_topk == 1
+            ), f"Only EAGLE with topk == 1 is supported for {model_arch}"
+            if not envs.SGLANG_ENABLE_SPEC_V2.get():
+                envs.SGLANG_ENABLE_SPEC_V2.set(True)
+                logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
 
     if server_args.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
         server_args.swa_full_tokens_ratio = 0.1

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2679,7 +2679,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         def get_spec_info():
             spec_info = None
-            if self.spec_algorithm.is_eagle() or self.spec_algorithm.is_standalone():
+            # V1 SUFFIX uses NgramVerifyInput at K = num_draft_tokens.
+            # V2 SUFFIX uses EagleVerifyInput (build_suffix_v2_eagle_verify_input).
+            # Route V2 SUFFIX through the Eagle branch when overlap is enabled;
+            # V1 SUFFIX stays on the Ngram branch below.
+            _suffix_v2 = (
+                self.spec_algorithm.is_suffix()
+                and not self.server_args.disable_overlap_schedule
+            )
+            if (
+                self.spec_algorithm.is_eagle()
+                or self.spec_algorithm.is_standalone()
+                or _suffix_v2
+            ):
                 from sglang.srt.speculative.eagle_info import EagleVerifyInput
 
                 if self.is_draft_worker:
@@ -2716,7 +2728,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     ),
                 )
 
-            elif self.spec_algorithm.is_ngram():
+            elif self.spec_algorithm.is_ngram() and not _suffix_v2:
                 from sglang.srt.speculative.ngram_info import NgramVerifyInput
 
                 spec_info = NgramVerifyInput(

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -393,6 +393,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if model_runner.server_args.enable_return_hidden_states:
             self.capture_hidden_mode = CaptureHiddenMode.FULL
 
+        # NOTE: SUFFIX (V1 + V2) intentionally captures in NULL hidden mode.
+        # It is model-free and never consumes target hidden states: V1 uses
+        # NgramVerifyInput (no capture_hidden_mode, requests NULL); V2's
+        # prepare_for_v2_verify requests NULL for is_suffix() too (see
+        # eagle_info_v2). Capturing NULL here lets both hit the cuda graph
+        # without allocating the unused FULL hidden-state buffers.
+
         self.max_bs = max(self.capture_bs)
         self.max_num_token = self.max_bs * self.num_tokens_per_bs
         self.attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -637,6 +637,11 @@ class ServerArgs:
     speculative_ngram_external_corpus_path: Optional[str] = None
     speculative_ngram_external_sam_budget: int = 0
     speculative_ngram_external_corpus_max_tokens: int = 10000000
+    # SUFFIX speculative decoding (arctic_inference SuffixDecodingCache)
+    speculative_suffix_max_tree_depth: int = 24
+    speculative_suffix_max_cached_requests: int = 10000
+    speculative_suffix_max_spec_factor: float = 1.0
+    speculative_suffix_min_token_prob: float = 0.1
     enable_multi_layer_eagle: bool = False
 
     # Adaptive speculative decoding
@@ -6183,6 +6188,30 @@ class ServerArgs:
             type=int,
             default=ServerArgs.speculative_ngram_external_corpus_max_tokens,
             help="Fail startup if the tokenized external ngram corpus exceeds this many tokens. Tune this based on your CPU memory budget.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-tree-depth",
+            type=int,
+            default=ServerArgs.speculative_suffix_max_tree_depth,
+            help="Max depth of the per-request suffix tree for SUFFIX speculative decoding.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-cached-requests",
+            type=int,
+            default=ServerArgs.speculative_suffix_max_cached_requests,
+            help="Max number of finished requests cached in the shared suffix tree for SUFFIX speculative decoding.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-spec-factor",
+            type=float,
+            default=ServerArgs.speculative_suffix_max_spec_factor,
+            help="SUFFIX max speculation factor: caps draft length relative to the matched suffix score.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-min-token-prob",
+            type=float,
+            default=ServerArgs.speculative_suffix_min_token_prob,
+            help="SUFFIX minimum per-token probability for a draft token to be proposed.",
         )
         parser.add_argument(
             "--speculative-adaptive",

--- a/python/sglang/srt/speculative/__init__.py
+++ b/python/sglang/srt/speculative/__init__.py
@@ -1,0 +1,4 @@
+# Importing this package registers plugin speculative-decoding algorithms.
+# SUFFIX (arctic_inference SuffixDecoding) registers itself on import; the
+# worker / arctic_inference are loaded lazily only when SUFFIX is selected.
+from sglang.srt.speculative import sgl_suffix_plugin  # noqa: F401

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -414,9 +414,18 @@ class EagleVerifyInputV2Mixin:
             if batch.forward_mode.is_idle()
             else ForwardMode.TARGET_VERIFY
         )
+        # SUFFIX is model-free and never consumes target hidden states, so it
+        # verifies in NULL capture mode and reuses the cheaper NULL cuda graph.
+        # Standalone EAGLE3 is likewise NULL. Every other non-standalone V2
+        # spec algo (EAGLE/MTP, and the HYBRID SUFFIX path that feeds MTP
+        # keep-up) still needs FULL. The getattr guard keeps this safe for
+        # pure EAGLE/MTP runs where the SUFFIX plugin (which installs
+        # is_suffix()) was never imported.
+        spec_algo = target_worker.model_runner.spec_algorithm
+        _is_suffix = getattr(spec_algo, "is_suffix", None)
         capture_mode = (
             CaptureHiddenMode.NULL
-            if target_worker.model_runner.spec_algorithm.is_standalone()
+            if spec_algo.is_standalone() or (callable(_is_suffix) and _is_suffix())
             else CaptureHiddenMode.FULL
         )
         batch.capture_hidden_mode = capture_mode

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -30,9 +30,8 @@ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.speculative.spec_utils import (
     TREE_SPEC_KERNEL_AVAILABLE,
+    align_evict_mask_to_page_size,
     assign_req_to_token_pool,
-    get_src_tgt_cache_loc,
-    get_target_cache_loc,
 )
 from sglang.srt.utils import is_cuda, is_hip, is_musa, next_power_of_2
 
@@ -224,50 +223,22 @@ class NgramVerifyInput(SpecInput):
             batch.token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
             batch.out_cache_loc = batch.out_cache_loc[self.accept_indices]
         else:
-            # Shift the accepted tokens to the beginning.
-            # Only evict the last part
-            src_cache_loc, tgt_cache_loc, to_free_num_slots = get_src_tgt_cache_loc(
+            # Linear-chain optimization: NGRAM/SUFFIX produce linear chain drafts,
+            # so accept_indices form a contiguous prefix per request. Instead of
+            # compacting via move_kv_cache (which NSA paginated KV pool does not
+            # support), free only full-empty pages and leave gaps in partial pages.
+            # Mirrors EAGLE/MTP's topk==1 cleanup path in eagle_info.py.
+            evict_mask = torch.full_like(self.draft_token, True, dtype=torch.bool)
+            evict_mask[self.accept_indices] = False
+            align_evict_mask_to_page_size[len(batch.seq_lens),](
                 batch.seq_lens,
-                batch.out_cache_loc,
-                self.accept_indices,
-                self.num_correct_drafts,
-                self.draft_token_num,
+                evict_mask,
                 page_size,
-            )
-            to_free_slots = torch.empty(
-                (to_free_num_slots.sum().item(),),
-                dtype=torch.int64,
-                device=to_free_num_slots.device,
-            )
-
-            # out_cache_loc: [0  1  2,  3  4  5,  6  7  8]
-            # accept_index:  [0 -1  2,  3  4 -1,  6 -1 -1]
-            # tgt_cache_loc: [0  1   ,  3  4   ,  6      ]
-            # to_free_slots: [      2,        5,     7  8]
-            # to_free_slots also needs to be page-aligned without the first partial page
-            #
-            # split each row of out_cache_loc into two parts.
-            # 1. the first part goes to tgt_cache_loc. length = num_correct_drafts[i] + 1
-            # 2. the second part goes to to_free_slots.
-            get_target_cache_loc[(bs,)](
-                tgt_cache_loc,
-                to_free_slots,
-                self.num_correct_drafts,
-                to_free_num_slots,
-                batch.out_cache_loc,
                 self.draft_token_num,
                 next_power_of_2(self.draft_token_num),
-                next_power_of_2(bs),
             )
-
-            # Free the kv cache
-            batch.token_to_kv_pool_allocator.free(to_free_slots)
-
-            # Copy the kv cache
-            batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
-                tgt_cache_loc, src_cache_loc
-            )
-            batch.out_cache_loc = tgt_cache_loc
+            batch.token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
+            batch.out_cache_loc = batch.out_cache_loc[self.accept_indices]
 
         num_correct_drafts_list = num_correct_drafts_cpu.tolist()
         for i, req in enumerate(batch.reqs):

--- a/python/sglang/srt/speculative/sgl_suffix_plugin.py
+++ b/python/sglang/srt/speculative/sgl_suffix_plugin.py
@@ -1,0 +1,68 @@
+"""Register the SUFFIX speculative-decoding algorithm.
+
+SUFFIX is registered as a *plugin* algorithm (``SpeculativeAlgorithm.register``)
+rather than a builtin enum value. ``_SuffixLike.is_ngram()`` returns ``True`` so
+SUFFIX transparently reuses every existing NGRAM dispatch branch in the
+scheduler / cuda-graph runner / model runner — the verify and KV-cache path is
+identical; only the draft source differs (see ``SuffixWorker``). The factory is
+imported lazily so ``arctic_inference`` is required only when SUFFIX is actually
+selected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Type
+
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_registry import CustomSpecAlgo
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+
+class _SuffixLike(CustomSpecAlgo):
+    """SUFFIX dispatches like NGRAM (shared verify / KV-cache path)."""
+
+    def is_ngram(self) -> bool:
+        return True
+
+    def is_suffix(self) -> bool:
+        return True
+
+    def create_future_map(
+        self,
+        device,
+        req_to_token_pool,
+        needs_cpu_seq_lens: bool = True,
+    ):
+        # CustomSpecAlgo base does not provide this (the scheduler calls it
+        # unconditionally); mirror SpeculativeAlgorithm.create_future_map.
+        from sglang.srt.managers.overlap_utils import FutureMap
+
+        return FutureMap(device, self, req_to_token_pool, needs_cpu_seq_lens)
+
+
+def _suffix_factory(server_args: "ServerArgs") -> Type:
+    from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+    return SuffixWorker
+
+
+def _validate_suffix_args(server_args: "ServerArgs") -> None:
+    required = (
+        "speculative_suffix_max_tree_depth",
+        "speculative_suffix_max_cached_requests",
+        "speculative_suffix_max_spec_factor",
+        "speculative_suffix_min_token_prob",
+    )
+    missing = [a for a in required if not hasattr(server_args, a)]
+    if missing:
+        raise ValueError(f"SUFFIX speculative decoding requires server args {missing}.")
+
+
+SpeculativeAlgorithm.register(
+    "SUFFIX",
+    supports_overlap=False,
+    validate_server_args=_validate_suffix_args,
+    spec_class=_SuffixLike,
+)(_suffix_factory)

--- a/python/sglang/srt/speculative/sgl_suffix_plugin.py
+++ b/python/sglang/srt/speculative/sgl_suffix_plugin.py
@@ -43,6 +43,13 @@ class _SuffixLike(CustomSpecAlgo):
 
 
 def _suffix_factory(server_args: "ServerArgs") -> Type:
+    # With overlap scheduling enabled, dispatch the V2 worker (BaseSpecWorker
+    # contract — takes the per-step batch and runs alongside the scheduler's
+    # plan/predict streams). Otherwise stay on the V1 NGRAMWorker subclass.
+    if not server_args.disable_overlap_schedule:
+        from sglang.srt.speculative.suffix_worker_v2 import SuffixWorkerV2
+
+        return SuffixWorkerV2
     from sglang.srt.speculative.suffix_worker import SuffixWorker
 
     return SuffixWorker
@@ -62,7 +69,7 @@ def _validate_suffix_args(server_args: "ServerArgs") -> None:
 
 SpeculativeAlgorithm.register(
     "SUFFIX",
-    supports_overlap=False,
+    supports_overlap=True,
     validate_server_args=_validate_suffix_args,
     spec_class=_SuffixLike,
 )(_suffix_factory)

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -159,9 +159,13 @@ def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:
         server_args = get_global_server_args()
 
     # STANDALONE drafts don't consume `spec_info.hidden_states` (vanilla LLM).
+    # SUFFIX is model-free (arctic suffix-tree draft) and likewise never
+    # produces or consumes target hidden states, so the overlap FutureMap must
+    # not try to allocate/read a hidden_states buffer for it. (HYBRID_SUFFIX_MTP
+    # is NOT exempt: its MTP keep-up path needs hidden states.)
     # multi_layer_eagle handles hidden_states internally, not via FutureMap.
     # TODO(lsyin): also skip when step == 1.
-    if server_args.speculative_algorithm == "STANDALONE":
+    if server_args.speculative_algorithm in ("STANDALONE", "SUFFIX"):
         return False
     return not server_args.enable_multi_layer_eagle
 

--- a/python/sglang/srt/speculative/suffix_cache_adapter.py
+++ b/python/sglang/srt/speculative/suffix_cache_adapter.py
@@ -1,0 +1,324 @@
+"""
+Suffix decoding cache adapter for SGLang v0.5.9.
+
+This wraps arctic_inference.suffix_decoding.SuffixDecodingCache and exposes an
+NgramCache-like interface used by NGRAMWorker:
+  - batch_get(...) -> flat draft tokens + flat tree mask
+  - batch_put(...) -> no-op / sanity check
+  - synchronize(), reset()
+
+The important difference from NGRAM is that suffix decoding needs full request
+history (prompt + generated tokens) and a stable request id.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import deque
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixCacheAdapter:
+    def __init__(
+        self,
+        draft_token_num: int,
+        max_batch_size: int,
+        max_tree_depth: int = 24,
+        max_cached_requests: int = 10000,
+        max_spec_factor: float = 1.0,
+        min_token_prob: float = 0.1,
+    ):
+        # Lazy import so normal SGLang startup does not require arctic-inference.
+        try:
+            from arctic_inference.suffix_decoding import SuffixDecodingCache
+        except ImportError as exc:
+            raise ImportError(
+                "SUFFIX speculative decoding requires Arctic Inference. "
+                "Install it with: pip install arctic-inference"
+            ) from exc
+
+        self.suffix_cache = SuffixDecodingCache(
+            max_tree_depth=max_tree_depth,
+            max_cached_requests=max_cached_requests,
+        )
+        self.draft_token_num = draft_token_num
+        self.max_batch_size = max_batch_size
+        self.max_tree_depth = max_tree_depth
+        self.max_spec_factor = max_spec_factor
+        self.min_token_prob = min_token_prob
+
+        # Optional debug: SUFFIX_DEBUG_TREE=1 dumps the first generated tree.
+        self.debug_tree_dump_remaining = int(os.environ.get("SUFFIX_DEBUG_TREE", "0"))
+
+        # SGLang request id -> [arctic request id, last token length added]
+        self.req_state: dict[str, list] = {}
+        # rid -> number of consecutive batch_get/batch_peek_scores calls the
+        # request has been ABSENT from the batch. Drives grace-period teardown
+        # in _cleanup_inactive_requests (see there for why).
+        self._absent_count: dict[str, int] = {}
+        self._cleanup_grace = int(os.environ.get("SUFFIX_CLEANUP_GRACE", "32"))
+
+        max_total_drafts = self.max_batch_size * self.draft_token_num
+        self.draft_buffer = np.empty((max_total_drafts,), dtype=np.int64)
+        self.mask_buffer = np.empty(
+            (self.max_batch_size, self.draft_token_num, self.draft_token_num),
+            dtype=bool,
+        )
+
+        # Last batch's per-request raw SuffixDecodingDraft results from
+        # arctic, populated by batch_get. Cleared at the start of each call.
+        self.last_drafts: list = []
+
+    def _cleanup_inactive_requests(self, active_req_ids: set[str]) -> None:
+        # Release a request's suffix tree only after it has been ABSENT from the
+        # batch for `_cleanup_grace` consecutive calls -- NOT immediately when it
+        # is missing from the current batch.
+        #
+        # Why: under pipeline parallelism (pp_loop_size > 1 micro-batching) and
+        # DP-attention, the per-step batch passed here is only a SUBSET of the
+        # active requests -- they rotate between micro-batches. The naive
+        # "tear down everything not in this batch" then deletes the local suffix
+        # tree of a request that is merely waiting its turn, forcing a full
+        # start_request() prompt-tree REBUILD (tens of ms for long prompts) when
+        # it returns next step. Measured ~26 rebuilds/request under PP, which
+        # made the suffix-tree build (not the C++ speculate, which is ~0.1ms)
+        # the dominant decode-step cost. The grace window spans micro-batch
+        # rotation, so still-active requests are never torn down; genuinely
+        # finished requests simply stop appearing and are released once the
+        # window elapses.
+        #
+        # This change only ever makes teardown LESS aggressive, so it cannot
+        # regress correctness -- worst case is freeing a finished request's local
+        # tree a few steps later. In non-PP / single-batch mode every active
+        # request is present every call, so this behaves like the old code
+        # (release on finish) just delayed by `_cleanup_grace` steps.
+        grace = self._cleanup_grace
+        absent = self._absent_count
+        active_backend_reqs = getattr(self.suffix_cache, "active_requests", set())
+        to_release = []
+        for rid in list(self.req_state):
+            if rid in active_req_ids:
+                absent.pop(rid, None)
+            elif absent.get(rid, 0) + 1 >= grace:
+                to_release.append(rid)
+            else:
+                absent[rid] = absent.get(rid, 0) + 1
+        for rid in to_release:
+            cache_req_id, _ = self.req_state.pop(rid)
+            absent.pop(rid, None)
+            if cache_req_id in active_backend_reqs:
+                self.suffix_cache.stop_request(cache_req_id)
+
+    def _get_or_create_cache_req_id(
+        self, sglang_req_id: str, prompt: List[int]
+    ) -> Tuple[str, int]:
+        if sglang_req_id not in self.req_state:
+            cache_req_id = sglang_req_id
+            self.suffix_cache.start_request(cache_req_id, prompt)
+            # The prompt is already loaded into the backend cache.
+            self.req_state[sglang_req_id] = [cache_req_id, len(prompt)]
+        cache_req_id, last_length = self.req_state[sglang_req_id]
+        return cache_req_id, last_length
+
+    def batch_get(
+        self,
+        batch_req_ids: List[str],
+        batch_prompts: List[List[int]],
+        batch_tokens: List[List[int]],
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        batch_size = len(batch_req_ids)
+        if batch_size == 0:
+            return np.empty((0,), dtype=np.int64), np.empty((0,), dtype=bool)
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                f"Batch size {batch_size} exceeds max_batch_size={self.max_batch_size}"
+            )
+
+        total_draft_tokens = batch_size * self.draft_token_num
+        draft_view = self.draft_buffer[:total_draft_tokens]
+        mask_view = self.mask_buffer[:batch_size]
+        mask_view.fill(False)
+
+        self._cleanup_inactive_requests(set(batch_req_ids))
+        self.last_drafts = []
+
+        for row, (sglang_req_id, prompt, tokens) in enumerate(
+            zip(batch_req_ids, batch_prompts, batch_tokens)
+        ):
+            cache_req_id, last_length = self._get_or_create_cache_req_id(
+                sglang_req_id, prompt
+            )
+
+            # Add only the verified delta since the previous step.
+            current_length = len(tokens)
+            if current_length > last_length:
+                new_tokens = tokens[last_length:current_length]
+                if cache_req_id in getattr(self.suffix_cache, "active_requests", set()):
+                    self.suffix_cache.add_active_response(cache_req_id, new_tokens)
+                    self.req_state[sglang_req_id][1] = current_length
+                else:
+                    logger.warning(
+                        "Suffix cache request %s is not active when updating",
+                        cache_req_id,
+                    )
+
+            # Arctic suffix decoding matches from the current suffix pattern.
+            pattern_start = max(0, len(tokens) - self.max_tree_depth)
+            pattern = tokens[pattern_start:]
+            draft = self.suffix_cache.speculate(
+                cache_req_id,
+                pattern,
+                max_spec_tokens=self.draft_token_num,
+                max_spec_factor=self.max_spec_factor,
+                min_token_prob=self.min_token_prob,
+            )
+            self.last_drafts.append(draft)
+
+            draft_ids = list(draft.token_ids)
+            draft_parents = list(draft.parents)
+            draft_ids, draft_parents = self._reorder_tree_bfs(draft_ids, draft_parents)
+            context_token = tokens[-1] if tokens else 0
+            draft_ids, draft_parents = self._inject_root_node(
+                draft_ids, draft_parents, context_token
+            )
+
+            original_len = len(draft_ids)
+            if original_len < self.draft_token_num:
+                pad_len = self.draft_token_num - original_len
+                draft_ids.extend([0] * pad_len)
+                draft_parents.extend([0] * pad_len)
+            elif original_len > self.draft_token_num:
+                draft_ids = draft_ids[: self.draft_token_num]
+                draft_parents = draft_parents[: self.draft_token_num]
+                original_len = self.draft_token_num
+
+            start = row * self.draft_token_num
+            end = start + self.draft_token_num
+            draft_view[start:end] = draft_ids
+
+            # Build ancestry mask: token i can attend to its ancestors and itself.
+            mask = mask_view[row]
+            for i in range(original_len):
+                mask[i, i] = True
+                parent = draft_parents[i]
+                while 0 <= parent < self.draft_token_num:
+                    mask[i, parent] = True
+                    parent = draft_parents[parent]
+
+            if self.debug_tree_dump_remaining > 0 and original_len > 0:
+                logger.warning(
+                    "[SUFFIX DEBUG] req=%s len=%d ids=%s",
+                    sglang_req_id,
+                    original_len,
+                    draft_ids,
+                )
+                logger.warning("[SUFFIX DEBUG] mask=\n%s", mask.astype(int))
+                self.debug_tree_dump_remaining -= 1
+
+        tree_mask = mask_view.reshape(-1)[: total_draft_tokens * self.draft_token_num]
+        return draft_view, tree_mask
+
+    def batch_put(
+        self, batch_req_ids: List[str], batch_tokens: List[List[int]]
+    ) -> None:
+        # Cache update is performed in batch_get before speculation, because the
+        # suffix backend needs a per-request incremental state.
+        for rid in batch_req_ids:
+            if rid not in self.req_state:
+                logger.debug("batch_put called before batch_get for request %s", rid)
+
+    def erase_match_state(self, req_ids: List[str]) -> None:
+        # Release finished requests from the suffix cache (NGRAMWorker calls this
+        # with finished req ids after each step). Mirrors NgramCorpus.erase_match_state.
+        active = getattr(self.suffix_cache, "active_requests", set())
+        for rid in req_ids:
+            state = self.req_state.pop(rid, None)
+            self._absent_count.pop(rid, None)
+            if state is not None and state[0] in active:
+                self.suffix_cache.stop_request(state[0])
+
+    # External-corpus management is an NGRAM-only feature; SUFFIX has no SAM.
+    # Stubbed so the duck-typed NGRAMWorker / HTTP handlers fail clearly if used.
+    def commit_external_corpus_load(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def list_external_corpora(self, *args, **kwargs):
+        return []
+
+    def load_external_corpus_named(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def remove_external_corpus(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def synchronize(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        for cache_req_id in list(getattr(self.suffix_cache, "active_requests", set())):
+            self.suffix_cache.stop_request(cache_req_id)
+        self.req_state.clear()
+        self._absent_count.clear()
+
+    def _reorder_tree_bfs(
+        self, token_ids: List[int], parents: List[Optional[int]]
+    ) -> Tuple[List[int], List[int]]:
+        """Ensure parents precede descendants; SGLang reconstruct assumes this."""
+        n = len(token_ids)
+        if n <= 1:
+            return token_ids, [(-1 if p is None else p) for p in parents]
+
+        children: List[List[int]] = [[] for _ in range(n)]
+        roots: List[int] = []
+        for idx, parent in enumerate(parents):
+            if parent is None or parent < 0 or parent >= n:
+                roots.append(idx)
+            else:
+                children[parent].append(idx)
+        if not roots:
+            roots = [0]
+
+        order: List[int] = []
+        visited = [False] * n
+        for root in roots:
+            q = deque([root])
+            while q:
+                node = q.popleft()
+                if visited[node]:
+                    continue
+                visited[node] = True
+                order.append(node)
+                q.extend(children[node])
+        for idx in range(n):
+            if not visited[idx]:
+                order.append(idx)
+
+        if order == list(range(n)):
+            return token_ids, [(-1 if p is None else p) for p in parents]
+
+        remap = {old: new for new, old in enumerate(order)}
+        reordered_ids = [token_ids[old] for old in order]
+        reordered_parents: List[int] = []
+        for old in order:
+            parent = parents[old]
+            if parent is None or parent < 0:
+                reordered_parents.append(-1)
+            else:
+                reordered_parents.append(remap.get(parent, -1))
+        return reordered_ids, reordered_parents
+
+    def _inject_root_node(
+        self, token_ids: List[int], parents: List[int], context_token: int
+    ) -> Tuple[List[int], List[int]]:
+        """Insert latest verified token as root node to match NGRAM layout."""
+        rooted_ids = [context_token]
+        rooted_parents = [-1]
+        for parent in parents:
+            rooted_parents.append(0 if parent < 0 else parent + 1)
+        rooted_ids.extend(token_ids)
+        return rooted_ids, rooted_parents

--- a/python/sglang/srt/speculative/suffix_v2_draft_builder.py
+++ b/python/sglang/srt/speculative/suffix_v2_draft_builder.py
@@ -1,0 +1,135 @@
+"""SUFFIX V2 linear-chain draft → EagleVerifyInput converter.
+
+Phase 2.x design: SUFFIX V2 doesn't write its own verify path. Instead it
+expresses its linear chain as a topk=1 EAGLE tree and reuses EAGLE V2's
+`verify_tree_greedy` kernel + `prepare_for_v2_verify` / `sample` scaffold.
+
+Layout for `K = num_verify_tokens` per req, `bs` total reqs:
+  flat draft array       shape (bs*K,)         [bonus_0, sfx_0_1, sfx_0_2, ..., sfx_0_(K-1),
+                                                bonus_1, sfx_1_1, ...]
+  positions              shape (bs*K,)         positions[i*K+j] = seq_lens[i] + j
+  retrieve_index         shape (bs, K) int64   retrieve_index[i, j] = i*K + j
+  retrieve_next_token    shape (bs, K) int64   = i*K + j + 1 if j<K-1 else -1
+  retrieve_next_sibling  shape (bs, K) int64   all -1 (no siblings in topk=1)
+
+EAGLE's `verify_tree_greedy` kernel walks these arrays without caring whether
+the tree is degenerate (linear) or branching. As long as next_sibling is -1
+everywhere and next_token forms a single chain, the kernel produces the same
+"accept the longest matching prefix" semantics that we'd get from a custom
+NgramVerifyInput.greedy_verify, but with no custom kernel.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+
+def build_linear_retrieve_arrays(
+    bs: int,
+    K: int,
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build retrieve_index / retrieve_next_token / retrieve_next_sibling for
+    a topk=1 linear chain of K tokens per req.
+
+    Same shapes/dtypes as EAGLE's `build_tree_kernel_efficient` output (the
+    int64 / shape=(bs, K) format `verify_tree_greedy` expects).
+    """
+    # retrieve_index[i, j] = i*K + j → GLOBAL flat index into bs*K candidates
+    # array. The kernel uses this to look up the actual draft token value
+    # given a (req, local_node) pair.
+    retrieve_index = torch.arange(bs * K, dtype=torch.int64, device=device).view(bs, K)
+
+    # retrieve_next_token[i, j] = LOCAL index (per-req, range [0, K-1] or -1)
+    # of node j's first child. For linear chain: child of j is j+1, leaf is K-1.
+    # NOT a flat global index — kernel walks within per-req tree, then resolves
+    # to candidates[retrieve_index[i, that_local]].
+    local_arange = torch.arange(K, dtype=torch.int64, device=device).view(1, K)
+    next_token_local = local_arange + 1
+    next_token_local = next_token_local.expand(bs, K).contiguous()
+    next_token_local[:, -1] = -1
+    retrieve_next_token = next_token_local
+
+    # retrieve_next_sibling: linear chain has no siblings anywhere → all -1
+    retrieve_next_sibling = torch.full((bs, K), -1, dtype=torch.int64, device=device)
+
+    return retrieve_index, retrieve_next_token, retrieve_next_sibling
+
+
+def build_linear_positions(seq_lens: torch.Tensor, K: int) -> torch.Tensor:
+    """Build per-draft-token absolute positions for a linear chain.
+
+    positions[i*K + j] = seq_lens[i] + j
+
+    Shape: (bs*K,) int64. Matches EAGLE's `positions` tensor format consumed
+    by the target attention forward.
+    """
+    bs = seq_lens.numel()
+    device = seq_lens.device
+    # offsets[j] = j  (broadcast across bs)
+    offsets = torch.arange(K, dtype=torch.int64, device=device).view(1, K)
+    seq_lens_i64 = seq_lens.to(torch.int64).view(bs, 1)
+    positions = (seq_lens_i64 + offsets).view(bs * K)
+    return positions
+
+
+def build_suffix_v2_verify_arrays(
+    bonus_tokens: torch.Tensor,
+    suffix_draft_tokens: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """One-shot builder for the SUFFIX V2 → EagleVerifyInput tensor pieces.
+
+    Args:
+        bonus_tokens: (bs,) int32 — first token of each chain (the "+1" from
+            previous verify, becomes draft position 0).
+        suffix_draft_tokens: (bs, K-1) int32 — remaining K-1 spec tokens per
+            req, queried from the suffix tree. Pad shorter chains with any
+            value; target.argmax will reject them and accept length will cut.
+        seq_lens: (bs,) int32/int64 — current sequence lengths (pre-verify).
+
+    Returns:
+        draft_token_flat:        (bs*K,) int32
+        positions:               (bs*K,) int64
+        retrieve_index:          (bs, K) int64
+        retrieve_next_token:     (bs, K) int64
+        retrieve_next_sibling:   (bs, K) int64
+
+    Caller still needs to attach `custom_mask` and the other EagleVerifyInput
+    fields (spec_steps, topk=1, draft_token_num=K, etc.) — see
+    `build_suffix_v2_eagle_verify_input`.
+    """
+    bs = bonus_tokens.numel()
+    K = 1 + suffix_draft_tokens.size(1)
+    device = bonus_tokens.device
+    assert (
+        suffix_draft_tokens.size(0) == bs
+    ), f"bs mismatch: bonus_tokens={bs}, suffix_draft_tokens={suffix_draft_tokens.shape}"
+    assert (
+        seq_lens.numel() == bs
+    ), f"bs mismatch: seq_lens={seq_lens.numel()} vs bonus_tokens={bs}"
+
+    # Flat draft array: [bonus_0, sfx_0_1..sfx_0_(K-1), bonus_1, sfx_1_1..., ...]
+    # Match EAGLE convention: bonus prepended, then spec tokens.
+    # Dtype = int64: that's what verify_tree_greedy's sgl_kernel expects
+    # (matches EagleVerifyInput.create_idle_input dtype=torch.long).
+    draft_token_flat = (
+        torch.cat((bonus_tokens.view(bs, 1), suffix_draft_tokens), dim=1)
+        .view(bs * K)
+        .to(torch.int64)
+    )
+
+    positions = build_linear_positions(seq_lens, K)
+    retrieve_index, retrieve_next_token, retrieve_next_sibling = (
+        build_linear_retrieve_arrays(bs, K, device)
+    )
+
+    return (
+        draft_token_flat,
+        positions,
+        retrieve_index,
+        retrieve_next_token,
+        retrieve_next_sibling,
+    )

--- a/python/sglang/srt/speculative/suffix_v2_draft_builder_full.py
+++ b/python/sglang/srt/speculative/suffix_v2_draft_builder_full.py
@@ -1,0 +1,208 @@
+"""SUFFIX V2 standalone draft builder — M3b.
+
+Wraps `arctic_inference.SuffixDecodingCache` with a V2-friendly tensor
+interface. Handles per-request state lifecycle (start/update/stop) and
+returns padded GPU tensors ready to feed into the M2 EagleVerifyInput
+builder.
+
+Key design decisions:
+- Uses arctic's default `use_tree_spec=False` → linear chain (matches our
+  V2 design's "topk=1 linear" assumption).
+- Keys state by sglang `rid` (Hashable string). Never by req_pool_index
+  (per design doc §3.4: pool slots get reused, would corrupt history).
+- Padding: short matches (< K-1) are padded with token_id=0 + valid_mask
+  False. Downstream verify will reject the padded slots — accept length
+  naturally cuts at the real match length.
+- Pattern construction: last `max_tree_depth` tokens (matching V1's
+  policy for parity).
+
+This builder is stateful (suffix tree per rid). Caller must invoke
+`start_request` for each new rid, `stop_request` on finish, and
+`update_with_accepted` after each verify step to push accepted tokens
+into the suffix tree (so future speculations include them).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixV2DraftBuilder:
+    """Standalone V2 draft builder over `arctic_inference.SuffixDecodingCache`.
+
+    Returns padded GPU tensors:
+      draft_tokens: (bs, K_minus_1) int32 — speculated tokens, padded with 0
+      draft_lens:   (bs,) int32           — actual match length per req
+      valid_mask:   (bs, K_minus_1) bool  — True for [:draft_lens[i]]
+    """
+
+    def __init__(
+        self,
+        max_cached_requests: int = 10000,
+        max_tree_depth: int = 64,
+        max_spec_factor: float = 2.0,
+        min_token_prob: float = 0.1,
+    ):
+        from arctic_inference.suffix_decoding import SuffixDecodingCache
+
+        self.cache = SuffixDecodingCache(
+            max_tree_depth=max_tree_depth,
+            max_cached_requests=max_cached_requests,
+        )
+        warmup_path = os.environ.get("ARCTIC_SUFFIX_GLOBAL_WARMUP_PATH")
+        warmup_count = getattr(self.cache, "_warmup_count", 0)
+        if warmup_path:
+            logger.info(
+                "SuffixV2DraftBuilder: arctic global tree warmup loaded "
+                "%d records from %s (max_tree_depth=%d max_cached=%d)",
+                warmup_count,
+                warmup_path,
+                max_tree_depth,
+                max_cached_requests,
+            )
+        else:
+            logger.info(
+                "SuffixV2DraftBuilder: no warmup "
+                "(ARCTIC_SUFFIX_GLOBAL_WARMUP_PATH unset); "
+                "max_tree_depth=%d max_cached=%d",
+                max_tree_depth,
+                max_cached_requests,
+            )
+        self.max_spec_factor = max_spec_factor
+        self.min_token_prob = min_token_prob
+        self.max_tree_depth = max_tree_depth
+
+        # rid → length of tokens already pushed into the suffix cache.
+        # Lets `update_with_accepted` push only the delta since last call.
+        self._pushed_len: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Per-request lifecycle
+    # ------------------------------------------------------------------
+    def start_request(self, rid: str, prompt_tokens: Sequence[int]) -> None:
+        """Register a new request with its prompt. Must be called before any
+        query/update for this rid."""
+        self.cache.start_request(rid, list(prompt_tokens))
+        self._pushed_len[rid] = len(prompt_tokens)
+
+    def update_with_accepted(self, rid: str, all_tokens: Sequence[int]) -> None:
+        """Push the delta of accepted tokens since last call into the suffix
+        tree. Idempotent if all_tokens hasn't grown.
+
+        Caller passes the FULL accumulated tokens (prompt + all output so
+        far); we slice out the new tail using our tracked `_pushed_len`.
+        """
+        pushed = self._pushed_len.get(rid, 0)
+        cur = len(all_tokens)
+        if cur > pushed:
+            new = list(all_tokens[pushed:cur])
+            if rid in self.cache.active_requests:
+                self.cache.add_active_response(rid, new)
+            self._pushed_len[rid] = cur
+
+    def stop_request(self, rid: str) -> None:
+        """Finish a request — release local tree state. Global tree retains
+        the response (with FIFO eviction governed by max_cached_requests)."""
+        if rid in self.cache.active_requests:
+            self.cache.stop_request(rid)
+        self._pushed_len.pop(rid, None)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+    def query_batch(
+        self,
+        rids: List[str],
+        current_tokens: List[Sequence[int]],
+        K_minus_1: int,
+        device: torch.device,
+        return_scores: bool = False,
+        max_remaining_per_req: Optional[Sequence[int]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Query the suffix cache for each req's next draft.
+
+        Args:
+            rids: per-req identifiers (must have been registered via
+                  `start_request`).
+            current_tokens: full prompt+output for each req (used to form
+                  the suffix pattern for matching).
+            K_minus_1: number of draft tokens to request per req (chain
+                  width K minus the bonus slot).
+            device: target device for returned tensors.
+            return_scores: when True, also returns per-req scores (Python
+                  list, for the HYBRID selector).
+            max_remaining_per_req: optional per-req ceiling on draft length
+                  (e.g. ctx_len - cur_seq_len - 1). Prevents the verify
+                  step from overshooting context_len and producing an
+                  overlap-schedule "zombie" verify on the next iteration
+                  (see patch_nsa_zombie_overflow.py for the symptom).
+                  When None, no per-req cap; each req gets up to K_minus_1.
+
+        Returns:
+            draft_tokens: (bs, K_minus_1) int32, padded with 0
+            draft_lens:   (bs,) int32, actual length per req
+            valid_mask:   (bs, K_minus_1) bool
+            scores:       List[float] (bs,) — only if return_scores=True
+        """
+        bs = len(rids)
+        assert len(current_tokens) == bs
+        if max_remaining_per_req is not None:
+            assert len(max_remaining_per_req) == bs, (
+                f"max_remaining_per_req has {len(max_remaining_per_req)} entries, "
+                f"expected bs={bs}"
+            )
+
+        draft_tokens_np = np.zeros((bs, K_minus_1), dtype=np.int32)
+        draft_lens_np = np.zeros(bs, dtype=np.int32)
+        valid_mask_np = np.zeros((bs, K_minus_1), dtype=bool)
+        scores: List[float] = [0.0] * bs if return_scores else []
+
+        for i, (rid, tokens) in enumerate(zip(rids, current_tokens)):
+            # Per-req draft ceiling: K_minus_1 floor by remaining ctx room
+            # (if provided). 0 means this req is at the boundary — skip
+            # drafting entirely; verify still runs with bonus-only.
+            req_K = K_minus_1
+            if max_remaining_per_req is not None:
+                req_K = min(req_K, max(0, int(max_remaining_per_req[i])))
+            if req_K == 0:
+                if return_scores:
+                    scores[i] = 0.0
+                continue
+
+            # Take last max_tree_depth tokens as pattern. Arctic also clips
+            # internally but doing it here keeps pattern shorter for arctic.
+            pattern_start = max(0, len(tokens) - self.max_tree_depth)
+            pattern = list(tokens[pattern_start:])
+
+            draft = self.cache.speculate(
+                rid,
+                pattern,
+                max_spec_tokens=req_K,
+                max_spec_factor=self.max_spec_factor,
+                min_token_prob=self.min_token_prob,
+                # use_tree_spec=False (default) → linear chain
+            )
+
+            actual_len = min(len(draft.token_ids), req_K)
+            if actual_len > 0:
+                draft_tokens_np[i, :actual_len] = list(draft.token_ids[:actual_len])
+                draft_lens_np[i] = actual_len
+                valid_mask_np[i, :actual_len] = True
+            if return_scores:
+                scores[i] = float(getattr(draft, "score", 0.0))
+
+        result = (
+            torch.from_numpy(draft_tokens_np).to(device),
+            torch.from_numpy(draft_lens_np).to(device),
+            torch.from_numpy(valid_mask_np).to(device),
+        )
+        if return_scores:
+            return result + (scores,)
+        return result

--- a/python/sglang/srt/speculative/suffix_v2_verify_input.py
+++ b/python/sglang/srt/speculative/suffix_v2_verify_input.py
@@ -1,0 +1,134 @@
+"""Build a complete EagleVerifyInput from a SUFFIX linear-chain draft.
+
+M2 of the SUFFIX V2 overlap work. Builds on M1's draft_builder (retrieve_*
+arrays + positions) and adds:
+  - custom_mask construction for the FULL_MASK layout (per-row prefix=True
+    + lower-triangular K-block for linear chain)
+  - All remaining EagleVerifyInput dataclass fields
+    (spec_steps, topk=1, draft_token_num, capture_hidden_mode,
+     seq_lens_sum, seq_lens_cpu)
+
+Once this returns a populated EagleVerifyInput, the EAGLE V2 verify scaffold
+(`prepare_for_v2_verify` → target forward(is_verify=True) → `sample`) can be
+reused verbatim — no SUFFIX-specific verify path.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.speculative.eagle_info import EagleVerifyInput
+from sglang.srt.speculative.suffix_v2_draft_builder import build_suffix_v2_verify_arrays
+
+
+def build_suffix_v2_custom_mask(
+    bs: int,
+    K: int,
+    seq_lens_cpu: torch.Tensor,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build the FULL_MASK custom_mask for a topk=1 linear chain.
+
+    Per-req block layout (K rows × (seq_lens[i] + K) cols, row-major):
+      row j: [True] * seq_lens[i] + [True] * (j+1) + [False] * (K-j-1)
+      (i.e., prefix all attended, then lower-triangular within K-block)
+
+    Concatenated across reqs in flat layout. Total size:
+        sum_i K * (seq_lens[i] + K) = K * seq_lens_sum + K * K * bs
+
+    Args:
+        bs: batch size
+        K: draft_token_num (chain width per req)
+        seq_lens_cpu: per-req seq_lens, shape (bs,) on CPU (int)
+        device: target device for the output mask
+
+    Returns:
+        custom_mask: (K * seq_lens_sum + K*K*bs,) bool tensor on `device`
+    """
+    assert (
+        seq_lens_cpu.numel() == bs
+    ), f"seq_lens_cpu has {seq_lens_cpu.numel()} entries, expected bs={bs}"
+
+    # Build the K-block lower-triangular mask once (same for every req).
+    # k_block[j, k] = True iff k <= j  (i.e., position j attends to k in chain)
+    k_block = torch.tril(torch.ones((K, K), dtype=torch.bool, device=device))  # (K, K)
+
+    # Concatenate per-req chunks. Each chunk is K rows × (seq_lens[i] + K) cols
+    # flattened row-major.
+    chunks = []
+    seq_lens_list = seq_lens_cpu.tolist()
+    for sl in seq_lens_list:
+        prefix_block = torch.ones((K, sl), dtype=torch.bool, device=device)
+        per_req = torch.cat((prefix_block, k_block), dim=1)  # (K, sl + K)
+        chunks.append(per_req.reshape(-1))  # flatten row-major to (K * (sl + K),)
+    custom_mask = (
+        torch.cat(chunks) if chunks else torch.empty(0, dtype=torch.bool, device=device)
+    )
+    return custom_mask
+
+
+def build_suffix_v2_eagle_verify_input(
+    bonus_tokens: torch.Tensor,
+    suffix_draft_tokens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    seq_lens_cpu: Optional[torch.Tensor] = None,
+    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.NULL,
+) -> EagleVerifyInput:
+    """Build a complete EagleVerifyInput from SUFFIX linear chain draft.
+
+    Args:
+        bonus_tokens: (bs,) int — first token per chain (from prev step's verify)
+        suffix_draft_tokens: (bs, K-1) int — suffix-cache-queried spec tokens
+        seq_lens: (bs,) int — per-req current seq length (on device)
+        seq_lens_cpu: (bs,) int on CPU; computed from seq_lens if None
+        capture_hidden_mode: NULL for standalone SUFFIX, FULL if downstream
+            needs hidden states (e.g., HYBRID V2 with MTP keep-up).
+
+    Returns:
+        EagleVerifyInput ready to be assigned to the batch's spec_info
+        and passed through EAGLE V2's verify scaffold (`prepare_for_v2_verify`,
+        target forward(is_verify=True), `sample`).
+    """
+    bs = bonus_tokens.numel()
+    K = 1 + suffix_draft_tokens.size(1)
+    device = bonus_tokens.device
+
+    if seq_lens_cpu is None:
+        seq_lens_cpu = seq_lens.cpu()
+
+    # M1 builder: draft_token_flat + positions + retrieve_*
+    (
+        draft_token_flat,
+        positions,
+        retrieve_index,
+        retrieve_next_token,
+        retrieve_next_sibling,
+    ) = build_suffix_v2_verify_arrays(
+        bonus_tokens=bonus_tokens,
+        suffix_draft_tokens=suffix_draft_tokens,
+        seq_lens=seq_lens,
+    )
+
+    # M2: custom_mask (FULL_MASK layout, linear chain = lower-triangular K-block)
+    custom_mask = build_suffix_v2_custom_mask(bs, K, seq_lens_cpu, device)
+
+    seq_lens_sum = int(seq_lens_cpu.sum().item())
+
+    return EagleVerifyInput(
+        draft_token=draft_token_flat,
+        custom_mask=custom_mask,
+        positions=positions,
+        retrieve_index=retrieve_index,
+        retrieve_next_token=retrieve_next_token,
+        retrieve_next_sibling=retrieve_next_sibling,
+        retrieve_cum_len=None,
+        spec_steps=K - 1,  # number of draft steps (excluding bonus)
+        topk=1,  # linear chain = topk=1
+        draft_token_num=K,  # K tokens per req in candidates
+        capture_hidden_mode=capture_hidden_mode,
+        seq_lens_sum=seq_lens_sum,
+        seq_lens_cpu=seq_lens_cpu,
+    )

--- a/python/sglang/srt/speculative/suffix_worker.py
+++ b/python/sglang/srt/speculative/suffix_worker.py
@@ -1,0 +1,97 @@
+"""SUFFIX speculative-decoding worker (no pipeline parallelism).
+
+SUFFIX is *model-free* speculative decoding (Snowflake ArcticInference's
+SuffixDecoding): a CPU suffix tree built over each request's prompt + generated
+tokens proposes draft continuations, which are verified in a single target
+forward pass. It is especially effective on agentic / repetitive workloads and
+adds no draft-model GPU cost.
+
+Implementation reuses :class:`NGRAMWorker` unchanged for the verify + KV-cache
+machinery; the only difference is the *draft source*. ``NGRAMWorker`` reads
+draft candidates from ``self.ngram_corpus`` (an n-gram corpus); here we replace
+that attribute with a :class:`SuffixCacheAdapter` wrapping
+``arctic_inference``'s ``SuffixDecodingCache``, and override the two hooks that
+talk to it so the adapter is fed each request's full token history (the suffix
+tree needs prompt + output, not just the recent n-gram pattern).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.ngram_worker import NGRAMWorker
+from sglang.srt.speculative.suffix_cache_adapter import SuffixCacheAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixWorker(NGRAMWorker):
+    """``NGRAMWorker`` whose draft source is an Arctic suffix tree.
+
+    Tensor parallelism is supported as-is (inherited from ``NGRAMWorker``: the
+    suffix draft is built per-rank on CPU and the target forward is TP-sharded
+    transparently). Pipeline parallelism and overlap-scheduling (spec-v2) are
+    added by follow-on workers. ``forward_batch_generation`` and all verify/KV
+    logic are inherited from ``NGRAMWorker`` verbatim.
+    """
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        attn_cp_rank: int,
+        moe_dp_rank: int,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        super().__init__(
+            server_args=server_args,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+            dp_rank=dp_rank,
+            moe_ep_rank=moe_ep_rank,
+            attn_cp_rank=attn_cp_rank,
+            moe_dp_rank=moe_dp_rank,
+            nccl_port=nccl_port,
+            target_worker=target_worker,
+        )
+        # Swap the n-gram corpus for the suffix-tree adapter. The inherited
+        # _prepare_draft_tokens / _update_ngram_corpus call self.ngram_corpus,
+        # which we override below to pass the adapter full request history.
+        self.ngram_corpus = SuffixCacheAdapter(
+            draft_token_num=server_args.speculative_num_draft_tokens,
+            max_batch_size=self.max_batch_size,
+            max_tree_depth=server_args.speculative_suffix_max_tree_depth,
+            max_cached_requests=server_args.speculative_suffix_max_cached_requests,
+            max_spec_factor=server_args.speculative_suffix_max_spec_factor,
+            min_token_prob=server_args.speculative_suffix_min_token_prob,
+        )
+
+    def _prepare_draft_tokens(self, batch: ScheduleBatch):
+        bs = batch.batch_size()
+        self.ngram_corpus.synchronize()
+        req_ids: List[str] = []
+        prompts: List[List[int]] = []
+        tokens: List[List[int]] = []
+        for req in batch.reqs:
+            req_ids.append(req.rid)
+            prompts.append(req.origin_input_ids)
+            tokens.append(req.origin_input_ids + req.output_ids)
+        req_drafts, mask = self.ngram_corpus.batch_get(req_ids, prompts, tokens)
+        total_draft_token_num = len(req_drafts)
+        assert (
+            total_draft_token_num == bs * self.draft_token_num
+        ), f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
+        return req_drafts, mask
+
+    def _update_ngram_corpus(self, batch: ScheduleBatch):
+        req_ids = [req.rid for req in batch.reqs]
+        tokens = [req.origin_input_ids + req.output_ids for req in batch.reqs]
+        self.ngram_corpus.batch_put(req_ids, tokens)

--- a/python/sglang/srt/speculative/suffix_worker_v2.py
+++ b/python/sglang/srt/speculative/suffix_worker_v2.py
@@ -1,0 +1,609 @@
+"""SuffixWorkerV2 — M4 skeleton.
+
+Glues M1 (linear chain → verify arrays), M2 (complete EagleVerifyInput),
+M3b (SuffixV2DraftBuilder) into a Spec V2 worker that:
+
+  - Reuses EAGLE V2's verify scaffold (prepare_for_v2_verify, target
+    forward with is_verify=True, EagleVerifyInput.sample) verbatim
+  - Replaces only the "draft" step: arctic suffix tree query instead of
+    EAGLE draft model forward
+  - Maintains per-rid token history for arctic add_active_response calls
+
+Status: SKELETON. Not yet wired into sgl_suffix_plugin. End-to-end
+integration test deferred until plugin registration + first server boot.
+
+Open issues (to resolve before first server boot):
+
+  [I1] How do we get the rid → accepted-tokens delta after each verify?
+       Maintain our own `_req_tokens: Dict[rid, list[int]]` cache.
+       After each step we read predict[accept_index] on CPU (sync on
+       verify_done) and stash into `_pending_accepted`; next step drains
+       it into the arctic tree before querying. CPU-sync cost accepted
+       for M4; M6 will fold this into a CPU hook that runs after verify
+       completes (no extra sync vs the existing batch.maybe_wait_verify_done).
+
+  [I2] resolved: `mwb.reqs` is populated unconditionally by
+       `ScheduleBatch.get_model_worker_batch()` (schedule_batch.py:2617).
+       Use `[req.rid for req in mwb.reqs]`.
+
+  [I3] resolved: prompts come from `req.origin_input_ids` (already on CPU,
+       per-req) — no slicing of `mwb.input_ids` needed.
+
+  [I4] capture_hidden_mode: we pass NULL (standalone SUFFIX, no MTP keep-up
+       needed). For HYBRID V2 future use, this becomes FULL.
+
+  [I5] Overlap event-stream: `plan_stream`, `_draft_done_event`,
+       `record_stream` patterns from EAGLEWorkerV2.verify mostly transfer
+       directly; we don't have a draft model forward to wait on, so the
+       `_draft_done_event` synchronization may simplify.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional
+
+import torch
+
+# sglang imports (resolved at runtime on pod where sglang is installed)
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
+from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.eagle_info_v2 import fill_bonus_tokens
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.suffix_v2_draft_builder_full import SuffixV2DraftBuilder
+from sglang.srt.speculative.suffix_v2_verify_input import (
+    build_suffix_v2_eagle_verify_input,
+)
+
+
+class SuffixDraftWorker(BaseDraftWorker):
+    """Stub draft worker for SUFFIX V2.
+
+    SUFFIX doesn't use a separate draft model — drafts come from arctic
+    suffix tree query handled inside SuffixWorkerV2 directly. BaseDraftWorker
+    requires `draft()` and `draft_extend()` to exist as abstract methods, so
+    we provide no-op implementations.
+    """
+
+    def draft(self, *args, **kwargs):
+        # SUFFIX V2 doesn't run a draft model forward. Query happens inside
+        # SuffixWorkerV2._decode_step via SuffixV2DraftBuilder.
+        raise NotImplementedError(
+            "SuffixDraftWorker.draft() is intentionally a stub — see "
+            "SuffixWorkerV2._decode_step for the actual suffix tree query."
+        )
+
+    def draft_extend(self, *args, **kwargs):
+        raise NotImplementedError(
+            "SuffixDraftWorker.draft_extend() is intentionally a stub."
+        )
+
+
+class SuffixWorkerV2(BaseSpecWorker):
+    """SUFFIX speculative-decoding worker on the Spec V2 contract.
+
+    Per-batch flow (decode):
+
+      1. mwb.spec_info is the EagleDraftInput from prev step (carries
+         bonus_tokens, new_seq_lens, verify_done event — resolved by
+         FutureMap).
+      2. CPU-sync on verify_done so we can read the prev step's accepted
+         tokens (TODO I1: need them on CPU to update arctic tree).
+      3. update_with_accepted(rid, full_history) — push delta into tree.
+      4. query_batch(rids, current_tokens, K-1) → suffix draft tokens.
+      5. build_suffix_v2_eagle_verify_input(...) → EagleVerifyInput
+         (topk=1 linear chain).
+      6. EAGLE V2 verify scaffold:
+         a. prepare_for_v2_verify (allocates KV slots, sets up cuda graph)
+         b. target_worker.forward_batch_generation(is_verify=True)
+         c. verify_input.sample(batch, logits, vocab_mask)
+      7. Build next_draft_input = EagleDraftInput(bonus_tokens, new_seq_lens,
+         verify_done) and stash next step's expected accept tokens for I1.
+      8. Return GenerationBatchResult.
+
+    Per-batch flow (extend / prefill):
+
+      1. Standard target forward (no spec).
+      2. Initialize arctic cache state for new reqs (start_request).
+      3. Build next_draft_input with bonus_tokens = next_token_ids.
+    """
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        attn_cp_rank: int,
+        moe_dp_rank: int,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        self.server_args = server_args
+        self.tp_rank = tp_rank
+        self.gpu_id = gpu_id
+        self.device = server_args.device
+        self.page_size = server_args.page_size
+        self._target_worker = target_worker
+        self._draft_worker = SuffixDraftWorker()
+
+        # K = chain width per req (bonus slot + K-1 spec slots).
+        self.K = server_args.speculative_num_draft_tokens
+        assert self.K >= 2, "speculative_num_draft_tokens must be >= 2 for SUFFIX V2"
+        self.K_minus_1 = self.K - 1
+
+        # Model context length — used to cap each req's draft chain so the
+        # verify step can't overshoot ctx_len and produce an overlap-schedule
+        # zombie verify on the next iteration. See patch_nsa_zombie_overflow.py
+        # for the underlying crash this prevents at the source.
+        self._max_context_len = int(target_worker.model_runner.model_config.context_len)
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
+            target_worker.get_memory_pool()
+        )
+
+        # The suffix tree query backend. Wraps arctic SuffixDecodingCache.
+        self.draft_builder = SuffixV2DraftBuilder(
+            max_cached_requests=server_args.speculative_suffix_max_cached_requests,
+            max_tree_depth=server_args.speculative_suffix_max_tree_depth,
+            max_spec_factor=server_args.speculative_suffix_max_spec_factor,
+            min_token_prob=server_args.speculative_suffix_min_token_prob,
+        )
+
+        # Per-rid token history (prompt + all accepted output so far). Used
+        # both for arctic add_active_response (delta push) and as the
+        # pattern context for the next query.
+        # See [I1] in module docstring.
+        self._req_tokens: Dict[str, List[int]] = {}
+
+        # Stash the previous step's accepted tokens until the next step
+        # consumes them. Populated at end of _decode_step, drained at start
+        # of next _decode_step. See [I1].
+        # Maps rid → list[int] (accepted tokens from prev step).
+        self._pending_accepted: Dict[str, List[int]] = {}
+
+        # Epoch-based GC. Scheduler doesn't give us a per-rid finish hook
+        # and individual batches don't list all currently-active reqs
+        # (prefill and decode are scheduled in SEPARATE batches), so we
+        # can't prune based on a single batch's rid set. Instead we tag
+        # each rid with the step number it was last seen and GC rids
+        # unseen for `_gc_epoch_threshold` batches. The threshold is large
+        # enough to ride out prefill↔decode interleaving and the longest
+        # plausible quiescence (preemption / retraction-rerun) before the
+        # scheduler officially drops the req.
+        self._step_idx: int = 0
+        self._rid_last_seen: Dict[str, int] = {}
+        self._gc_epoch_threshold: int = 256
+
+        # Debug-only periodic GC stats log; on with SUFFIX_V2_DEBUG=1.
+        import os as _os
+
+        self._debug = _os.environ.get("SUFFIX_V2_DEBUG", "0") == "1"
+        # Per-phase timing log (heavy); on with SUFFIX_V2_TIMING=1.
+        self._timing = _os.environ.get("SUFFIX_V2_TIMING", "0") == "1"
+
+        # M6: deferred CPU work. End of each step builds a closure that
+        # (a) sync's on this step's verify_done, (b) reads predict/accept_index
+        # to CPU, (c) populates _pending_accepted. Start of next step drains
+        # the closure BEFORE doing any other CPU work. The scheduler-side
+        # work between worker returns (store_to_map, copy_to_cpu, output_ids
+        # update, etc.) now overlaps with the GPU sync wait, instead of the
+        # previous design where the sync blocked end-of-step return.
+        self._deferred: Optional[Callable[[], None]] = None
+
+    # ------------------------------------------------------------------
+    # BaseSpecWorker contract
+    # ------------------------------------------------------------------
+    @property
+    def target_worker(self):
+        return self._target_worker
+
+    @property
+    def draft_worker(self):
+        return self._draft_worker
+
+    def clear_cache_pool(self):
+        # Drain any pending deferred work first so the GPU tensor references
+        # the closure holds are released before reset.
+        self._drain_deferred()
+        # Reset arctic cache + per-rid state on flush.
+        for rid in list(self._req_tokens.keys()):
+            self.draft_builder.stop_request(rid)
+        self._req_tokens.clear()
+        self._pending_accepted.clear()
+        self._rid_last_seen.clear()
+        # The token_to_kv_pool_allocator is shared with target_worker; it
+        # handles its own clear via the scheduler's flush path.
+
+    def _drain_deferred(self) -> None:
+        """Run the previous step's deferred CPU work (GPU sync + read).
+        Always safe to call — no-op when nothing is deferred."""
+        if self._deferred is not None:
+            commit, self._deferred = self._deferred, None
+            commit()
+
+    # ------------------------------------------------------------------
+    # Main entry
+    # ------------------------------------------------------------------
+    def forward_batch_generation(
+        self, mwb: ScheduleBatch, on_publish=None
+    ) -> GenerationBatchResult:
+        import time as _t
+
+        t_start = _t.perf_counter() if self._timing else 0.0
+        self._step_idx += 1
+        # M6: complete prev step's deferred CPU work (sync + read + populate
+        # _pending_accepted). Runs after scheduler-side work has had a chance
+        # to overlap with the GPU sync wait.
+        self._drain_deferred()
+        t_drained = _t.perf_counter() if self._timing else 0.0
+        if mwb.forward_mode.is_idle():
+            result = self._idle_step(mwb)
+            self._maybe_publish(on_publish, result)
+            return result
+        # Touch last-seen epoch for every rid in this batch.
+        if mwb.reqs:
+            for req in mwb.reqs:
+                self._rid_last_seen[req.rid] = self._step_idx
+            # GC: prune rids unseen for many epochs (long-finished reqs).
+            # Cheap O(n) sweep — n is bounded by max_running_requests.
+            if self._req_tokens:
+                self._gc_stale_rids()
+        if mwb.forward_mode.is_extend() or mwb.is_extend_in_batch:
+            result = self._extend_step(mwb)
+            self._maybe_publish(on_publish, result)
+            if self._timing:
+                self._log_timing("EXTEND", t_start, t_drained, _t.perf_counter(), mwb)
+            return result
+        result = self._decode_step(mwb)
+        self._maybe_publish(on_publish, result)
+        if self._timing:
+            self._log_timing("DECODE", t_start, t_drained, _t.perf_counter(), mwb)
+        return result
+
+    @staticmethod
+    def _maybe_publish(on_publish, result: GenerationBatchResult) -> None:
+        """Overlap-scheduling fence (spec-v2 contract). The scheduler passes
+        on_publish=partial(future_map.publish, future_indices); calling it with
+        this step's new_seq_lens lets the scheduler resolve seq_lens for the
+        overlapped next batch. SUFFIX has no post-verify GPU work, so the
+        verify-end fence is here (vs EAGLEWorkerV2 which fires it before its
+        draft-extend tail)."""
+        if on_publish is not None and result.new_seq_lens is not None:
+            on_publish(result.new_seq_lens)
+
+    def _log_timing(self, kind, t_start, t_drained, t_end, mwb) -> None:
+        try:
+            import logging
+
+            logging.getLogger("sglang.spec.suffix_v2").info(
+                "[SUFFIX_V2_TIME] step=%d kind=%s bs=%d drain=%.2fms total=%.2fms",
+                self._step_idx,
+                kind,
+                len(mwb.reqs) if mwb.reqs else 0,
+                (t_drained - t_start) * 1000,
+                (t_end - t_start) * 1000,
+            )
+        except Exception:
+            pass
+
+    def _gc_stale_rids(self) -> None:
+        threshold = self._step_idx - self._gc_epoch_threshold
+        if threshold <= 0:
+            return
+        dropped = 0
+        for rid in list(self._req_tokens.keys()):
+            if self._rid_last_seen.get(rid, 0) < threshold:
+                self.draft_builder.stop_request(rid)
+                self._req_tokens.pop(rid, None)
+                self._pending_accepted.pop(rid, None)
+                self._rid_last_seen.pop(rid, None)
+                dropped += 1
+        if self._debug and (dropped or self._step_idx % 100 == 0):
+            try:
+                import logging
+
+                logging.getLogger("sglang.spec.suffix_v2").info(
+                    "[SUFFIX_V2_GC] step=%d dropped=%d kept=%d arctic_active=%d",
+                    self._step_idx,
+                    dropped,
+                    len(self._req_tokens),
+                    len(self.draft_builder.cache.active_requests),
+                )
+            except Exception:
+                pass
+
+    def _idle_step(self, mwb: ScheduleBatch) -> GenerationBatchResult:
+        """Empty batch — scheduler still calls into the worker so it can
+        keep its sampling loop fired. Forward through target, mirror EAGLE's
+        idle path."""
+        batch_output = self._target_worker.forward_batch_generation(mwb)
+        idle_new_seq_lens = torch.empty(0, device=self.device, dtype=torch.int32)
+        batch_output.next_draft_input = self._make_next_draft_input(
+            bonus_tokens=torch.empty(0, device=self.device, dtype=torch.int32),
+        )
+        # Expose new_seq_lens for the overlap publish fence (empty for idle).
+        batch_output.new_seq_lens = idle_new_seq_lens
+        return batch_output
+
+    def _make_next_draft_input(
+        self,
+        bonus_tokens: torch.Tensor,
+    ) -> EagleDraftInput:
+        """Build the next-step EagleDraftInput carried via FutureMap.
+
+        FutureMap (overlap_utils.py _lazy_init_buf) unconditionally reads
+        `draft_input.topk_p[0]` and `draft_input.topk_index[0]` to derive
+        buffer shapes. SUFFIX V2 has no real per-step draft probabilities,
+        so we pass dummy (bs, 1) zeros that round-trip safely through the
+        buffer without being consumed.
+
+        spec_need_hidden_states is patched to return False for SUFFIX, so
+        we don't populate hidden_states.
+
+        new_seq_lens / verify_done are NOT fields here: current upstream
+        main carries new_seq_lens on GenerationBatchResult (published via
+        on_publish, see _maybe_publish) and drives the post-verify CPU sync
+        with a worker-local cuda event (see _decode_step) instead of an
+        EagleDraftInput-stashed one.
+        """
+        bs = int(bonus_tokens.numel())
+        return EagleDraftInput(
+            topk_p=torch.zeros((bs, 1), device=self.device, dtype=torch.float32),
+            topk_index=torch.zeros((bs, 1), device=self.device, dtype=torch.int64),
+            bonus_tokens=bonus_tokens,
+        )
+
+    # ------------------------------------------------------------------
+    # Extend path
+    # ------------------------------------------------------------------
+    def _extend_step(self, mwb: ScheduleBatch) -> GenerationBatchResult:
+        import time as _t
+
+        t0 = _t.perf_counter() if self._timing else 0.0
+        # Standalone SUFFIX → NULL capture mode (no hidden states needed).
+        mwb.capture_hidden_mode = CaptureHiddenMode.NULL
+        batch_output = self._target_worker.forward_batch_generation(mwb)
+        t_target = _t.perf_counter() if self._timing else 0.0
+
+        # Initialize arctic cache state for any req we haven't seen.
+        # [I3]: needs prompt tokens on CPU at this point.
+        self._initialize_new_reqs(mwb)
+        t_init = _t.perf_counter() if self._timing else 0.0
+
+        # Bonus token for next decode step = the just-generated next_token_ids.
+        bonus = batch_output.next_token_ids.to(torch.int32)
+        new_seq_lens = (mwb.seq_lens + 1).to(torch.int32)
+
+        # M6: defer the CPU read of bonus into _pending_accepted to the start
+        # of the next step. Closure holds GPU tensor refs alive.
+        rids_snapshot = self._extract_rids(mwb)
+        pending = self._pending_accepted
+        bonus_gpu = bonus
+
+        def _commit_extend() -> None:
+            bonus_cpu = bonus_gpu.cpu().tolist()
+            for rid, tok in zip(rids_snapshot, bonus_cpu):
+                pending[rid] = [int(tok)]
+
+        self._deferred = _commit_extend
+
+        batch_output.next_draft_input = self._make_next_draft_input(
+            bonus_tokens=bonus,
+        )
+        # Expose new_seq_lens for the overlap publish fence.
+        batch_output.new_seq_lens = new_seq_lens
+        if self._timing:
+            t_end = _t.perf_counter()
+            import logging
+
+            logging.getLogger("sglang.spec.suffix_v2").info(
+                "[SUFFIX_V2_EXTEND_BREAKDOWN] step=%d bs=%d target=%.2fms init_reqs=%.2fms tail=%.2fms",
+                self._step_idx,
+                len(mwb.reqs) if mwb.reqs else 0,
+                (t_target - t0) * 1000,
+                (t_init - t_target) * 1000,
+                (t_end - t_init) * 1000,
+            )
+        return batch_output
+
+    def _initialize_new_reqs(self, mwb: ScheduleBatch) -> None:
+        """Register any unseen rid with the arctic suffix cache.
+
+        Reads prompts straight from `req.origin_input_ids` (already on CPU).
+        """
+        for req in mwb.reqs:
+            rid = req.rid
+            if rid in self._req_tokens:
+                continue
+            prompt = list(req.origin_input_ids)
+            self.draft_builder.start_request(rid, prompt)
+            self._req_tokens[rid] = prompt
+
+    # ------------------------------------------------------------------
+    # Decode path
+    # ------------------------------------------------------------------
+    def _decode_step(self, mwb: ScheduleBatch) -> GenerationBatchResult:
+        import time as _t
+
+        t0 = _t.perf_counter() if self._timing else 0.0
+        prev_draft: EagleDraftInput = mwb.spec_info
+        assert prev_draft is not None, "decode step requires prev spec_info"
+
+        # M6: prev verify_done sync now happens inside the deferred closure
+        # drained at top of forward_batch_generation, not here.
+
+        rids = self._extract_rids(mwb)
+        bs = len(rids)
+
+        # 1. Drain pending accepted tokens from prev step → push into arctic tree.
+        for rid in rids:
+            accepted = self._pending_accepted.pop(rid, None)
+            if accepted:
+                self._req_tokens.setdefault(rid, []).extend(accepted)
+                self.draft_builder.update_with_accepted(rid, self._req_tokens[rid])
+
+        t_drain_pending = _t.perf_counter() if self._timing else 0.0
+
+        # 2. Suffix tree query → linear draft tokens per req.
+        current_tokens = [self._req_tokens[rid] for rid in rids]
+        # Per-req draft cap = ctx_len - cur_seq_len - 1 (the -1 leaves room for
+        # the bonus token without overshooting). Prevents zombie verify steps.
+        seq_lens_list = mwb.seq_lens.cpu().tolist()
+        max_remaining = [max(0, self._max_context_len - sl - 1) for sl in seq_lens_list]
+        draft_tokens, draft_lens, valid_mask = self.draft_builder.query_batch(
+            rids=rids,
+            current_tokens=current_tokens,
+            K_minus_1=self.K_minus_1,
+            device=self.device,
+            max_remaining_per_req=max_remaining,
+        )
+        t_query = _t.perf_counter() if self._timing else 0.0
+
+        # 3. Build the linear EagleVerifyInput.
+        bonus_tokens = prev_draft.bonus_tokens  # (bs,) int32 on device
+        seq_lens_cpu = mwb.seq_lens.cpu()
+        verify_input = build_suffix_v2_eagle_verify_input(
+            bonus_tokens=bonus_tokens,
+            suffix_draft_tokens=draft_tokens,
+            seq_lens=mwb.seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+        )
+        mwb.spec_info = verify_input
+
+        # 4. Run the EAGLE V2 verify scaffold. Replicate the essential calls
+        # from EAGLEWorkerV2.verify() — minus draft-tp-context, mamba,
+        # MRoPE which we don't have for SUFFIX standalone.
+        verify_forward_batch, can_run_cuda_graph = verify_input.prepare_for_v2_verify(
+            self.req_to_token_pool,
+            mwb,
+            self._target_worker,
+        )
+
+        t_prepare = _t.perf_counter() if self._timing else 0.0
+        forward_batch_output = self._target_worker.forward_batch_generation(
+            batch=None,
+            forward_batch=verify_forward_batch,
+            is_verify=True,
+            skip_attn_backend_init=True,
+        )
+        logits_output = forward_batch_output.logits_output
+        t_target = _t.perf_counter() if self._timing else 0.0
+
+        # 5. Sample via EAGLE V2's verify_input.sample (handles grammar,
+        # sampling_info, tree_greedy / target_only_speculative paths).
+        vocab_mask = None  # grammar not yet supported in V2 SUFFIX
+        predict, accept_lens, accept_index = verify_input.sample(
+            mwb, logits_output, vocab_mask
+        )
+        # Clamp acceptance to the real suffix-match length. Short matches are
+        # right-padded to K-1 with token-id 0 (query_batch returns draft_lens =
+        # the real per-req match length). The verify chain mask is causal, so
+        # every real position (chain depth <= draft_lens) is computed from clean
+        # context and is safe to accept. A padding 0 at depth > draft_lens can
+        # still be spuriously accepted when the target's own argmax there is 0,
+        # which would advance seq_lens past the real output and feed a fake 0
+        # into the arctic tree via the commit closure below. Cap at
+        # bonus + draft_lens so only real positions ever count.
+        accept_lens = torch.minimum(accept_lens, (draft_lens + 1).to(accept_lens.dtype))
+        new_seq_lens = mwb.seq_lens + accept_lens
+
+        # 6. Build next_draft_input via fill_bonus_tokens (same kernel EAGLE uses).
+        if not mwb.forward_mode.is_idle():
+            accept_tokens_gpu = predict[accept_index]  # (bs * K,) int32 padded with -1?
+            bonus_tokens = torch.empty_like(accept_lens, dtype=torch.int32)
+            fill_bonus_tokens[(bs,)](
+                accept_tokens_gpu,
+                accept_lens,
+                bonus_tokens,
+                self.K,
+            )
+        else:
+            bonus_tokens = torch.empty(0, device=self.device, dtype=torch.int32)
+
+        next_draft_input = self._make_next_draft_input(
+            bonus_tokens=bonus_tokens,
+        )
+
+        # 7. M6: defer the CPU read of predict + accept_index. Closure captures
+        # GPU tensors (kept alive via the closure ref) + a verify-done event +
+        # rids snapshot, and populates _pending_accepted at start of next step.
+        # Current upstream main no longer exposes verify_done on EagleDraftInput,
+        # so record a worker-local event on the current stream after the verify
+        # kernels are enqueued; synchronize() on it fences the CPU read.
+        rids_snapshot = list(rids)
+        pending = self._pending_accepted
+        predict_gpu = predict
+        accept_index_gpu = accept_index
+        accept_lens_gpu = accept_lens
+        verify_done_event = torch.get_device_module(self.device).Event()
+        verify_done_event.record()
+
+        def _commit_decode() -> None:
+            verify_done_event.synchronize()
+            ai_cpu = accept_index_gpu.cpu().tolist()
+            pr_cpu = predict_gpu.cpu().tolist()
+            al_cpu = accept_lens_gpu.cpu().tolist()
+            for i, rid in enumerate(rids_snapshot):
+                acc = []
+                for j in ai_cpu[i]:
+                    if j == -1:
+                        break
+                    acc.append(int(pr_cpu[j]))
+                # Truncate to the clamped accept length so a spuriously
+                # accepted padding-0 (see clamp after sample()) never enters
+                # the suffix tree.
+                acc = acc[: int(al_cpu[i])]
+                if acc:
+                    pending[rid] = acc
+
+        self._deferred = _commit_decode
+
+        if self._timing:
+            t_end = _t.perf_counter()
+            import logging
+
+            logging.getLogger("sglang.spec.suffix_v2").info(
+                "[SUFFIX_V2_DECODE_BREAKDOWN] step=%d bs=%d drain_pend=%.2fms query=%.2fms prepare=%.2fms target=%.2fms tail=%.2fms total=%.2fms",
+                self._step_idx,
+                bs,
+                (t_drain_pending - t0) * 1000,
+                (t_query - t_drain_pending) * 1000,
+                (t_prepare - t_query) * 1000,
+                (t_target - t_prepare) * 1000,
+                (t_end - t_target) * 1000,
+                (t_end - t0) * 1000,
+            )
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=predict,
+            can_run_cuda_graph=can_run_cuda_graph,
+            speculative_num_draft_tokens=self.K,
+            next_draft_input=next_draft_input,
+            accept_lens=accept_lens,
+            new_seq_lens=new_seq_lens,
+            routed_experts_output=forward_batch_output.routed_experts_output,
+            indexer_topk_output=forward_batch_output.indexer_topk_output,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _extract_rids(self, mwb: ScheduleBatch) -> List[str]:
+        """Pull per-req rids from the batch.
+
+        `mwb.reqs` is populated by ScheduleBatch.get_model_worker_batch
+        (schedule_batch.py:2617) on every batch, so this is reliable.
+        """
+        return [req.rid for req in mwb.reqs]

--- a/test/registered/unit/spec/test_suffix_registry.py
+++ b/test/registered/unit/spec/test_suffix_registry.py
@@ -1,0 +1,119 @@
+"""Unit tests for the SUFFIX speculative-decoding plugin registration.
+
+CPU-only: exercises the plugin wiring (registration, duck-typed predicates,
+arg validation, lazy factory) without loading a model or arctic_inference.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.speculative import sgl_suffix_plugin
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_registry import (
+    _REGISTRY,
+    CustomSpecAlgo,
+    _assert_custom_spec_algo_conforms,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _SuffixRegistered(CustomTestCase):
+    """Re-register SUFFIX into an isolated registry so tests don't leak."""
+
+    def setUp(self):
+        self._snapshot = _REGISTRY.copy()
+        _REGISTRY.clear()
+        SpeculativeAlgorithm.register(
+            "SUFFIX",
+            supports_overlap=False,
+            validate_server_args=sgl_suffix_plugin._validate_suffix_args,
+            spec_class=sgl_suffix_plugin._SuffixLike,
+        )(sgl_suffix_plugin._suffix_factory)
+        self.algo = SpeculativeAlgorithm.from_string("SUFFIX")
+
+    def tearDown(self):
+        _REGISTRY.clear()
+        _REGISTRY.update(self._snapshot)
+
+
+class TestSuffixRegistration(_SuffixRegistered):
+    def test_from_string_returns_custom_spec(self):
+        self.assertIsInstance(self.algo, CustomSpecAlgo)
+        self.assertEqual(self.algo.name, "SUFFIX")
+
+    def test_case_insensitive(self):
+        self.assertIs(
+            SpeculativeAlgorithm.from_string("suffix"),
+            SpeculativeAlgorithm.from_string("SUFFIX"),
+        )
+
+    def test_dispatches_like_ngram(self):
+        # SUFFIX reuses NGRAM's verify / KV-cache dispatch.
+        self.assertTrue(self.algo.is_ngram())
+        self.assertTrue(self.algo.is_suffix())
+
+    def test_other_predicates_false(self):
+        self.assertFalse(self.algo.is_eagle())
+        self.assertFalse(self.algo.is_eagle3())
+        self.assertFalse(self.algo.is_standalone())
+        self.assertFalse(self.algo.is_none())
+        self.assertTrue(self.algo.is_speculative())
+
+    def test_v1_does_not_support_overlap(self):
+        self.assertFalse(self.algo.supports_overlap)
+        self.assertFalse(self.algo.supports_spec_v2())
+
+    def test_not_equal_to_builtin(self):
+        self.assertNotEqual(self.algo, SpeculativeAlgorithm.NGRAM)
+        self.assertNotEqual(self.algo, SpeculativeAlgorithm.EAGLE)
+
+
+class TestSuffixConformance(_SuffixRegistered):
+    def test_spec_class_conforms(self):
+        # _SuffixLike must satisfy the enum's is_*/supports_* duck-type contract.
+        _assert_custom_spec_algo_conforms(sgl_suffix_plugin._SuffixLike)
+
+    def test_provides_create_future_map(self):
+        # The scheduler calls create_future_map() unconditionally; CustomSpecAlgo's
+        # base does not define it, so _SuffixLike must (regression guard).
+        self.assertTrue(callable(getattr(self.algo, "create_future_map", None)))
+
+
+class TestSuffixFactory(_SuffixRegistered):
+    def test_factory_returns_suffix_worker(self):
+        # Lazy: importing SuffixWorker does not require arctic_inference (that is
+        # imported only when the worker is constructed).
+        from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+        server_args = SimpleNamespace(disable_overlap_schedule=True)
+        self.assertIs(self.algo.create_worker(server_args), SuffixWorker)
+
+    def test_factory_rejects_overlap(self):
+        server_args = SimpleNamespace(disable_overlap_schedule=False)
+        with self.assertRaisesRegex(ValueError, "does not support overlap"):
+            self.algo.create_worker(server_args)
+
+
+class TestSuffixArgValidation(_SuffixRegistered):
+    _FIELDS = (
+        "speculative_suffix_max_tree_depth",
+        "speculative_suffix_max_cached_requests",
+        "speculative_suffix_max_spec_factor",
+        "speculative_suffix_min_token_prob",
+    )
+
+    def test_validator_passes_with_all_fields(self):
+        sa = SimpleNamespace(**{f: 1 for f in self._FIELDS})
+        self.algo.validate_server_args(sa)  # does not raise
+
+    def test_validator_raises_when_field_missing(self):
+        sa = SimpleNamespace(**{f: 1 for f in self._FIELDS[1:]})  # drop the first
+        with self.assertRaisesRegex(ValueError, "speculative_suffix_max_tree_depth"):
+            self.algo.validate_server_args(sa)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
  ## Motivation

  This PR adds a V2 (overlap-scheduled) implementation of the SUFFIX speculative decoding algorithm introduced by the previous SUFFIX V1 work (https://github.com/sgl-project/sglang/pull/...).

  The existing V1 worker subclasses `NGRAMWorker` and takes a `ScheduleBatch` synchronously, which forces `--disable-overlap-schedule` (V1's verify path is incompatible with the V2 overlap scheduler's plan/predict streams). On long-context agentic workloads the synchronous path leaves a large idle window between suffix-tree query and target
  forward — the V2 worker recovers it.

  V2 implements the same algorithm as a `BaseSpecWorker` that takes a `ModelWorkerBatch`, so it slots into the V2 overlap scheduler exactly like EAGLE V2 / STANDALONE V2. The same `--speculative-algorithm SUFFIX` CLI is used; V1 vs V2 is implicit from `--disable-overlap-schedule`.

> **Note:** This PR is built on top of #27582 (currently open). The diff shows both PR1's V1 commits and the new V2 commits (4 commits total). After #27582 merges this PR can be rebased onto `main` for a clean 2-commit V2-only diff.

  ## Modifications

  Two commits, both under `python/sglang/srt/speculative/` and `model_executor/`:

  1. **Add SUFFIX V2 worker (overlap scheduling)** — four new files:
     - `suffix_worker_v2.py` — `SuffixWorkerV2(BaseSpecWorker)`. Per decode step: drain accepted tokens into per-req history, query the suffix cache for K−1 draft tokens per req, build a topk=1 EagleVerifyInput, run target verify, post-process accept/next-token, emit next EagleDraftInput. Includes a per-req `ctx_len - cur_seq_len - 1` cap on
  draft length to prevent the verify step from overshooting `context_length` and producing a stale "zombie" verify on the next iteration.
     - `suffix_v2_draft_builder_full.py` — `SuffixV2DraftBuilder` wraps `arctic_inference.SuffixDecodingCache` with `start_request`/`stop_request`/`update_with_accepted`/`query_batch(..., max_remaining_per_req)`.
     - `suffix_v2_draft_builder.py` — `build_linear_retrieve_arrays(bs, K, device)` constructs topk=1 EAGLE retrieve_index / retrieve_next_token / retrieve_next_sibling tensors so SUFFIX's linear chain reuses EAGLE's `verify_tree_greedy` kernel.
     - `suffix_v2_verify_input.py` — `build_suffix_v2_eagle_verify_input(...)` assembles draft_token / positions / custom_mask / retrieve arrays.

     Plugin (`sgl_suffix_plugin.py`) now registers SUFFIX with `supports_overlap=True` and the `_suffix_factory` dispatches V2 when overlap is enabled, V1 otherwise.

  2. **Enable cuda graph capture for SUFFIX V2 verify** — two source-level wirings:
     - `cuda_graph_runner.py` — set `capture_hidden_mode = CaptureHiddenMode.FULL` when `is_suffix()` at capture init. Without this, V2 runtime sets `verify_input.capture_hidden_mode = FULL` via `prepare_for_v2_verify` but capture-time mode is NULL → `can_run`'s `capture_hidden_mode_matches` check fails → every verify falls back to eager.
     - `model_runner.py` `get_spec_info()` — route V2 SUFFIX (`is_suffix()` AND `not disable_overlap_schedule`) through the `EagleVerifyInput` branch (it shares `verify_tree_greedy` with EAGLE/STANDALONE); keep V1 SUFFIX on the `NgramVerifyInput` branch.

     V1 SUFFIX (`NgramVerifyInput`) has no `capture_hidden_mode` attribute, so its runtime requested mode is NULL — `can_run`'s `requested == NULL` short-circuit passes, and widening to `is_suffix()` does not break V1.

  ## Accuracy Tests

  No changes to model forward, kernels, or sampling logic. Verify path reuses EAGLE's `verify_tree_greedy` kernel (already covered by existing EAGLE tests). The only model-visible additions are draft-token selection (delegated to the same arctic suffix tree as V1) and the per-req draft-length cap (which only changes when an output approaches
  `context_length`).

  Manually verified deterministic output across V1 and V2 on agent-replay prompts (same prompts → same generated tokens with `temperature=0`, modulo the deferred-EOS for sequences capped at `context_length`).

  ## Speed Tests and Profiling

  GLM-5-FP8, 16-card H100 (2 nodes TP=16, `--mem-fraction-static 0.85 --context-length 32768 --max-total-tokens 131072 --max-running-requests 32`), dataset = SWE-bench, agent-replay mode. Run for 4 speculative algorithms × 3 concurrencies. Hierarchical KV cache enabled (`--enable-hierarchical-cache --hicache-ratio 2.0`).

### conc = 4

  | spec | ok/total | dur(s) | in_tok | out_tok | TTFT(ms) | TPOT(ms) | E2EL(ms) | out_tps | tot_tps | spd(tot) | cache_hit | accept_len | accept_rate | gen_tps |
  |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
  | baseline      | 641/815 | 1016 | 5,630,030 | 131,043 | 526 | 27.8  | 6256 | 129.0 | 5671  | 1.000× | 73.0% | -    | -     | 145.4 |
  | mtp           | 641/815 |  490 | 5,630,030 | 113,055 | 487 | 14.0  | 3007 | 230.5 | 11711 | 2.065× | 81.6% | 3.43 | 0.811 | 269.4 |
  | dflash-800k-d8| 641/815 |  872 | 5,630,030 | 131,089 | 601 | 27.4  | 5324 | 150.3 | 6605  | 1.165× | 66.0% | 2.54 | 0.218 | 170.7 |
  | **sfxv2**| 641/815 |  673 | 5,630,030 | 121,394 | 484 | 20.02 | 4091 | 180.4 | **8549** | **1.507×** | 79.9% | 3.00 | 0.133 | 199.2 |

  ### conc = 8
  
  | spec | ok/total | dur(s) | in_tok | out_tok | TTFT(ms) | TPOT(ms) | E2EL(ms) | out_tps | tot_tps | spd(tot) | cache_hit | accept_len | accept_rate | gen_tps |
  |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
  | baseline      | 641/815 | 597 | 5,630,030 | 121,822 |  645 | 32.5  | 6706 | 204.0 | 9631  | 1.000× | 93.2% | -    | -     | 204.7 |
  | mtp           | 641/815 | 406 | 5,630,030 | 127,725 |  670 | 19.7  | 4528 | 314.9 | 14194 | 1.474× | 86.7% | 3.47 | 0.829 | 331.6 |
  | dflash-800k-d8| 641/815 | 645 | 5,630,030 | 120,151 | 1251 | 36.2  | 7217 | 186.4 | 8919  | 0.926× | 74.2% | 2.44 | 0.185 | 190.6 |
  | **sfxv2**| 641/815 | 368 | 5,630,030 | 114,412 |  518 | 18.28 | 4007 | 310.9 | **15612** | **1.826×** | 95.4% | 3.87 | 0.191 | 282.7 |

  ### conc = 16

  | spec | ok/total | dur(s) | in_tok | out_tok | TTFT(ms) | TPOT(ms) | E2EL(ms) | out_tps | tot_tps | spd(tot) | cache_hit | accept_len | accept_rate | gen_tps |
  |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
  | baseline      | 641/815 | 531 | 5,630,030 | 115,629 | 3774 | 39.4  | 10572 | 217.9 | 10829 | 1.000× | 91.4% | -    | -     | 212.2 |
  | mtp           | 641/815 | 357 | 5,630,030 | 129,786 | 2407 | 22.8  |  6423 | 363.1 | 16114 | 1.488× | 94.2% | 3.45 | 0.853 | 319.1 |
  | dflash-800k-d8| 641/815 | 515 | 5,630,030 | 114,984 | 3921 | 38.1  |  9966 | 223.3 | 11157 | 1.030× | 88.4% | 2.22 | 0.154 | 204.9 |
  | **sfxv2**| 641/815 | 291 | 5,630,030 | 118,233 | 2302 | 19.88 |  5952 | 406.5 | **19764** | **1.825×** | 95.2% | 5.19 | 0.279 | 382.1 |

  ### Highlights

  - **1.5× – 1.83× total-token throughput** vs no-spec baseline across the three concurrency levels.
  - **TPOT halved or better** at all concurrencies (e.g. c=16: 39.4ms → 19.88ms = −50%).
  - **Decode cuda graph hit rate 100%** end-to-end (without the `cuda_graph_runner.py` change, V2 falls back to eager and TPOT regresses to ~150ms).
  - **accept_len scales with concurrency** (3.00 → 3.87 → 5.19) as the global suffix tree warms up and cross-request matches improve, which is the expected behavior for SUFFIX on agent-replay workloads.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->