### PR TITLE
Fix SWA KV pool slot leak in unified radix cache

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -335,6 +335,19 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         else:
             self.full_to_swa_index_mapping[full_indices] = swa_indices
 
+    def clear_swa_mapping(self, full_indices: torch.Tensor) -> None:
+        """Clear full->swa entries without freeing any swa slot.
+
+        A SWA-tombstone node owns no swa slot, so its full->swa mapping must be
+        0. If it is stale (points to a slot already reused by another full),
+        free_swa on it would erroneously free that live slot. Clear instead.
+        """
+        if full_indices.numel() == 0:
+            return
+        if _is_npu:
+            full_indices = full_indices.to(torch.int64)
+        self.full_to_swa_index_mapping[full_indices] = 0
+
     def free_swa(self, free_index: torch.Tensor):
         swa_indices = self.full_to_swa_index_mapping[free_index]
         swa_indices = swa_indices[swa_indices > 0]

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -177,7 +177,12 @@ class SWAComponent(TreeComponent):
         ), f"{self.component_type}: swa_evicted_seqlen must be page-aligned, {swa_evicted_seqlen=}"
 
         if swa_evicted_seqlen <= total_prefix_len:
-            # Branch 1: entire value_slice is within SWA window — recover
+            # Branch 1: entire value_slice is within SWA window — recover.
+            # node is a SWA tombstone; clear its stale full->swa mapping before
+            # freeing, else free_swa frees a slot already reused by value_slice.
+            self.cache.token_to_kv_pool_allocator.clear_swa_mapping(
+                node.component_data[BASE_COMPONENT_TYPE].value
+            )
             self.cache.token_to_kv_pool_allocator.free(
                 node.component_data[BASE_COMPONENT_TYPE].value
             )
@@ -190,6 +195,9 @@ class SWAComponent(TreeComponent):
         elif swa_evicted_seqlen < total_prefix_len + prefix_len:
             # Branch 2: value_slice[start_idx:] is within SWA window — partial recover
             start_idx = swa_evicted_seqlen - total_prefix_len
+            self.cache.token_to_kv_pool_allocator.clear_swa_mapping(
+                node.component_data[BASE_COMPONENT_TYPE].value[start_idx:]
+            )
             self.cache.token_to_kv_pool_allocator.free(
                 node.component_data[BASE_COMPONENT_TYPE].value[start_idx:]
             )


### PR DESCRIPTION
## Motivation

With HiCache (write-through) on a hybrid-SWA model, a long-running server can abort with `SWA Pool Mem Leak Detected` from the memory invariant check, after the SWA KV pool slowly leaks slots (one page at a time) until the accounting no longer balances.

Root cause is in `SWAComponent.update_component_on_insert_overlap`. When an insert overlaps an existing SWA-tombstone node, the recover branches free the node's old base value through `free_swa`. A SWA-tombstone owns no swa slot, so its `full_to_swa_index_mapping` entry should be 0, but it can be stale and point to a swa slot already reused by the incoming `value_slice`. `free_swa` then frees that still-live slot, corrupting `swa_attn_allocator`'s free-slot accounting and leaking until the invariant aborts.

Reproduced deterministically with a SWA + HiCache workload that churns the radix tree (with `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY=1`). Before the fix the server aborts within minutes. After the fix it runs cleanly for 25+ minutes with the busy memory check on.

## Modifications

- Add `SWATokenToKVPoolAllocator.clear_swa_mapping`, which clears `full_to_swa_index_mapping` entries without freeing any swa slot.
- In both recover branches of `update_component_on_insert_overlap`, clear the stale mapping before freeing the tombstone's base, restoring the invariant that a SWA-tombstone node has no full to swa mapping.













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27154239903](https://github.com/sgl-project/sglang/actions/runs/27154239903)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27154506872](https://github.com/sgl-project/sglang/actions/runs/27154506872)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->