### PR TITLE
[AMD] Gate quark mxfp4 kv_b_proj post-processing on per-layer quant method

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -62,6 +62,7 @@ from sglang.srt.models.deepseek_common.utils import (
 from sglang.srt.utils import bind_or_assign, get_bool_env_var, log_info_on_rank0
 
 if _use_aiter_gfx95:
+    from sglang.srt.layers.quantization.quark.quark import QuarkLinearMethod
     from sglang.srt.layers.quantization.quark.utils import quark_post_load_weights
 
 logger = logging.getLogger(__name__)
@@ -572,9 +573,9 @@ class DeepseekV2WeightLoaderMixin:
                 _use_aiter_gfx95
                 and self.quant_config is not None
                 and self.quant_config.get_name() == "quark"
-                and self.config.architectures
-                and self.config.architectures[0]
-                == "DeepseekV3ForCausalLM"  # Avoid processing other models like GlmMoeDsaForCausalLM
+                # Only post-process if quark actually quantized to mxfp4
+                # If kv_b_proj gets UnquantizedLinearMethod, it must be skipped.
+                and isinstance(self_attn.kv_b_proj.quant_method, QuarkLinearMethod)
             ):
                 w_kc, self_attn.w_scale_k, w_vc, self_attn.w_scale_v = (
                     quark_post_load_weights(self_attn, w, "mxfp4")


### PR DESCRIPTION
## Motivation
The gfx95x quark mxfp4 `kv_b_proj` post-processing gated on architecture name (== "DeepseekV3ForCausalLM"), as introduced in #22543, could cause the following issues:

  - An excluded blockwise-fp8 `kv_b_proj` layer in a quark checkpoint still enters `quark_post_load_weights` and crashes with
  Unexpected w.dtype: torch.float8_e4m3fn.
  - amd/DeepSeek-V3.2-mxfp4 reports arch DeepseekV32ForCausalLM, so a valid mxfp4 kv_b_proj that needs to be post processed is skipped.

## Modifications
Fix: gate on the per-layer quant method (`isinstance(kv_b_proj.quant_method, QuarkLinearMethod)`) instead of arch name. Excluded layers get `UnquantizedLinearMethod` and are skipped; mxfp4 layers are processed correctly.

## Verification
 - [x] Load and inference test amd/DeepSeek-R1-MXFP4 on gfx95 success
 - [x] Load and inference test amd/DeepSeek-V3.2-mxfp4 on gfx95 success
 - [x] Load and inference test deepseek-ai/DeepSeek-V3.2 on gfx95 success

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27289149691](https://github.com/sgl-project/sglang/actions/runs/27289149691)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27289149062](https://github.com/sgl-project/sglang/actions/runs/27289149062)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->