### PR TITLE
perf: remove sampler hot-path sync for custom logit processors

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -761,6 +761,36 @@ def get_token_ids_logprobs_batch_optimized(
     return output_token_ids_logprobs_val, output_token_ids_logprobs_idx
 
 
+def _expand_custom_logit_processor_indices(
+    batch_indices: torch.Tensor,
+    num_tokens_in_batch: int,
+) -> torch.Tensor:
+    """Expand per-request row indices into per-token row indices.
+
+    With speculative decoding each request occupies ``num_tokens_in_batch``
+    consecutive rows in ``logits``. Request ``r`` therefore maps to rows
+    ``r * num_tokens_in_batch ... r * num_tokens_in_batch + num_tokens_in_batch - 1``.
+    """
+    if num_tokens_in_batch == 1:
+        return batch_indices
+
+    token_offsets = torch.arange(
+        num_tokens_in_batch, dtype=batch_indices.dtype, device=batch_indices.device
+    )
+    return (batch_indices[:, None] * num_tokens_in_batch + token_offsets).reshape(-1)
+
+
+def _custom_logit_processor_covers_full_batch(
+    batch_indices: Optional[List[int]], batch_size: int
+) -> bool:
+    """Whether the processor applies to every request in order (0, 1, ..., bs-1)."""
+    return (
+        batch_indices is not None
+        and len(batch_indices) == batch_size
+        and all(idx == expected for expected, idx in enumerate(batch_indices))
+    )
+
+
 def apply_custom_logit_processor(
     logits: torch.Tensor,
     sampling_batch_info: SamplingBatchInfo,
@@ -778,32 +808,85 @@ def apply_custom_logit_processor(
         f"({num_tokens_in_batch})"
     )
 
-    for _, (
+    for processor_key, (
         processor,
         batch_mask,
     ) in sampling_batch_info.custom_logit_processor.items():
-        # Get the batch indices that need to be processed
-        batch_indices = batch_mask.nonzero(as_tuple=True)[0]
-
         assert batch_mask.shape[0] == len(sampling_batch_info), (
             f"The number of batch mask ({batch_mask.shape[0]}) does not match the number of "
             f"sampling_batch_info ({len(sampling_batch_info)})"
         )
-        batch_mask = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
 
-        # Under speculative decoding each request occupies num_tokens_in_batch
-        # consecutive rows in logits, and repeat_interleave above keeps those rows
-        # contiguous. The params list must be expanded the same way so it lines up
-        # with the selected rows; otherwise the processor receives fewer params than
-        # rows and silently skips the trailing draft-token rows.
-        params = [
-            sampling_batch_info.custom_params[i]
-            for i in batch_indices
-            for _ in range(num_tokens_in_batch)
+        # Prefer the precomputed compact params/indices populated at batch build
+        # time; they let us skip the GPU mask.nonzero() sync on the hot path.
+        processor_params = None
+        processor_param_map = getattr(
+            sampling_batch_info, "custom_logit_processor_params", None
+        )
+        if processor_param_map is not None:
+            processor_params = processor_param_map.get(processor_key)
+
+        processor_indices = None
+        processor_indices_map = getattr(
+            sampling_batch_info, "custom_logit_processor_indices_device", None
+        )
+        if processor_indices_map is not None:
+            processor_indices = processor_indices_map.get(processor_key)
+
+        processor_batch_indices = None
+        processor_batch_indices_map = getattr(
+            sampling_batch_info, "custom_logit_processor_indices", None
+        )
+        if processor_batch_indices_map is not None:
+            processor_batch_indices = processor_batch_indices_map.get(processor_key)
+
+        if processor_params is None or processor_indices is None:
+            # Fallback for manually constructed SamplingBatchInfo objects.
+            # nonzero()/tolist() here can trigger an implicit GPU-to-CPU sync.
+            batch_indices = batch_mask.nonzero(as_tuple=True)[0]
+            batch_indices_list = batch_indices.tolist()
+            processor_indices = torch.tensor(
+                batch_indices_list, dtype=torch.long, device=logits.device
+            )
+            processor_batch_indices = batch_indices_list
+            processor_params = [
+                sampling_batch_info.custom_params[i] for i in batch_indices_list
+            ]
+
+        if not processor_params:
+            continue
+
+        # Each request occupies num_tokens_in_batch consecutive rows under spec
+        # decoding, so the params list must be expanded to match the row count.
+        expanded_params = [
+            param for param in processor_params for _ in range(num_tokens_in_batch)
         ]
 
-        # Apply the processor to the logits
-        logits[batch_mask] = processor(logits[batch_mask], params)
+        covers_full_batch = _custom_logit_processor_covers_full_batch(
+            processor_batch_indices, len(sampling_batch_info)
+        )
+        if covers_full_batch:
+            expanded_indices = None
+        else:
+            expanded_indices = _expand_custom_logit_processor_indices(
+                processor_indices, num_tokens_in_batch
+            )
+
+        if expanded_indices is not None and expanded_indices.numel() == 0:
+            continue
+
+        if covers_full_batch:
+            processor_logits = logits
+        else:
+            processor_logits = logits.index_select(0, expanded_indices)
+
+        processed_logits = processor(processor_logits, expanded_params)
+
+        if covers_full_batch:
+            if processed_logits is not logits:
+                logits.copy_(processed_logits)
+        else:
+            logits.index_copy_(0, expanded_indices, processed_logits)
 
         logger.debug(
             f"Custom logit processor {processor.__class__.__name__} is applied."

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -791,11 +791,19 @@ def apply_custom_logit_processor(
         )
         batch_mask = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
 
+        # Under speculative decoding each request occupies num_tokens_in_batch
+        # consecutive rows in logits, and repeat_interleave above keeps those rows
+        # contiguous. The params list must be expanded the same way so it lines up
+        # with the selected rows; otherwise the processor receives fewer params than
+        # rows and silently skips the trailing draft-token rows.
+        params = [
+            sampling_batch_info.custom_params[i]
+            for i in batch_indices
+            for _ in range(num_tokens_in_batch)
+        ]
+
         # Apply the processor to the logits
-        logits[batch_mask] = processor(
-            logits[batch_mask],
-            [sampling_batch_info.custom_params[i] for i in batch_indices],
-        )
+        logits[batch_mask] = processor(logits[batch_mask], params)
 
         logger.debug(
             f"Custom logit processor {processor.__class__.__name__} is applied."

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -62,6 +62,16 @@ class SamplingBatchInfo:
     custom_logit_processor: Optional[
         Dict[int, Tuple[CustomLogitProcessor, torch.Tensor]]
     ] = None
+    # Per-processor compact params aligned with the selected batch rows.
+    custom_logit_processor_params: Optional[
+        Dict[int, List[Optional[Dict[str, Any]]]]
+    ] = None
+    # Per-processor CPU batch indices used to maintain compact params without
+    # calling the GPU mask.nonzero() on the sampler hot path.
+    custom_logit_processor_indices: Optional[Dict[int, List[int]]] = None
+    # Per-processor device batch indices used by the sampler to avoid boolean
+    # mask indexing on the hot path.
+    custom_logit_processor_indices_device: Optional[Dict[int, torch.Tensor]] = None
 
     # Used for deterministic sampling
     sampling_seed: Optional[torch.Tensor] = None
@@ -135,21 +145,35 @@ class SamplingBatchInfo:
                     processor_dict[processor_str] = []
                 processor_dict[processor_str].append(i)
 
-            merged_custom_logit_processor = {
-                hash(processor_str): (
+            custom_params = [r.sampling_params.custom_params for r in reqs]
+            merged_custom_logit_processor = {}
+            custom_logit_processor_params = {}
+            custom_logit_processor_indices = {}
+            custom_logit_processor_indices_device = {}
+            for processor_str, true_indices in processor_dict.items():
+                processor_key = hash(processor_str)
+                true_indices_tensor = torch.tensor(true_indices, dtype=torch.long)
+                merged_custom_logit_processor[processor_key] = (
                     # The deserialized custom logit processor object
                     CustomLogitProcessor.from_str(processor_str),
                     # The mask tensor for the requests that use this custom logit processor
                     torch.zeros(len(reqs), dtype=torch.bool)
-                    .scatter_(0, torch.tensor(true_indices), True)
+                    .scatter_(0, true_indices_tensor, True)
                     .to(device, non_blocking=True),
                 )
-                for processor_str, true_indices in processor_dict.items()
-            }
-            custom_params = [r.sampling_params.custom_params for r in reqs]
+                custom_logit_processor_indices[processor_key] = true_indices
+                custom_logit_processor_indices_device[processor_key] = (
+                    true_indices_tensor.to(device, non_blocking=True)
+                )
+                custom_logit_processor_params[processor_key] = [
+                    custom_params[i] for i in true_indices
+                ]
         else:
             merged_custom_logit_processor = None
             custom_params = None
+            custom_logit_processor_params = None
+            custom_logit_processor_indices = None
+            custom_logit_processor_indices_device = None
 
         # Each penalizers will do nothing if they evaluate themselves as not required by looking at
         # the sampling_params of the requests (See {_is_required()} of each penalizers). So this
@@ -184,6 +208,9 @@ class SamplingBatchInfo:
             has_custom_logit_processor=has_custom_logit_processor,
             custom_params=custom_params,
             custom_logit_processor=merged_custom_logit_processor,
+            custom_logit_processor_params=custom_logit_processor_params,
+            custom_logit_processor_indices=custom_logit_processor_indices,
+            custom_logit_processor_indices_device=custom_logit_processor_indices_device,
             device=device,
             logit_bias=logit_bias,
         )
@@ -296,21 +323,96 @@ class SamplingBatchInfo:
         self, keep_indices: List[int], keep_indices_device: torch.Tensor
     ):
         """Filter the custom logit processor and custom params"""
-        self.custom_logit_processor = {
-            k: (p, mask[keep_indices_device])
-            for k, (p, mask) in self.custom_logit_processor.items()
-            if torch.any(
-                mask[keep_indices_device]
-            )  # ignore the custom logit processor whose mask is all False
-        }
-        self.custom_params = [self.custom_params[i] for i in keep_indices]
+        self._ensure_custom_logit_processor_metadata()
+
+        old_custom_params = self.custom_params or [None] * len(self)
+        old_indices = self.custom_logit_processor_indices or {}
+        old_to_new = {old_idx: new_idx for new_idx, old_idx in enumerate(keep_indices)}
+
+        new_custom_logit_processor = {}
+        new_custom_logit_processor_params = {}
+        new_custom_logit_processor_indices = {}
+        new_custom_logit_processor_indices_device = {}
+        for k, (processor, mask) in self.custom_logit_processor.items():
+            pairs = [
+                (old_to_new[idx], old_custom_params[idx])
+                for idx in old_indices.get(k, [])
+                if idx in old_to_new
+            ]
+            if not pairs:
+                # Ignore the custom logit processor whose rows are all dropped.
+                continue
+
+            pairs.sort(key=lambda item: item[0])
+            filtered_indices = [idx for idx, _ in pairs]
+            new_custom_logit_processor[k] = (processor, mask[keep_indices_device])
+            new_custom_logit_processor_indices[k] = filtered_indices
+            new_custom_logit_processor_indices_device[k] = torch.tensor(
+                filtered_indices, dtype=torch.long, device=self.device
+            )
+            new_custom_logit_processor_params[k] = [param for _, param in pairs]
+
+        self.custom_logit_processor = new_custom_logit_processor
+        self.custom_logit_processor_params = new_custom_logit_processor_params
+        self.custom_logit_processor_indices = new_custom_logit_processor_indices
+        self.custom_logit_processor_indices_device = (
+            new_custom_logit_processor_indices_device
+        )
+        self.custom_params = [old_custom_params[i] for i in keep_indices]
 
         # If the custom logit processor is an empty dict, set the flag to False,
         # and set the custom logit processor and custom params to None.
         if len(self.custom_logit_processor) == 0:
             self.custom_logit_processor = None
+            self.custom_logit_processor_params = None
+            self.custom_logit_processor_indices = None
+            self.custom_logit_processor_indices_device = None
             self.custom_params = None
             self.has_custom_logit_processor = False
+
+    def _ensure_custom_logit_processor_metadata(self):
+        """Lazily rebuild the compact params/indices metadata.
+
+        Manually constructed SamplingBatchInfo objects (e.g. in tests) may only
+        carry custom_logit_processor + custom_params. In that case we recover the
+        per-processor indices from the mask once, so filter/merge can stay on the
+        compact path without GPU syncs afterwards.
+        """
+        if self.custom_logit_processor is None:
+            self.custom_logit_processor_params = None
+            self.custom_logit_processor_indices = None
+            self.custom_logit_processor_indices_device = None
+            return
+
+        if (
+            self.custom_logit_processor_params is not None
+            and self.custom_logit_processor_indices is not None
+            and self.custom_logit_processor_indices_device is not None
+        ):
+            return
+
+        custom_params = self.custom_params or [None] * len(self)
+        old_processor_params = self.custom_logit_processor_params or {}
+        old_processor_indices = self.custom_logit_processor_indices or {}
+        old_processor_indices_device = self.custom_logit_processor_indices_device or {}
+        self.custom_logit_processor_params = {}
+        self.custom_logit_processor_indices = {}
+        self.custom_logit_processor_indices_device = {}
+        for k, (_, mask) in self.custom_logit_processor.items():
+            indices = old_processor_indices.get(k)
+            if indices is None:
+                indices = mask.nonzero(as_tuple=True)[0].tolist()
+            self.custom_logit_processor_indices[k] = indices
+            processor_params = old_processor_params.get(k)
+            if processor_params is None:
+                processor_params = [custom_params[i] for i in indices]
+            self.custom_logit_processor_params[k] = processor_params
+            indices_device = old_processor_indices_device.get(k)
+            if indices_device is None:
+                indices_device = torch.tensor(
+                    indices, dtype=torch.long, device=self.device
+                )
+            self.custom_logit_processor_indices_device[k] = indices_device
 
     @staticmethod
     def merge_custom_logit_processor(
@@ -357,20 +459,48 @@ class SamplingBatchInfo:
 
         # Merge the custom logit processors and custom params lists
         if self.has_custom_logit_processor or other.has_custom_logit_processor:
+            self._ensure_custom_logit_processor_metadata()
+            other._ensure_custom_logit_processor_metadata()
+            self_custom_params = self.custom_params or [None] * len(self)
+            other_custom_params = other.custom_params or [None] * len(other)
+            left_processor_indices = self.custom_logit_processor_indices or {}
+            right_processor_indices = other.custom_logit_processor_indices or {}
+            bs1 = len(self)
+            bs2 = len(other)
+
             # Merge the custom logit processors
             self.custom_logit_processor = (
                 SamplingBatchInfo.merge_custom_logit_processor(
                     self.custom_logit_processor,
                     other.custom_logit_processor,
-                    len(self),
-                    len(other),
+                    bs1,
+                    bs2,
                     self.device,
                 )
             )
+            # Merge the compact params/indices metadata, shifting the right-hand
+            # side indices by bs1 to account for the concatenated batch.
+            keys = set(left_processor_indices.keys()).union(
+                right_processor_indices.keys()
+            )
+            self.custom_logit_processor_indices = {}
+            self.custom_logit_processor_indices_device = {}
+            self.custom_logit_processor_params = {}
+            for k in keys:
+                left_indices = left_processor_indices.get(k, [])
+                right_indices = right_processor_indices.get(k, [])
+                merged_indices = left_indices + [idx + bs1 for idx in right_indices]
+                self.custom_logit_processor_indices[k] = merged_indices
+                self.custom_logit_processor_indices_device[k] = torch.tensor(
+                    merged_indices, dtype=torch.long, device=self.device
+                )
+                self.custom_logit_processor_params[k] = [
+                    self_custom_params[i] for i in left_indices
+                ] + [other_custom_params[i] for i in right_indices]
+
             # Merge the custom params lists
-            self.custom_params = self.custom_params or [None] * len(self)
-            other.custom_params = other.custom_params or [None] * len(other)
-            self.custom_params.extend(other.custom_params)
+            self.custom_params = self_custom_params
+            self.custom_params.extend(other_custom_params)
 
             # Set the flag to True if any of the two has custom logit processor
             self.has_custom_logit_processor = True

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -443,5 +443,61 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         self.assertEqual(result[1, 4].item(), 0.0)
 
 
+# apply_custom_logit_processor — sampler-side fan-out under speculative decoding
+class _DummySamplingBatchInfo:
+    """Minimal stand-in for SamplingBatchInfo used by apply_custom_logit_processor."""
+
+    def __init__(self, custom_params, custom_logit_processor):
+        self.custom_params = custom_params
+        self.custom_logit_processor = custom_logit_processor
+
+    def __len__(self):
+        return len(self.custom_params)
+
+
+class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
+    """Regression test: params must be expanded per draft-token row.
+
+    With speculative decoding a request occupies num_tokens_in_batch consecutive
+    rows in the logits tensor. Previously the params list was not expanded to
+    match, so a row-consuming processor (e.g. the n-gram one) only saw params for
+    the first row of each request and silently skipped the trailing draft rows.
+    """
+
+    vocab_size = 8
+
+    def test_params_expanded_to_every_draft_row(self):
+        from sglang.srt.layers.sampler import apply_custom_logit_processor
+
+        draft_token_num = 2
+        batch_size = 3
+        logits = torch.zeros(
+            (batch_size * draft_token_num, self.vocab_size), dtype=torch.float
+        )
+        original = logits.clone()
+
+        # Repeated bigrams [1,2,3,1,2]; prefix (2) → DeepseekOCR bans token 3.
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        ocr_params = {"__req__": req, "ngram_size": 2, "window_size": 100}
+        custom_params = [None, ocr_params, None]
+        batch_mask = torch.tensor([False, True, False])
+        processor = DeepseekOCRNoRepeatNGramLogitProcessor()
+        sampling_info = _DummySamplingBatchInfo(
+            custom_params=custom_params,
+            custom_logit_processor={1: (processor, batch_mask)},
+        )
+
+        apply_custom_logit_processor(
+            logits, sampling_info, num_tokens_in_batch=draft_token_num
+        )
+
+        # Request at batch index 1 occupies rows 2 and 3 — BOTH must be banned.
+        for row in (2, 3):
+            self.assertTrue(torch.isinf(logits[row, 3]) and logits[row, 3] < 0)
+        # All other rows untouched.
+        untouched = [0, 1, 4, 5]
+        self.assertTrue(torch.equal(logits[untouched], original[untouched]))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -8,6 +8,7 @@ register_cpu_ci(est_time=7, suite="base-b-test-cpu")
 import json
 import unittest
 from array import array
+from unittest import mock
 from unittest.mock import MagicMock
 
 import torch
@@ -443,30 +444,42 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         self.assertEqual(result[1, 4].item(), 0.0)
 
 
-# apply_custom_logit_processor — sampler-side fan-out under speculative decoding
+# apply_custom_logit_processor — sampler-side fan-out (incl. spec decoding)
 class _DummySamplingBatchInfo:
     """Minimal stand-in for SamplingBatchInfo used by apply_custom_logit_processor."""
 
-    def __init__(self, custom_params, custom_logit_processor):
+    def __init__(
+        self,
+        custom_params,
+        custom_logit_processor,
+        custom_logit_processor_params=None,
+        custom_logit_processor_indices=None,
+        custom_logit_processor_indices_device=None,
+    ):
         self.custom_params = custom_params
         self.custom_logit_processor = custom_logit_processor
+        self.custom_logit_processor_params = custom_logit_processor_params
+        self.custom_logit_processor_indices = custom_logit_processor_indices
+        self.custom_logit_processor_indices_device = (
+            custom_logit_processor_indices_device
+        )
 
     def __len__(self):
         return len(self.custom_params)
 
 
-class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
-    """Regression test: params must be expanded per draft-token row.
-
-    With speculative decoding a request occupies num_tokens_in_batch consecutive
-    rows in the logits tensor. Previously the params list was not expanded to
-    match, so a row-consuming processor (e.g. the n-gram one) only saw params for
-    the first row of each request and silently skipped the trailing draft rows.
-    """
+class TestApplyCustomLogitProcessor(CustomTestCase):
+    """Cover apply_custom_logit_processor, especially spec decoding (num_tokens>1)."""
 
     vocab_size = 8
 
-    def test_params_expanded_to_every_draft_row(self):
+    def _ocr_params(self, req):
+        return {"__req__": req, "ngram_size": 2, "window_size": 100}
+
+    def test_spec_decoding_expands_params_to_every_draft_row(self):
+        """Each request spans num_tokens_in_batch rows; the processor must run on all
+        of them. Before the fix the params list was not expanded per token, so only the
+        first draft-token row of a masked request was processed."""
         from sglang.srt.layers.sampler import apply_custom_logit_processor
 
         draft_token_num = 2
@@ -476,10 +489,9 @@ class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
         )
         original = logits.clone()
 
-        # Repeated bigrams [1,2,3,1,2]; prefix (2) → DeepseekOCR bans token 3.
+        # Repeated bigrams [1,2,3,1,2] with prefix (2) → DeepseekOCR bans token 3.
         req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
-        ocr_params = {"__req__": req, "ngram_size": 2, "window_size": 100}
-        custom_params = [None, ocr_params, None]
+        custom_params = [None, self._ocr_params(req), None]
         batch_mask = torch.tensor([False, True, False])
         processor = DeepseekOCRNoRepeatNGramLogitProcessor()
         sampling_info = _DummySamplingBatchInfo(
@@ -492,11 +504,49 @@ class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
         )
 
         # Request at batch index 1 occupies rows 2 and 3 — BOTH must be banned.
-        for row in (2, 3):
+        banned_rows = [2, 3]
+        untouched_rows = [0, 1, 4, 5]
+        for row in banned_rows:
             self.assertTrue(torch.isinf(logits[row, 3]) and logits[row, 3] < 0)
-        # All other rows untouched.
-        untouched = [0, 1, 4, 5]
-        self.assertTrue(torch.equal(logits[untouched], original[untouched]))
+        self.assertTrue(torch.equal(logits[untouched_rows], original[untouched_rows]))
+
+    def test_uses_compact_params_without_mask_nonzero(self):
+        """When the compact params/indices metadata is present, the sampler must not
+        fall back to mask.nonzero() on the hot path."""
+        from sglang.srt.layers.sampler import apply_custom_logit_processor
+
+        draft_token_num = 2
+        batch_size = 3
+        logits = torch.zeros(
+            (batch_size * draft_token_num, self.vocab_size), dtype=torch.float
+        )
+        original = logits.clone()
+
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        params = self._ocr_params(req)
+        custom_params = [None, params, None]
+        batch_mask = torch.tensor([False, True, False])
+        processor = DeepseekOCRNoRepeatNGramLogitProcessor()
+        sampling_info = _DummySamplingBatchInfo(
+            custom_params=custom_params,
+            custom_logit_processor={1: (processor, batch_mask)},
+            custom_logit_processor_params={1: [params]},
+            custom_logit_processor_indices={1: [1]},
+            custom_logit_processor_indices_device={1: torch.tensor([1])},
+        )
+
+        with mock.patch.object(
+            torch.Tensor,
+            "nonzero",
+            side_effect=AssertionError("nonzero must not be called on the hot path"),
+        ):
+            apply_custom_logit_processor(
+                logits, sampling_info, num_tokens_in_batch=draft_token_num
+            )
+
+        for row in [2, 3]:
+            self.assertTrue(torch.isinf(logits[row, 3]) and logits[row, 3] < 0)
+        self.assertTrue(torch.equal(logits[[0, 1, 4, 5]], original[[0, 1, 4, 5]]))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -303,6 +303,15 @@ class TestFilterBatch(CustomTestCase):
         self.assertEqual(info.custom_params, [{"a": 1}, {"c": 3}])
         mask = info.custom_logit_processor[42][1]
         self.assertEqual(mask.shape[0], 2)
+        # Compact params/indices metadata is kept consistent with the filter.
+        self.assertEqual(info.custom_logit_processor_params[42], [{"a": 1}, {"c": 3}])
+        self.assertEqual(info.custom_logit_processor_indices[42], [0, 1])
+        self.assertTrue(
+            torch.equal(
+                info.custom_logit_processor_indices_device[42],
+                torch.tensor([0, 1], dtype=torch.long, device=DEVICE),
+            )
+        )
 
     def test_filter_removes_all_custom_processors(self):
         """Test cleanup when filter removes all requests using a processor."""
@@ -316,6 +325,9 @@ class TestFilterBatch(CustomTestCase):
         info.filter_batch([0, 2], keep)
         self.assertFalse(info.has_custom_logit_processor)
         self.assertIsNone(info.custom_logit_processor)
+        self.assertIsNone(info.custom_logit_processor_params)
+        self.assertIsNone(info.custom_logit_processor_indices)
+        self.assertIsNone(info.custom_logit_processor_indices_device)
 
     def test_filter_with_none_sampling_seed(self):
         """Test that filter preserves None sampling_seed without error."""
@@ -382,6 +394,15 @@ class TestMergeBatch(CustomTestCase):
         info1.merge_batch(info2)
         self.assertTrue(info1.has_custom_logit_processor)
         self.assertEqual(len(info1.custom_params), 2)
+        # Only info1's row carries the processor; merged metadata reflects that.
+        self.assertEqual(info1.custom_logit_processor_params[1], [{"a": 1}])
+        self.assertEqual(info1.custom_logit_processor_indices[1], [0])
+        self.assertTrue(
+            torch.equal(
+                info1.custom_logit_processor_indices_device[1],
+                torch.tensor([0], dtype=torch.long, device=DEVICE),
+            )
+        )
 
     def test_merge_with_none_sampling_seed(self):
         """Test that merge preserves None when both sampling_seeds are None."""
@@ -576,6 +597,15 @@ class TestFromScheduleBatch(CustomTestCase):
         self.assertFalse(mask[1].item())
         # custom_params should be collected for all reqs
         self.assertEqual(len(info.custom_params), 2)
+        # Compact params/indices are built alongside the mask at batch build time.
+        self.assertEqual(info.custom_logit_processor_params[key], [{"token_ids": [1]}])
+        self.assertEqual(info.custom_logit_processor_indices[key], [0])
+        self.assertTrue(
+            torch.equal(
+                info.custom_logit_processor_indices_device[key],
+                torch.tensor([0], dtype=torch.long, device=DEVICE),
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`apply_custom_logit_processor` runs on the sampler hot path. Today, for every batch that uses a custom logit processor, it recovers the affected rows by calling:

```python
batch_mask.nonzero(as_tuple=True)[0]
```

and then indexes logits with a boolean mask.

`mask.nonzero()` introduces an implicit GPU-to-CPU synchronization on every sampling step. This stalls the CUDA stream and prevents scheduler overlap — CPU-side scheduling overlapping with GPU compute — from hiding latency. As a result, serving throughput is hurt whenever custom logit processors are enabled.

The row metadata needed to address the affected logits is already known when the batch is built, at the same time the mask is constructed. Therefore, we can avoid recomputing it on the sampler hot path.

## Dependency

This PR is stacked on top of [#27771](https://github.com/sgl-project/sglang/pull/27771).

The per-token expansion correctness is covered by the previous stacked PR and its regression test. This PR focuses on removing the hot-path `nonzero()` synchronization by carrying compact per-processor metadata through `SamplingBatchInfo`.

## Modifications

This PR maintains compact per-processor metadata alongside the existing custom logit processor mask, and updates the sampler to consume that metadata instead of calling `nonzero()`.

### `sampling/sampling_batch_info.py`

Add three fields kept in lockstep with `custom_logit_processor`:

- `custom_logit_processor_params`: compact params for the selected rows
- `custom_logit_processor_indices`: selected row indices on CPU
- `custom_logit_processor_indices_device`: the same indices on device

These fields are populated in `from_schedule_batch` and kept consistent through:

- `_filter_batch_custom_logit_processor`
- `merge_batch`, with right-hand batch indices shifted by `bs1`

This PR also adds `_ensure_custom_logit_processor_metadata()`, which lazily rebuilds the compact metadata from the mask for manually constructed `SamplingBatchInfo` objects, such as those used in tests. This keeps filter and merge operations on the compact metadata path when possible.

### `layers/sampler.py`

Rewrite `apply_custom_logit_processor` to use the precomputed device indices via `index_select` and `index_copy_`, instead of boolean-mask indexing.

The sampler now also has:

- a fast in-place path when a processor covers the whole batch
- a fallback path using `mask.nonzero()` for externally constructed `SamplingBatchInfo` objects that do not carry the new metadata
- helper functions:
  - `_expand_custom_logit_processor_indices`
  - `_custom_logit_processor_covers_full_batch`

This is a behavior-preserving refactor. Custom logit processors receive the same logits and params as before, and there are no public API or output changes.

## Accuracy Tests

Added coverage for compact metadata consistency and sampler behavior.

### `test/registered/unit/sampling/test_sampling_batch_info.py`

Added assertions that compact params and indices stay consistent through:

- `from_schedule_batch`
- `filter_batch`
- `merge_batch`

### `test/registered/unit/sampling/test_custom_logit_processor.py`

Added `test_uses_compact_params_without_mask_nonzero`, which patches `torch.Tensor.nonzero` to raise and verifies that the sampler does not call it when compact metadata is present.

```bash
python -m pytest test/registered/unit/sampling/test_sampling_batch_info.py \
                 test/registered/unit/sampling/test_custom_logit_processor.py -q
# 75 passed
```




## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27264325858](https://github.com/sgl-project/sglang/actions/runs/27264325858)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27264324695](https://github.com/sgl-project/sglang/actions/runs/27264324695)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->