### PR TITLE
[Fix] Register Qwen3_5ForCausalLM/Qwen3_5MoeForCausalLM for text-only checkpoints

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -2084,4 +2084,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
 
 
-EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]
+EntryClass = [
+    Qwen3_5MoeForConditionalGeneration,
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5ForCausalLM,
+    Qwen3_5MoeForCausalLM,
+]

--- a/test/registered/unit/models/test_qwen3_5_entry_class.py
+++ b/test/registered/unit/models/test_qwen3_5_entry_class.py
@@ -1,0 +1,44 @@
+"""Regression test for Qwen3.5 text-only entry-class registration.
+
+A text-only SFT of Qwen3.5 (e.g. trained via ``AutoModelForCausalLM``)
+writes ``architectures: ["Qwen3_5ForCausalLM"]`` to ``config.json``. The
+``Qwen3_5ForCausalLM`` / ``Qwen3_5MoeForCausalLM`` classes existed but were
+missing from the module's ``EntryClass`` list, so SGLang could not resolve
+the architecture and refused to serve the checkpoint. See issue #27872.
+"""
+
+from sglang.srt.models.registry import ModelRegistry
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestQwen35EntryClass(CustomTestCase):
+    def test_text_only_for_causal_lm_archs_registered(self):
+        archs = ModelRegistry.get_supported_archs()
+        self.assertIn("Qwen3_5ForCausalLM", archs)
+        self.assertIn("Qwen3_5MoeForCausalLM", archs)
+
+    def test_for_causal_lm_archs_resolve_to_classes(self):
+        from sglang.srt.models.qwen3_5 import (
+            Qwen3_5ForCausalLM,
+            Qwen3_5MoeForCausalLM,
+        )
+
+        dense_cls, _ = ModelRegistry.resolve_model_cls("Qwen3_5ForCausalLM")
+        moe_cls, _ = ModelRegistry.resolve_model_cls("Qwen3_5MoeForCausalLM")
+        self.assertIs(dense_cls, Qwen3_5ForCausalLM)
+        self.assertIs(moe_cls, Qwen3_5MoeForCausalLM)
+
+        # The resolved classes must expose the serving contract (a runnable
+        # forward plus weight loading), not just be name-resolvable.
+        for cls in (dense_cls, moe_cls):
+            self.assertTrue(callable(getattr(cls, "forward", None)))
+            self.assertTrue(callable(getattr(cls, "load_weights", None)))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #27872.

A text-only SFT of Qwen3.5 trained via `AutoModelForCausalLM` writes `architectures: ["Qwen3_5ForCausalLM"]` into `config.json`. SGLang defines `Qwen3_5ForCausalLM` (dense) and `Qwen3_5MoeForCausalLM` (MoE) — they are complete, weight-loadable model classes and are already used as the `language_model_cls` of the multimodal `*ForConditionalGeneration` wrappers — but the module's `EntryClass` list only contained the two `*ForConditionalGeneration` classes:

```python
EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]
```

So `ModelRegistry` cannot resolve `Qwen3_5ForCausalLM`, and serving a text-only checkpoint fails with a "not supported architecture" error. vLLM fixed the analogous gap in [vllm-project/vllm#39316](https://github.com/vllm-project/vllm/pull/39316).

## Modifications

- Register `Qwen3_5ForCausalLM` and `Qwen3_5MoeForCausalLM` in `EntryClass` so text-only Qwen3.5 checkpoints serve directly (no need for the original config + `--language-only` workaround).
- Add a CPU unit test (`test/registered/unit/models/test_qwen3_5_entry_class.py`) asserting both architectures resolve via `ModelRegistry` to the expected classes and that the resolved classes expose the serving contract (`forward` / `load_weights`).

No collision: these class names are not registered by any other module (they are only imported as building blocks in `minicpmv.py` / `qwen3_5_mtp.py`, the latter registering a differently-named `Qwen3_5ForCausalLMMTP`).

## Checklist

- [x] Format with pre-commit (isort/ruff/black all pass).
- [x] Added a unit test for the change.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27333001141](https://github.com/sgl-project/sglang/actions/runs/27333001141)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27333000455](https://github.com/sgl-project/sglang/actions/runs/27333000455)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->