### PR TITLE
[Model] Add HrmTextForCausalLM (Hierarchical Reasoning Model - Text)

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -792,6 +792,23 @@ class ModelConfig:
         if "IQuestLoopCoderForCausalLM" in self.hf_config.architectures:
             loop_num = getattr(self.hf_text_config, "loop_num", 1)
             self.num_attention_layers = int(self.num_hidden_layers * int(loop_num))
+        if "HrmTextForCausalLM" in self.hf_config.architectures:
+            # HRM-Text unrolls two transformer stacks across nested H/L cycles;
+            # each recurrence step occupies its own KV cache slot. The total is
+            # num_layers_per_stack * H_cycles * (L_cycles + 1). A native
+            # transformers >= 5.9.0 config already inflates num_hidden_layers to
+            # this value in __post_init__, but compute it explicitly so KV
+            # allocation is correct even if num_hidden_layers carries the raw
+            # per-stack count.
+            H_cycles = self.hf_text_config.H_cycles
+            L_cycles = self.hf_text_config.L_cycles
+            num_layers_per_stack = (
+                getattr(self.hf_text_config, "num_layers_per_stack", None)
+                or self.num_hidden_layers
+            )
+            self.num_attention_layers = (
+                int(num_layers_per_stack) * H_cycles * (L_cycles + 1)
+            )
         if "WhisperForConditionalGeneration" in self.hf_config.architectures:
             # Whisper has unique layer ID scheme:
             # - Encoder self-attention: 0 to encoder_layers-1 (no KV cache)

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1329,6 +1329,18 @@ class ModelConfig:
             # while for GLM-4.6v, it is 'glm4v_moe_vision'.
         )
         needs_tf_v5 = is_glm_46vmoe
+        # Older transformers lacks the native hrm_text config, so it silently
+        # falls back to TransformersForCausalLM and loads fused weights as junk.
+        architectures = getattr(self.hf_config, "architectures", []) or []
+        is_hrm_text = getattr(self.hf_config, "model_type", None) == "hrm_text" or (
+            "HrmTextForCausalLM" in architectures
+        )
+        if is_hrm_text and version.parse(tf_version_str) < version.parse("5.9.0"):
+            raise ValueError(
+                f"HRM-Text (model type {self.hf_config.model_type!r}) requires "
+                f"transformers >= 5.9.0, but {tf_version_str} is installed. "
+                "Please upgrade transformers."
+            )
 
         tf_version = version.parse(tf_version_str)
         required_version = version.parse("5.0.0dev0")

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -793,13 +793,9 @@ class ModelConfig:
             loop_num = getattr(self.hf_text_config, "loop_num", 1)
             self.num_attention_layers = int(self.num_hidden_layers * int(loop_num))
         if "HrmTextForCausalLM" in self.hf_config.architectures:
-            # HRM-Text unrolls two transformer stacks across nested H/L cycles;
-            # each recurrence step occupies its own KV cache slot. The total is
-            # num_layers_per_stack * H_cycles * (L_cycles + 1). A native
-            # transformers >= 5.9.0 config already inflates num_hidden_layers to
-            # this value in __post_init__, but compute it explicitly so KV
-            # allocation is correct even if num_hidden_layers carries the raw
-            # per-stack count.
+            # Compute KV slot count explicitly: native 5.9.0 configs inflate
+            # num_hidden_layers to this in __post_init__, but non-native ones
+            # may carry the raw per-stack count.
             H_cycles = self.hf_text_config.H_cycles
             L_cycles = self.hf_text_config.L_cycles
             num_layers_per_stack = (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1002,6 +1002,37 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def model_specific_adjustment(self):
         server_args = self.server_args
 
+        # HRM-Text (and any prefix-LM recurrent model) needs bidirectional
+        # attention over the prompt during prefill. That is only honored by the
+        # Triton backend, and only when CUDA graphs and chunked prefill are off
+        # (see TritonAttnBackend.allow_bidirectional_attention_in_extend). Cross-
+        # request prefix (radix) caching is also unsafe because the recurrent
+        # forward writes direction-dependent KV into many slots. Force the
+        # required settings here rather than rely on the user passing flags.
+        hf_config = self.model_config.hf_config
+        is_prefix_lm_recurrent = (
+            getattr(hf_config, "model_type", None) == "hrm_text"
+            or "HrmTextForCausalLM" in getattr(hf_config, "architectures", [])
+        ) and getattr(hf_config, "prefix_lm", False)
+        if is_prefix_lm_recurrent:
+            if server_args.attention_backend not in (None, "triton"):
+                logger.warning(
+                    f"Overriding --attention-backend "
+                    f"{server_args.attention_backend!r} -> 'triton': only the "
+                    "Triton backend supports HRM-Text's bidirectional prefix "
+                    "attention."
+                )
+            server_args.attention_backend = "triton"
+            server_args.chunked_prefill_size = -1
+            server_args.disable_radix_cache = True
+            server_args.disable_cuda_graph = True
+            logger.warning(
+                "HRM-Text (prefix_lm) detected: forcing --attention-backend "
+                "triton, --chunked-prefill-size -1, --disable-radix-cache, and "
+                "--disable-cuda-graph for correctness of the bidirectional "
+                "prompt attention."
+            )
+
         if self.is_multimodal:
             if not self.is_multimodal_chunked_prefill_supported:
                 server_args.chunked_prefill_size = -1

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1010,10 +1010,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # forward writes direction-dependent KV into many slots. Force the
         # required settings here rather than rely on the user passing flags.
         hf_config = self.model_config.hf_config
-        is_prefix_lm_recurrent = (
-            getattr(hf_config, "model_type", None) == "hrm_text"
-            or "HrmTextForCausalLM" in getattr(hf_config, "architectures", [])
-        ) and getattr(hf_config, "prefix_lm", False)
+        is_hrm_text = getattr(
+            hf_config, "model_type", None
+        ) == "hrm_text" or "HrmTextForCausalLM" in getattr(
+            hf_config, "architectures", []
+        )
+        # prefix_lm defaults to True upstream; defaulting False would skip the
+        # bidirectional-attention forcing and silently produce junk output.
+        is_prefix_lm_recurrent = is_hrm_text and getattr(hf_config, "prefix_lm", True)
         if is_prefix_lm_recurrent:
             if server_args.attention_backend not in (None, "triton"):
                 logger.warning(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1002,13 +1002,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def model_specific_adjustment(self):
         server_args = self.server_args
 
-        # HRM-Text (and any prefix-LM recurrent model) needs bidirectional
-        # attention over the prompt during prefill. That is only honored by the
-        # Triton backend, and only when CUDA graphs and chunked prefill are off
-        # (see TritonAttnBackend.allow_bidirectional_attention_in_extend). Cross-
-        # request prefix (radix) caching is also unsafe because the recurrent
-        # forward writes direction-dependent KV into many slots. Force the
-        # required settings here rather than rely on the user passing flags.
+        # HRM-Text needs bidirectional prompt attention (prefill), which only the
+        # Triton backend honors and only with cuda graph / chunked prefill off
+        # (TritonAttnBackend.allow_bidirectional_attention_in_extend). Radix cache
+        # is also unsafe: the recurrent forward writes direction-dependent KV
+        # across many slots.
         hf_config = self.model_config.hf_config
         is_hrm_text = getattr(
             hf_config, "model_type", None

--- a/python/sglang/srt/models/hrm_text.py
+++ b/python/sglang/srt/models/hrm_text.py
@@ -1,0 +1,497 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Inference-only HRM-Text (Hierarchical Reasoning Model -- Text) model.
+
+Reference HuggingFace implementation:
+    transformers/models/hrm_text/modeling_hrm_text.py  (transformers >= 5.9.0)
+
+The model runs a hierarchical recurrent forward over two transformer stacks
+(``H`` slow, ``L`` fast) inside nested loops. Each recurrence step gets its own
+KV cache slot via a unique ``RadixAttention(layer_id=...)``; the global layer
+index for a given ``(step, layer_in_stack)`` is
+``step * num_layers_per_stack + layer_in_stack`` -- the same ``cycle_offset``
+formula used by the HF reference. The total KV slot count is
+``num_layers_per_stack * H_cycles * (L_cycles + 1)`` (==
+``config.num_hidden_layers`` after the HF config ``__post_init__`` inflation),
+which ``ModelConfig`` exposes as ``num_attention_layers``.
+
+PrefixLM attention (prompt bidirectional during prefill, completion causal at
+decode) is expressed with ``attn_type=AttentionType.DECODER_BIDIRECTIONAL``.
+That mode is only honored by the Triton attention backend and only when
+``--disable-cuda-graph`` and ``--chunked-prefill-size=-1`` are set;
+``ModelRunner.model_specific_adjustment`` forces those settings (plus
+``--disable-radix-cache``) for this model.
+
+The on-disk attention weight ``attn.gqkv_proj.weight`` is a single tensor with
+rows concatenated as ``[gate | q | k | v]`` along dim 0; ``mlp.gate_up_proj``
+is ``[gate | up]``. Both are loaded directly by ``MergedColumnParallelLinear``'s
+fused-on-disk auto-split path (``loaded_shard_id=None``).
+"""
+
+import logging
+from typing import Iterable, Optional, Tuple
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.distributed import get_tensor_model_parallel_world_size
+from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import (
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.radix_attention import AttentionType, RadixAttention
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+
+def _num_layers_per_stack(config: PretrainedConfig) -> int:
+    """Layers in one (H or L) stack.
+
+    With a native transformers >= 5.9.0 config, ``__post_init__`` rewrites
+    ``num_hidden_layers`` to ``num_layers_per_stack * H_cycles * (L_cycles + 1)``
+    and stores the per-stack count in ``num_layers_per_stack``. Fall back to
+    deriving it if the attribute is absent.
+    """
+    nlps = getattr(config, "num_layers_per_stack", None)
+    if nlps is not None:
+        return int(nlps)
+    return config.num_hidden_layers // (config.H_cycles * (config.L_cycles + 1))
+
+
+def _steps_used(config: PretrainedConfig, stack_kind: str) -> list[int]:
+    """Recurrence steps at which a given stack runs.
+
+    L runs at ``{h*(L+1)+l : 0 <= h < H, 0 <= l < L}``; H runs at the trailing
+    ``{h*(L+1)+L : 0 <= h < H}``. The two sets are disjoint, so each
+    ``(step, layer_in_stack)`` maps to a unique global KV layer index.
+    """
+    H_cycles = config.H_cycles
+    L_cycles = config.L_cycles
+    if stack_kind == "L":
+        return [
+            h * (L_cycles + 1) + low_idx
+            for h in range(H_cycles)
+            for low_idx in range(L_cycles)
+        ]
+    return [h * (L_cycles + 1) + L_cycles for h in range(H_cycles)]
+
+
+class HrmTextMLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if hidden_act != "silu":
+            raise ValueError(
+                f"HrmTextMLP only supports hidden_act='silu', got {hidden_act!r}"
+            )
+        # Fused [gate | up] matching the on-disk `mlp.gate_up_proj.weight`.
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("gate_up_proj", prefix),
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("down_proj", prefix),
+        )
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class HrmTextAttention(nn.Module):
+    """One self-attention block; projection weights shared across recurrence
+    steps. The per-step KV cache slots are realized by the (weightless)
+    ``RadixAttention`` instances in ``self.attn``, keyed by recurrence step.
+    """
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_idx_in_stack: int,
+        stack_kind: str,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+
+        self.total_num_heads = config.num_attention_heads
+        assert self.total_num_heads % tp_size == 0, (
+            f"num_attention_heads={self.total_num_heads} must be divisible "
+            f"by tp_size={tp_size}"
+        )
+        # HF main hardcodes MHA (num_key_value_groups=1). We follow.
+        self.total_num_kv_heads = config.num_attention_heads
+        self.num_heads = self.total_num_heads // tp_size
+        self.num_kv_heads = self.total_num_kv_heads // tp_size
+        self.head_dim = getattr(
+            config, "head_dim", self.hidden_size // self.total_num_heads
+        )
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+
+        # gqkv_proj: 4-way fused [gate | q | k | v] matching the on-disk
+        # `attn.gqkv_proj.weight` row layout. The weight_loader auto-splits the
+        # fused disk tensor along the output dim by `output_sizes` (the
+        # `loaded_shard_id is None` path). MHA only: GQA would need
+        # QKVParallelLinear semantics for q/k/v shard replication.
+        per_head_size = self.total_num_heads * self.head_dim
+        self.gqkv_proj = MergedColumnParallelLinear(
+            self.hidden_size,
+            [per_head_size] * 4,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("gqkv_proj", prefix),
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("o_proj", prefix),
+        )
+
+        # HF 5.9.0 stores rope params in `config.rope_parameters`
+        # (e.g. {"rope_theta": 10000.0, "rope_type": "default"}); older/flat
+        # configs may expose `rope_theta` directly. Support both.
+        rope_parameters = getattr(config, "rope_parameters", None) or {}
+        rope_theta = rope_parameters.get("rope_theta", None)
+        if rope_theta is None:
+            rope_theta = getattr(config, "rope_theta", 10000.0)
+        rope_type = rope_parameters.get("rope_type", "default")
+        # "default" rope = no scaling; pass the dict through otherwise.
+        rope_scaling = None if rope_type in ("default", None) else rope_parameters
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=rope_theta,
+            is_neox_style=True,
+            rope_scaling=rope_scaling,
+        )
+
+        # One RadixAttention per recurrence step this stack runs at. Each gets a
+        # unique `layer_id` (== global KV slot) so the recurrent forward writes
+        # to disjoint cache slots. These modules hold no parameters.
+        num_layers_per_stack = _num_layers_per_stack(config)
+        self.attn = nn.ModuleDict()
+        for step in _steps_used(config, stack_kind):
+            global_idx = step * num_layers_per_stack + layer_idx_in_stack
+            self.attn[str(step)] = RadixAttention(
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+                scaling=self.scaling,
+                num_kv_heads=self.num_kv_heads,
+                layer_id=global_idx,
+                attn_type=AttentionType.DECODER_BIDIRECTIONAL,
+                quant_config=quant_config,
+                prefix=add_prefix(f"attn.{step}", prefix),
+            )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        current_step: int,
+    ) -> torch.Tensor:
+        gqkv, _ = self.gqkv_proj(hidden_states)
+        g, q, k, v = gqkv.split(
+            [self.q_size, self.q_size, self.kv_size, self.kv_size], dim=-1
+        )
+        q, k = self.rotary_emb(positions, q, k)
+        attn_out = self.attn[str(current_step)](q, k, v, forward_batch)
+        # Sigmoid gate (HrmText / Qwen3Next style).
+        attn_out = torch.sigmoid(g) * attn_out
+        out, _ = self.o_proj(attn_out)
+        return out
+
+
+class HrmTextDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_idx_in_stack: int,
+        stack_kind: str,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.self_attn = HrmTextAttention(
+            config=config,
+            layer_idx_in_stack=layer_idx_in_stack,
+            stack_kind=stack_kind,
+            quant_config=quant_config,
+            prefix=add_prefix("self_attn", prefix),
+        )
+        self.mlp = HrmTextMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+        )
+        # Parameterless RMSNorm (HF HrmTextRMSNorm has no weight).
+        self.input_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, has_weight=False
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, has_weight=False
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        current_step: int,
+    ) -> torch.Tensor:
+        # Pre-norm residual; norm a copy and add residual outside (matches HF).
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            current_step=current_step,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class HrmTextStack(nn.Module):
+    """A single transformer stack -- instantiated twice (H and L)."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        stack_kind: str,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        num_layers_per_stack = _num_layers_per_stack(config)
+        self.layers = nn.ModuleList(
+            [
+                HrmTextDecoderLayer(
+                    config=config,
+                    layer_idx_in_stack=i,
+                    stack_kind=stack_kind,
+                    quant_config=quant_config,
+                    prefix=add_prefix(f"layers.{i}", prefix),
+                )
+                for i in range(num_layers_per_stack)
+            ]
+        )
+        self.final_norm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, has_weight=False
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        current_step_base: int,
+    ) -> torch.Tensor:
+        for layer in self.layers:
+            hidden_states = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+                current_step=current_step_base,
+            )
+        return self.final_norm(hidden_states)
+
+
+class HrmTextModel(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("embed_tokens", prefix),
+        )
+        self.L_module = HrmTextStack(
+            config=config,
+            stack_kind="L",
+            quant_config=quant_config,
+            prefix=add_prefix("L_module", prefix),
+        )
+        self.H_module = HrmTextStack(
+            config=config,
+            stack_kind="H",
+            quant_config=quant_config,
+            prefix=add_prefix("H_module", prefix),
+        )
+        # Frozen learned initial low-cycle state (disk key `model.z_L_init`).
+        self.z_L_init = nn.Parameter(
+            torch.zeros(config.hidden_size), requires_grad=False
+        )
+
+        # HF uses config.embedding_scale (= 1 / initializer_range), NOT
+        # sqrt(hidden_size).
+        self.embedding_scale = getattr(config, "embedding_scale", None)
+        if self.embedding_scale is None:
+            init_range = getattr(config, "initializer_range", 0.02)
+            self.embedding_scale = 1.0 / init_range
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if input_embeds is not None:
+            hidden_states_high_cycle = input_embeds
+        else:
+            hidden_states_high_cycle = self.embed_tokens(input_ids)
+        hidden_states_high_cycle = hidden_states_high_cycle * self.embedding_scale
+
+        hidden_states_low_cycle = (
+            self.z_L_init.to(
+                dtype=hidden_states_high_cycle.dtype,
+                device=hidden_states_high_cycle.device,
+            )
+            .expand_as(hidden_states_high_cycle)
+            .contiguous()
+        )
+
+        H_cycles = self.config.H_cycles
+        L_cycles = self.config.L_cycles
+        for high_cycle_idx in range(H_cycles):
+            for low_cycle_idx in range(L_cycles):
+                step = high_cycle_idx * (L_cycles + 1) + low_cycle_idx
+                hidden_states_low_cycle = self.L_module(
+                    positions=positions,
+                    hidden_states=hidden_states_low_cycle + hidden_states_high_cycle,
+                    forward_batch=forward_batch,
+                    current_step_base=step,
+                )
+            step = high_cycle_idx * (L_cycles + 1) + L_cycles
+            hidden_states_high_cycle = self.H_module(
+                positions=positions,
+                hidden_states=hidden_states_high_cycle + hidden_states_low_cycle,
+                forward_batch=forward_batch,
+                current_step_base=step,
+            )
+
+        return hidden_states_high_cycle
+
+
+class HrmTextForCausalLM(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.quant_config = quant_config
+
+        self.model = HrmTextModel(
+            config=config,
+            quant_config=quant_config,
+            prefix=add_prefix("model", prefix),
+        )
+
+        if config.tie_word_embeddings:
+            self.lm_head = self.model.embed_tokens
+        else:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("lm_head", prefix),
+            )
+        self.logits_processor = LogitsProcessor(config)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+    ):
+        hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
+        return self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch
+        )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        # On-disk attention weights use `.attn.`; our modules use `.self_attn.`
+        # (the per-step RadixAttention modules under `.self_attn.attn.{step}`
+        # hold no parameters, so they never receive weights). Disk tensors are
+        # already fused -- gqkv_proj / gate_up_proj load via the fused-on-disk
+        # auto-split path, so no stacked_params_mapping is needed.
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            if ".attn." in name:
+                name = name.replace(".attn.", ".self_attn.", 1)
+            if name not in params_dict:
+                # e.g. parameterless final_norm has no disk weight; skip strays.
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+
+
+EntryClass = HrmTextForCausalLM

--- a/python/sglang/srt/models/hrm_text.py
+++ b/python/sglang/srt/models/hrm_text.py
@@ -13,30 +13,24 @@
 # ==============================================================================
 """Inference-only HRM-Text (Hierarchical Reasoning Model -- Text) model.
 
-Reference HuggingFace implementation:
-    transformers/models/hrm_text/modeling_hrm_text.py  (transformers >= 5.9.0)
+Reference: transformers/models/hrm_text (transformers >= 5.9.0).
 
-The model runs a hierarchical recurrent forward over two transformer stacks
-(``H`` slow, ``L`` fast) inside nested loops. Each recurrence step gets its own
-KV cache slot via a unique ``RadixAttention(layer_id=...)``; the global layer
-index for a given ``(step, layer_in_stack)`` is
-``step * num_layers_per_stack + layer_in_stack`` -- the same ``cycle_offset``
-formula used by the HF reference. The total KV slot count is
-``num_layers_per_stack * H_cycles * (L_cycles + 1)`` (==
-``config.num_hidden_layers`` after the HF config ``__post_init__`` inflation),
-which ``ModelConfig`` exposes as ``num_attention_layers``.
+HRM-Text runs a hierarchical recurrent forward over two transformer stacks
+(``H`` slow, ``L`` fast) in nested loops. Each recurrence step gets its own KV
+cache slot via a unique ``RadixAttention(layer_id=...)``; the global index for
+``(step, layer)`` is ``step * num_layers_per_stack + layer``. The total slot
+count ``num_layers_per_stack * H_cycles * (L_cycles + 1)`` equals the HF config
+``num_hidden_layers`` after ``__post_init__`` inflation, exposed by
+``ModelConfig`` as ``num_attention_layers``.
 
-PrefixLM attention (prompt bidirectional during prefill, completion causal at
-decode) is expressed with ``attn_type=AttentionType.DECODER_BIDIRECTIONAL``.
-That mode is only honored by the Triton attention backend and only when
-``--disable-cuda-graph`` and ``--chunked-prefill-size=-1`` are set;
-``ModelRunner.model_specific_adjustment`` forces those settings (plus
-``--disable-radix-cache``) for this model.
+PrefixLM (prompt bidirectional at prefill, causal at decode) uses
+``AttentionType.DECODER_BIDIRECTIONAL``, which only the Triton backend honors
+and only with cuda graph / chunked prefill / radix cache off --
+``ModelRunner.model_specific_adjustment`` forces those for this model.
 
-The on-disk attention weight ``attn.gqkv_proj.weight`` is a single tensor with
-rows concatenated as ``[gate | q | k | v]`` along dim 0; ``mlp.gate_up_proj``
-is ``[gate | up]``. Both are loaded directly by ``MergedColumnParallelLinear``'s
-fused-on-disk auto-split path (``loaded_shard_id=None``).
+On-disk ``attn.gqkv_proj.weight`` is fused ``[gate | q | k | v]`` rows and
+``mlp.gate_up_proj`` is ``[gate | up]``; both load directly via
+``MergedColumnParallelLinear``'s fused-on-disk auto-split path.
 """
 
 import logging
@@ -71,10 +65,9 @@ logger = logging.getLogger(__name__)
 def _num_layers_per_stack(config: PretrainedConfig) -> int:
     """Layers in one (H or L) stack.
 
-    With a native transformers >= 5.9.0 config, ``__post_init__`` rewrites
-    ``num_hidden_layers`` to ``num_layers_per_stack * H_cycles * (L_cycles + 1)``
-    and stores the per-stack count in ``num_layers_per_stack``. Fall back to
-    deriving it if the attribute is absent.
+    Native configs store this in ``num_layers_per_stack`` after ``__post_init__``
+    rewrites ``num_hidden_layers`` to the inflated total; fall back to deriving
+    it for non-native configs.
     """
     nlps = getattr(config, "num_layers_per_stack", None)
     if nlps is not None:
@@ -83,11 +76,10 @@ def _num_layers_per_stack(config: PretrainedConfig) -> int:
 
 
 def _steps_used(config: PretrainedConfig, stack_kind: str) -> list[int]:
-    """Recurrence steps at which a given stack runs.
+    """Recurrence steps at which a stack runs.
 
-    L runs at ``{h*(L+1)+l : 0 <= h < H, 0 <= l < L}``; H runs at the trailing
-    ``{h*(L+1)+L : 0 <= h < H}``. The two sets are disjoint, so each
-    ``(step, layer_in_stack)`` maps to a unique global KV layer index.
+    L runs at ``h*(L+1)+l`` (``0<=h<H, 0<=l<L``); H runs at the trailing
+    ``h*(L+1)+L``. Disjoint, so each ``(step, layer)`` maps to a unique KV index.
     """
     H_cycles = config.H_cycles
     L_cycles = config.L_cycles
@@ -114,7 +106,6 @@ class HrmTextMLP(nn.Module):
             raise ValueError(
                 f"HrmTextMLP only supports hidden_act='silu', got {hidden_act!r}"
             )
-        # Fused [gate | up] matching the on-disk `mlp.gate_up_proj.weight`.
         self.gate_up_proj = MergedColumnParallelLinear(
             hidden_size,
             [intermediate_size] * 2,
@@ -139,10 +130,9 @@ class HrmTextMLP(nn.Module):
 
 
 class HrmTextAttention(nn.Module):
-    """One self-attention block; projection weights shared across recurrence
-    steps. The per-step KV cache slots are realized by the (weightless)
-    ``RadixAttention`` instances in ``self.attn``, keyed by recurrence step.
-    """
+    """Self-attention block; projection weights are shared across recurrence
+    steps, while per-step KV slots come from weightless ``RadixAttention``
+    instances keyed by step in ``self.attn``."""
 
     def __init__(
         self,
@@ -161,7 +151,7 @@ class HrmTextAttention(nn.Module):
             f"num_attention_heads={self.total_num_heads} must be divisible "
             f"by tp_size={tp_size}"
         )
-        # HF main hardcodes MHA (num_key_value_groups=1). We follow.
+        # HF hardcodes MHA (kv heads == q heads); no GQA.
         self.total_num_kv_heads = config.num_attention_heads
         self.num_heads = self.total_num_heads // tp_size
         self.num_kv_heads = self.total_num_kv_heads // tp_size
@@ -172,11 +162,8 @@ class HrmTextAttention(nn.Module):
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
 
-        # gqkv_proj: 4-way fused [gate | q | k | v] matching the on-disk
-        # `attn.gqkv_proj.weight` row layout. The weight_loader auto-splits the
-        # fused disk tensor along the output dim by `output_sizes` (the
-        # `loaded_shard_id is None` path). MHA only: GQA would need
-        # QKVParallelLinear semantics for q/k/v shard replication.
+        # Fused [gate | q | k | v] on disk; MHA only (GQA would need
+        # QKVParallelLinear's q/k/v shard replication).
         per_head_size = self.total_num_heads * self.head_dim
         self.gqkv_proj = MergedColumnParallelLinear(
             self.hidden_size,
@@ -193,9 +180,7 @@ class HrmTextAttention(nn.Module):
             prefix=add_prefix("o_proj", prefix),
         )
 
-        # HF 5.9.0 stores rope params in `config.rope_parameters`
-        # (e.g. {"rope_theta": 10000.0, "rope_type": "default"}); older/flat
-        # configs may expose `rope_theta` directly. Support both.
+        # rope_parameters (HF 5.9.0) or flat rope_theta for older configs.
         rope_parameters = getattr(config, "rope_parameters", None) or {}
         rope_theta = rope_parameters.get("rope_theta", None)
         if rope_theta is None:
@@ -212,9 +197,8 @@ class HrmTextAttention(nn.Module):
             rope_scaling=rope_scaling,
         )
 
-        # One RadixAttention per recurrence step this stack runs at. Each gets a
-        # unique `layer_id` (== global KV slot) so the recurrent forward writes
-        # to disjoint cache slots. These modules hold no parameters.
+        # One weightless RadixAttention per step, each with a unique layer_id
+        # (= global KV slot) so the recurrent forward writes disjoint slots.
         num_layers_per_stack = _num_layers_per_stack(config)
         self.attn = nn.ModuleDict()
         for step in _steps_used(config, stack_kind):
@@ -288,7 +272,6 @@ class HrmTextDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
         current_step: int,
     ) -> torch.Tensor:
-        # Pre-norm residual; norm a copy and add residual outside (matches HF).
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
         hidden_states = self.self_attn(
@@ -477,17 +460,14 @@ class HrmTextForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        # On-disk attention weights use `.attn.`; our modules use `.self_attn.`
-        # (the per-step RadixAttention modules under `.self_attn.attn.{step}`
-        # hold no parameters, so they never receive weights). Disk tensors are
-        # already fused -- gqkv_proj / gate_up_proj load via the fused-on-disk
-        # auto-split path, so no stacked_params_mapping is needed.
+        # Disk keys use `.attn.`; rename to our `.self_attn.`. The per-step
+        # RadixAttention modules hold no params, and disk tensors are already
+        # fused so no stacked_params_mapping is needed.
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
             if ".attn." in name:
                 name = name.replace(".attn.", ".self_attn.", 1)
             if name not in params_dict:
-                # e.g. parameterless final_norm has no disk weight; skip strays.
                 continue
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)


### PR DESCRIPTION
HRM-Text shipped in [transformers 5.9.0](https://github.com/huggingface/transformers/pull/46025). The model runs a hierarchical recurrent forward over two transformer stacks (`H` slow, `L` fast) inside nested H/L cycle loops; each recurrence step consumes a distinct KV cache slot, matching transformers' `cycle_offset` formula. Attention uses a sigmoid gate (Qwen3Next-style) and a fused gate+q+k+v projection on disk.

This PR adds the model file plus two small touch points in `model_config.py` and `model_runner.py` (explained below). It mirrors our vLLM implementation of the same model.

## Architecture

- `models/hrm_text.py`: full model. Each recurrence step gets its own `RadixAttention` instance under an `nn.ModuleDict`, with a unique `layer_id = step * num_layers_per_stack + layer_in_stack`, so a distinct KV cache slot is allocated per cycle step. Total slots = `num_layers_per_stack * H_cycles * (L_cycles + 1)`, equal to `config.num_hidden_layers` after HF's `__post_init__` inflation.
- The HF on-disk schema fuses gate/q/k/v into a single `attn.gqkv_proj.weight` (rows `[gate | q | k | v]`) and gate/up into `mlp.gate_up_proj.weight`. Both load directly via `MergedColumnParallelLinear`'s fused-on-disk path; `load_weights` only renames the `.attn.` prefix to `.self_attn.`. Sigmoid attention gate, parameterless RMSNorm, `embedding_scale`, and a frozen `z_L_init` round out the model.
- `model_config.py`: a `num_attention_layers` branch computing the unrolled KV-slot count for HRM (so KV allocation is correct regardless of how `num_hidden_layers` is carried).

## PrefixLM attention and the two open questions

HRM-Text is a PrefixLM: the prompt attends bidirectionally during prefill, the completion is causal at decode. I'd appreciate guidance on the two points below, since both touch SGLang internals beyond the model file.

1. **Bidirectional attention is backend-limited.** I express it via `AttentionType.DECODER_BIDIRECTIONAL`, which today is only honored by the Triton backend (and only when cuda graph + chunked prefill are off). FlashInfer/FA3 recognize `ENCODER_ONLY` but not `DECODER_BIDIRECTIONAL`. So the model is effectively pinned to Triton. Is there a preferred way to make bidirectional-prefill backend-agnostic?

2. **Bidirectional prefill is incompatible with chunked-prefill and radix cache.** Both assume causal attention: chunking the prompt freezes early-chunk tokens before later prompt tokens exist, and radix cache reuses KV keyed by token-id prefix, but bidirectional KV at position i depends on the whole prompt, not just 0..i. I currently force `chunked_prefill_size=-1` + `disable_radix_cache` + `disable_cuda_graph` + Triton in `model_runner.model_specific_adjustment` for `prefix_lm` models. This works but is heavy-handed and lives in a core file. Is there a cleaner per-model / per-layer hook you'd prefer (e.g. a flag the scheduler reads)?

## Validation

`HRM-Text-1B`, GSM8K (first 50): 41/50 at tp=2, 40/50 at tp=1, matching our vLLM reference (the tp=1/tp=2 difference is greedy-decode tie-breaking, not a correctness gap). Requires transformers >= 5.9.0 for the native `hrm_text` config.

























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28002067096](https://github.com/sgl-project/sglang/actions/runs/28002067096)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28084166670](https://github.com/sgl-project/sglang/actions/runs/28084166670)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->