### PR TITLE
[AMD] Register JIT kernel unit tests for AMD CI (first batch)

### DIFF
--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -10,10 +10,11 @@ from sglang.jit_kernel.activation import (
     run_activation,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=20, suite="jit-kernel-unit-test-amd")
 
 
 OPS = SUPPORTED_ACTIVATIONS

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -23,10 +23,11 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=16, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 configs = list(
     itertools.product(


### PR DESCRIPTION
## Summary

Register two JIT kernel unit tests for AMD via `register_amd_ci(suite="jit-kernel-unit-test-amd")`, alongside the existing `register_cuda_ci`. CUDA registrations are unchanged.

- `test/registered/jit/test_activation.py`
- `test/registered/jit/test_per_token_group_quant_8bit.py`

## Motivation

#27644 moved the JIT kernel tests + benchmarks into `test/registered/jit/` and registered them for **CUDA** — but AMD only has 4 registrations there. AMD's kernel tests otherwise run through a **hardcoded `pytest` list** in the `sgl-kernel-unit-test-amd` job, which is invisible to the `test/registered/` coverage tooling (`ci_coverage_report.py`) and doesn't benefit from LPT auto-partitioning or `run_suite` features.

This is a small **first step** toward bringing AMD kernel tests into the unified registration system, the same way #27644 did for CUDA.

## Why these two files first

- **`test_activation.py`** — AMD already runs an activation kernel test in the `sgl-kernel-unit-test-amd` job, so this kernel path is exercised on ROCm today.
- **`test_per_token_group_quant_8bit.py`** — the test is already ROCm-aware: `_is_hip = is_hip(); fp8_type_ = torch.float8_e4m3fnuz if _is_hip else torch.float8_e4m3fn`. It's written to run on both backends.

## Verification

Parsed locally with `ci_register.ut_parse_one_file`:
- Both files parse with **CUDA + AMD** backends.
- `jit-kernel-unit-test-amd` grows **4 → 6**.
- Both have a runnable `if __name__ == "__main__":` block.

## Question for maintainers

The broader opportunity is to migrate AMD's ~45 `sgl-kernel/tests/` files (currently a hardcoded `pytest` list in `sgl-kernel-unit-test-amd`) into the registered system and run them via `run_suite`, mirroring #27644. Before doing that larger migration, I'd appreciate guidance on:
1. Whether registering AMD against the JIT kernel tests (this PR's approach) is preferred, vs. migrating the AOT `sgl-kernel/tests/` suite.
2. Which JIT kernels have validated ROCm support (so the next batch only registers ones expected to pass).

CI on this PR will confirm whether these two pass on the AMD runners.

## Test plan

- [ ] AMD `jit-kernel-unit-test-amd` runs `test_activation.py` and `test_per_token_group_quant_8bit.py` and they pass.
- [ ] CUDA `base-b-kernel-unit-1-gpu-large` / `nightly-kernel-1-gpu` behavior unchanged.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27236412733](https://github.com/sgl-project/sglang/actions/runs/27236412733)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27236412543](https://github.com/sgl-project/sglang/actions/runs/27236412543)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->