### PR TITLE
[CI] Fix stale ngram bookkeeping owner sites

### DIFF
--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -66,21 +66,6 @@ _OWNER_SITES = {
     ("speculative/eagle_info.py", "EagleVerifyInput.verify", "kv_committed_len"): 1,
     ("speculative/eagle_info.py", "EagleVerifyInput.verify", "kv_allocated_len"): 1,
     ("speculative/eagle_info.py", "EagleVerifyInput.verify", "spec_verify_ct"): 1,
-    (
-        "speculative/ngram_info.py",
-        "NgramVerifyInput._fill_requests",
-        "spec_verify_ct",
-    ): 1,
-    (
-        "speculative/ngram_info.py",
-        "NgramVerifyInput._free_cache",
-        "kv_committed_len",
-    ): 1,
-    (
-        "speculative/ngram_info.py",
-        "NgramVerifyInput._free_cache",
-        "kv_allocated_len",
-    ): 1,
     ("speculative/dflash_info.py", "DFlashVerifyInput.verify", "kv_committed_len"): 1,
     ("speculative/dflash_info.py", "DFlashVerifyInput.verify", "kv_allocated_len"): 1,
     ("speculative/dflash_info.py", "DFlashVerifyInput.verify", "spec_verify_ct"): 1,


### PR DESCRIPTION
## Summary

Remove stale ngram bookkeeping owner-site entries left after #17260 removed the old `NgramVerifyInput._fill_requests` and `_free_cache` paths, fixing the ownership test added in #27710

Fixes https://github.com/sgl-project/sglang/actions/runs/27271813037/job/80542982353

cc @hnyls2002 















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27273334729](https://github.com/sgl-project/sglang/actions/runs/27273334729)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27273334644](https://github.com/sgl-project/sglang/actions/runs/27273334644)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->