### PR TITLE
Bump ray minimum version to 2.55.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -116,7 +116,7 @@ diffusion = [
 ]
 
 ray = [
-  "ray[default]>=2.54.0",
+  "ray[default]>=2.55.1",
 ]
 
 tracing = [


### PR DESCRIPTION
Lifts the minimum required Ray version from `>=2.54.0` to `>=2.55.1` to pick up the fixes and improvements in the [ray-2.55.1 release](https://github.com/ray-project/ray/releases/tag/ray-2.55.1).

Particularly to support RDT in the sglang ray backend for weight sync.

## Changes
- `python/pyproject.toml`: `ray[default]>=2.54.0` → `ray[default]>=2.55.1`