### PR TITLE
Shorten DSV4 unload warning

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1583,7 +1583,9 @@ class DeepseekV4ForCausalLM(nn.Module):
         }
         if unloaded_params:
             logger.warning(
-                f"Some weights are not initialized from checkpoints: {unloaded_params}"
+                "Some weights are not initialized from checkpoints: "
+                f"count={len(unloaded_params)}. "
+                "Ignore this message for RL weight update."
             )
 
         self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)


### PR DESCRIPTION
## Summary
- Shorten DeepSeek V4 unloaded-weight warnings to a count-only message
- Add a note that this warning can be ignored for RL weight updates

## Validation
- `pre-commit run --files python/sglang/srt/models/deepseek_v4.py`
- Covered by the DeepSeek V4 16-node disaggregate debug run that reached step 1 with this change in place

Note: the DeepGEMM cache-dir fix was removed from this PR and will be handled separately.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->