### PR TITLE
fix: DSV4 DP attention CUDA graph metadata buffer stability

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -790,13 +790,39 @@ class DeepseekV4AttnBackend(
         # materialization is recorded inside the cuda graph; a no-op (Full
         # already) when PREP_IN_CUDA_GRAPH=0.
         if isinstance(self.forward_metadata, DSV4RawVerifyMetadata):
-            self.forward_metadata = self.make_forward_metadata_from_raw_verify(
-                raw_metadata=self.forward_metadata,
-            )
+            full_buf = self._lookup_full_metadata_buffer()
+            if full_buf is not None:
+                temp = self.make_forward_metadata_from_raw_verify(
+                    raw_metadata=self.forward_metadata,
+                )
+                full_buf.copy_(temp)
+                self.forward_metadata = full_buf
+            else:
+                self.forward_metadata = self.make_forward_metadata_from_raw_verify(
+                    raw_metadata=self.forward_metadata,
+                )
         elif isinstance(self.forward_metadata, DSV4RawDecodeMetadata):
-            self.forward_metadata = self.make_forward_metadata_from_raw_decode(
-                raw_metadata=self.forward_metadata,
-            )
+            full_buf = self._lookup_full_metadata_buffer()
+            if full_buf is not None:
+                temp = self.make_forward_metadata_from_raw_decode(
+                    raw_metadata=self.forward_metadata,
+                )
+                full_buf.copy_(temp)
+                self.forward_metadata = full_buf
+            else:
+                self.forward_metadata = self.make_forward_metadata_from_raw_decode(
+                    raw_metadata=self.forward_metadata,
+                )
+
+    def _lookup_full_metadata_buffer(self) -> "DSV4Metadata | None":
+        current_meta = self.forward_metadata
+        for bucket, bs_dict in self.cuda_graph_metadata_of_bucket_and_bs.items():
+            for bs, saved_meta in bs_dict.items():
+                if saved_meta is current_meta:
+                    return self.cuda_graph_full_metadata_of_bucket_and_bs.get(
+                        bucket, {}
+                    ).get(bs)
+        return None
 
         # Compute the SWA KV-store write target once per forward and cache it on
         # the metadata for every layer's store. This is recorded inside the cuda
@@ -1075,6 +1101,9 @@ class DeepseekV4AttnBackend(
                 ],
             ],
         ] = {bucket: {} for bucket in _GraphBucket}
+        self.cuda_graph_full_metadata_of_bucket_and_bs: Dict[
+            _GraphBucket, Dict[int, DSV4Metadata]
+        ] = {}
         self.draft_extend_num_tokens_per_bs = (
             max_num_tokens // max_bs if max_bs > 0 else 1
         )
@@ -1115,6 +1144,17 @@ class DeepseekV4AttnBackend(
         # restore raw so capture re-runs the upgrade inside the graph.
         current_raw = getattr(self, "_current_capture_raw", None)
         if current_raw is not None:
+            # Save the warmup-upgraded full metadata as graph-persistent
+            # buffers so init_forward_metadata_in_graph can copy into them
+            # during CUDA graph replay instead of allocating new tensors.
+            if envs.SGLANG_PREP_IN_CUDA_GRAPH.get() and isinstance(metadata, DSV4Metadata):
+                for bucket, bs_dict in self.cuda_graph_metadata_of_bucket_and_bs.items():
+                    for bs, saved in bs_dict.items():
+                        if saved is current_raw:
+                            self.cuda_graph_full_metadata_of_bucket_and_bs.setdefault(
+                                bucket, {}
+                            )[bs] = metadata
+                            break
             self.forward_metadata = current_raw
 
     def get_swa_out_cache_loc(self, forward_batch: ForwardBatch) -> torch.Tensor:


### PR DESCRIPTION
When SGLANG_PREP_IN_CUDA_GRAPH=1 (default) and DP attention is enabled, init_forward_metadata_in_graph() was creating new DSV4Metadata objects during each CUDA graph replay cycle. These newly allocated tensors could land at addresses that downstream graph-captured attention ops did not expect, causing garbled greedy decode outputs.

Fix: pre-allocate graph-persistent full-metadata buffers during warmup and write upgraded metadata values into them via copy_() instead of allocating fresh objects. A fallback to the original behavior is kept for non-CUDA-graph paths.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When --dp N --enable-dp-attention is used on DeepSeek-V4-Flash with CUDA graph enabled, greedy decode outputs become non-deterministic and produce semantic corruption such as repeated characters (e.g. "由由由", "求求求"). The issue reproduces consistently:

temperature=0 (greedy) yields different outputs across identical requests
With --disable-cuda-graph or SGLANG_PREP_IN_CUDA_GRAPH=0 the output is correct
Not related to EPLB, DeepEP, tokenizer, or enable-dp-lm-head
Root cause: init_forward_metadata_in_graph() (aka _maybe_upgrade_forward_metadata in v0.5.12) creates new DSV4Metadata objects during each CUDA graph replay cycle via make_forward_metadata_from_raw_decode(). These newly allocated tensors land at addresses in the CUDA graph memory pool that differ from the addresses captured during graph construction, causing downstream attention ops to read stale/incorrect metadata — notably the FlashMLA page table and compression metadata tensors.

## Modifications

Single file: python/sglang/srt/layers/attention/deepseek_v4_backend.py

init_cuda_graph_state: add cuda_graph_full_metadata_of_bucket_and_bs dict to hold pre-allocated full-metadata buffer objects alongside the existing raw-metadata dict.
on_after_cuda_graph_warmup: when SGLANG_PREP_IN_CUDA_GRAPH=1 and the warmup replay triggers a raw→full upgrade, save the resulting DSV4Metadata object into the full-metadata buffer dict. This ensures the full metadata's tensors are allocated once and reused across all replay cycles.
init_forward_metadata_in_graph / _maybe_upgrade_forward_metadata: instead of unconditionally calling make_forward_metadata_from_raw_*() and assigning the result to self.forward_metadata, first look up the pre-allocated full-metadata buffer. If one exists, compute the upgrade into a temporary and copy_() the values into the persistent buffer, then point self.forward_metadata at the persistent buffer. Falls back to the original behavior when no buffer exists (non-CUDA-graph paths).
Add _lookup_full_metadata_buffer() helper.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27195854874](https://github.com/sgl-project/sglang/actions/runs/27195854874)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27195854591](https://github.com/sgl-project/sglang/actions/runs/27195854591)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->