### PR TITLE
Disable MiniMax-M2.7 custom all-reduce on gfx942

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -66,6 +66,7 @@ from sglang.srt.utils.common import (
     is_cpu,
     is_cuda,
     is_flashinfer_available,
+    is_gfx942_supported,
     is_hip,
     is_hopper_with_cuda_12_3,
     is_host_cpu_arm64,
@@ -102,6 +103,13 @@ MIMO_V2_MODEL_ARCHS = (
 LLAMA4_MODEL_ARCHS = (
     "Llama4ForConditionalGeneration",
     "Llama4ForCausalLM",
+)
+MINIMAX_M2_MODEL_ARCHS = ("MiniMaxM2ForCausalLM",)
+MINIMAX_M27_MODEL_MARKERS = (
+    "minimax-m2.7",
+    "minimax_m2.7",
+    "minimax-m27",
+    "minimax_m27",
 )
 
 SAMPLING_BACKEND_CHOICES = {"flashinfer", "pytorch", "ascend"}
@@ -3167,6 +3175,40 @@ class ServerArgs:
     def _handle_amd_specifics(self):
         if is_hip():
             self.triton_attention_num_kv_splits = 16
+            self._handle_minimax_m27_gfx942_custom_all_reduce()
+
+    def _handle_minimax_m27_gfx942_custom_all_reduce(self):
+        if (
+            self.disable_custom_all_reduce
+            or self.tp_size <= 1
+            or not is_gfx942_supported()
+        ):
+            return
+
+        hf_config = self.get_model_config().hf_config
+        model_archs = getattr(hf_config, "architectures", None) or []
+        if not model_archs or model_archs[0] not in MINIMAX_M2_MODEL_ARCHS:
+            return
+
+        model_identifiers = [
+            self.model_path,
+            getattr(hf_config, "_name_or_path", None),
+            getattr(hf_config, "name_or_path", None),
+        ]
+        if not any(
+            marker in str(identifier).lower()
+            for identifier in model_identifiers
+            if identifier is not None
+            for marker in MINIMAX_M27_MODEL_MARKERS
+        ):
+            return
+
+        self.disable_custom_all_reduce = True
+        logger.warning(
+            "Disabling custom all-reduce for MiniMax-M2.7 on AMD gfx942 "
+            "(MI300X/MI325X). This avoids the unsafe decode-time ROCm custom "
+            "all-reduce path reported in sgl-project/sglang#22714."
+        )
 
     def _handle_nccl_pre_warm(self):
         # pre_warm_nccl is only used with CUDA or HIP hardware

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
@@ -467,6 +468,70 @@ class TestHiCacheArgs(unittest.TestCase):
         args._handle_hicache()
 
         self.assertEqual(args.decode_attention_backend, "triton")
+
+
+class TestAMDSpecificArgs(unittest.TestCase):
+    def _make_minimax_args(
+        self,
+        *,
+        model_path: str = "MiniMaxAI/MiniMax-M2.7",
+        arch: str = "MiniMaxM2ForCausalLM",
+        tp_size: int = 4,
+    ) -> ServerArgs:
+        args = ServerArgs.__new__(ServerArgs)
+        args.model_path = model_path
+        args.tp_size = tp_size
+        args.disable_custom_all_reduce = False
+        args.triton_attention_num_kv_splits = 8
+
+        hf_config = SimpleNamespace(architectures=[arch], _name_or_path=model_path)
+        args.get_model_config = lambda: SimpleNamespace(hf_config=hf_config)
+        return args
+
+    @patch("sglang.srt.server_args.is_gfx942_supported", return_value=True)
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_minimax_m27_gfx942_disables_custom_all_reduce(
+        self, _mock_is_hip, _mock_is_gfx942_supported
+    ):
+        args = self._make_minimax_args()
+
+        args._handle_amd_specifics()
+
+        self.assertEqual(args.triton_attention_num_kv_splits, 16)
+        self.assertTrue(args.disable_custom_all_reduce)
+
+    @patch("sglang.srt.server_args.is_gfx942_supported", return_value=True)
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_minimax_m27_gfx942_keeps_tp1_custom_all_reduce_setting(
+        self, _mock_is_hip, _mock_is_gfx942_supported
+    ):
+        args = self._make_minimax_args(tp_size=1)
+
+        args._handle_amd_specifics()
+
+        self.assertFalse(args.disable_custom_all_reduce)
+
+    @patch("sglang.srt.server_args.is_gfx942_supported", return_value=False)
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_minimax_m27_non_gfx942_keeps_custom_all_reduce_setting(
+        self, _mock_is_hip, _mock_is_gfx942_supported
+    ):
+        args = self._make_minimax_args()
+
+        args._handle_amd_specifics()
+
+        self.assertFalse(args.disable_custom_all_reduce)
+
+    @patch("sglang.srt.server_args.is_gfx942_supported", return_value=True)
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_minimax_m25_gfx942_keeps_custom_all_reduce_setting(
+        self, _mock_is_hip, _mock_is_gfx942_supported
+    ):
+        args = self._make_minimax_args(model_path="MiniMaxAI/MiniMax-M2.5")
+
+        args._handle_amd_specifics()
+
+        self.assertFalse(args.disable_custom_all_reduce)
 
 
 class TestNgramExternalSamArgs(CustomTestCase):


### PR DESCRIPTION
## Summary
- Automatically disables SGLang custom all-reduce for `MiniMaxAI/MiniMax-M2.7` on ROCm gfx942 (MI300X/MI325X) when tensor parallelism is active.
- Keeps the gate narrow: TP=1, non-gfx942 ROCm, and MiniMax-M2.5 continue to use the existing custom all-reduce default.
- Adds server-args regression coverage for the gfx942 MiniMax-M2.7 gate and nearby unaffected cases.

## Issue
Related to https://github.com/sgl-project/sglang/issues/22714.

## Root Cause / Hypothesis
Issue #22714 reports MiniMax-M2.7 decode crashes/hangs on 4x MI300X with ROCm, including `HSA_STATUS_ERROR_EXCEPTION` / `assert_async_cuda_kernel`. Follow-up testing in the issue showed `--attention-backend aiter` improved behavior, but `--disable-custom-all-reduce` was the load-bearing change for stable short bursts and a longer decode. This points at the ROCm gfx942 custom/quick all-reduce path used under TP as unsafe for this model path during decode.

## Fix
For ROCm gfx942 only, and only when the resolved model identifies as MiniMax M2.7 with `tp_size > 1`, default `disable_custom_all_reduce=True`. This makes the runtime take the RCCL/NCCL fallback path that the issue reporter found stable, without broadly disabling custom all-reduce for all ROCm models or newer gfx95x paths.

## Tests
- `python -m py_compile python\sglang\srt\server_args.py test\registered\unit\server_args\test_server_args.py`
- `python -m ruff check --select=F401,F821 python\sglang\srt\server_args.py test\registered\unit\server_args\test_server_args.py`
- Fleet validation: `job-e93c7e0e` on `h19u25`, image `lmsysorg/sglang:v0.5.10.post1-rocm720-mi30x`, cloned branch commit `c91d66dbf96360ace37cc1923e5f94f0c27e1c32`, ran changed-file `py_compile` and standalone assertions for the MiniMax-M2.7/gfx942 gate.

## Caveats
- I did not run the full 4x MI300X `MiniMaxAI/MiniMax-M2.7` serving reproduction, so this PR should not be treated as proven to fully close #22714 yet.
- A targeted pytest run in the ROCm 0.5.10 image was blocked by an image dependency mismatch during collection (`huggingface_hub` strict dataclass handling) before reaching this test class; upstream CI should run it in the current test environment.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27174371736](https://github.com/sgl-project/sglang/actions/runs/27174371736)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27174371622](https://github.com/sgl-project/sglang/actions/runs/27174371622)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->