### PR TITLE
[AMD] fix moriep quant kernel not implemented issue

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -18,7 +18,7 @@ from sglang.srt.layers.moe.moe_runner.base import (
     register_pre_permute,
 )
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
-from sglang.srt.utils import get_int_env_var
+from sglang.srt.utils import get_bool_env_var, get_int_env_var
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher.base import CombineInput
@@ -322,10 +322,25 @@ def _pre_permute_deepep_to_aiter(
         is_w4a4 = weight_quant == AiterQuantType.PER_1X32
         is_fp4_dispatch = hidden_states.dtype == torch.float4_e2m1fn_x2
 
+        # AITER fused_moe Clamped-SwiGLU is dispatched with
+        # gate_mode=INTERLEAVE, for which AITER picks a bf16/fp8 `q_dtype_a`
+        # Refer to https://github.com/ROCm/aiter/blob/a2617c366dc7271a1662ecda2023d19f6ccefcec/aiter/fused_moe.py#L406-L412
+        swiglu_interleave = quant_info.swiglu_limit > 0 and get_bool_env_var(
+            "SGLANG_USE_AITER_MOE_GU_ITLV"
+        )
+
         if is_w4a4 and a1_scale is not None and not is_fp4_dispatch:
             # W4A4 weights with FP8 dispatch: dequant FP8->BF16 first; the
             # FP4 per_1x32 path needs BF16 input.
             hidden_states = upscale(
+                hidden_states, a1_scale, num_local_tokens, output_dtype
+            )
+            a1_scale = None
+        elif is_w4a4 and is_fp4_dispatch and a1_scale is not None and swiglu_interleave:
+            # W4A4 weights + FP4 dispatch on the clamped-SwiGLU/INTERLEAVE
+            # path: AITER expects a bf16/fp8 activation here, not fp4x2.
+            # Dequant FP4->BF16 and let fused_moe re-quantize internally.
+            hidden_states = upscale_mxfp4(
                 hidden_states, a1_scale, num_local_tokens, output_dtype
             )
             a1_scale = None

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -326,7 +326,7 @@ def _pre_permute_deepep_to_aiter(
         # gate_mode=INTERLEAVE, for which AITER picks a bf16/fp8 `q_dtype_a`
         # Refer to https://github.com/ROCm/aiter/blob/a2617c366dc7271a1662ecda2023d19f6ccefcec/aiter/fused_moe.py#L406-L412
         swiglu_interleave = quant_info.swiglu_limit > 0 and get_bool_env_var(
-            "SGLANG_USE_AITER_MOE_GU_ITLV"
+            "SGLANG_USE_AITER_MOE_GU_ITLV", "true"
         )
 
         if is_w4a4 and a1_scale is not None and not is_fp4_dispatch:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This patch is to fix the dsv4 server + mori ep8 crash during warmup with the following error message:

server command:
```bash
SGLANG_MORI_DISPATCH_DTYPE=fp4         \
SGLANG_MORI_COMBINE_DTYPE=fp8               \
SGLANG_DEFAULT_THINKING=1                      \
SGLANG_DSV4_REASONING_EFFORT=max               \
SGLANG_OPT_DEEPGEMM_HC_PRENORM=false           \
SGLANG_USE_AITER=1                             \
SGLANG_USE_ROCM700A=0                          \
SGLANG_OPT_USE_FUSED_COMPRESS=true             \
SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
SGLANG_OPT_FP8_WO_A_GEMM=false                 \
SGLANG_OPT_USE_JIT_INDEXER_METADATA=false      \
SGLANG_OPT_USE_TOPK_V2=false                   \
SGLANG_OPT_USE_AITER_INDEXER=true              \
SGLANG_OPT_USE_TILELANG_INDEXER=false          \
SGLANG_OPT_USE_TILELANG_MHC_PRE=false          \
SGLANG_OPT_USE_TILELANG_MHC_POST=false         \
SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1            \
SGLANG_OPT_USE_FUSED_COMPRESS_TRITON=true      \
SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false      \
SGLANG_ROCM_USE_MULTI_STREAM=false             \
AITER_BF16_FP8_MOE_BOUND=0                     \
SGLANG_EAGER_INPUT_NO_COPY=true                \
sglang serve \
    --model-path /models/DeepSeek-V4-Pro \
    --trust-remote-code \
    --tp-size 8 --ep-size 8 --dp-size 8 \
	--moe-a2a-backend mori \
    --deepep-mode normal --enable-dp-attention \
    --disable-radix-cache \
    --attention-backend dsv4 \
    --page-size 256 \
    --mem-fraction-static 0.90 \
    --swa-full-tokens-ratio 0.1 \
    --disable-shared-experts-fusion \
    --tool-call-parser deepseekv4 \
    --reasoning-parser deepseek-v4 \
    --kv-cache-dtype fp8_e4m3 \
    --chunked-prefill-size 16384 \
    --cuda-graph-max-bs 512 \
    --max-running-requests 512 \
    --port 8000
```

```bash
AITER] /sgl-workspace/aiter/aiter_meta/csrc/kernels/quant_kernels.cu:920 dynamic_per_group_scaled_quant_kernel not implemented for dtype fp4x2
Fatal Python error: Aborted
```

## Modifications

<!-- Detail the changes made in this pull request. -->

- `python/sglang/srt/layers/moe/moe_runner/aiter.py`, `_pre_permute_deepep_to_aiter`: when the activation is FP4-dispatched into a W4A4 (`per_1x32`) expert on the clamped-SwiGLU + INTERLEAVE path (`swiglu_limit > 0` and `SGLANG_USE_AITER_MOE_GU_ITLV`), dequant the FP4 activation back to BF16 via `upscale_mxfp4` and set `a1_scale=None`, letting `fused_moe` re-quantize internally to the dtype the kernel expects. This mirrors the existing W4A4+FP8-dispatch and FP8-weight+FP4-dispatch dequant branches.
- The INTERLEAVE detection reads `get_bool_env_var("SGLANG_USE_AITER_MOE_GU_ITLV", "true")` with an explicit `"true"` default, matching the env's real default and the value `AiterRunnerCore.run()` uses to choose `gate_mode`, so the pre-permute decision and the kernel dispatch agree (the default must be `True`; omitting it would default to `False` and skip the dequant).
- No change for the SiLU/SEPARATED path (e.g. DeepSeek-R1 MXFP4): FP4 activations still flow straight through with no extra dequant.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

DeepSeek-V4-Pro, 8x MI355 (gfx950), `--tp 8 --ep 8 --dp 8 --moe-a2a-backend mori --deepep-mode normal`, gsm8k (1300 questions). All three dispatch dtypes now start successfully with zero `fp4x2` aborts and consistent accuracy:

| `SGLANG_MORI_DISPATCH_DTYPE` | Accuracy | Invalid |
|---|---|---|
| fp4 (auto) | 0.945 | 0.000 |
| fp8) | 0.949 | 0.002 |
| bf16) | 0.943 | 0.001 |

cc @Duyi-Wang  @kkHuang-amd 

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27322522924](https://github.com/sgl-project/sglang/actions/runs/27322522924)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27378546739](https://github.com/sgl-project/sglang/actions/runs/27378546739)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->