### PR TITLE
[AMD] Fix DSA device-to-host direct test on rocm720 (page_size%16 assert)

### DIFF
--- a/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
+++ b/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
@@ -153,6 +153,12 @@ class TestDSAHiCacheTransfer(unittest.TestCase):
     def test_device_to_host_indexer_kernel(self):
         self._run_device_to_host_indexer_copy(io_backend="kernel")
 
+    @unittest.skipIf(
+        is_hip(),
+        "DSATokenToKVPool with page_size=1 (used on HIP) trips the ROCm 7.2.0 "
+        "HIP-preshuffle assert `page_size % 16 == 0` during pool construction "
+        "(seen on pr-test-amd-rocm720). The rest of this file passes on AMD.",
+    )
     def test_device_to_host_indexer_direct(self):
         self._run_device_to_host_indexer_copy(io_backend="direct")
 


### PR DESCRIPTION
## Summary

Fixes CI error `pr-test-amd-rocm720` `stage-b-1gpu-small` ([failing job](https://github.com/sgl-project/sglang/actions/runs/27296881485/job/80631921934)).

#25939 registered `test/registered/unit/mem_cache/test_dsa_pool_host_unit.py` on AMD. The test forces `page_size = 1 if is_hip() else 64`, but on **ROCm 7.2.0** (`pr-test-amd-rocm720`) `DSATokenToKVPool` construction asserts `page_size % 16 == 0` via the HIP-preshuffle path:

```
AssertionError: HIP preshuffle requires page_size to be a multiple of 16, got 1
  test_dsa_pool_host_unit.py:55 _run_device_to_host_indexer_copy
    -> DSATokenToKVPool(...)
```

## Root cause

Both `TestDSAHiCacheTransfer` device-to-host methods call the same `_run_device_to_host_indexer_copy` helper, which builds a `DSATokenToKVPool` with `page_size=1` on HIP. `test_device_to_host_indexer_kernel` was already skipped on AMD in #25939 (the `kernel` IO backend is CUDA-only), but `test_device_to_host_indexer_direct` was left enabled — and it trips the same `page_size % 16` assert on rocm720.

The mi300/mi325 lane (`pr-test-amd`) runs an older ROCm without that assert, so `direct` passed there — which is why #25939's verification looked green. The rocm720 lane is the one that exposes it.

## Fix

Add `@unittest.skipIf(is_hip(), ...)` to `test_device_to_host_indexer_direct`, mirroring the existing skip on the `kernel` variant. This makes both `TestDSAHiCacheTransfer` device-to-host methods CUDA-only and consistent across **both** AMD lanes (mi3xx + rocm720). The rest of the file — `TestDSAOffloadSignatures` and the other 60+ cases — keeps running on AMD.

## Verification

- **PR Test (AMD)** (mi3xx lane): https://github.com/sgl-project/sglang/actions/runs/27315450936 — confirms the change is benign on the standard AMD lane (this file already passed there; `direct` is now additionally skipped on HIP).
- **PR Test (AMD) rocm720** (the lane that exposes R169): https://github.com/sgl-project/sglang/actions/runs/27315994071 — `workflow_dispatch`-ed on this ref (branch pushed to the upstream repo for dispatch). This directly re-runs `stage-b-test-1-gpu-small-amd-rocm720`, where the `page_size % 16` assert was hitting.

## Test plan

- [x] `black --check`, `isort --check`, and the project AST registry parser pass.
- [x] Standard `pr-test-amd` re-run dispatched (linked above).
- [x] `pr-test-amd-rocm720` `stage-b-1gpu-small` **green** on this file — all 14 small partitions + stage-a passed on the dispatched run ([27315994071](https://github.com/sgl-project/sglang/actions/runs/27315994071)); R169 cleared.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27315451050](https://github.com/sgl-project/sglang/actions/runs/27315451050)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27315569135](https://github.com/sgl-project/sglang/actions/runs/27315569135)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


