### PR TITLE
Fix bench_serving GSP dataset crash for in-process Namespace callers

### DIFF
--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -55,8 +55,8 @@ class GeneratedSharedPrefixDataset(BaseDataset):
     @classmethod
     def from_args(cls, args: Namespace) -> "GeneratedSharedPrefixDataset":
         assert not getattr(args, "tokenize_prompt", False)
-        group_distribution = args.gsp_group_distribution
-        zipf_alpha = args.gsp_zipf_alpha
+        group_distribution = getattr(args, "gsp_group_distribution", "uniform")
+        zipf_alpha = getattr(args, "gsp_zipf_alpha", None)
 
         # Defensive validation for in-process callers that construct a
         # Namespace by hand and bypass the argparse boundary in


### PR DESCRIPTION
## Problem

`GeneratedSharedPrefixDataset.from_args` read `args.gsp_group_distribution` and `args.gsp_zipf_alpha` via **direct attribute access**. In-process callers that build a `Namespace` by hand (e.g. `get_benchmark_args` in `test/.../test_utils.py`) don't set these recently-added fields, so `from_args` raised:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'gsp_group_distribution'
```

This broke `test_bench_serving_functionality.py::test_gsp_multi_turn` in the nightly suite ([run 27110545438](https://github.com/sgl-project/sglang/actions/runs/27110545438)).

## Fix

Read both fields via `getattr` with defaults matching the dataclass field defaults and the argparse CLI defaults (`"uniform"` / `None`) — consistent with every other field already accessed via `getattr` in the same method. CLI behavior is unchanged; the method's documented contract to defend against hand-built Namespaces is restored.

## Verification

Confirmed `getattr` returns the correct defaults against the test's `SimpleNamespace` (no `AttributeError`); the zipf validation path (`gsp_group_distribution="zipf"` without `gsp_zipf_alpha` → `ValueError`) is unchanged. Module compiles clean.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27179010242](https://github.com/sgl-project/sglang/actions/runs/27179010242)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27179010187](https://github.com/sgl-project/sglang/actions/runs/27179010187)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->