### PR TITLE
[kv-events] Surface cache salt on BlockStored.extra_keys

### DIFF
--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -90,6 +90,14 @@ class BlockStored(KVCacheEvent):
     block_size: int
     lora_id: Optional[int]
     medium: Optional[str] = None
+    # Per-block extra classification inputs aligned with ``block_hashes`` (entry
+    # ``i`` belongs to ``block_hashes[i]``), or ``None`` when no block in this
+    # event carries any. Holds the request's ``extra_key`` namespace -- the cache
+    # salt and/or LoRA id -- on the first block of a sequence. This namespace
+    # classifies blocks in the radix tree without changing ``block_hashes``, so
+    # surfacing it here lets prefix-cache-aware routers reconstruct namespaced
+    # block identities.
+    extra_keys: Optional[list[Optional[tuple[str, ...]]]] = None
 
 
 class BlockRemoved(KVCacheEvent):

--- a/python/sglang/srt/mem_cache/events.py
+++ b/python/sglang/srt/mem_cache/events.py
@@ -53,6 +53,14 @@ class KVCacheEventMixin:
                 ):
                     parent_block_hash = hash_str_to_int64(node.parent.hash_value[-1])
 
+            # ``extra_key`` (cache salt and/or LoRA id) namespaces the whole
+            # subtree but is not folded into the block hash, so surface it on the
+            # sequence's first block (the node rooted at the tree root). Later
+            # blocks are not namespaced in the hash, so consumers propagate it
+            # along the parent_block_hash links they reconstruct.
+            extra_key = node.key.extra_key
+            is_first_block_node = node.parent is None or node.parent == self.root_node
+
             page_index = 0
             logical_len = len(node.key)
             is_bigram = node.key.is_bigram
@@ -69,6 +77,10 @@ class KVCacheEventMixin:
 
                 block_hash = hash_str_to_int64(node.hash_value[page_index])
 
+                extra_keys = None
+                if extra_key and is_first_block_node and page_index == 0:
+                    extra_keys = [(extra_key,)]
+
                 self.kv_event_queue.append(
                     BlockStored(
                         block_hashes=[block_hash],
@@ -77,6 +89,7 @@ class KVCacheEventMixin:
                         block_size=len(page_tokens),
                         lora_id=None,
                         medium=medium,
+                        extra_keys=extra_keys,
                     )
                 )
 

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -515,6 +515,79 @@ class TestRadixCache(unittest.TestCase):
         for event in remove_events:
             self.assertGreater(len(event.block_hashes), 0)
 
+    def test_kv_cache_events_extra_keys_on_first_block(self):
+        """extra_key is surfaced on the first BlockStored only, as a 1-tuple."""
+        cache = RadixCache.create_simulated(page_size=4, enable_kv_cache_events=True)
+
+        # Salted sequence spanning two pages.
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", [1, 2, 3, 4, 5, 6, 7, 8]), "salt-A"),
+                value=None,
+            )
+        )
+        salted = [e for e in cache.take_events() if isinstance(e, BlockStored)]
+        self.assertEqual(len(salted), 2)
+        self.assertEqual(salted[0].extra_keys, [("salt-A",)])
+        self.assertIsNone(salted[1].extra_keys)
+
+        # Unsalted sequence: every block omits extra_keys.
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", [9, 10, 11, 12, 13, 14, 15, 16]), None),
+                value=None,
+            )
+        )
+        unsalted = [e for e in cache.take_events() if isinstance(e, BlockStored)]
+        self.assertEqual(len(unsalted), 2)
+        for event in unsalted:
+            self.assertIsNone(event.extra_keys)
+
+    def test_kv_cache_events_salt_not_reemitted_on_shared_prefix(self):
+        """A continuation in the same salt namespace does not re-emit the salt."""
+        cache = RadixCache.create_simulated(page_size=4, enable_kv_cache_events=True)
+
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", [1, 2, 3, 4, 5, 6, 7, 8]), "salt-A"),
+                value=None,
+            )
+        )
+        cache.take_events()  # drain the first-insert events
+
+        # Shares the first page; the diverging leaf is rooted below the shared
+        # node, so it is not a first block and carries no extra_keys.
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", [1, 2, 3, 4, 9, 10, 11, 12]), "salt-A"),
+                value=None,
+            )
+        )
+        events = [e for e in cache.take_events() if isinstance(e, BlockStored)]
+        self.assertGreater(len(events), 0)
+        for event in events:
+            self.assertIsNone(event.extra_keys)
+
+    def test_kv_cache_events_same_tokens_different_salt(self):
+        """Same tokens + different salt collide on block_hash; extra_keys disambiguates."""
+        cache = RadixCache.create_simulated(page_size=4, enable_kv_cache_events=True)
+
+        cache.insert(
+            InsertParams(key=RadixKey(array("q", [1, 2, 3, 4]), "salt-A"), value=None)
+        )
+        a = [e for e in cache.take_events() if isinstance(e, BlockStored)][0]
+
+        cache.insert(
+            InsertParams(key=RadixKey(array("q", [1, 2, 3, 4]), "salt-B"), value=None)
+        )
+        b = [e for e in cache.take_events() if isinstance(e, BlockStored)][0]
+
+        # block_hash does not fold in the salt, so the two collide ...
+        self.assertEqual(a.block_hashes, b.block_hashes)
+        # ... and extra_keys is the only signal that tells them apart.
+        self.assertEqual(a.extra_keys, [("salt-A",)])
+        self.assertEqual(b.extra_keys, [("salt-B",)])
+
     def test_extra_key_isolation(self):
         """Test that keys with different extra_key values are isolated."""
         cache = RadixCache.create_simulated()


### PR DESCRIPTION
## Motivation

SGLang's KV-cache events (`BlockStored`) carry no `extra_keys` field, so the cache salt that SGLang folds into a block's radix-tree namespace is not visible to external KV-event consumers. Prefix-cache-aware routers therefore cannot reconstruct salted block identities from the event stream, and route salted requests as cache-misses.

Closes #27682.

## What this does

Adds an `extra_keys` field to `BlockStored`, populated with the request's `extra_key` namespace (the cache salt and/or LoRA id) on the **first block** of a sequence.

- `disaggregation/kv_events.py`: new `extra_keys: Optional[list[Optional[tuple[str, ...]]]]` field, aligned with `block_hashes`, defaulting to `None`. Appended last so the `msgspec` `array_like` / `omit_defaults` wire format stays backward/forward compatible with existing consumers and the replay buffer.
- `mem_cache/events.py`: `_record_store_event` surfaces `extra_key` as `[(extra_key,)]` on the first block (the node rooted at the tree root, page 0), and `None` otherwise.

## Design notes

- The cache salt namespaces blocks in the radix tree but is **not** folded into the block hash. Two requests with identical tokens but different salts therefore emit identical `block_hashes`; `extra_keys` is the disambiguator. Consumers key on `(block_hash, extra_keys)` and propagate the salt along the `parent_block_hash` links they reconstruct.
- Surfaced on the first block only. Not added to `BlockRemoved` (salt-ambiguous removals are unchanged). Multimodal content identifiers are out of scope for this PR.

## Tests

New unit tests in `test/registered/unit/mem_cache/test_radix_cache_unit.py`:
- `test_kv_cache_events_extra_keys_on_first_block` — salt surfaces on the first block only; unsalted sequences omit it.
- `test_kv_cache_events_salt_not_reemitted_on_shared_prefix` — a continuation in the same salt namespace does not re-emit the salt (survives node splits).
- `test_kv_cache_events_same_tokens_different_salt` — same tokens + different salt collide on `block_hash`, and `extra_keys` is the only disambiguating signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27245210763](https://github.com/sgl-project/sglang/actions/runs/27245210763)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27245210714](https://github.com/sgl-project/sglang/actions/runs/27245210714)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->