### PR TITLE
Hybrid suffix mtp v2

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -93,6 +93,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [project.optional-dependencies]
+suffix = ["arctic_inference>=0.1.2"]  # SUFFIX speculative decoding (model-free, CPU suffix tree)
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 diffusion = [

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -48,8 +48,9 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
         )
 
     if server_args.speculative_algorithm is not None:
-        # DSv4 supports EAGLE (spec-v2) and SUFFIX (model-free, NGRAMWorker family).
-        _allowed = {"EAGLE", "SUFFIX"}
+        # DSv4 supports EAGLE (spec-v2), SUFFIX (model-free, NGRAMWorker
+        # family), and HYBRID_SUFFIX_MTP (per-batch SUFFIX/MTP/NONE dispatch).
+        _allowed = {"EAGLE", "SUFFIX", "HYBRID_SUFFIX_MTP"}
         assert (
             server_args.speculative_algorithm in _allowed
         ), f"Speculative algorithm {server_args.speculative_algorithm} not supported for {model_arch}; allowed: {sorted(_allowed)}"

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from sglang.srt.environ import envs
+
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
@@ -46,12 +48,18 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
         )
 
     if server_args.speculative_algorithm is not None:
+        # DSv4 supports EAGLE (spec-v2) and SUFFIX (model-free, NGRAMWorker family).
+        _allowed = {"EAGLE", "SUFFIX"}
         assert (
-            server_args.speculative_algorithm == "EAGLE"
-        ), f"Only EAGLE speculative algorithm is supported for {model_arch}"
-        assert (
-            server_args.speculative_eagle_topk == 1
-        ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
+            server_args.speculative_algorithm in _allowed
+        ), f"Speculative algorithm {server_args.speculative_algorithm} not supported for {model_arch}; allowed: {sorted(_allowed)}"
+        if server_args.speculative_algorithm == "EAGLE":
+            assert (
+                server_args.speculative_eagle_topk == 1
+            ), f"Only EAGLE with topk == 1 is supported for {model_arch}"
+            if not envs.SGLANG_ENABLE_SPEC_V2.get():
+                envs.SGLANG_ENABLE_SPEC_V2.set(True)
+                logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
 
     if server_args.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
         server_args.swa_full_tokens_ratio = 0.1

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1951,6 +1951,12 @@ class SchedulerDisaggregationDecodeMixin:
             # if there are still retracted requests, we do not allocate new requests
             return
 
+        # Model-free spec (SUFFIX): drain one budgeted prewarm step per loop
+        # iteration (duck-typed; None / EAGLE draft workers have no such method).
+        prewarm_step = getattr(self.draft_worker, "prewarm_step", None)
+        if prewarm_step is not None:
+            prewarm_step()
+
         if not hasattr(self, "polling_count"):
             self.polling_count = 0
             self.polling_interval = (
@@ -1962,6 +1968,12 @@ class SchedulerDisaggregationDecodeMixin:
         if self.polling_count % self.polling_interval == 0:
             req_conns, _ = self.disagg_decode_prealloc_queue.pop_preallocated()
             self.disagg_decode_transfer_queue.extend(req_conns)
+            # Model-free spec (SUFFIX): start rebuilding the per-request suffix
+            # tree while the KV transfer is in flight, so the build cost does
+            # not land on the first decode step.
+            prewarm = getattr(self.draft_worker, "prewarm_disagg_requests", None)
+            if prewarm is not None and req_conns:
+                prewarm([decode_req.req for decode_req in req_conns])
             transferred_reqs = (
                 self.disagg_decode_transfer_queue.pop_transferred()
             )  # the requests which kv has arrived

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -702,6 +702,11 @@ class Envs:
 
     # Ngram
     SGLANG_NGRAM_FORCE_GREEDY_VERIFY = EnvBool(False)
+    # Expand the verify tree mask to FULL (prefix + tree block) per request.
+    # Backends that derive TARGET_VERIFY semantics from seq_lens and never
+    # read spec_info.custom_mask (e.g. DeepSeek-V4 NSA) can turn this off to
+    # skip a per-step CPU mask build that grows with context length.
+    SGLANG_NGRAM_USE_FULL_MASK = EnvBool(True)
 
     # Warmup
     SGLANG_WARMUP_TIMEOUT = EnvFloat(-1) # in seconds. If a warmup forward batch takes longer than this, the server will crash to prevent hanging. Recommend to increase warmup timeout to 1800 to accommodate some kernel JIT precache e.g. deep gemm

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -989,6 +989,24 @@ class DeepseekSparseAttnBackend(
             token_to_batch_idx = dsa_cp_round_robin_split_data(token_to_batch_idx)
         return (ks, ke), token_to_batch_idx
 
+    def _cuda_graph_draft_token_num(
+        self, forward_mode: ForwardMode, spec_info: Optional[SpecInput]
+    ) -> int:
+        """Per-graph draft width = the count added to seq_lens for this forward.
+
+        Used both as the metadata-dict sub-key and as the verify/extend width.
+        HYBRID_SUFFIX_MTP captures three target-verify graphs at different widths
+        (K_suffix / K_mtp / 1) on the SAME backend, so the width must come from
+        the batch's spec_info, not the static config. Returns 0 for decode/idle
+        so a width-1 NONE verify never collides with a plain decode graph.
+        """
+        if forward_mode.is_target_verify():
+            w = getattr(spec_info, "draft_token_num", None)
+            return int(w) if w else self.speculative_num_draft_tokens
+        if forward_mode.is_draft_extend_v2():
+            return self.speculative_num_draft_tokens
+        return 0
+
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         """Initialize CUDA graph state for the attention backend.
 
@@ -997,7 +1015,20 @@ class DeepseekSparseAttnBackend(
 
         This creates fixed-size tensors that will be reused during CUDA graph replay
         to avoid memory allocations.
+
+        Idempotent / grow-only: HYBRID_SUFFIX_MTP builds three decode graph
+        runners (K_suffix / K_mtp / 1) that share this one backend instance and
+        each call init_cuda_graph_state. The widest runner (K_suffix) is built
+        first, so later (narrower) calls must NOT wipe the already-allocated
+        buffers or the per-(bs, width) entries captured so far. Only (re)allocate
+        when the request needs more tokens than currently provisioned.
         """
+        if (
+            getattr(self, "decode_cuda_graph_metadata", None) is not None
+            and getattr(self, "_cuda_graph_max_num_tokens", 0) >= max_num_tokens
+        ):
+            return
+        self._cuda_graph_max_num_tokens = max_num_tokens
         self.decode_cuda_graph_metadata: Dict = {
             "cache_seqlens": torch.ones(
                 max_num_tokens, dtype=torch.int32, device=self.device
@@ -1079,29 +1110,31 @@ class DeepseekSparseAttnBackend(
             else:
                 flashmla_metadata = None
         elif forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
-            cache_seqlens_int32 = (seq_lens + self.speculative_num_draft_tokens).to(
-                torch.int32
+            # Per-graph width (K_suffix / K_mtp / 1 for HYBRID); equals the
+            # static config for builtin EAGLE/NGRAM.
+            cg_draft_token_num = self._cuda_graph_draft_token_num(
+                forward_mode, spec_info
             )
+            cache_seqlens_int32 = (seq_lens + cg_draft_token_num).to(torch.int32)
             cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
             max_seqlen_q = 1
             page_table_1 = self.decode_cuda_graph_metadata["page_table"][
-                : bs * self.speculative_num_draft_tokens, :
+                : bs * cg_draft_token_num, :
             ]
             max_seqlen_k = page_table_1.shape[1]
 
             cu_seqlens_q = torch.arange(
                 0,
-                bs * self.speculative_num_draft_tokens + 1,
+                bs * cg_draft_token_num + 1,
                 1,
                 dtype=torch.int32,
                 device=self.device,
             )
 
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
+            extend_seq_lens_cpu = [cg_draft_token_num] * bs
 
             seqlens_int32_cpu = [
-                self.speculative_num_draft_tokens + kv_len
-                for kv_len in seq_lens.tolist()
+                cg_draft_token_num + kv_len for kv_len in seq_lens.tolist()
             ]
             seqlens_expanded = torch.cat(
                 [
@@ -1121,12 +1154,12 @@ class DeepseekSparseAttnBackend(
             dsa_cache_seqlens_int32 = compute_dsa_seqlens(
                 seqlens_expanded, dsa_index_topk=self.dsa_index_topk
             )
-            dsa_extend_seq_lens_list = [1] * bs * self.speculative_num_draft_tokens
+            dsa_extend_seq_lens_list = [1] * bs * cg_draft_token_num
 
             if self.dsa_decode_impl == "flashmla_kv":
                 flashmla_metadata = self.decode_cuda_graph_metadata[
                     "flashmla_metadata"
-                ].slice(slice(0, bs * self.speculative_num_draft_tokens + 1))
+                ].slice(slice(0, bs * cg_draft_token_num + 1))
 
                 flashmla_metadata.copy_(
                     self._compute_flashmla_metadata(
@@ -1173,6 +1206,15 @@ class DeepseekSparseAttnBackend(
             real_page_table=real_page_table,
             dsa_extend_seq_lens_list=dsa_extend_seq_lens_list,
         )
+        # Key by (bs, width) so HYBRID's three target-verify graphs (K_suffix /
+        # K_mtp / 1) coexist on this shared backend instead of clobbering one
+        # bs slot. width=0 for decode/idle keeps those distinct from a width-1
+        # NONE verify. Also keep the legacy bs-only key so single-K call sites
+        # (the multi-step draft wrapper / from_precomputed fast path) that look
+        # up `[bs]` keep working unchanged — for a single-K backend both keys
+        # point at the same (only) entry.
+        cg_key = (bs, self._cuda_graph_draft_token_num(forward_mode, spec_info))
+        self.decode_cuda_graph_metadata[cg_key] = metadata
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_metadata = metadata
 
@@ -1195,7 +1237,11 @@ class DeepseekSparseAttnBackend(
         """
         assert seq_lens_cpu is not None
 
-        if bs not in self.decode_cuda_graph_metadata:
+        # (bs, width) key so HYBRID's K_suffix / K_mtp / 1 verify graphs each
+        # resolve to their own captured metadata (see _cuda_graph_draft_token_num).
+        cg_draft_token_num = self._cuda_graph_draft_token_num(forward_mode, spec_info)
+        cg_key = (bs, cg_draft_token_num)
+        if cg_key not in self.decode_cuda_graph_metadata:
             self._build_forward_metadata_cuda_graph(
                 bs,
                 None,
@@ -1216,7 +1262,7 @@ class DeepseekSparseAttnBackend(
         req_pool_indices = req_pool_indices[:bs]
 
         # Normal Decode
-        metadata: DSAMetadata = self.decode_cuda_graph_metadata[bs]
+        metadata: DSAMetadata = self.decode_cuda_graph_metadata[cg_key]
         if forward_mode.is_decode_or_idle():
             # Normal Decode
             max_len = int(seq_lens_cpu.max().item())
@@ -1234,31 +1280,29 @@ class DeepseekSparseAttnBackend(
             metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
             seqlens_expanded = cache_seqlens
         elif forward_mode.is_target_verify():
-            max_seqlen_k = int(
-                seq_lens_cpu.max().item() + self.speculative_num_draft_tokens
-            )
+            max_seqlen_k = int(seq_lens_cpu.max().item() + cg_draft_token_num)
 
-            cache_seqlens = (seq_lens + self.speculative_num_draft_tokens).to(
-                torch.int32
-            )
+            cache_seqlens = (seq_lens + cg_draft_token_num).to(torch.int32)
             metadata.cache_seqlens_int32.copy_(cache_seqlens)
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
             )
             page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
             page_indices = torch.repeat_interleave(
-                page_indices, repeats=self.speculative_num_draft_tokens, dim=0
+                page_indices, repeats=cg_draft_token_num, dim=0
             )
-            metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
+            metadata.page_table_1[: page_indices.shape[0], :max_seqlen_k].copy_(
+                page_indices
+            )
+            extend_seq_lens_cpu = [cg_draft_token_num] * bs
 
             seqlens_expanded = seqlens_expand_triton(
                 torch.tensor(
                     extend_seq_lens_cpu, dtype=torch.int32, device=self.device
                 ),
                 cache_seqlens,
-                self.speculative_num_draft_tokens * bs,
-                self.speculative_num_draft_tokens,
+                cg_draft_token_num * bs,
+                cg_draft_token_num,
             )
             metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
             dsa_cache_seqlens = compute_dsa_seqlens(
@@ -1381,6 +1425,8 @@ class DeepseekSparseAttnBackend(
         """
         self.set_dsa_prefill_impl(forward_batch=None)
 
+        # Single-K fast path (multi-step draft wrapper): the legacy bs-only key
+        # is kept in sync by _build_forward_metadata_cuda_graph's dual store.
         metadata = self.decode_cuda_graph_metadata[bs]
 
         # Track whether fused kernel succeeded

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -623,7 +623,16 @@ class DeepseekSparseAttnBackend(
         device = forward_batch.seq_lens.device
 
         if forward_batch.forward_mode.is_target_verify():
-            draft_token_num = self.speculative_num_draft_tokens
+            # Per-forward verify width. HYBRID_SUFFIX_MTP verifies at K_suffix
+            # for the SUFFIX backend and K_mtp (= num_steps + 1) for the MTP
+            # backend on the SAME target, so the metadata width must come from
+            # the batch's spec_info, not the static config. Falls back to the
+            # config value for builtin EAGLE/NGRAM (whose spec_info carries the
+            # same number).
+            draft_token_num = (
+                getattr(forward_batch.spec_info, "draft_token_num", None)
+                or self.speculative_num_draft_tokens
+            )
         else:
             draft_token_num = 0
 
@@ -672,22 +681,22 @@ class DeepseekSparseAttnBackend(
             max_seqlen_q = 1
             cu_seqlens_q = torch.arange(
                 0,
-                batch_size * self.speculative_num_draft_tokens + 1,
+                batch_size * draft_token_num + 1,
                 1,
                 dtype=torch.int32,
                 device=device,
             )
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
+            extend_seq_lens_cpu = [draft_token_num] * batch_size
             forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
 
             seqlens_expanded = seqlens_expand_triton(
                 torch.tensor(extend_seq_lens_cpu, dtype=torch.int32, device=device),
                 cache_seqlens_int32,
-                self.speculative_num_draft_tokens * batch_size,
-                self.speculative_num_draft_tokens,
+                draft_token_num * batch_size,
+                draft_token_num,
             )
             page_table = torch.repeat_interleave(
-                page_table, repeats=self.speculative_num_draft_tokens, dim=0
+                page_table, repeats=draft_token_num, dim=0
             )
         elif forward_batch.forward_mode.is_draft_extend_v2():
             assert (
@@ -708,18 +717,28 @@ class DeepseekSparseAttnBackend(
                 device=device,
             )
 
+            # Per-forward draft-extend width. HYBRID_SUFFIX_MTP's MTP backend
+            # draft-extends by K_mtp (= num_steps + 1) while the target backend's
+            # static speculative_num_draft_tokens is K_suffix, so the metadata
+            # width must come from the batch, not the config. For builtin EAGLE
+            # V2 these are equal, so behaviour is unchanged.
+            draft_extend_width = (
+                forward_batch.extend_num_tokens // batch_size
+                if batch_size > 0
+                else self.speculative_num_draft_tokens
+            )
             seqlens_expanded = seqlens_expand_triton(
                 forward_batch.extend_seq_lens,
                 cache_seqlens_int32,
                 sum(extend_seq_lens_cpu),
-                self.speculative_num_draft_tokens,
+                draft_extend_width,
             )
             if forward_batch.forward_mode.is_draft_extend_v2():
-                # DRAFT_EXTEND_V2: V2 worker pre-fills draft KV cache with ALL speculated
-                # tokens upfront. All requests extend by the same fixed
-                # (speculative_num_draft_tokens). Use scalar to avoid GPU sync.
+                # DRAFT_EXTEND_V2: V2 worker pre-fills draft KV cache with ALL
+                # speculated tokens upfront; all requests extend by the same
+                # fixed width (draft_extend_width above).
                 page_table = torch.repeat_interleave(
-                    page_table, repeats=self.speculative_num_draft_tokens, dim=0
+                    page_table, repeats=draft_extend_width, dim=0
                 )
             else:
                 # DRAFT_EXTEND: the draft worker extends by (num_correct_drafts + 1)

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -202,8 +202,11 @@ class FutureMap:
             )
 
     def _resolve_spec_extras(self, batch: ScheduleBatch) -> None:
-        if self.spec_algo.is_ngram():
+        if self.spec_algo.is_ngram() and not self.spec_algo.is_hybrid_suffix_mtp():
             # FIXME: remove once precomputed draft is supported.
+            # HYBRID is exempt: its cross-iter draft input is an EagleDraftInput
+            # (MTP topk_p / hidden_states), not an NgramVerifyInput, so it needs
+            # the full EAGLE-style resolve/stash relay.
             return
         draft_input: EagleDraftInput = batch.spec_info
         if draft_input is None:
@@ -327,8 +330,11 @@ class FutureMap:
         future_indices: torch.Tensor,
         payload: Union[torch.Tensor, EagleDraftInput],
     ) -> None:
-        if self.spec_algo.is_ngram():
+        if self.spec_algo.is_ngram() and not self.spec_algo.is_hybrid_suffix_mtp():
             # FIXME: remove once precomputed draft is supported.
+            # HYBRID is exempt: its cross-iter draft input is an EagleDraftInput
+            # (MTP topk_p / hidden_states), not an NgramVerifyInput, so it needs
+            # the full EAGLE-style resolve/stash relay.
             return
         indices = future_indices
         if indices.shape[0] == 0:

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -51,7 +51,11 @@ def get_draft_kv_pool(
 ):
     """Return (draft_token_to_kv_pool, draft_model_config) for the current
     draft worker, or (None, None) when no draft KV pool is available."""
-    if draft_worker is None or spec_algorithm.is_ngram():
+    if draft_worker is None or (
+        spec_algorithm.is_ngram() and not spec_algorithm.is_hybrid_suffix_mtp()
+    ):
+        # HYBRID is exempt: the MTP backend writes a real EAGLE draft KV chain,
+        # so its draft KV pool must be allocated despite is_ngram() being True.
         return None, None
 
     # V2 workers nest the draft runner under `.draft_worker`.

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2597,10 +2597,23 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # the two narrower runners alongside the main one; the hybrid worker's
         # verify() swaps decode_cuda_graph_runner to the K-matching runner
         # before each verify forward (keyed on spec_info.draft_token_num).
+        #
+        # NOTE: the two narrower graphs share the SAME attention backend
+        # instance as the main runner. The upstream DSA backend sizes its
+        # cuda-graph metadata (e.g. flashmla num_splits) for ONE K (the main
+        # K_suffix); capturing a second runner at a different K overwrites /
+        # mismatches that buffer ("tensor a (N) must match tensor b (M)").
+        # Until the DSA backend keys cuda-graph metadata by (bs, K), the extra
+        # graphs are OFF by default: SUFFIX runs on the main K_suffix graph and
+        # MTP / NONE fall back to eager (verify()'s runner-swap finds them
+        # absent and keeps the main runner, whose width check then routes the
+        # narrower batch to eager). Opt in with ARCTIC_HYBRID_EXTRA_GRAPHS=1
+        # on backends that support multi-K metadata.
         self.short_chain_graph_runner = None
         self.baseline_chain_graph_runner = None
         if (
-            not self.is_draft_worker
+            os.environ.get("ARCTIC_HYBRID_EXTRA_GRAPHS", "0") == "1"
+            and not self.is_draft_worker
             and self.spec_algorithm.is_hybrid_suffix_mtp()
             and self.decode_cuda_graph_runner is not None
             and self.device == "cuda"
@@ -2616,17 +2629,29 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
             sc_tic = time.perf_counter()
             sc_before = get_available_gpu_memory(self.device, self.gpu_id)
-            self.short_chain_graph_runner = HybridShortChainCudaGraphRunner(self)
-            self.baseline_chain_graph_runner = HybridBaselineCudaGraphRunner(self)
-            sc_after = get_available_gpu_memory(self.device, self.gpu_id)
-            logger.info(
-                "Capture HYBRID short-chain (K=%d) + baseline (K=1) cuda graphs "
-                "end. elapsed=%.2f s, mem usage=%.2f GB, avail mem=%.2f GB.",
-                self.server_args.speculative_num_steps + 1,
-                time.perf_counter() - sc_tic,
-                sc_before - sc_after,
-                sc_after,
-            )
+            try:
+                self.short_chain_graph_runner = HybridShortChainCudaGraphRunner(self)
+                self.baseline_chain_graph_runner = HybridBaselineCudaGraphRunner(self)
+                sc_after = get_available_gpu_memory(self.device, self.gpu_id)
+                logger.info(
+                    "Capture HYBRID short-chain (K=%d) + baseline (K=1) cuda "
+                    "graphs end. elapsed=%.2f s, mem usage=%.2f GB, avail "
+                    "mem=%.2f GB.",
+                    self.server_args.speculative_num_steps + 1,
+                    time.perf_counter() - sc_tic,
+                    sc_before - sc_after,
+                    sc_after,
+                )
+            except Exception as e:
+                self.short_chain_graph_runner = None
+                self.baseline_chain_graph_runner = None
+                logger.warning(
+                    "HYBRID extra cuda graphs (short-chain/baseline) failed to "
+                    "capture (%s); MTP / NONE paths will run eager. This is "
+                    "expected on attention backends whose cuda-graph metadata "
+                    "is not keyed by (bs, K).",
+                    repr(e),
+                )
 
     def init_prefill_cuda_graph(self, force_for_draft_worker: bool = False):
         """Initialize prefill CUDA graph runner."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2598,21 +2598,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # verify() swaps decode_cuda_graph_runner to the K-matching runner
         # before each verify forward (keyed on spec_info.draft_token_num).
         #
-        # NOTE: the two narrower graphs share the SAME attention backend
-        # instance as the main runner. The upstream DSA backend sizes its
-        # cuda-graph metadata (e.g. flashmla num_splits) for ONE K (the main
-        # K_suffix); capturing a second runner at a different K overwrites /
-        # mismatches that buffer ("tensor a (N) must match tensor b (M)").
-        # Until the DSA backend keys cuda-graph metadata by (bs, K), the extra
-        # graphs are OFF by default: SUFFIX runs on the main K_suffix graph and
-        # MTP / NONE fall back to eager (verify()'s runner-swap finds them
-        # absent and keeps the main runner, whose width check then routes the
-        # narrower batch to eager). Opt in with ARCTIC_HYBRID_EXTRA_GRAPHS=1
-        # on backends that support multi-K metadata.
+        # The three graphs share the SAME attention backend instance as the
+        # main runner. The DSA backend keys its cuda-graph metadata by
+        # (bs, draft_token_num) and sizes its shared buffers grow-only (widest
+        # = main K_suffix, built first), so the K_mtp and K=1 graphs capture
+        # alongside the K_suffix one without clobbering it. Enabled by default;
+        # set ARCTIC_HYBRID_EXTRA_GRAPHS=0 to force MTP/NONE eager (the worker's
+        # verify() runner-swap then finds them absent and keeps the main runner).
         self.short_chain_graph_runner = None
         self.baseline_chain_graph_runner = None
         if (
-            os.environ.get("ARCTIC_HYBRID_EXTRA_GRAPHS", "0") == "1"
+            os.environ.get("ARCTIC_HYBRID_EXTRA_GRAPHS", "1") == "1"
             and not self.is_draft_worker
             and self.spec_algorithm.is_hybrid_suffix_mtp()
             and self.decode_cuda_graph_runner is not None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2590,6 +2590,44 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"mem usage={self.graph_mem_usage:.2f} GB, avail mem={after_mem:.2f} GB."
         )
 
+        # HYBRID_SUFFIX_MTP runs three chain widths per step (chosen per batch
+        # by its internal HybridBackendSelector): K_suffix (e.g. 16) for the
+        # SUFFIX path captured by the main runner above, K_mtp = num_steps + 1
+        # for the MTP path, and K = 1 for the NONE (plain decode) path. Capture
+        # the two narrower runners alongside the main one; the hybrid worker's
+        # verify() swaps decode_cuda_graph_runner to the K-matching runner
+        # before each verify forward (keyed on spec_info.draft_token_num).
+        self.short_chain_graph_runner = None
+        self.baseline_chain_graph_runner = None
+        if (
+            not self.is_draft_worker
+            and self.spec_algorithm.is_hybrid_suffix_mtp()
+            and self.decode_cuda_graph_runner is not None
+            and self.device == "cuda"
+            and self.server_args.speculative_num_draft_tokens
+            != self.server_args.speculative_num_steps + 1
+        ):
+            from sglang.srt.model_executor.runner.hybrid_baseline_cuda_graph_runner import (
+                HybridBaselineCudaGraphRunner,
+            )
+            from sglang.srt.model_executor.runner.hybrid_short_chain_cuda_graph_runner import (
+                HybridShortChainCudaGraphRunner,
+            )
+
+            sc_tic = time.perf_counter()
+            sc_before = get_available_gpu_memory(self.device, self.gpu_id)
+            self.short_chain_graph_runner = HybridShortChainCudaGraphRunner(self)
+            self.baseline_chain_graph_runner = HybridBaselineCudaGraphRunner(self)
+            sc_after = get_available_gpu_memory(self.device, self.gpu_id)
+            logger.info(
+                "Capture HYBRID short-chain (K=%d) + baseline (K=1) cuda graphs "
+                "end. elapsed=%.2f s, mem usage=%.2f GB, avail mem=%.2f GB.",
+                self.server_args.speculative_num_steps + 1,
+                time.perf_counter() - sc_tic,
+                sc_before - sc_after,
+                sc_after,
+            )
+
     def init_prefill_cuda_graph(self, force_for_draft_worker: bool = False):
         """Initialize prefill CUDA graph runner."""
         self.prefill_cuda_graph_runner = None

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -405,6 +405,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 if self.model_runner.spec_algorithm.is_eagle()
                 or self.model_runner.spec_algorithm.is_standalone()
                 or self.model_runner.spec_algorithm.is_dflash()
+                # NGRAM/SUFFIX verify is a fixed num_tokens_per_bs target verify
+                # whose global token count is coefficient-scaled by
+                # num_tokens_per_bs exactly like eagle; without dividing it back
+                # under dp-attention it selects graph[bs*K] -> the captured DSA
+                # paged-MQA schedule metadata batch_size mismatches runtime
+                # (deep_gemm asserts _batch_size == batch_size).
+                or self.model_runner.spec_algorithm.is_ngram()
                 else max(forward_batch.global_num_tokens_cpu)
             )
         else:
@@ -901,6 +908,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 if self.model_runner.spec_algorithm.is_eagle()
                 or self.model_runner.spec_algorithm.is_standalone()
                 or self.model_runner.spec_algorithm.is_dflash()
+                # NGRAM/SUFFIX: divide back so dp-attention replay selects
+                # graph[bs] not graph[bs*K] (see note in can_run).
+                or self.model_runner.spec_algorithm.is_ngram()
                 else max_num_tokens
             )
             bs = self._pad_to_bucket(int(max_batch_size), self.capture_bs)

--- a/python/sglang/srt/model_executor/runner/hybrid_baseline_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/hybrid_baseline_cuda_graph_runner.py
@@ -1,0 +1,41 @@
+"""CudaGraphRunner for HYBRID_SUFFIX_MTP's NONE-backend (K=1, no spec).
+
+Third cuda graph runner alongside:
+  - main ``decode_cuda_graph_runner``        — K = ``speculative_num_draft_tokens``
+                                               (SUFFIX TARGET_VERIFY)
+  - ``hybrid_short_chain_cuda_graph_runner`` — K = ``speculative_num_steps + 1``
+                                               (MTP TARGET_VERIFY)
+  - this ``hybrid_baseline_cuda_graph_runner`` — K = 1 (NONE)
+
+``HybridSuffixMTPWorkerV2.verify`` swaps ``model_runner.decode_cuda_graph_runner``
+to the K-matching runner before the verify forward (keyed on
+``spec_info.draft_token_num``), so the right graph claims each step without
+any width-probing dispatch.
+
+K=1 is set via ``DecodeCudaGraphRunner``'s ``speculative_num_draft_tokens``
+constructor override. The graphs capture in TARGET_VERIFY mode — which is what
+the NONE path actually runs: ``_decode_step_none`` builds a K=1
+``EagleVerifyInput`` (bonus only, no spec slots) and goes through the EAGLE V2
+verify scaffold, which runs in TARGET_VERIFY mode.
+"""
+
+from __future__ import annotations
+
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+
+
+class HybridBaselineCudaGraphRunner(DecodeCudaGraphRunner):
+    """CudaGraphRunner for the HYBRID NONE-backend path (K=1)."""
+
+    def __init__(self, model_runner):
+        # K=1 chain has 0 draft steps (bonus only) — keep the capture-time
+        # EagleVerifyInput's spec_steps consistent with its draft_token_num.
+        super().__init__(
+            model_runner, speculative_num_steps=0, speculative_num_draft_tokens=1
+        )
+
+        assert (
+            self.num_tokens_per_bs == 1
+        ), f"baseline runner expected num_tokens_per_bs=1, got {self.num_tokens_per_bs}"

--- a/python/sglang/srt/model_executor/runner/hybrid_short_chain_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/hybrid_short_chain_cuda_graph_runner.py
@@ -1,0 +1,50 @@
+"""CudaGraphRunner for HYBRID_SUFFIX_MTP's MTP-backend path.
+
+Captures TARGET_VERIFY graphs at K = ``speculative_num_steps + 1`` (the EAGLE
+draft-chain width) so the MTP backend runs on a cuda graph instead of falling
+back to eager.
+
+Coexists with two sibling runners that share the same ``model_runner`` and
+``attn_backend`` (only their static input buffers + graph dict are
+per-instance):
+  - main ``decode_cuda_graph_runner`` — K = ``speculative_num_draft_tokens``
+    (the wide SUFFIX chain)
+  - ``hybrid_baseline_cuda_graph_runner`` — K = 1 (NONE path)
+
+``HybridSuffixMTPWorkerV2.verify`` selects the matching runner by setting
+``model_runner.decode_cuda_graph_runner`` to it immediately before the verify
+forward (keyed on ``spec_info.draft_token_num``), then restores the main
+runner afterward — so there is no width-probing dispatch to maintain.
+
+K is set via ``DecodeCudaGraphRunner``'s ``speculative_num_draft_tokens``
+constructor override; ``get_num_tokens_per_bs_for_target_verify`` returns it
+verbatim for the HYBRID plugin algorithm. ``capture_hidden_mode`` is forced to
+FULL automatically because HYBRID reports ``is_eagle()`` True, so the parent's
+``get_spec_info`` takes the EAGLE branch (EagleVerifyInput, FULL hidden mode +
+hidden_states buffer) — the same input the MTP keep-up path needs at replay.
+"""
+
+from __future__ import annotations
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+
+
+class HybridShortChainCudaGraphRunner(DecodeCudaGraphRunner):
+    """CudaGraphRunner for the HYBRID MTP path verify (K = num_steps + 1)."""
+
+    def __init__(self, model_runner):
+        short_k = model_runner.server_args.speculative_num_steps + 1
+        super().__init__(model_runner, speculative_num_draft_tokens=short_k)
+
+        # Sanity-check: parent picked up K=short_k from the ctor override.
+        assert self.num_tokens_per_bs == short_k, (
+            f"short-chain runner expected num_tokens_per_bs={short_k}, "
+            f"got {self.num_tokens_per_bs}"
+        )
+        assert self.capture_forward_mode == ForwardMode.TARGET_VERIFY, (
+            f"short-chain runner expected TARGET_VERIFY mode, "
+            f"got {self.capture_forward_mode}"
+        )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1588,6 +1588,24 @@ class ServerArgs:
         "Fail startup if the tokenized external ngram corpus exceeds this many tokens. Tune this based on your CPU memory budget.",
     ] = 10000000
 
+    # SUFFIX speculative decoding (arctic_inference SuffixDecodingCache)
+    speculative_suffix_max_tree_depth: A[
+        int,
+        "Max depth of the per-request suffix tree for SUFFIX speculative decoding.",
+    ] = 24
+    speculative_suffix_max_cached_requests: A[
+        int,
+        "Max number of finished requests cached in the shared suffix tree for SUFFIX speculative decoding.",
+    ] = 10000
+    speculative_suffix_max_spec_factor: A[
+        float,
+        "SUFFIX max speculation factor: caps draft length relative to the matched suffix score.",
+    ] = 1.0
+    speculative_suffix_min_token_prob: A[
+        float,
+        "SUFFIX minimum per-token probability for a draft token to be proposed.",
+    ] = 0.1
+
     # -------------------------------------------------------------------------
     # Expert parallelism
     # -------------------------------------------------------------------------

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1606,6 +1606,14 @@ class ServerArgs:
         "SUFFIX minimum per-token probability for a draft token to be proposed.",
     ] = 0.1
 
+    # HYBRID_SUFFIX_MTP (per-batch SUFFIX / MTP / NONE dispatch)
+    speculative_hybrid_mtp_always_warm: A[
+        bool,
+        "HYBRID_SUFFIX_MTP: after a SUFFIX-backed step, also run the MTP draft "
+        "keep-up forward so a subsequent MTP-picked step starts with warm draft "
+        "state (extra compute per SUFFIX step; off by default).",
+    ] = False
+
     # -------------------------------------------------------------------------
     # Expert parallelism
     # -------------------------------------------------------------------------

--- a/python/sglang/srt/speculative/__init__.py
+++ b/python/sglang/srt/speculative/__init__.py
@@ -1,0 +1,4 @@
+# Importing this package registers plugin speculative-decoding algorithms.
+# SUFFIX (arctic_inference SuffixDecoding) registers itself on import; the
+# worker / arctic_inference are loaded lazily only when SUFFIX is selected.
+from sglang.srt.speculative import sgl_suffix_plugin  # noqa: F401

--- a/python/sglang/srt/speculative/hybrid_backend_selector.py
+++ b/python/sglang/srt/speculative/hybrid_backend_selector.py
@@ -1,0 +1,480 @@
+"""Per-batch backend selector for HYBRID_SUFFIX_MTP speculative decoding.
+
+HYBRID_SUFFIX_MTP routes each verify batch to one of three backends:
+
+  - **SUFFIX** — arctic suffix-tree draft + EAGLE-style verify.
+    Cheap CPU draft, wide chain (K = ``speculative_num_draft_tokens``,
+    typically 16). Wins when the prompt or output history has repetitive
+    structure the suffix tree can match.
+  - **MTP** — EAGLE V2 draft model + verify. GPU draft, narrow chain
+    (K = ``speculative_num_steps + 1``, typically 4). Wins when SUFFIX
+    has no match but the draft model still produces useful tokens.
+  - **NONE** — plain decode, no spec (K = 1). Wins when the batch is
+    large enough that the extra K tokens of verify steal more time than
+    the accepted drafts save.
+
+Per-batch inputs to ``choose()``:
+
+  - ``suffix_scores`` — per-request SUFFIX peek score (tree match strength).
+  - ``mtp_scores``   — per-request MTP head top-1 probability (free signal,
+    obtained without an extra forward pass).
+
+The selector also maintains an online EMA of realized accept length per
+backend (fed via ``note_accept`` after every step) to detect when SUFFIX
+is paying off relative to MTP, and an ε-exploration knob so SUFFIX runs
+at least ``explore_p`` of the time and its EMA stays fresh.
+
+All thresholds are env-tunable. Defaults are set for DSv4 / GLM-5 on
+H200 with agentic + long-prompt workloads; tune for other hardware.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+from enum import Enum
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+class Backend(Enum):
+    SUFFIX = "SUFFIX"
+    MTP = "MTP"
+    NONE = "NONE"
+
+
+class HybridBackendSelector:
+    """Picks SUFFIX / MTP / NONE per batch.
+
+    Selection rule (default path; overridden by force / debug knobs below):
+
+      1. If no suffix_scores (cold-start / empty batch): pick SUFFIX so
+         the next step's keep-up populates Eagle warm state.
+      2. Compute ``mean_score`` = mean of suffix_scores, ``bs`` = batch size,
+         ``T_high`` = piecewise-linear threshold at this bs (see
+         ``_t_high_for_bs``).
+      3. Tentative tier-1: ``mean_score >= T_high`` → SUFFIX, else → MTP.
+      4. If SUFFIX picked and both EMAs are warm and per-batch score is
+         not overwhelming (< sfx_gate_override), demote to MTP unless
+         ``ema_sfx - ema_mtp >= break_even(bs)``.
+      5. NONE diversion: at ``bs >= NONE_FORCE_BS``, override pick to NONE
+         (large bs saturates GPU; spec verify becomes net-negative).
+         Optional legacy paths (tier-1 score-based + EMA absolute
+         break-even) available below NONE_FORCE_BS, off by default.
+      6. ε-explore: any would-be MTP pick is flipped to SUFFIX with
+         probability ``explore_p`` so ``ema_sfx`` stays fresh.
+
+    Debug knobs (``ARCTIC_HYBRID_SWITCH_DEBUG``):
+
+      ``alternate``         — flip backend every step (hot-switch stress test)
+      ``mtp_first_n=N``     — N MTP steps then SUFFIX (MTP→SUFFIX transition)
+      ``suffix_first_n=N``  — N SUFFIX steps then MTP (SUFFIX→MTP transition)
+
+    Force knob (``ARCTIC_HYBRID_FORCE_BACKEND=SUFFIX|MTP|NONE``) pins one
+    backend for A/B testing.
+
+    Env-tunable thresholds — see ``__init__`` for the full list. Selected
+    ones:
+
+      ARCTIC_HYBRID_T_HIGH_AT_BS{1,16,32}    piecewise SUFFIX-score cutoff
+      ARCTIC_HYBRID_BREAK_EVEN_AT_BS{1,4,16,32}
+                                             EMA Δaccept break-even
+      ARCTIC_HYBRID_NONE_FORCE_BS=N          bs >= N → NONE (saturated GPU)
+      ARCTIC_HYBRID_EMA_ALPHA=0.05           EMA smoothing factor
+      ARCTIC_HYBRID_EXPLORE_P=0.01           ε-explore probability
+      ARCTIC_HYBRID_SFX_GATE_OVERRIDE=5.0    score bypassing EMA gate
+      ARCTIC_HYBRID_MTP_CONF_THRESHOLD=0.6   T_mtp (reserved; not used in
+                                             current rule)
+      ARCTIC_HYBRID_SUFFIX_LOW_THRESHOLD=1.5 T_low (reserved)
+    """
+
+    def __init__(self, server_args: ServerArgs):
+        self.server_args = server_args
+        self._forced = os.environ.get("ARCTIC_HYBRID_FORCE_BACKEND", "").upper()
+        if self._forced and self._forced not in ("SUFFIX", "MTP", "NONE"):
+            logger.warning(
+                "ARCTIC_HYBRID_FORCE_BACKEND=%s ignored (expected SUFFIX|MTP|NONE)",
+                self._forced,
+            )
+            self._forced = ""
+        self._debug_mode = self._parse_debug_mode()
+        self._step = 0
+
+        def _envf(name: str, default: float) -> float:
+            try:
+                return float(os.environ.get(name, str(default)))
+            except ValueError:
+                logger.warning("%s invalid, falling back to %.2f", name, default)
+                return default
+
+        # Piecewise-linear T_high(bs): SUFFIX picked when mean_score >= T_high.
+        # Threshold rises with bs because SUFFIX's wider K verify gets
+        # progressively more expensive vs MTP's narrower K as the batch saturates.
+        self.t_high_at_bs1 = _envf("ARCTIC_HYBRID_T_HIGH_AT_BS1", 2.0)
+        self.t_high_at_bs16 = _envf("ARCTIC_HYBRID_T_HIGH_AT_BS16", 4.5)
+        self.t_high_at_bs32 = _envf("ARCTIC_HYBRID_T_HIGH_AT_BS32", 7.5)
+        logger.info(
+            "HybridBackendSelector T_high anchors: bs1=%.2f bs16=%.2f bs32=%.2f",
+            self.t_high_at_bs1,
+            self.t_high_at_bs16,
+            self.t_high_at_bs32,
+        )
+
+        # Periodic per-step decision logging.
+        self._sel_log_every = max(
+            1, int(os.environ.get("ARCTIC_HYBRID_SELECTOR_LOG_EVERY", "20"))
+        )
+        self._suffix_picks = 0
+        self._mtp_picks = 0
+        self._none_picks = 0
+        self._sfx_override_picks = 0
+        self._sum_mean_score = 0.0
+        self._sum_mean_mtp = 0.0
+        self._mtp_seen = 0
+
+        # EMA-Δaccept gate with ε-exploration.
+        # Tracks realized accept length per backend; SUFFIX is only picked
+        # in the warm state if it has accumulated enough accept advantage
+        # over MTP to clear a bs-dependent break-even (which approximates
+        # the per-step verify-cost ratio).
+        self._ema_alpha = _envf("ARCTIC_HYBRID_EMA_ALPHA", 0.05)
+        self._explore_p = _envf("ARCTIC_HYBRID_EXPLORE_P", 0.01)
+        self._warmup_min_samples = int(_envf("ARCTIC_HYBRID_EMA_WARMUP_N", 3))
+
+        # When the per-batch SUFFIX score is overwhelmingly high, bypass the
+        # EMA gate and pick SUFFIX. EMA is cumulative and can be stale; a
+        # strong per-batch score is fresh and should override. Set <= 0 to
+        # disable.
+        self._sfx_gate_override = _envf("ARCTIC_HYBRID_SFX_GATE_OVERRIDE", 5.0)
+
+        # Piecewise-linear break_even(bs) for the SUFFIX-vs-MTP EMA gate.
+        # Δaccept_EMA (ema_sfx - ema_mtp) must clear this for SUFFIX to be
+        # picked in the warm state. The bs=4 anchor is interpolated between
+        # bs1 and bs16 by default; set it explicitly to add a kink in the
+        # low-bs segment.
+        self.be_at_bs1 = _envf("ARCTIC_HYBRID_BREAK_EVEN_AT_BS1", 2.0)
+        self.be_at_bs16 = _envf("ARCTIC_HYBRID_BREAK_EVEN_AT_BS16", 6.0)
+        self.be_at_bs32 = _envf("ARCTIC_HYBRID_BREAK_EVEN_AT_BS32", 6.0)
+        _be4_default = self.be_at_bs1 + (self.be_at_bs16 - self.be_at_bs1) * 3.0 / 15.0
+        self.be_at_bs4 = _envf("ARCTIC_HYBRID_BREAK_EVEN_AT_BS4", _be4_default)
+        self._ema_sfx_accept = None
+        self._ema_mtp_accept = None
+        self._ema_sfx_n = 0
+        self._ema_mtp_n = 0
+        self._explore_picks = 0
+
+        # NONE diversion — primary rule: simple bs cutoff. At large bs the
+        # batch compute saturates GPU; the extra-K verify of any spec
+        # backend steals work without producing enough accepts to pay back.
+        # The cutoff is a function of model + hardware (not workload).
+        # Set very high (e.g., 10000) to effectively disable NONE.
+        self._none_force_bs = int(_envf("ARCTIC_HYBRID_NONE_FORCE_BS", 64))
+
+        # Per-backend absolute EMA break-evens — secondary, opt-in NONE rule.
+        # After the tier-1/EMA gate picks SUFFIX or MTP, if that backend's
+        # EMA accept length is below its own break-even (verify cost ratio
+        # vs baseline single-token decode), divert to NONE. Different
+        # thresholds because K=32 SUFFIX verify is ~2× the cost of K=4 MTP
+        # verify. Set the relevant threshold to 0 to disable this rule for
+        # that backend.
+        self._none_sfx_at_bs1 = _envf("ARCTIC_HYBRID_NONE_SFX_AT_BS1", 1.0)
+        self._none_sfx_at_bs16 = _envf("ARCTIC_HYBRID_NONE_SFX_AT_BS16", 1.5)
+        self._none_sfx_at_bs32 = _envf("ARCTIC_HYBRID_NONE_SFX_AT_BS32", 2.0)
+        self._none_mtp_at_bs1 = _envf("ARCTIC_HYBRID_NONE_MTP_AT_BS1", 0.5)
+        self._none_mtp_at_bs16 = _envf("ARCTIC_HYBRID_NONE_MTP_AT_BS16", 0.8)
+        self._none_mtp_at_bs32 = _envf("ARCTIC_HYBRID_NONE_MTP_AT_BS32", 1.0)
+
+        # Score-based fast NONE trigger — secondary, opt-in (default off).
+        # When set (both > 0), at bs >= _none_min_bs, if BOTH mean SUFFIX
+        # score < _none_tier1_sfx AND mean MTP confidence < _none_tier1_mtp,
+        # divert to NONE without waiting for EMA warmup.
+        self._none_min_bs = int(_envf("ARCTIC_HYBRID_NONE_MIN_BS", 16))
+        self._none_tier1_sfx = _envf("ARCTIC_HYBRID_NONE_TIER1_SFX", 0.0)
+        self._none_tier1_mtp = _envf("ARCTIC_HYBRID_NONE_TIER1_MTP", 0.0)
+
+        # Single-threshold NONE rule — opt-in (default off). When > 0,
+        # replaces per-backend break-evens with a max(ema_sfx, ema_mtp) <
+        # _t_none check.
+        self._t_none = _envf("ARCTIC_HYBRID_T_NONE", 0.0)
+
+        logger.info(
+            "HybridBackendSelector EMA gate: alpha=%.3f explore_p=%.3f warmup_n=%d "
+            "break_even(SUFFIX-vs-MTP) anchors bs1=%.2f bs4=%.2f bs16=%.2f bs32=%.2f",
+            self._ema_alpha,
+            self._explore_p,
+            self._warmup_min_samples,
+            self.be_at_bs1,
+            self.be_at_bs4,
+            self.be_at_bs16,
+            self.be_at_bs32,
+        )
+        logger.info(
+            "HybridBackendSelector NONE: force_bs=%d (bs>=this → NONE); "
+            "tier-1 sfx=%.2f mtp=%.2f (off if 0); "
+            "per-backend EMA break-even SUFFIX bs1/16/32=%.2f/%.2f/%.2f "
+            "MTP=%.2f/%.2f/%.2f; t_none=%.2f min_bs=%d",
+            self._none_force_bs,
+            self._none_tier1_sfx,
+            self._none_tier1_mtp,
+            self._none_sfx_at_bs1,
+            self._none_sfx_at_bs16,
+            self._none_sfx_at_bs32,
+            self._none_mtp_at_bs1,
+            self._none_mtp_at_bs16,
+            self._none_mtp_at_bs32,
+            self._t_none,
+            self._none_min_bs,
+        )
+
+    def note_accept(self, backend, mean_accept):
+        """Update the per-backend EMA of realized accept length. Called by
+        the worker after each decode step (accept_lens is already
+        materialized on CPU via the step's mandatory sync — free signal).
+
+        NONE picks are intentionally not recorded: accept_len is trivially
+        1, and feeding NONE outcomes into the SUFFIX/MTP EMAs would make
+        NONE self-reinforcing.
+        """
+        a = self._ema_alpha
+        if backend == Backend.SUFFIX:
+            self._ema_sfx_accept = (
+                mean_accept
+                if self._ema_sfx_accept is None
+                else (1 - a) * self._ema_sfx_accept + a * mean_accept
+            )
+            self._ema_sfx_n += 1
+        elif backend == Backend.MTP:
+            self._ema_mtp_accept = (
+                mean_accept
+                if self._ema_mtp_accept is None
+                else (1 - a) * self._ema_mtp_accept + a * mean_accept
+            )
+            self._ema_mtp_n += 1
+
+    def _none_threshold_sfx(self, bs: int) -> float:
+        """SUFFIX absolute EMA break-even (floor below which SUFFIX is
+        net-negative vs baseline at this bs). Piecewise-linear through
+        ``(1, _none_sfx_at_bs1)``, ``(16, _none_sfx_at_bs16)``,
+        ``(32, _none_sfx_at_bs32)``; extrapolates the (16, 32) slope past 32.
+        """
+        if bs <= 1:
+            return self._none_sfx_at_bs1
+        if bs <= 16:
+            return (
+                self._none_sfx_at_bs1
+                + (self._none_sfx_at_bs16 - self._none_sfx_at_bs1) * (bs - 1) / 15.0
+            )
+        slope_hi = (self._none_sfx_at_bs32 - self._none_sfx_at_bs16) / 16.0
+        return self._none_sfx_at_bs16 + slope_hi * (bs - 16)
+
+    def _none_threshold_mtp(self, bs: int) -> float:
+        """MTP absolute EMA break-even. Lower than SUFFIX's because K=4
+        verify is cheaper than K=32. Piecewise-linear through the same bs
+        anchors as ``_none_threshold_sfx``."""
+        if bs <= 1:
+            return self._none_mtp_at_bs1
+        if bs <= 16:
+            return (
+                self._none_mtp_at_bs1
+                + (self._none_mtp_at_bs16 - self._none_mtp_at_bs1) * (bs - 1) / 15.0
+            )
+        slope_hi = (self._none_mtp_at_bs32 - self._none_mtp_at_bs16) / 16.0
+        return self._none_mtp_at_bs16 + slope_hi * (bs - 16)
+
+    def _break_even_for_bs(self, bs: int) -> float:
+        """Piecewise-linear break_even(bs) through ``(1, be_at_bs1)``,
+        ``(4, be_at_bs4)``, ``(16, be_at_bs16)``, ``(32, be_at_bs32)``.
+        ``ema_sfx - ema_mtp`` must clear this for SUFFIX to be picked in
+        the warm state. The bs=4 anchor decouples low-bs from mid-bs so a
+        steeper low-bs segment can suppress marginal SUFFIX picks at
+        bs∈[1, 4] without affecting bs=8+ behavior."""
+        if bs <= 1:
+            return self.be_at_bs1
+        if bs <= 4:
+            return self.be_at_bs1 + (self.be_at_bs4 - self.be_at_bs1) * (bs - 1) / 3.0
+        if bs <= 16:
+            return self.be_at_bs4 + (self.be_at_bs16 - self.be_at_bs4) * (bs - 4) / 12.0
+        slope_hi = (self.be_at_bs32 - self.be_at_bs16) / 16.0
+        return self.be_at_bs16 + slope_hi * (bs - 16)
+
+    def _t_high_for_bs(self, bs: int) -> float:
+        """Piecewise-linear T_high(bs) through ``(1, t_high_at_bs1)``,
+        ``(16, t_high_at_bs16)``, ``(32, t_high_at_bs32)``; extrapolates
+        the (16, 32) slope past 32."""
+        if bs <= 1:
+            return self.t_high_at_bs1
+        if bs <= 16:
+            return (
+                self.t_high_at_bs1
+                + (self.t_high_at_bs16 - self.t_high_at_bs1) * (bs - 1) / 15.0
+            )
+        slope_hi = (self.t_high_at_bs32 - self.t_high_at_bs16) / 16.0
+        return self.t_high_at_bs16 + slope_hi * (bs - 16)
+
+    def _parse_debug_mode(self):
+        raw = os.environ.get("ARCTIC_HYBRID_SWITCH_DEBUG", "").strip()
+        if not raw:
+            return None
+        if raw == "alternate":
+            return ("alternate", None)
+        for prefix, who in (
+            ("mtp_first_n=", Backend.MTP),
+            ("suffix_first_n=", Backend.SUFFIX),
+        ):
+            if raw.startswith(prefix):
+                try:
+                    n = int(raw[len(prefix) :])
+                    return (prefix.rstrip("="), (who, n))
+                except ValueError:
+                    pass
+        logger.warning("ARCTIC_HYBRID_SWITCH_DEBUG=%s unrecognized", raw)
+        return None
+
+    def choose(
+        self,
+        batch: ScheduleBatch,
+        suffix_scores: Optional[List[float]] = None,
+        mtp_scores: Optional[List[float]] = None,
+    ) -> Backend:
+        if self._forced == "MTP":
+            return Backend.MTP
+        if self._forced == "SUFFIX":
+            return Backend.SUFFIX
+        if self._forced == "NONE":
+            return Backend.NONE
+        if self._debug_mode is not None:
+            mode, payload = self._debug_mode
+            step, self._step = self._step, self._step + 1
+            if mode == "alternate":
+                return Backend.MTP if (step % 2) else Backend.SUFFIX
+            if mode in ("mtp_first_n", "suffix_first_n"):
+                who, n = payload
+                other = Backend.SUFFIX if who == Backend.MTP else Backend.MTP
+                return who if step < n else other
+
+        if not suffix_scores:
+            # Cold-start / empty batch: no useful peek — pick SUFFIX so the
+            # next step's keep-up fires (Eagle warm-up).
+            return Backend.SUFFIX
+        mean_score = sum(suffix_scores) / len(suffix_scores)
+        mean_mtp = sum(mtp_scores) / len(mtp_scores) if mtp_scores else None
+        bs = len(suffix_scores)
+        t_high = self._t_high_for_bs(bs)
+
+        # Tier-1 + EMA gate. SUFFIX requires mean_score >= T_high; once both
+        # EMAs are warm, additionally requires ema_sfx - ema_mtp >=
+        # break_even(bs) unless the per-batch score is overwhelmingly high.
+        warmed = (
+            self._ema_sfx_accept is not None
+            and self._ema_mtp_accept is not None
+            and self._ema_sfx_n >= self._warmup_min_samples
+            and self._ema_mtp_n >= self._warmup_min_samples
+        )
+        if mean_score >= t_high:
+            if not warmed:
+                tentative = Backend.SUFFIX
+            elif self._sfx_gate_override > 0 and mean_score >= self._sfx_gate_override:
+                tentative = Backend.SUFFIX
+                self._sfx_override_picks = getattr(self, "_sfx_override_picks", 0) + 1
+            else:
+                delta = self._ema_sfx_accept - self._ema_mtp_accept
+                tentative = (
+                    Backend.SUFFIX
+                    if delta >= self._break_even_for_bs(bs)
+                    else Backend.MTP
+                )
+        else:
+            tentative = Backend.MTP
+
+        # NONE diversion.
+        #   Primary: bs >= _none_force_bs → NONE.
+        #   Below that, optional secondary rules below _none_min_bs only fire
+        #   when explicitly enabled (their thresholds > 0).
+        pick = tentative
+        if bs >= self._none_force_bs:
+            pick = Backend.NONE
+        elif bs >= self._none_min_bs:
+            if (
+                self._none_tier1_sfx > 0
+                and self._none_tier1_mtp > 0
+                and mean_score < self._none_tier1_sfx
+                and mean_mtp is not None
+                and mean_mtp < self._none_tier1_mtp
+            ):
+                pick = Backend.NONE
+            elif warmed and self._t_none == 0:
+                if tentative == Backend.SUFFIX:
+                    sfx_be = self._none_threshold_sfx(bs)
+                    if sfx_be > 0 and self._ema_sfx_accept < sfx_be:
+                        pick = Backend.NONE
+                else:
+                    mtp_be = self._none_threshold_mtp(bs)
+                    if mtp_be > 0 and self._ema_mtp_accept < mtp_be:
+                        pick = Backend.NONE
+            elif self._t_none > 0 and warmed and mean_score < t_high:
+                if max(self._ema_sfx_accept, self._ema_mtp_accept) < self._t_none:
+                    pick = Backend.NONE
+
+        if pick == Backend.MTP and random.random() < self._explore_p:
+            pick = Backend.SUFFIX
+            self._explore_picks += 1
+
+        # Per-step counters for periodic logging.
+        self._step += 1
+        self._sum_mean_score += mean_score
+        if mean_mtp is not None:
+            self._sum_mean_mtp += mean_mtp
+            self._mtp_seen += 1
+        if pick == Backend.SUFFIX:
+            self._suffix_picks += 1
+        elif pick == Backend.MTP:
+            self._mtp_picks += 1
+        else:
+            self._none_picks += 1
+        if self._step % self._sel_log_every == 0:
+            tot = self._suffix_picks + self._mtp_picks + self._none_picks
+            avg_score = self._sum_mean_score / tot if tot else 0.0
+            avg_mtp = (
+                self._sum_mean_mtp / self._mtp_seen if self._mtp_seen else float("nan")
+            )
+            ema_sfx_str = (
+                f"{self._ema_sfx_accept:.2f}"
+                if self._ema_sfx_accept is not None
+                else "n/a"
+            )
+            ema_mtp_str = (
+                f"{self._ema_mtp_accept:.2f}"
+                if self._ema_mtp_accept is not None
+                else "n/a"
+            )
+            logger.info(
+                "[HYBRID_SELECTOR] step=%d bs=%d T_high=%.2f sfx=%.2f mtp=%.2f pick=%s | "
+                "since-start: suffix=%d (%.1f%%) mtp=%d (%.1f%%) none=%d (%.1f%%) "
+                "avg_sfx_score=%.2f avg_mtp_score=%.2f ema_sfx=%s ema_mtp=%s "
+                "sfx_override=%d (%.1f%%)",
+                self._step,
+                bs,
+                t_high,
+                mean_score,
+                mean_mtp if mean_mtp is not None else float("nan"),
+                pick.value,
+                self._suffix_picks,
+                100.0 * self._suffix_picks / max(1, tot),
+                self._mtp_picks,
+                100.0 * self._mtp_picks / max(1, tot),
+                self._none_picks,
+                100.0 * self._none_picks / max(1, tot),
+                avg_score,
+                avg_mtp,
+                ema_sfx_str,
+                ema_mtp_str,
+                self._sfx_override_picks,
+                100.0 * self._sfx_override_picks / max(1, self._suffix_picks),
+            )
+        return pick

--- a/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
@@ -1,0 +1,832 @@
+"""HybridSuffixMTPWorkerV2 — V2-API HYBRID worker (overlap scheduling).
+
+Subclasses ``EAGLEWorkerV2`` and dispatches each batch among three
+backends decided by ``HybridBackendSelector``:
+
+  - **SUFFIX** — arctic suffix-tree draft + EAGLE-style verify at
+    ``K = speculative_num_draft_tokens``. Followed by an optional MTP
+    keep-up forward (under ``--speculative-hybrid-mtp-always-warm``) so a
+    later MTP-picked step starts with warm draft state.
+  - **MTP** — standard EAGLE V2 draft + verify (delegated to ``super``),
+    ``K = speculative_num_steps + 1``.
+  - **NONE** — plain target decode, no spec, ``K = 1``.
+
+All three backends produce different verify input widths; dispatch to
+three captured cuda graphs (main K_suffix, short_chain K_mtp, baseline
+K=1) is handled transparently by ``ModelRunner._forward_raw`` via each
+runner's width-based ``can_run``.
+
+SUFFIX backend per-step flow:
+  1. Pull current tokens per req (``req.origin_input_ids +
+     req.output_ids``). In overlap mode this lags realized accepts by
+     <= 1 step, which is corrected by the post-verify push below.
+  2. Update arctic with the delta tokens; query for K-1 spec tokens per req.
+  3. Build an ``EagleVerifyInput`` at K (linear chain, FULL hidden mode).
+  4. Run ``self.verify(mwb)``.
+  5. Post-verify: read realized ``accept_lens`` + accepted token ids from
+     the batch result and push them back into arctic so the next peek
+     reflects exact history (not the overlap-lagged ``req.output_ids``).
+  6. Optionally fire ``_draft_extend_for_decode`` for MTP keep-up.
+
+A V1 variant is intentionally not provided: SUFFIX V1's NGRAMWorker
+subclass cannot live under the overlap scheduler, so a V1-only hybrid
+has no upside.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable, Dict, List, Optional
+
+import torch
+
+from sglang.srt.layers.moe.utils import (
+    speculative_moe_a2a_backend_context,
+    speculative_moe_backend_context,
+)
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.eagle_worker_v2 import EAGLEWorkerV2
+from sglang.srt.speculative.hybrid_backend_selector import (
+    Backend,
+    HybridBackendSelector,
+)
+from sglang.srt.speculative.suffix_v2_draft_builder_full import SuffixV2DraftBuilder
+from sglang.srt.speculative.suffix_v2_verify_input import (
+    build_suffix_v2_eagle_verify_input,
+)
+
+
+class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        attn_cp_rank: int,
+        moe_dp_rank: int,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        # Unlock K_suffix > K_mtp.
+        #
+        # The launch passes --speculative-num-draft-tokens K_suffix (the
+        # wide SUFFIX chain, typically 16). EAGLE V2's draft_forward calls
+        # torch.topk(score_list, K - 1) where score_list has num_steps × topk
+        # columns, so K - 1 must be <= num_steps × topk (= num_steps for the
+        # typical topk=1). Letting super().__init__ see K_suffix directly
+        # would crash the draft cuda graph capture with "selected index k
+        # out of range".
+        #
+        # Workaround: temporarily lower speculative_num_draft_tokens to
+        # K_mtp = num_steps + 1 for the duration of super().__init__. The
+        # main target cuda graph runner was already captured BEFORE
+        # maybe_init_draft_worker at the real K_suffix (sglang init order:
+        # model_runner.init_device_graphs → maybe_init_draft_worker), so we
+        # keep that one. The *draft* cuda graph (EagleDraftCudaGraphRunner)
+        # is captured INSIDE super().__init__ at the temporary K_mtp,
+        # satisfying the topk invariant. After super returns, restore
+        # K_suffix for our SUFFIX verify input construction.
+        K_suffix = server_args.speculative_num_draft_tokens
+        K_mtp = server_args.speculative_num_steps + 1
+        assert K_suffix >= 2 and K_mtp >= 2
+        if K_suffix != K_mtp:
+            server_args.speculative_num_draft_tokens = K_mtp
+        try:
+            super().__init__(
+                server_args=server_args,
+                gpu_id=gpu_id,
+                tp_rank=tp_rank,
+                dp_rank=dp_rank,
+                moe_ep_rank=moe_ep_rank,
+                attn_cp_rank=attn_cp_rank,
+                moe_dp_rank=moe_dp_rank,
+                nccl_port=nccl_port,
+                target_worker=target_worker,
+            )
+        finally:
+            if K_suffix != K_mtp:
+                server_args.speculative_num_draft_tokens = K_suffix
+
+        # Two chain widths. SUFFIX path uses K_suffix (matches main cuda
+        # graph); MTP path uses self.speculative_num_draft_tokens (set by
+        # super to K_mtp).
+        self.K_suffix: int = K_suffix
+        self.K_mtp: int = K_mtp
+        # Aliases for code paths that read self.K.
+        self.K = K_suffix
+        self.K_minus_1 = K_suffix - 1
+
+        # Model context length — used to cap each req's SUFFIX draft chain so
+        # the verify step can't overshoot ctx_len and produce an overlap-
+        # schedule zombie verify (which manifests as NSA page-table OOB at
+        # the attention backend).
+        self._max_context_len = int(target_worker.model_runner.model_config.context_len)
+
+        # PD prefill instance: the MTP/EAGLE side stays fully alive (its draft
+        # extend produces the draft KV that PD transfers to the decode
+        # instance), but the SUFFIX side never speculates there — skip the
+        # arctic backend (no warmup load, no prompt-tree builds).
+        self._is_disagg_prefill = server_args.disaggregation_mode == "prefill"
+
+        # SUFFIX-side state (mirrors SuffixWorkerV2).
+        self.suffix_draft_builder = (
+            None
+            if self._is_disagg_prefill
+            else SuffixV2DraftBuilder(
+                max_cached_requests=server_args.speculative_suffix_max_cached_requests,
+                max_tree_depth=server_args.speculative_suffix_max_tree_depth,
+                max_spec_factor=server_args.speculative_suffix_max_spec_factor,
+                min_token_prob=server_args.speculative_suffix_min_token_prob,
+            )
+        )
+
+        # PD decode instance: prebuilt requests pending suffix-tree prewarm
+        # (rid -> Req); see prewarm_disagg_requests / prewarm_step.
+        self._prewarm_pending: Dict[str, object] = {}
+        self._req_tokens: Dict[str, List[int]] = {}
+        self._pending_accepted: Dict[str, List[int]] = {}
+        self._step_idx: int = 0
+        self._rid_last_seen: Dict[str, int] = {}
+        self._gc_epoch_threshold: int = 256
+
+        # Deferred CPU work — same pattern as SuffixWorkerV2. Populated by
+        # the SUFFIX path; MTP path stays managed by EAGLEWorkerV2 internals
+        # (its own delay_sample_func mechanism).
+        self._deferred: Optional[Callable[[], None]] = None
+
+        # Per-batch backend chooser (SUFFIX / MTP / NONE). Self-contained —
+        # only needs server_args, and choose() infers bs from len(suffix_scores).
+        # ARCTIC_HYBRID_FORCE_BACKEND env var pins one backend for A/B testing.
+        self.selector = HybridBackendSelector(server_args)
+
+        # Cache of the current step's arctic query, populated by
+        # _peek_suffix_scores and consumed by _decode_step_suffix to avoid
+        # a second arctic query when SUFFIX is picked.
+        # Layout: (step_idx, draft_tokens, draft_lens, valid_mask, bonus_cpu, current_tokens_list)
+        self._cached_suffix_drafts = None
+
+        # Debug
+        import os as _os
+
+        self._debug = _os.environ.get("HYBRID_V2_DEBUG", "0") == "1"
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def clear_cache_pool(self):
+        # Drain deferred so closure-held GPU refs release before reset.
+        self._drain_deferred()
+        for rid in list(self._req_tokens.keys()):
+            self.suffix_draft_builder.stop_request(rid)
+        self._req_tokens.clear()
+        self._pending_accepted.clear()
+        self._rid_last_seen.clear()
+        # Parent's allocator/pool is shared with target; scheduler resets it.
+
+    def _drain_deferred(self) -> None:
+        if self._deferred is not None:
+            commit, self._deferred = self._deferred, None
+            commit()
+
+    # ------------------------------------------------------------------
+    # Main entry
+    # ------------------------------------------------------------------
+    def forward_batch_generation(
+        self, mwb: ScheduleBatch, on_publish=None
+    ) -> GenerationBatchResult:
+        self._step_idx += 1
+        self._drain_deferred()
+
+        if mwb.forward_mode.is_idle():
+            # Just punt to EAGLE V2's idle handling (it fires on_publish).
+            return super().forward_batch_generation(mwb, on_publish)
+
+        if mwb.forward_mode.is_extend() or mwb.is_extend_in_batch:
+            # EAGLE V2 extend = target prefill + MTP draft prefill. Drives MTP
+            # state forward; SUFFIX side just needs the prompt registered.
+            # Parent fires on_publish at the target-end fence.
+            result = super().forward_batch_generation(mwb, on_publish)
+            # Init arctic for any new rid (cheap; skipped for known rids).
+            # PD prefill instance: no arctic backend (decode side rebuilds).
+            if not self._is_disagg_prefill:
+                self._initialize_new_reqs(mwb)
+            # Tag last_seen for epoch GC.
+            if mwb.reqs:
+                for req in mwb.reqs:
+                    self._rid_last_seen[req.rid] = self._step_idx
+            return result
+
+        # DECODE
+        if mwb.reqs:
+            for req in mwb.reqs:
+                self._rid_last_seen[req.rid] = self._step_idx
+            if self._req_tokens:
+                self._gc_stale_rids()
+        # PD decode instance: cold-start / prewarm-sync prebuilt requests
+        # (no extend step ran here to initialize the suffix side).
+        self._reconcile_disagg_reqs(mwb)
+
+        # Peek SUFFIX + MTP scores, let selector choose backend. The peek is
+        # side-effecting on arctic (start_request / add_active_response) so
+        # the SUFFIX tree stays warm even on MTP-picked steps.
+        use_scores = self._selector_uses_scores()
+        # Diagnostic: at peek time, compare token-delta-pushed-to-arctic
+        # against last step's actual accept_len. If delta < accept_len, the
+        # bonus-append context fix is missing some accepted tokens (V2
+        # overlap output_ids lag) — that under-feeds arctic tree and biases
+        # ema_sfx low even when warmup data exists.
+        if os.environ.get("HYBRID_V2_ARCTIC_DELTA_PROBE") and mwb.reqs:
+            _last_acc = getattr(self, "_last_accept_per_rid", {})
+            for req in mwb.reqs:
+                rid = req.rid
+                prev_len = len(self._req_tokens.get(rid, []))
+                new_len = (
+                    len(req.origin_input_ids)
+                    + len(req.output_ids)
+                    + (
+                        1
+                        if mwb.spec_info is not None
+                        and hasattr(mwb.spec_info, "bonus_tokens")
+                        else 0
+                    )
+                )
+                delta = new_len - prev_len
+                last_acc = _last_acc.get(rid, None)
+                if last_acc is not None and self._step_idx % 50 == 0:
+                    logging.getLogger("sglang.spec.hybrid_v2").info(
+                        "[ARCTIC_DELTA_PROBE] step=%d rid=%s delta=%d "
+                        "last_accept_len=%.2f shortfall=%s",
+                        self._step_idx,
+                        str(rid)[-6:],
+                        delta,
+                        last_acc,
+                        max(0, last_acc - delta),
+                    )
+        suffix_scores = self._peek_suffix_scores(mwb) if use_scores else None
+        mtp_scores = self._peek_mtp_scores(mwb) if use_scores else None
+        backend = self.selector.choose(
+            mwb,
+            suffix_scores=suffix_scores,
+            mtp_scores=mtp_scores,
+        )
+
+        # Cold-start: arrival-time decoder may have spec_info that isn't an
+        # EagleDraftInput (e.g., after filter/restart). MTP needs warm
+        # EagleDraftInput on mwb.spec_info; promote to SUFFIX if absent.
+        if backend == Backend.MTP and not isinstance(mwb.spec_info, EagleDraftInput):
+            backend = Backend.SUFFIX
+
+        if backend == Backend.SUFFIX:
+            result = self._decode_step_suffix(mwb, on_publish)
+        elif backend == Backend.MTP:
+            # Parent fires on_publish at its verify-end fence.
+            result = super().forward_batch_generation(mwb, on_publish)
+        elif backend == Backend.NONE:
+            result = self._decode_step_none(mwb, on_publish)
+        else:
+            raise AssertionError(f"unknown backend {backend!r}")
+
+        # Post-verify: push actual accepted tokens to arctic tree. Fixes the
+        # bonus-only feedback bug — under V2 overlap, req.output_ids lags so
+        # appending only the bonus to peek context misses (accept_len - 1)
+        # spec-accepted tokens per step. Read them straight from result.
+        K_used = (
+            self.K_suffix
+            if backend == Backend.SUFFIX
+            else (self.K_mtp if backend == Backend.MTP else 1)
+        )
+        if (
+            result is not None
+            and result.accept_lens is not None
+            and result.next_token_ids is not None
+            and backend in (Backend.SUFFIX, Backend.MTP)
+            and mwb.reqs
+        ):
+            try:
+                accept_cpu = result.accept_lens.cpu().tolist()
+                # predict tensor is flat (bs * K,) — chunk by K per req.
+                predict_cpu = result.next_token_ids.cpu().tolist()
+                for i, req in enumerate(mwb.reqs):
+                    rid = req.rid
+                    a = int(accept_cpu[i])
+                    if a <= 0 or rid not in self._req_tokens:
+                        continue
+                    new_tokens = predict_cpu[i * K_used : i * K_used + a]
+                    self._req_tokens[rid].extend(int(t) for t in new_tokens)
+                    self.suffix_draft_builder.update_with_accepted(
+                        rid, self._req_tokens[rid]
+                    )
+
+                # Update selector EMA with mean accept length.
+                if accept_cpu:
+                    self.selector.note_accept(
+                        backend, sum(accept_cpu) / len(accept_cpu)
+                    )
+                    if os.environ.get("HYBRID_V2_ARCTIC_DELTA_PROBE"):
+                        if not hasattr(self, "_last_accept_per_rid"):
+                            self._last_accept_per_rid = {}
+                        for req, a in zip(mwb.reqs, accept_cpu):
+                            self._last_accept_per_rid[req.rid] = a
+            except Exception as e:
+                logging.getLogger("sglang.spec.hybrid_v2").warning(
+                    "[HYBRID_V2_POST_VERIFY] push failed: %s", e
+                )
+        elif (
+            result is not None
+            and result.accept_lens is not None
+            and backend == Backend.NONE
+        ):
+            # NONE path: K=1, only bonus generated. Still update arctic so
+            # tree reflects every generated token.
+            try:
+                accept_cpu = result.accept_lens.cpu().tolist()
+                predict_cpu = (
+                    result.next_token_ids.cpu().tolist()
+                    if result.next_token_ids is not None
+                    else None
+                )
+                if predict_cpu is not None:
+                    for i, req in enumerate(mwb.reqs):
+                        rid = req.rid
+                        if rid not in self._req_tokens:
+                            continue
+                        self._req_tokens[rid].append(int(predict_cpu[i]))
+                        self.suffix_draft_builder.update_with_accepted(
+                            rid, self._req_tokens[rid]
+                        )
+            except Exception:
+                pass
+
+        return result
+
+    def _selector_uses_scores(self) -> bool:
+        """Mirror V1's check — skip the peek when force/debug knobs short-circuit
+        the choice anyway."""
+        s = self.selector
+        return not (
+            getattr(s, "_forced", "") or getattr(s, "_debug_mode", None) is not None
+        )
+
+    def _peek_suffix_scores(self, mwb: ScheduleBatch) -> List[float]:
+        """Per-req arctic-suffix-tree speculation score.
+
+        Side effects (idempotent, matches V1):
+          - register any new rid with arctic (start_request)
+          - push delta tokens (origin + output + bonus) since last sighting
+          - run arctic.speculate to populate the per-req draft + score
+
+        We also stash the just-queried drafts on `self._cached_suffix_drafts`
+        keyed by step_idx so _decode_step_suffix can reuse them WITHOUT a
+        second arctic call (saves arctic CPU work on SUFFIX-picked steps).
+        """
+        rids = [req.rid for req in mwb.reqs]
+        if not rids:
+            self._cached_suffix_drafts = None
+            return []
+
+        # Context: use self._req_tokens[rid] as the authoritative token
+        # history. Post-verify hook keeps it in sync with actually-generated
+        # tokens (predict[accept_index]), avoiding the V2 overlap output_ids
+        # lag that loses (accept_len-1) tokens per step. On cold start, init
+        # from req.origin_input_ids + req.output_ids (prefill state).
+        bonus_cpu = mwb.spec_info.bonus_tokens.cpu().tolist()
+        current_tokens_list: List[List[int]] = []
+        for req, b in zip(mwb.reqs, bonus_cpu):
+            rid = req.rid
+            if rid not in self._req_tokens:
+                # Cold-start: prefill leaves output_ids = [first_token] which
+                # equals this peek's bonus. Use bonus to avoid double-counting.
+                init_tokens = list(req.origin_input_ids) + list(req.output_ids)
+                # If output_ids doesn't yet contain the bonus, append it.
+                if not init_tokens or init_tokens[-1] != int(b):
+                    init_tokens.append(int(b))
+                self.suffix_draft_builder.start_request(rid, init_tokens)
+                self._req_tokens[rid] = init_tokens
+            current_tokens_list.append(self._req_tokens[rid])
+
+        # Per-req draft cap: ctx_len - cur_seq_len - 1 prevents zombie verify
+        # at context boundary (see SuffixWorkerV2 for rationale).
+        seq_lens_list = mwb.seq_lens.cpu().tolist()
+        max_remaining = [max(0, self._max_context_len - sl - 1) for sl in seq_lens_list]
+        draft_tokens, draft_lens, valid_mask, scores = (
+            self.suffix_draft_builder.query_batch(
+                rids=rids,
+                current_tokens=current_tokens_list,
+                K_minus_1=self.K_suffix - 1,
+                device=self.device,
+                return_scores=True,
+                max_remaining_per_req=max_remaining,
+            )
+        )
+        # Stash for _decode_step_suffix's reuse.
+        self._cached_suffix_drafts = (
+            self._step_idx,
+            draft_tokens,
+            draft_lens,
+            valid_mask,
+            bonus_cpu,
+            current_tokens_list,
+        )
+        return scores
+
+    def _peek_mtp_scores(self, mwb: ScheduleBatch) -> Optional[List[float]]:
+        """Read MTP's confidence for the next draft token from prev step's
+        EagleDraftInput.topk_p[:, 0]. Free byproduct of EAGLE V2's keep-up;
+        cost is one [bs]-float D2H copy.
+
+        Returns None on cold-start (no warm Eagle state) — selector treats
+        that as 'no MTP confidence'.
+        """
+        spec_info = mwb.spec_info
+        if not isinstance(spec_info, EagleDraftInput):
+            return None
+        tp = getattr(spec_info, "topk_p", None)
+        if tp is None or tp.numel() == 0 or tp.ndim < 2:
+            return None
+        try:
+            col0 = tp[:, 0].detach().cpu().tolist()
+        except Exception:
+            return None
+        return col0
+
+    # ------------------------------------------------------------------
+    # SUFFIX backend
+    # ------------------------------------------------------------------
+    def _decode_step_suffix(
+        self, mwb: ScheduleBatch, on_publish=None
+    ) -> GenerationBatchResult:
+        """SUFFIX target verify with optional MTP keep-up.
+
+        Builds an EagleVerifyInput from the arctic suffix tree (linear chain
+        at K), runs the EAGLE V2 verify scaffold, then optionally fires MTP
+        keep-up to populate next_draft_input.topk_p/hidden_states so a
+        subsequent MTP step has warm state.
+
+        on_publish (overlap fence) fires right after verify, BEFORE the MTP
+        keep-up — same placement as EAGLEWorkerV2 (publish before its
+        draft-extend tail) so the scheduler can prepare the next batch while
+        keep-up runs.
+
+        Tokens-context: read req.origin_input_ids + req.output_ids each call.
+        In overlap mode this lags realized accepts by <= 1 step; the
+        post-verify hook in forward_batch_generation pushes the missing
+        accept_lens-1 tokens back into arctic to keep the tree exact.
+        """
+        rids = [req.rid for req in mwb.reqs]
+        bs = len(rids)
+
+        # Reuse drafts from _peek_suffix_scores if this step already queried
+        # arctic. Else do the full peek inline (used when selector is in
+        # force/debug mode and skipped the peek phase).
+        cached = self._cached_suffix_drafts
+        if cached is not None and cached[0] == self._step_idx:
+            _, draft_tokens, draft_lens, valid_mask, bonus_cpu, current_tokens_list = (
+                cached
+            )
+            self._cached_suffix_drafts = None  # consume
+        else:
+            # FORCE mode bypassed peek. Use authoritative _req_tokens (kept
+            # in sync by post-verify hook). Cold-start init same as peek.
+            bonus_cpu = mwb.spec_info.bonus_tokens.cpu().tolist()
+            current_tokens_list = []
+            for req, b in zip(mwb.reqs, bonus_cpu):
+                rid = req.rid
+                if rid not in self._req_tokens:
+                    init_tokens = list(req.origin_input_ids) + list(req.output_ids)
+                    if not init_tokens or init_tokens[-1] != int(b):
+                        init_tokens.append(int(b))
+                    self.suffix_draft_builder.start_request(rid, init_tokens)
+                    self._req_tokens[rid] = init_tokens
+                current_tokens_list.append(self._req_tokens[rid])
+            # Per-req draft cap to prevent zombie verify at context boundary.
+            seq_lens_list = mwb.seq_lens.cpu().tolist()
+            max_remaining = [
+                max(0, self._max_context_len - sl - 1) for sl in seq_lens_list
+            ]
+            draft_tokens, draft_lens, valid_mask = (
+                self.suffix_draft_builder.query_batch(
+                    rids=rids,
+                    current_tokens=current_tokens_list,
+                    K_minus_1=self.K_minus_1,
+                    device=self.device,
+                    max_remaining_per_req=max_remaining,
+                )
+            )
+
+        if self._debug and self._step_idx % 10 == 0:
+            import logging
+
+            logger = logging.getLogger("sglang.spec.hybrid_v2")
+            bonus_cpu = mwb.spec_info.bonus_tokens.cpu().tolist()
+            drafts_cpu = draft_tokens.cpu().tolist()
+            last_tokens = [t[-5:] for t in current_tokens_list[:2]]
+            logger.info(
+                "[HYBRID_V2_SUFFIX] step=%d bs=%d K=%d ctx_lens=%s draft_lens=%s "
+                "bonus=%s drafts[0]=%s ctx_tail=%s arctic_active=%d",
+                self._step_idx,
+                bs,
+                self.K,
+                [len(t) for t in current_tokens_list],
+                draft_lens.cpu().tolist(),
+                bonus_cpu[:4],
+                drafts_cpu[0] if drafts_cpu else None,
+                last_tokens,
+                len(self.suffix_draft_builder.cache.active_requests),
+            )
+
+        # 3. Build EagleVerifyInput. capture_hidden_mode=FULL so the target
+        #    forward emits hidden_states for the MTP keep-up.
+        bonus_tokens = mwb.spec_info.bonus_tokens
+        verify_input = build_suffix_v2_eagle_verify_input(
+            bonus_tokens=bonus_tokens,
+            suffix_draft_tokens=draft_tokens,
+            seq_lens=mwb.seq_lens,
+            seq_lens_cpu=mwb.seq_lens_cpu,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+        )
+        mwb.spec_info = verify_input
+
+        # 4. Run EAGLE V2's verify scaffold (handles prepare_for_v2_verify,
+        #    target forward, sample, fill_bonus_tokens, next_draft_input).
+        batch_output = self.verify(mwb)
+        # Overlap fence at verify-end, before the keep-up tail (mirrors
+        # EAGLEWorkerV2's publish before draft-extend).
+        if on_publish is not None and batch_output.new_seq_lens is not None:
+            on_publish(batch_output.new_seq_lens)
+
+        # 5. MTP keep-up. V2 path: slice predict/hidden/out_cache_loc to
+        # K_target per req, call super's _draft_extend_for_decode which
+        # uses uniform K_target chains. V1's variable-length flat-accept
+        # approach doesn't fit V2's DSv4 kernel signatures (the fused
+        # K-norm-rope kernel binds B from kv.size(0) and requires positions /
+        # out_loc to share that B).
+        self._run_keepup_after_suffix_v2(mwb, batch_output)
+        ndi = batch_output.next_draft_input
+        if ndi.topk_p is None:
+            # Fallback: keep-up didn't run or failed silently. Fill placeholder
+            # zeros for FutureMap.
+            bs_actual = int(ndi.bonus_tokens.numel())
+            ndi.topk_p = torch.zeros(
+                (bs_actual, 1), device=self.device, dtype=torch.float32
+            )
+            ndi.topk_index = torch.zeros(
+                (bs_actual, 1), device=self.device, dtype=torch.int64
+            )
+        if ndi.hidden_states is None:
+            target_hidden = batch_output.logits_output.hidden_states
+            if target_hidden is None:
+                # Defensive: shouldn't happen with FULL capture_hidden_mode.
+                hidden_dim = self._target_worker.model_runner.model_config.hidden_size
+                ndi.hidden_states = torch.zeros(
+                    (bs, hidden_dim),
+                    device=self.device,
+                    dtype=torch.bfloat16,
+                )
+            else:
+                ndi.hidden_states = torch.zeros(
+                    (bs, target_hidden.shape[-1]),
+                    device=target_hidden.device,
+                    dtype=target_hidden.dtype,
+                )
+
+        return batch_output
+
+    # ------------------------------------------------------------------
+    # Helpers (shared with future SUFFIX/NONE paths)
+    # ------------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # PD disaggregation: decode-side suffix-tree prewarm + reconcile
+    # (mirrors SuffixWorkerV2; the MTP side needs nothing here — its draft KV
+    # arrives via the PD transfer and its first draft input via
+    # build_eagle_disagg_draft_input).
+    # ------------------------------------------------------------------
+    def prewarm_disagg_requests(self, reqs) -> None:
+        """Enqueue prebuilt requests for suffix-tree prewarm while their KV
+        transfer is still in flight. Idempotent per rid."""
+        for req in reqs:
+            rid = req.rid
+            if rid in self._req_tokens or rid in self._prewarm_pending:
+                continue
+            self._prewarm_pending[rid] = req
+
+    def prewarm_step(self, token_budget: int = 32768) -> None:
+        """Build at most token_budget prompt tokens of pending prewarm trees
+        (scheduler thread; arctic is not thread-safe)."""
+        spent = 0
+        while self._prewarm_pending and spent < token_budget:
+            rid, req = self._prewarm_pending.popitem()
+            if rid in self._req_tokens:
+                continue
+            prompt = list(req.origin_input_ids)
+            self.suffix_draft_builder.start_request(rid, prompt)
+            self._req_tokens[rid] = prompt
+            spent += len(prompt)
+
+    def _reconcile_disagg_reqs(self, mwb: ScheduleBatch) -> None:
+        """Cold-start prebuilt requests that outran the prewarm and append the
+        transferred output tail (the prefill-produced first token) for
+        prewarmed ones. No-op for colocated/ongoing requests."""
+        for req in mwb.reqs:
+            rid = req.rid
+            self._prewarm_pending.pop(rid, None)
+            tracked = self._req_tokens.get(rid)
+            if tracked is None:
+                tracked = list(req.origin_input_ids)
+                self.suffix_draft_builder.start_request(rid, tracked)
+                self._req_tokens[rid] = tracked
+            expected = len(req.origin_input_ids) + len(req.output_ids)
+            if len(tracked) < expected:
+                tracked.extend(
+                    req.output_ids[len(tracked) - len(req.origin_input_ids) :]
+                )
+                self.suffix_draft_builder.update_with_accepted(rid, tracked)
+
+    def _initialize_new_reqs(self, mwb: ScheduleBatch) -> None:
+        for req in mwb.reqs:
+            rid = req.rid
+            if rid in self._req_tokens:
+                continue
+            prompt = list(req.origin_input_ids)
+            self.suffix_draft_builder.start_request(rid, prompt)
+            self._req_tokens[rid] = prompt
+
+    # ------------------------------------------------------------------
+    # NONE backend: trivial K=1 target decode, no spec
+    # ------------------------------------------------------------------
+    def _decode_step_none(
+        self, mwb: ScheduleBatch, on_publish=None
+    ) -> GenerationBatchResult:
+        """Plain K=1 target decode — selector picks this when spec overhead
+        exceeds savings (typically at large bs).
+
+        Builds an EagleVerifyInput with K=1 (just bonus, no spec slots).
+        super.verify(mwb) dispatches to model_runner._forward_raw whose
+        width-based runner pick lands on the baseline_chain runner
+        (captured at K=1). accept_lens is always 1 (only bonus accepted).
+
+        No MTP keep-up — NONE means we're skipping spec for this step. If
+        the next step's selector picks MTP it sees no warm Eagle state and
+        gets promoted back to SUFFIX by the cold-start guard in
+        forward_batch_generation. Placeholder zeros for
+        next_draft_input.{topk_p, topk_index, hidden_states} keep
+        FutureMap's store_to_map happy.
+        """
+        bs = len(mwb.reqs)
+        bonus_tokens = mwb.spec_info.bonus_tokens
+
+        # K=1 chain: bonus only, no spec tokens. K_minus_1 = 0 → empty (bs, 0).
+        empty_draft = torch.empty((bs, 0), dtype=torch.int32, device=self.device)
+        verify_input = build_suffix_v2_eagle_verify_input(
+            bonus_tokens=bonus_tokens,
+            suffix_draft_tokens=empty_draft,
+            seq_lens=mwb.seq_lens,
+            seq_lens_cpu=mwb.seq_lens_cpu,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+        )
+        mwb.spec_info = verify_input
+
+        batch_output = self.verify(mwb)
+        # Overlap fence at verify-end (no keep-up tail on the NONE path).
+        if on_publish is not None and batch_output.new_seq_lens is not None:
+            on_publish(batch_output.new_seq_lens)
+
+        # Fill placeholder zeros for FutureMap (no keep-up, no real MTP state).
+        ndi = batch_output.next_draft_input
+        if ndi.topk_p is None:
+            bs_actual = int(ndi.bonus_tokens.numel())
+            ndi.topk_p = torch.zeros(
+                (bs_actual, 1), device=self.device, dtype=torch.float32
+            )
+            ndi.topk_index = torch.zeros(
+                (bs_actual, 1), device=self.device, dtype=torch.int64
+            )
+        if ndi.hidden_states is None:
+            target_hidden = batch_output.logits_output.hidden_states
+            if target_hidden is not None:
+                bs_actual = int(ndi.bonus_tokens.numel())
+                ndi.hidden_states = torch.zeros(
+                    (bs_actual, target_hidden.shape[-1]),
+                    device=target_hidden.device,
+                    dtype=target_hidden.dtype,
+                )
+
+        return batch_output
+
+    # ------------------------------------------------------------------
+    # SUFFIX → MTP keep-up (V2-style, uniform K_target per req)
+    # ------------------------------------------------------------------
+    def _run_keepup_after_suffix_v2(self, mwb: ScheduleBatch, batch_output) -> None:
+        """Uniform-K_target keep-up via super's _draft_extend_for_decode.
+
+        Approach:
+          1. Slice predict + hidden + out_cache_loc from K_src-wide verify
+             to first K_target positions per req (= bs * K_target each).
+          2. Cap accept_lens to K_target for select_index correctness inside
+             _draft_extend_for_decode.
+          3. Wrap into a synthetic batch_result with the sliced tensors.
+          4. Call super's _draft_extend_for_decode under draft contexts.
+
+        super's _draft_extend_for_decode internally:
+          - constructs EagleDraftInput w/ num_tokens_per_req = K_target
+          - prepare_for_extend_to_fill_draft_kvcache sets
+            forward_mode = DRAFT_EXTEND_V2, batch.input_ids = predict
+            (now bs * K_target), seq_lens += K_target, extend_seq_lens =
+            [K_target for _ in range(bs)]
+          - runs draft model forward (cuda graph or eager)
+          - select_index = i * K_target + (capped_accept_lens[i] - 1)
+          - softmax + fast_topk for next_draft_input.topk_p/topk_index
+          - assigns hidden_states from draft output at select_index
+
+        Lossy when accept_lens > K_target — we drop accepted positions
+        beyond K_target. Rare in practice (typical accept_lens 1-3).
+        """
+        if batch_output is None:
+            return
+        accept_lens = batch_output.accept_lens
+        if accept_lens is None or mwb.forward_mode.is_idle():
+            return
+        target_hidden = batch_output.logits_output.hidden_states
+        if target_hidden is None:
+            return
+        if batch_output.next_token_ids is None or batch_output.next_draft_input is None:
+            return
+
+        K_src = self.K_suffix
+        K_target = self.K_mtp
+        bs = len(mwb.reqs)
+
+        # Slice indices: for each req, take its first K_target positions of
+        # the K_src-wide chain. Shape (bs * K_target,) flat.
+        # idx = arange(bs)[:, None] * K_src + arange(K_target)[None, :]
+        if K_src == K_target:
+            # Fast path: no slicing needed.
+            sliced_predict = batch_output.next_token_ids
+            sliced_hidden = target_hidden
+            sliced_out_cache_loc = mwb.out_cache_loc
+        else:
+            row = torch.arange(bs, device=self.device).unsqueeze(1) * K_src
+            col = torch.arange(K_target, device=self.device).unsqueeze(0)
+            sliced_idx = (row + col).flatten()
+            sliced_predict = batch_output.next_token_ids[sliced_idx]
+            sliced_hidden = target_hidden[sliced_idx]
+            sliced_out_cache_loc = mwb.out_cache_loc[sliced_idx]
+
+        capped_accept_lens = torch.clamp(accept_lens, max=K_target)
+
+        # Build synthetic batch_result. We need:
+        #   - next_token_ids: shape (bs * K_target,)
+        #   - logits_output.hidden_states: shape (bs * K_target, hidden_dim)
+        #   - accept_lens: capped to K_target
+        #   - next_draft_input: SAME object as batch_output.next_draft_input
+        #     (so super's _draft_extend_for_decode in-place writes propagate)
+        import copy
+        from dataclasses import replace
+
+        fake_logits = copy.copy(batch_output.logits_output)
+        fake_logits.hidden_states = sliced_hidden
+
+        fake_result = replace(
+            batch_output,
+            next_token_ids=sliced_predict,
+            accept_lens=capped_accept_lens,
+            logits_output=fake_logits,
+        )
+        # Ensure next_draft_input is the SAME object (replace shallow-copies
+        # the dataclass; field references are preserved).
+        assert fake_result.next_draft_input is batch_output.next_draft_input
+
+        # Patch mwb.out_cache_loc to the sliced version so the draft model's
+        # KV write hits bs*K_target slots (matches super's assumption).
+        out_cache_loc_backup = mwb.out_cache_loc
+        mwb.out_cache_loc = sliced_out_cache_loc
+
+        try:
+            with (
+                self._draft_worker.draft_tp_context(
+                    self._draft_worker.draft_runner.tp_group
+                ),
+                speculative_moe_backend_context(),
+                speculative_moe_a2a_backend_context(),
+            ):
+                self._draft_worker._draft_extend_for_decode(mwb, fake_result)
+        finally:
+            mwb.out_cache_loc = out_cache_loc_backup
+
+    def _gc_stale_rids(self) -> None:
+        threshold = self._step_idx - self._gc_epoch_threshold
+        if threshold <= 0:
+            return
+        for rid in list(self._req_tokens.keys()):
+            if self._rid_last_seen.get(rid, 0) < threshold:
+                self.suffix_draft_builder.stop_request(rid)
+                self._req_tokens.pop(rid, None)
+                self._pending_accepted.pop(rid, None)
+                self._rid_last_seen.pop(rid, None)

--- a/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
@@ -132,21 +132,15 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         # the attention backend).
         self._max_context_len = int(target_worker.model_runner.model_config.context_len)
 
-        # Three target-side cuda-graph runners (captured in the target
-        # model_runner's init_decode_cuda_graph, which already ran during
-        # target_worker construction):
-        #   - main  decode_cuda_graph_runner       — K_suffix (SUFFIX path)
-        #   - short_chain_graph_runner             — K_mtp    (MTP path)
-        #   - baseline_chain_graph_runner          — K=1      (NONE path)
-        # verify() swaps target_model_runner.decode_cuda_graph_runner to the
-        # K-matching runner (keyed on spec_info.draft_token_num) immediately
-        # before the verify forward, then restores the main runner. When
-        # K_suffix == K_mtp the narrower runners are absent (None); the main
-        # runner serves both and the swap is a no-op.
-        _tmr = target_worker.model_runner
-        self._main_decode_runner = _tmr.decode_cuda_graph_runner
-        self._short_chain_runner = getattr(_tmr, "short_chain_graph_runner", None)
-        self._baseline_runner = getattr(_tmr, "baseline_chain_graph_runner", None)
+        # The three target-side cuda-graph runners (main K_suffix +
+        # short_chain K_mtp + baseline K=1) are captured by the target
+        # model_runner's init_decode_cuda_graph, which on this sglang version
+        # runs AFTER the spec worker is constructed — so they do NOT exist yet
+        # here. verify() reads them lazily from target_worker.model_runner at
+        # runtime (where they are set) and swaps decode_cuda_graph_runner to the
+        # K-matching one, keyed on spec_info.draft_token_num. When
+        # K_suffix == K_mtp the narrower runners are absent and the entry
+        # (main) runner serves both — the swap is a no-op.
 
         # PD prefill instance: the MTP/EAGLE side stays fully alive (its draft
         # extend produces the draft KV that PD transfers to the decode
@@ -410,20 +404,23 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         verify_input = batch.spec_info
         K = getattr(verify_input, "draft_token_num", None)
         tmr = self.target_worker.model_runner
-        prev_runner = tmr.decode_cuda_graph_runner
+        # The entry runner is the main K_suffix runner (set by the target's
+        # init_decode_cuda_graph). Read the two narrower runners lazily — they
+        # only exist by decode time, not at __init__.
+        prev_runner = getattr(tmr, "decode_cuda_graph_runner", None)
+        short_runner = getattr(tmr, "short_chain_graph_runner", None)
+        baseline_runner = getattr(tmr, "baseline_chain_graph_runner", None)
         prev_steps = self.speculative_num_steps
         prev_ndt = self.speculative_num_draft_tokens
 
         if K is not None:
-            if K == self.K_mtp and self._short_chain_runner is not None:
-                tmr.decode_cuda_graph_runner = self._short_chain_runner
-            elif K == 1 and self._baseline_runner is not None:
-                tmr.decode_cuda_graph_runner = self._baseline_runner
-            else:
-                # K_suffix (or any unmatched width): the main runner. If no
-                # captured graph matches the width, can_run_graph's ngram width
-                # check fails and verify falls back to eager — correct, slower.
-                tmr.decode_cuda_graph_runner = self._main_decode_runner
+            if K == self.K_mtp and short_runner is not None:
+                tmr.decode_cuda_graph_runner = short_runner
+            elif K == 1 and baseline_runner is not None:
+                tmr.decode_cuda_graph_runner = baseline_runner
+            # else: K_suffix (or any unmatched width) keeps the entry/main
+            # runner. If no captured graph matches the width, can_run_graph's
+            # ngram width check fails and verify falls back to eager (slower).
             self.speculative_num_steps = K - 1
             self.speculative_num_draft_tokens = K
         try:

--- a/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
@@ -123,27 +123,14 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         self.K_suffix: int = K_suffix
         self.K_mtp: int = K_mtp
 
-        # Multi-K target caveat (DSA / DSv4): when K_suffix != K_mtp the target
-        # must verify at two widths, but the DSA attention backend sizes its
-        # cuda-graph metadata + deep_gemm paged-MQA schedule for ONE K (the main
-        # K_suffix). A K_mtp-width forward (incl. the spec warmup) then trips
-        # `deep_gemm ... _batch_size == batch_size`. Until DSA keys that metadata
-        # by (bs, K), run HYBRID with K_suffix == K_mtp (i.e.
-        # --speculative-num-draft-tokens == --speculative-num-steps + 1) on DSA
-        # backends; the selector still mixes SUFFIX / MTP / NONE at uniform K.
-        if K_suffix != K_mtp:
-            logging.getLogger("sglang.spec.hybrid_v2").warning(
-                "HYBRID_SUFFIX_MTP started with K_suffix=%d != K_mtp=%d. On the "
-                "DSA/DSv4 attention backend the target can only verify at a "
-                "single K, so the wide-SUFFIX path will crash at warmup "
-                "(deep_gemm _batch_size assert). Set "
-                "--speculative-num-draft-tokens to %d (= --speculative-num-steps "
-                "+ 1) for uniform-K HYBRID, or use a backend whose cuda-graph "
-                "metadata is keyed by (bs, K).",
-                K_suffix,
-                K_mtp,
-                K_mtp,
-            )
+        # Multi-K on DSA: the target verifies at K_suffix (SUFFIX backend) and
+        # K_mtp (MTP backend) on the SAME model. The DSA attention backend
+        # derives its per-forward verify/draft-extend width from the batch's
+        # spec_info (see dsa_backend.init_forward_metadata), so both widths
+        # coexist. The K_suffix verify runs on the captured cuda graph; the
+        # K_mtp (MTP) verify runs eager unless ARCTIC_HYBRID_EXTRA_GRAPHS=1
+        # captures a K_mtp graph (which needs the DSA cuda-graph metadata dict
+        # keyed by (bs, K) — not yet wired).
         # Aliases for code paths that read self.K.
         self.K = K_suffix
         self.K_minus_1 = K_suffix - 1

--- a/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
@@ -122,6 +122,28 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         # super to K_mtp).
         self.K_suffix: int = K_suffix
         self.K_mtp: int = K_mtp
+
+        # Multi-K target caveat (DSA / DSv4): when K_suffix != K_mtp the target
+        # must verify at two widths, but the DSA attention backend sizes its
+        # cuda-graph metadata + deep_gemm paged-MQA schedule for ONE K (the main
+        # K_suffix). A K_mtp-width forward (incl. the spec warmup) then trips
+        # `deep_gemm ... _batch_size == batch_size`. Until DSA keys that metadata
+        # by (bs, K), run HYBRID with K_suffix == K_mtp (i.e.
+        # --speculative-num-draft-tokens == --speculative-num-steps + 1) on DSA
+        # backends; the selector still mixes SUFFIX / MTP / NONE at uniform K.
+        if K_suffix != K_mtp:
+            logging.getLogger("sglang.spec.hybrid_v2").warning(
+                "HYBRID_SUFFIX_MTP started with K_suffix=%d != K_mtp=%d. On the "
+                "DSA/DSv4 attention backend the target can only verify at a "
+                "single K, so the wide-SUFFIX path will crash at warmup "
+                "(deep_gemm _batch_size assert). Set "
+                "--speculative-num-draft-tokens to %d (= --speculative-num-steps "
+                "+ 1) for uniform-K HYBRID, or use a backend whose cuda-graph "
+                "metadata is keyed by (bs, K).",
+                K_suffix,
+                K_mtp,
+                K_mtp,
+            )
         # Aliases for code paths that read self.K.
         self.K = K_suffix
         self.K_minus_1 = K_suffix - 1

--- a/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/hybrid_suffix_mtp_worker_v2.py
@@ -11,10 +11,12 @@ backends decided by ``HybridBackendSelector``:
     ``K = speculative_num_steps + 1``.
   - **NONE** — plain target decode, no spec, ``K = 1``.
 
-All three backends produce different verify input widths; dispatch to
-three captured cuda graphs (main K_suffix, short_chain K_mtp, baseline
-K=1) is handled transparently by ``ModelRunner._forward_raw`` via each
-runner's width-based ``can_run``.
+All three backends produce different verify input widths. The three
+captured cuda graphs (main K_suffix, short_chain K_mtp, baseline K=1)
+live on the target ``model_runner``; ``verify()`` swaps
+``model_runner.decode_cuda_graph_runner`` to the K-matching runner
+(keyed on ``spec_info.draft_token_num``) immediately before the verify
+forward and restores the main runner afterward.
 
 SUFFIX backend per-step flow:
   1. Pull current tokens per req (``req.origin_input_ids +
@@ -130,6 +132,22 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         # the attention backend).
         self._max_context_len = int(target_worker.model_runner.model_config.context_len)
 
+        # Three target-side cuda-graph runners (captured in the target
+        # model_runner's init_decode_cuda_graph, which already ran during
+        # target_worker construction):
+        #   - main  decode_cuda_graph_runner       — K_suffix (SUFFIX path)
+        #   - short_chain_graph_runner             — K_mtp    (MTP path)
+        #   - baseline_chain_graph_runner          — K=1      (NONE path)
+        # verify() swaps target_model_runner.decode_cuda_graph_runner to the
+        # K-matching runner (keyed on spec_info.draft_token_num) immediately
+        # before the verify forward, then restores the main runner. When
+        # K_suffix == K_mtp the narrower runners are absent (None); the main
+        # runner serves both and the swap is a no-op.
+        _tmr = target_worker.model_runner
+        self._main_decode_runner = _tmr.decode_cuda_graph_runner
+        self._short_chain_runner = getattr(_tmr, "short_chain_graph_runner", None)
+        self._baseline_runner = getattr(_tmr, "baseline_chain_graph_runner", None)
+
         # PD prefill instance: the MTP/EAGLE side stays fully alive (its draft
         # extend produces the draft KV that PD transfers to the decode
         # instance), but the SUFFIX side never speculates there — skip the
@@ -166,6 +184,14 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         # only needs server_args, and choose() infers bs from len(suffix_scores).
         # ARCTIC_HYBRID_FORCE_BACKEND env var pins one backend for A/B testing.
         self.selector = HybridBackendSelector(server_args)
+
+        # Run the MTP keep-up forward after every SUFFIX step so a later
+        # MTP-picked step starts with warm draft state. Off by default (extra
+        # compute per SUFFIX step); when off, MTP picks are promoted to SUFFIX
+        # by the cold-start guard, so HYBRID effectively mixes SUFFIX + NONE.
+        self._always_warm = bool(
+            getattr(server_args, "speculative_hybrid_mtp_always_warm", False)
+        )
 
         # Cache of the current step's arctic query, populated by
         # _peek_suffix_scores and consumed by _decode_step_suffix to avoid
@@ -367,6 +393,46 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
 
         return result
 
+    def verify(self, batch: ScheduleBatch):
+        """Route the verify forward to the K-matching target cuda-graph runner.
+
+        All three backends funnel through here: SUFFIX / NONE call ``self.verify``
+        directly; the MTP path reaches it via ``super().forward_batch_generation``
+        (dynamic dispatch). The parent ``EAGLEWorkerV2.verify`` hardcodes the
+        verify width to ``speculative_num_steps + 1`` (= K_mtp) and drives
+        ``model_runner.decode_cuda_graph_runner`` — both correct only for the MTP
+        path. Here we (a) swap the target decode runner to the graph captured at
+        the batch's actual width and (b) temporarily align
+        ``speculative_num_steps`` / ``speculative_num_draft_tokens`` to that
+        width, then restore both. Width is read from ``spec_info.draft_token_num``
+        (set by the SUFFIX/NONE converter and by the MTP draft path).
+        """
+        verify_input = batch.spec_info
+        K = getattr(verify_input, "draft_token_num", None)
+        tmr = self.target_worker.model_runner
+        prev_runner = tmr.decode_cuda_graph_runner
+        prev_steps = self.speculative_num_steps
+        prev_ndt = self.speculative_num_draft_tokens
+
+        if K is not None:
+            if K == self.K_mtp and self._short_chain_runner is not None:
+                tmr.decode_cuda_graph_runner = self._short_chain_runner
+            elif K == 1 and self._baseline_runner is not None:
+                tmr.decode_cuda_graph_runner = self._baseline_runner
+            else:
+                # K_suffix (or any unmatched width): the main runner. If no
+                # captured graph matches the width, can_run_graph's ngram width
+                # check fails and verify falls back to eager — correct, slower.
+                tmr.decode_cuda_graph_runner = self._main_decode_runner
+            self.speculative_num_steps = K - 1
+            self.speculative_num_draft_tokens = K
+        try:
+            return super().verify(batch)
+        finally:
+            tmr.decode_cuda_graph_runner = prev_runner
+            self.speculative_num_steps = prev_steps
+            self.speculative_num_draft_tokens = prev_ndt
+
     def _selector_uses_scores(self) -> bool:
         """Mirror V1's check — skip the peek when force/debug knobs short-circuit
         the choice anyway."""
@@ -562,13 +628,16 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         if on_publish is not None and batch_output.new_seq_lens is not None:
             on_publish(batch_output.new_seq_lens)
 
-        # 5. MTP keep-up. V2 path: slice predict/hidden/out_cache_loc to
-        # K_target per req, call super's _draft_extend_for_decode which
-        # uses uniform K_target chains. V1's variable-length flat-accept
-        # approach doesn't fit V2's DSv4 kernel signatures (the fused
-        # K-norm-rope kernel binds B from kv.size(0) and requires positions /
-        # out_loc to share that B).
-        self._run_keepup_after_suffix_v2(mwb, batch_output)
+        # 5. MTP keep-up (gated by --speculative-hybrid-mtp-always-warm). V2
+        # path: slice predict/hidden/out_cache_loc to K_target per req, call
+        # super's _draft_extend_for_decode which uses uniform K_target chains.
+        # V1's variable-length flat-accept approach doesn't fit V2's DSv4 kernel
+        # signatures (the fused K-norm-rope kernel binds B from kv.size(0) and
+        # requires positions / out_loc to share that B). When disabled, MTP
+        # draft state stays cold and the cold-start guard in
+        # forward_batch_generation promotes any MTP pick back to SUFFIX.
+        if self._always_warm:
+            self._run_keepup_after_suffix_v2(mwb, batch_output)
         ndi = batch_output.next_draft_input
         if ndi.topk_p is None:
             # Fallback: keep-up didn't run or failed silently. Fill placeholder
@@ -668,9 +737,9 @@ class HybridSuffixMTPWorkerV2(EAGLEWorkerV2):
         exceeds savings (typically at large bs).
 
         Builds an EagleVerifyInput with K=1 (just bonus, no spec slots).
-        super.verify(mwb) dispatches to model_runner._forward_raw whose
-        width-based runner pick lands on the baseline_chain runner
-        (captured at K=1). accept_lens is always 1 (only bonus accepted).
+        self.verify(mwb) swaps in the baseline_chain runner (captured at
+        K=1, keyed on draft_token_num==1) for the verify forward.
+        accept_lens is always 1 (only bonus accepted).
 
         No MTP keep-up — NONE means we're skipping spec for this step. If
         the next step's selector picks MTP it sees no warm Eagle state and

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -31,9 +32,6 @@ from sglang.srt.utils.async_probe import maybe_detect_inf, maybe_detect_nan
 logger = logging.getLogger(__name__)
 
 
-USE_FULL_MASK = True
-
-
 class NGRAMWorker(BaseSpecWorker):
     def alloc_memory_pool(self, **kwargs):
         # The target memory pool does not exist yet when __init__ runs.
@@ -57,6 +55,12 @@ class NGRAMWorker(BaseSpecWorker):
     ):
         self.server_args = server_args
         self.enable_overlap = not server_args.disable_overlap_schedule
+        # NOTE: QLEN_MASK is faster than FULL_MASK, but requires
+        # corresponding changes in flashinfer. Testing shows about 8%
+        # performance improvement (roughly proportional to batch size).
+        # Backends that never read spec_info.custom_mask (e.g. DeepSeek-V4
+        # NSA) can disable the FULL expansion outright.
+        self.use_full_mask = envs.SGLANG_NGRAM_USE_FULL_MASK.get()
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self.tp_rank = tp_rank
@@ -74,17 +78,24 @@ class NGRAMWorker(BaseSpecWorker):
         # rids of the last decode batch; used to erase corpus match state for
         # requests that left the batch (see forward_batch_generation).
         self._prev_decode_rids: set = set()
+        # Erase corpus match state as soon as a request leaves the decode
+        # batch. Draft sources that manage their own request lifecycle (e.g.
+        # SUFFIX's adapter, which uses a grace window so pipeline-parallel
+        # micro-batch rotation does not look like departure and trigger a
+        # full local-tree rebuild from the prompt every other step) set this
+        # False.
+        self.corpus_gc_on_departure = True
 
-        self.ngram_corpus = NgramCorpus(
-            min_bfs_breadth=server_args.speculative_ngram_min_bfs_breadth,
-            max_bfs_breadth=server_args.speculative_ngram_max_bfs_breadth,
-            match_type=server_args.speculative_ngram_match_type,
-            capacity=server_args.speculative_ngram_capacity,
-            max_trie_depth=server_args.speculative_ngram_max_trie_depth,
-            draft_token_num=server_args.speculative_num_draft_tokens,
-            external_sam_budget=server_args.speculative_ngram_external_sam_budget,
-            external_corpus_max_tokens=server_args.speculative_ngram_external_corpus_max_tokens,
-        )
+        # Linear-chain draft sources (e.g. SUFFIX) accept a contiguous prefix
+        # of the canonical [seq_lens, seq_lens + K) verify slots, so accepted
+        # KV is already at its target location and the post-verify move is an
+        # identity — subclasses set this True to skip it. Skipping also
+        # enables KV pools that do not implement move_kv_cache (e.g.
+        # DeepSeek-V4's NSA paginated pool). BFS n-gram trees accept
+        # non-contiguous slots and must keep the move.
+        self.drafts_are_linear_chains = False
+
+        self.ngram_corpus = self._create_draft_source(server_args)
         if server_args.speculative_ngram_external_corpus_path is not None:
             from sglang.srt.speculative.cpp_ngram.external_corpus import (
                 iter_external_corpus_chunks,
@@ -114,6 +125,21 @@ class NGRAMWorker(BaseSpecWorker):
     def draft_worker(self) -> Optional[EagleDraftWorkerBase]:
         # NGRAM has no draft model; drafts come from the CPU-side corpus.
         return None
+
+    def _create_draft_source(self, server_args: ServerArgs):
+        # Factory hook: subclasses with a different draft source (e.g. SUFFIX's
+        # arctic suffix tree) override this instead of paying NgramCorpus
+        # construction (capacity-sized C++ allocation) and then discarding it.
+        return NgramCorpus(
+            min_bfs_breadth=server_args.speculative_ngram_min_bfs_breadth,
+            max_bfs_breadth=server_args.speculative_ngram_max_bfs_breadth,
+            match_type=server_args.speculative_ngram_match_type,
+            capacity=server_args.speculative_ngram_capacity,
+            max_trie_depth=server_args.speculative_ngram_max_trie_depth,
+            draft_token_num=server_args.speculative_num_draft_tokens,
+            external_sam_budget=server_args.speculative_ngram_external_sam_budget,
+            external_corpus_max_tokens=server_args.speculative_ngram_external_corpus_max_tokens,
+        )
 
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
@@ -298,7 +324,7 @@ class NGRAMWorker(BaseSpecWorker):
 
         # NOTE: QLEN_MASK is faster than FULL_MASK, but requires corresponding changes in flashinfer.
         # Testing shows about 8% performance improvement (the effect is roughly proportional to batch size).
-        if USE_FULL_MASK:
+        if self.use_full_mask:
             tree_mask = []
             mask = mask.reshape(bs, self.draft_token_num, self.draft_token_num)
             # TODO(siyuan): the for loop here leads to significant overhead in large batch size. Can be written into a kernel.
@@ -448,12 +474,16 @@ class NGRAMWorker(BaseSpecWorker):
             # The KV mover expects drafts-only counts. NGRAM's
             # accept_lens includes the bonus token, matching scheduler output.
             num_correct_drafts_per_req = accept_lens - 1
-            move_accept_tokens_to_target_kvcache(
-                batch,
-                accept_index,
-                num_correct_drafts_per_req,
-                self.token_to_kv_pool_allocator,
-            )
+            if not self.drafts_are_linear_chains:
+                # Linear-chain accepts already occupy the canonical target
+                # slots (see the flag in __init__) — the move would be an
+                # identity, and the KV pool may not support it at all.
+                move_accept_tokens_to_target_kvcache(
+                    batch,
+                    accept_index,
+                    num_correct_drafts_per_req,
+                    self.token_to_kv_pool_allocator,
+                )
             if batch.return_logprob:
                 # The last arg is the accept_index row width minus 1. NGRAM's
                 # accept_index is (bs, draft_token_num) -- the tree depth is not
@@ -474,11 +504,12 @@ class NGRAMWorker(BaseSpecWorker):
             # req.finished() is unusable here: under overlap it flips at result
             # processing, one iteration after the request left the batch.
             # The last batch's entries persist while idle (bounded, small).
-            cur_rids = {req.rid for req in batch.reqs}
-            departed_rids = self._prev_decode_rids - cur_rids
-            if departed_rids:
-                self.ngram_corpus.erase_match_state(list(departed_rids))
-            self._prev_decode_rids = cur_rids
+            if self.corpus_gc_on_departure:
+                cur_rids = {req.rid for req in batch.reqs}
+                departed_rids = self._prev_decode_rids - cur_rids
+                if departed_rids:
+                    self.ngram_corpus.erase_match_state(list(departed_rids))
+                self._prev_decode_rids = cur_rids
             batch.forward_mode = ForwardMode.DECODE
 
         else:

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -291,9 +291,28 @@ class NGRAMWorker(BaseSpecWorker):
         return req_drafts, mask
 
     def _prepare_for_speculative_decoding(self, batch: ScheduleBatch):
-        # Decode-only: extend goes through the plain target forward, and an
-        # IDLE batch must keep its forward_mode instead of being rewritten to
-        # TARGET_VERIFY below (relevant once DP attention support lands).
+        # DP-attention: an idle rank still runs forward_idle and must take part
+        # in every per-layer DP collective in lockstep with active ranks. Give
+        # it a spec_info so ForwardBatch.init_new scales global_num_tokens by
+        # draft_token_num exactly like active ranks (init_new only applies the
+        # coefficient when spec_info is set); keep forward_mode=IDLE so it runs
+        # forward_idle rather than the TARGET_VERIFY rewrite below.
+        #
+        # BUT only when the GLOBAL step is decode/verify. If the global step is
+        # extend (is_extend_in_batch is globally synced across DP ranks), the
+        # active ranks run plain prefill with NO draft_token_num coefficient, so
+        # an idle rank must not apply it either — otherwise its global_num_tokens
+        # (and the resulting MoE DeepEP all-to-all sizing / dense-vs-deepep path)
+        # diverges from the active extend ranks and the DP collective deadlocks.
+        # Mirrors EAGLEWorkerV2's `is_extend() or is_extend_in_batch` dispatch.
+        if batch.forward_mode.is_idle():
+            if not batch.is_extend_in_batch:
+                batch.spec_info = NgramVerifyInput(
+                    draft_token_num=self.draft_token_num,
+                    new_seq_lens=batch.seq_lens,
+                )
+            return
+        # Decode-only: extend goes through the plain target forward.
         if not batch.forward_mode.is_decode():
             return
 
@@ -511,6 +530,29 @@ class NGRAMWorker(BaseSpecWorker):
                     self.ngram_corpus.erase_match_state(list(departed_rids))
                 self._prev_decode_rids = cur_rids
             batch.forward_mode = ForwardMode.DECODE
+
+        elif batch.forward_mode.is_idle():
+            # DP-attention idle rank: run forward_idle so this rank emits the
+            # same per-layer DP collectives as the active ranks' verify
+            # (spec_info set in _prepare_for_speculative_decoding scales
+            # global_num_tokens to match). bs == 0, so the result is empty and
+            # discarded; only well-shaped 0-row tensors must reach the overlap
+            # scheduler (copy_to_cpu / next_draft_input).
+            batch_result = self.target_worker.forward_batch_generation(batch)
+            logits_output, can_run_cuda_graph = (
+                batch_result.logits_output,
+                batch_result.can_run_cuda_graph,
+            )
+            new_seq_lens = batch.seq_lens.clone()
+            next_token_ids = (
+                batch_result.next_token_ids
+                if batch_result.next_token_ids is not None
+                else torch.empty(0, dtype=torch.int64, device=self.device)
+            )
+            accept_tokens = torch.empty(0, dtype=torch.int32, device=self.device)
+
+            if on_publish is not None:
+                on_publish(new_seq_lens)
 
         else:
             batch_result = self.target_worker.forward_batch_generation(batch)

--- a/python/sglang/srt/speculative/sgl_suffix_plugin.py
+++ b/python/sglang/srt/speculative/sgl_suffix_plugin.py
@@ -31,6 +31,19 @@ class _SuffixLike(CustomSpecAlgo):
     def is_suffix(self) -> bool:
         return True
 
+    def has_draft_kv(self) -> bool:
+        # SUFFIX dispatches like NGRAM: the draft tree lives only in the verify
+        # mask, no draft KV chains are written. Mirrors the builtin enum's
+        # ``not is_ngram()``; the CustomSpecAlgo base conservatively defaults True.
+        return False
+
+    def carries_draft_hidden_states(self) -> bool:
+        # Model-free: the disagg prefill->decode transfer ships nothing beyond
+        # the bonus token (no draft hidden states), so the metadata buffer uses
+        # the minimal RDMA pad. The CustomSpecAlgo base omits this method
+        # entirely, but Scheduler.init_disaggregation (decode mode) calls it.
+        return False
+
     def create_future_map(
         self,
         device,
@@ -42,6 +55,25 @@ class _SuffixLike(CustomSpecAlgo):
         from sglang.srt.managers.overlap_utils import FutureMap
 
         return FutureMap(device, self, req_to_token_pool, needs_cpu_seq_lens)
+
+    def build_disagg_draft_input(
+        self,
+        batch,
+        server_args,
+        last_tokens_tensor,
+        future_map,
+    ):
+        # PD disaggregation: reconstruct the first decode batch's draft input
+        # on the decode instance (see suffix_disaggregation.py). SUFFIX is
+        # model-free, so unlike EAGLE nothing beyond the bonus token has to be
+        # shipped from the prefill instance.
+        from sglang.srt.speculative.suffix_disaggregation import (
+            build_suffix_disagg_draft_input,
+        )
+
+        return build_suffix_disagg_draft_input(
+            batch, server_args, last_tokens_tensor, future_map
+        )
 
 
 def _suffix_factory(server_args: ServerArgs) -> Type:

--- a/python/sglang/srt/speculative/sgl_suffix_plugin.py
+++ b/python/sglang/srt/speculative/sgl_suffix_plugin.py
@@ -1,0 +1,70 @@
+"""Register the SUFFIX speculative-decoding algorithm.
+
+SUFFIX is registered as a *plugin* algorithm (``SpeculativeAlgorithm.register``)
+rather than a builtin enum value. ``_SuffixLike.is_ngram()`` returns ``True`` so
+SUFFIX transparently reuses every existing NGRAM dispatch branch in the
+scheduler / cuda-graph runner / model runner — the verify and KV-cache path is
+identical; only the draft source differs (see ``SuffixWorker``). NGRAM's worker
+is spec-v2 native, so SUFFIX inherits overlap-scheduling support
+(``supports_overlap=True``; the scheduler drives the same worker synchronously
+when overlap is disabled). The factory is imported lazily so
+``arctic_inference`` is required only when SUFFIX is actually selected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Type
+
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_registry import CustomSpecAlgo
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+
+class _SuffixLike(CustomSpecAlgo):
+    """SUFFIX dispatches like NGRAM (shared verify / KV-cache path)."""
+
+    def is_ngram(self) -> bool:
+        return True
+
+    def is_suffix(self) -> bool:
+        return True
+
+    def create_future_map(
+        self,
+        device,
+        req_to_token_pool,
+        needs_cpu_seq_lens: bool = True,
+    ):
+        # CustomSpecAlgo base does not provide this (the scheduler calls it
+        # unconditionally); mirror SpeculativeAlgorithm.create_future_map.
+        from sglang.srt.managers.overlap_utils import FutureMap
+
+        return FutureMap(device, self, req_to_token_pool, needs_cpu_seq_lens)
+
+
+def _suffix_factory(server_args: ServerArgs) -> Type:
+    from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+    return SuffixWorker
+
+
+def _validate_suffix_args(server_args: ServerArgs) -> None:
+    required = (
+        "speculative_suffix_max_tree_depth",
+        "speculative_suffix_max_cached_requests",
+        "speculative_suffix_max_spec_factor",
+        "speculative_suffix_min_token_prob",
+    )
+    missing = [a for a in required if not hasattr(server_args, a)]
+    if missing:
+        raise ValueError(f"SUFFIX speculative decoding requires server args {missing}.")
+
+
+SpeculativeAlgorithm.register(
+    "SUFFIX",
+    supports_overlap=True,
+    validate_server_args=_validate_suffix_args,
+    spec_class=_SuffixLike,
+)(_suffix_factory)

--- a/python/sglang/srt/speculative/sgl_suffix_plugin.py
+++ b/python/sglang/srt/speculative/sgl_suffix_plugin.py
@@ -1,4 +1,10 @@
-"""Register the SUFFIX speculative-decoding algorithm.
+"""Register the SUFFIX and HYBRID_SUFFIX_MTP speculative-decoding algorithms.
+
+HYBRID_SUFFIX_MTP (``_HybridLike`` / ``HybridSuffixMTPWorkerV2``) dispatches
+per batch among SUFFIX (NGRAM-style), MTP (EAGLE-style), and NONE (plain
+decode); it reports both ``is_ngram()`` and ``is_eagle()`` True so every
+builtin dispatch branch triggers, and swaps the matching cuda-graph runner
+before each verify.
 
 SUFFIX is registered as a *plugin* algorithm (``SpeculativeAlgorithm.register``)
 rather than a builtin enum value. ``_SuffixLike.is_ngram()`` returns ``True`` so
@@ -82,6 +88,55 @@ def _suffix_factory(server_args: ServerArgs) -> Type:
     return SuffixWorker
 
 
+class _HybridLike(CustomSpecAlgo):
+    """HYBRID_SUFFIX_MTP dispatches per-batch among SUFFIX (NGRAM-style),
+    MTP (EAGLE-style), and NONE (plain decode). It returns ``True`` for both
+    ``is_ngram()`` and ``is_eagle()`` so existing builtin-only branches still
+    trigger; the worker (``HybridSuffixMTPWorkerV2``) chooses the backend per
+    batch via :class:`HybridBackendSelector` and swaps the matching cuda-graph
+    runner before each verify.
+    """
+
+    def is_ngram(self) -> bool:
+        return True
+
+    def is_eagle(self) -> bool:
+        return True
+
+    def is_hybrid_suffix_mtp(self) -> bool:
+        return True
+
+    def has_draft_kv(self) -> bool:
+        # The MTP path writes a real EAGLE draft KV chain, so the draft KV pool
+        # must be allocated (unlike pure SUFFIX/NGRAM). The kv_cache_builder /
+        # overlap-FutureMap ngram short-circuits are exempted for HYBRID via
+        # ``is_ngram() and not is_hybrid_suffix_mtp()``.
+        return True
+
+    def carries_draft_hidden_states(self) -> bool:
+        # MTP keep-up carries draft hidden states (EAGLE-family). Only consulted
+        # in PD-disagg (out of scope here), but keep it EAGLE-consistent.
+        return True
+
+    def create_future_map(
+        self,
+        device,
+        req_to_token_pool,
+        needs_cpu_seq_lens: bool = True,
+    ):
+        from sglang.srt.managers.overlap_utils import FutureMap
+
+        return FutureMap(device, self, req_to_token_pool, needs_cpu_seq_lens)
+
+
+def _hybrid_factory(server_args: ServerArgs) -> Type:
+    from sglang.srt.speculative.hybrid_suffix_mtp_worker_v2 import (
+        HybridSuffixMTPWorkerV2,
+    )
+
+    return HybridSuffixMTPWorkerV2
+
+
 def _validate_suffix_args(server_args: ServerArgs) -> None:
     required = (
         "speculative_suffix_max_tree_depth",
@@ -100,3 +155,10 @@ SpeculativeAlgorithm.register(
     validate_server_args=_validate_suffix_args,
     spec_class=_SuffixLike,
 )(_suffix_factory)
+
+SpeculativeAlgorithm.register(
+    "HYBRID_SUFFIX_MTP",
+    supports_overlap=True,
+    validate_server_args=_validate_suffix_args,
+    spec_class=_HybridLike,
+)(_hybrid_factory)

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -115,6 +115,13 @@ class SpeculativeAlgorithm(Enum):
     def is_ngram(self) -> bool:
         return self == SpeculativeAlgorithm.NGRAM
 
+    def is_hybrid_suffix_mtp(self) -> bool:
+        # HYBRID_SUFFIX_MTP is a plugin algorithm (see sgl_suffix_plugin.py),
+        # never a builtin enum member; the stub keeps the duck-typed interface
+        # uniform so ``is_ngram() and not is_hybrid_suffix_mtp()`` style guards
+        # resolve on builtin enum values too.
+        return False
+
     def supports_target_verify_for_draft(self) -> bool:
         return self.is_dflash()
 

--- a/python/sglang/srt/speculative/spec_registry.py
+++ b/python/sglang/srt/speculative/spec_registry.py
@@ -82,6 +82,9 @@ class CustomSpecAlgo:
     def is_ngram(self) -> bool:
         return False
 
+    def is_hybrid_suffix_mtp(self) -> bool:
+        return False
+
     def supports_target_verify_for_draft(self) -> bool:
         return False
 

--- a/python/sglang/srt/speculative/spec_registry.py
+++ b/python/sglang/srt/speculative/spec_registry.py
@@ -92,6 +92,13 @@ class CustomSpecAlgo:
         # Conservative default: the larger KV reserve.
         return True
 
+    def need_topk(self) -> bool:
+        # Mirrors SpeculativeAlgorithm.need_topk: EAGLE-family / standalone draft
+        # paths carry topk sampling state. Plugins that dispatch like NGRAM
+        # short-circuit before this is consulted; HYBRID (is_eagle True) does
+        # traverse the EAGLE path in overlap_utils, so it must answer True here.
+        return self.is_eagle() or self.is_standalone()
+
     def handle_server_args(self, server_args: ServerArgs) -> None:
         pass
 

--- a/python/sglang/srt/speculative/suffix_cache_adapter.py
+++ b/python/sglang/srt/speculative/suffix_cache_adapter.py
@@ -1,0 +1,498 @@
+"""
+Suffix decoding cache adapter for SGLang v0.5.9.
+
+This wraps arctic_inference.suffix_decoding.SuffixDecodingCache and exposes an
+NgramCache-like interface used by NGRAMWorker:
+  - batch_get(...) -> flat draft tokens + flat tree mask
+  - batch_put(...) -> no-op / sanity check
+  - synchronize(), reset()
+
+The important difference from NGRAM is that suffix decoding needs full request
+history (prompt + generated tokens) and a stable request id.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import deque
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class SegmentedTokens:
+    """Read-only concatenated view over token-list segments.
+
+    The worker's per-request history is (origin_input_ids, output_ids,
+    spliced_accepts). Materializing their concatenation per request per decode
+    step costs O(seq_len) Python-int copies — at agent context lengths that
+    alone adds milliseconds per step. The adapter only ever needs len(), a
+    short tail slice (the match pattern), and the incremental delta slice, so
+    a lazy view that materializes only the requested slice suffices.
+    """
+
+    __slots__ = ("_segs", "_len")
+
+    def __init__(self, *segments):
+        self._segs = [s for s in segments if len(s) > 0]
+        self._len = sum(len(s) for s in self._segs)
+
+    def __len__(self) -> int:
+        return self._len
+
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            start, stop, step = idx.indices(self._len)
+            if step != 1:
+                raise ValueError("SegmentedTokens slices must be contiguous")
+            out: List[int] = []
+            pos = 0
+            for seg in self._segs:
+                seg_len = len(seg)
+                lo = max(start - pos, 0)
+                hi = min(stop - pos, seg_len)
+                if lo < hi:
+                    out.extend(seg[lo:hi])
+                pos += seg_len
+                if pos >= stop:
+                    break
+            return out
+        if idx < 0:
+            idx += self._len
+        if not 0 <= idx < self._len:
+            raise IndexError(idx)
+        for seg in self._segs:
+            if idx < len(seg):
+                return seg[idx]
+            idx -= len(seg)
+        raise IndexError(idx)
+
+
+class SuffixCacheAdapter:
+    def __init__(
+        self,
+        draft_token_num: int,
+        max_batch_size: int,
+        max_tree_depth: int = 24,
+        max_cached_requests: int = 10000,
+        max_spec_factor: float = 1.0,
+        min_token_prob: float = 0.1,
+    ):
+        # Lazy import so normal SGLang startup does not require arctic-inference.
+        try:
+            from arctic_inference.suffix_decoding import SuffixDecodingCache
+        except ImportError as exc:
+            raise ImportError(
+                "SUFFIX speculative decoding requires Arctic Inference. "
+                "Install it with: pip install arctic-inference"
+            ) from exc
+
+        self.suffix_cache = SuffixDecodingCache(
+            max_tree_depth=max_tree_depth,
+            max_cached_requests=max_cached_requests,
+        )
+        self.draft_token_num = draft_token_num
+        self.max_batch_size = max_batch_size
+        self.max_tree_depth = max_tree_depth
+        self.max_spec_factor = max_spec_factor
+        self.min_token_prob = min_token_prob
+
+        # Optional debug: SUFFIX_DEBUG_TREE=1 dumps the first generated tree.
+        self.debug_tree_dump_remaining = int(os.environ.get("SUFFIX_DEBUG_TREE", "0"))
+        # Optional debug: SUFFIX_DEBUG_FEED=N dumps per-request feed/query
+        # content for the first N batch_get rows (0 = off).
+        self._feed_dump_remaining = int(os.environ.get("SUFFIX_DEBUG_FEED", "0"))
+        # Optional debug: SUFFIX_DEBUG_STATS=N logs draft-length/score stats
+        # every N batch_get calls (0 = off).
+        self._stats_every = int(os.environ.get("SUFFIX_DEBUG_STATS", "0"))
+        self._stats_calls = 0
+        self._stats_drafts = 0
+        self._stats_draft_tokens = 0
+        self._stats_empty = 0
+        self._stats_score_sum = 0.0
+        self._stats_capped = 0
+
+        # SGLang request id -> [arctic request id, last token length added]
+        self.req_state: dict[str, list] = {}
+        # rid -> number of consecutive batch_get/batch_peek_scores calls the
+        # request has been ABSENT from the batch. Drives grace-period teardown
+        # in _cleanup_inactive_requests (see there for why).
+        self._absent_count: dict[str, int] = {}
+        self._cleanup_grace = int(os.environ.get("SUFFIX_CLEANUP_GRACE", "32"))
+
+        max_total_drafts = self.max_batch_size * self.draft_token_num
+        self.draft_buffer = np.empty((max_total_drafts,), dtype=np.int64)
+        self.mask_buffer = np.empty(
+            (self.max_batch_size, self.draft_token_num, self.draft_token_num),
+            dtype=bool,
+        )
+        # Precomputed for the linear-chain fast path in batch_get: arctic
+        # chain drafts have parents == [-1, 0, 1, ...] and their (rooted +
+        # chain-padded) ancestry mask is exactly the K x K lower triangle.
+        self._chain_parents = list(range(-1, self.draft_token_num))
+        self._tril = np.tril(
+            np.ones((self.draft_token_num, self.draft_token_num), dtype=bool)
+        )
+
+        # Last batch's per-request raw SuffixDecodingDraft results from
+        # arctic, populated by batch_get. Cleared at the start of each call.
+        self.last_drafts: list = []
+
+    def _cleanup_inactive_requests(self, active_req_ids: set[str]) -> None:
+        # Release a request's suffix tree only after it has been ABSENT from the
+        # batch for `_cleanup_grace` consecutive calls -- NOT immediately when it
+        # is missing from the current batch.
+        #
+        # Why: under pipeline parallelism (pp_loop_size > 1 micro-batching) and
+        # DP-attention, the per-step batch passed here is only a SUBSET of the
+        # active requests -- they rotate between micro-batches. The naive
+        # "tear down everything not in this batch" then deletes the local suffix
+        # tree of a request that is merely waiting its turn, forcing a full
+        # start_request() prompt-tree REBUILD (tens of ms for long prompts) when
+        # it returns next step. Measured ~26 rebuilds/request under PP, which
+        # made the suffix-tree build (not the C++ speculate, which is ~0.1ms)
+        # the dominant decode-step cost. The grace window spans micro-batch
+        # rotation, so still-active requests are never torn down; genuinely
+        # finished requests simply stop appearing and are released once the
+        # window elapses.
+        #
+        # This change only ever makes teardown LESS aggressive, so it cannot
+        # regress correctness -- worst case is freeing a finished request's local
+        # tree a few steps later. In non-PP / single-batch mode every active
+        # request is present every call, so this behaves like the old code
+        # (release on finish) just delayed by `_cleanup_grace` steps.
+        grace = self._cleanup_grace
+        absent = self._absent_count
+        active_backend_reqs = getattr(self.suffix_cache, "active_requests", set())
+        to_release = []
+        for rid in list(self.req_state):
+            if rid in active_req_ids:
+                absent.pop(rid, None)
+            elif absent.get(rid, 0) + 1 >= grace:
+                to_release.append(rid)
+            else:
+                absent[rid] = absent.get(rid, 0) + 1
+        for rid in to_release:
+            cache_req_id, _ = self.req_state.pop(rid)
+            absent.pop(rid, None)
+            if cache_req_id in active_backend_reqs:
+                self.suffix_cache.stop_request(cache_req_id)
+
+    def _get_or_create_cache_req_id(
+        self, sglang_req_id: str, prompt: List[int]
+    ) -> Tuple[str, int]:
+        if sglang_req_id not in self.req_state:
+            cache_req_id = sglang_req_id
+            self.suffix_cache.start_request(cache_req_id, prompt)
+            # The prompt is already loaded into the backend cache.
+            self.req_state[sglang_req_id] = [cache_req_id, len(prompt)]
+        cache_req_id, last_length = self.req_state[sglang_req_id]
+        return cache_req_id, last_length
+
+    def batch_get(
+        self,
+        batch_req_ids: List[str],
+        batch_prompts: List[List[int]],
+        batch_tokens: List[List[int]],
+        max_lens: Optional[List[int]] = None,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        # max_lens: optional per-request cap on the real (non-padding) draft
+        # chain length, including the re-fed root token. The worker passes
+        # context_len - seq_len - 1 so a verify step can never accept past the
+        # context window (an overshoot leaves a zombie request whose next
+        # verify reads out-of-range KV slots).
+        batch_size = len(batch_req_ids)
+        if batch_size == 0:
+            return np.empty((0,), dtype=np.int64), np.empty((0,), dtype=bool)
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                f"Batch size {batch_size} exceeds max_batch_size={self.max_batch_size}"
+            )
+
+        total_draft_tokens = batch_size * self.draft_token_num
+        draft_view = self.draft_buffer[:total_draft_tokens]
+        mask_view = self.mask_buffer[:batch_size]
+        mask_view.fill(False)
+
+        self._cleanup_inactive_requests(set(batch_req_ids))
+        self.last_drafts = []
+
+        for row, (sglang_req_id, prompt, tokens) in enumerate(
+            zip(batch_req_ids, batch_prompts, batch_tokens)
+        ):
+            cache_req_id, last_length = self._get_or_create_cache_req_id(
+                sglang_req_id, prompt
+            )
+
+            # Add only the verified delta since the previous step.
+            current_length = len(tokens)
+            if current_length > last_length:
+                new_tokens = tokens[last_length:current_length]
+                if cache_req_id in getattr(self.suffix_cache, "active_requests", set()):
+                    self.suffix_cache.add_active_response(cache_req_id, new_tokens)
+                    self.req_state[sglang_req_id][1] = current_length
+                else:
+                    logger.warning(
+                        "Suffix cache request %s is not active when updating",
+                        cache_req_id,
+                    )
+            elif current_length < last_length:
+                # The caller's token stream must be monotonic; a shrink means
+                # the cursor desynchronized (already-fed tokens vanished).
+                # Re-anchor without feeding so the desync cannot compound.
+                logger.warning(
+                    "Suffix cache cursor regressed for %s (%d -> %d); re-anchoring",
+                    sglang_req_id,
+                    last_length,
+                    current_length,
+                )
+                self.req_state[sglang_req_id][1] = current_length
+
+            # Arctic suffix decoding matches from the current suffix pattern.
+            pattern_start = max(0, len(tokens) - self.max_tree_depth)
+            pattern = tokens[pattern_start:]
+            draft = self.suffix_cache.speculate(
+                cache_req_id,
+                pattern,
+                max_spec_tokens=self.draft_token_num,
+                max_spec_factor=self.max_spec_factor,
+                min_token_prob=self.min_token_prob,
+            )
+            self.last_drafts.append(draft)
+
+            if self._feed_dump_remaining > 0:
+                self._feed_dump_remaining -= 1
+                logger.info(
+                    "[SUFFIX FEED] rid=%s plen=%d tlen=%d pat_tail=%s "
+                    "dlen=%d score=%.2f match=%d",
+                    str(sglang_req_id)[-10:],
+                    len(prompt),
+                    len(tokens),
+                    pattern[-6:],
+                    len(draft.token_ids),
+                    float(getattr(draft, "score", 0.0)),
+                    int(getattr(draft, "match_len", -1)),
+                )
+
+            if self._stats_every:
+                self._stats_drafts += 1
+                self._stats_draft_tokens += len(draft.token_ids)
+                self._stats_empty += not draft.token_ids
+                self._stats_score_sum += float(getattr(draft, "score", 0.0))
+
+            draft_ids = list(draft.token_ids)
+            draft_parents = list(draft.parents)
+            context_token = tokens[-1] if tokens else 0
+
+            # Fast path: arctic linear chains (use_tree_spec=False, the
+            # production mode) have parents == [-1, 0, 1, ...]. With root
+            # injection and chain-extension padding the per-request layout is
+            # then fully determined: ids = [root, d1.., 0-pad..] and the
+            # ancestry mask is exactly the K x K lower triangle -- one memcpy
+            # instead of the BFS reorder + per-node Python parent walks.
+            n = len(draft_ids)
+            is_chain = draft_parents == self._chain_parents[:n]
+            if is_chain:
+                draft_ids.insert(0, context_token)
+                # Context-window cap (keep at least the root) + clamp to K.
+                cap = self.draft_token_num
+                if max_lens is not None:
+                    cap = max(1, min(cap, max_lens[row]))
+                if len(draft_ids) > cap:
+                    del draft_ids[cap:]
+                    if self._stats_every and cap < self.draft_token_num:
+                        self._stats_capped += 1
+                original_len = len(draft_ids)
+                if original_len < self.draft_token_num:
+                    draft_ids.extend([0] * (self.draft_token_num - original_len))
+                mask_view[row] = self._tril
+            else:
+                draft_ids, draft_parents = self._reorder_tree_bfs(
+                    draft_ids, draft_parents
+                )
+                draft_ids, draft_parents = self._inject_root_node(
+                    draft_ids, draft_parents, context_token
+                )
+
+                # Context-window cap: a BFS-ordered prefix is itself a valid
+                # tree (parents precede children), so plain truncation is
+                # safe. Keep at least the root -- the verify layout requires
+                # one real token.
+                if max_lens is not None:
+                    cap = max(1, min(self.draft_token_num, max_lens[row]))
+                    if len(draft_ids) > cap:
+                        draft_ids = draft_ids[:cap]
+                        draft_parents = draft_parents[:cap]
+                        if self._stats_every:
+                            self._stats_capped += 1
+
+                original_len = len(draft_ids)
+                if original_len < self.draft_token_num:
+                    # Pad as a CHAIN EXTENSION (parent = previous node), not
+                    # as detached zero-rows: reconstruct then assigns padding
+                    # rows monotone positions (seq + i) exactly like a full
+                    # chain. Detached padding rows get depth-0 positions
+                    # (= seq_lens), whose rotary/router values perturb the
+                    # batched MoE numerics of the REAL rows in the same verify
+                    # forward — enough to flip near-tie argmax and drift the
+                    # greedy trajectory. Padding is still never accepted: the
+                    # walk stops at the last real node unless the target
+                    # argmax is literally token 0.
+                    pad_len = self.draft_token_num - original_len
+                    draft_ids.extend([0] * pad_len)
+                    draft_parents.extend(
+                        range(original_len - 1, original_len - 1 + pad_len)
+                    )
+                elif original_len > self.draft_token_num:
+                    draft_ids = draft_ids[: self.draft_token_num]
+                    draft_parents = draft_parents[: self.draft_token_num]
+                    original_len = self.draft_token_num
+
+                # Build ancestry mask: token i can attend to its ancestors and
+                # itself. Includes the chain-extension padding rows so the
+                # reconstructed positions stay monotone (see padding above).
+                mask = mask_view[row]
+                for i in range(len(draft_ids)):
+                    mask[i, i] = True
+                    parent = draft_parents[i]
+                    while 0 <= parent < self.draft_token_num:
+                        mask[i, parent] = True
+                        parent = draft_parents[parent]
+
+            start = row * self.draft_token_num
+            end = start + self.draft_token_num
+            draft_view[start:end] = draft_ids
+            mask = mask_view[row]
+
+            if self.debug_tree_dump_remaining > 0 and original_len > 0:
+                logger.warning(
+                    "[SUFFIX DEBUG] req=%s len=%d ids=%s",
+                    sglang_req_id,
+                    original_len,
+                    draft_ids,
+                )
+                logger.warning("[SUFFIX DEBUG] mask=\n%s", mask.astype(int))
+                self.debug_tree_dump_remaining -= 1
+
+        if self._stats_every:
+            self._stats_calls += 1
+            if self._stats_calls % self._stats_every == 0 and self._stats_drafts:
+                logger.info(
+                    "[SUFFIX STATS] calls=%d drafts=%d avg_draft_len=%.2f "
+                    "empty_frac=%.3f avg_score=%.2f capped=%d",
+                    self._stats_calls,
+                    self._stats_drafts,
+                    self._stats_draft_tokens / self._stats_drafts,
+                    self._stats_empty / self._stats_drafts,
+                    self._stats_score_sum / self._stats_drafts,
+                    self._stats_capped,
+                )
+
+        tree_mask = mask_view.reshape(-1)[: total_draft_tokens * self.draft_token_num]
+        return draft_view, tree_mask
+
+    def batch_put(
+        self,
+        batch_req_ids: List[str],
+        batch_tokens: Optional[List[List[int]]] = None,
+    ) -> None:
+        # Cache update is performed in batch_get before speculation, because the
+        # suffix backend needs a per-request incremental state. batch_tokens is
+        # accepted (and ignored) for NgramCorpus interface compatibility.
+        for rid in batch_req_ids:
+            if rid not in self.req_state:
+                logger.debug("batch_put called before batch_get for request %s", rid)
+
+    def erase_match_state(self, req_ids: List[str]) -> None:
+        # Release finished requests from the suffix cache (NGRAMWorker calls this
+        # with finished req ids after each step). Mirrors NgramCorpus.erase_match_state.
+        active = getattr(self.suffix_cache, "active_requests", set())
+        for rid in req_ids:
+            state = self.req_state.pop(rid, None)
+            self._absent_count.pop(rid, None)
+            if state is not None and state[0] in active:
+                self.suffix_cache.stop_request(state[0])
+
+    # External-corpus management is an NGRAM-only feature; SUFFIX has no SAM.
+    # Stubbed so the duck-typed NGRAMWorker / HTTP handlers fail clearly if used.
+    def commit_external_corpus_load(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def list_external_corpora(self, *args, **kwargs):
+        return []
+
+    def load_external_corpus_named(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def remove_external_corpus(self, *args, **kwargs):
+        raise NotImplementedError("SUFFIX speculative decoding has no external corpus.")
+
+    def synchronize(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        for cache_req_id in list(getattr(self.suffix_cache, "active_requests", set())):
+            self.suffix_cache.stop_request(cache_req_id)
+        self.req_state.clear()
+        self._absent_count.clear()
+
+    def _reorder_tree_bfs(
+        self, token_ids: List[int], parents: List[Optional[int]]
+    ) -> Tuple[List[int], List[int]]:
+        """Ensure parents precede descendants; SGLang reconstruct assumes this."""
+        n = len(token_ids)
+        if n <= 1:
+            return token_ids, [(-1 if p is None else p) for p in parents]
+
+        children: List[List[int]] = [[] for _ in range(n)]
+        roots: List[int] = []
+        for idx, parent in enumerate(parents):
+            if parent is None or parent < 0 or parent >= n:
+                roots.append(idx)
+            else:
+                children[parent].append(idx)
+        if not roots:
+            roots = [0]
+
+        order: List[int] = []
+        visited = [False] * n
+        for root in roots:
+            q = deque([root])
+            while q:
+                node = q.popleft()
+                if visited[node]:
+                    continue
+                visited[node] = True
+                order.append(node)
+                q.extend(children[node])
+        for idx in range(n):
+            if not visited[idx]:
+                order.append(idx)
+
+        if order == list(range(n)):
+            return token_ids, [(-1 if p is None else p) for p in parents]
+
+        remap = {old: new for new, old in enumerate(order)}
+        reordered_ids = [token_ids[old] for old in order]
+        reordered_parents: List[int] = []
+        for old in order:
+            parent = parents[old]
+            if parent is None or parent < 0:
+                reordered_parents.append(-1)
+            else:
+                reordered_parents.append(remap.get(parent, -1))
+        return reordered_ids, reordered_parents
+
+    def _inject_root_node(
+        self, token_ids: List[int], parents: List[int], context_token: int
+    ) -> Tuple[List[int], List[int]]:
+        """Insert latest verified token as root node to match NGRAM layout."""
+        rooted_ids = [context_token]
+        rooted_parents = [-1]
+        for parent in parents:
+            rooted_parents.append(0 if parent < 0 else parent + 1)
+        rooted_ids.extend(token_ids)
+        return rooted_ids, rooted_parents

--- a/python/sglang/srt/speculative/suffix_disaggregation.py
+++ b/python/sglang/srt/speculative/suffix_disaggregation.py
@@ -1,0 +1,85 @@
+"""SUFFIX speculative decoding under PD disaggregation.
+
+SUFFIX is model-free: its draft source is a CPU suffix tree over each
+request's prompt + generated tokens, both of which are already part of the
+request metadata that rides the PD protocol. Unlike EAGLE, nothing extra
+(topk_p / topk_index / hidden states) has to be captured on the prefill
+instance or shipped through the KV-transfer metadata buffers.
+
+The decode instance therefore only needs two things:
+
+1. ``build_suffix_disagg_draft_input`` — reconstruct the first decode batch's
+   cross-iteration spec_info. On the ngram-v2 stack that relay object is a
+   ``NgramVerifyInput`` carrying the previous round's ``accept_tokens`` /
+   ``accept_lens`` (which ``SuffixWorker._prepare_draft_tokens`` stages). On
+   the very first decode step ``_missing_tail`` returns ``[]`` (the
+   prefill-produced bonus token is already in ``req.output_ids``), so those
+   values are never consumed; we still provide well-shaped tensors with the
+   bonus at slot 0. The cross-step seq_lens relay goes through
+   ``future_map.publish`` with SUFFIX's ``seq_lens + 1`` convention (the
+   generated text is always ``seq_lens + 1`` tokens long; EAGLE publishes
+   ``seq_lens`` as-is). ``FutureMap.stash`` is a no-op for ``is_ngram()`` —
+   the NgramVerifyInput object itself is not relayed through the FutureMap
+   (the worker rebuilds it each step), so nothing else has to be shipped.
+
+2. Suffix-tree state, which is rebuilt decode-side from
+   ``req.origin_input_ids`` — by the prewarm hook while the KV transfer is
+   still in flight (see ``SuffixWorker.prewarm_disagg_requests``), or lazily
+   at the first decode step for requests that outran the prewarm (the
+   ``SuffixCacheAdapter`` builds the tree on first ``batch_get``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.speculative.ngram_info import NgramVerifyInput
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.overlap_utils import FutureMap
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.server_args import ServerArgs
+
+
+def build_suffix_disagg_draft_input(
+    batch: ScheduleBatch,
+    server_args: ServerArgs,
+    last_tokens_tensor: torch.Tensor,
+    future_map: FutureMap,
+) -> NgramVerifyInput:
+    bs = int(last_tokens_tensor.numel())
+    draft_token_num = int(server_args.speculative_num_draft_tokens)
+    device = batch.device
+
+    # SUFFIX publish convention: seq_lens + 1 (the pending bonus token is
+    # counted into the relayed length).
+    new_seq_lens = (batch.seq_lens + 1).to(torch.int64)
+
+    # accept_tokens / accept_lens are the "previous round's accepts" that
+    # _prepare_draft_tokens stages. Unused on the first decode step
+    # (_missing_tail returns [] because the bonus token is already in
+    # req.output_ids), but must be present and well-shaped: (bs * K,) flat
+    # tokens with the bonus at each request's slot 0, and (bs,) lens of 1.
+    accept_tokens = torch.zeros(
+        (bs * draft_token_num,), dtype=torch.int32, device=device
+    )
+    accept_tokens[::draft_token_num] = last_tokens_tensor.to(torch.int32)
+    accept_lens = torch.ones((bs,), dtype=torch.int64, device=device)
+
+    spec_info = NgramVerifyInput(
+        draft_token_num=draft_token_num,
+        new_seq_lens=new_seq_lens,
+        accept_tokens=accept_tokens,
+        accept_lens=accept_lens,
+    )
+
+    if batch.enable_overlap:
+        spec_info.future_indices = batch.req_pool_indices
+        # Only the seq_lens relay matters for SUFFIX; FutureMap.stash is a
+        # no-op for is_ngram() so the NgramVerifyInput is not shipped through
+        # it (the worker rebuilds each step's verify input).
+        future_map.publish(spec_info.future_indices, new_seq_lens)
+
+    return spec_info

--- a/python/sglang/srt/speculative/suffix_v2_draft_builder.py
+++ b/python/sglang/srt/speculative/suffix_v2_draft_builder.py
@@ -1,0 +1,135 @@
+"""SUFFIX V2 linear-chain draft → EagleVerifyInput converter.
+
+Phase 2.x design: SUFFIX V2 doesn't write its own verify path. Instead it
+expresses its linear chain as a topk=1 EAGLE tree and reuses EAGLE V2's
+`verify_tree_greedy` kernel + `prepare_for_v2_verify` / `sample` scaffold.
+
+Layout for `K = num_verify_tokens` per req, `bs` total reqs:
+  flat draft array       shape (bs*K,)         [bonus_0, sfx_0_1, sfx_0_2, ..., sfx_0_(K-1),
+                                                bonus_1, sfx_1_1, ...]
+  positions              shape (bs*K,)         positions[i*K+j] = seq_lens[i] + j
+  retrieve_index         shape (bs, K) int64   retrieve_index[i, j] = i*K + j
+  retrieve_next_token    shape (bs, K) int64   = i*K + j + 1 if j<K-1 else -1
+  retrieve_next_sibling  shape (bs, K) int64   all -1 (no siblings in topk=1)
+
+EAGLE's `verify_tree_greedy` kernel walks these arrays without caring whether
+the tree is degenerate (linear) or branching. As long as next_sibling is -1
+everywhere and next_token forms a single chain, the kernel produces the same
+"accept the longest matching prefix" semantics that we'd get from a custom
+NgramVerifyInput.greedy_verify, but with no custom kernel.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+
+def build_linear_retrieve_arrays(
+    bs: int,
+    K: int,
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build retrieve_index / retrieve_next_token / retrieve_next_sibling for
+    a topk=1 linear chain of K tokens per req.
+
+    Same shapes/dtypes as EAGLE's `build_tree_kernel_efficient` output (the
+    int64 / shape=(bs, K) format `verify_tree_greedy` expects).
+    """
+    # retrieve_index[i, j] = i*K + j → GLOBAL flat index into bs*K candidates
+    # array. The kernel uses this to look up the actual draft token value
+    # given a (req, local_node) pair.
+    retrieve_index = torch.arange(bs * K, dtype=torch.int64, device=device).view(bs, K)
+
+    # retrieve_next_token[i, j] = LOCAL index (per-req, range [0, K-1] or -1)
+    # of node j's first child. For linear chain: child of j is j+1, leaf is K-1.
+    # NOT a flat global index — kernel walks within per-req tree, then resolves
+    # to candidates[retrieve_index[i, that_local]].
+    local_arange = torch.arange(K, dtype=torch.int64, device=device).view(1, K)
+    next_token_local = local_arange + 1
+    next_token_local = next_token_local.expand(bs, K).contiguous()
+    next_token_local[:, -1] = -1
+    retrieve_next_token = next_token_local
+
+    # retrieve_next_sibling: linear chain has no siblings anywhere → all -1
+    retrieve_next_sibling = torch.full((bs, K), -1, dtype=torch.int64, device=device)
+
+    return retrieve_index, retrieve_next_token, retrieve_next_sibling
+
+
+def build_linear_positions(seq_lens: torch.Tensor, K: int) -> torch.Tensor:
+    """Build per-draft-token absolute positions for a linear chain.
+
+    positions[i*K + j] = seq_lens[i] + j
+
+    Shape: (bs*K,) int64. Matches EAGLE's `positions` tensor format consumed
+    by the target attention forward.
+    """
+    bs = seq_lens.numel()
+    device = seq_lens.device
+    # offsets[j] = j  (broadcast across bs)
+    offsets = torch.arange(K, dtype=torch.int64, device=device).view(1, K)
+    seq_lens_i64 = seq_lens.to(torch.int64).view(bs, 1)
+    positions = (seq_lens_i64 + offsets).view(bs * K)
+    return positions
+
+
+def build_suffix_v2_verify_arrays(
+    bonus_tokens: torch.Tensor,
+    suffix_draft_tokens: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """One-shot builder for the SUFFIX V2 → EagleVerifyInput tensor pieces.
+
+    Args:
+        bonus_tokens: (bs,) int32 — first token of each chain (the "+1" from
+            previous verify, becomes draft position 0).
+        suffix_draft_tokens: (bs, K-1) int32 — remaining K-1 spec tokens per
+            req, queried from the suffix tree. Pad shorter chains with any
+            value; target.argmax will reject them and accept length will cut.
+        seq_lens: (bs,) int32/int64 — current sequence lengths (pre-verify).
+
+    Returns:
+        draft_token_flat:        (bs*K,) int32
+        positions:               (bs*K,) int64
+        retrieve_index:          (bs, K) int64
+        retrieve_next_token:     (bs, K) int64
+        retrieve_next_sibling:   (bs, K) int64
+
+    Caller still needs to attach `custom_mask` and the other EagleVerifyInput
+    fields (spec_steps, topk=1, draft_token_num=K, etc.) — see
+    `build_suffix_v2_eagle_verify_input`.
+    """
+    bs = bonus_tokens.numel()
+    K = 1 + suffix_draft_tokens.size(1)
+    device = bonus_tokens.device
+    assert (
+        suffix_draft_tokens.size(0) == bs
+    ), f"bs mismatch: bonus_tokens={bs}, suffix_draft_tokens={suffix_draft_tokens.shape}"
+    assert (
+        seq_lens.numel() == bs
+    ), f"bs mismatch: seq_lens={seq_lens.numel()} vs bonus_tokens={bs}"
+
+    # Flat draft array: [bonus_0, sfx_0_1..sfx_0_(K-1), bonus_1, sfx_1_1..., ...]
+    # Match EAGLE convention: bonus prepended, then spec tokens.
+    # Dtype = int64: that's what verify_tree_greedy's sgl_kernel expects
+    # (matches EagleVerifyInput.create_idle_input dtype=torch.long).
+    draft_token_flat = (
+        torch.cat((bonus_tokens.view(bs, 1), suffix_draft_tokens), dim=1)
+        .view(bs * K)
+        .to(torch.int64)
+    )
+
+    positions = build_linear_positions(seq_lens, K)
+    retrieve_index, retrieve_next_token, retrieve_next_sibling = (
+        build_linear_retrieve_arrays(bs, K, device)
+    )
+
+    return (
+        draft_token_flat,
+        positions,
+        retrieve_index,
+        retrieve_next_token,
+        retrieve_next_sibling,
+    )

--- a/python/sglang/srt/speculative/suffix_v2_draft_builder_full.py
+++ b/python/sglang/srt/speculative/suffix_v2_draft_builder_full.py
@@ -1,0 +1,208 @@
+"""SUFFIX V2 standalone draft builder — M3b.
+
+Wraps `arctic_inference.SuffixDecodingCache` with a V2-friendly tensor
+interface. Handles per-request state lifecycle (start/update/stop) and
+returns padded GPU tensors ready to feed into the M2 EagleVerifyInput
+builder.
+
+Key design decisions:
+- Uses arctic's default `use_tree_spec=False` → linear chain (matches our
+  V2 design's "topk=1 linear" assumption).
+- Keys state by sglang `rid` (Hashable string). Never by req_pool_index
+  (per design doc §3.4: pool slots get reused, would corrupt history).
+- Padding: short matches (< K-1) are padded with token_id=0 + valid_mask
+  False. Downstream verify will reject the padded slots — accept length
+  naturally cuts at the real match length.
+- Pattern construction: last `max_tree_depth` tokens (matching V1's
+  policy for parity).
+
+This builder is stateful (suffix tree per rid). Caller must invoke
+`start_request` for each new rid, `stop_request` on finish, and
+`update_with_accepted` after each verify step to push accepted tokens
+into the suffix tree (so future speculations include them).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixV2DraftBuilder:
+    """Standalone V2 draft builder over `arctic_inference.SuffixDecodingCache`.
+
+    Returns padded GPU tensors:
+      draft_tokens: (bs, K_minus_1) int32 — speculated tokens, padded with 0
+      draft_lens:   (bs,) int32           — actual match length per req
+      valid_mask:   (bs, K_minus_1) bool  — True for [:draft_lens[i]]
+    """
+
+    def __init__(
+        self,
+        max_cached_requests: int = 10000,
+        max_tree_depth: int = 64,
+        max_spec_factor: float = 2.0,
+        min_token_prob: float = 0.1,
+    ):
+        from arctic_inference.suffix_decoding import SuffixDecodingCache
+
+        self.cache = SuffixDecodingCache(
+            max_tree_depth=max_tree_depth,
+            max_cached_requests=max_cached_requests,
+        )
+        warmup_path = os.environ.get("ARCTIC_SUFFIX_GLOBAL_WARMUP_PATH")
+        warmup_count = getattr(self.cache, "_warmup_count", 0)
+        if warmup_path:
+            logger.info(
+                "SuffixV2DraftBuilder: arctic global tree warmup loaded "
+                "%d records from %s (max_tree_depth=%d max_cached=%d)",
+                warmup_count,
+                warmup_path,
+                max_tree_depth,
+                max_cached_requests,
+            )
+        else:
+            logger.info(
+                "SuffixV2DraftBuilder: no warmup "
+                "(ARCTIC_SUFFIX_GLOBAL_WARMUP_PATH unset); "
+                "max_tree_depth=%d max_cached=%d",
+                max_tree_depth,
+                max_cached_requests,
+            )
+        self.max_spec_factor = max_spec_factor
+        self.min_token_prob = min_token_prob
+        self.max_tree_depth = max_tree_depth
+
+        # rid → length of tokens already pushed into the suffix cache.
+        # Lets `update_with_accepted` push only the delta since last call.
+        self._pushed_len: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Per-request lifecycle
+    # ------------------------------------------------------------------
+    def start_request(self, rid: str, prompt_tokens: Sequence[int]) -> None:
+        """Register a new request with its prompt. Must be called before any
+        query/update for this rid."""
+        self.cache.start_request(rid, list(prompt_tokens))
+        self._pushed_len[rid] = len(prompt_tokens)
+
+    def update_with_accepted(self, rid: str, all_tokens: Sequence[int]) -> None:
+        """Push the delta of accepted tokens since last call into the suffix
+        tree. Idempotent if all_tokens hasn't grown.
+
+        Caller passes the FULL accumulated tokens (prompt + all output so
+        far); we slice out the new tail using our tracked `_pushed_len`.
+        """
+        pushed = self._pushed_len.get(rid, 0)
+        cur = len(all_tokens)
+        if cur > pushed:
+            new = list(all_tokens[pushed:cur])
+            if rid in self.cache.active_requests:
+                self.cache.add_active_response(rid, new)
+            self._pushed_len[rid] = cur
+
+    def stop_request(self, rid: str) -> None:
+        """Finish a request — release local tree state. Global tree retains
+        the response (with FIFO eviction governed by max_cached_requests)."""
+        if rid in self.cache.active_requests:
+            self.cache.stop_request(rid)
+        self._pushed_len.pop(rid, None)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+    def query_batch(
+        self,
+        rids: List[str],
+        current_tokens: List[Sequence[int]],
+        K_minus_1: int,
+        device: torch.device,
+        return_scores: bool = False,
+        max_remaining_per_req: Optional[Sequence[int]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Query the suffix cache for each req's next draft.
+
+        Args:
+            rids: per-req identifiers (must have been registered via
+                  `start_request`).
+            current_tokens: full prompt+output for each req (used to form
+                  the suffix pattern for matching).
+            K_minus_1: number of draft tokens to request per req (chain
+                  width K minus the bonus slot).
+            device: target device for returned tensors.
+            return_scores: when True, also returns per-req scores (Python
+                  list, for the HYBRID selector).
+            max_remaining_per_req: optional per-req ceiling on draft length
+                  (e.g. ctx_len - cur_seq_len - 1). Prevents the verify
+                  step from overshooting context_len and producing an
+                  overlap-schedule "zombie" verify on the next iteration
+                  (see patch_nsa_zombie_overflow.py for the symptom).
+                  When None, no per-req cap; each req gets up to K_minus_1.
+
+        Returns:
+            draft_tokens: (bs, K_minus_1) int32, padded with 0
+            draft_lens:   (bs,) int32, actual length per req
+            valid_mask:   (bs, K_minus_1) bool
+            scores:       List[float] (bs,) — only if return_scores=True
+        """
+        bs = len(rids)
+        assert len(current_tokens) == bs
+        if max_remaining_per_req is not None:
+            assert len(max_remaining_per_req) == bs, (
+                f"max_remaining_per_req has {len(max_remaining_per_req)} entries, "
+                f"expected bs={bs}"
+            )
+
+        draft_tokens_np = np.zeros((bs, K_minus_1), dtype=np.int32)
+        draft_lens_np = np.zeros(bs, dtype=np.int32)
+        valid_mask_np = np.zeros((bs, K_minus_1), dtype=bool)
+        scores: List[float] = [0.0] * bs if return_scores else []
+
+        for i, (rid, tokens) in enumerate(zip(rids, current_tokens)):
+            # Per-req draft ceiling: K_minus_1 floor by remaining ctx room
+            # (if provided). 0 means this req is at the boundary — skip
+            # drafting entirely; verify still runs with bonus-only.
+            req_K = K_minus_1
+            if max_remaining_per_req is not None:
+                req_K = min(req_K, max(0, int(max_remaining_per_req[i])))
+            if req_K == 0:
+                if return_scores:
+                    scores[i] = 0.0
+                continue
+
+            # Take last max_tree_depth tokens as pattern. Arctic also clips
+            # internally but doing it here keeps pattern shorter for arctic.
+            pattern_start = max(0, len(tokens) - self.max_tree_depth)
+            pattern = list(tokens[pattern_start:])
+
+            draft = self.cache.speculate(
+                rid,
+                pattern,
+                max_spec_tokens=req_K,
+                max_spec_factor=self.max_spec_factor,
+                min_token_prob=self.min_token_prob,
+                # use_tree_spec=False (default) → linear chain
+            )
+
+            actual_len = min(len(draft.token_ids), req_K)
+            if actual_len > 0:
+                draft_tokens_np[i, :actual_len] = list(draft.token_ids[:actual_len])
+                draft_lens_np[i] = actual_len
+                valid_mask_np[i, :actual_len] = True
+            if return_scores:
+                scores[i] = float(getattr(draft, "score", 0.0))
+
+        result = (
+            torch.from_numpy(draft_tokens_np).to(device),
+            torch.from_numpy(draft_lens_np).to(device),
+            torch.from_numpy(valid_mask_np).to(device),
+        )
+        if return_scores:
+            return result + (scores,)
+        return result

--- a/python/sglang/srt/speculative/suffix_v2_verify_input.py
+++ b/python/sglang/srt/speculative/suffix_v2_verify_input.py
@@ -1,0 +1,134 @@
+"""Build a complete EagleVerifyInput from a SUFFIX linear-chain draft.
+
+M2 of the SUFFIX V2 overlap work. Builds on M1's draft_builder (retrieve_*
+arrays + positions) and adds:
+  - custom_mask construction for the FULL_MASK layout (per-row prefix=True
+    + lower-triangular K-block for linear chain)
+  - All remaining EagleVerifyInput dataclass fields
+    (spec_steps, topk=1, draft_token_num, capture_hidden_mode,
+     seq_lens_sum, seq_lens_cpu)
+
+Once this returns a populated EagleVerifyInput, the EAGLE V2 verify scaffold
+(`prepare_for_v2_verify` → target forward(is_verify=True) → `sample`) can be
+reused verbatim — no SUFFIX-specific verify path.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.speculative.eagle_info import EagleVerifyInput
+from sglang.srt.speculative.suffix_v2_draft_builder import build_suffix_v2_verify_arrays
+
+
+def build_suffix_v2_custom_mask(
+    bs: int,
+    K: int,
+    seq_lens_cpu: torch.Tensor,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build the FULL_MASK custom_mask for a topk=1 linear chain.
+
+    Per-req block layout (K rows × (seq_lens[i] + K) cols, row-major):
+      row j: [True] * seq_lens[i] + [True] * (j+1) + [False] * (K-j-1)
+      (i.e., prefix all attended, then lower-triangular within K-block)
+
+    Concatenated across reqs in flat layout. Total size:
+        sum_i K * (seq_lens[i] + K) = K * seq_lens_sum + K * K * bs
+
+    Args:
+        bs: batch size
+        K: draft_token_num (chain width per req)
+        seq_lens_cpu: per-req seq_lens, shape (bs,) on CPU (int)
+        device: target device for the output mask
+
+    Returns:
+        custom_mask: (K * seq_lens_sum + K*K*bs,) bool tensor on `device`
+    """
+    assert (
+        seq_lens_cpu.numel() == bs
+    ), f"seq_lens_cpu has {seq_lens_cpu.numel()} entries, expected bs={bs}"
+
+    # Build the K-block lower-triangular mask once (same for every req).
+    # k_block[j, k] = True iff k <= j  (i.e., position j attends to k in chain)
+    k_block = torch.tril(torch.ones((K, K), dtype=torch.bool, device=device))  # (K, K)
+
+    # Concatenate per-req chunks. Each chunk is K rows × (seq_lens[i] + K) cols
+    # flattened row-major.
+    chunks = []
+    seq_lens_list = seq_lens_cpu.tolist()
+    for sl in seq_lens_list:
+        prefix_block = torch.ones((K, sl), dtype=torch.bool, device=device)
+        per_req = torch.cat((prefix_block, k_block), dim=1)  # (K, sl + K)
+        chunks.append(per_req.reshape(-1))  # flatten row-major to (K * (sl + K),)
+    custom_mask = (
+        torch.cat(chunks) if chunks else torch.empty(0, dtype=torch.bool, device=device)
+    )
+    return custom_mask
+
+
+def build_suffix_v2_eagle_verify_input(
+    bonus_tokens: torch.Tensor,
+    suffix_draft_tokens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    seq_lens_cpu: Optional[torch.Tensor] = None,
+    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.NULL,
+) -> EagleVerifyInput:
+    """Build a complete EagleVerifyInput from SUFFIX linear chain draft.
+
+    Args:
+        bonus_tokens: (bs,) int — first token per chain (from prev step's verify)
+        suffix_draft_tokens: (bs, K-1) int — suffix-cache-queried spec tokens
+        seq_lens: (bs,) int — per-req current seq length (on device)
+        seq_lens_cpu: (bs,) int on CPU; computed from seq_lens if None
+        capture_hidden_mode: NULL for standalone SUFFIX, FULL if downstream
+            needs hidden states (e.g., HYBRID V2 with MTP keep-up).
+
+    Returns:
+        EagleVerifyInput ready to be assigned to the batch's spec_info
+        and passed through EAGLE V2's verify scaffold (`prepare_for_v2_verify`,
+        target forward(is_verify=True), `sample`).
+    """
+    bs = bonus_tokens.numel()
+    K = 1 + suffix_draft_tokens.size(1)
+    device = bonus_tokens.device
+
+    if seq_lens_cpu is None:
+        seq_lens_cpu = seq_lens.cpu()
+
+    # M1 builder: draft_token_flat + positions + retrieve_*
+    (
+        draft_token_flat,
+        positions,
+        retrieve_index,
+        retrieve_next_token,
+        retrieve_next_sibling,
+    ) = build_suffix_v2_verify_arrays(
+        bonus_tokens=bonus_tokens,
+        suffix_draft_tokens=suffix_draft_tokens,
+        seq_lens=seq_lens,
+    )
+
+    # M2: custom_mask (FULL_MASK layout, linear chain = lower-triangular K-block)
+    custom_mask = build_suffix_v2_custom_mask(bs, K, seq_lens_cpu, device)
+
+    seq_lens_sum = int(seq_lens_cpu.sum().item())
+
+    return EagleVerifyInput(
+        draft_token=draft_token_flat,
+        custom_mask=custom_mask,
+        positions=positions,
+        retrieve_index=retrieve_index,
+        retrieve_next_token=retrieve_next_token,
+        retrieve_next_sibling=retrieve_next_sibling,
+        retrieve_cum_len=None,
+        spec_steps=K - 1,  # number of draft steps (excluding bonus)
+        topk=1,  # linear chain = topk=1
+        draft_token_num=K,  # K tokens per req in candidates
+        capture_hidden_mode=capture_hidden_mode,
+        seq_lens_sum=seq_lens_sum,
+        seq_lens_cpu=seq_lens_cpu,
+    )

--- a/python/sglang/srt/speculative/suffix_worker.py
+++ b/python/sglang/srt/speculative/suffix_worker.py
@@ -45,7 +45,7 @@ overlap scheduling).
 from __future__ import annotations
 
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -95,6 +95,47 @@ class SuffixWorker(NGRAMWorker):
         # Cap per-request draft length so verify can't overshoot the context
         # window (the -1 leaves room for the bonus token).
         self._max_context_len = int(target_worker.model_runner.model_config.context_len)
+        # PD disaggregation (decode instance): prebuilt requests whose suffix
+        # tree should be rebuilt while their KV transfer is still in flight
+        # (rid -> Req). Drained by prewarm_step(), enqueued by
+        # prewarm_disagg_requests() from the decode scheduler's transfer-queue
+        # polling loop. Empty (and unused) on colocated / prefill instances.
+        self._prewarm_pending: Dict[str, object] = {}
+
+    # ------------------------------------------------------------------
+    # PD disaggregation: decode-side suffix-tree prewarm
+    #
+    # Correctness does NOT depend on prewarm: a prebuilt request that reaches
+    # its first decode step un-prewarmed is cold-started lazily inside the
+    # adapter's batch_get (_get_or_create_cache_req_id), and the transferred
+    # output tail (the prefill-produced bonus token) is appended there by the
+    # normal absolute-length delta. Prewarm only moves the tens-of-ms prompt
+    # tree build off the first decode step, overlapping it with KV transfer.
+    # ------------------------------------------------------------------
+    def prewarm_disagg_requests(self, reqs) -> None:
+        """Enqueue prebuilt requests for suffix-tree prewarm. Idempotent per
+        rid; skips requests whose tree the adapter already tracks."""
+        for req in reqs:
+            rid = req.rid
+            if rid in self.ngram_corpus.req_state or rid in self._prewarm_pending:
+                continue
+            self._prewarm_pending[rid] = req
+
+    def prewarm_step(self, token_budget: int = 32768) -> None:
+        """Build at most ``token_budget`` prompt tokens worth of pending
+        prewarm trees. Runs on the scheduler thread (arctic is not
+        thread-safe); the budget bounds the per-iteration stall. The adapter's
+        own grace window keeps a prewarmed tree alive until its first decode."""
+        spent = 0
+        while self._prewarm_pending and spent < token_budget:
+            rid, req = self._prewarm_pending.popitem()
+            if rid in self.ngram_corpus.req_state:
+                continue
+            prompt = list(req.origin_input_ids)
+            # Seed the backend tree with the prompt; the transferred output
+            # tail is appended later as the batch_get delta on first decode.
+            self.ngram_corpus._get_or_create_cache_req_id(rid, prompt)
+            spent += len(prompt)
 
     def _create_draft_source(self, server_args: ServerArgs):
         # The inherited forward flow reaches self.ngram_corpus only through

--- a/python/sglang/srt/speculative/suffix_worker.py
+++ b/python/sglang/srt/speculative/suffix_worker.py
@@ -1,0 +1,208 @@
+"""SUFFIX speculative-decoding worker.
+
+SUFFIX is *model-free* speculative decoding (Snowflake ArcticInference's
+SuffixDecoding): a CPU suffix tree built over each request's prompt +
+generated tokens proposes draft continuations, which are verified in a
+single target forward pass. It is especially effective on agentic /
+repetitive workloads and adds no draft-model GPU cost.
+
+Implementation reuses :class:`NGRAMWorker` unchanged for the entire spec-v2
+machinery (draft slot assignment, target verify, ``NgramVerifyInput.sample``,
+overlap ``on_publish`` fence, corpus lifecycle); the only difference is the
+*draft source*. ``_create_draft_source`` swaps the C++ n-gram corpus for a
+:class:`SuffixCacheAdapter` wrapping ``arctic_inference``'s
+``SuffixDecodingCache``, and we override the two hooks that talk to it:
+
+  - ``_prepare_draft_tokens`` — the suffix tree matches against the request's
+    *full* history (prompt + output), not just a recent n-gram window, and
+    needs per-request lifecycle (``start_request``) keyed by rid.
+  - ``_update_ngram_corpus`` — feed the realized tokens back into the tree.
+
+Unlike the base class, the previous round's accepts are NOT spliced
+unconditionally under overlap: result processing usually lags one iteration,
+but whenever another batch (e.g. a prefill chunk) runs between two decode
+steps of this batch, the lagging result HAS been processed into
+``req.output_ids`` by the time we are called again — an unconditional splice
+then duplicates the whole accept run. The base trie's bounded-window insert
+shrugs that off; the suffix adapter feeds the tree by absolute-length delta,
+so a duplicated splice both corrupts the tree content and desynchronizes the
+delta cursor, degrading match length from then on. We therefore reconstruct
+the exact frontier from ``seq_lens`` (invariant: the generated text is always
+``seq_lens + 1`` tokens long — the trailing bonus token's KV is committed by
+the *next* verify) and splice only the genuinely missing tail.
+
+SUFFIX drafts are linear chains (arctic ``use_tree_spec=False``), so accepted
+tokens always form a contiguous prefix of the canonical verify slots —
+``drafts_are_linear_chains = True`` skips the post-verify KV move (an
+identity for chains, and unsupported by DeepSeek-V4's NSA paginated pool).
+
+Per-request draft length is additionally capped at
+``context_len - seq_len - 1`` so a verify step can never overshoot the
+context window (which would produce an out-of-range zombie verify under
+overlap scheduling).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.ngram_worker import NGRAMWorker
+from sglang.srt.speculative.suffix_cache_adapter import (
+    SegmentedTokens,
+    SuffixCacheAdapter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixWorker(NGRAMWorker):
+    """``NGRAMWorker`` whose draft source is an Arctic suffix tree."""
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        attn_cp_rank: int,
+        moe_dp_rank: int,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        super().__init__(
+            server_args=server_args,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+            dp_rank=dp_rank,
+            moe_ep_rank=moe_ep_rank,
+            attn_cp_rank=attn_cp_rank,
+            moe_dp_rank=moe_dp_rank,
+            nccl_port=nccl_port,
+            target_worker=target_worker,
+        )
+        # Arctic chains: accepted KV needs no post-verify move (see base flag).
+        self.drafts_are_linear_chains = True
+        # The adapter manages request lifecycle itself with a grace window
+        # (absence from the batch is NOT departure under PP micro-batch
+        # rotation; immediate erase forces a full local-tree rebuild from the
+        # prompt on every return). See SuffixCacheAdapter._cleanup_inactive_requests.
+        self.corpus_gc_on_departure = False
+        # Cap per-request draft length so verify can't overshoot the context
+        # window (the -1 leaves room for the bonus token).
+        self._max_context_len = int(target_worker.model_runner.model_config.context_len)
+
+    def _create_draft_source(self, server_args: ServerArgs):
+        # The inherited forward flow reaches self.ngram_corpus only through
+        # the hooks we override below, plus synchronize() /
+        # erase_match_state(), which the adapter provides with matching
+        # signatures.
+        #
+        # SuffixCacheAdapter sizes preallocated draft buffers from
+        # max_batch_size, which the base NGRAMWorker only resolves in the
+        # deferred alloc_memory_pool() (max_running_requests is not known at
+        # worker __init__). NGRAMWorker.__init__ calls this eagerly, so return
+        # None then and let alloc_memory_pool() (overridden below) rebuild it.
+        if getattr(self, "max_batch_size", None) is None:
+            return None
+        return SuffixCacheAdapter(
+            draft_token_num=server_args.speculative_num_draft_tokens,
+            max_batch_size=self.max_batch_size,
+            max_tree_depth=server_args.speculative_suffix_max_tree_depth,
+            max_cached_requests=server_args.speculative_suffix_max_cached_requests,
+            max_spec_factor=server_args.speculative_suffix_max_spec_factor,
+            min_token_prob=server_args.speculative_suffix_min_token_prob,
+        )
+
+    def alloc_memory_pool(self, **kwargs):
+        # Base sets self.max_batch_size (+ NGRAM preallocated tensors) here —
+        # only now can the suffix adapter size its buffers. Rebuild the draft
+        # source that __init__'s eager call deferred to None.
+        super().alloc_memory_pool(**kwargs)
+        self.ngram_corpus = self._create_draft_source(self.server_args)
+
+    def _missing_tail(self, batch: ScheduleBatch, i: int, target_len: int) -> List[int]:
+        """The tail of request i's history that is not yet in
+        ``req.output_ids``. Under overlap, ``output_ids`` lags by the last
+        round's accepts ONLY when that result has not been processed yet
+        (another batch running in between processes it); splice exactly the
+        missing tail of the staged accept run — never unconditionally (see
+        module docstring)."""
+        req = batch.reqs[i]
+        missing = target_len - len(req.origin_input_ids) - len(req.output_ids)
+        if missing <= 0:
+            # Result already processed; an unconditional splice would
+            # duplicate the accept run here.
+            return []
+        a = self.prev_accept_lens[i]
+        stride = self.draft_token_num
+        prev = self.prev_token_ids[i * stride : i * stride + a]
+        if missing > a:
+            # Should not happen (result processing lags at most one round);
+            # feed what we have rather than corrupting the tree with a hole.
+            logger.warning(
+                "SUFFIX frontier gap exceeds staged accepts "
+                "(missing=%d staged=%d rid=%s)",
+                missing,
+                a,
+                req.rid,
+            )
+            return prev
+        return prev[a - missing :]
+
+    def _prepare_draft_tokens(self, batch: ScheduleBatch):
+        bs = len(batch.reqs)
+
+        # Stage the previous round's accepts (mirrors the base class); they
+        # are consumed by _request_tokens only for requests whose output_ids
+        # actually lag.
+        prev_token_ids, prev_accept_lens = (
+            batch.spec_info.accept_tokens,
+            batch.spec_info.accept_lens,
+        )
+        if not prev_token_ids.is_cpu:
+            prev_token_ids = prev_token_ids.cpu()
+            prev_accept_lens = prev_accept_lens.cpu()
+        self.prev_token_ids = prev_token_ids.tolist()
+        self.prev_accept_lens = prev_accept_lens.tolist()
+
+        self.ngram_corpus.synchronize()
+        req_ids: List[str] = []
+        prompts: List[List[int]] = []
+        tokens: List[List[int]] = []
+        max_lens: List[int] = []
+        seq_lens_cpu = batch.seq_lens_cpu.tolist()
+        for i, req in enumerate(batch.reqs):
+            req_ids.append(req.rid)
+            # Pass references, not copies — the adapter materializes only
+            # the short slices it needs (per-step O(seq_len) copies otherwise
+            # dominate the decode-step CPU budget at agent context lengths).
+            prompts.append(req.origin_input_ids)
+            # Full history — the suffix tree matches arbitrarily long
+            # patterns, unlike the trie's bounded window. seq_lens + 1 is the
+            # exact text frontier (see module docstring).
+            tokens.append(
+                SegmentedTokens(
+                    req.origin_input_ids,
+                    req.output_ids,
+                    self._missing_tail(batch, i, seq_lens_cpu[i] + 1),
+                )
+            )
+            max_lens.append(max(0, self._max_context_len - seq_lens_cpu[i] - 1))
+        req_drafts, mask = self.ngram_corpus.batch_get(
+            req_ids, prompts, tokens, max_lens=max_lens
+        )
+        total_draft_token_num = len(req_drafts)
+        assert (
+            total_draft_token_num == bs * self.draft_token_num
+        ), f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
+        return req_drafts, mask
+
+    def _update_ngram_corpus(self, batch: ScheduleBatch):
+        # The adapter ingests tokens incrementally inside batch_get;
+        # batch_put is a per-request sanity hook only (no token payload).
+        self.ngram_corpus.batch_put([req.rid for req in batch.reqs])

--- a/test/registered/unit/spec/test_suffix_registry.py
+++ b/test/registered/unit/spec/test_suffix_registry.py
@@ -1,0 +1,117 @@
+"""Unit tests for the SUFFIX speculative-decoding plugin registration.
+
+CPU-only: exercises the plugin wiring (registration, duck-typed predicates,
+arg validation, lazy factory) without loading a model or arctic_inference.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.speculative import sgl_suffix_plugin
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_registry import (
+    _REGISTRY,
+    CustomSpecAlgo,
+    _assert_custom_spec_algo_conforms,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _SuffixRegistered(CustomTestCase):
+    """Re-register SUFFIX into an isolated registry so tests don't leak."""
+
+    def setUp(self):
+        self._snapshot = _REGISTRY.copy()
+        _REGISTRY.clear()
+        SpeculativeAlgorithm.register(
+            "SUFFIX",
+            supports_overlap=True,
+            validate_server_args=sgl_suffix_plugin._validate_suffix_args,
+            spec_class=sgl_suffix_plugin._SuffixLike,
+        )(sgl_suffix_plugin._suffix_factory)
+        self.algo = SpeculativeAlgorithm.from_string("SUFFIX")
+
+    def tearDown(self):
+        _REGISTRY.clear()
+        _REGISTRY.update(self._snapshot)
+
+
+class TestSuffixRegistration(_SuffixRegistered):
+    def test_from_string_returns_custom_spec(self):
+        self.assertIsInstance(self.algo, CustomSpecAlgo)
+        self.assertEqual(self.algo.name, "SUFFIX")
+
+    def test_case_insensitive(self):
+        self.assertIs(
+            SpeculativeAlgorithm.from_string("suffix"),
+            SpeculativeAlgorithm.from_string("SUFFIX"),
+        )
+
+    def test_dispatches_like_ngram(self):
+        # SUFFIX reuses NGRAM's verify / KV-cache dispatch.
+        self.assertTrue(self.algo.is_ngram())
+        self.assertTrue(self.algo.is_suffix())
+
+    def test_other_predicates_false(self):
+        self.assertFalse(self.algo.is_eagle())
+        self.assertFalse(self.algo.is_eagle3())
+        self.assertFalse(self.algo.is_standalone())
+        self.assertFalse(self.algo.is_none())
+        self.assertTrue(self.algo.is_speculative())
+
+    def test_supports_overlap_spec_v2(self):
+        # The worker rides NGRAM's spec-v2-native machinery, so overlap
+        # scheduling is supported (and supports_spec_v2 follows it).
+        self.assertTrue(self.algo.supports_overlap)
+        self.assertTrue(self.algo.supports_spec_v2())
+
+    def test_not_equal_to_builtin(self):
+        self.assertNotEqual(self.algo, SpeculativeAlgorithm.NGRAM)
+        self.assertNotEqual(self.algo, SpeculativeAlgorithm.EAGLE)
+
+
+class TestSuffixConformance(_SuffixRegistered):
+    def test_spec_class_conforms(self):
+        # _SuffixLike must satisfy the enum's is_*/supports_* duck-type contract.
+        _assert_custom_spec_algo_conforms(sgl_suffix_plugin._SuffixLike)
+
+    def test_provides_create_future_map(self):
+        # The scheduler calls create_future_map() unconditionally; CustomSpecAlgo's
+        # base does not define it, so _SuffixLike must (regression guard).
+        self.assertTrue(callable(getattr(self.algo, "create_future_map", None)))
+
+
+class TestSuffixFactory(_SuffixRegistered):
+    def test_factory_returns_suffix_worker(self):
+        # Lazy: importing SuffixWorker does not require arctic_inference (that is
+        # imported only when the worker is constructed).
+        from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+        for disable_overlap in (True, False):
+            server_args = SimpleNamespace(disable_overlap_schedule=disable_overlap)
+            self.assertIs(self.algo.create_worker(server_args), SuffixWorker)
+
+
+class TestSuffixArgValidation(_SuffixRegistered):
+    _FIELDS = (
+        "speculative_suffix_max_tree_depth",
+        "speculative_suffix_max_cached_requests",
+        "speculative_suffix_max_spec_factor",
+        "speculative_suffix_min_token_prob",
+    )
+
+    def test_validator_passes_with_all_fields(self):
+        sa = SimpleNamespace(**{f: 1 for f in self._FIELDS})
+        self.algo.validate_server_args(sa)  # does not raise
+
+    def test_validator_raises_when_field_missing(self):
+        sa = SimpleNamespace(**{f: 1 for f in self._FIELDS[1:]})  # drop the first
+        with self.assertRaisesRegex(ValueError, "speculative_suffix_max_tree_depth"):
+            self.algo.validate_server_args(sa)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

Adds a `HYBRID_SUFFIX_MTP` speculative-decoding algorithm that routes each
verify batch among three backends based on per-batch signals:

  - **SUFFIX** — arctic suffix-tree draft + EAGLE-style verify at the wide
    chain (`K = speculative_num_draft_tokens`, typically 16). Wins on
    prompts with repetitive / replayable structure.
  - **MTP** — standard EAGLE V2 draft + verify (`K = speculative_num_steps
    + 1`, typically 4). Wins when SUFFIX has no match but the draft model
    still produces useful tokens.
  - **NONE** — plain decode, no spec (`K = 1`). Wins at large batch sizes
    where the extra-K verify steals more time than the accepted drafts
    save.

A single workload often has all three regimes (agent prompts → SUFFIX,
follow-up generation → MTP, saturated batches → NONE). Pure SUFFIX or
pure MTP each leave one of those regimes on the table; HYBRID picks per
batch and recovers all three.

This PR is based on previous work (https://github.com/sgl-project/sglang/pull/27585) and is **V2 only** — it inherits `EAGLEWorkerV2` and runs under the
overlap scheduler. A V1 variant is not provided because the V1 SUFFIX
worker (`NGRAMWorker` subclass) cannot live under overlap scheduling, so
a V1-only hybrid has no upside.

## Modifications

- **`HybridBackendSelector`** (`hybrid_backend_selector.py`) — per-batch
  chooser. Inputs are the SUFFIX peek score (tree match strength) and
  the MTP head's top-1 confidence (a free signal already in
  `mwb.spec_info.topk_p` from the previous keep-up). Also tracks an
  online EMA of realized accept length per backend and ε-explores so
  SUFFIX EMA stays fresh. All thresholds are env-tunable for sweeps.
- **`HybridSuffixMTPWorkerV2`** (`hybrid_suffix_mtp_worker_v2.py`) —
  inherits `EAGLEWorkerV2` and dispatches per batch via the selector.
  SUFFIX path optionally runs an extra `draft_extend_for_decode` after
  every step (`--speculative-hybrid-mtp-always-warm`) so a later
  MTP-picked step starts with warm draft state; without it, the first
  MTP step after a SUFFIX run pays a one-time keep-up cost.
- **Three cuda graph runners per `ModelRunner`** — main runner stays at
  `K = speculative_num_draft_tokens` (SUFFIX); two new runners capture
  at `K = speculative_num_steps + 1` (MTP) and `K = 1` (NONE).
  `_forward_raw` dispatches in width-ascending order; each runner's
  `can_run` short-circuits when `forward_batch.input_ids.numel()`
  doesn't match its captured K, so the right runner claims each step
  with no extra coordination.
- **DSv4 attention backend** — `TARGET_VERIFY` per-bs metadata cache is
  re-keyed by `(bs, K)` instead of `bs` alone so the main runner and the
  short-chain MTP runner don't overwrite each other.
- **`cuda_graph_runner` capture mode** — extends the existing SUFFIX V2
  `capture_hidden_mode=FULL` trigger to also fire on HYBRID (MTP step
  needs last-layer hidden states for draft KV sync; SUFFIX step inherits
  V2's FULL request).
- **Plugin registration** — `HYBRID_SUFFIX_MTP` is registered via
  `SpeculativeAlgorithm.register`. Its spec class returns `True` for
  both `is_ngram()` and `is_eagle()` so existing builtin dispatch sites
  trigger; the worker disambiguates per batch internally.
- **`--speculative-hybrid-mtp-always-warm`** flag for the keep-up
  policy above.

## Speed Tests and Profiling

Setup: DeepSeek-V4-Flash (744B, FP8 + bf16 marlin MoE), 8×H100 80GB,
TP=8, `--max-running-requests 16`, `--mem-fraction-static 0.70`. Each
dataset benchmarked under its own server boot with a per-dataset arctic
warmup file. Configs:

| spec       | flags                                                                                          |
| ---------- | ---------------------------------------------------------------------------------------------- |
| baseline   | (no spec)                                                                                      |
| mtp_v2     | `EAGLE`, `num-steps=3`, `eagle-topk=1`, `num-draft-tokens=4`                                   |
| suffix_v2  | `SUFFIX`, `num-draft-tokens=16`                                                                |
| hybrid_v2  | `HYBRID_SUFFIX_MTP`, `num-draft-tokens=16`, `num-steps=3`, `ARCTIC_HYBRID_SFX_GATE_OVERRIDE=5.0` |

Speedup is `tot_tps(spec) / tot_tps(baseline)` for the same dataset at
the same concurrency.

#### SWE bench — long-prompt agentic

| conc | baseline dur (s) | mtp_v2 | suffix_v2 | **hybrid_v2** |
| ---: | ---: | ---: | ---: | ---: |
|  2 | 1658 | 1.91× | 2.38× | **3.20×** |
|  4 | 1065 | 1.44× | 2.48× | 1.65× |
|  8 |  815 | 1.71× | 2.63× | **2.19×** |
| 16 |  728 | 1.73× | 3.19× | **2.71×** |

HYBRID wins outright at c=2 (mixes SUFFIX-when-matched with MTP fallback
on dry batches). At higher conc pure SUFFIX is best on this workload —
the selector still over-picks SUFFIX vs the ideal at c=4 (known
calibration issue; see Open items below).

#### humaneval — code generation

| conc | baseline dur (s) | mtp_v2 | suffix_v2 | **hybrid_v2** |
| ---: | ---: | ---: | ---: | ---: |
|  2 | 296 | 1.95× | 2.11× | **4.11×** |
|  4 | 150 | 1.71× | 1.67× | **1.96×** |
|  8 |  88 | 1.53× | 1.37× | 1.32× |
| 16 |  54 | **1.34×** | 1.18× | 1.09× |
| 32 |  53 | **1.37×** | 1.22× | 1.11× |

HYBRID dominates at low conc by combining MTP's general accept with
SUFFIX's bursty match runs. At high conc MTP V2 alone wins (HYBRID's
selector still picks SUFFIX too often).

#### mbpp — code generation

| conc | baseline dur (s) | mtp_v2 | suffix_v2 | **hybrid_v2** |
| ---: | ---: | ---: | ---: | ---: |
|  2 | 367 | 1.82× | 1.83× | **4.63×** |
|  4 | 210 | 1.64× | 1.81× | **3.89×** |
|  8 | 131 | 1.48× | 1.48× | 1.28× |
| 16 |  91 | **1.33×** | 1.32× | 1.16× |
| 32 |  89 | **1.39×** | 1.37× | 1.15× |

Same pattern: large wins at low conc, falls behind pure MTP/SUFFIX at
high conc.

#### gsm8k — short reasoning

| conc | baseline dur (s) | mtp_v2 | suffix_v2 | **hybrid_v2** |
| ---: | ---: | ---: | ---: | ---: |
|  2 | 520 | 1.80× | 1.90× | 1.83× |
|  4 | 285 | 1.58× | **1.60×** | 1.36× |
|  8 | 170 | **1.40×** | 1.29× | 1.20× |
| 16 | 110 | **1.27×** | 1.09× | 1.10× |

Workload has no repetition, so SUFFIX adds little; HYBRID tracks pure
MTP V2 at low conc and underperforms at high conc.

#### mtbench — open-ended chat

| conc | baseline dur (s) | mtp_v2 | suffix_v2 | **hybrid_v2** |
| ---: | ---: | ---: | ---: | ---: |
|  2 | 159 | 1.77× | 1.35× | **2.12×** |
|  4 |  83 | **1.59×** | 1.21× | 1.38× |
|  8 |  45 | **1.34×** | 0.91× | 1.12× |
| 16 |  26 | **1.24×** | 0.72× | 0.97× |

Where SUFFIX hurts (high conc), HYBRID's NONE path keeps it close to
baseline (0.97×) while pure SUFFIX regresses to 0.72×. Pure MTP is best
here.

#### Selector pick distribution

Cumulative across all conc within each dataset:

| dataset      | SUFFIX% | MTP% | NONE% |
| :----------- | ---: | ---: | ---: |
| agent_replay | 84% | 16% | 0% |
| humaneval    | 59% | 41% | 0% |
| mtbench      | 28% | 72% | 0% |
| mbpp         | 65% | 35% | 0% |
| gsm8k        | 34% | 66% | 0% |

NONE only auto-fires above `ARCTIC_HYBRID_NONE_FORCE_BS=64` (off in
these runs; the longest dataset, agent_replay c=16, peaks at bs=16).

#### Cuda graph capture cost

For `K_suffix=16, K_mtp=4` on DSv4-Flash 8×H100: ~10–15 s extra startup
for the short-chain runner, ~5–8 s extra for the baseline runner, +150–
300 MB graph mem each. Capture is done in parallel with the rest of
initialization.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28013859310](https://github.com/sgl-project/sglang/actions/runs/28013859310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28013858457](https://github.com/sgl-project/sglang/actions/runs/28013858457)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->