### PR TITLE
[Spec] Fix stop string missed mid-chunk in spec-decode finish check

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1205,10 +1205,8 @@ class Req(ReqDllmMixin):
             self.sampling_params.stop_regex_max_len + 1,
         )
 
-        # Spec decode commits up to num_draft_tokens per step. A stop string can
-        # land mid-chunk (more tokens accepted after it); widen the window by the
-        # newly accepted count so it is still seen, else the fixed tail slides
-        # past it and the stop is missed (over-generation).
+        # Spec decode commits multiple tokens per step; widen the window by the
+        # accepted count so a stop string landing mid-chunk is not skipped.
         tail_len = min(max_len_tail_str + num_new_tokens - 1, len(self.output_ids))
         return self.tokenizer.decode(self.output_ids[-tail_len:])
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1192,7 +1192,7 @@ class Req(ReqDllmMixin):
 
         return self.surr_and_decode_ids, self.read_offset - self.surr_offset
 
-    def tail_str(self) -> str:
+    def tail_str(self, num_new_tokens: int = 1) -> str:
         # Check stop strings and stop regex patterns together
         if (
             len(self.sampling_params.stop_strs) == 0
@@ -1205,7 +1205,11 @@ class Req(ReqDllmMixin):
             self.sampling_params.stop_regex_max_len + 1,
         )
 
-        tail_len = min(max_len_tail_str, len(self.output_ids))
+        # Spec decode commits up to num_draft_tokens per step. A stop string can
+        # land mid-chunk (more tokens accepted after it); widen the window by the
+        # newly accepted count so it is still seen, else the fixed tail slides
+        # past it and the stop is missed (over-generation).
+        tail_len = min(max_len_tail_str + num_new_tokens - 1, len(self.output_ids))
         return self.tokenizer.decode(self.output_ids[-tail_len:])
 
     def check_match_stop_str_prefix(self) -> bool:
@@ -1261,12 +1265,12 @@ class Req(ReqDllmMixin):
 
         return False
 
-    def _check_str_based_finish(self):
+    def _check_str_based_finish(self, num_new_tokens: int = 1):
         if (
             len(self.sampling_params.stop_strs) > 0
             or len(self.sampling_params.stop_regex_strs) > 0
         ):
-            tail_str = self.tail_str()
+            tail_str = self.tail_str(num_new_tokens)
 
             # Check stop strings
             if len(self.sampling_params.stop_strs) > 0:
@@ -1331,7 +1335,7 @@ class Req(ReqDllmMixin):
         if self._check_vocab_boundary_finish(new_accepted_tokens):
             return
 
-        if self._check_str_based_finish():
+        if self._check_str_based_finish(new_accepted_len):
             return
 
     def reset_for_retract(self):

--- a/test/registered/unit/managers/test_spec_stop_string_finish.py
+++ b/test/registered/unit/managers/test_spec_stop_string_finish.py
@@ -1,0 +1,76 @@
+"""Regression test for stop-string detection under speculative decoding.
+
+Speculative decoding commits multiple tokens per step, so a stop string can land
+mid-chunk (with more tokens accepted after it in the same step). The finish check
+(`Req.update_finish_state` -> `_check_str_based_finish` -> `tail_str`) must widen
+its scan window by the accepted-token count, otherwise the fixed tail slides past
+the stop string and the request over-generates instead of stopping.
+
+Pure CPU unit test: drives `update_finish_state` directly on a `Req` with a fake
+tokenizer; no model / GPU.
+"""
+
+import unittest
+from array import array
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# Token id -> decoded text. Concatenated by the fake tokenizer's decode().
+STOP_ID = 1
+ID_TO_TEXT = {STOP_ID: "STOP"}
+for _i in range(10, 40):
+    ID_TO_TEXT[_i] = chr(ord("a") + (_i % 26))
+
+
+class _FakeTokenizer:
+    eos_token_id = -1
+    additional_stop_token_ids = None
+
+    def decode(self, ids):
+        return "".join(ID_TO_TEXT[int(i)] for i in ids)
+
+
+def _make_req(output_ids, stop=None, max_new_tokens=1000):
+    sp = SamplingParams(max_new_tokens=max_new_tokens, stop=stop)
+    sp.normalize(tokenizer=None)  # char-based stop_str_max_len
+    req = Req(
+        rid="t",
+        origin_input_text="",
+        origin_input_ids=array("q", [0]),
+        sampling_params=sp,
+        eos_token_ids=set(),
+        vocab_size=10_000,
+    )
+    req.tokenizer = _FakeTokenizer()
+    req.output_ids = array("q", output_ids)
+    return req
+
+
+class TestSpecStopStringFinish(unittest.TestCase):
+    def test_stop_str_midchunk_finishes(self):
+        # `stop_str_max_len` == len("STOP") == 4, so the old fixed window was 5
+        # tokens. A 6-token spec chunk with "STOP" at its front leaves "STOP"
+        # 6 tokens back -> outside the old window, inside the widened one.
+        prefix = [10, 11, 12]
+        chunk = [STOP_ID, 20, 21, 22, 23, 24]
+        req = _make_req(prefix + chunk, stop=["STOP"])
+        req.update_finish_state(new_accepted_len=len(chunk))
+        self.assertTrue(
+            req.finished(),
+            "stop string committed mid-chunk must be detected, not skipped",
+        )
+        self.assertEqual(req.finished_reason.matched, "STOP")
+
+    def test_no_stop_str_does_not_finish(self):
+        # Control: the same chunk shape without the stop string must not finish.
+        req = _make_req([10, 11, 12, 20, 21, 22, 23, 24], stop=["STOP"])
+        req.update_finish_state(new_accepted_len=6)
+        self.assertFalse(req.finished())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_spec_stop_string_finish.py
+++ b/test/registered/unit/managers/test_spec_stop_string_finish.py
@@ -1,14 +1,5 @@
-"""Regression test for stop-string detection under speculative decoding.
-
-Speculative decoding commits multiple tokens per step, so a stop string can land
-mid-chunk (with more tokens accepted after it in the same step). The finish check
-(`Req.update_finish_state` -> `_check_str_based_finish` -> `tail_str`) must widen
-its scan window by the accepted-token count, otherwise the fixed tail slides past
-the stop string and the request over-generates instead of stopping.
-
-Pure CPU unit test: drives `update_finish_state` directly on a `Req` with a fake
-tokenizer; no model / GPU.
-"""
+"""Regression: under spec decode a stop string committed mid-chunk must still
+trigger the finish check, else the request over-generates. Pure CPU."""
 
 import unittest
 from array import array
@@ -19,11 +10,8 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
-# Token id -> decoded text. Concatenated by the fake tokenizer's decode().
 STOP_ID = 1
-ID_TO_TEXT = {STOP_ID: "STOP"}
-for _i in range(10, 40):
-    ID_TO_TEXT[_i] = chr(ord("a") + (_i % 26))
+ID_TO_TEXT = {STOP_ID: "STOP", **{i: chr(ord("a") + i % 26) for i in range(10, 40)}}
 
 
 class _FakeTokenizer:
@@ -34,8 +22,8 @@ class _FakeTokenizer:
         return "".join(ID_TO_TEXT[int(i)] for i in ids)
 
 
-def _make_req(output_ids, stop=None, max_new_tokens=1000):
-    sp = SamplingParams(max_new_tokens=max_new_tokens, stop=stop)
+def _make_req(output_ids, stop):
+    sp = SamplingParams(max_new_tokens=1000, stop=stop)
     sp.normalize(tokenizer=None)  # char-based stop_str_max_len
     req = Req(
         rid="t",
@@ -52,21 +40,14 @@ def _make_req(output_ids, stop=None, max_new_tokens=1000):
 
 class TestSpecStopStringFinish(unittest.TestCase):
     def test_stop_str_midchunk_finishes(self):
-        # `stop_str_max_len` == len("STOP") == 4, so the old fixed window was 5
-        # tokens. A 6-token spec chunk with "STOP" at its front leaves "STOP"
-        # 6 tokens back -> outside the old window, inside the widened one.
-        prefix = [10, 11, 12]
-        chunk = [STOP_ID, 20, 21, 22, 23, 24]
-        req = _make_req(prefix + chunk, stop=["STOP"])
-        req.update_finish_state(new_accepted_len=len(chunk))
-        self.assertTrue(
-            req.finished(),
-            "stop string committed mid-chunk must be detected, not skipped",
-        )
+        # "STOP" sits 6 tokens back: outside the old (stop_str_max_len + 1)
+        # window, inside the one widened by new_accepted_len.
+        req = _make_req([10, 11, 12, STOP_ID, 20, 21, 22, 23, 24], stop=["STOP"])
+        req.update_finish_state(new_accepted_len=6)
+        self.assertTrue(req.finished())
         self.assertEqual(req.finished_reason.matched, "STOP")
 
     def test_no_stop_str_does_not_finish(self):
-        # Control: the same chunk shape without the stop string must not finish.
         req = _make_req([10, 11, 12, 20, 21, 22, 23, 24], stop=["STOP"])
         req.update_finish_state(new_accepted_len=6)
         self.assertFalse(req.finished())


### PR DESCRIPTION
Spec decode commits multiple tokens per step, but the stop-string finish check (`Req._check_str_based_finish` via `tail_str`) only scanned a fixed `stop_str_max_len + 1` token window. A stop string committed mid-chunk (with more tokens accepted after it) falls outside that window and is missed, so the request over-generates instead of stopping. Widen the window by the accepted-token count (`new_accepted_len`); non-spec / streaming paths (`num_new_tokens=1`) are unchanged.



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27187149674](https://github.com/sgl-project/sglang/actions/runs/27187149674)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27187149511](https://github.com/sgl-project/sglang/actions/runs/27187149511)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->