### PR TITLE
[Docs] Restore right-hand ToC on the DeepSeek-V4 cookbook page

### DIFF
--- a/.claude/skills/cookbook-add-model/references/mintlify-authoring.md
+++ b/.claude/skills/cookbook-add-model/references/mintlify-authoring.md
@@ -83,6 +83,12 @@ table is a live reference.
     model name + intent — e.g. `Deploy <Model> with SGLang — …` — aim for ~150–160 chars, and
     pack secondary keywords (variants + sizes, `Mixture-of-Experts` / architecture, target
     GPUs). Phrase it as a value prop, not a generic "`<Model>` is a … model" intro.
+- **No `mode:` on a model page.** Leave it unset so Mintlify renders the default layout
+  *with* the right-hand "On this page" table of contents — every model page relies on this.
+  `mode: wide` drops that ToC; it's only for the category `intro.mdx` card-grid landing pages
+  (which have no ToC by design). The Deploy/Playground panels don't need the extra width —
+  they self-cap at `maxWidth: 900px` and center, which fits the default column fine. (Symptom
+  of a stray `mode: wide`: the page loses its right-hand ToC while its siblings keep theirs.)
 - Frontmatter MUST be the first thing in the file — no comment or blank line before the
   opening `---`.
 

--- a/.claude/skills/cookbook-add-model/templates/page.mdx.tmpl
+++ b/.claude/skills/cookbook-add-model/templates/page.mdx.tmpl
@@ -2,7 +2,6 @@
 title: __MODEL_DISPLAY__
 description: "__ONE_LINER__"
 tag: NEW
-mode: wide
 ---
 
 {/* TEMPLATE — instantiate via the cookbook-add-model skill, then DELETE this banner.

--- a/.claude/skills/cookbook-review-pr/SKILL.md
+++ b/.claude/skills/cookbook-review-pr/SKILL.md
@@ -96,8 +96,12 @@ than restating.
   Launch port must match client/curl port on the same page.
 
 ### 7. Frontmatter
-- Every new MDX page has `title:` and `metatags.description:` (a real one-line value prop,
-  not copied from another vendor).
+- Every new MDX page has `title:` and a **top-level** `description:` (a real one-line value
+  prop, not copied from another vendor) — NOT `metatags.description` (non-canonical; the
+  top-level field is what renders as the subtitle and SEO meta — see mintlify-authoring).
+- **No `mode: wide` on a model page** — it hides the right-hand "On this page" ToC that every
+  other model page has. Leave `mode` unset (the Deploy/Playground panels self-cap at 900px, so
+  the default column holds them fine). `mode: wide` belongs only on category `intro.mdx` grids.
 - `tag: NEW` only for genuine new launches; when one is added, stale `tag: NEW` on older
   pages should be dropped in the same PR (`grep -RlE "^tag: NEW" docs_new/cookbook/`).
 - MDX imports BOTH `Deployment` and `Playground` from `/src/snippets/...` (absolute).

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -2,7 +2,6 @@
 title: DeepSeek-V4
 description: "Deploy DeepSeek-V4 with SGLang — verified launch commands, benchmarks, and tuning for the Flash (284B) and Pro (1.6T) Mixture-of-Experts models."
 tag: NEW
-mode: wide
 ---
 
 ## Deployment


### PR DESCRIPTION
## Motivation

The [DeepSeek-V4 cookbook page](https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4) is the **only** model page that renders without the right-hand "On this page" table of contents. Every other model page (DeepSeek-V3.2, Kimi-K2, Qwen3, MiniMax-M2, …) has one.

Cause: a stray `mode: wide` in the page's frontmatter. Mintlify's `wide` mode widens the content column *and suppresses the ToC* (the two are mutually exclusive). DeepSeek-V4 inherited the line from the page template (`.claude/skills/cookbook-add-model/templates/page.mdx.tmpl`), which hard-coded `mode: wide`; the only other pages with it are the category `intro.mdx` card grids, which have no ToC by design.

`mode: wide` was never needed on a model page: the shared Deploy/Playground engines cap their panel at `maxWidth: 900px` and center it (`_deployment.jsx`, `_playground.jsx`), which fits Mintlify's default content column alongside the ToC — so dropping it has no layout downside.

## Modifications

- **`docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`** — drop `mode: wide`; the right-hand ToC returns and the page now matches every other model page.
- **`.claude/skills/cookbook-add-model/templates/page.mdx.tmpl`** — drop `mode: wide` so newly stamped pages don't reintroduce the bug (this template was the root source).
- **`.claude/skills/cookbook-add-model/references/mintlify-authoring.md`** — document that model pages leave `mode` unset (`mode: wide` is only for category `intro.mdx` card grids).
- **`.claude/skills/cookbook-review-pr/SKILL.md`** — add a review check for a stray `mode: wide` on model pages, and fix a stale frontmatter rule (require top-level `description:`, not `metatags.description`) so the review skill agrees with the template and the authoring reference.

Docs-only change; no runtime/model code touched.

## Accuracy Tests

N/A — documentation only.

## Speed Tests and Profiling

N/A — documentation only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A — docs only)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results. (N/A — docs only)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27298024744](https://github.com/sgl-project/sglang/actions/runs/27298024744)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27298024742](https://github.com/sgl-project/sglang/actions/runs/27298024742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->