### PR TITLE
Fix HiRadix load-back host page lifetime

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1145,70 +1145,100 @@ class HiRadixCache(RadixCache):
         start_time = time.perf_counter()
         last_hit_node = node
         nodes_to_load = []
-        while node.evicted:
-            assert (
-                node.backuped
-            ), "No backup available on evicted nodes, should not happen"
-            nodes_to_load.insert(0, node)
-            node = node.parent
-        else:
-            ancester_node = node
+        protected_host_nodes = []
+        ancester_node = None
+        ancestor_locked = False
 
-        # protect the ancestor nodes from eviction
-        result = self.inc_lock_ref(ancester_node)
-        delta = result.delta
+        try:
+            while node.evicted:
+                node.protect_host()
+                protected_host_nodes.append(node)
+                self.evictable_host_leaves.discard(node)
+                if not node.backuped:
+                    logger.warning(
+                        "load_back: skip evicted node %d without host backup "
+                        "(last_hit_node=%d)",
+                        node.id,
+                        last_hit_node.id,
+                    )
+                    return None
+                nodes_to_load.insert(0, node)
+                node = node.parent
+            else:
+                ancester_node = node
 
-        # load it all or not at all
-        host_indices = torch.cat([n.host_value for n in nodes_to_load])
-        if len(host_indices) < self.load_back_threshold or (
-            len(host_indices) > mem_quota + delta if mem_quota is not None else False
-        ):
-            # skip loading back if the total size is too small or exceeding the memory quota
-            self.dec_lock_ref(ancester_node)
-            return None
+            # protect the ancestor nodes from eviction
+            result = self.inc_lock_ref(ancester_node)
+            ancestor_locked = True
+            delta = result.delta
 
-        device_indices = self.cache_controller.load(
-            host_indices=host_indices,
-            node_id=last_hit_node.id,
-            **self._get_extra_pools(),
-        )
-        if device_indices is None:
-            self.evict(EvictParams(num_tokens=len(host_indices)))
+            # load it all or not at all
+            host_values = [n.host_value for n in nodes_to_load]
+            if any(v is None for v in host_values):
+                logger.warning(
+                    "load_back: host backup disappeared while protecting node %d",
+                    last_hit_node.id,
+                )
+                return None
+            host_lengths = [len(v) for v in host_values]
+            host_indices = torch.cat(host_values)
+            if len(host_indices) < self.load_back_threshold or (
+                len(host_indices) > mem_quota + delta
+                if mem_quota is not None
+                else False
+            ):
+                # skip loading back if the total size is too small or exceeding the memory quota
+                return None
+
             device_indices = self.cache_controller.load(
                 host_indices=host_indices,
                 node_id=last_hit_node.id,
                 **self._get_extra_pools(),
             )
-        self.dec_lock_ref(ancester_node)
-        if device_indices is None:
-            # no sufficient GPU memory to load back KV caches
-            logger.warning(
-                "load_back: FAILED to load %d tokens for node %d "
-                "even after eviction (evictable_size=%d)",
-                len(host_indices),
-                last_hit_node.id,
-                self.evictable_size_,
-            )
-            return None
+            if device_indices is None:
+                self.evict(EvictParams(num_tokens=len(host_indices)))
+                device_indices = self.cache_controller.load(
+                    host_indices=host_indices,
+                    node_id=last_hit_node.id,
+                    **self._get_extra_pools(),
+                )
+            if device_indices is None:
+                # no sufficient GPU memory to load back KV caches
+                logger.warning(
+                    "load_back: FAILED to load %d tokens for node %d "
+                    "even after eviction (evictable_size=%d)",
+                    len(host_indices),
+                    last_hit_node.id,
+                    self.evictable_size_,
+                )
+                return None
 
-        self.ongoing_load_back[last_hit_node.id] = last_hit_node
-        offset = 0
-        for node in nodes_to_load:
-            node.value = device_indices[offset : offset + len(node.host_value)].clone()
-            offset += len(node.host_value)
-            # Block promoted from host to GPU -- emit store(GPU) so downstream
-            # indexers see it as device-local again.
-            self._record_store_event(node, medium=StorageMedium.GPU)
-        self.evictable_size_ += len(device_indices)
-        self.inc_lock_ref(last_hit_node)
+            self.ongoing_load_back[last_hit_node.id] = last_hit_node
+            offset = 0
+            for node, node_len in zip(nodes_to_load, host_lengths):
+                node.value = device_indices[offset : offset + node_len].clone()
+                offset += node_len
+                # Block promoted from host to GPU -- emit store(GPU) so downstream
+                # indexers see it as device-local again.
+                self._record_store_event(node, medium=StorageMedium.GPU)
+            self.evictable_size_ += len(device_indices)
+            self.inc_lock_ref(last_hit_node)
 
-        if self.metrics_collector is not None:
-            self.metrics_collector.observe_load_back_duration(
-                time.perf_counter() - start_time
-            )
-            self.metrics_collector.increment_load_back_num_tokens(len(device_indices))
+            if self.metrics_collector is not None:
+                self.metrics_collector.observe_load_back_duration(
+                    time.perf_counter() - start_time
+                )
+                self.metrics_collector.increment_load_back_num_tokens(
+                    len(device_indices)
+                )
 
-        return device_indices
+            return device_indices
+        finally:
+            if ancestor_locked:
+                self.dec_lock_ref(ancester_node)
+            for protected_node in protected_host_nodes:
+                protected_node.release_host()
+                self._update_host_leaf_status(protected_node)
 
     def init_load_back(
         self,

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -26,6 +26,7 @@ register_amd_ci(est_time=5, suite="stage-b-test-1-gpu-small-amd")
 
 import random
 import time
+import types
 import unittest
 import unittest.mock
 from array import array
@@ -39,6 +40,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
 )
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
 from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 
@@ -321,6 +323,57 @@ class TestTreeNode(unittest.TestCase):
 
         self.assertTrue(node1 < node2)
         self.assertFalse(node2 < node1)
+
+
+class TestHiRadixCacheLoadBack(unittest.TestCase):
+    """Regression tests for HiRadix load-back host-page lifetime handling."""
+
+    def setUp(self):
+        """Reset the node id counter before each test."""
+        TreeNode.counter = 0
+
+    def test_load_back_survives_host_value_clear_during_load(self):
+        """Load-back uses a host-value snapshot until device restore completes."""
+        cache = object.__new__(HiRadixCache)
+        cache.load_back_threshold = 1
+        cache.evictable_host_leaves = set()
+        cache.evictable_size_ = 0
+        cache.metrics_collector = None
+        cache.ongoing_load_back = {}
+        cache.inc_lock_ref = lambda node: types.SimpleNamespace(delta=0)
+        cache.dec_lock_ref = lambda node: None
+        cache.evict = lambda params: None
+        cache._get_extra_pools = lambda: {}
+        cache._record_store_event = lambda *args, **kwargs: None
+        cache._update_host_leaf_status = lambda node: None
+
+        root = TreeNode()
+        root.key = RadixKey(array("q", []))
+        root.value = torch.empty(0, dtype=torch.int64)
+
+        ancestor = TreeNode()
+        ancestor.parent = root
+        ancestor.key = RadixKey(array("q", [1]))
+        ancestor.value = torch.tensor([1], dtype=torch.int64)
+
+        child = TreeNode()
+        child.parent = ancestor
+        child.key = RadixKey(array("q", [2, 3, 4]))
+        child.value = None
+        child.host_value = torch.tensor([10, 11, 12], dtype=torch.int64)
+
+        def load_and_clear_host(**kwargs):
+            child.host_value = None
+            return torch.tensor([20, 21, 22], dtype=torch.int64)
+
+        cache.cache_controller = types.SimpleNamespace(load=load_and_clear_host)
+
+        loaded = cache.load_back(child)
+
+        self.assertTrue(torch.equal(loaded, torch.tensor([20, 21, 22])))
+        self.assertTrue(torch.equal(child.value, torch.tensor([20, 21, 22])))
+        self.assertEqual(child.host_ref_counter, 0)
+        self.assertIn(child.id, cache.ongoing_load_back)
 
 
 class TestRadixCache(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Protect host pages selected for HiRadix load-back before any operation that can trigger eviction.
- Snapshot the host tensors and their lengths before restoring them to device cache.
- Release the temporary host protection in `finally` and refresh host-leaf status after load-back exits.
- Add a regression test that clears `node.host_value` during `cache_controller.load()` to cover the load-back lifetime bug.

## Root cause

`HiRadixCache.load_back()` can re-enter eviction while it is still restoring host-backed nodes to GPU memory. The failing path is:

```text
schedule_policy.add_one_req
  -> tree_cache.init_load_back()
  -> HiRadixCache.load_back()
  -> cache_controller.load()
  -> evict() when GPU KV space is insufficient
  -> write_backup(..., write_back=True)
  -> evict_host() when the host pool is also under pressure
```

With **write-back** policy, that nested `evict_host()` can release host pages that `load_back()` is still using in the same scheduler call stack. The old code then reads `len(node.host_value)` after the restore attempt. If `evict_host()` has already cleared that field, load-back crashes with:

```text
TypeError: object of type 'NoneType' has no len()
```

This is a host-page lifetime issue during synchronous re-entrant eviction, not a race between two Python threads.

## Fix

The fix pins the host pages that are part of the load-back path:

1. Call `protect_host()` on every evicted node selected for load-back.
2. Remove those nodes from `evictable_host_leaves` while the load-back is active.
3. Snapshot `host_value` and `host_lengths` before calling into code that can evict.
4. Use the snapshotted lengths when slicing restored device indices.
5. Release the temporary host protection in `finally` so skipped and failed load-backs do not leak host references.

## Validation

- `python3 -m py_compile python/sglang/srt/mem_cache/hiradix_cache.py test/registered/unit/mem_cache/test_radix_cache_unit.py`
- `git diff --check upstream/main..HEAD`
- Using official image `lmsysorg/sglang:v0.5.12.post1` with a CPU-only container:
  - no-fix image source + the new regression test fails with the expected `TypeError` at the old `len(node.host_value)` line
  - fixed `hiradix_cache.py` + the same regression test passes







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27182888273](https://github.com/sgl-project/sglang/actions/runs/27182888273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27182888181](https://github.com/sgl-project/sglang/actions/runs/27182888181)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->