### PR TITLE
Pre-compute chunked metadata for GDN layers in NPU

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 from sgl_kernel_npu.fla.fused_gdn_gating import (
@@ -15,10 +15,15 @@ from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend
     AscendMambaAttnBackendBase,
 )
 from sglang.srt.layers.attention.linear.gdn_backend import GDNKernelDispatcher
+from sglang.srt.layers.attention.linear.gdn_chunk_meta import (
+    GDNChunkedPrefillMetadata,
+    build_gdn_chunked_prefill_meta,
+)
 from sglang.srt.layers.attention.linear.utils import (
     get_linear_attn_decode_backend,
     get_linear_attn_prefill_backend,
 )
+from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -28,6 +33,21 @@ from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 fused_gdn_gating = fused_gdn_gating_npu
 causal_conv1d_fn = causal_conv1d_fn_npu
 causal_conv1d_update = causal_conv1d_update_npu
+
+
+def _cu_seqlens_cpu_from_seq_lens(seq_lens_cpu) -> torch.Tensor:
+    if isinstance(seq_lens_cpu, torch.Tensor):
+        seq_lens = seq_lens_cpu.detach()
+        if seq_lens.device.type != "cpu":
+            seq_lens = seq_lens.cpu()
+        seq_lens = seq_lens.to(dtype=torch.int32)
+    else:
+        seq_lens = torch.tensor(seq_lens_cpu, dtype=torch.int32)
+
+    cu_seqlens = torch.empty(seq_lens.numel() + 1, dtype=torch.int32)
+    cu_seqlens[0] = 0
+    cu_seqlens[1:] = torch.cumsum(seq_lens, dim=0)
+    return cu_seqlens
 
 
 class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
@@ -46,6 +66,51 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()
         self.kernel_dispatcher = GDNKernelDispatcher(decode_backend, prefill_backend)
+        self.graph_mode = False
+        # Derive num_v_heads for GDN layers directly from model config so that
+        # init_forward_metadata can always pre-build metadata without waiting for
+        # a layer call.  Mirrors the model layer: num_v_heads = linear_num_value_heads
+        # // attn_tp_size.  Falls back to None for non-GDN configs; in that case
+        # _get_non_spec_chunked_prefill_meta will set it lazily on first use.
+        hf_cfg = model_runner.model_config.hf_config
+        raw_v_heads = getattr(hf_cfg, "linear_num_value_heads", None)
+        self._gdn_num_heads: Optional[int] = (
+            raw_v_heads // get_attention_tp_size() if raw_v_heads is not None else None
+        )
+        # Per-step cache: {num_heads -> GDNChunkedPrefillMetadata}, cleared each step.
+        self._gdn_meta_per_step: Dict[int, GDNChunkedPrefillMetadata] = {}
+
+    def _get_non_spec_chunked_prefill_meta(
+        self,
+        forward_batch: ForwardBatch,
+        num_heads: int,
+        device: torch.device,
+    ):
+        if (
+            self.graph_mode
+            or not forward_batch.forward_mode.is_extend_without_speculative()
+            or forward_batch.extend_seq_lens_cpu is None
+        ):
+            return None, None
+
+        cu_seqlens_cpu = getattr(self.forward_metadata, "cu_seqlens_cpu", None)
+        if cu_seqlens_cpu is None:
+            return None, None
+
+        # Per-step cache keyed by num_heads: pre-built in init_forward_metadata for
+        # known num_heads, or built lazily on first layer call and reused thereafter.
+        meta = self._gdn_meta_per_step.get(num_heads)
+        if meta is None:
+            meta = build_gdn_chunked_prefill_meta(
+                cu_seqlens_cpu=cu_seqlens_cpu,
+                num_heads=num_heads,
+                device=device,
+            )
+            self._gdn_meta_per_step[num_heads] = meta
+            # Remember num_heads so init_forward_metadata can pre-build next step.
+            self._gdn_num_heads = num_heads
+
+        return cu_seqlens_cpu, meta
 
     def prepare_gdn_inputs(
         self,
@@ -97,6 +162,32 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             forward_batch.spec_info,
         )
         self.graph_mode = False
+
+        # Reset per-step cache and pre-build GDN chunked prefill metadata.
+        # Building here (before model forward) ensures the H2D copy is issued
+        # before NPU compute starts. After the first step where _gdn_num_heads is
+        # learned from a layer call, all subsequent steps pre-build without any
+        # build inside the per-layer forward_extend hot path.
+        self._gdn_meta_per_step = {}
+        if (
+            forward_batch.forward_mode.is_extend_without_speculative()
+            and forward_batch.extend_seq_lens_cpu is not None
+        ):
+            cu_seqlens_cpu = _cu_seqlens_cpu_from_seq_lens(
+                forward_batch.extend_seq_lens_cpu
+            )
+            self.forward_metadata.cu_seqlens_cpu = cu_seqlens_cpu
+
+            if self._gdn_num_heads is not None:
+                self._gdn_meta_per_step[self._gdn_num_heads] = (
+                    build_gdn_chunked_prefill_meta(
+                        cu_seqlens_cpu=cu_seqlens_cpu,
+                        num_heads=self._gdn_num_heads,
+                        device=self.device,
+                    )
+                )
+        else:
+            self.forward_metadata.cu_seqlens_cpu = None
 
     def forward_decode(
         self,
@@ -300,6 +391,11 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
 
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)
+            cu_seqlens_cpu, prebuilt_meta = self._get_non_spec_chunked_prefill_meta(
+                forward_batch,
+                layer.num_v_heads,
+                mixed_qkv.device,
+            )
             core_attn_out, last_recurrent_state, h = self.kernel_dispatcher.extend(
                 q=query,
                 k=key,
@@ -309,6 +405,8 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
                 ssm_states=ssm_states,
                 cache_indices=cache_indices,
                 query_start_loc=query_start_loc,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+                prebuilt_meta=prebuilt_meta,
             )
             if last_recurrent_state is not None:
                 last_recurrent_state = last_recurrent_state.to(

--- a/python/sglang/srt/layers/attention/linear/gdn_chunk_meta.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_chunk_meta.py
@@ -1,0 +1,91 @@
+from dataclasses import dataclass
+
+import torch
+
+# Budget for cumsum block size selection on Ascend NPU, tuned against
+# shared-memory / kernel constraints. See vllm-ascend #7487.
+_GDN_CUMSUM_BLOCK_BUDGET = 2**18
+
+# Large block size used by solve_tril Triton kernel (LARGE_BLOCK_T in
+# sgl-kernel-npu solve_tril.py). See vllm-ascend #7487.
+_GDN_LARGE_BLOCK_SIZE = 608 * 2
+
+
+@dataclass(frozen=True)
+class GDNChunkedPrefillMetadata:
+    block_indices_cumsum: torch.Tensor
+    chunk_indices_chunk64: torch.Tensor
+    chunk_offsets_chunk64: torch.Tensor
+    chunk_indices_large_block: torch.Tensor
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 if x <= 1 else 1 << (x - 1).bit_length()
+
+
+def _chunk_counts(seq_lens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    return torch.div(seq_lens + chunk_size - 1, chunk_size, rounding_mode="floor")
+
+
+def _prepare_chunk_indices(
+    seq_lens: torch.Tensor, chunk_size: int, device: torch.device
+) -> torch.Tensor:
+    chunk_counts = _chunk_counts(seq_lens, chunk_size)
+    total_chunks = int(chunk_counts.sum().item())
+    if total_chunks == 0:
+        return torch.empty((0, 2), dtype=torch.int32, device=device)
+
+    seq_indices = torch.repeat_interleave(
+        torch.arange(chunk_counts.numel(), dtype=torch.int32), chunk_counts
+    )
+    # Vectorized: local_indices[i] = i - cumulative_offset_for_its_sequence.
+    # Avoids O(batch) Python-level arange calls + cat.
+    chunk_offsets_i64 = torch.zeros(chunk_counts.numel() + 1, dtype=torch.int64)
+    chunk_offsets_i64[1:] = torch.cumsum(chunk_counts.to(torch.int64), dim=0)
+    local_indices = (
+        torch.arange(total_chunks, dtype=torch.int64)
+        - chunk_offsets_i64[:-1].repeat_interleave(chunk_counts)
+    ).to(torch.int32)
+
+    result = torch.stack([seq_indices, local_indices], dim=1)
+    # Use pinned memory for faster non-blocking H2D transfer.
+    device_obj = torch.device(device) if isinstance(device, str) else device
+    if device_obj.type != "cpu":
+        result = result.pin_memory()
+    return result.to(device=device, non_blocking=True)
+
+
+def _prepare_chunk_offsets(
+    seq_lens: torch.Tensor, chunk_size: int, device: torch.device
+) -> torch.Tensor:
+    chunk_counts = _chunk_counts(seq_lens, chunk_size)
+    offsets = torch.empty(chunk_counts.numel() + 1, dtype=torch.int32, pin_memory=True)
+    offsets[0] = 0
+    offsets[1:] = torch.cumsum(chunk_counts, dim=0)
+    return offsets.to(device=device, non_blocking=True)
+
+
+def build_gdn_chunked_prefill_meta(
+    *,
+    cu_seqlens_cpu: torch.Tensor,
+    num_heads: int,
+    device: torch.device,
+    chunk_size: int = 64,
+    large_block_size: int = _GDN_LARGE_BLOCK_SIZE,
+) -> GDNChunkedPrefillMetadata:
+    cu_seqlens_cpu = cu_seqlens_cpu.to(device="cpu", dtype=torch.int32)
+    seq_lens = cu_seqlens_cpu[1:].to(torch.int64) - cu_seqlens_cpu[:-1].to(torch.int64)
+
+    cumsum_block_size = _next_power_of_2(
+        _GDN_CUMSUM_BLOCK_BUDGET // (num_heads * chunk_size)
+    )
+    return GDNChunkedPrefillMetadata(
+        block_indices_cumsum=_prepare_chunk_indices(
+            seq_lens, cumsum_block_size, device
+        ),
+        chunk_indices_chunk64=_prepare_chunk_indices(seq_lens, chunk_size, device),
+        chunk_offsets_chunk64=_prepare_chunk_offsets(seq_lens, chunk_size, device),
+        chunk_indices_large_block=_prepare_chunk_indices(
+            seq_lens, large_block_size, device
+        ),
+    )

--- a/python/sglang/srt/layers/attention/linear/gdn_chunk_meta.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_chunk_meta.py
@@ -3,11 +3,10 @@ from dataclasses import dataclass
 import torch
 
 # Budget for cumsum block size selection on Ascend NPU, tuned against
-# shared-memory / kernel constraints. See vllm-ascend #7487.
+# shared-memory / kernel constraints.
 _GDN_CUMSUM_BLOCK_BUDGET = 2**18
 
-# Large block size used by solve_tril Triton kernel (LARGE_BLOCK_T in
-# sgl-kernel-npu solve_tril.py). See vllm-ascend #7487.
+# Large block size used by solve_tril Triton kernel
 _GDN_LARGE_BLOCK_SIZE = 608 * 2
 
 

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
@@ -144,6 +144,15 @@ class TritonGDNKernel(LinearAttnKernelBase):
         if is_npu() or is_cpu():
             recurrent_state = ssm_states[cache_indices]
             recurrent_state_indices_args = {}
+
+        prefill_metadata_args = {}
+        prebuilt_meta = kwargs.get("prebuilt_meta")
+        cu_seqlens_cpu = kwargs.get("cu_seqlens_cpu")
+        if prebuilt_meta is not None:
+            prefill_metadata_args["prebuilt_meta"] = prebuilt_meta
+        if cu_seqlens_cpu is not None:
+            prefill_metadata_args["cu_seqlens_cpu"] = cu_seqlens_cpu
+
         return chunk_gated_delta_rule(
             q=q,
             k=k,
@@ -155,6 +164,7 @@ class TritonGDNKernel(LinearAttnKernelBase):
             head_first=False,
             use_qk_l2norm_in_kernel=True,
             **recurrent_state_indices_args,
+            **prefill_metadata_args,
         )
 
     def target_verify(


### PR DESCRIPTION
## Motivation

On the NPU GDN (gated delta net) **prefill** path, every GDN layer's chunked
delta-rule call recomputes the *same* chunk metadata — chunk indices/offsets for
`cumsum`, `chunk64`, and the `solve_tril` large-block — and issues per-layer
scalar device-to-host (D2H) syncs to read sequence lengths. For Qwen3.5-class
models the GDN layers dominate (e.g. 48 of 64 layers), so these per-layer
recomputations and D2H stalls accumulate and inflate prefill latency / TTFT.

This PR builds that metadata **once per prefill step** and reuses it across all
GDN layers, and passes a host-side `cu_seqlens_cpu` so the kernel reads the
sequence length without a D2H sync.

NPU-only; FLA chunk logic only. **Depends on the sgl-kernel-npu chunk changes in
sgl-project/sgl-kernel-npu#454 — that kernel PR must be merged first.** Refs #24597.

## Modifications

- **Add `gdn_chunk_meta.py`**: `GDNChunkedPrefillMetadata` dataclass +
  `build_gdn_chunked_prefill_meta()` helper that precomputes the chunk-index /
  offset variants (cumsum block, `chunk64`, large-block) on CPU and issues an
  async (pinned, `non_blocking`) H2D copy.
- **`ascend_gdn_backend.py`**: build/cache the metadata once in
  `init_forward_metadata` (before model forward), keyed by `num_heads`; derive
  `num_heads` from `linear_num_value_heads // attn_tp_size` so the pre-build can
  fire without waiting for a layer call; consume the cached metadata in the
  non-spec extend path; thread `cu_seqlens_cpu` / `prebuilt_meta` to the kernel
  dispatcher.
- **`gdn_triton.py`**: thread `cu_seqlens_cpu` / `prebuilt_meta` through
  `extend()`, injecting them **only when present** so CUDA/CPU callers (which
  never pass them) are unaffected.

## Accuracy Tests

Evaluated with evalscope, NEXTN/MTP spec decoding enabled. The change does not
alter model outputs — it only pre-computes metadata the kernel previously
recomputed per layer.

| Model | Dataset | Metric | #Q | Score |
|---|---|---|---|---|
| Qwen3.5-27B-w8a8-mtp | gsm8k | mean_acc | 100 | 0.97 |
| Qwen3.5-397B-A17B-w4a8-mtp | ceval (OVERALL) | mean_acc | 1346 | 0.9049 |

## Speed Tests and Profiling

**Hardware:** Ascend 910C × 4 (TP=4), node NPU-A3.
**Model:** Qwen3.5-27B (64 layers: 48 GDN + 16 full-attention), bf16.
**Server config:** `--max-prefill-tokens` 32K (16K input) / 80K (64K input),
`--mem-fraction-static 0.6`, `--chunked-prefill-size -1`, NEXTN spec decoding
(3 steps, draft tokens = 4).
**Baseline:** sglang `ascend/release/PoC_20260415` + sgl-kernel-npu `origin/main`.
**Current:** this PR + sgl-kernel-npu#454.

Profiling of one 16K prefill stage:

| Stage | Baseline | Current | Δ | % |
|---|---|---|---|---|
| Stage Total | 4097.40 ms | 3590.53 ms | −506.87 ms | **−12.4%** |
| Computing (NPU ops) | 2048.38 ms | 2017.37 ms | −31.01 ms | −1.5% |
| Communication (not overlapped) | 535.40 ms | 373.72 ms | −161.68 ms | **−30.2%** |
| Free (CPU wait / sync) | 1513.62 ms | 1199.45 ms | −314.17 ms | **−20.8%** |

The largest wins are in non-overlapped communication and CPU wait/sync time,
consistent with removing per-layer D2H syncs and the redundant host-side
metadata computation.

End-to-end serving (mean over the run):

| Input | Variant | Mean TTFT (ms) | Mean TPOT (ms) | Output Thpt (tok/s) | Duration (s) |
|---|---|---|---|---|---|
| 3.5K | baseline | 1257 | 12.21 | 74.45 | 115.5 |
| 3.5K | current | 1106 (−12.2%) | 12.19 (−0.1%) | 75.34 (+1.2%) | 112.4 |
| 16K | baseline | 2971 | 12.26 | 65.97 | 62.1 |
| 16K | current | 2854 (−3.9%) | 11.06 (−9.8%) | 72.24 (+9.5%) | 56.7 |
| 64K | baseline | 11061 | 12.59 | 42.74 | 95.8 |
| 64K | current | 10964 (−0.9%) | 12.58 (−0.1%) | 42.95 (+0.5%) | 95.4 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27207849622](https://github.com/sgl-project/sglang/actions/runs/27207849622)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27207850559](https://github.com/sgl-project/sglang/actions/runs/27207850559)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
