### PR TITLE
Isolate DeepGEMM cache per process

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -31,10 +31,14 @@ _IS_FIRST_RANK_ON_NODE = envs.SGLANG_IS_FIRST_RANK_ON_NODE.get()
 _IN_PRECOMPILE_STAGE = envs.SGLANG_IN_DEEPGEMM_PRECOMPILE_STAGE.get()
 _FAST_WARMUP = envs.SGLANG_JIT_DEEPGEMM_FAST_WARMUP.get()
 
-# Force redirect deep_gemm cache_dir
-os.environ["DG_JIT_CACHE_DIR"] = os.getenv(
+# Force redirect deep_gemm cache_dir.
+_dg_cache_dir = os.getenv(
     "SGLANG_DG_CACHE_DIR", os.path.join(os.path.expanduser("~"), ".cache", "deep_gemm")
 )
+if os.getenv("SGLANG_DG_CACHE_DIR_PER_PROCESS", "0").lower() in ("1", "true", "yes"):
+    _dg_cache_dir = os.path.join(_dg_cache_dir, f"pid_{os.getpid()}")
+os.makedirs(_dg_cache_dir, exist_ok=True)
+os.environ["DG_JIT_CACHE_DIR"] = _dg_cache_dir
 
 # Refer to https://github.com/deepseek-ai/DeepGEMM/commit/d75b218b7b8f4a5dd5406ac87905039ead3ae42f
 # NVRTC may have performance loss with some cases.


### PR DESCRIPTION
## Summary
- Create the configured DeepGEMM JIT cache directory before assigning `DG_JIT_CACHE_DIR`
- Support `SGLANG_DG_CACHE_DIR_PER_PROCESS=1` by appending a process-specific cache subdirectory
- Keep the default cache path unchanged when the new env var is not set

## Root cause
Multiple SGLang processes can concurrently JIT into the same DeepGEMM cache directory. DeepGEMM/TVM treats a concurrent `tmp` directory creation `EEXIST` as fatal, so cold-cache multi-engine startup can fail.

## Validation
- `pre-commit run --files python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py`
- `pre-commit run --all-files` was attempted; it reformatted unrelated existing Lora/forward_batch files, so those hook-generated unrelated edits were not included in this PR
- Covered by the DeepSeek V4 16-node disaggregate debug run that reached step 1 with this change in place

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->