### PR TITLE
[CPU] Fix DeepSeek-V4 Env Issue

### DIFF
--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -42,8 +42,7 @@ RUN source $HOME/.local/bin/env && \
     uv pip install . && \
     cd ../sgl-kernel && \
     cp pyproject_cpu.toml pyproject.toml && \
-    uv pip install . && \
-    uv pip install apache-tvm-ffi==0.1.11
+    uv pip install .
 
 ENV SGLANG_USE_CPU_ENGINE=1
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4:/usr/lib/x86_64-linux-gnu/libtbbmalloc.so:/opt/.venv/lib/libiomp5.so

--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -42,7 +42,8 @@ RUN source $HOME/.local/bin/env && \
     uv pip install . && \
     cd ../sgl-kernel && \
     cp pyproject_cpu.toml pyproject.toml && \
-    uv pip install .
+    uv pip install . && \
+    uv pip install apache-tvm-ffi==0.1.11
 
 ENV SGLANG_USE_CPU_ENGINE=1
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4:/usr/lib/x86_64-linux-gnu/libtbbmalloc.so:/opt/.venv/lib/libiomp5.so

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -19,6 +19,7 @@ dependencies = [
   "IPython",
   "aiohttp",
   "anthropic>=0.20.0",
+  "apache-tvm-ffi==0.1.11",
   "blobfile==3.0.0",
   "build",
   "compressed-tensors",


### PR DESCRIPTION
## Motivation

The latest `tvm-ffi` package does not work with DeepSeek-V4 env.

## Modifications

Solidate `apache-tvm-ffi` package version to `0.1.11` which was the verified.

The fix was validated locally.