### PR TITLE
[Kernel] Support fused RoPE kernel for partial rotary dim

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -38,6 +38,7 @@ _is_cpu = is_cpu()
 _is_xpu = is_xpu()
 _is_musa = is_musa()
 _is_mps = is_mps()
+_FUSED_ROPE_SUPPORTED_DIMS = {64, 128, 256, 512}
 
 if _is_cuda:
     from sglang.jit_kernel.rope import apply_rope_with_cos_sin_cache_inplace
@@ -98,8 +99,12 @@ class RotaryEmbedding(MultiPlatformOp):
         if not (_is_cuda or _is_xpu or envs.SGLANG_ROPE_CACHE_FP32.get()):
             cache = cache.to(dtype)
 
+        use_fused_cuda_rope = _is_cuda and (
+            self.head_size in _FUSED_ROPE_SUPPORTED_DIMS
+            or self.rotary_dim in _FUSED_ROPE_SUPPORTED_DIMS
+        )
         if (
-            (not (_is_cuda) or self.head_size not in [64, 128, 256, 512])
+            not use_fused_cuda_rope
             and not (_is_cpu)
             and not (_is_xpu)
             and not (_is_npu)
@@ -367,6 +372,14 @@ class RotaryEmbedding(MultiPlatformOp):
         fused_set_kv_buffer_arg: Optional[Union[FusedSetKVBufferArg, dict]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not self.use_fallback_kernel:
+            if (
+                fused_set_kv_buffer_arg is not None
+                and self.head_size != self.rotary_dim
+            ):
+                raise NotImplementedError(
+                    "Fused RoPE + KV cache store requires head_size == rotary_dim. "
+                    "Partial rotary embedding should use the separate KV cache store path."
+                )
             batch_size = positions.size(0)
             q_rope = query.view(batch_size, -1, self.head_size)
             k_rope = key.view(batch_size, -1, self.head_size)

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -237,6 +237,59 @@ def test_partial_rope(batch_size: int, is_neox: bool, rope_dim: int, head_dim: i
     triton.testing.assert_close(k_fi, k_jit, atol=atol, rtol=rtol)
 
 
+@pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
+@pytest.mark.parametrize("dtype", DTYPE_LIST)
+def test_rotary_embedding_uses_fused_kernel_for_partial_rope(
+    is_neox: bool, dtype: torch.dtype
+) -> None:
+    from sglang.srt.layers.rotary_embedding import RotaryEmbedding
+    from sglang.srt.server_args import (
+        ServerArgs,
+        set_global_server_args_for_scheduler,
+    )
+
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    # Real MiMo-V2.5-Pro attention shape: head_dim=192 with a partial rotary dim
+    # of 64 (partial_rotary_factor=0.334) and 128 query / 8 KV heads. head_dim=192
+    # is not one of the fused kernel's supported dims, so the fused path must be
+    # selected via rotary_dim=64 instead.
+    batch_size = 129
+    num_qo_heads = 128
+    num_kv_heads = 8
+    head_dim = 192
+    rope_dim = 64
+    max_position = 4096
+
+    rotary_emb = RotaryEmbedding(
+        head_size=head_dim,
+        rotary_dim=rope_dim,
+        max_position_embeddings=max_position,
+        base=ROPE_BASE,
+        is_neox_style=is_neox,
+        dtype=dtype,
+    ).to(DEVICE)
+
+    assert not rotary_emb.use_fallback_kernel
+    assert rotary_emb.cos_sin_cache.dtype == torch.float32
+
+    q = torch.randn(batch_size, num_qo_heads, head_dim, device=DEVICE, dtype=dtype)
+    k = torch.randn(batch_size, num_kv_heads, head_dim, device=DEVICE, dtype=dtype)
+    positions = torch.randint(
+        0, max_position, (batch_size,), device=DEVICE, dtype=torch.int32
+    )
+
+    q_ref, k_ref = q.clone(), k.clone()
+    q_out, k_out = q.clone(), k.clone()
+
+    flashinfer_rope(q_ref, k_ref, rotary_emb.cos_sin_cache, positions.long(), is_neox)
+    rotary_emb(positions, q_out, k_out)
+
+    assert rotary_emb.cos_sin_cache.dtype == torch.float32
+    triton.testing.assert_close(q_ref, q_out, atol=1e-2, rtol=1e-2)
+    triton.testing.assert_close(k_ref, k_out, atol=1e-2, rtol=1e-2)
+
+
 @pytest.mark.parametrize("batch_size", BS_LIST)
 @pytest.mark.parametrize("gqa_ratio", GQA_RATIO)
 @pytest.mark.parametrize("num_kv_heads", NUM_KV_HEADS_LIST)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Models with **partial rotary embedding** (`rotary_dim < head_size`) currently take the fallback `rotary_embedding` path on CUDA, because dispatch only checks whether `head_size` is one of the fused kernel's supported dims `{64, 128, 256, 512}`.
For example, the MiMo-V2 family uses `head_dim=192` with `partial_rotary_factor=0.334` → `rotary_dim=64`. Since `192` is not a supported dim, these models miss the fused kernel even though the rotary dimension itself (`64`) is fully supported.
The fallback path is not only slower — it is also **less numerically accurate for bf16/fp16 models**. On CUDA the `cos_sin_cache` is kept in fp32 for numerical stability, but the fallback path downcasts it to the query dtype before calling the kernel:
```python
self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
```
The fallback kernel is templated on a single `scalar_t`, so once the cache is bf16 the entire rotation (cos/sin and the multiply-adds) runs in bf16. The fused kernel instead requires the cache to stay fp32 and upcasts q/k to fp32 internally, so cos/sin are always computed in fp32.
The fused kernel (`apply_rope_with_cos_sin_cache_inplace`) and the `forward_cuda` slicing path already handle partial rotary dim correctly — the kernel rotates `rotary_dim` elements per head and uses an independent `head_stride` to skip the pass-through tail. Only the dispatch gate was keeping these models off it.

## Modifications

- Add `_FUSED_ROPE_SUPPORTED_DIMS = {64, 128, 256, 512}`.
- Gate the CUDA fused-kernel dispatch on `head_size` **or** `rotary_dim` being a supported dim, so partial-rope models (e.g. `head_size=192, rotary_dim=64`) take the fused path. Models that already used the fused kernel (e.g. `head_size=128`) are unaffected.
- Guard the fused RoPE + KV-cache-store path with a clear `NotImplementedError` when `head_size != rotary_dim`. That fused store kernel requires `head_size == rotary_dim` (it stores the whole head as one block), so partial rope must use the separate KV-cache-store path.
- Add a layer-level test asserting that a partial-rope `RotaryEmbedding` selects the fused kernel (`use_fallback_kernel is False`), keeps its `cos_sin_cache` in fp32 across a forward, and matches the flashinfer reference.

## Accuracy Tests

New test in `python/sglang/jit_kernel/tests/test_rope.py`:
```
pytest python/sglang/jit_kernel/tests/test_rope.py -k partial_rope -v
```
`test_rotary_embedding_uses_fused_kernel_for_partial_rope` builds a partial-rope `RotaryEmbedding` (MiMo-V2.5-Pro shape: `head_dim=192`, `rotary_dim=64`, 128 q / 8 kv heads), asserts the fused kernel is selected and the `cos_sin_cache` stays fp32 across the forward, and checks the output against the flashinfer reference for both NeoX and GPT-J styles in fp16/bf16 (`atol=rtol=1e-2`).
The existing kernel-level partial-rope coverage (`test_partial_rope`, `test_rope`) continues to pass unchanged.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29502319877](https://github.com/sgl-project/sglang/actions/runs/29502319877)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29502319739](https://github.com/sgl-project/sglang/actions/runs/29502319739)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->