### PR TITLE
feat: add NVTX markers for the scheduler main loop

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -85,6 +85,7 @@ from sglang.srt.observability.req_time_stats import (
 )
 from sglang.srt.utils import get_num_new_pages
 from sglang.srt.utils.network import NetworkAddress
+from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = logging.getLogger(__name__)
@@ -1780,6 +1781,7 @@ class SchedulerDisaggregationDecodeMixin:
 
         return GenerationBatchResult()
 
+    @nvtx_annotated_method("scheduler.get_next_batch_to_run")
     def get_next_disagg_decode_batch_to_run(
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -60,6 +60,7 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
+from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
@@ -395,6 +396,7 @@ class SchedulerDisaggregationPrefillMixin:
             if room is not None and room in kv_mgr.transfer_infos:
                 prefetch(room)
 
+    @nvtx_annotated_method("scheduler.get_next_batch_to_run")
     def get_next_disagg_prefill_batch_to_run(
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -243,6 +243,7 @@ class Envs:
     SGLANG_PROFILE_WITH_STACK = EnvBool(True)
     SGLANG_PROFILE_RECORD_SHAPES = EnvBool(True)
     SGLANG_PROFILE_V2 = EnvBool(False)
+    SGLANG_ENABLE_NVTX = EnvBool(False)
     SGLANG_RECORD_STEP_TIME = EnvBool(False)
     SGLANG_FORCE_SHUTDOWN = EnvBool(False)
     SGLANG_DEBUG_MEMORY_POOL = EnvBool(False)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -259,6 +259,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_tokenizer_from_processor,
 )
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
+from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
@@ -1536,6 +1537,7 @@ class Scheduler(
 
         return disable_overlap_for_batch or need_grammar_sync
 
+    @nvtx_annotated_method("scheduler.process_input_requests")
     def process_input_requests(self, recv_reqs: List):
         now = time.monotonic()
         self.session_controller.maybe_reap(now)
@@ -2412,6 +2414,7 @@ class Scheduler(
         # todo hisparse, maybe other info to contain for the new batch
         return batch
 
+    @nvtx_annotated_method("scheduler.get_next_batch_to_run")
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:
         if self.enable_fpm:
             self._fpm_batch_t0 = time.monotonic()
@@ -2982,6 +2985,7 @@ class Scheduler(
             else:
                 batch.sampling_info = sched_sampling_info
 
+    @nvtx_annotated_method("scheduler.run_batch")
     def run_batch(
         self,
         batch: ScheduleBatch,
@@ -3209,6 +3213,7 @@ class Scheduler(
         if batch_result.logits_output is not None:
             batch_result.logits_output.next_token_logits = None
 
+    @nvtx_annotated_method("scheduler.process_batch_result")
     def process_batch_result(
         self,
         batch: ScheduleBatch,

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -29,6 +29,7 @@ from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
 )
+from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -67,6 +68,7 @@ class SchedulerRequestReceiver:
             return False
         return num_recv_reqs >= self.max_recv_per_poll
 
+    @nvtx_annotated_method("scheduler.recv_requests")
     def recv_requests(
         self,
     ) -> List[Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput, Any]]:

--- a/python/sglang/srt/utils/nvtx_utils.py
+++ b/python/sglang/srt/utils/nvtx_utils.py
@@ -1,0 +1,98 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Lightweight NVTX annotations for the scheduler main loop.
+
+Enabled via the ``SGLANG_ENABLE_NVTX`` environment variable (off by default).
+When disabled, the decorator/context manager add zero runtime overhead so they
+are safe to leave on hot scheduler paths.
+"""
+
+import logging
+from contextlib import contextmanager, nullcontext
+from functools import wraps
+
+import torch
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+_NVTX_ENV_ENABLED = envs.SGLANG_ENABLE_NVTX.get()
+_nvtx_module = None
+if _NVTX_ENV_ENABLED:
+    try:
+        import nvtx as _nvtx_module  # type: ignore
+    except ImportError:
+        logger.warning(
+            "SGLANG_ENABLE_NVTX is set, but the `nvtx` package is missing. "
+            "NVTX annotations are disabled."
+        )
+
+NVTX_ENABLED = _nvtx_module is not None
+
+# Colors are assigned per scheduler main-loop stage so the markers are easy to
+# distinguish in Nsight Systems.
+_NVTX_COLOR_MAP = {
+    # === Scheduler main loop (pipeline order) ===
+    "scheduler.recv_requests": "blue",
+    "scheduler.process_input_requests": "purple",
+    "scheduler.get_next_batch_to_run": "green",
+    "scheduler.run_batch": "red",
+    "scheduler.process_batch_result": "cyan",
+}
+
+
+@contextmanager
+def _nvtx_range_enabled(debug_name: str):
+    color = _NVTX_COLOR_MAP.get(debug_name)
+    # record_function carries a non-trivial (~microseconds) cost per call even
+    # when no PyTorch profiler is collecting, so only pay it when one is active
+    # (e.g. Chrome-trace export). For Nsight-only runs the nvtx.annotate marker
+    # alone is enough.
+    if torch.autograd._profiler_enabled():
+        with torch.autograd.profiler.record_function(debug_name):
+            with _nvtx_module.annotate(debug_name, color=color):
+                yield
+    else:
+        with _nvtx_module.annotate(debug_name, color=color):
+            yield
+
+
+if NVTX_ENABLED:
+    nvtx_range = _nvtx_range_enabled
+else:
+    # When NVTX is disabled, hand back a shared no-op context manager so hot
+    # paths using `with nvtx_range(...)` pay no per-call generator overhead.
+    _NULL_CONTEXT = nullcontext()
+
+    def nvtx_range(debug_name: str):
+        return _NULL_CONTEXT
+
+
+def nvtx_annotated_method(debug_name: str):
+    # Decide at decoration time. When NVTX is disabled this returns the
+    # original function untouched, so decorated methods on hot paths have zero
+    # runtime cost.
+    if not NVTX_ENABLED:
+        return lambda func: func
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with nvtx_range(debug_name):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When profiling the scheduler with Nsight Systems, the CPU-side scheduling work is hard to read: the main loop shows up as one undifferentiated block, so it is not obvious how time splits across receiving requests, scheduling the next batch, launching the forward pass, and post-processing results.

This PR adds lightweight, **opt-in** NVTX range markers to the core steps of the scheduler main loop, so each stage is a named, colored span in the Nsight timeline. The markers also cover the PD-disaggregated event loops, so the same spans line up across normal, prefill (P) and decode (D) deployments and can be compared side by side.

## Design

- **Off by default, zero overhead.** Markers are gated behind the `SGLANG_ENABLE_NVTX` environment variable. When it is unset, the decorator returns the original function untouched and the context manager hands back a shared no-op, so decorated hot paths pay no runtime cost. The decision is made once at import time, not per call.
- **Graceful degradation.** If `SGLANG_ENABLE_NVTX` is set but the `nvtx` package is not installed, a warning is logged and the markers degrade to no-ops instead of raising.
- **Optional `record_function` integration.** When a PyTorch profiler is active, the same span is also emitted via `torch.autograd.profiler.record_function` (e.g. for Chrome-trace export); otherwise only the cheaper `nvtx.annotate` marker is used.
- **Scope kept intentionally small.** Only the top-level main-loop stages are instrumented. Finer-grained markers (sub-steps, DP-attn, GPU forward, speculative decoding) can be layered on later by reusing the same `nvtx_utils` helpers.

## Instrumented functions

### Scheduler main loop (`event_loop_normal` / `event_loop_overlap`)

| Stage | Function | Marker | Color |
|---|---|---|---|
| Receive requests | `SchedulerRequestReceiver.recv_requests` | `scheduler.recv_requests` | blue |
| Process inputs | `Scheduler.process_input_requests` | `scheduler.process_input_requests` | purple |
| Pick next batch | `Scheduler.get_next_batch_to_run` | `scheduler.get_next_batch_to_run` | green |
| Run forward | `Scheduler.run_batch` | `scheduler.run_batch` | red |
| Post-process | `Scheduler.process_batch_result` | `scheduler.process_batch_result` | cyan |

### PD-disaggregated loops

The receive / run / post-process steps reuse the same `Scheduler` methods above, so they are already marked. Only the "pick next batch" step uses dedicated functions per role; these are annotated with the **same** `scheduler.get_next_batch_to_run` marker so the spans align across P, D and normal nodes.

| Role | Event loop | "Pick next batch" function | Marker |
|---|---|---|---|
| Prefill (P) | `event_loop_*_disagg_prefill` | `get_next_disagg_prefill_batch_to_run` | `scheduler.get_next_batch_to_run` |
| Decode (D) | `event_loop_*_disagg_decode` | `get_next_disagg_decode_batch_to_run` | `scheduler.get_next_batch_to_run` |

## Usage

```bash
pip install nvtx
SGLANG_ENABLE_NVTX=1 nsys profile -t cuda,nvtx python -m sglang.launch_server ...
```

## Profiling result

With SGLANG_ENABLE_NVTX=1, the scheduler stages are shown as named NVTX ranges in Nsight Systems. This makes the CPU-side main loop easier to inspect and compare across different deployment modes.

#### Prefill node：

The prefill scheduler shows the same top-level scheduling stages, including the role-specific batch selection step annotated as scheduler.get_next_batch_to_run.

<img width="2633" height="386" alt="image" src="https://github.com/user-attachments/assets/816e75de-ad9d-4a54-9ae0-c2e5461901c5" />

#### Decode node：

The decode scheduler uses the same marker names, making the decode-side scheduling loop directly comparable with both the prefill node and the normal scheduler loop.

<img width="2697" height="383" alt="image" src="https://github.com/user-attachments/assets/add30295-b786-4b6b-8e69-a72a60a65f34" />





## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27333849007](https://github.com/sgl-project/sglang/actions/runs/27333849007)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27333848677](https://github.com/sgl-project/sglang/actions/runs/27333848677)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->