### PR TITLE
Avoid syncing non-MTP weights to Qwen3.5 MTP draft runner

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -101,6 +101,10 @@ _is_hip = is_hip()
 logger = logging.getLogger(__name__)
 
 
+def _draft_model_needs_only_mtp_weights(model) -> bool:
+    return model.__class__.__name__ == "Qwen3_5ForCausalLMMTP"
+
+
 def _get_plan_stream(
     device: str,
 ) -> Tuple[any, contextlib.AbstractContextManager]:
@@ -157,9 +161,10 @@ class EagleDraftWorker(BaseDraftWorker):
 
         # Share the allocator with a target worker.
         # Draft and target worker own their own KV cache pools.
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
-            target_worker.get_memory_pool()
-        )
+        (
+            self.req_to_token_pool,
+            self.token_to_kv_pool_allocator,
+        ) = target_worker.get_memory_pool()
 
         # Init draft worker
         if server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
@@ -428,9 +433,11 @@ class EagleDraftWorker(BaseDraftWorker):
         with canary_outside_ctx:
             # Run draft
             if can_cuda_graph:
-                parent_list, top_scores_index, draft_tokens = (
-                    self.cuda_graph_runner.replay(forward_batch)
-                )
+                (
+                    parent_list,
+                    top_scores_index,
+                    draft_tokens,
+                ) = self.cuda_graph_runner.replay(forward_batch)
             else:
                 if (
                     not forward_batch.forward_mode.is_idle()
@@ -453,7 +460,10 @@ class EagleDraftWorker(BaseDraftWorker):
 
         # Build tree mask
         # Directly write to cuda graph buffers for verify attn
-        tree_mask_buf, position_buf = (
+        (
+            tree_mask_buf,
+            position_buf,
+        ) = (
             self.target_worker.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
         )
 
@@ -840,9 +850,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
             server_args.speculative_algorithm
         )
 
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
-            target_worker.get_memory_pool()
-        )
+        (
+            self.req_to_token_pool,
+            self.token_to_kv_pool_allocator,
+        ) = target_worker.get_memory_pool()
 
         # Override the context length of the draft model to be the same as the target model.
         server_args.context_length = target_worker.model_runner.model_config.context_len
@@ -1193,12 +1204,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # Batch 1: Target verify
         # Prepare for target verify in a separate stream
         with self.plan_stream_ctx:
-            verify_forward_batch, can_run_cuda_graph = (
-                verify_input.prepare_for_v2_verify(
-                    self.req_to_token_pool,
-                    batch,
-                    self.target_worker,
-                )
+            (
+                verify_forward_batch,
+                can_run_cuda_graph,
+            ) = verify_input.prepare_for_v2_verify(
+                self.req_to_token_pool,
+                batch,
+                self.target_worker,
             )
 
         # Cover post-prepare rebinds: draft_token, plan_stream-allocated out_cache_loc.
@@ -1461,12 +1473,27 @@ class EAGLEWorkerV2(BaseSpecWorker):
         named_tensors = MultiprocessingSerializer.deserialize(
             recv_req.serialized_named_tensors[self.tp_rank]
         )
-        success, message = self.draft_worker.draft_runner.update_weights_from_tensor(
-            named_tensors=named_tensors,
-            load_format=recv_req.load_format,
-        )
-        if not success:
-            return success, message
+        # Avoid moving full target weights to the draft device when the draft
+        # model only consumes MTP branch weights.
+        if _draft_model_needs_only_mtp_weights(
+            self.draft_worker.draft_runner.model
+        ) and isinstance(named_tensors, list):
+            draft_named_tensors = [
+                (name, tensor) for name, tensor in named_tensors if "mtp" in name
+            ]
+        else:
+            draft_named_tensors = named_tensors
+
+        if draft_named_tensors:
+            (
+                success,
+                message,
+            ) = self.draft_worker.draft_runner.update_weights_from_tensor(
+                named_tensors=draft_named_tensors,
+                load_format=recv_req.load_format,
+            )
+            if not success:
+                return success, message
 
         success, message = self.target_worker.model_runner.update_weights_from_tensor(
             named_tensors=named_tensors,


### PR DESCRIPTION

## Motivation

Qwen3.5 MTP draft model only consumes MTP branch weights during `update_weights`, but the EAGLE V2 weight update path currently sends the full target weight list to the draft runner first.

`Qwen3_5ForCausalLMMTP.load_weights()` skips non-MTP tensors, but this happens after `ModelRunner.update_weights_from_tensor()` unwraps/moves tensors to the draft device. For large models, this creates unnecessary temporary GPU memory usage during online weight sync.

## Modifications

- Detect the Qwen3.5 MTP draft model in `EAGLEWorkerV2.update_weights_from_tensor`.
- Filter draft-side `named_tensors` to MTP branch weights before calling `draft_runner.update_weights_from_tensor`.
- Keep the target model update path unchanged: the target worker still receives the full weight list.
- Keep behavior unchanged for other draft models and non-list weight update formats.

## Accuracy Tests

This change does not modify model forward logic, kernels, sampling, or target model weight loading.

For Qwen3.5 MTP draft model, non-MTP tensors were already ignored by `Qwen3_5ForCausalLMMTP.load_weights()`. This PR only skips those tensors earlier, before moving them to the draft device. Therefore the loaded draft weights are expected to be identical.

Ran:

```bash
python3 -m py_compile python/sglang/srt/speculative/eagle_worker_v2.py
pre-commit run --files python/sglang/srt/speculative/eagle_worker_v2.py
```

## Speed Tests and Profiling
No inference speed benchmark was run. This change is expected to reduce temporary GPU memory usage during update_weights for Qwen3.5 MTP speculative decoding, not change steady-state inference speed.

## Checklist

Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).

Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27263938567](https://github.com/sgl-project/sglang/actions/runs/27263938567)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27263938406](https://github.com/sgl-project/sglang/actions/runs/27263938406)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->