### PR TITLE
Suffix decoding pp

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -91,6 +91,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [project.optional-dependencies]
+suffix = ["arctic_inference>=0.1.2"]  # SUFFIX speculative decoding (model-free, CPU suffix tree)
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 diffusion = [

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -34,16 +34,18 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
     ], f"{server_args.kv_cache_dtype} is not supported for {model_arch}"
 
     if server_args.speculative_algorithm is not None:
+        # DSv4 supports EAGLE (spec-v2) and SUFFIX (model-free, NGRAMWorker family).
+        _allowed = {"EAGLE", "SUFFIX"}
         assert (
-            server_args.speculative_algorithm == "EAGLE"
-        ), f"Only EAGLE speculative algorithm is supported for {model_arch}"
-        assert (
-            server_args.speculative_eagle_topk == 1
-        ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
-
-        if not envs.SGLANG_ENABLE_SPEC_V2.get():
-            envs.SGLANG_ENABLE_SPEC_V2.set(True)
-            logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
+            server_args.speculative_algorithm in _allowed
+        ), f"Speculative algorithm {server_args.speculative_algorithm} not supported for {model_arch}; allowed: {sorted(_allowed)}"
+        if server_args.speculative_algorithm == "EAGLE":
+            assert (
+                server_args.speculative_eagle_topk == 1
+            ), f"Only EAGLE with topk == 1 is supported for {model_arch}"
+            if not envs.SGLANG_ENABLE_SPEC_V2.get():
+                envs.SGLANG_ENABLE_SPEC_V2.set(True)
+                logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
 
     if server_args.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
         server_args.swa_full_tokens_ratio = 0.1

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3103,9 +3103,15 @@ class Scheduler(
                     return_hidden_states=batch.return_hidden_states,
                 )
             else:
+                # PP+SUFFIX needs pp_proxy_tensors threaded into the worker
+                # even when spec is on (the PP-aware SuffixWorker forwards it
+                # to target_worker.forward_batch_generation). Other spec
+                # algorithms don't read pp_proxy_tensors at the worker level
+                # but ignore the kwarg, so threading it unconditionally is
+                # safe.
                 kwargs = (
                     {"pp_proxy_tensors": pp_proxy_tensors}
-                    if self.spec_algorithm.is_none()
+                    if self.spec_algorithm.is_none() or self.spec_algorithm.is_suffix()
                     else {}
                 )
                 resolve_forward_inputs(batch, self.future_map)

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -966,6 +966,25 @@ class SchedulerPPMixin:
         tensor_dict = {
             "next_token_ids": result.next_token_ids,
         }
+        # PP+SUFFIX: ship the suffix verify result (accept_indices,
+        # num_accept_tokens) up the existing last->first ring so the non-last
+        # rank can replay the CPU side of verify (append output_ids, free
+        # rejected KV) inside _pp_prep_batch_result. Only the last rank
+        # produces accept; non-last ranks see batch.spec_info populated but
+        # without accept tensors. Skipped for spec-v2 (overlap path).
+        if (
+            not batch.spec_algorithm.is_none()
+            and not batch.is_spec_v2
+            and batch.spec_info is not None
+            and getattr(batch.spec_info, "accept_indices", None) is not None
+            and getattr(batch.spec_info, "num_accept_tokens", None) is not None
+        ):
+            tensor_dict["suffix_accept_indices"] = batch.spec_info.accept_indices.to(
+                torch.int64
+            )
+            tensor_dict["suffix_num_accept"] = batch.spec_info.num_accept_tokens.to(
+                torch.int64
+            )
 
         if batch.return_logprob:
             logprob_dict = get_logprob_dict_from_result(result)
@@ -1102,7 +1121,21 @@ class SchedulerPPMixin:
         # PP rank 0 also relays into output_tokens_buf so the next iter's
         # resolve_forward_inputs finds these tokens for the decode portion
         # of mixed-chunk batches (which gather via mix_running_indices).
-        self.future_map.stash(batch.req_pool_indices, batch.input_ids)
+        if "suffix_accept_indices" in pp_outputs.tensors:
+            # PP+SUFFIX: next_token_ids is the flat variable-length accept
+            # stream (sum(num_accept) tokens, not one per req). Relay one
+            # token per req — its LAST accepted token — which matches the
+            # non-spec semantic (the req's current newest token).
+            # batch.input_ids keeps the full stream for the spec bookkeeping
+            # below; the next decode iter rebuilds input_ids from the draft
+            # chain anyway.
+            _num_accept = pp_outputs["suffix_num_accept"].to(torch.int64)
+            _last_per_req = torch.cumsum(_num_accept, dim=0) - 1
+            self.future_map.stash(
+                batch.req_pool_indices, batch.input_ids[_last_per_req]
+            )
+        else:
+            self.future_map.stash(batch.req_pool_indices, batch.input_ids)
         output_result = GenerationBatchResult(
             logits_output=logits_output,
             pp_hidden_states_proxy_tensors=None,
@@ -1111,11 +1144,39 @@ class SchedulerPPMixin:
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
         )
+        # PP+SUFFIX deferred verify propagation. The last rank ran the
+        # verify and shipped its accept tensors up the ring; here on the
+        # receiving rank we (a) replay the CPU side of verify so KV/output
+        # stay in lockstep, and (b) feed the accept count into spec metrics.
+        if "suffix_accept_indices" in pp_outputs.tensors:
+            if (
+                not self.pp_group.is_last_rank
+                and getattr(self, "draft_worker", None) is not None
+                and hasattr(self.draft_worker, "apply_deferred_accept")
+            ):
+                self.draft_worker.apply_deferred_accept(
+                    batch,
+                    pp_outputs["suffix_accept_indices"],
+                    pp_outputs["next_token_ids"],
+                    pp_outputs["suffix_num_accept"],
+                    self.page_size,
+                )
+            _na = pp_outputs["suffix_num_accept"]
+            output_result.num_correct_drafts = int(_na.sum().item()) - int(_na.numel())
         return output_result
 
     def _pp_process_batch_result(
         self: Scheduler, batch: ScheduleBatch, output_result: GenerationBatchResult
     ):
+        # _PATCH_PP_DEFER_FREE: run the SUFFIX last-rank deferred spec free before
+        # post-processing, so KV-full retraction stays symmetric across PP ranks.
+        if (
+            self.pp_group.is_last_rank
+            and getattr(batch, "_pp_pending_spec_free", False)
+            and getattr(self, "draft_worker", None) is not None
+            and hasattr(self.draft_worker, "apply_deferred_free")
+        ):
+            self.draft_worker.apply_deferred_free(batch, self.page_size)
         self.process_batch_result(batch, output_result)
 
     def _pp_send_output_to_next_stage(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -739,6 +739,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         assert (
             (not model_has_mtp_layers)
             or (self.spec_algorithm.is_none())
+            # _PATCH_PP_MTP_SUFFIX: SUFFIX uses a CPU suffix-tree draft, not
+            # the MTP layers, so PP-splitting the model is fine for it.
+            or (getattr(self.server_args, "speculative_algorithm", None) == "SUFFIX")
             or (
                 (not self.spec_algorithm.is_none())
                 and (self.num_effective_layers == model_num_layers)

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1088,7 +1088,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
         else:
             assert isinstance(output, PPProxyTensors)
-            return PPProxyTensors({k: v[: self.bs] for k, v in output.tensors.items()})
+            # _PATCH_PP_PROXY_RETURN: PP hidden states have bs*num_tokens_per_bs
+            # rows (one per token); slicing to bs truncates spec verify hidden
+            # to 1 token/req and ships stale hidden for the rest.
+            _pp_ntok = self.bs * self.num_tokens_per_bs
+            return PPProxyTensors({k: v[:_pp_ntok] for k, v in output.tensors.items()})
 
     # -----------------------------------------------------------------
     # spec info

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -129,12 +129,21 @@ class DecodeInputBuffers(ForwardInputBuffers):
             if pp_size > 1:
                 is_mhc = hc_hidden_size is not None
                 hs = hc_hidden_size if is_mhc else hidden_size
+                # PP hidden states carry one row per *token*
+                # (max_num_token = max_bs * num_tokens_per_bs), not per
+                # request. Normal decode has num_tokens_per_bs == 1 so
+                # max_num_token == max_bs and a (max_bs, hs) buffer happens
+                # to be right-sized; for SUFFIX/NGRAM verify
+                # (num_tokens_per_bs == draft_token_num, e.g. 32) the buffer
+                # must be max_num_token-wide or stage-1 attention sees a
+                # max_bs-token hidden against a max_num_token-token positions
+                # tensor and rotary's view(num_tokens, -1, head_size) crashes.
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                    "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
                 }
                 if not is_mhc:
                     pp_proxy_tensors["residual"] = torch.zeros(
-                        (max_bs, hidden_size), dtype=dtype
+                        (max_num_token, hidden_size), dtype=dtype
                     )
             else:
                 pp_proxy_tensors = None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7749,9 +7749,20 @@ class ServerArgs:
         )
 
         if self.pp_size > 1:
+            # _PATCH_PP_SUFFIX_ASSERT: PP supports SUFFIX speculative decoding
+            # ONLY (CPU-draft NGRAM family, no draft-model forward). EAGLE / EAGLE3
+            # / NEXTN / STANDALONE / HYBRID_SUFFIX_MTP need a draft forward that the
+            # PP deferred-verify path does not implement, so they stay forbidden.
             assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
-            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+                self.disable_overlap_schedule
+            ), "Pipeline parallelism is not compatible with overlap schedule"
+            assert (
+                self.speculative_algorithm is None
+                or self.speculative_algorithm == "SUFFIX"
+            ), (
+                "Pipeline parallelism with speculative decoding supports only "
+                f"SUFFIX (got speculative_algorithm={self.speculative_algorithm})"
+            )
 
         assert not (
             self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -637,6 +637,11 @@ class ServerArgs:
     speculative_ngram_external_corpus_path: Optional[str] = None
     speculative_ngram_external_sam_budget: int = 0
     speculative_ngram_external_corpus_max_tokens: int = 10000000
+    # SUFFIX speculative decoding (arctic_inference SuffixDecodingCache)
+    speculative_suffix_max_tree_depth: int = 24
+    speculative_suffix_max_cached_requests: int = 10000
+    speculative_suffix_max_spec_factor: float = 1.0
+    speculative_suffix_min_token_prob: float = 0.1
     enable_multi_layer_eagle: bool = False
 
     # Adaptive speculative decoding
@@ -6183,6 +6188,30 @@ class ServerArgs:
             type=int,
             default=ServerArgs.speculative_ngram_external_corpus_max_tokens,
             help="Fail startup if the tokenized external ngram corpus exceeds this many tokens. Tune this based on your CPU memory budget.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-tree-depth",
+            type=int,
+            default=ServerArgs.speculative_suffix_max_tree_depth,
+            help="Max depth of the per-request suffix tree for SUFFIX speculative decoding.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-cached-requests",
+            type=int,
+            default=ServerArgs.speculative_suffix_max_cached_requests,
+            help="Max number of finished requests cached in the shared suffix tree for SUFFIX speculative decoding.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-spec-factor",
+            type=float,
+            default=ServerArgs.speculative_suffix_max_spec_factor,
+            help="SUFFIX max speculation factor: caps draft length relative to the matched suffix score.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-min-token-prob",
+            type=float,
+            default=ServerArgs.speculative_suffix_min_token_prob,
+            help="SUFFIX minimum per-token probability for a draft token to be proposed.",
         )
         parser.add_argument(
             "--speculative-adaptive",

--- a/python/sglang/srt/speculative/__init__.py
+++ b/python/sglang/srt/speculative/__init__.py
@@ -1,0 +1,4 @@
+# Importing this package registers plugin speculative-decoding algorithms.
+# SUFFIX (arctic_inference SuffixDecoding) registers itself on import; the
+# worker / arctic_inference are loaded lazily only when SUFFIX is selected.
+from sglang.srt.speculative import sgl_suffix_plugin  # noqa: F401

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -265,6 +265,10 @@ class NgramVerifyInput(SpecInput):
         target_predict = target_predict.reshape(bs, self.draft_token_num)
 
         candidates = self.draft_token.reshape(bs, self.draft_token_num)
+        # _PATCH_PAD_CAND: SUFFIX padding slots (token 0) must never match a
+        # target prediction -> mark them unmatchable so they're never accepted.
+        candidates = candidates.clone()
+        candidates[candidates == 0] = -1
         predict_shape = list(logits_output.next_token_logits.shape)[:-1]
         predict_shape[-1] += 1
         self.predict = torch.empty(predict_shape, dtype=torch.int32, device=self.device)
@@ -295,6 +299,10 @@ class NgramVerifyInput(SpecInput):
     ):
         bs = batch.batch_size()
         candidates = self.draft_token.reshape(bs, self.draft_token_num)
+        # _PATCH_PAD_CAND: SUFFIX padding slots (token 0) must never match a
+        # target prediction -> mark them unmatchable so they're never accepted.
+        candidates = candidates.clone()
+        candidates[candidates == 0] = -1
         predict_shape = list(logits_output.next_token_logits.shape)[:-1]
         predict_shape[-1] += 1
         self.predict = torch.empty(predict_shape, dtype=torch.int32, device=self.device)
@@ -364,6 +372,7 @@ class NgramVerifyInput(SpecInput):
         logits_output: LogitsProcessorOutput,
         page_size: int,
         vocab_mask: Optional[torch.Tensor] = None,  # For grammar
+        defer_apply: bool = False,  # _PATCH_PP_DEFER_APPLY
     ) -> torch.Tensor:
         bs = self.retrieve_index.shape[0]
         sampling_info = batch.sampling_info
@@ -432,10 +441,12 @@ class NgramVerifyInput(SpecInput):
         num_accept_tokens_cpu = num_correct_drafts_cpu + 1
         num_correct_drafts = num_correct_drafts_cpu.sum().item()
 
-        self._free_cache(batch, page_size, num_correct_drafts_cpu)
-
-        batch.seq_lens.add_(self.num_accept_tokens)
-        batch.seq_lens_cpu.add_(num_accept_tokens_cpu)
+        # _PATCH_PP_DEFER_APPLY: on a PP last rank the caller defers the free +
+        # seq_lens advance so KV occupancy stays symmetric with non-last ranks.
+        if not defer_apply:
+            self._free_cache(batch, page_size, num_correct_drafts_cpu)
+            batch.seq_lens.add_(self.num_accept_tokens)
+            batch.seq_lens_cpu.add_(num_accept_tokens_cpu)
         # Keep seq_lens_sum in sync; attn backends size kv_indices from it.
         batch.seq_lens_sum += int(num_accept_tokens_cpu.sum())
 

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -30,9 +30,8 @@ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.speculative.spec_utils import (
     TREE_SPEC_KERNEL_AVAILABLE,
+    align_evict_mask_to_page_size,
     assign_req_to_token_pool,
-    get_src_tgt_cache_loc,
-    get_target_cache_loc,
 )
 from sglang.srt.utils import is_cuda, is_hip, is_musa, next_power_of_2
 
@@ -224,50 +223,22 @@ class NgramVerifyInput(SpecInput):
             batch.token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
             batch.out_cache_loc = batch.out_cache_loc[self.accept_indices]
         else:
-            # Shift the accepted tokens to the beginning.
-            # Only evict the last part
-            src_cache_loc, tgt_cache_loc, to_free_num_slots = get_src_tgt_cache_loc(
+            # Linear-chain optimization: NGRAM/SUFFIX produce linear chain drafts,
+            # so accept_indices form a contiguous prefix per request. Instead of
+            # compacting via move_kv_cache (which NSA paginated KV pool does not
+            # support), free only full-empty pages and leave gaps in partial pages.
+            # Mirrors EAGLE/MTP's topk==1 cleanup path in eagle_info.py.
+            evict_mask = torch.full_like(self.draft_token, True, dtype=torch.bool)
+            evict_mask[self.accept_indices] = False
+            align_evict_mask_to_page_size[len(batch.seq_lens),](
                 batch.seq_lens,
-                batch.out_cache_loc,
-                self.accept_indices,
-                self.num_correct_drafts,
-                self.draft_token_num,
+                evict_mask,
                 page_size,
-            )
-            to_free_slots = torch.empty(
-                (to_free_num_slots.sum().item(),),
-                dtype=torch.int64,
-                device=to_free_num_slots.device,
-            )
-
-            # out_cache_loc: [0  1  2,  3  4  5,  6  7  8]
-            # accept_index:  [0 -1  2,  3  4 -1,  6 -1 -1]
-            # tgt_cache_loc: [0  1   ,  3  4   ,  6      ]
-            # to_free_slots: [      2,        5,     7  8]
-            # to_free_slots also needs to be page-aligned without the first partial page
-            #
-            # split each row of out_cache_loc into two parts.
-            # 1. the first part goes to tgt_cache_loc. length = num_correct_drafts[i] + 1
-            # 2. the second part goes to to_free_slots.
-            get_target_cache_loc[(bs,)](
-                tgt_cache_loc,
-                to_free_slots,
-                self.num_correct_drafts,
-                to_free_num_slots,
-                batch.out_cache_loc,
                 self.draft_token_num,
                 next_power_of_2(self.draft_token_num),
-                next_power_of_2(bs),
             )
-
-            # Free the kv cache
-            batch.token_to_kv_pool_allocator.free(to_free_slots)
-
-            # Copy the kv cache
-            batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
-                tgt_cache_loc, src_cache_loc
-            )
-            batch.out_cache_loc = tgt_cache_loc
+            batch.token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
+            batch.out_cache_loc = batch.out_cache_loc[self.accept_indices]
 
         num_correct_drafts_list = num_correct_drafts_cpu.tolist()
         for i, req in enumerate(batch.reqs):

--- a/python/sglang/srt/speculative/sgl_suffix_plugin.py
+++ b/python/sglang/srt/speculative/sgl_suffix_plugin.py
@@ -1,0 +1,68 @@
+"""Register the SUFFIX speculative-decoding algorithm.
+
+SUFFIX is registered as a *plugin* algorithm (``SpeculativeAlgorithm.register``)
+rather than a builtin enum value. ``_SuffixLike.is_ngram()`` returns ``True`` so
+SUFFIX transparently reuses every existing NGRAM dispatch branch in the
+scheduler / cuda-graph runner / model runner — the verify and KV-cache path is
+identical; only the draft source differs (see ``SuffixWorker``). The factory is
+imported lazily so ``arctic_inference`` is required only when SUFFIX is actually
+selected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Type
+
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_registry import CustomSpecAlgo
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+
+class _SuffixLike(CustomSpecAlgo):
+    """SUFFIX dispatches like NGRAM (shared verify / KV-cache path)."""
+
+    def is_ngram(self) -> bool:
+        return True
+
+    def is_suffix(self) -> bool:
+        return True
+
+    def create_future_map(
+        self,
+        device,
+        req_to_token_pool,
+        needs_cpu_seq_lens: bool = True,
+    ):
+        # CustomSpecAlgo base does not provide this (the scheduler calls it
+        # unconditionally); mirror SpeculativeAlgorithm.create_future_map.
+        from sglang.srt.managers.overlap_utils import FutureMap
+
+        return FutureMap(device, self, req_to_token_pool, needs_cpu_seq_lens)
+
+
+def _suffix_factory(server_args: "ServerArgs") -> Type:
+    from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+    return SuffixWorker
+
+
+def _validate_suffix_args(server_args: "ServerArgs") -> None:
+    required = (
+        "speculative_suffix_max_tree_depth",
+        "speculative_suffix_max_cached_requests",
+        "speculative_suffix_max_spec_factor",
+        "speculative_suffix_min_token_prob",
+    )
+    missing = [a for a in required if not hasattr(server_args, a)]
+    if missing:
+        raise ValueError(f"SUFFIX speculative decoding requires server args {missing}.")
+
+
+SpeculativeAlgorithm.register(
+    "SUFFIX",
+    supports_overlap=False,
+    validate_server_args=_validate_suffix_args,
+    spec_class=_SuffixLike,
+)(_suffix_factory)

--- a/python/sglang/srt/speculative/suffix_cache_adapter.py
+++ b/python/sglang/srt/speculative/suffix_cache_adapter.py
@@ -1,0 +1,324 @@
+"""
+Suffix decoding cache adapter for SGLang v0.5.9.
+
+This wraps arctic_inference.suffix_decoding.SuffixDecodingCache and exposes an
+NgramCache-like interface used by NGRAMWorker:
+  - batch_get(...) -> flat draft tokens + flat tree mask
+  - batch_put(...) -> no-op / sanity check
+  - synchronize(), reset()
+
+The important difference from NGRAM is that suffix decoding needs full request
+history (prompt + generated tokens) and a stable request id.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import deque
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixCacheAdapter:
+    def __init__(
+        self,
+        draft_token_num: int,
+        max_batch_size: int,
+        max_tree_depth: int = 24,
+        max_cached_requests: int = 10000,
+        max_spec_factor: float = 1.0,
+        min_token_prob: float = 0.1,
+    ):
+        # Lazy import so normal SGLang startup does not require arctic-inference.
+        try:
+            from arctic_inference.suffix_decoding import SuffixDecodingCache
+        except ImportError as exc:
+            raise ImportError(
+                "SUFFIX speculative decoding requires Arctic Inference. "
+                "Install it with: pip install arctic-inference"
+            ) from exc
+
+        self.suffix_cache = SuffixDecodingCache(
+            max_tree_depth=max_tree_depth,
+            max_cached_requests=max_cached_requests,
+        )
+        self.draft_token_num = draft_token_num
+        self.max_batch_size = max_batch_size
+        self.max_tree_depth = max_tree_depth
+        self.max_spec_factor = max_spec_factor
+        self.min_token_prob = min_token_prob
+
+        # Optional debug: SUFFIX_DEBUG_TREE=1 dumps the first generated tree.
+        self.debug_tree_dump_remaining = int(os.environ.get("SUFFIX_DEBUG_TREE", "0"))
+
+        # SGLang request id -> [arctic request id, last token length added]
+        self.req_state: dict[str, list] = {}
+        # rid -> number of consecutive batch_get/batch_peek_scores calls the
+        # request has been ABSENT from the batch. Drives grace-period teardown
+        # in _cleanup_inactive_requests (see there for why).
+        self._absent_count: dict[str, int] = {}
+        self._cleanup_grace = int(os.environ.get("SUFFIX_CLEANUP_GRACE", "32"))
+
+        max_total_drafts = self.max_batch_size * self.draft_token_num
+        self.draft_buffer = np.empty((max_total_drafts,), dtype=np.int64)
+        self.mask_buffer = np.empty(
+            (self.max_batch_size, self.draft_token_num, self.draft_token_num),
+            dtype=bool,
+        )
+
+        # Last batch's per-request raw SuffixDecodingDraft results from
+        # arctic, populated by batch_get. Cleared at the start of each call.
+        self.last_drafts: list = []
+
+    def _cleanup_inactive_requests(self, active_req_ids: set[str]) -> None:
+        # Release a request's suffix tree only after it has been ABSENT from the
+        # batch for `_cleanup_grace` consecutive calls -- NOT immediately when it
+        # is missing from the current batch.
+        #
+        # Why: under pipeline parallelism (pp_loop_size > 1 micro-batching) and
+        # DP-attention, the per-step batch passed here is only a SUBSET of the
+        # active requests -- they rotate between micro-batches. The naive
+        # "tear down everything not in this batch" then deletes the local suffix
+        # tree of a request that is merely waiting its turn, forcing a full
+        # start_request() prompt-tree REBUILD (tens of ms for long prompts) when
+        # it returns next step. Measured ~26 rebuilds/request under PP, which
+        # made the suffix-tree build (not the C++ speculate, which is ~0.1ms)
+        # the dominant decode-step cost. The grace window spans micro-batch
+        # rotation, so still-active requests are never torn down; genuinely
+        # finished requests simply stop appearing and are released once the
+        # window elapses.
+        #
+        # This change only ever makes teardown LESS aggressive, so it cannot
+        # regress correctness -- worst case is freeing a finished request's local
+        # tree a few steps later. In non-PP / single-batch mode every active
+        # request is present every call, so this behaves like the old code
+        # (release on finish) just delayed by `_cleanup_grace` steps.
+        grace = self._cleanup_grace
+        absent = self._absent_count
+        active_backend_reqs = getattr(self.suffix_cache, "active_requests", set())
+        to_release = []
+        for rid in list(self.req_state):
+            if rid in active_req_ids:
+                absent.pop(rid, None)
+            elif absent.get(rid, 0) + 1 >= grace:
+                to_release.append(rid)
+            else:
+                absent[rid] = absent.get(rid, 0) + 1
+        for rid in to_release:
+            cache_req_id, _ = self.req_state.pop(rid)
+            absent.pop(rid, None)
+            if cache_req_id in active_backend_reqs:
+                self.suffix_cache.stop_request(cache_req_id)
+
+    def _get_or_create_cache_req_id(
+        self, sglang_req_id: str, prompt: List[int]
+    ) -> Tuple[str, int]:
+        if sglang_req_id not in self.req_state:
+            cache_req_id = sglang_req_id
+            self.suffix_cache.start_request(cache_req_id, prompt)
+            # The prompt is already loaded into the backend cache.
+            self.req_state[sglang_req_id] = [cache_req_id, len(prompt)]
+        cache_req_id, last_length = self.req_state[sglang_req_id]
+        return cache_req_id, last_length
+
+    def batch_get(
+        self,
+        batch_req_ids: List[str],
+        batch_prompts: List[List[int]],
+        batch_tokens: List[List[int]],
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        batch_size = len(batch_req_ids)
+        if batch_size == 0:
+            return np.empty((0,), dtype=np.int64), np.empty((0,), dtype=bool)
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                f"Batch size {batch_size} exceeds max_batch_size={self.max_batch_size}"
+            )
+
+        total_draft_tokens = batch_size * self.draft_token_num
+        draft_view = self.draft_buffer[:total_draft_tokens]
+        mask_view = self.mask_buffer[:batch_size]
+        mask_view.fill(False)
+
+        self._cleanup_inactive_requests(set(batch_req_ids))
+        self.last_drafts = []
+
+        for row, (sglang_req_id, prompt, tokens) in enumerate(
+            zip(batch_req_ids, batch_prompts, batch_tokens)
+        ):
+            cache_req_id, last_length = self._get_or_create_cache_req_id(
+                sglang_req_id, prompt
+            )
+
+            # Add only the verified delta since the previous step.
+            current_length = len(tokens)
+            if current_length > last_length:
+                new_tokens = tokens[last_length:current_length]
+                if cache_req_id in getattr(self.suffix_cache, "active_requests", set()):
+                    self.suffix_cache.add_active_response(cache_req_id, new_tokens)
+                    self.req_state[sglang_req_id][1] = current_length
+                else:
+                    logger.warning(
+                        "Suffix cache request %s is not active when updating",
+                        cache_req_id,
+                    )
+
+            # Arctic suffix decoding matches from the current suffix pattern.
+            pattern_start = max(0, len(tokens) - self.max_tree_depth)
+            pattern = tokens[pattern_start:]
+            draft = self.suffix_cache.speculate(
+                cache_req_id,
+                pattern,
+                max_spec_tokens=self.draft_token_num,
+                max_spec_factor=self.max_spec_factor,
+                min_token_prob=self.min_token_prob,
+            )
+            self.last_drafts.append(draft)
+
+            draft_ids = list(draft.token_ids)
+            draft_parents = list(draft.parents)
+            draft_ids, draft_parents = self._reorder_tree_bfs(draft_ids, draft_parents)
+            context_token = tokens[-1] if tokens else 0
+            draft_ids, draft_parents = self._inject_root_node(
+                draft_ids, draft_parents, context_token
+            )
+
+            original_len = len(draft_ids)
+            if original_len < self.draft_token_num:
+                pad_len = self.draft_token_num - original_len
+                draft_ids.extend([0] * pad_len)
+                draft_parents.extend([0] * pad_len)
+            elif original_len > self.draft_token_num:
+                draft_ids = draft_ids[: self.draft_token_num]
+                draft_parents = draft_parents[: self.draft_token_num]
+                original_len = self.draft_token_num
+
+            start = row * self.draft_token_num
+            end = start + self.draft_token_num
+            draft_view[start:end] = draft_ids
+
+            # Build ancestry mask: token i can attend to its ancestors and itself.
+            mask = mask_view[row]
+            for i in range(original_len):
+                mask[i, i] = True
+                parent = draft_parents[i]
+                while 0 <= parent < self.draft_token_num:
+                    mask[i, parent] = True
+                    parent = draft_parents[parent]
+
+            if self.debug_tree_dump_remaining > 0 and original_len > 0:
+                logger.warning(
+                    "[SUFFIX DEBUG] req=%s len=%d ids=%s",
+                    sglang_req_id,
+                    original_len,
+                    draft_ids,
+                )
+                logger.warning("[SUFFIX DEBUG] mask=\n%s", mask.astype(int))
+                self.debug_tree_dump_remaining -= 1
+
+        tree_mask = mask_view.reshape(-1)[: total_draft_tokens * self.draft_token_num]
+        return draft_view, tree_mask
+
+    def batch_put(
+        self, batch_req_ids: List[str], batch_tokens: List[List[int]]
+    ) -> None:
+        # Cache update is performed in batch_get before speculation, because the
+        # suffix backend needs a per-request incremental state.
+        for rid in batch_req_ids:
+            if rid not in self.req_state:
+                logger.debug("batch_put called before batch_get for request %s", rid)
+
+    def erase_match_state(self, req_ids: List[str]) -> None:
+        # Release finished requests from the suffix cache (NGRAMWorker calls this
+        # with finished req ids after each step). Mirrors NgramCorpus.erase_match_state.
+        active = getattr(self.suffix_cache, "active_requests", set())
+        for rid in req_ids:
+            state = self.req_state.pop(rid, None)
+            self._absent_count.pop(rid, None)
+            if state is not None and state[0] in active:
+                self.suffix_cache.stop_request(state[0])
+
+    # External-corpus management is an NGRAM-only feature; SUFFIX has no SAM.
+    # Stubbed so the duck-typed NGRAMWorker / HTTP handlers fail clearly if used.
+    def commit_external_corpus_load(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def list_external_corpora(self, *args, **kwargs):
+        return []
+
+    def load_external_corpus_named(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def remove_external_corpus(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def synchronize(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        for cache_req_id in list(getattr(self.suffix_cache, "active_requests", set())):
+            self.suffix_cache.stop_request(cache_req_id)
+        self.req_state.clear()
+        self._absent_count.clear()
+
+    def _reorder_tree_bfs(
+        self, token_ids: List[int], parents: List[Optional[int]]
+    ) -> Tuple[List[int], List[int]]:
+        """Ensure parents precede descendants; SGLang reconstruct assumes this."""
+        n = len(token_ids)
+        if n <= 1:
+            return token_ids, [(-1 if p is None else p) for p in parents]
+
+        children: List[List[int]] = [[] for _ in range(n)]
+        roots: List[int] = []
+        for idx, parent in enumerate(parents):
+            if parent is None or parent < 0 or parent >= n:
+                roots.append(idx)
+            else:
+                children[parent].append(idx)
+        if not roots:
+            roots = [0]
+
+        order: List[int] = []
+        visited = [False] * n
+        for root in roots:
+            q = deque([root])
+            while q:
+                node = q.popleft()
+                if visited[node]:
+                    continue
+                visited[node] = True
+                order.append(node)
+                q.extend(children[node])
+        for idx in range(n):
+            if not visited[idx]:
+                order.append(idx)
+
+        if order == list(range(n)):
+            return token_ids, [(-1 if p is None else p) for p in parents]
+
+        remap = {old: new for new, old in enumerate(order)}
+        reordered_ids = [token_ids[old] for old in order]
+        reordered_parents: List[int] = []
+        for old in order:
+            parent = parents[old]
+            if parent is None or parent < 0:
+                reordered_parents.append(-1)
+            else:
+                reordered_parents.append(remap.get(parent, -1))
+        return reordered_ids, reordered_parents
+
+    def _inject_root_node(
+        self, token_ids: List[int], parents: List[int], context_token: int
+    ) -> Tuple[List[int], List[int]]:
+        """Insert latest verified token as root node to match NGRAM layout."""
+        rooted_ids = [context_token]
+        rooted_parents = [-1]
+        for parent in parents:
+            rooted_parents.append(0 if parent < 0 else parent + 1)
+        rooted_ids.extend(token_ids)
+        return rooted_ids, rooted_parents

--- a/python/sglang/srt/speculative/suffix_worker.py
+++ b/python/sglang/srt/speculative/suffix_worker.py
@@ -1,4 +1,4 @@
-"""SUFFIX speculative-decoding worker (no pipeline parallelism).
+"""SUFFIX speculative-decoding worker with pipeline-parallel (pp_size > 1) support.
 
 SUFFIX is *model-free* speculative decoding (Snowflake ArcticInference's
 SuffixDecoding): a CPU suffix tree built over each request's prompt + generated
@@ -13,6 +13,41 @@ that attribute with a :class:`SuffixCacheAdapter` wrapping
 ``arctic_inference``'s ``SuffixDecodingCache``, and override the two hooks that
 talk to it so the adapter is fed each request's full token history (the suffix
 tree needs prompt + output, not just the recent n-gram pattern).
+
+For ``pp_size == 1`` this is byte-for-byte the base SUFFIX behavior (it
+delegates to NGRAMWorker.forward_batch_generation). The PP path is only taken
+when ``pp_size > 1``.
+
+PP design (Approach A — replicate drafts, propagate accept):
+  - SUFFIX's draft comes from a CPU suffix tree over origin_input_ids +
+    output_ids, not from a draft-model forward. Every PP rank runs that tree
+    independently and produces an IDENTICAL draft (requests are broadcast
+    around the PP ring so every rank has the prompt; each rank maintains its
+    own output_ids). Draft, tree mask, and KV-slot allocation are therefore
+    identical on all ranks with zero cross-rank communication.
+  - The LAST rank has logits: it runs the normal NGRAM verify (compute accept
+    + free its own KV + append its own output_ids), and ships
+    ``{accept_indices, num_accept}`` up the EXISTING last->first PP output
+    ring alongside ``next_token_ids``.
+  - NON-LAST ranks forward-only (return hidden states), leaving
+    ``batch.spec_info`` populated. When the ring delivers the accept (during
+    the scheduler's result-preprocess step), :meth:`apply_deferred_accept`
+    replays the CPU side of verify: append output_ids, free rejected KV,
+    compact ``out_cache_loc``, advance ``seq_lens``.
+
+Why the per-rank KV allocators stay in lockstep (requires
+``--pp-async-batch-depth 0``, ``pp_loop_size == 2``): alloc happens at forward
+(identical program point on all ranks); the last rank frees during verify (end
+of its launch), the non-last rank frees during result-preprocess of that
+micro-batch (which sits right before the NEXT micro-batch's launch / alloc).
+In alloc/free program order both ranks emit
+``...alloc(A) free(A) alloc(B) free(B)...`` identically, so the free-lists
+evolve identically. We also canonicalize (merge + sort) the free list before
+each verify alloc as belt-and-suspenders.
+
+Constraints on the PP path: ``page_size == 1`` for the canonicalized free
+list, ``pp_async_batch_depth == 0``, greedy verify (no logprob across ranks
+since logits live only on the last rank).
 """
 
 from __future__ import annotations
@@ -20,9 +55,14 @@ from __future__ import annotations
 import logging
 from typing import List, Optional
 
+import torch
+
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.ngram_info import NgramVerifyInput
 from sglang.srt.speculative.ngram_worker import NGRAMWorker
 from sglang.srt.speculative.suffix_cache_adapter import SuffixCacheAdapter
 
@@ -34,9 +74,8 @@ class SuffixWorker(NGRAMWorker):
 
     Tensor parallelism is supported as-is (inherited from ``NGRAMWorker``: the
     suffix draft is built per-rank on CPU and the target forward is TP-sharded
-    transparently). Pipeline parallelism and overlap-scheduling (spec-v2) are
-    added by follow-on workers. ``forward_batch_generation`` and all verify/KV
-    logic are inherited from ``NGRAMWorker`` verbatim.
+    transparently). Overlap-scheduling (spec-v2) is provided by
+    :class:`SuffixWorkerV2`. Pipeline parallelism is supported below.
     """
 
     def __init__(
@@ -73,6 +112,9 @@ class SuffixWorker(NGRAMWorker):
             max_spec_factor=server_args.speculative_suffix_max_spec_factor,
             min_token_prob=server_args.speculative_suffix_min_token_prob,
         )
+        self.pp_group = target_worker.pp_group
+
+    # ---- suffix-tree overrides (apply to both PP and non-PP) ---------------
 
     def _prepare_draft_tokens(self, batch: ScheduleBatch):
         bs = batch.batch_size()
@@ -95,3 +137,233 @@ class SuffixWorker(NGRAMWorker):
         req_ids = [req.rid for req in batch.reqs]
         tokens = [req.origin_input_ids + req.output_ids for req in batch.reqs]
         self.ngram_corpus.batch_put(req_ids, tokens)
+
+    # ---- forward dispatch -------------------------------------------------
+
+    def forward_batch_generation(self, batch: ScheduleBatch, pp_proxy_tensors=None):
+        # Non-PP: unchanged base NGRAM/SUFFIX path (with the suffix-tree draft
+        # override above). The PP-specific machinery below is skipped entirely.
+        if self.pp_group.world_size == 1:
+            return super().forward_batch_generation(batch)
+
+        is_decode = (
+            not batch.forward_mode.is_extend() and not batch.forward_mode.is_idle()
+        )
+        if is_decode:
+            self._canonicalize_allocator(batch)
+
+        self._prepare_for_speculative_decoding(batch)
+        # The target worker takes the ScheduleBatch directly (it builds the
+        # ForwardBatch internally); spec_info / forward_mode were set on
+        # ``batch`` by _prepare_for_speculative_decoding above.
+
+        if not batch.forward_mode.is_target_verify():
+            # Extend / idle — plain forward, thread pp_proxy.
+            return self.target_worker.forward_batch_generation(
+                batch, pp_proxy_tensors=pp_proxy_tensors
+            )
+
+        if self.pp_group.is_last_rank:
+            return self._verify_last_rank(batch, pp_proxy_tensors)
+        return self._forward_non_last_rank(batch, pp_proxy_tensors)
+
+    # ---- allocator canonicalization (cross-rank determinism) --------------
+
+    @staticmethod
+    def _canonicalize_allocator(batch: ScheduleBatch) -> None:
+        alloc = batch.token_to_kv_pool_allocator
+        # DSv4 (and other paged / hybrid-SWA models) use an allocator whose
+        # ``free_pages`` is None (it keeps separate full / SWA free lists), so
+        # the simple ``page_size == 1`` free-list canonicalization does not
+        # apply. The cross-rank free-list determinism it provides is only
+        # needed for the plain TokenToKVPoolAllocator; skip it otherwise.
+        if getattr(alloc, "free_pages", None) is None:
+            return
+        rel = getattr(alloc, "release_pages", None)
+        if rel is not None and rel.numel() > 0:
+            alloc.free_pages = torch.cat((alloc.free_pages, rel))
+            alloc.release_pages = torch.empty(
+                (0,), dtype=alloc.free_pages.dtype, device=alloc.free_pages.device
+            )
+        alloc.free_pages, _ = torch.sort(alloc.free_pages)
+
+    # ---- last rank: run verify, ship accept up the ring -------------------
+
+    def _verify_last_rank(self, batch, pp_proxy_tensors):
+        batch_result = self.target_worker.forward_batch_generation(
+            batch, pp_proxy_tensors=pp_proxy_tensors, is_verify=True
+        )
+        logits_output = batch_result.logits_output
+        verify_input: NgramVerifyInput = batch.spec_info
+
+        # Defer the rejected-KV free + seq_lens advance to the result-preprocess
+        # step (apply_deferred_free), mirroring the non-last rank's
+        # apply_deferred_accept timing. Otherwise the last rank frees rejected
+        # draft KV *immediately* (here) while non-last ranks free it one
+        # micro-batch later — during that window non-last ranks see a smaller
+        # token_to_kv_pool_allocator.available_size(), check_decode_mem()
+        # diverges across ranks, ranks reach DIFFERENT KV-full retraction
+        # decisions, divergent per-rank batch shapes, and finally a CUDA
+        # device-side assert (paged free OOB) on the deferred-apply rank, or a
+        # ring deadlock / hang. ``_fill_requests`` (output_ids append) still
+        # runs immediately inside verify(); only the KV / seq_lens side is
+        # deferred, so output handling is unchanged.
+        logits_output, next_token_ids, num_correct = verify_input.verify(
+            batch, logits_output, self.page_size, vocab_mask=None, defer_apply=True
+        )
+        # Snapshot out_cache_loc / draft_token now (forward has run, values are
+        # final) so the deferred ``_free_cache`` reads a private copy, not a
+        # cuda-graph static buffer the next micro-batch overwrites. (Same race
+        # the non-last rank guards.)
+        if self.page_size > 1:
+            if getattr(batch, "out_cache_loc", None) is not None:
+                batch.out_cache_loc = batch.out_cache_loc.clone()
+            if getattr(verify_input, "draft_token", None) is not None:
+                verify_input.draft_token = verify_input.draft_token.clone()
+        # ``batch.spec_info`` now carries ``accept_indices`` (1D) +
+        # ``num_accept_tokens`` — the scheduler's _pp_prepare_tensor_dict reads
+        # these to ship up the ring, and _pp_process_batch_result calls
+        # apply_deferred_free on this rank.
+        batch._pp_pending_spec_free = True
+        self._update_ngram_corpus(batch)
+        finished = [r.rid for r in batch.reqs if r.finished() or r.is_retracted]
+        if finished:
+            self.ngram_corpus.erase_match_state(finished)
+        batch.forward_mode = ForwardMode.DECODE
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=next_token_ids,
+            num_correct_drafts=num_correct,
+            num_correct_drafts_per_req_cpu=verify_input.num_correct_drafts.cpu().tolist(),
+            can_run_cuda_graph=batch_result.can_run_cuda_graph,
+            accept_lens=verify_input.num_accept_tokens,
+        )
+
+    # ---- non-last rank: forward only, defer the apply ---------------------
+
+    def _forward_non_last_rank(self, batch, pp_proxy_tensors):
+        # Forward only — return hidden states. KV free / output_ids append are
+        # deferred to apply_deferred_accept when the ring delivers the accept.
+        batch_result = self.target_worker.forward_batch_generation(
+            batch, pp_proxy_tensors=pp_proxy_tensors, is_verify=True
+        )
+        # With a paged KV pool (page_size > 1, e.g. DSv4), ``out_cache_loc`` and
+        # the verify ``draft_token`` can alias cuda-graph static buffers that
+        # the NEXT micro-batch overwrites before this micro-batch's *deferred*
+        # ``_free_cache`` runs — the paged free indexes garbage slots, raising
+        # a CUDA "index out of bounds" device assert. Snapshot them into
+        # private tensors now (the forward has run, so the values are final on
+        # this stream). This is the actual race fix; a sync before
+        # ``_free_cache`` is insufficient because the clobber is concurrent,
+        # not merely earlier. (``page_size == 1`` is unaffected: the snapshot
+        # is a cheap clone of two small tensors.)
+        if self.page_size > 1:
+            if getattr(batch, "out_cache_loc", None) is not None:
+                batch.out_cache_loc = batch.out_cache_loc.clone()
+            vi = batch.spec_info
+            if vi is not None and getattr(vi, "draft_token", None) is not None:
+                vi.draft_token = vi.draft_token.clone()
+        # Keep batch.spec_info (the NgramVerifyInput) intact for the deferred
+        # apply — it holds draft_token, out_cache_loc, retrieve_*.
+        batch.forward_mode = ForwardMode.DECODE
+        return GenerationBatchResult(
+            logits_output=None,
+            pp_hidden_states_proxy_tensors=batch_result.pp_hidden_states_proxy_tensors,
+            can_run_cuda_graph=batch_result.can_run_cuda_graph,
+        )
+
+    # ---- deferred apply on the non-last rank ------------------------------
+
+    def apply_deferred_accept(
+        self,
+        batch: ScheduleBatch,
+        accept_indices: torch.Tensor,
+        accept_tokens: torch.Tensor,
+        num_accept_tokens: torch.Tensor,
+        page_size: int,
+    ) -> None:
+        """Replay the CPU side of NgramVerifyInput.verify on a non-last rank,
+        given the accept result computed by the last rank. Must run during the
+        result-preprocess step (before the next micro-batch's alloc) so the
+        free-list stays in lockstep with the last rank."""
+        verify_input: NgramVerifyInput = batch.spec_info
+        verify_input.accept_indices = accept_indices
+        verify_input.num_accept_tokens = num_accept_tokens
+
+        num_accept_cpu = num_accept_tokens.cpu().tolist()
+        accept_tokens_cpu = accept_tokens.cpu().tolist()
+        num_correct_drafts_cpu = (num_accept_tokens - 1).cpu()
+
+        # 1. append output_ids (mirror _fill_requests CPU side)
+        think_end_id = batch.model_config.think_end_id
+        cursor = 0
+        for i, req in enumerate(batch.reqs):
+            n = num_accept_cpu[i]
+            for tok in accept_tokens_cpu[cursor : cursor + n]:
+                req.output_ids.append(tok)
+                if req.require_reasoning and think_end_id is not None:
+                    req.update_reasoning_tokens(tok, think_end_id)
+                req.update_finish_state()
+                if req.finished():
+                    break
+            cursor += n
+            req.spec_verify_ct += 1
+            ncd = num_accept_cpu[i] - 1
+            req.spec_num_correct_drafts += ncd
+            if hasattr(req, "update_spec_correct_drafts_histogram"):
+                req.update_spec_correct_drafts_histogram(ncd)
+
+        # 2. free rejected KV + compact out_cache_loc + req_to_token + committed.
+        # With a paged KV pool (page_size > 1, e.g. DSv4's SWA allocator) the
+        # free kernel page-aligns over out_cache_loc; if the producing async
+        # work (cuda-graph forward / ring recv) for out_cache_loc /
+        # accept_indices has not completed, the free indexes garbage slots and
+        # raises a CUDA "index out of bounds" device assert. Make it
+        # deterministic with a sync. This is cheap (~0.03ms): by the
+        # deferred-apply point the GPU work is normally already done, so the
+        # sync is a near-no-op except in the rare racing window.
+        if page_size > 1 and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        verify_input._free_cache(batch, page_size, num_correct_drafts_cpu)
+
+        # 3. advance seq_lens
+        batch.seq_lens.add_(num_accept_tokens)
+        batch.seq_lens_cpu.add_(num_accept_tokens.cpu())
+
+        self._update_ngram_corpus(batch)
+        finished = [r.rid for r in batch.reqs if r.finished() or r.is_retracted]
+        if finished:
+            self.ngram_corpus.erase_match_state(finished)
+
+    # ---- deferred free on the LAST rank (symmetry with non-last) ----------
+
+    def apply_deferred_free(self, batch: ScheduleBatch, page_size: int) -> None:
+        """Last-rank counterpart to :meth:`apply_deferred_accept`: run the
+        rejected-KV free + ``seq_lens`` advance that ``verify(defer_apply=True)``
+        skipped, at the same loop position the non-last rank frees.
+        ``_fill_requests`` already appended the accepted output_ids inside
+        verify(), so only the KV / seq_lens side is replayed here. Deferring
+        the free on *every* rank makes per-rank KV occupancy identical at
+        ``get_next_batch_to_run``, so KV-full retraction decisions stay in
+        lockstep across the pipeline (see :meth:`_verify_last_rank`)."""
+        if not getattr(batch, "_pp_pending_spec_free", False):
+            return
+        batch._pp_pending_spec_free = False
+        verify_input: NgramVerifyInput = batch.spec_info
+        if (
+            verify_input is None
+            or getattr(verify_input, "num_accept_tokens", None) is None
+        ):
+            return
+        num_accept_tokens = verify_input.num_accept_tokens
+        num_correct_drafts_cpu = (num_accept_tokens - 1).cpu()
+        # Same race guard as apply_deferred_accept: with a paged KV pool the
+        # free kernel page-aligns over ``out_cache_loc``; make the producing
+        # GPU work deterministic before indexing (cheap — usually already
+        # complete).
+        if page_size > 1 and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        verify_input._free_cache(batch, page_size, num_correct_drafts_cpu)
+        batch.seq_lens.add_(num_accept_tokens)
+        batch.seq_lens_cpu.add_(num_accept_tokens.cpu())

--- a/python/sglang/srt/speculative/suffix_worker.py
+++ b/python/sglang/srt/speculative/suffix_worker.py
@@ -1,0 +1,97 @@
+"""SUFFIX speculative-decoding worker (no pipeline parallelism).
+
+SUFFIX is *model-free* speculative decoding (Snowflake ArcticInference's
+SuffixDecoding): a CPU suffix tree built over each request's prompt + generated
+tokens proposes draft continuations, which are verified in a single target
+forward pass. It is especially effective on agentic / repetitive workloads and
+adds no draft-model GPU cost.
+
+Implementation reuses :class:`NGRAMWorker` unchanged for the verify + KV-cache
+machinery; the only difference is the *draft source*. ``NGRAMWorker`` reads
+draft candidates from ``self.ngram_corpus`` (an n-gram corpus); here we replace
+that attribute with a :class:`SuffixCacheAdapter` wrapping
+``arctic_inference``'s ``SuffixDecodingCache``, and override the two hooks that
+talk to it so the adapter is fed each request's full token history (the suffix
+tree needs prompt + output, not just the recent n-gram pattern).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.ngram_worker import NGRAMWorker
+from sglang.srt.speculative.suffix_cache_adapter import SuffixCacheAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixWorker(NGRAMWorker):
+    """``NGRAMWorker`` whose draft source is an Arctic suffix tree.
+
+    Tensor parallelism is supported as-is (inherited from ``NGRAMWorker``: the
+    suffix draft is built per-rank on CPU and the target forward is TP-sharded
+    transparently). Pipeline parallelism and overlap-scheduling (spec-v2) are
+    added by follow-on workers. ``forward_batch_generation`` and all verify/KV
+    logic are inherited from ``NGRAMWorker`` verbatim.
+    """
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        attn_cp_rank: int,
+        moe_dp_rank: int,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        super().__init__(
+            server_args=server_args,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+            dp_rank=dp_rank,
+            moe_ep_rank=moe_ep_rank,
+            attn_cp_rank=attn_cp_rank,
+            moe_dp_rank=moe_dp_rank,
+            nccl_port=nccl_port,
+            target_worker=target_worker,
+        )
+        # Swap the n-gram corpus for the suffix-tree adapter. The inherited
+        # _prepare_draft_tokens / _update_ngram_corpus call self.ngram_corpus,
+        # which we override below to pass the adapter full request history.
+        self.ngram_corpus = SuffixCacheAdapter(
+            draft_token_num=server_args.speculative_num_draft_tokens,
+            max_batch_size=self.max_batch_size,
+            max_tree_depth=server_args.speculative_suffix_max_tree_depth,
+            max_cached_requests=server_args.speculative_suffix_max_cached_requests,
+            max_spec_factor=server_args.speculative_suffix_max_spec_factor,
+            min_token_prob=server_args.speculative_suffix_min_token_prob,
+        )
+
+    def _prepare_draft_tokens(self, batch: ScheduleBatch):
+        bs = batch.batch_size()
+        self.ngram_corpus.synchronize()
+        req_ids: List[str] = []
+        prompts: List[List[int]] = []
+        tokens: List[List[int]] = []
+        for req in batch.reqs:
+            req_ids.append(req.rid)
+            prompts.append(req.origin_input_ids)
+            tokens.append(req.origin_input_ids + req.output_ids)
+        req_drafts, mask = self.ngram_corpus.batch_get(req_ids, prompts, tokens)
+        total_draft_token_num = len(req_drafts)
+        assert (
+            total_draft_token_num == bs * self.draft_token_num
+        ), f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
+        return req_drafts, mask
+
+    def _update_ngram_corpus(self, batch: ScheduleBatch):
+        req_ids = [req.rid for req in batch.reqs]
+        tokens = [req.origin_input_ids + req.output_ids for req in batch.reqs]
+        self.ngram_corpus.batch_put(req_ids, tokens)

--- a/test/registered/unit/spec/test_suffix_registry.py
+++ b/test/registered/unit/spec/test_suffix_registry.py
@@ -1,0 +1,119 @@
+"""Unit tests for the SUFFIX speculative-decoding plugin registration.
+
+CPU-only: exercises the plugin wiring (registration, duck-typed predicates,
+arg validation, lazy factory) without loading a model or arctic_inference.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.speculative import sgl_suffix_plugin
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_registry import (
+    _REGISTRY,
+    CustomSpecAlgo,
+    _assert_custom_spec_algo_conforms,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _SuffixRegistered(CustomTestCase):
+    """Re-register SUFFIX into an isolated registry so tests don't leak."""
+
+    def setUp(self):
+        self._snapshot = _REGISTRY.copy()
+        _REGISTRY.clear()
+        SpeculativeAlgorithm.register(
+            "SUFFIX",
+            supports_overlap=False,
+            validate_server_args=sgl_suffix_plugin._validate_suffix_args,
+            spec_class=sgl_suffix_plugin._SuffixLike,
+        )(sgl_suffix_plugin._suffix_factory)
+        self.algo = SpeculativeAlgorithm.from_string("SUFFIX")
+
+    def tearDown(self):
+        _REGISTRY.clear()
+        _REGISTRY.update(self._snapshot)
+
+
+class TestSuffixRegistration(_SuffixRegistered):
+    def test_from_string_returns_custom_spec(self):
+        self.assertIsInstance(self.algo, CustomSpecAlgo)
+        self.assertEqual(self.algo.name, "SUFFIX")
+
+    def test_case_insensitive(self):
+        self.assertIs(
+            SpeculativeAlgorithm.from_string("suffix"),
+            SpeculativeAlgorithm.from_string("SUFFIX"),
+        )
+
+    def test_dispatches_like_ngram(self):
+        # SUFFIX reuses NGRAM's verify / KV-cache dispatch.
+        self.assertTrue(self.algo.is_ngram())
+        self.assertTrue(self.algo.is_suffix())
+
+    def test_other_predicates_false(self):
+        self.assertFalse(self.algo.is_eagle())
+        self.assertFalse(self.algo.is_eagle3())
+        self.assertFalse(self.algo.is_standalone())
+        self.assertFalse(self.algo.is_none())
+        self.assertTrue(self.algo.is_speculative())
+
+    def test_v1_does_not_support_overlap(self):
+        self.assertFalse(self.algo.supports_overlap)
+        self.assertFalse(self.algo.supports_spec_v2())
+
+    def test_not_equal_to_builtin(self):
+        self.assertNotEqual(self.algo, SpeculativeAlgorithm.NGRAM)
+        self.assertNotEqual(self.algo, SpeculativeAlgorithm.EAGLE)
+
+
+class TestSuffixConformance(_SuffixRegistered):
+    def test_spec_class_conforms(self):
+        # _SuffixLike must satisfy the enum's is_*/supports_* duck-type contract.
+        _assert_custom_spec_algo_conforms(sgl_suffix_plugin._SuffixLike)
+
+    def test_provides_create_future_map(self):
+        # The scheduler calls create_future_map() unconditionally; CustomSpecAlgo's
+        # base does not define it, so _SuffixLike must (regression guard).
+        self.assertTrue(callable(getattr(self.algo, "create_future_map", None)))
+
+
+class TestSuffixFactory(_SuffixRegistered):
+    def test_factory_returns_suffix_worker(self):
+        # Lazy: importing SuffixWorker does not require arctic_inference (that is
+        # imported only when the worker is constructed).
+        from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+        server_args = SimpleNamespace(disable_overlap_schedule=True)
+        self.assertIs(self.algo.create_worker(server_args), SuffixWorker)
+
+    def test_factory_rejects_overlap(self):
+        server_args = SimpleNamespace(disable_overlap_schedule=False)
+        with self.assertRaisesRegex(ValueError, "does not support overlap"):
+            self.algo.create_worker(server_args)
+
+
+class TestSuffixArgValidation(_SuffixRegistered):
+    _FIELDS = (
+        "speculative_suffix_max_tree_depth",
+        "speculative_suffix_max_cached_requests",
+        "speculative_suffix_max_spec_factor",
+        "speculative_suffix_min_token_prob",
+    )
+
+    def test_validator_passes_with_all_fields(self):
+        sa = SimpleNamespace(**{f: 1 for f in self._FIELDS})
+        self.algo.validate_server_args(sa)  # does not raise
+
+    def test_validator_raises_when_field_missing(self):
+        sa = SimpleNamespace(**{f: 1 for f in self._FIELDS[1:]})  # drop the first
+        with self.assertRaisesRegex(ValueError, "speculative_suffix_max_tree_depth"):
+            self.algo.validate_server_args(sa)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

This PR adds **pipeline-parallel (`pp_size > 1`) support** for the SUFFIX speculative decoding algorithm introduced in #27582 (V1).

Today the scheduler rejects any spec algorithm when `pp_size > 1` because each existing draft worker (EAGLE / STANDALONE) requires a separate draft-model forward pass — wiring that across the pipeline would need new cross-rank send/recv. SUFFIX is the **first model-free** spec algorithm and naturally avoids that problem: every PP rank already has `req.origin_input_ids + req.output_ids` (prompts are broadcast around the ring; each rank appends its own accepted tokens), so every rank can independently build an **identical** suffix-tree draft with zero extra communication. We exploit that to enable PP for SUFFIX with no new wire traffic — only the existing last→first PP output ring carries a couple of extra accept tensors.

## Modifications

Three commits, all confined to existing files (no new files):

### 1. Add pipeline-parallel (`pp_size > 1`) support for SUFFIX speculative decoding

The protocol (Approach A — replicate drafts, propagate accept):

* **All ranks** build the same draft from the suffix tree. The tree state is a deterministic function of `req.origin_input_ids + req.output_ids`, which every rank already has.
* **LAST rank** runs the normal NGRAM verify and adds `{accept_indices, num_accept_tokens}` to the existing PP `pp_outputs` dict alongside `next_token_ids`.
* **NON-LAST ranks** forward-only; the scheduler's `_pp_prep_batch_result` invokes `draft_worker.apply_deferred_accept` on the receiving rank when those tensors arrive.
* **On every rank** the rejected-KV free is deferred to the result-preprocess step (`apply_deferred_free` on the last rank, `apply_deferred_accept` on non-last). This keeps per-rank KV occupancy identical at `get_next_batch_to_run`, so KV-full retraction decisions stay in lockstep across the pipeline — without this, ranks diverge on retraction and either device-side-assert (paged free OOB) or deadlock the ring.

Files in this commit:

* `speculative/suffix_worker.py` — branch `forward_batch_generation` to `_verify_last_rank` / `_forward_non_last_rank` when `pp_size > 1`. New `apply_deferred_accept` and `apply_deferred_free`. `pp_size == 1` path is byte-for-byte unchanged (still delegates to `super().forward_batch_generation`).
* `server_args.py` — lift the spec-incompatible-with-PP assertion to allow SUFFIX. EAGLE / STANDALONE remain banned under PP.
* `model_executor/model_runner.py` — widen the existing PP+MTP assertion to also allow SUFFIX.
* `managers/scheduler.py` — thread `pp_proxy_tensors` into `forward_batch_generation` for SUFFIX too (the PP-aware SuffixWorker forwards it down).

### 2. PP scheduler + cuda graph wiring for SUFFIX deferred verify

The three pieces that make the protocol from commit 1 functional end-to-end:

* `managers/scheduler_pp_mixin.py`

  * `_pp_prepare_tensor_dict`: ship `accept_indices` and `num_accept_tokens` up the ring when the last rank produced a SUFFIX verify result.
  * `_pp_prep_batch_result`: on the receiving rank, invoke `draft_worker.apply_deferred_accept`; also feed accept count into spec metrics.
  * `_pp_process_batch_result`: on the last rank, drain `draft_worker.apply_deferred_free` before normal post-processing.
* `model_executor/cuda_graph_runner.py`: PP `pp_proxy_tensors` capture buffer was sized `(max_bs, hidden)` — correct only when `num_tokens_per_bs == 1`. SUFFIX/NGRAM verify has `num_tokens_per_bs == draft_token_num`, so PP hidden states need `(max_num_token, hidden)` rows. Without this fix the stage-1 rotary `view(num_tokens, -1, head_size)` crashes on PP spec verify. This was never triggered before because PP+spec was forbidden; commit 1 lifts that restriction.

### 3. Add `pad_candidates` + `defer_apply` to `NgramVerifyInput` for PP SUFFIX

`NgramVerifyInput` is shared between NGRAM and SUFFIX (via plugin registration). Two PP-driven additions:

* **`pad_candidates`**: under PP the verify-time draft tensor may have trailing zero rows; without padding the greedy verify reads past valid indices into the padded zone and the rank's accept tensor disagrees with the last rank's. Two sites are guarded.
* **`defer_apply` flag** on `NgramVerifyInput.verify`: when True, the verify computes accept and appends `output_ids` but skips the rejected-KV free + `seq_lens` advance — those are replayed by `SuffixWorker.apply_deferred_free` / `apply_deferred_accept` at the result-preprocess step.

Non-PP behavior is unchanged: `defer_apply` defaults to False and the pad zone is empty when `pp_size == 1`.

### Allocator lockstep — why this works

The protocol requires per-rank KV allocator free-lists to evolve in lockstep, otherwise `available_size()` diverges and `check_decode_mem()` triggers asymmetric retractions.

* **Alloc** happens at forward (identical program point on all ranks).
* **Free** happens at result-preprocess (now deferred on every rank — both last and non-last).
* With `--pp-async-batch-depth 0` and `pp_loop_size == 2`, the alloc/free interleave is `...alloc(A) free(A) alloc(B) free(B)...` on every rank.
* As belt-and-suspenders, `_canonicalize_allocator` (merge `release_pages` into `free_pages` + sort) runs before each verify alloc.

### Constraints (PP path only)

* `--pp-async-batch-depth 0`
* `page_size == 1` for the canonicalized free list (other allocators like DSv4's hybrid-SWA skip canonicalization but still work)
* Greedy verify (no `return_logprob` across ranks since logits live only on the last rank)

## Accuracy Tests

PP path is exercised end-to-end on DSv4-Flash + Minimax-M2.7 with `pp_size=2` on 5090 GPUs. The CPU-side verify replay on non-last ranks mirrors `NgramVerifyInput.verify` step-for-step (`_fill_requests` → `_free_cache` → `seq_lens.add_`), and we confirm:

* Per-rank `req.output_ids` are identical (last rank appends inside `verify(defer_apply=True)`; non-last rank appends inside `apply_deferred_accept`).
* Per-rank KV allocator `available_size()` matches at every `get_next_batch_to_run` (lockstep retained over thousands of decode steps on DSv4-Flash and Minimax-M2.7).

## Speed Tests and Profiling

  Pipeline parallelism lets a model that does not fit in one node run SUFFIX speculative decoding across nodes. Benchmarked on **MiniMax-M2.7** (230B) on **16×RTX 5090 = 2 nodes**, **TP=8 × PP=2 × EP=8**, cuda graph on, SUFFIX **K=32**. Workload: swe bench, `--max-running-requests 16` `--max-concurrency 16` (achieved mean concurrency ≈ 3.5, peak 9). 

  | metric | baseline (no spec) | **SUFFIX (PP=2)** | SUFFIX vs baseline |
  |---|---|---|---|
  | **wall-clock (s)** | 1543.6 | **636.5** | **2.42× faster** |
  | output throughput (tok/s) | 235 | **~570** | **2.42×** |
  | median TPOT (ms) | 23.5 | **10.4** | **2.26× faster** |
  | median TTFT (ms) | 337 | **203** | 1.66× faster |
  | median E2E (ms) | 12 413 | **5 543** | **2.24× faster** |
  | mean accept length | 1.00 | **~5.6 tok/step** | — |
  | completed / errors | 708 / 0 | 708 / 0 | — |

  **PP+SUFFIX is correct and 2.42× faster than the no-spec baseline** on this cross-node deployment,
  accepting ~5.6 tokens per verify step with no hangs/crashes and byte-identical task completion.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->