### PR TITLE
ci: run pr-test-extra on release branch cuts (not just base suites)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -80,9 +80,10 @@ jobs:
     secrets: inherit
 
   call-pr-test-extra:
-    if: github.event_name == 'schedule' || inputs.test_parallel_dispatch == true
+    if: github.event_name == 'schedule' || inputs.test_parallel_dispatch == true || inputs.run_all_tests == true
     uses: ./.github/workflows/pr-test-extra.yml
     with:
+      git_ref: ${{ inputs.git_ref || '' }}
       run_all_tests: true
     secrets: inherit
 


### PR DESCRIPTION
## Problem

The **Release Branch Cut** workflow calls `pr-test.yml` with `run_all_tests: true` to validate the full test matrix against the freshly cut release branch. But the `call-pr-test-extra` job that dispatches the **extra** suites (`pr-test-extra.yml`) only fired on:

```yaml
if: github.event_name == 'schedule' || inputs.test_parallel_dispatch == true
```

A release cut comes in as a `workflow_call` with `run_all_tests: true` and neither of those is set, so the job was **skipped** — release branches were validated with only the `base-a`/`base-b` suites and **none of the extra suites**. (Seen in the latest Release Branch Cut run, where only base stages ran downstream.)

## Fix

Two changes to `call-pr-test-extra` in `pr-test.yml`:

1. Add `inputs.run_all_tests == true` to the trigger condition, so release cuts (and manual run-all dispatches) include the extra suites — matching the scheduled cron behavior that `run_all_tests` is documented to mirror.
2. Thread `git_ref` into `pr-test-extra.yml`. Without it the extra suites would have run against the **default branch** instead of the release branch, defeating the purpose.

`run_all_tests: true` is already passed, and `pr-test-extra.yml` already skips its health-check fast-fail when `run_all_tests` is set (`SKIP_PR_TEST_HEALTH_CHECK`), so no other inputs need forwarding.

## Effect

- **Release branch cuts**: now run base **and** extra suites against the release branch.
- **Scheduled cron / `test_parallel_dispatch`**: unchanged (already triggered; empty `git_ref` → default branch as before).
- **Normal PRs**: unchanged (`run_all_tests` is false).

## Verification

`pr-test.yml` validates as YAML. Confirmed `pr-test-extra.yml` accepts `git_ref` (workflow_call input) and that its `SKIP_PR_TEST_HEALTH_CHECK` already keys off `run_all_tests`.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27182287583](https://github.com/sgl-project/sglang/actions/runs/27182287583)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27182287499](https://github.com/sgl-project/sglang/actions/runs/27182287499)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->