### PR TITLE
[Perf] Skip per-call mat_a/scales_a padding in cutlass FP8 blockwise GEMM

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -565,6 +565,59 @@ def sglang_per_token_group_quant_fp8(
     return x_q, x_s
 
 
+def sglang_per_token_group_quant_fp8_row_padded(
+    x: torch.Tensor,
+    group_size: int,
+    eps: float = 1e-10,
+    row_alignment: int = 4,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-token-group quant writing into row-padded buffers (col-major scales).
+
+    The cutlass fp8_blockwise_scaled_mm wrapper pads mat_a / scales_a to a
+    multiple of 4 rows on every call (a zeros fill + a cat for each of mat_a
+    and scales_a). Allocating the quant outputs with rows already aligned to
+    ``row_alignment`` makes the wrapper's pad_tensor() short-circuit (pad_rows
+    == 0), removing 2x fill + 2x cat kernels per GEMM. Rows in [m, m_pad) are
+    uninitialized garbage; the caller must slice the GEMM output back to m.
+    """
+    assert x.dim() == 2, "row-padded quant expects a 2D input"
+    assert (
+        x.shape[-1] % group_size == 0
+    ), "the last dimension of `x` must be divisible by `group_size`"
+    assert x.is_contiguous(), "`x` is not contiguous"
+
+    if not (enable_sgl_per_token_group_quant_8bit and group_size in (16, 32, 64, 128)):
+        # No v2 kernel available: keep the legacy unpadded path and let the
+        # GEMM wrapper do the padding.
+        return sglang_per_token_group_quant_fp8(
+            x, group_size, eps, column_major_scales=True
+        )
+
+    m, k = x.shape
+    m_pad = ceil_align(m, row_alignment)
+    # mat_a buffer: (m_pad, k) row-major fp8
+    x_q = torch.empty((m_pad, k), device=x.device, dtype=fp8_dtype)
+    # scales_a buffer: column-major (stride(0) == 1), shape (m_pad, k // group)
+    x_s = torch.empty(
+        (k // group_size, m_pad), device=x.device, dtype=torch.float32
+    ).transpose(0, 1)
+    if m > 0:
+        sgl_per_token_group_quant_8bit(
+            x,
+            x_q[:m],
+            x_s[:m],
+            group_size,
+            eps,
+            fp8_min,
+            fp8_max,
+            False,  # scale_ue8m0
+            False,  # fuse_silu_and_mul
+            None,  # masked_m
+            enable_v2=True,
+        )
+    return x_q, x_s
+
+
 def sglang_per_token_group_quant_fp8_ue8m0(
     x: torch.Tensor,
     group_size: int,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 import torch
 
 from sglang.srt.layers import deep_gemm_wrapper
-from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.srt.layers.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+    sglang_per_token_group_quant_fp8_row_padded,
+)
 from sglang.srt.layers.quantization.mxfp4_tensor import MXFP4QuantizeUtil
 from sglang.srt.utils.common import torch_release
 
@@ -635,12 +638,19 @@ def cutlass_w8a8_block_fp8_linear_with_fallback(
     input_2d = input.view(-1, input.shape[-1])
     output_shape = [*input.shape[:-1], weight.shape[0]]
 
-    q_input, x_scale = per_token_group_quant_fp8(
-        input_2d, block_size[1], column_major_scales=True
+    # Quantize into row-padded buffers so the sgl-kernel wrapper's per-call
+    # pad_tensor() on mat_a / scales_a short-circuits (saves 2x fill + 2x cat
+    # kernels per GEMM). weight_scale.T is left as a K-major view because the
+    # kernel requires scales_b.stride(0) == 1 and materializes it internally.
+    q_input, x_scale = sglang_per_token_group_quant_fp8_row_padded(
+        input_2d, block_size[1]
     )
     output = fp8_blockwise_scaled_mm(
         q_input, weight.T, x_scale, weight_scale.T, out_dtype=input_2d.dtype
     )
+    if output.shape[0] != input_2d.shape[0]:
+        # GEMM ran on the row-padded buffer; drop the padding rows.
+        output = output[: input_2d.shape[0]]
     if bias is not None:
         output += bias
     return output.to(dtype=input_2d.dtype).view(*output_shape)

--- a/test/registered/quant/test_fp8_blockwise_row_padding.py
+++ b/test/registered/quant/test_fp8_blockwise_row_padding.py
@@ -1,0 +1,136 @@
+"""Unit tests for the row-padded quant path of the cutlass FP8 blockwise linear.
+
+`cutlass_w8a8_block_fp8_linear_with_fallback` quantizes activations into
+row-aligned buffers (`sglang_per_token_group_quant_fp8_row_padded`) so the
+`fp8_blockwise_scaled_mm` wrapper's per-call mat_a/scales_a padding short-
+circuits. These tests pin the invariant that this is numerically identical to
+the legacy unpadded path, across both row-aligned and unaligned M.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_kernel import (
+    fp8_dtype,
+    per_token_group_quant_fp8,
+    sglang_per_token_group_quant_fp8_row_padded,
+)
+from sglang.srt.layers.quantization.fp8_utils import (
+    _check_cutlass_block_fp8_hardware_support,
+    cutlass_w8a8_block_fp8_linear_with_fallback,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
+
+_FP8_MAX = torch.finfo(fp8_dtype).max
+_BLOCK = 128
+# Cover M == 1 (greedy decode), small unaligned M (speculative draft tokens),
+# the 4-row alignment boundary, and a large aligned batch.
+_M_VALUES = [1, 2, 3, 4, 5, 7, 13, 16, 31, 64, 256]
+
+
+def _quant_weight_blockwise(weight_bf16: torch.Tensor, block: int = _BLOCK):
+    """Block-quantize a (N, K) bf16 weight to fp8 with (N//block, K//block) fp32 scales."""
+    n, k = weight_bf16.shape
+    assert n % block == 0 and k % block == 0
+    w = weight_bf16.float().reshape(n // block, block, k // block, block)
+    amax = w.abs().amax(dim=(1, 3)).clamp(min=1e-12)  # (N//block, K//block)
+    scale = amax / _FP8_MAX
+    wq = (w / scale[:, None, :, None]).clamp(-_FP8_MAX, _FP8_MAX).to(fp8_dtype)
+    return wq.reshape(n, k), scale.to(torch.float32)
+
+
+def _legacy_cutlass_linear(x_2d, weight, weight_scale):
+    """The pre-optimization path: unpadded quant, wrapper pads internally."""
+    from sgl_kernel import fp8_blockwise_scaled_mm
+
+    q_input, x_scale = per_token_group_quant_fp8(x_2d, _BLOCK, column_major_scales=True)
+    return fp8_blockwise_scaled_mm(
+        q_input, weight.T, x_scale, weight_scale.T, out_dtype=x_2d.dtype
+    )
+
+
+@unittest.skipUnless(
+    _check_cutlass_block_fp8_hardware_support(),
+    "cutlass block FP8 requires Hopper (SM90) or newer",
+)
+class TestFP8BlockwiseRowPadding(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.K = 512
+        cls.N = 256
+        torch.manual_seed(0)
+
+    def test_quant_buffers_row_aligned(self):
+        """Row-padded quant returns 4-aligned, M-major buffers whose live rows
+        match the legacy column-major quant bit-for-bit."""
+        for m in _M_VALUES:
+            x = torch.randn(m, self.K, device="cuda", dtype=torch.bfloat16) * 0.1
+            xq, xs = sglang_per_token_group_quant_fp8_row_padded(x, _BLOCK)
+            m_pad = (m + 3) // 4 * 4
+
+            self.assertEqual(xq.shape, (m_pad, self.K), f"M={m}")
+            self.assertEqual(xs.shape[0], m_pad, f"M={m}")
+            # scales_a must stay M-major (stride(0) == 1) for the kernel contract.
+            self.assertEqual(xs.stride(0), 1, f"M={m}")
+
+            xq_ref, xs_ref = per_token_group_quant_fp8(
+                x, _BLOCK, column_major_scales=True
+            )
+            self.assertEqual(xq_ref.shape, (m, self.K), f"M={m}")
+            # Live rows are produced by the same kernel, so they must be identical.
+            self.assertTrue(
+                torch.equal(xq[:m].view(torch.uint8), xq_ref.view(torch.uint8)),
+                f"quantized activation mismatch at M={m}",
+            )
+            torch.testing.assert_close(xs[:m], xs_ref, atol=0.0, rtol=0.0)
+
+    def test_gemm_bit_exact_vs_legacy(self):
+        """The full linear (row-padded) is bit-identical to the legacy unpadded GEMM."""
+        weight_bf16 = (
+            torch.randn(self.N, self.K, device="cuda", dtype=torch.bfloat16) * 0.1
+        )
+        weight, weight_scale = _quant_weight_blockwise(weight_bf16)
+
+        for m in _M_VALUES:
+            x = torch.randn(m, self.K, device="cuda", dtype=torch.bfloat16) * 0.1
+
+            out_ref = _legacy_cutlass_linear(x, weight, weight_scale)
+            out_new = cutlass_w8a8_block_fp8_linear_with_fallback(
+                input=x,
+                weight=weight,
+                block_size=[_BLOCK, _BLOCK],
+                weight_scale=weight_scale,
+            )
+
+            self.assertEqual(out_new.shape, (m, self.N), f"M={m}")
+            self.assertTrue(
+                torch.equal(out_ref, out_new),
+                f"row-padded GEMM differs from legacy at M={m}: "
+                f"max_abs_diff={(out_ref.float() - out_new.float()).abs().max().item()}",
+            )
+
+    def test_linear_matches_bf16_reference(self):
+        """Sanity: the FP8 linear stays close to a bf16 reference matmul."""
+        weight_bf16 = (
+            torch.randn(self.N, self.K, device="cuda", dtype=torch.bfloat16) * 0.1
+        )
+        weight, weight_scale = _quant_weight_blockwise(weight_bf16)
+
+        for m in [1, 5, 64]:
+            x = torch.randn(m, self.K, device="cuda", dtype=torch.bfloat16) * 0.1
+            ref = (x.float() @ weight_bf16.float().T).to(torch.bfloat16)
+            out = cutlass_w8a8_block_fp8_linear_with_fallback(
+                input=x,
+                weight=weight,
+                block_size=[_BLOCK, _BLOCK],
+                weight_scale=weight_scale,
+            )
+            torch.testing.assert_close(out, ref, atol=0.5, rtol=0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The cutlass FP8 blockwise linear path (`cutlass_w8a8_block_fp8_linear_with_fallback`) quantizes the activation, then calls `fp8_blockwise_scaled_mm`, whose sgl-kernel wrapper pads `mat_a` and `scales_a` up to a multiple of 4 rows on every invocation. Each pad is a `torch.zeros` fill plus a `torch.cat`, so every GEMM emits 2 extra fill and 2 extra cat kernels. This PR allocates the quantization outputs with row count already aligned to 4 up front, so the wrapper's `pad_tensor()` short-circuits (`pad_rows == 0`) and those four memory kernels are never launched. The GEMM then runs on the padded buffer and the caller slices the output back to the real row count.

This is a memory-traffic and kernel-count reduction only. The GEMM math, the quantization kernel, and the numerical result are unchanged.

## Motivation

In a decode-heavy trace (Qwen3.5-122B-A10B-FP8, TP=4, NEXTN speculative decoding) the per-GEMM kernel sequence is `group_quant -> fill -> cat -> fill -> cat -> copy -> copy -> cutlass_fp8_gemm`. The two fill and two cat kernels come entirely from `pad_tensor()` padding `mat_a` (the quantized activation) and `scales_a` (its column-major scales) to a 4-row boundary. The cutlass SM90 blockwise kernel requires the A operand row count to be a multiple of 4, and during speculative decode M is just 1 to 5 (the draft token count), so this padding fires on essentially every call. Because the quant output buffers are freshly allocated on every call, the wrapper has to re-pad each time, even though the required alignment is known before quantization. Allocating aligned buffers in the quant step removes that work without touching the kernel.

## How it works

The alignment requirement cannot be removed, but it can be paid once, for free, at buffer-allocation time in the quant step, instead of as a separate fill plus cat pass before every GEMM. The diagram below contrasts the two call flows: in the legacy path the wrapper rebuilds padded copies of `mat_a` and `scales_a` on each call; in this PR the quant step allocates 4-row-aligned buffers, so the wrapper's `pad_tensor()` sees `pad_rows == 0` and skips the fill and cat entirely.

<!-- Replace the relative path with a drag-and-drop uploaded image URL when opening the PR; GitHub does not render repo-relative image paths in PR bodies. -->
<img width="1537" height="1486" alt="image" src="https://github.com/user-attachments/assets/d0fa475a-1cee-4b50-85ac-0d3c6b7f4f80" />

Correctness follows from the memory layout in the bottom row of the diagram. A blockwise FP8 GEMM is row-independent along M, so the result of row `i` depends only on input row `i`. The legacy path appends freshly zeroed rows to reach `m_pad`; this PR allocates `m_pad` rows and leaves the tail uninitialized (garbage). Either way the first `m` rows are computed from identical inputs, and the output is sliced back to `m`, so the garbage rows are never read and cannot affect the result.

## Modifications

`python/sglang/srt/layers/quantization/fp8_kernel.py`: adds `sglang_per_token_group_quant_fp8_row_padded`, which allocates `x_q` as `(m_pad, k)` and the column-major `x_s` as `(m_pad, k // group)` where `m_pad = ceil_align(m, 4)`, runs the existing v2 quant kernel on the `[:m]` slices, and returns the full padded buffers. The `x_s` buffer is built as `(k // group, m_pad)` then transposed so that `stride(0) == 1`, which is the M-major layout the kernel requires for `scales_a`. Rows in `[m, m_pad)` are left uninitialized on purpose. When the v2 kernel is unavailable (group size not in {16, 32, 64, 128}) it falls back to the existing `sglang_per_token_group_quant_fp8` and lets the wrapper pad as before.

`python/sglang/srt/layers/quantization/fp8_utils.py`: `cutlass_w8a8_block_fp8_linear_with_fallback` now calls the row-padded quant and slices the GEMM output back to the original row count (`output[: input_2d.shape[0]]`) before adding bias. `weight_scale.T` is still passed as-is: the kernel requires `scales_b.stride(0) == 1` (a K-major view) and materializes its own contiguous copy internally, so that one is out of scope here.

## Correctness

A blockwise FP8 GEMM is row-independent along M, so computing extra padding rows cannot change the first `m` output rows; the uninitialized tail is sliced off and never read. A direct unit comparison against the existing unpadded path is bit-exact (`max_abs_diff == 0`) for `M` in {1, 2, 3, 4, 5, 7, 13, 64} on H20-3e (SM90), covering both already-aligned and unaligned M. End to end, a greedy 512-token completion is byte-for-byte identical before and after the change.

## Performance

Measured on H20-3e, TP=4, Qwen3.5-122B-A10B-FP8, NEXTN speculative decoding (num-steps 4, eagle-topk 1, draft-tokens 5), CUDA graph on, radix cache off.

The figure below is from two torch profiler traces captured under the same workload (310 decode steps each). Panel A shows per-step GPU time by kernel family, panel B shows memory-op launches per FP8 GEMM.
<img width="1069" height="797" alt="image" src="https://github.com/user-attachments/assets/2e5431ec-b36c-4745-aa7a-51fe4449f72f" />

Decode-loop kernel counts from the traces:

| Kernel family | Baseline | This PR |
|---|---|---|
| cutlass FP8 GEMM | 23.4k launches, 454 ms | 23.4k launches, 454 ms |
| group quant | 35.0k launches, 107 ms | 35.0k launches, 107 ms |
| fill | ~65k launches, ~69 ms | 315 launches, 0.4 ms |
| cat | ~63k launches, ~89 ms | 364 launches, 0.7 ms |

End-to-end:

| Workload | Baseline | This PR | Delta |
|---|---|---|---|
| bs=1 single request, latency | 2.21 s | 2.21 s | no change |
| concurrency 64, output throughput | 2617 tok/s | 2671 tok/s | +2.1% |

The fill and cat kernels are essentially eliminated from the decode loop (about 158 ms of GPU time on this trace). The end-to-end gain is small and only shows up in the GPU-bound regime: a single bs=1 request is CPU-bound on speculative-decode scheduling, so removing GPU-side memory kernels off the critical path leaves latency unchanged. Under concurrency 64 the GPU is more saturated and the saved kernels translate into a measured +2.1% throughput, stable across four runs with no overlap against the baseline runs.

## Test plan

- [x] Unit: `test/registered/quant/test_fp8_blockwise_row_padding.py` asserts the row-padded buffers are 4-row aligned with M-major scales, the live rows match the legacy quant element-for-element, the full linear is `torch.equal` to the legacy unpadded GEMM for M in {1, 2, 3, 4, 5, 7, 13, 16, 31, 64, 256}, and a bf16 reference sanity bound. 3/3 pass on H20-3e (SM90); a negative control that drops the output slice fails as expected.
- [x] E2E: greedy 512-token completion byte-identical before and after.
- [x] Throughput: concurrency 64, 256 requests, +2.1% output tok/s, four runs each, non-overlapping.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27332192942](https://github.com/sgl-project/sglang/actions/runs/27332192942)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27332221473](https://github.com/sgl-project/sglang/actions/runs/27332221473)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->