### PR TITLE
[Speculative] Add DFlash speculative decoding for the MiMo-V2.5 Pro MXFP4 target

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -129,11 +129,6 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
 
 
 def _handle_dflash(server_args: ServerArgs) -> None:
-    if server_args.enable_dp_attention:
-        raise ValueError(
-            "Currently DFLASH speculative decoding does not support dp attention."
-        )
-
     if server_args.pp_size != 1:
         raise ValueError(
             "Currently DFLASH speculative decoding only supports pp_size == 1."

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -852,7 +852,14 @@ class FlashAttentionBackend(AttentionBackend):
         is_swa_layer = (
             layer.sliding_window_size is not None and layer.sliding_window_size > -1
         )
-        window_size = (layer.sliding_window_size, 0) if is_swa_layer else (-1, -1)
+        if is_swa_layer and layer.attn_type == AttentionType.ENCODER_ONLY:
+            # Non-causal attention (e.g. DFlash draft block) needs a symmetric
+            # window so each token can attend to both sides within the window.
+            window_size = (layer.sliding_window_size, layer.sliding_window_size)
+        elif is_swa_layer:
+            window_size = (layer.sliding_window_size, 0)
+        else:
+            window_size = (-1, -1)
         k_descale, v_descale = None, None
         # only use kv scaling if: 1) fp8 kv is explicitly enabled, 2) RadixAttention
         # has corresponding quantization method so that layer.k_scale is not None,
@@ -1359,7 +1366,14 @@ class FlashAttentionBackend(AttentionBackend):
         is_swa_layer = (
             layer.sliding_window_size is not None and layer.sliding_window_size > -1
         )
-        window_size = (layer.sliding_window_size, 0) if is_swa_layer else (-1, -1)
+        if is_swa_layer and layer.attn_type == AttentionType.ENCODER_ONLY:
+            # Non-causal attention (e.g. DFlash draft block) needs a symmetric
+            # window so each token can attend to both sides within the window.
+            window_size = (layer.sliding_window_size, layer.sliding_window_size)
+        elif is_swa_layer:
+            window_size = (layer.sliding_window_size, 0)
+        else:
+            window_size = (-1, -1)
 
         causal = True
         if layer.is_cross_attention or layer.attn_type == AttentionType.ENCODER_ONLY:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -143,6 +143,9 @@ ACTIVATION_SCHEMES = ["static", "dynamic"]
 
 logger = logging.getLogger(__name__)
 
+# OCP MXFP4 micro-scaling block size: one e8m0 scale per 32 e2m1 elements.
+MXFP4_BLOCK_SIZE = 32
+
 
 class Fp8Config(QuantizationConfig):
     """Config class for FP8."""
@@ -156,6 +159,7 @@ class Fp8Config(QuantizationConfig):
         packed_modules_mapping: Optional[Dict[str, List[str]]] = None,
         use_mxfp8: bool = False,
         is_fp4_experts: bool = False,
+        store_dtype: str = "fp8",
     ) -> None:
         super().__init__()
         # DSV4 mxfp4-packed (True) vs converted FP8 (False); injected by
@@ -178,6 +182,12 @@ class Fp8Config(QuantizationConfig):
             )
         self.packed_modules_mapping = packed_modules_mapping or {}
         self.use_mxfp8 = use_mxfp8
+        assert store_dtype in ("fp8", "mxfp4")
+        if store_dtype == "mxfp4":
+            assert is_checkpoint_fp8_serialized and activation_scheme == "dynamic"
+            if weight_block_size is None:
+                weight_block_size = [128, 128]
+        self.store_dtype = store_dtype
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
                 raise ValueError(
@@ -238,6 +248,7 @@ class Fp8Config(QuantizationConfig):
                 normalized.append(f"model.{base}")
             ignored_layers = normalized
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
+        store_dtype = cls.get_from_keys_or(config, ["store_dtype"], "fp8")
         if use_mxfp8 and weight_block_size is not None:
             logger.warning(
                 "MXFP8 ignoring incoming weight_block_size in config.json; it is fixed to [1, 32]."
@@ -250,6 +261,7 @@ class Fp8Config(QuantizationConfig):
             weight_block_size=weight_block_size,
             packed_modules_mapping=packed_modules_mapping,
             use_mxfp8=use_mxfp8,
+            store_dtype=store_dtype,
         )
 
     def get_quant_method(
@@ -952,6 +964,65 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                         )
 
         # WEIGHTS
+        if self.quant_config.store_dtype == "mxfp4":
+            mx_block = MXFP4_BLOCK_SIZE
+            assert (
+                hidden_size % mx_block == 0
+            ), f"mxfp4 requires hidden_size divisible by {mx_block}, got {hidden_size}"
+            assert intermediate_size_per_partition % mx_block == 0, (
+                f"mxfp4 requires intermediate_size_per_partition divisible by {mx_block}, "
+                f"got {intermediate_size_per_partition}"
+            )
+            w13_weight = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    2 * intermediate_size_per_partition,
+                    hidden_size // 2,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            w2_weight = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    hidden_size,
+                    intermediate_size_per_partition // 2,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_weight", w13_weight)
+            set_weight_attrs(w13_weight, extra_weight_attrs)
+            layer.register_parameter("w2_weight", w2_weight)
+            set_weight_attrs(w2_weight, extra_weight_attrs)
+            w13_weight_scale = torch.nn.Parameter(
+                torch.ones(
+                    num_experts,
+                    2 * intermediate_size_per_partition,
+                    hidden_size // mx_block,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            w2_weight_scale = torch.nn.Parameter(
+                torch.ones(
+                    num_experts,
+                    hidden_size,
+                    intermediate_size_per_partition // mx_block,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_weight_scale", w13_weight_scale)
+            layer.register_parameter("w2_weight_scale", w2_weight_scale)
+            extra_weight_attrs.update(
+                {"quant_method": FusedMoeWeightScaleSupported.BLOCK.value}
+            )
+            set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+            set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+            layer.w13_input_scale = None
+            layer.w2_input_scale = None
+            return
         if self.is_fp4_expert:
             w13_weight = torch.nn.Parameter(
                 torch.empty(
@@ -1578,7 +1649,70 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             align_mxfp8_moe_weights_for_flashinfer_trtllm(layer)
 
+    def _mxfp4_dequant_to_block_fp8(self, layer: Module) -> None:
+        """Convert mxfp4 storage (uint8 packed e2m1 + uint8 e8m0 block scales)
+        to block-wise fp8 (e4m3 + fp32 scale_inv) once at load time so the
+        runtime forward path is identical to a regular fp8 block-quant MoE."""
+        from sglang.srt.layers.quantization.fp8_utils import per_block_cast_to_fp8
+        from sglang.srt.layers.quantization.mxfp4_tensor import MXFP4QuantizeUtil
+
+        mx_block = MXFP4_BLOCK_SIZE
+        logger.info(
+            "mxfp4->fp8: converting MoE weights. w13=%s w2=%s",
+            getattr(layer, "w13_weight", None) is not None,
+            getattr(layer, "w2_weight", None) is not None,
+        )
+
+        def _convert(weight_name: str, scale_name: str):
+            packed = getattr(layer, weight_name).data
+            scale = getattr(layer, scale_name).data
+            num_experts = packed.shape[0]
+            fp8_chunks = []
+            scale_chunks = []
+            for e in range(num_experts):
+                w_bf16 = MXFP4QuantizeUtil.dequantize(
+                    packed[e].cuda(),
+                    dtype=torch.bfloat16,
+                    scale=scale[e].cuda(),
+                    block_sizes=[mx_block],
+                )
+                w_fp8, w_scale = per_block_cast_to_fp8(w_bf16)
+                fp8_chunks.append(w_fp8)
+                scale_chunks.append(w_scale)
+            return (
+                torch.stack(fp8_chunks, dim=0).contiguous(),
+                torch.stack(scale_chunks, dim=0).contiguous(),
+            )
+
+        w13_fp8, w13_scale_inv = _convert("w13_weight", "w13_weight_scale")
+        w2_fp8, w2_scale_inv = _convert("w2_weight", "w2_weight_scale")
+
+        del layer.w13_weight, layer.w13_weight_scale
+        del layer.w2_weight, layer.w2_weight_scale
+
+        layer.register_parameter(
+            "w13_weight", torch.nn.Parameter(w13_fp8, requires_grad=False)
+        )
+        layer.register_parameter(
+            "w13_weight_scale_inv",
+            torch.nn.Parameter(w13_scale_inv, requires_grad=False),
+        )
+        layer.register_parameter(
+            "w2_weight", torch.nn.Parameter(w2_fp8, requires_grad=False)
+        )
+        layer.register_parameter(
+            "w2_weight_scale_inv",
+            torch.nn.Parameter(w2_scale_inv, requires_grad=False),
+        )
+
     def process_weights_after_loading(self, layer: Module) -> None:
+        if self.quant_config.store_dtype == "mxfp4":
+            logger.info("store_dtype=mxfp4: dispatching to _mxfp4_dequant_to_block_fp8")
+            self._mxfp4_dequant_to_block_fp8(layer)
+            # Fall through to block_quant post-processing (deep_gemm ue8m0,
+            # triton swizzle, etc.) since the converted weights are now
+            # standard fp8 block-quant.
+
         if _is_hip and _use_hip_int4:
             self.process_weights_hip_int4(layer)
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -401,7 +401,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         # Disable for token embedding overrides (dynamic per-request)
         if forward_batch.replace_embeds is not None:
             return False
-        if self.require_mlp_tp_gather:
+        if (
+            self.require_mlp_tp_gather
+            and forward_batch.global_num_tokens_cpu is not None
+        ):
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
                 if self.model_runner.spec_algorithm.is_eagle()

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -44,6 +44,18 @@ logger = logging.getLogger(__name__)
 def _get_dflash_layer_attention_params(
     config, layer_id: int
 ) -> Tuple[int, AttentionType]:
+    # MiMo-style draft: every layer is windowed AND bidirectional (full attention
+    # over the draft block within a sliding window). This combination is not
+    # expressible via `layer_types`, which models only causal `sliding_attention`
+    # vs non-windowed `full_attention`.
+    draft_cfg = parse_dflash_draft_config(draft_hf_config=config)
+    if draft_cfg.use_swa:
+        swa_window = draft_cfg.swa_window_size
+        if swa_window is None:
+            swa_window = getattr(config, "sliding_window", None)
+        window_left = int(swa_window) - 1 if swa_window else -1
+        return window_left, AttentionType.ENCODER_ONLY
+
     layer_types = get_dflash_layer_types(config)
     if layer_types is None:
         return -1, AttentionType.ENCODER_ONLY
@@ -136,12 +148,24 @@ class DFlashAttention(nn.Module):
             base=rope_theta,
             rope_scaling=rope_scaling,
             is_neox_style=rope_is_neox_style,
+            partial_rotary_factor=float(getattr(config, "partial_rotary_factor", 1.0)),
         )
 
         self.scaling = head_dim**-0.5
         self.sliding_window_size, self.attn_type = _get_dflash_layer_attention_params(
             config, layer_id
         )
+
+        # MiMo DFlash draft extras from dflash_config: a per-head attention sink bias
+        # and a value scale. Defaults preserve the generic (sink-less, unscaled) draft.
+        draft_cfg = parse_dflash_draft_config(draft_hf_config=config)
+        self.v_scale: Optional[float] = draft_cfg.attention_value_scale
+        self.attention_sink_bias = (
+            nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
+            if draft_cfg.attention_sink_bias
+            else None
+        )
+
         self.attn = RadixAttention(
             num_heads=self.num_heads,
             head_dim=head_dim,
@@ -185,7 +209,16 @@ class DFlashAttention(nn.Module):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
             q, k = apply_qk_norm(q, k, self.q_norm, self.k_norm, self.head_dim)
             q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v, forward_batch)
+        if self.v_scale is not None:
+            v = v * self.v_scale
+        # Forward the attention sink bias only when this draft has one; backends
+        # without sink support (e.g. FlashInfer) reject the `sinks=` kwarg.
+        if self.attention_sink_bias is not None:
+            attn_output = self.attn(
+                q, k, v, forward_batch, sinks=self.attention_sink_bias
+            )
+        else:
+            attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
 
@@ -452,6 +485,12 @@ class DFlashDraftModel(nn.Module):
                         f"(num_context_features={self.num_context_features}, hidden_size={int(self.config.hidden_size)}), "
                         f"but got {tuple(loaded_weight.shape)} for weight '{name}'."
                     )
+                if resolved_name.endswith("attention_sink_bias"):
+                    # The checkpoint stores the sink bias for all heads; copy the
+                    # slice owned by this TP rank (matching self.num_heads).
+                    start = get_parallel().tp_rank * param.numel()
+                    param.data.copy_(loaded_weight[start : start + param.numel()])
+                    continue
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -730,11 +730,22 @@ class MiMoV2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Self Attention
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states, residual, forward_batch
-        )
+        if captured_last_layer_outputs is not None:
+            hidden_states, residual = (
+                self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                    hidden_states,
+                    residual,
+                    forward_batch,
+                    captured_last_layer_outputs=captured_last_layer_outputs,
+                )
+            )
+        else:
+            hidden_states, residual = self.layer_communicator.prepare_attn(
+                hidden_states, residual, forward_batch
+            )
 
         if hidden_states.shape[0] != 0:
             hidden_states = self.self_attn(
@@ -880,6 +891,9 @@ class MiMoV2Model(nn.Module):
         else:
             self.norm = PPMissingLayer(return_tuple=True)
 
+        # For EAGLE3 / DFLASH aux hidden state capture.
+        self.layers_to_capture: List[int] = []
+
     def get_input_embedding(self, input_ids: torch.Tensor) -> torch.Tensor:
         if hasattr(self.config, "scale_emb"):
             return self.get_input_embeddings()(input_ids) * self.config.scale_emb
@@ -907,6 +921,9 @@ class MiMoV2Model(nn.Module):
             assert pp_proxy_tensors is not None
             hidden_states = pp_proxy_tensors["hidden_states"]
             residual = pp_proxy_tensors["residual"]
+
+        # TBO path skips per-layer capture; DFLASH+TBO is unsupported.
+        aux_hidden_states: List[torch.Tensor] = []
 
         if forward_batch.can_run_tbo:
             tbo_start_layer = self.start_layer
@@ -938,11 +955,29 @@ class MiMoV2Model(nn.Module):
         else:
             for i in range(self.start_layer, self.end_layer):
                 layer = self.layers[i]
+                # Capture the residual stream entering this layer (= output of the
+                # previous target layer) via the layer communicator, which records
+                # it at the attention scatter mode (TP_ATTN_FULL). This keeps every
+                # captured tensor in one consistent layout under DP attention, where
+                # the per-layer residual stream alternates scattered/gathered.
+                capture_buf = aux_hidden_states if i in self.layers_to_capture else None
                 hidden_states, residual = layer(
                     positions,
                     hidden_states,
                     forward_batch,
                     residual,
+                    captured_last_layer_outputs=capture_buf,
+                )
+            # DFLASH may also request capture *after* the final layer (e.g.
+            # target_layer_ids ends at num_hidden_layers-1, so layers_to_capture
+            # contains end_layer). The final residual stream is already at the
+            # model-output scatter mode (TP_ATTN_FULL), matching the in-loop
+            # captures; clone to avoid the post-loop norm mutating it in place.
+            if self.end_layer in self.layers_to_capture:
+                aux_hidden_states.append(
+                    (hidden_states + residual).clone()
+                    if residual is not None
+                    else hidden_states.clone()
                 )
 
         hidden_states_before_norm = None
@@ -964,7 +999,10 @@ class MiMoV2Model(nn.Module):
                 else:
                     hidden_states, _ = self.norm(hidden_states, residual)
 
-        return hidden_states, hidden_states_before_norm
+        if len(aux_hidden_states) == 0:
+            return hidden_states, hidden_states_before_norm
+
+        return hidden_states, hidden_states_before_norm, aux_hidden_states
 
     # If this function is called, it should always initialize KV cache scale
     # factors (or else raise an exception). Thus, handled exceptions should
@@ -1051,6 +1089,9 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
         self.logits_processor = (
             LogitsProcessor(config) if not self.config.encoder_only else None
         )
+
+        # For DFLASH aux hidden state capture (target model side).
+        self.capture_aux_hidden_states = False
 
         vision_config = getattr(config, "vision_config", None)
         audio_config = getattr(config, "audio_config", None)
@@ -1209,7 +1250,7 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
         ), "forward() should not be called in encoder_only mode"
 
         if self._is_multimodal:
-            hidden_states, hidden_states_before_norm = general_mm_embed_routine(
+            model_out = general_mm_embed_routine(
                 input_ids=input_ids,
                 forward_batch=forward_batch,
                 language_model=self.model,
@@ -1218,7 +1259,7 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
                 pp_proxy_tensors=pp_proxy_tensors,
             )
         else:
-            hidden_states, hidden_states_before_norm = self.model(
+            model_out = self.model(
                 input_ids,
                 positions,
                 forward_batch,
@@ -1226,12 +1267,19 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
                 pp_proxy_tensors=pp_proxy_tensors,
             )
 
+        aux_hidden_states = None
+        if isinstance(model_out, tuple) and len(model_out) == 3:
+            hidden_states, hidden_states_before_norm, aux_hidden_states = model_out
+        else:
+            hidden_states, hidden_states_before_norm = model_out
+
         if self.pp_group.is_last_rank:
             return self.logits_processor(
                 input_ids,
                 hidden_states,
                 self.lm_head,
                 forward_batch,
+                aux_hidden_states=aux_hidden_states,
                 hidden_states_before_norm=hidden_states_before_norm,
             )
         else:
@@ -1463,6 +1511,20 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         if self.model is not None:
             self.model.load_kv_cache_scales(quantization_param_path)
+
+    def set_dflash_layers_to_capture(self, layer_ids: List[int]):
+        if not self.pp_group.is_last_rank:
+            return
+
+        if layer_ids is None:
+            raise ValueError(
+                "DFLASH requires explicit layer_ids for aux hidden capture."
+            )
+
+        self.capture_aux_hidden_states = True
+        # SGLang captures "before layer i". To capture the hidden state after target
+        # layer `k` (HF-style), we capture before layer `k + 1`.
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from numbers import Integral
@@ -423,6 +424,10 @@ class DFlashDraftConfig:
     target_layer_ids: Optional[List[int]]
     mask_token: str
     mask_token_id: Optional[int]
+    attention_sink_bias: bool = False
+    attention_value_scale: Optional[float] = None
+    use_swa: bool = False
+    swa_window_size: Optional[int] = None
 
     def require_num_layers(self) -> int:
         if self.num_hidden_layers is None:
@@ -541,6 +546,47 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
                 f"got {mask_token_id}."
             )
 
+    raw_attention_sink_bias = dflash_cfg.get("attention_sink_bias", False)
+    if not isinstance(raw_attention_sink_bias, bool):
+        raise ValueError(
+            "DFLASH dflash_config.attention_sink_bias must be a bool, "
+            f"got {raw_attention_sink_bias!r} (type={type(raw_attention_sink_bias).__name__})."
+        )
+    attention_sink_bias = bool(raw_attention_sink_bias)
+
+    raw_attention_value_scale = dflash_cfg.get("attention_value_scale", None)
+    if raw_attention_value_scale is None:
+        attention_value_scale: Optional[float] = None
+    else:
+        if isinstance(raw_attention_value_scale, bool) or not isinstance(
+            raw_attention_value_scale, (int, float)
+        ):
+            raise ValueError(
+                "DFLASH dflash_config.attention_value_scale must be int|float|None, "
+                f"got {raw_attention_value_scale!r} "
+                f"(type={type(raw_attention_value_scale).__name__})."
+            )
+        attention_value_scale = float(raw_attention_value_scale)
+        if not math.isfinite(attention_value_scale):
+            raise ValueError(
+                "DFLASH dflash_config.attention_value_scale must be finite, "
+                f"got {attention_value_scale}."
+            )
+
+    raw_use_swa = dflash_cfg.get("use_swa", False)
+    if not isinstance(raw_use_swa, bool):
+        raise ValueError(
+            "DFLASH dflash_config.use_swa must be a bool, "
+            f"got {raw_use_swa!r} (type={type(raw_use_swa).__name__})."
+        )
+    use_swa = bool(raw_use_swa)
+
+    swa_window_size = _parse_optional_int(
+        dflash_cfg.get("swa_window_size", None),
+        field_name="DFLASH swa_window_size",
+        min_value=1,
+    )
+
     return DFlashDraftConfig(
         num_hidden_layers=num_hidden_layers,
         num_target_layers=num_target_layers,
@@ -548,6 +594,10 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
         target_layer_ids=parsed_target_layer_ids,
         mask_token=mask_token,
         mask_token_id=mask_token_id,
+        attention_sink_bias=attention_sink_bias,
+        attention_value_scale=attention_value_scale,
+        use_swa=use_swa,
+        swa_window_size=swa_window_size,
     )
 
 

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1,11 +1,14 @@
 import logging
 import math
+import os
 from copy import deepcopy
 from typing import List, Optional
 
 import torch
+import torch.nn.functional as F
 
 from sglang.srt.distributed import get_tp_group
+from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -33,14 +36,23 @@ from sglang.srt.speculative.dflash_utils import (
 )
 from sglang.srt.speculative.eagle_info_v2 import assign_extend_cache_locs_func
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
+from sglang.srt.speculative.spec_utils import (
+    assign_req_to_token_pool_func,
+    draft_tp_context,
+)
 from sglang.srt.speculative.triton_ops.dflash_accept_bonus import (
     _compute_dflash_accept_bonus_triton_unchecked,
 )
 from sglang.srt.speculative.triton_ops.dflash_prepare_block import (
     _prepare_dflash_draft_block_unchecked,
 )
-from sglang.srt.utils import get_available_gpu_memory, is_cuda, is_hip, is_npu
+from sglang.srt.utils import (
+    empty_context,
+    get_available_gpu_memory,
+    is_cuda,
+    is_hip,
+    is_npu,
+)
 
 _is_npu = is_npu()
 
@@ -146,18 +158,30 @@ class DFlashWorkerV2(BaseSpecWorker):
             target_worker.model_runner.model_config.context_len
         )
         saved_server_args = get_global_server_args()
-        self._draft_worker = TpModelWorker(
-            server_args=draft_server_args,
-            gpu_id=gpu_id,
-            tp_rank=tp_rank,
-            moe_ep_rank=moe_ep_rank,
-            pp_rank=0,
-            attn_cp_rank=attn_cp_rank,
-            moe_dp_rank=moe_dp_rank,
-            dp_rank=dp_rank,
-            nccl_port=nccl_port,
-            is_draft_worker=True,
+        # Under dp attention, build the draft worker on the per-DP attention TP group so
+        # its tensor-parallel plumbing (head sharding, draft-token sampling all-gather)
+        # stays within one DP group, independent of idle peer DP ranks.
+        self.draft_tp_context = (
+            draft_tp_context if server_args.enable_dp_attention else empty_context
         )
+        draft_init_ctx = (
+            draft_tp_context(get_attention_tp_group())
+            if server_args.enable_dp_attention
+            else empty_context()
+        )
+        with draft_init_ctx:
+            self._draft_worker = TpModelWorker(
+                server_args=draft_server_args,
+                gpu_id=gpu_id,
+                tp_rank=tp_rank,
+                moe_ep_rank=moe_ep_rank,
+                pp_rank=0,
+                attn_cp_rank=attn_cp_rank,
+                moe_dp_rank=moe_dp_rank,
+                dp_rank=dp_rank,
+                nccl_port=nccl_port,
+                is_draft_worker=True,
+            )
         set_global_server_args_for_scheduler(saved_server_args)
         self.draft_model_runner = self._draft_worker.model_runner
         # Keep the same alias that other spec-v2 workers expose.
@@ -253,6 +277,18 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._bonus_id_bufs: List[torch.Tensor] = []
         self._out_tokens_bufs: List[torch.Tensor] = []
         self._new_seq_lens_bufs: List[torch.Tensor] = []
+
+        # Merge the trained mask embedding (mask_embedding.pt) into the target
+        # embedding table before snapshotting it, so the draft's MASK block positions
+        # use the learned vector instead of the target's untrained mask-token row.
+        self._maybe_merge_trained_mask_embedding()
+
+        # Under dp attention the active and idle DP groups run different code paths, so
+        # the attn-TP all_reduce inside VocabParallelEmbedding gets mismatched calls
+        # across ranks. Gather the full embedding to GPU once (all ranks sync here), then
+        # do a collective-free, sync-free on-device lookup at runtime.
+        self._full_embed_gpu: Optional[torch.Tensor] = None
+        self._cache_full_embed_weight()
 
     @property
     def target_worker(self) -> TpModelWorker:
@@ -386,6 +422,131 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
             self._use_fused_kv_materialize = False
             self._fused_kv_helper = None
+
+    def _maybe_merge_trained_mask_embedding(self) -> None:
+        """Merge a trained mask embedding into the target model's embedding table.
+
+        During DFlash training the mask-token embedding can be trained separately and
+        saved as ``mask_embedding.pt`` in the draft checkpoint directory. If present,
+        overwrite the corresponding row in the target embedding table so inference uses
+        the learned representation (the target's own mask-token row is typically an
+        untrained added-vocab slot ~= 0). For per-position mask embeddings
+        (``per_position=True``), keep them on the worker and apply per block offset at
+        draft time instead of merging into the table.
+
+        Handles VocabParallelEmbedding TP sharding: each rank only updates the row if
+        the mask token falls within its local shard range.
+        """
+        self._per_position_mask_embeddings = None
+
+        draft_model_path = self.server_args.speculative_draft_model_path
+        if draft_model_path is None:
+            return
+
+        mask_emb_path = os.path.join(draft_model_path, "mask_embedding.pt")
+        if not os.path.exists(mask_emb_path):
+            return
+
+        saved = torch.load(mask_emb_path, map_location=self.device, weights_only=True)
+        embedding_tensor = saved["embedding"]
+        saved_token_id = int(saved["mask_token_id"])
+
+        if saved_token_id != self._mask_token_id:
+            raise ValueError(
+                f"DFLASH mask_embedding.pt was trained with mask_token_id={saved_token_id}, "
+                f"but the current resolved mask_token_id={self._mask_token_id}. "
+                "These must match."
+            )
+
+        target_model = self.target_worker.model_runner.model
+        embed_module = target_model.get_input_embeddings()
+
+        if saved.get("per_position"):
+            self._per_position_mask_embeddings = embedding_tensor.to(
+                embed_module.weight.dtype
+            )
+            if self.tp_rank == 0:
+                logger.info(
+                    "Loaded per-position mask embeddings (shape=%s, source=%s)",
+                    list(self._per_position_mask_embeddings.shape),
+                    mask_emb_path,
+                )
+            return
+
+        token_id = self._mask_token_id
+        shard_indices = getattr(embed_module, "shard_indices", None)
+        with torch.no_grad():
+            if shard_indices is not None:
+                # VocabParallelEmbedding: only update if this token is in our shard.
+                start = shard_indices.org_vocab_start_index
+                end = shard_indices.org_vocab_end_index
+                if start <= token_id < end:
+                    local_idx = token_id - start
+                    embed_module.weight[local_idx].copy_(
+                        embedding_tensor.to(embed_module.weight.dtype)
+                    )
+            else:
+                embed_module.weight[token_id].copy_(
+                    embedding_tensor.to(embed_module.weight.dtype)
+                )
+
+        if self.tp_rank == 0:
+            logger.info(
+                "Merged trained mask embedding into target model "
+                "(mask_token_id=%s, source=%s)",
+                self._mask_token_id,
+                mask_emb_path,
+            )
+
+    def _cache_full_embed_weight(self) -> None:
+        """Cache the full target embedding replicated on GPU during init.
+
+        With dp attention the active and idle DP groups run different code paths, so the
+        attn-TP all_reduce inside VocabParallelEmbedding gets mismatched calls (idle DP
+        ranks skip the draft step) and corrupts results. Gather the full embedding once
+        during init (all ranks sync) and keep it replicated on GPU, so the draft block-id
+        lookup is a collective-free, sync-free on-device ``F.embedding``.
+        """
+        self._full_embed_gpu = None
+
+        if not self.server_args.enable_dp_attention:
+            return
+
+        target_model = self.target_worker.model_runner.model
+        tp_group = get_tp_group()
+        tp_size = int(tp_group.world_size)
+        if tp_size <= 1:
+            return
+
+        def _broadcast_gather(local_shard, tp_group, tp_size, tp_rank):
+            """Gather shards on GPU via sequential broadcast (one shard at a time)."""
+            import torch.distributed as dist
+
+            parts = []
+            for r in range(tp_size):
+                if r == tp_rank:
+                    buf = local_shard.contiguous()
+                else:
+                    buf = torch.empty_like(local_shard)
+                dist.broadcast(buf, src=tp_group.ranks[r], group=tp_group.device_group)
+                parts.append(buf.clone())
+            return torch.cat(parts, dim=0)
+
+        # Full embed_tokens, kept replicated on GPU (sync-free runtime lookup).
+        embed_module = target_model.get_input_embeddings()
+        local_w = embed_module.weight.data
+        shard = getattr(embed_module, "shard_indices", None)
+        num_org = int(shard.num_org_elements) if shard else local_w.shape[0]
+        vocab_size = int(self.target_worker.model_runner.model_config.vocab_size)
+        self._full_embed_gpu = _broadcast_gather(
+            local_w[:num_org], tp_group, tp_size, self.tp_rank
+        )[:vocab_size]
+        if self.tp_rank == 0:
+            logger.info(
+                "DFLASH cached embed on GPU: shape=%s, mask_norm=%.4f",
+                list(self._full_embed_gpu.shape),
+                self._full_embed_gpu[self._mask_token_id].float().norm().item(),
+            )
 
     def _ensure_draft_block_buffers(self, bs: int) -> None:
         cap = (
@@ -849,6 +1010,24 @@ class DFlashWorkerV2(BaseSpecWorker):
                 f"DFLASH positions must be 1D, got shape={tuple(positions.shape)}."
             )
         num_tokens = int(target_hidden.shape[0])
+        # With --enable-dp-attention, prepare_mlp_sync_batch rounds each DP rank's
+        # global_num_tokens up to a multiple of attn_tp_size for reduce-scatter
+        # alignment, so target_hidden can carry trailing padding rows that are not real
+        # tokens. Drop them before materializing into the draft KV; otherwise the padding
+        # rows write into slots belonging to other requests and corrupt their cache.
+        expected_tokens = int(cache_loc.numel())
+        if num_tokens > expected_tokens:
+            if not getattr(self, "_logged_dp_padding_trim", False):
+                logger.warning(
+                    "DFLASH target_hidden has %d trailing DP-padding row(s); trimming "
+                    "to cache_loc length=%d (target_hidden=%d). Logged once per worker.",
+                    num_tokens - expected_tokens,
+                    expected_tokens,
+                    num_tokens,
+                )
+                self._logged_dp_padding_trim = True
+            target_hidden = target_hidden[:expected_tokens]
+            num_tokens = expected_tokens
         if int(cache_loc.numel()) != num_tokens:
             raise ValueError(
                 "DFLASH cache_loc length mismatch: "
@@ -898,7 +1077,9 @@ class DFlashWorkerV2(BaseSpecWorker):
             if commit_lens.dtype != torch.int32:
                 commit_lens = commit_lens.to(torch.int32)
 
-        with torch.inference_mode():
+        with torch.inference_mode(), self.draft_tp_context(
+            self.draft_model_runner.tp_group
+        ):
             ctx_hidden = self.draft_model.project_target_hidden(target_hidden)
 
             if cache_loc_2d is not None:
@@ -1221,49 +1402,49 @@ class DFlashWorkerV2(BaseSpecWorker):
             if on_publish is not None:
                 on_publish(batch_output.new_seq_lens)
 
-            if logits_output.hidden_states is None:
-                raise RuntimeError(
-                    "DFLASH requires target aux hidden capture for prefill, but got None. "
-                    "Make sure the target model has DFlash layers-to-capture configured."
-                )
-
-            if (
-                model_worker_batch.extend_lens is None
-                or model_worker_batch.prefix_lens is None
-            ):
-                raise RuntimeError(
-                    "DFLASH expected extend_lens / prefix_lens to be populated in extend mode, "
-                    "but got None."
-                )
-
-            # Materialize prompt tokens into the draft KV cache immediately. This is required
-            # for radix cache safety (the scheduler may update radix after prefill returns).
             device = next_token_ids.device
-            ctx_lens = torch.tensor(
-                model_worker_batch.extend_lens, dtype=torch.int32, device=device
-            )
-            draft_seq_lens = torch.tensor(
-                model_worker_batch.prefix_lens, dtype=torch.int32, device=device
-            )
 
-            if model_worker_batch.out_cache_loc is None:
-                raise RuntimeError(
-                    "DFLASH prefill expected out_cache_loc, but got None."
+            # An idle DP rank during an extend-in-batch step has no local prompt
+            # tokens (extend_lens / prefix_lens are None): it runs the target forward
+            # above to stay in collective lockstep with the active DP group, then skips
+            # draft-KV materialization.
+            if (
+                model_worker_batch.extend_lens is not None
+                and model_worker_batch.prefix_lens is not None
+            ):
+                if logits_output.hidden_states is None:
+                    raise RuntimeError(
+                        "DFLASH requires target aux hidden capture for prefill, but got None. "
+                        "Make sure the target model has DFlash layers-to-capture configured."
+                    )
+
+                # Materialize prompt tokens into the draft KV cache immediately. This is required
+                # for radix cache safety (the scheduler may update radix after prefill returns).
+                ctx_lens = torch.tensor(
+                    model_worker_batch.extend_lens, dtype=torch.int32, device=device
                 )
-            positions, _ = compute_position(
-                self.model_runner.server_args.attention_backend,
-                draft_seq_lens,
-                ctx_lens,
-                int(sum(model_worker_batch.extend_lens)),
-            )
-            self._append_target_hidden_to_draft_kv_by_loc(
-                target_hidden=logits_output.hidden_states,
-                cache_loc=model_worker_batch.out_cache_loc,
-                positions=positions,
-            )
+                draft_seq_lens = torch.tensor(
+                    model_worker_batch.prefix_lens, dtype=torch.int32, device=device
+                )
 
-            # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
-            logits_output.hidden_states = None
+                if model_worker_batch.out_cache_loc is None:
+                    raise RuntimeError(
+                        "DFLASH prefill expected out_cache_loc, but got None."
+                    )
+                positions, _ = compute_position(
+                    self.model_runner.server_args.attention_backend,
+                    draft_seq_lens,
+                    ctx_lens,
+                    int(sum(model_worker_batch.extend_lens)),
+                )
+                self._append_target_hidden_to_draft_kv_by_loc(
+                    target_hidden=logits_output.hidden_states,
+                    cache_loc=model_worker_batch.out_cache_loc,
+                    positions=positions,
+                )
+
+                # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
+                logits_output.hidden_states = None
 
             batch_output.next_draft_input = self._make_next_draft_input_prefill(
                 verified_id=next_token_ids,
@@ -1288,6 +1469,27 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
 
         if model_worker_batch.forward_mode.is_idle():
+            # Under dp attention an idle DP rank must still run the target verify
+            # forward (in IDLE mode) so its cross-DP collectives (MoE all-to-all,
+            # attention gather) stay in lockstep with the active DP group. The draft
+            # block is skipped here: the draft forward's collectives are within-rank.
+            if self.server_args.enable_dp_attention:
+                idle_verify_input = DFlashVerifyInput(
+                    draft_token=torch.empty((0,), dtype=torch.long, device=self.device),
+                    positions=torch.empty((0,), dtype=torch.int64, device=self.device),
+                    draft_token_num=int(self.block_size),
+                    custom_mask=None,
+                    capture_hidden_mode=CaptureHiddenMode.FULL,
+                )
+                idle_verify_forward_batch, _ = idle_verify_input.prepare_for_verify(
+                    model_worker_batch, self.target_worker
+                )
+                self.target_worker.forward_batch_generation(
+                    batch=None,
+                    forward_batch=idle_verify_forward_batch,
+                    is_verify=True,
+                    skip_attn_backend_init=True,
+                )
             empty_ids = torch.empty((0,), dtype=torch.int64, device=self.device)
             empty_lens = torch.empty((0,), dtype=torch.int32, device=self.device)
             next_draft_input = self._make_next_draft_input_decode(
@@ -1396,7 +1598,19 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
             verify_out_cache_loc_2d.copy_(verify_out_cache_loc.view(bs, block_size))
 
-        noise_embedding = embed_module(block_ids)
+        # Use the GPU-replicated full embedding under dp attention (collective-free,
+        # no host-device sync); otherwise the on-device VocabParallelEmbedding path.
+        if self._full_embed_gpu is not None:
+            noise_embedding = F.embedding(block_ids, self._full_embed_gpu)
+        else:
+            noise_embedding = embed_module(block_ids)
+        if self._per_position_mask_embeddings is not None:
+            is_mask = block_ids == self._mask_token_id
+            pos_in_block = torch.arange(self.block_size, device=block_ids.device)
+            pos_embeds = self._per_position_mask_embeddings[pos_in_block]
+            noise_embedding[is_mask] = pos_embeds.unsqueeze(0).expand(bs, -1, -1)[
+                is_mask
+            ]
         input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
 
         positions = positions_2d.reshape(-1)
@@ -1476,7 +1690,9 @@ class DFlashWorkerV2(BaseSpecWorker):
             capture_hidden_mode=CaptureHiddenMode.NULL,
         )
 
-        with torch.inference_mode():
+        with torch.inference_mode(), self.draft_tp_context(
+            self.draft_model_runner.tp_group
+        ):
             draft_logits_output = self.draft_model_runner.forward(
                 forward_batch
             ).logits_output
@@ -1485,10 +1701,13 @@ class DFlashWorkerV2(BaseSpecWorker):
         if draft_hidden is None:
             raise RuntimeError("DFLASH draft model returned no hidden states.")
         draft_hidden = draft_hidden.view(bs, int(self.block_size), -1)
-        draft_next = self._greedy_sample_from_vocab_parallel_head(
-            hidden_states=draft_hidden[:, 1:, :].reshape(-1, draft_hidden.shape[-1]),
-            lm_head=lm_head,
-        ).view(bs, int(self.block_size) - 1)
+        with self.draft_tp_context(self.draft_model_runner.tp_group):
+            draft_next = self._greedy_sample_from_vocab_parallel_head(
+                hidden_states=draft_hidden[:, 1:, :].reshape(
+                    -1, draft_hidden.shape[-1]
+                ),
+                lm_head=lm_head,
+            ).view(bs, int(self.block_size) - 1)
 
         draft_tokens = self._draft_block_tokens_buf[:bs]
         draft_tokens[:, 0].copy_(block_ids[:, 0])

--- a/test/registered/spec/dflash/test_dflash_mimo_v2_fp4.py
+++ b/test/registered/spec/dflash/test_dflash_mimo_v2_fp4.py
@@ -1,0 +1,103 @@
+import os
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=1800, suite="nightly-8-gpu-common", nightly=True)
+
+# Public checkpoints: target = https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash
+# (the FP4 mxfp4 target at the repo root), draft = the repo's `dflash/` subfolder. Because
+# the draft is a subfolder (not its own repo id), download the repo and point
+# MIMO_V2_DFLASH_DRAFT at the local `<repo>/dflash` path:
+#   hf download XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash --local-dir /models/mimo-fp4-dflash
+#   export MIMO_V2_FP4_TARGET=/models/mimo-fp4-dflash
+#   export MIMO_V2_DFLASH_DRAFT=/models/mimo-fp4-dflash/dflash
+MIMO_V2_FP4_TARGET = os.environ.get(
+    "MIMO_V2_FP4_TARGET", "XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash"
+)
+MIMO_V2_DFLASH_DRAFT = os.environ.get("MIMO_V2_DFLASH_DRAFT", "")
+
+
+@unittest.skipUnless(
+    MIMO_V2_DFLASH_DRAFT,
+    "Set MIMO_V2_DFLASH_DRAFT to the local DFlash draft subfolder "
+    "(<repo>/dflash) to run. Needs a 16-GPU (TP16/DP2) runner.",
+)
+class TestMiMoV2FP4DFlash(CustomTestCase, GSM8KMixin):
+    """GSM8K + accept-length check for the FP4 MiMo-V2-Pro target with its DFlash draft.
+
+    Mirrors the internal v0.5.10 deployment eval (TP16/DP2/EP16, dp-attention, fa3),
+    which scored AIME25 28/30 at accept-length ~4. The 1T FP4 target cannot fit a
+    single device, so this needs a 16-GPU (TP16/DP2 => attn_tp=8) runner.
+    """
+
+    model = MIMO_V2_FP4_TARGET
+    draft_model = MIMO_V2_DFLASH_DRAFT
+    gsm8k_accuracy_thres = 0.85
+    gsm8k_accept_length_thres = 3.5
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        launch_args = [
+            "--trust-remote-code",
+            "--speculative-algorithm",
+            "DFLASH",
+            "--speculative-draft-model-path",
+            cls.draft_model,
+            "--speculative-num-draft-tokens",
+            "8",
+            "--quantization",
+            "fp8",
+            "--attention-backend",
+            "fa3",
+            "--tensor-parallel-size",
+            "16",
+            "--data-parallel-size",
+            "2",
+            "--ep-size",
+            "16",
+            "--enable-dp-attention",
+            "--enable-dp-lm-head",
+            "--moe-dense-tp-size",
+            "1",
+            "--reasoning-parser",
+            "qwen3",
+            "--tool-call-parser",
+            "mimo",
+            "--page-size",
+            "1",
+            "--disable-overlap-schedule",
+        ]
+        old_value = os.environ.get("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN")
+        os.environ["SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN"] = "1"
+        try:
+            with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1):
+                cls.process = popen_launch_server(
+                    cls.model,
+                    cls.base_url,
+                    timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                    other_args=launch_args,
+                )
+        finally:
+            if old_value is None:
+                del os.environ["SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN"]
+            else:
+                os.environ["SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN"] = old_value
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Adds DFlash speculative decoding for the FP4 `MiMoV2ForCausalLM` (MiMo-V2-Pro/MiMo-V2.5-Pro) target,
building on the existing upstream DFLASH feature. Single-machine scope (TP / DP-attention
/ EP; no PD disaggregation).

- Adds the DFlash aux-hidden-state capture hook to the MiMo-V2 target
  (`set_dflash_layers_to_capture` + the three-tuple decoder return), capturing the target
  feature via `prepare_attn_and_capture_last_layer_outputs` so it stays in a consistent
  `TP_ATTN_FULL` layout under DP attention.
- Adds the MiMo-V2 DFlash draft pieces: attention sink bias, value scale, and
  sliding-window config parsed from the draft config; RoPE base read from the draft config
  (fail-loud if absent). `sinks=` is forwarded to attention only when the draft has a
  trained sink bias, since backends without sink support (e.g. FlashInfer) reject the kwarg.
- Supports the FP4 backbone: `mxfp4`-packed MoE storage (uint8 e2m1 weights + uint8 block
  scales, `store_dtype=mxfp4`) is dequantized to block-wise FP8 once at load (reusing
  `per_block_cast_to_fp8`), so the runtime path is a regular FP8 block-quant MoE.
- Uses a symmetric sliding window for the block-bidirectional `ENCODER_ONLY` draft path
  while the target stays causal.
- Enables DFlash under DP attention: gathers the full embedding / lm-head to CPU and
  indexes there to avoid the embedding all-reduce, adds idle-DP-rank synchronization
  forwards, and trims trailing DP-padding rows from the captured target hidden before
  appending to the draft KV cache.
- Materializes the draft prefill KV via the sequential per-layer path; the fused
  materialize kernel corrupts draft KV on long prompts (token-repeat at generation start,
  accept-length drop).

## Serving

Model weights: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash

8-GPU-per-node, 2-node DP-attention example (TP=16, DP=2, EP=16 ⇒ effective attention TP 8).
The DFlash draft lives in the target repo's `dflash/` subfolder, so download the repo and
point `--speculative-draft-model-path` at the local `<repo>/dflash` path:

```bash
hf download XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash --local-dir /models/mimo-v2-fp4-dflash
sglang serve \
  --trust-remote-code \
  --model-path /models/MiMo-V2.5-Pro-FP4-DFlash \
  --speculative-algorithm DFLASH \
  --speculative-draft-model-path /models/MiMo-V2.5-Pro-FP4-DFlash/dflash \
  --speculative-num-draft-tokens 8 \
  --tp 16 --dp 2 --ep-size 16 \
  --enable-dp-attention --enable-dp-lm-head \
  --quantization fp8 \
  --attention-backend fa3 \
  --moe-dense-tp-size 1 \
  --mem-fraction-static 0.65 \
  --reasoning-parser qwen3 \
  --tool-call-parser mimo \
  --disable-overlap-schedule \
  --host 0.0.0.0 --port 30000
```

## Tests

- `pre-commit run -a` passed.
- `python -m py_compile` of the changed files passed.
- Validated end-to-end on this branch (real `upstream/main` + this graft), 2 nodes × 8 GPU,
  TP16 / DP2 / EP16, dp-attention, fa3, FP4 `MiMo-V2.5-Pro` target + SWA1024 DFlash draft:
  - Cross-dataset (webdev) run: 100/100 prompts completed with coherent generations.
- The same DFlash logic is independently validated on the internal v0.5.10 deployment:
  AIME25 (greedy, thinking) 28/30.
- The existing registered DFLASH test (`test/registered/spec/dflash/test_dflash.py`) still
  passes; it exercises the conditional-`sinks=` path (a sink-less draft on FlashInfer).
- Added registered GSM8K + accept-length coverage for the FP4 MiMo-V2 DFlash target:
  `test/registered/spec/dflash/test_dflash_mimo_v2_fp4.py::TestMiMoV2FP4DFlash::test_gsm8k`.
  It auto-skips unless `MIMO_V2_DFLASH_DRAFT` is set (the DFlash draft lives in the target
  repo's `dflash/` subfolder) and needs a 16-GPU (TP16/DP2) runner.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->