### PR TITLE
route collectives through nccl2

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -297,11 +297,31 @@ class GroupCoordinator:
             self.device = torch.device("cpu")
         self.device_module = torch.get_device_module(self.device)
 
+        # The world PG uses the in-tree "nccl2" backend and is created eagerly
+        # device-bound (see init_distributed_environment). Most subgroups (TP/DP,
+        # etc.) are carved from it with split_group, which requires the parent
+        # communicator to be initialized/bound up front; the device subgroup
+        # retains the parent's "cuda:nccl2" backend and the cpu subgroup
+        # additionally keeps "cpu:gloo" for direct CPU-side coordination.
+        #
+        # The pipeline-parallel group (group_name "pp") is the sole exception:
+        # its device subgroup uses the "nccl-lazy" backend for per-peer lazy P2P
+        # comms (send/recv overlap). nccl2 does not support the eager new_group
+        # split path, so that nccl-lazy device group is built members-only via
+        # new_group with use_local_synchronization=True (non-members short-circuit
+        # before the absent eager-split path over the nccl2 parent). Its cpu group
+        # is still split from the world PG like every other cpu group.
+        #
+        # Non-nccl2 paths (e.g. a plain gloo or NPU/XPU run) fall back to the
+        # upstream new_group path.
+        is_mooncake = "mooncake" in torch_distributed_backend
+        use_nccl2 = is_cuda_alike() and torch_distributed_backend != "gloo"
+        is_pipeline = group_name == "pp"
         for ranks in group_ranks:
             active_ranks = torch.ones(len(ranks), dtype=torch.int32, device=self.device)
             active_ranks_cpu = torch.ones(len(ranks), dtype=torch.int32)
             subgroup_timeout = _MODEL_PARALLEL_GROUP_TIMEOUT
-            if "mooncake" in torch_distributed_backend:
+            if is_mooncake:
                 from mooncake.ep import MooncakeBackendOptions
 
                 device_group = torch.distributed.new_group(
@@ -315,6 +335,43 @@ class GroupCoordinator:
                     backend="mooncake-cpu",
                     pg_options=MooncakeBackendOptions(active_ranks_cpu, recovered_rank),
                     timeout=subgroup_timeout,
+                )
+            elif use_nccl2 and is_pipeline:
+                # Members-only nccl-lazy subgroup for per-peer P2P; bound to this
+                # rank's real CUDA device so non-contiguous PP recv lands on the
+                # right device.
+                device_group = torch.distributed.new_group(
+                    ranks,
+                    backend="nccl-lazy",
+                    pg_options=get_torch_distributed_pg_options(group_name),
+                    use_local_synchronization=True,
+                    timeout=subgroup_timeout,
+                    device_id=torch.device(f"cuda:{local_rank}"),
+                )
+                # a group with `gloo` backend, to allow direct coordination
+                # between processes through the CPU. Split from the world PG like
+                # the non-PP path (only the device group needs nccl-lazy).
+                cpu_group = torch.distributed.split_group(
+                    split_ranks=[ranks],
+                    backend="cpu:gloo,cuda:nccl2",
+                    timeout=gloo_timeout,
+                )
+            elif use_nccl2:
+                # split_group is collective over the parent (world) PG, so every
+                # world rank enters this call with the same split; ranks outside
+                # `ranks` get a non-group member handle that is never used below.
+                device_group = torch.distributed.split_group(
+                    split_ranks=[ranks],
+                    backend="cuda:nccl2",
+                    pg_options=get_torch_distributed_pg_options(group_name),
+                    timeout=subgroup_timeout,
+                )
+                # a group with `gloo` backend, to allow direct coordination
+                # between processes through the CPU.
+                cpu_group = torch.distributed.split_group(
+                    split_ranks=[ranks],
+                    backend="cpu:gloo,cuda:nccl2",
+                    timeout=gloo_timeout,
                 )
             else:
                 pg_options = get_torch_distributed_pg_options(group_name)
@@ -1792,6 +1849,17 @@ def init_distributed_environment(
             ) from e
         mooncake_ep.set_host_ip(get_local_ip_auto())
 
+    # Resolve local_rank up front: it is not available on a torch ProcessGroup
+    # (see https://github.com/pytorch/pytorch/issues/122816) and is needed both
+    # for the world device binding below and for init_world_group.
+    if local_rank == -1:
+        # local rank not set, this usually happens in single-node setting,
+        # where we can use rank as local rank
+        if distributed_init_method == "env://":
+            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        else:
+            local_rank = rank
+
     if not torch.distributed.is_initialized():
         global _MODEL_PARALLEL_GROUP_TIMEOUT
         assert distributed_init_method is not None, (
@@ -1814,30 +1882,40 @@ def init_distributed_environment(
         else:
             pg_options = get_torch_distributed_pg_options()
 
+        # Bind the world PG to its CUDA device so subgroups can be carved from it
+        # with split_group, which requires an eagerly initialized/bound parent
+        # communicator. The world backend is routed to the in-tree "nccl2"
+        # backend; PyTorch auto-qualifies "nccl2" -> "cpu:gloo,cuda:nccl2", and
+        # split subgroups reuse the c10d store, so no extra MASTER_PORT or
+        # per-backend env seeding is needed.
+        device_id = (
+            torch.device(f"cuda:{local_rank}")
+            if is_cuda_alike() and backend != "gloo"
+            else None
+        )
+
+        # Route the world backend to the in-tree nccl2 backend.
+        world_backend = backend
+        if world_backend == "nccl":
+            world_backend = "nccl2"
+        elif world_backend == "cuda:nccl":
+            world_backend = "cuda:nccl2"
+
         # this backend is used for WORLD
         torch.distributed.init_process_group(
-            backend=backend,
+            backend=world_backend,
             init_method=distributed_init_method,
             world_size=world_size,
             rank=rank,
             timeout=timeout,
             pg_options=pg_options,
+            device_id=device_id,
         )
 
         # Create a global TCPStore for coordination (used by NIXL)
         if moe_a2a_backend == "nixl":
             _create_global_tcp_store(rank, world_size)
 
-    # set the local rank
-    # local_rank is not available in torch ProcessGroup,
-    # see https://github.com/pytorch/pytorch/issues/122816
-    if local_rank == -1:
-        # local rank not set, this usually happens in single-node
-        # setting, where we can use rank as local rank
-        if distributed_init_method == "env://":
-            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-        else:
-            local_rank = rank
     global _WORLD
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))


### PR DESCRIPTION

Summary:
# Route sglang's distributed process groups through the in-tree nccl2 backend

## Summary

This routes sglang's process-group setup through PyTorch's in-tree `nccl2`
backend. The world PG is initialized on a device_id-bound `cpu:gloo,cuda:nccl2`,
and every collective subgroup (TP/DP/etc.) is carved from it with
`torch.distributed.split_group` (`cuda:nccl2` for the device group,
`cpu:gloo,cuda:nccl2` for the cpu group). The pipeline-parallel group is the
sole exception: its device group uses `new_group(backend="nccl-lazy",
use_local_synchronization=True, device_id=...)` for per-peer lazy
point-to-point communicators (overlapping send/recv), while its cpu group is
`split_group`.

## Why this shape

nccl2 supports comm-split but not the stock eager-`new_group` no-color-split
path, so every world subset is created via `split_group` (collective, hashed,
self-contained) except PP, which needs `nccl-lazy` for P2P overlap. The
`mooncake` backend and the non-nccl2 fallback keep their own `new_group` paths,
preserved byte-for-byte.

## What changed

### `parallel_state.py`

- `init_distributed_environment`: resolve `local_rank` up front (it is not
  available on a torch `ProcessGroup`) and use it to bind the world PG to its
  cuda device (`device_id`); the world backend is routed to nccl2
  (`cpu:gloo,cuda:nccl2`).
- `GroupCoordinator.__init__`: non-PP groups are built via `split_group`
  (`cuda:nccl2` device, `cpu:gloo,cuda:nccl2` cpu). The PP group
  (`group_name == "pp"`) uses `nccl-lazy` `new_group` for its device group and
  `split_group` for its cpu group.

## Test Plan

Static parse check; the nccl2 split_group + nccl-lazy-PP design is validated
end-to-end by the Megatron pp2_dp2 bit-exact smoke on 4xH100 (world/tp/dp
ProcessGroupNCCL2, pp ProcessGroupNCCLLazy, BIT_EXACT_PASS). sglang-specific GPU
parity is pending.

```
python -c "import ast; ast.parse(open('python/sglang/srt/distributed/parallel_state.py').read())"
```

Authored with the assistance of an AI coding agent.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->