### PR TITLE
[Fix] Validate resample_patch_embed new_size for DeepSeek Janus Pro

### DIFF
--- a/python/sglang/srt/models/deepseek_janus_pro.py
+++ b/python/sglang/srt/models/deepseek_janus_pro.py
@@ -254,6 +254,18 @@ def resample_patch_embed(
     except ImportError:
         from torch.func import vmap
 
+    try:
+        new_size = [int(x) for x in new_size]
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"new_size elements must be integers, got {new_size}"
+        ) from None
+
+    if not all(x > 0 for x in new_size):
+        raise ValueError(
+            f"new_size elements must be positive, got {new_size}"
+        )
+
     assert len(patch_embed.shape) == 4, "Four dimensions expected"
     assert len(new_size) == 2, "New shape should only be hw"
     old_size = patch_embed.shape[-2:]


### PR DESCRIPTION
Replaces #14100. Resubmitted with only the focused fix. @hnyls2002

## Motivation

`resample_patch_embed()` receives `new_size` derived from user-provided
`patch_size` config via `to_2tuple()`. When users pass invalid values
(negative, zero, or non-numeric), the function passes them through to
`F.interpolate`, which produces cryptic internal torch errors instead of
pointing to the actual config mistake.

## Modifications

- Convert `new_size` elements to `int` via `int(x)` to handle float and
  other numeric types, with a clear error when conversion fails
- Validate all elements are positive (> 0) with a clear error message
- The existing `vmap` import block is untouched

## Accuracy Tests

Not applicable. Purely input validation, no model output affected.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27258395175](https://github.com/sgl-project/sglang/actions/runs/27258395175)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27258395111](https://github.com/sgl-project/sglang/actions/runs/27258395111)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->