### PR TITLE
Fix decode KV offload release with decode radix cache

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -167,9 +167,9 @@ class DecodeKVCacheOffloadManager:
         incremental_tokens = all_tokens[start:end]
         incremental_indices = token_indices[start:end]
 
-        # Prefill-aligned GPU slots are freed at request finish in
-        # _release_finished_req, NOT here. The decoding request
-        # continues to attend to those slots via req_to_token; freeing
+        # Prefill-aligned GPU slots not retained by the radix tree are freed
+        # at request finish in _release_finished_req, NOT here. The decoding
+        # request continues to attend to those slots via req_to_token; freeing
         # them mid-decode races with concurrent admission, which can
         # reuse the slots and produce cross-pollinated KV reads.
 
@@ -252,29 +252,40 @@ class DecodeKVCacheOffloadManager:
     def _release_finished_req(self, req: Req, start_offset: int):
         # Defensive guard: ReqToTokenPool.free sets req_pool_idx to None,
         # so a previously-released request must be skipped here to avoid
-        # non-idempotent side effects (e.g. tree_cache.protected_size_
-        # double-decrement, host pool double-free).
+        # non-idempotent side effects (e.g. releasing a radix-cache lock or
+        # host allocation twice).
         if req.req_pool_idx is None or req.req_pool_idx == -1:
             return
 
         kv_committed_len = req.pop_committed_kv_cache()
+        cache_protected_len = min(req.cache_protected_len, kv_committed_len)
 
-        # Free the prefill-aligned slots. Previously this was done
-        # eagerly in offload_kv_cache (mid-decode), which raced with
-        # concurrent admission. Now consolidated here at request
+        # Free prefill-aligned slots not retained by the radix tree.
+        # Previously this was done eagerly in offload_kv_cache (mid-decode),
+        # which raced with concurrent admission. Now consolidated here at request
         # finish, where the request is guaranteed to no longer attend
         # to those slots.
         state = self.offloaded_state.get(req.rid)
-        if state is not None and state.prefill_len > 0:
+        if state is not None and cache_protected_len < state.prefill_len:
+            # The radix tree owns [0, cache_protected_len). Only return the
+            # remainder of the prefill allocation to the device pool.
             prefill_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, : state.prefill_len
+                req.req_pool_idx, cache_protected_len : state.prefill_len
             ]
             self.token_to_kv_pool_allocator.free(prefill_indices)
-        start = start_offset
+
+        # cache_unfinished_req may have extended the radix-owned prefix into
+        # the incremental decode region. Keep those slots allocated until the
+        # tree evicts them; freeing them here would leave live radix nodes
+        # pointing at allocator slots that can immediately be reused.
+        start = max(start_offset, cache_protected_len)
         end = kv_committed_len
         # Free the incremental part of the request (DSA-aware)
-        kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, start:end]
-        self.token_to_kv_pool_allocator.free(kv_indices)
+        if start < end:
+            kv_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, start:end
+            ]
+            self.token_to_kv_pool_allocator.free(kv_indices)
 
         # Free over-allocated KV cache slots (e.g. from speculative decoding v2).
         # Without spec v2, start_p == end_p so this is a no-op.
@@ -287,8 +298,15 @@ class DecodeKVCacheOffloadManager:
             ]
             self.token_to_kv_pool_allocator.free(overalloc_indices)
 
+        # Release the prefix-cache lock through the cache API so the node lock
+        # refs and evictable/protected accounting stay in sync. In particular,
+        # decode-side HiCache may replace req.last_node after restoring an
+        # L2/L3 prefix, while req.prefix_indices can also contain unaligned
+        # tokens that were never protected by the radix tree.
+        if req.last_node is not None:
+            self.tree_cache.dec_lock_ref(req.last_node)
+
         self.req_to_token_pool.free(req)
-        self.tree_cache.protected_size_ -= len(req.prefix_indices)
         if req.rid in self.offloaded_state:
             del self.offloaded_state[req.rid]
 
@@ -341,8 +359,9 @@ class DecodeKVCacheOffloadManager:
         else:
             prefill_len = state.prefill_len
             inc_len = state.inc_len
-        # Prefill-aligned slots are freed by _release_finished_req. Make
-        # sure state exists so it can find prefill_len.
+        # Prefill-aligned slots not retained by the radix tree are freed by
+        # _release_finished_req. Make sure state exists so it can find
+        # prefill_len.
         if state is None:
             self.offloaded_state[req.rid] = OffloadedState(
                 prefill_len=prefill_len, inc_len=0, last_hash=None

--- a/test/registered/disaggregation/test_specv2_kvcache_offloading.py
+++ b/test/registered/disaggregation/test_specv2_kvcache_offloading.py
@@ -2,7 +2,8 @@
 Unit tests for _release_finished_req in DecodeKVCacheOffloadManager.
 
 Verifies that over-allocated KV cache slots (from speculative decoding v2)
-are correctly freed when a request finishes, preventing GPU memory leaks.
+are correctly freed and prefix-cache locks are released through the cache API
+when a request finishes, preventing GPU memory leaks and accounting corruption.
 
 Requires: torch, sglang (run in an environment with sglang installed)
 """
@@ -27,6 +28,7 @@ def _make_mock_req(
     kv_allocated_len: int,
     prefix_indices_len: int = 0,
     rid: int = 0,
+    cache_protected_len: int = 0,
 ):
     """Create a mock Req with the KV cache state needed for testing."""
     req = MagicMock()
@@ -37,6 +39,8 @@ def _make_mock_req(
     req.kv_committed_freed = False
     req.kv_overallocated_freed = False
     req.prefix_indices = list(range(prefix_indices_len))
+    req.last_node = MagicMock(name=f"last_node_{rid}")
+    req.cache_protected_len = cache_protected_len
 
     def pop_committed():
         assert not req.kv_committed_freed
@@ -170,8 +174,8 @@ class TestReleaseFinishedReq(unittest.TestCase):
         expected_committed = torch.arange(4, 10, dtype=torch.int64)
         self.assertTrue(torch.equal(freed[0], expected_committed))
 
-    def test_prefix_indices_decremented(self):
-        """protected_size_ is decremented by len(req.prefix_indices)."""
+    def test_prefix_lock_released_via_cache_api(self):
+        """Release the matched prefix node instead of mutating cache counters."""
         manager, _ = _make_manager(pool_size=32)
         manager.tree_cache.protected_size_ = 10
         req = _make_mock_req(
@@ -181,9 +185,27 @@ class TestReleaseFinishedReq(unittest.TestCase):
             prefix_indices_len=5,
         )
 
+        last_node = req.last_node
         manager._release_finished_req(req, start_offset=0)
 
-        self.assertEqual(manager.tree_cache.protected_size_, 5)
+        manager.tree_cache.dec_lock_ref.assert_called_once_with(last_node)
+        # The manager must not reach into cache implementation details.
+        self.assertEqual(manager.tree_cache.protected_size_, 10)
+
+    def test_no_prefix_node_skips_lock_release(self):
+        """Requests without a matched radix node have no lock to release."""
+        manager, _ = _make_manager(pool_size=32)
+        req = _make_mock_req(
+            req_pool_idx=0,
+            kv_committed_len=20,
+            kv_allocated_len=20,
+            prefix_indices_len=5,
+        )
+        req.last_node = None
+
+        manager._release_finished_req(req, start_offset=0)
+
+        manager.tree_cache.dec_lock_ref.assert_not_called()
 
     def test_release_finished_req_frees_prefill_when_state_present(self):
         """
@@ -216,6 +238,53 @@ class TestReleaseFinishedReq(unittest.TestCase):
         self.assertTrue(torch.equal(freed[1], expected_committed))
         # State entry is removed at the end of _release_finished_req.
         self.assertNotIn(rid, manager.offloaded_state)
+
+    def test_radix_owned_prefix_is_not_returned_to_allocator(self):
+        """A restored/cached prefix remains allocated while the tree owns it."""
+        manager, freed = _make_manager(pool_size=32)
+        rid = "req-protected-prefix"
+        req = _make_mock_req(
+            req_pool_idx=0,
+            kv_committed_len=20,
+            kv_allocated_len=20,
+            rid=rid,
+            cache_protected_len=12,
+        )
+        manager.offloaded_state[rid] = OffloadedState(
+            prefill_len=8, inc_len=4, last_hash=None
+        )
+
+        last_node = req.last_node
+        manager._release_finished_req(req, start_offset=8)
+
+        # [0:12] is still owned by the radix tree. Only the uncached tail is
+        # returned; dec_lock_ref makes the retained prefix evictable.
+        self.assertEqual(len(freed), 1)
+        self.assertTrue(torch.equal(freed[0], torch.arange(12, 20, dtype=torch.int64)))
+        manager.tree_cache.dec_lock_ref.assert_called_once_with(last_node)
+
+    def test_partially_protected_prefill_only_frees_unowned_ranges(self):
+        """Free around a radix-owned prefix without double-freeing any slot."""
+        manager, freed = _make_manager(pool_size=32)
+        rid = "req-partial-protected-prefix"
+        req = _make_mock_req(
+            req_pool_idx=0,
+            kv_committed_len=20,
+            kv_allocated_len=20,
+            rid=rid,
+            cache_protected_len=4,
+        )
+        manager.offloaded_state[rid] = OffloadedState(
+            prefill_len=8, inc_len=0, last_hash=None
+        )
+
+        manager._release_finished_req(req, start_offset=8)
+
+        # [0:4] belongs to the tree. The rest is released in two disjoint
+        # ranges split at the prefill/incremental boundary.
+        self.assertEqual(len(freed), 2)
+        self.assertTrue(torch.equal(freed[0], torch.arange(4, 8, dtype=torch.int64)))
+        self.assertTrue(torch.equal(freed[1], torch.arange(8, 20, dtype=torch.int64)))
 
     def test_release_finished_req_skips_prefill_free_when_prefill_len_zero(self):
         """


### PR DESCRIPTION
## Motivation

Fixes #27666.

The issue is triggered by a compatibility problem between `--disaggregation-decode-enable-radix-cache` and `--disaggregation-decode-enable-offload-kvcache` on a decode worker. `--disaggregation-decode-enable-radix-cache` alone does not reproduce this failure. I verified that the combined configuration can reproduce the crash with all HiCache write policies.

When decode-side radix cache is enabled, part of a request's KV slots may already be owned by the radix tree. However, the decode KV offload finalization path may still treat those slots as request-owned and return them to the KV-pool allocator. It may also directly mutate `tree_cache.protected_size_` instead of releasing the radix node lock through the cache API. This can lead to invalid KV-pool accounting, such as a negative protected count, and crash the decode worker after a request finishes.

## Modifications

This PR fixes `DecodeKVCacheOffloadManager._release_finished_req()` by:

* using `req.cache_protected_len` to identify radix-owned KV slots;
* preserving `[0, cache_protected_len)` instead of returning those slots to the allocator;
* releasing only request-owned KV ranges after offload completion;
* releasing `req.last_node` through `tree_cache.dec_lock_ref`;
* removing the direct mutation of `tree_cache.protected_size_`.

Unit tests are added/updated in `test_specv2_kvcache_offloading.py` to cover radix-owned prefixes, partially protected prefill ranges, radix lock release, and existing speculative over-allocation cleanup paths.

## Accuracy Tests

This PR only changes KV-cache ownership/release bookkeeping in the decode offload finalization path. It does not change model forward logic or output computation.

No accuracy impact is expected.

## Speed Tests and Profiling

This change is not on the per-token decode hot path. It only adds small boundary checks during request finalization/offload cleanup.

No speed impact is expected.

## Test Results

```bash
python test/registered/disaggregation/test_specv2_kvcache_offloading.py -v
```

```text
Ran 16 tests in 0.017s
OK
```

```bash
python -m py_compile \
  python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py \
  test/registered/disaggregation/test_specv2_kvcache_offloading.py

git diff --check
```

Result: passed.

Manual verification was performed using the same setup as #27666: Qwen3-32B, TP1 prefill + TP1 decode, NIXL, HiCache file backend, page size 64, and both decode flags enabled. Before the fix, the decode worker could crash after a request with invalid KV-pool accounting, e.g. a negative protected count. After the fix, repeated short and long requests completed successfully, and the decode worker stayed healthy.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27255596711](https://github.com/sgl-project/sglang/actions/runs/27255596711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27255596603](https://github.com/sgl-project/sglang/actions/runs/27255596603)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->