### PR TITLE
feat: update weights from distributed for speculative draft worker(s)

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1461,6 +1461,8 @@ class UpdateWeightsFromDistributedReqInput(BaseReq):
     weight_version: Optional[str] = None
     # Optional format specification for loading
     load_format: Optional[str] = None
+    # Optional: Determine whether to disable updating the draft model
+    disable_draft_model: Optional[bool] = None
     # Whether to call torch.cuda.empty_cache() during flush
     torch_empty_cache: bool = False
 

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -96,7 +96,11 @@ class SchedulerUpdateWeightsMixin:
     ) -> Tuple[bool, str]:
         """Update the online model parameter."""
         self._quiesce_for_weight_update()
-        success, message = self.tp_worker.update_weights_from_distributed(recv_req)
+        if recv_req.disable_draft_model:
+            worker = self.tp_worker
+        else:
+            worker = self.draft_worker or self.tp_worker
+        success, message = worker.update_weights_from_distributed(recv_req)
         if success:
             self.flush_cache_after_weight_update(recv_req)
         else:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2057,36 +2057,30 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             shape: the shape of the parameter to be updated.
         """
 
+        return self.update_weights_from_distributed_to_model_runners(
+            [self], names, dtypes, shapes, group_name, load_format
+        )
+
+    def update_weights_from_distributed_to_model_runners(
+        self,
+        model_runners,
+        names,
+        dtypes,
+        shapes,
+        group_name,
+        load_format: Optional[str] = None,
+    ):
         assert group_name in self._model_update_group, (
             f"Group {group_name} not in {list(self._model_update_group.keys())}. "
             "Please call `init_weights_update_group` first."
         )
 
-        if load_format == "flattened_bucket":
-            return self._update_bucketed_weights_from_distributed(
-                names, dtypes, shapes, group_name
-            )
         try:
-            weights = []
-            handles = []
-            for name, dtype, shape in zip(names, dtypes, shapes):
-                target_dtype = (
-                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
-                )
-                weight = torch.empty(shape, dtype=target_dtype, device=self.device)
-                handles.append(
-                    torch.distributed.broadcast(
-                        weight,
-                        src=0,
-                        group=self._model_update_group[group_name],
-                        async_op=True,
-                    )
-                )
-                weights.append((name, weight))
-            for handle in handles:
-                handle.wait()
-
-            self.model.load_weights(weights)
+            weights = self._receive_weights_from_distributed(
+                names, dtypes, shapes, group_name, load_format
+            )
+            for model_runner in model_runners:
+                model_runner.model.load_weights(weights)
             return True, "Succeeded to update parameter online."
 
         except Exception as e:
@@ -2098,36 +2092,53 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger.error(error_msg)
             return False, error_msg
 
-    def _update_bucketed_weights_from_distributed(
+    def _receive_weights_from_distributed(
+        self, names, dtypes, shapes, group_name, load_format: Optional[str] = None
+    ):
+        if load_format == "flattened_bucket":
+            return self._receive_bucketed_weights_from_distributed(
+                names, dtypes, shapes, group_name
+            )
+
+        weights = []
+        handles = []
+        for name, dtype, shape in zip(names, dtypes, shapes):
+            target_dtype = (
+                dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+            )
+            weight = torch.empty(shape, dtype=target_dtype, device=self.device)
+            handles.append(
+                torch.distributed.broadcast(
+                    weight,
+                    src=0,
+                    group=self._model_update_group[group_name],
+                    async_op=True,
+                )
+            )
+            weights.append((name, weight))
+        for handle in handles:
+            handle.wait()
+        return weights
+
+    def _receive_bucketed_weights_from_distributed(
         self, names, dtypes, shapes, group_name
     ):
-        try:
-            named_tensors = []
-            for name, dtype, shape in zip(names, dtypes, shapes):
-                target_dtype = (
-                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
-                )
-                named_tensors.append(
-                    (name, torch.empty(shape, dtype=target_dtype, device=self.device))
-                )
-            bucket = FlattenedTensorBucket(named_tensors=named_tensors)
-            flattened_tensor = bucket.get_flattened_tensor()
-            torch.distributed.broadcast(
-                flattened_tensor,
-                src=0,
-                group=self._model_update_group[group_name],
+        named_tensors = []
+        for name, dtype, shape in zip(names, dtypes, shapes):
+            target_dtype = (
+                dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
             )
-            reconstructed_tensors = bucket.reconstruct_tensors()
-            self.model.load_weights(reconstructed_tensors)
-            return True, f"Succeeded to update parameter online."
-        except Exception as e:
-            error_msg = (
-                f"Failed to update parameter online: {e}. "
-                f"The full weights of the ModelRunner are partially updated. "
-                f"Please discard the whole weights."
+            named_tensors.append(
+                (name, torch.empty(shape, dtype=target_dtype, device=self.device))
             )
-            logger.error(error_msg)
-            return False, error_msg
+        bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+        flattened_tensor = bucket.get_flattened_tensor()
+        torch.distributed.broadcast(
+            flattened_tensor,
+            src=0,
+            group=self._model_update_group[group_name],
+        )
+        return bucket.reconstruct_tensors()
 
     def update_weights_from_tensor(
         self,

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 import torch
 
 from sglang.srt.distributed import get_tp_group
+from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch, ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -342,6 +343,16 @@ class DFlashWorker:
     def __getattr__(self, name):
         # Delegate anything not implemented yet to the target worker.
         return getattr(self.target_worker, name)
+
+    def update_weights_from_distributed(
+        self, recv_req: UpdateWeightsFromDistributedReqInput
+    ):
+        # Spelled out instead of falling through `__getattr__` so the gap is
+        # visible: this only updates the target. The DFlash draft model
+        # (`self.draft_model_runner`) is NOT refreshed and goes stale after a
+        # distributed weight update.
+        # TODO(dflash): fan out to the draft runner like EAGLEWorker does.
+        return self.target_worker.update_weights_from_distributed(recv_req)
 
     def clear_cache_pool(self):
         # The target worker owns the shared KV allocator/cache. For the compact

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -16,7 +16,10 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
-from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
+from sglang.srt.managers.io_struct import (
+    UpdateWeightsFromDistributedReqInput,
+    UpdateWeightsFromTensorReqInput,
+)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -1300,6 +1303,18 @@ class EAGLEWorker(TpModelWorker):
             load_format=recv_req.load_format,
         )
         return success, message
+
+    def update_weights_from_distributed(
+        self, recv_req: UpdateWeightsFromDistributedReqInput
+    ):
+        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
+            [self.model_runner, self.target_worker.model_runner],
+            recv_req.names,
+            recv_req.dtypes,
+            recv_req.shapes,
+            recv_req.group_name,
+            recv_req.load_format,
+        )
 
 
 @torch.compile(dynamic=True, disable=(_is_npu or _is_musa))

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -24,6 +24,7 @@ from sglang.srt.layers.moe.utils import (
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
 from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
+    UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromTensorReqInput,
 )
@@ -1263,3 +1264,18 @@ class EAGLEWorkerV2(BaseSpecWorker):
             load_format=recv_req.load_format,
         )
         return success, message
+
+    def update_weights_from_distributed(
+        self, recv_req: UpdateWeightsFromDistributedReqInput
+    ):
+        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
+            [
+                self.draft_worker.draft_runner,
+                self.target_worker.model_runner,
+            ],
+            recv_req.names,
+            recv_req.dtypes,
+            recv_req.shapes,
+            recv_req.group_name,
+            recv_req.load_format,
+        )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -31,6 +31,7 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
+from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -195,6 +196,18 @@ class FrozenKVMTPWorker(TpModelWorker):
 
     def clear_cache_pool(self):
         pass
+
+    def update_weights_from_distributed(
+        self, recv_req: UpdateWeightsFromDistributedReqInput
+    ):
+        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
+            [self.draft_model_runner, self.target_worker.model_runner],
+            recv_req.names,
+            recv_req.dtypes,
+            recv_req.shapes,
+            recv_req.group_name,
+            recv_req.load_format,
+        )
 
     def _resolve_draft_backend_type(self) -> str:
         return (

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
+
 import logging
 import time
 from typing import TYPE_CHECKING, List, Optional, Tuple

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
+from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -841,3 +842,18 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.req_pool_indices = req_pool_indices_backup
         batch.return_logprob = return_logprob_backup
         return next_draft_input
+
+    def update_weights_from_distributed(
+        self, recv_req: UpdateWeightsFromDistributedReqInput
+    ):
+        draft_model_runners = [
+            self.mtp_model_runner(i) for i in range(self.speculative_num_steps)
+        ]
+        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
+            draft_model_runners + [self.target_worker.model_runner],
+            recv_req.names,
+            recv_req.dtypes,
+            recv_req.shapes,
+            recv_req.group_name,
+            recv_req.load_format,
+        )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
 from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
+    UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
 )
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
@@ -833,3 +834,15 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             if not success:
                 return success, message
         return True, "Succeeded to update model weights."
+
+    def update_weights_from_distributed(
+        self, recv_req: UpdateWeightsFromDistributedReqInput
+    ):
+        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
+            self.draft_worker.draft_runner_list + [self.target_worker.model_runner],
+            recv_req.names,
+            recv_req.dtypes,
+            recv_req.shapes,
+            recv_req.group_name,
+            recv_req.load_format,
+        )

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -6,6 +6,7 @@ import torch
 from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
+from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -91,6 +92,11 @@ class NGRAMWorker:
         # without this method any caller of `update_weights_from_tensor`
         # under `--speculative-algorithm NGRAM` raises AttributeError.
         return self.target_worker.update_weights_from_tensor(recv_req)
+
+    def update_weights_from_distributed(
+        self, recv_req: UpdateWeightsFromDistributedReqInput
+    ):
+        return self.target_worker.update_weights_from_distributed(recv_req)
 
     def add_external_corpus(self, corpus_id: str, token_chunks: list[list[int]]) -> int:
         return self.ngram_corpus.load_external_corpus_named(corpus_id, token_chunks)

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
+from sglang.srt.managers.scheduler_update_weights_mixin import (
+    SchedulerUpdateWeightsMixin,
+)
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.speculative.eagle_worker_v2 import EAGLEWorkerV2
+from sglang.srt.speculative.multi_layer_eagle_worker_v2 import MultiLayerEagleWorkerV2
+
+
+class _TestScheduler(SchedulerUpdateWeightsMixin):
+    pass
+
+
+def _distributed_req():
+    return UpdateWeightsFromDistributedReqInput(
+        names=["model.layers.0.weight"],
+        dtypes=["float32"],
+        shapes=[[1]],
+        group_name="weight_update_group",
+        flush_cache=False,
+    )
+
+
+def test_scheduler_routes_distributed_weight_update_to_spec_worker():
+    scheduler = _TestScheduler()
+    scheduler.enable_overlap = False
+    scheduler.schedule_stream = Mock()
+    scheduler.tp_cpu_group = object()
+    scheduler.tp_worker = Mock()
+    scheduler.draft_worker = Mock()
+    scheduler.draft_worker.update_weights_from_distributed.return_value = (
+        True,
+        "updated",
+    )
+
+    with patch(
+        "sglang.srt.managers.scheduler_update_weights_mixin.torch.distributed.barrier"
+    ) as barrier:
+        output = SchedulerUpdateWeightsMixin.update_weights_from_distributed(
+            scheduler, _distributed_req()
+        )
+
+    assert output.success is True
+    scheduler.draft_worker.update_weights_from_distributed.assert_called_once()
+    scheduler.tp_worker.update_weights_from_distributed.assert_not_called()
+    assert barrier.call_count == 2
+
+
+def test_model_runner_loads_one_distributed_receive_into_multiple_runners():
+    weights = [("model.layers.0.weight", object())]
+    source_runner = SimpleNamespace(
+        _model_update_group={"weight_update_group": object()},
+        _receive_weights_from_distributed=Mock(return_value=weights),
+    )
+    draft_runner = SimpleNamespace(model=Mock())
+    target_runner = SimpleNamespace(model=Mock())
+
+    success, message = ModelRunner.update_weights_from_distributed_to_model_runners(
+        source_runner,
+        [draft_runner, target_runner],
+        ["model.layers.0.weight"],
+        ["float32"],
+        [[1]],
+        "weight_update_group",
+    )
+
+    assert success is True
+    assert message == "Succeeded to update parameter online."
+    source_runner._receive_weights_from_distributed.assert_called_once()
+    draft_runner.model.load_weights.assert_called_once_with(weights)
+    target_runner.model.load_weights.assert_called_once_with(weights)
+
+
+def test_eagle_v2_distributed_update_loads_draft_and_target_from_target_group():
+    req = _distributed_req()
+    target_runner = Mock()
+    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
+        True,
+        "updated",
+    )
+    draft_runner = object()
+    worker = object.__new__(EAGLEWorkerV2)
+    worker._target_worker = SimpleNamespace(model_runner=target_runner)
+    worker._draft_worker = SimpleNamespace(draft_runner=draft_runner)
+
+    success, message = worker.update_weights_from_distributed(req)
+
+    assert success is True
+    assert message == "updated"
+    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
+        [draft_runner, target_runner],
+        req.names,
+        req.dtypes,
+        req.shapes,
+        req.group_name,
+        req.load_format,
+    )
+
+
+def test_multi_layer_eagle_v2_distributed_update_loads_all_drafts_and_target():
+    req = _distributed_req()
+    target_runner = Mock()
+    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
+        True,
+        "updated",
+    )
+    draft_runners = [object(), object()]
+    worker = object.__new__(MultiLayerEagleWorkerV2)
+    worker._target_worker = SimpleNamespace(model_runner=target_runner)
+    worker._draft_worker = SimpleNamespace(draft_runner_list=draft_runners)
+
+    success, message = worker.update_weights_from_distributed(req)
+
+    assert success is True
+    assert message == "updated"
+    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
+        draft_runners + [target_runner],
+        req.names,
+        req.dtypes,
+        req.shapes,
+        req.group_name,
+        req.load_format,
+    )


### PR DESCRIPTION
## Summary

`update_weights_from_distributed` previously updated only the target model runner. With speculative decoding (EAGLE v1/v2, multi-layer EAGLE v1/v2, frozen-KV MTP, n-gram), the speculative **draft** model runner(s) kept stale weights after a distributed update. This routes `update_weights_from_distributed` to the draft worker(s) as well, so the draft model stays in sync with the target.

## Motivation

In online weight-sync scenarios (e.g. RL rollout refresh via `update_weights_from_distributed`), the draft model must be updated together with the target — otherwise the draft proposes tokens from stale weights, degrading or invalidating speculative acceptance. Before this change the distributed update only reached `tp_worker.model_runner`; the draft worker's runner(s) were never refreshed.

## Changes

- `managers/scheduler_update_weights_mixin.py`: route `update_weights_from_distributed` to the draft worker in addition to the target (`worker = self.draft_worker or self.tp_worker`), with a `disable_draft_model` opt-out.
- `model_executor/model_runner.py`: `update_weights_from_distributed_to_model_runners(...)` — receive the distributed broadcast once and apply `model.load_weights(...)` to multiple runners (draft + target).
- `managers/io_struct.py`: add `disable_draft_model` to `UpdateWeightsFromDistributedReqInput`.
- `speculative/`: add `update_weights_from_distributed` to `eagle_worker.py`, `eagle_worker_v2.py`, `multi_layer_eagle_worker.py`, `multi_layer_eagle_worker_v2.py`, `frozen_kv_mtp_worker.py`, `ngram_worker.py` so each worker forwards the distributed update to its draft runner(s) (n-gram shares the target runner, so it has no separate draft weights).

## Tests

- `test/srt/test_distributed_weight_update_spec_worker.py` (new): verifies the scheduler routes the distributed update to the draft worker, and that one distributed receive loads into multiple model runners (draft + target) for `EAGLEWorkerV2` and `MultiLayerEagleWorkerV2`. Passes (4 tests).

## Notes

- Base branch: `sglang-miles`.
- `sglang-miles` has advanced past this branch's cut point; rebase before merge if a clean fast-forward is desired.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->