### PR TITLE
[Fix][Bench] use ShareGPT text prompts for image dataset to avoid garbled text

### DIFF
--- a/python/sglang/benchmark/datasets/common.py
+++ b/python/sglang/benchmark/datasets/common.py
@@ -46,6 +46,10 @@ def load_sharegpt_conversations(dataset_path: str) -> List[Tuple[str, str]]:
         )
         for data in dataset
     ]
+    if not dataset:
+        raise ValueError(
+            f"No valid conversations with at least 2 turns found in dataset: {dataset_path}"
+        )
     random.shuffle(dataset)
     return dataset
 

--- a/python/sglang/benchmark/datasets/common.py
+++ b/python/sglang/benchmark/datasets/common.py
@@ -1,11 +1,14 @@
+import json
 import random
 from abc import ABC, abstractmethod
 from argparse import Namespace
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
+
+from sglang.benchmark.utils import download_and_cache_hf_file, is_file_valid_json
 
 ASSISTANT_SUFFIX = "Assistant:"
 SHAREGPT_REPO_ID = "anon8231489123/ShareGPT_Vicuna_unfiltered"
@@ -16,6 +19,40 @@ MOONCAKE_DATASET_URL = {
     "synthetic": "https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/synthetic_trace.jsonl",
     "toolagent": "https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/toolagent_trace.jsonl",
 }
+
+
+def load_sharegpt_conversations(dataset_path: str) -> List[Tuple[str, str]]:
+    """Load ShareGPT dataset and return (prompt, completion) pairs.
+
+    Downloads the dataset if the path is invalid, filters to conversations
+    with ≥2 turns, extracts the first two turns, and shuffles the result.
+    """
+    if not is_file_valid_json(dataset_path):
+        dataset_path = download_and_cache_hf_file(
+            repo_id=SHAREGPT_REPO_ID,
+            filename=SHAREGPT_FILENAME,
+        )
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    dataset = [
+        data
+        for data in dataset
+        if len(data.get("conversations", data.get("conversation", []))) >= 2
+    ]
+    dataset = [
+        (
+            data.get("conversations", data.get("conversation", []))[0]["value"],
+            data.get("conversations", data.get("conversation", []))[1]["value"],
+        )
+        for data in dataset
+    ]
+    random.shuffle(dataset)
+    return dataset
+
+
+def load_sharegpt_prompts(dataset_path: str) -> List[str]:
+    """Load ShareGPT dataset and return first-turn user messages only."""
+    return [prompt for prompt, _ in load_sharegpt_conversations(dataset_path)]
 
 
 @dataclass

--- a/python/sglang/benchmark/datasets/image.py
+++ b/python/sglang/benchmark/datasets/image.py
@@ -202,19 +202,17 @@ def _gen_sharegpt_text_prompts(
 
     for target_len in input_lens:
         # Find a non-empty prompt (cycle through dataset if needed)
-        prompt = None
-        while prompt is None:
+        prompt_token_ids = []
+        while not prompt_token_ids:
             try:
                 candidate = next(data_iter)
             except StopIteration:
+                # Re-shuffle and restart
                 random.shuffle(dataset)
                 data_iter = iter(dataset)
                 candidate = next(data_iter)
-            if len(tokenizer.encode(candidate)) == 0:
-                continue
-            prompt = candidate
+            prompt_token_ids = tokenizer.encode(candidate)
 
-        prompt_token_ids = tokenizer.encode(prompt)
         prompt_len = len(prompt_token_ids)
 
         if prompt_len > target_len:

--- a/python/sglang/benchmark/datasets/image.py
+++ b/python/sglang/benchmark/datasets/image.py
@@ -1,5 +1,4 @@
 import io
-import json
 import random
 import warnings
 from argparse import Namespace
@@ -12,18 +11,13 @@ from PIL import Image
 from transformers import AutoProcessor
 
 from sglang.benchmark.datasets.common import (
-    SHAREGPT_FILENAME,
-    SHAREGPT_REPO_ID,
     BaseDataset,
     DatasetRow,
     compute_random_lens,
     gen_mm_prompt,
+    load_sharegpt_prompts,
 )
-from sglang.benchmark.utils import (
-    download_and_cache_hf_file,
-    get_processor,
-    is_file_valid_json,
-)
+from sglang.benchmark.utils import get_processor
 
 
 @dataclass
@@ -201,30 +195,7 @@ def _gen_sharegpt_text_prompts(
     If there are not enough conversations to cover all requests, the dataset is
     reshuffled and reused cyclically.
     """
-    # Download sharegpt if necessary
-    if not is_file_valid_json(dataset_path):
-        dataset_path = download_and_cache_hf_file(
-            repo_id=SHAREGPT_REPO_ID,
-            filename=SHAREGPT_FILENAME,
-        )
-
-    # Load the dataset
-    with open(dataset_path) as f:
-        dataset = json.load(f)
-
-    # Filter out conversations with less than 2 turns
-    dataset = [
-        data
-        for data in dataset
-        if len(data.get("conversations", data.get("conversation", []))) >= 2
-    ]
-    # Only keep the first turn's user message
-    dataset = [
-        data.get("conversations", data.get("conversation", []))[0]["value"]
-        for data in dataset
-    ]
-    # Shuffle the dataset
-    random.shuffle(dataset)
+    dataset = load_sharegpt_prompts(dataset_path)
 
     prompts: List[str] = []
     data_iter = iter(dataset)
@@ -236,12 +207,10 @@ def _gen_sharegpt_text_prompts(
             try:
                 candidate = next(data_iter)
             except StopIteration:
-                # Re-shuffle and restart
                 random.shuffle(dataset)
                 data_iter = iter(dataset)
                 candidate = next(data_iter)
-            prompt_token_ids = tokenizer.encode(candidate)
-            if len(prompt_token_ids) == 0:
+            if len(tokenizer.encode(candidate)) == 0:
                 continue
             prompt = candidate
 

--- a/python/sglang/benchmark/datasets/image.py
+++ b/python/sglang/benchmark/datasets/image.py
@@ -1,4 +1,6 @@
 import io
+import json
+import random
 import warnings
 from argparse import Namespace
 from dataclasses import dataclass
@@ -10,12 +12,18 @@ from PIL import Image
 from transformers import AutoProcessor
 
 from sglang.benchmark.datasets.common import (
+    SHAREGPT_FILENAME,
+    SHAREGPT_REPO_ID,
     BaseDataset,
     DatasetRow,
     compute_random_lens,
     gen_mm_prompt,
 )
-from sglang.benchmark.utils import get_processor
+from sglang.benchmark.utils import (
+    download_and_cache_hf_file,
+    get_processor,
+    is_file_valid_json,
+)
 
 
 @dataclass
@@ -30,6 +38,7 @@ class ImageDataset(BaseDataset):
     image_resolution: str
     backend: str
     random_image_count: bool
+    dataset_path: str = ""
 
     @classmethod
     def from_args(cls, args: Namespace) -> "ImageDataset":
@@ -44,6 +53,7 @@ class ImageDataset(BaseDataset):
             image_resolution=args.image_resolution,
             backend=args.backend,
             random_image_count=args.random_image_count,
+            dataset_path=args.dataset_path,
         )
 
     def load(self, tokenizer=None, model_id=None) -> List[DatasetRow]:
@@ -60,6 +70,7 @@ class ImageDataset(BaseDataset):
             image_resolution=self.image_resolution,
             backend=self.backend,
             random_image_count=self.random_image_count,
+            dataset_path=self.dataset_path,
         )
 
 
@@ -178,6 +189,76 @@ def create_mm_data_row(
     )
 
 
+def _gen_sharegpt_text_prompts(
+    tokenizer,
+    dataset_path: str,
+    input_lens: List[int],
+) -> List[str]:
+    """Generate text prompts from ShareGPT conversations, matching target token lengths.
+
+    Uses the same logic as the random dataset: samples from real ShareGPT conversations,
+    tokenizes, truncates/repeats to match target length, then decodes back to text.
+    If there are not enough conversations to cover all requests, the dataset is
+    reshuffled and reused cyclically.
+    """
+    # Download sharegpt if necessary
+    if not is_file_valid_json(dataset_path):
+        dataset_path = download_and_cache_hf_file(
+            repo_id=SHAREGPT_REPO_ID,
+            filename=SHAREGPT_FILENAME,
+        )
+
+    # Load the dataset
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+
+    # Filter out conversations with less than 2 turns
+    dataset = [
+        data
+        for data in dataset
+        if len(data.get("conversations", data.get("conversation", []))) >= 2
+    ]
+    # Only keep the first turn's user message
+    dataset = [
+        data.get("conversations", data.get("conversation", []))[0]["value"]
+        for data in dataset
+    ]
+    # Shuffle the dataset
+    random.shuffle(dataset)
+
+    prompts: List[str] = []
+    data_iter = iter(dataset)
+
+    for target_len in input_lens:
+        # Find a non-empty prompt (cycle through dataset if needed)
+        prompt = None
+        while prompt is None:
+            try:
+                candidate = next(data_iter)
+            except StopIteration:
+                # Re-shuffle and restart
+                random.shuffle(dataset)
+                data_iter = iter(dataset)
+                candidate = next(data_iter)
+            prompt_token_ids = tokenizer.encode(candidate)
+            if len(prompt_token_ids) == 0:
+                continue
+            prompt = candidate
+
+        prompt_token_ids = tokenizer.encode(prompt)
+        prompt_len = len(prompt_token_ids)
+
+        if prompt_len > target_len:
+            input_ids = prompt_token_ids[:target_len]
+        else:
+            ratio = (target_len + prompt_len - 1) // prompt_len
+            input_ids = (prompt_token_ids * ratio)[:target_len]
+
+        prompts.append(tokenizer.decode(input_ids))
+
+    return prompts
+
+
 def sample_image_requests(
     num_requests: int,
     image_count: int,
@@ -190,6 +271,7 @@ def sample_image_requests(
     image_resolution: str,
     backend: str,
     random_image_count: bool = False,
+    dataset_path: str = "",
 ) -> List[DatasetRow]:
     """Generate requests with images.
 
@@ -254,16 +336,32 @@ def sample_image_requests(
 
     dataset: List[DatasetRow] = []
     total_image_bytes = 0
+
+    # Pre-generate text prompts: use ShareGPT if dataset_path is provided, otherwise random tokens
+    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    if dataset_path:
+        print(f"Using ShareGPT dataset for text prompts: {dataset_path}")
+        text_prompts = _gen_sharegpt_text_prompts(tokenizer, dataset_path, input_lens)
+    else:
+        text_prompts = None
+
     for i in range(num_requests):
         # Get the number of images for this request
         request_image_count = int(image_counts[i])
 
         # Generate text prompt
-        text_prompt = gen_mm_prompt(
-            processor.tokenizer if hasattr(processor, "tokenizer") else processor,
-            processor.image_token_id if hasattr(processor, "image_token_id") else None,
-            int(input_lens[i]),
-        )
+        if text_prompts is not None:
+            text_prompt = text_prompts[i]
+        else:
+            text_prompt = gen_mm_prompt(
+                tokenizer,
+                (
+                    processor.image_token_id
+                    if hasattr(processor, "image_token_id")
+                    else None
+                ),
+                int(input_lens[i]),
+            )
 
         # Generate image list
         images, images_base64, images_bytes = zip(

--- a/python/sglang/benchmark/datasets/random.py
+++ b/python/sglang/benchmark/datasets/random.py
@@ -1,5 +1,3 @@
-import json
-import random
 from argparse import Namespace
 from dataclasses import dataclass
 from typing import List
@@ -8,13 +6,11 @@ import numpy as np
 from transformers import PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets.common import (
-    SHAREGPT_FILENAME,
-    SHAREGPT_REPO_ID,
     BaseDataset,
     DatasetRow,
     compute_random_lens,
+    load_sharegpt_prompts,
 )
-from sglang.benchmark.utils import download_and_cache_hf_file, is_file_valid_json
 
 
 @dataclass
@@ -84,42 +80,17 @@ def sample_random_requests(
     if random_sample:
         # Sample token ids from ShareGPT and repeat/truncate them to satisfy the input_lens
 
-        # Download sharegpt if necessary
-        if not is_file_valid_json(dataset_path):
-            dataset_path = download_and_cache_hf_file(
-                repo_id=SHAREGPT_REPO_ID,
-                filename=SHAREGPT_FILENAME,
-            )
-
-        # Load the dataset.
-        with open(dataset_path) as f:
-            dataset = json.load(f)
-        # Filter out the conversations with less than 2 turns.
-        dataset = [
-            data
-            for data in dataset
-            if len(data.get("conversations", data.get("conversation", []))) >= 2
-        ]
-        # Only keep the first two turns of each conversation.
-        dataset = [
-            (
-                data.get("conversations", data.get("conversation", []))[0]["value"],
-                data.get("conversations", data.get("conversation", []))[1]["value"],
-            )
-            for data in dataset
-        ]
-        # Shuffle the dataset.
-        random.shuffle(dataset)
+        # Load and filter ShareGPT prompts
+        dataset = load_sharegpt_prompts(dataset_path)
 
         # Filter out sequences that are too long or too short
         input_requests: List[DatasetRow] = []
-        for data in dataset:
+        for prompt in dataset:
             i = len(input_requests)
             if i == num_prompts:
                 break
 
-            # Tokenize the prompts and completions.
-            prompt = data[0]
+            # Tokenize the prompts.
             prompt_token_ids = tokenizer.encode(prompt)
             prompt_len = len(prompt_token_ids)
 

--- a/python/sglang/benchmark/datasets/sharegpt.py
+++ b/python/sglang/benchmark/datasets/sharegpt.py
@@ -1,5 +1,3 @@
-import json
-import random
 from argparse import Namespace
 from dataclasses import dataclass
 from typing import List, Optional
@@ -9,16 +7,11 @@ from transformers import PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets.common import (
     ASSISTANT_SUFFIX,
-    SHAREGPT_FILENAME,
-    SHAREGPT_REPO_ID,
     BaseDataset,
     DatasetRow,
+    load_sharegpt_conversations,
 )
-from sglang.benchmark.utils import (
-    download_and_cache_hf_file,
-    is_file_valid_json,
-    remove_suffix,
-)
+from sglang.benchmark.utils import remove_suffix
 
 
 @dataclass
@@ -68,36 +61,9 @@ def sample_sharegpt_requests(
     if fixed_output_len is not None and fixed_output_len < 4:
         raise ValueError("output_len too small")
 
-    # Download sharegpt if necessary
-    if not is_file_valid_json(dataset_path) and dataset_path == "":
-        dataset_path = download_and_cache_hf_file(
-            repo_id=SHAREGPT_REPO_ID,
-            filename=SHAREGPT_FILENAME,
-        )
+    # Load and filter ShareGPT conversations
+    dataset = load_sharegpt_conversations(dataset_path)
 
-    # Load the dataset.
-    with open(dataset_path) as f:
-        dataset = json.load(f)
-
-    # Filter out the conversations with less than 2 turns.
-    dataset = [
-        data
-        for data in dataset
-        if len(data.get("conversations", data.get("conversation", []))) >= 2
-    ]
-    # Only keep the first two turns of each conversation.
-    dataset = [
-        (
-            data.get("conversations", data.get("conversation", []))[0]["value"],
-            data.get("conversations", data.get("conversation", []))[1]["value"],
-        )
-        for data in dataset
-    ]
-
-    # Shuffle the dataset.
-    random.shuffle(dataset)
-
-    # Filter out sequences that are too long or too short
     filtered_dataset: List[DatasetRow] = []
     for i in range(len(dataset)):
         if len(filtered_dataset) == num_requests:

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -384,7 +384,7 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertTrue(all(isinstance(row, DatasetRow) for row in rows))
         self.assertTrue(all(row.image_data for row in rows))
 
-    def test_image_sampler_with_share_gpt_dataset(self):
+    def test_image_sampler_with_sharegpt_dataset(self):
         dataset_path = self._write_sharegpt_json()
         rows = sample_image_requests(
             num_requests=2,

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -384,6 +384,26 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertTrue(all(isinstance(row, DatasetRow) for row in rows))
         self.assertTrue(all(row.image_data for row in rows))
 
+    def test_image_sampler_with_share_gpt_dataset(self):
+        dataset_path = self._write_sharegpt_json()
+        rows = sample_image_requests(
+            num_requests=2,
+            image_count=1,
+            input_len=8,
+            output_len=4,
+            range_ratio=0.0,
+            processor=self.processor,
+            image_content="blank",
+            image_format="png",
+            image_resolution="8x8",
+            backend="sglang",
+            random_image_count=False,
+            dataset_path=dataset_path,
+        )
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(isinstance(row, DatasetRow) for row in rows))
+        self.assertTrue(all(row.image_data for row in rows))
+
     def test_gen_mm_prompt_excludes_special_tokens(self):
         tokenizer = create_lightweight_tokenizer()
         multimodal_special_tokens = [


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The image dataset previously generated text prompts by randomly sampling token IDs from the tokenizer vocabulary and decoding them back to text (via gen_mm_prompt). For tokenizers with large multilingual vocabularies (e.g., Kimi-K2.6, Qwen3-VL), this produced garbled output mixing random Chinese, English, symbols, and invalid Unicode sequences, making the text prompt unusable for meaningful benchmarking.

In contrast, the random dataset always sampled from real ShareGPT conversations, producing clean, readable English text.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Extracted a public method to load the ShareGPT dataset. 
- Modified the prompt generation logic for the image dataset: 
  - now, when a ShareGPT dataset input is provided, it generates prompts identical to those in random mode; 
  - otherwise, it falls back to the previous behavior before this PR (which might generate garbled text due to the tokenizer). 
- Added a new image dataset test case with fake sharegpt, which takes 0.08s to run locally.

<img width="2400" height="479" alt="PixPin_2026-06-11_17-37-39" src="https://github.com/user-attachments/assets/4a6159ab-5344-433a-94e6-363b9010e3d4" />


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27337752210](https://github.com/sgl-project/sglang/actions/runs/27337752210)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27337752069](https://github.com/sgl-project/sglang/actions/runs/27337752069)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->