### PR TITLE
[Fix] model implementation bugs: Gemma3 RoPE/Gemma3n init + AfmoeMoE import

### DIFF
--- a/python/sglang/srt/models/afmoe.py
+++ b/python/sglang/srt/models/afmoe.py
@@ -47,7 +47,7 @@ from sglang.srt.layers.linear import (
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.triton_utils import fused_moe
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention

--- a/python/sglang/srt/models/gemma3_causal.py
+++ b/python/sglang/srt/models/gemma3_causal.py
@@ -580,9 +580,8 @@ class Gemma3TextModel(PreTrainedModel):
 
         global_config = copy.deepcopy(config)
         global_config.rope_parameters = {
+            **rope_params["full_attention"],
             "rope_theta": global_theta,
-            "factor": config.rope_parameters["full_attention"]["factor"],
-            "rope_type": "linear",
         }
         self.rotary_emb = Gemma3RotaryEmbedding(config=global_config)
         self.gradient_checkpointing = False

--- a/python/sglang/srt/models/gemma3n_causal.py
+++ b/python/sglang/srt/models/gemma3n_causal.py
@@ -389,16 +389,17 @@ class Gemma3nAttention(nn.Module):
                 self.head_dim,
                 rotary_dim=self.head_dim,
                 max_position=config.max_position_embeddings,
-                base=config.rope_local_base_freq,
+                base=config.rope_parameters.get("sliding_attention", {}).get("rope_theta", 10000.0),
                 rope_scaling={"rope_type": "default"},
             )
         else:
+            full_attn_rope = config.rope_parameters.get("full_attention", {})
             self.rotary_emb = get_rope(
                 self.head_dim,
                 rotary_dim=self.head_dim,
                 max_position=config.max_position_embeddings,
-                base=config.rope_parameters["rope_theta"],
-                rope_scaling=config.rope_parameters,
+                base=full_attn_rope.get("rope_theta", 1000000.0),
+                rope_scaling=full_attn_rope if full_attn_rope else {"rope_type": "default"},
             )
 
         self.sliding_window = config.sliding_window if self.is_sliding else None

--- a/python/sglang/srt/models/gemma3n_mm.py
+++ b/python/sglang/srt/models/gemma3n_mm.py
@@ -445,8 +445,8 @@ class Gemma3nForConditionalGeneration(PreTrainedModel):
             input_ids, hidden_states, self.language_model.embed_tokens, forward_batch
         )
 
-    def tie_weights(self):
-        return self.language_model.tie_weights()
+    def tie_weights(self, **kwargs):
+        return self.language_model.tie_weights(**kwargs)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [


### PR DESCRIPTION
## Motivation

Four model initialization/inference bugs causing server crashes on `gemma-3-1b-it`, `gemma-3n-E2B-it`/`E4B-it`, and AfmoeMoE models (e.g. `arcee-ai/Trinity-*`). All fixes are correctness-only with no effect on model outputs or forward-pass performance.

## Modifications

### 1. `gemma3_causal.py` — `KeyError: 'factor'` for `gemma-3-1b-it`

Old code unconditionally read `config.rope_parameters["full_attention"]["factor"]` and hardcoded `"rope_type": "linear"` when building the global RoPE config. The 1B model's `full_attention` dict has `rope_type=default` with **no `factor` key**, so this always crashed.

The 4B/12B/27B models have `rope_type=linear, factor=8.0` in `full_attention` — the old code accidentally worked for them because it hardcoded matching values.

**Fix:** Spread `rope_params["full_attention"]` directly. For 1B: `{rope_type: default, rope_theta: 1000000}` (correct, no factor). For 4B/12B/27B: `{rope_type: linear, factor: 8.0, rope_theta: 1000000}` — identical to before.

### 2. `gemma3n_causal.py` — `AttributeError: rope_local_base_freq` + `KeyError: rope_theta`

Both caused by applying `Gemma3Attention` (Gemma3) patterns to `Gemma3nAttention` (Gemma3n) without adapting to `Gemma3nTextConfig`'s structure:

**a) Sliding attention** — `base=config.rope_local_base_freq` crashes because `Gemma3nTextConfig` (a `@strict` dataclass) has no such attribute. The sliding-attention theta lives at `rope_parameters["sliding_attention"]["rope_theta"]`, where `convert_rope_params_to_dict()` stores it during config init.

**b) Global attention** — `base=config.rope_parameters["rope_theta"]` crashes because `Gemma3nTextConfig.rope_parameters` is always nested (`{sliding_attention: {...}, full_attention: {...}}`) — there is no flat top-level `"rope_theta"` key.

**Fix:** Read both thetas from `rope_parameters["sliding_attention"]` and `rope_parameters["full_attention"]` respectively.

### 3. `gemma3n_mm.py` — `TypeError: tie_weights() got unexpected keyword argument 'recompute_mapping'`

Transformers v5 changed `PreTrainedModel.tie_weights()` to accept `(missing_keys, recompute_mapping)` and calls it with `tie_weights(recompute_mapping=False)` during `init_weights()` and `tie_weights(missing_keys=..., recompute_mapping=False)` during `from_pretrained()`. The old override `def tie_weights(self)` had no `**kwargs`, crashing at both call sites.

**Fix:** Add `**kwargs` and forward to `language_model.tie_weights(**kwargs)`. `language_model` is `Gemma3nTextModel(PreTrainedModel)` which inherits the full v5 signature — safe and backwards-compatible.

### 4. `afmoe.py` — `TypeError: 'module' object is not callable` on every forward pass

`from sglang.srt.layers.moe.moe_runner.triton_utils import fused_moe` silently imports the `fused_moe.py` **submodule** instead of the function, because `triton_utils/__init__.py` does not re-export `fused_moe`. Calling the module raises `TypeError` on every `AfmoeMoE.forward()`.

**Fix:** Import from the full path: `from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe`, matching `deepseek.py`, `dbrx.py`, and other MoE models.

## Accuracy Tests

No model output changes — all fixes are in initialization and import paths only.

## Speed Tests and Profiling

No performance impact.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27325966807](https://github.com/sgl-project/sglang/actions/runs/27325966807)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27325966712](https://github.com/sgl-project/sglang/actions/runs/27325966712)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->