### PR TITLE
[mamba/causal_conv1d] Fix fp16 dtype type-join in Triton kernels

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/causal_conv1d_triton.py
+++ b/python/sglang/srt/layers/attention/mamba/causal_conv1d_triton.py
@@ -120,45 +120,47 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         load_init_state = False
         if HAS_INITIAL_STATES:  # the new HAS_INITIAL_STATES
             load_init_state = tl.load(has_initial_states_ptr + idx_seq).to(tl.int1)
+        # Cast conv_states loads to x's dtype so the load_init_state if/else SSA join below sees one dtype.
+        col_dtype: tl.constexpr = x_ptr.dtype.element_ty
         if load_init_state:
-            # load from conv_states
+            # load from conv_states (cast to x dtype to keep col* uniform)
             prior_tokens = conv_states_base + (state_len - 1) * stride_conv_state_tok
             mask_w = idx_feats < dim
             if KERNEL_WIDTH == 2:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
             if KERNEL_WIDTH == 3:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
                 conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
             if KERNEL_WIDTH == 4:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col2 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
                 conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok  # [BLOCK_N]
-                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
                 conv_states_ptrs = prior_tokens - 2 * stride_conv_state_tok  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
             if KERNEL_WIDTH == 5:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col3 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col3 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
                 conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok  # [BLOCK_N]
-                col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col2 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
                 conv_states_ptrs = prior_tokens - 2 * stride_conv_state_tok  # [BLOCK_N]
-                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
                 conv_states_ptrs = prior_tokens - 3 * stride_conv_state_tok  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
         else:
             # prior-tokens are zeros
             if KERNEL_WIDTH >= 2:  # STRATEGY1
                 # first chunk and does not have prior-token, so just set to 0
-                col0 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+                col0 = tl.zeros((BLOCK_N,), dtype=col_dtype)
             if KERNEL_WIDTH >= 3:  # STRATEGY1
-                col1 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+                col1 = tl.zeros((BLOCK_N,), dtype=col_dtype)
             if KERNEL_WIDTH >= 4:  # STRATEGY1
-                col2 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+                col2 = tl.zeros((BLOCK_N,), dtype=col_dtype)
             if KERNEL_WIDTH >= 5:  # STRATEGY1
-                col3 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+                col3 = tl.zeros((BLOCK_N,), dtype=col_dtype)
 
         # STEP 2:
         # here prepare data for updating conv_state
@@ -688,18 +690,20 @@ def _causal_conv1d_update_kernel(
     mask_w = idx_feats < dim
 
     prior_tokens = conv_states_base + conv_state_token_offset * stride_conv_state_tok
+    # Same col_dtype trick as _causal_conv1d_fwd_kernel; keeps col_i = matrix_x reassignments uniform.
+    col_dtype: tl.constexpr = x_ptr.dtype.element_ty
     if KERNEL_WIDTH >= 2:
         conv_states_ptrs = prior_tokens  # [BLOCK_N]
-        col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+        col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
     if KERNEL_WIDTH >= 3:
         conv_states_ptrs = prior_tokens + 1 * stride_conv_state_tok  # [BLOCK_N]
-        col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+        col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
     if KERNEL_WIDTH >= 4:
         conv_states_ptrs = prior_tokens + 2 * stride_conv_state_tok  # [BLOCK_N]
-        col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+        col2 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
     if KERNEL_WIDTH == 5:
         conv_states_ptrs = prior_tokens + 3 * stride_conv_state_tok  # [BLOCK_N]
-        col3 = tl.load(conv_states_ptrs, mask_w, 0.0)
+        col3 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
 
     # STEP 2: assume state_len > seqlen
     idx_tokens = tl.arange(0, NP2_STATELEN)  # [BLOCK_M]


### PR DESCRIPTION
## Motivation

`_causal_conv1d_fwd_kernel` and `_causal_conv1d_update_kernel` in
`sglang/srt/layers/attention/mamba/causal_conv1d_triton.py` fail to JIT-compile when
the model is launched with `--dtype float16` for any KDA / Mamba-conv-using model:

```
triton.compiler.errors.CompilationError: at line ...:
    AssertionError("Mismatched type for col0 between then block
                    (<['256'], bf16>) and else block (<['256'], fp16>)")
```

Root cause: the kernels read prior tokens from the `conv_states` cache and the cache's
element dtype is **independent of the model dtype**: SGLang stores it as
`bfloat16` by default (`SGLANG_MAMBA_CONV_DTYPE`). Inside the kernel:

- The `HAS_INITIAL_STATES → load_init_state == True` branch loads `col*` from
  `conv_states` → values carry the cache dtype (`bf16`).
- The `else` branch initializes `col*` via `tl.zeros(..., dtype=x_ptr.dtype.element_ty)`
  → values carry the model dtype (`fp16`).

Triton's SSA join over the two `if/else` branches requires identical element types;
when the model dtype differs from the cache dtype the union fails at compile time
and the engine never reaches the launch site, hard-crashing `--dtype float16`
inference for the whole Kimi-Linear / hybrid-linear-attention family.

The bf16-default training/inference path is unaffected (both `x` and `conv_states`
are bf16, so the type-join is trivial).

## Modifications

Introduce a `col_dtype: tl.constexpr` taken from the model dtype and cast both
branches to it. The unification target is `x_ptr.dtype.element_ty` (the model
dtype) — not the cache dtype — because the same `col*` variables are later
overwritten with values loaded from `x` further down the kernel
(e.g. `col0 = matrix_x`), which already carry the model dtype. Standardizing on
the model dtype avoids a second downstream join.

Concretely, in both `_causal_conv1d_fwd_kernel` and
`_causal_conv1d_update_kernel`:

```python
col_dtype: tl.constexpr = x_ptr.dtype.element_ty
if load_init_state:
    # load from conv_states (cast to x dtype to keep col* uniform)
    if KERNEL_WIDTH == 2:
        col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
    if KERNEL_WIDTH == 3:
        col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(col_dtype)
        ...
else:
    # prior-tokens are zeros
    if KERNEL_WIDTH >= 2:
        col0 = tl.zeros((BLOCK_N,), dtype=col_dtype)
    if KERNEL_WIDTH >= 3:
        col1 = tl.zeros((BLOCK_N,), dtype=col_dtype)
    ...
```

`+23 / -19`, one file. The bf16+bf16 default path is **byte-identical**: `.to(bf16)`
of a bf16 load is a no-op, and `tl.zeros(..., dtype=bf16)` is exactly what the
unpatched else-branch produced.

| | bf16 model (default) | fp16 model + bf16 conv_states (this PR fixes) |
|---|---|---|
| `_causal_conv1d_fwd_kernel` | byte-identical | compiles + correct output |
| `_causal_conv1d_update_kernel` | byte-identical | compiles + correct output |
| Default Triton compile | passes (today) | passes (this PR) |

## Backwards compatibility audit

Every model under `sglang/srt/models/` that uses causal-conv1d goes through
the `causal_conv1d_fn` / `causal_conv1d_update` wrappers in
`sglang/srt/layers/attention/mamba/causal_conv1d.py`, which dispatch to the
patched Triton kernels (`_causal_conv1d_fwd_kernel`, `_causal_conv1d_update_kernel`).
There is no model that bypasses the wrappers to call the kernels directly. The
known callers as of this PR:

| Model family | KERNEL_WIDTH | Default cache dtype | Default model dtype |
|---|---|---|---|
| LFM2 / LFM2-MoE | 3 (`conv_L_cache`) | bf16 | bf16 |
| Kimi-Linear (KDA) | 4 (`short_conv_kernel_size`) | bf16 | bf16 |
| Qwen3-Next / Qwen3.5 (GDN backend) | varies | bf16 | bf16 |
| Falcon-H1, Granite-Hybrid, Jet-Nemotron, Nemotron-H | varies | bf16 | bf16 |

`SGLANG_MAMBA_CONV_DTYPE` is registered once at `python/sglang/srt/environ.py`
with a default of `bfloat16` (single source for all callers), so the
default cache dtype is bf16 across the board.

**Default-path claim**: with `cache_dtype == model_dtype == bf16`, the patched
kernel is byte-identical to the upstream kernel — the `.to(col_dtype)` cast we
introduce is a same-dtype cast, resolved at compile time (`tl.constexpr
col_dtype = x_ptr.dtype.element_ty`), and dropped by Triton's optimizer.

**Verified empirically** (RTX 4070Ti SM 8.9):

```text
=== KERNEL_WIDTH=3, bf16+bf16, seed=42 (LFM2 production path) ===
  [patched]  sum=285.653198
  [upstream] sum=285.653198
  torch.equal(upstream, patched) = True; max abs diff = 0.0

=== KERNEL_WIDTH=4, bf16+bf16, seed=42 (Kimi-Linear production path) ===
  [patched]  sum=292.020142
  [upstream] sum=292.020142
  torch.equal(upstream, patched) = True; max abs diff = 0.0
```

(Test harness:
[`smoke_pr7.py byte-identical`](https://github.com/QIU023/torchtitan_attention_residual/blob/main/Raising_PRs/PR7_sglang_kda_causal_conv1d_fp16/smoke_pr7.py)
— same process, `git checkout` swaps the kernel between `upstream/main` and
this PR head, fixed-seed inputs, `torch.equal()` compare.)

**Non-default-path claim**: any configuration where `cache_dtype != model_dtype`
(e.g. `--dtype float16`, `--dtype float32`, or user-set
`SGLANG_MAMBA_CONV_DTYPE` override) hits the Triton SSA type-join failure on
**upstream/main** and never reaches the launch site. There is no "pre-patch
behavior" to compare against in those configurations — the PR strictly enables
previously-broken paths without any way to regress them.

## Accuracy Tests

The smoke iterates the 4-case dtype matrix over both production `KERNEL_WIDTH`
values: **`KW=3`** (LFM2 / LFM2-MoE — `conv_L_cache`) and **`KW=4`**
(Kimi-Linear KDA — `short_conv_kernel_size`; from the
[Kimi-Linear-48B-A3B-Instruct config.json](https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct/raw/main/config.json)).
Verified on RTX 4070Ti (SM 8.9) with torch 2.11.0+cu130, triton 3.6.0:

```text
Prefill (_causal_conv1d_fwd_kernel):
  KW3_baseline_bf16_bf16              PASS  (LFM2)
  KW3_bug_repro_fp16_x_bf16_state     PASS  (LFM2 fp16 inference — this PR fixes)
  KW3_inverted_bf16_x_fp16_state      FAIL  (see "Follow-up" below)
  KW3_all_fp16                        PASS
  KW4_baseline_bf16_bf16              PASS  (Kimi-Linear)
  KW4_bug_repro_fp16_x_bf16_state     PASS  (Kimi-Linear fp16 inference — this PR fixes)
  KW4_inverted_bf16_x_fp16_state      FAIL  (same follow-up; symmetric across KWs)
  KW4_all_fp16                        PASS

Decode (_causal_conv1d_update_kernel):
  KW3_decode_baseline_bf16_bf16       PASS
  KW3_decode_bug_repro_fp16_x_bf16_state    PASS
  KW3_decode_inverted_bf16_x_fp16_state     PASS  (decode path is symmetrically clean)
  KW3_decode_all_fp16                 PASS
  KW4_decode_baseline_bf16_bf16       PASS
  KW4_decode_bug_repro_fp16_x_bf16_state    PASS
  KW4_decode_inverted_bf16_x_fp16_state     PASS
  KW4_decode_all_fp16                 PASS
```

The production-relevant `bug_repro_fp16_x_bf16_state` case passes on every
combination of `KERNEL_WIDTH ∈ {3, 4}` × {prefill, decode} — i.e. both LFM2 and
Kimi-Linear fp16 inference paths are unblocked, with both kernels touched by the
patch covered.

Smoke harness:
[`smoke_pr7.py`](https://github.com/QIU023/torchtitan_attention_residual/blob/main/Raising_PRs/PR7_sglang_kda_causal_conv1d_fp16/smoke_pr7.py)
— one file, three CLI subcommands:

```bash
python smoke_pr7.py prefill          # _causal_conv1d_fwd_kernel dtype matrix
python smoke_pr7.py decode           # _causal_conv1d_update_kernel dtype matrix
python smoke_pr7.py byte-identical   # bf16+bf16 vs upstream/main (torch.equal)
python smoke_pr7.py all              # all three back-to-back (default)
```

All modes are GPU-required but zero-network: they import only the patched
kernel module and feed synthetic inputs (prefill: `dim=64 × seqlen=8` varlen
batch; decode: `batch=2 × dim=64` single-token step). The decode inputs mirror
the production decode callers (`kda_backend.py` / `lfm2.py`):
`conv_state_indices` only, no `cache_seqlens` (the circular-buffer arg is
documented "not implemented yet" in the wrapper and unused by every in-tree
caller). The `byte-identical` mode additionally calls `git checkout` inside
the sglang submodule to swap the kernel between `upstream/main` and the
patched HEAD.

**End-to-end research-fork verification** (Kimi-Linear AttnRes inference under
`--dtype float16`): coherent 8/8 on the smoke prompt set at **44.5 tok/s** vs
the bf16 baseline's **44.6 tok/s**; documented in our research repo's Phase 11
benchmark output.

## Speed Tests and Profiling

Kernel-internal change with no extra ops on the bf16 path → no measurable
throughput change on the default bf16+bf16 path (verified end-to-end:
44.6 → 44.6 tok/s on Kimi-Linear AttnRes 1.4B-active).

The fp16+bf16 path goes from **not compiling** (hard crash at first KDA layer)
to **44.5 tok/s** on the same model — within 0.2% of the bf16 baseline.

### Interaction with `fp8` weight-only quantization

`causal_conv1d` consumes activations only; SGLang's `--quantization fp8` is
weight-only and leaves activations at the requested model dtype:

- `--quantization fp8 --dtype bfloat16` → kernel sees `x=bf16`, `conv_states=bf16`,
  baseline path, unaffected by this PR.
- `--quantization fp8 --dtype float16` → kernel sees `x=fp16`, `conv_states=bf16`,
  exactly the bug this PR fixes; covered by the same smoke.

So fp8 inference picks the fix up for free.

### Follow-up (out of scope for this PR)

The prefill kernel has a structurally analogous SSA type-join in the **write-back**
path (`tl.store(conv_states_ptrs_target, new_conv_state, mask)` where
`new_conv_state` is sourced from `tl.load(x_ptrs, ...)` in the
`state_len <= seqlen` branch but from `tl.where(mask, conv_state, loaded_x)` in
the `load_init_state` branch). Triggering it requires the inverse-dtype
configuration (`x.dtype=bf16` + `conv_states.dtype=fp16`), which SGLang's defaults
(`SGLANG_MAMBA_CONV_DTYPE=bfloat16` regardless of model dtype) do not produce in
current code. Keeping this PR scoped to the production-hit site; a symmetric fix
for write-back is a clean follow-up if anyone ever wants to override the cache
dtype.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). *(Verified locally against sglang's pinned hook versions on the patched file: `isort 7.0.0`, `black 26.1.0`, `ruff 0.15.1` with sglang's `--select=F401,F821`, `codespell 2.4.1` — all clean.)*
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(No CI-registered test in this PR — the smoke scripts linked above exercise the exact failure mode and are runnable in isolation. Happy to add a registered test under `test/registered/unit/` if maintainers prefer.)*
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). *(Direct kernel smoke matrix above; end-to-end bf16 vs fp16 throughput parity 44.6 ≈ 44.5 tok/s.)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27265156808](https://github.com/sgl-project/sglang/actions/runs/27265156808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27265153423](https://github.com/sgl-project/sglang/actions/runs/27265153423)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->