### PR TITLE
feat: add kv_cache_usage_perc prometheus metric

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -328,6 +328,15 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
+        self.kv_cache_usage_perc = Gauge(
+            name="sglang:kv_cache_usage_perc",
+            documentation=(
+                "KV cache usage percentage (0.0–1.0). "
+                "Mirrors vLLM's vllm:gpu_cache_usage_perc for compatibility."
+            ),
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
 
         # =================================================================
         # Absolute token counts
@@ -1270,6 +1279,7 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         self._log_gauge(self.full_token_usage, stats.full_token_usage)
         self._log_gauge(self.swa_token_usage, stats.swa_token_usage)
         self._log_gauge(self.mamba_usage, stats.mamba_usage)
+        self._log_gauge(self.kv_cache_usage_perc, stats.token_usage)
 
         # Absolute token counts
         self._log_gauge(self.num_used_tokens, stats.num_used_tokens)


### PR DESCRIPTION
## Summary

Add `sglang:kv_cache_usage_perc` Prometheus gauge to track KV cache utilization, providing feature parity with vLLM's `vllm:gpu_cache_usage_perc`.

## Changes

- Added `kv_cache_usage_perc` Gauge in `SchedulerMetricsCollector` (metrics_collector.py)
- Reports same value as `token_usage` (0.0-1.0 range), representing fraction of KV cache memory currently in use
- Logged via `log_stats()` alongside existing memory pool metrics

## Testing

- Syntax validation passed (`python -m py_compile`)
- Metric follows existing naming conventions and multiprocess mode (`mostrecent`)

Fixes sgl-project/sglang#5979









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27221649535](https://github.com/sgl-project/sglang/actions/runs/27221649535)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27221648995](https://github.com/sgl-project/sglang/actions/runs/27221648995)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->