### PR TITLE
fix: apply custom logit processors in EAGLE v2 verify path

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -582,6 +582,7 @@ def eagle_sample(
     from sglang.srt.layers.dp_attention import (
         is_dp_attention_enabled,
     )
+    from sglang.srt.layers.sampler import apply_custom_logit_processor
     from sglang.srt.runtime_context import get_server_args
     from sglang.srt.sampling.penaltylib.repetition_penalty import (
         apply_scaling_penalties,
@@ -605,6 +606,17 @@ def eagle_sample(
     next_token_logits = logits_output.next_token_logits
 
     sanitize_nan_logits(next_token_logits, "verify: target model logits")
+
+    # Apply the custom logit processors if registered in the sampling info.
+    # Done before penalties and the grammar mask, matching the other spec
+    # backends (eagle_info / ngram_info / dflash_utils) so a custom processor
+    # cannot override tokens the grammar mask has already forbidden.
+    if sampling_info.has_custom_logit_processor:
+        apply_custom_logit_processor(
+            next_token_logits,
+            sampling_info,
+            num_tokens_in_batch=verify_input.draft_token_num,
+        )
 
     # Apply penalty
     # This is a relaxed version of penalties for speculative decoding.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Custom logit processors are applied in the verify step of every speculative decoding backend — `eagle_info.py`, `ngram_info.py`, and `dflash_info.py` all call `apply_custom_logit_processor(...)` — **except** the EAGLE v2 backend (`eagle_info_v2.py`), which omits it. As a result, any custom logit processor (e.g. `DisallowedTokensLogitsProcessor`, the thinking-budget processors, the DeepSeek-OCR n-gram processor) is silently ignored when running with EAGLE v2.



## Modifications

`python/sglang/srt/speculative/eagle_info_v2.py`: in `EagleVerifyInputV2Mixin.sample()`, after the grammar mask is applied, call
`apply_custom_logit_processor` with `num_tokens_in_batch=self.draft_token_num`,exactly mirroring the other three spec backends.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29503578069](https://github.com/sgl-project/sglang/actions/runs/29503578069)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29503581690](https://github.com/sgl-project/sglang/actions/runs/29503581690)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->