### PR TITLE
Fix fp16 NaN flake in spec CI: bf16 eagle fixture; sanitize NaN logits in sampler

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -629,9 +629,10 @@ class Envs:
     # page alignment). Off in prod; tests turn it on to fail-fast on
     # numerical / index violations instead of getting silent NaN cascades.
     SGLANG_ENABLE_ASYNC_ASSERT = EnvBool(False)
-    # Log a throttled, sync-free warning when NaN logits are detected and
-    # sanitized (see sanitize_nan_logits). No-op when the assert gate is on.
-    SGLANG_LOG_NAN_LOGITS = EnvBool(False)
+    # Sanitize NaN logits before sampling kernels (see sanitize_nan_logits).
+    SGLANG_SANITIZE_NAN_LOGITS = EnvBool(True)
+    # Throttled sync-free warning on NaN logits; no-op when the assert gate is on.
+    SGLANG_LOG_NAN_LOGITS = EnvBool(True)
 
     # VLM
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -629,6 +629,9 @@ class Envs:
     # page alignment). Off in prod; tests turn it on to fail-fast on
     # numerical / index violations instead of getting silent NaN cascades.
     SGLANG_ENABLE_ASYNC_ASSERT = EnvBool(False)
+    # Log a throttled, sync-free warning when NaN logits are detected and
+    # sanitized (see sanitize_nan_logits). No-op when the assert gate is on.
+    SGLANG_LOG_NAN_LOGITS = EnvBool(False)
 
     # VLM
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -629,10 +629,9 @@ class Envs:
     # page alignment). Off in prod; tests turn it on to fail-fast on
     # numerical / index violations instead of getting silent NaN cascades.
     SGLANG_ENABLE_ASYNC_ASSERT = EnvBool(False)
-    # Sanitize NaN logits before sampling kernels (see sanitize_nan_logits).
+    # Sanitize NaN logits before sampling kernels and log a throttled warning
+    # (see sanitize_nan_logits).
     SGLANG_SANITIZE_NAN_LOGITS = EnvBool(True)
-    # Throttled sync-free warning on NaN logits; no-op when the assert gate is on.
-    SGLANG_LOG_NAN_LOGITS = EnvBool(True)
 
     # VLM
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -16,7 +16,7 @@ from sglang.srt.layers.utils.logprob import get_token_ids_logprobs, get_top_logp
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils.async_probe import maybe_detect_nan
+from sglang.srt.utils.async_probe import maybe_detect_nan, maybe_warn_nan
 from sglang.srt.utils.common import (
     get_bool_env_var,
     is_cuda,
@@ -87,15 +87,14 @@ class Sampler(nn.Module):
         """Apply custom logit processors and sanitize non-finite logits."""
         if sampling_info.has_custom_logit_processor:
             apply_custom_logit_processor(logits, sampling_info)
-        # Detect first (gated on SGLANG_ENABLE_ASYNC_ASSERT, on in CI), then
-        # sanitize unconditionally: NaN logits (e.g. fp16 activation overflow)
-        # fed to sampling kernels are undefined behavior and can come back as
-        # out-of-vocab token ids; +Inf turns into NaN probs after softmax.
-        # NaN/-Inf -> dtype min (-Inf vocab masks stay effectively excluded;
-        # a fully poisoned row degrades to uniform), +Inf -> dtype max.
-        # No Inf detection here: -Inf is legitimate in logits (vocab masks).
+        # NaN logits (e.g. fp16 activation overflow) are undefined behavior in
+        # sampling kernels and can come back as out-of-vocab token ids, so
+        # detect (assert in CI, sync-free warning in prod), then sanitize.
+        # +-1e30 rather than dtype min/max: the latter overflows to +-Inf
+        # under the temperature division below.
         maybe_detect_nan(logits, "sampler: next_token_logits")
-        torch.nan_to_num_(logits, nan=torch.finfo(logits.dtype).min)
+        maybe_warn_nan(logits, "sampler: next_token_logits")
+        torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
         return logits
 
     def forward(

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -88,10 +88,10 @@ class Sampler(nn.Module):
         if sampling_info.has_custom_logit_processor:
             apply_custom_logit_processor(logits, sampling_info)
         # NaN logits (e.g. fp16 activation overflow) are undefined behavior in
-        # sampling kernels and can come back as out-of-vocab token ids, so
-        # detect (assert in CI, sync-free warning in prod), then sanitize.
-        # +-1e30 rather than dtype min/max: the latter overflows to +-Inf
-        # under the temperature division below.
+        # sampling kernels and can come back as out-of-vocab token ids; detect
+        # before sanitizing so the probes see the raw values. +-1e30 rather
+        # than dtype min/max: the latter overflows to +-Inf under the
+        # temperature division below.
         maybe_detect_nan(logits, "sampler: next_token_logits")
         maybe_warn_nan(logits, "sampler: next_token_logits")
         torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -16,7 +16,7 @@ from sglang.srt.layers.utils.logprob import get_token_ids_logprobs, get_top_logp
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils.async_probe import maybe_detect_nan, maybe_warn_nan
+from sglang.srt.utils.async_probe import sanitize_nan_logits
 from sglang.srt.utils.common import (
     get_bool_env_var,
     is_cuda,
@@ -87,14 +87,7 @@ class Sampler(nn.Module):
         """Apply custom logit processors and sanitize non-finite logits."""
         if sampling_info.has_custom_logit_processor:
             apply_custom_logit_processor(logits, sampling_info)
-        # NaN logits (e.g. fp16 activation overflow) are undefined behavior in
-        # sampling kernels and can come back as out-of-vocab token ids; detect
-        # before sanitizing so the probes see the raw values. +-1e30 rather
-        # than dtype min/max: the latter overflows to +-Inf under the
-        # temperature division below.
-        maybe_detect_nan(logits, "sampler: next_token_logits")
-        maybe_warn_nan(logits, "sampler: next_token_logits")
-        torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
+        sanitize_nan_logits(logits, "sampler: next_token_logits")
         return logits
 
     def forward(

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -16,6 +16,7 @@ from sglang.srt.layers.utils.logprob import get_token_ids_logprobs, get_top_logp
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
 from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils.async_probe import maybe_detect_nan
 from sglang.srt.utils.common import (
     get_bool_env_var,
     is_cuda,
@@ -83,9 +84,18 @@ class Sampler(nn.Module):
     def _preprocess_logits(
         self, logits: torch.Tensor, sampling_info: SamplingBatchInfo
     ) -> torch.Tensor:
-        """Apply custom logit processors."""
+        """Apply custom logit processors and sanitize non-finite logits."""
         if sampling_info.has_custom_logit_processor:
             apply_custom_logit_processor(logits, sampling_info)
+        # Detect first (gated on SGLANG_ENABLE_ASYNC_ASSERT, on in CI), then
+        # sanitize unconditionally: NaN logits (e.g. fp16 activation overflow)
+        # fed to sampling kernels are undefined behavior and can come back as
+        # out-of-vocab token ids; +Inf turns into NaN probs after softmax.
+        # NaN/-Inf -> dtype min (-Inf vocab masks stay effectively excluded;
+        # a fully poisoned row degrades to uniform), +Inf -> dtype max.
+        # No Inf detection here: -Inf is legitimate in logits (vocab masks).
+        maybe_detect_nan(logits, "sampler: next_token_logits")
+        torch.nan_to_num_(logits, nan=torch.finfo(logits.dtype).min)
         return logits
 
     def forward(

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -45,7 +45,11 @@ from sglang.srt.speculative.triton_ops.cache_locs import (
 from sglang.srt.speculative.triton_ops.eagle import (
     fill_bonus_tokens as fill_bonus_tokens,
 )
-from sglang.srt.utils.async_probe import maybe_detect_nan, maybe_detect_oob
+from sglang.srt.utils.async_probe import (
+    maybe_detect_nan,
+    maybe_detect_oob,
+    maybe_warn_nan,
+)
 from sglang.srt.utils.common import is_cuda, is_hip, is_musa, is_npu
 
 _is_cuda = is_cuda()
@@ -473,6 +477,13 @@ class EagleVerifyInputV2Mixin:
         bs = len(batch.seq_lens)
         sampling_info = batch.sampling_info
         next_token_logits = logits_output.next_token_logits
+
+        # NaN logits (e.g. fp16 activation overflow on degenerate draft
+        # branches) are undefined behavior in the verify kernels; warn
+        # (sync-free, prod) and sanitize. +-1e30 instead of dtype min/max so
+        # the temperature division cannot overflow back to +-Inf.
+        maybe_warn_nan(next_token_logits, "verify: target model logits")
+        torch.nan_to_num_(next_token_logits, nan=-1e30, posinf=1e30, neginf=-1e30)
 
         # Apply penalty
         # This is a relaxed version of penalties for speculative decoding.

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -478,10 +478,10 @@ class EagleVerifyInputV2Mixin:
         sampling_info = batch.sampling_info
         next_token_logits = logits_output.next_token_logits
 
-        # NaN logits (e.g. fp16 activation overflow on degenerate draft
-        # branches) are undefined behavior in the verify kernels; warn
-        # (sync-free, prod) and sanitize. +-1e30 instead of dtype min/max so
-        # the temperature division cannot overflow back to +-Inf.
+        # NaN logits (fp16 activation overflow on degenerate draft branches)
+        # are undefined behavior in the verify kernels; warn and sanitize
+        # (the CI assert probe already runs in the callers). +-1e30 instead of
+        # dtype min/max so the temperature division cannot overflow to +-Inf.
         maybe_warn_nan(next_token_logits, "verify: target model logits")
         torch.nan_to_num_(next_token_logits, nan=-1e30, posinf=1e30, neginf=-1e30)
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -48,7 +48,7 @@ from sglang.srt.speculative.triton_ops.eagle import (
 from sglang.srt.utils.async_probe import (
     maybe_detect_nan,
     maybe_detect_oob,
-    maybe_warn_nan,
+    sanitize_nan_logits,
 )
 from sglang.srt.utils.common import is_cuda, is_hip, is_musa, is_npu
 
@@ -478,12 +478,7 @@ class EagleVerifyInputV2Mixin:
         sampling_info = batch.sampling_info
         next_token_logits = logits_output.next_token_logits
 
-        # NaN logits (fp16 activation overflow on degenerate draft branches)
-        # are undefined behavior in the verify kernels; warn and sanitize
-        # (the CI assert probe already runs in the callers). +-1e30 instead of
-        # dtype min/max so the temperature division cannot overflow to +-Inf.
-        maybe_warn_nan(next_token_logits, "verify: target model logits")
-        torch.nan_to_num_(next_token_logits, nan=-1e30, posinf=1e30, neginf=-1e30)
+        sanitize_nan_logits(next_token_logits, "verify: target model logits")
 
         # Apply penalty
         # This is a relaxed version of penalties for speculative decoding.

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -59,9 +59,11 @@ _nan_warner = _AsyncNanWarner()
 
 
 def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
-    """Non-fatal counterpart of maybe_detect_nan, active when the assert gate
-    is OFF: warn (throttled, sync-free) instead of crashing. Callers are
-    expected to sanitize the tensor themselves."""
+    """Non-fatal counterpart of maybe_detect_nan, gated on
+    SGLANG_LOG_NAN_LOGITS: warn (throttled, sync-free) instead of crashing.
+    Callers are expected to sanitize the tensor themselves."""
+    if not envs.SGLANG_LOG_NAN_LOGITS.get():
+        return
     if envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
         # The hard assert path already covers detection.
         return
@@ -71,12 +73,12 @@ def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
 
 
 def sanitize_nan_logits(logits: torch.Tensor, msg: str = ""):
-    """Detect NaN (assert in CI, throttled sync-free warning in prod), then
-    sanitize in place: NaN logits (e.g. fp16 activation overflow) are
-    undefined behavior in sampling kernels and can come back as out-of-vocab
-    token ids. Replacement is +-1e30 rather than dtype min/max because
-    callers divide logits by temperature, which would overflow dtype min/max
-    to +-Inf and softmax back to NaN."""
+    """Detect NaN (assert in CI; opt-in throttled warning in prod via
+    SGLANG_LOG_NAN_LOGITS), then sanitize in place: NaN logits (e.g. fp16
+    activation overflow) are undefined behavior in sampling kernels and can
+    come back as out-of-vocab token ids. Replacement is +-1e30 rather than
+    dtype min/max because callers divide logits by temperature, which would
+    overflow dtype min/max to +-Inf and softmax back to NaN."""
     maybe_detect_nan(logits, msg)
     maybe_warn_nan(logits, msg)
     torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -5,11 +5,69 @@ When the gate is on, a violation surfaces as an assertion at the next CUDA
 sync point instead of as a silent NaN cascade or illegal-address crash.
 """
 
+import logging
+import time
 from typing import Optional
 
 import torch
 
 from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+
+class _AsyncNanWarner:
+    """Non-fatal NaN monitor: device-side detection accumulates into a GPU
+    counter copied to pinned host memory without any stream sync; the host
+    reads the (slightly stale) value on a later call and warns, throttled."""
+
+    WARN_INTERVAL_S = 30.0
+
+    def __init__(self):
+        self._dev = None
+        self._host = None
+        self._reported = 0
+        self._last_warn_time = 0.0
+
+    def check(self, tensor: torch.Tensor, msg: str):
+        if not tensor.is_cuda:
+            return
+        if self._dev is None:
+            self._dev = torch.zeros(1, dtype=torch.int32, device=tensor.device)
+            self._host = torch.zeros(1, dtype=torch.int32, pin_memory=True)
+
+        # Report hits enqueued on earlier steps (pinned-memory read, no sync).
+        seen = int(self._host[0])
+        now = time.monotonic()
+        if seen > self._reported and now - self._last_warn_time >= self.WARN_INTERVAL_S:
+            logger.warning(
+                "NaN detected in %s (%d batches so far); values were sanitized "
+                "before sampling. This usually indicates numerical overflow "
+                "(e.g. fp16 activations) or an upstream bug producing NaN.",
+                msg,
+                seen,
+            )
+            self._reported = seen
+            self._last_warn_time = now
+
+        # Enqueue this step's detection (async, no sync).
+        self._dev.add_(torch.isnan(tensor).any().to(torch.int32))
+        self._host.copy_(self._dev, non_blocking=True)
+
+
+_nan_warner = _AsyncNanWarner()
+
+
+def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
+    """Non-fatal counterpart of maybe_detect_nan, active when the assert gate
+    is OFF: warn (throttled, sync-free) instead of crashing. Callers are
+    expected to sanitize the tensor themselves."""
+    if envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
+        # The hard assert path already covers detection.
+        return
+    if tensor is None:
+        return
+    _nan_warner.check(tensor, msg)
 
 
 def maybe_detect_nan(tensor: Optional[torch.Tensor], msg: str = ""):

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -6,7 +6,6 @@ sync point instead of as a silent NaN cascade or illegal-address crash.
 """
 
 import logging
-import time
 from typing import Optional
 
 import torch
@@ -17,38 +16,33 @@ logger = logging.getLogger(__name__)
 
 
 class _AsyncNanWarner:
-    """Non-fatal NaN monitor: device-side detection accumulates into a GPU
-    counter copied to pinned host memory without any stream sync; the host
-    reads the (slightly stale) value on a later call and warns, throttled."""
-
-    WARN_INTERVAL_S = 30.0
+    """One-shot NaN monitor: device-side detection lands in pinned host
+    memory without any stream sync; the host reads the (slightly stale) flag
+    on a later call, warns once, and stops detecting."""
 
     def __init__(self):
         self._dev = None
         self._host = None
-        self._reported = 0
-        self._last_warn_time = 0.0
+        self._warned = False
 
     def check(self, tensor: torch.Tensor, msg: str):
-        if not tensor.is_cuda:
+        if self._warned or not tensor.is_cuda:
             return
         if self._dev is None:
             self._dev = torch.zeros(1, dtype=torch.int32, device=tensor.device)
             self._host = torch.zeros(1, dtype=torch.int32, pin_memory=True)
 
-        # Report hits enqueued on earlier steps (pinned-memory read, no sync).
-        seen = int(self._host[0])
-        now = time.monotonic()
-        if seen > self._reported and now - self._last_warn_time >= self.WARN_INTERVAL_S:
+        # Report a hit enqueued on an earlier step (pinned read, no sync).
+        if int(self._host[0]):
             logger.warning(
-                "NaN detected in %s (%d batches so far); values were sanitized "
-                "before sampling. This usually indicates numerical overflow "
-                "(e.g. fp16 activations) or an upstream bug producing NaN.",
+                "NaN detected in %s; values were sanitized before sampling. "
+                "This usually indicates numerical overflow (e.g. fp16 "
+                "activations) or an upstream bug producing NaN. "
+                "Logged once; further occurrences are silent.",
                 msg,
-                seen,
             )
-            self._reported = seen
-            self._last_warn_time = now
+            self._warned = True
+            return
 
         # Enqueue this step's detection (async, no sync).
         self._dev.add_(torch.isnan(tensor).any().to(torch.int32))

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -70,6 +70,18 @@ def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
     _nan_warner.check(tensor, msg)
 
 
+def sanitize_nan_logits(logits: torch.Tensor, msg: str = ""):
+    """Detect NaN (assert in CI, throttled sync-free warning in prod), then
+    sanitize in place: NaN logits (e.g. fp16 activation overflow) are
+    undefined behavior in sampling kernels and can come back as out-of-vocab
+    token ids. Replacement is +-1e30 rather than dtype min/max because
+    callers divide logits by temperature, which would overflow dtype min/max
+    to +-Inf and softmax back to NaN."""
+    maybe_detect_nan(logits, msg)
+    maybe_warn_nan(logits, msg)
+    torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
+
+
 def maybe_detect_nan(tensor: Optional[torch.Tensor], msg: str = ""):
     """Async NaN check — no GPU-CPU sync, error surfaces at next sync point."""
     if not envs.SGLANG_ENABLE_ASYNC_ASSERT.get():

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -61,8 +61,6 @@ _nan_warner = _AsyncNanWarner()
 def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
     """Non-fatal counterpart of maybe_detect_nan: throttled sync-free warning
     instead of crashing. Callers sanitize the tensor themselves."""
-    if not envs.SGLANG_LOG_NAN_LOGITS.get():
-        return
     if envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
         # The hard assert path already covers detection.
         return
@@ -78,9 +76,10 @@ def sanitize_nan_logits(logits: torch.Tensor, msg: str = ""):
     rather than dtype min/max because callers divide logits by temperature,
     which would overflow dtype min/max to +-Inf and softmax back to NaN."""
     maybe_detect_nan(logits, msg)
+    if not envs.SGLANG_SANITIZE_NAN_LOGITS.get():
+        return
     maybe_warn_nan(logits, msg)
-    if envs.SGLANG_SANITIZE_NAN_LOGITS.get():
-        torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
+    torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
 
 
 def maybe_detect_nan(tensor: Optional[torch.Tensor], msg: str = ""):

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -59,9 +59,8 @@ _nan_warner = _AsyncNanWarner()
 
 
 def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
-    """Non-fatal counterpart of maybe_detect_nan, gated on
-    SGLANG_LOG_NAN_LOGITS: warn (throttled, sync-free) instead of crashing.
-    Callers are expected to sanitize the tensor themselves."""
+    """Non-fatal counterpart of maybe_detect_nan: throttled sync-free warning
+    instead of crashing. Callers sanitize the tensor themselves."""
     if not envs.SGLANG_LOG_NAN_LOGITS.get():
         return
     if envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
@@ -73,15 +72,15 @@ def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
 
 
 def sanitize_nan_logits(logits: torch.Tensor, msg: str = ""):
-    """Detect NaN (assert in CI; opt-in throttled warning in prod via
-    SGLANG_LOG_NAN_LOGITS), then sanitize in place: NaN logits (e.g. fp16
-    activation overflow) are undefined behavior in sampling kernels and can
-    come back as out-of-vocab token ids. Replacement is +-1e30 rather than
-    dtype min/max because callers divide logits by temperature, which would
-    overflow dtype min/max to +-Inf and softmax back to NaN."""
+    """Detect NaN (assert in CI, throttled warning in prod), then sanitize in
+    place: NaN logits (e.g. fp16 activation overflow) are undefined behavior
+    in sampling kernels and can come back as out-of-vocab token ids. +-1e30
+    rather than dtype min/max because callers divide logits by temperature,
+    which would overflow dtype min/max to +-Inf and softmax back to NaN."""
     maybe_detect_nan(logits, msg)
     maybe_warn_nan(logits, msg)
-    torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
+    if envs.SGLANG_SANITIZE_NAN_LOGITS.get():
+        torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
 
 
 def maybe_detect_nan(tensor: Optional[torch.Tensor], msg: str = ""):

--- a/python/sglang/test/server_fixtures/spec_eagle_fixture.py
+++ b/python/sglang/test/server_fixtures/spec_eagle_fixture.py
@@ -61,7 +61,11 @@ class SpecEagleServerBase(CustomTestCase):
     mem_fraction_static = 0.75
     max_running_requests = 8
     chunked_prefill_size = 128
-    dtype = "float16"
+    # bf16 rather than fp16: fp16 inference can overflow the fp16 range on
+    # degenerate draft branches in verify (massive-activation channels reach
+    # ~5e4, vs the 65504 fp16 max), which becomes Inf -> NaN under RMSNorm and
+    # trips the CI NaN asserts. bf16 has fp32-equivalent range.
+    dtype = "bfloat16"
     cuda_graph_max_bs = None
     trust_remote_code = True
 

--- a/python/sglang/test/server_fixtures/spec_eagle_fixture.py
+++ b/python/sglang/test/server_fixtures/spec_eagle_fixture.py
@@ -61,10 +61,8 @@ class SpecEagleServerBase(CustomTestCase):
     mem_fraction_static = 0.75
     max_running_requests = 8
     chunked_prefill_size = 128
-    # bf16 rather than fp16: fp16 inference can overflow the fp16 range on
-    # degenerate draft branches in verify (massive-activation channels reach
-    # ~5e4, vs the 65504 fp16 max), which becomes Inf -> NaN under RMSNorm and
-    # trips the CI NaN asserts. bf16 has fp32-equivalent range.
+    # bf16 rather than fp16: fp16 activations can overflow (-> Inf -> NaN) on
+    # degenerate draft branches in verify and trip the CI NaN asserts.
     dtype = "bfloat16"
     cuda_graph_max_bs = None
     trust_remote_code = True


### PR DESCRIPTION
Fixes the flaky NaN device assert in `test_spec_eagle_fa3.py` (e.g. https://github.com/sgl-project/sglang/actions/runs/27318076885/job/80706381850): fp16 activation overflow on a degenerate draft branch during EAGLE verify becomes Inf -> NaN under RMSNorm. Switch the spec EAGLE fixtures to bf16, and sanitize NaN logits at the sampler entry so NaN can never reach the sampling kernels (undefined behavior there, can come back as out-of-vocab token ids).





















































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27333007401](https://github.com/sgl-project/sglang/actions/runs/27333007401)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27333007194](https://github.com/sgl-project/sglang/actions/runs/27333007194)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->