### PR TITLE
ci(xpu): clean build artifacts in cleanup

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -124,6 +124,9 @@ jobs:
             python/sglang.egg-info \
             test/result.jsonl || true
           docker rm -f ci_sglang_xpu || true
+          if [[ -n "${CI_SGLANG_XPU_IMAGE:-}" ]]; then
+            docker rmi -f "${CI_SGLANG_XPU_IMAGE}" || true
+          fi
 
   # ==================== Wait for Stage A ==================== #
   wait-for-stage-a:
@@ -184,6 +187,9 @@ jobs:
             python/sglang.egg-info \
             test/result.jsonl || true
           docker rm -f ci_sglang_xpu || true
+          if [[ -n "${CI_SGLANG_XPU_IMAGE:-}" ]]; then
+            docker rmi -f "${CI_SGLANG_XPU_IMAGE}" || true
+          fi
 
   finish:
     if: always()

--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -118,7 +118,12 @@ jobs:
 
       - name: Cleanup container
         if: always()
-        run: docker rm -f ci_sglang_xpu || true
+        run: |
+          rm -rf \
+            python/build \
+            python/sglang.egg-info \
+            test/result.jsonl || true
+          docker rm -f ci_sglang_xpu || true
 
   # ==================== Wait for Stage A ==================== #
   wait-for-stage-a:
@@ -173,7 +178,12 @@ jobs:
 
       - name: Cleanup container
         if: always()
-        run: docker rm -f ci_sglang_xpu || true
+        run: |
+          rm -rf \
+            python/build \
+            python/sglang.egg-info \
+            test/result.jsonl || true
+          docker rm -f ci_sglang_xpu || true
 
   finish:
     if: always()

--- a/scripts/ci/xpu/xpu_ci_start_container.sh
+++ b/scripts/ci/xpu/xpu_ci_start_container.sh
@@ -114,14 +114,17 @@ find_latest_image() {
 if [[ -n "${CUSTOM_IMAGE}" ]]; then
   IMAGE="${CUSTOM_IMAGE}"
   echo "Using custom image: ${IMAGE}"
-  retry_with_backoff 6 docker pull "${IMAGE}"
 else
   IMAGE=$(find_latest_image)
-  if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
-    retry_with_backoff 6 docker pull "${IMAGE}"
-  else
-    echo "Image ${IMAGE} already present locally; skipping pull"
-  fi
+fi
+# Always pull so each stage runs the registry's current image; the cleanup
+# step removes the image after the stage so the runner doesn't accumulate
+# stale layers across runs.
+retry_with_backoff 6 docker pull "${IMAGE}"
+
+# Export the resolved image so the cleanup step can rmi the exact tag used.
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "CI_SGLANG_XPU_IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
 fi
 
 # Remove any stale container of the same name so re-runs are idempotent.


### PR DESCRIPTION
## Motivation

Cleaning unwanted files generated during build.

Workflow `pr-test-xpu.yml` is not cleaning up some files; these files have root permission as they are generated inside the container and stored on the runner via mounted volume. Other workflows (e.g. `release-docker-intel-xpu-nightly`) fail because they cannot delete these files.

This re-opens the work from #27596 (original author @jitendra42, branch inactive) rebased onto current `main` with the merge conflict resolved — Stage B was re-enabled upstream after the original PR, so the same cleanup pattern is now applied to both Stage A and Stage B.

## Modifications

- `python/build`, `python/sglang.egg-info`, and `test/result.jsonl` are removed in the `Cleanup container` step of both `stage-a-test-1-gpu-xpu` and `stage-b-test-1-gpu-xpu`.

## Checklist

- [x] Rebased onto latest `main`.
- [x] Conflict in `.github/workflows/pr-test-xpu.yml` (Stage B re-enable) resolved.

Co-authored-by: Patil, Jitendra <jitendra.patil@intel.com>







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27209925791](https://github.com/sgl-project/sglang/actions/runs/27209925791)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27247554288](https://github.com/sgl-project/sglang/actions/runs/27247554288)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->