### PR TITLE
[WIP] Improve CUDA IPC to make it production-ready

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -616,9 +616,9 @@ class Envs:
 
     # VLM Item CUDA IPC Transport
     SGLANG_USE_CUDA_IPC_TRANSPORT = EnvBool(False)
-    SGLANG_USE_IPC_POOL_HANDLE_CACHE = EnvBool(False)
-    SGLANG_MM_FEATURE_CACHE_MB = EnvInt(1 * 1024)
-    SGLANG_MM_ITEM_MEM_POOL_RECYCLE_INTERVAL_SEC = EnvFloat(0.05)
+    # With CUDA IPC on, set to 1 to keep the feature on device (zero-copy view)
+    # instead of copying it to host at receipt (see CudaIpcTensorTransportProxy).
+    SGLANG_CUDA_IPC_KEEP_ON_DEVICE = EnvBool(False)
 
     # Mamba
     SGLANG_MAMBA_CONV_DTYPE = EnvStr("bfloat16")

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -21,7 +21,6 @@ from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
     MultimodalInputs,
-    SimpleCudaIpcProxy,
 )
 from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalStaticCache
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -1255,7 +1254,7 @@ def hash_feature(f):
         return int.from_bytes(hash_bytes, byteorder="big", signed=False)
     elif isinstance(f, torch.Tensor):
         return tensor_hash([f])
-    elif isinstance(f, (CudaIpcTensorTransportProxy, SimpleCudaIpcProxy)):
+    elif isinstance(f, CudaIpcTensorTransportProxy):
         reconstruct_t = f.reconstruct_on_target_device(torch.cuda.current_device())
         return tensor_hash([reconstruct_t])
     return data_hash(f)

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -21,6 +21,7 @@ from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
     MultimodalInputs,
+    SimpleCudaIpcProxy,
 )
 from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalStaticCache
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -1254,7 +1255,7 @@ def hash_feature(f):
         return int.from_bytes(hash_bytes, byteorder="big", signed=False)
     elif isinstance(f, torch.Tensor):
         return tensor_hash([f])
-    elif isinstance(f, CudaIpcTensorTransportProxy):
+    elif isinstance(f, (CudaIpcTensorTransportProxy, SimpleCudaIpcProxy)):
         reconstruct_t = f.reconstruct_on_target_device(torch.cuda.current_device())
         return tensor_hash([reconstruct_t])
     return data_hash(f)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -106,7 +106,10 @@ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs, get_global_server_args
 from sglang.srt.utils import flatten_nested_list
-from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
+from sglang.srt.utils.cuda_ipc_transport_utils import (
+    CudaIpcTensorTransportProxy,
+    SimpleCudaIpcProxy,
+)
 
 if TYPE_CHECKING:
     from typing import Any, Dict
@@ -345,28 +348,28 @@ class MultimodalDataItem:
         ret.validate()
         return ret
 
+    def _is_ipc_proxy(self, obj):
+        return isinstance(obj, (CudaIpcTensorTransportProxy, SimpleCudaIpcProxy))
+
     def has_cuda_ipc_proxy(self):
         return (
-            isinstance(self.feature, CudaIpcTensorTransportProxy)
-            or isinstance(self.precomputed_embeddings, CudaIpcTensorTransportProxy)
+            self._is_ipc_proxy(self.feature)
+            or self._is_ipc_proxy(self.precomputed_embeddings)
             or any(
-                isinstance(value, CudaIpcTensorTransportProxy)
-                for value in self.model_specific_data.values()
+                self._is_ipc_proxy(value) for value in self.model_specific_data.values()
             )
         )
 
     def reconstruct(self, target_device: int):
         """materialize cuda ipc proxy tensors in-place on target_device"""
-        if isinstance(self.feature, CudaIpcTensorTransportProxy):
+        if self._is_ipc_proxy(self.feature):
             self.feature = self.feature.reconstruct_on_target_device(target_device)
-        if isinstance(self.precomputed_embeddings, CudaIpcTensorTransportProxy):
+        if self._is_ipc_proxy(self.precomputed_embeddings):
             self.precomputed_embeddings = (
                 self.precomputed_embeddings.reconstruct_on_target_device(target_device)
             )
         for extra_key in self.model_specific_data:
-            if isinstance(
-                self.model_specific_data[extra_key], CudaIpcTensorTransportProxy
-            ):
+            if self._is_ipc_proxy(self.model_specific_data[extra_key]):
                 extra_data = self.model_specific_data[
                     extra_key
                 ].reconstruct_on_target_device(target_device)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -106,10 +106,7 @@ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs, get_global_server_args
 from sglang.srt.utils import flatten_nested_list
-from sglang.srt.utils.cuda_ipc_transport_utils import (
-    CudaIpcTensorTransportProxy,
-    SimpleCudaIpcProxy,
-)
+from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
 
 if TYPE_CHECKING:
     from typing import Any, Dict
@@ -349,7 +346,7 @@ class MultimodalDataItem:
         return ret
 
     def _is_ipc_proxy(self, obj):
-        return isinstance(obj, (CudaIpcTensorTransportProxy, SimpleCudaIpcProxy))
+        return isinstance(obj, CudaIpcTensorTransportProxy)
 
     def has_cuda_ipc_proxy(self):
         return (

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -30,12 +30,7 @@ from sglang.srt.utils import (
     load_video,
     logger,
 )
-from sglang.srt.utils.cuda_ipc_transport_utils import (
-    MM_FEATURE_CACHE_SIZE,
-    MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL,
-    CudaIpcTensorTransportProxy,
-    MmItemMemoryPool,
-)
+from sglang.srt.utils.cuda_ipc_transport_utils import SimpleCudaIpcProxy
 
 _is_cpu = is_cpu()
 _is_npu = is_npu()
@@ -259,25 +254,9 @@ class BaseMultimodalProcessor(ABC):
         skip_mm_pool = kwargs.get("skip_mm_pool", False)
 
         if SGL_USE_CUDA_IPC and not skip_mm_pool:
-            # SGLANG_MM_FEATURE_CACHE_MB is the total pool budget across all
-            # tokenizer workers. Each worker gets an equal share so that adding
-            # workers doesn't multiply the GPU-side footprint.
-            worker_num = self.server_args.tokenizer_worker_num
-            per_worker_pool_size = max(
-                MM_FEATURE_CACHE_SIZE // worker_num,
-                128 * 1024 * 1024,
-            )
-            logger.info(
-                "MmItemMemoryPool size per tokenizer worker: %.0f MiB "
-                "(budget %.0f MiB / %d worker(s))",
-                per_worker_pool_size / (1024 * 1024),
-                MM_FEATURE_CACHE_SIZE / (1024 * 1024),
-                worker_num,
-            )
-            self.cudaipc_mmfeature_pool = MmItemMemoryPool(
-                per_worker_pool_size,
-                MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL,
-            )
+            # SimpleCudaIpcProxy uses per-tensor CUDA IPC handles instead of a
+            # pre-allocated memory pool.  No pool allocation is needed.
+            logger.info("CUDA IPC transport enabled (per-tensor mode, no memory pool)")
 
     def compute_mrope_positions(self, input_ids, mm_items):
         """Compute M-RoPE positions from expanded input_ids and multimodal items.
@@ -469,16 +448,13 @@ class BaseMultimodalProcessor(ABC):
             return_tensors="pt",
             **kwargs,
         )
-        if not self.server_args.keep_mm_feature_on_device:
-            # move feature tensors to cpu
+        if not SGL_USE_CUDA_IPC:
+            # Move feature tensors to CPU for cross-process pickle transport.
             for feature_name in self.FEATURE_NAMES:
-                if SGL_USE_CUDA_IPC:
-                    pass
-                else:
-                    if feature_name in result and isinstance(
-                        result[feature_name], torch.Tensor
-                    ):
-                        result[feature_name] = result[feature_name].to("cpu")
+                if feature_name in result and isinstance(
+                    result[feature_name], torch.Tensor
+                ):
+                    result[feature_name] = result[feature_name].to("cpu")
 
         return result
 
@@ -1212,30 +1188,15 @@ class BaseMultimodalProcessor(ABC):
         return torch.tensor(input_ids, dtype=torch.long).flatten()
 
     def _wrap_tensor_for_cuda_ipc(self, tensor: torch.Tensor):
-        """helper function to turn a tensor into a cuda-ipc tensor"""
+        """helper function to turn a tensor into a cuda-ipc proxy"""
         if not tensor.is_cuda:
             return tensor
 
-        sync_flag, available_slice, byte_offset = (
-            self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(tensor)
-        )
-        if isinstance(available_slice, torch.Tensor):
-            available_slice.copy_(tensor.view(torch.int8).view(-1), non_blocking=True)
-            return CudaIpcTensorTransportProxy(
-                data=available_slice,
-                info_data=tensor,
-                sync_buffer_meta=sync_flag,
-                pool_ipc_handle=(
-                    self.cudaipc_mmfeature_pool._pool_ipc_handle
-                    if _IPC_POOL_HANDLE_CACHE
-                    else None
-                ),
-                pool_byte_offset=byte_offset,
-                pool_device_index=self.cudaipc_mmfeature_pool._pool_device_index,
-            )
-        if self.server_args.keep_mm_feature_on_device:
-            return tensor
-        return tensor.cpu()
+        try:
+            return SimpleCudaIpcProxy.from_tensor(tensor)
+        except Exception as e:
+            logger.warning("Failed to create CUDA IPC proxy: %s", e)
+            return tensor.cpu()
 
     def resolve_image_token_counts(self, images: List) -> List[int]:
         """Per-image expanded token counts, computed without re-tokenizing.

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -30,14 +30,16 @@ from sglang.srt.utils import (
     load_video,
     logger,
 )
-from sglang.srt.utils.cuda_ipc_transport_utils import SimpleCudaIpcProxy
+from sglang.srt.utils.cuda_ipc_transport_utils import (
+    CudaIpcTensorTransportProxy,
+    start_ipc_collect_sweeper,
+)
 
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 
 SGL_USE_CUDA_IPC = envs.SGLANG_USE_CUDA_IPC_TRANSPORT.get()
-_IPC_POOL_HANDLE_CACHE = envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.get()
 
 
 @dataclasses.dataclass
@@ -254,9 +256,10 @@ class BaseMultimodalProcessor(ABC):
         skip_mm_pool = kwargs.get("skip_mm_pool", False)
 
         if SGL_USE_CUDA_IPC and not skip_mm_pool:
-            # SimpleCudaIpcProxy uses per-tensor CUDA IPC handles instead of a
-            # pre-allocated memory pool.  No pool allocation is needed.
+            # Per-tensor CUDA IPC (no pool); start the producer-side reclaimer so
+            # the IPC limbo is swept and producer GPU memory stays bounded.
             logger.info("CUDA IPC transport enabled (per-tensor mode, no memory pool)")
+            start_ipc_collect_sweeper()
 
     def compute_mrope_positions(self, input_ids, mm_items):
         """Compute M-RoPE positions from expanded input_ids and multimodal items.
@@ -1193,7 +1196,7 @@ class BaseMultimodalProcessor(ABC):
             return tensor
 
         try:
-            return SimpleCudaIpcProxy.from_tensor(tensor)
+            return CudaIpcTensorTransportProxy.from_tensor(tensor)
         except Exception as e:
             logger.warning("Failed to create CUDA IPC proxy: %s", e)
             return tensor.cpu()

--- a/python/sglang/srt/multimodal/processors/ernie45_vl.py
+++ b/python/sglang/srt/multimodal/processors/ernie45_vl.py
@@ -349,16 +349,13 @@ class Ernie4_5_VLImageProcessor(SGLangBaseProcessor):
                     if result["pixel_values_videos"].numel() == 0:
                         del result["pixel_values_videos"]
 
-        if not self.server_args.keep_mm_feature_on_device:
-            # move feature tensors to cpu
+        if not SGL_USE_CUDA_IPC:
+            # Move feature tensors to CPU for cross-process pickle transport.
             for feature_name in self.FEATURE_NAMES:
-                if SGL_USE_CUDA_IPC:
-                    pass
-                else:
-                    if feature_name in result and isinstance(
-                        result[feature_name], torch.Tensor
-                    ):
-                        result[feature_name] = result[feature_name].to("cpu")
+                if feature_name in result and isinstance(
+                    result[feature_name], torch.Tensor
+                ):
+                    result[feature_name] = result[feature_name].to("cpu")
 
         return result
 

--- a/python/sglang/srt/multimodal/processors/midashenglm.py
+++ b/python/sglang/srt/multimodal/processors/midashenglm.py
@@ -6,6 +6,7 @@ import torch
 from sglang.srt.managers.schedule_batch import Modality, MultimodalProcessorOutput
 from sglang.srt.models.midashenglm import MiDashengLMModel
 from sglang.srt.multimodal.processors.base_processor import (
+    SGL_USE_CUDA_IPC,
     BaseMultimodalProcessor,
     MultimodalSpecialTokens,
 )
@@ -70,7 +71,7 @@ class MiDashengLMMultimodalProcessor(BaseMultimodalProcessor):
             **kwargs,
         )
 
-        if not getattr(self.server_args, "keep_mm_feature_on_device", False):
+        if not SGL_USE_CUDA_IPC:
             for feature_name in ["input_values"]:
                 if feature_name in result:
                     result[feature_name] = result[feature_name].cpu()

--- a/python/sglang/srt/multimodal/processors/moss_vl.py
+++ b/python/sglang/srt/multimodal/processors/moss_vl.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import re
 import tempfile
@@ -24,7 +25,9 @@ from sglang.srt.multimodal.processors.base_processor import (
 from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
-from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
+from sglang.srt.utils.cuda_ipc_transport_utils import SimpleCudaIpcProxy
+
+logger = logging.getLogger(__name__)
 
 
 class MossVLImageProcessor(SGLangBaseProcessor):
@@ -554,41 +557,22 @@ class MossVLImageProcessor(SGLangBaseProcessor):
             if SGL_USE_CUDA_IPC:
                 for item in mm_items:
                     if isinstance(item.feature, torch.Tensor) and item.feature.is_cuda:
-                        sync_flag, available_slice = (
-                            self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(
-                                item.feature
-                            )
-                        )
-                        if isinstance(available_slice, torch.Tensor):
-                            available_slice.copy_(
-                                item.feature.reshape(-1).view(torch.int8),
-                                non_blocking=True,
-                            )
-                            item.feature = CudaIpcTensorTransportProxy(
-                                data=available_slice,
-                                info_data=item.feature,
-                                sync_buffer_meta=sync_flag,
-                            )
+                        try:
+                            item.feature = SimpleCudaIpcProxy.from_tensor(item.feature)
+                        except Exception as e:
+                            logger.warning("Failed to create CUDA IPC proxy: %s", e)
                     elif (
                         isinstance(item.precomputed_embeddings, torch.Tensor)
                         and item.precomputed_embeddings.is_cuda
                     ):
-                        sync_flag, available_slice = (
-                            self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(
-                                item.precomputed_embeddings
+                        try:
+                            item.precomputed_embeddings = (
+                                SimpleCudaIpcProxy.from_tensor(
+                                    item.precomputed_embeddings
+                                )
                             )
-                        )
-                        if isinstance(available_slice, torch.Tensor):
-                            flattened = item.precomputed_embeddings.reshape(-1)
-                            available_slice.copy_(
-                                flattened.view(torch.int8),
-                                non_blocking=True,
-                            )
-                            item.precomputed_embeddings = CudaIpcTensorTransportProxy(
-                                data=available_slice,
-                                info_data=item.precomputed_embeddings,
-                                sync_buffer_meta=sync_flag,
-                            )
+                        except Exception as e:
+                            logger.warning("Failed to create CUDA IPC proxy: %s", e)
 
             return MultimodalProcessorOutput(
                 input_ids=input_ids.tolist(),

--- a/python/sglang/srt/multimodal/processors/moss_vl.py
+++ b/python/sglang/srt/multimodal/processors/moss_vl.py
@@ -25,7 +25,7 @@ from sglang.srt.multimodal.processors.base_processor import (
 from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
-from sglang.srt.utils.cuda_ipc_transport_utils import SimpleCudaIpcProxy
+from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
 
 logger = logging.getLogger(__name__)
 
@@ -558,7 +558,7 @@ class MossVLImageProcessor(SGLangBaseProcessor):
                 for item in mm_items:
                     if isinstance(item.feature, torch.Tensor) and item.feature.is_cuda:
                         try:
-                            item.feature = SimpleCudaIpcProxy.from_tensor(item.feature)
+                            item.feature = CudaIpcTensorTransportProxy.from_tensor(item.feature)
                         except Exception as e:
                             logger.warning("Failed to create CUDA IPC proxy: %s", e)
                     elif (
@@ -567,7 +567,7 @@ class MossVLImageProcessor(SGLangBaseProcessor):
                     ):
                         try:
                             item.precomputed_embeddings = (
-                                SimpleCudaIpcProxy.from_tensor(
+                                CudaIpcTensorTransportProxy.from_tensor(
                                     item.precomputed_embeddings
                                 )
                             )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -786,7 +786,7 @@ class ServerArgs:
     enforce_shared_experts_fusion: bool = False
     disable_chunked_prefix_cache: bool = False
     disable_fast_image_processor: bool = False
-    keep_mm_feature_on_device: bool = False
+
     enable_return_hidden_states: bool = False
     enable_return_routed_experts: bool = False
     enable_return_indexer_topk: bool = False
@@ -6768,11 +6768,7 @@ class ServerArgs:
             action="store_true",
             help="Adopt base image processor instead of fast image processor.",
         )
-        parser.add_argument(
-            "--keep-mm-feature-on-device",
-            action="store_true",
-            help="Keep multimodal feature tensors on device after processing to save D2H copy.",
-        )
+
         parser.add_argument(
             "--enable-return-hidden-states",
             action="store_true",

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -1,524 +1,46 @@
-import fcntl
 import logging
 import threading
 import time
-from multiprocessing import shared_memory
-from typing import Any, Tuple
 
-import numpy as np
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.server_args import get_global_server_args
 
 logger = logging.getLogger(__name__)
 
-MM_FEATURE_CACHE_SIZE = envs.SGLANG_MM_FEATURE_CACHE_MB.get() * 1024 * 1024
 
-MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL = (
-    envs.SGLANG_MM_ITEM_MEM_POOL_RECYCLE_INTERVAL_SEC.get()
-)
-
-SHM_LOCK_FILE = "/tmp/shm_wr_lock.lock"
+_ipc_collect_thread = None
+_ipc_collect_lock = threading.Lock()
 
 
-# Cache for pool-level IPC handles on the consumer side.
-# Key: the pool CUDA IPC handle tuple. Value: opened UntypedStorage.
-_pool_storage_cache: dict = {}
-_pool_cache_lock = threading.Lock()
-
-
-def _normalize_pool_cache_key(pool_handle, pool_device_index: int) -> tuple[Any, ...]:
-    normalized_handle = (
-        pool_handle if isinstance(pool_handle, tuple) else tuple(pool_handle)
-    )
-    return (pool_device_index, normalized_handle)
-
-
-def _open_pooled_storage_uncached(pool_handle):
-    return torch.UntypedStorage._new_shared_cuda(*pool_handle)
-
-
-def _pool_handle_cache_get_or_open(cache_key, pool_handle):
-    storage = _pool_storage_cache.get(cache_key)
-    if storage is None:
-        with _pool_cache_lock:
-            storage = _pool_storage_cache.get(cache_key)
-            if storage is None:
-                storage = _open_pooled_storage_uncached(pool_handle)
-                _pool_storage_cache[cache_key] = storage
-    return storage
-
-
-def _pool_handle_cache_set(cache_key, storage):
-    with _pool_cache_lock:
-        _pool_storage_cache[cache_key] = storage
-
-
-def _pool_handle_cache_invalidate(cache_key):
-    with _pool_cache_lock:
-        _pool_storage_cache.pop(cache_key, None)
-
-
-def _pool_handle_cache_clear():
-    with _pool_cache_lock:
-        _pool_storage_cache.clear()
-
-
-class ShmSyncBuffer:
-    def __init__(self, byte_size: int = 4):
-        self.buffer = shared_memory.SharedMemory(create=True, size=byte_size)
-        self.buffer_wrapper = np.ndarray(1, dtype=np.float32, buffer=self.buffer.buf)
-        self.buffer_wrapper *= 0
-        self.meta_data = {
-            "handle": self.buffer.name,
-            "shape": self.buffer_wrapper.shape,
-            "dtype": str(self.buffer_wrapper.dtype),
-        }
-
-    def __del__(self):
-        if isinstance(self.buffer, shared_memory.SharedMemory):
-            self.buffer.close()
-            self.buffer.unlink()
-
-
-class MmItemMemoryChunk:
-    def __init__(self, area: Tuple, sync_buffer: ShmSyncBuffer):
-        self.area = area
-        self.sync_flag = sync_buffer
-
-    @property
-    def mem_size(self):
-        return self.area[1] - self.area[0]
-
-    @property
-    def start(self):
-        return self.area[0]
-
-    @property
-    def end(self):
-        return self.area[1]
-
-    def try_to_recycle(self) -> bool:
-        try:
-            tp_num = get_global_server_args().tp_size
-        except Exception:
-            logger.info(
-                "get_global_server_args has not been inited , skip this turn 's recycle"
-            )
-            return False
-
-        val = float(self.sync_flag.buffer_wrapper.item())
-        logger.debug(f"[try_to_recycle] area={self.area}, flag={val}, tp_size={tp_num}")
-
-        if val == float(tp_num):
-            self.sync_flag.buffer_wrapper *= 0.0
-            return True
-
-        return False
-
-
-class MmItemMemoryPool:
-    def __init__(self, memory_size, recycle_interval):
-        self.memory_pool = torch.empty(
-            memory_size, dtype=torch.int8, device="cuda"
-        ).contiguous()
-        storage = self.memory_pool.untyped_storage()
-        self._pool_ipc_handle = storage._share_cuda_()
-        self._pool_device_index = self.memory_pool.device.index
-
-        self.sync_flag_list = []
-
-        init_chunk = MmItemMemoryChunk((0, memory_size), self.pop_sync_buffer())
-        self.available_chunks = [init_chunk]
-        self.occupied_chunks = []
-
-        self._lock = threading.Lock()
-        self._pool_full_warned = False
-
-        self._recycle_interval = recycle_interval
-        self._stop_recycler = False
-        self._recycle_thread = threading.Thread(
-            target=self._recycle_loop, name="MmItemMemoryPoolRecycler", daemon=True
-        )
-        self._recycle_thread.start()
-
-        logger.debug(
-            f"[MmItemMemoryPool] init: memory_size={memory_size}, "
-            f"recycle_interval={recycle_interval}s"
-        )
-
-    def shutdown(self):
-        self._stop_recycler = True
-        if self._recycle_thread.is_alive():
-            self._recycle_thread.join(timeout=1.0)
-
-    def _recycle_loop(self):
-        while not self._stop_recycler:
-            try:
-                with self._lock:
-                    self.recycle_chunks()
-                    self.merge_chunks()
-            except Exception as e:
-                logger.warning(
-                    f"[MmItemMemoryPool] recycle loop error: {e}", exc_info=True
-                )
-
-            time.sleep(self._recycle_interval)
-
-    def clear_sync_flag_list(self):
-        # call each chunk's __del__
-        self.sync_flag_list.clear()
-
-    def pop_sync_buffer(self):
-        if len(self.sync_flag_list) == 0:
-            try:
-                new_sync_buffer = ShmSyncBuffer()
-                return new_sync_buffer
-            except:
-                logger.info("allocate shm buffer failed")
-                raise RuntimeError
-        else:
-            return self.sync_flag_list.pop()
-
-    def push_sync_buffer(self, sync_buffer):
-        self.sync_flag_list.append(sync_buffer)
-
-    def get_available_chunk(self, src_tensor: torch.Tensor) -> MmItemMemoryChunk:
-        # find currently available_chunks contain a available chunk or not
-        # if not, return None
-        src_tensor_size = src_tensor.numel() * src_tensor.element_size()
-        min_size = self.memory_pool.numel() * self.memory_pool.element_size() + 1
-        selected_chunk = None
-        for chunk in self.available_chunks:
-            if chunk.mem_size >= src_tensor_size:
-                if chunk.mem_size < min_size:
-                    min_size = chunk.mem_size
-                    selected_chunk = chunk
-
-        if selected_chunk:
-            occupied_chunk_area = (
-                selected_chunk.start,
-                selected_chunk.start + src_tensor_size,
-            )
-            occupied_chunk_sync_flag = selected_chunk.sync_flag
-            new_occupied_chunk = MmItemMemoryChunk(
-                occupied_chunk_area, occupied_chunk_sync_flag
-            )
-
-            self.occupied_chunks.append(new_occupied_chunk)
-            self.available_chunks.remove(selected_chunk)
-
-            available_split_chunk_area = (new_occupied_chunk.end, selected_chunk.end)
-            # add a new chunk
-            if available_split_chunk_area[0] != available_split_chunk_area[1]:
-                split_available_chunk = MmItemMemoryChunk(
-                    available_split_chunk_area, self.pop_sync_buffer()
-                )
-                self.available_chunks.append(split_available_chunk)
-
-            return new_occupied_chunk
-
-        return None
-
-    def return_a_slice_tensor_with_flag(self, src_tensor: torch.Tensor):
-        with self._lock:
-            available_chunk = self.get_available_chunk(src_tensor)
-            if available_chunk is not None:
-                return (
-                    available_chunk.sync_flag.meta_data,
-                    self.memory_pool[available_chunk.start : available_chunk.end],
-                    available_chunk.start,
-                )
-        self._warn_pool_full_once(src_tensor)
-        return None, None, None
-
-    def _warn_pool_full_once(self, src_tensor: torch.Tensor):
-        if self._pool_full_warned:
+def start_ipc_collect_sweeper(interval_sec: float = 0.1):
+    """Periodically run torch.cuda.ipc_collect() so the producer reclaims the
+    per-tensor IPC limbo; without it producer GPU memory grows with the backlog."""
+    global _ipc_collect_thread
+    with _ipc_collect_lock:
+        if _ipc_collect_thread is not None and _ipc_collect_thread.is_alive():
             return
-        self._pool_full_warned = True
-        pool_mb = (
-            self.memory_pool.numel() * self.memory_pool.element_size() / (1024 * 1024)
+
+        def _loop():
+            while True:
+                try:
+                    torch.cuda.ipc_collect()
+                except Exception as e:
+                    logger.warning("ipc_collect sweep failed: %s", e)
+                time.sleep(interval_sec)
+
+        _ipc_collect_thread = threading.Thread(
+            target=_loop, name="CudaIpcCollectSweeper", daemon=True
         )
-        need_mb = src_tensor.numel() * src_tensor.element_size() / (1024 * 1024)
-        logger.warning(
-            "MmItemMemoryPool has no free chunk large enough for a %.2f MiB tensor "
-            "(pool size: %.2f MiB); falling back to non-IPC transport. "
-            "Consider increasing SGLANG_MM_FEATURE_CACHE_MB.",
-            need_mb,
-            pool_mb,
+        _ipc_collect_thread.start()
+        logger.info(
+            "Started CUDA IPC collect sweeper (interval=%.0f ms)", interval_sec * 1000
         )
-
-    def recycle_chunks(self):
-
-        new_occupied_chunks = []
-        for chunk in self.occupied_chunks:
-            if chunk.try_to_recycle():
-                self.available_chunks.append(chunk)
-            else:
-                new_occupied_chunks.append(chunk)
-        self.occupied_chunks = new_occupied_chunks
-
-    def merge_chunks(self):
-        # merge_all_available_chunks
-        merged_chunks = []
-        for chunk in sorted(self.available_chunks, key=lambda x: x.start):
-            if len(merged_chunks) == 0:
-                merged_chunks.append(chunk)
-            else:
-                if chunk.start == merged_chunks[-1].end:
-                    to_merge_chunk = merged_chunks.pop()
-                    to_merge_chunk_sync = to_merge_chunk.sync_flag
-                    merged_chunk_area = (to_merge_chunk.start, chunk.end)
-                    merged_chunks.append(
-                        MmItemMemoryChunk(merged_chunk_area, to_merge_chunk_sync)
-                    )
-                    self.push_sync_buffer(chunk.sync_flag)
-                else:
-                    merged_chunks.append(chunk)
-
-        self.available_chunks = merged_chunks
 
 
 class CudaIpcTensorTransportProxy:
-    """
-    A torch.tensor's proxy used to do inter-process data-sharing
-    including:
-
-    torch.tensor(on gpu)'s cuda-ipc-hande infos
-    a shm sync buffer's meta data which is used to sync between different process
-    """
-
-    def __init__(
-        self,
-        data: torch.Tensor,
-        info_data: torch.Tensor,
-        sync_buffer_meta,
-        pool_ipc_handle=None,
-        pool_byte_offset: int = 0,
-        pool_device_index: int = 0,
-    ):
-
-        if (not isinstance(data, torch.Tensor)) or (
-            not isinstance(info_data, torch.Tensor)
-        ):
-            raise TypeError(
-                f"Input 'data' must be a torch.Tensor, but got {type(data)}"
-            )
-
-        if pool_ipc_handle is not None:
-            self.proxy_state = {
-                "ipc_extra": {
-                    "pool_handle": pool_ipc_handle,
-                    "pool_byte_offset": pool_byte_offset,
-                    "pool_device_index": pool_device_index,
-                    "shape": data.shape,
-                    "dtype": data.dtype,
-                    "stride": data.stride(),
-                    "storage_offset": 0,
-                    "nbytes": data.numel() * data.element_size(),
-                    "recons_shape": info_data.shape,
-                    "recons_dtype": info_data.dtype,
-                },
-                "tensor_data": None,
-            }
-        else:
-            self.proxy_state = self.get_proxy_state(data, info_data)
-        self.reconstruct_tensor = None
-        self.sync_data_meta = sync_buffer_meta
-        self.sync_buffer = None
-
-    @property
-    def get_sync_flag(self):
-        if not self.sync_buffer:
-            shm_name = self.sync_data_meta["handle"]
-            self.sync_buffer = shared_memory.SharedMemory(name=shm_name)
-
-        shape = self.sync_data_meta["shape"]
-        dtype = self.sync_data_meta["dtype"]
-        return np.ndarray(shape, dtype=dtype, buffer=self.sync_buffer.buf)
-
-    def close_shm(self):
-        self.sync_buffer.close()
-        self.sync_buffer = None
-
-    def get_proxy_state(self, data, info_data):
-        # acquire all serialize metadata from _metadata
-        state = {}
-
-        try:
-            storage = data.untyped_storage()
-            handle = storage._share_cuda_()
-
-            state["ipc_extra"] = {
-                "handle": handle,
-                "shape": data.shape,
-                "dtype": data.dtype,
-                "stride": data.stride(),
-                "device_index": data.device.index,
-                "storage_offset": data.storage_offset(),
-                "recons_shape": info_data.shape,
-                "recons_dtype": info_data.dtype,
-            }
-            state["tensor_data"] = None
-        except Exception as e:
-            # Failed to get CUDA IPC handle (possibly tp). Falling back to default transport.
-            state["ipc_extra"] = None
-            state["tensor_data"] = data
-
-        return state
-
-    def _reconstruct_from_ipc_extra(
-        self, ipc_extra, *, use_cache: bool, rebuild_device_idx: int
-    ):
-        shape = ipc_extra["shape"]
-        dtype = ipc_extra["dtype"]
-        stride = ipc_extra["stride"]
-        # Redirect handle[0] to the consumer's device so _new_shared_cuda's
-        # CUDAGuard stays there; peer access handles the cross-GPU open.
-        pool_handle = ipc_extra["pool_handle"]
-        redirected_handle = (rebuild_device_idx,) + tuple(pool_handle)[1:]
-        target_device = torch.device(f"cuda:{rebuild_device_idx}")
-        cache_key = _normalize_pool_cache_key(pool_handle, rebuild_device_idx)
-
-        with torch.cuda.device(target_device):
-            if use_cache:
-                storage = _pool_handle_cache_get_or_open(cache_key, redirected_handle)
-                storage_to_cache = None
-            else:
-                storage = _open_pooled_storage_uncached(redirected_handle)
-                storage_to_cache = storage
-            slice_storage = storage[
-                ipc_extra["pool_byte_offset"] : ipc_extra["pool_byte_offset"]
-                + ipc_extra["nbytes"]
-            ]
-            slice_tensor = torch.empty(0, dtype=dtype, device=target_device).set_(
-                slice_storage,
-                storage_offset=ipc_extra["storage_offset"],
-                size=shape,
-                stride=stride,
-            )
-
-        return slice_tensor, target_device, cache_key, storage_to_cache
-
-    def _copy_slice_tensor_to_target(
-        self,
-        slice_tensor: torch.Tensor,
-        rebuild_device: torch.device,
-        recons_shape,
-        recons_dtype,
-    ):
-        with torch.cuda.device(rebuild_device):
-            reconstructed_tensor = torch.empty(
-                recons_shape, dtype=recons_dtype, device=rebuild_device
-            ).contiguous()
-            reconstructed_tensor.view(torch.int8).view(-1).copy_(slice_tensor)
-
-            open(SHM_LOCK_FILE, "a").close()
-            # write the shm_sync_buffer with a file lock
-            with open(SHM_LOCK_FILE, "w+") as f:
-                fcntl.flock(f, fcntl.LOCK_EX)
-                sync_flag = self.get_sync_flag
-                sync_flag += 1
-                fcntl.flock(f, fcntl.LOCK_UN)
-
-            self.close_shm()
-
-        return reconstructed_tensor
-
-    def reconstruct_on_target_device(self, rebuild_device_idx):
-        rebuild_device = torch.device(f"cuda:{rebuild_device_idx}")
-        if (
-            isinstance(self.reconstruct_tensor, torch.Tensor)
-            and self.reconstruct_tensor.device == rebuild_device
-        ):
-            return self.reconstruct_tensor
-
-        if self.proxy_state["ipc_extra"]:
-            ipc_extra = self.proxy_state["ipc_extra"]
-            recons_shape = ipc_extra["recons_shape"]
-            recons_dtype = ipc_extra["recons_dtype"]
-
-            if "pool_handle" in ipc_extra:
-                try:
-                    (
-                        slice_tensor,
-                        _target_device,
-                        cache_key,
-                        storage_to_cache,
-                    ) = self._reconstruct_from_ipc_extra(
-                        ipc_extra,
-                        use_cache=True,
-                        rebuild_device_idx=rebuild_device_idx,
-                    )
-                except Exception as e:
-                    cache_key = _normalize_pool_cache_key(
-                        ipc_extra["pool_handle"], rebuild_device_idx
-                    )
-                    logger.info(
-                        "Failed to deserialize from cached pooled CUDA IPC handle (%s). "
-                        "Invalidating cache entry and retrying uncached.",
-                        e,
-                    )
-                    _pool_handle_cache_invalidate(cache_key)
-                    (
-                        slice_tensor,
-                        _target_device,
-                        _cache_key,
-                        storage_to_cache,
-                    ) = self._reconstruct_from_ipc_extra(
-                        ipc_extra,
-                        use_cache=False,
-                        rebuild_device_idx=rebuild_device_idx,
-                    )
-                    if storage_to_cache is not None:
-                        _pool_handle_cache_set(cache_key, storage_to_cache)
-            else:
-                # Non-pooled path: redirect handle[0] the same way as the pooled path.
-                try:
-                    original_handle = ipc_extra["handle"]
-                    redirected_handle = (rebuild_device_idx,) + tuple(original_handle)[
-                        1:
-                    ]
-                    target_device = torch.device(f"cuda:{rebuild_device_idx}")
-                    with torch.cuda.device(target_device):
-                        storage = torch.UntypedStorage._new_shared_cuda(
-                            *redirected_handle
-                        )
-                        slice_tensor = torch.empty(
-                            0, dtype=ipc_extra["dtype"], device=target_device
-                        ).set_(
-                            storage,
-                            storage_offset=ipc_extra["storage_offset"],
-                            size=ipc_extra["shape"],
-                            stride=ipc_extra["stride"],
-                        )
-                except Exception as e:
-                    logger.info("Failed to deserialize from CUDA IPC handle (%s).", e)
-                    raise
-
-            reconstructed_tensor = self._copy_slice_tensor_to_target(
-                slice_tensor, rebuild_device, recons_shape, recons_dtype
-            )
-        elif isinstance(self.proxy_state["tensor_data"], torch.Tensor):
-            reconstructed_tensor = self.proxy_state["tensor_data"].to(
-                rebuild_device, non_blocking=True
-            )
-        else:
-            raise TypeError("invalid proxy_state")
-
-        self.reconstruct_tensor = reconstructed_tensor
-        return self.reconstruct_tensor
-
-
-class SimpleCudaIpcProxy:
-    """Per-tensor CUDA IPC proxy. No pool, no sync flag, no polling thread.
-
-    Producer: wraps a CUDA tensor's IPC handle for pickle transport.
-    Consumer: opens handle -> zero-copy view into producer's GPU memory.
-    Lifecycle: producer storage is prevented from GC by holding a reference;
-               consumer views are freed when the proxy is GC'd.
-    """
+    """Per-tensor CUDA IPC proxy: producer shares a CUDA tensor's handle, the
+    consumer copies it out to host and releases the producer."""
 
     def __init__(
         self,
@@ -528,7 +50,6 @@ class SimpleCudaIpcProxy:
         stride,
         device_index,
         storage_offset,
-        storage_ref=None,
     ):
         self.ipc_state = {
             "handle": handle,
@@ -538,25 +59,18 @@ class SimpleCudaIpcProxy:
             "device_index": device_index,
             "storage_offset": storage_offset,
         }
-        # Hold a reference to the producer's storage so that the underlying
-        # GPU memory stays alive until this proxy (and all its consumer views)
-        # are garbage-collected.  _share_cuda_() also pins the storage
-        # internally (CudaIPCSentDataLimbo), but we keep an explicit ref
-        # as a safety net.
-        self._storage_ref = storage_ref
         self._reconstructed = None
 
     def __getstate__(self):
-        # Exclude _storage_ref from pickle: it's only needed on the producer
-        # to prevent GC.  The consumer reconstructs via the IPC handle.
+        # The reconstructed tensor is consumer-local; never pickle it.
         state = self.__dict__.copy()
-        state["_storage_ref"] = None
         state["_reconstructed"] = None
         return state
 
     @classmethod
     def from_tensor(cls, tensor: torch.Tensor):
-        """Producer side: get IPC handle from tensor (no copy)."""
+        """Producer side: share the tensor's IPC handle (no copy). Keep no storage
+        ref; CudaIPCSentDataLimbo owns it, else the GPU stays pinned per request."""
         storage = tensor.untyped_storage()
         handle = storage._share_cuda_()
         return cls(
@@ -566,31 +80,40 @@ class SimpleCudaIpcProxy:
             stride=tensor.stride(),
             device_index=tensor.device.index,
             storage_offset=tensor.storage_offset(),
-            storage_ref=storage,
         )
 
     def reconstruct_on_target_device(self, rebuild_device_idx):
-        """Consumer side: open IPC handle -> zero-copy view."""
-        if (
-            self._reconstructed is not None
-            and self._reconstructed.device.index == rebuild_device_idx
-        ):
+        """Consumer side: open the handle, copy to host, release the producer so
+        queued requests hold no GPU memory. SGLANG_CUDA_IPC_KEEP_ON_DEVICE=1 keeps it on device."""
+        if self._reconstructed is not None:
             return self._reconstructed
 
         handle = self.ipc_state["handle"]
         target_device = torch.device(f"cuda:{rebuild_device_idx}")
         redirected_handle = (rebuild_device_idx,) + tuple(handle)[1:]
+        shape = self.ipc_state["shape"]
+        dtype = self.ipc_state["dtype"]
+        stride = self.ipc_state["stride"]
+        s_offset = self.ipc_state["storage_offset"]
+
+        keep_on_device = envs.SGLANG_CUDA_IPC_KEEP_ON_DEVICE.get()
 
         with torch.cuda.device(target_device):
             storage = torch.UntypedStorage._new_shared_cuda(*redirected_handle)
-            shape = self.ipc_state["shape"]
-            dtype = self.ipc_state["dtype"]
-            stride = self.ipc_state["stride"]
-            s_offset = self.ipc_state["storage_offset"]
+            view = torch.empty(0, dtype=dtype, device=target_device).set_(
+                storage, storage_offset=s_offset, size=shape, stride=stride
+            )
 
-            # Zero-copy view into producer's memory
-            self._reconstructed = torch.empty(
-                0, dtype=dtype, device=target_device
-            ).set_(storage, storage_offset=s_offset, size=shape, stride=stride)
+            if keep_on_device:
+                # Keep a zero-copy view on device; producer stays pinned until freed.
+                self._reconstructed = view
+                return self._reconstructed
 
+            # Copy out to host, then drop the view so the producer can reclaim.
+            host_tensor = torch.empty(view.shape, dtype=view.dtype, device="cpu")
+            host_tensor.copy_(view)
+            del view
+            del storage
+
+        self._reconstructed = host_tensor
         return self._reconstructed

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -509,3 +509,88 @@ class CudaIpcTensorTransportProxy:
 
         self.reconstruct_tensor = reconstructed_tensor
         return self.reconstruct_tensor
+
+
+class SimpleCudaIpcProxy:
+    """Per-tensor CUDA IPC proxy. No pool, no sync flag, no polling thread.
+
+    Producer: wraps a CUDA tensor's IPC handle for pickle transport.
+    Consumer: opens handle -> zero-copy view into producer's GPU memory.
+    Lifecycle: producer storage is prevented from GC by holding a reference;
+               consumer views are freed when the proxy is GC'd.
+    """
+
+    def __init__(
+        self,
+        handle,
+        shape,
+        dtype,
+        stride,
+        device_index,
+        storage_offset,
+        storage_ref=None,
+    ):
+        self.ipc_state = {
+            "handle": handle,
+            "shape": shape,
+            "dtype": dtype,
+            "stride": stride,
+            "device_index": device_index,
+            "storage_offset": storage_offset,
+        }
+        # Hold a reference to the producer's storage so that the underlying
+        # GPU memory stays alive until this proxy (and all its consumer views)
+        # are garbage-collected.  _share_cuda_() also pins the storage
+        # internally (CudaIPCSentDataLimbo), but we keep an explicit ref
+        # as a safety net.
+        self._storage_ref = storage_ref
+        self._reconstructed = None
+
+    def __getstate__(self):
+        # Exclude _storage_ref from pickle: it's only needed on the producer
+        # to prevent GC.  The consumer reconstructs via the IPC handle.
+        state = self.__dict__.copy()
+        state["_storage_ref"] = None
+        state["_reconstructed"] = None
+        return state
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor):
+        """Producer side: get IPC handle from tensor (no copy)."""
+        storage = tensor.untyped_storage()
+        handle = storage._share_cuda_()
+        return cls(
+            handle=handle,
+            shape=tensor.shape,
+            dtype=tensor.dtype,
+            stride=tensor.stride(),
+            device_index=tensor.device.index,
+            storage_offset=tensor.storage_offset(),
+            storage_ref=storage,
+        )
+
+    def reconstruct_on_target_device(self, rebuild_device_idx):
+        """Consumer side: open IPC handle -> zero-copy view."""
+        if (
+            self._reconstructed is not None
+            and self._reconstructed.device.index == rebuild_device_idx
+        ):
+            return self._reconstructed
+
+        handle = self.ipc_state["handle"]
+        target_device = torch.device(f"cuda:{rebuild_device_idx}")
+        redirected_handle = (rebuild_device_idx,) + tuple(handle)[1:]
+
+        with torch.cuda.device(target_device):
+            storage = torch.UntypedStorage._new_shared_cuda(*redirected_handle)
+            shape = self.ipc_state["shape"]
+            dtype = self.ipc_state["dtype"]
+            stride = self.ipc_state["stride"]
+            s_offset = self.ipc_state["storage_offset"]
+
+            # Zero-copy view into producer's memory
+            self._reconstructed = torch.empty(
+                0, dtype=dtype, device=target_device
+            ).set_(storage, storage_offset=s_offset, size=shape, stride=stride)
+
+        return self._reconstructed

--- a/test/manual/vlm/bench_cuda_ipc_overhead.py
+++ b/test/manual/vlm/bench_cuda_ipc_overhead.py
@@ -1,0 +1,219 @@
+"""Benchmark cudaIpcGetMemHandle / cudaIpcOpenMemHandle overhead.
+
+Usage:
+    python bench_cuda_ipc_overhead.py
+
+Measures:
+  1. _share_cuda_()       — wraps cudaIpcGetMemHandle (producer side)
+  2. _new_shared_cuda()   — wraps cudaIpcOpenMemHandle (consumer side, separate process)
+  3. GPU-to-GPU copy      — baseline comparison (same device)
+
+Tests multiple tensor sizes typical for VLM features.
+"""
+
+import multiprocessing as mp
+import pickle
+import time
+
+import torch
+
+WARMUP = 10
+REPEAT = 100
+
+# Fine-grained sizes: 64KB to 512MB
+SIZES = [
+    ("64 KB", 64 * 1024),
+    ("256 KB", 256 * 1024),
+    ("512 KB", 512 * 1024),
+    ("1 MB", 1 * 1024 * 1024),
+    ("2 MB", 2 * 1024 * 1024),
+    ("4 MB", 4 * 1024 * 1024),
+    ("8 MB", 8 * 1024 * 1024),
+    ("16 MB", 16 * 1024 * 1024),
+    ("32 MB", 32 * 1024 * 1024),
+    ("64 MB", 64 * 1024 * 1024),
+    ("128 MB", 128 * 1024 * 1024),
+    ("256 MB", 256 * 1024 * 1024),
+    ("512 MB", 512 * 1024 * 1024),
+]
+
+
+def bench_share_cuda(tensor, warmup=WARMUP, repeat=REPEAT):
+    """Measure _share_cuda_() = cudaIpcGetMemHandle."""
+    storage = tensor.untyped_storage()
+    for _ in range(warmup):
+        h = storage._share_cuda_()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        h = storage._share_cuda_()
+        t1 = time.perf_counter()
+        times.append(t1 - t0)
+    return h, times
+
+
+def _consumer_worker(handles_bytes, device_idx, warmup, repeat, result_pipe):
+    """Child process: open IPC handles and measure latency."""
+    handles = pickle.loads(handles_bytes)
+    target = torch.device(f"cuda:{device_idx}")
+
+    results = {}
+    for label, handle in handles:
+        redirected = (device_idx,) + tuple(handle)[1:]
+
+        # warmup
+        for _ in range(warmup):
+            with torch.cuda.device(target):
+                s = torch.UntypedStorage._new_shared_cuda(*redirected)
+            del s
+
+        torch.cuda.synchronize()
+        times = []
+        for _ in range(repeat):
+            t0 = time.perf_counter()
+            with torch.cuda.device(target):
+                s = torch.UntypedStorage._new_shared_cuda(*redirected)
+            t1 = time.perf_counter()
+            times.append(t1 - t0)
+            del s
+
+        results[label] = times
+
+    result_pipe.send(results)
+    result_pipe.close()
+
+
+def bench_open_handle_batch(
+    handles_with_labels, device_idx, warmup=WARMUP, repeat=REPEAT
+):
+    """Measure _new_shared_cuda() for all sizes in one child process."""
+    parent_conn, child_conn = mp.Pipe()
+    handles_bytes = pickle.dumps(handles_with_labels)
+
+    p = mp.Process(
+        target=_consumer_worker,
+        args=(handles_bytes, device_idx, warmup, repeat, child_conn),
+    )
+    p.start()
+    results = parent_conn.recv()
+    p.join()
+    return results
+
+
+def bench_gpu_copy(tensor, warmup=WARMUP, repeat=REPEAT):
+    """Measure GPU-to-GPU copy (same device) as baseline."""
+    dst = torch.empty_like(tensor)
+    for _ in range(warmup):
+        dst.copy_(tensor)
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(repeat):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        dst.copy_(tensor)
+        torch.cuda.synchronize()
+        t1 = time.perf_counter()
+        times.append(t1 - t0)
+    return times
+
+
+def median_us(times):
+    s = sorted(times)
+    mid = len(s) // 2
+    return s[mid] * 1e6
+
+
+def p95_us(times):
+    s = sorted(times)
+    idx = int(len(s) * 0.95)
+    return s[idx] * 1e6
+
+
+def main():
+    mp.set_start_method("spawn", force=True)
+    device = torch.device("cuda:0")
+    print(f"Device: {torch.cuda.get_device_name(0)}")
+    print(f"Warmup: {WARMUP}, Repeat: {REPEAT}")
+    print()
+
+    # Phase 1: producer-side GetHandle + GPU copy for all sizes
+    tensors = {}
+    share_results = {}
+    copy_results = {}
+    handles_with_labels = []
+
+    for label, nbytes in SIZES:
+        tensor = torch.empty(nbytes, dtype=torch.int8, device=device)
+        tensors[label] = tensor
+        handle, share_times = bench_share_cuda(tensor)
+        share_results[label] = share_times
+        copy_results[label] = bench_gpu_copy(tensor)
+        handles_with_labels.append((label, handle))
+
+    # Phase 2: consumer-side OpenHandle (all sizes in one child process)
+    open_results = bench_open_handle_batch(handles_with_labels, device.index)
+
+    # Print results
+    print(
+        f"{'Size':>8}  {'GetHandle':>10} {'(p95)':>7}  {'OpenHandle':>10} {'(p95)':>7}  "
+        f"{'GPU copy':>9} {'(p95)':>7}  {'Open/copy':>10}"
+    )
+    print("-" * 90)
+
+    for label, nbytes in SIZES:
+        share_us = median_us(share_results[label])
+        share_p95 = p95_us(share_results[label])
+        open_us = median_us(open_results[label])
+        open_p95 = p95_us(open_results[label])
+        copy_us = median_us(copy_results[label])
+        copy_p95 = p95_us(copy_results[label])
+
+        ratio = f"{open_us / copy_us:.1f}x" if copy_us > 0 else "N/A"
+
+        print(
+            f"{label:>8}  {share_us:>8.1f}us {share_p95:>6.1f}  {open_us:>8.1f}us {open_p95:>6.1f}  "
+            f"{copy_us:>7.1f}us {copy_p95:>6.1f}  {ratio:>10}"
+        )
+
+    # Phase 3: batch open N handles to measure total time
+    print()
+    print("=== Batch open N handles (total time) ===")
+    print(f"{'N tensors':>10}  {'Total open (ms)':>16}  {'Per tensor (us)':>16}")
+    print("-" * 48)
+
+    for n in [1, 10, 50, 100, 300]:
+        # Create N tensors of 2MB each
+        batch_tensors = []
+        batch_handles = []
+        for i in range(n):
+            t = torch.empty(2 * 1024 * 1024, dtype=torch.int8, device=device)
+            batch_tensors.append(t)
+            storage = t.untyped_storage()
+            h = storage._share_cuda_()
+            batch_handles.append((f"t{i}", h))
+
+        open_res = bench_open_handle_batch(
+            batch_handles, device.index, warmup=3, repeat=20
+        )
+
+        # Sum median per-tensor times
+        total_us = sum(median_us(open_res[f"t{i}"]) for i in range(n))
+        print(f"{n:>10}  {total_us/1000:>14.2f}ms  {total_us/n:>14.1f}us")
+
+        del batch_tensors
+        torch.cuda.empty_cache()
+
+    del tensors
+    torch.cuda.empty_cache()
+
+    print()
+    print("GetHandle  = cudaIpcGetMemHandle  (producer)")
+    print("OpenHandle = cudaIpcOpenMemHandle  (consumer)")
+    print("GPU copy   = same-device memcpy")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/vlm/test_mm_utils.py
+++ b/test/manual/vlm/test_mm_utils.py
@@ -12,9 +12,7 @@ from sglang.srt.managers.schedule_batch import (
 
 
 def _make_proxy_with_reconstruct_result(tensor: torch.Tensor):
-    proxy = mm_utils.CudaIpcTensorTransportProxy.__new__(
-        mm_utils.CudaIpcTensorTransportProxy
-    )
+    proxy = mm_utils.CudaIpcTensorTransportProxy.__new__(mm_utils.CudaIpcTensorTransportProxy)
     proxy.reconstruct_on_target_device = Mock(return_value=tensor)
     return proxy
 

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -113,7 +113,6 @@ class TestProcessMmDataKwargs(unittest.TestCase):
         server_args = MagicMock()
         server_args.mm_process_config = mm_process_config
         server_args.disable_fast_image_processor = True
-        server_args.keep_mm_feature_on_device = True
 
         mock_processor = MagicMock()
         mock_processor.__class__.__name__ = "TestProcessor"
@@ -210,7 +209,6 @@ class TestOverrideProcessorsConfigInjection(unittest.TestCase):
         server_args = MagicMock()
         server_args.mm_process_config = mm_process_config
         server_args.disable_fast_image_processor = True
-        server_args.keep_mm_feature_on_device = False
 
         mock_hf_processor = MagicMock()
         mock_hf_processor.__class__.__name__ = "TestProcessor"


### PR DESCRIPTION
1. Remove `--keep-mm-feature-on-device`: keeping multimodal features on the GPU only matters when CUDA IPC transport is enabled, since that is what shares them zero-copy across processes (without IPC a GPU feature still has to be moved to host to cross the process boundary). The per-tensor path ties "keep on device" directly to `SGLANG_USE_CUDA_IPC_TRANSPORT` (`if not SGL_USE_CUDA_IPC: -> .to("cpu")`), making the standalone flag redundant.

2. Remove the pooled mechanism: a pool has to pre-allocate a fixed-size GPU buffer whose size is hard to get right (too small overflows, too large wastes memory), whereas a per-tensor IPC handle is cheap enough per request (and will move to per-request granularity later), so the pool's fixed reservation and extra machinery are not worth it.

3. With CUDA IPC transport enabled by default, still copy the feature into CPU (host) memory on receipt: in theory many requests can be queued, and the multimodal data of that many in-flight requests could exhaust GPU memory (CUDA OOM), so by default it is parked on host and moved back to device only at prefill. An env var (`SGLANG_CUDA_IPC_KEEP_ON_DEVICE=1`) decides whether to keep it on device instead (the zero-copy view).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27216662229](https://github.com/sgl-project/sglang/actions/runs/27216662229)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27216659797](https://github.com/sgl-project/sglang/actions/runs/27216659797)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->