### PR TITLE
[AMD][CI] Enable SGLANG_USE_ROCM_FLYDSL=1 in diffusion e2e tests

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -650,10 +650,16 @@ jobs:
           # AMD CI: All 1-GPU tests except FLUX.2 (FLUX.1 covers same code path)
           # Tests: T2V, T2I, I2V, LoRA
           #
+          # Enable the ROCm FlyDSL fused norm/scale-shift path (PR #22786) so the
+          # forward_hip integration in multimodal_gen layernorm gets real e2e
+          # coverage. The kernel engages when the DiT hidden dim is a multiple of
+          # 5120 (e.g. Wan 14B) and otherwise falls back to native. See #27521.
+          #
           # HF download env vars:
           # - HF_HUB_ENABLE_HF_TRANSFER=1: Use faster hf_transfer for downloads (if available)
           # - HF_HUB_DISABLE_SYMLINKS_WARNING=1: Suppress symlink warnings
           docker exec \
+            -e SGLANG_USE_ROCM_FLYDSL=1 \
             -e SGLANG_E2E_TOLERANCE=0.3 \
             -e SGLANG_STAGE_TIME_TOLERANCE=0.2 \
             -e SGLANG_NON_DENOISE_STAGE_TIME_TOLERANCE=0.6 \
@@ -789,10 +795,17 @@ jobs:
           # AMD CI: All 2-GPU tests including LoRA
           # Tests: T2V, T2I, I2V, LoRA
           #
+          # Enable the ROCm FlyDSL fused norm/scale-shift path (PR #22786) so the
+          # forward_hip integration in multimodal_gen layernorm gets real e2e
+          # coverage. The Wan 14B models in this suite have hidden dim 5120, so
+          # they actually exercise the kernel; other dims fall back to native.
+          # See #27521.
+          #
           # HF download env vars:
           # - HF_HUB_ENABLE_HF_TRANSFER=1: Use faster hf_transfer for downloads (if available)
           # - HF_HUB_DISABLE_SYMLINKS_WARNING=1: Suppress symlink warnings
           docker exec \
+            -e SGLANG_USE_ROCM_FLYDSL=1 \
             -e SGLANG_E2E_TOLERANCE=0.3 \
             -e SGLANG_STAGE_TIME_TOLERANCE=0.2 \
             -e SGLANG_NON_DENOISE_STAGE_TIME_TOLERANCE=0.6 \

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -694,10 +694,16 @@ jobs:
           # AMD CI: All 1-GPU tests except FLUX.2 (FLUX.1 covers same code path)
           # Tests: T2V, T2I, I2V, LoRA
           #
+          # Enable the ROCm FlyDSL fused norm/scale-shift path (PR #22786) so the
+          # forward_hip integration in multimodal_gen layernorm gets real e2e
+          # coverage. The kernel engages when the DiT hidden dim is a multiple of
+          # 5120 (e.g. Wan 14B) and otherwise falls back to native. See #27521.
+          #
           # HF download env vars:
           # - HF_HUB_ENABLE_HF_TRANSFER=1: Use faster hf_transfer for downloads (if available)
           # - HF_HUB_DISABLE_SYMLINKS_WARNING=1: Suppress symlink warnings
           docker exec \
+            -e SGLANG_USE_ROCM_FLYDSL=1 \
             -e SGLANG_E2E_TOLERANCE=0.3 \
             -e SGLANG_STAGE_TIME_TOLERANCE=0.2 \
             -e SGLANG_NON_DENOISE_STAGE_TIME_TOLERANCE=0.6 \
@@ -833,10 +839,17 @@ jobs:
           # AMD CI: All 2-GPU tests including LoRA
           # Tests: T2V, T2I, I2V, LoRA
           #
+          # Enable the ROCm FlyDSL fused norm/scale-shift path (PR #22786) so the
+          # forward_hip integration in multimodal_gen layernorm gets real e2e
+          # coverage. The Wan 14B models in this suite have hidden dim 5120, so
+          # they actually exercise the kernel; other dims fall back to native.
+          # See #27521.
+          #
           # HF download env vars:
           # - HF_HUB_ENABLE_HF_TRANSFER=1: Use faster hf_transfer for downloads (if available)
           # - HF_HUB_DISABLE_SYMLINKS_WARNING=1: Suppress symlink warnings
           docker exec \
+            -e SGLANG_USE_ROCM_FLYDSL=1 \
             -e SGLANG_E2E_TOLERANCE=0.3 \
             -e SGLANG_STAGE_TIME_TOLERANCE=0.2 \
             -e SGLANG_NON_DENOISE_STAGE_TIME_TOLERANCE=0.6 \


### PR DESCRIPTION
## Motivation

Tracking issue #27521 ([AMD] PR CI new test cases to cover), item for #22786.

PR #22786 added the FlyDSL fused norm/scale-shift kernels and wired them into
`multimodal_gen/runtime/layers/layernorm.py` (`forward_hip` of
`_ScaleResidualNormScaleShift` / `_NormScaleShift`). That integration branch is
gated behind `SGLANG_USE_ROCM_FLYDSL=1`, and **no PR-CI job sets it**, so every
diffusion test took the `forward_native` fallback and the wiring was never
exercised end-to-end (the kernel itself is covered by `test_flydsl_fused_norm.py`,
but not the layer wrapper). This was the one coverage gap flagged on the merge of
#22786.

This PR enables `SGLANG_USE_ROCM_FLYDSL=1` for the AMD diffusion e2e suites so the
`forward_hip` FlyDSL path is actually executed in CI.

@yctseng0211 Please help to verify. Thanks!

## Modifications

Add `-e SGLANG_USE_ROCM_FLYDSL=1` to the `docker exec` that runs
`multimodal_gen/test/run_suite.py` in the four AMD diffusion jobs:

- `.github/workflows/pr-test-amd.yml`: `multimodal-gen-test-1-gpu-amd`, `multimodal-gen-test-2-gpu-amd`
- `.github/workflows/pr-test-amd-rocm720.yml`: `multimodal-gen-test-1-gpu-amd-rocm720`, `multimodal-gen-test-2-gpu-amd-rocm720`

Why this gives real coverage and is safe:

- The Wan 14B cases in the 2-GPU suite (`wan2_2_t2v/i2v_a14b_*`, `wan2_1_t2v/i2v_14b_*`)
  have DiT `inner_dim = 40 × 128 = 5120`, which is exactly `FLYDSL_NORM_MIN_ALIGNED_DIM`,
  so they hit the real FlyDSL kernel.
- Other models (dims not divisible by 5120) and any environment without the `flydsl`
  package fall back to native via the existing D-size guard and import guard, so no
  test is destabilized.

No model/runtime code is changed — this is CI-only enablement of an existing,
guarded code path.

## Accuracy Tests

The FlyDSL kernel is numerically validated against the native reference in
`python/sglang/jit_kernel/tests/diffusion/test_flydsl_fused_norm.py` (RMS/Layer,
multiple B/L shapes). The diffusion e2e suites additionally assert output accuracy
within `SGLANG_E2E_TOLERANCE=0.3`, so this run also validates the wrapper end-to-end
on real Wan 14B generations. CI on this PR exercises the new path on the AMD runners.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27154908897](https://github.com/sgl-project/sglang/actions/runs/27154908897)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27222930617](https://github.com/sgl-project/sglang/actions/runs/27222930617)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->