### PR TITLE
[DO NOT MERGE] Debug Nemotron CI for release

### DIFF
--- a/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_nightly.py
+++ b/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_nightly.py
@@ -7,6 +7,7 @@ from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings, is_blackwell_system
 
 # Runs on both Hopper and Blackwell via nightly-8-gpu-common suite
+# [DO NOT MERGE] Debug-only touch to trigger CI rerun on release/v0.5.13
 register_cuda_ci(est_time=5400, suite="nightly-8-gpu-common", nightly=True)
 
 NEMOTRON_3_SUPER_BF16_MODEL = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"


### PR DESCRIPTION
**Note: since this PR is still failing, it seems not related to this revert**

Debug-only PR to reproduce the Nemotron-3-Super NVFP4 + MTP NaN (`verify: target model logits`) on real CI hardware against `release/v0.5.13`.

Cannot reproduce locally (likely arch mismatch: local B300/sm_103 vs CI B200/sm_100). Using `/rerun-test` to trigger the registered runners.

**Do not merge.** Single no-op comment change only.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27280504008](https://github.com/sgl-project/sglang/actions/runs/27280504008)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27280504438](https://github.com/sgl-project/sglang/actions/runs/27280504438)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->