### PR TITLE
feat: Support HiCache for MiMo-V2 models (2/N)

### DIFF
--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -221,6 +221,9 @@ __global__ void transfer_kernel_impl(
     int64_t item_size_bytes,
     int64_t src_layout_dim,
     int64_t dst_layout_dim,
+    int64_t v_item_size_bytes,
+    int64_t v_src_layout_dim,
+    int64_t v_dst_layout_dim,
     const uintptr_t* __restrict__ src_k_layer_tbl,
     const uintptr_t* __restrict__ dst_k_layer_tbl,
     const uintptr_t* __restrict__ src_v_layer_tbl,
@@ -247,10 +250,15 @@ __global__ void transfer_kernel_impl(
 
       if constexpr (!IsMLA) {
         const char* src_v_ptr = SrcOffsetFn(
-            static_cast<const char*>(src_v), src_v_layer_tbl, layer_id, src_layout_dim, src_page_id, item_size_bytes);
+            static_cast<const char*>(src_v),
+            src_v_layer_tbl,
+            layer_id,
+            v_src_layout_dim,
+            src_page_id,
+            v_item_size_bytes);
         char* dst_v_ptr = DstOffsetFn(
-            static_cast<char*>(dst_v), dst_v_layer_tbl, layer_id, dst_layout_dim, dst_page_id, item_size_bytes);
-        transfer_item_warp(lane_id, src_v_ptr, dst_v_ptr, item_size_bytes);
+            static_cast<char*>(dst_v), dst_v_layer_tbl, layer_id, v_dst_layout_dim, dst_page_id, v_item_size_bytes);
+        transfer_item_warp(lane_id, src_v_ptr, dst_v_ptr, v_item_size_bytes);
       }
     }
   }
@@ -276,7 +284,10 @@ void transfer_kv_launcher(
     int64_t block_quota,
     int64_t num_warps_per_block,
     const int64_t page_size = 16,
-    const int64_t head_num = 1) {
+    const int64_t head_num = 1,
+    const int64_t k_head_dim = 0,
+    const int64_t v_head_dim = 0,
+    bool device2host = true) {
   TORCH_CHECK(src_indices.is_cuda(), "Source indices must be a CUDA tensor");
   TORCH_CHECK(dst_indices.is_cuda(), "Destination indices must be a CUDA tensor");
   TORCH_CHECK(src_indices.scalar_type() == at::kLong, "Source indices must be of type long");
@@ -300,8 +311,36 @@ void transfer_kv_launcher(
   const uintptr_t* src_v_tbl_ptr = IsMLA || !src_v_layers.defined() ? nullptr : src_v_layers.data_ptr<uintptr_t>();
   const uintptr_t* dst_v_tbl_ptr = IsMLA || !dst_v_layers.defined() ? nullptr : dst_v_layers.data_ptr<uintptr_t>();
 
+  // Asymmetric K/V (head_dim != v_head_dim, e.g. MiMo V2):
+  // public ops pass K-sized ``item_size`` and ``src/dst_layout_dim`` for ABI
+  // compatibility. Rescale them to V-sized counterparts by
+  // ``v_head_dim / k_head_dim``. Only the page-first ("K-shaped") side
+  // actually uses ``layout_dim`` for addressing -- ``device2host`` tells us
+  // which side that is (true=backup, pf on dst; false=load, pf on src). The
+  // other "L-shaped" side uses a per-layer base table (``lf_tbl``) or a dummy
+  // 0, so its ``layout_dim`` is left untouched. Symmetric K/V short-circuits
+  // to ``v_* = *`` and is bit-identical to the pre-asymmetric behavior.
+  int64_t v_src_layout_dim;
+  int64_t v_dst_layout_dim;
+  bool different_head_dim = k_head_dim != v_head_dim;
+  if (device2host) {
+    TORCH_CHECK(
+        !different_head_dim || dst_layout_dim % k_head_dim == 0,
+        "Destination layout dimension must be divisible by k head dimension");
+    v_src_layout_dim = src_layout_dim;
+    v_dst_layout_dim = different_head_dim ? dst_layout_dim / k_head_dim * v_head_dim : dst_layout_dim;
+  } else {
+    TORCH_CHECK(
+        !different_head_dim || src_layout_dim % k_head_dim == 0,
+        "Source layout dimension must be divisible by k head dimension");
+    v_src_layout_dim = different_head_dim ? src_layout_dim / k_head_dim * v_head_dim : src_layout_dim;
+    v_dst_layout_dim = dst_layout_dim;
+  }
+  int64_t v_item_size = different_head_dim ? item_size / k_head_dim * v_head_dim : item_size;
+
   cudaStream_t torch_current_stream = at::cuda::getCurrentCUDAStream();
   if constexpr (PageHeadLayout) {
+    TORCH_CHECK(!different_head_dim, "Page head layout does not support different head dimension between k and v");
     transfer_page_head_kernel_impl<SrcOffsetFn, DstOffsetFn><<<grid_dim, threads_per_block, 0, torch_current_stream>>>(
         src_k_ptr,
         dst_k_ptr,
@@ -337,6 +376,9 @@ void transfer_kv_launcher(
         item_size,
         src_layout_dim,
         dst_layout_dim,
+        v_item_size,
+        v_src_layout_dim,
+        v_dst_layout_dim,
         src_k_tbl_ptr,
         dst_k_tbl_ptr,
         src_v_tbl_ptr,
@@ -389,6 +431,12 @@ void transfer_kv_per_layer_pf_lf(
     int64_t block_quota,
     int64_t num_warps_per_block) {
   at::Tensor empty;
+  // Auto-derive K/V head_dim from the per-layer destination tensors so that
+  // asymmetric K/V (head_dim != v_head_dim) works without a public ABI bump.
+  // Symmetric K/V is unaffected: when both equal, the launcher's
+  // ``different_head_dim`` branch is a no-op.
+  const int64_t k_head_dim = dst_k.size(-1);
+  const int64_t v_head_dim = dst_v.size(-1);
   transfer_kv_launcher<get_global_offset_pf<const char>, get_global_offset_lf<char>, false>(
       src_k,
       dst_k,
@@ -406,7 +454,12 @@ void transfer_kv_per_layer_pf_lf(
       empty,
       empty,
       block_quota,
-      num_warps_per_block);
+      num_warps_per_block,
+      /*page_size=*/16,
+      /*head_num=*/1,
+      k_head_dim,
+      v_head_dim,
+      /*device2host=*/false);
 }
 
 void transfer_kv_per_layer_ph_lf(
@@ -493,6 +546,9 @@ void transfer_kv_all_layer_lf_pf(
     int64_t num_warps_per_block) {
   TORCH_CHECK(num_layers == src_k_layers.size(0), "Number of layers in source k tensor does not match num_layers");
   at::Tensor empty;
+  // Auto-derive K/V head_dim from the destination tensors.
+  const int64_t k_head_dim = dst_k.size(-1);
+  const int64_t v_head_dim = dst_v.size(-1);
   transfer_kv_launcher<get_global_offset_lf_tbl<const char>, get_global_offset_pf<char>, false>(
       empty,
       dst_k,
@@ -510,7 +566,12 @@ void transfer_kv_all_layer_lf_pf(
       src_v_layers,
       empty,
       block_quota,
-      num_warps_per_block);
+      num_warps_per_block,
+      /*page_size=*/16,
+      /*head_num=*/1,
+      k_head_dim,
+      v_head_dim,
+      /*device2host=*/true);
 }
 
 void transfer_kv_all_layer_lf_ph(

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -320,9 +320,24 @@ void transfer_kv_launcher(
   // other "L-shaped" side uses a per-layer base table (``lf_tbl``) or a dummy
   // 0, so its ``layout_dim`` is left untouched. Symmetric K/V short-circuits
   // to ``v_* = *`` and is bit-identical to the pre-asymmetric behavior.
+  TORCH_CHECK(
+      (k_head_dim == 0) == (v_head_dim == 0),
+      "k_head_dim and v_head_dim must be either both unset (0) or both > 0; got k_head_dim=",
+      k_head_dim,
+      ", v_head_dim=",
+      v_head_dim);
   int64_t v_src_layout_dim;
   int64_t v_dst_layout_dim;
   bool different_head_dim = k_head_dim != v_head_dim;
+  if (different_head_dim) {
+    TORCH_CHECK(
+        item_size % k_head_dim == 0,
+        "item_size (",
+        item_size,
+        ") must be divisible by k_head_dim (",
+        k_head_dim,
+        ") for asymmetric K/V rescaling");
+  }
   if (device2host) {
     TORCH_CHECK(
         !different_head_dim || dst_layout_dim % k_head_dim == 0,
@@ -337,10 +352,26 @@ void transfer_kv_launcher(
     v_dst_layout_dim = dst_layout_dim;
   }
   int64_t v_item_size = different_head_dim ? item_size / k_head_dim * v_head_dim : item_size;
+  // ``transfer_item_warp`` copies in uint64 chunks; rescaled V item size must
+  // stay 8-byte aligned or the tail bytes are silently dropped.
+  TORCH_CHECK(
+      v_item_size % 8 == 0,
+      "Rescaled V item byte size (",
+      v_item_size,
+      ") must be divisible by 8");
 
   cudaStream_t torch_current_stream = at::cuda::getCurrentCUDAStream();
   if constexpr (PageHeadLayout) {
-    TORCH_CHECK(!different_head_dim, "Page head layout does not support different head dimension between k and v");
+    // Page-head callers don't pass k_head_dim/v_head_dim, so different_head_dim
+    // alone can't catch the asymmetric case. Detect it from tensor shapes.
+    if constexpr (!IsMLA) {
+      TORCH_CHECK(
+          !dst_k.defined() || !dst_v.defined() || dst_k.size(-1) == dst_v.size(-1),
+          "Page head layout does not support different head dimension between k and v; got dst_k last-dim=",
+          dst_k.size(-1),
+          ", dst_v last-dim=",
+          dst_v.size(-1));
+    }
     transfer_page_head_kernel_impl<SrcOffsetFn, DstOffsetFn><<<grid_dim, threads_per_block, 0, torch_current_stream>>>(
         src_k_ptr,
         dst_k_ptr,

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -354,11 +354,7 @@ void transfer_kv_launcher(
   int64_t v_item_size = different_head_dim ? item_size / k_head_dim * v_head_dim : item_size;
   // ``transfer_item_warp`` copies in uint64 chunks; rescaled V item size must
   // stay 8-byte aligned or the tail bytes are silently dropped.
-  TORCH_CHECK(
-      v_item_size % 8 == 0,
-      "Rescaled V item byte size (",
-      v_item_size,
-      ") must be divisible by 8");
+  TORCH_CHECK(v_item_size % 8 == 0, "Rescaled V item byte size (", v_item_size, ") must be divisible by 8");
 
   cudaStream_t torch_current_stream = at::cuda::getCurrentCUDAStream();
   if constexpr (PageHeadLayout) {

--- a/sgl-kernel/tests/test_kvcacheio.py
+++ b/sgl-kernel/tests/test_kvcacheio.py
@@ -5,12 +5,14 @@ import torch
 from sgl_kernel.kvcacheio import (
     transfer_kv_all_layer,
     transfer_kv_all_layer_direct_lf_pf,
+    transfer_kv_all_layer_lf_pf,
     transfer_kv_all_layer_lf_ph,
     transfer_kv_all_layer_mla,
     transfer_kv_direct,
     transfer_kv_per_layer,
     transfer_kv_per_layer_direct_pf_lf,
     transfer_kv_per_layer_mla,
+    transfer_kv_per_layer_pf_lf,
 )
 
 from sglang.srt.utils import get_cuda_version, is_hip
@@ -709,6 +711,201 @@ def test_transfer_kv_page_head(
         torch.testing.assert_close(dst_k_pool_kernel, dst_k_pool_ref)
         torch.testing.assert_close(dst_v_pool_kernel, dst_v_pool_ref)
     torch.set_default_dtype(original_dtype)
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric K/V (head_dim != v_head_dim) tests for the HiCache transfer
+# kernels touched by the MiMo V2 fix. Covers transfer_kv_per_layer_pf_lf and
+# transfer_kv_all_layer_lf_pf, each in symmetric (128, 128) and MiMo V2
+# asymmetric (192, 128) flavors. Reference is plain PyTorch indexed copy, the
+# kernel only memcpys, so equality is byte-exact.
+# ---------------------------------------------------------------------------
+
+_ASYM_NUM_LAYERS = 4
+_ASYM_HEAD_NUM = 2
+_ASYM_PAGE_SIZE = 16
+_ASYM_TOTAL_PAGES = 32
+
+
+def _asym_layout_sizes(head_num, head_dim, num_layers, dtype):
+    token_stride = head_num * head_dim * dtype.itemsize
+    layout_dim = token_stride * num_layers
+    return token_stride, layout_dim
+
+
+def _asym_make_indices(num_pages_to_transfer, page_size, total_pages, device):
+    perm = torch.randperm(total_pages, dtype=torch.int64)
+    src_pages = perm[:num_pages_to_transfer]
+    dst_pages = perm[num_pages_to_transfer : 2 * num_pages_to_transfer]
+    src = torch.cat(
+        [torch.arange(int(p) * page_size, (int(p) + 1) * page_size) for p in src_pages]
+    )
+    dst = torch.cat(
+        [torch.arange(int(p) * page_size, (int(p) + 1) * page_size) for p in dst_pages]
+    )
+    return src.to(device), dst.to(device)
+
+
+def _asym_data_ptrs(per_layer_tensors, device):
+    return torch.tensor(
+        [t.data_ptr() for t in per_layer_tensors],
+        dtype=torch.uint64,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "head_dim, v_head_dim",
+    # (192, 128) matches MiMo-V2-Flash's real qk_head_dim / v_head_dim.
+    [(128, 128), (192, 128)],
+    ids=["symmetric", "asymmetric_mimo_v2_flash"],
+)
+def test_transfer_kv_per_layer_pf_lf_asymmetric(dtype, head_dim, v_head_dim):
+    """H (page_first, separate K/V) -> D (layer_first, per-layer view)."""
+    torch.cuda.manual_seed(42)
+    device = "cuda"
+    layer_id = 1
+    num_pages_to_transfer = 4
+    total_tokens = _ASYM_TOTAL_PAGES * _ASYM_PAGE_SIZE
+
+    src_indices, dst_indices = _asym_make_indices(
+        num_pages_to_transfer, _ASYM_PAGE_SIZE, _ASYM_TOTAL_PAGES, device
+    )
+
+    # Asymmetric K/V is exercised by allocating K and V independently with
+    # their own trailing dim. The symmetric case uses the same two-tensor
+    # shape so the reference path stays uniform; this matches the production
+    # MHATokenToKVPoolHost.k_buffer / .v_buffer accessors which yield K and V
+    # slices regardless of whether the underlying allocation is fused.
+    src_k_host = torch.randn(
+        total_tokens,
+        _ASYM_NUM_LAYERS,
+        _ASYM_HEAD_NUM,
+        head_dim,
+        dtype=dtype,
+        pin_memory=True,
+    )
+    src_v_host = torch.randn(
+        total_tokens,
+        _ASYM_NUM_LAYERS,
+        _ASYM_HEAD_NUM,
+        v_head_dim,
+        dtype=dtype,
+        pin_memory=True,
+    )
+    dst_k_dev = torch.zeros(
+        _ASYM_NUM_LAYERS,
+        total_tokens,
+        _ASYM_HEAD_NUM,
+        head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    dst_v_dev = torch.zeros(
+        _ASYM_NUM_LAYERS,
+        total_tokens,
+        _ASYM_HEAD_NUM,
+        v_head_dim,
+        dtype=dtype,
+        device=device,
+    )
+
+    k_token_stride, k_layout_dim = _asym_layout_sizes(
+        _ASYM_HEAD_NUM, head_dim, _ASYM_NUM_LAYERS, dtype
+    )
+    transfer_kv_per_layer_pf_lf(
+        src_k=src_k_host,
+        dst_k=dst_k_dev[layer_id],
+        src_v=src_v_host,
+        dst_v=dst_v_dev[layer_id],
+        src_indices=src_indices,
+        dst_indices=dst_indices,
+        layer_id=layer_id,
+        item_size=k_token_stride,
+        src_layout_dim=k_layout_dim,
+    )
+    torch.cuda.synchronize()
+
+    expected_k = src_k_host[src_indices.cpu(), layer_id].to(device)
+    expected_v = src_v_host[src_indices.cpu(), layer_id].to(device)
+    torch.testing.assert_close(dst_k_dev[layer_id, dst_indices], expected_k)
+    torch.testing.assert_close(dst_v_dev[layer_id, dst_indices], expected_v)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "head_dim, v_head_dim",
+    [(128, 128), (192, 128)],
+    ids=["symmetric", "asymmetric_mimo_v2_flash"],
+)
+def test_transfer_kv_all_layer_lf_pf_asymmetric(dtype, head_dim, v_head_dim):
+    """D (layer_first, layer-ptr table) -> H (page_first, separate K/V)."""
+    torch.cuda.manual_seed(42)
+    device = "cuda"
+    num_pages_to_transfer = 4
+    total_tokens = _ASYM_TOTAL_PAGES * _ASYM_PAGE_SIZE
+
+    src_indices, dst_indices = _asym_make_indices(
+        num_pages_to_transfer, _ASYM_PAGE_SIZE, _ASYM_TOTAL_PAGES, device
+    )
+
+    src_k_layers = [
+        torch.randn(total_tokens, _ASYM_HEAD_NUM, head_dim, dtype=dtype, device=device)
+        for _ in range(_ASYM_NUM_LAYERS)
+    ]
+    src_v_layers = [
+        torch.randn(
+            total_tokens, _ASYM_HEAD_NUM, v_head_dim, dtype=dtype, device=device
+        )
+        for _ in range(_ASYM_NUM_LAYERS)
+    ]
+    src_k_ptrs = _asym_data_ptrs(src_k_layers, device)
+    src_v_ptrs = _asym_data_ptrs(src_v_layers, device)
+
+    dst_k_host = torch.zeros(
+        total_tokens,
+        _ASYM_NUM_LAYERS,
+        _ASYM_HEAD_NUM,
+        head_dim,
+        dtype=dtype,
+        pin_memory=True,
+    )
+    dst_v_host = torch.zeros(
+        total_tokens,
+        _ASYM_NUM_LAYERS,
+        _ASYM_HEAD_NUM,
+        v_head_dim,
+        dtype=dtype,
+        pin_memory=True,
+    )
+
+    k_token_stride, k_layout_dim = _asym_layout_sizes(
+        _ASYM_HEAD_NUM, head_dim, _ASYM_NUM_LAYERS, dtype
+    )
+    transfer_kv_all_layer_lf_pf(
+        src_k_layers=src_k_ptrs,
+        dst_k=dst_k_host,
+        src_v_layers=src_v_ptrs,
+        dst_v=dst_v_host,
+        src_indices=src_indices,
+        dst_indices=dst_indices,
+        item_size=k_token_stride,
+        dst_layout_dim=k_layout_dim,
+        num_layers=_ASYM_NUM_LAYERS,
+    )
+    torch.cuda.synchronize()
+
+    dst_idx_cpu = dst_indices.cpu()
+    for layer_id in range(_ASYM_NUM_LAYERS):
+        torch.testing.assert_close(
+            dst_k_host[dst_idx_cpu, layer_id],
+            src_k_layers[layer_id][src_indices].cpu(),
+        )
+        torch.testing.assert_close(
+            dst_v_host[dst_idx_cpu, layer_id],
+            src_v_layers[layer_id][src_indices].cpu(),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Adds asymmetric K/V (different head_dim for K vs V) support to the
HiCache KV transfer CUDA kernel path used by MiMo-V2 models, and
introduces targeted regression tests to validate both symmetric
and asymmetric configurations.

This is the sgl-kernel side of MiMo-V2 HiCache enablement; the host pool /
server-args side is in #27378.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Extend the core transfer kernel/launcher to compute V-specific `item_size` and `layout_dim` independently from K when head dims differ.
- Auto-derive `k_head_dim`/`v_head_dim` in the affected public entrypoints (`transfer_kv_per_layer_pf_lf`, `transfer_kv_all_layer_lf_pf`) without changing their ABI.
- Add new pytest coverage for symmetric (128/128) and MiMo-V2-like asymmetric (192/128) transfers.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27185387685](https://github.com/sgl-project/sglang/actions/runs/27185387685)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27185387613](https://github.com/sgl-project/sglang/actions/runs/27185387613)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->