### PR TITLE
[Test] Add unit tests for observability/utils, embed_types, mooncake_trace

### DIFF
--- a/test/registered/unit/managers/test_embed_types.py
+++ b/test/registered/unit/managers/test_embed_types.py
@@ -1,0 +1,80 @@
+"""Unit tests for managers/embed_types.py - no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestPositionalEmbeds(CustomTestCase):
+    def test_list_of_1d_tensors_stacked(self):
+        """List of 1-D [hidden_dim] tensors is stacked into [N, hidden_dim]."""
+        embeds = [torch.ones(4), torch.zeros(4)]
+        pe = PositionalEmbeds(embeds=embeds, positions=[0, 1])
+        self.assertEqual(tuple(pe.embeds.shape), (2, 4))
+
+    def test_list_of_2d_tensors_concatenated(self):
+        """List of [1, hidden_dim] tensors is concatenated into [N, hidden_dim]."""
+        embeds = [torch.ones(1, 4), torch.zeros(1, 4)]
+        pe = PositionalEmbeds(embeds=embeds, positions=[0, 1])
+        self.assertEqual(tuple(pe.embeds.shape), (2, 4))
+
+    def test_prestacked_tensor_accepted(self):
+        """Pre-stacked [N, hidden_dim] tensor passes through to shape validation."""
+        t = torch.ones(3, 4)
+        pe = PositionalEmbeds(embeds=t, positions=[0, 1, 2])
+        self.assertEqual(tuple(pe.embeds.shape), (3, 4))
+
+    def test_single_1d_tensor_in_list(self):
+        """Single 1-D tensor in list produces shape [1, hidden_dim]."""
+        pe = PositionalEmbeds(embeds=[torch.ones(8)], positions=[5])
+        self.assertEqual(tuple(pe.embeds.shape), (1, 8))
+
+    def test_single_2d_tensor_in_list(self):
+        """Single [1, hidden_dim] tensor in list produces shape [1, hidden_dim]."""
+        pe = PositionalEmbeds(embeds=[torch.ones(1, 8)], positions=[5])
+        self.assertEqual(tuple(pe.embeds.shape), (1, 8))
+
+    def test_empty_list_raises(self):
+        """Empty embeds list is rejected; torch.cat on an empty sequence raises."""
+        with self.assertRaises((ValueError, RuntimeError)):
+            PositionalEmbeds(embeds=[], positions=[])
+
+    def test_count_mismatch_from_list_raises(self):
+        """Embed count after stacking not matching positions length raises ValueError."""
+        with self.assertRaises(ValueError):
+            PositionalEmbeds(
+                embeds=[torch.ones(4), torch.ones(4)],
+                positions=[0],
+            )
+
+    def test_count_mismatch_from_tensor_raises(self):
+        """Pre-stacked tensor row count not matching positions length raises ValueError."""
+        with self.assertRaises(ValueError):
+            PositionalEmbeds(embeds=torch.ones(3, 4), positions=[0, 1])
+
+    def test_1d_stack_values_preserved(self):
+        """Values in 1-D input tensors are preserved exactly after stacking."""
+        a = torch.tensor([1.0, 2.0, 3.0])
+        b = torch.tensor([4.0, 5.0, 6.0])
+        pe = PositionalEmbeds(embeds=[a, b], positions=[0, 1])
+        self.assertTrue(torch.equal(pe.embeds[0], a))
+        self.assertTrue(torch.equal(pe.embeds[1], b))
+
+    def test_2d_cat_values_preserved(self):
+        """Values in [1, hidden_dim] input tensors are preserved exactly after concat."""
+        a = torch.tensor([[1.0, 2.0]])
+        b = torch.tensor([[3.0, 4.0]])
+        pe = PositionalEmbeds(embeds=[a, b], positions=[0, 1])
+        self.assertTrue(torch.equal(pe.embeds[0], a[0]))
+        self.assertTrue(torch.equal(pe.embeds[1], b[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/observability/test_mooncake_trace.py
+++ b/test/registered/unit/observability/test_mooncake_trace.py
@@ -1,0 +1,126 @@
+"""Unit tests for observability/mooncake_trace.py - no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.observability.mooncake_trace import (
+    mooncake_trace_func,
+    mooncake_trace_slice,
+)
+from sglang.test.test_utils import CustomTestCase
+
+_PATCH_CONVERT = "sglang.srt.observability.mooncake_trace.convert_time_to_realtime_ns"
+
+
+class TestMooncakeTraceSlice(CustomTestCase):
+    def setUp(self):
+        self.stage = MagicMock()
+        self.stage.stage_name = "test_stage"
+        self.stage.level = 2
+
+    def test_none_ctx_returns_early(self):
+        """None trace_ctx returns immediately without calling convert or any trace method."""
+        with patch(_PATCH_CONVERT) as mock_convert:
+            mooncake_trace_slice(None, self.stage, 0.5)
+        mock_convert.assert_not_called()
+
+    def test_disabled_tracing_skips_all_calls(self):
+        """tracing_enable=False returns before convert, trace_slice_start, and trace_slice_end."""
+        ctx = MagicMock()
+        ctx.tracing_enable = False
+        with patch(_PATCH_CONVERT) as mock_convert:
+            mooncake_trace_slice(ctx, self.stage, 0.5)
+        mock_convert.assert_not_called()
+        ctx.trace_slice_start.assert_not_called()
+        ctx.trace_slice_end.assert_not_called()
+
+    def test_enabled_tracing_calls_start_and_end(self):
+        """Enabled tracing converts start_ts and calls trace_slice_start then trace_slice_end."""
+        ctx = MagicMock()
+        ctx.tracing_enable = True
+        with patch(_PATCH_CONVERT, return_value=9999) as mock_convert:
+            mooncake_trace_slice(ctx, self.stage, 0.5)
+        mock_convert.assert_called_once_with(0.5)
+        ctx.trace_slice_start.assert_called_once_with("test_stage", 2, 9999)
+        ctx.trace_slice_end.assert_called_once_with(
+            "test_stage", 2, thread_finish_flag=False
+        )
+
+    def test_thread_finish_flag_forwarded(self):
+        """thread_finish_flag=True propagates to the trace_slice_end call."""
+        ctx = MagicMock()
+        ctx.tracing_enable = True
+        with patch(_PATCH_CONVERT, return_value=1):
+            mooncake_trace_slice(ctx, self.stage, 0.5, thread_finish_flag=True)
+        ctx.trace_slice_end.assert_called_once_with(
+            "test_stage", 2, thread_finish_flag=True
+        )
+
+
+class TestMooncakeTraceFunc(CustomTestCase):
+    def setUp(self):
+        self.stage = MagicMock()
+        self.stage.stage_name = "op_name"
+        self.stage.level = 1
+
+    def _make_doubler(self):
+        """Return a function decorated with mooncake_trace_func that doubles its argument."""
+
+        @mooncake_trace_func(self.stage)
+        def fn(self_inner, x):
+            return x * 2
+
+        return fn
+
+    def test_none_ctx_calls_original_function(self):
+        """self.trace_ctx=None bypasses tracing: convert not called, result correct."""
+        fn = self._make_doubler()
+        caller = MagicMock()
+        caller.trace_ctx = None
+        with patch(_PATCH_CONVERT) as mock_convert:
+            result = fn(caller, 3)
+        self.assertEqual(result, 6)
+        mock_convert.assert_not_called()
+
+    def test_enabled_ctx_calls_start_and_end(self):
+        """Non-None trace_ctx causes trace_slice_start and trace_slice_end to be called."""
+        fn = self._make_doubler()
+        caller = MagicMock()
+        with patch(_PATCH_CONVERT, return_value=42):
+            result = fn(caller, 5)
+        self.assertEqual(result, 10)
+        caller.trace_ctx.trace_slice_start.assert_called_once_with("op_name", 1, 42)
+        # mooncake_trace_func does not pass thread_finish_flag to trace_slice_end
+        caller.trace_ctx.trace_slice_end.assert_called_once_with("op_name", 1)
+
+    def test_return_value_preserved(self):
+        """Wrapped function return value passes through the decorator unchanged."""
+
+        @mooncake_trace_func(self.stage)
+        def fn(self_inner, a, b):
+            return a + b
+
+        caller = MagicMock()
+        with patch(_PATCH_CONVERT, return_value=1):
+            result = fn(caller, 7, 8)
+        self.assertEqual(result, 15)
+
+    def test_kwargs_forwarded(self):
+        """Keyword arguments are forwarded correctly to the wrapped function."""
+
+        @mooncake_trace_func(self.stage)
+        def fn(self_inner, x, multiplier=1):
+            return x * multiplier
+
+        caller = MagicMock()
+        with patch(_PATCH_CONVERT, return_value=1):
+            result = fn(caller, 3, multiplier=4)
+        self.assertEqual(result, 12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/observability/test_utils.py
+++ b/test/registered/unit/observability/test_utils.py
@@ -1,0 +1,139 @@
+"""Unit tests for observability/utils.py - no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.observability.utils import (
+    exponential_buckets,
+    generate_buckets,
+    two_sides_exponential_buckets,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestTwoSidesExponentialBuckets(CustomTestCase):
+    def test_middle_value_always_present(self):
+        """Middle value is always included in the output."""
+        result = two_sides_exponential_buckets(5.0, 3.0, 6)
+        self.assertIn(5.0, result)
+
+    def test_symmetric_expansion(self):
+        """Symmetric expansion around middle produces the correct sorted values."""
+        # half_count = ceil(4/2) = 2
+        # i=0: distance=2 -> 12.0, 8.0; i=1: distance=4 -> 14.0, 6.0
+        result = two_sides_exponential_buckets(10.0, 2.0, 4)
+        self.assertEqual(result, [6.0, 8.0, 10.0, 12.0, 14.0])
+
+    def test_odd_count_applies_ceil(self):
+        """Odd count: math.ceil determines half_count, producing an extra pair."""
+        # count=3 -> half_count=ceil(3/2)=2
+        # i=0: distance=2 -> 7.0, 3.0; i=1: distance=4 -> 9.0, 1.0
+        result = two_sides_exponential_buckets(5.0, 2.0, 3)
+        self.assertEqual(result, [1.0, 3.0, 5.0, 7.0, 9.0])
+
+    def test_left_side_clamped_to_zero(self):
+        """Negative left-side values are clamped to 0 and not emitted negative."""
+        # half_count=1; i=0: distance=2 -> 3.0, max(0, 1.0-2)=0.0
+        result = two_sides_exponential_buckets(1.0, 2.0, 2)
+        self.assertNotIn(-1.0, result)
+        self.assertIn(0.0, result)
+
+    def test_repeated_zero_clamps_deduplicated(self):
+        """Multiple left-side values clamped to 0 appear only once in the output."""
+        # middle=0.0: all left distances clamp to 0.0; set removes duplicates
+        result = two_sides_exponential_buckets(0.0, 2.0, 4)
+        self.assertEqual(result.count(0.0), 1)
+
+    def test_count_one(self):
+        """count=1 produces middle plus exactly one expansion pair."""
+        # half_count=ceil(1/2)=1; i=0: distance=2 -> 12.0, 8.0
+        result = two_sides_exponential_buckets(10.0, 2.0, 1)
+        self.assertIn(10.0, result)
+        self.assertIn(12.0, result)
+        self.assertIn(8.0, result)
+
+    def test_zero_clamp_dedup_with_positive_middle(self):
+        """Zero-clamped duplicates from a positive middle appear only once."""
+        # middle=4.0, base=2.0, count=6 -> half_count=3
+        # i=1: distance=4 -> max(0, 0.0)=0.0; i=2: distance=8 -> max(0,-4.0)=0.0
+        # raw list has two 0.0s; deduplication must produce exactly one
+        result = two_sides_exponential_buckets(4.0, 2.0, 6)
+        self.assertEqual(result.count(0.0), 1)
+        self.assertEqual(len(result), len(set(result)))
+
+
+class TestGenerateBuckets(CustomTestCase):
+    # unsorted and contains a duplicate to exercise both sort and dedup
+    _DEFAULT = [5.0, 1.0, 3.0, 1.0]
+
+    def test_empty_rule_falls_back_to_default(self):
+        """Empty buckets_rule list returns sorted, deduplicated default_buckets."""
+        result = generate_buckets([], self._DEFAULT)
+        self.assertEqual(result, sorted(set(self._DEFAULT)))
+
+    def test_default_rule_deduplicates_and_sorts(self):
+        """Rule ['default'] returns sorted, deduplicated default_buckets."""
+        result = generate_buckets(["default"], self._DEFAULT)
+        self.assertEqual(result, sorted(set(self._DEFAULT)))
+
+    def test_tse_rule_delegates_to_two_sides(self):
+        """Rule ['tse', ...] output matches two_sides_exponential_buckets directly."""
+        result = generate_buckets(["tse", "10.0", "2.0", "4"], [])
+        expected = two_sides_exponential_buckets(10.0, 2.0, 4)
+        self.assertEqual(result, expected)
+
+    def test_tse_base_equal_one_raises(self):
+        """Rule ['tse', ...] with base==1.0 raises AssertionError."""
+        with self.assertRaises(AssertionError):
+            generate_buckets(["tse", "5.0", "1.0", "4"], [])
+
+    def test_tse_base_below_one_raises(self):
+        """Rule ['tse', ...] with base<1.0 raises AssertionError."""
+        with self.assertRaises(AssertionError):
+            generate_buckets(["tse", "5.0", "0.5", "4"], [])
+
+    def test_custom_rule_converts_sorts_and_deduplicates(self):
+        """Rule ['custom', ...] converts remainder to float, sorts, and deduplicates."""
+        result = generate_buckets(["custom", "3.0", "1.0", "2.0", "2.0"], [])
+        self.assertEqual(result, [1.0, 2.0, 3.0])
+
+    def test_unknown_rule_raises_assertion_error(self):
+        """Unrecognized rule triggers AssertionError via the assert rule == 'custom' guard."""
+        with self.assertRaises(AssertionError):
+            generate_buckets(["unknown_rule"], [1.0])
+
+
+class TestExponentialBuckets(CustomTestCase):
+    def test_geometric_sequence(self):
+        """Output is exactly start * (width ** i) for i in range(length)."""
+        result = exponential_buckets(1.0, 2.0, 4)
+        self.assertEqual(result, [1.0, 2.0, 4.0, 8.0])
+
+    def test_length_of_output(self):
+        """Output contains exactly `length` elements."""
+        result = exponential_buckets(2.0, 3.0, 5)
+        self.assertEqual(len(result), 5)
+
+    def test_zero_length_returns_empty(self):
+        """length=0 returns an empty list."""
+        result = exponential_buckets(1.0, 2.0, 0)
+        self.assertEqual(result, [])
+
+    def test_width_one_produces_constant_sequence(self):
+        """width=1.0 yields all values equal to start."""
+        result = exponential_buckets(5.0, 1.0, 3)
+        self.assertEqual(result, [5.0, 5.0, 5.0])
+
+    def test_non_unit_start_scales_all_values(self):
+        """Non-unit start scales every element proportionally."""
+        result = exponential_buckets(2.0, 3.0, 3)
+        self.assertAlmostEqual(result[0], 2.0)
+        self.assertAlmostEqual(result[1], 6.0)
+        self.assertAlmostEqual(result[2], 18.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes part of #20865 (unit test coverage tracking issue).

Three source files under `python/sglang/srt/` had no corresponding test
in `test/registered/unit/`. This PR adds coverage for them.

## Modifications

- `test/registered/unit/observability/test_utils.py`
  Tests `two_sides_exponential_buckets`, `generate_buckets`, and
  `exponential_buckets`. Covers zero-clamping behavior, deduplication,
  ceil half-count for odd counts, TSE base validation, custom rule
  parsing, and the unknown-rule assertion guard.

- `test/registered/unit/managers/test_embed_types.py`
  Tests `PositionalEmbeds.__post_init__`. Covers 1-D stack path,
  2-D cat path, pre-stacked tensor passthrough, empty-list error,
  shape-mismatch ValueError for both list and tensor inputs, and
  value preservation after stacking and concatenation.

- `test/registered/unit/observability/test_mooncake_trace.py`
  Tests `mooncake_trace_slice` and `mooncake_trace_func`. Covers
  early return on None context, early return on disabled tracing
  (verifying convert_time_to_realtime_ns is not called in either
  case), correct forwarding of stage name, level, and converted
  timestamp, thread_finish_flag propagation, and kwargs forwarding.

All three files register for `base-a-test-cpu`. No server is launched.
No model weights are loaded.

## Accuracy Tests

N/A — pure unit tests, no model output.

## Speed Tests and Profiling

N/A

## Test Run

```
python3 -m unittest test/registered/unit/observability/test_utils.py \
                    test/registered/unit/managers/test_embed_types.py \
                    test/registered/unit/observability/test_mooncake_trace.py -v
```

```
Ran 19 tests in 0.000s # test_utils.py
Ran 10 tests in 0.014s # test_embed_types.py
Ran  8 tests in 0.003s # test_mooncake_trace.py
```

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27559084792](https://github.com/sgl-project/sglang/actions/runs/27559084792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27559082541](https://github.com/sgl-project/sglang/actions/runs/27559082541)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->