### PR TITLE
[AMD] Unregister jit per_token_group_quant_8bit + activation tests — kernels don't build on ROCm (fixes R165)

### DIFF
--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -10,11 +10,10 @@ from sglang.jit_kernel.activation import (
     run_activation,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
-register_amd_ci(est_time=20, suite="jit-kernel-unit-test-amd")
 
 
 OPS = SUPPORTED_ACTIVATIONS

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -23,11 +23,10 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
 )
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
-register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 configs = list(
     itertools.product(


### PR DESCRIPTION
## Problem (R165)

#27722 (branched off the unmerged #27717) accidentally added `register_amd_ci(suite="jit-kernel-unit-test-amd")` to two CUDA-only JIT tests, breaking both AMD jit CI jobs (`pr-test-amd`, `pr-test-amd-rocm720`).

## What MI325 CI proved

Both tests fail because their **JIT kernels don't compile on ROCm** — these are kernel-source issues, not test-level ones:

**`test_per_token_group_quant_8bit`** — after trimming the case count enough to reach compilation, `hipcc` static-asserts:
```
per_token_group_quant_8bit.cuh:20 GroupReduceMax: __shfl_xor_sync(mask=0xffff0000/0x0000ffff, ...)
amd_warp_sync_functions.h:332: error: static assertion failed:
  'sizeof(unsigned int) == 8': The mask must be a 64-bit integer
→ ninja status 1  (192/192 runnable cases failed at compile)
```
The kernel uses a 32-bit warp mask + `warp==32` lane math; HIP needs a 64-bit mask + `warp==64` semantics.

**`test_activation`** — `clang`-HIP rejects the kernel template:
```
activation.cuh:213: cannot initialize return object of type
  'decltype(ActivationKernel<__half,false>::unary_kernel<kReLU2>)' ...
utils.cuh:301: function 'forward<const auto &>' ... cannot be used before it is defined
→ ninja status 1  (all 73 cases failed at compile)
```

## Fix

Both tests **never ran on AMD before #27722** and can't until their kernels are ported to ROCm (warp-size-correct reduction; template fixes) — kernel-team work needing numerical validation. Remove the two stray `register_amd_ci` lines (CUDA registrations untouched). This unblocks R165 on both AMD jit jobs.

## Follow-up

A separate issue should track the ROCm kernel ports so these can be re-registered for AMD later:
- `per_token_group_quant_8bit.cuh`: 64-bit warp mask + warp==64 reduction.
- `activation.cuh` / `utils.cuh`: HIP template return-type / `forward` ordering.

## Validation

- MI325 dispatch on the budget-trimmed variant reached compilation and produced the `__shfl_xor_sync` 64-bit-mask error (192/192 fail) — confirming the kernel, not the test, is the blocker.
- MI325 dispatch confirmed `test_activation` fails identically at `load_inline()`/hipcc.
- After this PR, the AMD `jit-kernel-unit-test-amd` suite no longer includes either test.

## Test plan

- [ ] AMD `jit-kernel-unit-test-amd` (pr-test-amd + rocm720) no longer runs these two tests and goes green.
- [ ] CUDA `base-b-kernel-unit-1-gpu-large` / `nightly-kernel-1-gpu` unchanged.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27371803512](https://github.com/sgl-project/sglang/actions/runs/27371803512)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27371803046](https://github.com/sgl-project/sglang/actions/runs/27371803046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->