### PR TITLE
Remove Req.extend_logprob_start_len field and make it pure

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -74,8 +74,6 @@ class ScheduleBatchDisaggregationDecodeMixin:
             req.is_retracted = False
             pre_lens.append(pre_len)
 
-        extend_input_logprob_token_ids = None
-
         # Set fields
         self.input_ids = torch.tensor(
             sum(input_ids, array("q")), dtype=torch.int32, device=self.device
@@ -99,9 +97,8 @@ class ScheduleBatchDisaggregationDecodeMixin:
         self.extend_num_tokens = extend_num_tokens
         self.prefix_lens = [len(r.prefix_indices) for r in reqs]
         self.extend_lens = [r.extend_range.length for r in reqs]
-        # Prebuilt reqs already had input logprobs computed on the prefill server.
-        self.extend_logprob_start_lens = [0] * len(reqs)
-        self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
+        self.extend_logprob_start_lens = None
+        self.extend_input_logprob_token_ids = None
         self.multimodal_inputs = [r.multimodal_inputs for r in reqs]
 
         # Build sampling info

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -73,7 +73,6 @@ class ScheduleBatchDisaggregationDecodeMixin:
                 req.already_computed = seq_len
             req.is_retracted = False
             pre_lens.append(pre_len)
-            req.extend_logprob_start_len = 0
 
         extend_input_logprob_token_ids = None
 
@@ -100,7 +99,8 @@ class ScheduleBatchDisaggregationDecodeMixin:
         self.extend_num_tokens = extend_num_tokens
         self.prefix_lens = [len(r.prefix_indices) for r in reqs]
         self.extend_lens = [r.extend_range.length for r in reqs]
-        self.extend_logprob_start_lens = [r.extend_logprob_start_len for r in reqs]
+        # Prebuilt reqs already had input logprobs computed on the prefill server.
+        self.extend_logprob_start_lens = [0] * len(reqs)
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
         self.multimodal_inputs = [r.multimodal_inputs for r in reqs]
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1637,21 +1637,10 @@ def compute_extend_logprob_start_len(
     extend_len: int,
     full_untruncated_fill_len: int,
 ) -> int:
-    """Relative position within an extend window where input-logprob computation starts.
-
-    Pure function of the extend forward inputs; it holds no Req state. Callers snapshot
-    the result at forward-assembly time into ScheduleBatch.extend_logprob_start_lens,
-    because the value is bound to one extend forward, not to live Req state (under
-    overlap scheduling the Req's prefix_indices/extend_range/logprob_start_len are
-    overwritten by the next round before the current forward's output is processed).
-
-    Key variables:
-    - logprob_start_len: absolute position in the full sequence where logprob starts
-      (-1 means "no input logprobs", i.e. start at the very end of the sequence).
-    - prefix_len: number of cached prefix tokens (extend window starts here).
-    - extend_len: number of tokens processed in this extend window.
-    - full_untruncated_fill_len: full sequence length, used to resolve the -1 sentinel.
-    """
+    # Key variables:
+    # - logprob_start_len: Absolute position in full sequence where logprob computation begins
+    # - extend_logprob_start_len: Relative position within current extend batch where logprob computation begins
+    # - extend_input_len: Number of tokens that need to be processed in this extend batch
     if logprob_start_len == -1:
         resolved_start = full_untruncated_fill_len
     else:
@@ -2030,9 +2019,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         orig_seq_lens = [max(r.extend_range.end, len(r.origin_input_ids)) for r in reqs]
         prefix_lens = [len(r.prefix_indices) for r in reqs]
         extend_lens = [r.extend_range.length for r in reqs]
-        # Snapshot the per-req input-logprob start (relative to the extend window).
-        # Encoder-decoder stripping adjusts this list in place in
-        # prepare_encoder_info_extend; do not recompute it afterwards.
         extend_logprob_start_lens = [
             compute_extend_logprob_start_len(
                 logprob_start_len=r.logprob_start_len,
@@ -2190,12 +2176,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 ]
                 extend_input_logprob_token_ids.extend(logprob_token_ids)
 
-                # We will need extend_len - extend_logprob_start_len number of
+                # We will need req.extend_range.length - extend_logprob_start_lens[i] number of
                 # tokens, and logprob_token_ids is for input logprob, so pad the rest of them by 0.
                 extend_input_logprob_token_ids.extend(
                     [0]
                     * (
-                        extend_lens[i]
+                        req.extend_range.length
                         - extend_logprob_start_lens[i]
                         - len(logprob_token_ids)
                     )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -844,8 +844,6 @@ class Req(ReqDllmMixin):
         # Prefix info
         # The indices to kv cache for the shared prefix.
         self.prefix_indices: torch.Tensor = torch.empty((0,), dtype=torch.int64)
-        # The relative logprob_start_len in an extend batch
-        self.extend_logprob_start_len = 0
         # TODO(ispobock): rename to last_device_node
         self.last_node: Any = None
         self.last_host_node: Any = None
@@ -1098,7 +1096,6 @@ class Req(ReqDllmMixin):
 
     def set_extend_range(self, start: int, end: int) -> None:
         self.extend_range = Range(start, end)
-        self._recompute_extend_logprob_start_len()
 
     def get_fill_ids(self) -> array:
         return self.full_untruncated_fill_ids[: self.extend_range.end]
@@ -1458,7 +1455,6 @@ class Req(ReqDllmMixin):
         self.input_token_logprobs = None
         self.temp_input_top_logprobs_val = None
         self.temp_input_top_logprobs_idx = None
-        self.extend_logprob_start_len = 0
         self.inflight_middle_chunks = 0
         self.mamba_pool_idx = None
         self.mamba_ping_pong_track_buffer = None
@@ -1523,23 +1519,6 @@ class Req(ReqDllmMixin):
         )
         logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
         self.has_log_time_stats = True
-
-    def _recompute_extend_logprob_start_len(self):
-        # Setting extend_input_len and computing the relative logprob_start_len in an extend batch
-        #
-        # Key variables:
-        # - logprob_start_len: Absolute position in full sequence where logprob computation begins
-        # - extend_logprob_start_len: Relative position within current extend batch where logprob computation begins
-        # - extend_input_len: Number of tokens that need to be processed in this extend batch
-        if self.logprob_start_len == -1:
-            logprob_start_len = len(self.full_untruncated_fill_ids)
-        else:
-            # logprob_start_len should be at least the length of the prefix indices
-            logprob_start_len = max(self.logprob_start_len, len(self.prefix_indices))
-        self.extend_logprob_start_len = min(
-            logprob_start_len - len(self.prefix_indices),
-            self.extend_range.length,
-        )
 
     def set_finish_with_abort(self, error_msg: str):
         if get_tensor_model_parallel_rank() == 0:
@@ -1649,6 +1628,36 @@ def retract_all(
             hisparse_coordinator=hisparse_coordinator,
         )
     return retracted_reqs
+
+
+def compute_extend_logprob_start_len(
+    *,
+    logprob_start_len: int,
+    prefix_len: int,
+    extend_len: int,
+    full_untruncated_fill_len: int,
+) -> int:
+    """Relative position within an extend window where input-logprob computation starts.
+
+    Pure function of the extend forward inputs; it holds no Req state. Callers snapshot
+    the result at forward-assembly time into ScheduleBatch.extend_logprob_start_lens,
+    because the value is bound to one extend forward, not to live Req state (under
+    overlap scheduling the Req's prefix_indices/extend_range/logprob_start_len are
+    overwritten by the next round before the current forward's output is processed).
+
+    Key variables:
+    - logprob_start_len: absolute position in the full sequence where logprob starts
+      (-1 means "no input logprobs", i.e. start at the very end of the sequence).
+    - prefix_len: number of cached prefix tokens (extend window starts here).
+    - extend_len: number of tokens processed in this extend window.
+    - full_untruncated_fill_len: full sequence length, used to resolve the -1 sentinel.
+    """
+    if logprob_start_len == -1:
+        resolved_start = full_untruncated_fill_len
+    else:
+        # logprob_start_len should be at least the length of the prefix indices
+        resolved_start = max(logprob_start_len, prefix_len)
+    return min(resolved_start - prefix_len, extend_len)
 
 
 def _compute_chunked_req_next_prompt_token(
@@ -2004,9 +2013,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 req.extend_range = req.extend_range._replace(
                     start=req.extend_range.start + encoder_len
                 )
-                req.extend_logprob_start_len = max(
-                    0, req.extend_logprob_start_len - encoder_len
-                )
             req.logprob_start_len = max(req.logprob_start_len, encoder_len)
 
     def prepare_for_extend(self):
@@ -2024,6 +2030,18 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         orig_seq_lens = [max(r.extend_range.end, len(r.origin_input_ids)) for r in reqs]
         prefix_lens = [len(r.prefix_indices) for r in reqs]
         extend_lens = [r.extend_range.length for r in reqs]
+        # Snapshot the per-req input-logprob start (relative to the extend window).
+        # Encoder-decoder stripping adjusts this list in place in
+        # prepare_encoder_info_extend; do not recompute it afterwards.
+        extend_logprob_start_lens = [
+            compute_extend_logprob_start_len(
+                logprob_start_len=r.logprob_start_len,
+                prefix_len=prefix_lens[i],
+                extend_len=extend_lens[i],
+                full_untruncated_fill_len=len(r.full_untruncated_fill_ids),
+            )
+            for i, r in enumerate(reqs)
+        ]
 
         _pin = is_pin_memory_available(self.device)
         # Stay on pinned CPU; H2D is deferred to forward stream via
@@ -2172,13 +2190,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 ]
                 extend_input_logprob_token_ids.extend(logprob_token_ids)
 
-                # We will need req.extend_range.length - req.extend_logprob_start_len number of
+                # We will need extend_len - extend_logprob_start_len number of
                 # tokens, and logprob_token_ids is for input logprob, so pad the rest of them by 0.
                 extend_input_logprob_token_ids.extend(
                     [0]
                     * (
-                        req.extend_range.length
-                        - req.extend_logprob_start_len
+                        extend_lens[i]
+                        - extend_logprob_start_lens[i]
                         - len(logprob_token_ids)
                     )
                 )
@@ -2237,7 +2255,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]
             self.token_ids_logprobs = [r.logprob.token_ids_logprob for r in reqs]
 
-        self.extend_logprob_start_lens = [r.extend_logprob_start_len for r in reqs]
+        self.extend_logprob_start_lens = extend_logprob_start_lens
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
 
         if get_global_server_args().enable_mamba_extra_buffer():

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3340,9 +3340,18 @@ class Scheduler(
                     req.extend_range.length if req.extend_range is not None else 0
                     for req in batch.reqs
                 ]
-                batch_result.extend_logprob_start_len_per_req = [
-                    req.extend_logprob_start_len for req in batch.reqs
-                ]
+                # extend_logprob_start_lens is the forward-time snapshot (already
+                # encoder-adjusted). It is aligned with batch.reqs only right after
+                # prepare_for_extend/mix_with_running; filter_batch/merge_batch do not
+                # maintain it, so a decode batch may carry a stale, misaligned list.
+                # That is harmless (decode never consumes it) but we fall back to zeros
+                # to keep the per-req list aligned with batch.reqs.
+                start_lens = batch.extend_logprob_start_lens
+                batch_result.extend_logprob_start_len_per_req = (
+                    list(start_lens)
+                    if start_lens is not None and len(start_lens) == len(batch.reqs)
+                    else [0] * len(batch.reqs)
+                )
             else:
                 batch_result.extend_input_len_per_req = None
                 batch_result.extend_logprob_start_len_per_req = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3340,17 +3340,8 @@ class Scheduler(
                     req.extend_range.length if req.extend_range is not None else 0
                     for req in batch.reqs
                 ]
-                # extend_logprob_start_lens is the forward-time snapshot (already
-                # encoder-adjusted). It is aligned with batch.reqs only right after
-                # prepare_for_extend/mix_with_running; filter_batch/merge_batch do not
-                # maintain it, so a decode batch may carry a stale, misaligned list.
-                # That is harmless (decode never consumes it) but we fall back to zeros
-                # to keep the per-req list aligned with batch.reqs.
-                start_lens = batch.extend_logprob_start_lens
                 batch_result.extend_logprob_start_len_per_req = (
-                    list(start_lens)
-                    if start_lens is not None and len(start_lens) == len(batch.reqs)
-                    else [0] * len(batch.reqs)
+                    batch.extend_logprob_start_lens
                 )
             else:
                 batch_result.extend_input_len_per_req = None

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -79,7 +79,6 @@ class TestPrefillAdder(CustomTestCase):
         req.priority = priority
         req.prefix_indices = []
         req.full_untruncated_fill_ids = []
-        req.extend_logprob_start_len = 0
         req.output_ids = [0] * output_len
         req.sampling_params = SimpleNamespace(max_new_tokens=max_new_tokens)
         req.time_stats = SimpleNamespace(wait_queue_entry_time=wait_time)


### PR DESCRIPTION
Stacked on #27611 (base branch `tom/extend-range-inline`).

## Motivation

`extend_logprob_start_len` answers: *"in this extend forward, from which relative position do we start computing input logprobs?"* That value is bound to **one extend forward**, not to the live `Req` state.

Under overlap scheduling this distinction matters for correctness. The event loop is:

```
iter N:   batch_N = get_next_batch_to_run()   # init_next_round_input + set_extend_range for N's reqs
          run_batch(batch_N)                   # forward submitted
          result_queue.append((batch_N.copy(), result_N))
          pop_and_process()                    # processes batch_{N-1}
iter N+1: batch_{N+1} = get_next_batch_to_run()  # chunked req continues -> overwrites its
                                                  #   prefix_indices / extend_range / logprob_start_len
          ...
          pop_and_process()                    # processes batch_N  <-- here req state is already N+1's
```

So when `batch_N`'s output is processed, a chunked req's `prefix_indices` / `extend_range` / `logprob_start_len` have **already been overwritten** by iteration N+1. This is exactly what the `scheduler.py` comment ("these values ... can be modified by overlap schedule") refers to.

## Field vs property vs free function

| Approach | Computation | Snapshot home | Risk |
|---|---|---|---|
| Cached `Req` field (before) | computed in `set_extend_range`, side effect | long-lived mutable `Req` field | can go stale; looks like a `Req` attribute and tempts reads at the wrong time |
| `@property` | computed on read | none | **silently wrong** under overlap — recomputes from already-overwritten inputs |
| **Free function + caller snapshot (this PR)** | pure function | `ScheduleBatch.extend_logprob_start_lens` (bound to one forward) | none structurally — there is no `Req` field to read at the wrong time |

A `@property` is the worst option: it implies the value is a pure function of *current* `Req` state and can be read anytime. But it is only meaningful at forward-assembly time; read later (e.g. in `process_batch_result` under overlap) it recomputes from mutated inputs and produces a value that corresponds to no real forward — without raising.

The free function keeps the single pure computation, but forces callers to snapshot it at the right moment into the batch, which is the value's real owner. Making a snapshot *the only way to hold the value* converts the previously-implicit timing contract ("read before the next round overwrites the inputs") into something that is structurally impossible to get wrong.

## Chunked prefill + overlap timing

- **Chunked prefill alone:** no risk. Each round computes from that round's `prefix_indices` / `extend_range`; the formula is correct per chunk (start before this chunk -> 0; inside -> relative offset; in a later chunk -> `extend_len`, i.e. no input logprobs this chunk).
- **Chunked + overlap:** the two snapshot points (`prepare_for_extend` building the batch list inside iter N's `get_next_batch_to_run`, and `run_batch` copying `extend_logprob_start_len_per_req` inside iter N) both happen **before** iter N+1's overwrite. Consumers (`batch_result_processor`) read only the snapshot, never the live req state.

---

# FAQ (reviewer questions)

## Q: `compute_extend_logprob_start_len` doesn't take `encoder_len` — is encoder handling missing?

No. The free function computes the **pre-encoder base** value, which is exactly what the old `Req._recompute_extend_logprob_start_len` computed — that method did not take `encoder_len` either. The encoder adjustment was, and still is, a **separate incremental step** applied later to the snapshot list in `prepare_encoder_info_extend`:

```python
self.extend_logprob_start_lens[i] = max(0, old_start_len - encoder_len)
```

So the final value the consumer reads is encoder-adjusted; the subtraction simply lives on the snapshot, not in the function.

It **cannot** be folded into the function: the encoder step is incremental (`-= encoder_len` on the already-resolved value) and it also clobbers `logprob_start_len` to `max(logprob_start_len, encoder_len)`, destroying the `-1` sentinel. A from-scratch recompute (even given `encoder_len`) therefore could not reconstruct the correct value. Splitting it as "pure base in the function, incremental encoder delta on the snapshot" is the only correct decomposition.

## Q: You deleted the per-`Req` `extend_logprob_start_len` decrement in `prepare_encoder_info_extend` — is it still equivalent?

Yes. That function had **two** parallel writes of the same quantity:
1. the snapshot **list**: `self.extend_logprob_start_lens[i] = max(0, old_start_len - encoder_len)` (inside `if self.extend_input_logprob_token_ids is not None:`), and
2. the **`Req` field**: `req.extend_logprob_start_len = max(0, req.extend_logprob_start_len - encoder_len)` (unconditional loop) — **deleted here**.

Both apply the identical `max(0, x - encoder_len)` to the same pre-encoder value, so they always agreed. The only case where they diverged is `return_logprob == False` (then write #1 is skipped because `extend_input_logprob_token_ids is None`, but write #2 still ran) — and in that case the value is **never consumed** (the downstream reader in `run_batch` is itself gated on `if batch.return_logprob:`, and `logits_processor` only uses it when computing logprobs). In the only case the value is consumed (`return_logprob == True`), write #1 runs and yields a bit-identical value, and `run_batch` now reads the list instead of the field. The field write was pure redundancy.

## Q: Why does `run_batch` assign the batch snapshot directly, with no alignment guard?

```python
batch_result.extend_logprob_start_len_per_req = batch.extend_logprob_start_lens
```

`extend_logprob_start_len_per_req` is consumed **only** in prefill/extend output processing (`_apply_prefill_logprobs` / `_apply_chunked_prefill_logprobs`), where it is indexed per req. Those run only for extend/mixed/prebuilt batches, and for those `batch.extend_logprob_start_lens` is freshly built by `prepare_for_extend` (and extended with `[0]*running_bs` in `mix_with_running`), so it is non-None and aligned with `batch.reqs`.

`filter_batch` / `merge_batch` do **not** maintain `extend_logprob_start_lens`, so a decode batch can carry a stale / misaligned / None list. That is harmless: decode result processing never reads `extend_logprob_start_len_per_req`. An earlier revision added a `len(start_lens) == len(batch.reqs)` guard with a zeros fallback to preserve the old "per-req list always aligned with `batch.reqs`" invariant, but since the value is provably never consumed in the misaligned (decode) case, the guard was pure defense against a hypothetical future decode-side reader and was dropped for simplicity.

## Q: Does the disagg PREBUILT path need input logprobs? Why are both fields set to `None`?

No. In disaggregation, input logprobs are produced by the **prefill** server's real EXTEND forward and transferred; the decode server's PREBUILT batch runs **no forward over its own tokens** (`run_batch` short-circuits to `_run_batch_prebuilt`, and `process_batch_result_prebuilt` does no logprob work — see its `# Logprobs should be handled on the prefill engine.` note). PREBUILT is classified as neither extend nor decode/idle, and the only reader of a non-None `extend_input_logprob_token_ids` (`prepare_encoder_info_extend`) is reachable only from `prepare_for_extend`, never from `prepare_for_prebuilt`.

So `prepare_for_prebuilt` sets both `extend_logprob_start_lens` and `extend_input_logprob_token_ids` to `None` (they were dead boilerplate copied from `prepare_for_extend`; `ScheduleBatch` already defaults both to `None`). Setting them explicitly documents that PREBUILT intentionally produces no input logprobs.

---

## Change list

- Add module-level `compute_extend_logprob_start_len(...)` (pure; the old `_recompute` formula verbatim, including the carried-over key-variables comment). Delete `Req._recompute_extend_logprob_start_len`, the `Req.extend_logprob_start_len` field, its init/reset assignments, and the `set_extend_range` side effect.
- `prepare_for_extend` builds the snapshot list via the free function; the input-logprob token-id padding reads `extend_logprob_start_lens[i]` instead of the field (the sibling `req.extend_range.length` term is left untouched to keep the diff minimal).
- `prepare_encoder_info_extend` only adjusts the batch list in place; the redundant per-`Req` field decrement is dropped.
- Disagg prebuilt path sets `extend_logprob_start_lens` and `extend_input_logprob_token_ids` to `None` (input logprobs are computed on the prefill server).
- `run_batch` sources `extend_logprob_start_len_per_req` directly from the batch snapshot.
- Drop the now-dead `req.extend_logprob_start_len = 0` line in `test_prefill_adder.py`.



































































































































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28139904307](https://github.com/sgl-project/sglang/actions/runs/28139904307)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28139904230](https://github.com/sgl-project/sglang/actions/runs/28139904230)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->