### PR TITLE
[diffusion][ROCm][Perf]: Enable BF16 attention and MXFP4 compilation on ROCm

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -137,6 +137,61 @@ class AITerImpl(AttentionImpl):
         self.softmax_scale = softmax_scale
 
     @torch.compiler.disable
+    def _forward_fp8(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """
+        FP8 FMHA prefill path. Kept out of the compiled graph (the aiter FP8
+        quant + FMHA kernels are not torch.compile-safe); only invoked when
+        SGLANG_DIFFUSION_AITER_FP8_ATTN=1.
+
+        Returns the attention output, or None if the FP8 FMHA kernel does not
+        support the current shapes, in which case the caller falls back to the
+        (compilable) BF16 path.
+        """
+        if query.dtype != _fp8_dtype:
+            q_fp8, q_scale = aiter.per_tensor_quant(query, quant_dtype=_fp8_dtype)
+            k_fp8, k_scale = aiter.per_tensor_quant(key, quant_dtype=_fp8_dtype)
+            v_fp8, v_scale = aiter.per_tensor_quant(value, quant_dtype=_fp8_dtype)
+        else:
+            q_fp8, k_fp8, v_fp8 = query, key, value
+            one = torch.tensor(1.0, dtype=torch.float32, device=query.device)
+            q_scale = k_scale = v_scale = one
+
+        d_q = q_fp8.shape[-1]
+        d_k = k_fp8.shape[-1]
+        d_v = v_fp8.shape[-1]
+        h_q = q_fp8.shape[2]
+        h_kv = k_fp8.shape[2]
+
+        if _can_use_fmha_fp8_prefill(d_q, d_k, d_v, h_q, h_kv):
+            return _fmha_fp8_prefill_attention(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                softmax_scale=self.softmax_scale,
+                is_causal=self.causal,
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+            )
+
+        logger.warning_once(
+            "FP8 FMHA prefill unsupported for this shape (need gfx950-class AITER, "
+            "full MHA, q/k/v head_dim=%d; got q=%d, k=%d, v=%d, num_heads=%d, "
+            "num_kv_heads=%d). Falling back to BF16.",
+            _FMHA_FP8_HEAD_DIM,
+            d_q,
+            d_k,
+            d_v,
+            h_q,
+            h_kv,
+        )
+        return None
+
     def forward(
         self,
         query: torch.Tensor,
@@ -159,44 +214,9 @@ class AITerImpl(AttentionImpl):
             Output tensor of shape [batch_size, seq_len, num_heads, head_dim]
         """
         if _use_fp8_attn:
-            if query.dtype != _fp8_dtype:
-                q_fp8, q_scale = aiter.per_tensor_quant(query, quant_dtype=_fp8_dtype)
-                k_fp8, k_scale = aiter.per_tensor_quant(key, quant_dtype=_fp8_dtype)
-                v_fp8, v_scale = aiter.per_tensor_quant(value, quant_dtype=_fp8_dtype)
-            else:
-                q_fp8, k_fp8, v_fp8 = query, key, value
-                one = torch.tensor(1.0, dtype=torch.float32, device=query.device)
-                q_scale = k_scale = v_scale = one
-
-            d_q = q_fp8.shape[-1]
-            d_k = k_fp8.shape[-1]
-            d_v = v_fp8.shape[-1]
-            h_q = q_fp8.shape[2]
-            h_kv = k_fp8.shape[2]
-
-            if _can_use_fmha_fp8_prefill(d_q, d_k, d_v, h_q, h_kv):
-                return _fmha_fp8_prefill_attention(
-                    q_fp8,
-                    k_fp8,
-                    v_fp8,
-                    softmax_scale=self.softmax_scale,
-                    is_causal=self.causal,
-                    q_scale=q_scale,
-                    k_scale=k_scale,
-                    v_scale=v_scale,
-                )
-
-            logger.warning_once(
-                "FP8 FMHA prefill unsupported for this shape (need gfx950-class AITER, "
-                "full MHA, q/k/v head_dim=%d; got q=%d, k=%d, v=%d, num_heads=%d, "
-                "num_kv_heads=%d). Falling back to BF16.",
-                _FMHA_FP8_HEAD_DIM,
-                d_q,
-                d_k,
-                d_v,
-                h_q,
-                h_kv,
-            )
+            output = self._forward_fp8(query, key, value)
+            if output is not None:
+                return output
 
         # BF16 path
         output, _ = aiter.flash_attn_func(

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -142,6 +142,61 @@ class AITerImpl(AttentionImpl):
         self.softmax_scale = softmax_scale
 
     @torch.compiler.disable
+    def _forward_fp8(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """
+        FP8 FMHA prefill path. Kept out of the compiled graph (the aiter FP8
+        quant + FMHA kernels are not torch.compile-safe); only invoked when
+        SGLANG_DIFFUSION_AITER_FP8_ATTN=1.
+
+        Returns the attention output, or None if the FP8 FMHA kernel does not
+        support the current shapes, in which case the caller falls back to the
+        (compilable) BF16 path.
+        """
+        if query.dtype != _fp8_dtype:
+            q_fp8, q_scale = aiter.per_tensor_quant(query, quant_dtype=_fp8_dtype)
+            k_fp8, k_scale = aiter.per_tensor_quant(key, quant_dtype=_fp8_dtype)
+            v_fp8, v_scale = aiter.per_tensor_quant(value, quant_dtype=_fp8_dtype)
+        else:
+            q_fp8, k_fp8, v_fp8 = query, key, value
+            one = torch.tensor(1.0, dtype=torch.float32, device=query.device)
+            q_scale = k_scale = v_scale = one
+
+        d_q = q_fp8.shape[-1]
+        d_k = k_fp8.shape[-1]
+        d_v = v_fp8.shape[-1]
+        h_q = q_fp8.shape[2]
+        h_kv = k_fp8.shape[2]
+
+        if _can_use_fmha_fp8_prefill(d_q, d_k, d_v, h_q, h_kv):
+            return _fmha_fp8_prefill_attention(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                softmax_scale=self.softmax_scale,
+                is_causal=self.causal,
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+            )
+
+        logger.warning_once(
+            "FP8 FMHA prefill unsupported for this shape (need gfx950-class AITER, "
+            "full MHA, q/k/v head_dim=%d; got q=%d, k=%d, v=%d, num_heads=%d, "
+            "num_kv_heads=%d). Falling back to BF16.",
+            _FMHA_FP8_HEAD_DIM,
+            d_q,
+            d_k,
+            d_v,
+            h_q,
+            h_kv,
+        )
+        return None
+
     def forward(
         self,
         query: torch.Tensor,
@@ -164,44 +219,9 @@ class AITerImpl(AttentionImpl):
             Output tensor of shape [batch_size, seq_len, num_heads, head_dim]
         """
         if _use_fp8_attn:
-            if query.dtype != _fp8_dtype:
-                q_fp8, q_scale = aiter.per_tensor_quant(query, quant_dtype=_fp8_dtype)
-                k_fp8, k_scale = aiter.per_tensor_quant(key, quant_dtype=_fp8_dtype)
-                v_fp8, v_scale = aiter.per_tensor_quant(value, quant_dtype=_fp8_dtype)
-            else:
-                q_fp8, k_fp8, v_fp8 = query, key, value
-                one = torch.tensor(1.0, dtype=torch.float32, device=query.device)
-                q_scale = k_scale = v_scale = one
-
-            d_q = q_fp8.shape[-1]
-            d_k = k_fp8.shape[-1]
-            d_v = v_fp8.shape[-1]
-            h_q = q_fp8.shape[2]
-            h_kv = k_fp8.shape[2]
-
-            if _can_use_fmha_fp8_prefill(d_q, d_k, d_v, h_q, h_kv):
-                return _fmha_fp8_prefill_attention(
-                    q_fp8,
-                    k_fp8,
-                    v_fp8,
-                    softmax_scale=self.softmax_scale,
-                    is_causal=self.causal,
-                    q_scale=q_scale,
-                    k_scale=k_scale,
-                    v_scale=v_scale,
-                )
-
-            logger.warning_once(
-                "FP8 FMHA prefill unsupported for this shape (need gfx950-class AITER, "
-                "full MHA, q/k/v head_dim=%d; got q=%d, k=%d, v=%d, num_heads=%d, "
-                "num_kv_heads=%d). Falling back to BF16.",
-                _FMHA_FP8_HEAD_DIM,
-                d_q,
-                d_k,
-                d_v,
-                h_q,
-                h_kv,
-            )
+            output = self._forward_fp8(query, key, value)
+            if output is not None:
+                return output
 
         # BF16 path
         output = aiter.flash_attn_func(

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp4.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp4.py
@@ -17,6 +17,7 @@ from sglang.multimodal_gen.runtime.models.parameter import (
 )
 from sglang.srt.layers.quantization.utils import is_layer_skipped
 from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.srt.utils.common import direct_register_custom_op
 
 logger = logging.getLogger(__name__)
 _is_hip = is_hip()
@@ -38,6 +39,36 @@ if _is_hip:
 # dimension (N) is smaller than its minimum tile size.
 # Layers with output_size falls below this threshold will stay unquantized
 _MXFP4_MIN_OUTPUT_DIM = 256
+
+
+if _is_hip and gemm_a4w4 is not None and dynamic_mxfp4_quant is not None:
+
+    def _mxfp4_quant_gemm(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        x_fp4, x_scale = dynamic_mxfp4_quant(x, shuffle=True)
+        return gemm_a4w4(x_fp4, weight, x_scale, weight_scale)
+
+    def _mxfp4_quant_gemm_fake(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        # weight is [output_size_per_partition, ...]; gemm output is [M, N].
+        return torch.empty(
+            (x.shape[0], weight.shape[0]), dtype=x.dtype, device=x.device
+        )
+
+    # Wrap the activation-quant + A4W4 gemm in a single functional custom op.
+    # This keeps the whole layer torch.compile compatible.
+    direct_register_custom_op(
+        op_name="mxfp4_diffusion_quant_gemm",
+        op_func=_mxfp4_quant_gemm,
+        mutates_args=[],
+        fake_impl=_mxfp4_quant_gemm_fake,
+    )
 
 
 class Mxfp4Config(QuantizationConfig):
@@ -216,21 +247,17 @@ class Mxfp4LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-
-        if not is_gfx95_supported():
-            raise RuntimeError(
-                "MXFP4 inference requires ROCm and MI350+ (gfx95x). "
-                "Current platform not supported."
-            )
+        # Platform support is validated once in process_weights_after_loading;
+        # the gemm runs through a functional custom op so this stays compilable.
 
         # Handle 3D input tensors [batch, seq, hidden]
         original_shape = x.shape
         if x.dim() == 3:
             x = x.view(-1, x.shape[-1])
 
-        x_fp4, x_scale = dynamic_mxfp4_quant(x, shuffle=True)
-
-        y = gemm_a4w4(x_fp4, layer.weight, x_scale, layer.weight_scale)
+        y = torch.ops.sglang.mxfp4_diffusion_quant_gemm(
+            x, layer.weight, layer.weight_scale
+        )
 
         if bias is not None:
             y = y + bias

--- a/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
@@ -6,6 +6,7 @@ such as Nunchaku validation, NVFP4 fallback adjustments, and post-load patching
 are handled here behind a small helper/adapter layer.
 """
 
+import inspect
 import json
 import os
 import re
@@ -603,13 +604,16 @@ def _resolve_quant_config(
         # Online-quant convention: for `fp8` and `mxfp4`, a no-arg
         # QuantizationConfig() selects the post-load path -- weights load
         # in source dtype and are quantized in
-        # process_weights_after_loading.
+        # process_weights_after_loading. Forward --quantization-ignored-layers
+        # only to configs whose constructor accepts it.
         quant_cls = get_quantization_config(server_args.quantization)
         quant_kwargs = {}
-        if server_args.quantization in {"fp8", "mxfp4"}:
-            quant_kwargs["ignored_layers"] = getattr(
-                server_args, "quantization_ignored_layers", None
-            )
+        ignored_layers = server_args.quantization_ignored_layers
+        if (
+            ignored_layers
+            and "ignored_layers" in inspect.signature(quant_cls).parameters
+        ):
+            quant_kwargs["ignored_layers"] = list(ignored_layers)
         return quant_cls(**quant_kwargs)
 
     quant_config = get_quant_config(hf_config, component_model_path)

--- a/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
@@ -6,6 +6,7 @@ such as Nunchaku validation, NVFP4 fallback adjustments, and post-load patching
 are handled here behind a small helper/adapter layer.
 """
 
+import inspect
 import json
 import os
 import re
@@ -1106,13 +1107,17 @@ def _resolve_quant_config(
         # Online-quant convention: for `fp8`, `mxfp4` and `kitchen_int8`, a
         # no-arg QuantizationConfig() selects the post-load path -- weights
         # load in source dtype and are quantized in
-        # process_weights_after_loading.
+        # process_weights_after_loading. Forward
+        # --quantization-ignored-layers only to configs whose constructor
+        # accepts it.
         quant_cls = get_quantization_config(server_args.quantization)
         quant_kwargs = {}
-        if server_args.quantization in {"fp8", "mxfp4", "kitchen_int8"}:
-            quant_kwargs["ignored_layers"] = getattr(
-                server_args, "quantization_ignored_layers", None
-            )
+        ignored_layers = server_args.quantization_ignored_layers
+        if (
+            ignored_layers
+            and "ignored_layers" in inspect.signature(quant_cls).parameters
+        ):
+            quant_kwargs["ignored_layers"] = list(ignored_layers)
         return quant_cls(**quant_kwargs)
 
     quant_config = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Currently, the entire AITER attention code path has a `torch.compile.disable` decorator, introduced in #20319 . This is only required for the FP8 path, not BF16. This hurts the performance of some models (such as FLUX) a lot. This PR limits the scope of that decorator.

PR #21431 added support for MXFP4 quantization and for skipping the quantization for certain layers (`--quantization-ignored-layers`). The MXFP4 implementation was not torch.compile compatible, so only way to use it with compile enabled was to add a `torch.compile.disable` decorator. This PR wraps the quantization in a custom op that is opaque to the compiler, allowing it to be compiled correctly. Also wires in the ignored layers that weren't properly used before.


## Modifications

<!-- Detail the changes made in this pull request. -->

1. Limit the `torch.compile.disable` decorator only to the FP8 path, instead of the full AITER implementation.
2. Create a custom op for the MXFP4 operations, making it torch.compile compatible.
3. Wire in the `--quantization-ignored-layers` values to the quantization layers.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

FLUX2 quantization output with/without compile enabled:
<img width="1024" height="1024" alt="Add_a_cute_hat_to_the_cat_20260609-161429_e4db20c2" src="https://github.com/user-attachments/assets/3ab624f0-ebea-436b-a78f-d65f8a4c636b" />
<img width="1024" height="1024" alt="Add_a_cute_hat_to_the_cat_20260609-161707_75a682ef" src="https://github.com/user-attachments/assets/49f0589f-e992-46a6-8c44-31adc33baa78" />

FLUX1 comparison before/after AITER fix:
<img width="1024" height="1024" alt="Add_a_cute_hat_to_the_cat_20260609-165521_5a2a1646" src="https://github.com/user-attachments/assets/a42f4500-70ff-45ae-bce7-c853dc9c8d21" />
<img width="1024" height="1024" alt="Add_a_cute_hat_to_the_cat_20260609-170100_c7487305" src="https://github.com/user-attachments/assets/260bfdac-a574-419a-a6d7-32d1af0e1d06" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

FLUX perf gain after the AITER fix:
```
#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 1231.62 ms | 991.54 ms | **-240.08 ms (-19.5%)** | ✅ |
| **Throughput** | 0.81 req/s | 1.01 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.03 | 0.04 | +0.01 | +29.1% | ⚪️ |
| TextEncodingStage | 16.77 | 20.91 | +4.14 | +24.7% | ⚪️ |
| LatentPreparationStage | 0.10 | 0.18 | +0.08 | +74.8% | ⚪️ |
| TimestepPreparationStage | 0.30 | 0.45 | +0.16 | +52.4% | ⚪️ |
| DenoisingStage | 1206.86 | 962.03 | -244.83 | -20.3% | 🟢 |
| DecodingStage | 4.28 | 4.95 | +0.67 | +15.6% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.04 | 0.04 | -0.01 | -13.6% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.01 | 0.00 | -0.00 | -50.0% | ⚪️ |
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
6. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34816075534](https://github.com/sgl-project/sglang/actions/runs/34816075534)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34816075410](https://github.com/sgl-project/sglang/actions/runs/34816075410)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34816075553](https://github.com/sgl-project/sglang/actions/runs/34816075553)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->