### PR TITLE
ci(xpu): pull intel/sglang-dev:latest and clean workspace properly

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -119,10 +119,24 @@ jobs:
       - name: Cleanup container
         if: always()
         run: |
+          # pip install ran as root inside the container against the
+          # bind-mounted workspace, so build artifacts are root-owned on
+          # the host. Chown them back before rm to avoid Permission denied.
+          docker run --rm -v "${{ github.workspace }}:/w" busybox:latest \
+            chown -R "$(id -u):$(id -g)" /w || true
+          # Wipe everything the run wrote into the workspace so the next
+          # job starts from a clean tree.
           rm -rf \
             python/build \
+            python/dist \
             python/sglang.egg-info \
-            test/result.jsonl || true
+            python/sglang/*.egg-info \
+            test/result.jsonl \
+            test/results \
+            test/.pytest_cache \
+            .pytest_cache || true
+          find . -type d -name "__pycache__" -prune -exec rm -rf {} + || true
+          find . -type f -name "*.pyc" -delete || true
           docker rm -f ci_sglang_xpu || true
           if [[ -n "${CI_SGLANG_XPU_IMAGE:-}" ]]; then
             docker rmi -f "${CI_SGLANG_XPU_IMAGE}" || true
@@ -177,15 +191,31 @@ jobs:
       - name: Run stage-b tests
         timeout-minutes: 60
         run: |
-          docker exec ci_sglang_xpu bash -c "source /opt/venv/bin/activate && cd /sglang-checkout/test && python3 run_suite.py --hw xpu --suite stage-b-test-1-gpu-xpu"
+          # --continue-on-error: run every file even if an earlier one fails,
+          # so a single regression doesn't hide the status of the rest.
+          docker exec ci_sglang_xpu bash -c "source /opt/venv/bin/activate && cd /sglang-checkout/test && python3 run_suite.py --hw xpu --suite stage-b-test-1-gpu-xpu --continue-on-error"
 
       - name: Cleanup container
         if: always()
         run: |
+          # pip install ran as root inside the container against the
+          # bind-mounted workspace, so build artifacts are root-owned on
+          # the host. Chown them back before rm to avoid Permission denied.
+          docker run --rm -v "${{ github.workspace }}:/w" busybox:latest \
+            chown -R "$(id -u):$(id -g)" /w || true
+          # Wipe everything the run wrote into the workspace so the next
+          # job starts from a clean tree.
           rm -rf \
             python/build \
+            python/dist \
             python/sglang.egg-info \
-            test/result.jsonl || true
+            python/sglang/*.egg-info \
+            test/result.jsonl \
+            test/results \
+            test/.pytest_cache \
+            .pytest_cache || true
+          find . -type d -name "__pycache__" -prune -exec rm -rf {} + || true
+          find . -type f -name "*.pyc" -delete || true
           docker rm -f ci_sglang_xpu || true
           if [[ -n "${CI_SGLANG_XPU_IMAGE:-}" ]]; then
             docker rmi -f "${CI_SGLANG_XPU_IMAGE}" || true

--- a/scripts/ci/xpu/xpu_ci_start_container.sh
+++ b/scripts/ci/xpu/xpu_ci_start_container.sh
@@ -1,29 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
-# Start the Intel XPU CI container (ci_sglang_xpu) using the latest nightly
-# intel/sglang-dev image published by .github/workflows/release-docker-intel-xpu-nightly.yml.
+# Start the Intel XPU CI container (ci_sglang_xpu) using the intel/sglang-dev:latest
+# image published by .github/workflows/release-docker-intel-xpu-nightly.yml.
 #
-# Walks back N days through nightly date-stamped tags, pulls the first match,
-# then starts a long-running container that subsequent steps `docker exec` into.
+# Pulls the :latest tag and starts a long-running container that subsequent
+# steps `docker exec` into.
 
 CONTAINER_NAME="ci_sglang_xpu"
 IMAGE_REPO="intel/sglang-dev"
-TAG_PREFIX="nightly-dev-xpu-bmg"
-LOOKBACK_DAYS=7
+IMAGE_TAG="latest"
 CUSTOM_IMAGE=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --custom-image) CUSTOM_IMAGE="$2"; shift 2;;
     --container-name) CONTAINER_NAME="$2"; shift 2;;
-    --lookback-days) LOOKBACK_DAYS="$2"; shift 2;;
+    --image-tag) IMAGE_TAG="$2"; shift 2;;
     -h|--help)
       echo "Usage: $0 [OPTIONS]"
       echo "Options:"
       echo "  --custom-image IMAGE     Use a specific Docker image directly"
       echo "  --container-name NAME    Override container name (default: ${CONTAINER_NAME})"
-      echo "  --lookback-days N        Days of nightly tags to scan (default: ${LOOKBACK_DAYS})"
+      echo "  --image-tag TAG          Tag of ${IMAGE_REPO} to pull (default: ${IMAGE_TAG})"
       exit 0
       ;;
     *) echo "Unknown option $1"; exit 1;;
@@ -64,58 +63,12 @@ if [[ -n "${DOCKERHUB_INTEL_USERNAME:-}" && -n "${DOCKERHUB_INTEL_TOKEN:-}" ]]; 
   fi
 fi
 
-# Locate the latest published nightly image. Walks back LOOKBACK_DAYS days of
-# date-stamped tags (commit-hash suffix is unknown, so we query Docker Hub).
-find_latest_image() {
-  local days_back target_date matched_tag
-
-  # Local cache first.
-  for (( days_back=0; days_back<LOOKBACK_DAYS; days_back++ )); do
-    target_date=$(date -d "${days_back} days ago" +%Y%m%d)
-    matched_tag=$(docker images --format '{{.Repository}}:{{.Tag}}' \
-      --filter "reference=${IMAGE_REPO}:${TAG_PREFIX}-${target_date}-*" \
-      | sort -r | head -n 1)
-    if [[ -n "${matched_tag}" ]]; then
-      echo "Found cached image locally: ${matched_tag}" >&2
-      echo "${matched_tag}"
-      return 0
-    fi
-  done
-
-  # Then query Docker Hub for any tag matching the date prefix.
-  for (( days_back=0; days_back<LOOKBACK_DAYS; days_back++ )); do
-    target_date=$(date -d "${days_back} days ago" +%Y%m%d)
-    echo "Checking Docker Hub for: ${IMAGE_REPO}:${TAG_PREFIX}-${target_date}-*" >&2
-    matched_tag=$(curl -fsSL \
-      "https://registry.hub.docker.com/v2/repositories/${IMAGE_REPO}/tags?page_size=100&name=${TAG_PREFIX}-${target_date}" \
-      2>/dev/null \
-      | grep -o '"name":"[^"]*"' | cut -d'"' -f4 | head -n 1 || true)
-    if [[ -n "${matched_tag}" ]]; then
-      echo "Found published image: ${IMAGE_REPO}:${matched_tag}" >&2
-      echo "${IMAGE_REPO}:${matched_tag}"
-      return 0
-    fi
-  done
-
-  # Final fallback: any locally cached image matching the prefix.
-  matched_tag=$(docker images --format '{{.Repository}}:{{.Tag}}' \
-    --filter "reference=${IMAGE_REPO}:${TAG_PREFIX}-*" \
-    | sort -r | head -n 1)
-  if [[ -n "${matched_tag}" ]]; then
-    echo "Using cached fallback image: ${matched_tag}" >&2
-    echo "${matched_tag}"
-    return 0
-  fi
-
-  echo "Error: no ${IMAGE_REPO}:${TAG_PREFIX}-* image found in the last ${LOOKBACK_DAYS} days" >&2
-  return 1
-}
-
 if [[ -n "${CUSTOM_IMAGE}" ]]; then
   IMAGE="${CUSTOM_IMAGE}"
   echo "Using custom image: ${IMAGE}"
 else
-  IMAGE=$(find_latest_image)
+  IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+  echo "Using image: ${IMAGE}"
 fi
 # Always pull so each stage runs the registry's current image; the cleanup
 # step removes the image after the stage so the runner doesn't accumulate


### PR DESCRIPTION
## Summary
- `scripts/ci/xpu/xpu_ci_start_container.sh`: pull `intel/sglang-dev:latest` directly. The publish workflow tags `:latest` alongside the date-stamped nightly tag, so walking back through dated tags is no longer needed. `--lookback-days` is replaced by `--image-tag` for callers that still want to pin a specific tag.
- `.github/workflows/pr-test-xpu.yml`: chown the workspace back to the runner user before `rm` in both stage-a and stage-b cleanup steps. `pip install` runs as root inside the container against the bind-mounted workspace, so build artifacts on the host were root-owned and `rm` failed with `Permission denied` (silently due to `|| true`). Also broaden the `rm` so the tree is fully clean (egg-info, dist/, pytest cache, `__pycache__`, `*.pyc`).
- Add `--continue-on-error` to the stage-b `run_suite.py` call so a single failing file doesn't hide the status of the rest.

## Test plan
- [ ] `pr-test-xpu.yml` runs on this PR
- [ ] Stage-a cleanup logs no longer show `Permission denied` lines
- [ ] Stage-b runs every registered file even when one fails (visible in test summary)
- [ ] `xpu_ci_start_container.sh --help` lists `--image-tag` (no `--lookback-days`)















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27323811281](https://github.com/sgl-project/sglang/actions/runs/27323811281)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27323811182](https://github.com/sgl-project/sglang/actions/runs/27323811182)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->