### PR TITLE
[Draft] Introduce RuntimeContext (PoC for consolidating process-level global state)

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.attention.utils import canonicalize_stride
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.runtime_context import BufferSpec, get_context
 from sglang.srt.utils import is_flashinfer_available
 from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
 
@@ -40,9 +41,6 @@ if TYPE_CHECKING:
 # Default workspace size in MB for TRTLLM MHA
 # Can be configured via SGLANG_FLASHINFER_WORKSPACE_SIZE environment variable
 DEFAULT_WORKSPACE_SIZE_MB = 512
-
-# Reuse this workspace buffer across all TRTLLM MHA wrappers
-global_zero_init_workspace_buffer = None
 
 
 @dataclass
@@ -104,15 +102,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         # Workspace allocation
         self.workspace_size = workspace_size_bytes
-        # Allocate buffers
-        global global_zero_init_workspace_buffer
-        if global_zero_init_workspace_buffer is None:
-            global_zero_init_workspace_buffer = torch.zeros(
-                self.workspace_size,
+        # Lazily allocate the workspace; the buffer cache shares one tensor across
+        # backend instances.
+        ctx = get_context()
+        ctx.buffers.register(
+            BufferSpec(
+                name="trtllm.mha_workspace",
+                shape=self.workspace_size,  # 1-D uint8 workspace (size in bytes)
                 dtype=torch.uint8,
                 device=model_runner.device,
             )
-        self.workspace_buffer = global_zero_init_workspace_buffer
+        )
+        self.workspace_buffer = ctx.buffers.get_persistent_buffer(
+            "trtllm.mha_workspace"
+        )
 
         # CUDA graph state
         self.decode_cuda_graph_metadata = {}

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -76,6 +76,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
@@ -234,7 +235,7 @@ class AttentionInputs:
     def tp_all_gather_hidden_states(self, hidden_states, forward_batch):
         total_tokens = forward_batch.input_ids.shape[0]
         output = hidden_states.new_empty((total_tokens, hidden_states.shape[-1]))
-        get_tp_group().all_gather_into_tensor(output, hidden_states)
+        get_parallel().tp_group.all_gather_into_tensor(output, hidden_states)
         return output
 
     def fetch_qkv_latent(self):
@@ -673,7 +674,7 @@ class LayerCommunicator:
         ), f"Expected total tokens {hidden_states.shape[0]} % tp_size {self._context.tp_size} to be 0"
         local_tokens = hidden_states.shape[0] // self._context.tp_size
         output = hidden_states.new_empty(local_tokens, *hidden_states.shape[1:])
-        get_tp_group().reduce_scatter_tensor(output, hidden_states)
+        get_parallel().tp_group.reduce_scatter_tensor(output, hidden_states)
         if residual is not None:
             residual = residual.tensor_split(self._context.tp_size)[
                 self._context.tp_rank

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -27,6 +27,7 @@ from sglang.srt.layers.moe.utils import (
     get_deepep_output_dtype,
     is_tbo_enabled,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import (
     get_bool_env_var,
     is_blackwell,
@@ -928,7 +929,8 @@ class DeepEPDispatcher(BaseDispatcher):
         return self._get_impl().combine_b(*inner_state)
 
     def _get_impl(self) -> _DeepEPDispatcherImplBase:
-        is_extend_in_batch = get_is_extend_in_batch()
+        is_extend_in_batch = get_flags().is_extend_in_batch
+        assert is_extend_in_batch == get_is_extend_in_batch()
         resolved_deepep_mode = self.deepep_mode.resolve(is_extend_in_batch)
         if resolved_deepep_mode == DeepEPMode.NORMAL:
             return self._normal_dispatcher

--- a/python/sglang/srt/layers/moe/token_dispatcher/mooncake.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/mooncake.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
 )
 from sglang.srt.layers.moe.topk import TopKOutput
 from sglang.srt.layers.moe.utils import DeepEPMode
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import get_int_env_var
 
 logger = logging.getLogger(__name__)
@@ -373,7 +374,8 @@ class MooncakeEPDispatcher(BaseDispatcher):
         return self._get_impl().combine_b(*inner_state)
 
     def _get_impl(self) -> _MooncakeEPDispatcherImpl:
-        is_extend_in_batch = get_is_extend_in_batch()
+        is_extend_in_batch = get_flags().is_extend_in_batch
+        assert is_extend_in_batch == get_is_extend_in_batch()
         resolved_deepep_mode = self.deepep_mode.resolve(is_extend_in_batch)
         if resolved_deepep_mode == DeepEPMode.NORMAL:
             raise NotImplementedError

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.moe.utils import (
     DeepEPMode,
     is_tbo_enabled,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import (
     get_bool_env_var,
     get_int_env_var,
@@ -1105,7 +1106,8 @@ class MoriEPDispatcher(BaseDispatcher):
         return self._get_impl().combine_b(*inner_state)
 
     def _get_impl(self) -> _MoriEPDispatcherImplBase:
-        is_extend_in_batch = get_is_extend_in_batch()
+        is_extend_in_batch = get_flags().is_extend_in_batch
+        assert is_extend_in_batch == get_is_extend_in_batch()
         resolved_deepep_mode = self.deepep_mode.resolve(is_extend_in_batch)
         if resolved_deepep_mode == DeepEPMode.NORMAL:
             return self._normal_dispatcher

--- a/python/sglang/srt/layers/moe/token_dispatcher/nixl.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nixl.py
@@ -24,6 +24,7 @@ from sglang.srt.layers.moe.token_dispatcher.deepep import (
 )
 from sglang.srt.layers.moe.topk import TopKOutput
 from sglang.srt.layers.moe.utils import DeepEPMode
+from sglang.srt.runtime_context import get_flags
 
 try:
     from nixl_ep import Buffer
@@ -439,7 +440,8 @@ class NixlEPDispatcher(BaseDispatcher):
         return self._get_impl().combine_b(*inner_state)
 
     def _get_impl(self) -> _NixlEPDispatcherImplBase:
-        is_extend_in_batch = get_is_extend_in_batch()
+        is_extend_in_batch = get_flags().is_extend_in_batch
+        assert is_extend_in_batch == get_is_extend_in_batch()
         resolved_deepep_mode = self.deepep_mode.resolve(is_extend_in_batch)
         if resolved_deepep_mode == DeepEPMode.NORMAL:
             raise NotImplementedError("Normal mode is not supported for Nixl EP yet.")

--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -26,10 +26,8 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutputFormat,
 )
 from sglang.srt.layers.moe.topk import StandardTopKOutput, TopKOutput, TopKOutputChecker
-from sglang.srt.layers.moe.utils import (
-    get_moe_runner_backend,
-    should_use_flashinfer_cutlass_moe_fp4_allgather,
-)
+from sglang.srt.layers.moe.utils import get_moe_runner_backend
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils.common import (
     get_bool_env_var,
     get_device,
@@ -118,7 +116,7 @@ class StandardDispatcher(BaseDispatcher):
         self, hidden_states: torch.Tensor, topk_output: TopKOutput
     ) -> StandardDispatchOutput:
 
-        if should_use_flashinfer_cutlass_moe_fp4_allgather():
+        if get_flags().moe.use_cutlass_fp4_allgather:
             # all-gather fp4 hidden states
             if (
                 fp4_quantize_flashinfer is None
@@ -221,7 +219,7 @@ class StandardDispatcher(BaseDispatcher):
 
     def combine(self, combine_input: StandardCombineInput) -> torch.Tensor:
         (hidden_states,) = combine_input
-        if should_use_flashinfer_cutlass_moe_fp4_allgather():
+        if get_flags().moe.use_cutlass_fp4_allgather:
             hidden_states, global_hidden_states = (
                 get_local_dp_buffer(get_tp_group()),
                 hidden_states,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -56,6 +56,7 @@ from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     ForwardBatchDeepSeekMHAMixin,
 )
 from sglang.srt.model_executor.triton_ops.position import compute_position_triton
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     is_cuda,
@@ -1126,6 +1127,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             buffer_len, num_tokens, dp_padding_mode.is_max_len(), global_num_tokens
         )
         set_is_extend_in_batch(self.is_extend_in_batch)
+        # mirror into the context flag while the legacy global is still read
+        get_flags().is_extend_in_batch = self.is_extend_in_batch
 
         bs = self.batch_size
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -181,6 +181,12 @@ from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
 from sglang.srt.model_loader.utils import set_default_torch_dtype
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.platforms import current_platform
+from sglang.srt.runtime_context import (
+    get_context,
+    get_tp_rank,
+    get_tp_size,
+    init_context,
+)
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import (
     ServerArgs,
@@ -537,8 +543,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self.device == "cpu":
             self.init_threads_binding()
 
-        # Get available memory before model loading
-        pre_model_load_memory = self.init_torch_distributed()
+        # init_context runs init_torch_distributed, builds + publishes the context,
+        # and stashes the pre-model-load memory on ctx.metrics (read by init_memory_pool).
+        init_context(self)
 
         # Initialize MooncakeTransferEngine
         self.init_shared_mooncake_transfer_engine()
@@ -567,7 +574,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self._linear_attn_registry_cache: Any = _UNSET
 
         # Initialize the model runner
-        self.initialize(pre_model_load_memory)
+        self.initialize()
         self.check_quantized_moe_compatibility()
 
         if (
@@ -628,7 +635,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 port=self.dist_port,
             )
 
-    def initialize(self, pre_model_load_memory: float):
+    def initialize(self):
         server_args = self.server_args
 
         self.memory_saver_adapter = TorchMemorySaverAdapter.create(
@@ -756,7 +763,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Apply torch TP if the model supports it
         supports_torch_tp = getattr(self.model, "supports_torch_tp", False)
-        if self.tp_size > 1 and supports_torch_tp:
+        if get_tp_size() > 1 and supports_torch_tp:
             self.apply_torch_tp()
 
         # Init lora
@@ -780,7 +787,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.configure_kv_cache_dtype()
 
         # Init memory pool and attention backends
-        self.init_memory_pool(pre_model_load_memory)
+        self.init_memory_pool()
+
+        # Freeze the context: materialize static derived flags and close the static
+        # write surface (the flag inputs are all resolved by this point).
+        get_context().freeze()
 
         # Must be called AFTER init_memory_pool so the pool object exists for
         # canary to monkey-patch, and BEFORE init_device_graphs so warmup
@@ -1332,7 +1343,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             and self.server_args.remote_instance_weight_loader_backend
             == RemoteInstanceWeightLoaderBackend.NCCL
         ):
-            if self.tp_rank == 0:
+            if get_tp_rank() == 0:
                 instance_ip = NetworkAddress.resolve_host(socket.gethostname())
                 t = threading.Thread(
                     target=trigger_init_weights_send_group_for_remote_instance_request,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -38,6 +38,7 @@ from sglang.srt.mem_cache.memory_pool import (
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.platforms import current_platform
+from sglang.srt.runtime_context import get_context
 from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_float4_e2m1fn_x2,
@@ -963,7 +964,11 @@ class ModelRunnerKVCacheMixin:
         config.mem_fraction_static = self.server_args.mem_fraction_static
         return config
 
-    def init_memory_pool(self: ModelRunner, pre_model_load_memory: int):
+    def init_memory_pool(self: ModelRunner):
+        # The pre-model-load memory measurement lives on the context (stashed by
+        # init_context); read it here at the point of use instead of threading it
+        # through initialize() / init_memory_pool() signatures.
+        pre_model_load_memory = get_context().metrics.pre_model_load_memory
         if not self.spec_algorithm.is_none() and self.is_draft_worker:
             assert (
                 self.memory_pool_config is not None

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1,0 +1,460 @@
+"""One structured container for process-static control state.
+
+A single ``RuntimeContext``, accessed via ``get_context()``, replacing process-level
+globals that were scattered across many files. Organized by subsystem:
+
+  ctx.parallel : the parallel topology — every dim's size + rank and the group
+                 handles (``tp_group``).
+  ctx.flags    : flags, grouped under a subsystem wrapper when they form a family
+                 (``flags.attn.*`` / ``flags.moe.*``) and flat for a lone general
+                 property (``flags.is_extend_in_batch``).
+  ctx.buffers  : lazily-materialized buffers — ``get_persistent_buffer()`` allocates
+                 once and caches; ``get_temporary_buffer()`` allocates per-forward.
+  ctx.metrics  : init-time measurements (e.g. ``pre_model_load_memory``).
+
+Flags are read and written via plain attribute access, symmetric:
+``get_flags().attn.use_mla_backend`` to read, ``... = value`` to write. Static flag
+groups become read-only after ``freeze()``; there are no per-flag setter/getter
+functions.
+
+Lifecycle: ``init_context(model_runner)`` runs ``init_torch_distributed`` and
+publishes the resolved context once; ``freeze()`` materializes static derived flags
+and closes the static write surface; ``reset_context()`` is the single teardown point.
+
+Concurrency: ``_context`` is a plain module-level global, safe because a worker
+process resolves and runs synchronously on one thread.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Parallel topology: sizes + ranks + long-lived group handles, co-located
+# (the "parallel" subsystem owns both the scalars and the groups).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ParallelContext:
+    """Resolved parallel topology of this process — each dim's size + rank plus the
+    process-group handles. All fields default so the container can be constructed
+    empty (tests) or built by ``RuntimeContext.from_model_runner``. ``*_rank`` fields
+    that the main (tp_worker) path does not pass stay ``None``.
+    """
+
+    # --- engine side (known at ModelRunner.__init__) ---
+    tp_size: int = 1
+    tp_rank: int = 0
+    pp_size: int = 1
+    pp_rank: int = 0
+    dp_size: int = 1  # folded by enable_dp_attention
+    dp_rank: Optional[int] = None
+    moe_ep_size: int = 1
+    moe_ep_rank: int = 0
+    moe_dp_size: int = 1
+    moe_dp_rank: Optional[int] = None
+    attn_cp_size: int = 1
+    attn_cp_rank: Optional[int] = None
+    # --- attention side (resolved by initialize_dp_attention) ---
+    attn_tp_size: Optional[int] = None
+    attn_tp_rank: Optional[int] = None
+    attn_dp_size: Optional[int] = None
+    attn_dp_rank: Optional[int] = None
+    # --- group handles --- (other groups stay in parallel_state for now)
+    tp_group: Optional[Any] = None
+
+
+# ---------------------------------------------------------------------------
+# Flags: subsystem wrapper for a family, flat for a lone general property.
+# ---------------------------------------------------------------------------
+
+
+class _StaticFlags:
+    """Mixin for a static flag group: plain attribute reads/writes (symmetric),
+    writable until ``freeze()``, frozen after. A scoped test/debug change goes
+    through ``override()``; there are NO per-flag / per-group setter functions and
+    no routing registry. Deliberately not a dataclass itself so the ``__dict__``-based
+    ``__setattr__`` guard works on the subclass."""
+
+    _frozen = False  # class default; flipped per-instance by freeze()
+
+    def __setattr__(self, name, value):
+        if name != "_frozen":
+            if self.__dict__.get("_frozen"):
+                raise RuntimeError(
+                    f"{name!r} is a frozen static flag; use override() on this "
+                    "flag group for a scoped test/debug change"
+                )
+            if name not in self.__dataclass_fields__:  # typo-safety (no slots)
+                raise AttributeError(f"{type(self).__name__} has no flag {name!r}")
+        object.__setattr__(self, name, value)
+
+    def freeze(self) -> None:
+        self._frozen = True
+
+    @contextmanager
+    def override(self, **kwargs):
+        """Scoped set-with-restore that bypasses ``freeze`` (the only sanctioned
+        post-freeze mutation), restoring on exception too:
+        ``with get_flags().attn.override(use_mla_backend=True): ...``"""
+        for name in kwargs:  # validate all keys before mutating any (transactional)
+            if name not in self.__dataclass_fields__:
+                raise AttributeError(f"{type(self).__name__} has no flag {name!r}")
+        saved = []
+        for name, value in kwargs.items():
+            saved.append((name, getattr(self, name)))
+            object.__setattr__(self, name, value)  # bypass freeze guard
+        try:
+            yield
+        finally:
+            for name, old in saved:
+                object.__setattr__(self, name, old)
+
+
+@dataclass
+class AttnFlags(_StaticFlags):
+    """Attention-subsystem static flags."""
+
+    # set from the model at init.
+    use_mla_backend: bool = False
+
+
+@dataclass
+class MoeFlags(_StaticFlags):
+    """MoE-subsystem static flags."""
+
+    # materialized at freeze() from should_use_flashinfer_cutlass_moe_fp4_allgather().
+    use_cutlass_fp4_allgather: bool = False
+
+
+@dataclass(slots=True)
+class Flags:
+    """The flags namespace. A subsystem family gets a wrapper (``attn`` / ``moe``);
+    a lone general property stays flat (``is_extend_in_batch``). Reads and writes
+    are symmetric attribute access — ``get_flags().attn.use_mla_backend`` to read,
+    ``... = value`` to write — with no setter functions. The static sub-structs
+    enforce freeze; the flat per-forward field is freely writable each forward."""
+
+    attn: AttnFlags = field(default_factory=AttnFlags)
+    moe: MoeFlags = field(default_factory=MoeFlags)
+    # per-forward, flat — a batch-level property, not a moe/attn family member.
+    is_extend_in_batch: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Buffers: lazy materialize-at-get + cache + release.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BufferSpec:
+    """Metadata for a lazily-materialized buffer (dtype/device, plus a fixed
+    ``shape`` for a persistent buffer) — NOT the physical tensor:
+
+    - **Persistent** buffer: ``shape`` is fixed; ``get_persistent_buffer(name)``
+      allocates it once and caches it (reused across forwards — e.g. an attention
+      workspace).
+    - **Temporary** buffer: the size depends on the forward, so ``shape`` is left
+      ``None`` here and passed per-forward to ``get_temporary_buffer(name, shape)``,
+      which allocates a fresh tensor each call and does NOT cache it (e.g. a DP
+      all-gather scratch buffer)."""
+
+    name: str  # layered namespace key, e.g. "trtllm.mha_workspace"
+    dtype: "torch.dtype"
+    device: "torch.device"
+    # fixed shape for a persistent buffer (int for 1-D, or a tuple); None ⇒ temporary.
+    shape: "Optional[int | tuple[int, ...]]" = None
+
+
+class BufferStore:
+    """Two buffer lifecycles behind one registry of dtype/device specs:
+
+    - ``get_persistent_buffer(name)`` — allocate once on first access (with the
+      registered fixed ``shape``) and cache, so every caller shares one tensor
+      (``data_ptr`` stable), equivalent to the old ``global ... if None`` init-once.
+    - ``get_temporary_buffer(name, shape)`` — allocate a fresh tensor of the
+      per-forward ``shape`` each call, NOT cached.
+
+    ``release`` (folded into reset) drops the persistent cache so a fresh engine /
+    test re-allocates; temporary buffers hold no state to release."""
+
+    def __init__(self) -> None:
+        self._specs: dict = {}
+        self._cache: dict = {}
+
+    def register(self, spec: "BufferSpec") -> None:
+        # pure addition: record metadata, never allocate here (idempotent).
+        self._specs[spec.name] = spec
+
+    def get_persistent_buffer(self, name: str):
+        """Persistent buffer: allocate once (registered ``shape``) and cache."""
+        buf = self._cache.get(name)
+        if buf is None:  # lazy: allocate on first access, then cache
+            import torch
+
+            spec = self._specs[name]
+            assert spec.shape is not None, (
+                f"{name!r} is a dynamic buffer (no fixed shape) — call "
+                "get_temporary_buffer(name, shape) instead of get_persistent_buffer(name)"
+            )
+            buf = torch.zeros(spec.shape, dtype=spec.dtype, device=spec.device)
+            self._cache[name] = buf
+        return buf
+
+    def get_temporary_buffer(self, name: str, shape):
+        """Temporary buffer: allocate a FRESH tensor of ``shape`` each call, sized by
+        the current forward, NOT cached (dtype/device come from the registered spec).
+        Contrast ``get_persistent_buffer``, which is allocate-once + cached. The DP
+        all-gather buffers (``dp_attention._DpGatheredBufferWrapper``) are the
+        canonical real instance — each forward allocates ``(buffer_len, hidden_size)``
+        afresh."""
+        import torch
+
+        spec = self._specs[name]
+        return torch.empty(shape, dtype=spec.dtype, device=spec.device)
+
+    def release(self) -> None:
+        # drop cached persistent tensors; next get_persistent_buffer re-allocates.
+        self._cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# The one context object.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class Metrics:
+    """Runtime measurements captured at init (not config). ``pre_model_load_memory``
+    is the available GPU memory before model load (measured by
+    init_torch_distributed), read later by init_memory_pool to size the KV cache —
+    so it lives on the context instead of being threaded through call signatures."""
+
+    pre_model_load_memory: Optional[float] = None
+
+
+@dataclass(slots=True)
+class RuntimeContext:
+    parallel: ParallelContext = field(default_factory=ParallelContext)
+    flags: Flags = field(default_factory=Flags)
+    buffers: BufferStore = field(default_factory=BufferStore)
+    metrics: Metrics = field(default_factory=Metrics)
+    _frozen: bool = False
+
+    @classmethod
+    def from_model_runner(cls, model_runner) -> "RuntimeContext":
+        """Build the context from a fully-initialized ModelRunner — call ONCE,
+        AFTER ``init_torch_distributed``. By then every parallel dim (engine +
+        attention) and the TP group are resolved, so the whole context is built
+        in one shot — no early-publish + in-place fill, no ``dataclasses.replace``.
+        The 12+ field enumeration lives here (the construction site), not at the
+        call-site.
+
+        Engine sizes/ranks are read off the model_runner (already resolved — e.g.
+        ``dp_size`` is folded); the attention dims + ``tp_group`` come from the
+        ``dp_attention`` / ``distributed`` getters. ``server_args`` alone is not
+        enough: per-process ranks come from the distributed env, not server_args."""
+        from sglang.srt.distributed import get_tp_group
+        from sglang.srt.layers.dp_attention import (
+            get_attention_cp_rank,
+            get_attention_cp_size,
+            get_attention_dp_rank,
+            get_attention_dp_size,
+            get_attention_tp_rank,
+            get_attention_tp_size,
+        )
+
+        mr = model_runner
+        return cls(
+            parallel=ParallelContext(
+                tp_size=mr.tp_size,
+                tp_rank=mr.tp_rank,
+                pp_size=mr.pp_size,
+                pp_rank=mr.pp_rank,
+                dp_size=mr.dp_size,
+                dp_rank=mr.dp_rank,
+                moe_ep_size=mr.moe_ep_size,
+                moe_ep_rank=mr.moe_ep_rank,
+                moe_dp_size=mr.moe_dp_size,
+                moe_dp_rank=mr.moe_dp_rank,
+                attn_cp_size=get_attention_cp_size(),
+                attn_cp_rank=get_attention_cp_rank(),
+                attn_tp_size=get_attention_tp_size(),
+                attn_tp_rank=get_attention_tp_rank(),
+                attn_dp_size=get_attention_dp_size(),
+                attn_dp_rank=get_attention_dp_rank(),
+                tp_group=get_tp_group(),
+            ),
+            flags=Flags(attn=AttnFlags(use_mla_backend=mr.use_mla_backend)),
+        )
+
+    def freeze(self) -> None:
+        """Materialize static derived flags and close the static write surface.
+
+        Lands after ``init_memory_pool`` per resolution cycle — i.e. after
+        ``initialize_dp_attention`` + ``initialize_moe_config`` — so the predicate
+        inputs are resolved. A second ModelRunner re-publishes a fresh (unfrozen)
+        context, so multi-runner is safe. After this, ``set_flags`` on a static
+        flag raises (use ``override`` for a scoped test/debug change)."""
+        # Materialize the derived flag: the predicate stays the single source of
+        # truth (its clauses are not reimplemented), we just cache its result. This
+        # is the last static write — do it before freezing the moe group.
+        from sglang.srt.layers.moe.utils import (
+            should_use_flashinfer_cutlass_moe_fp4_allgather,
+        )
+
+        self.flags.moe.use_cutlass_fp4_allgather = (
+            should_use_flashinfer_cutlass_moe_fp4_allgather()
+        )
+        self.flags.attn.freeze()
+        self.flags.moe.freeze()
+        self._frozen = True
+
+
+# ---------------------------------------------------------------------------
+# Module-global lifecycle (single publish / single teardown).
+# ---------------------------------------------------------------------------
+
+_context: Optional[RuntimeContext] = None
+
+
+def set_context(ctx: RuntimeContext) -> None:
+    """Low-level publish primitive (overwrite the module global). Used by
+    ``init_context`` and by tests that publish a hand-built context. A second
+    ModelRunner re-publishes a fresh, unfrozen context, so multi-runner
+    (EAGLE draft+target) is safe."""
+    global _context
+    _context = ctx
+
+
+def init_context(model_runner) -> None:
+    """Resolve and publish the process context — the single runtime entry point.
+
+    Runs ``model_runner.init_torch_distributed()`` (which sets up the process
+    groups + dp-attention and measures the available GPU memory before model
+    load), builds the context from the now-resolved topology, stashes that
+    measurement on ``ctx.metrics``, and publishes. Returns nothing — consumers
+    read ``get_context()`` (e.g. init_memory_pool reads
+    ``get_context().metrics.pre_model_load_memory``)."""
+    pre_model_load_memory = model_runner.init_torch_distributed()
+    ctx = RuntimeContext.from_model_runner(model_runner)
+    ctx.metrics.pre_model_load_memory = pre_model_load_memory
+    set_context(ctx)
+
+
+def get_context() -> RuntimeContext:
+    if _context is None:
+        raise ValueError("RuntimeContext not initialized — call init_context() first")
+    return _context
+
+
+def has_context() -> bool:
+    return _context is not None
+
+
+def reset_context() -> None:
+    """Single teardown point — the legacy globals have no such primitive
+    (a multi-engine / test-isolation hazard). Drops cached buffers + the tp_group
+    reference; the group's own destroy stays in destroy_model_parallel()."""
+    global _context
+    if _context is not None:
+        _context.buffers.release()
+        _context.parallel.tp_group = None
+    _context = None
+
+
+# ---------------------------------------------------------------------------
+# Flags read / write surface (one getter, one generic setter).
+# ---------------------------------------------------------------------------
+
+
+def get_flags() -> Flags:
+    """The flags namespace — the single read surface for flags. Reads and writes
+    are symmetric attribute access: ``get_flags().attn.use_mla_backend`` /
+    ``get_flags().moe.use_cutlass_fp4_allgather`` / ``get_flags().is_extend_in_batch``.
+    Writing a static flag after ``freeze()`` raises; per-forward flat flags are
+    freely writable; a scoped test change uses ``<group>.override(...)``.
+
+    There is intentionally NO per-flag ``get_<name>()`` accessor (mirrors the
+    no-per-flag-setter rule) — read the leaf off ``get_flags()`` directly."""
+    return get_context().flags
+
+
+# ---------------------------------------------------------------------------
+# Parallel accessors — thin reads off ctx.parallel.<field>. New names; they do
+# NOT alias the existing parallel_state group readers (those stay).
+# ---------------------------------------------------------------------------
+
+
+def get_parallel() -> ParallelContext:
+    """The parallel-topology namespace — sizes/ranks + group handles. Read leaves
+    directly: ``get_parallel().tp_size`` / ``get_parallel().tp_group`` (or the typed
+    scalar accessors below)."""
+    return get_context().parallel
+
+
+def get_tp_size() -> int:
+    return get_parallel().tp_size
+
+
+def get_tp_rank() -> int:
+    return get_parallel().tp_rank
+
+
+def get_pp_size() -> int:
+    return get_parallel().pp_size
+
+
+def get_pp_rank() -> int:
+    return get_parallel().pp_rank
+
+
+def get_dp_size() -> int:
+    return get_parallel().dp_size
+
+
+def get_dp_rank() -> Optional[int]:
+    return get_parallel().dp_rank
+
+
+def get_moe_ep_size() -> int:
+    return get_parallel().moe_ep_size
+
+
+def get_moe_ep_rank() -> int:
+    return get_parallel().moe_ep_rank
+
+
+def get_moe_dp_size() -> int:
+    return get_parallel().moe_dp_size
+
+
+def get_moe_dp_rank() -> Optional[int]:
+    return get_parallel().moe_dp_rank
+
+
+def get_attn_cp_size() -> int:
+    return get_parallel().attn_cp_size
+
+
+def get_attn_cp_rank() -> Optional[int]:
+    return get_parallel().attn_cp_rank
+
+
+def get_attn_tp_size() -> Optional[int]:
+    return get_parallel().attn_tp_size
+
+
+def get_attn_tp_rank() -> Optional[int]:
+    return get_parallel().attn_tp_rank
+
+
+def get_attn_dp_size() -> Optional[int]:
+    return get_parallel().attn_dp_size
+
+
+def get_attn_dp_rank() -> Optional[int]:
+    return get_parallel().attn_dp_rank

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,6 +1,7 @@
 import logging
 
-from sglang.srt.server_args import ServerArgs, get_global_server_args
+from sglang.srt.runtime_context import get_flags
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import is_blackwell, is_hip, is_musa
 
 logger = logging.getLogger(__name__)
@@ -117,7 +118,7 @@ class DraftBackendFactory:
         return DeepseekSparseAttnBackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_flashinfer_decode_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not get_flags().attn.use_mla_backend:
             from sglang.srt.layers.attention.flashinfer_backend import (
                 FlashInferMultiStepDraftBackend,
             )
@@ -192,7 +193,7 @@ class DraftBackendFactory:
         )
 
     def _create_trtllm_mla_decode_backend(self, backend: str = "trtllm-gen"):
-        if not get_global_server_args().use_mla_backend:
+        if not get_flags().attn.use_mla_backend:
             raise ValueError(
                 "trtllm_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -212,7 +213,7 @@ class DraftBackendFactory:
         return self._create_trtllm_mla_decode_backend(backend="cute-dsl")
 
     def _create_tokenspeed_mla_decode_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not get_flags().attn.use_mla_backend:
             raise ValueError(
                 "tokenspeed_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -249,7 +250,7 @@ class DraftBackendFactory:
         )
 
     def _create_flashinfer_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not get_flags().attn.use_mla_backend:
             from sglang.srt.layers.attention.flashinfer_backend import (
                 FlashInferAttnBackend,
             )
@@ -297,7 +298,7 @@ class DraftBackendFactory:
         return TRTLLMHAAttnBackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_trtllm_mla_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not get_flags().attn.use_mla_backend:
             raise ValueError(
                 "trtllm_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -307,7 +308,7 @@ class DraftBackendFactory:
         return TRTLLMMLABackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_tokenspeed_mla_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not get_flags().attn.use_mla_backend:
             raise ValueError(
                 "tokenspeed_mla backend requires MLA model (use_mla_backend=True)."
             )

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -1,0 +1,328 @@
+"""Unit tests for the unified runtime_context (Global Context Object). CPU-only.
+
+Covers the lifecycle (set/get/reset), parallel accessors + in-place attention
+fill, the flags hierarchy with symmetric attribute read/write + freeze discipline
++ scoped override, the lazy BufferStore, ctx.metrics, and the from_model_runner
+factory (engine fields off the runner, attention dims + tp_group off the getters).
+"""
+
+import dataclasses
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.runtime_context import (
+    BufferSpec,
+    BufferStore,
+    ParallelContext,
+    RuntimeContext,
+    get_attn_tp_size,
+    get_context,
+    get_flags,
+    get_tp_rank,
+    get_tp_size,
+    has_context,
+    reset_context,
+    set_context,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_PREDICATE = (
+    "sglang.srt.layers.moe.utils.should_use_flashinfer_cutlass_moe_fp4_allgather"
+)
+
+
+def _publish(**parallel_kw) -> None:
+    set_context(RuntimeContext(parallel=ParallelContext(**parallel_kw)))
+
+
+def _ws_spec() -> BufferSpec:
+    return BufferSpec(
+        name="t.ws", shape=16, dtype=torch.uint8, device=torch.device("cpu")
+    )
+
+
+class TestLifecycle(unittest.TestCase):
+    def setUp(self):
+        reset_context()
+
+    def tearDown(self):
+        reset_context()
+
+    def test_get_before_init_raises(self):
+        self.assertFalse(has_context())
+        with self.assertRaises(ValueError):
+            get_context()
+        with self.assertRaises(ValueError):
+            get_tp_size()
+
+    def test_set_publishes(self):
+        _publish(tp_size=4, tp_rank=2)
+        self.assertTrue(has_context())
+        self.assertEqual(get_tp_size(), 4)
+        self.assertEqual(get_tp_rank(), 2)
+
+    def test_reset_clears_drops_group_and_releases_buffers(self):
+        set_context(RuntimeContext(parallel=ParallelContext(tp_group="G")))
+        ctx = get_context()
+        ctx.buffers.register(_ws_spec())
+        ctx.buffers.get_persistent_buffer("t.ws")
+        reset_context()
+        self.assertFalse(has_context())
+        self.assertIsNone(ctx.parallel.tp_group)  # group reference dropped
+        self.assertEqual(ctx.buffers._cache, {})  # buffers released
+        with self.assertRaises(ValueError):
+            get_context()
+
+    def test_republish_overwrites(self):
+        _publish(tp_size=2)
+        _publish(tp_size=8)
+        self.assertEqual(get_tp_size(), 8)
+
+
+class TestParallel(unittest.TestCase):
+    def setUp(self):
+        reset_context()
+
+    def tearDown(self):
+        reset_context()
+
+    def test_in_place_attention_fill(self):
+        _publish(tp_size=8, tp_rank=3, pp_size=2, dp_size=4)
+        self.assertEqual(get_tp_size(), 8)
+        self.assertIsNone(get_attn_tp_size())  # default until filled
+        # in-place fill (no dataclasses.replace, no re-publish)
+        get_context().parallel.attn_tp_size = 4
+        get_context().parallel.tp_group = "TPG"
+        self.assertEqual(get_attn_tp_size(), 4)
+        self.assertEqual(get_context().parallel.tp_group, "TPG")
+        self.assertEqual(get_tp_size(), 8)  # engine dim unchanged
+
+
+class TestFlags(unittest.TestCase):
+    def setUp(self):
+        reset_context()
+
+    def tearDown(self):
+        reset_context()
+
+    def test_default_false(self):
+        set_context(RuntimeContext())
+        self.assertFalse(get_flags().attn.use_mla_backend)
+        self.assertFalse(get_flags().moe.use_cutlass_fp4_allgather)
+        self.assertFalse(get_flags().is_extend_in_batch)
+
+    def test_hierarchy_and_symmetric_write(self):
+        set_context(RuntimeContext())
+        get_flags().attn.use_mla_backend = True  # write == read shape
+        self.assertTrue(get_flags().attn.use_mla_backend)
+        self.assertTrue(get_flags().attn.use_mla_backend)
+        get_flags().is_extend_in_batch = True  # flat per-forward
+        self.assertTrue(get_flags().is_extend_in_batch)
+
+    def test_freeze_materializes_moe_and_locks_static(self):
+        set_context(RuntimeContext())
+        get_flags().attn.use_mla_backend = True
+        with mock.patch(_PREDICATE, return_value=True):
+            get_context().freeze()
+        self.assertTrue(get_flags().moe.use_cutlass_fp4_allgather)  # materialized
+        with self.assertRaises(RuntimeError):  # static write after freeze
+            get_flags().attn.use_mla_backend = False
+        self.assertTrue(get_flags().attn.use_mla_backend)  # unchanged
+        get_flags().is_extend_in_batch = True  # per-forward still writable
+        self.assertTrue(get_flags().is_extend_in_batch)
+
+    def test_typo_raises(self):
+        set_context(RuntimeContext())
+        with self.assertRaises(AttributeError):
+            get_flags().attn.use_mla_backened = True  # not a declared flag
+
+    def test_override_scoped_and_restores(self):
+        set_context(RuntimeContext())
+        get_flags().attn.use_mla_backend = True
+        with mock.patch(_PREDICATE, return_value=False):
+            get_context().freeze()  # frozen — override must still work
+        with get_flags().attn.override(use_mla_backend=False):
+            self.assertFalse(get_flags().attn.use_mla_backend)
+        self.assertTrue(get_flags().attn.use_mla_backend)  # restored
+
+        class _Boom(Exception):
+            pass
+
+        with self.assertRaises(_Boom):
+            with get_flags().attn.override(use_mla_backend=False):
+                raise _Boom()
+        self.assertTrue(get_flags().attn.use_mla_backend)  # restored despite exception
+
+    def test_override_unknown_flag_raises(self):
+        set_context(RuntimeContext())
+        with self.assertRaises(AttributeError):
+            with get_flags().attn.override(bogus=1):
+                pass
+
+    def test_override_invalid_key_does_not_leak_valid_change(self):
+        # transactional: an invalid key aborts before mutating the valid one
+        set_context(RuntimeContext())
+        attn = get_flags().attn
+        with self.assertRaises(AttributeError):
+            with attn.override(use_mla_backend=True, bogus=1):
+                pass
+        self.assertFalse(attn.use_mla_backend)  # not left flipped
+
+    def test_multi_runner_fresh_unfrozen(self):
+        set_context(RuntimeContext())
+        c1 = get_context()
+        with mock.patch(_PREDICATE, return_value=True):
+            c1.freeze()
+        set_context(RuntimeContext())  # second runner re-publishes fresh
+        c2 = get_context()
+        self.assertIsNot(c2, c1)
+        get_flags().attn.use_mla_backend = True  # unfrozen → ok
+        self.assertTrue(get_flags().attn.use_mla_backend)
+
+    def test_structs_are_dataclasses(self):
+        # flat per-forward field lives directly on Flags, not under a wrapper
+        flags = RuntimeContext().flags
+        self.assertIn("is_extend_in_batch", flags.__dataclass_fields__)
+        self.assertNotIn("is_extend_in_batch", flags.attn.__dataclass_fields__)
+
+
+class TestBuffers(unittest.TestCase):
+    def test_register_does_not_allocate(self):
+        store = BufferStore()
+        store.register(_ws_spec())
+        self.assertEqual(store._cache, {})
+
+    def test_get_persistent_buffer_allocates_once_and_caches(self):
+        store = BufferStore()
+        store.register(_ws_spec())
+        self.assertIs(
+            store.get_persistent_buffer("t.ws"), store.get_persistent_buffer("t.ws")
+        )
+
+    def test_shape_dtype_device(self):
+        store = BufferStore()
+        store.register(_ws_spec())
+        buf = store.get_persistent_buffer("t.ws")
+        self.assertEqual(tuple(buf.shape), (16,))
+        self.assertEqual(buf.dtype, torch.uint8)
+        self.assertEqual(buf.device.type, "cpu")
+
+    def test_release_reallocates(self):
+        store = BufferStore()
+        store.register(_ws_spec())
+        a = store.get_persistent_buffer("t.ws")
+        store.release()
+        self.assertEqual(store._cache, {})
+        self.assertIsNot(a, store.get_persistent_buffer("t.ws"))
+
+    def test_register_idempotent(self):
+        store = BufferStore()
+        store.register(_ws_spec())
+        store.register(_ws_spec())
+        self.assertIs(
+            store.get_persistent_buffer("t.ws"), store.get_persistent_buffer("t.ws")
+        )
+
+    def test_shape_is_element_count_for_any_dtype(self):
+        # shape is an element count passed straight to torch.zeros — correct for
+        # any dtype (no bytes/element conflation).
+        store = BufferStore()
+        store.register(
+            BufferSpec(
+                name="t.f16", shape=8, dtype=torch.float16, device=torch.device("cpu")
+            )
+        )
+        buf = store.get_persistent_buffer("t.f16")
+        self.assertEqual(buf.numel(), 8)
+        self.assertEqual(buf.dtype, torch.float16)
+
+    def test_temporary_buffer_fresh_per_call_not_cached(self):
+        # temporary: allocate fresh each call, sized per-forward, never cached
+        store = BufferStore()
+        store.register(
+            BufferSpec(name="tmp", dtype=torch.float16, device=torch.device("cpu"))
+        )
+        a = store.get_temporary_buffer("tmp", (4, 8))  # "forward 1"
+        b = store.get_temporary_buffer("tmp", (4, 8))  # "forward 2", same size
+        self.assertIsNot(a, b)  # fresh each call, not cached
+        self.assertEqual(tuple(a.shape), (4, 8))
+        self.assertEqual(a.dtype, torch.float16)
+        c = store.get_temporary_buffer("tmp", (2, 8))  # "forward 3", different size
+        self.assertEqual(tuple(c.shape), (2, 8))
+        self.assertEqual(store._cache, {})  # nothing cached
+
+    def test_get_persistent_buffer_on_temporary_spec_raises(self):
+        # a temporary spec (no fixed shape) must not be fetched via the persistent path
+        store = BufferStore()
+        store.register(
+            BufferSpec(name="tmp", dtype=torch.uint8, device=torch.device("cpu"))
+        )
+        with self.assertRaises(AssertionError):
+            store.get_persistent_buffer("tmp")
+
+
+class TestMetrics(unittest.TestCase):
+    def setUp(self):
+        reset_context()
+
+    def tearDown(self):
+        reset_context()
+
+    def test_metrics_round_trip(self):
+        set_context(RuntimeContext())
+        self.assertIsNone(get_context().metrics.pre_model_load_memory)
+        get_context().metrics.pre_model_load_memory = 42.0
+        self.assertEqual(get_context().metrics.pre_model_load_memory, 42.0)
+
+
+class TestFromModelRunner(unittest.TestCase):
+    """The factory: engine dims off the runner, attention dims + tp_group off the
+    getters, use_mla_backend off the runner. Stubs the getters (no GPU/distributed)."""
+
+    def setUp(self):
+        reset_context()
+
+    def tearDown(self):
+        reset_context()
+
+    def test_reads_engine_attention_and_use_mla(self):
+        class FakeMR:
+            tp_size = 2
+            tp_rank = 1
+            pp_size = 1
+            pp_rank = 0
+            dp_size = 1
+            dp_rank = None
+            moe_ep_size = 1
+            moe_ep_rank = 0
+            moe_dp_size = 1
+            moe_dp_rank = None
+            use_mla_backend = True
+
+        getters = {
+            "get_attention_cp_size": 1,
+            "get_attention_cp_rank": 0,
+            "get_attention_tp_size": 2,
+            "get_attention_tp_rank": 1,
+            "get_attention_dp_size": 1,
+            "get_attention_dp_rank": 0,
+        }
+        with mock.patch("sglang.srt.distributed.get_tp_group", return_value="TPG"):
+            with mock.patch.multiple(
+                "sglang.srt.layers.dp_attention",
+                **{k: (lambda v=v: v) for k, v in getters.items()},
+            ):
+                ctx = RuntimeContext.from_model_runner(FakeMR())
+        self.assertEqual(ctx.parallel.tp_size, 2)
+        self.assertEqual(ctx.parallel.tp_rank, 1)
+        self.assertEqual(ctx.parallel.attn_tp_size, 2)
+        self.assertEqual(ctx.parallel.tp_group, "TPG")
+        self.assertTrue(ctx.flags.attn.use_mla_backend)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Draft / WIP — a proof of concept opening a larger, incremental refactor. This PoC is for design discussion and is **not intended to be merged** as-is — the actual landing is the incremental rollout, not this PR. Design and API feedback very welcome.**

## Motivation

SGLang's process-level state — parallel topology, derived feature flags, lazily-allocated workspaces, and a few init-time measurements — is currently spread across many module-level globals and ad-hoc `get_/set_/is_/should_` accessors in ~15 files. That makes the state hard to discover, hard to reset cleanly (a known multi-engine / test-isolation hazard), and it pushes branch conditions to be re-composed at each call site.

**This PR is a proof of concept for a larger refactor** that consolidates this state into one structured process context, `RuntimeContext`, read through thin accessors with a clear resolve → freeze lifecycle. Rather than migrating everything at once, it establishes the container + the access patterns and migrates a **representative slice of each subsystem**, so the shape can be validated and discussed before a broader rollout. Follow-up PRs will migrate the remaining call sites and retire the legacy globals.

## Modifications

- Add `RuntimeContext` (`get_context()`), organized by subsystem:
  - `ctx.parallel` — parallel topology: each dim's size + rank, plus group handles.
  - `ctx.flags` — feature flags, grouped under a subsystem wrapper when they form a family (`flags.attn.*` / `flags.moe.*`) and flat for a lone general property.
  - `ctx.buffers` — lazily-materialized buffers, covering both lifecycles:
    - **persistent** — `get_persistent_buffer(name)` allocates once and caches (reused across forwards, e.g. an attention workspace);
    - **temporary** — `get_temporary_buffer(name, shape)` allocates a fresh tensor per forward, sized by the batch, not cached (the canonical case is the DP all-gather scratch buffer).
  - `ctx.metrics` — init-time measurements (e.g. pre-model-load memory).
- Published once at `ModelRunner` init via `init_context(model_runner)`; `freeze()` materializes static derived flags and closes the static write surface after resolution; `reset_context()` is a single teardown point.
- Flags use symmetric attribute access — `get_flags().attn.use_mla_backend` to read, `... = value` to write — with a freeze guard on static groups and a scoped `override(...)` for tests (no per-flag setter/getter functions).
- Migrate a **representative** set of readers onto the context: parallel sizes/ranks, a MoE dispatch flag, the MLA-backend flag, the TP group handle, an attention workspace buffer (persistent), and the per-forward "extend in batch" flag.
- **Behavior-preserving:** the legacy globals are kept and dual-written, with parity assertions at the migrated readers during the transition — nothing is removed yet.
- Unit tests for the container (lifecycle, flags + freeze, persistent + temporary buffers, metrics, factory).

## Accuracy Tests

Qwen3-0.6B, `--tp 2`, GSM8K: **0.66** — matches the pre-change baseline (behavior-preserving).

## Speed Tests and Profiling

No measurable impact expected: the change is attribute-level indirection on the init / forward paths, with no kernel or algorithm change.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include \`/tag-and-rerun-ci\`, \`/tag-run-ci-label\`, \`/rerun-failed-ci\`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27381771402](https://github.com/sgl-project/sglang/actions/runs/27381771402)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27381771274](https://github.com/sgl-project/sglang/actions/runs/27381771274)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
