### PR TITLE
Defer DeepGEMM PDL setup to worker init

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -205,11 +205,10 @@ def tf32_hc_prenorm_gemm(
 
 
 def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
-    if ENABLE_JIT_DEEPGEMM:
-        # deep_gemm.set_pdl can initialize CUDA state, so run it only after the
-        # scheduler/TP worker has been forked and assigned a GPU.
-        if envs.SGLANG_DEEPGEMM_PDL.get() and hasattr(deep_gemm, "set_pdl"):
-            deep_gemm.set_pdl(True)
+    # deep_gemm.set_pdl can initialize CUDA state, so run it only after the
+    # scheduler/TP worker has been forked and assigned a GPU.
+    if envs.SGLANG_DEEPGEMM_PDL.get() and hasattr(deep_gemm, "set_pdl"):
+        deep_gemm.set_pdl(True)
 
     compile_utils.update_deep_gemm_config(gpu_id, server_args)
 

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -21,7 +21,6 @@ if ENABLE_JIT_DEEPGEMM:
     from deep_gemm.utils.layout import get_mn_major_tma_aligned_tensor  # noqa: F401
 
 _SANITY_CHECK = envs.SGLANG_DEEPGEMM_SANITY_CHECK.get()
-_PDL_CONFIGURED = False
 
 
 # TODO maybe rename these functions
@@ -206,14 +205,11 @@ def tf32_hc_prenorm_gemm(
 
 
 def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
-    global _PDL_CONFIGURED
-
-    if not _PDL_CONFIGURED and ENABLE_JIT_DEEPGEMM:
+    if ENABLE_JIT_DEEPGEMM:
         # deep_gemm.set_pdl can initialize CUDA state, so run it only after the
         # scheduler/TP worker has been forked and assigned a GPU.
         if envs.SGLANG_DEEPGEMM_PDL.get() and hasattr(deep_gemm, "set_pdl"):
             deep_gemm.set_pdl(True)
-        _PDL_CONFIGURED = True
 
     compile_utils.update_deep_gemm_config(gpu_id, server_args)
 

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -20,10 +20,22 @@ if ENABLE_JIT_DEEPGEMM:
     import deep_gemm
     from deep_gemm.utils.layout import get_mn_major_tma_aligned_tensor  # noqa: F401
 
+_SANITY_CHECK = envs.SGLANG_DEEPGEMM_SANITY_CHECK.get()
+_PDL_CONFIGURED = False
+
+
+def _maybe_set_deep_gemm_pdl():
+    global _PDL_CONFIGURED
+
+    if _PDL_CONFIGURED or not ENABLE_JIT_DEEPGEMM:
+        return
+
+    # deep_gemm.set_pdl can initialize CUDA state, so run it only after the
+    # scheduler/TP worker has been forked and assigned a GPU.
     if envs.SGLANG_DEEPGEMM_PDL.get() and hasattr(deep_gemm, "set_pdl"):
         deep_gemm.set_pdl(True)
 
-_SANITY_CHECK = envs.SGLANG_DEEPGEMM_SANITY_CHECK.get()
+    _PDL_CONFIGURED = True
 
 
 # TODO maybe rename these functions
@@ -208,6 +220,7 @@ def tf32_hc_prenorm_gemm(
 
 
 def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
+    _maybe_set_deep_gemm_pdl()
     compile_utils.update_deep_gemm_config(gpu_id, server_args)
 
 

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -24,20 +24,6 @@ _SANITY_CHECK = envs.SGLANG_DEEPGEMM_SANITY_CHECK.get()
 _PDL_CONFIGURED = False
 
 
-def _maybe_set_deep_gemm_pdl():
-    global _PDL_CONFIGURED
-
-    if _PDL_CONFIGURED or not ENABLE_JIT_DEEPGEMM:
-        return
-
-    # deep_gemm.set_pdl can initialize CUDA state, so run it only after the
-    # scheduler/TP worker has been forked and assigned a GPU.
-    if envs.SGLANG_DEEPGEMM_PDL.get() and hasattr(deep_gemm, "set_pdl"):
-        deep_gemm.set_pdl(True)
-
-    _PDL_CONFIGURED = True
-
-
 # TODO maybe rename these functions
 def grouped_gemm_nt_f8f8bf16_masked(
     lhs: Tuple[torch.Tensor, torch.Tensor],
@@ -220,7 +206,15 @@ def tf32_hc_prenorm_gemm(
 
 
 def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
-    _maybe_set_deep_gemm_pdl()
+    global _PDL_CONFIGURED
+
+    if not _PDL_CONFIGURED and ENABLE_JIT_DEEPGEMM:
+        # deep_gemm.set_pdl can initialize CUDA state, so run it only after the
+        # scheduler/TP worker has been forked and assigned a GPU.
+        if envs.SGLANG_DEEPGEMM_PDL.get() and hasattr(deep_gemm, "set_pdl"):
+            deep_gemm.set_pdl(True)
+        _PDL_CONFIGURED = True
+
     compile_utils.update_deep_gemm_config(gpu_id, server_args)
 
 


### PR DESCRIPTION
## Summary

- Defer DeepGEMM PDL setup until worker initialization.
- Run the setup through the existing DeepGEMM config path.

## Before

Representative pre-fix `nvidia-smi` process list, sanitized to remove host paths and PIDs:

```text
GPU  Process name             GPU Memory
0    python3                  716 MiB
0    sglang::scheduler_TP0   5824 MiB
0    sglang::scheduler_TP1    740 MiB
0    sglang::scheduler_TP2    740 MiB
0    sglang::scheduler_TP3    740 MiB
0    sglang::detokenizer      740 MiB
1    sglang::scheduler_TP1   5792 MiB
2    sglang::scheduler_TP2   5792 MiB
3    sglang::scheduler_TP3   5792 MiB
```

## Verification

- `python3 -m py_compile python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py`
- `git diff --check`

## Original commits

- `baf07ecb33ca79e4ef7d6cbe66bb6041143a1be0`
- `3c169cd443038f946269a672e8273b44b460e493`
- `9550ba550c28d38a8f37e9919b8cf6d69a41bb7c`
- `8cc54abe7241639dc293033b0da7eef568d1fc34`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27200752236](https://github.com/sgl-project/sglang/actions/runs/27200752236)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27200751616](https://github.com/sgl-project/sglang/actions/runs/27200751616)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->