### PR TITLE
test(sgl-router): cover sticky scale-up no-redistribution e2e

### DIFF
--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -253,3 +253,85 @@ async fn only_the_configured_header_name_is_honored() {
     assert_eq!(sticky_count(&metrics, "hit"), 1);
     assert_eq!(sticky_count(&metrics, "no_routing_key"), 1);
 }
+
+/// True-sticky scale-up: a worker that joins the registry at runtime must
+/// NOT redistribute an already-pinned key — the defining difference from
+/// consistent hashing, where adding a node remaps a fraction of keys. The
+/// policy unit tests assert this over a bare worker slice; this drives it
+/// end-to-end through the HTTP stack and a live `WorkerRegistry::add`, so
+/// the freshly-added worker is a genuine healthy candidate the policy could
+/// pick — and provably doesn't.
+#[tokio::test]
+async fn adding_a_worker_does_not_redistribute_existing_key() {
+    let w0 = MockWorker::start(vec![]).await;
+    let w1 = MockWorker::start(vec![]).await;
+    let ctx = build_sticky_ctx("x-sgl-routing-key", &[w0.url.clone(), w1.url.clone()]);
+    let app = build_router(ctx.clone());
+
+    // Pin "alice" to whichever worker the round-robin fallback selects.
+    let res = app
+        .clone()
+        .oneshot(chat_request(Some(("x-sgl-routing-key", "alice"))))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let pinned_url = success_counts(&ctx.metrics.render())
+        .into_iter()
+        .find(|(_, c)| *c > 0)
+        .map(|(url, _)| url)
+        .expect("first request should have been served by some worker");
+
+    // Scale up: a third worker joins the registry at runtime. With no
+    // circuit breaker configured it is immediately a healthy candidate
+    // (`healthy_workers_for` filters only on the breaker), so the policy
+    // *could* route to it — the assertions below prove it does not.
+    let w2 = MockWorker::start(vec![]).await;
+    ctx.registry
+        .add(WorkerSpec {
+            id: WorkerId("w2".into()),
+            url: w2.url.clone(),
+            mode: WorkerMode::Plain,
+            model_ids: vec![ModelId("tiny".into())],
+            bootstrap_port: None,
+        })
+        .unwrap();
+    // Guard the premise: w2 really is an eligible candidate now, so the
+    // "policy doesn't pick it" assertions below are meaningful and can't
+    // pass vacuously if a future change stops enumerating added workers.
+    assert_eq!(
+        ctx.registry
+            .healthy_workers_for(&ModelId("tiny".into()))
+            .len(),
+        3,
+        "added worker must be an eligible candidate"
+    );
+
+    const N: usize = 5;
+    for _ in 0..N {
+        let res = app
+            .clone()
+            .oneshot(chat_request(Some(("x-sgl-routing-key", "alice"))))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    let metrics = ctx.metrics.render();
+    let counts = success_counts(&metrics);
+    // All N+1 successes stayed on the original pin — nothing leaked to the
+    // newly-added worker or the other pre-existing one.
+    assert_eq!(
+        counts.get(&pinned_url).copied().unwrap_or(0),
+        (N + 1) as u64,
+        "all same-key requests must stay on the original pin: {counts:?}"
+    );
+    assert_eq!(
+        counts.values().sum::<u64>(),
+        (N + 1) as u64,
+        "no request should leak to another worker: {counts:?}"
+    );
+    // One initial assign, the pin survived the scale-up (no remap), N hits.
+    assert_eq!(sticky_count(&metrics, "assigned"), 1, "{metrics}");
+    assert_eq!(sticky_count(&metrics, "remap"), 0, "{metrics}");
+    assert_eq!(sticky_count(&metrics, "hit"), N as u64, "{metrics}");
+}


### PR DESCRIPTION
## Motivation

The experimental `sgl-router` sticky-session policy (`experimental/sgl-router/src/policies/sticky.rs`) is *true-sticky*: unlike consistent hashing, adding a worker must never redistribute an already-pinned routing key — an existing key is only remapped when its pinned worker leaves the healthy candidate set.

This property was covered at the bare-policy **unit** level (`adding_a_worker_does_not_redistribute_existing_key` in `sticky.rs`, which calls `policy.select` over a literal worker slice), but **not end-to-end**. The existing integration tests in `tests/proxy/sticky_routing.rs` cover same-key pinning, remap-on-removal, keyless fallback, and dynamic header name — but none exercise a runtime scale-up. A regression in the `registry-add → candidate-set → policy` path (e.g. re-seeding pins on registry mutation) would slip past the unit test.

## Modifications

- Add integration test `adding_a_worker_does_not_redistribute_existing_key` to `experimental/sgl-router/tests/proxy/sticky_routing.rs`.
  - Pins a key, then performs a live `WorkerRegistry::add` of a third worker through the full HTTP stack.
  - Guards the premise by asserting the new worker is actually an eligible candidate (`healthy_workers_for(...).len() == 3`), so the test cannot pass vacuously if a future change stops enumerating added workers.
  - Asserts every subsequent same-key request stays on the original pin: `assigned=1`, `remap=0`, and all `N+1` successes land on the original `worker_url` with nothing leaking to the new or other worker.

No production code changes — test-only.

## Checklist

- [x] `cargo test --test proxy sticky_routing` — 5/5 pass.
- [x] `cargo fmt --check` clean; `pre-commit` (rustfmt sgl-router) passes.
- [x] Reuses the existing in-process `MockWorker` harness; deterministic (eviction sweeper pushed out of the test window, no sleeps).













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27248944153](https://github.com/sgl-project/sglang/actions/runs/27248944153)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27250178672](https://github.com/sgl-project/sglang/actions/runs/27250178672)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->