### PR TITLE
[NPU] Fix dead patch_model monkey-patch breaking NPU torch.compile capture

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -35,10 +35,8 @@ import torch
 import tqdm
 from torch.profiler import ProfilerActivity, profile
 
-from sglang.srt.compilation.torch_compile_decoration import (
-    patch_model,
-    set_torch_compile_config,
-)
+from sglang.srt.compilation import torch_compile_decoration
+from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
 from sglang.srt.distributed import get_tensor_model_parallel_rank
 from sglang.srt.distributed.parallel_state import (
     graph_capture,
@@ -815,7 +813,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
             for variant_label, _variant_has_lora in lora_variants:
                 _set_capture_lora_variant(variant_label)
-                with patch_model(
+                with torch_compile_decoration.patch_model(
                     self.model_runner.model,
                     bs in self.compile_bs,
                     num_tokens=bs * self.num_tokens_per_bs,


### PR DESCRIPTION
## Motivation

The CUDA graph runner/backend refactor (#23906) broke the NPU `--enable-torch-compile` path. NPU CI (`test_npu_compile_graph_tp1_bf16.py`) fails during decode CUDA graph capture with:

```
torch._inductor.exc.InductorError: AssertionError:
make_fallback(aten.split_with_sizes.default): a decomposition exists, we should switch to it.
-> Exception: Capture cuda graph failed
```

The tell is that **inductor runs at all** — on Ascend NPU, `torch.compile` must use the `npugraph_ex` backend, never inductor.

### Root cause

`NPUGraphRunner` customizes the compile backend by monkey-patching:

```python
from sglang.srt.compilation import torch_compile_decoration
torch_compile_decoration.patch_model = patch_model_npu   # uses get_compiler_backend("npugraph_ex")
```

The refactor moved `patch_model` out of `cuda_graph_runner.py` into `compilation/torch_compile_decoration.py`, and the decode runner now imports it **by value**:

```python
# decode_cuda_graph_runner.py
from sglang.srt.compilation.torch_compile_decoration import patch_model  # local copy
...
with patch_model(...) as forward:   # reads the local copy, not the module attribute
```

`from module import name` binds a *copy* of the reference into the decode runner's namespace. Rebinding `torch_compile_decoration.patch_model` afterward changes the attribute on the source module only — the call site keeps using its own copy. The NPU override became a silent no-op, so capture fell back to the default inductor-mode `patch_model`, which crashes on NPU.

Pre-refactor this worked because `patch_model` was both defined and called inside the same module (`cuda_graph_runner.py`), so the monkey-patch targeted exactly the global the call site read.

## Modifications

Resolve `patch_model` through the module at call time in `decode_cuda_graph_runner.py`:

- Import the `torch_compile_decoration` module instead of pulling `patch_model` in by value.
- Call `torch_compile_decoration.patch_model(...)` at the capture site.

This honors the NPU runner's monkey-patch again and restores the pre-refactor behavior. `set_torch_compile_config` is unaffected (it is not monkey-patched).

## Accuracy Tests

Behavior on GPU is unchanged (module attribute resolves to the same default `patch_model`). NPU `--enable-torch-compile` capture now uses the `npugraph_ex` backend as before.

## Checklist

- [x] Format your code according to the Format code with pre-commit.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27261024403](https://github.com/sgl-project/sglang/actions/runs/27261024403)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27261024119](https://github.com/sgl-project/sglang/actions/runs/27261024119)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->