### PR TITLE
Fix MiMo-V2.5-Pro DP-attention dp size in cookbook deployment snippet

### DIFF
--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -93,13 +93,17 @@ export const MiMoV25Deployment = () => {
   };
 
   // Per (variant, hardware): HF slug, tp, multinode info, Blackwell flag.
-  // V2.5 (base) checkpoint has TP=4-interleaved fused qkv_proj, so attention
-  // TP per DP group MUST be 4. Effective TP/DP = 4. With tp=8 → dp=2; tp=4 → dp=1.
+  // The attention qkv_proj is TP-interleaved, so attention-TP per DP group is
+  // fixed: V2.5 (base) is TP=4-interleaved, V2.5-Pro is TP=8-interleaved. When
+  // tp exceeds that factor, DP-attention is required with `dp = tp / factor`
+  // (Pro: tp/8, base: tp/4); when tp equals the factor there is a single
+  // attention group and no `dp` field is set. So Pro on Hopper (tp=16) needs
+  // dp=2, while Pro on Blackwell (tp=8) needs no dp-attention at all.
   // TPU rows go through the sgl-jax stack (`python -m sgl_jax.launch_server`),
   // not the CUDA `sglang serve` binary; tp == total JAX devices across nodes.
   const HW_VARIANT_SPEC = {
-    "pro|h200":     { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2,  blackwell: false, jax: false },
-    "pro|h100":     { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2,  blackwell: false, jax: false },
+    "pro|h200":     { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2,  blackwell: false, jax: false, dp: 2 },
+    "pro|h100":     { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2,  blackwell: false, jax: false, dp: 2 },
     "pro|b200":     { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 8,  multinode: false,             blackwell: true,  jax: false },
     "pro|gb300":    { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 8,  multinode: true,  nnodes: 2,  blackwell: true,  jax: false },
     "pro|tpu-v7x":  { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 32, multinode: true,  nnodes: 4,  blackwell: false, jax: true  },
@@ -132,13 +136,18 @@ export const MiMoV25Deployment = () => {
     const blackwell = spec ? spec.blackwell : false;
     const jax = spec ? spec.jax : false;
     const c = {};
-    if (!isPro) {
-      // V2.5 checkpoint is TP=4-interleaved; tp/dp must equal 4. With dp>1 we
-      // must use DP-attention; with dp=1 it must be off (single attention group).
-      if (spec && spec.dp > 1) {
-        c.dpAttention = { force: "enabled", reason: "V2.5 checkpoint is TP=4-interleaved; DP-attention is required (--dp = tp/4)." };
+    // Both checkpoints are TP-interleaved (Pro: 8, base: 4), so attention-TP per
+    // DP group must equal that factor. When the spec carries dp>1 (Pro/Hopper
+    // tp=16, base tp=8) DP-attention with `--dp = tp/factor` is required; without
+    // it a bare `--tp` gives attn_tp = tp != factor and the loader rejects the
+    // checkpoint. When no dp>1 (Pro/Blackwell tp=8, base tp=4) it's a single
+    // attention group and DP-attention must stay off.
+    if (spec && !jax) {
+      const factor = isPro ? 8 : 4;
+      if (spec.dp > 1) {
+        c.dpAttention = { force: "enabled", reason: `Checkpoint is TP=${factor}-interleaved; DP-attention is required (--dp = tp/${factor} = ${spec.dp}).` };
       } else {
-        c.dpAttention = { force: "disabled", reason: "Single attention group on this hardware (tp=4, dp=1)." };
+        c.dpAttention = { force: "disabled", reason: `Single attention group on this hardware (tp=${factor}, no dp-attention).` };
       }
     }
     if (blackwell) {
@@ -281,8 +290,10 @@ export const MiMoV25Deployment = () => {
     const useDeepep = !blackwell && deepep === "enabled";
     const useEp = isPro && !blackwell && expertParallelism === "enabled";
     const useDpAttn = dpAttention === "enabled";
-    // dp size: V2.5 picks tp/4 from spec; Pro picks tp.
-    const dpSize = !isPro ? spec.dp : tp;
+    // dp size = required DP-attention degree from the spec (tp/factor), for both
+    // variants. Only read when useDpAttn is on, which computeConstraints forces
+    // exactly for the specs that carry dp>1 (Pro/Hopper tp=16 → 2, base tp=8 → 2).
+    const dpSize = spec.dp;
 
     // ---- env (kept inline before `sglang serve`, matching the verified launch style) ----
     const envVars = [];


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The MiMo-V2.5 cookbook deployment generator (`docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx`) produced an **unstartable** command for MiMo-V2.5-Pro whenever DP-attention was used.
The Pro FP8 checkpoint ships a **TP=8-interleaved fused `qkv_proj`** (`num_key_value_heads = 8`), because quantization is done per attention-TP shard. The model loader (`mimo_v2.py`) therefore requires the runtime **attention-TP per DP group to be exactly 8**, otherwise it raises:
```
MiMoV2 fused qkv_proj checkpoint is TP=8-interleaved; got attention tp_size=<n>
```
Since `attn_tp = tp / dp` (`layers/dp_attention.py`), DP-attention is only valid when `dp = tp / 8`.
The snippet instead computed the Pro DP size as `tp`:
```js
const dpSize = !isPro ? spec.dp : tp;   // Pro: dp == tp  ← wrong
```
So on a 2-node Hopper deployment (`tp=16`) it emitted `--dp 16` (equal to `--ep`), giving `attn_tp = 16/16 = 1 ≠ 8` and a load-time crash. This is exactly the failure mode discussed by the model author in the day0 enablement thread, who confirmed *"our model only supports TP8"* and that *"dpsize should be set to 2"* for the `tp=16` recipe — see https://github.com/sgl-project/sglang/pull/23808#issuecomment-4456780386.
In addition, `computeConstraints` only enforced a DP-attention choice for the V2.5 (base) variant, so Pro on Hopper also defaulted to a bare `--tp 16` (DP-attention off) — which fails the same way (`attn_tp = 16 ≠ 8`).

## Modifications

Treat both variants uniformly: attention-TP per DP group must equal the checkpoint's interleave factor (**Pro: 8**, base: 4), so `dp = tp / factor`.
- **`HW_VARIANT_SPEC`**: give the Pro Hopper rows (`pro|h200`, `pro|h100`, `tp=16`) `dp: 2`. The Pro Blackwell rows (`pro|b200`, `pro|gb300`, `tp=8`) carry no `dp` field → single attention group, DP-attention off.
- **`computeConstraints`**: generalize the DP-attention constraint to Pro as well. When the spec carries `dp > 1`, DP-attention is **forced on** (`--dp = tp/factor`); otherwise it is **forced off** (and the UI grays out the "Enabled" radio).
- **`dpSize`**: read `spec.dp` for both variants instead of falling back to `tp` for Pro.
## Resulting commands (Pro)
| Hardware | DP-attention | Generated |
| --- | --- | --- |
| H100 / H200 (tp=16) | forced **on** | `--tp 16 --dp 2 --enable-dp-attention` |
| B200 / GB300 (tp=8) | forced **off** (grayed out) | `--tp 8` |
All four combinations now satisfy `attn_tp == 8`. The Hopper output matches the verified day0 recipe (`--tp 16 --dp 2 --ep 16`) from #23808.
## Scope / notes
- One file changed: `docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx`. No runtime / model code touched.
- The V2.5 (base, TP=4-interleaved) behavior is unchanged.
- On standard 8-GPU Blackwell (`tp=8`) DP-attention would require `dp=1` (a no-op single group), so it is intentionally disabled in the panel rather than emitting a meaningless flag.



<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27198272063](https://github.com/sgl-project/sglang/actions/runs/27198272063)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27282112730](https://github.com/sgl-project/sglang/actions/runs/27282112730)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->