### PR TITLE
feat: add repetition truncation logit processor

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -405,7 +405,9 @@ class CompletionResponseChoice(BaseModel):
     index: int
     text: str
     logprobs: Optional[LogProbs] = None
-    finish_reason: Optional[Literal["stop", "length", "content_filter", "abort"]] = None
+    finish_reason: Optional[
+        Literal["stop", "length", "content_filter", "abort", "repetition_truncation"]
+    ] = None
     matched_stop: Union[None, int, str] = None
     hidden_states: Optional[object] = None
 
@@ -439,7 +441,9 @@ class CompletionResponseStreamChoice(BaseModel):
     index: int
     text: str
     logprobs: Optional[LogProbs] = None
-    finish_reason: Optional[Literal["stop", "length", "content_filter", "abort"]] = None
+    finish_reason: Optional[
+        Literal["stop", "length", "content_filter", "abort", "repetition_truncation"]
+    ] = None
     matched_stop: Union[None, int, str] = None
     hidden_states: Optional[object] = None
 
@@ -950,7 +954,13 @@ class ChatCompletionResponseChoice(BaseModel):
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: Optional[
         Literal[
-            "stop", "length", "tool_calls", "content_filter", "function_call", "abort"
+            "stop",
+            "length",
+            "tool_calls",
+            "content_filter",
+            "function_call",
+            "abort",
+            "repetition_truncation",
         ]
     ] = None
     matched_stop: Union[None, int, str] = None
@@ -1009,7 +1019,13 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: Optional[
         Literal[
-            "stop", "length", "tool_calls", "content_filter", "function_call", "abort"
+            "stop",
+            "length",
+            "tool_calls",
+            "content_filter",
+            "function_call",
+            "abort",
+            "repetition_truncation",
         ]
     ] = None
     matched_stop: Union[None, int, str] = None

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -665,6 +665,10 @@ class Envs:
     # Logits processor
     SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK = EnvBool(False)
     SGLANG_LOGITS_PROCESSER_CHUNK_SIZE = EnvInt(2048)
+    # Debug-only: mark the repetition_truncation finish reason when a repeat is
+    # detected, but do not actually truncate the output. For observing detection
+    # rates in production without affecting generations.
+    SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY = EnvBool(False)
 
     # Tool-Call behavior
     SGLANG_TOOL_STRICT_LEVEL = EnvInt(ToolStrictLevel.OFF)

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -761,6 +761,36 @@ def get_token_ids_logprobs_batch_optimized(
     return output_token_ids_logprobs_val, output_token_ids_logprobs_idx
 
 
+def _expand_custom_logit_processor_indices(
+    batch_indices: torch.Tensor,
+    num_tokens_in_batch: int,
+) -> torch.Tensor:
+    """Expand per-request row indices into per-token row indices.
+
+    With speculative decoding each request occupies ``num_tokens_in_batch``
+    consecutive rows in ``logits``. Request ``r`` therefore maps to rows
+    ``r * num_tokens_in_batch ... r * num_tokens_in_batch + num_tokens_in_batch - 1``.
+    """
+    if num_tokens_in_batch == 1:
+        return batch_indices
+
+    token_offsets = torch.arange(
+        num_tokens_in_batch, dtype=batch_indices.dtype, device=batch_indices.device
+    )
+    return (batch_indices[:, None] * num_tokens_in_batch + token_offsets).reshape(-1)
+
+
+def _custom_logit_processor_covers_full_batch(
+    batch_indices: Optional[List[int]], batch_size: int
+) -> bool:
+    """Whether the processor applies to every request in order (0, 1, ..., bs-1)."""
+    return (
+        batch_indices is not None
+        and len(batch_indices) == batch_size
+        and all(idx == expected for expected, idx in enumerate(batch_indices))
+    )
+
+
 def apply_custom_logit_processor(
     logits: torch.Tensor,
     sampling_batch_info: SamplingBatchInfo,
@@ -778,32 +808,85 @@ def apply_custom_logit_processor(
         f"({num_tokens_in_batch})"
     )
 
-    for _, (
+    for processor_key, (
         processor,
         batch_mask,
     ) in sampling_batch_info.custom_logit_processor.items():
-        # Get the batch indices that need to be processed
-        batch_indices = batch_mask.nonzero(as_tuple=True)[0]
-
         assert batch_mask.shape[0] == len(sampling_batch_info), (
             f"The number of batch mask ({batch_mask.shape[0]}) does not match the number of "
             f"sampling_batch_info ({len(sampling_batch_info)})"
         )
-        batch_mask = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
 
-        # Under speculative decoding each request occupies num_tokens_in_batch
-        # consecutive rows in logits, and repeat_interleave above keeps those rows
-        # contiguous. The params list must be expanded the same way so it lines up
-        # with the selected rows; otherwise the processor receives fewer params than
-        # rows and silently skips the trailing draft-token rows.
-        params = [
-            sampling_batch_info.custom_params[i]
-            for i in batch_indices
-            for _ in range(num_tokens_in_batch)
+        # Prefer the precomputed compact params/indices populated at batch build
+        # time; they let us skip the GPU mask.nonzero() sync on the hot path.
+        processor_params = None
+        processor_param_map = getattr(
+            sampling_batch_info, "custom_logit_processor_params", None
+        )
+        if processor_param_map is not None:
+            processor_params = processor_param_map.get(processor_key)
+
+        processor_indices = None
+        processor_indices_map = getattr(
+            sampling_batch_info, "custom_logit_processor_indices_device", None
+        )
+        if processor_indices_map is not None:
+            processor_indices = processor_indices_map.get(processor_key)
+
+        processor_batch_indices = None
+        processor_batch_indices_map = getattr(
+            sampling_batch_info, "custom_logit_processor_indices", None
+        )
+        if processor_batch_indices_map is not None:
+            processor_batch_indices = processor_batch_indices_map.get(processor_key)
+
+        if processor_params is None or processor_indices is None:
+            # Fallback for manually constructed SamplingBatchInfo objects.
+            # nonzero()/tolist() here can trigger an implicit GPU-to-CPU sync.
+            batch_indices = batch_mask.nonzero(as_tuple=True)[0]
+            batch_indices_list = batch_indices.tolist()
+            processor_indices = torch.tensor(
+                batch_indices_list, dtype=torch.long, device=logits.device
+            )
+            processor_batch_indices = batch_indices_list
+            processor_params = [
+                sampling_batch_info.custom_params[i] for i in batch_indices_list
+            ]
+
+        if not processor_params:
+            continue
+
+        # Each request occupies num_tokens_in_batch consecutive rows under spec
+        # decoding, so the params list must be expanded to match the row count.
+        expanded_params = [
+            param for param in processor_params for _ in range(num_tokens_in_batch)
         ]
 
-        # Apply the processor to the logits
-        logits[batch_mask] = processor(logits[batch_mask], params)
+        covers_full_batch = _custom_logit_processor_covers_full_batch(
+            processor_batch_indices, len(sampling_batch_info)
+        )
+        if covers_full_batch:
+            expanded_indices = None
+        else:
+            expanded_indices = _expand_custom_logit_processor_indices(
+                processor_indices, num_tokens_in_batch
+            )
+
+        if expanded_indices is not None and expanded_indices.numel() == 0:
+            continue
+
+        if covers_full_batch:
+            processor_logits = logits
+        else:
+            processor_logits = logits.index_select(0, expanded_indices)
+
+        processed_logits = processor(processor_logits, expanded_params)
+
+        if covers_full_batch:
+            if processed_logits is not logits:
+                logits.copy_(processed_logits)
+        else:
+            logits.index_copy_(0, expanded_indices, processed_logits)
 
         logger.debug(
             f"Custom logit processor {processor.__class__.__name__} is applied."

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -791,11 +791,19 @@ def apply_custom_logit_processor(
         )
         batch_mask = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
 
+        # Under speculative decoding each request occupies num_tokens_in_batch
+        # consecutive rows in logits, and repeat_interleave above keeps those rows
+        # contiguous. The params list must be expanded the same way so it lines up
+        # with the selected rows; otherwise the processor receives fewer params than
+        # rows and silently skips the trailing draft-token rows.
+        params = [
+            sampling_batch_info.custom_params[i]
+            for i in batch_indices
+            for _ in range(num_tokens_in_batch)
+        ]
+
         # Apply the processor to the logits
-        logits[batch_mask] = processor(
-            logits[batch_mask],
-            [sampling_batch_info.custom_params[i] for i in batch_indices],
-        )
+        logits[batch_mask] = processor(logits[batch_mask], params)
 
         logger.debug(
             f"Custom logit processor {processor.__class__.__name__} is applied."

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -211,6 +211,16 @@ class FINISH_ABORT(BaseFinishReason):
         }
 
 
+class FINISH_REPEAT_TRUNCATION(BaseFinishReason):
+    def __init__(self):
+        super().__init__()
+
+    def to_json(self):
+        return {
+            "type": "repetition_truncation",
+        }
+
+
 class Modality(Enum):
     IMAGE = auto()
     VIDEO = auto()
@@ -743,6 +753,12 @@ class Req(ReqDllmMixin):
             sampling_params.custom_params = sampling_params.custom_params | {
                 "__req__": self
             }
+        elif custom_logit_processor is not None:
+            # A server-side default custom logit processor may be set without the
+            # client passing any custom_params; still inject the req handle so the
+            # processor can read req.output_ids / eos_token_ids.
+            sampling_params = copy.copy(sampling_params)
+            sampling_params.custom_params = {"__req__": self}
         self.sampling_params = sampling_params
         self.custom_logit_processor = custom_logit_processor
         self.return_hidden_states = return_hidden_states
@@ -787,6 +803,8 @@ class Req(ReqDllmMixin):
         # set to_finish instead of directly setting finished_reason.
         # Note: We should never set finished_reason in the middle, the req will get filtered and never respond
         self.to_finish: Optional[BaseFinishReason] = None
+        # Whether a repetition was detected in this request's output.
+        self.repetition_detected = False
         self.stream = stream
         self.eos_token_ids = eos_token_ids
         self.vocab_size = vocab_size

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -21,6 +21,7 @@ from sglang.srt.managers.io_struct import (
     GetLoadsReqInput,
 )
 from sglang.srt.managers.schedule_batch import (
+    FINISH_REPEAT_TRUNCATION,
     BaseFinishReason,
     Req,
 )
@@ -349,9 +350,18 @@ class _GenerationStreamAccumulator:
         send_output_token_logprobs_offset = req.send_output_token_logprobs_offset
         self.rids.append(req.rid)
         self.http_worker_ipcs.append(req.http_worker_ipc)
-        self.finished_reasons.append(
+        finish_reason_data = (
             req.finished_reason.to_json() if req.finished_reason else None
         )
+        # Surface repetition truncation as the finish reason when it was detected,
+        # unless the request finished for a more specific terminal reason (abort).
+        if finish_reason_data and req.repetition_detected:
+            if finish_reason_data.get("type") not in (
+                "abort",
+                "repetition_truncation",
+            ):
+                finish_reason_data = FINISH_REPEAT_TRUNCATION().to_json()
+        self.finished_reasons.append(finish_reason_data)
         self.decoded_texts.append(req.decoded_text)
         decode_ids, read_offset = req.init_incremental_detokenize()
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -289,6 +289,30 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Init request dispatcher
         self.init_request_dispatcher()
 
+        # Init server-side default custom logit processor
+        self.maybe_init_default_custom_logit_processor()
+
+    def maybe_init_default_custom_logit_processor(self):
+        """Resolve --default-custom-logit-processor to a serialized processor.
+
+        Stored as self.default_custom_logit_processor (None when unset) and used
+        as the fallback when a request does not provide its own processor.
+        """
+        from sglang.srt.sampling.custom_logit_processor import (
+            DEFAULT_CUSTOM_LOGIT_PROCESSOR_REGISTRY,
+        )
+
+        self.default_custom_logit_processor = None
+        server_args = self.server_args
+        if (
+            server_args.enable_custom_logit_processor
+            and server_args.default_custom_logit_processor is not None
+        ):
+            processor_cls = DEFAULT_CUSTOM_LOGIT_PROCESSOR_REGISTRY[
+                server_args.default_custom_logit_processor
+            ]
+            self.default_custom_logit_processor = processor_cls.to_str()
+
     def init_model_config(self):
         server_args = self.server_args
         model_config_class = getattr(self, "model_config_class", ModelConfig)
@@ -1122,7 +1146,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 input_embeds=input_embeds,
                 positional_embed_overrides=obj.positional_embed_overrides,
                 session_params=session_params,
-                custom_logit_processor=obj.custom_logit_processor,
+                custom_logit_processor=(
+                    obj.custom_logit_processor
+                    if obj.custom_logit_processor is not None
+                    else self.default_custom_logit_processor
+                ),
                 require_reasoning=obj.require_reasoning,
                 return_hidden_states=obj.return_hidden_states,
                 return_routed_experts=obj.return_routed_experts,

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1941,6 +1941,24 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
         self.load_back_duration_seconds.labels(**self.labels).observe(duration_seconds)
 
 
+class LogitProcessorCollector(_StatLoggerDIMixin):
+    def __init__(self) -> None:
+        # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
+        from prometheus_client import Counter as _PromCounter
+
+        Counter = self._counter_cls or _PromCounter
+
+        self.repetition_truncation_detected_count = Counter(
+            name="sglang:repetition_truncation_detected_count",
+            documentation="The number of requests the repetition-truncation processor inspected.",
+        )
+
+        self.repetition_truncation_truncated_count = Counter(
+            name="sglang:repetition_truncation_truncated_count",
+            documentation="The number of requests truncated due to detected repetition.",
+        )
+
+
 def get_histogram_conf_from_env(env_var_name: str) -> Optional[List[float]]:
     """
     Get the histogram configuration from the environment variable.

--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -1,12 +1,16 @@
 import json
+import logging
 from abc import ABC, abstractmethod
 from array import array
+from collections import deque
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 import dill
 import orjson
 import torch
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -19,6 +23,40 @@ def _cache_from_str(json_str: str):
     """
     data = orjson.loads(json_str)
     return dill.loads(bytes.fromhex(data["callable"]))
+
+
+@lru_cache(maxsize=1)
+def _get_logit_processor_collector_impl():
+    from sglang.srt.observability.metrics_collector import LogitProcessorCollector
+
+    return LogitProcessorCollector()
+
+
+def _is_logit_processor_metrics_rank() -> bool:
+    try:
+        from sglang.srt.layers.dp_attention import get_attention_tp_rank
+
+        return get_attention_tp_rank() == 0
+    except (AssertionError, ValueError):
+        try:
+            from sglang.srt.distributed import get_tensor_model_parallel_rank
+
+            return get_tensor_model_parallel_rank() == 0
+        except (AssertionError, ValueError):
+            return True
+
+
+def _get_logit_processor_collector():
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        if not get_global_server_args().enable_metrics:
+            return None
+    except ValueError:
+        return None
+    if not _is_logit_processor_metrics_rank():
+        return None
+    return _get_logit_processor_collector_impl()
 
 
 class CustomLogitProcessor(ABC):
@@ -201,3 +239,247 @@ class DeepseekOCRNoRepeatNGramLogitProcessor(CustomLogitProcessor):
             logits[batch_idx, indices] = -float("inf")
 
         return logits
+
+
+# Default n-gram repetition-truncation tuning. These are empirically tuned
+# defaults; they can be overridden per request through ``custom_params``.
+DEFAULT_REPETITION_TRUNCATION_NGRAM_SIZE = 300
+DEFAULT_REPETITION_TRUNCATION_WINDOW_SIZE = 8300
+DEFAULT_REPETITION_TRUNCATION_MIN_REPEAT = 15
+DEFAULT_REPETITION_TRUNCATION_MIN_CONTENT_LENGTH = 16384
+
+
+class RepetitionTruncationLogitProcessor(CustomLogitProcessor):
+    """Detect n-gram repetition in a request's output and truncate via forced EOS.
+
+    Model-agnostic: works for any autoregressive LM. When an n-gram repeats at
+    least ``min_repeat`` times within a sliding window over the most recent
+    ``window_size`` output tokens, the request is finished with a forced EOS and
+    a ``repetition_truncation`` finish reason.
+
+    Tuning knobs are read from each request's ``custom_params`` and fall back to
+    the module-level ``DEFAULT_REPETITION_TRUNCATION_*`` constants:
+      - ``ngram_size``: length of the repeated n-gram to look for.
+      - ``window_size``: size of the sliding window (in output tokens).
+      - ``min_repeat``: how many times an n-gram must occur to count as a repeat
+        (clamped to a minimum of 2 so a single occurrence never triggers).
+      - ``min_content_length``: minimum output length before detection kicks in.
+      - ``eos_token_id``: the token to force; defaults to the request's first
+        ``eos_token_ids`` entry, so no model-specific id is hard-coded.
+
+    Set ``SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY=1`` to mark the finish
+    reason without actually truncating (for observing detection in production).
+    """
+
+    REQ_PARAM_KEY: str = "__req__"
+    CACHE_ATTR: str = "_repetition_truncation_cache"
+    DETECT_FLAG_ATTR: str = "_repetition_truncation_detected"
+    ACTION_SKIP: str = "skip"
+    ACTION_FORCE_STOP: str = "force_stop"
+
+    @staticmethod
+    def _read_int(params: Dict[str, Any], key: str, default: int) -> int:
+        value = params.get(key)
+        if value is None:
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _resolve_eos_token_id(params: Dict[str, Any], req: "Req") -> Optional[int]:
+        eos = params.get("eos_token_id")
+        if eos is not None:
+            try:
+                return int(eos)
+            except (TypeError, ValueError):
+                return None
+        eos_token_ids = getattr(req, "eos_token_ids", None)
+        if eos_token_ids:
+            return next(iter(eos_token_ids))
+        return None
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        custom_param_list: Optional[List[Dict[str, Any]]] = None,
+    ) -> torch.Tensor:
+        if not custom_param_list:
+            return logits
+
+        from sglang.srt.environ import envs
+
+        debug_detect_only = envs.SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY.get()
+        collector = _get_logit_processor_collector()
+        # Per-request decision cache for this batch (spec decoding can repeat a
+        # request across several rows; we want one decision applied to all rows).
+        per_req_action = {}
+
+        for batch_idx, params in enumerate(custom_param_list):
+            if not params:
+                continue
+
+            req = params.get(self.REQ_PARAM_KEY)
+            if req is None:
+                continue
+
+            eos_token_id = self._resolve_eos_token_id(params, req)
+
+            # A request already flagged for truncation keeps forcing EOS on every
+            # subsequent row until it is filtered out of the batch.
+            if req.repetition_detected and not debug_detect_only:
+                if eos_token_id is not None:
+                    logits[batch_idx, :] = -float("inf")
+                    logits[batch_idx, eos_token_id] = 0.0
+                continue
+
+            action = per_req_action.get(req)
+            if action is not None:
+                # Same request seen again in this batch: reuse the decision.
+                if action == self.ACTION_SKIP:
+                    continue
+                if eos_token_id is not None:
+                    logits[batch_idx, :] = -float("inf")
+                    logits[batch_idx, eos_token_id] = 0.0
+                continue
+
+            ngram_size = self._read_int(
+                params, "ngram_size", DEFAULT_REPETITION_TRUNCATION_NGRAM_SIZE
+            )
+            window_size = self._read_int(
+                params, "window_size", DEFAULT_REPETITION_TRUNCATION_WINDOW_SIZE
+            )
+            min_repeat = max(
+                2,
+                self._read_int(
+                    params, "min_repeat", DEFAULT_REPETITION_TRUNCATION_MIN_REPEAT
+                ),
+            )
+            min_content_length = self._read_int(
+                params,
+                "min_content_length",
+                DEFAULT_REPETITION_TRUNCATION_MIN_CONTENT_LENGTH,
+            )
+
+            if ngram_size <= 1 or window_size <= 0 or window_size < ngram_size:
+                logger.warning(
+                    "RepetitionTruncation processor skipped due to invalid config: "
+                    "window_size=%s, ngram_size=%s",
+                    window_size,
+                    ngram_size,
+                )
+                per_req_action[req] = self.ACTION_SKIP
+                continue
+
+            sequence = req.output_ids
+            seq_len = len(sequence)
+            if seq_len < min_content_length or seq_len < ngram_size:
+                per_req_action[req] = self.ACTION_SKIP
+                continue
+
+            if collector is not None and not getattr(req, self.DETECT_FLAG_ATTR, False):
+                collector.repetition_truncation_detected_count.inc()
+                setattr(req, self.DETECT_FLAG_ATTR, True)
+
+            repeated = self._update_cache_and_detect(
+                req, sequence, seq_len, ngram_size, window_size, min_repeat
+            )
+            if not repeated:
+                per_req_action[req] = self.ACTION_SKIP
+                continue
+
+            if collector is not None and req.repetition_detected is False:
+                collector.repetition_truncation_truncated_count.inc()
+
+            req.repetition_detected = True
+            if debug_detect_only:
+                per_req_action[req] = self.ACTION_SKIP
+                continue
+
+            if req.to_finish is None:
+                from sglang.srt.managers.schedule_batch import FINISH_REPEAT_TRUNCATION
+
+                req.to_finish = FINISH_REPEAT_TRUNCATION()
+
+            if eos_token_id is not None:
+                logits[batch_idx, :] = -float("inf")
+                logits[batch_idx, eos_token_id] = 0.0
+            per_req_action[req] = self.ACTION_FORCE_STOP
+
+        return logits
+
+    def _update_cache_and_detect(
+        self,
+        req: "Req",
+        sequence,
+        seq_len: int,
+        ngram_size: int,
+        window_size: int,
+        min_repeat: int,
+    ) -> bool:
+        """Incrementally maintain a sliding-window n-gram count for ``req``.
+
+        Instead of rescanning the whole output on every decode step, the cache
+        appends only the newly formed n-grams and evicts those that fall outside
+        the last ``window_size`` tokens. Returns True if any n-gram in the window
+        currently occurs at least ``min_repeat`` times.
+        """
+        cache = getattr(req, self.CACHE_ATTR, None)
+        if cache is None:
+            cache = {
+                "last_len": 0,
+                "queue_start": 0,
+                "queue": deque(),
+                "ngram_counts": {},
+            }
+            setattr(req, self.CACHE_ATTR, cache)
+
+        last_len = cache["last_len"]
+        if seq_len < last_len:
+            # Sequence can shrink on speculative-decoding retraction; reset.
+            cache["queue"].clear()
+            cache["ngram_counts"].clear()
+            cache["queue_start"] = 0
+            last_len = 0
+
+        if seq_len != last_len:
+            start_i = max(0, last_len - ngram_size + 1)
+            end_i = seq_len - ngram_size
+            if end_i >= start_i:
+                queue = cache["queue"]
+                ngram_counts = cache["ngram_counts"]
+                if not queue:
+                    cache["queue_start"] = start_i
+                for i in range(start_i, end_i + 1):
+                    ngram = tuple(sequence[i : i + ngram_size])
+                    queue.append(ngram)
+                    ngram_counts[ngram] = ngram_counts.get(ngram, 0) + 1
+            cache["last_len"] = seq_len
+
+            # Evict n-grams that start before the sliding window.
+            min_start = max(0, seq_len - window_size)
+            queue = cache["queue"]
+            ngram_counts = cache["ngram_counts"]
+            queue_start = cache["queue_start"]
+            while queue and queue_start < min_start:
+                ngram = queue.popleft()
+                count = ngram_counts[ngram] - 1
+                if count:
+                    ngram_counts[ngram] = count
+                else:
+                    del ngram_counts[ngram]
+                queue_start += 1
+            cache["queue_start"] = queue_start
+
+        ngram_counts = cache["ngram_counts"]
+        if not ngram_counts:
+            return False
+        return any(count >= min_repeat for count in ngram_counts.values())
+
+
+# Maps the --default-custom-logit-processor choice to its processor class. This
+# is the single source of truth for server-side default processors.
+DEFAULT_CUSTOM_LOGIT_PROCESSOR_REGISTRY = {
+    "RepetitionTruncationLogitProcessor": RepetitionTruncationLogitProcessor,
+}

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -62,6 +62,16 @@ class SamplingBatchInfo:
     custom_logit_processor: Optional[
         Dict[int, Tuple[CustomLogitProcessor, torch.Tensor]]
     ] = None
+    # Per-processor compact params aligned with the selected batch rows.
+    custom_logit_processor_params: Optional[
+        Dict[int, List[Optional[Dict[str, Any]]]]
+    ] = None
+    # Per-processor CPU batch indices used to maintain compact params without
+    # calling the GPU mask.nonzero() on the sampler hot path.
+    custom_logit_processor_indices: Optional[Dict[int, List[int]]] = None
+    # Per-processor device batch indices used by the sampler to avoid boolean
+    # mask indexing on the hot path.
+    custom_logit_processor_indices_device: Optional[Dict[int, torch.Tensor]] = None
 
     # Used for deterministic sampling
     sampling_seed: Optional[torch.Tensor] = None
@@ -135,21 +145,35 @@ class SamplingBatchInfo:
                     processor_dict[processor_str] = []
                 processor_dict[processor_str].append(i)
 
-            merged_custom_logit_processor = {
-                hash(processor_str): (
+            custom_params = [r.sampling_params.custom_params for r in reqs]
+            merged_custom_logit_processor = {}
+            custom_logit_processor_params = {}
+            custom_logit_processor_indices = {}
+            custom_logit_processor_indices_device = {}
+            for processor_str, true_indices in processor_dict.items():
+                processor_key = hash(processor_str)
+                true_indices_tensor = torch.tensor(true_indices, dtype=torch.long)
+                merged_custom_logit_processor[processor_key] = (
                     # The deserialized custom logit processor object
                     CustomLogitProcessor.from_str(processor_str),
                     # The mask tensor for the requests that use this custom logit processor
                     torch.zeros(len(reqs), dtype=torch.bool)
-                    .scatter_(0, torch.tensor(true_indices), True)
+                    .scatter_(0, true_indices_tensor, True)
                     .to(device, non_blocking=True),
                 )
-                for processor_str, true_indices in processor_dict.items()
-            }
-            custom_params = [r.sampling_params.custom_params for r in reqs]
+                custom_logit_processor_indices[processor_key] = true_indices
+                custom_logit_processor_indices_device[processor_key] = (
+                    true_indices_tensor.to(device, non_blocking=True)
+                )
+                custom_logit_processor_params[processor_key] = [
+                    custom_params[i] for i in true_indices
+                ]
         else:
             merged_custom_logit_processor = None
             custom_params = None
+            custom_logit_processor_params = None
+            custom_logit_processor_indices = None
+            custom_logit_processor_indices_device = None
 
         # Each penalizers will do nothing if they evaluate themselves as not required by looking at
         # the sampling_params of the requests (See {_is_required()} of each penalizers). So this
@@ -184,6 +208,9 @@ class SamplingBatchInfo:
             has_custom_logit_processor=has_custom_logit_processor,
             custom_params=custom_params,
             custom_logit_processor=merged_custom_logit_processor,
+            custom_logit_processor_params=custom_logit_processor_params,
+            custom_logit_processor_indices=custom_logit_processor_indices,
+            custom_logit_processor_indices_device=custom_logit_processor_indices_device,
             device=device,
             logit_bias=logit_bias,
         )
@@ -296,21 +323,96 @@ class SamplingBatchInfo:
         self, keep_indices: List[int], keep_indices_device: torch.Tensor
     ):
         """Filter the custom logit processor and custom params"""
-        self.custom_logit_processor = {
-            k: (p, mask[keep_indices_device])
-            for k, (p, mask) in self.custom_logit_processor.items()
-            if torch.any(
-                mask[keep_indices_device]
-            )  # ignore the custom logit processor whose mask is all False
-        }
-        self.custom_params = [self.custom_params[i] for i in keep_indices]
+        self._ensure_custom_logit_processor_metadata()
+
+        old_custom_params = self.custom_params or [None] * len(self)
+        old_indices = self.custom_logit_processor_indices or {}
+        old_to_new = {old_idx: new_idx for new_idx, old_idx in enumerate(keep_indices)}
+
+        new_custom_logit_processor = {}
+        new_custom_logit_processor_params = {}
+        new_custom_logit_processor_indices = {}
+        new_custom_logit_processor_indices_device = {}
+        for k, (processor, mask) in self.custom_logit_processor.items():
+            pairs = [
+                (old_to_new[idx], old_custom_params[idx])
+                for idx in old_indices.get(k, [])
+                if idx in old_to_new
+            ]
+            if not pairs:
+                # Ignore the custom logit processor whose rows are all dropped.
+                continue
+
+            pairs.sort(key=lambda item: item[0])
+            filtered_indices = [idx for idx, _ in pairs]
+            new_custom_logit_processor[k] = (processor, mask[keep_indices_device])
+            new_custom_logit_processor_indices[k] = filtered_indices
+            new_custom_logit_processor_indices_device[k] = torch.tensor(
+                filtered_indices, dtype=torch.long, device=self.device
+            )
+            new_custom_logit_processor_params[k] = [param for _, param in pairs]
+
+        self.custom_logit_processor = new_custom_logit_processor
+        self.custom_logit_processor_params = new_custom_logit_processor_params
+        self.custom_logit_processor_indices = new_custom_logit_processor_indices
+        self.custom_logit_processor_indices_device = (
+            new_custom_logit_processor_indices_device
+        )
+        self.custom_params = [old_custom_params[i] for i in keep_indices]
 
         # If the custom logit processor is an empty dict, set the flag to False,
         # and set the custom logit processor and custom params to None.
         if len(self.custom_logit_processor) == 0:
             self.custom_logit_processor = None
+            self.custom_logit_processor_params = None
+            self.custom_logit_processor_indices = None
+            self.custom_logit_processor_indices_device = None
             self.custom_params = None
             self.has_custom_logit_processor = False
+
+    def _ensure_custom_logit_processor_metadata(self):
+        """Lazily rebuild the compact params/indices metadata.
+
+        Manually constructed SamplingBatchInfo objects (e.g. in tests) may only
+        carry custom_logit_processor + custom_params. In that case we recover the
+        per-processor indices from the mask once, so filter/merge can stay on the
+        compact path without GPU syncs afterwards.
+        """
+        if self.custom_logit_processor is None:
+            self.custom_logit_processor_params = None
+            self.custom_logit_processor_indices = None
+            self.custom_logit_processor_indices_device = None
+            return
+
+        if (
+            self.custom_logit_processor_params is not None
+            and self.custom_logit_processor_indices is not None
+            and self.custom_logit_processor_indices_device is not None
+        ):
+            return
+
+        custom_params = self.custom_params or [None] * len(self)
+        old_processor_params = self.custom_logit_processor_params or {}
+        old_processor_indices = self.custom_logit_processor_indices or {}
+        old_processor_indices_device = self.custom_logit_processor_indices_device or {}
+        self.custom_logit_processor_params = {}
+        self.custom_logit_processor_indices = {}
+        self.custom_logit_processor_indices_device = {}
+        for k, (_, mask) in self.custom_logit_processor.items():
+            indices = old_processor_indices.get(k)
+            if indices is None:
+                indices = mask.nonzero(as_tuple=True)[0].tolist()
+            self.custom_logit_processor_indices[k] = indices
+            processor_params = old_processor_params.get(k)
+            if processor_params is None:
+                processor_params = [custom_params[i] for i in indices]
+            self.custom_logit_processor_params[k] = processor_params
+            indices_device = old_processor_indices_device.get(k)
+            if indices_device is None:
+                indices_device = torch.tensor(
+                    indices, dtype=torch.long, device=self.device
+                )
+            self.custom_logit_processor_indices_device[k] = indices_device
 
     @staticmethod
     def merge_custom_logit_processor(
@@ -357,20 +459,48 @@ class SamplingBatchInfo:
 
         # Merge the custom logit processors and custom params lists
         if self.has_custom_logit_processor or other.has_custom_logit_processor:
+            self._ensure_custom_logit_processor_metadata()
+            other._ensure_custom_logit_processor_metadata()
+            self_custom_params = self.custom_params or [None] * len(self)
+            other_custom_params = other.custom_params or [None] * len(other)
+            left_processor_indices = self.custom_logit_processor_indices or {}
+            right_processor_indices = other.custom_logit_processor_indices or {}
+            bs1 = len(self)
+            bs2 = len(other)
+
             # Merge the custom logit processors
             self.custom_logit_processor = (
                 SamplingBatchInfo.merge_custom_logit_processor(
                     self.custom_logit_processor,
                     other.custom_logit_processor,
-                    len(self),
-                    len(other),
+                    bs1,
+                    bs2,
                     self.device,
                 )
             )
+            # Merge the compact params/indices metadata, shifting the right-hand
+            # side indices by bs1 to account for the concatenated batch.
+            keys = set(left_processor_indices.keys()).union(
+                right_processor_indices.keys()
+            )
+            self.custom_logit_processor_indices = {}
+            self.custom_logit_processor_indices_device = {}
+            self.custom_logit_processor_params = {}
+            for k in keys:
+                left_indices = left_processor_indices.get(k, [])
+                right_indices = right_processor_indices.get(k, [])
+                merged_indices = left_indices + [idx + bs1 for idx in right_indices]
+                self.custom_logit_processor_indices[k] = merged_indices
+                self.custom_logit_processor_indices_device[k] = torch.tensor(
+                    merged_indices, dtype=torch.long, device=self.device
+                )
+                self.custom_logit_processor_params[k] = [
+                    self_custom_params[i] for i in left_indices
+                ] + [other_custom_params[i] for i in right_indices]
+
             # Merge the custom params lists
-            self.custom_params = self.custom_params or [None] * len(self)
-            other.custom_params = other.custom_params or [None] * len(other)
-            self.custom_params.extend(other.custom_params)
+            self.custom_params = self_custom_params
+            self.custom_params.extend(other_custom_params)
 
             # Set the flag to True if any of the two has custom logit processor
             self.has_custom_logit_processor = True

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -781,6 +781,7 @@ class ServerArgs:
     enable_draft_weights_cpu_backup: bool = False
     allow_auto_truncate: bool = False
     enable_custom_logit_processor: bool = False
+    default_custom_logit_processor: Optional[str] = None
     flashinfer_mla_disable_ragged: bool = False
     disable_shared_experts_fusion: bool = False
     enforce_shared_experts_fusion: bool = False
@@ -6764,6 +6765,15 @@ class ServerArgs:
             help="Enable users to pass custom logit processors to the server (disabled by default for security)",
         )
         parser.add_argument(
+            "--default-custom-logit-processor",
+            type=str,
+            default=ServerArgs.default_custom_logit_processor,
+            choices=["RepetitionTruncationLogitProcessor"],
+            help="The default custom logit processor to apply when "
+            "--enable-custom-logit-processor is set but a request does not "
+            "specify its own.",
+        )
+        parser.add_argument(
             "--flashinfer-mla-disable-ragged",
             action="store_true",
             help="Not using ragged prefill wrapper when running flashinfer mla",
@@ -7444,6 +7454,25 @@ class ServerArgs:
                 "served_model_name cannot contain a colon (':') character. "
                 "The colon is reserved for the 'model:adapter' syntax used in LoRA adapter specification. "
                 f"Invalid value: '{self.served_model_name}'"
+            )
+
+        # Check custom logit processor
+        if (
+            self.default_custom_logit_processor is not None
+            and not self.enable_custom_logit_processor
+        ):
+            raise ValueError(
+                "--default-custom-logit-processor requires "
+                "--enable-custom-logit-processor to be set."
+            )
+        if (
+            self.default_custom_logit_processor == "RepetitionTruncationLogitProcessor"
+            and envs.SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY.get()
+        ):
+            logger.warning(
+                "SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY is enabled; "
+                "repetition will be detected but output will not be truncated. "
+                "This is intended for debugging only."
             )
 
         # Check LoRA

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -443,5 +443,61 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         self.assertEqual(result[1, 4].item(), 0.0)
 
 
+# apply_custom_logit_processor — sampler-side fan-out under speculative decoding
+class _DummySamplingBatchInfo:
+    """Minimal stand-in for SamplingBatchInfo used by apply_custom_logit_processor."""
+
+    def __init__(self, custom_params, custom_logit_processor):
+        self.custom_params = custom_params
+        self.custom_logit_processor = custom_logit_processor
+
+    def __len__(self):
+        return len(self.custom_params)
+
+
+class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
+    """Regression test: params must be expanded per draft-token row.
+
+    With speculative decoding a request occupies num_tokens_in_batch consecutive
+    rows in the logits tensor. Previously the params list was not expanded to
+    match, so a row-consuming processor (e.g. the n-gram one) only saw params for
+    the first row of each request and silently skipped the trailing draft rows.
+    """
+
+    vocab_size = 8
+
+    def test_params_expanded_to_every_draft_row(self):
+        from sglang.srt.layers.sampler import apply_custom_logit_processor
+
+        draft_token_num = 2
+        batch_size = 3
+        logits = torch.zeros(
+            (batch_size * draft_token_num, self.vocab_size), dtype=torch.float
+        )
+        original = logits.clone()
+
+        # Repeated bigrams [1,2,3,1,2]; prefix (2) → DeepseekOCR bans token 3.
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        ocr_params = {"__req__": req, "ngram_size": 2, "window_size": 100}
+        custom_params = [None, ocr_params, None]
+        batch_mask = torch.tensor([False, True, False])
+        processor = DeepseekOCRNoRepeatNGramLogitProcessor()
+        sampling_info = _DummySamplingBatchInfo(
+            custom_params=custom_params,
+            custom_logit_processor={1: (processor, batch_mask)},
+        )
+
+        apply_custom_logit_processor(
+            logits, sampling_info, num_tokens_in_batch=draft_token_num
+        )
+
+        # Request at batch index 1 occupies rows 2 and 3 — BOTH must be banned.
+        for row in (2, 3):
+            self.assertTrue(torch.isinf(logits[row, 3]) and logits[row, 3] < 0)
+        # All other rows untouched.
+        untouched = [0, 1, 4, 5]
+        self.assertTrue(torch.equal(logits[untouched], original[untouched]))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -8,6 +8,7 @@ register_cpu_ci(est_time=7, suite="base-b-test-cpu")
 import json
 import unittest
 from array import array
+from unittest import mock
 from unittest.mock import MagicMock
 
 import torch
@@ -443,30 +444,42 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         self.assertEqual(result[1, 4].item(), 0.0)
 
 
-# apply_custom_logit_processor — sampler-side fan-out under speculative decoding
+# apply_custom_logit_processor — sampler-side fan-out (incl. spec decoding)
 class _DummySamplingBatchInfo:
     """Minimal stand-in for SamplingBatchInfo used by apply_custom_logit_processor."""
 
-    def __init__(self, custom_params, custom_logit_processor):
+    def __init__(
+        self,
+        custom_params,
+        custom_logit_processor,
+        custom_logit_processor_params=None,
+        custom_logit_processor_indices=None,
+        custom_logit_processor_indices_device=None,
+    ):
         self.custom_params = custom_params
         self.custom_logit_processor = custom_logit_processor
+        self.custom_logit_processor_params = custom_logit_processor_params
+        self.custom_logit_processor_indices = custom_logit_processor_indices
+        self.custom_logit_processor_indices_device = (
+            custom_logit_processor_indices_device
+        )
 
     def __len__(self):
         return len(self.custom_params)
 
 
-class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
-    """Regression test: params must be expanded per draft-token row.
-
-    With speculative decoding a request occupies num_tokens_in_batch consecutive
-    rows in the logits tensor. Previously the params list was not expanded to
-    match, so a row-consuming processor (e.g. the n-gram one) only saw params for
-    the first row of each request and silently skipped the trailing draft rows.
-    """
+class TestApplyCustomLogitProcessor(CustomTestCase):
+    """Cover apply_custom_logit_processor, especially spec decoding (num_tokens>1)."""
 
     vocab_size = 8
 
-    def test_params_expanded_to_every_draft_row(self):
+    def _ocr_params(self, req):
+        return {"__req__": req, "ngram_size": 2, "window_size": 100}
+
+    def test_spec_decoding_expands_params_to_every_draft_row(self):
+        """Each request spans num_tokens_in_batch rows; the processor must run on all
+        of them. Before the fix the params list was not expanded per token, so only the
+        first draft-token row of a masked request was processed."""
         from sglang.srt.layers.sampler import apply_custom_logit_processor
 
         draft_token_num = 2
@@ -476,10 +489,9 @@ class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
         )
         original = logits.clone()
 
-        # Repeated bigrams [1,2,3,1,2]; prefix (2) → DeepseekOCR bans token 3.
+        # Repeated bigrams [1,2,3,1,2] with prefix (2) → DeepseekOCR bans token 3.
         req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
-        ocr_params = {"__req__": req, "ngram_size": 2, "window_size": 100}
-        custom_params = [None, ocr_params, None]
+        custom_params = [None, self._ocr_params(req), None]
         batch_mask = torch.tensor([False, True, False])
         processor = DeepseekOCRNoRepeatNGramLogitProcessor()
         sampling_info = _DummySamplingBatchInfo(
@@ -492,11 +504,49 @@ class TestApplyCustomLogitProcessorSpecDecoding(CustomTestCase):
         )
 
         # Request at batch index 1 occupies rows 2 and 3 — BOTH must be banned.
-        for row in (2, 3):
+        banned_rows = [2, 3]
+        untouched_rows = [0, 1, 4, 5]
+        for row in banned_rows:
             self.assertTrue(torch.isinf(logits[row, 3]) and logits[row, 3] < 0)
-        # All other rows untouched.
-        untouched = [0, 1, 4, 5]
-        self.assertTrue(torch.equal(logits[untouched], original[untouched]))
+        self.assertTrue(torch.equal(logits[untouched_rows], original[untouched_rows]))
+
+    def test_uses_compact_params_without_mask_nonzero(self):
+        """When the compact params/indices metadata is present, the sampler must not
+        fall back to mask.nonzero() on the hot path."""
+        from sglang.srt.layers.sampler import apply_custom_logit_processor
+
+        draft_token_num = 2
+        batch_size = 3
+        logits = torch.zeros(
+            (batch_size * draft_token_num, self.vocab_size), dtype=torch.float
+        )
+        original = logits.clone()
+
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        params = self._ocr_params(req)
+        custom_params = [None, params, None]
+        batch_mask = torch.tensor([False, True, False])
+        processor = DeepseekOCRNoRepeatNGramLogitProcessor()
+        sampling_info = _DummySamplingBatchInfo(
+            custom_params=custom_params,
+            custom_logit_processor={1: (processor, batch_mask)},
+            custom_logit_processor_params={1: [params]},
+            custom_logit_processor_indices={1: [1]},
+            custom_logit_processor_indices_device={1: torch.tensor([1])},
+        )
+
+        with mock.patch.object(
+            torch.Tensor,
+            "nonzero",
+            side_effect=AssertionError("nonzero must not be called on the hot path"),
+        ):
+            apply_custom_logit_processor(
+                logits, sampling_info, num_tokens_in_batch=draft_token_num
+            )
+
+        for row in [2, 3]:
+            self.assertTrue(torch.isinf(logits[row, 3]) and logits[row, 3] < 0)
+        self.assertTrue(torch.equal(logits[[0, 1, 4, 5]], original[[0, 1, 4, 5]]))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/sampling/test_repetition_truncation_logit_processor.py
+++ b/test/registered/unit/sampling/test_repetition_truncation_logit_processor.py
@@ -1,0 +1,226 @@
+"""Unit tests for RepetitionTruncationLogitProcessor."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.sampler import apply_custom_logit_processor
+from sglang.srt.managers.schedule_batch import FINISH_REPEAT_TRUNCATION
+from sglang.srt.sampling.custom_logit_processor import (
+    RepetitionTruncationLogitProcessor,
+)
+from sglang.test.test_utils import CustomTestCase
+
+EOS = 99
+
+
+class DummyReq:
+    def __init__(self, output_ids, rid="req", eos_token_id=EOS):
+        self.output_ids = list(output_ids)
+        self.repetition_detected = False
+        self.to_finish = None
+        self.rid = rid
+        self.eos_token_ids = {eos_token_id} if eos_token_id is not None else set()
+
+
+class DummySamplingBatchInfo:
+    def __init__(
+        self,
+        custom_params,
+        custom_logit_processor,
+        custom_logit_processor_params=None,
+        custom_logit_processor_indices=None,
+        custom_logit_processor_indices_device=None,
+    ):
+        self.custom_params = custom_params
+        self.custom_logit_processor = custom_logit_processor
+        self.custom_logit_processor_params = custom_logit_processor_params
+        self.custom_logit_processor_indices = custom_logit_processor_indices
+        self.custom_logit_processor_indices_device = (
+            custom_logit_processor_indices_device
+        )
+
+    def __len__(self):
+        return len(self.custom_params)
+
+
+class TestRepetitionTruncationLogitProcessor(CustomTestCase):
+    vocab_size = 128
+
+    def _base_params(self, req, **overrides):
+        params = {
+            RepetitionTruncationLogitProcessor.REQ_PARAM_KEY: req,
+            "ngram_size": 3,
+            "window_size": 8,
+            "min_content_length": 3,
+            "min_repeat": 2,
+        }
+        params.update(overrides)
+        return params
+
+    def _run(self, req, logits, params, req_count=1):
+        processor = RepetitionTruncationLogitProcessor()
+        return processor(logits, [params] * req_count)
+
+    def _assert_unchanged(self, original, result):
+        self.assertTrue(torch.equal(original, result))
+
+    def _assert_skip(self, output_ids, expected_detected=False, **param_overrides):
+        logits = torch.randn((1, self.vocab_size))
+        req = DummyReq(output_ids)
+        params = self._base_params(req, **param_overrides)
+        out = self._run(req, logits.clone(), params)
+        self._assert_unchanged(logits, out)
+        self.assertEqual(req.repetition_detected, expected_detected)
+        self.assertIsNone(req.to_finish)
+
+    def _assert_force_stop(self, output_ids, **param_overrides):
+        logits = torch.zeros((1, self.vocab_size))
+        req = DummyReq(output_ids)
+        params = self._base_params(req, **param_overrides)
+        out = self._run(req, logits, params)
+
+        self.assertTrue(req.repetition_detected)
+        self.assertIsInstance(req.to_finish, FINISH_REPEAT_TRUNCATION)
+        self.assertEqual(out[0, EOS].item(), 0.0)
+        mask = torch.ones(self.vocab_size, dtype=torch.bool)
+        mask[EOS] = False
+        self.assertTrue(torch.isinf(out[0][mask]).all())
+        self.assertTrue((out[0][mask] < 0).all())
+
+    # --- defaults / config ---
+
+    def test_default_min_repeat_clamped_to_two(self):
+        """A min_repeat below 2 is clamped, so a single occurrence never triggers."""
+        # [1,2,3] forms one (1,2,3) trigram → one occurrence, must not truncate.
+        self._assert_skip([1, 2, 3, 4, 5, 6], min_repeat=1)
+
+    def test_module_defaults_used_when_params_absent(self):
+        """When ngram/window params are omitted, the module-level defaults apply."""
+        from sglang.srt.sampling import custom_logit_processor as clp
+
+        # A short output is well below the default ngram_size / min_content_length,
+        # so with only the req handle provided the processor skips it.
+        req = DummyReq([1, 2, 3])
+        logits = torch.randn((1, self.vocab_size))
+        params = {RepetitionTruncationLogitProcessor.REQ_PARAM_KEY: req}
+        out = self._run(req, logits.clone(), params)
+        self._assert_unchanged(logits, out)
+        self.assertGreaterEqual(clp.DEFAULT_REPETITION_TRUNCATION_MIN_REPEAT, 2)
+
+    def test_invalid_config_skips(self):
+        self._assert_skip([1, 2, 3, 1, 2, 3], ngram_size=1, window_size=0)
+
+    def test_window_smaller_than_ngram_skips(self):
+        self._assert_skip([1, 2, 3, 4, 1, 2, 3, 4], ngram_size=4, window_size=3)
+
+    def test_min_content_length_skip(self):
+        self._assert_skip([1, 2, 3, 4, 5, 6], min_content_length=10)
+
+    def test_seq_len_shorter_than_ngram(self):
+        self._assert_skip([1, 2, 3], min_content_length=1, ngram_size=4)
+
+    def test_min_repeat_threshold(self):
+        self._assert_skip([1, 2, 3, 1, 2, 3, 4, 5], min_repeat=3)
+
+    def test_repeat_outside_window_skips(self):
+        self._assert_skip([1, 2, 3, 7, 8, 9, 1, 2, 3], window_size=3, min_repeat=2)
+
+    # --- detection / truncation ---
+
+    def test_force_stop_on_ngram_repeat(self):
+        self._assert_force_stop([1, 2, 3, 1, 2, 3, 4, 5])
+
+    def test_eos_token_id_param_overrides_req(self):
+        """custom_params['eos_token_id'] takes precedence over req.eos_token_ids."""
+        logits = torch.zeros((1, self.vocab_size))
+        req = DummyReq([1, 2, 3, 1, 2, 3, 4, 5], eos_token_id=5)
+        params = self._base_params(req, eos_token_id=7)
+        out = self._run(req, logits, params)
+        self.assertTrue(req.repetition_detected)
+        self.assertEqual(out[0, 7].item(), 0.0)
+        self.assertTrue(torch.isinf(out[0, 5]) and out[0, 5] < 0)
+
+    def test_debug_detect_only_marks_without_truncating(self):
+        with envs.SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY.override(True):
+            logits = torch.randn((1, self.vocab_size))
+            req = DummyReq([1, 2, 3, 1, 2, 3, 4, 5])
+            params = self._base_params(req)
+            out = self._run(req, logits.clone(), params)
+            self._assert_unchanged(logits, out)
+            self.assertTrue(req.repetition_detected)
+            self.assertIsNone(req.to_finish)
+
+    def test_cache_reset_on_seq_shrink(self):
+        with envs.SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY.override(True):
+            req = DummyReq([1, 2, 3, 4, 5, 6, 7])
+            logits = torch.randn((1, self.vocab_size))
+            params = self._base_params(req, min_repeat=3)
+            out = self._run(req, logits.clone(), params)
+            self._assert_unchanged(logits, out)
+            self.assertFalse(req.repetition_detected)
+
+            # Shrink the sequence to trigger a cache reset; still no repeat.
+            req.output_ids = [1, 2, 3]
+            out = self._run(req, logits.clone(), params)
+            self._assert_unchanged(logits, out)
+            self.assertFalse(req.repetition_detected)
+
+    def test_cached_action_reused_across_rows(self):
+        """The same request appearing in multiple rows reuses one decision."""
+        req_count = 2
+        logits = torch.zeros((req_count, self.vocab_size))
+        req = DummyReq([1, 2, 3, 1, 2, 3, 4, 5])
+        params = self._base_params(req)
+        out = self._run(req, logits, params, req_count=req_count)
+
+        self.assertTrue(req.repetition_detected)
+        self.assertIsInstance(req.to_finish, FINISH_REPEAT_TRUNCATION)
+        for row in range(req_count):
+            self.assertEqual(out[row, EOS].item(), 0.0)
+            mask = torch.ones(self.vocab_size, dtype=torch.bool)
+            mask[EOS] = False
+            self.assertTrue(torch.isinf(out[row][mask]).all())
+
+    # --- integration with the sampler fan-out (spec decoding) ---
+
+    def test_sampler_masks_only_target_rows_with_spec_tokens(self):
+        draft_token_num = 2
+        batch_size = 3
+        logits = torch.arange(
+            batch_size * draft_token_num * self.vocab_size, dtype=torch.float
+        ).reshape(batch_size * draft_token_num, self.vocab_size)
+        original = logits.clone()
+
+        req = DummyReq([1, 2, 3, 1, 2, 3, 4, 5], rid="masked-req")
+        params = self._base_params(req)
+        custom_params = [None, params, None]
+        batch_mask = torch.tensor([False, True, False])
+
+        processor = RepetitionTruncationLogitProcessor()
+        sampling_info = DummySamplingBatchInfo(
+            custom_params=custom_params,
+            custom_logit_processor={1: (processor, batch_mask)},
+        )
+        apply_custom_logit_processor(
+            logits, sampling_info, num_tokens_in_batch=draft_token_num
+        )
+
+        changed_rows = [2, 3]
+        unchanged_rows = [0, 1, 4, 5]
+        self.assertTrue(torch.equal(logits[unchanged_rows], original[unchanged_rows]))
+        for row in changed_rows:
+            self.assertEqual(logits[row, EOS].item(), 0.0)
+            mask = torch.ones(self.vocab_size, dtype=torch.bool)
+            mask[EOS] = False
+            self.assertTrue(torch.isinf(logits[row][mask]).all())
+            self.assertTrue((logits[row][mask] < 0).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -303,6 +303,15 @@ class TestFilterBatch(CustomTestCase):
         self.assertEqual(info.custom_params, [{"a": 1}, {"c": 3}])
         mask = info.custom_logit_processor[42][1]
         self.assertEqual(mask.shape[0], 2)
+        # Compact params/indices metadata is kept consistent with the filter.
+        self.assertEqual(info.custom_logit_processor_params[42], [{"a": 1}, {"c": 3}])
+        self.assertEqual(info.custom_logit_processor_indices[42], [0, 1])
+        self.assertTrue(
+            torch.equal(
+                info.custom_logit_processor_indices_device[42],
+                torch.tensor([0, 1], dtype=torch.long, device=DEVICE),
+            )
+        )
 
     def test_filter_removes_all_custom_processors(self):
         """Test cleanup when filter removes all requests using a processor."""
@@ -316,6 +325,9 @@ class TestFilterBatch(CustomTestCase):
         info.filter_batch([0, 2], keep)
         self.assertFalse(info.has_custom_logit_processor)
         self.assertIsNone(info.custom_logit_processor)
+        self.assertIsNone(info.custom_logit_processor_params)
+        self.assertIsNone(info.custom_logit_processor_indices)
+        self.assertIsNone(info.custom_logit_processor_indices_device)
 
     def test_filter_with_none_sampling_seed(self):
         """Test that filter preserves None sampling_seed without error."""
@@ -382,6 +394,15 @@ class TestMergeBatch(CustomTestCase):
         info1.merge_batch(info2)
         self.assertTrue(info1.has_custom_logit_processor)
         self.assertEqual(len(info1.custom_params), 2)
+        # Only info1's row carries the processor; merged metadata reflects that.
+        self.assertEqual(info1.custom_logit_processor_params[1], [{"a": 1}])
+        self.assertEqual(info1.custom_logit_processor_indices[1], [0])
+        self.assertTrue(
+            torch.equal(
+                info1.custom_logit_processor_indices_device[1],
+                torch.tensor([0], dtype=torch.long, device=DEVICE),
+            )
+        )
 
     def test_merge_with_none_sampling_seed(self):
         """Test that merge preserves None when both sampling_seeds are None."""
@@ -576,6 +597,15 @@ class TestFromScheduleBatch(CustomTestCase):
         self.assertFalse(mask[1].item())
         # custom_params should be collected for all reqs
         self.assertEqual(len(info.custom_params), 2)
+        # Compact params/indices are built alongside the mask at batch build time.
+        self.assertEqual(info.custom_logit_processor_params[key], [{"token_ids": [1]}])
+        self.assertEqual(info.custom_logit_processor_indices[key], [0])
+        self.assertTrue(
+            torch.equal(
+                info.custom_logit_processor_indices_device[key],
+                torch.tensor([0], dtype=torch.long, device=DEVICE),
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Long autoregressive generations sometimes fall into degenerate n-gram loops (the model repeats the same short span indefinitely). There is currently no built-in way to detect this server-side and stop the request cleanly.

This adds a **model-agnostic** `RepetitionTruncationLogitProcessor`: when an n-gram repeats often enough within a sliding window over the most recent output tokens, the request is finished with a forced EOS and a new `repetition_truncation` finish reason. It works for any autoregressive LM — no model-specific token ids are hard-coded (the EOS comes from the request's own `eos_token_ids`).

It is a faster sibling of the existing `DeepseekOCRNoRepeatNGramLogitProcessor`: instead of rescanning the whole output every step, it maintains an incremental sliding-window n-gram count per request.

## Modifications

- **`sampling/custom_logit_processor.py`** — new `RepetitionTruncationLogitProcessor`.
  - Tuning knobs (`ngram_size`, `window_size`, `min_repeat`, `min_content_length`) are read from each request's `custom_params`, falling back to module-level `DEFAULT_REPETITION_TRUNCATION_*` constants (empirically chosen defaults). This follows the existing `custom_params` convention rather than introducing per-knob env vars.
  - EOS resolved from `custom_params["eos_token_id"]` or the request's `eos_token_ids`; nothing model-specific is hard-coded.
  - Incremental `deque` + count cache per request; resets on speculative-decoding retraction; one decision is reused across the multiple rows a request occupies under spec decoding.
  - `DEFAULT_CUSTOM_LOGIT_PROCESSOR_REGISTRY` maps the CLI choice to the class.
- **`managers/schedule_batch.py`** — `FINISH_REPEAT_TRUNCATION` finish reason; `Req.repetition_detected` flag; inject `__req__` into `custom_params` when a server-side default processor is set but the client sent no `custom_params`.
- **`managers/scheduler_components/output_streamer.py`** — surface `repetition_truncation` as the finish reason when detected (unless a more specific terminal reason like `abort` already applies).
- **`entrypoints/openai/protocol.py`** — add `"repetition_truncation"` to the completion/chat `finish_reason` Literals.
- **`server_args.py`** — `--default-custom-logit-processor` (choice: `RepetitionTruncationLogitProcessor`); validated to require `--enable-custom-logit-processor`.
- **`managers/tokenizer_manager.py`** — `maybe_init_default_custom_logit_processor` resolves the default and uses it as the fallback when a request omits its own.
- **`environ.py`** — `SGLANG_DEBUG_REPETITION_TRUNCATION_DETECT_ONLY` (debug: mark the finish reason without truncating, for observing detection rates).
- **`observability/metrics_collector.py`** — `LogitProcessorCollector` with `sglang:repetition_truncation_detected_count` / `sglang:repetition_truncation_truncated_count` counters.

## Accuracy Tests

New `test/registered/unit/sampling/test_repetition_truncation_logit_processor.py` (14 cases): config validation/skip paths, default-constant fallback, EOS resolution + `custom_params` override, forced-EOS truncation, debug detect-only mode, cache reset on sequence shrink, decision reuse across rows, and the sampler fan-out under speculative decoding (`num_tokens_in_batch > 1`).

```
python -m pytest test/registered/unit/sampling/ -q
# 195 passed
```

## Offline Evaluation

We manually annotated 20K model outputs and used grid search to determine the best detection parameters. By default, detection is enabled only after the output length exceeds 16,384 tokens. It then maintains n-gram statistics within a sliding window over the most recent 8,300 output tokens, using an n-gram size of 300 tokens. If any n-gram appears at least 15 times within the window, the processor treats it as repetition and triggers repetition_truncation.

On the annotated dataset, the processor achieves zero false positives while keeping the false negative rate below 10%. Meanwhile, it incrementally maintains the n-gram count cache inside the sliding window, avoiding a full rescan of the entire output at every decoding step. This space-for-time strategy significantly reduces runtime overhead, and the actual execution time is much lower than the n-gram post-processing plugin used in DeepSeek-OCR.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27264328965](https://github.com/sgl-project/sglang/actions/runs/27264328965)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27264328663](https://github.com/sgl-project/sglang/actions/runs/27264328663)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->