### PR TITLE
[AMD] Update test_aiter_allgather_amd.py data types alignment between benchmark aiter and custom all-reduce kernel

### DIFF
--- a/test/registered/ops/test_aiter_allgather_amd.py
+++ b/test/registered/ops/test_aiter_allgather_amd.py
@@ -35,13 +35,6 @@ class TestAiterAllGatherAmd(unittest.TestCase):
             "float32",
             "float16",
             "bfloat16",
-            "uint64_t",
-            "int64_t",
-            "uint32_t",
-            "int32_t",
-            "int16_t",
-            "uint8_t",
-            "int8_t",
         ]
         # Keep the CI matrix compact: one small metadata shape and one
         # medium aligned 2-D shape exercise both naive and vectorized kernels.


### PR DESCRIPTION
## Motivation

`test_aiter_allgather_amd.py` (in the `stage-c-test-large-8-gpu-amd` suite) was failing on AMD CI. The test drives `benchmark/kernels/all_gather/benchmark_aiter.py` with a sweep of dtypes that included integer types:

```
float32, float16, bfloat16, uint64_t, int64_t, uint32_t, int32_t, int16_t, uint8_t, int8_t
```

The aiter all-gather path is implemented on top of the custom all-reduce kernel, which only supports floating-point element types. Passing any integer dtype makes the kernel raise:

```
RuntimeError: custom allreduce only supports float32, float16 and bfloat16
```

So every integer dtype in the sweep was guaranteed to fail. The test was exercising dtypes the underlying kernel does not (and is not intended to) support, rather than catching a real regression.

## Modifications

- Drop the unsupported integer dtypes (`uint64_t, int64_t, uint32_t, int32_t, int16_t, uint8_t, int8_t`) from the dtype sweep in `test/registered/ops/test_aiter_allgather_amd.py`, keeping only the supported floating-point types (`float32, float16, bfloat16`).
- This is a test-only change; no kernel, runtime, or model code is modified.

## Accuracy Tests

Not applicable — this change does not touch any kernel or model forward path, so model outputs are unaffected. The correctness portion of the all-gather test (comparing aiter all-gather against RCCL for the supported float dtypes) continues to run and passes.

Verified on upstream AMD CI: the `test_aiter_allgather_amd.py` step is **green** across the MI325 and MI35x stage-c runs (`✓ PASSED`). The remaining failures in the same job group are pre-existing and unrelated to this change (the allreduce-fusion residual-accuracy test, addressed separately in #28226, and pre-existing MI35x/cuda-graph issues).

## Speed Tests and Profiling

Not applicable — no change to inference or kernel execution paths; this only removes unsupported dtypes from a test's parameter sweep, so there is no performance impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27287444851](https://github.com/sgl-project/sglang/actions/runs/27287444851)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27287445563](https://github.com/sgl-project/sglang/actions/runs/27287445563)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->