### PR TITLE
Title: [HiCache] Add --hicache-numa-binding for storage thread NUMA pinning

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -47,6 +47,7 @@ from sglang.srt.layers.dp_attention import (
 )
 from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
 from sglang.srt.utils import get_device_module
+from sglang.srt.utils.numa_utils import numa_bind_to_node
 
 logger = logging.getLogger(__name__)
 
@@ -264,6 +265,7 @@ class HiCacheController:
         model_name: Optional[str] = None,
         storage_backend_extra_config: Optional[dict] = None,
         enable_storage_metrics: bool = False,
+        numa: Optional[int] = None,
     ):
         self.tp_group = tp_group
         self.attn_cp_group = attn_cp_group
@@ -285,6 +287,7 @@ class HiCacheController:
         self.storage_backend = None
         self.storage_backend_type = None
         self.enable_storage_metrics = enable_storage_metrics
+        self._numa = numa
 
         # Draft KV pool support (best-effort piggyback on target L2/L3 ops).
         self.has_draft = False
@@ -386,6 +389,14 @@ class HiCacheController:
     def _all_reduce_prefetch_groups(self, tensor: torch.Tensor, op) -> None:
         for group in self.prefetch_sync_groups:
             torch.distributed.all_reduce(tensor, op=op, group=group)
+
+    def _bind_storage_thread(self):
+        """Bind current thread to remote NUMA node for storage I/O.
+
+        No-op when _numa is not configured (default).
+        """
+        if self._numa is not None:
+            numa_bind_to_node(self._numa)
 
     def _start_storage_threads(self):
         """Start storage prefetch/backup threads and their queues.
@@ -1008,6 +1019,7 @@ class HiCacheController:
         """
         Auxiliary function conducting IO operations for prefetching.
         """
+        self._bind_storage_thread()
         while not self.storage_stop_event.is_set():
             try:
                 operation = self.prefetch_buffer.get(block=True, timeout=1)
@@ -1065,6 +1077,7 @@ class HiCacheController:
         """
         Manage prefetching operations from storage backend to host memory.
         """
+        self._bind_storage_thread()
         self.prefetch_buffer = Queue()
         self.prefetch_io_aux_thread = threading.Thread(
             target=self.prefetch_io_aux_func, daemon=True
@@ -1234,6 +1247,7 @@ class HiCacheController:
         """
         Manage backup operations from host memory to storage backend.
         """
+        self._bind_storage_thread()
         while not self.storage_stop_event.is_set():
             try:
                 operation = self.backup_queue.get(block=True, timeout=1)

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -106,6 +106,34 @@ class HiRadixCache(RadixCache):
         self.attn_tp_group = params.attn_tp_cache_group
         self.pp_group = params.pp_cache_group
         self.tp_world_size = torch.distributed.get_world_size(group=self.tp_group)
+
+        # Resolve NUMA binding for storage threads from rank:numa mapping
+        numa = None
+        if server_args.hicache_numa_binding:
+            tp_rank = torch.distributed.get_rank(self.tp_group)
+            try:
+                for entry in server_args.hicache_numa_binding.split(","):
+                    entry = entry.strip()
+                    if not entry:
+                        continue
+                    r, n = entry.split(":", 1)
+                    if int(r.strip()) == tp_rank:
+                        numa = int(n.strip())
+                        break
+            except ValueError:
+                logger.exception(
+                    "Invalid format for --hicache-numa-binding: '%s'. "
+                    "Expected 'rank:numa,rank:numa,...'.",
+                    server_args.hicache_numa_binding,
+                )
+                raise
+            if numa is not None:
+                logger.info(
+                    "HiCache storage thread NUMA binding: rank=%d -> NUMA %d",
+                    tp_rank,
+                    numa,
+                )
+
         self.pp_rank = params.pp_rank
         self.pp_size = params.pp_size
         self.enable_storage = server_args.hicache_storage_backend is not None
@@ -154,6 +182,7 @@ class HiRadixCache(RadixCache):
                 model_name=server_args.served_model_name,
                 storage_backend_extra_config=extra_config,
                 enable_storage_metrics=self.enable_storage_metrics,
+                numa=numa,
             )
         self._apply_storage_runtime_config(
             storage_backend=server_args.hicache_storage_backend,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -692,6 +692,7 @@ class ServerArgs:
     hicache_write_policy: str = "write_through"
     hicache_io_backend: str = "kernel"
     hicache_mem_layout: str = "layer_first"
+    hicache_numa_binding: Optional[str] = None
     hicache_storage_backend: Optional[str] = None
     hicache_storage_prefetch_policy: str = "timeout"
     hicache_storage_backend_extra_config: Optional[str] = None
@@ -6312,6 +6313,12 @@ class ServerArgs:
             ],
             default=ServerArgs.hicache_mem_layout,
             help="The layout of host memory pool for hierarchical cache.",
+        )
+        parser.add_argument(
+            "--hicache-numa-binding",
+            type=str,
+            default=ServerArgs.hicache_numa_binding,
+            help="Comma-separated rank:numa bindings for HiCache storage threads, e.g. '0:7,1:5'.",
         )
         parser.add_argument(
             "--hicache-storage-backend",

--- a/test/registered/unit/mem_cache/test_hicache_numa.py
+++ b/test/registered/unit/mem_cache/test_hicache_numa.py
@@ -1,0 +1,69 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _resolve_numa(binding_str, rank):
+    """Emulates the inline parsing logic in hiradix_cache.py."""
+    if not binding_str or not binding_str.strip():
+        return None
+    numa = None
+    for entry in binding_str.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        r, n = entry.split(":", 1)
+        if int(r.strip()) == rank:
+            numa = int(n.strip())
+            break
+    return numa
+
+
+class TestHiCacheNumaBinding(unittest.TestCase):
+
+    def test_resolve_multi_rank(self):
+        self.assertEqual(_resolve_numa("0:7,1:5,2:5,3:7", 0), 7)
+        self.assertEqual(_resolve_numa("0:7,1:5,2:5,3:7", 1), 5)
+        self.assertEqual(_resolve_numa("0:7,1:5,2:5,3:7", 2), 5)
+        self.assertEqual(_resolve_numa("0:7,1:5,2:5,3:7", 3), 7)
+        self.assertIsNone(_resolve_numa("0:7,1:5", 99))
+
+    def test_single_rank(self):
+        self.assertEqual(_resolve_numa("0:7", 0), 7)
+
+    def test_none_input(self):
+        self.assertIsNone(_resolve_numa(None, 0))
+
+    def test_empty_string(self):
+        self.assertIsNone(_resolve_numa("", 0))
+
+    def test_whitespace_only(self):
+        self.assertIsNone(_resolve_numa("   ", 0))
+
+    def test_whitespace_handling(self):
+        self.assertEqual(_resolve_numa(" 0 : 7 , 1 : 5 ", 0), 7)
+        self.assertEqual(_resolve_numa(" 0 : 7 , 1 : 5 ", 1), 5)
+
+    def test_trailing_comma(self):
+        self.assertEqual(_resolve_numa("0:7,", 0), 7)
+
+    def test_empty_entry_between_commas(self):
+        self.assertEqual(_resolve_numa("0:7,,1:5", 0), 7)
+        self.assertEqual(_resolve_numa("0:7,,1:5", 1), 5)
+
+    def test_non_integer_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_numa("a:7", 0)
+        with self.assertRaises(ValueError):
+            _resolve_numa("0:b", 0)
+
+    def test_missing_colon_raises(self):
+        # Use a tp_rank that doesn't match "1:5" so it reaches the malformed entry
+        with self.assertRaises(ValueError):
+            _resolve_numa("1:5,0", 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Pin HiCache storage I/O threads (prefetch, backup, prefetch_io_aux)
   to specific NUMA nodes via --hicache-numa-binding.

   Usage:
     --hicache-numa-binding "0:7,1:5,2:5,3:7"  # tp_rank → NUMA node

   Prevents storage threads from competing with GPU DMA on the
   GPU-local NUMA node.

   Changes (3 files, +40 lines):
   - server_args.py: Add hicache_numa_binding field and CLI argument
   - hiradix_cache.py: Parse rank:numa mapping, resolve per-rank node
   - cache_controller.py: Add _bind_storage_thread(), called in
     3 storage thread functions (reuses existing numa_bind_to_node)

   No new dependencies. Backward compatible (default None = no-op).

   Performance (8-NUMA-node, file backend, write_through):
   - Storage SET p99: 72385us → 1076us (-98.5%)
   - Storage SET BW:  0.037 → 0.252 GB/s (+581%)
   - Page Backup p99: 2830957us → 66699us (-97.6%)



































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27250497580](https://github.com/sgl-project/sglang/actions/runs/27250497580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27250497504](https://github.com/sgl-project/sglang/actions/runs/27250497504)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->