### PR TITLE
test: Cover GSP benchmark default args

### DIFF
--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -960,6 +960,16 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
     # CLI / from_args validation
     # ------------------------------------------------------------------
 
+    def test_from_args_defaults_optional_distribution_fields(self):
+        args = make_args(dataset_name="generated-shared-prefix")
+        delattr(args, "gsp_group_distribution")
+        delattr(args, "gsp_zipf_alpha")
+
+        dataset = GeneratedSharedPrefixDataset.from_args(args)
+
+        self.assertEqual(dataset.group_distribution, "uniform")
+        self.assertIsNone(dataset.zipf_alpha)
+
     def test_from_args_rejects_invalid_distribution_and_alpha(self):
         # Defensive validation in from_args protects in-process callers
         # that build a Namespace by hand and bypass the argparse boundary


### PR DESCRIPTION
## Summary
- Add regression coverage for generated-shared-prefix benchmark callers that construct args without the optional GSP distribution fields.
- Confirms `GeneratedSharedPrefixDataset.from_args()` defaults missing `gsp_group_distribution` / `gsp_zipf_alpha` to uniform sampling.

## Context
The AMD nightly failure was:
- Job: https://github.com/sgl-project/sglang/actions/runs/27182068211/job/80419864238
- Failing file: `test/registered/bench_fn/test_bench_serving_functionality.py`
- Error: `AttributeError: 'types.SimpleNamespace' object has no attribute 'gsp_group_distribution'`

Latest `main` already contains the production fix from #27580. This PR is based directly on latest `main` and adds the focused regression test only.

## Testing
- `python3 -m py_compile test/registered/bench_fn/test_benchmark_datasets_api.py`
- `git diff --check origin/main...HEAD`

Note: I could not run the full `test_benchmark_datasets_api.py` locally with bare Python because the full test module imports runtime dependencies including `torch`; CI has the expected environment for that file.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27250440061](https://github.com/sgl-project/sglang/actions/runs/27250440061)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27250440028](https://github.com/sgl-project/sglang/actions/runs/27250440028)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->