### PR TITLE
[Triton] Fix low-batch long-context decode occupancy: context-gated KV-splits cap

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/metadata.py
+++ b/python/sglang/srt/layers/attention/triton_ops/metadata.py
@@ -19,6 +19,8 @@ def get_num_kv_splits_triton(
     max_kv_splits,
     device_core_count,
     MAX_NUM_SEQ: tl.constexpr,
+    LONG_CTX_SPLIT_THRESHOLD: tl.constexpr = 24576,
+    SHORT_CTX_SPLIT_CAP: tl.constexpr = 8,
 ):
     # TODO: this method is tunable, we need more online serving data to tune it
     offs_seq = tl.arange(0, MAX_NUM_SEQ)
@@ -30,7 +32,28 @@ def get_num_kv_splits_triton(
     min_seq_len = tl.min(seq_lens)
     if max_seq_len * 8 < min_seq_len * 10:
         min_seq_len = max_seq_len
-    max_kv_splits_1 = tl.minimum(tl.cdiv(max_seq_len, min_seq_len), max_kv_splits)
+    # Per-sequence context-aware split cap. `max_kv_splits` (and the attn_logits/attn_lse
+    # buffers) are sized for the long-context maximum, but short-context decode is fast and
+    # not SM-underfilled enough to benefit from more splits (extra splits only perturb the
+    # fp reduce order with no speedup). Gate the effective cap DOWN to the previous value
+    # below LONG_CTX_SPLIT_THRESHOLD. The threshold is the LATEST per-dtype decode-speedup
+    # knee measured on A100 (bs=1): the heavier quantized kernels underfill earlier (~14k),
+    # bf16 ~20k, fp8 ~24k; 24576 is fp8's knee, so below it NO dtype benefits (-> gating it
+    # down costs nothing and keeps it bit-identical) and at/above it every dtype shows real
+    # speedup. Deployments that only run the heavier dtypes can lower this for extra 14-24k
+    # gains. Gate on each lane's OWN seq_lens, not the batch max: under continuous batching
+    # a short request is routinely co-scheduled with a long one, and keying off max_seq_len
+    # would drag every member onto the long path. Per-sequence gating keeps a short
+    # sequence's picked split count bit-identical to the previous default regardless of who
+    # it shares the batch with, while a genuinely long sequence still opens up to the full
+    # cap. Buffers are sized for the cap, so any per-lane value <= cap is safe; high batch
+    # still self-limits via the token_grid divisor below.
+    eff_max_kv_splits = tl.where(
+        seq_lens >= LONG_CTX_SPLIT_THRESHOLD,
+        max_kv_splits,
+        tl.minimum(max_kv_splits, SHORT_CTX_SPLIT_CAP),
+    )
+    max_kv_splits_1 = tl.minimum(tl.cdiv(max_seq_len, min_seq_len), eff_max_kv_splits)
     kv_chunk_size_1 = tl.cdiv(max_seq_len, max_kv_splits_1)
 
     # NOTE: this is a hack to let num_kv_split grows up with seqlen gradually
@@ -46,7 +69,7 @@ def get_num_kv_splits_triton(
         block_h = tl.minimum(block_h, num_kv_group)
         token_grid = num_seq * num_group * tl.cdiv(num_head, block_h)
     max_kv_splits_2 = tl.minimum(
-        tl.cdiv(ext_device_core_count, token_grid), max_kv_splits
+        tl.cdiv(ext_device_core_count, token_grid), eff_max_kv_splits
     )
     kv_chunk_size_2 = tl.cdiv(max_seq_len, max_kv_splits_2)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -802,7 +802,16 @@ class ServerArgs:
     torchao_config: str = ""
     enable_p2p_check: bool = False
     triton_attention_reduce_in_fp32: bool = False
-    triton_attention_num_kv_splits: int = 8
+    # Max flash-decoding KV splits; also sizes the per-step attn_logits/attn_lse split
+    # buffers. Raised 8->64 so long-context low-batch decode can fill the SMs (the grid
+    # is only batch*head_blocks blocks otherwise: 0.59/SM at bs=1 on an A100). The
+    # occupancy-aware heuristic (get_num_kv_splits_triton) gates this DOWN to the previous
+    # value (8) per-sequence below its long-context threshold, so any sequence shorter than
+    # the threshold stays bit-identical to the old default (even when co-scheduled with a
+    # long request); only genuinely long sequences open up to 64 (measured 1.2-3.5x decode
+    # speedup, bf16/fp8/quantized alike), and high batch still self-limits well below the
+    # cap via the grid divisor. (AMD/HIP keeps its own cap via _handle_amd_specifics.)
+    triton_attention_num_kv_splits: int = 64
     triton_attention_split_tile_size: Optional[int] = None
     num_continuous_decode_steps: int = 1
     delete_ckpt_after_loading: bool = False
@@ -7016,7 +7025,11 @@ class ServerArgs:
             "--triton-attention-num-kv-splits",
             type=int,
             default=ServerArgs.triton_attention_num_kv_splits,
-            help="The number of KV splits in flash decoding Triton kernel. Larger value is better in longer context scenarios. The default value is 8.",
+            help="Max number of KV splits in the flash-decoding Triton kernel; also sizes the "
+            "per-step attention split buffers. The occupancy-aware heuristic gates this down "
+            "per-sequence for short context (which stays bit-identical to the old default) and "
+            "only uses the full value for long context, where it fills otherwise-idle SMs. "
+            "Lower it to reduce the split-buffer footprint on memory-constrained GPUs.",
         )
         parser.add_argument(
             "--triton-attention-split-tile-size",

--- a/test/registered/attention/test_triton_attention_kernels.py
+++ b/test/registered/attention/test_triton_attention_kernels.py
@@ -865,6 +865,63 @@ class TestTritonAttention(CustomTestCase):
             unified_seq = unified_kv_indices[start_idx:end_idx]
             self.assertEqual(len(unified_seq), prefix_len + extend_len)
 
+    def _pick_kv_splits(self, seq_lens_list, cap):
+        import triton
+
+        from sglang.srt.layers.attention.triton_ops.metadata import (
+            get_num_kv_splits_triton,
+        )
+        from sglang.srt.utils import get_device_core_count
+
+        device = get_device()
+        bs = len(seq_lens_list)
+        seq_lens = torch.tensor(seq_lens_list, dtype=torch.int64, device=device)
+        num_kv_splits = torch.empty((bs,), dtype=torch.int32, device=device)
+        num_seq, num_group = bs, 1
+        num_head, num_kv_head = 32, 8  # Llama-3.1-8B GQA shape
+        sched_seq = 256 if num_seq < 256 else triton.next_power_of_2(num_seq)
+        get_num_kv_splits_triton[(1,)](
+            num_kv_splits,
+            seq_lens,
+            num_seq,
+            num_group,
+            num_head,
+            num_kv_head,
+            cap,
+            get_device_core_count(0),
+            MAX_NUM_SEQ=sched_seq,
+        )
+        return num_kv_splits.tolist()
+
+    def test_get_num_kv_splits_context_gating(self):
+        # The context-aware gate must keep short-context sequences bit-identical to the
+        # previous (cap=8) behavior -- including when a short request is co-scheduled with a
+        # long one under continuous batching -- while letting genuinely long sequences use
+        # the raised cap. The picked split count fully determines the flash-decode reduction
+        # order, so an unchanged split count means bit-identical output.
+        SHORT, LONG = (
+            2048,
+            32768,
+        )  # below / above the long-context split threshold (24576)
+
+        # 1) pure short batch: raising the cap must not change any pick.
+        self.assertEqual(
+            self._pick_kv_splits([SHORT, 1024, 1500], cap=8),
+            self._pick_kv_splits([SHORT, 1024, 1500], cap=64),
+            "short-context split counts changed when the cap was raised",
+        )
+
+        # 2) mixed batch: short members stay == their cap=8 picks; the long member opens up.
+        mixed = [1024, LONG, SHORT]
+        base = self._pick_kv_splits(mixed, cap=8)
+        gated = self._pick_kv_splits(mixed, cap=64)
+        self.assertEqual(gated[0], base[0], "short member drifted in a mixed batch")
+        self.assertEqual(gated[2], base[2], "short member drifted in a mixed batch")
+        self.assertGreater(gated[1], 8, "long member did not use the raised cap")
+        self.assertLessEqual(
+            gated[1], 64, "split count exceeded the cap (buffer overflow)"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# [Triton] Fix low-batch long-context decode occupancy: context-gated KV-splits cap (1.2–3.5× decode speedup)

## Summary

Low-batch, long-context decode on the **Triton attention backend** leaves much of the
GPU idle. The flash-decoding grid is `(batch, head_blocks, kv_splits)`; the `kv_splits`
dimension is bounded by `triton_attention_num_kv_splits` (default **8**). At `bs=1` this
caps the grid at `head_blocks * 8` blocks regardless of how long the context is — so the
occupancy-aware heuristic `get_num_kv_splits_triton`, which *already* wants more splits as
the sequence grows, is throttled before it can fill the machine.

This PR lifts that ceiling **only where it helps and only without changing short-context
numerics**, via a per-sequence context gate. It is a **general Triton-decode fix**,
independent of any KV-cache dtype (validated on bf16, fp8_e5m2, and a 4-bit quantized
cache alike). *(Found while profiling a quantized-KV decode path; the fix and its benefit
are dtype-general.)*

## Why this is a hardware-independent problem (not just "an A100 number")

The underfill is **geometric**. At `bs=1` the decode grid launches exactly

```
head_blocks * cap     blocks
```

so for any GPU with `N` SMs, the device is underfilled whenever `head_blocks * cap < N`.
With `cap=8` and Llama-3.1-8B (`head_blocks=8`) that is `64` blocks — below the SM count
of essentially **every current data-center GPU** (A100 108, H100 132, A10G 80, L40S 142, …)
at low batch. The A100 measurement below (`64 blocks = 0.59 blocks/SM`, ~40% idle) is one
instance of a problem that holds across hardware; the heuristic stays occupancy-aware, this
PR just removes the artificial `cap` that prevented it from acting.

## The fix

- **`server_args.py`** — `triton_attention_num_kv_splits` default `8 → 64`. This also sizes
  the per-step `attn_logits`/`attn_lse` split buffers for the long-context maximum.
  AMD/HIP keeps its own cap (16) via `_handle_amd_specifics`, untouched.
- **`triton_ops/metadata.py`** — inside `get_num_kv_splits_triton`, a **per-sequence context
  gate**: a sequence keeps the previous cap (`8`) until **its own length** crosses
  `LONG_CTX_SPLIT_THRESHOLD`, above which it may use the full cap.

```python
eff_max_kv_splits = tl.where(
    seq_lens >= LONG_CTX_SPLIT_THRESHOLD,           # per-lane, NOT batch max
    max_kv_splits,                                  # long seq: full cap (64)
    tl.minimum(max_kv_splits, SHORT_CTX_SPLIT_CAP), # short seq: previous cap (8)
)
```

`eff_max_kv_splits` then replaces `max_kv_splits` in the two existing clamps — the logic
delta is three lines; the rest is constexpr params, comments, and a unit test. No new
server arg, no call-site change (constexpr defaults), no kernel-signature break.

### Interaction with the existing AMD/HIP cap

Upstream already treats this cap as hardware-dependent: `_handle_amd_specifics` sets
`triton_attention_num_kv_splits = 16` on HIP. That is itself evidence that the cap needs to
scale with the device — this PR extends the same idea to the CUDA default with a
per-sequence gate, and **the two coexist cleanly**:

- The default change is dataclass-level (`8 → 64`); `_handle_amd_specifics` runs after init
  and still pins **16 on AMD**, so the raised CUDA default does **not** touch the AMD cap.
- The per-sequence context gate lives in the **shared** `get_num_kv_splits_triton`, so AMD
  benefits from the same logic — within its cap of 16, genuinely long sequences open up to
  16 splits (better long-context occupancy) while short sequences are gated back down.
- **One honest caveat:** `SHORT_CTX_SPLIT_CAP = 8` is the *prior CUDA* default. On AMD,
  whose prior cap is 16, the gate therefore caps short context at ≤8 rather than ≤16 — a
  minor, conservative change (short context is not split-bound, so fewer splits there is at
  worst neutral and reduces buffer pressure). I do **not** have AMD hardware to measure
  this. If you'd prefer AMD short-context to stay bit-identical to its prior behavior, I can
  make `SHORT_CTX_SPLIT_CAP` backend-conditional (8 on CUDA, 16 on HIP) — just say the word.

### Why gate **per-sequence**, not on the batch max

`get_num_kv_splits_triton` derives the per-step chunk sizes from `max_seq_len`. Gating on
`tl.max(seq_lens)` would let **one long request drag every short request in the same
continuous-batching step onto the long path**, shifting the short requests' split counts —
and therefore their floating-point reduction order. Keying the gate off each lane's **own**
`seq_lens` keeps every short sequence bit-identical to the previous default *regardless of
who it is batched with*. (Buffers are sized by the cap, so any per-lane value `<= cap` is
safe.) This is covered by the new unit test.

## Verification

All numbers: **A100-SXM4-80GB, single card, Llama-3.1-8B, TP=1, bs=1 unless noted.** The
*speedup magnitudes* are A100-specific; the *underfill* they address is hardware-general
(above). Cross-GPU magnitudes are not yet measured.

| # | Check | Result |
|---|-------|--------|
| 1 | **Decode-step speedup** (split 8→64, same dtype) | quantized ~14k **1.13×** → 32k **1.77×**; bf16 ~20k **1.11×** → 32k **1.25×**; fp8 ~24k **1.07×** → 32k **1.25×**; up to **~3.5×** at 120k |
| 2 | **Per-lane bit-identical** | every sequence `< threshold` keeps its baseline split count in **pure and mixed** batches; only sequences `>= threshold` change — new unit test `test_get_num_kv_splits_context_gating` |
| 3 | **Existing kernel tests** | triton decode / grouped-decode / context attention tests pass |
| 4 | **High batch self-limits** | bs 8/32/64 pick 16·19 / 4·5 / 2·3 splits — all below the cap, via the unchanged `token_grid` divisor |
| 5 | **Memory** | split buffers sized by the cap; KV-pool token capacity **unchanged** |
| 6 | **CUDA graph** | `bs 1→256` capture intact (gate is device-side arithmetic over `seq_lens`) |

### Cross-dtype speedup knee (bs=1, ms/step → speedup vs split=8)

| ctx | quantized | bf16 | fp8_e5m2 | gate @24576 |
|-----|-----------|------|----------|-------------|
| 8k–12k | 1.00–1.04× | 1.01× | 1.00× | closed (bit-identical) |
| 14336 | 1.13× | 1.06× | 1.01× | closed |
| 16384 | 1.19× | 1.01× | 1.00× | closed |
| 20480 | ~1.3× | 1.11× | 1.02× | closed |
| 24576 | ~1.4× | 1.16× | 1.07× | **opens** |
| 32768 | 1.77× | 1.25× | 1.25× | open |

### Reproducing the numbers (no private scripts)

The correctness claim is reproduced by the included unit test. The performance numbers
above reproduce with stock sglang tooling — the cap is a server arg, so a plain A/B on
`triton_attention_num_kv_splits` isolates the effect:

```bash
# Decode-only microbench, bs=1, long context. Run twice and compare decode latency:
#   baseline (old cap):
python -m sglang.bench_one_batch --model-path <llama-3.1-8b> \
    --attention-backend triton --batch-size 1 --input-len 32768 --output-len 64 \
    --triton-attention-num-kv-splits 8
#   this PR (new cap):
python -m sglang.bench_one_batch --model-path <llama-3.1-8b> \
    --attention-backend triton --batch-size 1 --input-len 32768 --output-len 64 \
    --triton-attention-num-kv-splits 64
# speedup = decode_median(8) / decode_median(64)
```

Sweep `--input-len ∈ {8k…120k}` and `--kv-cache-dtype ∈ {auto(bf16), fp8_e5m2, …}` to
trace the per-dtype knee. Because the gate clamps short context to 8 regardless of the cap,
the A/B only diverges once `input-len ≥ LONG_CTX_SPLIT_THRESHOLD` — which is exactly the
table above. (The microbench scripts I used live outside this repo; nothing here depends on
them.)

---

## Anticipated questions

### Why cap = 64 (not 32 or 128)?

`64` is the measured knee (bs=1, ms/step):

| ctx | dtype | split=32 | split=64 | split=128 |
|-----|-------|----------|----------|-----------|
| 120k | quantized | 38.4 | **28.4** | 29.4 |
| 120k | bf16 | 22.0 | **21.5** | 29.2 |
| 32k | quantized | 18.9 | 19.1 | 19.0 |
| 32k | bf16 | 14.8 | 15.6 | 15.2 |

- **`cap=32` under-splits long context** — 120k loses ~1.35× vs 64 (quantized 38.4→28.4).
- **`cap=128` helps nowhere and hurts the longest** (120k bf16 21.5→**29.2**, over-split
  overhead) while **doubling** the split-buffer footprint.

So 64 captures the long-context win at the smallest buffer cost.

### Memory impact on small cards

`triton_attention_num_kv_splits` is **shared by all Triton-backend users**, so `8 → 64`
affects everyone on the Triton backend. The resident `attn_logits`/`attn_lse` split buffers
scale linearly with the cap:

```
buffer ≈ batch × q_heads × cap × head_dim   (×2 for logits + lse)
```

i.e. an **~8× increase** in that buffer (absolute size depends on batch/heads). Measured
**+235 MB** with ample headroom on 80 GB; impact on **24/40 GB** cards is for maintainers
to weigh. If it's a concern, I'm happy to **(a)** make the cap backend/VRAM-conditional,
**(b)** size the buffers to the gated maximum rather than the raw cap, or **(c)** keep a
lower default and document the long-context flag — whichever you prefer.

### Why change the default at all, instead of pure runtime adaptivity?

It **is** adaptive — the per-sequence context gate is the adaptivity. The default change
only raises the *ceiling* the existing occupancy-aware heuristic is allowed to reach;
`cap=8` was an artificial clamp that fired before the formula could fill the GPU. Short
context and high batch are unchanged (high batch self-limits below the cap via the existing
`token_grid` divisor; short context is gated back to 8 and stays bit-identical). The cap is
not a blanket "use 64 splits" — it is the upper bound of an adaptive function.

## Provenance / prior art

Found bottom-up, no external prior art for the occupancy issue: a sparse-V decode
experiment produced **no speedup** → `torch.profiler` showed the **decode kernel dominated**
the step → a **grid-size probe** showed the `cap=8` occupancy floor. The fix builds on
sglang's own `get_num_kv_splits_triton` heuristic and the flash-decoding split mechanism.

## Scope / non-goals

- Triton attention backend only; other backends (FlashInfer, FA3, …) untouched.
- No change to short-context behavior, the high-batch path, or KV-pool capacity.
- Cross-GPU **speedup magnitudes** (24/40 GB, non-A100 SM counts) not yet measured; the
  underfill itself is argued hardware-generally above.

---

### Reviewers

cc **@ch-wan** — most frequent author of the Triton attention backend and last to touch
the kv-splits heuristic (handle confirmed from commit email). The engineers who centralized
the Triton utility kernels into `metadata.py` (#26000) and other frequent backend owners may
also be interested; I've left their handles for the maintainers / auto-assignment to add
rather than risk pinging the wrong account.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27263691228](https://github.com/sgl-project/sglang/actions/runs/27263691228)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27263690941](https://github.com/sgl-project/sglang/actions/runs/27263690941)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->