### PR TITLE
[BUG FIX]Fix DSA CPU offload mamba indices signature

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2360,13 +2360,13 @@ class DSATokenToKVPool(MLATokenToKVPool):
             pool=self, buf=buf, loc=loc, index_k=index_k, index_k_scale=index_k_scale
         )
 
-    def get_cpu_copy(self, indices):
+    def get_cpu_copy(self, indices, mamba_indices=None):
         # DSA keeps a page-indexed index_k_with_scale_buffer alongside kv_buffer.
         # Retract frees the slots/pages and they get reused by other reqs'
         # set_index_k_scale_buffer, so we must offload it here too -- otherwise
         # resume restores kv_buffer but leaves foreign index/scale in place and
         # DSA attention reads garbage at those token positions.
-        kv_cache_cpu = super().get_cpu_copy(indices)
+        kv_cache_cpu = super().get_cpu_copy(indices, mamba_indices=mamba_indices)
 
         page_indices = indices[:: self.page_size] // self.page_size
         torch.cuda.synchronize()
@@ -2385,8 +2385,10 @@ class DSATokenToKVPool(MLATokenToKVPool):
 
         return {"kv": kv_cache_cpu, "index_k": index_k_cpu}
 
-    def load_cpu_copy(self, kv_cache_cpu_dict, indices):
-        super().load_cpu_copy(kv_cache_cpu_dict["kv"], indices)
+    def load_cpu_copy(self, kv_cache_cpu_dict, indices, mamba_indices=None):
+        super().load_cpu_copy(
+            kv_cache_cpu_dict["kv"], indices, mamba_indices=mamba_indices
+        )
 
         page_indices = indices[:: self.page_size] // self.page_size
         index_k_cpu = kv_cache_cpu_dict["index_k"]

--- a/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
+++ b/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 
 import torch
@@ -13,6 +14,14 @@ from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestDSAOffloadSignatures(unittest.TestCase):
+    def test_cpu_copy_methods_accept_mamba_indices(self):
+        for method_name in ("get_cpu_copy", "load_cpu_copy"):
+            with self.subTest(method_name=method_name):
+                signature = inspect.signature(getattr(DSATokenToKVPool, method_name))
+                self.assertIn("mamba_indices", signature.parameters)
 
 
 class TestDSAHiCacheTransfer(unittest.TestCase):


### PR DESCRIPTION
  ## Motivation

  Decode disaggregation may retract running requests under sustained load and offload their KV cache to CPU. The allocator forwards the optional `mamba_indices` argument to the underlying KV pool during
  CPU offload.

  `DSATokenToKVPool.get_cpu_copy()` and `load_cpu_copy()` did not accept this argument, which can raise a runtime `TypeError` when DSA KV cache is offloaded during retract.

  ## Modifications

  - Add optional `mamba_indices=None` parameters to `DSATokenToKVPool.get_cpu_copy()` and `load_cpu_copy()`.
  - Forward `mamba_indices` to the parent MLA KV pool CPU offload methods.
  - Add a unit test that checks DSA CPU copy methods keep accepting `mamba_indices`.

  ## Accuracy Tests

  Not applicable. This PR only fixes a CPU offload method signature mismatch and does not change model forward computation or output numerics.

  ## Speed Tests and Profiling

  Not applicable. This PR only changes optional argument forwarding on the retract/offload path and should not affect normal inference performance.

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://
  docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27189178937](https://github.com/sgl-project/sglang/actions/runs/27189178937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27189178882](https://github.com/sgl-project/sglang/actions/runs/27189178882)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->