### PR TITLE
Avoid dual semantics of extend_input_len by computing the candidate on the fly

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1218,8 +1218,6 @@ class Req(ReqDllmMixin):
                 )
             )
 
-        self.set_extend_input_len(input_len - len(self.prefix_indices))
-
     def _compute_max_prefix_len(self, input_len: int) -> int:
         # NOTE: the matched length is at most 1 less than the input length to enable logprob computation
         max_prefix_len = input_len - 1

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -659,7 +659,7 @@ class PrefillAdder:
             * self.page_size
         )
 
-        req.extend_input_len = trunc_len
+        req.set_extend_input_len(trunc_len)
         req.fill_len = prefix_len + trunc_len
 
         self.can_run_list.append(req)
@@ -679,9 +679,13 @@ class PrefillAdder:
             return AddReqResult.NO_TOKEN
 
         # Truncate input length to available tokens and update request metadata
-        truncated = req.extend_input_len > _rem_tokens
-        req.extend_input_len = min(req.extend_input_len, _rem_tokens)
-        req.fill_len = len(req.prefix_indices) + req.extend_input_len
+        cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
+            req.prefix_indices
+        )
+        truncated = cand_extend_input_len > _rem_tokens
+        new_len = min(cand_extend_input_len, _rem_tokens)
+        req.set_extend_input_len(new_len)
+        req.fill_len = len(req.prefix_indices) + new_len
         self.can_run_list.append(req)
 
         # Update budget: reserve max_new_tokens only if not truncated
@@ -719,9 +723,13 @@ class PrefillAdder:
                     return req
                 _rem_tokens = self.rem_chunk_tokens
 
-        truncated = req.extend_input_len > _rem_tokens
-        req.set_extend_input_len(min(req.extend_input_len, _rem_tokens))
-        req.fill_len = len(req.prefix_indices) + req.extend_input_len
+        cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
+            req.prefix_indices
+        )
+        truncated = cand_extend_input_len > _rem_tokens
+        new_len = min(cand_extend_input_len, _rem_tokens)
+        req.set_extend_input_len(new_len)
+        req.fill_len = len(req.prefix_indices) + new_len
         self.can_run_list.append(req)
         self._update_prefill_budget(
             0,
@@ -755,11 +763,14 @@ class PrefillAdder:
                 self.tree_cache.dec_lock_ref(last_node)
 
     def add_one_req_ignore_eos(self, req: Req):
-        paged_input = self.ceil_paged_tokens(req.extend_input_len)
+        cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
+            req.prefix_indices
+        )
+        paged_input = self.ceil_paged_tokens(cand_extend_input_len)
         if paged_input > min(self.cur_rem_tokens, self.rem_total_tokens):
             return AddReqResult.NO_TOKEN
         if self.is_hybrid_swa:
-            if self._swa_budget_for_req(req.extend_input_len) > self.rem_swa_tokens:
+            if self._swa_budget_for_req(cand_extend_input_len) > self.rem_swa_tokens:
                 return AddReqResult.NO_TOKEN
 
         def add_req_state(r, insert_sort=False):
@@ -799,7 +810,7 @@ class PrefillAdder:
             # Skip this logic for swa. The SWA has different memory management, and
             # this mechanism is underestimating the memory usage.
             cur_rem_tokens = self.cur_rem_tokens - self.ceil_paged_tokens(
-                req.extend_input_len
+                cand_extend_input_len
             )
             tokens_freed = 0
             for i, (tokens_left, tokens_occupied) in enumerate(self.req_states):
@@ -825,13 +836,13 @@ class PrefillAdder:
             self._add_dllm_req(req, 0)
         elif (
             self.rem_chunk_tokens is None  # chunked prefill is disabled
-            or req.extend_input_len <= self.rem_chunk_tokens  # it is the last chunk
+            or cand_extend_input_len <= self.rem_chunk_tokens  # it is the last chunk
         ):
             # Non-chunked prefill — the whole sequence is committed this iter.
+            req.set_extend_input_len(
+                len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
+            )
             req.fill_len = len(req.full_untruncated_fill_ids)
-            assert (
-                req.fill_len == len(req.prefix_indices) + req.extend_input_len
-            ), f"{req.fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
             self.can_run_list.append(req)
             self._update_prefill_budget(
                 0,
@@ -889,10 +900,13 @@ class PrefillAdder:
             max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
             CLIP_MAX_NEW_TOKENS,
         )
-        total_tokens = req.extend_input_len + max_new + self.page_size
+        cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
+            req.prefix_indices
+        )
+        total_tokens = cand_extend_input_len + max_new + self.page_size
 
         # adjusting the input_tokens based on host_hit_length and page_size
-        real_input_tokens = req.extend_input_len - req.host_hit_length
+        real_input_tokens = cand_extend_input_len - req.host_hit_length
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
 
@@ -901,7 +915,7 @@ class PrefillAdder:
 
         if self.is_hybrid_swa:
             swa_needed = self._swa_budget_for_req(
-                req.extend_input_len, swa_host_hit_length=req.swa_host_hit_length
+                cand_extend_input_len, swa_host_hit_length=req.swa_host_hit_length
             )
             if swa_needed >= self.rem_swa_tokens:
                 return AddReqResult.NO_TOKEN
@@ -923,7 +937,7 @@ class PrefillAdder:
 
             if self.is_hybrid_swa:
                 swa_needed = self._swa_budget_for_req(
-                    req.extend_input_len, swa_host_hit_length=req.swa_host_hit_length
+                    cand_extend_input_len, swa_host_hit_length=req.swa_host_hit_length
                 )
                 if swa_needed >= self.rem_swa_tokens:
                     return AddReqResult.NO_TOKEN
@@ -937,13 +951,12 @@ class PrefillAdder:
                     )
                 )
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
-                req.set_extend_input_len(
-                    len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
-                )
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
 
-            input_tokens = self.ceil_paged_tokens(req.extend_input_len)
+            input_tokens = self.ceil_paged_tokens(
+                len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
+            )
 
             if (
                 self.rem_chunk_tokens is None
@@ -967,10 +980,10 @@ class PrefillAdder:
                 self._req_inc_lock_ref(req)
             elif self.rem_chunk_tokens is None or input_tokens <= self.rem_chunk_tokens:
                 # Non-chunked prefill — the whole sequence is committed this iter.
+                req.set_extend_input_len(
+                    len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
+                )
                 req.fill_len = len(req.full_untruncated_fill_ids)
-                assert (
-                    req.fill_len == len(req.prefix_indices) + req.extend_input_len
-                ), f"{req.fill_len=} {len(req.prefix_indices)=} {req.extend_input_len=}"
                 self.can_run_list.append(req)
 
                 self._req_inc_lock_ref(req)
@@ -1052,7 +1065,8 @@ class PrefillAdder:
 
         preemptible_reqs = []
         min_tokens_to_remove = (
-            req.extend_input_len
+            len(req.full_untruncated_fill_ids)
+            - len(req.prefix_indices)
             + min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
             - self.rem_total_tokens
         )

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -77,6 +77,8 @@ class TestPrefillAdder(CustomTestCase):
         req.rid = str(rid)
         req.priority = priority
         req.extend_input_len = 0
+        req.prefix_indices = []
+        req.full_untruncated_fill_ids = []
         req.extend_logprob_start_len = 0
         req.output_ids = [0] * output_len
         req.sampling_params = SimpleNamespace(max_new_tokens=max_new_tokens)


### PR DESCRIPTION
## The dual semantics

`Req.extend_input_len` meant **two different things depending on the request's lifecycle phase**:

1. **Before admission (propose):** the *candidate* — the untruncated extend length the request *wants* to run. It was stored eagerly (`set_extend_input_len(get_full_untruncated_fill_len() - len(prefix_indices))`) and the `PrefillAdder` read it back to make admission / chunking decisions.
2. **After admission (commit):** the *committed* extend length the request will actually run this iteration — equal to the candidate when the whole sequence fits, or a smaller truncated value on chunked prefill.

So the same field was overloaded as both the scheduler's **input** ("how much do I want?") and its **output** ("how much did I commit to?").

## The change

Stop storing the candidate. The candidate is computed **on the fly** (`get_full_untruncated_fill_len() - len(prefix_indices)`) wherever the `PrefillAdder` needs it, and `extend_input_len` is written **only at commit time**. After this, `extend_input_len` has a **single meaning**: the committed extend length. The committed `(extend_fill_len, extend_input_len)` pair is unchanged.

Note that the eager candidate store happened in **two** places, both removed here — "on the fly" is not just about the init line:

- `init_next_round_input` no longer ends with `set_extend_input_len(...)` — the per-round eager store is gone.
- The **host-load-back path** in `add_one_req` (which, after growing `prefix_indices` via `init_load_back`, used to *re-store* the candidate with its own `set_extend_input_len(...)`) likewise drops that store; the budget read immediately after now recomputes the candidate on the fly against the **grown** prefix.

Concretely:
- Every `PrefillAdder` pre-commit read of `req.extend_input_len` becomes the on-the-fly candidate expression (including the post-host-load-back read above).
- Each admission branch that commits a request sets its final `extend_input_len` via `set_extend_input_len` at commit (the chunked paths already did; the non-chunked / dllm / staging paths now do too, taking over the `extend_logprob_start_len` recompute that the deleted stores used to perform).

## Why

Resolving the dual semantics is a prerequisite for the follow-up consolidation (#27610): once the candidate no longer needs a stored home in `extend_input_len`, the two length fields (`extend_input_len`, `extend_fill_len`) can collapse into a single immutable `Range`. Isolating it here keeps that mechanical rename clean and keeps the one behavioral nuance below reviewable on its own.

## Behavior

Preserved, with one isolated exception: the dllm / staging commit paths now recompute `extend_logprob_start_len` against the **truncated** length rather than the untruncated candidate. This is only observable for dllm chunked prefill with cross-chunk input logprobs, where the truncated value is the more correct one.

No tests run (per request); `py_compile` + `pre-commit` clean. The only test touched is `test_prefill_adder.py` (mocks now supply `get_full_untruncated_fill_len` for the on-the-fly candidate).

Stacked on #27575; #27610 stacks on this.



















































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->