### PR TITLE
[PD] Fix negative prefill kv_transfer_alloc_ms under optimistic prefill

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -24,6 +24,8 @@ class StateType(str, enum.Enum):
 class KVTransferMetric:
     # Backends that cannot isolate transfer latency can leave this as None.
     transfer_latency_s: Optional[float] = None
+    # Backends that cannot isolate allocation wait latency can leave this as None.
+    alloc_latency_s: Optional[float] = None
     transfer_total_bytes: Optional[int] = None
 
 

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -903,7 +903,13 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
             bootstrap_ms = (
                 self.bootstrap_done_time - self.prefill_bootstrap_queue_entry_time
             ) * 1000
-            alloc_ms = (self.wait_queue_entry_time - self.bootstrap_done_time) * 1000
+            if transfer_metric.alloc_latency_s is not None:
+                alloc_ms = transfer_metric.alloc_latency_s * 1000
+            else:
+                alloc_ms = (
+                    max(0.0, self.wait_queue_entry_time - self.bootstrap_done_time)
+                    * 1000
+                )
 
             result["bootstrap_ms"] = bootstrap_ms
             result["alloc_ms"] = alloc_ms


### PR DESCRIPTION
Prefill `alloc_ms` was `wait_queue_entry_time - bootstrap_done_time`. With optimistic prefill the request enters the wait queue before bootstrap completes, so this delta inverts and `sglang:kv_transfer_alloc_ms` goes negative.

Add optional `KVTransferMetric.alloc_latency_s` so a backend can report the real alloc wait; prefill uses it when present, else falls back to `max(0, wait_queue_entry_time - bootstrap_done_time)`. Non-inverted values are unchanged; decode is untouched.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27327097307](https://github.com/sgl-project/sglang/actions/runs/27327097307)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27452790119](https://github.com/sgl-project/sglang/actions/runs/27452790119)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->