### PR TITLE
deepep: opt-in use_fabric for MNNVL cross-node DeepEP

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -240,6 +240,7 @@ class DeepEPBuffer:
             num_qps_per_rank=num_qps_per_rank,
             # TODO can be false when unneeded
             allow_mnnvl=True,
+            use_fabric=get_bool_env_var("SGLANG_DEEPEP_USE_FABRIC"),
         )
         return cls._buffer
 


### PR DESCRIPTION
## Motivation

On a single MNNVL / NVL72 ComputeDomain that spans multiple nodes (e.g. GB200/GB300), normal-mode DeepEP fails at `Buffer.__init__` with `CUDA error 400: invalid resource handle`. The NVLink buffer setup exchanges CUDA IPC handles, which cannot be imported across the separate hosts of the fabric. (Low-latency mode already works there via `allow_mnnvl`; this extends the normal/high-throughput path.)

## Modifications

Add an opt-in `SGLANG_DEEPEP_USE_FABRIC` env var (default off) that passes `use_fabric=True` to the DeepEP `Buffer`, so the NVLink buffers use `CU_MEM_HANDLE_TYPE_FABRIC` handles instead of CUDA IPC handles. Default off, so existing behavior is unchanged.

## Accuracy Tests

No effect when disabled (default). When enabled, verified correct generations on a 2-node EP8 GB300 MNNVL deployment.

## Speed Tests and Profiling

N/A — enables a configuration that otherwise fails to start.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27302527054](https://github.com/sgl-project/sglang/actions/runs/27302527054)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27302526806](https://github.com/sgl-project/sglang/actions/runs/27302526806)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->