### PR TITLE
[sgl] Fix kimi-k2.5 EAGLE3 MLA draft embeds for batched MM prefill

### DIFF
--- a/python/sglang/srt/models/kimi_k25_eagle3.py
+++ b/python/sglang/srt/models/kimi_k25_eagle3.py
@@ -261,9 +261,10 @@ class Eagle3MLAModel(nn.Module):
                 and not forward_batch.forward_mode.is_draft_extend(include_v2=True)
             ):
                 assert embeds is not None
-                embeds = torch.cat(
-                    [embeds[:-1], self.embed_tokens(input_ids[-1].unsqueeze(0))]
-                )
+                last_indices = (
+                    forward_batch.extend_start_loc + forward_batch.extend_seq_lens - 1
+                ).long()
+                embeds[last_indices] = self.embed_tokens(input_ids[last_indices])
             if embeds is None:
                 embeds = self.embed_tokens(input_ids)
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes a silent correctness bug in the kimi-k2.5 EAGLE3 MLA draft model when serving multimodal requests with batch size greater than 1.

The draft model patches multimodal-aware input embeddings by overlaying real `embed_tokens` results on top of the target's `mm_input_embeds`. current code only patched the very last position of the flat extend buffer, which assumed batch size 1. For larger batches, requests 0..N-2 silently kept stale `mm_input_embeds` at their per-request last-token position — no crash, but wrong draft inputs and degraded acceptance rates.

This PR computes each request's last-token index from `extend_start_loc + extend_seq_lens - 1` and scatters `embed_tokens(input_ids[last_indices])` into all of those positions in one in-place assignment. Correct for any batch size, and as a bonus avoids the full-tensor allocation that `torch.cat` paid every step.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27190358657](https://github.com/sgl-project/sglang/actions/runs/27190358657)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27227065914](https://github.com/sgl-project/sglang/actions/runs/27227065914)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->