### PR TITLE
ci: partition the H200 nightly 'Run test' step across the matrix

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -228,7 +228,7 @@ jobs:
           GPU_CONFIG: "8-gpu-h200"
         run: |
           cd test
-          python3 run_suite.py --hw cuda --suite nightly-8-gpu-h200 --nightly --continue-on-error
+          python3 run_suite.py --hw cuda --suite nightly-8-gpu-h200 --nightly --continue-on-error --auto-partition-id=${{ matrix.partition }} --auto-partition-size=4
 
       - name: Collect performance metrics
         if: always()


### PR DESCRIPTION
## Problem

`nightly-test-general-8-gpu-h200` fans out over a 4-way `matrix.partition`. The **Run common 8-GPU model tests** step partitions correctly via `--auto-partition-id`/`--auto-partition-size`, but the **Run test** step (suite `nightly-8-gpu-h200`) was missing those flags — so the entire suite ran in all four partition jobs.

That suite currently holds a single ~900s test (`test_unified_radix_cache_kl_nightly.py`), so every one of the four partitions re-ran the same test: 4× the GPU-hours and 4× duplicate failure reports.

Observed in [run 27110545438](https://github.com/sgl-project/sglang/actions/runs/27110545438) — all four `nightly-test-general-8-gpu-h200 (0..3)` jobs ran `test_unified_radix_cache_kl_nightly.py`.

## Fix

Pass the same auto-partition flags the sibling common-tests step already uses. With one test and size 4, the LPT partitioner assigns it to partition 0 and partitions 1–3 skip ("No tests found … Skipping"); the split scales as the H200-only suite grows.

## Verification

Dry-ran the partition split for the suite at size 4: the single test lands in exactly one partition, the other three are empty. Workflow YAML validates.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27178703087](https://github.com/sgl-project/sglang/actions/runs/27178703087)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27178703048](https://github.com/sgl-project/sglang/actions/runs/27178703048)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->