### PR TITLE
fix: DSV4 BCG compress-prefill plan OOB on underfilled (tiny) prefill replay

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
@@ -203,7 +203,11 @@ __global__ __launch_bounds__(1024, 1)  //
   if (is_mtp_extend) {
     // Path 1: token-driven. Each global token id maps to exactly one (batch_id, j).
     const uint32_t E = s_max_extend;
-    for (uint32_t k = tx; k < num_q; k += block_size) {
+    // num_q is the padded buffer size (graph bucket), not the work size: cap the
+    // loop at the real token count so batch_id = k / E stays < batch_size on an
+    // underfilled replay; Stage D pads [counter, num_q) with invalid.
+    const uint32_t num_real_q = params.batch_size * E;
+    for (uint32_t k = tx; k < num_real_q; k += block_size) {
       const uint32_t batch_id = k / E;
       const uint32_t j = k % E;
       const int32_t pl = s_prefix_len[batch_id];


### PR DESCRIPTION
## Motivation

Under breakable CUDA graph (BCG) with `--enforce-piecewise-cuda-graph`, a DeepSeek-V4 prefill that is **much smaller than the captured graph bucket** crashes the scheduler with an illegal memory access (IMA) in the DSV4 paged-compressor prefill plan (`plan_compress_prefill`, `c_plan.cuh`). The most reliable trigger is the tiny startup server-warmup request (a few tokens) replayed into e.g. the 2048-token bucket; any short real prefill hits the same path.

**Root cause.** `plan_compress_prefill_kernel0` has a fast path for uniform extend lengths, selected purely by the condition `min(extend_len) == max(extend_len) && extend_len <= 32` (named "MTP-uniform" but **not** specific to speculative decoding — the startup server-warmup, which sends `dp_size` identical short prompts that batch into a uniform `extend_len = 6` prefill, takes it too). This path iterates the flat token id `k` over `num_q_tokens` and decomposes `batch_id = k / E` (`E = extend_len`), implicitly assuming `num_q_tokens == batch_size * E` (the real token count). But `num_q_tokens` is the **buffer** size: under BCG replay it is the padded static graph bucket (e.g. 2048), not the real token count. When `num_q_tokens >> batch_size * E` (a small uniform-extend request padded into a large bucket), `batch_id` runs far past `batch_size`, reads uninitialized per-batch shared state, and emits bogus non-`invalid` plan entries whose out-of-range `batch_id` then indexes `rid_ptr` / `req_to_token` out of bounds in `plan_compress_prefill_kernel_1` → IMA.

The non-uniform path (`min != max`, or `extend_len > 32`) is unaffected: it loops `batch_id < batch_size` then `j < el` (never indexed by `num_q_tokens`), and Stage D pads the remaining `[counter, num_q)` entries with `invalid` (which `kernel_1` skips).

**When it triggers.** Enforced/enabled BCG + a capture bucket much larger than the request + all active requests sharing the same `extend_len <= 32`. Independent of GPU SKU and of `--disable-radix-cache`. Normal long prefills (`extend_len > 32`, or near-bucket-full) are not affected.

## Modifications

`python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh`: bound the MTP-uniform work loop by the real token count (`batch_size * E`) instead of the buffer size `num_q_tokens`. The padded tail `[counter, num_q)` is already filled with `invalid` by Stage D, so this matches the general path and the documented "pad to `num_q_tokens` with invalid" contract. (1 file changed, +11/-1; most of it is an explanatory comment.)

Functional verification — DeepSeek-V4-Pro, B200 and B300, direct `launch_server` (startup warmup on). Exact config:

```bash
export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1
export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND=1
export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=2048
export SGLANG_EXPERIMENTAL_ENABLE_PIECEWISE_CUDA_GRAPH_MOE_A2A=1
export SGLANG_OPT_USE_ONLINE_COMPRESS=1

python3 -m sglang.launch_server \
  --model-path /model --trust-remote-code \
  --tp 8 --dp-size 8 --enable-dp-attention --moe-a2a-backend megamoe \
  --context-length 16384 --chunked-prefill-size 16384 --max-prefill-tokens 16384 \
  --mem-fraction-static 0.835 --max-running-requests 4352 --swa-full-tokens-ratio 0.075 \
  --enable-mixed-chunk --cuda-graph-max-bs 16 \
  --enable-breakable-cuda-graph --enforce-piecewise-cuda-graph --piecewise-cuda-graph-tokens 2048 \
  --disable-radix-cache
```

| Arm | Before | After |
|---|---|---|
| B300 | IMA at `c_plan.cuh`; scheduler dies during init | server fires up on all 8 ranks; full random-8k/1k benchmark completes; 0 IMA |
| B200 | IMA at `c_plan.cuh` | server fires up; benchmark completes; 0 IMA |

(`--disable-radix-cache` is not required to reproduce — see the controls below; it just matches the run.)

Diagnosis controls (before fix): reproduced on both B200 and B300 (not GPU-specific) and with radix cache on and off (not radix-related); confirmed under `CUDA_LAUNCH_BLOCKING=1` so the fault is attributed synchronously to `plan_prefill` (not an async mis-report).

## Accuracy Tests

GSM8K parity for DSV4 BCG was validated during the BCG enablement work (#25195) on DeepSeek-V4-Pro (B300, MegaMoE + FP4): BCG ~0.963-0.966 vs no-BCG ~0.964, i.e. within run-to-run noise (e.g. BCG 0.9635 vs no-BCG 0.9642 in the same A/B; the merged PR head scored 0.9658).

This change does not alter those paths: it is a no-op when the prefill is not underfilled (`batch_size * E == num_q_tokens`), which is the case for the GSM8K workload. For the underfilled case it only makes the padded tail `invalid` — the same plan the general path / Stage D already produce — so real-token outputs are unchanged.

## Speed Tests and Profiling

The change only removes bogus padded-region iterations from the plan kernel (strictly less work), so no inference-speed regression is expected. The repro config above completed the full random-8k/1k benchmark after the fix.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27252580454](https://github.com/sgl-project/sglang/actions/runs/27252580454)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27317028312](https://github.com/sgl-project/sglang/actions/runs/27317028312)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->