### PR TITLE
[DO NOT MERGE] Nemotron: trtllm_mha + mamba extra_buffer — CI debug for release

### DIFF
--- a/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
+++ b/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
@@ -23,7 +23,16 @@ NEMOTRON_3_SUPER_NVFP4_ARGS = [
     "nemotron_3",
     "--tool-call-parser",
     "qwen3_coder",
-    "--disable-radix-cache",
+    # [DO NOT MERGE] debug: trtllm_mha full-attention + mamba extra_buffer
+    # (radix cache on -> dropped --disable-radix-cache; page_size divides
+    # mamba_track_interval=256). Tests whether the NaN is the flashinfer
+    # full-attention backend.
+    "--attention-backend",
+    "trtllm_mha",
+    "--mamba-scheduler-strategy",
+    "extra_buffer",
+    "--page-size",
+    "64",
     "--model-loader-extra-config",
     '{"enable_multithread_load": true, "num_threads": 17}',
 ]

--- a/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_nightly.py
+++ b/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_nightly.py
@@ -19,7 +19,16 @@ BASE_ARGS = [
     "nemotron_3",
     "--tool-call-parser",
     "qwen3_coder",
-    "--disable-radix-cache",
+    # [DO NOT MERGE] debug: trtllm_mha full-attention + mamba extra_buffer
+    # (radix cache on -> dropped --disable-radix-cache; page_size divides
+    # mamba_track_interval=256). Tests whether the NaN is the flashinfer
+    # full-attention backend.
+    "--attention-backend",
+    "trtllm_mha",
+    "--mamba-scheduler-strategy",
+    "extra_buffer",
+    "--page-size",
+    "64",
 ]
 
 BF16_LOADER_ARGS = [


### PR DESCRIPTION
Seems to still be failing.


Debug-only PR for the Nemotron-3-Super NVFP4 + MTP NaN (`verify: target model logits`) on `release/v0.5.13`.

Hypothesis: the NaN comes from the **flashinfer full-attention backend**, not the MoE/mamba changes. This swaps full attention to **trtllm_mha** and switches Mamba scheduling to **extra_buffer** (radix cache on).

Changes (both 8-gpu and 4-gpu Nemotron NVFP4 tests):
- drop `--disable-radix-cache`
- `--attention-backend trtllm_mha`
- `--mamba-scheduler-strategy extra_buffer`
- `--page-size 64` (divides `mamba_track_interval=256`; `mamba_cache_chunk_size` auto-derives)

Rationale: trtllm_mha can't use `page_size=1`, and MambaRadixCache `no_buffer` forces `page_size=1`, so trtllm_mha + radix cache requires `extra_buffer`. This is the same proven combo as the GB300 Qwen3.5 MTP test. PDL/gated-RMSNorm and routed-sf are left intact here, so this isolates the attention-backend axis.

Isolation matrix (all off release/v0.5.13):
- #27810 — release as-is (baseline, expected NaN)
- #27812 — revert routed_scaling_factor fusion
- this PR — trtllm_mha full-attn + extra_buffer

**Do not merge.**











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27282994985](https://github.com/sgl-project/sglang/actions/runs/27282994985)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27282993837](https://github.com/sgl-project/sglang/actions/runs/27282993837)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->