### PR TITLE
Support DFLASH with DP attention

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -131,11 +131,6 @@ def handle_speculative_decoding(server_args: "ServerArgs") -> None:
 
 
 def _handle_dflash(server_args: "ServerArgs") -> None:
-    if server_args.enable_dp_attention:
-        raise ValueError(
-            "Currently DFLASH speculative decoding does not support dp attention."
-        )
-
     if server_args.pp_size != 1:
         raise ValueError(
             "Currently DFLASH speculative decoding only supports pp_size == 1."
@@ -246,6 +241,17 @@ def _handle_dflash(server_args: "ServerArgs") -> None:
         )
     else:
         logger.warning("Spec v2 is enabled by default for DFLASH speculative decoding.")
+
+    if (
+        server_args.enable_dp_attention
+        and not server_args.enable_dp_attention_local_control_broadcast
+    ):
+        server_args.enable_dp_attention_local_control_broadcast = True
+        logger.warning(
+            "DP attention local control broadcast is enabled because DFLASH "
+            "spec-v2 runs an inner target verify forward that needs every DP "
+            "scheduler to produce its active or idle companion batch."
+        )
 
     if server_args.enable_mixed_chunk:
         server_args.enable_mixed_chunk = False

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -26,7 +26,7 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.speculative.spec_info import SpecInput
+from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.utils import (
     get_int_env_var,
     is_flashinfer_available,
@@ -554,16 +554,39 @@ class FlashInferAttnBackend(AttentionBackend):
                 self.prefill_wrappers_paged, False, False
             )
         elif forward_batch.forward_mode.is_target_verify():
+            if (
+                forward_batch.spec_info is not None
+                and forward_batch.spec_info.spec_input_type
+                == SpecInputType.DFLASH_VERIFY
+            ):
+                prefix_lens = forward_batch.seq_lens
+                draft_token_num = int(forward_batch.spec_info.draft_token_num)
+                seq_lens = prefix_lens + draft_token_num
+                seq_lens_cpu = (
+                    forward_batch.seq_lens_cpu + draft_token_num
+                    if forward_batch.seq_lens_cpu is not None
+                    else None
+                )
+                seq_lens_sum = forward_batch.seq_lens_sum + (
+                    draft_token_num * int(forward_batch.batch_size)
+                )
+                spec_info = None
+            else:
+                prefix_lens = None
+                seq_lens = forward_batch.seq_lens
+                seq_lens_cpu = forward_batch.seq_lens_cpu
+                seq_lens_sum = forward_batch.seq_lens_sum
+                spec_info = forward_batch.spec_info
             self.indices_updater_prefill.update(
                 forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                forward_batch.seq_lens_cpu,
-                forward_batch.seq_lens_sum,
-                prefix_lens=None,
+                seq_lens,
+                seq_lens_cpu,
+                seq_lens_sum,
+                prefix_lens=prefix_lens,
                 prefill_wrappers=self.prefill_wrappers_verify,
                 use_ragged=False,
                 encoder_lens=forward_batch.encoder_lens,
-                spec_info=forward_batch.spec_info,
+                spec_info=spec_info,
             )
             self.forward_metadata = PrefillMetadata(
                 self.prefill_wrappers_verify, False, False

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1434,8 +1434,11 @@ class Scheduler(
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
         # DFLASH fences its shared req_to_token writes with verify_done /
         # plan-stream deps, so the global WAR barrier only serializes plan
-        # overlap. TODO: generalize this global-barrier enablement policy.
-        self._war_barrier_enabled = is_cuda() and not self.spec_algorithm.is_dflash()
+        # overlap. DP attention adds cross-rank planning/MLP synchronization,
+        # so keep the WAR barrier for DFLASH in that mode.
+        self._war_barrier_enabled = is_cuda() and (
+            not self.spec_algorithm.is_dflash() or self.server_args.enable_dp_attention
+        )
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)
 
@@ -1704,6 +1707,12 @@ class Scheduler(
             pool_stats_observer=self.pool_stats_observer,
             get_last_batch=lambda: self.last_batch,
             get_running_batch=lambda: self.running_batch,
+            get_extra_uncached_tokens=lambda: (
+                int(self.draft_worker.uncached_kv_cache_tokens())
+                if self.draft_worker is not None
+                and hasattr(self.draft_worker, "uncached_kv_cache_tokens")
+                else 0
+            ),
         )
 
     def init_kv_events_publisher(self) -> None:

--- a/python/sglang/srt/managers/scheduler_components/invariant_checker.py
+++ b/python/sglang/srt/managers/scheduler_components/invariant_checker.py
@@ -54,6 +54,7 @@ class SchedulerInvariantChecker:
     pool_stats_observer: SchedulerPoolStatsObserver
     get_last_batch: Callable
     get_running_batch: Callable
+    get_extra_uncached_tokens: Callable[[], int] = lambda: 0
     count_req_pool_leak_warnings: int = 0
     count_memory_leak_warnings: int = 0
     recent_busy_msgs: Deque[str] = field(
@@ -201,6 +202,7 @@ class SchedulerInvariantChecker:
 
         ps = self.pool_stats_observer.get_pool_stats()
         full_uncached, swa_uncached = self._get_total_uncached_sizes()
+        full_uncached += int(self.get_extra_uncached_tokens())
 
         full_leak, full_msg = self._check_full_pool(ps, uncached=full_uncached)
 
@@ -267,6 +269,7 @@ class SchedulerInvariantChecker:
         """Check memory invariant across all pools. Returns (has_leak, messages)."""
         has_leak = False
         messages = []
+        uncached += int(self.get_extra_uncached_tokens())
 
         full_leak, full_msg = self._check_full_pool(ps, uncached=uncached)
         has_leak |= full_leak

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1287,29 +1287,34 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 self.req_pool_indices = self.req_pool_indices[:bs]
                 if self.seq_lens_cpu is not None:
                     self.seq_lens_cpu = self.seq_lens_cpu[:bs]
-                logits_output.next_token_logits = logits_output.next_token_logits[
-                    :num_tokens
-                ]
+                if logits_output.next_token_logits is not None:
+                    logits_output.next_token_logits = logits_output.next_token_logits[
+                        :num_tokens
+                    ]
                 logits_output.hidden_states = logits_output.hidden_states[:num_tokens]
             elif self.forward_mode.is_target_verify():  # verify
                 num_tokens = bs * self.spec_info.draft_token_num
-                logits_output.next_token_logits = logits_output.next_token_logits[
-                    :num_tokens
-                ]
+                if logits_output.next_token_logits is not None:
+                    logits_output.next_token_logits = logits_output.next_token_logits[
+                        :num_tokens
+                    ]
                 logits_output.hidden_states = logits_output.hidden_states[:num_tokens]
             elif self.forward_mode.is_draft_extend():  # draft extend
                 self.spec_info.num_correct_drafts = self.spec_info.num_correct_drafts[
                     :bs
                 ]
                 self.spec_info.num_accept_tokens = self.spec_info.num_accept_tokens[:bs]
-                logits_output.next_token_logits = logits_output.next_token_logits[:bs]
+                if logits_output.next_token_logits is not None:
+                    logits_output.next_token_logits = logits_output.next_token_logits[:bs]
                 logits_output.hidden_states = logits_output.hidden_states[:bs]
             elif self.forward_mode.is_draft_extend_v2():  # draft extend_v2
                 bs = bs * self.spec_info.num_tokens_per_req
-                logits_output.next_token_logits = logits_output.next_token_logits[:bs]
+                if logits_output.next_token_logits is not None:
+                    logits_output.next_token_logits = logits_output.next_token_logits[:bs]
                 logits_output.hidden_states = logits_output.hidden_states[:bs]
             elif self.forward_mode.is_extend() or self.forward_mode.is_idle():
-                logits_output.next_token_logits = logits_output.next_token_logits[:bs]
+                if logits_output.next_token_logits is not None:
+                    logits_output.next_token_logits = logits_output.next_token_logits[:bs]
                 logits_output.hidden_states = logits_output.hidden_states[:bs]
 
             if hasattr(self, "hidden_states_backup"):
@@ -1318,7 +1323,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 self.out_cache_loc = self.output_cache_loc_backup
 
         elif self.forward_mode.is_decode() or self.forward_mode.is_idle():
-            logits_output.next_token_logits = logits_output.next_token_logits[:bs]
+            if logits_output.next_token_logits is not None:
+                logits_output.next_token_logits = logits_output.next_token_logits[:bs]
             if logits_output.hidden_states is not None:
                 logits_output.hidden_states = logits_output.hidden_states[:bs]
         elif self.forward_mode.is_extend():

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3328,7 +3328,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # called from the idle path can re-read a prior batch's req_pool
         # indices and trigger SWA mapping use-after-free.
         if forward_batch.batch_size > 0:
-            if not self.server_args.enable_pdmux:
+            skip_eager_copy = (
+                forward_batch.spec_algorithm == SpeculativeAlgorithm.DFLASH
+                and forward_batch.input_embeds is not None
+            )
+            if not self.server_args.enable_pdmux and not skip_eager_copy:
                 forward_batch = self._eager_fb_view(forward_batch, pp_proxy_tensors)
             self.attn_backend.init_forward_metadata(forward_batch)
         else:
@@ -3337,6 +3341,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         kwargs = {}
         if self.support_pp:
             kwargs["pp_proxy_tensors"] = pp_proxy_tensors
+        if forward_batch.input_embeds is not None:
+            kwargs["input_embeds"] = forward_batch.input_embeds
         ctx = (
             self.device_timer.wrap(metadata={"category": "idle"})
             if self.device_timer
@@ -3541,29 +3547,42 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             if self.hisparse_coordinator is not None:
                 self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
 
-            # Forward without cuda graph
-            if forward_batch.forward_mode.is_decode():
-                ret = self.forward_decode(
-                    forward_batch,
-                    pp_proxy_tensors=pp_proxy_tensors,
-                )
-            elif forward_batch.forward_mode.is_split_prefill():
-                ret = self.forward_split_prefill(
-                    forward_batch,
-                    reinit_attn_backend=reinit_attn_backend,
-                    forward_count=split_forward_count,
-                )
-            elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
-                ret, can_run_graph = self.forward_extend(
-                    forward_batch,
-                    pp_proxy_tensors=pp_proxy_tensors,
-                )
-            elif forward_batch.forward_mode.is_idle():
-                ret = self.forward_idle(
-                    forward_batch, pp_proxy_tensors=pp_proxy_tensors
-                )
-            else:
-                raise ValueError(f"Invalid forward mode: {forward_batch.forward_mode}")
+            spec_info_for_idle_padding = None
+            if (
+                forward_batch.forward_mode.is_idle()
+                and forward_batch.spec_algorithm == SpeculativeAlgorithm.DFLASH
+                and forward_batch.spec_info is not None
+            ):
+                spec_info_for_idle_padding = forward_batch.spec_info
+                forward_batch.spec_info = None
+
+            try:
+                # Forward without cuda graph
+                if forward_batch.forward_mode.is_decode():
+                    ret = self.forward_decode(
+                        forward_batch,
+                        pp_proxy_tensors=pp_proxy_tensors,
+                    )
+                elif forward_batch.forward_mode.is_split_prefill():
+                    ret = self.forward_split_prefill(
+                        forward_batch,
+                        reinit_attn_backend=reinit_attn_backend,
+                        forward_count=split_forward_count,
+                    )
+                elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
+                    ret, can_run_graph = self.forward_extend(
+                        forward_batch,
+                        pp_proxy_tensors=pp_proxy_tensors,
+                    )
+                elif forward_batch.forward_mode.is_idle():
+                    ret = self.forward_idle(
+                        forward_batch, pp_proxy_tensors=pp_proxy_tensors
+                    )
+                else:
+                    raise ValueError(f"Invalid forward mode: {forward_batch.forward_mode}")
+            finally:
+                if spec_info_for_idle_padding is not None:
+                    forward_batch.spec_info = spec_info_for_idle_padding
 
             if (
                 forward_batch.global_num_tokens_cpu is not None

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -154,7 +154,9 @@ class DFlashAttention(nn.Module):
         else:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
             q, k = apply_qk_norm(q, k, self.q_norm, self.k_norm, self.head_dim)
+            q, k = q.contiguous(), k.contiguous()
             q, k = self.rotary_emb(positions, q, k)
+        q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
@@ -177,12 +179,12 @@ class DFlashAttention(nn.Module):
             )
             kv = F.linear(hidden_states, weight, bias)
             k, v = kv.split([self.kv_size, self.kv_size], dim=-1)
-            return k, v
+            return k.contiguous(), v.contiguous()
 
         # Fallback: compute full QKV and discard Q (keeps compatibility with quantized weights).
         qkv, _ = self.qkv_proj(hidden_states)
         _, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        return k, v
+        return k.contiguous(), v.contiguous()
 
     def apply_k_norm(self, k: torch.Tensor) -> torch.Tensor:
         k_by_head = k.reshape(-1, self.head_dim)
@@ -193,7 +195,7 @@ class DFlashAttention(nn.Module):
         # Match K shape so RoPE kernel head-count check passes on all backends.
         dummy_q = k.new_empty(k.shape)
         _, k = self.rotary_emb(positions, dummy_q, k)
-        return k
+        return k.contiguous()
 
 
 class DFlashMLP(nn.Module):

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -175,11 +175,14 @@ class DFlashVerifyInput(SpecInput):
 
     # Shape info for padding (e.g., DP attention / CUDA graph).
     num_tokens_per_batch: int = -1
+    num_tokens_per_req: int = -1
 
     def __post_init__(self):
         super().__init__(spec_input_type=SpecInputType.DFLASH_VERIFY)
         if self.num_tokens_per_batch == -1:
             self.num_tokens_per_batch = int(self.draft_token_num)
+        if self.num_tokens_per_req == -1:
+            self.num_tokens_per_req = int(self.draft_token_num)
 
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.draft_token_num, self.draft_token_num
@@ -262,35 +265,35 @@ class DFlashVerifyInput(SpecInput):
         self,
         batch: ScheduleBatch,
         target_worker: "TpModelWorker",
+        *,
+        force_target_verify: bool = False,
     ) -> tuple[ForwardBatch, bool]:
         """Prepare a DFLASH verify forward batch for overlap scheduling.
 
         Unlike spec-v1, the overlap path already computes and stores
         `batch.out_cache_loc` before this method is called. This helper only
-        packages the verify forward and pre-initializes either CUDA-graph replay
-        metadata or eager attention metadata so the actual forward can run with
-        `skip_attn_backend_init=True`.
+        packages the verify forward. CUDA-graph replay is pre-prepared here;
+        eager attention metadata is initialized by the normal forward path after
+        DP-attention padding has finalized the batch shapes.
         """
         batch.input_ids = self.draft_token
         batch.spec_info = self
         batch.forward_mode = (
             ForwardMode.IDLE
-            if batch.forward_mode.is_idle()
+            if batch.forward_mode.is_idle() and not force_target_verify
             else ForwardMode.TARGET_VERIFY
         )
         batch.capture_hidden_mode = self.capture_hidden_mode
         verify_forward_batch = ForwardBatch.init_new(batch, target_worker.model_runner)
 
         can_run_cuda_graph = bool(
-            target_worker.model_runner.graph_runner
+            not target_worker.model_runner.server_args.enable_dp_attention
+            and target_worker.model_runner.graph_runner
             and target_worker.model_runner.graph_runner.can_run(verify_forward_batch)
         )
         if can_run_cuda_graph:
             target_worker.model_runner.graph_runner.replay_prepare(verify_forward_batch)
-        elif not batch.forward_mode.is_idle():
-            target_worker.model_runner.attn_backend.init_forward_metadata(
-                verify_forward_batch
-            )
+            verify_forward_batch.mark_forward_metadata_ready()
 
         return verify_forward_batch, can_run_cuda_graph
 

--- a/python/sglang/srt/speculative/dflash_info_v2.py
+++ b/python/sglang/srt/speculative/dflash_info_v2.py
@@ -51,6 +51,7 @@ class DFlashDraftInputV2(SpecInput):
     verify_done: Optional[torch.cuda.Event] = None
     max_top_k: int = 1
     uniform_top_k_value: Optional[int] = None
+    committed_seq_lens_cpu: Optional[torch.Tensor] = None
     cur_allocated_seq_lens_cpu: Optional[torch.Tensor] = None
     planning_seq_lens_cpu: Optional[torch.Tensor] = None
     planning_seq_lens_sum: Optional[int] = None
@@ -284,6 +285,8 @@ class DFlashDraftInputV2(SpecInput):
             self.cur_allocated_seq_lens_cpu = self.cur_allocated_seq_lens_cpu[
                 new_indices.cpu()
             ]
+        if self.committed_seq_lens_cpu is not None:
+            self.committed_seq_lens_cpu = self.committed_seq_lens_cpu[new_indices.cpu()]
         if self.planning_seq_lens_cpu is not None:
             self.planning_seq_lens_cpu = self.planning_seq_lens_cpu[new_indices.cpu()]
             self.planning_seq_lens_sum = int(self.planning_seq_lens_cpu.sum().item())
@@ -310,6 +313,14 @@ class DFlashDraftInputV2(SpecInput):
             )
         elif spec_info.cur_allocated_seq_lens_cpu is not None:
             self.cur_allocated_seq_lens_cpu = spec_info.cur_allocated_seq_lens_cpu
+
+        if self.committed_seq_lens_cpu is not None:
+            assert spec_info.committed_seq_lens_cpu is not None
+            self.committed_seq_lens_cpu = torch.cat(
+                [self.committed_seq_lens_cpu, spec_info.committed_seq_lens_cpu]
+            )
+        elif spec_info.committed_seq_lens_cpu is not None:
+            self.committed_seq_lens_cpu = spec_info.committed_seq_lens_cpu
 
         if self.planning_seq_lens_cpu is not None:
             assert spec_info.planning_seq_lens_cpu is not None

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -1,11 +1,19 @@
 import logging
 import math
+from contextlib import nullcontext
 from copy import deepcopy
 from typing import Optional
 
 import torch
 
 from sglang.srt.distributed import get_tp_group
+from sglang.srt.layers.dp_attention import (
+    DpPaddingMode,
+    get_attention_dp_rank,
+    get_attention_tp_group,
+    get_attention_tp_size,
+)
+from sglang.srt.layers.utils.cp_utils import get_cp_padding_align_size
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -28,7 +36,11 @@ from sglang.srt.speculative.dflash_utils import (
     resolve_dflash_verify_mask_policy,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
+from sglang.srt.speculative.spec_utils import (
+    assign_req_to_token_pool_func,
+    draft_tp_context,
+)
+from sglang.srt.utils.common import ceil_align
 from sglang.srt.utils import is_cuda, is_npu
 
 _is_npu = is_npu()
@@ -95,6 +107,8 @@ class DFlashWorker:
         target_req_to_token_pool, target_token_to_kv_pool_allocator = (
             target_worker.get_memory_pool()
         )
+        self._target_req_to_token_pool = target_req_to_token_pool
+        self._target_token_to_kv_pool_allocator = target_token_to_kv_pool_allocator
         shared_req_to_token_pool = (
             None if self.use_compact_draft_cache else target_req_to_token_pool
         )
@@ -141,26 +155,40 @@ class DFlashWorker:
         draft_server_args.context_length = (
             target_worker.model_runner.model_config.context_len
         )
-        saved_server_args = get_global_server_args()
-        self.draft_worker = TpModelWorker(
-            server_args=draft_server_args,
-            gpu_id=gpu_id,
-            tp_rank=tp_rank,
-            moe_ep_rank=moe_ep_rank,
-            pp_rank=0,
-            attn_cp_rank=attn_cp_rank,
-            moe_dp_rank=moe_dp_rank,
-            dp_rank=dp_rank,
-            nccl_port=nccl_port,
-            is_draft_worker=True,
-            req_to_token_pool=shared_req_to_token_pool,
-            token_to_kv_pool_allocator=target_token_to_kv_pool_allocator,
-            memory_pool_config=target_worker.model_runner.memory_pool_config,
+        backup_disable_cuda_graph = draft_server_args.disable_cuda_graph
+        draft_server_args.disable_cuda_graph = True
+        init_ctx = (
+            draft_tp_context(get_attention_tp_group())
+            if server_args.enable_dp_attention
+            else nullcontext()
         )
+        saved_server_args = get_global_server_args()
+        with init_ctx:
+            self.draft_worker = TpModelWorker(
+                server_args=draft_server_args,
+                gpu_id=gpu_id,
+                tp_rank=tp_rank,
+                moe_ep_rank=moe_ep_rank,
+                pp_rank=0,
+                attn_cp_rank=attn_cp_rank,
+                moe_dp_rank=moe_dp_rank,
+                dp_rank=dp_rank,
+                nccl_port=nccl_port,
+                is_draft_worker=True,
+                req_to_token_pool=shared_req_to_token_pool,
+                token_to_kv_pool_allocator=target_token_to_kv_pool_allocator,
+                memory_pool_config=target_worker.model_runner.memory_pool_config,
+            )
         set_global_server_args_for_scheduler(saved_server_args)
         self.draft_model_runner = self.draft_worker.model_runner
         # Keep the same alias that other spec-v2 workers expose.
         self.draft_worker.draft_runner = self.draft_model_runner
+        self.draft_tp_context = (
+            draft_tp_context if server_args.enable_dp_attention else nullcontext
+        )
+        self.draft_model_runner.server_args.disable_cuda_graph = backup_disable_cuda_graph
+        with self.draft_tp_context(self.draft_model_runner.tp_group):
+            self.draft_model_runner.init_device_graphs()
         self.draft_model = self.draft_model_runner.model
         draft_config = parse_dflash_draft_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config
@@ -241,6 +269,327 @@ class DFlashWorker:
         self._fused_kv_helper: Optional[object] = None
         if self._use_fused_kv_materialize:
             self._init_fused_kv_helper()
+
+        self._dp_token_metadata_cache: dict[
+            tuple[int, ...], tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        ] = {}
+        self._dflash_dp_max_pad_bs = max(
+            1, int(server_args.max_running_requests or 1)
+        )
+        self._dflash_dp_max_pad_tokens = self._dflash_dp_max_pad_bs * int(
+            self.block_size
+        )
+        self._dflash_dp_max_pad_alloc_tokens = ceil_align(
+            self._dflash_dp_max_pad_tokens, int(self.page_size)
+        )
+        self._dflash_dp_pad_alloc_cache_loc: Optional[torch.Tensor] = None
+        self._dflash_dp_uncached_kv_cache_tokens = 0
+        self._dflash_dp_pad_input_ids = torch.full(
+            (self._dflash_dp_max_pad_tokens,),
+            int(self._mask_token_id),
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self._dflash_dp_pad_seq_lens = torch.zeros(
+            (self._dflash_dp_max_pad_bs,), dtype=torch.int64, device=self.device
+        )
+        self._dflash_dp_pad_seq_lens_cpu = torch.zeros(
+            (self._dflash_dp_max_pad_bs,), dtype=torch.int64, device="cpu"
+        )
+        self._dflash_dp_pad_req_pool_indices = torch.zeros(
+            (self._dflash_dp_max_pad_bs,), dtype=torch.int64, device=self.device
+        )
+        self._dflash_dp_pad_out_cache_loc = torch.zeros(
+            (self._dflash_dp_max_pad_tokens,), dtype=torch.int64, device=self.device
+        )
+        self._init_dp_attention_verify_padding_cache()
+        self._dflash_dp_pad_positions = torch.arange(
+            int(self.block_size), dtype=torch.int64, device=self.device
+        ).repeat(self._dflash_dp_max_pad_bs)
+
+    def _init_dp_attention_verify_padding_cache(self) -> None:
+        if not self.server_args.enable_dp_attention:
+            return
+
+        pad_alloc_cache_loc = self._target_token_to_kv_pool_allocator.alloc(
+            self._dflash_dp_max_pad_alloc_tokens
+        )
+        if pad_alloc_cache_loc is None:
+            raise RuntimeError(
+                "DFLASH DP attention could not reserve scratch KV slots for "
+                "verify padding. Requested "
+                f"{self._dflash_dp_max_pad_alloc_tokens} slots."
+            )
+        self._dflash_dp_pad_alloc_cache_loc = pad_alloc_cache_loc
+        self._dflash_dp_pad_out_cache_loc = pad_alloc_cache_loc[
+            : self._dflash_dp_max_pad_tokens
+        ]
+        self._dflash_dp_uncached_kv_cache_tokens = int(pad_alloc_cache_loc.numel())
+        self._target_req_to_token_pool.req_to_token[
+            0, : int(self.block_size)
+        ] = self._dflash_dp_pad_out_cache_loc[: int(self.block_size)].to(
+            self._target_req_to_token_pool.req_to_token.dtype
+        )
+
+    def uncached_kv_cache_tokens(self) -> int:
+        return int(self._dflash_dp_uncached_kv_cache_tokens)
+
+    def _sync_dp_attention_target_verify(self) -> None:
+        if not self.server_args.enable_dp_attention:
+            return
+
+        tp_group = self.target_worker.model_runner.tp_group
+        if tp_group.world_size <= 1:
+            return
+
+        torch.distributed.barrier(group=tp_group.cpu_group)
+
+    def _has_uneven_dp_attention_tokens(
+        self, global_num_tokens_cpu: Optional[list[int]]
+    ) -> bool:
+        if global_num_tokens_cpu is None or len(global_num_tokens_cpu) <= 1:
+            return False
+        return len({int(num_tokens) for num_tokens in global_num_tokens_cpu}) > 1
+
+    def _attach_dp_attention_token_metadata(
+        self,
+        forward_batch: ForwardBatch,
+        num_tokens: int,
+        *,
+        gather_global_num_tokens: bool = True,
+    ) -> Optional[list[int]]:
+        if not self.server_args.enable_dp_attention:
+            return None
+
+        num_tokens = int(num_tokens)
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            and forward_batch.spec_algorithm == SpeculativeAlgorithm.DFLASH
+        ):
+            forward_batch.is_extend_in_batch = True
+
+        tp_group = self.target_worker.model_runner.tp_group
+        if gather_global_num_tokens and tp_group.world_size > 1:
+            global_num_tokens_cpu = [
+                int(token_count)
+                for token_count in tp_group.all_gather_object(num_tokens)
+            ]
+        else:
+            global_num_tokens_cpu = [num_tokens] * int(self.server_args.dp_size)
+        metadata_key = tuple(global_num_tokens_cpu)
+        metadata = self._dp_token_metadata_cache.get(metadata_key)
+        if metadata is None:
+            global_num_tokens_gpu = torch.tensor(
+                global_num_tokens_cpu, dtype=torch.int64, device=self.device
+            )
+            global_num_tokens_for_logprob_gpu = torch.tensor(
+                global_num_tokens_cpu, dtype=torch.int64, device=self.device
+            )
+            num_token_non_padded = torch.tensor(
+                num_tokens, dtype=torch.int32, device=self.device
+            )
+            metadata = (
+                global_num_tokens_gpu,
+                global_num_tokens_for_logprob_gpu,
+                num_token_non_padded,
+            )
+            self._dp_token_metadata_cache[metadata_key] = metadata
+
+        forward_batch.can_run_dp_cuda_graph = False
+        forward_batch.original_global_num_tokens_cpu = global_num_tokens_cpu
+        forward_batch.global_num_tokens_cpu = global_num_tokens_cpu
+        forward_batch.global_num_tokens_gpu = metadata[0]
+        forward_batch.global_num_tokens_for_logprob_cpu = global_num_tokens_cpu
+        forward_batch.global_num_tokens_for_logprob_gpu = metadata[1]
+        forward_batch.num_token_non_padded_cpu = num_tokens
+        forward_batch.num_token_non_padded = metadata[2]
+        return global_num_tokens_cpu
+
+    def _pad_dp_attention_input_embeds(
+        self,
+        forward_batch: ForwardBatch,
+        global_num_tokens_cpu: Optional[list[int]],
+    ) -> None:
+        if (
+            global_num_tokens_cpu is None
+            or forward_batch.input_embeds is None
+            or len(global_num_tokens_cpu) <= 1
+        ):
+            return
+
+        global_num_tokens = [
+            ceil_align(int(num_tokens), get_attention_tp_size())
+            for num_tokens in global_num_tokens_cpu
+        ]
+        cp_align_size = get_cp_padding_align_size()
+        global_num_tokens = [
+            ceil_align(num_tokens, cp_align_size)
+            for num_tokens in global_num_tokens
+        ]
+        padding_mode = DpPaddingMode.get_dp_padding_mode(
+            forward_batch.is_extend_in_batch, global_num_tokens
+        )
+        if padding_mode.is_max_len():
+            padded_num_tokens = max(global_num_tokens)
+        else:
+            padded_num_tokens = global_num_tokens[get_attention_dp_rank()]
+
+        cur_num_tokens = int(forward_batch.input_embeds.shape[0])
+        if padded_num_tokens <= cur_num_tokens:
+            return
+
+        pad_shape = (
+            padded_num_tokens - cur_num_tokens,
+            *forward_batch.input_embeds.shape[1:],
+        )
+        forward_batch.input_embeds = torch.cat(
+            [
+                forward_batch.input_embeds,
+                forward_batch.input_embeds.new_zeros(pad_shape),
+            ],
+            dim=0,
+        )
+
+    def _pad_dp_attention_dflash_verify_batch(
+        self,
+        forward_batch: ForwardBatch,
+        global_num_tokens_cpu: Optional[list[int]],
+    ) -> int:
+        if (
+            global_num_tokens_cpu is None
+            or not self.server_args.enable_dp_attention
+            or forward_batch.spec_info is None
+            or not forward_batch.forward_mode.is_target_verify()
+        ):
+            return int(forward_batch.input_ids.shape[0])
+
+        padded_num_tokens = max(int(x) for x in global_num_tokens_cpu)
+        cur_num_tokens = int(forward_batch.input_ids.shape[0])
+        if padded_num_tokens <= cur_num_tokens:
+            return cur_num_tokens
+
+        draft_token_num = int(forward_batch.spec_info.draft_token_num)
+        if padded_num_tokens % draft_token_num != 0:
+            raise RuntimeError(
+                "DFLASH DP attention verify padding expected token counts to be "
+                f"multiples of draft_token_num={draft_token_num}, got {padded_num_tokens}."
+            )
+
+        padded_bs = padded_num_tokens // draft_token_num
+        pad_bs = padded_bs - int(forward_batch.batch_size)
+        if pad_bs <= 0:
+            return cur_num_tokens
+
+        pad_tokens = padded_num_tokens - cur_num_tokens
+        if pad_bs > self._dflash_dp_pad_req_pool_indices.shape[0]:
+            raise RuntimeError(
+                "DFLASH DP attention verify padding buffers are too small. "
+                f"Requested {pad_bs} slots."
+            )
+        pad_out_cache_loc = self._dflash_dp_pad_out_cache_loc[:pad_tokens].to(
+            forward_batch.out_cache_loc.dtype
+        )
+        pad_req_pool_indices = self._dflash_dp_pad_req_pool_indices[:pad_bs].to(
+            forward_batch.req_pool_indices.dtype
+        )
+
+        pad_input_ids = self._dflash_dp_pad_input_ids[:pad_tokens].to(
+            forward_batch.input_ids.dtype
+        )
+        forward_batch.input_ids = torch.cat(
+            [
+                forward_batch.input_ids,
+                pad_input_ids,
+            ],
+            dim=0,
+        )
+        forward_batch.req_pool_indices = torch.cat(
+            [
+                forward_batch.req_pool_indices,
+                pad_req_pool_indices,
+            ],
+            dim=0,
+        )
+        forward_batch.seq_lens = torch.cat(
+            [
+                forward_batch.seq_lens,
+                self._dflash_dp_pad_seq_lens[:pad_bs].to(forward_batch.seq_lens.dtype),
+            ],
+            dim=0,
+        )
+        if forward_batch.seq_lens_cpu is not None:
+            forward_batch.seq_lens_cpu = torch.cat(
+                [
+                    forward_batch.seq_lens_cpu,
+                    self._dflash_dp_pad_seq_lens_cpu[:pad_bs].to(
+                        forward_batch.seq_lens_cpu.dtype
+                    ),
+                ],
+                dim=0,
+            )
+        setattr(
+            forward_batch,
+            "_original_batch_size",
+            getattr(forward_batch, "_original_batch_size", forward_batch.batch_size),
+        )
+        forward_batch.batch_size = padded_bs
+
+        forward_batch.out_cache_loc = torch.cat(
+            [
+                forward_batch.out_cache_loc,
+                pad_out_cache_loc,
+            ],
+            dim=0,
+        )
+        pad_positions = self._dflash_dp_pad_positions[:pad_tokens].to(
+            forward_batch.positions.dtype
+        )
+        forward_batch.positions = torch.cat(
+            [forward_batch.positions, pad_positions], dim=0
+        )
+        forward_batch.spec_info.draft_token = torch.cat(
+            [forward_batch.spec_info.draft_token, pad_input_ids], dim=0
+        )
+        forward_batch.spec_info.positions = torch.cat(
+            [forward_batch.spec_info.positions, pad_positions], dim=0
+        )
+        forward_batch.spec_info.num_tokens_per_batch = padded_num_tokens
+        forward_batch.lora_ids.extend([None] * pad_bs)
+        return padded_num_tokens
+
+    def _prepare_dp_attention_dflash_verify_batch(
+        self,
+        forward_batch: ForwardBatch,
+        local_num_tokens: int,
+    ) -> int:
+        """Attach DP metadata after DFLASH verify padding has finalized shape."""
+        global_num_tokens_cpu = self._attach_dp_attention_token_metadata(
+            forward_batch, num_tokens=local_num_tokens
+        )
+        padded_num_tokens = self._pad_dp_attention_dflash_verify_batch(
+            forward_batch, global_num_tokens_cpu
+        )
+        if padded_num_tokens != local_num_tokens or self._has_uneven_dp_attention_tokens(
+            global_num_tokens_cpu
+        ):
+            self._attach_dp_attention_token_metadata(
+                forward_batch,
+                num_tokens=padded_num_tokens,
+                gather_global_num_tokens=False,
+            )
+        return padded_num_tokens
+
+    def _free_dp_attention_dflash_verify_padding(
+        self, forward_batch: ForwardBatch
+    ) -> None:
+        return
+
+    def _is_local_prefill_batch(self, batch: ScheduleBatch) -> bool:
+        return batch.forward_mode.is_extend_without_speculative() or (
+            batch.is_extend_in_batch
+            and batch.extend_lens is not None
+            and batch.prefix_lens is not None
+        )
 
     def _init_fused_kv_helper(self) -> None:
         """Initialize the fused KV materialization helper with pre-stacked weights."""
@@ -358,15 +707,21 @@ class DFlashWorker:
         # Delegate anything not implemented yet to the target worker.
         return getattr(self.target_worker, name)
 
-    def on_verify_complete_cpu(self, num_accepted_drafts_per_req: list[int]) -> None:
+    def on_verify_complete_cpu(
+        self, num_accepted_drafts_per_req: list[int], batch_size: int = 0
+    ) -> None:
         pass
 
     def clear_cache_pool(self):
         # The target worker owns the shared KV allocator/cache. For the compact
         # sliding-window path, the draft req->token view is rebuilt from committed
         # target state before each draft forward, so there is nothing persistent
-        # to flush here.
-        pass
+        # to flush here. DP-attention target-verify padding uses a tiny target
+        # KV scratch region, so reserve it again after the target allocator is
+        # cleared.
+        self._dflash_dp_pad_alloc_cache_loc = None
+        self._dflash_dp_uncached_kv_cache_tokens = 0
+        self._init_dp_attention_verify_padding_cache()
 
     def _gather_req_to_token_masked(
         self,
@@ -671,9 +1026,17 @@ class DFlashWorker:
                 spec_algorithm=SpeculativeAlgorithm.DFLASH,
                 spec_info=draft_spec_info,
                 capture_hidden_mode=CaptureHiddenMode.NULL,
+                lora_ids=[None] * bs,
             )
+            global_num_tokens_cpu = self._attach_dp_attention_token_metadata(
+                forward_batch,
+                num_tokens=bs * self.block_size,
+            )
+            self._pad_dp_attention_input_embeds(forward_batch, global_num_tokens_cpu)
 
-            with torch.inference_mode():
+            with torch.inference_mode(), self.draft_tp_context(
+                self.draft_model_runner.tp_group
+            ):
                 draft_logits_output = self.draft_model_runner.forward(
                     forward_batch
                 ).logits_output
@@ -1342,7 +1705,7 @@ class DFlashWorker:
                 "Invariant broken: DFLASH batch requested return_logprob, but scheduler should have rejected this request."
             )
 
-        if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
+        if self._is_local_prefill_batch(batch):
             batch.capture_hidden_mode = CaptureHiddenMode.FULL
             batch_result = self.target_worker.forward_batch_generation(batch, **kwargs)
             logits_output, next_token_ids = (
@@ -1390,6 +1753,37 @@ class DFlashWorker:
                 next_token_ids=next_token_ids,
                 num_correct_drafts=0,
                 can_run_cuda_graph=batch_result.can_run_cuda_graph,
+            )
+
+        if batch.forward_mode.is_idle():
+            target_batch_result = None
+            if self.server_args.enable_dp_attention:
+                spec_info_backup = batch.spec_info
+                can_run_dp_cuda_graph_backup = batch.can_run_dp_cuda_graph
+                batch.spec_info = None
+                batch.can_run_dp_cuda_graph = False
+                try:
+                    target_batch_result = self.target_worker.forward_batch_generation(
+                        batch, **kwargs
+                    )
+                finally:
+                    batch.spec_info = spec_info_backup
+                    batch.can_run_dp_cuda_graph = can_run_dp_cuda_graph_backup
+            return GenerationBatchResult(
+                logits_output=(
+                    target_batch_result.logits_output
+                    if target_batch_result is not None
+                    else None
+                ),
+                next_token_ids=torch.empty(
+                    (0,), dtype=torch.int64, device=self.device
+                ),
+                num_correct_drafts=0,
+                can_run_cuda_graph=(
+                    target_batch_result.can_run_cuda_graph
+                    if target_batch_result is not None
+                    else False
+                ),
             )
 
         # Decode / target-verify stage.

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -6,6 +6,7 @@ import torch
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.mem_cache.common import alloc_token_slots
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -145,12 +146,33 @@ class DFlashWorkerV2(DFlashWorker):
             )
             self._warned_sampling_fallback = True
 
+    def _should_clamp_dp_attention_commit_lens(
+        self, bs: int, commit_lens_cpu: torch.Tensor
+    ) -> bool:
+        """Prevent rank-local DFLASH accepts from desynchronizing DP schedulers."""
+        if not self.server_args.enable_dp_attention or bs <= 1:
+            return False
+
+        local_commit_lens = tuple(int(commit_len) for commit_len in commit_lens_cpu)
+        tp_group = self.target_worker.model_runner.tp_group
+        if tp_group.world_size <= 1:
+            return False
+
+        global_commit_lens = [
+            tuple(commit_lens)
+            for commit_lens in tp_group.all_gather_object(local_commit_lens)
+        ]
+        return any(
+            commit_lens != local_commit_lens for commit_lens in global_commit_lens
+        )
+
     def _make_next_draft_input_prefill(
         self,
         *,
         verified_id: torch.Tensor,
         seq_lens: torch.Tensor,
         verify_done: Optional[torch.cuda.Event] = None,
+        committed_seq_lens_cpu: Optional[torch.Tensor] = None,
         cur_allocated_seq_lens_cpu: Optional[torch.Tensor] = None,
     ) -> DFlashDraftInputV2:
         bs = int(seq_lens.numel())
@@ -162,6 +184,7 @@ class DFlashWorkerV2(DFlashWorker):
             new_seq_lens=seq_lens.to(dtype=torch.int64),
             hidden_states=torch.empty((bs, 0), device=device, dtype=torch.float16),
             verify_done=verify_done,
+            committed_seq_lens_cpu=committed_seq_lens_cpu,
             cur_allocated_seq_lens_cpu=cur_allocated_seq_lens_cpu,
         )
 
@@ -171,6 +194,7 @@ class DFlashWorkerV2(DFlashWorker):
         verified_id: torch.Tensor,
         new_seq_lens: torch.Tensor,
         verify_done: Optional[torch.cuda.Event] = None,
+        committed_seq_lens_cpu: Optional[torch.Tensor] = None,
         cur_allocated_seq_lens_cpu: Optional[torch.Tensor] = None,
     ) -> DFlashDraftInputV2:
         bs = int(new_seq_lens.numel())
@@ -182,6 +206,7 @@ class DFlashWorkerV2(DFlashWorker):
             new_seq_lens=new_seq_lens.to(dtype=torch.int64),
             hidden_states=torch.empty((bs, 0), device=device, dtype=torch.float16),
             verify_done=verify_done,
+            committed_seq_lens_cpu=committed_seq_lens_cpu,
             cur_allocated_seq_lens_cpu=cur_allocated_seq_lens_cpu,
         )
 
@@ -201,7 +226,12 @@ class DFlashWorkerV2(DFlashWorker):
             or model_worker_batch.is_extend_in_batch
         ):
             # Target prefill: capture DFlash aux hidden states for prompt tokens.
-            model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+            is_local_prefill = self._is_local_prefill_batch(model_worker_batch)
+            model_worker_batch.capture_hidden_mode = (
+                CaptureHiddenMode.FULL
+                if is_local_prefill
+                else CaptureHiddenMode.NULL
+            )
             batch_output = self.target_worker.forward_batch_generation(
                 model_worker_batch
             )
@@ -211,8 +241,22 @@ class DFlashWorkerV2(DFlashWorker):
                 batch_output.next_token_ids,
             )
             batch_output.new_seq_lens = model_worker_batch.seq_lens
-            if on_publish is not None:
-                on_publish(batch_output.new_seq_lens)
+
+            if not is_local_prefill:
+                device = model_worker_batch.seq_lens.device
+                verified_id = torch.empty((0,), dtype=torch.int32, device=device)
+                batch_output.next_draft_input = self._make_next_draft_input_prefill(
+                    verified_id=verified_id,
+                    seq_lens=model_worker_batch.seq_lens,
+                    committed_seq_lens_cpu=model_worker_batch.seq_lens_cpu,
+                    cur_allocated_seq_lens_cpu=model_worker_batch.seq_lens_cpu,
+                )
+                verify_done = torch.get_device_module(device).Event()
+                verify_done.record()
+                batch_output.next_draft_input.verify_done = verify_done
+                if on_publish is not None:
+                    on_publish(batch_output.new_seq_lens)
+                return batch_output
 
             if logits_output.hidden_states is None:
                 raise RuntimeError(
@@ -261,11 +305,14 @@ class DFlashWorkerV2(DFlashWorker):
             batch_output.next_draft_input = self._make_next_draft_input_prefill(
                 verified_id=next_token_ids,
                 seq_lens=model_worker_batch.seq_lens,
+                committed_seq_lens_cpu=model_worker_batch.seq_lens_cpu,
                 cur_allocated_seq_lens_cpu=model_worker_batch.seq_lens_cpu,
             )
             verify_done = torch.get_device_module(device).Event()
             verify_done.record()
             batch_output.next_draft_input.verify_done = verify_done
+            if on_publish is not None:
+                on_publish(batch_output.new_seq_lens)
             return batch_output
 
         # Decode / target-verify stage.
@@ -281,6 +328,153 @@ class DFlashWorkerV2(DFlashWorker):
             )
 
         if model_worker_batch.forward_mode.is_idle():
+            block_size = int(self.block_size)
+
+            idle_draft_tokens = block_size
+
+            scratch_cache_loc = alloc_token_slots(
+                model_worker_batch.tree_cache, 2 * block_size
+            )
+            scratch_prefix_len = 1
+            scratch_verify_out_cache_loc = scratch_cache_loc[
+                scratch_prefix_len : scratch_prefix_len + block_size
+            ]
+            scratch_req_pool_indices = torch.zeros(
+                (1,), dtype=torch.int64, device=self.device
+            )
+            scratch_verify_seq_lens = torch.full(
+                (1,), scratch_prefix_len, dtype=torch.int64, device=self.device
+            )
+            scratch_verify_seq_lens_cpu = torch.full(
+                (1,), scratch_prefix_len, dtype=torch.int64
+            )
+            scratch_start = torch.zeros((1,), dtype=torch.int64, device=self.device)
+            scratch_end = torch.full(
+                (1,),
+                scratch_prefix_len + block_size,
+                dtype=torch.int64,
+                device=self.device,
+            )
+            assign_req_to_token_pool_func(
+                scratch_req_pool_indices,
+                self.model_runner.req_to_token_pool.req_to_token,
+                scratch_start,
+                scratch_end,
+                scratch_cache_loc[: scratch_prefix_len + block_size],
+                1,
+            )
+
+            idle_input_ids = torch.full(
+                (idle_draft_tokens,),
+                int(self._mask_token_id),
+                dtype=torch.int64,
+                device=self.device,
+            )
+            idle_positions = torch.arange(
+                scratch_prefix_len,
+                scratch_prefix_len + idle_draft_tokens,
+                dtype=torch.int64,
+                device=self.device,
+            )
+            idle_input_embeds = (
+                self.target_worker.model_runner.model.get_input_embeddings()(
+                    idle_input_ids
+                )
+            )
+
+            draft_forward_batch = ForwardBatch(
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                batch_size=1,
+                input_ids=idle_input_ids,
+                req_pool_indices=scratch_req_pool_indices,
+                seq_lens=scratch_verify_seq_lens,
+                out_cache_loc=scratch_verify_out_cache_loc,
+                seq_lens_sum=scratch_prefix_len,
+                seq_lens_cpu=scratch_verify_seq_lens_cpu,
+                positions=idle_positions,
+                input_embeds=idle_input_embeds,
+                spec_algorithm=SpeculativeAlgorithm.DFLASH,
+                spec_info=self._draft_block_spec_info,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+                lora_ids=[None],
+            )
+            global_num_tokens_cpu = self._attach_dp_attention_token_metadata(
+                draft_forward_batch,
+                num_tokens=idle_draft_tokens,
+            )
+            self._pad_dp_attention_input_embeds(
+                draft_forward_batch, global_num_tokens_cpu
+            )
+            with torch.inference_mode(), self.draft_tp_context(
+                self.draft_model_runner.tp_group
+            ):
+                draft_logits_output = self.draft_model_runner.forward(
+                    draft_forward_batch
+                ).logits_output
+
+            draft_hidden = draft_logits_output.hidden_states
+            if draft_hidden is None:
+                raise RuntimeError("DFLASH idle draft model returned no hidden states.")
+            draft_hidden = draft_hidden.view(1, int(self.block_size), -1)
+            target_lm_head = getattr(
+                self.target_worker.model_runner.model, "lm_head", None
+            )
+            if target_lm_head is None or not hasattr(target_lm_head, "weight"):
+                raise RuntimeError(
+                    "DFLASH requires the target model to expose `lm_head` with `weight`."
+                )
+            self._greedy_sample_from_vocab_parallel_head(
+                hidden_states=draft_hidden[:, 1:, :].reshape(
+                    -1, draft_hidden.shape[-1]
+                ),
+                lm_head=target_lm_head,
+            )
+
+            verify_input = DFlashVerifyInput(
+                draft_token=torch.full(
+                    (block_size,),
+                    int(self._mask_token_id),
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+                positions=torch.arange(
+                    scratch_prefix_len,
+                    scratch_prefix_len + block_size,
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+                draft_token_num=block_size,
+                custom_mask=None,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+            )
+            verify_forward_batch = ForwardBatch(
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                batch_size=1,
+                input_ids=verify_input.draft_token,
+                req_pool_indices=scratch_req_pool_indices,
+                seq_lens=scratch_verify_seq_lens,
+                out_cache_loc=scratch_verify_out_cache_loc,
+                seq_lens_sum=scratch_prefix_len,
+                seq_lens_cpu=scratch_verify_seq_lens_cpu,
+                positions=verify_input.positions,
+                spec_algorithm=SpeculativeAlgorithm.DFLASH,
+                spec_info=verify_input,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+                lora_ids=[None],
+            )
+            self._prepare_dp_attention_dflash_verify_batch(
+                verify_forward_batch, local_num_tokens=block_size
+            )
+            self._sync_dp_attention_target_verify()
+            try:
+                target_batch_output = self.target_worker.forward_batch_generation(
+                    batch=None,
+                    forward_batch=verify_forward_batch,
+                    is_verify=True,
+                )
+            finally:
+                self._free_dp_attention_dflash_verify_padding(verify_forward_batch)
+            self._sync_dp_attention_target_verify()
             empty_ids = torch.empty((0,), dtype=torch.int64, device=self.device)
             empty_lens = torch.empty((0,), dtype=torch.int32, device=self.device)
             next_draft_input = self._make_next_draft_input_decode(
@@ -291,14 +485,20 @@ class DFlashWorkerV2(DFlashWorker):
                 on_publish(next_draft_input.new_seq_lens)
             verify_done = torch.get_device_module(self.device).Event()
             verify_done.record()
+            # The idle companion uses temporary KV slots only to make every DP
+            # rank participate in the same draft/verify collectives. Fence the
+            # stream before returning those slots to the shared allocator.
+            verify_done.synchronize()
+            model_worker_batch.token_to_kv_pool_allocator.free(scratch_cache_loc)
             next_draft_input.verify_done = verify_done
             return GenerationBatchResult(
-                logits_output=None,
+                logits_output=target_batch_output.logits_output,
                 next_token_ids=empty_ids,
                 accept_lens=empty_lens,
                 next_draft_input=next_draft_input,
-                can_run_cuda_graph=False,
+                can_run_cuda_graph=target_batch_output.can_run_cuda_graph,
                 speculative_num_draft_tokens=int(self.block_size),
+                extra_keep_alive_refs=[verify_forward_batch],
             )
 
         # `seq_lens` is carried over from the previous overlap iteration and may have been
@@ -330,6 +530,10 @@ class DFlashWorkerV2(DFlashWorker):
 
         block_ids = self._draft_block_ids_buf[:bs]
         prefix_lens = model_worker_batch.seq_lens
+        if draft_input.committed_seq_lens_cpu is not None:
+            prefix_lens = draft_input.committed_seq_lens_cpu.to(
+                device=device, dtype=prefix_lens.dtype
+            )
         positions_2d = self._draft_block_positions_buf[:bs]
         verify_out_cache_loc_2d = self._draft_verify_out_cache_loc_buf[:bs]
         if self._use_triton_prepare_block:
@@ -432,15 +636,12 @@ class DFlashWorkerV2(DFlashWorker):
             draft_seq_lens_sum = int(seq_lens_cpu.sum().item())
         else:
             # Non-windowed path uses the shared overallocated mapping directly.
-            # Backend planning only needs a safe upper bound for the committed
-            # prefix lengths, not the full allocator reservation length.
+            # DFLASH attention metadata receives committed prefix lengths and
+            # internally appends the fixed draft block.
             draft_seq_lens = prefix_lens
-            if draft_input.planning_seq_lens_cpu is not None:
-                seq_lens_cpu.copy_(draft_input.planning_seq_lens_cpu)
-                draft_seq_lens_sum = int(draft_input.planning_seq_lens_sum)
-            elif draft_input.reserved_seq_lens_cpu is not None:
-                seq_lens_cpu.copy_(draft_input.reserved_seq_lens_cpu)
-                draft_seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
+            if draft_input.committed_seq_lens_cpu is not None:
+                seq_lens_cpu.copy_(draft_input.committed_seq_lens_cpu)
+                draft_seq_lens_sum = int(draft_input.committed_seq_lens_cpu.sum().item())
             elif model_worker_batch.seq_lens_cpu is not None:
                 seq_lens_cpu.copy_(model_worker_batch.seq_lens_cpu)
                 draft_seq_lens_sum = (
@@ -466,9 +667,17 @@ class DFlashWorkerV2(DFlashWorker):
             spec_algorithm=SpeculativeAlgorithm.DFLASH,
             spec_info=self._draft_block_spec_info,
             capture_hidden_mode=CaptureHiddenMode.NULL,
+            lora_ids=[None] * bs,
         )
+        global_num_tokens_cpu = self._attach_dp_attention_token_metadata(
+            forward_batch,
+            num_tokens=bs * int(self.block_size),
+        )
+        self._pad_dp_attention_input_embeds(forward_batch, global_num_tokens_cpu)
 
-        with torch.inference_mode():
+        with torch.inference_mode(), self.draft_tp_context(
+            self.draft_model_runner.tp_group
+        ):
             draft_logits_output = self.draft_model_runner.forward(
                 forward_batch
             ).logits_output
@@ -509,27 +718,36 @@ class DFlashWorkerV2(DFlashWorker):
         seq_lens_pre_verify = (
             model_worker_batch.seq_lens.clone() if need_mamba_verify_commit else None
         )
-        seq_lens_cpu_backup = model_worker_batch.seq_lens_cpu
-        seq_lens_sum_backup = model_worker_batch.seq_lens_sum
-        if draft_input.planning_seq_lens_cpu is not None:
-            model_worker_batch.seq_lens_cpu = draft_input.planning_seq_lens_cpu
-            model_worker_batch.seq_lens_sum = int(draft_input.planning_seq_lens_sum)
-        elif draft_input.reserved_seq_lens_cpu is not None:
-            model_worker_batch.seq_lens_cpu = draft_input.reserved_seq_lens_cpu
-            model_worker_batch.seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
+        can_run_dp_cuda_graph_backup = model_worker_batch.can_run_dp_cuda_graph
+        model_worker_batch.can_run_dp_cuda_graph = False
+        try:
+            if draft_input.committed_seq_lens_cpu is not None:
+                model_worker_batch.seq_lens = prefix_lens
+                model_worker_batch.seq_lens_cpu = draft_input.committed_seq_lens_cpu
+                model_worker_batch.seq_lens_sum = int(
+                    draft_input.committed_seq_lens_cpu.sum().item()
+                )
 
-        verify_forward_batch, _ = verify_input.prepare_for_v2_verify(
-            model_worker_batch, self.target_worker
-        )
-        model_worker_batch.seq_lens_cpu = seq_lens_cpu_backup
-        model_worker_batch.seq_lens_sum = seq_lens_sum_backup
+            verify_forward_batch, _ = verify_input.prepare_for_v2_verify(
+                model_worker_batch, self.target_worker
+            )
+            local_verify_num_tokens = bs * int(self.block_size)
+            self._prepare_dp_attention_dflash_verify_batch(
+                verify_forward_batch, local_num_tokens=local_verify_num_tokens
+            )
 
-        target_out = self.target_worker.forward_batch_generation(
-            batch=None,
-            forward_batch=verify_forward_batch,
-            is_verify=True,
-            skip_attn_backend_init=True,
-        )
+            self._sync_dp_attention_target_verify()
+            try:
+                target_out = self.target_worker.forward_batch_generation(
+                    batch=None,
+                    forward_batch=verify_forward_batch,
+                    is_verify=True,
+                )
+            finally:
+                self._free_dp_attention_dflash_verify_padding(verify_forward_batch)
+            self._sync_dp_attention_target_verify()
+        finally:
+            model_worker_batch.can_run_dp_cuda_graph = can_run_dp_cuda_graph_backup
         logits_output = target_out.logits_output
         can_run_cuda_graph = target_out.can_run_cuda_graph
 
@@ -625,6 +843,24 @@ class DFlashWorkerV2(DFlashWorker):
                     1, accept_len.to(torch.int64)[:, None], bonus[:, None]
                 )
 
+        remaining_lens_cpu = [
+            max(req.sampling_params.max_new_tokens - len(req.output_ids), 0)
+            for req in model_worker_batch.reqs
+        ]
+        remaining_lens = torch.tensor(
+            remaining_lens_cpu, dtype=commit_lens.dtype, device=device
+        )
+        commit_lens = torch.minimum(commit_lens, remaining_lens)
+        commit_lens_cpu = commit_lens.detach().to(device="cpu", dtype=torch.int64)
+        if self._should_clamp_dp_attention_commit_lens(bs, commit_lens_cpu):
+            # Keep DFLASH target-verify progress shape-symmetric across DP ranks.
+            # Rank-local multi-token accepts can otherwise leave one scheduler in
+            # a different next-step state than its DP peers.
+            commit_lens.clamp_(max=1)
+            commit_lens_cpu.clamp_(max=1)
+        if new_seq_lens is not None:
+            new_seq_lens = prefix_lens + commit_lens.to(prefix_lens.dtype)
+
         if need_mamba_verify_commit:
             assert seq_lens_pre_verify is not None
             self._update_target_mamba_state_after_verify(
@@ -633,6 +869,11 @@ class DFlashWorkerV2(DFlashWorker):
                 commit_lens=commit_lens,
             )
 
+        committed_seq_lens_cpu = (
+            model_worker_batch.seq_lens_cpu.to(dtype=torch.int64) + commit_lens_cpu
+            if model_worker_batch.seq_lens_cpu is not None
+            else None
+        )
         if new_seq_lens is None:
             new_seq_lens = prefix_lens + commit_lens.to(prefix_lens.dtype)
         if on_publish is not None:
@@ -660,6 +901,7 @@ class DFlashWorkerV2(DFlashWorker):
         next_draft_input = self._make_next_draft_input_decode(
             verified_id=bonus,
             new_seq_lens=new_seq_lens,
+            committed_seq_lens_cpu=committed_seq_lens_cpu,
             cur_allocated_seq_lens_cpu=draft_input.reserved_seq_lens_cpu,
         )
         verify_done = torch.get_device_module(device).Event()

--- a/test/registered/spec/dflash/test_dflash.py
+++ b/test/registered/spec/dflash/test_dflash.py
@@ -21,6 +21,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=302, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=360, stage="extra-b", runner_config="2-gpu-large")
 
 
 class TestDFlashServerBase(CustomTestCase, MatchedStopMixin, GSM8KMixin):
@@ -155,6 +156,57 @@ class TestDFlashServerSpecV2(TestDFlashServerBase):
 
 class TestDFlashServerSpecV2PlanStream(TestDFlashServerSpecV2):
     overlap_plan_stream = True
+
+
+class TestDFlashServerSpecV2DPAttention(TestDFlashServerSpecV2):
+    model = "Qwen/Qwen3-8B"
+    draft_model = "z-lab/Qwen3-8B-DFlash-b16"
+    max_running_requests = 16
+    other_launch_args = [
+        "--tp-size",
+        "2",
+        "--dp-size",
+        "2",
+        "--enable-dp-attention",
+        "--mem-fraction-static",
+        "0.8",
+    ]
+
+    def test_finish_stop_eos(self):
+        qwen_format_prompt = """\
+<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+What is 2 + 2?<|im_end|>
+<|im_start|>assistant
+"""
+        qwen_eos_token_ids = [151643, 151645]
+        self._run_completions_generation(
+            prompt=qwen_format_prompt,
+            max_tokens=1000,
+            finish_reason="stop",
+            matched_stop=qwen_eos_token_ids,
+        )
+        self._run_chat_completions_generation(
+            prompt="What is 2 + 2?",
+            max_tokens=1000,
+            finish_reason="stop",
+            matched_stop=qwen_eos_token_ids,
+        )
+
+    @unittest.skip(
+        "Qwen DP-attention coverage is a distributed DFLASH smoke; "
+        "GSM8K accuracy is covered by the base DFLASH classes."
+    )
+    def test_gsm8k(self):
+        pass
+
+    @unittest.skip(
+        "Qwen DP-attention coverage is a distributed DFLASH smoke; "
+        "radix stress is covered by the base DFLASH spec-v2 class."
+    )
+    def test_radix_attention(self):
+        pass
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -662,6 +662,31 @@ class TestCutedslMoeMaxNumTokens(unittest.TestCase):
         self.assertEqual(args.cutedsl_moe_max_num_tokens(), 512)
 
 
+class TestDFlashServerArgs(unittest.TestCase):
+    def test_dflash_allows_dp_attention(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            speculative_algorithm="DFLASH",
+            speculative_draft_model_path="dummy-draft",
+            speculative_num_draft_tokens=4,
+            tp_size=2,
+            dp_size=2,
+            enable_dp_attention=True,
+        )
+        with patch(
+            "sglang.srt.utils.hf_transformers_utils.get_config",
+            return_value=MagicMock(architectures=[]),
+        ):
+            handle_speculative_decoding(server_args)
+
+        self.assertEqual(server_args.speculative_algorithm, "DFLASH")
+        self.assertTrue(server_args.enable_dp_attention)
+        self.assertEqual(server_args.speculative_num_steps, 1)
+        self.assertEqual(server_args.speculative_eagle_topk, 1)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 4)
+        self.assertTrue(server_args.enable_dp_attention_local_control_broadcast)
+
+
 class TestSamplingBackendTokenOracleEnvGate(CustomTestCase):
     """The 'token_oracle' choice is gated on SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE.
 


### PR DESCRIPTION
## Summary
- enable DFLASH spec-v2 target verify to run with DP attention by preparing symmetric active/idle verify batches
- add DP-attention token metadata/padding support around DFLASH verify forwards
- synchronize DFLASH commit vectors across DP ranks before allowing multi-token accepts, preventing rank-local progress divergence
- add Qwen3-8B DFLASH + DP-attention smoke coverage and server-args validation

This PR is stacked on David Wang's DFLASH spec-v2 work in #23000, with base branch `dcw02/dflash-spec-v2`.

## Testing
- `python3 -m py_compile python/sglang/srt/speculative/dflash_worker_v2.py python/sglang/srt/speculative/dflash_worker.py python/sglang/srt/model_executor/forward_batch_info.py python/sglang/srt/model_executor/model_runner.py python/sglang/srt/speculative/dflash_info.py python/sglang/srt/speculative/dflash_info_v2.py`
- `git diff --check`
- `python3 -m ruff check --select F841 python/sglang/srt/speculative/dflash_worker.py python/sglang/srt/speculative/dflash_worker_v2.py`
- H200 pj job: `python3 -m unittest test.registered.spec.dflash.test_dflash.TestDFlashServerSpecV2DPAttention` with Qwen/Qwen3-8B + z-lab/Qwen3-8B-DFlash-b16: 9 tests OK, 2 skipped
- H200 pj job: `python3 test/registered/unit/server_args/test_server_args.py`: 57 tests OK
- H200 pj job raw uneven DP-attention repro with Qwen3-8B returned HTTP 200 without hanging

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->