### PR TITLE
feat(tool-call): support per-token streaming for MiMo tool calls

### DIFF
--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -221,6 +221,17 @@ class _MiMoStreamingSAX:
         # exception). All _emit calls become no-ops; the detector layer
         # converts the consumed raw bytes back to normal_text on completion.
         self._tool_call_suppressed: bool = False
+        # True once anything (a function name or an argument fragment) has been
+        # emitted to the client for this tool_call. A parse error *after* this
+        # point can no longer be handled by re-surfacing raw bytes (that would
+        # duplicate already-streamed output), so the detector must finalize the
+        # partial call instead of suppressing it. See _process_complete_xml_elements.
+        self._emitted_to_client: bool = False
+        # True when this tool_call completed via a parse error *after* partial
+        # emit (finalized rather than suppressed). The detector uses this to
+        # discard the broken tool_call's leftover bytes instead of leaking them
+        # as normal_text.
+        self._tool_call_errored: bool = False
 
     def _init_parser(self):
         self._parser = ParserCreate()
@@ -245,33 +256,10 @@ class _MiMoStreamingSAX:
     def get_remaining_buffer(self) -> str:
         return self._raw_buffer[self._last_processed_pos :]
 
-    def reset_for_next_tool_call(self):
-        remaining = self.get_remaining_buffer()
-        self._parser.Parse("</root>", True)
-        self._init_parser()
-        self._raw_buffer = remaining
-        self._last_processed_pos = 0
-        self._current_function_name = None
-        self._current_param_name = None
-        self._current_param_value = ""
-        self._current_param_json_sent = ""
-        self._parameters = {}
-        self._param_count = 0
-        self._start_quote_emitted = False
-        self._trailing_newline_pending = False
-        self._defer_mode = False
-        self._defer_raw_value = ""
-        self._pre_inside_parameter = False
-        self._pre_param_buffer = ""
-        self._pre_param_name = None
-        self._pre_is_string_passthrough = False
-        self._tool_call_completed = False
-        self._in_tool_call = False
-        self._tool_call_suppressed = False
-
     def _emit(self, name: Optional[str] = None, parameters: str = ""):
         if self._tool_call_suppressed:
             return
+        self._emitted_to_client = True
         self._pending_calls.append(
             ToolCallItem(tool_index=-1, name=name, parameters=parameters)
         )
@@ -290,6 +278,24 @@ class _MiMoStreamingSAX:
                 if preprocessed:
                     self._parser.Parse(preprocessed, False)
             except Exception as e:
+                if self._emitted_to_client:
+                    # A function name and/or partial args have already been
+                    # streamed to the client. Re-surfacing the raw bytes as
+                    # normal_text would duplicate that output, and leaving the
+                    # tool_index un-advanced would collide the next call onto
+                    # this one. Instead, finalize the partial tool_call: mark
+                    # completion (not suppression) so the detector closes it
+                    # out and advances current_tool_id normally.
+                    logger.warning(
+                        "Error parsing XML element after partial emit: %s "
+                        "(element=%r); finalizing the partial tool_call",
+                        e,
+                        element[:100],
+                    )
+                    self._tool_call_completed = True
+                    self._tool_call_errored = True
+                    self._last_processed_pos = end_pos
+                    return
                 logger.warning(
                     "Error parsing XML element: %s (element=%r); "
                     "fail-closing this tool_call -- detector will surface "
@@ -297,10 +303,11 @@ class _MiMoStreamingSAX:
                     e,
                     element[:100],
                 )
-                # Fail-closed: keep _emit a no-op for the rest of the
-                # outstanding bytes, hand control back to the detector by
-                # marking completion. The detector layer will drop this SAX
-                # instance and replay the buffer tail on a fresh one.
+                # Nothing has been emitted yet, so fail-closed is safe: keep
+                # _emit a no-op for the rest of the outstanding bytes and hand
+                # control back to the detector by marking completion. The
+                # detector layer will surface the consumed raw bytes as
+                # normal_text and drop this SAX instance.
                 self._tool_call_suppressed = True
                 self._tool_call_completed = True
                 self._last_processed_pos = end_pos
@@ -390,6 +397,12 @@ class _MiMoStreamingSAX:
             self._pre_param_buffer += chunk
             return ""
 
+        # Rewrite MiMo's <function=name> / <parameter=name> into attribute form
+        # so expat can parse them. Note: a parameter/function *name* containing
+        # '>' or '"' would break these regexes (the name is matched with [^>]+
+        # then re-emitted inside double quotes). MiMo tool/param names are
+        # identifiers, so this is not a concern in practice; param *values* with
+        # '>'/'"' are handled separately via _escape_xml_special_chars.
         processed = re.sub(r"<function=([^>]+)>", r'<function name="\1">', chunk)
         processed = re.sub(r"<parameter=([^>]+)>", r'<parameter name="\1">', processed)
 
@@ -454,6 +467,12 @@ class _MiMoStreamingSAX:
             self._trailing_newline_pending = False
 
             if param_name:
+                # The streamed argument fragments are hand-assembled to match
+                # json.dumps' DEFAULT separators (", " between items, ": " after
+                # keys). The reconciliation on the client side concatenates
+                # these fragments into one JSON string, so this must stay in
+                # sync with the json.dumps calls below -- do not switch either
+                # side to compact separators=(",", ":").
                 if self._param_count == 0:
                     json_start = f'{{"{param_name}": '
                 else:
@@ -500,16 +519,28 @@ class _MiMoStreamingSAX:
         self._current_param_value += original_data
 
         if _is_string_param_type(param_type):
-            full_json = json.dumps(self._current_param_value, ensure_ascii=False)[1:-1]
-            diff = full_json[len(self._current_param_json_sent) :]
-            self._current_param_json_sent = full_json
+            # Escape only the newly-arrived characters and append, rather than
+            # re-dumping the whole accumulated value each chunk (which would be
+            # O(n^2) on long string params -- exactly this PR's target case).
+            # JSON string escaping is per-character, so escaping the increment
+            # in isolation is equivalent; the only cross-chunk concern, a
+            # trailing newline, is already deferred via _trailing_newline_pending.
+            diff = json.dumps(original_data, ensure_ascii=False)[1:-1]
+            self._current_param_json_sent += diff
             if diff:
                 self._emit(parameters=diff)
         else:
             # Unreachable in normal flow: non-string params are intercepted by
             # _preprocess_xml_chunk and routed into defer mode before any
             # content reaches expat. The defer branch above handles them.
-            # Kept only as a safety net if preprocessing logic changes.
+            # Kept only as a safety net if preprocessing logic changes -- the
+            # warning surfaces such a regression instead of failing silently.
+            logger.warning(
+                "Non-string param %r reached _char_data streaming path; "
+                "expected it to be deferred by _preprocess_xml_chunk. "
+                "Preprocessing logic may have regressed.",
+                self._current_param_name,
+            )
             converted = _convert_param_value(
                 self._current_param_value,
                 self._current_param_name,
@@ -678,6 +709,12 @@ class MiMoDetector(BaseFormatDetector):
 
         String parameters are streamed as JSON fragments per-token.
         Complex-type parameters are buffered until </parameter> closes.
+
+        Note: text appearing *between* tool calls is surfaced as normal_text
+        here, whereas the one-shot ``detect_and_parse`` drops it (it only keeps
+        text before the first tool call). This is intentional -- streaming
+        cannot know a later tool call is coming, so it must forward interstitial
+        text as it arrives rather than retroactively discard it.
         """
         self._buffer += new_text
         all_calls: List[ToolCallItem] = []
@@ -706,11 +743,14 @@ class MiMoDetector(BaseFormatDetector):
 
             if self._sax.tool_call_completed:
                 if self._sax._tool_call_suppressed:
-                    # Mirror of detect_and_parse's unknown-tool handling
-                    # (and of the SAX exception fail-closed path): the raw
-                    # bytes consumed by SAX flow back out as normal text;
-                    # current_tool_id is NOT bumped because no tool call
-                    # was surfaced to the client.
+                    # Suppression only happens before anything was emitted
+                    # (unknown function, or a parse error before the first
+                    # _emit). Nothing reached the client, so the consumed raw
+                    # bytes flow back out as normal_text and current_tool_id is
+                    # NOT bumped. A parse error *after* partial emit does not
+                    # take this path -- the SAX finalizes the partial call
+                    # instead (tool_call_completed without suppression), which
+                    # falls through to the normal completion branch below.
                     all_normal_text += self._sax._raw_buffer[
                         : self._sax._last_processed_pos
                     ]
@@ -728,8 +768,19 @@ class MiMoDetector(BaseFormatDetector):
                         "arguments"
                     ] = self._sax._parameters.copy()
                 self.current_tool_id += 1
+                errored = self._sax._tool_call_errored
                 remaining = self._sax.get_remaining_buffer()
                 self._sax = None
+                if errored:
+                    # The partial call was finalized after a parse error. Its
+                    # leftover bytes (the tail of the broken tool_call, e.g. a
+                    # dangling </function>) are garbage: drop them up to the
+                    # next <tool_call> rather than leaking them as normal_text.
+                    next_call = remaining.find(self.bot_token)
+                    if next_call != -1:
+                        self._buffer = remaining[next_call:]
+                        continue
+                    break
                 if remaining.strip():
                     self._buffer = remaining
                     continue

--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -13,18 +13,26 @@
 # ==============================================================================
 
 import ast
-import html
 import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
+from xml.parsers.expat import ParserCreate
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.core_types import StreamingParseResult, _GetInfoFunc
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
 
 logger = logging.getLogger(__name__)
+
+_STRING_TYPES = frozenset(["string", "str", "text", "varchar", "char", "enum"])
+_COMPLEX_TYPES = frozenset(["object", "array", "arr"])
+_COMPLEX_PREFIXES = ("dict", "list")
 
 
 def _get_param_type(func_name: str, param_name: str, tools: List[Tool]) -> str:
@@ -42,9 +50,11 @@ def _convert_param_value(
 ) -> Any:
     """
     Convert parameter value based on its type in the schema.
-    Adapted from vllm-project/vllm (vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py)
+    Adapted from vllm-project/vllm (vllm/tool_parsers/qwen3coder_tool_parser.py)
     """
-    param_value = html.unescape(param_value)
+    # NOTE: MiMo emits raw parameter text. We deliberately do NOT call
+    # html.unescape() here: it would corrupt values such as "&current" into
+    # "¤t".
 
     # Handle null value for any type
     if param_value.lower() == "null":
@@ -52,7 +62,7 @@ def _convert_param_value(
 
     param_type = _get_param_type(func_name, param_name, tools)
 
-    if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
+    if param_type in _STRING_TYPES:
         return param_value
     elif (
         param_type.startswith("int")
@@ -104,7 +114,7 @@ def _convert_param_value(
         return param_value == "true"
     else:
         if (
-            param_type in ["object", "array", "arr"]
+            param_type in _COMPLEX_TYPES
             or param_type.startswith("dict")
             or param_type.startswith("list")
         ):
@@ -134,6 +144,469 @@ def _convert_param_value(
         return param_value
 
 
+def _is_complex_param_type(param_type: str) -> bool:
+    if param_type in _COMPLEX_TYPES:
+        return True
+    return param_type.startswith(_COMPLEX_PREFIXES)
+
+
+def _is_string_param_type(param_type: str) -> bool:
+    return param_type in _STRING_TYPES
+
+
+def _escape_xml_special_chars(text: str) -> str:
+    text = text.replace("&", "&amp;")
+    text = text.replace("<", "&lt;")
+    text = text.replace(">", "&gt;")
+    text = text.replace('"', "&quot;")
+    text = text.replace("'", "&apos;")
+    return text
+
+
+class _MiMoStreamingSAX:
+    """
+    Incremental SAX-based streaming parser for MiMo XML tool calls.
+    Uses Python's xml.parsers.expat to parse the XML-ish format token-by-token.
+
+    For string-type parameters: streams JSON-escaped content per-token.
+    For complex-type parameters: buffers until </parameter>, then emits at once.
+
+    Derived from vllm-project/vllm
+    (vllm/tool_parsers/qwen3xml_tool_parser.py, ``StreamingXMLToolCallParser``),
+    with the following intentional divergences:
+      - Fail-closed on parse errors: a malformed element suppresses the
+        current tool_call and the consumed raw bytes are surfaced as
+        normal_text, instead of swallowing the expat exception and
+        continuing with dirty parser state.
+      - Unknown-function suppression in the streaming path, aligned with
+        ``detect_and_parse`` / ``SGLANG_FORWARD_UNKNOWN_TOOLS``.
+      - Multi tool_call orchestration is lifted to the detector layer; each
+        SAX instance handles exactly one tool_call.
+      - Simplified defer decision (every non-string param is deferred) and
+        explicit JSON ``null`` for empty non-string params.
+    """
+
+    def __init__(self, tools: List[Tool]):
+        self.tools = tools
+        self._tool_indices: Dict[str, int] = {
+            t.function.name: i for i, t in enumerate(tools) if t.function.name
+        }
+        self._init_parser()
+
+        self._raw_buffer: str = ""
+        self._last_processed_pos: int = 0
+
+        self._current_function_name: Optional[str] = None
+        self._current_param_name: Optional[str] = None
+        self._current_param_value: str = ""
+        self._current_param_json_sent: str = ""
+        self._parameters: Dict[str, Any] = {}
+        self._param_count: int = 0
+        self._start_quote_emitted: bool = False
+        self._trailing_newline_pending: bool = False
+
+        self._defer_mode: bool = False
+        self._defer_raw_value: str = ""
+
+        self._pre_inside_parameter: bool = False
+        self._pre_param_buffer: str = ""
+        self._pre_param_name: Optional[str] = None
+        self._pre_is_string_passthrough: bool = False
+
+        self._pending_calls: List[ToolCallItem] = []
+        self._tool_call_completed: bool = False
+        self._in_tool_call: bool = False
+        # Set when this tool_call must not surface to the client (unknown
+        # function with forwarding disabled, or recovered from a parse
+        # exception). All _emit calls become no-ops; the detector layer
+        # converts the consumed raw bytes back to normal_text on completion.
+        self._tool_call_suppressed: bool = False
+
+    def _init_parser(self):
+        self._parser = ParserCreate()
+        self._parser.StartElementHandler = self._start_element
+        self._parser.EndElementHandler = self._end_element
+        self._parser.CharacterDataHandler = self._char_data
+        self._parser.Parse("<root>", False)
+
+    def feed_chunk(self, chunk: str) -> List[ToolCallItem]:
+        self._tool_call_completed = False
+        self._pending_calls = []
+        self._raw_buffer += chunk
+        self._process_complete_xml_elements()
+        result = self._pending_calls
+        self._pending_calls = []
+        return result
+
+    @property
+    def tool_call_completed(self) -> bool:
+        return self._tool_call_completed
+
+    def get_remaining_buffer(self) -> str:
+        return self._raw_buffer[self._last_processed_pos :]
+
+    def reset_for_next_tool_call(self):
+        remaining = self.get_remaining_buffer()
+        self._parser.Parse("</root>", True)
+        self._init_parser()
+        self._raw_buffer = remaining
+        self._last_processed_pos = 0
+        self._current_function_name = None
+        self._current_param_name = None
+        self._current_param_value = ""
+        self._current_param_json_sent = ""
+        self._parameters = {}
+        self._param_count = 0
+        self._start_quote_emitted = False
+        self._trailing_newline_pending = False
+        self._defer_mode = False
+        self._defer_raw_value = ""
+        self._pre_inside_parameter = False
+        self._pre_param_buffer = ""
+        self._pre_param_name = None
+        self._pre_is_string_passthrough = False
+        self._tool_call_completed = False
+        self._in_tool_call = False
+        self._tool_call_suppressed = False
+
+    def _emit(self, name: Optional[str] = None, parameters: str = ""):
+        if self._tool_call_suppressed:
+            return
+        self._pending_calls.append(
+            ToolCallItem(tool_index=-1, name=name, parameters=parameters)
+        )
+
+    def _process_complete_xml_elements(self):
+        while self._last_processed_pos < len(self._raw_buffer):
+            if self._tool_call_completed:
+                break
+            element, end_pos = self._find_next_complete_element(
+                self._last_processed_pos
+            )
+            if element is None:
+                break
+            try:
+                preprocessed = self._preprocess_xml_chunk(element)
+                if preprocessed:
+                    self._parser.Parse(preprocessed, False)
+            except Exception as e:
+                logger.warning(
+                    "Error parsing XML element: %s (element=%r); "
+                    "fail-closing this tool_call -- detector will surface "
+                    "the consumed raw bytes as normal text",
+                    e,
+                    element[:100],
+                )
+                # Fail-closed: keep _emit a no-op for the rest of the
+                # outstanding bytes, hand control back to the detector by
+                # marking completion. The detector layer will drop this SAX
+                # instance and replay the buffer tail on a fresh one.
+                self._tool_call_suppressed = True
+                self._tool_call_completed = True
+                self._last_processed_pos = end_pos
+                return
+            self._last_processed_pos = end_pos
+
+    def _find_next_complete_element(self, start_pos: int) -> Tuple[Optional[str], int]:
+        buf = self._raw_buffer[start_pos:]
+        if not buf:
+            return None, start_pos
+
+        if buf.startswith("<"):
+            next_lt = buf.find("<", 1)
+            next_gt = buf.find(">", 1)
+            if next_lt != -1 and next_gt != -1:
+                if next_lt < next_gt:
+                    return buf[:next_lt], start_pos + next_lt
+                else:
+                    return buf[: next_gt + 1], start_pos + next_gt + 1
+            elif next_lt != -1:
+                return buf[:next_lt], start_pos + next_lt
+            elif next_gt != -1:
+                return buf[: next_gt + 1], start_pos + next_gt + 1
+            else:
+                if self._in_tool_call or self._pre_inside_parameter:
+                    return None, start_pos
+                for prefix in (
+                    "<tool_call>",
+                    "</tool_call>",
+                    "<function=",
+                    "</function>",
+                    "<parameter=",
+                    "</parameter>",
+                ):
+                    if prefix.startswith(buf) or buf.startswith(prefix[: len(buf)]):
+                        return None, start_pos
+                return buf, start_pos + len(buf)
+        else:
+            next_lt = buf.find("<")
+            if next_lt != -1:
+                return buf[:next_lt], start_pos + next_lt
+            else:
+                return buf, start_pos + len(buf)
+
+    def _preprocess_xml_chunk(self, chunk: str) -> str:
+        if self._pre_inside_parameter:
+            if chunk.startswith("</parameter>"):
+                body_text = self._pre_param_buffer
+                self._pre_inside_parameter = False
+                self._pre_param_buffer = ""
+                self._pre_is_string_passthrough = False
+
+                if self._defer_mode:
+                    self._defer_raw_value = body_text
+                    safe_text = _escape_xml_special_chars(body_text)
+                    self._pre_param_name = None
+                    return f"{safe_text}</parameter>"
+                else:
+                    self._pre_param_name = None
+                    return "</parameter>"
+
+            if self._pre_param_buffer == "" and not self._defer_mode:
+                param_type = (
+                    _get_param_type(
+                        self._current_function_name or "",
+                        self._pre_param_name or "",
+                        self.tools,
+                    )
+                    if self._pre_param_name
+                    else "string"
+                )
+                if _is_string_param_type(param_type):
+                    self._pre_is_string_passthrough = True
+                    # Sentinel: keeps _pre_param_buffer non-empty so subsequent
+                    # string content chunks short-circuit at the passthrough
+                    # check below instead of re-running _get_param_type.
+                    self._pre_param_buffer = " "
+                    return _escape_xml_special_chars(chunk)
+                else:
+                    self._defer_mode = True
+                    self._pre_param_buffer += chunk
+                    return ""
+
+            if self._pre_is_string_passthrough:
+                return _escape_xml_special_chars(chunk)
+
+            self._pre_param_buffer += chunk
+            return ""
+
+        processed = re.sub(r"<function=([^>]+)>", r'<function name="\1">', chunk)
+        processed = re.sub(r"<parameter=([^>]+)>", r'<parameter name="\1">', processed)
+
+        m = re.match(r'<parameter name="([^"]+)">', processed)
+        if m:
+            self._pre_param_name = m.group(1)
+            self._pre_inside_parameter = True
+            self._pre_param_buffer = ""
+            self._defer_mode = False
+            self._defer_raw_value = ""
+            return processed
+
+        is_tool_tag = any(
+            processed.startswith(t)
+            for t in (
+                "<tool_call>",
+                "</tool_call>",
+                "<function",
+                "</function>",
+                "<parameter",
+                "</parameter>",
+            )
+        )
+        if not is_tool_tag and self._in_tool_call:
+            return _escape_xml_special_chars(chunk)
+
+        return processed
+
+    def _start_element(self, name: str, attrs: Dict[str, str]):
+        if name == "root":
+            return
+        if name == "tool_call":
+            self._in_tool_call = True
+            self._parameters = {}
+            self._param_count = 0
+        elif name == "function":
+            func_name = attrs.get("name", "").strip()
+            self._current_function_name = func_name
+            if func_name:
+                # Mirror detect_and_parse: unknown functions are dropped
+                # unless SGLANG_FORWARD_UNKNOWN_TOOLS is set. Suppressing
+                # here (before _emit) is the only place where streaming can
+                # avoid leaking an unrecallable tool name to the client.
+                if (
+                    func_name not in self._tool_indices
+                    and not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+                ):
+                    logger.warning(
+                        "Unknown function in streaming tool_call: %s "
+                        "(suppressing; raw text will be returned as normal text)",
+                        func_name,
+                    )
+                    self._tool_call_suppressed = True
+                    return
+                self._emit(name=func_name, parameters="")
+        elif name == "parameter":
+            param_name = attrs.get("name", "").strip()
+            self._current_param_name = param_name
+            self._current_param_value = ""
+            self._current_param_json_sent = ""
+            self._start_quote_emitted = False
+            self._trailing_newline_pending = False
+
+            if param_name:
+                if self._param_count == 0:
+                    json_start = f'{{"{param_name}": '
+                else:
+                    json_start = f', "{param_name}": '
+                self._emit(parameters=json_start)
+                self._param_count += 1
+
+    def _char_data(self, data: str):
+        if not self._current_param_name:
+            return
+
+        if self._defer_mode:
+            original_data = data
+            if self._trailing_newline_pending:
+                original_data = "\n" + original_data
+                self._trailing_newline_pending = False
+            if original_data.endswith("\n"):
+                self._trailing_newline_pending = True
+                original_data = original_data[:-1]
+            self._current_param_value += original_data
+            return
+
+        param_type = _get_param_type(
+            self._current_function_name or "",
+            self._current_param_name,
+            self.tools,
+        )
+
+        if _is_string_param_type(param_type) and not self._start_quote_emitted:
+            self._emit(parameters='"')
+            self._start_quote_emitted = True
+
+        if not data:
+            return
+
+        original_data = data
+        if self._trailing_newline_pending:
+            original_data = "\n" + original_data
+            self._trailing_newline_pending = False
+        if original_data.endswith("\n"):
+            self._trailing_newline_pending = True
+            original_data = original_data[:-1]
+
+        self._current_param_value += original_data
+
+        if _is_string_param_type(param_type):
+            full_json = json.dumps(self._current_param_value, ensure_ascii=False)[1:-1]
+            diff = full_json[len(self._current_param_json_sent) :]
+            self._current_param_json_sent = full_json
+            if diff:
+                self._emit(parameters=diff)
+        else:
+            # Unreachable in normal flow: non-string params are intercepted by
+            # _preprocess_xml_chunk and routed into defer mode before any
+            # content reaches expat. The defer branch above handles them.
+            # Kept only as a safety net if preprocessing logic changes.
+            converted = _convert_param_value(
+                self._current_param_value,
+                self._current_param_name,
+                self._current_function_name or "",
+                self.tools,
+            )
+            output = json.dumps(converted, ensure_ascii=False)
+            diff = output[len(self._current_param_json_sent) :]
+            self._current_param_json_sent = output
+            if diff:
+                self._emit(parameters=diff)
+
+    def _end_element(self, name: str):
+        if name == "root":
+            return
+
+        if name == "parameter" and self._current_param_name:
+            param_name = self._current_param_name
+            param_value = self._current_param_value
+
+            if self._trailing_newline_pending:
+                param_value += "\n"
+                self._trailing_newline_pending = False
+
+            if self._defer_mode:
+                raw_text = (
+                    self._defer_raw_value if self._defer_raw_value else param_value
+                )
+                converted = _convert_param_value(
+                    raw_text,
+                    param_name,
+                    self._current_function_name or "",
+                    self.tools,
+                )
+                output = json.dumps(converted, ensure_ascii=False)
+                self._emit(parameters=output)
+                self._parameters[param_name] = converted
+            else:
+                param_type = _get_param_type(
+                    self._current_function_name or "",
+                    param_name,
+                    self.tools,
+                )
+
+                if _is_string_param_type(param_type):
+                    if not param_value and not self._start_quote_emitted:
+                        self._emit(parameters='""')
+                    else:
+                        remaining_json = json.dumps(param_value, ensure_ascii=False)[
+                            1:-1
+                        ]
+                        diff = remaining_json[len(self._current_param_json_sent) :]
+                        if diff:
+                            self._emit(parameters=diff)
+                        self._emit(parameters='"')
+                    self._parameters[param_name] = param_value
+                else:
+                    # Reachable only when the parameter has no content at all
+                    # (e.g. <parameter=n></parameter>): preprocessing never
+                    # entered defer mode, so we land here with param_value="".
+                    # For non-string types, emit JSON null rather than letting
+                    # _convert_param_value fall back to the empty string "".
+                    if param_value == "":
+                        self._emit(parameters="null")
+                        self._parameters[param_name] = None
+                    else:
+                        converted = _convert_param_value(
+                            param_value,
+                            param_name,
+                            self._current_function_name or "",
+                            self.tools,
+                        )
+                        output = json.dumps(converted, ensure_ascii=False)
+                        diff = output[len(self._current_param_json_sent) :]
+                        if diff:
+                            self._emit(parameters=diff)
+                        self._parameters[param_name] = converted
+
+            self._current_param_name = None
+            self._current_param_value = ""
+            self._current_param_json_sent = ""
+            self._start_quote_emitted = False
+            self._defer_mode = False
+            self._defer_raw_value = ""
+
+        elif name == "function":
+            if self._parameters:
+                self._emit(parameters="}")
+            else:
+                self._emit(parameters="{}")
+            self._current_function_name = None
+
+        elif name == "tool_call":
+            self._tool_call_completed = True
+            self._in_tool_call = False
+
+
 class MiMoDetector(BaseFormatDetector):
     """
     Detector for MiMo function call format.
@@ -144,6 +617,10 @@ class MiMoDetector(BaseFormatDetector):
         <parameter=command>pwd && ls</parameter>
         </function>
         </tool_call>
+
+    Supports per-token streaming for string parameters via SAX-based
+    incremental XML parsing. Complex-type parameters (object/array) are
+    buffered until </parameter> closes, then emitted at once.
     """
 
     def __init__(self):
@@ -155,6 +632,7 @@ class MiMoDetector(BaseFormatDetector):
         self.param_regex = re.compile(
             r"<parameter=([^>]+)>(.*?)</parameter>", re.DOTALL
         )
+        self._sax: Optional[_MiMoStreamingSAX] = None
 
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
@@ -196,55 +674,89 @@ class MiMoDetector(BaseFormatDetector):
         self, new_text: str, tools: List[Tool]
     ) -> StreamingParseResult:
         """
-        Streaming parsing: buffer until complete tool call block.
+        Per-token streaming parsing using SAX-based incremental XML parser.
+
+        String parameters are streamed as JSON fragments per-token.
+        Complex-type parameters are buffered until </parameter> closes.
         """
         self._buffer += new_text
-        current_text = self._buffer
+        all_calls: List[ToolCallItem] = []
+        all_normal_text = ""
 
-        start = current_text.find(self.bot_token)
-        if start == -1:
-            if self.current_tool_id > 0:
-                # Already processing tool calls, keep buffering
-                # (more tool calls might come, don't discard text yet)
-                return StreamingParseResult(normal_text="")
-            else:
-                # No tool calls seen yet, return as normal text
-                self._buffer = ""
-                return StreamingParseResult(normal_text=current_text)
+        while True:
+            if self._sax is None:
+                start = self._buffer.find(self.bot_token)
+                if start == -1:
+                    if self._ends_with_partial_token(self._buffer, self.bot_token):
+                        break
+                    all_normal_text += self._buffer
+                    self._buffer = ""
+                    break
 
-        # Find end token AFTER the start token
-        end = current_text.find(self.eot_token, start)
-        if end == -1:
-            # Incomplete tool call, return text before start and keep buffering
-            normal_text = current_text[:start]
-            self._buffer = current_text[start:]
-            return StreamingParseResult(normal_text=normal_text)
+                all_normal_text += self._buffer[:start]
+                self._buffer = self._buffer[start:]
+                self._sax = _MiMoStreamingSAX(tools)
+                if self.current_tool_id < 0:
+                    self.current_tool_id = 0
+                self._ensure_tracking_arrays()
 
-        # Parse the complete tool call block
-        result = self.detect_and_parse(current_text[: end + len(self.eot_token)], tools)
+            calls = self._sax.feed_chunk(self._buffer)
+            self._buffer = ""
+            all_calls.extend(self._process_sax_calls(calls))
 
-        if result.calls:
-            # Valid tool call - initialize tracking if first one
-            if self.current_tool_id == -1:
-                self.current_tool_id = 0
-                self.prev_tool_call_arr = []
-                self.streamed_args_for_tool = [""]
+            if self._sax.tool_call_completed:
+                if self._sax._tool_call_suppressed:
+                    # Mirror of detect_and_parse's unknown-tool handling
+                    # (and of the SAX exception fail-closed path): the raw
+                    # bytes consumed by SAX flow back out as normal text;
+                    # current_tool_id is NOT bumped because no tool call
+                    # was surfaced to the client.
+                    all_normal_text += self._sax._raw_buffer[
+                        : self._sax._last_processed_pos
+                    ]
+                    remaining = self._sax.get_remaining_buffer()
+                    self._sax = None
+                    if remaining.strip():
+                        self._buffer = remaining
+                        continue
+                    break
 
-            while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                self.prev_tool_call_arr.append({})
-            while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                self.streamed_args_for_tool.append("")
+                if self._sax._parameters and self.current_tool_id < len(
+                    self.prev_tool_call_arr
+                ):
+                    self.prev_tool_call_arr[self.current_tool_id][
+                        "arguments"
+                    ] = self._sax._parameters.copy()
+                self.current_tool_id += 1
+                remaining = self._sax.get_remaining_buffer()
+                self._sax = None
+                if remaining.strip():
+                    self._buffer = remaining
+                    continue
+            break
 
-            call = result.calls[0]
-            self.prev_tool_call_arr[self.current_tool_id] = {
-                "name": call.name,
-                "arguments": json.loads(call.parameters) if call.parameters else {},
-            }
-            self.streamed_args_for_tool[self.current_tool_id] = call.parameters
+        return StreamingParseResult(normal_text=all_normal_text, calls=all_calls)
+
+    def _ensure_tracking_arrays(self):
+        while len(self.prev_tool_call_arr) <= self.current_tool_id:
+            self.prev_tool_call_arr.append({})
+        while len(self.streamed_args_for_tool) <= self.current_tool_id:
+            self.streamed_args_for_tool.append("")
+
+    def _process_sax_calls(self, calls: List[ToolCallItem]) -> List[ToolCallItem]:
+        result = []
+        for call in calls:
             call.tool_index = self.current_tool_id
-            self.current_tool_id += 1
-
-        self._buffer = current_text[end + len(self.eot_token) :]
+            if call.name is not None:
+                self._ensure_tracking_arrays()
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": call.name,
+                    "arguments": {},
+                }
+            if call.parameters:
+                self._ensure_tracking_arrays()
+                self.streamed_args_for_tool[self.current_tool_id] += call.parameters
+            result.append(call)
         return result
 
     def _parse_tool_call(
@@ -256,7 +768,6 @@ class MiMoDetector(BaseFormatDetector):
         Structure:
             tool_call_body contains: <function=name>...params...</function>
         """
-        # Match complete <function=name>body</function> block
         func_match = self.func_regex.search(tool_call_body)
         if not func_match:
             return None

--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -232,6 +232,12 @@ class _MiMoStreamingSAX:
         # discard the broken tool_call's leftover bytes instead of leaking them
         # as normal_text.
         self._tool_call_errored: bool = False
+        # True once the arguments object has been closed (a "}" or "{}" was
+        # emitted when </function> was handled). _finalize_partial_json() checks
+        # this so a parse error on the trailing </tool_call> -- after the object
+        # was already closed -- does not emit a second "}" and produce invalid
+        # JSON like '{"command": "ls"}}'.
+        self._arguments_json_closed: bool = False
 
     def _init_parser(self):
         self._parser = ParserCreate()
@@ -278,6 +284,11 @@ class _MiMoStreamingSAX:
             string value and close -> emit '""}'
           - parameter just closed, function not -> '{"k": "v"' -> emit "}"
         """
+        if self._arguments_json_closed:
+            # </function> was already handled and closed the object. A later
+            # parse error (e.g. on </tool_call>) must not append a second "}",
+            # which would make the arguments '{"command": "ls"}}' -- invalid.
+            return
         if self._current_param_name is not None:
             # A parameter is still open: close its value, then the object.
             if self._start_quote_emitted:
@@ -666,6 +677,7 @@ class _MiMoStreamingSAX:
                 self._emit(parameters="}")
             else:
                 self._emit(parameters="{}")
+            self._arguments_json_closed = True
             self._current_function_name = None
 
         elif name == "tool_call":

--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -264,6 +264,39 @@ class _MiMoStreamingSAX:
             ToolCallItem(tool_index=-1, name=name, parameters=parameters)
         )
 
+    def _finalize_partial_json(self):
+        """Emit whatever closing fragments are needed so the arguments already
+        streamed for this tool_call reassemble into valid JSON.
+
+        Called when a parse error interrupts a tool_call *after* args were
+        emitted. The already-streamed prefix depends on how far parsing got:
+
+          - no parameter opened yet -> "" streamed -> emit "{}"
+          - mid-string parameter, opening quote sent -> '{"k": "partial' ->
+            close the string and the object -> emit '"}'
+          - parameter key sent but no value yet -> '{"k": ' -> supply an empty
+            string value and close -> emit '""}'
+          - parameter just closed, function not -> '{"k": "v"' -> emit "}"
+        """
+        if self._current_param_name is not None:
+            # A parameter is still open: close its value, then the object.
+            if self._start_quote_emitted:
+                # '{"k": "partial'  -> need closing quote + brace
+                self._emit(parameters='"}')
+            else:
+                # '{"k": '  -> value never started; supply "" and close. For a
+                # deferred complex param this coerces the value to an empty
+                # string rather than its true type, but the priority on this
+                # error path is that the reassembled arguments parse as JSON.
+                self._emit(parameters='""}')
+        elif self._param_count > 0:
+            # One or more parameters fully streamed, object not yet closed:
+            # '{"k": "v"'  -> just close the object
+            self._emit(parameters="}")
+        else:
+            # Function opened but no parameter ever streamed: args is ""
+            self._emit(parameters="{}")
+
     def _process_complete_xml_elements(self):
         while self._last_processed_pos < len(self._raw_buffer):
             if self._tool_call_completed:
@@ -283,15 +316,17 @@ class _MiMoStreamingSAX:
                     # streamed to the client. Re-surfacing the raw bytes as
                     # normal_text would duplicate that output, and leaving the
                     # tool_index un-advanced would collide the next call onto
-                    # this one. Instead, finalize the partial tool_call: mark
-                    # completion (not suppression) so the detector closes it
-                    # out and advances current_tool_id normally.
+                    # this one. Instead, finalize the partial tool_call: emit
+                    # the closing JSON fragments so the streamed arguments
+                    # reassemble into valid JSON, then mark completion (not
+                    # suppression) so the detector advances current_tool_id.
                     logger.warning(
                         "Error parsing XML element after partial emit: %s "
                         "(element=%r); finalizing the partial tool_call",
                         e,
                         element[:100],
                     )
+                    self._finalize_partial_json()
                     self._tool_call_completed = True
                     self._tool_call_errored = True
                     self._last_processed_pos = end_pos

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -4701,9 +4701,10 @@ class TestMiMoDetectorStreaming(unittest.TestCase):
         self.assertEqual(tool_calls, {})
         self.assertIn("evil_unknown", normal_text)
 
-    def test_streaming_fail_closed_on_parse_error(self):
-        """If expat raises, the SAX must emit nothing, mark itself completed,
-        and flag suppression so the detector treats consumed bytes as text."""
+    def test_streaming_fail_closed_before_any_emit(self):
+        """If expat raises *before* anything is emitted, the SAX fail-closes:
+        emit nothing, mark completed, flag suppression so the detector treats
+        the consumed bytes as normal_text (no tool_index is consumed)."""
 
         class _AlwaysFailExpat:
             def Parse(self, s, end):
@@ -4717,6 +4718,51 @@ class TestMiMoDetectorStreaming(unittest.TestCase):
         self.assertEqual(calls, [])
         self.assertTrue(sax.tool_call_completed)
         self.assertTrue(sax._tool_call_suppressed)
+        self.assertFalse(sax._emitted_to_client)
+
+    def test_streaming_error_after_partial_emit_finalizes(self):
+        """A parse error *after* a name/args were already streamed must NOT
+        fail-close: re-surfacing raw bytes would duplicate the streamed output
+        and not advancing tool_index would collide the next call onto index 0.
+        Instead the SAX finalizes the partial call (completed, not suppressed),
+        and the detector advances current_tool_id so a following valid call
+        lands on index 1."""
+        detector = MiMoDetector()
+        tools = [self.bash_tool, self.write_tool]
+
+        # Feed a valid prefix so the function name + partial args stream out.
+        r1 = detector.parse_streaming_increment(
+            "<tool_call>\n<function=bash>\n<parameter=command>ls", tools
+        )
+        emitted_names = [c.name for c in r1.calls if c.name]
+        self.assertEqual(emitted_names, ["bash"])
+        self.assertIsNotNone(detector._sax)
+
+        # Now force the live parser to raise on the next element.
+        class _FailExpat:
+            def Parse(self, s, end):
+                import xml.parsers.expat as expat
+
+                raise expat.ExpatError("synthetic mid-stream failure")
+
+        detector._sax._parser = _FailExpat()
+        r2 = detector.parse_streaming_increment("</parameter>\n</function>", tools)
+        # The partial call was finalized (not re-surfaced as duplicate text).
+        self.assertEqual(r2.normal_text, "")
+        # current_tool_id advanced past the finalized call.
+        self.assertEqual(detector.current_tool_id, 1)
+
+        # A subsequent valid tool call lands on index 1, not colliding on 0.
+        r3 = detector.parse_streaming_increment(
+            "\n<tool_call>\n<function=write>\n"
+            "<parameter=path>/a</parameter>\n"
+            "<parameter=content>hi</parameter>\n</function>\n</tool_call>",
+            tools,
+        )
+        idxs = {c.tool_index for c in r3.calls}
+        self.assertEqual(idxs, {1})
+        names = [c.name for c in r3.calls if c.name]
+        self.assertEqual(names, ["write"])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -26,6 +26,7 @@ from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.function_call.kimik2_detector import KimiK2Detector
 from sglang.srt.function_call.lfm2_detector import Lfm2Detector
 from sglang.srt.function_call.llama32_detector import Llama32Detector
+from sglang.srt.function_call.mimo_detector import MiMoDetector, _MiMoStreamingSAX
 from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
@@ -4481,6 +4482,241 @@ class TestGemma4Detector(unittest.TestCase):
         params1 = json.loads(tool_calls_by_index[1]["parameters"])
         self.assertEqual(params0["location"], "Paris")
         self.assertEqual(params1["timezone"], "UTC")
+
+
+class TestMiMoDetectorStreaming(unittest.TestCase):
+    """
+    Per-token SAX-based streaming in MiMoDetector.
+
+    The detector emits arguments as incremental JSON fragments while the
+    model is still generating. These tests pin three things:
+      1. functional correctness of the streaming fragments,
+      2. that streaming output reassembles to exactly what the one-shot
+         ``detect_and_parse`` produces (alignment), and
+      3. streaming-only failure modes (unknown tool, parser error).
+    """
+
+    def setUp(self):
+        self.write_tool = Tool(
+            type="function",
+            function=Function(
+                name="write",
+                description="Write a file",
+                parameters={
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["path", "content"],
+                },
+            ),
+        )
+        self.calc_tool = Tool(
+            type="function",
+            function=Function(
+                name="calc",
+                description="Calculate",
+                parameters={
+                    "properties": {
+                        "shape": {"type": "string"},
+                        "dims": {"type": "object"},
+                        "precision": {"type": "integer"},
+                    }
+                },
+            ),
+        )
+        self.bash_tool = Tool(
+            type="function",
+            function=Function(
+                name="bash",
+                description="Run command",
+                parameters={"properties": {"command": {"type": "string"}}},
+            ),
+        )
+
+    def _collect_streaming(self, chunks, tools):
+        """Feed chunks one by one, accumulating per-tool name/params/text."""
+        detector = MiMoDetector()
+        text = ""
+        tool_calls = {}
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, tools)
+            text += result.normal_text
+            for call in result.calls:
+                idx = call.tool_index
+                if idx is None:
+                    continue
+                tc = tool_calls.setdefault(
+                    idx, {"name": "", "params": "", "chunk_count": 0}
+                )
+                if call.name:
+                    tc["name"] = call.name
+                if call.parameters:
+                    tc["params"] += call.parameters
+                    tc["chunk_count"] += 1
+        return text, tool_calls
+
+    # --- functional behavior -------------------------------------------------
+
+    def test_streaming_per_token_string(self):
+        """A string param is streamed as multiple incremental fragments
+        (not buffered into one), and reassembles to valid JSON."""
+        chunks = [
+            "<tool_call>",
+            "\n<function=write>",
+            "\n<parameter=path>/tmp/test.html</parameter>",
+            "\n<parameter=content>",
+            "<div>",
+            "Hello",
+            " World",
+            "</div>",
+            "</parameter>",
+            "\n</function>",
+            "\n</tool_call>",
+        ]
+        _, tool_calls = self._collect_streaming(chunks, [self.write_tool])
+        self.assertEqual(len(tool_calls), 1)
+        tc = tool_calls[0]
+        self.assertEqual(tc["name"], "write")
+        params = json.loads(tc["params"])
+        self.assertEqual(params["path"], "/tmp/test.html")
+        self.assertEqual(params["content"], "<div>Hello World</div>")
+        # Per-token streaming yields many fragments; the old buffered
+        # implementation would have produced exactly one.
+        self.assertGreater(tc["chunk_count"], 3)
+
+    def test_streaming_deferred_complex_type(self):
+        """object/array params can't be streamed incrementally as valid JSON,
+        so they are buffered until </parameter> and emitted at once."""
+        chunks = [
+            "<tool_call>\n<function=calc>\n<parameter=shape>rect</parameter>",
+            '\n<parameter=dims>{"w": 10, "h": 20}</parameter>',
+            "\n<parameter=precision>2</parameter>",
+            "\n</function>\n</tool_call>",
+        ]
+        _, tool_calls = self._collect_streaming(chunks, [self.calc_tool])
+        params = json.loads(tool_calls[0]["params"])
+        self.assertEqual(params["shape"], "rect")
+        self.assertEqual(params["dims"], {"w": 10, "h": 20})
+        self.assertEqual(params["precision"], 2)
+
+    def test_streaming_html_with_angle_brackets(self):
+        """`<`/`>`/`&` inside a string param must not confuse the XML parser
+        even when split across chunk boundaries."""
+        content = (
+            '<!DOCTYPE html><html><body><div class="x">Test &amp; Go'
+            "</div></body></html>"
+        )
+        chunks = [
+            "<tool_call>\n<function=write>\n",
+            "<parameter=path>/tmp/t.html</parameter>\n",
+            "<parameter=content>",
+        ]
+        chunks += [content[i : i + 10] for i in range(0, len(content), 10)]
+        chunks.append("</parameter>\n</function>\n</tool_call>")
+        _, tool_calls = self._collect_streaming(chunks, [self.write_tool])
+        params = json.loads(tool_calls[0]["params"])
+        self.assertEqual(params["content"], content)
+
+    def test_streaming_entity_not_unescaped(self):
+        """HTML entities are preserved verbatim. Guards against re-adding
+        html.unescape(), which would corrupt e.g. ``&current``."""
+        chunks = [
+            "<tool_call>\n<function=write>",
+            "\n<parameter=path>/tmp/e.html</parameter>",
+            "\n<parameter=content>&copy; 2026 &amp; more &current</parameter>",
+            "\n</function>\n</tool_call>",
+        ]
+        _, tool_calls = self._collect_streaming(chunks, [self.write_tool])
+        params = json.loads(tool_calls[0]["params"])
+        self.assertEqual(params["content"], "&copy; 2026 &amp; more &current")
+
+    def test_streaming_multi_tool_call(self):
+        """Two consecutive tool calls get distinct tool_index values and the
+        text between them is surfaced as normal_text."""
+        chunks = [
+            "Let me run then write.",
+            "<tool_call>\n<function=bash>",
+            "\n<parameter=command>ls</parameter>",
+            "\n</function>\n</tool_call>",
+            "\n<tool_call>\n<function=write>",
+            "\n<parameter=path>/tmp/f.txt</parameter>",
+            "\n<parameter=content>hi</parameter>",
+            "\n</function>\n</tool_call>",
+        ]
+        text, tool_calls = self._collect_streaming(
+            chunks, [self.bash_tool, self.write_tool]
+        )
+        self.assertIn("Let me run then write.", text)
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(tool_calls[0]["name"], "bash")
+        self.assertEqual(tool_calls[1]["name"], "write")
+        self.assertEqual(json.loads(tool_calls[0]["params"])["command"], "ls")
+        self.assertEqual(json.loads(tool_calls[1]["params"])["content"], "hi")
+
+    # --- alignment: streaming must equal non-streaming -----------------------
+
+    def test_streaming_matches_non_streaming(self):
+        """For a range of inputs and chunk granularities, the reassembled
+        streaming arguments must equal one-shot detect_and_parse output."""
+        tools = [self.write_tool, self.calc_tool, self.bash_tool]
+        cases = [
+            "<tool_call>\n<function=bash>\n<parameter=command>ls -la</parameter>"
+            "\n</function>\n</tool_call>",
+            "text before<tool_call>\n<function=write>\n"
+            "<parameter=path>/a.py</parameter>\n"
+            '<parameter=content>print("hi")\nx = 1</parameter>\n'
+            "</function>\n</tool_call>",
+            "<tool_call>\n<function=calc>\n<parameter=shape>box</parameter>\n"
+            '<parameter=dims>{"w": 1, "h": 2}</parameter>\n'
+            "<parameter=precision>3</parameter>\n</function>\n</tool_call>",
+            "<tool_call>\n<function=write>\n<parameter=path>/u.txt</parameter>\n"
+            "<parameter=content>你好 😀 &amp; <b>x</b></parameter>\n"
+            "</function>\n</tool_call>",
+        ]
+        for text in cases:
+            ns = MiMoDetector().detect_and_parse(text, tools)
+            ns_args = {c.name: json.loads(c.parameters) for c in ns.calls}
+            for size in (1, 7, len(text)):  # char-by-char, token-sized, single-shot
+                chunks = [text[i : i + size] for i in range(0, len(text), size)]
+                _, tcs = self._collect_streaming(chunks, tools)
+                st_args = {v["name"]: json.loads(v["params"]) for v in tcs.values()}
+                self.assertEqual(
+                    ns_args,
+                    st_args,
+                    f"alignment mismatch at chunk size {size} for: {text!r}",
+                )
+
+    # --- streaming-only failure modes ----------------------------------------
+
+    def test_streaming_unknown_tool_suppressed(self):
+        """An unknown function name must not surface a tool_call; its raw
+        bytes flow back as normal_text (mirrors detect_and_parse)."""
+        text = (
+            "prefix <tool_call>\n<function=evil_unknown>\n"
+            "<parameter=command>rm -rf /</parameter>\n</function>\n</tool_call>"
+        )
+        chunks = [text[i : i + 1] for i in range(len(text))]
+        normal_text, tool_calls = self._collect_streaming(chunks, [self.bash_tool])
+        self.assertEqual(tool_calls, {})
+        self.assertIn("evil_unknown", normal_text)
+
+    def test_streaming_fail_closed_on_parse_error(self):
+        """If expat raises, the SAX must emit nothing, mark itself completed,
+        and flag suppression so the detector treats consumed bytes as text."""
+
+        class _AlwaysFailExpat:
+            def Parse(self, s, end):
+                import xml.parsers.expat as expat
+
+                raise expat.ExpatError("synthetic parse failure")
+
+        sax = _MiMoStreamingSAX([self.bash_tool])
+        sax._parser = _AlwaysFailExpat()
+        calls = sax.feed_chunk("<tool_call><function=bash><parameter=command>")
+        self.assertEqual(calls, [])
+        self.assertTrue(sax.tool_call_completed)
+        self.assertTrue(sax._tool_call_suppressed)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -4780,6 +4780,43 @@ class TestMiMoDetectorStreaming(unittest.TestCase):
         names = [c.name for c in r3.calls if c.name]
         self.assertEqual(names, ["write"])
 
+    def test_streaming_error_after_function_close_no_double_brace(self):
+        """A parse error on the trailing </tool_call>, *after* </function>
+        already closed the arguments object, must not append a second '}'.
+        Guards against the reassembled args becoming '{"command": "ls"}}'
+        (JSONDecodeError: Extra data)."""
+        detector = MiMoDetector()
+        tools = [self.bash_tool]
+
+        args0 = ""
+        # Feed a complete function block through </function> so the object is
+        # closed by the normal path ("}" emitted).
+        r1 = detector.parse_streaming_increment(
+            "<tool_call>\n<function=bash>\n"
+            "<parameter=command>ls</parameter>\n</function>",
+            tools,
+        )
+        for c in r1.calls:
+            if c.tool_index == 0 and c.parameters:
+                args0 += c.parameters
+        self.assertEqual(json.loads(args0), {"command": "ls"})
+
+        # Now fail while parsing the trailing </tool_call>.
+        class _FailExpat:
+            def Parse(self, s, end):
+                import xml.parsers.expat as expat
+
+                raise expat.ExpatError("synthetic failure on </tool_call>")
+
+        detector._sax._parser = _FailExpat()
+        r2 = detector.parse_streaming_increment("\n</tool_call>", tools)
+        for c in r2.calls:
+            if c.tool_index == 0 and c.parameters:
+                args0 += c.parameters
+        # No extra "}" was appended: still valid, still the same object.
+        self.assertEqual(args0, '{"command": "ls"}')
+        self.assertEqual(json.loads(args0), {"command": "ls"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -4724,11 +4724,15 @@ class TestMiMoDetectorStreaming(unittest.TestCase):
         """A parse error *after* a name/args were already streamed must NOT
         fail-close: re-surfacing raw bytes would duplicate the streamed output
         and not advancing tool_index would collide the next call onto index 0.
-        Instead the SAX finalizes the partial call (completed, not suppressed),
+        Instead the SAX finalizes the partial call -- it emits the closing JSON
+        fragments so the streamed arguments still reassemble into valid JSON --
         and the detector advances current_tool_id so a following valid call
         lands on index 1."""
         detector = MiMoDetector()
         tools = [self.bash_tool, self.write_tool]
+
+        # Accumulate every argument fragment streamed for tool_index 0.
+        args0 = ""
 
         # Feed a valid prefix so the function name + partial args stream out.
         r1 = detector.parse_streaming_increment(
@@ -4737,6 +4741,11 @@ class TestMiMoDetectorStreaming(unittest.TestCase):
         emitted_names = [c.name for c in r1.calls if c.name]
         self.assertEqual(emitted_names, ["bash"])
         self.assertIsNotNone(detector._sax)
+        for c in r1.calls:
+            if c.tool_index == 0 and c.parameters:
+                args0 += c.parameters
+        # Mid-stream the client has an unterminated JSON prefix.
+        self.assertEqual(args0, '{"command": "ls')
 
         # Now force the live parser to raise on the next element.
         class _FailExpat:
@@ -4751,6 +4760,13 @@ class TestMiMoDetectorStreaming(unittest.TestCase):
         self.assertEqual(r2.normal_text, "")
         # current_tool_id advanced past the finalized call.
         self.assertEqual(detector.current_tool_id, 1)
+        for c in r2.calls:
+            if c.tool_index == 0 and c.parameters:
+                args0 += c.parameters
+        # The finalized arguments must be valid JSON the client can parse --
+        # not the truncated '{"command": "ls'. This is the core guarantee: a
+        # mid-stream parse error still yields a well-formed tool_call.
+        self.assertEqual(json.loads(args0), {"command": "ls"})
 
         # A subsequent valid tool call lands on index 1, not colliding on 0.
         r3 = detector.parse_streaming_increment(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`MiMoDetector` previously only supported a buffered streaming mode:
`parse_streaming_increment` accumulated text until a complete `<tool_call>...</tool_call>` block arrived, then emitted the entire tool call at once. This means clients receive no incremental tool-call arguments while the model is still generating — a poor experience for long arguments (e.g.file contents in a `write` call), where the user stares at a frozen UI until the whole block completes.
This PR adds **true per-token streaming** of tool-call arguments for the MiMo XML format:
```
<tool_call>
<function=write>
<parameter=path>/tmp/index.html</parameter>
<parameter=content>...</parameter>
</function>
</tool_call>
```

## Modifications

- New `_MiMoStreamingSAX` — an incremental SAX parser built on `xml.parsers.expat` that consumes the XML-ish MiMo format chunk-by-chunk.
  - **String parameters** are streamed as incremental JSON fragments, token by  token.
  - **Complex parameters** (`object` / `array`) cannot form valid intermediate   JSON, so they are buffered until `</parameter>` closes and emitted at once.
- `parse_streaming_increment` rewritten to drive the SAX parser and orchestrate  multiple consecutive tool calls, lifting multi-call handling out of the parser  into the detector layer.
- Removed the `html.unescape()` call in `_convert_param_value`: MiMo emits raw  parameter text, and unescaping corrupts values such as `&current` → `¤t`.

The SAX streaming approach is derived from vLLM's `qwen3xml_tool_parser.py`(`StreamingXMLToolCallParser`), with several intentional divergences that fix correctness issues:
- **Fail-closed on parse errors.** A malformed element suppresses the current tool call and surfaces the consumed raw bytes as `normal_text`, instead of swallowing the expat exception and continuing with dirty parser state.
- **Unknown-function suppression in the streaming path**, aligned with  `detect_and_parse` / `SGLANG_FORWARD_UNKNOWN_TOOLS`. The upstream parser  always emits the function name.
- **Multi tool-call orchestration moved to the detector layer**; each SAX  instance handles exactly one tool call.
- **Simplified defer decision** (every non-string param defers) and explicit  JSON `null` for empty non-string params.

Added `TestMiMoDetectorStreaming` to `test_function_call_parser.py` (CPU unitsuite), covering three areas:
- **Functional**: per-token string fragments, deferred complex types, angle  brackets split across chunk boundaries, HTML-entity preservation, multi  tool-call indexing.
- **Alignment**: reassembled streaming output equals one-shot `detect_and_parse` across char-by-char / token-sized / single-shot  chunkings — the core correctness guarantee.
- **Failure modes**: unknown-tool suppression, and fail-closed behavior when the parser raises.

Non-streaming `detect_and_parse` behavior is unchanged. No API or config changes.

  ## Real MiMo Tool-Call Validation

  To validate the removal of `html.unescape()` against real model output, I ran an end-to-end A/B test using the actual XiaomiMiMo/MiMo-V2-Flash.

  ### Server Configuration

  The model was served from this PR branch with the MiMo tool-call parser enabled:

  ```bash
  sglang serve \
    --model-path XiaomiMiMo/MiMo-V2-Flash \
    --trust-remote-code \
    --tp-size 8 \
    --dp-size 2 \
    --enable-dp-attention \
    --mem-fraction-static 0.75 \
    --max-running-requests 128 \
    --chunked-prefill-size 16384 \
    --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}' \
    --attention-backend fa3 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --enable-multi-layer-eagle \
    --reasoning-parser qwen3 \
    --tool-call-parser mimo
  ```

  ### Test Request

  I defined a `write(path: string, content: string)` tool and asked the model to call it with HTML containing literal `&`, `<`,`>`, `"`, and `&current`.

  The following request was used for the streaming validation:

  ```bash
  curl -N http://127.0.0.1:30000/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{
      "model": "XiaomiMiMo/MiMo-V2-Flash",
      "messages": [
        {
          "role": "user",
          "content": "Call the write tool exactly once. Use path /tmp/mimo-verification.html. The content must be exactly this single line, without markdown or explanation: <!DOCTYPE html><div class=\"price\">A & B < C > D; entity=&current; 中文测试 😀; streaming verification payload 0123456789 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ</div>"
        }
      ],
      "tools": [
        {
          "type": "function",
          "function": {
            "name": "write",
            "description": "Write exact text to a file",
            "parameters": {
              "type": "object",
              "properties": {
                "path": {
                  "type": "string"
                },
                "content": {
                  "type": "string"
                }
              },
              "required": [
                "path",
                "content"
              ]
            }
          }
        }
      ],
      "tool_choice": "auto",
      "stream": true,
      "temperature": 0,
      "max_tokens": 512,
      "chat_template_kwargs": {
        "enable_thinking": false
      }
    }'
  ```

  The response was returned as OpenAI-compatible SSE events. The `function.arguments` fragments were concatenated in arrival order and parsed with `json.loads()`.

  The same request was then repeated for the non-streaming path by changing only:

  ```json
  "stream": false
  ```


  The same two requests were run again after temporarily restoring:

  ```python
  param_value = html.unescape(param_value)
  ```

  This provided the A/B comparison between the PR implementation and the previous behavior.


  ### Results

  With this PR:

  ```text
  streaming:     entity=&current
  non-streaming: entity=&current
  ```

  The streaming response contained 42 incremental `function.arguments` fragments. After concatenation, `json.loads()` produced:

  ```json
  {
    "path": "/tmp/mimo-verification.html",
    "content": "<!DOCTYPE html><div class=\"price\">A & B < C > D; entity=&current; 中文测试 😀; streaming verification payload 0123456789 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ</div>"
  }
  ```

  The non-streaming response produced the same parsed arguments.

  After temporarily restoring `html.unescape()` and repeating the identical requests:

  ```text
  streaming:     entity=&current
  non-streaming: entity=¤t
  ```

  This is consistent with Python's behavior:

  ```python
  >>> html.unescape("&current")
  '¤t'
  ```

  Therefore, the real MiMoV2 sample confirms that the model emits literal parameter text and that applying `html.unescape()` corrupts the non-streaming value.


  ### Conclusion

  The real MiMoV2 tool-call sample confirms that MiMo emits literal parameter text containing &, <, >, and ", rather than
  requiring application-level HTML entity decoding.

  Without html.unescape(), both streaming and non-streaming parsing preserve the exact model-emitted value. Restoring it causes a lossy transformation:

  &current -> ¤t

  Therefore, removing html.unescape() is necessary to preserve real MiMo tool-call arguments and maintain alignment between streaming and non-streaming parsing.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29484627660](https://github.com/sgl-project/sglang/actions/runs/29484627660)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29484627480](https://github.com/sgl-project/sglang/actions/runs/29484627480)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->