### PR TITLE
[Docker] Force-reinstall nvidia-cutlass-dsl-libs-cu13 after torch for CUDA 13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -247,6 +247,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
                torch torchvision torchaudio --force-reinstall; \
            python3 -m pip install https://github.com/sgl-project/whl/releases/download/v${SGL_DEEP_GEMM_VERSION}/sgl_deep_gemm-${SGL_DEEP_GEMM_VERSION}+cu129-py3-none-manylinux2014_$(uname -m).whl --force-reinstall; \
        fi \
+    && if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+           CUTLASS_DSL_VERSION=$(pip show nvidia-cutlass-dsl 2>/dev/null | awk '/^Version:/{print $2}') && \
+           if [ -n "$CUTLASS_DSL_VERSION" ]; then \
+               python3 -m pip install --force-reinstall --no-deps \
+                   "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}"; \
+           fi; \
+       fi \
     && cd /sgl-workspace \
     && rm -rf /tmp/sglang_deps \
     && pip freeze | grep -v "^sglang==" > /sgl-workspace/constraints.txt


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When building the Docker image with `CUDA_VERSION=13.x`, the torch force-reinstall step (line 246-247) can overwrite `nvidia-cutlass-dsl-libs-cu13` files with mismatched versions from `-libs-base`. The two wheels (`-libs-base` and `-libs-cu13`) ship intentionally different content for the same paths:
- `cutlass/_mlir/dialects/_gpu_ops_gen.py`
- `cutlass/_mlir/_mlir_libs/_cutlass_ir.cpython-*.so`

If install order leaves the `.py` from one wheel and the `.so` from the other, `GPUModuleOp.__init__` raises:
```
TypeError: __init__(): incompatible function arguments.
```
at kernel-compile time during FlashInfer's `rmsnorm_cute` → `cute.compile()` → CUTLASS DSL MLIR generation during CUDA graph capture.

The CI already has this fix in `scripts/ci/cuda/ci_install_dependency.sh` (`force_reinstall_cutlass_dsl_libs_cu13` from #25958), but the Dockerfile is missing it — affecting users who build the Docker image directly.

## Modifications

- `docker/Dockerfile`: Added `nvidia-cutlass-dsl-libs-cu13` force-reinstall for CUDA 13.x after the torch reinstall, version-locked to the installed `nvidia-cutlass-dsl` version.

## Checklist

- [x] Format: `[Docker]` prefix in title
- [x] Scope: Single-file change, minimal diff
- [x] Backward compat: No-op for CUDA 12.x builds (guarded by version check)
- [x] Matches existing pattern: Same logic as `force_reinstall_cutlass_dsl_libs_cu13()` in CI scripts



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27228276635](https://github.com/sgl-project/sglang/actions/runs/27228276635)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27228275842](https://github.com/sgl-project/sglang/actions/runs/27228275842)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->