### PR TITLE
Add a debug tool to detect non-explicitly returned outputs under BCG

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -99,6 +99,7 @@ class BreakableCudaGraphBackend(BaseCudaGraphBackend):
             cuda_graph=graph,
             pool=self._pool,
             stream=self._capture_stream,
+            debug=get_bool_env_var("SGLANG_BCG_DEBUG"),
         ):
             out = captured_fn()
         self._graphs[shape_key] = graph

--- a/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph.py
+++ b/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph.py
@@ -34,6 +34,9 @@ try:
 except ImportError:
     rt = None
 
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph_debug import (
+    check_non_explicit_outputs,
+)
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.cuda_utils import (
     checkCudaErrors,
 )
@@ -214,7 +217,12 @@ def eager_on_graph(enable: bool):
 
             # Run the eager function once so it allocates its outputs and
             # writes real data into them.
-            output = inner(*args, **kwargs)
+            if capture.debug:
+                output, error_msg = check_non_explicit_outputs(inner, args, kwargs)
+                if error_msg is not None:
+                    capture._non_explicit_output_errors.append(error_msg)
+            else:
+                output = inner(*args, **kwargs)
 
             # Weak-ref the closure state. Storage lives with the segment
             # CUDAGraphs' mempool pin; Python refs don't need to prevent
@@ -276,6 +284,7 @@ class BreakableCUDAGraphCapture:
         pool=None,
         stream: torch.cuda.Stream | None = None,
         capture_error_mode: str = "global",
+        debug: bool = False,
     ):
         assert isinstance(
             cuda_graph, BreakableCUDAGraph
@@ -284,6 +293,8 @@ class BreakableCUDAGraphCapture:
         self._pool = pool if pool is not None else (0, 0)
         self._stream = stream
         self._capture_error_mode = capture_error_mode
+        self.debug = debug
+        self._non_explicit_output_errors: list[str] = []
         self._stream_ctx = None
         self._capture_token = None
         self._stream_token = None
@@ -313,6 +324,8 @@ class BreakableCUDAGraphCapture:
                 self._stream_ctx.__exit__(*args)
                 self._stream_ctx = None
             _uninstall_wait_stream_hook()
+        if self._non_explicit_output_errors and (not args or args[0] is None):
+            raise RuntimeError("\n\n".join(self._non_explicit_output_errors))
         return False
 
     def _begin_new_segment(self) -> None:

--- a/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph_debug.py
+++ b/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph_debug.py
@@ -1,0 +1,180 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Debug tools for breakable CUDA graph (BCG).
+
+BCG records a sequence of CUDA graphs broken apart by eager functions that
+can't be CUDA graphed. At each eager break, we copy the tensors returned by
+the eager function in a static buffer that the next graph consumes. This
+leaves room for developer errors that could be very difficult to debug: if
+an eager function allocates a new tensor that wasn't returned explicitly but
+survives outside of the eager call (like assigning to an instance variable if
+the eager function was a class method), the new tensor won't be copied to the
+next CUDA graph, causing a potential silent correctness issue.
+
+``check_non_explicit_outputs`` detects this at capture time and returns a
+list of tensors that were not returned explicitly.
+
+We detect it from the CUDA caching allocator's own allocation history. Around
+the eager call we turn on ``torch.cuda.memory._record_memory_history`` and read
+the raw snapshot's ``device_traces`` (the public ``memory_snapshot()`` returns
+only ``segments``). Replaying those alloc/free events tells us exactly which
+blocks were allocated during the call and are still alive when it returns.
+Subtracting the explicitly-returned (and ``mark_bcg_output``-marked) tensors
+leaves the non-explicit outputs.
+
+The tool doesn't help if a tensor is allocated outside the PyTorch caching
+allocator (a raw ``cudaMalloc`` in C++) or borrowed via DLPack.
+
+If the user is confident that a non-explicitly returned tensor is safe, they
+may mark that tensor with ``mark_bcg_output`` and avoid a false detection.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import weakref
+from contextvars import ContextVar
+from typing import Callable
+
+import torch
+
+# When debug capture is active this holds a list of `(weakref(storage),
+# storage.data_ptr())` tensors that the check should ignore. Holds no
+# strong reference, so it never keeps a tensor alive. Storage (not address) based: if
+# a marked tensor is freed mid-break and its address is reused by a real escape, the
+# dead weakref stops exempting that address, so the real escape is still caught.
+_safe_non_explicit_outputs: ContextVar[list | None] = ContextVar(
+    "bcg_safe_marks", default=None
+)
+
+
+def mark_bcg_output(*tensors: torch.Tensor) -> None:
+    marked_outputs = _safe_non_explicit_outputs.get()
+    if marked_outputs is None:
+        return
+    for t in tensors:
+        if torch.is_tensor(t) and t.numel() > 0:
+            st = t.untyped_storage()
+            marked_outputs.append((weakref.ref(st), st.data_ptr()))
+
+
+# TODO: probably the exact same things a tree_iter
+def _collect_tensors(obj, acc) -> None:
+    """Mirrors the BCG's ``_copy_output`` function to gather tensors."""
+    if torch.is_tensor(obj):
+        acc.append(obj)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            _collect_tensors(v, acc)
+    elif isinstance(obj, (list, tuple)):
+        for v in obj:
+            _collect_tensors(v, acc)
+    elif hasattr(obj, "__dict__"):
+        for v in vars(obj).values():
+            _collect_tensors(v, acc)
+
+
+def _get_marked_output_ptrs(marked_outputs: list) -> set:
+    return {
+        ptr
+        for ref, ptr in marked_outputs
+        if (st := ref()) is not None and st.data_ptr() == ptr
+    }
+
+
+def _get_tensor_storage_ptrs(output) -> set:
+    tensors: list = []
+    _collect_tensors(output, tensors)
+    return {t.untyped_storage().data_ptr() for t in tensors if t.numel() > 0}
+
+
+def _get_device_mem_trace(device_idx: int) -> list:
+    # The public `torch.cuda.memory_snapshot()` exposes only `segments`
+    # `device_traces` is reachable only through the private C++ function
+    snapshot = torch._C._cuda_memorySnapshot(None)
+    trace = snapshot.get("device_traces", [])
+    if trace and isinstance(trace[0], list):
+        return trace[device_idx] if device_idx < len(trace) else []
+    return trace
+
+
+def _get_live_tensors(trace: list) -> dict:
+    live_tensors: dict = {}
+    for event in trace:
+        action = event["action"]
+        if action == "alloc":
+            live_tensors[event["addr"]] = (event["size"], event.get("frames"))
+        elif action == "free_requested":
+            live_tensors.pop(event["addr"], None)
+    return live_tensors
+
+
+def _format_frames(frames) -> str | None:
+    if not frames:
+        return None
+    return "\n".join(
+        f'File "{f.get("filename")}", line {f.get("line")}, in {f.get("name")}'
+        for f in frames
+    )
+
+
+def _make_error_msg(fn_name: str, non_explicit_outputs: list) -> str:
+    lines = [
+        f"[BCG] eager break '{fn_name}' produced {len(non_explicit_outputs)} output(s) that "
+        "survive the call but are not returned. On replay, these are re-allocated "
+        "at fresh addresses with no copy-back, so downstream captured segments "
+        "read stale memory. Return them from the break, or write the result "
+        "in-place into a pre-existing buffer."
+    ]
+    for i, e in enumerate(non_explicit_outputs[:5], 1):
+        lines.append(f"  #{i}: data_ptr={e['ptr']:#x} nbytes={e['nbytes']}")
+        if e["frames"]:
+            lines.append(textwrap.indent(e["frames"], "      "))
+    if len(non_explicit_outputs) > 5:
+        lines.append(f"  ... and {len(non_explicit_outputs) - 5} more")
+    return "\n".join(lines)
+
+
+def check_non_explicit_outputs(inner: Callable, args: tuple, kwargs: dict):
+    """Run the eager break under allocator history recording and report any
+    tensor it allocated that survives the call but isn't returned."""
+    device_idx = torch.cuda.current_device()
+    torch.cuda.memory._record_memory_history(
+        "all",
+        context="alloc",
+        stacks="python",
+        max_entries=1_000_000,
+        clear_history=True,
+    )
+    token = _safe_non_explicit_outputs.set([])
+    try:
+        output = inner(*args, **kwargs)
+    finally:
+        marked_outputs = _safe_non_explicit_outputs.get()
+        _safe_non_explicit_outputs.reset(token)
+        trace = _get_device_mem_trace(device_idx)
+        torch.cuda.memory._record_memory_history(None)
+
+    explicit_outputs = _get_tensor_storage_ptrs(output) | _get_marked_output_ptrs(
+        marked_outputs
+    )
+    non_explicit_outputs = [
+        {"ptr": addr, "nbytes": size, "frames": _format_frames(frames)}
+        for addr, (size, frames) in _get_live_tensors(trace).items()
+        if not any(addr <= p < addr + size for p in explicit_outputs)
+    ]
+    name = getattr(inner, "__name__", repr(inner))
+    return output, (
+        _make_error_msg(name, non_explicit_outputs) if non_explicit_outputs else None
+    )

--- a/test/registered/cuda_graph/breakable/test_breakable_cuda_graph.py
+++ b/test/registered/cuda_graph/breakable/test_breakable_cuda_graph.py
@@ -327,5 +327,246 @@ class TestBreakableCudaGraph(CustomTestCase):
         self.assertGreaterEqual(score, 0.80)
 
 
+class TestBcgNonExplicitOutputs(CustomTestCase):
+    """debug=True raises on eager-break outputs that survive but are not explicitly
+    returned."""
+
+    # Distinctive size so a freed block is reused cleanly by an equally-sized alloc.
+    N = 1_000_003
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+        try:
+            from cuda.bindings import runtime  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("cuda-python not installed")
+
+        from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
+            BreakableCUDAGraph,
+            BreakableCUDAGraphCapture,
+            eager_on_graph,
+        )
+
+        cls.BreakableCUDAGraph = BreakableCUDAGraph
+        cls.BreakableCUDAGraphCapture = BreakableCUDAGraphCapture
+        cls.eager_on_graph = staticmethod(eager_on_graph)
+        cls.device = torch.device("cuda:0")
+
+        # State the registered test ops read/write; reset per test in setUp.
+        cls.op_sink = []  # non-explicit outputs
+        cls.op_holder = {}  # holds a tensor the reuse_custom_op ops free mid-break
+
+        # Register custom ops for the tests
+
+        from sglang.srt.utils.custom_op import register_custom_op
+
+        # A custom op registered via the old/legacy PyTorch API that
+        # leaks an output without explicitly returning it.
+        def leak_custom_op_old_api(src):
+            cls.op_sink.append(src * 3.0)
+            return src.clone()
+
+        cls._raw_lib = torch.library.Library("bcg_test_raw", "DEF")
+        cls._raw_lib.define("leak_custom_op_old_api(Tensor src) -> Tensor")
+        cls._raw_lib.impl("leak_custom_op_old_api", leak_custom_op_old_api, "CUDA")
+
+        # A custom op registered via the PyTorch API that reuses a memory block
+        @torch.library.custom_op("bcg_test::reuse_custom_op", mutates_args=["x"])
+        def reuse_custom_op(x: torch.Tensor) -> None:
+            cls.op_holder.pop("a", None)
+            cls.op_sink.append(torch.empty(cls.N, device=x.device))
+            x.add_(1.0)
+
+        # The inner custom op for the nested custom ops test
+        @torch.library.custom_op("bcg_test::inner_custom_op", mutates_args=["x"])
+        def inner_custom_op(x: torch.Tensor) -> None:
+            cls.op_sink.append(x * 5.0)
+            x.add_(1.0)
+
+        # The outer custom op for the nested custom ops test
+        @torch.library.custom_op("bcg_test::outer_custom_op", mutates_args=["x"])
+        def outer_custom_op(x: torch.Tensor) -> None:
+            torch.ops.bcg_test.inner_custom_op(x)
+
+        # Registers a custom op via SGL API (which in turn uses the old PyTorch API)
+        @register_custom_op(op_name="reuse_custom_op_sgl_api", mutates_args=["x"])
+        def reuse_custom_op_sgl_api(x: torch.Tensor) -> None:
+            cls.op_holder.pop("a", None)
+            cls.op_sink.append(torch.empty(cls.N, device=x.device))
+            x.add_(1.0)
+
+    def setUp(self):
+        self.op_sink.clear()
+        self.op_holder.clear()
+
+    def _run(self, body, debug):
+        graph = self.BreakableCUDAGraph()
+        stream = torch.cuda.Stream(self.device)
+        with self.BreakableCUDAGraphCapture(graph, stream=stream, debug=debug):
+            body()
+
+    def test_good_inplace_mutation(self):
+        out = torch.zeros(1024, device=self.device)
+        y = torch.zeros(1024, device=self.device)
+
+        @self.eager_on_graph(enable=True)
+        def clean(src, dst):
+            dst.copy_(src * 2.0)
+            return None
+
+        x = torch.ones(1024, device=self.device)
+        self._run(lambda: (clean(x, out), y.copy_(out + 1.0)), debug=True)
+
+    def test_good_new_alloc(self):
+        y = torch.zeros(1024, device=self.device)
+
+        @self.eager_on_graph(enable=True)
+        def returns_new(src):
+            return src * 2.0
+
+        x = torch.ones(1024, device=self.device)
+        self._run(lambda: y.copy_(returns_new(x) + 1.0), debug=True)
+
+    def test_non_explicit_output_raises(self):
+        sink = []
+        out = torch.zeros(1024, device=self.device)
+        y = torch.zeros(1024, device=self.device)
+
+        @self.eager_on_graph(enable=True)
+        def leaky(src, dst):
+            dst.copy_(src * 2.0)
+            sink.append(src * 3.0)
+            return None
+
+        x = torch.ones(1024, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "eager break"):
+            self._run(lambda: (leaky(x, out), y.copy_(out + 1.0)), debug=True)
+
+    def test_non_explicit_output_not_flagged_when_debug_off(self):
+        sink = []
+
+        @self.eager_on_graph(enable=True)
+        def leaky(src):
+            sink.append(src * 3.0)
+            return None
+
+        x = torch.ones(1024, device=self.device)
+        y = torch.zeros(1024, device=self.device)
+        self._run(lambda: (leaky(x), y.add_(1.0)), debug=False)
+
+    def test_non_explicit_output_reused_address_raises(self):
+        # A non-explicit output that reuses a freed address
+        sink = []
+        holder = {"a": torch.empty(self.N, device=self.device)}
+        torch.cuda.synchronize()
+
+        @self.eager_on_graph(enable=True)
+        def reuse_custom_op(src):
+            del holder["a"]
+            b = torch.empty(self.N, device=self.device)
+            sink.append(b)
+            return None
+
+        x = torch.ones(8, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "eager break"):
+            self._run(lambda: reuse_custom_op(x), debug=True)
+
+    def test_non_explicit_output_custom_op_raises(self):
+        # A non-explicit output allocated inside an op with no recoverable python body
+        # (old-style Library.impl, proxy for a C++/fused kernel).
+
+        @self.eager_on_graph(enable=True)
+        def via_opaque(src):
+            return torch.ops.bcg_test_raw.leak_custom_op_old_api(src)
+
+        x = torch.ones(4096, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "eager break"):
+            self._run(lambda: via_opaque(x), debug=True)
+
+    def test_non_explicit_output_custom_op_address_reuse_raises(self):
+        # A non-explicit output inside a torch.library.custom_op
+        self.op_holder["a"] = torch.empty(self.N, device=self.device)
+        torch.cuda.synchronize()
+
+        @self.eager_on_graph(enable=True)
+        def via_opaque(src):
+            torch.ops.bcg_test.reuse_custom_op(src)
+            return None
+
+        x = torch.ones(8, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "eager break"):
+            self._run(lambda: via_opaque(x), debug=True)
+
+    def test_non_explicit_output_sgl_custom_op_raises(self):
+        # Same reuse_custom_op case but for an op registered via the SGL API
+        # (old-style ``Library.impl``)
+        self.op_holder["a"] = torch.empty(self.N, device=self.device)
+        torch.cuda.synchronize()
+
+        @self.eager_on_graph(enable=True)
+        def via_opaque(src):
+            torch.ops.sglang.reuse_custom_op_sgl_api(src)
+            return None
+
+        x = torch.ones(8, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "eager break"):
+            self._run(lambda: via_opaque(x), debug=True)
+
+    def test_good_marked_non_explicit_output(self):
+        # mark_bcg_output lets the author exempt a known-safe non-explicit output
+        # so it is not reported.
+        from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph_debug import (
+            mark_bcg_output,
+        )
+
+        sink = []
+
+        @self.eager_on_graph(enable=True)
+        def leaky_but_safe(src):
+            out = src * 3.0
+            sink.append(out)
+            mark_bcg_output(out)
+            return None
+
+        x = torch.ones(1024, device=self.device)
+        self._run(lambda: leaky_but_safe(x), debug=True)
+
+    def test_non_explicit_output_marked_output_reused_address_raises(self):
+        # if a marked tensor is freed mid-break and a real
+        # non-explicit output reuses its address, the dead weakref stops exempting that
+        # address so it is still caught.
+        from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph_debug import (
+            mark_bcg_output,
+        )
+
+        sink = []
+
+        @self.eager_on_graph(enable=True)
+        def break_fn(src):
+            tmp = src * 2.0
+            mark_bcg_output(tmp)
+            del tmp
+            sink.append(torch.empty(self.N, device=self.device))
+            return None
+
+        x = torch.ones(self.N, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "eager break"):
+            self._run(lambda: break_fn(x), debug=True)
+
+    def test_non_explicit_output_nested_custom_op_raises(self):
+        # A non-explicit output allocated inside a nested custom op
+
+        @self.eager_on_graph(enable=True)
+        def via_opaque(src):
+            torch.ops.bcg_test.outer_custom_op(src)
+            return None
+
+        x = torch.ones(4096, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "eager break"):
+            self._run(lambda: via_opaque(x), debug=True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

BCG records a sequence of CUDA graphs broken apart by eager functions that can't be CUDA graphed. At each eager break, we copy the tensors returned by the eager function in a static buffer that the next graph consumes. This leaves room for developer errors that could be very difficult to debug: if an eager function allocates a new tensor that wasn't returned explicitly but survives outside of the eager call (like assigning to an instance variable if the eager function was a class method), the new tensor won't be copied to the next CUDA graph, causing a potential silent correctness issue.

``check_non_explicit_outputs`` detects this at capture time and returns a list of tensors that were not returned explicitly.

cc @galv @youkaichao 

## Modifications

Adds a new `breakable_cuda_graph_debug.py` file with the new code adding the debug tool. Everything else is surgical changes to inject it in the BCG infrastructure.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27259043813](https://github.com/sgl-project/sglang/actions/runs/27259043813)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27259043706](https://github.com/sgl-project/sglang/actions/runs/27259043706)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->