### PR TITLE
[CI] Move misplaced mhc kernel test into test/registered/kernels

### DIFF
--- a/test/registered/kernels/test_mhc_kernels.py
+++ b/test/registered/kernels/test_mhc_kernels.py
@@ -3,6 +3,9 @@ import torch
 
 import sglang.srt.layers.mhc as mhc
 from sglang.srt.layers.mhc import mhc_fused_post_pre, mhc_post, mhc_pre
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
 
 
 @pytest.mark.parametrize("hidden_size", [4096, 7168])
@@ -109,3 +112,9 @@ def test_mhc_fused_post_pre_matches_unfused(
     layer_atol = 2e-2 if use_norm else 2e-3
     layer_rtol = 2e-2 if use_norm else 2e-3
     torch.testing.assert_close(layer_out, layer_ref, atol=layer_atol, rtol=layer_rtol)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/kernels/test_mhc_kernels.py
+++ b/test/registered/kernels/test_mhc_kernels.py
@@ -5,7 +5,7 @@ import sglang.srt.layers.mhc as mhc
 from sglang.srt.layers.mhc import mhc_fused_post_pre, mhc_post, mhc_pre
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
 
 
 @pytest.mark.parametrize("hidden_size", [4096, 7168])


### PR DESCRIPTION
## Motivation

`tests/kernels/test_mhc_kernels.py` (added in #25976) is the **only** file under a stray top-level `tests/` directory, which sits outside the repo's `test/` tree. Because the CI runner only scans `test/registered/` (and the JIT kernel dirs), this test was never discovered or executed.

## Modifications

- Move the file to `test/registered/kernels/test_mhc_kernels.py`, alongside the other kernel correctness tests.
- Add the required module-level `register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")` so `run_suite.py` discovers it (small memory footprint; requires CUDA + TileLang).
- Add the standard pytest `__main__` footer per `test/README.md`.
- Remove the now-empty top-level `tests/` directory.

The test body itself is unchanged — this is a pure relocation + CI wiring fix.

## Checklist

- [x] Verified the imported symbols (`mhc_pre`, `mhc_post`, `mhc_fused_post_pre`, `is_dsa_prefill_cp_round_robin_split`) still exist in `sglang.srt.layers.mhc`
- [x] Confirmed the registration is AST-discoverable (literal `est_time`/`stage`/`runner_config`)
- [x] Matches the registration + footer pattern of existing `test/registered/kernels/` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27263719495](https://github.com/sgl-project/sglang/actions/runs/27263719495)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27263718691](https://github.com/sgl-project/sglang/actions/runs/27263718691)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->