### PR TITLE
[DO NOT MERGE] Revert routed_scaling_factor fusion — Nemotron CI debug for release

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1145,12 +1145,6 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
                 activation_type=activation,
             )[0]
 
-            if (
-                not layer.should_fuse_routed_scaling_factor_in_topk
-                and self.moe_runner_config.routed_scaling_factor is not None
-            ):
-                output.mul_(self.moe_runner_config.routed_scaling_factor)
-
             return StandardCombineInput(hidden_states=output)
 
         quant_info = TritonMoeQuantInfo(

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -511,12 +511,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 ),
             )[0]
 
-            if (
-                not layer.should_fuse_routed_scaling_factor_in_topk
-                and moe_runner_config.routed_scaling_factor is not None
-            ):
-                output.mul_(moe_runner_config.routed_scaling_factor)
-
             return StandardCombineInput(hidden_states=output)
         elif self.use_flashinfer_trtllm_moe:
             from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (

--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -184,7 +184,6 @@ class NemotronHMoE(nn.Module):
             layer_id=layer_idx,
             is_gated=False,
             routing_method_type=RoutingMethodType.DeepSeekV3,
-            routed_scaling_factor=self.routed_scaling_factor,
         )
         self.topk = TopK(
             top_k=config.num_experts_per_tok,
@@ -194,8 +193,7 @@ class NemotronHMoE(nn.Module):
             renormalize=config.norm_topk_prob,
             scoring_func="sigmoid",
             correction_bias=self.gate.e_score_correction_bias,
-            routed_scaling_factor=self.routed_scaling_factor,
-            apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
+            routed_scaling_factor=1.0,
         )
         if config.n_shared_experts:
             self.shared_experts = NemotronHMLP(
@@ -287,9 +285,14 @@ class NemotronHMoE(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
-        # routed_scaling_factor is fused into the experts call (applied by the
-        # MoE runner / topk), so final_hidden_states is already scaled.
         final_hidden_states, shared_output = self._forward_core(hidden_states)
+
+        # Fix FP16 overflow
+        if hidden_states.dtype != torch.float16:
+            final_hidden_states *= self.routed_scaling_factor
+        elif self.shared_experts is not None:
+            assert shared_output is not None
+            shared_output *= 1.0 / self.routed_scaling_factor
 
         if self.use_latent_moe:
             final_hidden_states, _ = self.fc2_latent_proj(final_hidden_states)


### PR DESCRIPTION
**Note: since this PR is still failing, it seems not related to this revert**

Debug-only PR for the Nemotron-3-Super NVFP4 + MTP NaN (`verify: target model logits`) on `release/v0.5.13`.

Reverts **only** the routed_scaling_factor fusion introduced in #26733, restoring the original `final_hidden_states *= self.routed_scaling_factor` in `NemotronHMoE.forward`:
- `nemotron_h.py`: drop `routed_scaling_factor` from the experts call; `topk` back to `routed_scaling_factor=1.0` (no `apply_routed_scaling_factor_on_output`); restore the FP16-overflow scaling block in `forward`.
- `modelopt_quant.py` / `unquant.py`: remove the added `output.mul_(routed_scaling_factor)` blocks.

Unrelated #26733 perf changes (router `torch.mm`, `relu2`, mamba `output=None`, gated-RMSNorm PDL) are left intact, to isolate whether the scaling fusion is implicated.

**Do not merge.**











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27281408240](https://github.com/sgl-project/sglang/actions/runs/27281408240)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27281407755](https://github.com/sgl-project/sglang/actions/runs/27281407755)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->