### PR TITLE
fix(tokenizer_manager): log full text on finish in incremental streaming (#27775)

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1477,9 +1477,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
                 if self.request_metrics_exporter_manager.exporter_enabled():
                     asyncio.create_task(
-                        self.request_metrics_exporter_manager.write_record(
-                            obj, log_out
-                        )
+                        self.request_metrics_exporter_manager.write_record(obj, log_out)
                     )
 
                 # Check if this was an abort/error created by scheduler

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1455,9 +1455,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     out["meta_info"][
                         "response_sent_to_client_ts"
                     ] = state.time_stats.get_response_sent_to_client_realtime()
+                # In incremental streaming, `out` carries only the final
+                # delta text; log the full accumulated response so the finish
+                # log matches non-streaming behavior instead of showing the
+                # last chunk only.
+                if incremental_stream and out.get("text") is not None:
+                    log_out = {**out, "text": state.get_text()}
+                else:
+                    log_out = out
                 self.request_logger.log_finished_request(
                     obj,
-                    out,
+                    log_out,
                     request=request,
                 )
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1456,11 +1456,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         "response_sent_to_client_ts"
                     ] = state.time_stats.get_response_sent_to_client_realtime()
                 # In incremental streaming, `out` carries only the final
-                # delta text; log the full accumulated response so the finish
-                # log matches non-streaming behavior instead of showing the
-                # last chunk only.
-                if incremental_stream and out.get("text") is not None:
-                    log_out = {**out, "text": state.get_text()}
+                # delta (text and/or output_ids); restore the full accumulated
+                # values so the finish log and metrics match non-streaming
+                # behavior instead of showing the last chunk only. Token-only
+                # outputs (e.g. --skip-tokenizer-init) carry output_ids but no
+                # text, so handle each field independently.
+                if incremental_stream:
+                    log_out = dict(out)
+                    if out.get("text") is not None:
+                        log_out["text"] = state.get_text()
+                    if out.get("output_ids") is not None:
+                        log_out["output_ids"] = state.output_ids.copy()
                 else:
                     log_out = out
                 self.request_logger.log_finished_request(
@@ -1471,7 +1477,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
                 if self.request_metrics_exporter_manager.exporter_enabled():
                     asyncio.create_task(
-                        self.request_metrics_exporter_manager.write_record(obj, out)
+                        self.request_metrics_exporter_manager.write_record(
+                            obj, log_out
+                        )
                     )
 
                 # Check if this was an abort/error created by scheduler


### PR DESCRIPTION
## Motivation

Fixes #27775.

When a request is served with `stream=True` **and** `--incremental-streaming-output` is enabled, the server-side `Finish request` log prints only the **last delta chunk** in `out['text']` instead of the full generated response. Non-streaming requests log the full text, so streaming workloads lose observability / auditability of the completed output.

## Root cause

In incremental streaming, every chunk emitted to the client — including the final one — is a delta (`out_dict = {"text": delta_text, ...}`). `_wait_one_response` passes that same delta-only `out` straight into `log_finished_request`, so the finish log captures only the last chunk.

The full text is already accumulated in `ReqState` and available via `state.get_text()` (the non-incremental streaming path already relies on it).

## Fix

In the `finished` branch of `_wait_one_response`, when the stream is incremental, log a shallow-copied view whose `text` is the full `state.get_text()`. The `out` object yielded to the client is left untouched, so the client still receives the delta as before. Guarded on `out.get("text") is not None` so token-only outputs (`BatchTokenIDOutput`, no `text` key) are unaffected.

Behavior is unchanged for non-streaming and non-incremental streaming requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27289569183](https://github.com/sgl-project/sglang/actions/runs/27289569183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27289568725](https://github.com/sgl-project/sglang/actions/runs/27289568725)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->