### PR TITLE
fix(qwen3-coder): handle JSON schema union types in tool-call parameter conversion

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -106,7 +106,19 @@ class Qwen3CoderDetector(BaseFormatDetector):
             isinstance(param_config[param_name], dict)
             and "type" in param_config[param_name]
         ):
-            param_type = str(param_config[param_name]["type"]).strip().lower()
+            raw_type = param_config[param_name]["type"]
+            if isinstance(raw_type, list):
+                # JSON Schema union type, e.g. ["boolean", "null"]. Pick the
+                # first non-null member so lowercase JSON bools reach the bool
+                # branch instead of degenerating to truthy strings.
+                non_null = [
+                    str(item).strip().lower()
+                    for item in raw_type
+                    if str(item).strip().lower() != "null"
+                ]
+                param_type = non_null[0] if non_null else "string"
+            else:
+                param_type = str(raw_type).strip().lower()
         else:
             param_type = "string"
         if param_type in ["string", "str", "text", "varchar", "char", "enum"]:

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2495,6 +2495,41 @@ class TestQwen3CoderDetector(unittest.TestCase):
         self.assertIsInstance(params["dry_run"], bool)
         self.assertEqual(params["dry_run"], True)
 
+    def test_boolean_union_type_parameter_conversion(self):
+        """
+        Test JSON-Schema union type conversion for boolean parameters.
+
+        Scenario: Tool schema uses ["boolean", "null"] and the model emits
+        JSON-style lowercase false.
+        Purpose: Verify false is parsed as bool False, not a truthy string.
+        """
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="sql_interpreter",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "dry_run": {"type": ["boolean", "null"]},
+                        },
+                    },
+                ),
+            )
+        ]
+        text = """<tool_call>
+<function=sql_interpreter>
+<parameter=query>SELECT 1</parameter>
+<parameter=dry_run>false</parameter>
+</function>
+</tool_call>"""
+        result = self.detector.detect_and_parse(text, tools)
+
+        params = json.loads(result.calls[0].parameters)
+        self.assertIsInstance(params["dry_run"], bool)
+        self.assertIs(params["dry_run"], False)
+
     def test_complex_array_parameter(self):
         """
         Test parsing of complex array parameters.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`Qwen3CoderDetector._convert_param_value` reads a parameter's declared type from the tool schema with `str(param_config[param_name]["type"]).strip().lower()`. This assumes `"type"` is always a scalar string.

JSON Schema permits a **union type** expressed as a list, e.g. `{"type": ["boolean", "null"]}`, which tools commonly emit for nullable parameters. In that case `str(["boolean", "null"])` produces the literal string `"['boolean', 'null']"`, which matches none of the known type branches and falls through to the default string handling. As a result a model-emitted `false`/`true` is returned as the **truthy string** `"false"`/`"true"` instead of a Python `bool`, silently corrupting tool arguments (`"false"` is truthy).

## Modifications

- In `python/sglang/srt/function_call/qwen3_coder_detector.py`, when the schema `type` is a list, drop `"null"` members and resolve to the first remaining type, so `["boolean", "null"]` routes to the boolean branch. Scalar types are unchanged. If the list contains only `"null"`, it falls back to `"string"`.
- The existing top-of-function `null` short-circuit (`param_value.lower() == "null"` → `None`) still handles actual null values, so dropping `"null"` from the type list only affects type *resolution*, not null handling.
- Added a unit test `test_boolean_union_type_parameter_conversion` in `test/registered/unit/function_call/test_function_call_parser.py` covering a `["boolean", "null"]` parameter with a JSON-style lowercase `false`, asserting it parses to `bool` `False`.

## Accuracy Tests

Not applicable — this change does not touch kernels or model forward code. Behavior is covered by the added parser unit test.

## Speed Tests and Profiling

Not applicable — no inference-path or performance impact; the change only affects schema type resolution during tool-call parsing.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27259286038](https://github.com/sgl-project/sglang/actions/runs/27259286038)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27259285374](https://github.com/sgl-project/sglang/actions/runs/27259285374)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->