### PR TITLE
[AMD][Perf] Tune extend attention block sizes for gfx950 (head_dim > 128)

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -23,13 +23,14 @@ import triton.language as tl
 from sglang.srt.layers.attention.triton_ops.prefill_attention import (
     context_attention_fwd,
 )
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_gfx95_supported, is_hip
 
 _is_cuda = is_cuda()
 if _is_cuda:
     CUDA_CAPABILITY = torch.cuda.get_device_capability()
 
 _is_hip = is_hip()
+_is_gfx95 = _is_hip and is_gfx95_supported()
 
 
 def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
@@ -61,8 +62,17 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
 
     # Determine BLOCK_M, BLOCK_N, and num_warps based on hardware
     if _is_hip:
-        BLOCK_M, BLOCK_N = (64, 64)
-        num_warps = 4
+        if _is_gfx95 and Lq > 128:
+            # gfx950 (CDNA4), head_dim > 128: a larger query tile halves KV bytes
+            # streamed per call (each workgroup reads the whole prefix); 8 warps
+            # hide the loads. Measured on MI350X head_dim 256: -36% kernel time,
+            # 28% -> 44% MFU, numerically equivalent (BLOCK_N reduction order
+            # unchanged). Other AMD archs / head dims keep the default below.
+            BLOCK_M, BLOCK_N = (128, 64)
+            num_warps = 8
+        else:
+            BLOCK_M, BLOCK_N = (64, 64)
+            num_warps = 4
     else:
         if _is_cuda and CUDA_CAPABILITY[0] == 12:
             # sm120 workstation Blackwell architecture (RTX Pro 6000) has a much smaller shared memory size (100K)

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -62,8 +62,8 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
 
     # Determine BLOCK_M, BLOCK_N, and num_warps based on hardware
     if _is_hip:
-        if _is_gfx95 and Lq > 128:
-            # gfx950 (CDNA4), head_dim > 128: a larger query tile halves KV bytes
+        if _is_gfx95 and 128 < Lq <= 256:
+            # gfx950 (CDNA4), 128 < head_dim <= 256: a larger query tile halves KV bytes
             # streamed per call (each workgroup reads the whole prefix); 8 warps
             # hide the loads. Measured on MI350X head_dim 256: -36% kernel time,
             # 28% -> 44% MFU, numerically equivalent (BLOCK_N reduction order

--- a/test/registered/attention/test_triton_attention_kernels.py
+++ b/test/registered/attention/test_triton_attention_kernels.py
@@ -328,10 +328,14 @@ class TestTritonAttention(CustomTestCase):
         self.assertEqual(
             ea._get_block_sizes_for_extend_attention(128, 128)[3:], (64, 64, 4)
         )
-        # head_dim > 128: tuned tile on gfx95, default elsewhere
+        # 128 < head_dim <= 256: tuned tile on gfx95, default elsewhere
         expected = (128, 64, 8) if ea._is_gfx95 else (64, 64, 4)
         self.assertEqual(
             ea._get_block_sizes_for_extend_attention(256, 256)[3:], expected
+        )
+        # head_dim > 256: falls back to the default on all HIP archs
+        self.assertEqual(
+            ea._get_block_sizes_for_extend_attention(576, 576)[3:], (64, 64, 4)
         )
 
     def _test_extend_attention_sliding_window_once(

--- a/test/registered/attention/test_triton_attention_kernels.py
+++ b/test/registered/attention/test_triton_attention_kernels.py
@@ -312,11 +312,27 @@ class TestTritonAttention(CustomTestCase):
     def test_extend_attention(self):
 
         # Define the varying parameter values
-        attention_values = [128, 96, 80, 13]
+        # 256 covers the head_dim > 128 block-size branch (tuned on gfx95)
+        attention_values = [256, 128, 96, 80, 13]
 
         # Loop through the values and call the method
         for value in attention_values:
             self._test_extend_attention_once(19, 12331, 12, 4, value)
+
+    def test_extend_attention_block_sizes(self):
+        from sglang.srt.layers.attention.triton_ops import extend_attention as ea
+
+        if not ea._is_hip:
+            self.skipTest("HIP-only block-size selection")
+        # head_dim <= 128 keeps the default config on all HIP archs
+        self.assertEqual(
+            ea._get_block_sizes_for_extend_attention(128, 128)[3:], (64, 64, 4)
+        )
+        # head_dim > 128: tuned tile on gfx95, default elsewhere
+        expected = (128, 64, 8) if ea._is_gfx95 else (64, 64, 4)
+        self.assertEqual(
+            ea._get_block_sizes_for_extend_attention(256, 256)[3:], expected
+        )
 
     def _test_extend_attention_sliding_window_once(
         self, B, N_CTX, H_Q, H_KV, D, WINDOW_SIZE


### PR DESCRIPTION
## Motivation

While profiling long-context prefill on MI350X (Qwen3.5-style GQA models, head_dim 256), the Triton extend kernel turned out to be the dominant cost: about 62% of GPU time at roughly 28% MFU, far below what the memory system allows.

The reason is that `_get_block_sizes_for_extend_attention` uses one hardcoded config for every HIP arch (`BLOCK_M=64, BLOCK_N=64, num_warps=4`), while the CUDA side tunes per arch and head_dim. Each workgroup streams the whole prefix KV, so KV traffic scales with `1/BLOCK_M`. At BLOCK_M=64 with a 32k chunk we move ~70 GB of KV per call. Doubling BLOCK_M halves that, and gfx950 has enough CUs and registers to hold the larger tile.

## Modifications

One branch in `extend_attention.py`: on gfx95 with head_dim > 128 use `(BLOCK_M=128, BLOCK_N=64, num_warps=8)`. Everything else keeps the current default. CUDA untouched, no env vars, no buffers, no graph-shape changes.

Also extends the existing tests: head_dim 256 in `test_extend_attention`, plus a small HIP block-size selection test asserting the gate is on for gfx95 and off elsewhere.

We tried BLOCK_N=128 too — it regresses (+19%), so it stays at 64. BLOCK_M=256 spills registers and is 2x slower; 128 is the sweet spot.

Note on #26283: it tunes the few-query verify shape (`max_len_extend <= 16`) in this function; conditions don't overlap, and I'm happy to rebase if it lands first.

## Accuracy Tests

GSM8K 5-shot, 200 ex on 35B with NEXTN: 0.970 with and without, identical std and accept length (3.36). Kernel matches stock under allclose at head_dim 256. num_warps changes warp reduction order, so equivalent, not bit-identical.

## Speed Tests (MI350X, BF16, M=32768, prefix 67k, median of 20)

| config | Hq16 | Hq32 |
|---|---|---|
| 64,64,4 (current) | 137.2 ms | 274.6 ms |
| 128,64,8 (this PR) | 87.5 ms (−36%) | 171.4 ms (−38%) |

In-server, 100K prompts, both arms concurrent, median of 3 traces: `_fwd_kernel` 14.4 → 10.3 s, full prefill 12.45 → 10.06 s. Gain shows in prefill compute; queue-bound serving medians don't move.

## Checklist
- [x] Code formatted with pre-commit (black / isort / ruff).
- [x] Unit tests added (`test/registered/attention/test_triton_attention_kernels.py`: head_dim 256 parity + HIP block-size selection).
- [x] Documentation — n/a (internal block-size heuristic; rationale documented inline in `extend_attention.py`).
- [x] Accuracy and speed benchmark results provided (above).
- [x] Follows SGLang code style.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27266246062](https://github.com/sgl-project/sglang/actions/runs/27266246062)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27266245139](https://github.com/sgl-project/sglang/actions/runs/27266245139)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->