### PR TITLE
[sglang-miles] RDT/NIXL weight sync support for Ray scheduler actors

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -123,7 +123,7 @@ diffusion = [
 ]
 
 ray = [
-  "ray[default]>=2.55.1",
+  "ray[default]>=2.56.0",
 ]
 
 tracing = [

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -802,10 +802,7 @@ class Engine(EngineScoreMixin, EngineBase):
 
         # Start the engine info bootstrap server if per-rank info is needed.
         engine_info_bootstrap_server = None
-        if (
-            server_args.remote_instance_weight_loader_start_seed_via_transfer_engine
-            and server_args.node_rank == 0
-        ):
+        if server_args.needs_engine_info_bootstrap() and server_args.node_rank == 0:
             bootstrap_port = server_args.engine_info_bootstrap_port
             if not is_port_available(bootstrap_port):
                 raise RuntimeError(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -610,6 +610,7 @@ class ModelRunner:
     def maybe_init_remote_instance_transfer_engine(self):
         if self.server_args.remote_instance_weight_loader_use_transfer_engine():
             self.remote_instance_weight_transporter.init_engine()
+        self.remote_instance_weight_transporter.maybe_init_parallelism_config()
 
     def maybe_init_expert_location_metadata(self):
         if self.is_draft_worker:

--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -53,9 +53,15 @@ class RemoteInstanceWeightTransporter:
         self.session_id = NetworkAddress(
             local_ip, self.engine.get_rpc_port()
         ).to_host_port_str()
-        self.parallelism_config = RankParallelismConfig.from_parallel_state(
-            self.tp_rank
-        )
+
+    def maybe_init_parallelism_config(self) -> None:
+        # Compute the per-rank parallelism config whenever it will be published to
+        # the bootstrap server (transfer engine, or RDT/NIXL which needs it without
+        # one).
+        if self.server_args.registers_parallelism_config():
+            self.parallelism_config = RankParallelismConfig.from_parallel_state(
+                self.tp_rank
+            )
 
     def maybe_register_and_publish_weight_info(self) -> None:
         if (
@@ -75,7 +81,7 @@ class RemoteInstanceWeightTransporter:
         # The P2P weight-update client needs each rank's parallelism layout to
         # map training-side parameters onto this rank's shards.
         if (
-            self.server_args.remote_instance_weight_loader_use_transfer_engine()
+            self.server_args.registers_parallelism_config()
             and self.parallelism_config is not None
         ):
             self._register_parallelism_config_to_bootstrap()

--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -55,9 +55,6 @@ class RemoteInstanceWeightTransporter:
         ).to_host_port_str()
 
     def maybe_init_parallelism_config(self) -> None:
-        # Compute the per-rank parallelism config whenever it will be published to
-        # the bootstrap server (transfer engine, or RDT/NIXL which needs it without
-        # one).
         if self.server_args.registers_parallelism_config():
             self.parallelism_config = RankParallelismConfig.from_parallel_state(
                 self.tp_rank

--- a/python/sglang/srt/ray/__init__.py
+++ b/python/sglang/srt/ray/__init__.py
@@ -1,3 +1,3 @@
-from sglang.srt.ray.engine import RayEngine
+from sglang.srt.ray.engine import RayEngine, get_scheduler_actor_name
 
-__all__ = ["RayEngine"]
+__all__ = ["RayEngine", "get_scheduler_actor_name"]

--- a/python/sglang/srt/ray/__init__.py
+++ b/python/sglang/srt/ray/__init__.py
@@ -1,3 +1,4 @@
-from sglang.srt.ray.engine import RayEngine, get_scheduler_actor_name
+from sglang.srt.ray.engine import RayEngine
+from sglang.srt.ray.http_server import launch_engine, launch_server, serve_http
 
-__all__ = ["RayEngine", "get_scheduler_actor_name"]
+__all__ = ["RayEngine", "launch_engine", "launch_server", "serve_http"]

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -203,11 +203,31 @@ def _create_scheduler_actor(
     return SchedulerActor.options(
         num_cpus=0,
         num_gpus=1,
+        # run_event_loop() blocks its worker thread for the actor's lifetime; allow
+        # extra threads so a concurrent pull_weights() (RDT weight sync) is not
+        # starved. Safe because generation is paused during the pull.
+        max_concurrency=4,
+        # The http `port` is unique per engine and known to the trainer, so it lets
+        # RDT discover this engine's scheduler actors by name (ray list_named_actors)
+        # without an HTTP round-trip, even when several engines share one node.
         name=(
             f"sglang_scheduler_node{rank0_node_ip}"
             f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
-            f"_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
+            f"_port{server_args.port}_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
         ),
+        # Detached so the trainer (a different Ray driver/job) can discover these via
+        # list_named_actors / get_actor for RDT pull_weights. Non-detached named
+        # actors are not listed cross-job. RayEngine.shutdown ray.kills them, so they
+        # don't leak past the engine's lifetime.
+        lifetime="detached",
+        # scheduler_actor uses the absolute GPU id from get_accelerator_ids(); that
+        # requires Ray NOT to remap CUDA_VISIBLE_DEVICES (else set_device(absolute)
+        # -> invalid device ordinal). The trainer job sets this in its runtime_env,
+        # but these actors are created by the sglang subprocess's job, so set it on
+        # the actor directly.
+        runtime_env={
+            "env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}
+        },
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=pg,
             placement_group_bundle_index=bundle_idx,

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -200,13 +200,15 @@ def _create_scheduler_actor(
         server_args, tp_rank
     )
 
+    rdt = server_args.enable_rdt_weight_sync
+
     return SchedulerActor.options(
         num_cpus=0,
         num_gpus=1,
         # run_event_loop() blocks its worker thread for the actor's lifetime; allow
-        # extra threads so a concurrent pull_weights() (RDT weight sync) is not
+        # one extra thread so a concurrent pull_weights() (RDT weight sync) is not
         # starved. Safe because generation is paused during the pull.
-        max_concurrency=4,
+        max_concurrency=2 if rdt else 1,
         # The http `port` is unique per engine and known to the trainer, so it lets
         # RDT discover this engine's scheduler actors by name (ray list_named_actors)
         # without an HTTP round-trip, even when several engines share one node.
@@ -219,15 +221,13 @@ def _create_scheduler_actor(
         # list_named_actors / get_actor for RDT pull_weights. Non-detached named
         # actors are not listed cross-job. RayEngine.shutdown ray.kills them, so they
         # don't leak past the engine's lifetime.
-        lifetime="detached",
+        lifetime="detached" if rdt else None,
         # scheduler_actor uses the absolute GPU id from get_accelerator_ids(); that
         # requires Ray NOT to remap CUDA_VISIBLE_DEVICES (else set_device(absolute)
         # -> invalid device ordinal). The trainer job sets this in its runtime_env,
         # but these actors are created by the sglang subprocess's job, so set it on
         # the actor directly.
-        runtime_env={
-            "env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}
-        },
+        runtime_env={"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}},
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=pg,
             placement_group_bundle_index=bundle_idx,

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -15,9 +15,11 @@
 
 from __future__ import annotations
 
+import contextvars
 import dataclasses
 import logging
 import threading
+from contextlib import contextmanager
 from typing import Callable, List, Optional
 
 import ray
@@ -35,6 +37,20 @@ from sglang.srt.ray.scheduler_actor import SchedulerActor
 from sglang.srt.server_args import PortArgs, ServerArgs
 
 logger = logging.getLogger(__name__)
+
+_caller_placement_group: contextvars.ContextVar[Optional[PlacementGroup]] = (
+    contextvars.ContextVar("sglang_ray_caller_placement_group", default=None)
+)
+
+
+@contextmanager
+def _placement_group_context(placement_group: Optional[PlacementGroup]):
+    """Expose launch-only state while Engine synchronously starts schedulers."""
+    token = _caller_placement_group.set(placement_group)
+    try:
+        yield
+    finally:
+        _caller_placement_group.reset(token)
 
 
 @dataclasses.dataclass
@@ -254,15 +270,17 @@ def _create_scheduler_actor(
 
 
 class RayEngine(Engine):
-    """Engine using Ray actors for scheduler processes."""
+    """Engine using Ray actors for scheduler processes.
 
-    def __init__(self, **kwargs):
-        placement_group = kwargs.pop("placement_group", None)
-        if "log_level" not in kwargs:
-            kwargs["log_level"] = "error"
-        server_args = ServerArgs(**kwargs)
-        server_args.override("ray.placement_group", placement_group=placement_group)
-        super().__init__(server_args=server_args)
+    Same constructor kwargs as :class:`Engine`, plus ``placement_group`` (a Ray
+    PlacementGroup handle, not a ServerArgs field).
+    """
+
+    def __init__(
+        self, *, placement_group: Optional[PlacementGroup] = None, **kwargs
+    ):
+        with _placement_group_context(placement_group):
+            super().__init__(**kwargs)
 
     def shutdown(self):
         """Shutdown the engine — kill Ray scheduler actors then local processes."""
@@ -286,7 +304,8 @@ class RayEngine(Engine):
             Tuple of (RaySchedulerInitResult, None).
             scheduler_procs is None since Ray uses actors instead of mp.Process.
         """
-        pg = server_args.placement_group or ray.util.get_current_placement_group()
+        placement_group = _caller_placement_group.get()
+        pg = placement_group or ray.util.get_current_placement_group()
         if pg is None:
             from ray.util.placement_group import (
                 placement_group as create_placement_group,
@@ -315,7 +334,7 @@ class RayEngine(Engine):
             )
             ray.get(pg.ready())
 
-        is_custom_pg = server_args.placement_group is not None
+        is_custom_pg = placement_group is not None
         nnodes = server_args.nnodes
         world_size = _compute_world_size(server_args)
 
@@ -451,6 +470,7 @@ class RayEngine(Engine):
                     pg,
                     bundle_for_node,
                     rank0_node_ip,
+                    is_custom_pg,
                 ),
                 None,
             )
@@ -463,6 +483,7 @@ class RayEngine(Engine):
         pg,
         bundle_for_node: Optional[List[int]],
         rank0_node_ip: str,
+        is_custom_pg: bool = False,
     ) -> RaySchedulerInitResult:
         """Launch DP schedulers via RayDataParallelController."""
         from sglang.srt.ray.data_parallel_controller import (
@@ -488,16 +509,16 @@ class RayEngine(Engine):
             server_args,
             dist_init_addr=f"{rank0_node_ip}:{port_args.nccl_port}",
         )
-        # dataclasses.replace only copies declared fields; placement_group is
-        # a dynamic attribute that must be manually appended after the rebuild.
-        dp_server_args.override(
-            "ray.placement_group", placement_group=server_args.placement_group
-        )
 
         # Create the DP controller in-process. This blocks until all actors
         # are initialized and their event loops have started.
         controller = RayDataParallelController(
-            dp_server_args, port_args, pg, bundle_for_node, rank0_node_ip
+            dp_server_args,
+            port_args,
+            pg,
+            bundle_for_node,
+            rank0_node_ip,
+            is_custom_pg,
         )
 
         # Start the DP controller's event loop in a daemon thread.

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -276,9 +276,7 @@ class RayEngine(Engine):
     PlacementGroup handle, not a ServerArgs field).
     """
 
-    def __init__(
-        self, *, placement_group: Optional[PlacementGroup] = None, **kwargs
-    ):
+    def __init__(self, *, placement_group: Optional[PlacementGroup] = None, **kwargs):
         with _placement_group_context(placement_group):
             super().__init__(**kwargs)
 

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -175,6 +175,23 @@ def _validate_custom_placement_group(pg: PlacementGroup, world_size: int) -> Non
         )
 
 
+def get_scheduler_actor_name(
+    *,
+    rank0_node_ip: str,
+    dp_rank: int,
+    pp_rank: int,
+    tp_rank: int,
+    port: int,
+    bundle_idx: int,
+) -> str:
+    """Return the Ray actor name for a SchedulerActor. Can be used to retrive scheduler ray actors"""
+    return (
+        f"sglang_scheduler_node{rank0_node_ip}"
+        f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
+        f"_port{port}_bundle{bundle_idx}"
+    )
+
+
 def _create_scheduler_actor(
     pg: PlacementGroup,
     bundle_idx: int,
@@ -208,12 +225,13 @@ def _create_scheduler_actor(
         # run_event_loop() blocks one thread for the actor's lifetime; leave a spare
         # for pull_weights, which the trainer calls while generation is paused.
         max_concurrency=2 if rdt else 1,
-        # The http `port` disambiguates engines co-located on one node, letting the
-        # trainer find these actors via list_named_actors.
-        name=(
-            f"sglang_scheduler_node{rank0_node_ip}"
-            f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
-            f"_port{server_args.port}_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
+        name=get_scheduler_actor_name(
+            rank0_node_ip=rank0_node_ip,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
+            tp_rank=tp_rank,
+            port=server_args.port,
+            bundle_idx=bundle_idx,
         ),
         # Non-detached named actors are not listed cross-job, so the trainer (a
         # separate Ray job) could not discover them. RayEngine.shutdown kills these.

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -181,14 +181,13 @@ def get_scheduler_actor_name(
     dp_rank: int,
     pp_rank: int,
     tp_rank: int,
-    port: int,
+    pg_id_hex: str,
     bundle_idx: int,
 ) -> str:
-    """Return the Ray actor name for a SchedulerActor. Can be used to retrive scheduler ray actors"""
     return (
         f"sglang_scheduler_node{rank0_node_ip}"
         f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
-        f"_port{port}_bundle{bundle_idx}"
+        f"_pg{pg_id_hex}_bundle{bundle_idx}"
     )
 
 
@@ -230,12 +229,9 @@ def _create_scheduler_actor(
             dp_rank=dp_rank,
             pp_rank=pp_rank,
             tp_rank=tp_rank,
-            port=server_args.port,
+            pg_id_hex=pg.id.hex()[:8],
             bundle_idx=bundle_idx,
         ),
-        # Non-detached named actors are not listed cross-job, so the trainer (a
-        # separate Ray job) could not discover them. RayEngine.shutdown kills these.
-        lifetime="detached" if rdt else None,
         # SchedulerActor calls set_device() with the absolute id from
         # get_accelerator_ids(), which is only valid if Ray leaves the mask alone.
         runtime_env={"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}},

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -205,28 +205,21 @@ def _create_scheduler_actor(
     return SchedulerActor.options(
         num_cpus=0,
         num_gpus=1,
-        # run_event_loop() blocks its worker thread for the actor's lifetime; allow
-        # one extra thread so a concurrent pull_weights() (RDT weight sync) is not
-        # starved. Safe because generation is paused during the pull.
+        # run_event_loop() blocks one thread for the actor's lifetime; leave a spare
+        # for pull_weights, which the trainer calls while generation is paused.
         max_concurrency=2 if rdt else 1,
-        # The http `port` is unique per engine and known to the trainer, so it lets
-        # RDT discover this engine's scheduler actors by name (ray list_named_actors)
-        # without an HTTP round-trip, even when several engines share one node.
+        # The http `port` disambiguates engines co-located on one node, letting the
+        # trainer find these actors via list_named_actors.
         name=(
             f"sglang_scheduler_node{rank0_node_ip}"
             f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
             f"_port{server_args.port}_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
         ),
-        # Detached so the trainer (a different Ray driver/job) can discover these via
-        # list_named_actors / get_actor for RDT pull_weights. Non-detached named
-        # actors are not listed cross-job. RayEngine.shutdown ray.kills them, so they
-        # don't leak past the engine's lifetime.
+        # Non-detached named actors are not listed cross-job, so the trainer (a
+        # separate Ray job) could not discover them. RayEngine.shutdown kills these.
         lifetime="detached" if rdt else None,
-        # scheduler_actor uses the absolute GPU id from get_accelerator_ids(); that
-        # requires Ray NOT to remap CUDA_VISIBLE_DEVICES (else set_device(absolute)
-        # -> invalid device ordinal). The trainer job sets this in its runtime_env,
-        # but these actors are created by the sglang subprocess's job, so set it on
-        # the actor directly.
+        # SchedulerActor calls set_device() with the absolute id from
+        # get_accelerator_ids(), which is only valid if Ray leaves the mask alone.
         runtime_env={"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}},
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=pg,

--- a/python/sglang/srt/ray/http_server.py
+++ b/python/sglang/srt/ray/http_server.py
@@ -29,16 +29,8 @@ def launch_engine(
     run_scheduler_process_func: Callable = run_scheduler_process,
     run_detokenizer_process_func: Callable = run_detokenizer_process,
 ):
-    """Create RayEngine subprocesses / SchedulerActors. Does not start HTTP.
-
-    Returns the ``_launch_subprocesses`` 5-tuple:
-    ``(tokenizer_manager, template_manager, port_args, scheduler_init_result,
-    subprocess_watchdog)``. ``scheduler_init_result.scheduler_actors`` are the
-    SchedulerActor handles.
-    """
+    """Create RayEngine subprocesses / SchedulerActors."""
     from sglang.srt.ray.engine import RayEngine
-
-    server_args.override("ray.http_server.clear_placement_group", placement_group=None)
 
     return RayEngine._launch_subprocesses(
         server_args,

--- a/python/sglang/srt/ray/http_server.py
+++ b/python/sglang/srt/ray/http_server.py
@@ -15,14 +15,72 @@
 
 from typing import Callable, Optional
 
-import ray
-
 from sglang.srt.entrypoints.engine import (
     init_tokenizer_manager,
     run_detokenizer_process,
     run_scheduler_process,
 )
 from sglang.srt.server_args import ServerArgs
+
+
+def launch_engine(
+    server_args: ServerArgs,
+    init_tokenizer_manager_func: Callable = init_tokenizer_manager,
+    run_scheduler_process_func: Callable = run_scheduler_process,
+    run_detokenizer_process_func: Callable = run_detokenizer_process,
+):
+    """Create RayEngine subprocesses / SchedulerActors. Does not start HTTP.
+
+    Returns the ``_launch_subprocesses`` 5-tuple:
+    ``(tokenizer_manager, template_manager, port_args, scheduler_init_result,
+    subprocess_watchdog)``. ``scheduler_init_result.scheduler_actors`` are the
+    SchedulerActor handles.
+    """
+    from sglang.srt.ray.engine import RayEngine
+
+    server_args.override("ray.http_server.clear_placement_group", placement_group=None)
+
+    return RayEngine._launch_subprocesses(
+        server_args,
+        init_tokenizer_manager_func=init_tokenizer_manager_func,
+        run_scheduler_process_func=run_scheduler_process_func,
+        run_detokenizer_process_func=run_detokenizer_process_func,
+    )
+
+
+def serve_http(
+    engine,
+    server_args: ServerArgs,
+    execute_warmup_func: Optional[Callable] = None,
+    launch_callback: Optional[Callable[[], None]] = None,
+):
+    """Block in uvicorn. ``engine`` is the 5-tuple from ``launch_engine``."""
+    from sglang.srt.entrypoints.http_server import (
+        _execute_server_warmup,
+        _setup_and_run_http_server,
+    )
+
+    if execute_warmup_func is None:
+        execute_warmup_func = _execute_server_warmup
+
+    (
+        tokenizer_manager,
+        template_manager,
+        port_args,
+        scheduler_init_result,
+        subprocess_watchdog,
+    ) = engine
+
+    _setup_and_run_http_server(
+        server_args,
+        tokenizer_manager,
+        template_manager,
+        port_args,
+        scheduler_init_result.scheduler_infos,
+        subprocess_watchdog,
+        execute_warmup_func=execute_warmup_func,
+        launch_callback=launch_callback,
+    )
 
 
 def launch_server(
@@ -37,47 +95,14 @@ def launch_server(
 
     Mirrors http_server.launch_server() but uses RayEngine for scheduler launching.
     """
-    from sglang.srt.entrypoints.http_server import (
-        _execute_server_warmup,
-        _setup_and_run_http_server,
-    )
-    from sglang.srt.ray.engine import RayEngine
-
-    if execute_warmup_func is None:
-        execute_warmup_func = _execute_server_warmup
-
-    placement_group = getattr(server_args, "placement_group", None)
-    if placement_group is not None and not ray.is_initialized():
-        ray.init(
-            address="auto",
-            runtime_env=getattr(server_args, "ray_runtime_env", None),
-            namespace=getattr(server_args, "ray_namespace", None),
-        )
-    server_args.override(
-        "ray.http_server.placement_group",
-        placement_group=placement_group,
-    )
-
-    (
-        tokenizer_manager,
-        template_manager,
-        port_args,
-        scheduler_init_result,
-        subprocess_watchdog,
-    ) = RayEngine._launch_subprocesses(
+    serve_http(
+        launch_engine(
+            server_args,
+            init_tokenizer_manager_func=init_tokenizer_manager_func,
+            run_scheduler_process_func=run_scheduler_process_func,
+            run_detokenizer_process_func=run_detokenizer_process_func,
+        ),
         server_args,
-        init_tokenizer_manager_func=init_tokenizer_manager_func,
-        run_scheduler_process_func=run_scheduler_process_func,
-        run_detokenizer_process_func=run_detokenizer_process_func,
-    )
-
-    _setup_and_run_http_server(
-        server_args,
-        tokenizer_manager,
-        template_manager,
-        port_args,
-        scheduler_init_result.scheduler_infos,
-        subprocess_watchdog,
         execute_warmup_func=execute_warmup_func,
         launch_callback=launch_callback,
     )

--- a/python/sglang/srt/ray/http_server.py
+++ b/python/sglang/srt/ray/http_server.py
@@ -15,6 +15,8 @@
 
 from typing import Callable, Optional
 
+import ray
+
 from sglang.srt.entrypoints.engine import (
     init_tokenizer_manager,
     run_detokenizer_process,
@@ -44,7 +46,16 @@ def launch_server(
     if execute_warmup_func is None:
         execute_warmup_func = _execute_server_warmup
 
-    server_args.override("ray.http_server.clear_placement_group", placement_group=None)
+    placement_group = getattr(server_args, "placement_group", None)
+    if placement_group is not None and not ray.is_initialized():
+        ray.init(
+            address="auto",
+            runtime_env=getattr(server_args, "ray_runtime_env", None),
+        )
+    server_args.override(
+        "ray.http_server.placement_group",
+        placement_group=placement_group,
+    )
 
     (
         tokenizer_manager,

--- a/python/sglang/srt/ray/http_server.py
+++ b/python/sglang/srt/ray/http_server.py
@@ -15,6 +15,8 @@
 
 from typing import Callable, Optional
 
+from ray.util.placement_group import PlacementGroup
+
 from sglang.srt.entrypoints.engine import (
     init_tokenizer_manager,
     run_detokenizer_process,
@@ -28,16 +30,19 @@ def launch_engine(
     init_tokenizer_manager_func: Callable = init_tokenizer_manager,
     run_scheduler_process_func: Callable = run_scheduler_process,
     run_detokenizer_process_func: Callable = run_detokenizer_process,
+    *,
+    placement_group: Optional[PlacementGroup] = None,
 ):
     """Create RayEngine subprocesses / SchedulerActors."""
-    from sglang.srt.ray.engine import RayEngine
+    from sglang.srt.ray.engine import RayEngine, _placement_group_context
 
-    return RayEngine._launch_subprocesses(
-        server_args,
-        init_tokenizer_manager_func=init_tokenizer_manager_func,
-        run_scheduler_process_func=run_scheduler_process_func,
-        run_detokenizer_process_func=run_detokenizer_process_func,
-    )
+    with _placement_group_context(placement_group):
+        return RayEngine._launch_subprocesses(
+            server_args,
+            init_tokenizer_manager_func=init_tokenizer_manager_func,
+            run_scheduler_process_func=run_scheduler_process_func,
+            run_detokenizer_process_func=run_detokenizer_process_func,
+        )
 
 
 def serve_http(

--- a/python/sglang/srt/ray/http_server.py
+++ b/python/sglang/srt/ray/http_server.py
@@ -51,6 +51,7 @@ def launch_server(
         ray.init(
             address="auto",
             runtime_env=getattr(server_args, "ray_runtime_env", None),
+            namespace=getattr(server_args, "ray_namespace", None),
         )
     server_args.override(
         "ray.http_server.placement_group",

--- a/python/sglang/srt/ray/scheduler_actor.py
+++ b/python/sglang/srt/ray/scheduler_actor.py
@@ -16,9 +16,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import ray
+from ray import ObjectRef
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import PortArgs, ServerArgs
@@ -119,6 +120,23 @@ class SchedulerActor:
     def get_info(self) -> Dict[str, Any]:
         """Return scheduler initialization info for handshake."""
         return self.scheduler.get_init_info()
+
+    def pull_weights(self, weights_refs: List[ObjectRef], param_names: list) -> bool:
+        """Pull pre-sharded weight bucket from trainer via RDT zero-copy.
+
+        Uses set_target_for_ref to RDMA directly into param.data buffers,
+        eliminating intermediate receive buffers and copy operations.
+
+        Have to pass weights_refs as a list to avoid resolving upon calling `pull_weights`
+        """
+        from ray.experimental import set_target_for_ref
+
+        model = self.scheduler.tp_worker.model_runner.model
+        params_dict = dict(model.named_parameters())
+        target_buffers = [params_dict[name].data for name in param_names]
+        set_target_for_ref(weights_refs[0], target_buffers)
+        ray.get(weights_refs[0])
+        return True
 
     def run_event_loop(self) -> None:
         """Run the scheduler's event loop. Blocks until shutdown."""

--- a/python/sglang/srt/ray/scheduler_actor.py
+++ b/python/sglang/srt/ray/scheduler_actor.py
@@ -121,22 +121,24 @@ class SchedulerActor:
         """Return scheduler initialization info for handshake."""
         return self.scheduler.get_init_info()
 
-    def pull_weights(self, weights_refs: List[ObjectRef], param_names: list) -> bool:
-        """Pull pre-sharded weight bucket from trainer via RDT zero-copy.
+    def pull_weights(
+        self, weights_refs: List[ObjectRef], param_names: List[str]
+    ) -> None:
+        """Pull a pre-sharded weight bucket from the trainer via RDT zero-copy.
 
-        Uses set_target_for_ref to RDMA directly into param.data buffers,
-        eliminating intermediate receive buffers and copy operations.
-
-        Have to pass weights_refs as a list to avoid resolving upon calling `pull_weights`
+        ``weights_refs`` is a list so Ray does not resolve the ref on call.
         """
+        import torch
         from ray.experimental import set_target_for_ref
+
+        # Runs on a different thread than run_event_loop, which owns the device binding.
+        torch.cuda.set_device(self.scheduler.ps.gpu_id)
 
         model = self.scheduler.tp_worker.model_runner.model
         params_dict = dict(model.named_parameters())
         target_buffers = [params_dict[name].data for name in param_names]
         set_target_for_ref(weights_refs[0], target_buffers)
         ray.get(weights_refs[0])
-        return True
 
     def run_event_loop(self) -> None:
         """Run the scheduler's event loop. Blocks until shutdown."""

--- a/python/sglang/srt/ray/scheduler_actor.py
+++ b/python/sglang/srt/ray/scheduler_actor.py
@@ -121,6 +121,19 @@ class SchedulerActor:
         """Return scheduler initialization info for handshake."""
         return self.scheduler.get_init_info()
 
+    def register_weight_for_rdt(self) -> None:
+        """Pin model parameters with NIXL for repeated RDT pulls."""
+        if self.scheduler.server_args.enable_memory_saver:
+            return
+
+        import torch
+        from ray.experimental import register_nixl_memory
+
+        torch.cuda.set_device(self.scheduler.ps.gpu_id)
+        model = self.scheduler.tp_worker.model_runner.model
+        for _, param in model.named_parameters():
+            register_nixl_memory(param.data)
+
     def pull_weights(
         self, weights_refs: List[ObjectRef], param_names: List[str]
     ) -> None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2673,6 +2673,10 @@ class ServerArgs:
         bool,
         "Start the EngineInfoBootstrapServer and register per-rank parallelism config WITHOUT the mooncake/verbs P2P transfer-engine seeding. Used by RDT (NIXL) weight sync, which needs /parallelism_config but not P2P memory registration.",
     ] = False
+    enable_rdt_weight_sync: A[
+        bool,
+        "Expose SchedulerActor.pull_weights for RDT (Ray Direct Transport / NIXL) weight sync from an external trainer job. Requires --use-ray; implies --enable-engine-info-bootstrap.",
+    ] = False
     engine_info_bootstrap_port: A[
         int,
         "Port for the engine info bootstrap server. Default is 6789. Must be set explicitly when running multiple instances on the same node.",
@@ -2931,6 +2935,8 @@ class ServerArgs:
         # _handle_model_specific_adjustments never runs.
         self._resolved_overrides = []
 
+        self._handle_rdt_weight_sync()
+
         if self.model_path.lower() in ["none", "dummy"]:
             return
 
@@ -3163,6 +3169,14 @@ class ServerArgs:
             and self.tokenizer_path != self.model_path
         ):
             ObjectStorageModel.download_and_get_path(self.tokenizer_path)
+
+    def _handle_rdt_weight_sync(self):
+        if not self.enable_rdt_weight_sync:
+            return
+        assert (
+            self.use_ray
+        ), "--enable-rdt-weight-sync requires --use-ray: the trainer pulls weights through named SchedulerActors."
+        self.enable_engine_info_bootstrap = True
 
     def _handle_pd_disaggregation(self):
         from sglang.srt.arg_groups.pd_disaggregation_hook import (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2675,7 +2675,7 @@ class ServerArgs:
     ] = False
     enable_rdt_weight_sync: A[
         bool,
-        "Expose SchedulerActor.pull_weights for RDT (Ray Direct Transport / NIXL) weight sync from an external trainer job. Requires --use-ray; implies --enable-engine-info-bootstrap.",
+        "Expose SchedulerActor.pull_weights for RDT (Ray Direct Transport / NIXL) weight sync. Requires --use-ray; implies --enable-engine-info-bootstrap.",
     ] = False
     engine_info_bootstrap_port: A[
         int,
@@ -3175,7 +3175,7 @@ class ServerArgs:
             return
         assert (
             self.use_ray
-        ), "--enable-rdt-weight-sync requires --use-ray: the trainer pulls weights through named SchedulerActors."
+        ), "--enable-rdt-weight-sync requires --use-ray: the trainer pulls weights through SchedulerActors."
         self.enable_engine_info_bootstrap = True
 
     def _handle_pd_disaggregation(self):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2671,7 +2671,7 @@ class ServerArgs:
     ] = False
     enable_engine_info_bootstrap: A[
         bool,
-        "Start the EngineInfoBootstrapServer and register per-rank parallelism config WITHOUT the mooncake/verbs P2P transfer-engine seeding. Used by RDT (NIXL) weight sync, which needs /parallelism_config but not P2P memory registration.",
+        "Start the EngineInfoBootstrapServer and register per-rank parallelism config, without the mooncake/verbs P2P transfer-engine seeding.",
     ] = False
     enable_rdt_weight_sync: A[
         bool,
@@ -8110,18 +8110,14 @@ class ServerArgs:
             return False
 
     def needs_engine_info_bootstrap(self) -> bool:
-        """Host the EngineInfoBootstrapServer on this node (rank 0). True for the
-        transfer-engine seed, and for RDT/NIXL weight sync (which needs the server
-        to expose parallelism config to the trainer, but not the P2P memory seeding)."""
+        """Whether this node (rank 0) hosts the EngineInfoBootstrapServer."""
         return (
             self.remote_instance_weight_loader_start_seed_via_transfer_engine
             or self.enable_engine_info_bootstrap
         )
 
     def registers_parallelism_config(self) -> bool:
-        """Publish this rank's parallelism config to the bootstrap server (hosted
-        locally by the seed, or remotely). True whenever a transfer engine is in use,
-        and for RDT/NIXL weight sync."""
+        """Whether this rank publishes its parallelism config to the bootstrap server."""
         return (
             self.remote_instance_weight_loader_use_transfer_engine()
             or self.enable_engine_info_bootstrap

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2669,6 +2669,10 @@ class ServerArgs:
         bool,
         "Start seed server via transfer engine backend for remote instance weight loader.",
     ] = False
+    enable_engine_info_bootstrap: A[
+        bool,
+        "Start the EngineInfoBootstrapServer and register per-rank parallelism config WITHOUT the mooncake/verbs P2P transfer-engine seeding. Used by RDT (NIXL) weight sync, which needs /parallelism_config but not P2P memory registration.",
+    ] = False
     engine_info_bootstrap_port: A[
         int,
         "Port for the engine info bootstrap server. Default is 6789. Must be set explicitly when running multiple instances on the same node.",
@@ -8090,6 +8094,24 @@ class ServerArgs:
             return True
         else:
             return False
+
+    def needs_engine_info_bootstrap(self) -> bool:
+        """Host the EngineInfoBootstrapServer on this node (rank 0). True for the
+        transfer-engine seed, and for RDT/NIXL weight sync (which needs the server
+        to expose parallelism config to the trainer, but not the P2P memory seeding)."""
+        return (
+            self.remote_instance_weight_loader_start_seed_via_transfer_engine
+            or self.enable_engine_info_bootstrap
+        )
+
+    def registers_parallelism_config(self) -> bool:
+        """Publish this rank's parallelism config to the bootstrap server (hosted
+        locally by the seed, or remotely). True whenever a transfer engine is in use,
+        and for RDT/NIXL weight sync."""
+        return (
+            self.remote_instance_weight_loader_use_transfer_engine()
+            or self.enable_engine_info_bootstrap
+        )
 
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event


### PR DESCRIPTION
## What

sglang-side support for **RDT (Ray Direct Transport / NIXL) weight sync** — lets the [miles](https://github.com/radixark/miles) trainer push RL weights to rollout engines via a zero-copy RDMA pull instead of NCCL broadcast. Paired with the miles-side PR (radixark/miles#1313), which has the perf write-up.

## Changes

- **`ray/scheduler_actor.py`** — add `pull_weights()`, which uses `ray.experimental.set_target_for_ref` to RDMA pre-sharded weight buckets directly into the model's `param.data` buffers (no intermediate receive buffers / copies).
- **`ray/engine.py` + `ray/data_parallel_controller.py`** — register `SchedulerActor`s as **detached** named actors with the http **port** baked into the name, so the trainer (a different Ray job) can discover them via `list_named_actors` even when several engines share a node; raise `max_concurrency` so a concurrent `pull_weights` is not starved while `run_event_loop` blocks; set `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1` so the absolute GPU id from `get_accelerator_ids()` stays valid.
- **`server_args.py`** — add `enable_engine_info_bootstrap` to start the engine-info bootstrap server and register per-rank parallelism config **without** the mooncake/verbs P2P transfer-engine seeding.
- **`entrypoints/engine.py` + `model_executor/model_runner.py`** — honor `enable_engine_info_bootstrap`; make the P2P transfer-engine memory registration non-fatal so EFA/verbs clusters where it fails don't crash the scheduler (RDT only needs the parallelism config).
- **`model_loader/loader.py`** — make `post_load_weights` public so the RDT path can invoke it.
- **`pyproject.toml`** — require `ray>=2.55.1` (`ray.experimental.set_target_for_ref`).

## Notes

Targeting the `sglang-miles` integration branch; rebased onto current `sglang-miles` (#28001, #29339).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32602261107](https://github.com/sgl-project/sglang/actions/runs/32602261107)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32602260844](https://github.com/sgl-project/sglang/actions/runs/32602260844)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->