### PR TITLE
Fix Mistral FA3 default attention backend

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -65,6 +65,7 @@ from sglang.srt.utils.common import (
     is_blackwell_supported,
     is_cpu,
     is_cuda,
+    is_fa3_default_disabled_architecture,
     is_flashinfer_available,
     is_hip,
     is_hopper_with_cuda_12_3,
@@ -2778,7 +2779,11 @@ class ServerArgs:
 
         if not use_mla_backend:
             # MHA architecture
-            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(self):
+            if (
+                is_hopper_with_cuda_12_3()
+                and is_no_spec_infer_or_topk_one(self)
+                and not is_fa3_default_disabled_architecture(model_config.hf_config)
+            ):
                 # Note: flashinfer 0.6.1 caused performance regression on Hopper attention kernel
                 # Before the kernel is fixed, we choose fa3 as the default backend on Hopper MHA
                 # ref: https://github.com/sgl-project/sglang/issues/17411

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2996,7 +2996,6 @@ def is_fa3_default_architecture(hf_config):
         "Olmo2ForCausalLM",
         "Gemma2ForCausalLM",
         "Gemma3ForConditionalGeneration",
-        "MixtralForCausalLM",
         "Qwen2ForCausalLM",
         "Qwen3ForCausalLM",
         "Qwen3MoeForCausalLM",
@@ -3013,6 +3012,17 @@ def is_fa3_default_architecture(hf_config):
         "MiMoV2FlashForCausalLM",
     }
     return architectures[0] in default_archs
+
+
+def is_fa3_default_disabled_architecture(hf_config):
+    architectures = getattr(hf_config, "architectures", None)
+    if not isinstance(architectures, list) or not architectures:
+        return False
+    disabled_archs = {
+        "MistralForCausalLM",
+        "MixtralForCausalLM",
+    }
+    return architectures[0] in disabled_archs
 
 
 # Can be more general if it is used in multiple places (keep it simple and thus not general now)

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
@@ -89,6 +90,55 @@ class TestLoadBalanceMethod(unittest.TestCase):
 
         self.assertIn("('nixl', 'mooncake')", str(context.exception))
         self.assertIn("'fake'", str(context.exception))
+
+
+class TestDefaultAttentionBackend(unittest.TestCase):
+    def _make_args(self):
+        args = ServerArgs.__new__(ServerArgs)
+        args.speculative_eagle_topk = None
+        args.page_size = 1
+        args.speculative_algorithm = None
+        return args
+
+    def _make_model_config(self, architecture):
+        return SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=[architecture]),
+            has_attention_sinks=False,
+        )
+
+    @patch("sglang.srt.server_args.is_mps", return_value=False)
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=False)
+    @patch("sglang.srt.server_args.is_flashinfer_available", return_value=True)
+    @patch("sglang.srt.server_args.is_hopper_with_cuda_12_3", return_value=True)
+    def test_mistral_architectures_do_not_default_to_fa3_on_hopper(
+        self,
+        _mock_is_hopper,
+        _mock_flashinfer,
+        _mock_sm100,
+        _mock_hip,
+        _mock_mps,
+    ):
+        args = self._make_args()
+
+        for architecture in ("MistralForCausalLM", "MixtralForCausalLM"):
+            with self.subTest(architecture=architecture):
+                backend = args._get_default_attn_backend(
+                    use_mla_backend=False,
+                    model_config=self._make_model_config(architecture),
+                )
+                self.assertEqual(backend, "flashinfer")
+
+    @patch("sglang.srt.server_args.is_hopper_with_cuda_12_3", return_value=True)
+    def test_llama_still_defaults_to_fa3_on_hopper(self, _mock_is_hopper):
+        args = self._make_args()
+
+        backend = args._get_default_attn_backend(
+            use_mla_backend=False,
+            model_config=self._make_model_config("LlamaForCausalLM"),
+        )
+
+        self.assertEqual(backend, "fa3")
 
 
 class TestPortArgs(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Avoid selecting FA3 as the default Hopper MHA backend for Mistral and Mixtral architectures.
- Fall back to the existing FlashInfer/Triton path for those models while preserving FA3 defaults for other Hopper MHA models.
- Add unit coverage for Mistral/Mixtral fallback and a Llama control case.

## Root Cause
PR #17425 changed Hopper MHA default selection to FA3 for all MHA models, bypassing the older model-specific FA3 allowlist that PR #6379 used to keep Mistral off FA3. The nightly GSM8K rerun shows Mistral and Mixtral accuracy below threshold while launching with `attention_backend=fa3`.

## Validation
- `git diff --check`
- `PYTHONPATH=python python3 -m py_compile python/sglang/srt/server_args.py python/sglang/srt/utils/common.py test/registered/unit/server_args/test_server_args.py`
- On `rx` H200 devbox `mistral-fa3-h200-test`: `PYTHONPATH=python python3 -m unittest discover -s test/registered/unit/server_args -p test_server_args.py -k TestDefaultAttentionBackend`
- On the same H200 devbox: full `PYTHONPATH=python python3 -m unittest discover -s test/registered/unit/server_args -p test_server_args.py` (`58 tests`)
- On the same H200 devbox with real HF configs: Mistral and Mixtral resolve to `flashinfer`; Qwen and Gemma still resolve to `fa3`.

Full GSM8K was not rerun on the devbox because the shared cache only had Mistral/Mixtral config metadata, not model weights; downloading full weights would be unnecessarily heavy for this PR-level validation.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27223331774](https://github.com/sgl-project/sglang/actions/runs/27223331774)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27223332471](https://github.com/sgl-project/sglang/actions/runs/27223332471)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->