### PR TITLE
Fix SGLang 0.5.12 DeepGEMM  startup compat

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -15,11 +15,11 @@ _is_musa = is_musa()
 
 
 def _compute_enable_deep_gemm():
+    if not envs.SGLANG_ENABLE_JIT_DEEPGEMM.get():
+        return False
+
     sm_version = get_device_sm()
     if (_is_cuda and sm_version < 90) or (_is_musa and sm_version < 31):
-        return False
-    # DeepGEMM requires TMEM/tcgen05 (SM100+datacenter), not available on SM120
-    if sm_version == 120:
         return False
     if not (_is_cuda or _is_musa):
         return False
@@ -29,7 +29,7 @@ def _compute_enable_deep_gemm():
     except ImportError:
         return False
 
-    return envs.SGLANG_ENABLE_JIT_DEEPGEMM.get()
+    return True
 
 
 ENABLE_JIT_DEEPGEMM = _compute_enable_deep_gemm()

--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -21,6 +21,9 @@ def _compute_enable_deep_gemm():
     sm_version = get_device_sm()
     if (_is_cuda and sm_version < 90) or (_is_musa and sm_version < 31):
         return False
+    # DeepGEMM requires TMEM/tcgen05 (SM100+datacenter), not available on SM120
+    if sm_version == 120:
+        return False
     if not (_is_cuda or _is_musa):
         return False
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes DeepGEMM optional dependency probing so `SGLANG_ENABLE_JIT_DEEPGEMM=false` is honored before importing `deep_gemm`.

Today `_compute_enable_deep_gemm()` imports `deep_gemm` before checking the env flag. That means environments with an installed but incompatible `deep_gemm` wheel can fail during SGLang import even when JIT DeepGEMM is explicitly disabled. For example, a CUDA 12 runtime with a CUDA 13 `deep_gemm/_C.so` fails with `libcudart.so.13: cannot open shared object file` before SGLang has a chance to return `False`.

This change makes the disable flag authoritative: if JIT DeepGEMM is disabled, SGLang returns `False` without importing the optional extension.



## Modifications

- Check `envs.SGLANG_ENABLE_JIT_DEEPGEMM.get()` before importing `deep_gemm`.
- Return `True` after the optional import succeeds, since the env flag has already been checked.
- Preserve the existing device capability guards and `ImportError` fallback.

## Accuracy Tests

n/a here

## Speed Tests and Profiling

n/a here

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27163213593](https://github.com/sgl-project/sglang/actions/runs/27163213593)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27163213365](https://github.com/sgl-project/sglang/actions/runs/27163213365)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->