### PR TITLE
fix: expand custom logit processor params per token in speculative de…

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -791,11 +791,19 @@ def apply_custom_logit_processor(
         )
         batch_mask = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
 
+        # Under speculative decoding each request occupies num_tokens_in_batch
+        # consecutive rows in logits, and repeat_interleave above keeps those rows
+        # contiguous. The params list must be expanded the same way so it lines up
+        # with the selected rows; otherwise the processor receives fewer params than
+        # rows and silently skips the trailing draft-token rows.
+        params = [
+            sampling_batch_info.custom_params[i]
+            for i in batch_indices
+            for _ in range(num_tokens_in_batch)
+        ]
+
         # Apply the processor to the logits
-        logits[batch_mask] = processor(
-            logits[batch_mask],
-            [sampling_batch_info.custom_params[i] for i in batch_indices],
-        )
+        logits[batch_mask] = processor(logits[batch_mask], params)
 
         logger.debug(
             f"Custom logit processor {processor.__class__.__name__} is applied."

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -443,5 +443,61 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         self.assertEqual(result[1, 4].item(), 0.0)
 
 
+# apply_custom_logit_processor — sampler-side fan-out under speculative decoding
+class _DummySamplingBatchInfo:
+    """Minimal stand-in for SamplingBatchInfo used by apply_custom_logit_processor."""
+
+    def __init__(self, custom_params, custom_logit_processor):
+        self.custom_params = custom_params
+        self.custom_logit_processor = custom_logit_processor
+
+    def __len__(self):
+        return len(self.custom_params)
+
+
+class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
+    """Regression test: params must be expanded per draft-token row.
+
+    With speculative decoding a request occupies num_tokens_in_batch consecutive
+    rows in the logits tensor. Previously the params list was not expanded to
+    match, so a row-consuming processor (e.g. the n-gram one) only saw params for
+    the first row of each request and silently skipped the trailing draft rows.
+    """
+
+    vocab_size = 8
+
+    def test_params_expanded_to_every_draft_row(self):
+        from sglang.srt.layers.sampler import apply_custom_logit_processor
+
+        draft_token_num = 2
+        batch_size = 3
+        logits = torch.zeros(
+            (batch_size * draft_token_num, self.vocab_size), dtype=torch.float
+        )
+        original = logits.clone()
+
+        # Repeated bigrams [1,2,3,1,2]; prefix (2) → DeepseekOCR bans token 3.
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        ocr_params = {"__req__": req, "ngram_size": 2, "window_size": 100}
+        custom_params = [None, ocr_params, None]
+        batch_mask = torch.tensor([False, True, False])
+        processor = DeepseekOCRNoRepeatNGramLogitProcessor()
+        sampling_info = _DummySamplingBatchInfo(
+            custom_params=custom_params,
+            custom_logit_processor={1: (processor, batch_mask)},
+        )
+
+        apply_custom_logit_processor(
+            logits, sampling_info, num_tokens_in_batch=draft_token_num
+        )
+
+        # Request at batch index 1 occupies rows 2 and 3 — BOTH must be banned.
+        for row in (2, 3):
+            self.assertTrue(torch.isinf(logits[row, 3]) and logits[row, 3] < 0)
+        # All other rows untouched.
+        untouched = [0, 1, 4, 5]
+        self.assertTrue(torch.equal(logits[untouched], original[untouched]))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Custom logit processors are broken under speculative decoding. When a verify step runs, each request occupies `num_tokens_in_batch` (= `draft_token_num`) consecutive rows in the logits tensor. `apply_custom_logit_processor` expands the boolean row mask with `torch.repeat_interleave(..., num_tokens_in_batch)` so it selects all of those rows, but it still builds the per-row params list with **one entry per request** rather than one entry per selected row:

```python
batch_mask = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
logits[batch_mask] = processor(
    logits[batch_mask],
    [sampling_batch_info.custom_params[i] for i in batch_indices],  # len == #reqs
)
```

For a processor that consumes params positionally (it iterates `enumerate(custom_param_list)`), the params list is shorter than the number of selected rows. The processor only ever sees params for the first draft-token row of each masked request and silently skips the remaining draft rows, so the processor is effectively not applied to most spec-decoded tokens.

This affects every speculative-decoding backend that calls the helper with `num_tokens_in_batch > 1` — `eagle_info.py`, `ngram_info.py`, and `dflash_info.py` all pass `num_tokens_in_batch=self.draft_token_num`.

## Modifications

- `python/sglang/srt/layers/sampler.py`: expand the params list per token so it  lines up with the `repeat_interleave`d row mask. `repeat_interleave` keeps  each request's rows contiguous, so repeating each request's params  `num_tokens_in_batch` times preserves row↔param alignment.

This is a minimal, behavior-preserving fix for the single-token (`num_tokens_in_batch == 1`) path — the expansion is a no-op there.

## Accuracy Tests

Added a regression test in `test/registered/unit/sampling/test_custom_logit_processor.py` (`TestApplyCustomLogitProcessorSpecDecoding`) that drives `apply_custom_logit_processor` with `num_tokens_in_batch=2` and a row-consuming processor (`DeepseekOCRNoRepeatNGramLogitProcessor`), asserting that **both** draft-token rows of the masked request are processed and all other rows are untouched. The test fails on `main` (only the first draft row is modified) and passes with this change.

```
python -m pytest test/registered/unit/sampling/test_custom_logit_processor.py -q
# 35 passed
```


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27264318712](https://github.com/sgl-project/sglang/actions/runs/27264318712)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27264318321](https://github.com/sgl-project/sglang/actions/runs/27264318321)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->