### PR TITLE
Fix Mistral3 text encoder TP accuracy

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/encoders/mistral_3.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/mistral_3.py
@@ -166,6 +166,7 @@ class MistralAttention(nn.Module):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
@@ -176,7 +177,22 @@ class MistralAttention(nn.Module):
         q = q.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
         k = k.reshape(batch_size, seq_len, self.num_kv_heads, self.head_dim)
         v = v.reshape(batch_size, seq_len, self.num_kv_heads, self.head_dim)
-        attn_output = self.attn(q, k, v)
+        attn_mask = None
+        if attention_mask is not None:
+            attn_mask = torch.tril(
+                torch.ones(
+                    (seq_len, seq_len), device=hidden_states.device, dtype=torch.bool
+                )
+            )
+            attn_mask = attn_mask[None, None, :, :].expand(
+                batch_size, 1, seq_len, seq_len
+            )
+            padding_mask = attention_mask.to(
+                device=hidden_states.device, dtype=torch.bool
+            )
+            attn_mask = attn_mask & padding_mask[:, None, None, :]
+
+        attn_output = self.attn(q, k, v, attn_mask=attn_mask)
         attn_output = attn_output.reshape(
             batch_size, seq_len, self.num_heads * self.head_dim
         )
@@ -233,13 +249,18 @@ class MistralDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
+        attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
-        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+        )
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
@@ -306,7 +327,12 @@ class MistralModel(nn.Module):
                     if residual is None
                     else (hidden_states + residual,)
                 )
-            hidden_states, residual = layer(position_ids, hidden_states, residual)
+            hidden_states, residual = layer(
+                position_ids,
+                hidden_states,
+                residual,
+                attention_mask=attention_mask,
+            )
 
         hidden_states, _ = self.norm(hidden_states, residual)
         if all_hidden_states is not None:

--- a/python/sglang/multimodal_gen/test/server/component_accuracy.py
+++ b/python/sglang/multimodal_gen/test/server/component_accuracy.py
@@ -493,6 +493,14 @@ class AccuracyEngine:
             if src_tensor is None:
                 unmatched_details.append(f"{name}: no matching source tensor")
                 continue
+            weight_loader = getattr(tensor, "weight_loader", None)
+            if callable(weight_loader) and src_tensor.numel() != tensor.numel():
+                weight_loader(
+                    tensor,
+                    src_tensor.to(device=tensor.device, dtype=tensor.dtype),
+                )
+                matched += 1
+                continue
             shard_context = shard_contexts.get(name)
             shard_world_size = (
                 shard_context.world_size if shard_context is not None else tp_world


### PR DESCRIPTION
## Summary
- propagate Mistral3 text-encoder attention_mask into native causal attention
- make component accuracy weight transfer use TP-aware parameter weight_loader for packed sharded params

## Context
Current multimodal_gen CI failures on unrelated PRs (for example #27876) point to FLUX.2/Mistral3 text-encoder regressions on main, not the Wan TI2V changes. The 2GPU encoder component test reported matched weights, but packed QKV/GateUp parameters were copied with naive tensor slicing instead of the runtime loader sharding semantics.

## Test Plan
- Not run locally per multimodal_gen development rules; rely on PR CI for GPU validation.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27330104042](https://github.com/sgl-project/sglang/actions/runs/27330104042)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27330171678](https://github.com/sgl-project/sglang/actions/runs/27330171678)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->