### PR TITLE
[AMD] Remove unintended jit register_amd_ci leaked via #27722 (fixes R165)

### DIFF
--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -10,11 +10,10 @@ from sglang.jit_kernel.activation import (
     run_activation,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
-register_amd_ci(est_time=20, suite="jit-kernel-unit-test-amd")
 
 
 OPS = SUPPORTED_ACTIVATIONS

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -23,11 +23,10 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
 )
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
-register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 configs = list(
     itertools.product(


### PR DESCRIPTION
## Problem (R165)

PR #27722 was accidentally branched off the **drafted, unmerged** #27717 instead of `main`, so its merge commit `f42a093` carried an extra commit (`e6dd1e036`) that added `register_amd_ci(suite="jit-kernel-unit-test-amd")` to two **CUDA-only** JIT tests:

- `test/registered/jit/test_per_token_group_quant_8bit.py`
- `test/registered/jit/test_activation.py`

`test_per_token_group_quant_8bit` then ran on the AMD jit CI and failed: **0/762 passed, step hard-killed at the 10-min budget** (~1872 cases ≈ 31 min). This is the **R165** failure cluster on both `pr-test-amd` and `pr-test-amd-rocm720` (first red 2026-06-10).

## Fix

Remove the two stray `register_amd_ci` lines (CUDA registrations untouched). #27722 only intended to migrate the two AMD 2-GPU allreduce kernel tests (`test_amd_deterministic_custom_allreduce` / `test_amd_nccl_allreduce_determinism`) into the registered system — those remain under `sgl-kernel-unit-test-2-gpu-amd` and are unaffected.

These JIT tests aren't validated on AMD; re-enabling them (with proper sharding / budget) belongs in the still-draft #27717.

## Verification

Parser check before/after (`ut_parse_one_file`):

| | before | after |
| --- | --- | --- |
| `jit-kernel-unit-test-amd` AMD suite | 7 files (incl. `test_per_token_group_quant_8bit.py`, `test_activation.py`) | **5 files** (both removed) |
| `sgl-kernel-unit-test-2-gpu-amd` (intended #27722) | 2 allreduce tests | **2 allreduce tests (intact)** |

AMD jit CI validation run linked in a follow-up comment.

## Test plan

- [ ] AMD `jit-kernel-unit-test-amd` no longer runs `test_per_token_group_quant_8bit.py` and the step completes within budget.
- [ ] CUDA `base-b-kernel-unit-1-gpu-large` / `nightly-kernel-1-gpu` unchanged.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27315352668](https://github.com/sgl-project/sglang/actions/runs/27315352668)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27315352568](https://github.com/sgl-project/sglang/actions/runs/27315352568)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->