### PR TITLE
fix: remap EPLB topk ids on CPU

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1675,9 +1675,7 @@ def _post_process_topk_ids(
         # That final pass re-zeros after any shared-expert append/remap, so a
         # second zeroing here would be redundant (zeroing is idempotent).
     elif _is_cpu:
-        topk_ids = topk_ids_logical_to_physical(
-            topk_ids, expert_location_dispatch_info
-        )
+        topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
         _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
 
     if recorder_topk_ids is None:

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1674,6 +1674,11 @@ def _post_process_topk_ids(
         # single pass at the end of this function (gated by SGLANG_MORI_NO_PAD_MASK).
         # That final pass re-zeros after any shared-expert append/remap, so a
         # second zeroing here would be redundant (zeroing is idempotent).
+    elif _is_cpu:
+        topk_ids = topk_ids_logical_to_physical(
+            topk_ids, expert_location_dispatch_info
+        )
+        _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
 
     if recorder_topk_ids is None:
         recorder_topk_ids = topk_ids

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -2,16 +2,20 @@ import unittest
 
 import torch
 
-from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.environ import envs
+from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.moe.topk import (
     TopKConfig,
+)
+from sglang.srt.layers.moe.topk import (
     biased_grouped_topk_impl as native_biased_grouped_topk,
-    select_experts,
 )
 from sglang.srt.layers.moe.topk import biased_topk_impl as native_biased_topk
 from sglang.srt.layers.moe.topk import fused_topk_torch_native as native_fused_topk
 from sglang.srt.layers.moe.topk import grouped_topk_gpu as native_grouped_topk
+from sglang.srt.layers.moe.topk import (
+    select_experts,
+)
 from sglang.srt.models.llama4 import Llama4MoE
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -3,8 +3,11 @@ import unittest
 import torch
 
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
+from sglang.srt.environ import envs
 from sglang.srt.layers.moe.topk import (
+    TopKConfig,
     biased_grouped_topk_impl as native_biased_grouped_topk,
+    select_experts,
 )
 from sglang.srt.layers.moe.topk import biased_topk_impl as native_biased_topk
 from sglang.srt.layers.moe.topk import fused_topk_torch_native as native_fused_topk
@@ -140,11 +143,9 @@ class TestBiasedGroupedTopK(CustomTestCase):
 
 
 class TestBiasedTopK(CustomTestCase):
-    def test_biased_topk_returns_logical_ids_with_eplb_info(self):
-        hidden_states = torch.ones(1, 4)
-        gating_output = torch.tensor([[10.0, 9.0, 1.0, 0.0]])
-        correction_bias = torch.zeros(4)
-        dispatch_info = ExpertLocationDispatchInfo(
+    @staticmethod
+    def _make_static_dispatch_info():
+        return ExpertLocationDispatchInfo(
             ep_dispatch_algorithm="static",
             partial_logical_to_rank_dispatch_physical_map=torch.tensor(
                 [2, 3, 0, 1], dtype=torch.int64
@@ -158,6 +159,12 @@ class TestBiasedTopK(CustomTestCase):
             num_physical_experts=4,
         )
 
+    def test_biased_topk_returns_logical_ids_with_eplb_info(self):
+        hidden_states = torch.ones(1, 4)
+        gating_output = torch.tensor([[10.0, 9.0, 1.0, 0.0]])
+        correction_bias = torch.zeros(4)
+        dispatch_info = self._make_static_dispatch_info()
+
         _, topk_ids = native_biased_topk(
             hidden_states=hidden_states,
             gating_output=gating_output,
@@ -169,6 +176,32 @@ class TestBiasedTopK(CustomTestCase):
         )
 
         torch.testing.assert_close(topk_ids, torch.tensor([[0, 1]], dtype=torch.int32))
+
+    def test_select_experts_maps_eplb_ids_on_cpu(self):
+        hidden_states = torch.ones(1, 4)
+        router_logits = torch.tensor([[10.0, 9.0, 1.0, 0.0]])
+        correction_bias = torch.zeros(4)
+        dispatch_info = self._make_static_dispatch_info()
+        topk_config = TopKConfig(
+            top_k=2,
+            renormalize=False,
+            correction_bias=correction_bias,
+            scoring_func="sqrtsoftplus",
+        )
+
+        with envs.SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK.override(False):
+            output = select_experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                topk_config=topk_config,
+                layer_id=0,
+                expert_location_dispatch_info=dispatch_info,
+            )
+
+        torch.testing.assert_close(
+            output.topk_ids,
+            torch.tensor([[2, 3]], dtype=output.topk_ids.dtype),
+        )
 
 
 class TestTopK(CustomTestCase):


### PR DESCRIPTION
## Motivation

EPLB remaps logical expert ids to physical expert ids during TopK post-processing on CUDA paths. On CPU, the post-processing path left the routed ids as logical ids, so immediate EPLB rebalancing with redundant experts could dispatch to the wrong physical experts.

## Modifications

- Map CPU `topk_ids` through `topk_ids_logical_to_physical` in `_post_process_topk_ids`.
- Keep `biased_topk_impl` returning logical ids and cover the full `select_experts` CPU path with EPLB dispatch info.

## Accuracy Tests

```bash
SGLANG_USE_CPU_ENGINE=1 PYTHONPATH=python python -m pytest test/registered/cpu/test_topk.py::TestBiasedTopK -q
```

## Speed Tests and Profiling

Not run; this change only updates CPU EPLB id post-processing.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28072097344](https://github.com/sgl-project/sglang/actions/runs/28072097344)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28072097233](https://github.com/sgl-project/sglang/actions/runs/28072097233)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->