### PR TITLE
[AMD] Fuse sigmoid + mul attention output gate into single Triton kernel

### DIFF
--- a/python/sglang/jit_kernel/tests/test_sigmoid_gate_mul.py
+++ b/python/sglang/jit_kernel/tests/test_sigmoid_gate_mul.py
@@ -1,0 +1,81 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=4, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=4, suite="jit-kernel-unit-test-amd")
+
+DEVICE = "cuda"
+
+
+def reference_sigmoid_gate_mul(x, gate):
+    return x * torch.sigmoid(gate)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 4096),
+        (4, 4096),
+        (8, 4096),
+        (32, 8192),
+        (1, 128),
+        (16, 16384),
+    ],
+)
+def test_sigmoid_gate_mul_correctness(shape, dtype):
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    torch.manual_seed(42)
+    x = torch.randn(shape, dtype=dtype, device=DEVICE)
+    gate = torch.randn(shape, dtype=dtype, device=DEVICE)
+
+    ref = reference_sigmoid_gate_mul(x, gate)
+    out = sigmoid_gate_mul(x, gate)
+
+    rtol = 1e-2 if dtype == torch.bfloat16 else 1e-3
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-3
+    torch.testing.assert_close(out, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("shape", [(4, 4096), (1, 128)])
+def test_sigmoid_gate_mul_does_not_modify_inputs(shape):
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    torch.manual_seed(42)
+    x = torch.randn(shape, dtype=torch.bfloat16, device=DEVICE)
+    gate = torch.randn(shape, dtype=torch.bfloat16, device=DEVICE)
+    x_orig = x.clone()
+    gate_orig = gate.clone()
+
+    sigmoid_gate_mul(x, gate)
+
+    torch.testing.assert_close(x, x_orig, rtol=0, atol=0)
+    torch.testing.assert_close(gate, gate_orig, rtol=0, atol=0)
+
+
+def test_sigmoid_gate_mul_output_dtype():
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    for dtype in [torch.bfloat16, torch.float16, torch.float32]:
+        x = torch.randn(4, 4096, dtype=dtype, device=DEVICE)
+        gate = torch.randn(4, 4096, dtype=dtype, device=DEVICE)
+        out = sigmoid_gate_mul(x, gate)
+        assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
+
+
+def test_sigmoid_gate_mul_contiguous_output():
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    x = torch.randn(4, 4096, dtype=torch.bfloat16, device=DEVICE)
+    gate = torch.randn(4, 4096, dtype=torch.bfloat16, device=DEVICE)
+    out = sigmoid_gate_mul(x, gate)
+    assert out.is_contiguous()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/python/sglang/jit_kernel/triton/sigmoid_gate_mul.py
+++ b/python/sglang/jit_kernel/triton/sigmoid_gate_mul.py
@@ -1,0 +1,29 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _sigmoid_gate_mul_kernel(
+    x_ptr,
+    gate_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask).to(tl.float32)
+    g = tl.load(gate_ptr + offsets, mask=mask).to(tl.float32)
+    out = x * tl.sigmoid(g)
+    tl.store(out_ptr + offsets, out.to(x_ptr.dtype.element_ty), mask=mask)
+
+
+def sigmoid_gate_mul(x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+    """Compute x * sigmoid(gate) in a single fused kernel."""
+    out = torch.empty_like(x)
+    n = x.numel()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+    _sigmoid_gate_mul_kernel[grid](x, gate, out, n, BLOCK_SIZE=1024)
+    return out

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -930,8 +930,15 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            gate = torch.sigmoid(gate)
-            attn_output = attn_output * gate
+            if _use_aiter:
+                from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+                    sigmoid_gate_mul,
+                )
+
+                attn_output = sigmoid_gate_mul(attn_output, gate)
+            else:
+                gate = torch.sigmoid(gate)
+                attn_output = attn_output * gate
 
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -930,7 +930,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            if _use_aiter:
+            if _is_hip:
                 from sglang.jit_kernel.triton.sigmoid_gate_mul import (
                     sigmoid_gate_mul,
                 )

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -54,7 +54,6 @@ from sglang.srt.utils import (
     make_layers,
     set_weight_attrs,
 )
-from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +65,6 @@ _is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu = is_cpu()
 _is_amx_available = cpu_has_amx_support()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
 if _is_npu:
@@ -823,7 +821,7 @@ class Qwen3HybridAttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            if _use_aiter:
+            if _is_hip:
                 from sglang.jit_kernel.triton.sigmoid_gate_mul import (
                     sigmoid_gate_mul,
                 )

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -49,10 +49,12 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
+    is_hip,
     is_npu,
     make_layers,
     set_weight_attrs,
 )
+from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +62,11 @@ from sglang.jit_kernel.triton.gdn_fused_proj import fused_qkvzba_split_reshape_c
 from sglang.srt.layers.attention.fla.fused_norm_gate import FusedRMSNormGated
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu = is_cpu()
 _is_amx_available = cpu_has_amx_support()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
 if _is_npu:
@@ -819,8 +823,15 @@ class Qwen3HybridAttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            gate = torch.sigmoid(gate)
-            attn_output = attn_output * gate
+            if _use_aiter:
+                from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+                    sigmoid_gate_mul,
+                )
+
+                attn_output = sigmoid_gate_mul(attn_output, gate)
+            else:
+                gate = torch.sigmoid(gate)
+                attn_output = attn_output * gate
 
         output, _ = self.o_proj(attn_output)
         return output


### PR DESCRIPTION
## Motivation

The Qwen3.5 `AttentionDecoderLayer` applies an output gate after the attention compute as two separate PyTorch elementwise kernels:

```python
gate = torch.sigmoid(gate)        # kernel launch #1
attn_output = attn_output * gate   # kernel launch #2
```

On MI355 (gfx950), HIP kernel launch overhead is ~4 us per kernel. These are tiny pointwise ops (16K elements at batch=4, decode) — purely launch-overhead bound. Two launches cost 8.6 us total where only ~4.5 us of actual work exists.

## Changes

- **New file**: `python/sglang/jit_kernel/triton/sigmoid_gate_mul.py` — a trivial Triton kernel that computes `x * sigmoid(gate)` in a single launch, promoting to float32 for the sigmoid.
- **`qwen3_5.py`**: Replace the two-op gate with the fused kernel, gated behind `_use_aiter` (HIP only). CUDA path unchanged.
- **`qwen3_next.py`**: Same change (identical gate pattern). Also adds `_use_aiter` module-level flag (was missing).

## Performance

**Model**: Qwen3.5-397B-A17B-MXFP4, TP2, MI355x, ISL=8192, OSL=1024, cc=4

### Kernel-level savings

| Metric | Before | After | Savings |
|---|---|---|---|
| Kernels per attention layer | 2 (sigmoid + mul) | 1 (fused Triton) | -1 kernel |
| Time per attention layer | 8.6 us | ~4.5 us | ~4.1 us |
| Total (15 attention layers) | 129 us | ~67 us | **~62 us** |

### E2E benchmark (40 prompts, cc=4, random ISL=8192 OSL=1024)

| Metric | Baseline | After | Delta |
|---|---|---|---|
| Total throughput (tok/s) | 3,152 | 3,398 | +7.8% |
| Output throughput (tok/s) | 314.2 | 308.0 | -2.0% |
| Median TTFT (ms) | 412.5 | 383.5 | -7.0% |
| Median ITL (ms) | 10.86 | 10.84 | -0.2% |
| Median TPOT (ms) | 12.06 | 11.94 | -1.0% |
| Median E2E Latency (ms) | 11,184 | 11,009 | -1.6% |

The kernel-level savings (~62 us) are <1% of iteration time (~10.9 ms), so the ITL improvement is within run-to-run noise. The TTFT and total throughput improvements are also likely noise from this run.

## Accuracy

| Metric | Value |
|---|---|
| GSM8K accuracy (2000 questions) | 0.911 |
| Invalid rate | 0.4% |
| Threshold | 0.88 |
| **Result** | **PASS** |

## Notes

- The same `sigmoid(gate) * x` pattern exists in `afmoe.py` and `bailing_moe_linear.py` — left for a follow-up PR.
- The Triton kernel works on both CUDA and HIP, but is only enabled on HIP via `_use_aiter` to avoid changing the CUDA code path.























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27216465278](https://github.com/sgl-project/sglang/actions/runs/27216465278)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27216464940](https://github.com/sgl-project/sglang/actions/runs/27216464940)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->