### PR TITLE
Disable async assert in Nemotron nightly tests

### DIFF
--- a/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
+++ b/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
@@ -1,6 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
+from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
@@ -69,12 +70,13 @@ class TestNvidiaNemotron3SuperNVFP4(CustomTestCase):
     def setUpClass(cls):
         cls.model = NEMOTRON_3_SUPER_NVFP4_MODEL
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=NEMOTRON_3_SUPER_NVFP4_ARGS,
-        )
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(0):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=NEMOTRON_3_SUPER_NVFP4_ARGS,
+            )
 
     @classmethod
     def tearDownClass(cls):
@@ -89,12 +91,13 @@ class TestNvidiaNemotron3SuperNVFP4MTP(CustomTestCase):
     def setUpClass(cls):
         cls.model = NEMOTRON_3_SUPER_NVFP4_MODEL
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=NEMOTRON_3_SUPER_NVFP4_ARGS + MTP_ARGS,
-        )
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(0):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=NEMOTRON_3_SUPER_NVFP4_ARGS + MTP_ARGS,
+            )
 
     @classmethod
     def tearDownClass(cls):

--- a/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_nightly.py
+++ b/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_nightly.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang.srt.environ import envs
 from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
@@ -76,23 +77,24 @@ class TestNvidiaNemotron3SuperNightly(unittest.TestCase):
             ),
         ]
 
-        run_combined_tests(
-            models=variants,
-            test_name="Nemotron-3-Super-120B-BF16",
-            accuracy_params=AccuracyTestParams(
-                dataset="gsm8k",
-                baseline_accuracy=GSM8K_BASELINE,
-                num_examples=1314,
-                num_threads=512,
-                max_tokens=16000,
-                temperature=1.0,
-                top_p=0.95,
-                repeat=1,
-            ),
-            performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_nemotron_3_super_bf16",
-            ),
-        )
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(0):
+            run_combined_tests(
+                models=variants,
+                test_name="Nemotron-3-Super-120B-BF16",
+                accuracy_params=AccuracyTestParams(
+                    dataset="gsm8k",
+                    baseline_accuracy=GSM8K_BASELINE,
+                    num_examples=1314,
+                    num_threads=512,
+                    max_tokens=16000,
+                    temperature=1.0,
+                    top_p=0.95,
+                    repeat=1,
+                ),
+                performance_params=PerformanceTestParams(
+                    profile_dir="performance_profiles_nemotron_3_super_bf16",
+                ),
+            )
 
     @unittest.skipIf(not is_blackwell_system(), "NVFP4 requires Blackwell")
     def test_nemotron_3_super_nvfp4(self):
@@ -112,23 +114,24 @@ class TestNvidiaNemotron3SuperNightly(unittest.TestCase):
             ),
         ]
 
-        run_combined_tests(
-            models=variants,
-            test_name="Nemotron-3-Super-120B-NVFP4",
-            accuracy_params=AccuracyTestParams(
-                dataset="gsm8k",
-                baseline_accuracy=GSM8K_BASELINE,
-                num_examples=1314,
-                num_threads=512,
-                max_tokens=16000,
-                temperature=1.0,
-                top_p=0.95,
-                repeat=1,
-            ),
-            performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_nemotron_3_super_nvfp4",
-            ),
-        )
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(0):
+            run_combined_tests(
+                models=variants,
+                test_name="Nemotron-3-Super-120B-NVFP4",
+                accuracy_params=AccuracyTestParams(
+                    dataset="gsm8k",
+                    baseline_accuracy=GSM8K_BASELINE,
+                    num_examples=1314,
+                    num_threads=512,
+                    max_tokens=16000,
+                    temperature=1.0,
+                    top_p=0.95,
+                    repeat=1,
+                ),
+                performance_params=PerformanceTestParams(
+                    profile_dir="performance_profiles_nemotron_3_super_nvfp4",
+                ),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Set `SGLANG_ENABLE_ASYNC_ASSERT=0` via `envs.SGLANG_ENABLE_ASYNC_ASSERT.override(0)` around Nemotron 3 Super nightly launches.
- Applies to the 8-GPU combined BF16/NVFP4 nightly and the 4-GPU NVFP4 nightly/MTP server launches.

## Testing
- `python -m py_compile test/registered/8-gpu-models/test_nvidia_nemotron_3_super_nightly.py test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py`
- `python - <<'PY' ... ast.parse + override-present check ... PY`
- `git diff --check`
- pre-commit hooks from `git commit` including Python AST, isort, ruff, black-jupyter, codespell, and registered-test CI registry checks

Note: I did not run the full nightly jobs locally because they require the target multi-GPU nightly hardware and model setup.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27312746027](https://github.com/sgl-project/sglang/actions/runs/27312746027)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27312745926](https://github.com/sgl-project/sglang/actions/runs/27312745926)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->