### PR TITLE
fix(sampler): guard torch.multinomial against zero-sum rows (#27618)

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -493,6 +493,15 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
         min_p_thresholds = probs_sort[:, 0] * min_ps
         probs_sort[probs_sort < min_p_thresholds.view(-1, 1)] = 0.0
 
+    # After top-k/top-p/min-p masking a row can sum to zero (degenerate probs or
+    # aggressive thresholds). torch.multinomial then raises "invalid multinomial
+    # distribution (sum of probabilities <= 0)", which is uncaught in the scheduler
+    # subprocess and brings the whole server down. Fall back to the top-1 token
+    # (column 0 of the descending-sorted probs) for any such row.
+    zero_rows = probs_sort.sum(dim=-1) <= 0
+    if zero_rows.any():
+        probs_sort[zero_rows, 0] = 1.0
+
     if sampling_seed is None:
         sampled_index = torch.multinomial(probs_sort, num_samples=1)
     else:


### PR DESCRIPTION
## Problem

Fixes #27618.

`top_k_top_p_min_p_sampling_from_probs_torch` in `python/sglang/srt/layers/sampler.py` applies top-k / top-p / min-p masks in place on `probs_sort` and then hands the result straight to `torch.multinomial`:

```python
probs_sort[(probs_sum - probs_sort) > top_ps.view(-1, 1)] = 0.0
...
sampled_index = torch.multinomial(probs_sort, num_samples=1)
```

If any row ends up summing to zero (degenerate input probabilities, or sufficiently aggressive thresholds), `torch.multinomial` raises:

```
RuntimeError: invalid multinomial distribution (sum of probabilities <= 0)
```

This exception is uncaught inside the scheduler subprocess, so the whole scheduler exits (SIGQUIT) and takes the server down — a single bad row turns into full-process death.

## Fix

Add a cheap defensive guard right before the `multinomial` call: detect rows whose masked probabilities sum to `<= 0` and fall back to the top-1 token for those rows (column 0 of the descending-sorted `probs_sort`).

- No behavior change for normal rows — only rows that currently **crash** are touched.
- Protects both the seeded and non-seeded sampling paths (the guard runs before the branch).
- 9 added lines, no deletions.

## Repro (from the issue)

A `probs_sort` row that is fully masked to zero before `torch.multinomial` reproduces the `RuntimeError`; with this guard the row deterministically samples its top-1 token instead of crashing the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27189908883](https://github.com/sgl-project/sglang/actions/runs/27189908883)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27189908786](https://github.com/sgl-project/sglang/actions/runs/27189908786)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->