### PR TITLE
Customize FUSE_ALLREDUCE_MAX_BATCH_SIZE

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -501,7 +501,9 @@ class Envs:
     SGLANG_FLASHINFER_USE_PAGED = EnvBool(False)
     # Default to the pick from flashinfer
     SGLANG_FLASHINFER_WORKSPACE_SIZE = EnvInt(384 * 1024 * 1024)
-    # Enable NVFP4 per-token activation scaling path for FlashInfer TRT-LLM MoE.
+    # Max token/batch size for FlashInfer allreduce fusion.
+    SGLANG_FUSE_ALLREDUCE_MAX_BATCH_SIZE = EnvInt(2048)
+    # Enable per-token NVFP4 activation scaling path for FlashInfer TRT-LLM MoE.
     SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION = EnvBool(False)
     # SGLang needs to know FlashInfer NVFP4 4over6 config to compute the global scale factor.
     FLASHINFER_NVFP4_4OVER6 = EnvBool(False)

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -160,9 +160,24 @@ def _fused_rmsnorm_fp8_per_token_quant(
         return (out_fp8, scale.unsqueeze(1))
 
 
-# TODO: According to the discussion in https://github.com/flashinfer-ai/flashinfer/issues/1223#issuecomment-3047256465
-# We set the max token num to 128 for allreduce fusion with min-latency case(use_oneshot=True).
-FUSE_ALLREDUCE_MAX_BATCH_SIZE = 2048
+_DEFAULT_FUSE_ALLREDUCE_MAX_BATCH_SIZE = 2048
+
+
+def _get_fuse_allreduce_max_batch_size() -> int:
+    max_batch_size = envs.SGLANG_FUSE_ALLREDUCE_MAX_BATCH_SIZE.get()
+    if max_batch_size <= 0:
+        logging.warning(
+            "Invalid SGLANG_FUSE_ALLREDUCE_MAX_BATCH_SIZE=%s; using default %s",
+            max_batch_size,
+            _DEFAULT_FUSE_ALLREDUCE_MAX_BATCH_SIZE,
+        )
+        return _DEFAULT_FUSE_ALLREDUCE_MAX_BATCH_SIZE
+    return max_batch_size
+
+
+# This cap gates FlashInfer allreduce fusion and sizes its pre-initialized
+# workspace. Override with SGLANG_FUSE_ALLREDUCE_MAX_BATCH_SIZE for experiments.
+FUSE_ALLREDUCE_MAX_BATCH_SIZE = _get_fuse_allreduce_max_batch_size()
 
 
 def apply_flashinfer_allreduce_fusion(batch_size: int):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`FUSE_ALLREDUCE_MAX_BATCH_SIZE` is hardcoded to 2048. For GLM5-FP8 1k1k Pareto benchmarks (from conc4 to conc256), prefill batches token count distribution is focused between 0 and 4k. Extending the flashinfer fused AR + norm kernel threshold from 2k to 4k is beneficial.

<img width="1784" height="807" alt="prefill_dist_1k1k" src="https://github.com/user-attachments/assets/4e29f796-208c-4f47-83aa-4a76a84f7581" />


## Modifications

- Made `FUSE_ALLREDUCE_MAX_BATCH_SIZE` configurable from env

## Accuracy Tests

No new kernels have been added.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

### `bench_one_batch` ISL 3k prefill
`FUSE_ALLREDUCE_MAX_BATCH_SIZE` = 2048
```bash
Prefill. latency: 0.19423 s, throughput:  15816.03 token/s
Decode 0. Batch size: 3, latency: 0.01348 s, throughput:    222.63 token/s
Decode 1. Batch size: 3, latency: 0.01316 s, throughput:    227.89 token/s
Decode 2. Batch size: 3, latency: 0.01313 s, throughput:    228.55 token/s
Decode 3. Batch size: 3, latency: 0.01317 s, throughput:    227.72 token/s
Decode 4. Batch size: 3, latency: 0.01309 s, throughput:    229.20 token/s
Decode.  median latency: 0.01306 s, median throughput:    229.67 token/s
```

`FUSE_ALLREDUCE_MAX_BATCH_SIZE` = 4096
```bash
Prefill. latency: 0.16999 s, throughput:  18072.18 token/s
Decode 0. Batch size: 3, latency: 0.01334 s, throughput:    224.96 token/s
Decode 1. Batch size: 3, latency: 0.01301 s, throughput:    230.59 token/s
Decode 2. Batch size: 3, latency: 0.01289 s, throughput:    232.74 token/s
Decode 3. Batch size: 3, latency: 0.01295 s, throughput:    231.71 token/s
Decode 4. Batch size: 3, latency: 0.01292 s, throughput:    232.23 token/s
Decode.  median latency: 0.01299 s, median throughput:    230.93 token/s
```
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27280036244](https://github.com/sgl-project/sglang/actions/runs/27280036244)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27280035988](https://github.com/sgl-project/sglang/actions/runs/27280035988)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->