### PR TITLE
Add Ascend NPU support for DeepSeek-V4-Flash architecture

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -14,24 +14,35 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
 
     server_args.attention_backend = "dsv4"
     server_args.page_size = 256
+    if server_args.kv_cache_dtype == "auto":
+        server_args.kv_cache_dtype = "fp8_e4m3"
+        logger.warning(
+            f"Setting KV cache dtype to {server_args.kv_cache_dtype} for {model_arch}."
+        )
+
+    if server_args.device == "npu":
+        # NPU keeps the device-aware "dsv4" backend (the registry routes it to
+        # the Ascend V4 subclass); only the pool geometry / dtype differ.
+        # set_default_server_args() pins all three backends to "ascend" for
+        # generic NPU models; undo that here so V4 stays consistently on dsv4.
+        server_args.prefill_attention_backend = "dsv4"
+        server_args.decode_attention_backend = "dsv4"
+        server_args.page_size = 128
+        server_args.kv_cache_dtype = "bfloat16"
+
     logger.info(
-        f"Use dsv4 attention backend for {model_arch}, setting page_size to 256."
+        f"Use dsv4 attention backend for {model_arch}, setting page_size to {server_args.page_size}."
     )
+    assert server_args.kv_cache_dtype in [
+        "fp8_e4m3",
+        "bfloat16",
+    ], f"{server_args.kv_cache_dtype} is not supported for {model_arch}"
 
     if server_args.max_running_requests is None:
         server_args.max_running_requests = 256
         logger.warning(
             f"Setting max_running_requests to {server_args.max_running_requests} for {model_arch}."
         )
-
-    if server_args.kv_cache_dtype == "auto":
-        server_args.kv_cache_dtype = "fp8_e4m3"
-        logger.warning(
-            f"Setting KV cache dtype to {server_args.kv_cache_dtype} for {model_arch}."
-        )
-    assert server_args.kv_cache_dtype in [
-        "fp8_e4m3"
-    ], f"{server_args.kv_cache_dtype} is not supported for {model_arch}"
 
     if server_args.speculative_algorithm is not None:
         assert (

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -523,6 +523,16 @@ class AscendAttnBackend(AttentionBackend):
                 dtype=torch.int64,
                 device=self.device,
             )
+        # V4-specific extra graph buffers. Default no-op on the base class;
+        # DeepseekV4AscendAttnBackend overrides.
+        self._init_dsv4_graph_buffers(max_bs=max_bs, max_num_tokens=max_num_tokens)
+
+    def _init_dsv4_graph_buffers(self, *, max_bs: int, max_num_tokens: int) -> None:
+        """Hook for V4-Flash to preallocate dsv4-specific graph buffers.
+
+        Default no-op. Overridden by DeepseekV4AscendAttnBackend.
+        """
+        pass
 
     def _init_cuda_graph_metadata(
         self,

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1,0 +1,1200 @@
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.hardware_backend.npu.attention.ascend_backend import AscendAttnBackend
+from sglang.srt.layers.attention.dsv4.compressor import CompressorBackendMixin
+from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
+from sglang.srt.layers.dp_attention import get_attention_tp_size
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+    from sglang.srt.model_executor.model_runner import ModelRunner
+    from sglang.srt.speculative.spec_info import SpecInput
+
+logger = logging.getLogger(__name__)
+
+
+def _walsh_hadamard_matrix(n: int, dtype: torch.dtype, device) -> torch.Tensor:
+    # n**-0.5 norm is baked in via the sqrt(2) division per doubling; _apply_hadamard is a plain matmul
+    cache = _walsh_hadamard_matrix._cache
+    key = (n, str(device))
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    if not ((n & (n - 1) == 0) and (n > 0)):
+        raise ValueError(f"n must be a positive power of 2, got {n}")
+    had = torch.ones(1, 1, dtype=torch.bfloat16, device=device)
+    while had.shape[0] != n:
+        had = torch.cat((torch.cat([had, had], 1), torch.cat([had, -had], 1)), 0)
+        had /= math.sqrt(2)
+    had = had.contiguous()
+    cache[key] = had
+    return had
+
+
+_walsh_hadamard_matrix._cache = {}
+
+
+def _apply_hadamard(inp: torch.Tensor, hadamard_matrix: torch.Tensor) -> torch.Tensor:
+    init_shape = inp.shape
+    flat = inp.view(-1, hadamard_matrix.shape[0])
+    return flat.matmul(hadamard_matrix).view(init_shape).to(torch.bfloat16)
+
+
+class CompressorAscendBackendMixin(CompressorBackendMixin):
+
+    def _build_npu_compress_metadata(self, forward_batch: "ForwardBatch") -> None:
+        fm = self.forward_metadata
+        is_decode = forward_batch.forward_mode.is_decode()
+        result = self._compute_compress_locs(
+            pool=forward_batch.token_to_kv_pool,
+            req_to_token=forward_batch.req_to_token_pool.req_to_token,
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens.to(torch.int32),
+            out_cache_loc=forward_batch.out_cache_loc,
+            is_decode=is_decode,
+            bs=forward_batch.batch_size,
+            device=forward_batch.seq_lens.device,
+            req_to_token_pool=forward_batch.req_to_token_pool,
+            out_cache_loc_dsv4=forward_batch.out_cache_loc_dsv4,
+        )
+        for k, v in result.items():
+            setattr(fm, k, v)
+        if not is_decode:
+            for ratio in self._dsv4_compress_ratios:
+                if ratio in (4, 128):
+                    if f"c{ratio}_state_loc" not in result:
+                        setattr(fm, f"c{ratio}_state_loc", None)
+                    if f"c{ratio}_loc" not in result:
+                        setattr(fm, f"c{ratio}_loc", None)
+
+        if (
+            forward_batch.forward_mode.is_prefill()
+            and not forward_batch.forward_mode.is_target_verify()
+            and self._dsv4_compress_ratios
+        ):
+            self._build_npu_compress_metadata_prefill(forward_batch)
+
+    def _build_npu_compress_metadata_prefill(
+        self, forward_batch: "ForwardBatch"
+    ) -> None:
+        # eager-only: prefill is never graph-captured, host reads (cu_cpu) are safe here
+        fm = self.forward_metadata
+        device = forward_batch.seq_lens.device
+        positions = forward_batch.positions
+        t = positions.shape[0]
+        bs = forward_batch.batch_size
+        cu = fm.actual_seq_lengths_q_pa
+
+        cu_cpu = cu.cpu().tolist()
+        ratio_lists: dict = {r: [] for r in self._dsv4_compress_ratios if r in (4, 128)}
+        for idx in range(bs):
+            start = int(cu_cpu[idx])
+            end = int(cu_cpu[idx + 1])
+            if end == start:
+                continue
+            seq = end - start
+            req_positions = positions[start:end]
+            for ratio in ratio_lists:
+                cutoff = seq - (seq % ratio)
+                if cutoff > 0:
+                    ratio_lists[ratio].append(req_positions[:cutoff:ratio])
+
+        for ratio in (4, 128):
+            if ratio not in ratio_lists:
+                continue
+            padding_size = min(t, t // ratio + bs)
+            padding = torch.zeros(padding_size, dtype=torch.int64, device=device)
+            if ratio_lists[ratio]:
+                cat = torch.cat(ratio_lists[ratio], dim=0).to(torch.int64)
+                assert cat.numel() <= padding.numel(), (
+                    f"positions_cmp_padding_c{ratio} overflow: "
+                    f"{cat.numel()} > {padding.numel()}"
+                )
+                padding[: cat.shape[0]].copy_(cat)
+            setattr(fm, f"positions_cmp_padding_c{ratio}", padding)
+
+        # start_pos=0: chunked prefill unsupported; seqused=None -> op derives lens from cu_seqlens
+        fm.start_pos = torch.zeros(bs, dtype=torch.int32, device=device)
+        fm.seqused = None
+
+        # bundle out_c*_loc is densely packed in batch order (matches cmp_kv); invalid under chunked prefill
+        bundle = forward_batch.out_cache_loc_dsv4
+        for ratio in (4, 128):
+            if ratio not in ratio_lists:
+                continue
+            bundle_loc = None
+            if bundle is not None:
+                bundle_loc = bundle.out_c4_loc if ratio == 4 else bundle.out_c128_loc
+            setattr(
+                fm,
+                f"c{ratio}_loc",
+                bundle_loc.to(torch.int32) if bundle_loc is not None else None,
+            )
+
+        # req_to_token_c*_state is not re-zeroed on slot reuse; zero pre-tail page cols so the kernel block-0 skip masks stale entries
+        page_size = self.page_size
+        for ratio in (4, 128):
+            spt = getattr(fm, f"c{ratio}_state_page_table", None)
+            if spt is None:
+                continue
+            for idx in range(bs):
+                seqlen = int(cu_cpu[idx + 1] - cu_cpu[idx])
+                if seqlen == 0:
+                    continue
+                tail = seqlen % 128
+                if ratio == 4:
+                    c_alloc_len = tail + 128 if (tail <= 3 and seqlen >= 128) else tail
+                else:
+                    c_alloc_len = tail
+                c_alloc_offset = seqlen - c_alloc_len
+                first_tail_page = c_alloc_offset // page_size
+                if first_tail_page > 0:
+                    spt[idx, :first_tail_page] = 0
+
+    def _compute_compress_locs(
+        self,
+        *,
+        pool,
+        req_to_token: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        out_cache_loc: torch.Tensor,
+        is_decode: bool,
+        bs: int,
+        device: torch.device,
+        req_to_token_pool,
+        out_cache_loc_dsv4,
+        is_graph: bool = False,
+    ) -> dict:
+        result: dict = {}
+        req_pool = req_pool_indices
+
+        seq_lens_max = int(seq_lens.max().item()) if bs > 0 else 0
+        n_pages = max(1, (seq_lens_max + self.page_size - 1) // self.page_size)
+
+        for ratio in self._dsv4_compress_ratios:
+            if ratio not in (4, 128):
+                continue
+            # state table holds one slot per RAW token; block 0 is the skip sentinel reserved by NPUCompressStatePool
+            state_table = (
+                req_to_token_pool.req_to_token_c4_state
+                if ratio == 4
+                else req_to_token_pool.req_to_token_c128_state
+            )
+            state_slots_2d = state_table[
+                req_pool.to(torch.int64), : n_pages * self.page_size
+            ]
+            state_page_2d = (state_slots_2d[:, :: self.page_size] // self.page_size).to(
+                torch.int32
+            )
+
+            if is_decode:
+                state_loc_decode = None
+                if out_cache_loc_dsv4 is not None:
+                    state_loc_decode = (
+                        out_cache_loc_dsv4.out_c4_state_loc
+                        if ratio == 4
+                        else out_cache_loc_dsv4.out_c128_state_loc
+                    )
+                if state_loc_decode is None:
+                    state_loc_decode = torch.zeros(
+                        bs,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                else:
+                    state_loc_decode = state_loc_decode.to(torch.int32)
+                compress_out_loc = torch.zeros(
+                    bs,
+                    dtype=torch.int32,
+                    device=device,
+                )
+                # bundle_loc and cmp_kv are both densely packed in batch order; scattering by batch index misaligns them (garbled-token TP regression)
+                if out_cache_loc_dsv4 is not None:
+                    bundle_loc = (
+                        out_cache_loc_dsv4.out_c4_loc
+                        if ratio == 4
+                        else out_cache_loc_dsv4.out_c128_loc
+                    )
+                    n_compress = bundle_loc.numel()
+                    if n_compress > 0:
+                        compress_out_loc[:n_compress] = bundle_loc.to(torch.int32)
+
+            result[f"c{ratio}_state_page_table"] = state_page_2d
+            if is_decode:
+                result[f"c{ratio}_state_loc"] = state_loc_decode
+                result[f"c{ratio}_loc"] = compress_out_loc
+
+            c_table = (
+                req_to_token_pool.req_to_token_c4
+                if ratio == 4
+                else req_to_token_pool.req_to_token_c128
+            )
+            # graph: keep shape aligned with the preallocated buffer; eager: clamp >=1 so kernels see a column
+            if is_graph:
+                n_c_tokens = seq_lens_max // ratio
+            else:
+                n_c_tokens = max(1, seq_lens_max // ratio)
+            slots = c_table[req_pool.to(torch.int64), :n_c_tokens]
+            c_page_table = (slots[:, :: self.page_size] // self.page_size).to(
+                torch.int32
+            )
+            result[f"c{ratio}_page_table"] = c_page_table
+
+        if is_decode:
+            valid = seq_lens > 0
+            positions_last = torch.clamp(seq_lens - 1, min=0)
+            for ratio in self._dsv4_compress_ratios:
+                if ratio not in (4, 128):
+                    continue
+                padding_size = min(bs, bs // ratio + bs)
+                padding = torch.zeros(padding_size, dtype=torch.int64, device=device)
+                should_compress = ((seq_lens % ratio) == 0) & valid
+                pos_cmp = positions_last[should_compress].to(torch.int64) + (1 - ratio)
+                if pos_cmp.numel() > 0:
+                    padding[: pos_cmp.shape[0]].copy_(pos_cmp)
+                result[f"positions_cmp_padding_c{ratio}"] = padding
+
+            result["start_pos"] = positions_last.to(torch.int32)
+            result["seqused"] = valid.to(torch.int32)
+
+        return result
+
+    def forward_core_compressor(
+        self,
+        x: torch.Tensor,
+        forward_batch: "ForwardBatch",
+        layer_id: int,
+        compressor,
+    ) -> None:
+        if forward_batch.forward_mode.is_idle():
+            return
+        compressor(x, forward_batch)
+
+    def forward_compress(
+        self,
+        compressor,
+        x: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> None:
+        from sglang.srt.layers.deepseek_v4_rope import (
+            get_fused_compressor_rope_cos_sin,
+        )
+
+        ratio = compressor.ratio
+        coff = 1 + int(compressor.overlap)
+        device = x.device
+        self._ensure_compressor_hadamard(compressor, device)
+        self._ensure_fused_caches(compressor)
+
+        fm = forward_batch.attn_backend.forward_metadata
+        positions_cmp = getattr(fm, f"positions_cmp_padding_c{ratio}", None)
+        page_table = getattr(fm, f"c{ratio}_state_page_table", None)
+        start_pos = getattr(fm, "start_pos", None)
+        seqused = getattr(fm, "seqused", None)
+        cu_seqlens = getattr(fm, "actual_seq_lengths_q_pa", None)
+        assert positions_cmp is not None and page_table is not None, (
+            "fused compressor needs backend metadata "
+            "(positions_cmp_padding / c*_state_page_table) — make sure "
+            "_build_npu_compress_metadata ran before this forward."
+        )
+        assert start_pos is not None, "fused compressor needs start_pos"
+        assert cu_seqlens is not None, "fused compressor needs cu_seqlens"
+
+        pool = forward_batch.token_to_kv_pool
+        state_cache = pool.get_state_cache(
+            compressor.layer_id, compressor.is_in_indexer
+        )
+
+        cos, sin = get_fused_compressor_rope_cos_sin(
+            compressor.freqs_cis, positions_cmp, dtype=torch.float32
+        )
+
+        cmp_kv = torch.ops.custom.compressor(
+            x,
+            compressor._fused_wkv_w,
+            compressor._fused_wgate_w,
+            state_cache,
+            compressor.ape,
+            compressor._fused_norm_weight_fp32,
+            rope_sin=sin,
+            rope_cos=cos,
+            rope_head_dim=compressor.rope_head_dim,
+            cmp_ratio=ratio,
+            state_block_table=page_table,
+            cu_seqlens=cu_seqlens,
+            seqused=seqused,
+            start_pos=start_pos,
+            coff=coff,
+            norm_eps=compressor.norm.variance_epsilon,
+            rotary_mode=2,
+            cache_mode=1,
+        )
+
+        # prefill output may be padded; trim to loc length
+        loc = getattr(fm, f"c{ratio}_loc", None)
+        if loc is not None and loc.numel() < cmp_kv.shape[0]:
+            cmp_kv = cmp_kv[: loc.numel()]
+
+        if forward_batch.attn_backend.graph_mode or cmp_kv.shape[0] > 0:
+            if compressor.rotate:
+                cmp_kv = _apply_hadamard(cmp_kv, compressor.hadamard_matrix)
+            self._compressor_epilog_npu(compressor, cmp_kv, forward_batch)
+
+    def _ensure_compressor_hadamard(self, compressor, device: torch.device) -> None:
+        if getattr(compressor, "hadamard_matrix", None) is None:
+            H = _walsh_hadamard_matrix(compressor.head_dim, torch.float32, device)
+            compressor.register_buffer("hadamard_matrix", H, persistent=False)
+
+    def _ensure_fused_caches(self, compressor) -> None:
+        if getattr(compressor, "_fused_wkv_w", None) is not None:
+            return
+        coff = 1 + int(compressor.overlap)
+        split = coff * compressor.head_dim
+        w = compressor.wkv_gate.weight
+        assert (
+            w.shape[0] == 2 * split
+        ), f"wkv_gate.weight rows={w.shape[0]} != 2*coff*head_dim={2*split}"
+        compressor._fused_wkv_w = w[:split]
+        compressor._fused_wgate_w = w[split:]
+        compressor._fused_norm_weight_fp32 = compressor.norm.weight.to(torch.float32)
+
+    def _compressor_epilog_npu(
+        self,
+        compressor,
+        kv: torch.Tensor,
+        forward_batch: ForwardBatch,
+        override_loc: Optional[torch.Tensor] = None,
+    ) -> None:
+        kv_scale: Optional[torch.Tensor] = None
+        li_kv_dtype = getattr(compressor, "li_kv_dtype", "bf16")
+        if li_kv_dtype == "int8" and compressor.is_in_indexer:
+            import torch_npu
+
+            kv, kv_scale = torch_npu.npu_dynamic_quant(kv)
+            kv_scale = kv_scale.to(torch.float16)
+
+        if override_loc is not None:
+            loc = override_loc
+        else:
+            backend_fm = forward_batch.attn_backend.forward_metadata
+            loc = backend_fm.c4_loc if compressor.ratio == 4 else backend_fm.c128_loc
+        forward_batch.token_to_kv_pool.set_compress_buffer(
+            compressor.layer_id,
+            loc,
+            kv,
+            kv_scale,
+            compressor.is_in_indexer,
+        )
+
+
+class C4IndexerAscendBackendMixin(C4IndexerBackendMixin):
+
+    def init_forward_metadata_indexer(self, core_attn_metadata):
+        # li_quant_metadata is built in _compute_kernel_metadata; None satisfies the mixin contract
+        return None
+
+    def forward_c4_indexer_npu(
+        self,
+        c4_indexer,
+        x: torch.Tensor,
+        q_lora: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.dp_attention import get_attention_tp_group
+
+        ratio = c4_indexer.compressor.ratio
+        device = x.device
+        self._ensure_npu_c4_indexer(c4_indexer, device)
+        bs = x.shape[0]
+        is_prefill = (
+            forward_batch.forward_mode.is_extend()
+            and not forward_batch.forward_mode.is_target_verify()
+        )
+
+        q = self._compute_q_npu(c4_indexer, q_lora, forward_batch.positions)
+
+        weights, _ = c4_indexer.weights_proj(x)
+        weights = weights * (c4_indexer.softmax_scale * c4_indexer.n_heads**-0.5)
+
+        c4_indexer.compressor(x, forward_batch)
+
+        li_kv_dtype = getattr(c4_indexer.compressor, "li_kv_dtype", "bf16")
+        if li_kv_dtype == "int8":
+            # empty/idle rank: T=0 indexer kernel deadlocks; check is_idle, not .item() (host sync breaks graph capture, ACL 107027)
+            if bs == 0 or forward_batch.forward_mode.is_idle():
+                return torch.full(
+                    (bs, self._dsv4_index_topk),
+                    -1,
+                    dtype=torch.int32,
+                    device=device,
+                )
+            li_cmp_kv = forward_batch.token_to_kv_pool.get_compress_buffer(
+                c4_indexer.layer_id, True
+            )
+            li_kv_scale = (
+                forward_batch.token_to_kv_pool.get_compress_dequant_scale_buffer(
+                    c4_indexer.layer_id, True
+                )
+            )
+            return self._forward_npu_fused(
+                c4_indexer, q, li_cmp_kv, li_kv_scale, weights, forward_batch
+            )
+
+        # bf16 fallback: per-request einsum + topk, slow but architecture-faithful
+        seqlens_cpu = forward_batch.seq_lens_cpu
+        end_pos = forward_batch.seq_lens.cumsum(dim=0)
+        page_table = forward_batch.attn_backend.forward_metadata.c4_page_table
+        attn_tp_size = get_attention_tp_size()
+        topk_idxs: list[torch.Tensor] = []
+        for i, _end_token in enumerate(end_pos):
+            seq_i = int(seqlens_cpu[i])
+            kv_indices = _get_kv_indices(
+                forward_batch, seq_i // ratio, page_table, i, seq_i // ratio
+            )
+            kv_cache_value = forward_batch.token_to_kv_pool.get_compress_buffer(
+                c4_indexer.layer_id, True, kv_indices
+            )
+            if is_prefill:
+                start = 0 if i == 0 else int(end_pos[i - 1])
+                end = int(end_pos[i])
+                index_score = torch.einsum(
+                    "shd,td->sht",
+                    q[start:end, ...],
+                    kv_cache_value.squeeze(1),
+                )
+                index_score = (
+                    index_score.relu_() * weights.unsqueeze(-1)[start:end, ...]
+                ).sum(dim=1)
+                if attn_tp_size > 1 and getattr(c4_indexer, "enable_indexer_tp", False):
+                    get_attention_tp_group().all_reduce(index_score)
+                arange_kv = torch.arange(seq_i // ratio, device=device)
+                arange_q = torch.arange(1, seq_i + 1, device=device).unsqueeze(1)
+                causal = arange_kv.repeat(seq_i, 1) >= (arange_q // ratio)
+                index_score += torch.where(
+                    causal, float("-inf"), torch.zeros((), device=device)
+                )
+                topk_idx = index_score.topk(
+                    min(self._dsv4_index_topk, seq_i // ratio), dim=-1
+                )[1]
+                drop = topk_idx >= (
+                    torch.arange(1, seq_i + 1, device=device).unsqueeze(1) // ratio
+                )
+                topk_idx = torch.where(drop, -1, topk_idx)
+            else:
+                index_score = torch.einsum(
+                    "shd,td->sht",
+                    q[i : i + 1, ...],
+                    kv_cache_value.squeeze(1),
+                )
+                index_score = (index_score.relu_() * weights.unsqueeze(-1)[i]).sum(
+                    dim=1
+                )
+                topk_idx = index_score.topk(
+                    min(self._dsv4_index_topk, seq_i // ratio), dim=-1
+                )[1]
+            topk_idx = F.pad(
+                topk_idx,
+                (0, self._dsv4_index_topk - topk_idx.shape[-1]),
+                mode="constant",
+                value=-1,
+            )
+            topk_idxs.append(topk_idx)
+        return torch.cat(topk_idxs, dim=0).to(dtype=torch.int32)
+
+    def _ensure_npu_c4_indexer(self, c4_indexer, device: torch.device) -> None:
+        c4_indexer.compressor.li_kv_dtype = "int8"
+        if getattr(c4_indexer, "hadamard_matrix", None) is None:
+            H = _walsh_hadamard_matrix(c4_indexer.head_dim, torch.float32, device)
+            c4_indexer.register_buffer("hadamard_matrix", H, persistent=False)
+
+    def _compute_q_npu(
+        self, c4_indexer, q_lora: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        from sglang.srt.layers.deepseek_v4_rope import v4_rope_inplace_npu
+
+        bs = q_lora.shape[0]
+        q, _ = c4_indexer.wq_b(q_lora)
+        q = q.view(bs, c4_indexer.n_local_heads, c4_indexer.head_dim)
+        v4_rope_inplace_npu(
+            q[..., -c4_indexer.rope_head_dim :],
+            None,
+            c4_indexer.freqs_cis,
+            positions,
+        )
+        return _apply_hadamard(q, c4_indexer.hadamard_matrix)
+
+    def _forward_npu_fused(
+        self,
+        c4_indexer,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        k_scale: torch.Tensor,
+        weights: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        import torch_npu
+
+        q_int8, q_scale = torch_npu.npu_dynamic_quant(q)
+        fm = forward_batch.attn_backend.forward_metadata
+        li_quant_metadata = fm.kernel_metadata["li_quant_metadata"]
+        kwargs = dict(
+            query=q_int8,
+            key=k,
+            key_dequant_scale=k_scale.squeeze(-2),
+            actual_seq_lengths_query=fm.actual_seq_lengths_q,
+            actual_seq_lengths_key=fm.actual_seq_lengths_kv,
+            block_table=fm.c4_page_table,
+            layout_query="TND",
+            layout_key="PA_BSND",
+            weights=weights.to(torch.float16),
+            query_dequant_scale=q_scale.to(torch.float16),
+            cmp_ratio=4,
+            query_quant_mode=0,
+            key_quant_mode=0,
+            sparse_mode=3,
+            sparse_count=self._dsv4_index_topk,
+            metadata=li_quant_metadata,
+        )
+        topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(**kwargs)
+        return topk_idxs.view(-1, self._dsv4_index_topk)
+
+    def forward_c4_indexer(
+        self,
+        *,
+        x: torch.Tensor,
+        q_lora: torch.Tensor,
+        forward_batch: "ForwardBatch",
+        c4_indexer=None,
+        alt_streams=None,
+        enable_multi_stream: bool = False,
+        q_lora_ready=None,
+    ) -> None:
+        if forward_batch.forward_mode.is_idle():
+            return
+        topk_idxs = self.forward_c4_indexer_npu(c4_indexer, x, q_lora, forward_batch)
+        self.forward_metadata.c4_topk_indices = topk_idxs
+
+
+class DeepseekV4AscendAttnBackend(
+    AscendAttnBackend, C4IndexerAscendBackendMixin, CompressorAscendBackendMixin
+):
+
+    def __init__(
+        self,
+        model_runner: "ModelRunner",
+        speculative_step_id: int = 0,
+    ):
+        super().__init__(model_runner, speculative_step_id=speculative_step_id)
+        cfg = model_runner.model_config
+        self._dsv4_config = cfg
+        tp_size = get_attention_tp_size()
+        self._dsv4_q_head_num = cfg.num_attention_heads // tp_size
+        self._dsv4_kv_head_num = 1  # V4 MQA / latent
+        self._dsv4_head_dim = cfg.head_dim
+        hf = getattr(cfg, "hf_config", cfg)
+        self._dsv4_index_topk = hf.index_topk
+        self._dsv4_index_n_heads = hf.index_n_heads
+        self._dsv4_index_head_dim = hf.index_head_dim
+        self._dsv4_compress_ratios = hf.compress_ratios
+        self._dsv4_has_c4 = 4 in self._dsv4_compress_ratios
+        self._dsv4_has_c128 = 128 in self._dsv4_compress_ratios
+        self._dsv4_sliding_window_size = (
+            cfg.sliding_window_size if cfg.sliding_window_size is not None else 128
+        )
+
+    def _init_dsv4_graph_buffers(self, *, max_bs: int, max_num_tokens: int) -> None:
+        device = self.device
+        block_tables_shape = self.graph_metadata["block_tables"].shape
+        max_pages = block_tables_shape[1]
+
+        # -1 = invalid-page sentinel; full max_pages width avoids aclnnInplaceCopy 161002 at odd seq-len alignments
+        self.graph_metadata["swa_page_table"] = torch.full(
+            (max_bs, max_pages), -1, dtype=torch.int32, device=device
+        )
+
+        self.graph_metadata["c4_page_table"] = torch.full(
+            (max_bs, max_pages), -1, dtype=torch.int32, device=device
+        )
+        self.graph_metadata["c128_page_table"] = torch.full(
+            (max_bs, max_pages), -1, dtype=torch.int32, device=device
+        )
+        self.graph_metadata["c4_state_page_table"] = torch.zeros(
+            (max_bs, max_pages), dtype=torch.int32, device=device
+        )
+        self.graph_metadata["c128_state_page_table"] = torch.zeros(
+            (max_bs, max_pages), dtype=torch.int32, device=device
+        )
+
+        # 1024 int32 per kernel-metadata buffer (fixed op metadata size)
+        for key in (
+            "kernel_metadata_c1a",
+            "kernel_metadata_c4a",
+            "kernel_metadata_c128a",
+            "kernel_metadata_li_quant",
+        ):
+            self.graph_metadata[key] = torch.zeros(
+                1024, dtype=torch.int32, device=device
+            )
+
+        self.graph_metadata["c4_topk_indices"] = torch.full(
+            (max_num_tokens, self._dsv4_index_topk),
+            -1,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def init_forward_metadata_capture_cuda_graph(
+        self,
+        bs: int,
+        num_tokens: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: "ForwardMode",
+        spec_info: Optional["SpecInput"],
+    ):
+        super().init_forward_metadata_capture_cuda_graph(
+            bs=bs,
+            num_tokens=num_tokens,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            encoder_lens=encoder_lens,
+            forward_mode=forward_mode,
+            spec_info=spec_info,
+        )
+        metadata = self.graph_metadata[bs]
+        device = self.device
+
+        if (
+            forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
+            or forward_mode.is_draft_extend()
+        ):
+            tokens_per_bs = self.speculative_num_draft_tokens
+        else:
+            tokens_per_bs = 1
+
+        metadata.actual_seq_lengths_q_pa = torch.arange(
+            0,
+            bs * tokens_per_bs + tokens_per_bs,
+            tokens_per_bs,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        # init >=1 so the captured kernel records valid attention work; replay overwrites in-place
+        metadata.actual_seq_lengths_kv = torch.ones(
+            bs,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        metadata.swa_page_table = self.graph_metadata["swa_page_table"][:bs, :]
+        metadata.c4_page_table = self.graph_metadata["c4_page_table"][:bs, :]
+        metadata.c128_page_table = self.graph_metadata["c128_page_table"][:bs, :]
+        metadata.c4_state_page_table = self.graph_metadata["c4_state_page_table"][
+            :bs, :
+        ]
+        metadata.c128_state_page_table = self.graph_metadata["c128_state_page_table"][
+            :bs, :
+        ]
+
+        n_tok = bs * tokens_per_bs
+        metadata.swa_loc = torch.zeros(n_tok, dtype=torch.int64, device=device)
+        metadata.c4_loc = torch.zeros(n_tok, dtype=torch.int64, device=device)
+        metadata.c128_loc = torch.zeros(n_tok, dtype=torch.int64, device=device)
+        metadata.c4_state_loc = torch.zeros(n_tok, dtype=torch.int64, device=device)
+        metadata.c128_state_loc = torch.zeros(n_tok, dtype=torch.int64, device=device)
+
+        c4_pad = min(n_tok, n_tok // 4 + bs)
+        c128_pad = min(n_tok, n_tok // 128 + bs)
+        metadata.positions_cmp_padding_c4 = torch.zeros(
+            c4_pad, dtype=torch.int64, device=device
+        )
+        metadata.positions_cmp_padding_c128 = torch.zeros(
+            c128_pad, dtype=torch.int64, device=device
+        )
+        metadata.start_pos = torch.zeros(bs, dtype=torch.int32, device=device)
+        metadata.seqused = torch.zeros(bs, dtype=torch.int32, device=device)
+
+        metadata.kernel_metadata = {
+            "c1a_metadata": self.graph_metadata["kernel_metadata_c1a"],
+            "c4a_metadata": self.graph_metadata["kernel_metadata_c4a"],
+            "c128a_metadata": self.graph_metadata["kernel_metadata_c128a"],
+            "li_quant_metadata": self.graph_metadata["kernel_metadata_li_quant"],
+        }
+
+        T = bs * tokens_per_bs
+        metadata.c4_topk_indices = self.graph_metadata["c4_topk_indices"][:T, :]
+
+        self.forward_metadata = metadata
+
+    def init_forward_metadata_replay_cuda_graph(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_sum: int,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: "ForwardMode",
+        spec_info: Optional["SpecInput"],
+        seq_lens_cpu: Optional[torch.Tensor],
+    ):
+        super().init_forward_metadata_replay_cuda_graph(
+            bs=bs,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            seq_lens_sum=seq_lens_sum,
+            encoder_lens=encoder_lens,
+            forward_mode=forward_mode,
+            spec_info=spec_info,
+            seq_lens_cpu=seq_lens_cpu,
+        )
+        fm = self.forward_metadata
+
+        forward_batch = getattr(self, "_replay_forward_batch", None)
+        if forward_batch is None:
+            raise RuntimeError(
+                "V4 graph replay called without a forward_batch — "
+                "cuda_graph_runner.replay_prepare must set "
+                "attn_backend._replay_forward_batch before calling replay_cuda_graph."
+            )
+
+        if (
+            forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
+            or forward_mode.is_draft_extend()
+        ):
+            tokens_per_bs = self.speculative_num_draft_tokens
+        else:
+            tokens_per_bs = 1
+
+        assert seq_lens_cpu is not None, (
+            "V4 graph replay requires seq_lens_cpu — buffers.seq_lens is stale on "
+            "NPU (Graph.update only refreshes fm.actual_seq_lengths_kv inside the "
+            "captured graph, not the device-side buffers.seq_lens)."
+        )
+        live_seq_lens = seq_lens_cpu[:bs].to(device=seq_lens.device, dtype=torch.int32)
+        fm.actual_seq_lengths_kv.copy_(live_seq_lens.clamp(min=1))
+
+        pool = forward_batch.token_to_kv_pool
+        req_to_token = forward_batch.req_to_token_pool.req_to_token
+        out_cache_loc = forward_batch.out_cache_loc
+        device = seq_lens.device
+
+        result = self._compute_compress_locs(
+            pool=pool,
+            req_to_token=req_to_token,
+            req_pool_indices=req_pool_indices[:bs],
+            seq_lens=live_seq_lens,
+            out_cache_loc=out_cache_loc,
+            is_decode=forward_mode.is_decode(),
+            bs=bs,
+            device=device,
+            req_to_token_pool=forward_batch.req_to_token_pool,
+            out_cache_loc_dsv4=forward_batch.out_cache_loc_dsv4,
+            is_graph=True,
+        )
+
+        def _copy_2d(dst: torch.Tensor, src: torch.Tensor, val: int) -> None:
+            dst.fill_(val)
+            dst[: src.shape[0], : src.shape[1]].copy_(src)
+
+        def _copy_1d(dst: torch.Tensor, src: torch.Tensor) -> None:
+            dst.fill_(0)
+            dst[: src.shape[0]].copy_(src)
+
+        for key in (
+            "c4_page_table",
+            "c128_page_table",
+            "c4_state_page_table",
+            "c128_state_page_table",
+        ):
+            if key in result:
+                _copy_2d(getattr(fm, key), result[key], 0 if "state" in key else -1)
+        for key in ("c4_loc", "c128_loc", "c4_state_loc", "c128_state_loc"):
+            if key in result:
+                _copy_1d(getattr(fm, key), result[key])
+
+        for key in (
+            "positions_cmp_padding_c4",
+            "positions_cmp_padding_c128",
+            "start_pos",
+            "seqused",
+        ):
+            if key in result and hasattr(fm, key) and getattr(fm, key) is not None:
+                _copy_1d(getattr(fm, key), result[key])
+
+        swa_loc = pool.translate_loc_from_full_to_swa(out_cache_loc).to(torch.int64)
+        _copy_1d(fm.swa_loc, swa_loc)
+
+        swa_src = (
+            fm.block_tables_swa if fm.block_tables_swa is not None else fm.block_tables
+        )
+        _copy_2d(fm.swa_page_table, swa_src, -1)
+        # base replay 0-pads the tail but page 0 is a real page; restore the -1 sentinel beyond valid pages
+        if bs > 0:
+            _spec = int(getattr(self, "speculative_num_draft_tokens", 0) or 0)
+            max_len = int(seq_lens_cpu[:bs].max()) + _spec
+            max_seq_pages = (max_len + self.page_size - 1) // self.page_size
+            if 0 < max_seq_pages < fm.swa_page_table.shape[1]:
+                fm.swa_page_table[:, max_seq_pages:].fill_(-1)
+
+        kernel_metadata_new = self._kernel_metadata_from_parts(
+            bs=bs,
+            actual_seq_lengths_q_pa=fm.actual_seq_lengths_q_pa,
+            actual_seq_lengths_kv=fm.actual_seq_lengths_kv,
+            block_tables=fm.block_tables,
+            max_seqlen_q=tokens_per_bs,
+            is_nextn=False,
+        )
+        for key in (
+            "c1a_metadata",
+            "c4a_metadata",
+            "c128a_metadata",
+            "li_quant_metadata",
+        ):
+            if key in kernel_metadata_new:
+                fm.kernel_metadata[key].copy_(kernel_metadata_new[key])
+
+        # -1 sentinel; the indexer overwrites valid rows each step
+        fm.c4_topk_indices.fill_(-1)
+
+        self.forward_metadata = fm
+
+    def init_forward_metadata(self, forward_batch: "ForwardBatch") -> None:
+        super().init_forward_metadata(forward_batch)
+        fm = self.forward_metadata
+
+        # idle DP-attention ranks: zero seq_lens trip the metadata kernel (AICPU 507018); skip and keep fields well-typed
+        if forward_batch.forward_mode.is_idle():
+            fm.actual_seq_lengths_q = None
+            fm.actual_seq_lengths_q_pa = None
+            fm.kernel_metadata = {}
+            return
+
+        device = forward_batch.seq_lens.device
+        # cu_seqlens_q must hold per-request QUERY token counts, not KV lens (KV lens here caused decode divergence)
+        if forward_batch.forward_mode.is_extend():
+            seq_lens_cpu = forward_batch.extend_seq_lens_cpu
+            if isinstance(seq_lens_cpu, list):
+                seq_lens_cpu = torch.tensor(seq_lens_cpu, dtype=torch.int32)
+            else:
+                seq_lens_cpu = seq_lens_cpu.int()
+            actual_q = torch.cumsum(seq_lens_cpu, dim=0).int().to(device)
+            fm.actual_seq_lengths_q = actual_q
+            fm.actual_seq_lengths_q_pa = torch.cat(
+                [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
+                dim=0,
+            )
+        elif forward_batch.forward_mode.is_decode():
+            B = forward_batch.batch_size
+            fm.actual_seq_lengths_q = torch.arange(
+                1, B + 1, dtype=torch.int32, device=device
+            )
+            fm.actual_seq_lengths_q_pa = torch.arange(
+                0, B + 1, dtype=torch.int32, device=device
+            )
+        elif (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
+        ):
+            B = forward_batch.batch_size
+            from sglang.srt.utils.common import get_global_server_args
+
+            n_draft = get_global_server_args().speculative_num_draft_tokens or 1
+            actual_q = torch.arange(
+                n_draft, B * n_draft + 1, n_draft, dtype=torch.int32, device=device
+            )
+            fm.actual_seq_lengths_q = actual_q
+            fm.actual_seq_lengths_q_pa = torch.cat(
+                [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
+                dim=0,
+            )
+        elif forward_batch.forward_mode.is_idle():
+            B = forward_batch.batch_size
+            fm.actual_seq_lengths_q = torch.arange(
+                1, B + 1, dtype=torch.int32, device=device
+            )
+            fm.actual_seq_lengths_q_pa = torch.arange(
+                0, B + 1, dtype=torch.int32, device=device
+            )
+            fm.actual_seq_lengths_kv = torch.ones(B, dtype=torch.int32, device=device)
+        else:
+            fm.actual_seq_lengths_q = None
+            fm.actual_seq_lengths_q_pa = None
+
+        fm.swa_page_table = (
+            fm.block_tables_swa if fm.block_tables_swa is not None else fm.block_tables
+        )
+
+        if fm.actual_seq_lengths_kv is None:
+            if fm.seq_lens_cpu_int is not None:
+                fm.actual_seq_lengths_kv = fm.seq_lens_cpu_int.to(
+                    device=forward_batch.seq_lens.device, dtype=torch.int32
+                )
+            else:
+                fm.actual_seq_lengths_kv = forward_batch.seq_lens.to(torch.int32)
+
+        fm.kernel_metadata = self._compute_kernel_metadata(forward_batch)
+
+        if self._dsv4_compress_ratios:
+            self._build_npu_compress_metadata(forward_batch)
+
+    def _compute_kernel_metadata(self, forward_batch: "ForwardBatch") -> dict:
+        fm = self.forward_metadata
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
+        ):
+            from sglang.srt.utils.common import get_global_server_args
+
+            max_seqlen_q = get_global_server_args().speculative_num_draft_tokens or 1
+        else:
+            max_seqlen_q = 1
+        return self._kernel_metadata_from_parts(
+            bs=forward_batch.batch_size,
+            actual_seq_lengths_q_pa=fm.actual_seq_lengths_q_pa,
+            actual_seq_lengths_kv=fm.actual_seq_lengths_kv,
+            block_tables=fm.block_tables,
+            max_seqlen_q=max_seqlen_q,
+            is_nextn=False,
+        )
+
+    def _kernel_metadata_from_parts(
+        self,
+        *,
+        bs: int,
+        actual_seq_lengths_q_pa: torch.Tensor,
+        actual_seq_lengths_kv: torch.Tensor,
+        block_tables: torch.Tensor,
+        max_seqlen_q: int,
+        is_nextn: bool,
+    ) -> dict:
+        common = {
+            "cu_seqlens_q": actual_seq_lengths_q_pa,
+            "seqused_kv": actual_seq_lengths_kv,
+            "cmp_ratio": 1,
+            "ori_mask_mode": 4,
+            "cmp_mask_mode": 3,
+            "ori_win_left": self._dsv4_sliding_window_size - 1,
+            "ori_win_right": 0,
+            "layout_q": "TND",
+            "layout_kv": "PA_ND",
+        }
+        base_kwargs = {
+            "batch_size": bs,
+            "num_heads_q": self._dsv4_q_head_num,
+            "num_heads_kv": self._dsv4_kv_head_num,
+            "head_dim": self._dsv4_head_dim,
+            "has_ori_kv": True,
+            "has_cmp_kv": False,
+        }
+        c1a_kwargs = base_kwargs | common
+        kernel_metadata = {
+            "c1a_metadata": torch.ops.custom.npu_sparse_attn_sharedkv_metadata(
+                **c1a_kwargs
+            )
+        }
+
+        if self._dsv4_has_c4:
+            c4a_overrides = {
+                "cmp_ratio": 4,
+                "has_cmp_kv": True,
+                "cmp_topk": self._dsv4_index_topk,
+            }
+            c4a_kwargs = c1a_kwargs | c4a_overrides
+            kernel_metadata["c4a_metadata"] = (
+                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c4a_kwargs)
+            )
+
+            if actual_seq_lengths_q_pa is not None:
+                # the indexer metadata op wants a fresh contiguous tensor without the leading 0
+                actual_q = actual_seq_lengths_q_pa[1:].clone()
+            else:
+                actual_q = actual_seq_lengths_kv
+            kernel_metadata["li_quant_metadata"] = (
+                torch.ops.custom.npu_quant_lightning_indexer_metadata(
+                    device=str(actual_q.device),
+                    actual_seq_lengths_query=actual_q,
+                    actual_seq_lengths_key=actual_seq_lengths_kv,
+                    layout_key="PA_BSND",
+                    sparse_count=self._dsv4_index_topk,
+                    sparse_mode=3,
+                    layout_query="TND",
+                    cmp_ratio=4,
+                    key_quant_mode=0,
+                    query_quant_mode=0,
+                    num_heads_q=self._dsv4_index_n_heads,
+                    num_heads_k=1,
+                    head_dim=self._dsv4_index_head_dim,
+                )
+            )
+
+        if self._dsv4_has_c128:
+            c128a_overrides = {"cmp_ratio": 128, "has_cmp_kv": True}
+            c128a_kwargs = c1a_kwargs | c128a_overrides
+            kernel_metadata["c128a_metadata"] = (
+                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c128a_kwargs)
+            )
+
+        return kernel_metadata
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: "RadixAttention",
+        forward_batch: "ForwardBatch",
+        *,
+        compress_ratio: int = 0,
+        attn_sink: Optional[torch.Tensor] = None,
+        save_kv_cache: bool = True,
+    ) -> torch.Tensor:
+        if compress_ratio not in (0, 4, 128):
+            raise ValueError(
+                f"V4 attention expects compress_ratio in (0, 4, 128); got {compress_ratio}"
+            )
+        # idle ranks only feed the MoE collectives; skip attn + store_cache and return zeros
+        if forward_batch.forward_mode.is_idle():
+            return torch.zeros_like(q)
+        # MQALayer prepass already stores K and passes save_kv_cache=False; True callers still get the write
+        if save_kv_cache:
+            self.store_cache(
+                layer_id=layer.layer_id, swa_k=k, forward_batch=forward_batch
+            )
+        if compress_ratio == 0:
+            return self._forward_dense(q, layer, forward_batch, attn_sink)
+        return self._forward_compressed(
+            q, layer, forward_batch, attn_sink, compress_ratio
+        )
+
+    def _forward_dense(
+        self,
+        q: torch.Tensor,
+        layer: "RadixAttention",
+        forward_batch: "ForwardBatch",
+        attn_sink: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        fm = self.forward_metadata
+        pool = forward_batch.token_to_kv_pool
+        ori_kv = pool.get_swa_buffer(layer.layer_id)
+
+        attn_kwargs = dict(
+            cu_seqlens_q=fm.actual_seq_lengths_q_pa,
+            seqused_kv=fm.actual_seq_lengths_kv,
+            ori_mask_mode=4,
+            ori_win_left=self._dsv4_sliding_window_size - 1,
+            ori_win_right=0,
+            layout_q="TND",
+            layout_kv="PA_ND",
+            q=q,
+            ori_kv=ori_kv,
+            ori_block_table=fm.swa_page_table,
+            sinks=attn_sink,
+            metadata=fm.kernel_metadata["c1a_metadata"],
+            softmax_scale=layer.scaling,
+        )
+        out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(**attn_kwargs)
+        return out
+
+    def _forward_compressed(
+        self,
+        q: torch.Tensor,
+        layer: "RadixAttention",
+        forward_batch: "ForwardBatch",
+        attn_sink: Optional[torch.Tensor],
+        compress_ratio: int,
+    ) -> torch.Tensor:
+        fm = self.forward_metadata
+        pool = forward_batch.token_to_kv_pool
+        metadata = fm.kernel_metadata.get(f"c{compress_ratio}a_metadata")
+        cmp_kv = pool.get_compress_buffer(layer.layer_id, False)
+
+        if metadata is None or cmp_kv is None:
+            raise RuntimeError(
+                "DeepseekV4AscendAttnBackend._forward_compressed: missing "
+                f"required state for layer_id={layer.layer_id} "
+                f"compress_ratio={compress_ratio}. "
+                f"metadata({'present' if metadata is not None else 'MISSING'}), "
+                f"cmp_kv({'present' if cmp_kv is not None else 'MISSING'}). "
+                f"Available kernel_metadata keys: {list(fm.kernel_metadata.keys())}. "
+                "This indicates a configuration / pool-init bug — silently "
+                "returning zeros would corrupt model output."
+            )
+
+        ori_kv = pool.get_swa_buffer(layer.layer_id)
+
+        ori_page_size = ori_kv.shape[1]
+        cmp_native_page_size = cmp_kv.shape[1]
+        cmp_block_table = getattr(fm, f"c{compress_ratio}_page_table")
+        assert cmp_native_page_size == ori_page_size, (
+            f"cmp page_size={cmp_native_page_size} != ori page_size={ori_page_size}; "
+            "c{N}_kv_pool must be allocated with the global page_size on NPU "
+            "(see NPUDeepSeekV4SingleKVPool.kernel_page_size)"
+        )
+
+        attn_kwargs = dict(
+            cu_seqlens_q=fm.actual_seq_lengths_q_pa,
+            seqused_kv=fm.actual_seq_lengths_kv,
+            ori_mask_mode=4,
+            ori_win_left=self._dsv4_sliding_window_size - 1,
+            ori_win_right=0,
+            layout_q="TND",
+            layout_kv="PA_ND",
+            q=q,
+            ori_kv=ori_kv,
+            ori_block_table=fm.swa_page_table,
+            sinks=attn_sink,
+            metadata=metadata,
+            softmax_scale=layer.scaling,
+            cmp_ratio=compress_ratio,
+            cmp_mask_mode=3,
+            cmp_kv=cmp_kv,
+            cmp_block_table=cmp_block_table,
+        )
+        # c4 attends via indexer topk; c128 reads the full compressed history
+        if compress_ratio == 4:
+            topk = fm.c4_topk_indices
+            attn_kwargs["cmp_sparse_indices"] = topk.view(-1, 1, topk.shape[-1])
+        else:
+            attn_kwargs["cmp_sparse_indices"] = None
+        out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(**attn_kwargs)
+        return out
+
+    def store_cache(self, *, layer_id: int, swa_k: torch.Tensor, forward_batch):
+        pool = forward_batch.token_to_kv_pool
+        swa_loc = pool.translate_loc_from_full_to_swa(forward_batch.out_cache_loc)
+        pool.set_swa_buffer(
+            layer_id=layer_id,
+            loc=swa_loc,
+            cache=swa_k,
+        )
+
+
+def _get_kv_indices(
+    forward_batch: ForwardBatch,
+    kv_len: int,
+    page_table: torch.Tensor,
+    req_idx: int,
+    seqlen: int,
+) -> torch.Tensor:
+    logic_start = max(0, seqlen - kv_len)
+    logic_end = seqlen
+    page_size = forward_batch.attn_backend.page_size
+    if page_size == 1:
+        return page_table[req_idx, logic_start:logic_end]
+    logic_pos = torch.arange(logic_start, logic_end, device=page_table.device)
+    block_id = logic_pos // page_size
+    offset_in_block = logic_pos % page_size
+    return page_table[req_idx, block_id] * page_size + offset_in_block

--- a/python/sglang/srt/hardware_backend/npu/dsv4_allocator.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4_allocator.py
@@ -1,0 +1,632 @@
+"""DSV4-NPU SWA + c4/c128 paged allocator.
+
+Subclasses :class:`SWATokenToKVPoolAllocator` and adds paged allocation for the
+c4/c128 compressed-KV pools and their tail-only compress-state pools, alongside
+the parent's full + SWA pools.
+
+Per ``alloc_extend`` / ``alloc_decode``:
+  1. super() allocates the full + SWA slots (``out_full_loc``).
+  2. Allocate c4/c128 KV slots — one compressed token per ``ratio`` raw tokens
+     (``seq_len // ratio - prefix_len // ratio``) — via the standard
+     :class:`NPUPagedTokenToKVPoolAllocator` over the pool's c4/c128 KV buffers.
+  3. Allocate the c4/c128 compress-state slots the same way, tail-only per req,
+     using the per-req lens the scheduler packed into ``DSV4StateLens``.
+  4. Return a :class:`DSV4OutCacheLoc` bundling all five slot families.
+
+State slots are paged because the NPU fused compressor runs ``cache_mode=1``; the
+base class' ``translate_kv_loc_to_compress_state_loc`` ring-hash is the CUDA-only
+path and is unused on NPU. The bundle is the explicit return value:
+mem_cache/common.py unpacks ``out_full_loc`` and stashes the bundle on
+``batch.out_cache_loc_dsv4``; ``DSV4NPUReqToTokenPool`` writes the per-req
+``req_to_token_c{4,128}[_state]`` tables that :meth:`free` and the last_loc
+lookups read back.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+
+import torch
+
+from sglang.srt.hardware_backend.npu.allocator_npu import NPUPagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+from sglang.srt.model_executor.forward_batch_info import DSV4OutCacheLoc, DSV4StateLens
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+
+
+def get_last_loc(
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    prefix_lens: torch.Tensor,
+) -> torch.Tensor:
+    """Slot id of each req's last already-allocated token, or -1 when
+    ``prefix_lens[i] == 0`` (fresh req).
+
+    Looks up ``req_to_token[req, prefix_lens - 1]`` to anchor the paged
+    allocator's ``alloc_extend`` on the real previous tail slot, preserving the
+    intra-page slot continuity the kernel's ``cmp_block_table`` relies on (the
+    allocator debug-asserts ``(last_loc + 1) % page_size == prefix_lens %
+    page_size``). Result dtype matches ``prefix_lens``.
+    """
+    req_pool_indices = req_pool_indices.to(torch.int64)
+    safe_idx = (prefix_lens.to(torch.int64) - 1).clamp(min=0)
+    looked_up = req_to_token[req_pool_indices, safe_idx].to(prefix_lens.dtype)
+    return torch.where(
+        prefix_lens > 0,
+        looked_up,
+        torch.full_like(prefix_lens, -1),
+    )
+
+
+class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
+    """SWA allocator + c4/c128 KV and compress-state paged allocators for DSV4 on NPU."""
+
+    def __init__(
+        self,
+        size: int,
+        size_swa: int,
+        page_size: int,
+        dtype: torch.dtype,
+        device: str,
+        kvcache,
+        need_sort: bool,
+    ):
+        super().__init__(
+            size=size,
+            size_swa=size_swa,
+            page_size=page_size,
+            dtype=dtype,
+            device=device,
+            kvcache=kvcache,
+            need_sort=need_sort,
+        )
+
+        def mk(pool_size, pool):
+            # The c4/c128 KV and state sub-pools implement KVCache, so they drop
+            # straight into the standard paged allocator. ``pool_size`` is in
+            # compressed-token (resp. state-slot) units; the allocator handles
+            # page-size granularity.
+            return NPUPagedTokenToKVPoolAllocator(
+                pool_size,
+                page_size=page_size,
+                dtype=dtype,
+                device=device,
+                kvcache=pool,
+                need_sort=need_sort,
+            )
+
+        self.c4_attn_allocator = mk(kvcache.c4_size, kvcache.c4_kv_pool)
+        self.c128_attn_allocator = mk(kvcache.c128_size, kvcache.c128_kv_pool)
+
+        # State allocators (paged, NPU-only). Any layer's pool works as the
+        # KVCache pointer — slot allocation is layer-agnostic; per-layer buffer
+        # access routes through DeepSeekV4TokenToKVPool.get_state_cache. Each is
+        # None when the model has no c{ratio} layers or a zero size budget.
+        self.c4_state_attn_allocator: Optional[NPUPagedTokenToKVPoolAllocator] = None
+        self.c128_state_attn_allocator: Optional[NPUPagedTokenToKVPoolAllocator] = None
+        state_pools = getattr(kvcache, "compress_state_pools", None)
+        if state_pools:
+
+            def first_state_pool(want_ratio):
+                return next(
+                    (
+                        p
+                        for r, p in zip(kvcache.compression_ratios, state_pools)
+                        if r == want_ratio and p is not None
+                    ),
+                    None,
+                )
+
+            c4_state_pool = first_state_pool(4)
+            c128_state_pool = first_state_pool(128)
+            if c4_state_pool is not None and kvcache.c4_state_pool_size > 0:
+                self.c4_state_attn_allocator = mk(
+                    kvcache.c4_state_pool_size, c4_state_pool
+                )
+            if c128_state_pool is not None and kvcache.c128_state_pool_size > 0:
+                self.c128_state_attn_allocator = mk(
+                    kvcache.c128_state_pool_size, c128_state_pool
+                )
+
+        # Returned by the c-pool helpers when a step adds no compressed tokens.
+        self._empty_loc = torch.empty((0,), dtype=torch.int64, device=device)
+
+        # Per-call handle to the DSV4NPUReqToTokenPool, stashed by alloc_extend/
+        # alloc_decode so the last_loc lookups can read req_to_token_c{4,128}
+        # [_state] without a permanent allocator->pool binding. None otherwise.
+        self._cur_req_to_token_pool = None
+
+    @staticmethod
+    def _compute_c_extend_counts(
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        ratio: int,
+    ) -> int:
+        """New compressed-K tokens this extend produces across the batch:
+        ``sum_i (seq_lens[i] // ratio - prefix_lens[i] // ratio)``."""
+        if prefix_lens_cpu is None or seq_lens_cpu is None:
+            return 0
+        diff = ((seq_lens_cpu // ratio) - (prefix_lens_cpu // ratio)).clamp(min=0)
+        return int(diff.sum().item())
+
+    @staticmethod
+    def _pool_exhausted(
+        ratio: int, kind: str, need: int, available: int
+    ) -> RuntimeError:
+        return RuntimeError(
+            f"DSV4 c{ratio} {kind} pool exhausted: need {need} new slots, "
+            f"available={available}. Raise --mem-fraction-static, lower "
+            f"--max-running-requests, or check that "
+            f"DSV4NPUTokenToKVPoolAllocator.free(req=...) releases {kind} slots "
+            f"on req finish."
+        )
+
+    def _alloc_state_extend(
+        self,
+        allocator: Optional[NPUPagedTokenToKVPoolAllocator],
+        raw_prefix_lens: torch.Tensor,
+        state_prefix_lens: torch.Tensor,
+        state_prefix_lens_cpu: torch.Tensor,
+        state_seq_lens: torch.Tensor,
+        state_seq_lens_cpu: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        last_loc_dtype: torch.dtype,
+        state_extend_num_tokens: int,
+        ratio: int,
+    ) -> torch.Tensor:
+        """Allocate tail-only state-pool slots for an extend at ``ratio``.
+
+        The state pool is a separate paged slot space; each req allocates only
+        its trailing window (cumulative lens precomputed by
+        ``ScheduleBatch._compute_dsv4_state_lens_*`` and passed via
+        ``DSV4StateLens``). ``state_last_loc`` is looked up from
+        ``req_to_token_c{ratio}_state`` at the RAW position
+        ``raw_prefix_lens - 1`` (the last position the previous extend/decode
+        populated). Returns ``_empty_loc`` when the allocator is absent (no
+        c{ratio} layers) or there is nothing to add.
+        """
+        if allocator is None or state_extend_num_tokens == 0:
+            return self._empty_loc
+
+        assert self._cur_req_to_token_pool is not None, (
+            "alloc_extend/alloc_decode must be called with req_to_token_pool= "
+            "for the state-pool last_loc lookup."
+        )
+        state_table = (
+            self._cur_req_to_token_pool.req_to_token_c4_state
+            if ratio == 4
+            else self._cur_req_to_token_pool.req_to_token_c128_state
+        )
+        state_last_loc = get_last_loc(
+            state_table, req_pool_indices, raw_prefix_lens
+        ).to(last_loc_dtype)
+
+        result = allocator.alloc_extend(
+            state_prefix_lens,
+            state_prefix_lens_cpu,
+            state_seq_lens,
+            state_seq_lens_cpu,
+            state_last_loc,
+            state_extend_num_tokens,
+        )
+        if result is None:
+            raise self._pool_exhausted(
+                ratio, "state", state_extend_num_tokens, allocator.available_size()
+            )
+        return result
+
+    def _alloc_c_extend(
+        self,
+        allocator: NPUPagedTokenToKVPoolAllocator,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        last_loc_dtype: torch.dtype,
+        ratio: int,
+    ) -> torch.Tensor:
+        """Allocate compressed-KV slots for an extend at ``ratio``.
+
+        Prefix/seq lens are translated to compressed units (``// ratio``); the
+        c-pool last_loc comes from ``req_to_token_c{ratio}`` via
+        :func:`get_last_loc` so the paged allocator continues in-page (or opens
+        a fresh page at a ratio boundary), keeping the intra-page continuity the
+        ``cmp_block_table`` reader relies on. Returns ``_empty_loc`` when this
+        step closes no compressed token.
+        """
+        c_extend = self._compute_c_extend_counts(prefix_lens_cpu, seq_lens_cpu, ratio)
+        if c_extend == 0:
+            return self._empty_loc
+
+        assert self._cur_req_to_token_pool is not None, (
+            "alloc_extend/alloc_decode must be called with req_to_token_pool= "
+            "for the c-pool last_loc lookup."
+        )
+        c_table = (
+            self._cur_req_to_token_pool.req_to_token_c4
+            if ratio == 4
+            else self._cur_req_to_token_pool.req_to_token_c128
+        )
+        c_prefix = (prefix_lens // ratio).to(prefix_lens.dtype)
+        c_seq = (seq_lens // ratio).to(seq_lens.dtype)
+        c_last_loc = get_last_loc(c_table, req_pool_indices, c_prefix).to(
+            last_loc_dtype
+        )
+
+        result = allocator.alloc_extend(
+            c_prefix,
+            prefix_lens_cpu // ratio,
+            c_seq,
+            seq_lens_cpu // ratio,
+            c_last_loc,
+            c_extend,
+        )
+        if result is None:
+            raise self._pool_exhausted(
+                ratio, "KV", c_extend, allocator.available_size()
+            )
+        return result
+
+    def _alloc_c_and_state(
+        self,
+        out_full_loc: torch.Tensor,
+        out_swa_loc: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc_dtype: torch.dtype,
+        req_pool_indices: Optional[torch.Tensor],
+        dsv4_state_lens: Optional[DSV4StateLens],
+    ) -> DSV4OutCacheLoc:
+        """Allocate c4/c128 KV + state slots and bundle them with full/swa loc.
+
+        Shared by alloc_extend / alloc_decode (which differ only in how
+        prefix_lens is derived). State lens are tail-only, precomputed by
+        ScheduleBatch._compute_dsv4_state_lens_*; raw prefix_lens drives the
+        state last_loc lookup.
+        """
+        assert req_pool_indices is not None, (
+            "DSV4NPUTokenToKVPoolAllocator requires req_pool_indices "
+            "(forwarded from batch.req_pool_indices)."
+        )
+        assert dsv4_state_lens is not None, (
+            "DSV4NPUTokenToKVPoolAllocator requires dsv4_state_lens "
+            "(ScheduleBatch._compute_dsv4_state_lens_*)."
+        )
+        out_c4_loc = self._alloc_c_extend(
+            self.c4_attn_allocator,
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            req_pool_indices,
+            last_loc_dtype,
+            ratio=4,
+        )
+        out_c128_loc = self._alloc_c_extend(
+            self.c128_attn_allocator,
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            req_pool_indices,
+            last_loc_dtype,
+            ratio=128,
+        )
+        out_c4_state_loc = self._alloc_state_extend(
+            self.c4_state_attn_allocator,
+            prefix_lens,
+            dsv4_state_lens.c4_prefix_lens,
+            dsv4_state_lens.c4_prefix_lens_cpu,
+            dsv4_state_lens.c4_seq_lens,
+            dsv4_state_lens.c4_seq_lens_cpu,
+            req_pool_indices,
+            last_loc_dtype,
+            dsv4_state_lens.c4_extend_num_tokens,
+            ratio=4,
+        )
+        out_c128_state_loc = self._alloc_state_extend(
+            self.c128_state_attn_allocator,
+            prefix_lens,
+            dsv4_state_lens.c128_prefix_lens,
+            dsv4_state_lens.c128_prefix_lens_cpu,
+            dsv4_state_lens.c128_seq_lens,
+            dsv4_state_lens.c128_seq_lens_cpu,
+            req_pool_indices,
+            last_loc_dtype,
+            dsv4_state_lens.c128_extend_num_tokens,
+            ratio=128,
+        )
+        return DSV4OutCacheLoc(
+            out_full_loc=out_full_loc,
+            out_swa_loc=out_swa_loc,
+            out_c4_loc=out_c4_loc,
+            out_c128_loc=out_c128_loc,
+            out_c4_state_loc=out_c4_state_loc,
+            out_c128_state_loc=out_c128_state_loc,
+        )
+
+    def compute_dsv4_state_lens_extend(
+        self, reqs: List["Req"], seq_lens: List[int]
+    ) -> Optional[DSV4StateLens]:
+        """Per-req c{4,128}_state pool alloc lens for extend (tail-only).
+
+        State pool stores only the trailing portion of each sequence (the c{N}
+        compressor's read/write window); the tail length depends on raw
+        seq_len's alignment to the SWA page boundary (128)::
+
+            c4_alloc_len  = tail + 128 if (tail <= 3 and seq_len >= 128) else tail
+            c128_alloc_len = tail                  where tail = seq_len % 128
+
+        Long prefills allocate only the trailing partial window, not slots for
+        already-compressed positions, so the small paged state pool (~256
+        slots/req) stays sufficient even for 28k-token prompts.
+
+        Mutates per-req cumulative state via getattr/setattr so the community
+        ``Req`` needs no DSV4 field declarations:
+          * ``req.c{4,128}_state_kv_len`` — cumulative slot count (prefix for
+            the paged allocator; never decreases on eviction).
+          * ``req.c{4,128}_state_alloc_offset`` — low-water raw-position mark
+            for eviction (see ``dsv4_common_hooks.maybe_evict_dsv4_state``).
+
+        Returns None when this model has no paged state pools (CUDA / non-V4 /
+        zero budget) — callers pass that straight through as ``dsv4_state_lens``.
+        Reference: iforgetmyname/sglang dsv4_release schedule_batch.py L1742-1747.
+        """
+        if self.c4_state_attn_allocator is None:
+            return None
+        c4_prefix: List[int] = []
+        c4_seq: List[int] = []
+        c128_prefix: List[int] = []
+        c128_seq: List[int] = []
+        for req, seq_len in zip(reqs, seq_lens):
+            tail = seq_len % 128
+            c4_alloc_len = tail + 128 if (tail <= 3 and seq_len >= 128) else tail
+            c128_alloc_len = tail
+
+            prev_c4 = getattr(req, "c4_state_kv_len", 0)
+            prev_c128 = getattr(req, "c128_state_kv_len", 0)
+            new_c4 = prev_c4 + c4_alloc_len
+            new_c128 = prev_c128 + c128_alloc_len
+
+            c4_prefix.append(prev_c4)
+            c4_seq.append(new_c4)
+            c128_prefix.append(prev_c128)
+            c128_seq.append(new_c128)
+
+            req.c4_state_kv_len = new_c4
+            req.c128_state_kv_len = new_c128
+            req.c4_state_alloc_offset = seq_len - c4_alloc_len
+            req.c128_state_alloc_offset = seq_len - c128_alloc_len
+
+        return self._pack_state_lens(
+            c4_prefix,
+            c4_seq,
+            c128_prefix,
+            c128_seq,
+            c4_extend_num_tokens=int(sum(s - p for s, p in zip(c4_seq, c4_prefix))),
+            c128_extend_num_tokens=int(
+                sum(s - p for s, p in zip(c128_seq, c128_prefix))
+            ),
+        )
+
+    def compute_dsv4_state_lens_decode(
+        self, reqs: List["Req"]
+    ) -> Optional[DSV4StateLens]:
+        """Per-req c{4,128}_state pool alloc lens for decode: exactly 1 new
+        state slot per req per pool. ``c{N}_state_alloc_offset`` does NOT
+        advance here (only eviction advances it). Returns None when there are
+        no paged state pools."""
+        if self.c4_state_attn_allocator is None:
+            return None
+        c4_prefix: List[int] = []
+        c4_seq: List[int] = []
+        c128_prefix: List[int] = []
+        c128_seq: List[int] = []
+        for req in reqs:
+            prev_c4 = getattr(req, "c4_state_kv_len", 0)
+            prev_c128 = getattr(req, "c128_state_kv_len", 0)
+            c4_prefix.append(prev_c4)
+            c4_seq.append(prev_c4 + 1)
+            c128_prefix.append(prev_c128)
+            c128_seq.append(prev_c128 + 1)
+            req.c4_state_kv_len = prev_c4 + 1
+            req.c128_state_kv_len = prev_c128 + 1
+
+        bs = len(reqs)
+        return self._pack_state_lens(
+            c4_prefix,
+            c4_seq,
+            c128_prefix,
+            c128_seq,
+            c4_extend_num_tokens=bs,
+            c128_extend_num_tokens=bs,
+        )
+
+    def _pack_state_lens(
+        self,
+        c4_prefix: List[int],
+        c4_seq: List[int],
+        c128_prefix: List[int],
+        c128_seq: List[int],
+        *,
+        c4_extend_num_tokens: int,
+        c128_extend_num_tokens: int,
+    ) -> DSV4StateLens:
+        c4_prefix_cpu = torch.tensor(c4_prefix, dtype=torch.int64)
+        c4_seq_cpu = torch.tensor(c4_seq, dtype=torch.int64)
+        c128_prefix_cpu = torch.tensor(c128_prefix, dtype=torch.int64)
+        c128_seq_cpu = torch.tensor(c128_seq, dtype=torch.int64)
+        return DSV4StateLens(
+            c4_prefix_lens=c4_prefix_cpu.to(self.device, non_blocking=True),
+            c4_prefix_lens_cpu=c4_prefix_cpu,
+            c4_seq_lens=c4_seq_cpu.to(self.device, non_blocking=True),
+            c4_seq_lens_cpu=c4_seq_cpu,
+            c4_extend_num_tokens=c4_extend_num_tokens,
+            c128_prefix_lens=c128_prefix_cpu.to(self.device, non_blocking=True),
+            c128_prefix_lens_cpu=c128_prefix_cpu,
+            c128_seq_lens=c128_seq_cpu.to(self.device, non_blocking=True),
+            c128_seq_lens_cpu=c128_seq_cpu,
+            c128_extend_num_tokens=c128_extend_num_tokens,
+        )
+
+    def alloc_extend(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        *,
+        req_pool_indices: Optional[torch.Tensor] = None,
+        dsv4_state_lens: Optional[DSV4StateLens] = None,
+        req_to_token_pool=None,
+    ) -> Optional[DSV4OutCacheLoc]:
+        # Stash the per-req tables for this call's last_loc lookups (read by
+        # _alloc_c_extend / _alloc_state_extend); no permanent allocator->pool ref.
+        self._cur_req_to_token_pool = req_to_token_pool
+        out_full_loc = super().alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if out_full_loc is None:
+            return None
+
+        out_swa_loc = self.translate_loc_from_full_to_swa(out_full_loc)
+        assert out_swa_loc is not None, (
+            "translate_loc_from_full_to_swa returned None — "
+            "full_to_swa_index_mapping not initialized?"
+        )
+        return self._alloc_c_and_state(
+            out_full_loc,
+            out_swa_loc,
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc.dtype,
+            req_pool_indices,
+            dsv4_state_lens,
+        )
+
+    def alloc_decode(
+        self,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        *,
+        req_pool_indices: Optional[torch.Tensor] = None,
+        dsv4_state_lens: Optional[DSV4StateLens] = None,
+        req_to_token_pool=None,
+    ) -> Optional[DSV4OutCacheLoc]:
+        self._cur_req_to_token_pool = req_to_token_pool
+        out_full_loc = super().alloc_decode(seq_lens, seq_lens_cpu, last_loc)
+        if out_full_loc is None:
+            return None
+
+        out_swa_loc = self.translate_loc_from_full_to_swa(out_full_loc)
+        # One new token per req; a compressed token closes when seq_len % ratio
+        # == 0. Model as an extend from (seq_len-1)//ratio to seq_len//ratio so
+        # _alloc_c_extend anchors on the real c-pool last_loc.
+        prefix_lens = (seq_lens - 1).clamp(min=0)
+        prefix_lens_cpu = (seq_lens_cpu - 1).clamp(min=0)
+        return self._alloc_c_and_state(
+            out_full_loc,
+            out_swa_loc,
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc.dtype,
+            req_pool_indices,
+            dsv4_state_lens,
+        )
+
+    def free(
+        self,
+        free_index: Optional[torch.Tensor] = None,
+        *,
+        req=None,
+        req_to_token_pool=None,
+    ):
+        """Unified free for full/swa/c4/c128 pools. Two forms (may co-fire):
+
+          * ``free(free_index)`` — full + SWA only (tail/radix eviction; no req
+            identity, so c-pool free can't run).
+          * ``free(req=, req_to_token_pool=)`` — from DSV4NPUReqToTokenPool.free
+            on req finish: reads the per-req slot lists from
+            ``req_to_token_c{4,128}[_state]`` and returns them to the c-pools
+            (the paged allocator dedupes by page).
+
+        KV pools free ``[0, kv_len // ratio)``. State pools are 1-per-raw-token
+        and free only the tail ``[c{N}_state_alloc_offset, kv_len)`` — the prefix
+        was already returned by ScheduleBatch._evict_swa (state rides SWA
+        eviction); freeing it again would double-free (caught by the paged
+        allocator's debug_mode assert, corrupts the free list otherwise).
+        """
+        if free_index is not None:
+            super().free(free_index)
+
+        if req is None or req_to_token_pool is None:
+            return
+        kv_len = req.kv_committed_len
+        req_pool_idx = req.req_pool_idx
+        if kv_len <= 0 or req_pool_idx is None:
+            return
+
+        # KV pools: free the leading [0, kv_len // ratio) compressed slots.
+        for ratio, allocator, table_attr in (
+            (4, self.c4_attn_allocator, "req_to_token_c4"),
+            (128, self.c128_attn_allocator, "req_to_token_c128"),
+        ):
+            n = kv_len // ratio
+            if n > 0 and hasattr(req_to_token_pool, table_attr):
+                slots = getattr(req_to_token_pool, table_attr)[req_pool_idx, :n]
+                # to int64 — paged allocator's free does cpu()//page_size on it.
+                allocator.free(slots.to(torch.int64))
+
+        # State pools: free only the tail [c{N}_state_alloc_offset, kv_len).
+        for ratio, allocator, table_attr, off_attr in (
+            (
+                4,
+                self.c4_state_attn_allocator,
+                "req_to_token_c4_state",
+                "c4_state_alloc_offset",
+            ),
+            (
+                128,
+                self.c128_state_attn_allocator,
+                "req_to_token_c128_state",
+                "c128_state_alloc_offset",
+            ),
+        ):
+            if allocator is None or not hasattr(req_to_token_pool, table_attr):
+                continue
+            off = getattr(req, off_attr, 0)
+            if kv_len > off:
+                slots = getattr(req_to_token_pool, table_attr)[req_pool_idx, off:kv_len]
+                allocator.free(slots.to(torch.int64))
+
+    def clear(self):
+        super().clear()
+        # SWATokenToKVPoolAllocator.__init__ calls clear() before our sub-
+        # allocators exist; getattr(..., None) tolerates that early call and the
+        # state allocators that stay None when the model has no c{ratio} layers.
+        for attr in (
+            "c4_attn_allocator",
+            "c128_attn_allocator",
+            "c4_state_attn_allocator",
+            "c128_state_attn_allocator",
+        ):
+            allocator = getattr(self, attr, None)
+            if allocator is not None:
+                allocator.clear()

--- a/python/sglang/srt/hardware_backend/npu/dsv4_common_hooks.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4_common_hooks.py
@@ -1,0 +1,366 @@
+"""Helpers used by mem_cache/common.py to wire DSV4-NPU per-req tables.
+
+mem_cache/common.py runs platform-agnostic alloc flow. When the model is
+DSV4 on NPU, ``alloc_paged_token_slots_{extend,decode}`` already stashed the
+:class:`DSV4OutCacheLoc` the allocator returned onto
+``batch.out_cache_loc_dsv4``. After each ``alloc_extend`` / ``alloc_decode``
+these hooks then:
+
+  1. Read the bundle from ``batch.out_cache_loc_dsv4``.
+  2. Write the per-pool slot ids into the per-req tables on the
+     :class:`DSV4NPUReqToTokenPool`.
+
+Non-DSV4 paths leave ``batch.out_cache_loc_dsv4`` None, so this module is a
+no-op for them.
+
+TODO: the disagg DSV4 path bypasses these hooks — it calls
+``allocator.alloc_extend`` directly then ``req_to_token_pool.write`` without
+going through ``mem_cache/common.py`` (see ``disaggregation/decode.py``). The
+DSV4OutCacheLoc bundle is still produced but never written into the per-req
+tables, so disagg + DSV4 is unsupported here (c-pages leak). Fixing requires
+calling these hooks from disagg's per-req alloc loop, or moving the write
+into the allocator itself.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+
+
+def maybe_write_dsv4_extend(
+    batch: "ScheduleBatch",
+    req_pool_indices_cpu: torch.Tensor,
+    prefix_lens_cpu: torch.Tensor,
+    seq_lens_cpu: torch.Tensor,
+) -> None:
+    """Post-alloc_extend hook for DSV4. No-op when allocator/pool is not DSV4.
+
+    For each compressed pool (c4 / c128), spreads the flat
+    ``out_c{4,128}_loc`` tensor across requests using per-req extend
+    counts (``seq_lens[i] // ratio - prefix_lens[i] // ratio``) and writes
+    the resulting slot ids into ``req_to_token_c{4,128}[req, prefix:seq]``.
+
+    Also writes ``req_to_token_swa[req, prefix:seq]`` with the swa slots
+    derived from out_full_loc via the SWA index mapping.
+    """
+    # The DSV4 allocator returns the DSV4OutCacheLoc bundle, which
+    # mem_cache/common.py already stashed on batch.out_cache_loc_dsv4. Read it
+    # here (no allocator side-channel). None on CUDA / non-V4 paths → no-op.
+    bundle = batch.out_cache_loc_dsv4
+    if bundle is None:
+        return
+
+    req_to_token_pool = batch.req_to_token_pool
+    if not hasattr(req_to_token_pool, "write_c4"):
+        # Non-DSV4 ReqToTokenPool — should not happen if dispatch is wired
+        # correctly, but skip defensively.
+        return
+
+    # SWA writes: prefix..seq token positions, one slot per raw token.
+    _write_per_req_slice(
+        req_to_token_pool.write_swa,
+        req_pool_indices_cpu,
+        prefix_lens_cpu,
+        seq_lens_cpu,
+        bundle.out_swa_loc,
+        ratio=1,
+    )
+
+    # c4 / c128 writes: prefix//ratio .. seq//ratio compressed positions.
+    _write_per_req_slice(
+        req_to_token_pool.write_c4,
+        req_pool_indices_cpu,
+        prefix_lens_cpu,
+        seq_lens_cpu,
+        bundle.out_c4_loc,
+        ratio=4,
+    )
+    _write_per_req_slice(
+        req_to_token_pool.write_c128,
+        req_pool_indices_cpu,
+        prefix_lens_cpu,
+        seq_lens_cpu,
+        bundle.out_c128_loc,
+        ratio=128,
+    )
+
+    # c4_state / c128_state writes: tail-only. Bundle has length
+    # ``sum(c{N}_state_alloc_len_i)`` (NOT total raw extend tokens) per
+    # ScheduleBatch._compute_dsv4_state_lens_extend. Each req's slot ids go
+    # at raw positions ``[req.c{N}_state_alloc_offset, seq_len)`` —
+    # corresponds to the trailing window the compressor reads / writes.
+    if bundle.out_c4_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c4_state"
+    ):
+        _write_state_tail_per_req(
+            req_to_token_pool.write_c4_state,
+            req_pool_indices_cpu,
+            [getattr(r, "c4_state_alloc_offset", 0) for r in batch.reqs],
+            seq_lens_cpu,
+            bundle.out_c4_state_loc,
+        )
+    if bundle.out_c128_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c128_state"
+    ):
+        _write_state_tail_per_req(
+            req_to_token_pool.write_c128_state,
+            req_pool_indices_cpu,
+            [getattr(r, "c128_state_alloc_offset", 0) for r in batch.reqs],
+            seq_lens_cpu,
+            bundle.out_c128_state_loc,
+        )
+
+
+def maybe_write_dsv4_decode(
+    batch: "ScheduleBatch",
+    seq_lens_cpu: torch.Tensor,
+    token_per_req: int,
+) -> None:
+    """Post-alloc_decode hook for DSV4. Spreads the new token slot ids
+    (one per req for swa, gated by ratio boundary for c4/c128) into the
+    per-req tables on DSV4NPUReqToTokenPool.
+
+    ``seq_lens_cpu`` is the POST-decode seq len (already incremented by
+    ``token_per_req``); the new compressed tokens go at positions
+    ``[(old_seq) // ratio, (new_seq) // ratio)``.
+    """
+    # The DSV4 allocator returns the DSV4OutCacheLoc bundle, which
+    # mem_cache/common.py already stashed on batch.out_cache_loc_dsv4. Read it
+    # here (no allocator side-channel). None on CUDA / non-V4 paths → no-op.
+    bundle = batch.out_cache_loc_dsv4
+    if bundle is None:
+        return
+
+    req_to_token_pool = batch.req_to_token_pool
+    if not hasattr(req_to_token_pool, "write_c4"):
+        return
+
+    prefix_lens_cpu = (seq_lens_cpu - token_per_req).clamp(min=0)
+    req_pool_indices_cpu = batch.req_pool_indices.cpu()
+
+    _write_per_req_slice(
+        req_to_token_pool.write_swa,
+        req_pool_indices_cpu,
+        prefix_lens_cpu,
+        seq_lens_cpu,
+        bundle.out_swa_loc,
+        ratio=1,
+    )
+    _write_per_req_slice(
+        req_to_token_pool.write_c4,
+        req_pool_indices_cpu,
+        prefix_lens_cpu,
+        seq_lens_cpu,
+        bundle.out_c4_loc,
+        ratio=4,
+    )
+    _write_per_req_slice(
+        req_to_token_pool.write_c128,
+        req_pool_indices_cpu,
+        prefix_lens_cpu,
+        seq_lens_cpu,
+        bundle.out_c128_loc,
+        ratio=128,
+    )
+
+    # State table decode writes: one slot per raw decode token (ratio=1).
+    if bundle.out_c4_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c4_state"
+    ):
+        _write_per_req_slice(
+            req_to_token_pool.write_c4_state,
+            req_pool_indices_cpu,
+            prefix_lens_cpu,
+            seq_lens_cpu,
+            bundle.out_c4_state_loc,
+            ratio=1,
+        )
+    if bundle.out_c128_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c128_state"
+    ):
+        _write_per_req_slice(
+            req_to_token_pool.write_c128_state,
+            req_pool_indices_cpu,
+            prefix_lens_cpu,
+            seq_lens_cpu,
+            bundle.out_c128_state_loc,
+            ratio=1,
+        )
+
+
+def _write_per_req(
+    write_fn,
+    req_pool_indices_cpu: torch.Tensor,
+    flat_loc: torch.Tensor,
+    bounds_fn,
+) -> None:
+    """Distribute a flat ``[total_alloc]`` slot tensor across reqs.
+
+    ``bounds_fn(i) -> (lo, hi)`` gives req i's write window; the matching
+    ``hi - lo`` slots are sliced off ``flat_loc`` in order and written via
+    ``write_fn((req_idx, slice(lo, hi)), values)``. flat_loc may be None /
+    empty when the alloc path bypassed DSV4NPUTokenToKVPoolAllocator (e.g.
+    page_size=1 or HiSparse wrapper); skip then.
+    """
+    if flat_loc is None or flat_loc.numel() == 0:
+        return
+    pt = 0
+    for i in range(req_pool_indices_cpu.shape[0]):
+        lo, hi = bounds_fn(i)
+        alloc_len = max(0, hi - lo)
+        if alloc_len == 0:
+            continue
+        req_idx = int(req_pool_indices_cpu[i].item())
+        chunk = flat_loc[pt : pt + alloc_len].to(torch.int32)
+        write_fn((req_idx, slice(lo, hi)), chunk)
+        pt += alloc_len
+
+
+def _write_state_tail_per_req(
+    write_fn,
+    req_pool_indices_cpu: torch.Tensor,
+    state_alloc_offsets: list,
+    seq_lens_cpu: torch.Tensor,
+    flat_loc: torch.Tensor,
+) -> None:
+    """Tail-only state write: req i's slots go at ``[state_alloc_offsets[i],
+    seq_lens[i])`` in ``req_to_token_c{N}_state``."""
+    _write_per_req(
+        write_fn,
+        req_pool_indices_cpu,
+        flat_loc,
+        lambda i: (int(state_alloc_offsets[i]), int(seq_lens_cpu[i].item())),
+    )
+
+
+def _write_per_req_slice(
+    write_fn,
+    req_pool_indices_cpu: torch.Tensor,
+    prefix_lens_cpu: torch.Tensor,
+    seq_lens_cpu: torch.Tensor,
+    flat_loc: torch.Tensor,
+    ratio: int,
+) -> None:
+    """Compressed-position write: req i's slots go at
+    ``[prefix_lens[i] // ratio, seq_lens[i] // ratio)``."""
+    _write_per_req(
+        write_fn,
+        req_pool_indices_cpu,
+        flat_loc,
+        lambda i: (
+            int(prefix_lens_cpu[i].item()) // ratio,
+            int(seq_lens_cpu[i].item()) // ratio,
+        ),
+    )
+
+
+def maybe_evict_dsv4_state(batch: "ScheduleBatch", req: "Req", pre_len: int) -> None:
+    """Per-decode evict for the DSV4-NPU compress-state pools, independent of
+    SWA evict cadence. Called every decode step from ``ScheduleBatch``.
+
+    The state pool is small (~2 pages c4 / ~3 pages c128 of raw positions per
+    req) — with a large sliding_window (SWA evict fires every
+    ``eviction_interval`` and needs ``pre_len > sliding_window + page_size`` to
+    free anything) the pool exhausts before the first SWA frontier advance, so
+    we drain it here on its own cadence.
+
+    Retention windows (kernel read window + decode lookahead margin) mirror
+    reference (iforgetmyname/sglang dsv4_release chunk_cache.py:140-144):
+    c4 = 8 + 16, c128 = 128 + 64 raw positions — intentionally smaller than one
+    SWA page so the first eviction fires before the small pool fills. Watermarks
+    are page-aligned so freed slots are whole pages reclaimable by the paged
+    allocator. ``req.c{4,128}_state_alloc_offset`` (read/written via getattr/
+    setattr) is the low-water mark. No-op on non-DSV4-NPU paths.
+    """
+    allocator = batch.token_to_kv_pool_allocator
+    pool = batch.req_to_token_pool
+    if not hasattr(allocator, "c4_state_attn_allocator") or (
+        allocator.c4_state_attn_allocator is None
+        and allocator.c128_state_attn_allocator is None
+    ):
+        return
+
+    page_size = batch.tree_cache.page_size
+    c4_watermark = ((max(0, pre_len - (8 + 16))) // page_size) * page_size
+    c128_watermark = ((max(0, pre_len - (128 + 64))) // page_size) * page_size
+
+    _free_state_range(
+        allocator.c4_state_attn_allocator,
+        pool,
+        "req_to_token_c4_state",
+        req,
+        "c4_state_alloc_offset",
+        c4_watermark,
+    )
+    _free_state_range(
+        allocator.c128_state_attn_allocator,
+        pool,
+        "req_to_token_c128_state",
+        req,
+        "c128_state_alloc_offset",
+        c128_watermark,
+    )
+
+
+def maybe_evict_dsv4_state_on_swa(
+    batch: "ScheduleBatch", req: "Req", new_swa_evicted_seqlen: int
+) -> None:
+    """Free compress-state slots that ride along with SWA eviction.
+
+    State at raw positions < ``swa_evicted_seqlen`` is no longer readable (the
+    compressor only reads the trailing ``2*ratio`` window) and is returned to
+    its paged allocator to keep the small state pool from exhausting on long
+    generations. Mirrors reference chunk_cache state eviction. No-op when the
+    DSV4-NPU state allocators are absent.
+
+    This path is needed for small-sliding-window models where
+    ``sliding_window < retention`` (e.g. c128 retention 192 > window 128):
+    in that case the watermark-based eviction alone may not free slots
+    fast enough, and the SWA-ride eviction is the primary reclaim mechanism.
+    For typical large-window models (DS-V4 with window >> 192), the
+    watermark eviction always runs first, making this path a no-op.
+    """
+    allocator = batch.token_to_kv_pool_allocator
+    pool = batch.req_to_token_pool
+    if not hasattr(allocator, "c4_state_attn_allocator"):
+        return
+    _free_state_range(
+        allocator.c4_state_attn_allocator,
+        pool,
+        "req_to_token_c4_state",
+        req,
+        "c4_state_alloc_offset",
+        new_swa_evicted_seqlen,
+    )
+    _free_state_range(
+        allocator.c128_state_attn_allocator,
+        pool,
+        "req_to_token_c128_state",
+        req,
+        "c128_state_alloc_offset",
+        new_swa_evicted_seqlen,
+    )
+
+
+def _free_state_range(
+    state_allocator,
+    pool,
+    table_attr: str,
+    req: "Req",
+    offset_attr: str,
+    watermark: int,
+) -> None:
+    """Free ``[alloc_offset, watermark)`` raw-position state slots for ``req``
+    and advance its low-water mark. No-op when the allocator/table is absent or
+    the watermark hasn't advanced past the current offset."""
+    offset = getattr(req, offset_attr, 0)
+    if state_allocator is None or not hasattr(pool, table_attr) or watermark <= offset:
+        return
+    free_slots = getattr(pool, table_attr)[req.req_pool_idx, offset:watermark]
+    state_allocator.free(free_slots.to(torch.int64))
+    setattr(req, offset_attr, watermark)

--- a/python/sglang/srt/hardware_backend/npu/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4_memory_pool.py
@@ -1,0 +1,621 @@
+"""NPU-only KV pool variant for DeepSeek-V4.
+
+Subclasses :class:`DeepSeekV4TokenToKVPool` to swap the ring-buffered
+:class:`CompressStatePool` for the paged :class:`NPUCompressStatePool` that
+the on-NPU fused compressor kernel (``torch.ops.custom.compressor`` with
+``cache_mode=1``) requires. Atlas A3 rejects ``cache_mode=2`` (ring) entirely,
+so this is the only valid layout on that hardware.
+
+Selected at pool construction time by
+:meth:`ModelRunnerKVCacheMixin._init_pools` when the model is DSV4 AND the
+device is NPU. CUDA continues to use the unchanged base class.
+
+The subclass overrides only:
+
+  * ``_make_attn_state_pool`` / ``_make_indexer_state_pool`` — the per-ratio
+    state-pool factories the base ``_init_paged_compress_states`` loop calls.
+    Both return :class:`NPUCompressStatePool` (paged, ``cache_mode=1``)
+    instead of the base's ring-buffered :class:`CompressStatePool`.
+  * ``translate_kv_loc_to_compress_state_loc`` — raise loudly. The ring
+    hash this method implements is meaningless on the paged kernel; callers
+    must consume ``out_cache_loc_dsv4.out_c{4,128}_state_loc`` from the
+    allocator bundle instead. Currently the only NPU caller that still
+    invokes translate is the unfused Python compressor decode path
+    (``layers/attention/dsv4/compressor.py``); with USE_FUSED_COMPRESSOR=1
+    that path is dead. If someone disables the fused compressor, they hit
+    the raise with a clear message.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple
+
+import torch
+import torch_npu
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+    ONLINE_C128,
+    DeepSeekV4IndexerPool,
+    DeepSeekV4SingleKVPool,
+    DeepSeekV4TokenToKVPool,
+)
+
+
+class NPUDeepSeekV4SingleKVPool(DeepSeekV4SingleKVPool):
+    """NPU bf16 variant of the full / SWA / c4 / c128 single-KV pool.
+
+    ``npu_sparse_attn_sharedkv`` reads KV in PA_ND layout
+    ``(num_pages, kernel_page_size, num_kv_heads=1, dim)`` with ``dim`` packing
+    K_nope + K_rope as bf16, and requires ``cmp_kv.shape[1] == ori_kv.shape[1]``.
+    So the c4/c128 pools (whose token-level page_size is ``page_size // ratio``)
+    are allocated at the GLOBAL ``kernel_page_size`` rather than their own
+    per-ratio page_size; the SWA pool uses ``kernel_page_size == page_size``.
+    The CUDA fp8-packed-bytes layout (the base ``create_buffer``) is untouched.
+    """
+
+    def __init__(self, *args, kernel_page_size: int, **kwargs):
+        # Set before super().__init__ — it calls _create_buffers() ->
+        # create_buffer(), which reads self.kernel_page_size.
+        self.kernel_page_size = kernel_page_size
+        super().__init__(*args, **kwargs)
+
+    def create_buffer(self, *, num_pages: int):
+        # Non-bf16 store dtype (should not happen on the NPU DSV4 path) falls
+        # back to the base packed layout.
+        if self.store_dtype != torch.bfloat16:
+            return super().create_buffer(num_pages=num_pages)
+        kv_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        self.kv_cache_total_dim = kv_dim
+        # Use the GLOBAL kernel_page_size so cmp_kv.shape[1] == ori_kv.shape[1].
+        # Writes are flat-indexed (set_compress_buffer flattens (0, 1) and
+        # indexes by loc), so page granularity affects only shape, not location.
+        npu_num_pages = (self.size + self.kernel_page_size + 1) // self.kernel_page_size
+        return torch.zeros(
+            npu_num_pages,
+            self.kernel_page_size,
+            1,
+            kv_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+
+
+def npu_state_pool_size(
+    *,
+    ratio: int,
+    page_size: int,
+    max_num_reqs: int,
+) -> int:
+    """Per-pool state slot count for the NPU paged state pool's
+    :class:`NPUPagedTokenToKVPoolAllocator`.
+
+    Sizing formula::
+
+        max(2, ceil(1.8 * ratio / page_size) + 1) * max_num_reqs * page_size
+
+    Sized for steady-state during decode: each req keeps roughly the trailing
+    ``sliding_window_size`` worth of state slots live at any one time (SWA
+    eviction in :meth:`ScheduleBatch._evict_swa` frees state slots as it
+    advances), and the 1.8x factor adds headroom for the tail-only allocation
+    pattern across page boundaries.
+
+    Prefill no longer drives sizing because allocation is tail-only — long
+    prompts only allocate ``c{ratio}_alloc_len`` slots (``≤ tail + 128`` for
+    c4, ``≤ tail`` for c128, where ``tail = seq_len % 128``), not the full raw
+    seqlen. See :meth:`ScheduleBatch._compute_dsv4_state_lens_extend` for the
+    per-req formula.
+
+    Result is in TOKEN units (matches the SGLang allocator
+    ``PagedTokenToKVPoolAllocator(size, ...)`` convention where
+    ``num_pages = size // page_size`` is the count of USABLE pages handed out
+    by ``free_pages = arange(1, num_pages+1)``). The BUFFER allocates one extra
+    page (see :class:`NPUCompressStatePool`, sized ``(num_pages + 1) *
+    page_size`` — page 0 is the kernel's skip-sentinel).
+    """
+    blocks_per_req = max(2, math.ceil(1.8 * ratio / page_size) + 1)
+    num_usable_pages = blocks_per_req * max_num_reqs
+    return num_usable_pages * page_size
+
+
+class NPUCompressStatePool(CompressStatePool):
+    """Paged compress-state pool for the NPU fused compressor kernel.
+
+    ``torch.ops.custom.compressor`` (cache_mode=1) reads/writes the compress
+    state via ``state_cache`` shape ``(block_num, page_size, 2*coff*head_dim)``
+    indexed by a paged ``state_block_table`` (block ids from 1; value 0 means
+    "skip this slot"). The CUDA :class:`CompressStatePool` sizes itself
+    ring-style, which misaddresses slots under cache_mode=1 (ring is also
+    unsupported on Atlas A3). This subclass keeps the parent's buffer layout
+    (``(self._size, 2*coff*head_dim)`` flat; ``state_cache_3d`` reshapes to
+    ``(num_blocks, page_size, 2*coff*head_dim)``) but replaces the size formula
+    with a paged one derived from ``max_num_reqs``. Block 0 is reserved as the
+    kernel's skip-sentinel (zero kv / -inf score) so any ``state_block_table``
+    entry defaulting to 0 lands in a deterministic, attention-neutral place.
+
+    NPU-only; CUDA keeps using the unchanged :class:`CompressStatePool`.
+    """
+
+    def __init__(
+        self,
+        *,
+        size: int,
+        overlap: bool,
+        head_dim: int,
+        dtype: torch.dtype,
+        device: str,
+        enable_memory_saver: bool,
+        ratio: int,
+        page_size: int,
+    ):
+        # Bypass parent __init__ entirely — its sizing path is ring-based
+        # (size + ring_size + 1, padded to lcm(ratio, page_size)) which is
+        # incompatible with the kernel's paged block-id contract. Re-do
+        # the buffer allocation ourselves; rest of the parent API
+        # (``state_cache_3d`` property, ``kv_score_buffer`` attribute,
+        # ``__getitem__`` semantics via KVAndScore) stays intact because
+        # we set the same fields.
+        assert ratio in (
+            4,
+            128,
+        ), f"NPUCompressStatePool only supports ratio in (4, 128); got {ratio}"
+        assert page_size > 1, (
+            "NPUCompressStatePool requires page_size>1 (kernel's "
+            "state_cache_3d view is (block_num, page_size, slot_dim)). "
+            "Got page_size=%d." % page_size
+        )
+
+        # ``size`` is the ALLOCATOR's size (num_usable_pages * page_size,
+        # output of :func:`npu_state_pool_size`). The buffer needs one EXTRA
+        # page so the allocator's free list ``arange(1, num_pages+1)`` can
+        # index it without OOB (page 0 = dummy/skip sentinel, pages
+        # 1..num_pages = real handed out by allocator). Mirrors the
+        # DeepSeekV4SingleKVPool convention
+        # ``num_pages = (size + page_size + 1) // page_size`` (= size/page_size + 1
+        # when size % page_size == 0).
+        num_usable_pages = (size + page_size - 1) // page_size
+        num_buffer_pages = num_usable_pages + 1
+        self._size = num_buffer_pages * page_size
+        self.page_size = page_size
+        # Mark this instance as "not ring-buffered" so any code that branches
+        # on ring_size sees a benign 0. Parent uses ring_size to derive
+        # state_loc via hashing; we replaced that with the paged allocator,
+        # but keep the attribute so downstream isinstance / hasattr probes
+        # don't break.
+        self.ring_size = 0
+        # online compress (3*head_dim slots) is a CUDA-only optimization
+        # (SGLANG_OPT_USE_ONLINE_COMPRESS) and does not interact with the
+        # NPU fused compressor; force off here so layout matches kernel
+        # expectations.
+        self.online = False
+
+        # Slot dim = 2 * coff * head_dim = [kv | score] concatenated, where
+        # coff = 1 (no overlap) or 2 (overlap). Matches CompressStatePool's
+        # non-online layout exactly so KVAndScore.kv / .score halves work.
+        self.last_dim = 2 * (1 + int(overlap)) * head_dim
+
+        # Reuse the parent's buffer-allocation helper (memory-saver region +
+        # custom mem pool + KVAndScore wrap); only ``self._size`` differs from
+        # the ring-based parent path.
+        self._alloc_kv_score_buffer(
+            dtype=dtype, device=device, enable_memory_saver=enable_memory_saver
+        )
+
+        # Reserve block 0 as the kernel's skip-sentinel:
+        # kv half zeroed, score half -inf so any softmax over it contributes 0.
+        # The paged allocator's free list excludes block 0, so real reqs never
+        # land here; only stale / unallocated state_block_table entries do.
+        self.kv_score_buffer.kv[:page_size].zero_()
+        self.kv_score_buffer.score[:page_size].fill_(float("-inf"))
+
+
+class NPUDeepSeekV4IndexerPool(DeepSeekV4IndexerPool):
+    """NPU c4-indexer pool. Keeps the base packed CUDA buffer (read by
+    get_contiguous_buf_infos / NSA) and ADDS dedicated int8 K + float16 scale
+    buffers in PA_ND layout at the global ``kernel_page_size``, written by
+    ``torch_npu.npu_scatter_nd_update_`` and read by
+    ``torch.ops.custom.npu_quant_lightning_indexer``.
+    """
+
+    def __init__(self, *args, kernel_page_size: int, **kwargs):
+        # Set before super().__init__ — it calls _create_buffer().
+        self._kernel_page_size = kernel_page_size
+        super().__init__(*args, **kwargs)
+
+    def _create_buffer(self):
+        # Base allocates the packed CUDA index_k_with_scale_buffer (kept for
+        # get_contiguous_buf_infos / NSA compat); then add the NPU buffers.
+        super()._create_buffer()
+        kp = self._kernel_page_size
+        npu_num_pages = (self.size + kp + 1) // kp
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.index_k_buffer = [
+                torch.zeros(
+                    npu_num_pages,
+                    kp,
+                    1,
+                    self.index_head_dim,
+                    dtype=torch.int8,
+                    device=self.device,
+                )
+                for _ in range(self.layer_num)
+            ]
+            self.index_scale_buffer = [
+                torch.zeros(
+                    npu_num_pages,
+                    kp,
+                    1,
+                    1,
+                    dtype=torch.float16,
+                    device=self.device,
+                )
+                for _ in range(self.layer_num)
+            ]
+
+    @property
+    def has_npu_storage(self) -> bool:
+        return True
+
+    def get_index_k(self, layer_id: int) -> torch.Tensor:
+        return self.index_k_buffer[layer_id]
+
+    def get_index_scale(self, layer_id: int) -> torch.Tensor:
+        return self.index_scale_buffer[layer_id]
+
+    def set_index_k_scale(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+        index_k_scale: Optional[torch.Tensor],
+    ) -> None:
+        # int8 K + fp16 scale come from _compressor_epilog_npu's npu_dynamic_quant
+        # output (index_k: int8 [T, D], index_k_scale: fp16 [T, 1]).
+        d = self.index_head_dim
+        loc_long = loc.view(-1, 1).long()
+        torch_npu.npu_scatter_nd_update_(
+            self.index_k_buffer[layer_id].view(-1, 1, d),
+            loc_long,
+            index_k.to(torch.int8).view(-1, 1, d),
+        )
+        if index_k_scale is not None:
+            torch_npu.npu_scatter_nd_update_(
+                self.index_scale_buffer[layer_id].view(-1, 1, 1),
+                loc_long,
+                index_k_scale.to(torch.float16).view(-1, 1, 1),
+            )
+
+
+class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
+    """NPU-only DSV4 KV pool with paged compress-state buffers.
+
+    The full / SWA / c4 / c128 KV pools use the NPU bf16 PA_ND layout
+    (:class:`NPUDeepSeekV4SingleKVPool`); the compress-state pool is paged
+    (:class:`NPUCompressStatePool`) rather than ring-buffered; and the indexer
+    pool adds dedicated int8 K + fp16 scale buffers
+    (:class:`NPUDeepSeekV4IndexerPool`). The generic-accessor / port-hook
+    methods at the bottom of this class are the NPU equivalents of the CUDA
+    DSV4 store-cache chain — kept here, not in the community base, which raises
+    ``NotImplementedError`` for them (CUDA goes through the radix / store_cache
+    accessors instead).
+    """
+
+    def _make_kv_pool(
+        self,
+        *,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        layer_num: int,
+        device: str,
+        enable_memory_saver: bool,
+        global_page_size: int,
+        cls: type = DeepSeekV4SingleKVPool,
+    ) -> NPUDeepSeekV4SingleKVPool:
+        # NPU does not use the HiSparse c4 device pool; fail loud if someone
+        # enables it so the silent layout mismatch surfaces at init.
+        assert cls is DeepSeekV4SingleKVPool, (
+            "enable_hisparse is not supported on the NPU DSV4 KV pool "
+            f"(got c4 pool class {cls.__name__})."
+        )
+        return NPUDeepSeekV4SingleKVPool(
+            size,
+            page_size,
+            dtype,
+            self.qk_nope_head_dim,
+            self.qk_rope_head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+            kernel_page_size=global_page_size,
+        )
+
+    def _get_state_pool(self, layer_id: int, from_indexer: bool) -> CompressStatePool:
+        """Select this layer's attention vs c4-indexer compress-state pool.
+        Wraps the community getters so the NPU port hooks below don't index the
+        pool lists directly."""
+        if from_indexer:
+            return self.get_indexer_compress_states(layer_id)
+        return self.get_attention_compress_states(layer_id)
+
+    def _make_attn_state_pool(
+        self, ratio: int, enable_memory_saver: bool
+    ) -> NPUCompressStatePool:
+        # ONLINE_C128 (CUDA-only optimization) collapses the c128 ring to
+        # size 1; the NPU fused compressor has no online mode, so the
+        # standard (kv, score) layout is the only valid one — assert the
+        # config mismatch early.
+        assert not (ratio == 128 and ONLINE_C128), (
+            "SGLANG_OPT_USE_ONLINE_COMPRESS is incompatible with the "
+            "NPU fused compressor (no online mode in the kernel)."
+        )
+        return NPUCompressStatePool(
+            size=self._state_pool_size(ratio),
+            overlap=ratio == 4,
+            head_dim=self.qk_nope_head_dim + self.qk_rope_head_dim,
+            dtype=self.state_dtype,
+            device=self.device,
+            enable_memory_saver=enable_memory_saver,
+            ratio=ratio,
+            page_size=self.swa_page_size,
+        )
+
+    def _make_indexer_state_pool(
+        self, ratio: int, enable_memory_saver: bool
+    ) -> NPUCompressStatePool:
+        # c4 indexer shares the c4 state pool size budget but has its own
+        # slot_dim (indexer_head_dim vs attention head_dim).
+        return NPUCompressStatePool(
+            size=self.c4_state_pool_size,
+            overlap=ratio == 4,
+            head_dim=self.indexer_head_dim,
+            device=self.device,
+            dtype=self.state_dtype,
+            enable_memory_saver=enable_memory_saver,
+            ratio=ratio,
+            page_size=self.swa_page_size,
+        )
+
+    def _make_indexer_pool(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        index_head_dim: int,
+        layer_num: int,
+        device: str,
+        enable_memory_saver: bool,
+    ) -> NPUDeepSeekV4IndexerPool:
+        # NPU dedicated int8 K + fp16 scale buffers use the GLOBAL page_size
+        # (= self.page_size) as kernel_page_size, matching ori_kv for the kernel.
+        return NPUDeepSeekV4IndexerPool(
+            size,
+            page_size,
+            dtype,
+            index_head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+            kernel_page_size=self.page_size,
+        )
+
+    def get_state_cache(self, layer_id: int, from_indexer: bool) -> torch.Tensor:
+        """fp32 ``[block_num, page_size, 2*coff*D]`` view of this layer's
+        kv+score buffer — the fused compressor op
+        (``torch.ops.custom.compressor``)'s ``state_cache`` argument."""
+        return self._get_state_pool(layer_id, from_indexer).state_cache_3d
+
+    # ------------------------------------------------------------------
+    # Generic KV accessors. The community base raises NotImplementedError for
+    # these (the CUDA DSV4 path uses set_swa_key_buffer_radix + store_cache);
+    # AscendAttnBackend.forward_extend reads KV through them, so we route to
+    # the right sub-pool by the layer's compression ratio.
+    # ------------------------------------------------------------------
+
+    def get_key_buffer(self, layer_id: int) -> torch.Tensor:
+        item = self.layer_mapping[layer_id]
+        ratio = item.compress_ratio
+        if ratio == 0:
+            return self.swa_kv_pool.kv_buffer[item.compress_layer_id]
+        if ratio == 4:
+            return self.c4_kv_pool.kv_buffer[item.compress_layer_id]
+        if ratio == 128:
+            return self.c128_kv_pool.kv_buffer[item.compress_layer_id]
+        raise ValueError(f"unsupported compress_ratio={ratio} for get_key_buffer")
+
+    def get_value_buffer(self, layer_id: int) -> torch.Tensor:
+        # V4 uses MQA / latent attention — the K buffer doubles as V.
+        return self.get_key_buffer(layer_id)
+
+    def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        buf = self.get_key_buffer(layer_id)
+        return buf, buf
+
+    def get_swa_buffer(
+        self, layer_id: int, loc: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Return the SWA layer's KV cache in PA_ND layout
+        (num_pages, page_size, num_kv_heads=1, dim). When ``loc`` is given,
+        flatten across (num_pages, page_size) and gather the matching tokens —
+        shape becomes (num_tokens, 1, dim).
+        """
+        # Index swa_kv_pool.kv_buffer by RAW layer_id, not by
+        # item.compress_layer_id: compress_layer_id is a per-bucket counter
+        # (c1/c4/c128 each starting at 0), so writes from different ratios
+        # would collide on the same kv_buffer slot. swa_kv_pool is sized with
+        # layer_num=total_layers, so per-layer slots already exist.
+        kv = self.swa_kv_pool.kv_buffer[layer_id]
+        if loc is not None:
+            kv = kv.flatten(0, 1)[loc]
+        return kv
+
+    def get_compress_buffer(
+        self,
+        layer_id: int,
+        from_indexer: bool = False,
+        loc: Optional[torch.Tensor] = None,
+    ) -> Optional[torch.Tensor]:
+        """Return the compressed KV buffer for a c4 / c128 layer.
+
+        Routes to c4 / c128 kv_pool by layer compression ratio. Returns
+        ``None`` for ratio == 0 (no compress KV exists). The
+        from_indexer=True branch returns the dedicated int8 K buffer that
+        ``torch.ops.custom.npu_quant_lightning_indexer`` consumes.
+        """
+        item = self.layer_mapping[layer_id]
+        if item.compress_ratio == 4:
+            if from_indexer:
+                kv = self.c4_indexer_kv_pool.get_index_k(item.compress_layer_id)
+            else:
+                kv = self.c4_kv_pool.kv_buffer[item.compress_layer_id]
+        elif item.compress_ratio == 128:
+            assert not from_indexer, "c128 has no indexer pool"
+            kv = self.c128_kv_pool.kv_buffer[item.compress_layer_id]
+        else:
+            return None
+        if loc is not None:
+            kv = kv.flatten(0, 1)[loc]
+        return kv
+
+    def set_swa_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache: torch.Tensor,
+    ) -> None:
+        """Write ``cache`` into the SWA pool at flat token positions ``loc``.
+
+        ``cache`` shape: (num_tokens, num_kv_heads=1, dim). The buffer view is
+        (num_pages, page_size, 1, dim) so we flatten the first two dims and
+        index_put.
+        """
+        # Index by raw layer_id (see get_swa_buffer) to avoid bucket collision.
+        buf = self.swa_kv_pool.kv_buffer[layer_id]
+        buf_flat = buf.flatten(0, 1)  # (num_pages * page_size, 1, dim)
+        # Caller (V4 MQALayer) may hand us cache shaped (T, dim); the buffer has
+        # an explicit num_kv_heads=1 axis, so insert it.
+        if cache.ndim == buf_flat.ndim - 1:
+            cache = cache.unsqueeze(1)
+        buf_flat[loc] = cache.to(buf_flat.dtype)
+
+    # ------------------------------------------------------------------
+    # NPU port hooks — used by dsv4/{compressor,indexer}.py forward_npu on top
+    # of CompressStatePool / NPUDeepSeekV4SingleKVPool / NPUDeepSeekV4IndexerPool.
+    # CompressStatePool stores a single fused [kv | score] tensor of shape
+    # (size, 2*coff*head_dim); split + cat is just a last-dim slice.
+    # ------------------------------------------------------------------
+
+    def set_state_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        kv: torch.Tensor,
+        score: torch.Tensor,
+        from_indexer: bool,
+    ) -> None:
+        # KVAndScore.kv_score is [..., 2*coff*head_dim] = [kv | score].
+        kv_score = self._get_state_pool(layer_id, from_indexer).kv_score_buffer.kv_score
+        last_dim = kv_score.shape[-1]
+        half = last_dim // 2
+        kv_view = kv.reshape(-1, half).to(kv_score.dtype)
+        score_view = score.reshape(-1, half).to(kv_score.dtype)
+        kv_score[loc, :half] = kv_view
+        kv_score[loc, half:] = score_view
+
+    def get_state_buffer(
+        self,
+        layer_id: int,
+        from_indexer: bool,
+        kv_indices: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        kv_score = self._get_state_pool(layer_id, from_indexer).kv_score_buffer.kv_score
+        if kv_indices is not None:
+            kv_score = kv_score[kv_indices]
+        last_dim = kv_score.shape[-1]
+        half = last_dim // 2
+        kv = kv_score[..., :half].unsqueeze(-2)  # add num_kv_heads=1 axis
+        score = kv_score[..., half:].unsqueeze(-2)
+        return kv, score
+
+    def set_compress_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        kv: torch.Tensor,
+        kv_scale: Optional[torch.Tensor],
+        from_indexer: bool,
+    ) -> None:
+        # Routes to:
+        #   from_indexer=True               → c4_indexer_kv_pool (int8 + scale)
+        #   from_indexer=False, ratio=4     → c4_kv_pool
+        #   from_indexer=False, ratio=128   → c128_kv_pool
+        #
+        # On NPU we bypass the CUDA fused_store_cache and do direct tensor
+        # writes against the bf16 buffer.
+        ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
+        device_type = kv.device.type
+        if from_indexer:
+            assert ratio == 4, f"indexer only on c4 layers, got ratio={ratio}"
+            if device_type == "npu":
+                assert (
+                    self.c4_indexer_kv_pool.has_npu_storage
+                ), "NPU index buffers not allocated — pool was init'd on CUDA?"
+                self.c4_indexer_kv_pool.set_index_k_scale(
+                    compress_layer_id, loc, kv, kv_scale
+                )
+                return
+            if kv_scale is None:
+                self.c4_indexer_kv_pool.set_index_fused(compress_layer_id, loc, kv)
+                return
+            self.c4_indexer_kv_pool.set_index_k_scale_buffer(
+                compress_layer_id, loc, kv, kv_scale
+            )
+            return
+        compress_pool = self.c4_kv_pool if ratio == 4 else self.c128_kv_pool
+        if device_type == "npu":
+            # PA_ND layout: kv_buffer[layer_id] shape = (num_pages, page_size,
+            # 1, kv_dim). Flatten (num_pages, page_size) and index by `loc`.
+            buf = compress_pool.kv_buffer[compress_layer_id]
+            buf_flat = buf.flatten(0, 1)
+            kv_view = kv.to(buf_flat.dtype)
+            if kv_view.ndim == buf_flat.ndim - 1:
+                kv_view = kv_view.unsqueeze(1)
+            buf_flat[loc] = kv_view
+            return
+        compress_pool.set_key_buffer_fused(compress_layer_id, loc, kv)
+
+    def get_compress_dequant_scale_buffer(
+        self,
+        layer_id: int,
+        from_indexer: bool,
+    ) -> torch.Tensor:
+        # Returns the float16 dequant scale buffer (NPU indexer pool's dedicated
+        # scale buffer alongside the int8 K buffer).
+        assert from_indexer, "only indexer compress pool has dequant scale"
+        compress_layer_id = self.layer_mapping[layer_id].compress_layer_id
+        return self.c4_indexer_kv_pool.get_index_scale(compress_layer_id)
+
+    def translate_kv_loc_to_compress_state_loc(
+        self,
+        kv_loc: torch.Tensor,
+        compress_ratio: int,
+    ) -> torch.Tensor:
+        # The parent implementation computes
+        # ``swa_page * ring_size + (swa_loc % ring_size)`` — a ring-buffer
+        # hash that has no meaning under the NPU fused compressor's paged
+        # cache_mode=1 contract. Allowing it to return a stale value would
+        # silently misaddress the state_block_table and corrupt compressed
+        # state across batches. Loud failure makes the misuse obvious.
+        raise RuntimeError(
+            "DSV4NPUTokenToKVPool.translate_kv_loc_to_compress_state_loc was "
+            "called, but the NPU fused compressor kernel uses a paged state "
+            "pool (cache_mode=1) and does not support ring-buffer state "
+            "addressing (cache_mode=2 is explicitly unsupported on Atlas A3). "
+            "Callers must consume out_cache_loc_dsv4.out_c{4,128}_state_loc "
+            "from the allocator bundle (set during alloc_extend/alloc_decode) "
+            "and read state_page_table from req_to_token_c{4,128}_state on "
+            "the DSV4NPUReqToTokenPool instead. See "
+            "hardware_backend/npu/dsv4_memory_pool.py for the rationale."
+        )

--- a/python/sglang/srt/hardware_backend/npu/dsv4_req_to_token_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4_req_to_token_pool.py
@@ -1,0 +1,140 @@
+"""DSV4-NPU per-request mapping pool.
+
+Subclass of ``ReqToTokenPool`` that adds five auxiliary per-request tables
+needed by the DSV4 attention backend:
+
+  * ``req_to_token_swa``        — slot ids in the SWA full-pool view
+  * ``req_to_token_c4``         — slot ids in the c4 compressed-KV pool
+  * ``req_to_token_c128``       — slot ids in the c128 compressed-KV pool
+  * ``req_to_token_c4_state``   — c4 state-pool slot ids, 1 per raw token
+  * ``req_to_token_c128_state`` — c128 state-pool slot ids, 1 per raw token
+
+Compressed KV pools store 1 slot per ``ratio`` raw tokens, so their per-req
+table column count is ``max_context_len // ratio``. swa mirrors the raw
+token count. Elements are token-level slot ids; the attention backend
+converts to page ids via ``// page_size`` when constructing PA_ND block
+tables.
+
+The c4/c128 STATE pools also have per-req tables here: the NPU fused
+compressor uses a paged state pool (``cache_mode=1``), so each raw token's
+state slot id is recorded (1 column per raw token) and the backend builds
+``state_block_table = req_to_token_c{N}_state[req, ::page_size] // page_size``
+to feed the kernel. (The base class' ``translate_kv_loc_to_compress_state_loc``
+ring-hash is the CUDA-only path; it is disabled on NPU.)
+
+Memory cost example (size=64, max_context_len=32K): swa 8MB + c4 2MB +
+c128 64KB ≈ 10MB extra on top of the base req_to_token (8MB).
+
+The tables are populated by the ``dsv4_common_hooks`` writers (driven from
+``mem_cache/common.py``) immediately after a successful alloc_extend /
+alloc_decode, using the per-pool slot indices returned in ``DSV4OutCacheLoc``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+
+
+class DSV4NPUReqToTokenPool(ReqToTokenPool):
+    """ReqToTokenPool extended with DSV4 SWA + c4/c128 per-req tables.
+
+    Drop-in replacement for ReqToTokenPool when the model is DeepSeek-V4 on
+    NPU. Selected by ``model_runner_kv_cache_mixin`` based on model arch +
+    device. Non-DSV4 and non-NPU paths continue to use the base class.
+
+    The auxiliary tables are intentionally NOT zeroed on ``clear()``: they are
+    indexed only by active rows (via req_pool_idx) and only each row's
+    ``[:seq_len]`` prefix is read, so stale entries past kv_committed_len are
+    unreachable by the attention metadata builder.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        max_context_len: int,
+        device: str,
+        enable_memory_saver: bool,
+    ):
+        super().__init__(size, max_context_len, device, enable_memory_saver)
+
+        memory_saver_adapter = TorchMemorySaverAdapter.create(
+            enable=enable_memory_saver
+        )
+
+        # Back-reference to the DSV4NPUTokenToKVPoolAllocator. Wired up via
+        # ``register_dsv4_allocator`` after both are constructed (see
+        # model_runner_kv_cache_mixin), so ``free(req)`` can release the
+        # c4/c128 pool pages held by the req before the req_pool_idx slot
+        # itself goes back to the free list. Stays None on construction so
+        # the base class clear() in __init__ can run safely.
+        self._dsv4_allocator = None
+
+        # (name, columns). swa + state tables hold 1 slot per raw token; c4 /
+        # c128 hold 1 slot per `ratio` raw tokens. State tables are per-token
+        # (NPU paged layout, torch.ops.custom.compressor cache_mode=1); the
+        # backend builds ``req_to_token_c{N}_state[req, ::page_size] //
+        # page_size`` for the kernel's state_block_table. All init zero so
+        # unallocated columns map to block 0 — the kernel's skip sentinel
+        # (NPUCompressStatePool clears block 0 to kv=0/score=-inf).
+        with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            for name, cols in (
+                ("req_to_token_swa", max_context_len),
+                ("req_to_token_c4", max(1, max_context_len // 4)),
+                ("req_to_token_c128", max(1, max_context_len // 128)),
+                ("req_to_token_c4_state", max_context_len),
+                ("req_to_token_c128_state", max_context_len),
+            ):
+                setattr(
+                    self,
+                    name,
+                    torch.zeros(
+                        (self._alloc_size, cols),
+                        dtype=torch.int32,
+                        device=device,
+                    ),
+                )
+
+    # ------------------------------------------------------------------
+    # Per-pool write helpers. mem_cache/common.py calls these directly
+    # after a successful alloc_extend/alloc_decode, using slot indices
+    # pulled from DSV4OutCacheLoc. Each method accepts (req_pool_idx,
+    # token_offset) coordinates and the corresponding flat slot id.
+    # ------------------------------------------------------------------
+
+    def write_swa(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_swa[indices] = values
+
+    def write_c4(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c4[indices] = values
+
+    def write_c128(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c128[indices] = values
+
+    def write_c4_state(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c4_state[indices] = values
+
+    def write_c128_state(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c128_state[indices] = values
+
+    def register_dsv4_allocator(self, allocator) -> None:
+        """Wire the DSV4NPUTokenToKVPoolAllocator ref so ``free(req)`` can
+        release c4/c128 pool pages alongside the req_pool_idx slot. This is a
+        one-way ref (pool -> allocator). The reverse direction (the allocator
+        reading these per-req tables for its c-pool / state last_loc lookup) is
+        no longer a stored back-ref: mem_cache/common.py passes this pool into
+        ``alloc_extend`` / ``alloc_decode`` per call instead."""
+        self._dsv4_allocator = allocator
+
+    def free(self, req):
+        # Trigger c4/c128 pool free via the allocator's unified free path;
+        # the actual c-pool release logic lives in
+        # ``DSV4NPUTokenToKVPoolAllocator.free``. _dsv4_allocator may be
+        # None during the brief window between this pool's __init__ and
+        # register_dsv4_allocator — defensive None check.
+        if self._dsv4_allocator is not None:
+            self._dsv4_allocator.free(req=req, req_to_token_pool=self)
+        super().free(req)

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -35,7 +35,11 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 import numpy as np
 import torch
 
-from sglang.srt.configs.model_config import AttentionArch, is_deepseek_dsa
+from sglang.srt.configs.model_config import (
+    AttentionArch,
+    is_deepseek_dsa,
+    is_deepseek_v4,
+)
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.runner import DecodeCudaGraphRunner
@@ -230,7 +234,11 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
 
         graph_key = self._make_graph_key(self.bs)
 
-        if not is_deepseek_dsa(self.model_runner.model_config.hf_config):
+        # Replay. DeepSeek-V4 (like DSA) skips the seq_lens cpu_update_input path.
+        if not (
+            is_deepseek_dsa(self.model_runner.model_config.hf_config)
+            or is_deepseek_v4(self.model_runner.model_config.hf_config)
+        ):
             if forward_batch.forward_mode.is_target_verify():
                 seq_lens_cpu = forward_batch.seq_lens.cpu() + self.num_tokens_per_bs
                 seq_lens = seq_lens_cpu.tolist() + [0] * (self.bs - self.raw_bs)

--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -26,8 +26,21 @@ def fused_topk_npu(
     renormalize = topk_config.renormalize
     correction_bias = topk_config.correction_bias
 
+    # norm_type=2: native sqrtsoftplus scoring (scores = sqrt(softplus(logits))),
+    if topk_config.scoring_func == "sqrtsoftplus":
+        topk_weights, topk_ids, _ = torch.ops.custom.npu_moe_gating_top_k(
+            x=router_logits,
+            k=topk_config.top_k,
+            bias=correction_bias,
+            input_ids=None,
+            tid2eid=None,
+            routed_scaling_factor=topk_config.routed_scaling_factor,
+            norm_type=2,
+        )
+        topk_weights = topk_weights.to(torch.float32)
+
     # Fast path: simple top-k without grouped routing and bias
-    if not use_grouped_topk and correction_bias is None:
+    elif not use_grouped_topk and correction_bias is None:
         topk_weights, topk_ids, _ = torch.ops.npu.npu_moe_gating_top_k_softmax(
             router_logits,
             k=topk_config.top_k,
@@ -88,5 +101,28 @@ def fused_topk_npu(
             layer_id=layer_id,
             topk_indices=topk_ids,
         )
+
+    return StandardTopKOutput(topk_weights, topk_ids, router_logits)
+
+
+def fused_hash_topk_npu(
+    router_logits: torch.Tensor,
+    input_ids: torch.Tensor,
+    tid2eid: torch.Tensor,
+    routed_scaling_factor: float,
+    expert_location_dispatch_info: Optional["ExpertLocationDispatchInfo"] = None,
+) -> "TopKOutput":
+    topk = tid2eid.size(1)
+    topk_weights, topk_ids, _ = torch.ops.custom.npu_moe_gating_top_k(
+        x=router_logits,
+        k=topk,
+        bias=None,
+        input_ids=input_ids,
+        tid2eid=tid2eid,
+        routed_scaling_factor=routed_scaling_factor,
+        norm_type=2,
+    )
+    if expert_location_dispatch_info is not None:
+        topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
 
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)

--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -99,6 +99,14 @@ def init_npu_backend():
 
     assert _is_npu, "NPU backend initialization called on non-NPU device."
 
+    try:
+        import custom_ops  # noqa: F401
+    except ImportError:
+        logger.warning(
+            "custom_ops is not installed; NPU custom ops (torch.ops.custom.*) "
+            "are unavailable. DeepSeek-V4 NPU fused paths require the custom_ops "
+            "wheel shipped in the CANN image and will fail if exercised."
+        )
     import sgl_kernel_npu  # noqa: F401
     import torch_npu
     from torch_npu.contrib import transfer_to_npu  # noqa: F401

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -126,7 +126,18 @@ def _create_nsa_compat(runner):
 
 @register_attention_backend("dsv4")
 def create_dsv4_backend(runner):
-    from sglang.srt.utils import is_hip
+    from sglang.srt.utils import is_hip, is_npu
+
+    if is_npu():
+        # V4's model code calls compressor/indexer/store_cache methods that
+        # AscendAttnBackend doesn't expose. Route to a subclass that mixes
+        # those in, keeping all the NPU-side ascend metadata & forward
+        # plumbing intact.
+        from sglang.srt.hardware_backend.npu.attention.ascend_dsv4_backend import (
+            DeepseekV4AscendAttnBackend,
+        )
+
+        return DeepseekV4AscendAttnBackend(runner)
 
     if is_hip():
         from sglang.srt.layers.attention.deepseek_v4_backend_hip_radix import (

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -23,13 +23,15 @@ from sglang.srt.layers.dp_attention import get_attention_cp_size
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
+from sglang.srt.layers.utils.multi_platform import MultiPlatformOp
 from sglang.srt.mem_cache.deepseek_v4_compress_state import (
     CompressStatePool,
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.models.deepseek_v2 import _is_hip
-from sglang.srt.utils import add_prefix, get_bool_env_var
+from sglang.srt.utils import add_prefix, get_bool_env_var, is_npu
 
+_is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _tgemm = None
 if _use_aiter:
@@ -341,7 +343,7 @@ def create_paged_compressor_data(
     return FusedCompressMetadata(write_loc=write_loc, extra_data=extra_data, plan=plan)
 
 
-class Compressor(nn.Module):
+class Compressor(MultiPlatformOp):
     def __init__(
         self,
         config: DeepSeekV4Config,
@@ -427,7 +429,7 @@ class Compressor(nn.Module):
             )
         return kv_score
 
-    def forward(
+    def forward_native(
         self,
         x: torch.Tensor,
         forward_batch: ForwardBatch,
@@ -454,6 +456,21 @@ class Compressor(nn.Module):
             forward_batch=forward_batch,
             is_paged=True,
         )
+
+    def forward_npu(self, x: torch.Tensor, forward_batch: ForwardBatch) -> torch.Tensor:
+        if forward_batch.forward_mode.is_idle():
+            assert x.shape[0] == 0
+            return x.new_empty(0, self.head_dim)
+
+        if dsa_use_prefill_cp(forward_batch):
+            x = cp_all_gather_rerange_output(
+                x,
+                get_attention_cp_size(),
+                forward_batch,
+                torch.cuda.current_stream(),
+            )
+
+        return forward_batch.attn_backend.forward_compress(self, x, forward_batch)
 
 
 if _is_hip and not envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():

--- a/python/sglang/srt/layers/deepseek_v4_rope.py
+++ b/python/sglang/srt/layers/deepseek_v4_rope.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from functools import lru_cache
 from typing import Optional
@@ -6,16 +7,29 @@ import torch
 import triton
 import triton.language as tl
 
+logger = logging.getLogger(__name__)
+
+# tilelang isn't shipped on every platform (e.g. Ascend NPU images) and the
+# only tilelang artifacts in this file are pass_configs that downstream
+# tilelang.jit decorators would consume — the kernels actually defined here
+# are Triton. Keep the import optional so this module loads on NPU.
 try:
     import tilelang
 
     tilelang.set_log_level("WARNING")
+
     pass_configs = {
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
         tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
     }
 except ImportError:
-    pass
+    logger.info(
+        "tilelang not installed; deepseek_v4_rope pass_configs unset. "
+        "Triton kernels in this module still run; only downstream tilelang.jit "
+        "consumers of pass_configs will need to handle the None."
+    )
+    tilelang = None
+    pass_configs = None
 
 FP8 = "float8_e4m3"
 BF16 = "bfloat16"
@@ -24,8 +38,20 @@ INT32 = "int32"
 
 
 @lru_cache(2)
+def _yarn_get_mscale(scale: float = 1.0, mscale: float = 1.0) -> float:
+    if scale <= 1:
+        return 1.0
+    return 0.1 * mscale * math.log(scale) + 1.0
+
+
 def precompute_freqs_cis(
-    dim, seqlen, original_seq_len, base, factor, beta_fast, beta_slow
+    dim,
+    seqlen,
+    original_seq_len,
+    base,
+    factor,
+    beta_fast,
+    beta_slow,
 ) -> torch.Tensor:
 
     def find_correction_dim(num_rotations, dim, base, max_seq_len):
@@ -180,6 +206,129 @@ def apply_rotary_emb_triton(
         )
 
     return x
+
+
+# Cache for the contiguous real/imag halves of each freqs_cis tensor used in
+# v4_rope_inplace_npu. complex freqs_cis.real / freqs_cis.imag are strided
+# views (stride=2 on the underlying interleaved real layout);
+_NPU_ROPE_CONTIG_CACHE: dict[int, tuple] = {}
+
+
+def _get_contig_freqs_real_imag(
+    freqs_cis: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return contiguous (real, imag) halves of ``freqs_cis``, cached by id.
+
+    Used by NPU rope paths to avoid the per-call StridedSlice materialization
+    triggered by aclnnIndex over the strided ``.real`` / ``.imag`` views of
+    the complex ``freqs_cis`` buffer. First call per freqs_cis pays the
+    contiguous() once; later calls reuse the cached tensors.
+
+    All callers within a single MQALayer (outer rope, indexer inner rope,
+    compressor epilog rope) get the same freqs_cis instance, so each layer
+    materializes at most one (real, imag) pair.
+    """
+    cache_key = id(freqs_cis)
+    cached = _NPU_ROPE_CONTIG_CACHE.get(cache_key)
+    if cached is None:
+        cached = (freqs_cis.real.contiguous(), freqs_cis.imag.contiguous())
+        _NPU_ROPE_CONTIG_CACHE[cache_key] = cached
+    return cached
+
+
+def get_fused_compressor_rope_cos_sin(
+    freqs_cis: torch.Tensor,
+    positions_cmp: torch.Tensor,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build (cos, sin) tensors shaped ``[T, rope_head_dim]`` for the fused
+    compressor op (``torch.ops.custom.compressor``).
+
+    The op consumes ``rope_cos`` / ``rope_sin`` of shape
+    ``[min(T, T//cmp_ratio + B), rope_head_dim]`` in bf16/fp16. We index
+    the cached contig real/imag halves of the complex ``freqs_cis`` and
+    interleave-double the last dim to match the kernel's expected layout
+    (matches dsv4_release ``ComplexExpRotaryEmbedding.cos_cache``, which
+    is built as ``complex_cache.real.repeat_interleave(2, dim=-1)``).
+
+    Safe to call from inside a captured aclgraph: both ``index_select`` and
+    ``repeat_interleave`` over a graph-input ``positions_cmp`` of fixed
+    capture-time shape produce static-shape outputs. Identical to what the
+    existing inplace_partial_rotary_mul fallback does at
+    :func:`v4_rope_inplace_npu`, just without the inverse / 4D-view step.
+    """
+    real_contig, imag_contig = _get_contig_freqs_real_imag(freqs_cis)
+    cos_half = real_contig.index_select(0, positions_cmp)
+    sin_half = imag_contig.index_select(0, positions_cmp)
+    cos = cos_half.repeat_interleave(2, dim=-1).to(dtype)
+    sin = sin_half.repeat_interleave(2, dim=-1).to(dtype)
+    return cos, sin
+
+
+def v4_rope_inplace_npu(
+    q_rope: torch.Tensor,
+    kv_rope: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    positions: torch.Tensor,
+    inverse: bool = False,
+) -> None:
+    """In-place interleaved RoPE for V4 — torch fallback used on NPU.
+
+    Mirrors main's CUDA `fused_rope` kernel: consecutive (even, odd) pairs
+    of x form complex pairs, with `freqs_cis` a complex tensor where
+    `freqs_cis.real[t, k]` = cos(theta_{t,k}), `freqs_cis.imag` = sin(...)
+    indexed by frequency pair k in [0, rope_dim/2).
+
+    NOTE on V4-Flash YARN `mscale`: when the model was trained with the
+    YARN magnitude-scale `mscale` ≠ 1.0, the cos/sin values stored in
+    `freqs_cis` MUST already be pre-multiplied by `mscale` at precompute
+    time — see `precompute_freqs_cis`. This function
+    just reads what's stored; it does NOT apply mscale here.
+
+    Prefer the NPU-native `torch.ops.custom.inplace_partial_rotary_mul`:
+    the torch fallback differs by ~1 ULP per element vs the kernel because
+    torch does bf16*bf16 muls with bf16 accumulation while the NPU kernel
+    accumulates in fp32; 43 layers × (Q + K) = 86 rope calls compound that
+    drift enough to flip argmax on marginal prompts.
+    """
+    # Build cos/sin caches in the layout the kernel expects:
+    # (T, 1, 1, rope_dim) with each freq pair value repeated twice for
+    # the interleaved pairing convention. Use contig real/imag views
+    # cached by id(freqs_cis); see _get_contig_freqs_real_imag.
+    freqs_real_contig, freqs_imag_contig = _get_contig_freqs_real_imag(freqs_cis)
+    cos_half = freqs_real_contig[positions]  # (T, rope_dim/2)
+    sin_half = freqs_imag_contig[positions]
+    if inverse:
+        sin_half = -sin_half
+    cos_full = cos_half.repeat_interleave(2, dim=-1).to(q_rope.dtype)
+    sin_full = sin_half.repeat_interleave(2, dim=-1).to(q_rope.dtype)
+    rope_dim = cos_full.shape[-1]
+    # repeat_interleave produces a contiguous tensor, so the .view()
+    # below already returns a contiguous result — no .contiguous() needed.
+    cos4 = cos_full.view(-1, 1, 1, rope_dim)
+    sin4 = sin_full.view(-1, 1, 1, rope_dim)
+    # q_rope: (T, n_heads, rope_dim) → (T, 1, n_heads, rope_dim) view
+    # kv_rope: (T, 1, rope_dim) → (T, 1, 1, rope_dim) view
+    q_view = q_rope.unsqueeze(1)
+    torch.ops.custom.inplace_partial_rotary_mul(
+        q_view,
+        cos4,
+        sin4,
+        rotary_mode="interleave",
+        partial_slice=[0, rope_dim],
+    )
+    if kv_rope is not None:
+        if kv_rope.dim() == 3:
+            kv_view = kv_rope.unsqueeze(1)
+        else:
+            kv_view = kv_rope.view(-1, 1, 1, rope_dim)
+        torch.ops.custom.inplace_partial_rotary_mul(
+            kv_view,
+            cos4,
+            sin4,
+            rotary_mode="interleave",
+            partial_slice=[0, rope_dim],
+        )
 
 
 @triton.jit

--- a/python/sglang/srt/layers/mhc.py
+++ b/python/sglang/srt/layers/mhc.py
@@ -2,8 +2,6 @@ import functools
 import math
 from typing import Tuple
 
-import tilelang
-import tilelang.language as T
 import torch
 
 from sglang.jit_kernel.utils import is_arch_support_pdl
@@ -11,12 +9,52 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.utils.common import strict_contiguous
 
-tilelang.set_log_level("WARNING")
+# Tilelang isn't packaged on every platform (notably Ascend NPU images) but
+# this module is imported transitively from deepseek_v4.py — module-load
+# must succeed even when tilelang is missing. The kernels themselves still
+# require tilelang at runtime; we replace the package with a stub that lets
+# `@tilelang.jit` decorations and `tilelang.PassConfigKey.*` references parse
+# without ImportError, and any actual call into the kernels raises a clear
+# message at execution time instead of crashing on import.
+try:
+    import tilelang
+    import tilelang.language as T
 
-pass_configs = {
-    tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
-}
+    tilelang.set_log_level("WARNING")
+
+    pass_configs = {
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    }
+except ImportError:
+
+    class _TilelangMissing:
+        """Stub so module-level @tilelang.jit and PassConfigKey accesses parse."""
+
+        def __getattr__(self, name):
+            if name == "jit":
+
+                def _jit(*_args, **_kwargs):
+                    def _wrap(fn):
+                        def _raise(*a, **k):
+                            raise RuntimeError(
+                                "tilelang is not installed; this kernel cannot run "
+                                "on the current platform"
+                            )
+
+                        return _raise
+
+                    return _wrap
+
+                return _jit
+            return _TilelangMissing()
+
+        def __call__(self, *_args, **_kwargs):
+            return _TilelangMissing()
+
+    tilelang = _TilelangMissing()
+    T = _TilelangMissing()
+    pass_configs = None
 
 FP8 = "float8_e4m3"
 BF16 = "bfloat16"
@@ -896,6 +934,63 @@ def mhc_post(
         residual.shape[-1],
     )
     return out
+
+
+def npu_hc_pre(
+    x: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int,
+    hc_sinkhorn_iters: int,
+    rms_norm_eps: float,
+    hc_eps: float,
+    forward_batch=None,
+) -> tuple:
+    """NPU-accelerated hc_pre via the custom_ops kernel.
+
+    Returns (y, post, comb, norm_fused).  norm_fused is always False
+    because npu_hc_pre does not fold input_layernorm — the caller must
+    apply it separately.
+    """
+    shape, dtype = x.size(), x.dtype
+
+    # IDLE / empty short-circuit, mirroring the dsv4-flash source.
+    # The kernel emits post/comb in fp32 (sinkhorn iterates in fp32),
+    # so the dummies must too — otherwise downstream comb/post-aware
+    # ops see a silent fp32 ↔ bf16 split between idle and non-idle
+    # batches.
+    is_idle = forward_batch is not None and forward_batch.forward_mode.is_idle()
+    if is_idle or x.shape[0] == 0:
+        bs = x.shape[0]
+        y = torch.empty((bs, shape[-1]), dtype=dtype, device=x.device)
+        post = torch.empty((bs, hc_mult), dtype=torch.float32, device=x.device)
+        comb = torch.empty(
+            (bs, hc_mult, hc_mult),
+            dtype=torch.float32,
+            device=x.device,
+        )
+        return y, post, comb, False
+
+    # Note the return order: (y, post, comb) — y is the (T, hidden)
+    # mixed activation, post / comb are the hc_post inputs. The
+    # fused kernel emits y in fp32 (sinkhorn iterates in fp32), so
+    # cast back to the input dtype before the downstream
+    # aclnnRmsNorm (which has no x=fp32 / gamma=bf16 overload).
+    y, post, comb = torch.ops.custom.npu_hc_pre(
+        x,
+        hc_fn,
+        hc_scale,
+        hc_base,
+        hc_mult=hc_mult,
+        hc_sinkhorn_iters=hc_sinkhorn_iters,
+        norm_eps=rms_norm_eps,
+        hc_eps=hc_eps,
+    )
+    # npu_hc_pre uses norm_eps for sinkhorn's internal RMS only; it does
+    # not fold input_layernorm. Return norm_fused=False so the caller
+    # applies the layernorm itself, matching the deepgemm/torch paths.
+    return y.to(dtype), post, comb, False
 
 
 @tilelang.jit(

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -19,7 +19,9 @@ from sglang.srt.layers.moe.topk import (
     _mask_topk_ids_padded_region,
     _zero_topk_weights_padded_region,
 )
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import is_hip, is_npu
+
+_is_npu = is_npu()
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +171,25 @@ class HashTopK(nn.Module):
                 routed_scaling_factor=self.routed_scaling_factor,
                 scoring_func=self.score_func,
             )
+        elif _is_npu:
+            # fused_shared_experts == 1 is not supported
+            from sglang.srt.hardware_backend.npu.moe.topk import fused_hash_topk_npu
+
+            # fused_hash_topk_npu already does topk_ids_logical_to_physical.
+            topk_output = fused_hash_topk_npu(
+                router_logits=router_logits,
+                input_ids=input_ids,
+                tid2eid=self.tid2eid,
+                routed_scaling_factor=self.routed_scaling_factor,
+                expert_location_dispatch_info=expert_location_dispatch_info,
+            )
+            # Record expert distribution (EPLB) and apply deepep-waterfill so the
+            # NPU path matches the CUDA tail below; only logical->physical (done
+            # in the kernel) and the HIP-only padding masking are skipped.
+            get_global_expert_distribution_recorder().on_select_experts(
+                topk_ids=topk_output.topk_ids
+            )
+            return self._apply_deepep_waterfill(topk_output, hidden_states.shape[0])
         else:
             topk_weights, topk_ids = self._forward_torch(router_logits, input_ids)
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8_moe.py
@@ -132,3 +132,25 @@ class NPUCompressedTensorsW8A8Int8DynamicMoE(CompressedTensorsMoEScheme):
     ) -> CombineInput:
 
         return self.kernel.apply(layer, dispatch_output)
+
+    def apply_without_routing_weights(
+        self,
+        layer,
+        hidden_states,
+        hidden_states_scale,
+        group_list_type,
+        group_list,
+        output_dtype,
+    ):
+        # NPU MoE forward bypasses MoeRunner and calls
+        # scheme.apply_without_routing_weights; the underlying
+        # NPUW8A8Int8DynamicMoEMethod kernel already implements this, so
+        # just expose it through the scheme.
+        return self.kernel.apply_without_routing_weights(
+            layer,
+            hidden_states,
+            hidden_states_scale,
+            group_list_type,
+            group_list,
+            output_dtype,
+        )

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -87,6 +87,17 @@ class ModelSlimConfig(QuantizationConfig):
 
     def __init__(self, quant_config: Dict[str, Any] = {}):
         super().__init__()
+        keys = [k for k in quant_config if isinstance(k, str)]
+        is_dsv4 = any(k.startswith("hc_head_") for k in keys)
+        if is_dsv4:
+            from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
+
+            remap = DeepseekV4ForCausalLM.remap_weight_name_to_dpsk_hf_format
+            quant_config = {
+                (remap(k) if isinstance(k, str) else k): v
+                for k, v in quant_config.items()
+            }
+
         self.quant_description = quant_config
         ignore = cast(List[str], quant_config.get("ignore", []))
         self.ignore = ignore if ignore is not None else []

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1684,6 +1684,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # The output locations of the KV cache
     out_cache_loc: torch.Tensor = None  # shape: [b], int64
+    # DSV4-NPU: bundled per-pool slots produced by DSV4NPUTokenToKVPoolAllocator
+    # (None on non-DSV4 paths). See hardware_backend/npu/dsv4_common_hooks.py.
+    # The c4/c128 compress-state alloc lens ride on ``batch.dsv4_state_lens``,
+    # set dynamically by those hooks (read via getattr in mem_cache/common.py).
+    out_cache_loc_dsv4: Optional[Any] = None
 
     # For hybrid GDN prefix cache
     mamba_track_indices: torch.Tensor = None  # shape: [b], int64
@@ -1970,7 +1975,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens_cpu = seq_lens_cpu
         self.extend_num_tokens = extend_num_tokens
 
-        # Allocate memory
+        # Allocate memory (DSV4-NPU c{4,128}_state alloc lens are computed inside
+        # the allocator, triggered from mem_cache/common.py.)
         out_cache_loc, req_pool_indices_tensor, req_pool_indices_cpu = alloc_for_extend(
             self
         )
@@ -2584,7 +2590,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if self.model_config.is_encoder_decoder:
             self.prepare_encoder_info_decode()
 
-        # Allocate memory
+        # Allocate memory (DSV4-NPU c{4,128}_state alloc lens are computed inside
+        # the allocator, triggered from mem_cache/common.py.)
         self.out_cache_loc = alloc_for_decode(self, token_per_req=1)
 
         # Update req-level memory management fields
@@ -2836,6 +2843,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     if req.decode_batch_idx % eviction_interval == 1:
                         self._evict_swa(req, req.seqlen - 1)
 
+                    # DSV4-NPU only (no-op elsewhere): the small paged
+                    # compress-state pool needs draining every decode step,
+                    # independent of SWA evict cadence.
+                    from sglang.srt.hardware_backend.npu.dsv4_common_hooks import (
+                        maybe_evict_dsv4_state,
+                    )
+
+                    maybe_evict_dsv4_state(self, req, req.seqlen - 1)
+
                     # Once the decode position has moved past the sliding window,
                     # the SWA portion of the prefill-time tree lock is no longer
                     # needed by this request. Convert it from protected to
@@ -2902,6 +2918,18 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 req.req_pool_idx, req.swa_evicted_seqlen : new_swa_evicted_seqlen
             ]
             self.token_to_kv_pool_allocator.free_swa(free_slots)
+
+            # DSV4-NPU only (no-op elsewhere): compress-state slots at raw
+            # positions < swa_evicted_seqlen ride along with SWA eviction.
+            # For small-window models where sliding_window < c128 retention (192),
+            # this is the primary reclaim mechanism (the watermark-based eviction
+            # alone can't free fast enough). No-op on CUDA / non-V4 paths.
+            # See hardware_backend/npu/dsv4_common_hooks.py.
+            from sglang.srt.hardware_backend.npu.dsv4_common_hooks import (
+                maybe_evict_dsv4_state_on_swa,
+            )
+
+            maybe_evict_dsv4_state_on_swa(self, req, new_swa_evicted_seqlen)
             req.swa_evicted_seqlen = new_swa_evicted_seqlen
 
     def __str__(self):

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -21,13 +21,16 @@ from sglang.srt.mem_cache.triton_ops.common import (
     write_req_to_token_pool_triton,
 )
 from sglang.srt.server_args import ServerArgs, get_global_server_args
-from sglang.srt.utils import is_hip, support_triton
+from sglang.srt.utils import is_hip, is_npu, support_triton
 from sglang.srt.utils.common import ceil_align
+
+_is_npu = is_npu()
 
 _is_hip = is_hip()
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+    from sglang.srt.model_executor.forward_batch_info import DSV4StateLens
 
 # Needs 2 + 1 slots for mamba request with prefix cache. 2 for ping pong cache, 1 for running mamba state.
 MAMBA_STATE_PER_REQ_PREFIX_CACHE = 3
@@ -267,6 +270,25 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
             tree_cache.evict(EvictParams(num_tokens=num_tokens))
 
 
+def _compute_dsv4_state_lens(batch, *, is_decode: bool):
+    """Per-req c{4,128}_state pool alloc lens (a ``DSV4StateLens``) for this
+    alloc step. The DSV4-NPU allocator owns the computation (it also mutates the
+    per-req cumulative state on each ``Req``); we just trigger it here, right
+    before the paged alloc that consumes the result.
+
+    None on CUDA / non-V4 paths (allocator has no ``compute_dsv4_state_lens_*``)
+    so the ``alloc_paged_token_slots_*`` forwarding stays a no-op.
+    """
+    allocator = batch.token_to_kv_pool_allocator
+    if not hasattr(allocator, "compute_dsv4_state_lens_extend"):
+        return None
+    if is_decode:
+        return allocator.compute_dsv4_state_lens_decode(batch.reqs)
+    return allocator.compute_dsv4_state_lens_extend(
+        batch.reqs, batch.seq_lens_cpu.tolist()
+    )
+
+
 def alloc_paged_token_slots_extend(
     tree_cache: BasePrefixCache,
     prefix_lens: torch.Tensor,
@@ -276,6 +298,9 @@ def alloc_paged_token_slots_extend(
     last_loc: torch.Tensor,
     extend_num_tokens: int,
     backup_state: bool = False,
+    req_pool_indices: Optional[torch.Tensor] = None,
+    dsv4_state_lens: Optional["DSV4StateLens"] = None,
+    batch=None,
 ):
     # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
@@ -286,14 +311,34 @@ def alloc_paged_token_slots_extend(
     if backup_state:
         state = allocator.backup_state()
 
-    out_cache_loc = allocator.alloc_extend(
+    is_dsv4 = req_pool_indices is not None and hasattr(allocator, "c4_attn_allocator")
+    extra_alloc_kwargs = {}
+    if is_dsv4:
+        extra_alloc_kwargs["req_pool_indices"] = req_pool_indices
+        # Pass the per-req tables in per call for the c-pool / state last_loc
+        # lookup; the allocator holds no reference to the pool.
+        if batch is not None:
+            extra_alloc_kwargs["req_to_token_pool"] = batch.req_to_token_pool
+        if dsv4_state_lens is not None:
+            extra_alloc_kwargs["dsv4_state_lens"] = dsv4_state_lens
+
+    out = allocator.alloc_extend(
         prefix_lens,
         prefix_lens_cpu,
         seq_lens,
         seq_lens_cpu,
         last_loc,
         extend_num_tokens,
+        **extra_alloc_kwargs,
     )
+
+    if is_dsv4:
+        bundle = out
+        out_cache_loc = None if bundle is None else bundle.out_full_loc
+        if batch is not None:
+            batch.out_cache_loc_dsv4 = bundle
+    else:
+        out_cache_loc = out
 
     if out_cache_loc is None:
         error_msg = (
@@ -389,6 +434,9 @@ def alloc_for_extend(
             seq_lens_cpu=batch.seq_lens_cpu,
             last_loc=torch.cat(last_loc),
             extend_num_tokens=batch.extend_num_tokens,
+            req_pool_indices=req_pool_indices_device,
+            dsv4_state_lens=_compute_dsv4_state_lens(batch, is_decode=False),
+            batch=batch,
         )
 
     # Write to req_to_token_pool
@@ -406,6 +454,21 @@ def alloc_for_extend(
         batch.req_to_token_pool,
     )
 
+    # DSV4-NPU hook: write the c4/c128/swa per-req tables from the bundle
+    # already stashed on batch.out_cache_loc_dsv4 above. No-op on non-DSV4
+    # paths (batch.out_cache_loc_dsv4 stays None there).
+    if _is_npu:
+        from sglang.srt.hardware_backend.npu.dsv4_common_hooks import (
+            maybe_write_dsv4_extend,
+        )
+
+        maybe_write_dsv4_extend(
+            batch,
+            req_pool_indices_cpu,
+            prefix_lens_cpu,
+            batch.seq_lens_cpu,
+        )
+
     return out_cache_loc, req_pool_indices_device, req_pool_indices_cpu
 
 
@@ -415,6 +478,9 @@ def alloc_paged_token_slots_decode(
     seq_lens_cpu: torch.Tensor,
     last_loc: torch.Tensor,
     token_per_req: int = 1,
+    req_pool_indices: Optional[torch.Tensor] = None,
+    dsv4_state_lens: Optional["DSV4StateLens"] = None,
+    batch=None,
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
@@ -422,7 +488,31 @@ def alloc_paged_token_slots_decode(
     num_tokens = len(seq_lens) * allocator.page_size
     evict_from_tree_cache(tree_cache, num_tokens)
 
-    out_cache_loc = allocator.alloc_decode(seq_lens, seq_lens_cpu, last_loc)
+    # DSV4-NPU allocator additionally needs req_pool_indices and the per-req
+    # c{4,128}_state pool lens (DSV4StateLens); it returns a DSV4OutCacheLoc
+    # bundle, which we unpack to out_full_loc and stash on the batch (see
+    # alloc_paged_token_slots_extend). Gate via hasattr so non-DSV4
+    # allocators stay unchanged.
+    is_dsv4 = req_pool_indices is not None and hasattr(allocator, "c4_attn_allocator")
+    extra_alloc_kwargs = {}
+    if is_dsv4:
+        extra_alloc_kwargs["req_pool_indices"] = req_pool_indices
+        # Per-call per-req tables for the last_loc lookup; the allocator holds
+        # no reference to the pool.
+        if batch is not None:
+            extra_alloc_kwargs["req_to_token_pool"] = batch.req_to_token_pool
+        if dsv4_state_lens is not None:
+            extra_alloc_kwargs["dsv4_state_lens"] = dsv4_state_lens
+
+    out = allocator.alloc_decode(seq_lens, seq_lens_cpu, last_loc, **extra_alloc_kwargs)
+
+    if is_dsv4:
+        bundle = out
+        out_cache_loc = None if bundle is None else bundle.out_full_loc
+        if batch is not None:
+            batch.out_cache_loc_dsv4 = bundle
+    else:
+        out_cache_loc = out
 
     if out_cache_loc is None:
         error_msg = (
@@ -466,6 +556,9 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
             seq_lens_cpu=batch.seq_lens_cpu + token_per_req,
             last_loc=last_loc,
             token_per_req=token_per_req,
+            req_pool_indices=batch.req_pool_indices,
+            dsv4_state_lens=_compute_dsv4_state_lens(batch, is_decode=True),
+            batch=batch,
         )
 
     # Write to req_to_token_pool
@@ -477,6 +570,20 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     batch.req_to_token_pool.write(
         (batch.req_pool_indices, locs), out_cache_loc.to(torch.int32)
     )
+
+    # DSV4-NPU hook: post-decode write of per-req c4/c128/swa tables from the
+    # bundle already stashed on batch.out_cache_loc_dsv4 above. No-op on
+    # non-DSV4 paths (batch.out_cache_loc_dsv4 stays None there).
+    if _is_npu:
+        from sglang.srt.hardware_backend.npu.dsv4_common_hooks import (
+            maybe_write_dsv4_decode,
+        )
+
+        maybe_write_dsv4_decode(
+            batch,
+            batch.seq_lens_cpu + token_per_req,
+            token_per_req,
+        )
 
     return out_cache_loc
 
@@ -534,6 +641,8 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
             req.mamba_pool_idx is not None
         ), "mamba state is freed while the tree cache does not manage mamba states"
         tree_cache.req_to_token_pool.free_mamba_cache(req)
+    # The DSV4-NPU ReqToTokenPool subclass's free() additionally releases the
+    # c4/c128 state pages; other ReqToTokenPool subclasses are a no-op here.
     tree_cache.req_to_token_pool.free(req)
 
 

--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from contextlib import nullcontext
+from math import gcd
 
 import torch
 
@@ -11,6 +12,10 @@ from sglang.srt.utils import is_hip
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 _is_hip = is_hip()
+
+
+def _lcm(a: int, b: int) -> int:
+    return a // gcd(a, b) * b
 
 
 @dataclasses.dataclass
@@ -87,9 +92,12 @@ class CompressStatePool:
         enable_memory_saver: bool,
         ratio: int,
         online: bool = False,
+        page_size: int = 1,
         swa_page_size: int = 0,
     ):
         self.ring_size = ring_size
+        self.online = online
+        self.page_size = page_size
         self.swa_page_size = swa_page_size
         self.enable_memory_saver = enable_memory_saver
 
@@ -99,38 +107,89 @@ class CompressStatePool:
             last_dim = 3 * head_dim
         else:
             self._size = size + self.ring_size + 1
-            self._size = (self._size + ratio - 1) // ratio * ratio
+            # Pad to lcm(ratio, page_size) so the flat buffer reshapes cleanly
+            # into [block_num, page_size, last_dim] for the fused compressor
+            # op (torch.ops.custom.compressor wants its state_cache in that
+            # 3D layout). page_size=1 (default) falls back to the original
+            # ratio-only padding.
+            pad_to = _lcm(ratio, page_size) if page_size > 1 else ratio
+            self._size = (self._size + pad_to - 1) // pad_to * pad_to
             last_dim = 2 * (1 + overlap) * head_dim
 
-        if _is_hip:
-            self.kv_score_buffer = KVAndScore(
-                torch.empty((self._size, last_dim), dtype=dtype, device=device)
-            )
-            if not online:
-                self.kv_score_buffer[-1].clear()
-        else:
-            self.memory_saver_adapter = TorchMemorySaverAdapter.create(
-                enable=enable_memory_saver
-            )
-            self.enable_custom_mem_pool, self.custom_mem_pool, _ = (
-                maybe_init_custom_mem_pool(device=device)
-            )
+        self.last_dim = last_dim
+        self._alloc_kv_score_buffer(
+            dtype=dtype, device=device, enable_memory_saver=enable_memory_saver
+        )
+        if not online:
+            self.kv_score_buffer[-1].clear()
 
-            with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
-                with (
-                    torch.cuda.use_mem_pool(self.custom_mem_pool)
-                    if self.custom_mem_pool
-                    else nullcontext()
-                ):
-                    self.kv_score_buffer = KVAndScore(
-                        torch.empty(
-                            (self._size, last_dim),
-                            dtype=dtype,
-                            device=device,
-                        )
+    def _alloc_kv_score_buffer(
+        self, *, dtype: torch.dtype, device: str, enable_memory_saver: bool
+    ) -> None:
+        """Allocate the flat ``(self._size, self.last_dim)`` kv+score buffer
+        under the memory-saver / custom-mem-pool context and wrap it in
+        :class:`KVAndScore`. Sets ``self.memory_saver_adapter``,
+        ``self.custom_mem_pool`` and ``self.kv_score_buffer``.
+
+        Subclasses (e.g. :class:`NPUCompressStatePool`) that compute a
+        different ``self._size`` reuse this instead of duplicating the
+        allocation boilerplate. Requires ``self._size`` and ``self.last_dim``
+        to be set already.
+        """
+        if _is_hip:
+            # HIP doesn't support the TorchMemorySaver / custom mem-pool region;
+            # allocate a plain buffer. (clear() is done by the caller.)
+            self.memory_saver_adapter = TorchMemorySaverAdapter.create(enable=False)
+            self.enable_custom_mem_pool = False
+            self.custom_mem_pool = None
+            self.kv_score_buffer = KVAndScore(
+                torch.empty(
+                    (self._size, self.last_dim),
+                    dtype=dtype,
+                    device=device,
+                )
+            )
+            return
+
+        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
+            enable=enable_memory_saver
+        )
+        self.enable_custom_mem_pool, self.custom_mem_pool, _ = (
+            maybe_init_custom_mem_pool(device=device)
+        )
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            with (
+                torch.cuda.use_mem_pool(self.custom_mem_pool)
+                if self.custom_mem_pool
+                else nullcontext()
+            ):
+                self.kv_score_buffer = KVAndScore(
+                    torch.empty(
+                        (self._size, self.last_dim),
+                        dtype=dtype,
+                        device=device,
                     )
-                    if not online:
-                        self.kv_score_buffer[-1].clear()
+                )
+
+    @property
+    def state_cache_3d(self) -> torch.Tensor:
+        """``[block_num, page_size, last_dim]`` view of the flat kv+score
+        buffer. ``last_dim = 2*(1+overlap)*head_dim`` — exactly the
+        ``2*coff*D`` layout the fused compressor op wants for its
+        ``state_cache`` argument (kv at ``[:, :, :coff*D]``, score at
+        ``[:, :, coff*D:]``). Only valid for the non-online buffer; the
+        online layout has ``last_dim = 3*head_dim`` which the fused path
+        doesn't use.
+        """
+        assert not self.online, (
+            "state_cache_3d is for the fused compressor path; "
+            "online (3*head_dim) buffer is indexer-only."
+        )
+        assert self.page_size > 1, (
+            "state_cache_3d requires page_size>1; pool was constructed "
+            "with the default page_size=1 (flat 2D layout)."
+        )
+        return self.kv_score_buffer.kv_score.view(-1, self.page_size, self.last_dim)
 
     def translate_from_swa_loc_to_state_loc(
         self, swa_loc: torch.Tensor

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -549,41 +549,42 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             self.unified_swa_ring_size = self.sliding_window + spec_extra
             self.unified_swa_pages = self.unified_kv_pool.swa_pages
         else:
+            # NPU overrides _make_kv_pool to swap in the bf16 PA_ND pools; the
+            # CUDA/HIP base ignores global_page_size. Keep the factory hooks so
+            # the NPU subclass stays live without forking this branch.
             self.unified_kv_pool = None
-            self.swa_kv_pool = DeepSeekV4SingleKVPool(
-                swa_size,
-                swa_page_size,
-                dtype,
-                qk_nope_head_dim,
-                qk_rope_head_dim,
-                layer_num,
-                device,
-                enable_memory_saver,
+            self.swa_kv_pool = self._make_kv_pool(
+                size=swa_size,
+                page_size=swa_page_size,
+                dtype=dtype,
+                layer_num=layer_num,
+                device=device,
+                enable_memory_saver=enable_memory_saver,
+                global_page_size=swa_page_size,
             )
 
             c4_kv_pool_type = DeepSeekV4SingleKVPool
             if enable_hisparse:
                 c4_kv_pool_type = HiSparseC4DevicePool
-            self.c4_kv_pool = c4_kv_pool_type(
-                c4_size,
-                c4_page_size,
-                dtype,
-                qk_nope_head_dim,
-                qk_rope_head_dim,
-                c4_layer_num,
-                device,
-                enable_memory_saver,
+            self.c4_kv_pool = self._make_kv_pool(
+                size=c4_size,
+                page_size=c4_page_size,
+                dtype=dtype,
+                layer_num=c4_layer_num,
+                device=device,
+                enable_memory_saver=enable_memory_saver,
+                global_page_size=page_size,
+                cls=c4_kv_pool_type,
             )
 
-            self.c128_kv_pool = DeepSeekV4SingleKVPool(
-                c128_size,
-                c128_page_size,
-                dtype,
-                qk_nope_head_dim,
-                qk_rope_head_dim,
-                c128_layer_num,
-                device,
-                enable_memory_saver,
+            self.c128_kv_pool = self._make_kv_pool(
+                size=c128_size,
+                page_size=c128_page_size,
+                dtype=dtype,
+                layer_num=c128_layer_num,
+                device=device,
+                enable_memory_saver=enable_memory_saver,
+                global_page_size=page_size,
             )
 
         indexer_size = (
@@ -591,7 +592,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             if (not _is_hip or envs.SGLANG_OPT_USE_COMPRESSOR_V2.get())
             else c4_size
         )
-        self.c4_indexer_kv_pool = DeepSeekV4IndexerPool(
+        self.c4_indexer_kv_pool = self._make_indexer_pool(
             indexer_size,
             c4_page_size,
             dtype,
@@ -676,47 +677,116 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
         return data_ptrs, data_lens, item_lens
 
+    def _make_kv_pool(
+        self,
+        *,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        layer_num: int,
+        device: str,
+        enable_memory_saver: bool,
+        global_page_size: int,
+        cls: type = DeepSeekV4SingleKVPool,
+    ) -> DeepSeekV4SingleKVPool:
+        """Build a full / SWA / c4 / c128 single-KV pool. ``global_page_size``
+        is the model-wide page_size (== ``page_size`` for the SWA pool, larger
+        for the per-ratio c4/c128 pools); the default CUDA pool ignores it.
+        Overridden by :class:`DSV4NPUTokenToKVPool` to swap in the NPU bf16
+        PA_ND variant, which needs ``global_page_size`` for its kernel view."""
+        del global_page_size  # CUDA pools key only off their own page_size
+        return cls(
+            size,
+            page_size,
+            dtype,
+            self.qk_nope_head_dim,
+            self.qk_rope_head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+        )
+
+    def _make_indexer_pool(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        index_head_dim: int,
+        layer_num: int,
+        device: str,
+        enable_memory_saver: bool,
+    ) -> DeepSeekV4IndexerPool:
+        """Build the c4 lightning-indexer K pool (packed CUDA layout).
+        Overridden by :class:`DSV4NPUTokenToKVPool` to swap in the
+        dedicated-buffer NPU variant (int8 K + fp16 scale)."""
+        return DeepSeekV4IndexerPool(
+            size,
+            page_size,
+            dtype,
+            index_head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+        )
+
+    def _state_pool_size(self, ratio: int) -> int:
+        return self.c4_state_pool_size if ratio == 4 else self.c128_state_pool_size
+
+    def _make_attn_state_pool(
+        self, ratio: int, enable_memory_saver: bool
+    ) -> CompressStatePool:
+        """Build the per-layer attention compress-state pool for ``ratio``
+        (4 or 128). Overridden by :class:`DSV4NPUTokenToKVPool` to swap the
+        ring-buffered pool for the NPU paged one."""
+        return CompressStatePool(
+            size=self._state_pool_size(ratio),
+            ring_size=self.get_ring_size(ratio),
+            overlap=ratio == 4,
+            head_dim=self.qk_nope_head_dim + self.qk_rope_head_dim,
+            dtype=self.state_dtype,
+            device=self.device,
+            enable_memory_saver=enable_memory_saver,
+            ratio=ratio,
+            online=(ratio == 128 and ONLINE_C128),
+            swa_page_size=self.swa_page_size,
+        )
+
+    def _make_indexer_state_pool(
+        self, ratio: int, enable_memory_saver: bool
+    ) -> CompressStatePool:
+        """Build the per-layer indexer compress-state pool (c4 only)."""
+        return CompressStatePool(
+            size=self._state_pool_size(ratio),
+            ring_size=self.get_ring_size(ratio),
+            overlap=ratio == 4,
+            head_dim=self.indexer_head_dim,
+            device=self.device,
+            dtype=self.state_dtype,
+            enable_memory_saver=enable_memory_saver,
+            ratio=ratio,
+            swa_page_size=self.swa_page_size,
+        )
+
     def _init_paged_compress_states(self, enable_memory_saver: bool):
-        c4_state_pool_size = self.c4_state_pool_size
-        c128_state_pool_size = self.c128_state_pool_size
         total_L = len(self.compression_ratios)
         self.compress_state_pools: List[Optional[CompressStatePool]] = [None] * total_L
         self.indexer_compress_state_pools: List[Optional[CompressStatePool]] = [
             None
         ] * total_L
 
+        # PP-stage range; pools built via factory hooks so the NPU subclass can
+        # swap in the paged variant. Only c4/c128 carry compress-state pools;
+        # only c4 carries an indexer state pool.
         for idx in range(self._stage_start, self._stage_end):
             ratio = self.compression_ratios[idx]
             if ratio == 0:
                 continue
-            overlap = ratio == 4
-            size = c4_state_pool_size if ratio == 4 else c128_state_pool_size
-            ring_size = self.get_ring_size(ratio)
-
-            self.compress_state_pools[idx] = CompressStatePool(
-                size=size,
-                ring_size=ring_size,
-                overlap=overlap,
-                head_dim=self.qk_nope_head_dim + self.qk_rope_head_dim,
-                dtype=self.state_dtype,
-                device=self.device,
-                enable_memory_saver=enable_memory_saver,
-                ratio=ratio,
-                online=(ratio == 128 and ONLINE_C128),
-                swa_page_size=self.swa_page_size,
+            self.compress_state_pools[idx] = self._make_attn_state_pool(
+                ratio, enable_memory_saver
             )
-
             if ratio == 4:
-                self.indexer_compress_state_pools[idx] = CompressStatePool(
-                    size=size,
-                    ring_size=ring_size,
-                    overlap=overlap,
-                    head_dim=self.indexer_head_dim,
-                    device=self.device,
-                    dtype=self.state_dtype,
-                    enable_memory_saver=enable_memory_saver,
-                    ratio=ratio,
-                    swa_page_size=self.swa_page_size,
+                self.indexer_compress_state_pools[idx] = self._make_indexer_state_pool(
+                    ratio, enable_memory_saver
                 )
 
     def _init_compressed_layer_mapping(self):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -237,6 +237,65 @@ def compute_local_num_token_non_padded(
 
 
 @dataclass
+class DSV4OutCacheLoc:
+    """Per-forward-pass KV cache allocation for DeepSeek-V4 on NPU.
+
+    Bundles slot indices for full/SWA pools, the two compressed-KV pools
+    (c4/c128), and the two compressed-state pools (c4_state/c128_state).
+    Populated by the NPU V4 allocator (DSV4NPUTokenToKVPoolAllocator) when
+    the model is DeepSeek-V4 on NPU; left as ``None`` on ForwardBatch
+    otherwise. CUDA's DSV4 path doesn't construct this bundle (state is
+    derived via translate_kv_loc_to_compress_state_loc there).
+
+    All fields are token-level slot ids in their respective pools (NOT page
+    ids). Attention backends convert to page ids via ``// page_size`` when
+    constructing PA_ND block tables.
+
+    State fields default to ``None`` so the bundle is constructible from
+    paths that allocate KV but not state (or vice versa); the NPU allocator
+    fills all six on real alloc, CUDA paths leave state ones None and use
+    the ring-hash translation instead.
+    """
+
+    out_full_loc: torch.Tensor
+    out_swa_loc: torch.Tensor
+    out_c4_loc: torch.Tensor
+    out_c128_loc: torch.Tensor
+    out_c4_state_loc: Optional[torch.Tensor] = None
+    out_c128_state_loc: Optional[torch.Tensor] = None
+
+
+@dataclass
+class DSV4StateLens:
+    """Per-extend/decode c4/c128 compress-state pool allocation lens (DSV4-NPU).
+
+    Built by ``ScheduleBatch._compute_dsv4_state_lens_{extend,decode}`` and
+    threaded through ``mem_cache/common.py`` to
+    ``DSV4NPUTokenToKVPoolAllocator.alloc_{extend,decode}``, which consumes:
+
+      * ``c{4,128}_prefix_lens`` / ``..._cpu`` — per-req prev cumulative
+        state-slot count (the paged allocator's ``prefix`` contract).
+      * ``c{4,128}_seq_lens`` / ``..._cpu`` — per-req new cumulative count.
+      * ``c{4,128}_extend_num_tokens`` — total new state slots this step.
+
+    Replaces the 10 loose ``c{4,128}_state_*`` kwargs the allocator used to
+    take: scheduler only produces this object, common only forwards it, the
+    allocator only consumes it.
+    """
+
+    c4_prefix_lens: torch.Tensor
+    c4_prefix_lens_cpu: torch.Tensor
+    c4_seq_lens: torch.Tensor
+    c4_seq_lens_cpu: torch.Tensor
+    c4_extend_num_tokens: int
+    c128_prefix_lens: torch.Tensor
+    c128_prefix_lens_cpu: torch.Tensor
+    c128_seq_lens: torch.Tensor
+    c128_seq_lens_cpu: torch.Tensor
+    c128_extend_num_tokens: int
+
+
+@dataclass
 class NgramEmbeddingInfo:
     """Ngram embedding state for LongCat models."""
 
@@ -305,6 +364,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # The original sequence length without being chunked. Qwen-1M related.
     orig_seq_lens: Optional[torch.Tensor] = None
 
+    # DSV4-NPU only: 6-tuple of per-pool allocation slots (full/swa/c4/c128/
+    # c4_state/c128_state). Populated by DSV4NPUTokenToKVPoolAllocator; the
+    # NPU ascend attention backend consumes this to construct PA_ND block
+    # tables. None for non-DSV4 paths.
+    out_cache_loc_dsv4: Optional[DSV4OutCacheLoc] = None
     # The indices to track mamba state with
     mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
     # The mask to track mamba state if needed
@@ -628,6 +692,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             req_pool_indices=batch.req_pool_indices,
             seq_lens=batch.seq_lens,
             out_cache_loc=batch.out_cache_loc,
+            out_cache_loc_dsv4=batch.out_cache_loc_dsv4,
             seq_lens_sum=batch.seq_lens_sum,
             # Inputs aliased by reference from ScheduleBatch
             seq_lens_cpu=seq_lens_cpu,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -366,7 +366,21 @@ class ModelRunnerKVCacheMixin:
                     start_layer=self.start_layer,
                 )
             else:
-                self.req_to_token_pool = ReqToTokenPool(
+                # DSV4 on NPU needs an extended ReqToTokenPool that holds
+                # per-req tables for swa / c4 / c128 / c4_state / c128_state
+                # alongside the regular req_to_token. See
+                # hardware_backend/npu/dsv4_req_to_token_pool.py for the
+                # rationale and memory cost. Non-DSV4 + non-NPU stays on
+                # the stock ReqToTokenPool.
+                req_to_token_pool_cls = ReqToTokenPool
+                if _is_npu and is_deepseek_v4(self.model_config.hf_config):
+                    from sglang.srt.hardware_backend.npu.dsv4_req_to_token_pool import (
+                        DSV4NPUReqToTokenPool,
+                    )
+
+                    req_to_token_pool_cls = DSV4NPUReqToTokenPool
+
+                self.req_to_token_pool = req_to_token_pool_cls(
                     size=max_num_reqs,
                     max_context_len=self.model_config.context_len
                     + extra_max_context_len,
@@ -387,7 +401,7 @@ class ModelRunnerKVCacheMixin:
 
         if is_dsv4_model:
             swa_page_size = self.page_size
-            assert swa_page_size == 256, "In paged swa mode, page_size must be 256."
+            # assert swa_page_size == 256, "In paged swa mode, page_size must be 256."
 
             if self.is_draft_worker:
                 from sglang.srt.models.deepseek_v4_nextn import (
@@ -399,13 +413,55 @@ class ModelRunnerKVCacheMixin:
                 ] * self.num_effective_layers
             else:
                 compression_ratios = self.model_config.compress_ratios
-            self.token_to_kv_pool = DeepSeekV4TokenToKVPool(
+
+            # NPU + DSV4 → use the paged-state subclass. The on-NPU fused
+            # compressor kernel (torch.ops.custom.compressor cache_mode=1)
+            # requires a paged state pool; Atlas A3 rejects cache_mode=2
+            # (ring), so we cannot share the CUDA ring-buffer state path.
+            # CUDA keeps the original DeepSeekV4TokenToKVPool exactly as
+            # before. NPU state pool sizes are recomputed here (they
+            # depend on max_running_requests; pool_configurator's earlier
+            # ring-based formula is overridden for NPU).
+            from sglang.srt.utils import is_npu as _is_npu_fn
+
+            if _is_npu_fn():
+                from sglang.srt.hardware_backend.npu.dsv4_memory_pool import (
+                    DSV4NPUTokenToKVPool,
+                    npu_state_pool_size,
+                )
+
+                pool_cls = DSV4NPUTokenToKVPool
+                # Recompute state pool sizes for the NPU paged formula.
+                # CUDA's ring sizes (already in self.c{4,128}_state_pool_size)
+                # are dropped on the NPU dispatch. With tail-only allocation
+                # (see ScheduleBatch._compute_dsv4_state_lens_extend), the
+                # reference per-req-budget formula is sufficient regardless of
+                # prefill length — long prompts only allocate ``tail+128``
+                # state slots for c4 and ``tail`` for c128 (tail = seq_len %
+                # 128), and steady-state decode is drained by sliding
+                # eviction in ``ScheduleBatch._evict_swa``.
+                c4_state_pool_size = npu_state_pool_size(
+                    ratio=4,
+                    page_size=self.page_size,
+                    max_num_reqs=self.max_running_requests,
+                )
+                c128_state_pool_size = npu_state_pool_size(
+                    ratio=128,
+                    page_size=self.page_size,
+                    max_num_reqs=self.max_running_requests,
+                )
+            else:
+                pool_cls = DeepSeekV4TokenToKVPool
+                c4_state_pool_size = self.c4_state_pool_size
+                c128_state_pool_size = self.c128_state_pool_size
+
+            self.token_to_kv_pool = pool_cls(
                 max_num_reqs=self.max_running_requests,
                 swa_size=self.swa_max_total_num_tokens,
                 c4_size=self.c4_max_total_num_tokens,
                 c128_size=self.c128_max_total_num_tokens,
-                c4_state_pool_size=self.c4_state_pool_size,
-                c128_state_pool_size=self.c128_state_pool_size,
+                c4_state_pool_size=c4_state_pool_size,
+                c128_state_pool_size=c128_state_pool_size,
                 page_size=self.page_size,
                 swa_page_size=swa_page_size,
                 sliding_window=self.model_config.window_size,
@@ -731,10 +787,22 @@ class ModelRunnerKVCacheMixin:
                 )
             elif _is_npu and (
                 self.server_args.attention_backend == "ascend"
+                or is_dsv4_model
                 or self.hybrid_gdn_config is not None
             ):
                 if self.is_hybrid_swa:
-                    self.token_to_kv_pool_allocator = SWATokenToKVPoolAllocator(
+                    # DSV4 on NPU: use the SWA allocator subclass that also
+                    # drives c4/c128 paged allocators and produces a 6-tuple
+                    # DSV4OutCacheLoc on each alloc_extend/alloc_decode.
+                    if is_dsv4_model:
+                        from sglang.srt.hardware_backend.npu.dsv4_allocator import (
+                            DSV4NPUTokenToKVPoolAllocator,
+                        )
+
+                        swa_allocator_cls = DSV4NPUTokenToKVPoolAllocator
+                    else:
+                        swa_allocator_cls = SWATokenToKVPoolAllocator
+                    self.token_to_kv_pool_allocator = swa_allocator_cls(
                         self.full_max_total_num_tokens,
                         self.swa_max_total_num_tokens,
                         page_size=self.page_size,
@@ -809,6 +877,13 @@ class ModelRunnerKVCacheMixin:
                     DeepSeekV4HiSparseTokenToKVPoolAllocator(
                         self.token_to_kv_pool_allocator
                     )
+                )
+
+            # DSV4-NPU: wire allocator back-ref into req_to_token_pool so its
+            # free(req) can release c4/c128 pool pages alongside the slot.
+            if hasattr(self.req_to_token_pool, "register_dsv4_allocator"):
+                self.req_to_token_pool.register_dsv4_allocator(
+                    self.token_to_kv_pool_allocator
                 )
 
         else:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -50,14 +50,18 @@ from sglang.srt.layers.communicator_dsa_cp import (
     dsa_cp_gather_hidden_states,
     dsa_cp_reduce_scatter_hidden_states,
 )
+from sglang.srt.layers.deepseek_v4_rope import v4_rope_inplace_npu
 from sglang.srt.layers.dp_attention import (
     _DpGatheredBufferWrapper,
     attn_tp_all_gather,
+    attn_tp_all_reduce,
     dp_gather_partial,
+    dp_gather_replicate,
     dp_scatter,
     get_attention_cp_rank,
     get_attention_cp_size,
     get_attention_dp_size,
+    get_attention_tp_group,
     get_attention_tp_rank,
     get_attention_tp_size,
     get_dp_global_num_tokens,
@@ -131,6 +135,13 @@ from sglang.srt.utils import (
 )
 from sglang.srt.utils.custom_op import register_custom_op
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+# NPU-only: bind torch_npu in this module's namespace. _compute_q_b /
+# _forward_prepare call torch_npu.npu_rms_norm directly; module-level imports
+# elsewhere (e.g. model_runner) don't make the name visible here. torch.ops.
+# custom.* is registered separately via hardware_backend.npu.utils.
+if _is_npu:
+    import torch_npu
 
 logger = logging.getLogger(__name__)
 
@@ -347,7 +358,12 @@ class MQALayer(nn.Module):
             if compress_ratio_override is not None
             else config.compress_ratios[layer_id]
         )
-        assert compress_ratio in [0, 4, 128]
+
+        assert compress_ratio in (
+            0,
+            4,
+            128,
+        ), f"V4 compress_ratio: expected one of (0, 4, 128), got {compress_ratio}"
         self.compress_ratio: Literal[0, 4, 128] = compress_ratio
 
         assert self.head_dim == config.head_dim
@@ -357,7 +373,11 @@ class MQALayer(nn.Module):
         if rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
 
-        rope_base = config.compress_rope_theta if self.compress_ratio else rope_theta
+        rope_base = (
+            config.compress_rope_theta
+            if self.compress_ratio in (4, 128)
+            else rope_theta
+        )
 
         self.rotary_emb = get_rope_wrapper(
             head_size=self.rope_head_dim,
@@ -371,11 +391,11 @@ class MQALayer(nn.Module):
 
         from sglang.srt.layers.deepseek_v4_rope import precompute_freqs_cis
 
-        assert self.compress_ratio in {0, 4, 128}
-        if self.compress_ratio:
-            original_seq_len = rope_scaling["original_max_position_embeddings"]
-        else:
-            original_seq_len = 0
+        # YARN correction applies to ALL layers regardless of compress_ratio:
+        # dense (ratio 0) and compressed (ratio 4/128) layers share the same
+        # YARN-corrected inv_freq; only the rope base differs (rope_theta vs
+        # compress_rope_theta).
+        original_seq_len = rope_scaling["original_max_position_embeddings"]
 
         freqs_cis = precompute_freqs_cis(
             dim=self.qk_rope_head_dim,
@@ -408,7 +428,7 @@ class MQALayer(nn.Module):
 
         self.compressor = None
         self.indexer = None
-        if self.compress_ratio:
+        if self.compress_ratio in (4, 128):
             self.compressor = Compressor(
                 config,
                 layer_id=self.layer_id,
@@ -487,7 +507,8 @@ class MQALayer(nn.Module):
             self.hidden_size,
             bias=False,
             quant_config=quant_config,
-            reduce_results=attn_tp_size > 1,
+            reduce_results=attn_tp_size == get_tensor_model_parallel_world_size()
+            and attn_tp_size > 1,
             prefix=add_prefix("wo_b", prefix),
             tp_rank=attn_tp_rank,
             tp_size=attn_tp_size,
@@ -530,6 +551,21 @@ class MQALayer(nn.Module):
     ) -> torch.Tensor:
         q, _ = self.wq_b(q)
         q = q.view(-1, self.n_local_heads, self.head_dim)
+        if _is_npu:
+            # NPU-native RMS norm with an all-ones dummy weight. triton
+            # rms_normalize_triton drifts ~1 ULP per layer vs the kernel; over
+            # 43 layers that flips argmax. fused_q_norm_rope is CUDA/tvm_ffi
+            # only, so NPU keeps the separate norm + rope path, using the
+            # torch-fallback rotary (v4_rope_inplace_npu).
+            _dummy = q.new_ones(q.shape[-1])
+            q = torch_npu.npu_rms_norm(q, _dummy, self.eps)[0]
+            v4_rope_inplace_npu(
+                q[..., -self.qk_rope_head_dim :],
+                None,
+                self.freqs_cis,
+                positions,
+            )
+            return q
         if q_out is None:
             q_out = torch.empty_like(q)
         # Fused warp-per-(token, head) rmsnorm-self + RoPE + write to q_out.
@@ -572,12 +608,26 @@ class MQALayer(nn.Module):
         positions: torch.Tensor,
         qkv_a: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Bf16-kv path used by the DSA prefill-CP case (needs all-gather)."""
+        """Bf16-kv path used by the DSA prefill-CP case (needs all-gather), and
+        by the NPU path (which writes the bf16 kv via the backend's store_cache
+        rather than the CUDA fused direct-to-cache kernel)."""
         if qkv_a is not None:
             kv = qkv_a[..., self.q_lora_rank :]
         else:
             kv, _ = self.wkv(x)
         kv = kv.contiguous()
+        if _is_npu:
+            # fused_norm_rope_inplace is a CUDA/tvm_ffi kernel; on NPU do the
+            # kv norm + torch-fallback rotary explicitly (matches the legacy
+            # inline NPU path).
+            kv = self.kv_norm(kv)
+            v4_rope_inplace_npu(
+                kv[..., -self.qk_rope_head_dim :].unsqueeze(1),
+                None,
+                self.freqs_cis,
+                positions,
+            )
+            return kv
         fused_norm_rope_inplace(
             kv,
             self.kv_norm.weight.data,
@@ -791,8 +841,11 @@ class MQALayer(nn.Module):
 
         unified = is_unified_kv_triton()
         is_decode = forward_batch.forward_mode.is_decode_or_idle()
-        do_fused_store = (unified and is_decode) or (
-            not unified and self.use_fused_qk_norm_rope
+        # fused_qk_norm_rope_swa_store is a CUDA/tvm_ffi kernel; NPU never takes
+        # the fused-store path (it uses the separate norm+rope+store_cache path
+        # below via _compute_q_b / _compute_kv_bf16).
+        do_fused_store = (not _is_npu) and (
+            (unified and is_decode) or (not unified and self.use_fused_qk_norm_rope)
         )
 
         if do_fused_store:
@@ -892,6 +945,17 @@ class MQALayer(nn.Module):
                     swa_k=kv,
                     forward_batch=forward_batch,
                 )
+            elif _is_npu:
+                # NPU: _compute_kv_to_cache uses a CUDA fused-store kernel. Mirror
+                # the legacy inline NPU path: compute bf16 kv (norm+rope) and let
+                # the ascend backend write it via store_cache; keep kv so the
+                # attention reads it directly (save_kv_cache=False downstream).
+                kv = self._compute_kv_bf16(x_linear, positions, qkv_a=qkv_a)
+                attn_backend.store_cache(
+                    layer_id=self.layer_id,
+                    swa_k=kv,
+                    forward_batch=forward_batch,
+                )
             else:
                 self._compute_kv_to_cache(
                     x_linear, positions, forward_batch, attn_backend, qkv_a=qkv_a
@@ -925,9 +989,6 @@ class MQALayer(nn.Module):
         x_quant=None,
     ) -> torch.Tensor:
         if not get_attn_tp_context().input_scattered and x.shape[0] == 0:
-            assert (
-                not self.wo_b.reduce_results
-            ), "short-circuiting allreduce will lead to hangs"
             return x
 
         attn_backend = get_attn_backend()
@@ -1033,13 +1094,23 @@ class MQALayer(nn.Module):
                     save_kv_cache=save_kv_cache,
                 )
             o = o[:, tp_slice, :]
-        fused_rope_inplace(
-            o[..., -self.qk_rope_head_dim :],
-            None,
-            self.freqs_cis,
-            positions=positions,
-            inverse=True,
-        )
+        if _is_npu:
+            # fused_rope_inplace is CUDA/tvm_ffi only; NPU uses the torch fallback.
+            v4_rope_inplace_npu(
+                o[..., -self.qk_rope_head_dim :],
+                None,
+                self.freqs_cis,
+                positions,
+                inverse=True,
+            )
+        else:
+            fused_rope_inplace(
+                o[..., -self.qk_rope_head_dim :],
+                None,
+                self.freqs_cis,
+                positions=positions,
+                inverse=True,
+            )
 
         o = o.view(o.shape[0], self.n_local_groups, -1)
 
@@ -1067,6 +1138,8 @@ class MQALayer(nn.Module):
             o = torch.einsum("tgd,grd->tgr", o, wo_a)
 
         o, _ = self.wo_b(o.flatten(1))
+        if self.tp_size > 1 and self.tp_size < get_tensor_model_parallel_world_size():
+            o = attn_tp_all_reduce(o)
 
         return o
 
@@ -1266,6 +1339,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         hc_scale: torch.Tensor,
         hc_base: torch.Tensor,
         norm: Optional[nn.Module] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ):
         """If *norm* is given and the TileLang path is active, the returned
         hidden_states are already post-norm (the norm is fused into the kernel)."""
@@ -1280,6 +1354,21 @@ class DeepseekV4DecoderLayer(nn.Module):
             return x_flat, mixes
 
         shape, dtype = x.size(), x.dtype
+
+        if _is_npu:
+            from sglang.srt.layers.mhc import npu_hc_pre
+
+            return npu_hc_pre(
+                x,
+                hc_fn,
+                hc_scale,
+                hc_base,
+                hc_mult=self.hc_mult,
+                hc_sinkhorn_iters=self.hc_sinkhorn_iters,
+                rms_norm_eps=self.rms_norm_eps,
+                hc_eps=self.hc_eps,
+                forward_batch=forward_batch,
+            )
 
         if x.shape[0] == 0:
             y = torch.empty((0, shape[-1]), dtype=dtype, device=x.device)
@@ -1372,6 +1461,9 @@ class DeepseekV4DecoderLayer(nn.Module):
                 (0, self.hc_mult, x.shape[-1]), dtype=x.dtype, device=x.device
             )
 
+        if _is_npu:
+            return torch.ops.custom.npu_hc_post(x, residual, post, comb)
+
         if envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get():
             from sglang.srt.layers.mhc import mhc_post
 
@@ -1413,7 +1505,10 @@ class DeepseekV4DecoderLayer(nn.Module):
         Optional[torch.Tensor],
         Optional[torch.Tensor],
     ]:
-        use_fused = self.use_fused_mhc_post_pre
+        # mhc_fused_post_pre / try_fused_hc_post_pre are CUDA/AMD-only fused
+        # kernels; NPU always takes the unfused hc_pre/hc_post path, where
+        # hc_pre receives forward_batch so npu_hc_pre can run.
+        use_fused = self.use_fused_mhc_post_pre and not _is_npu
 
         if prev_residual is not None and use_fused:
             residual, post, comb, hidden_states = mhc_fused_post_pre(
@@ -1445,6 +1540,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                 self.hc_attn_scale,
                 self.hc_attn_base,
                 norm=self.input_layernorm,
+                forward_batch=forward_batch,
             )
             if not norm_fused:
                 if _use_aiter and _is_gfx95_supported:
@@ -1515,6 +1611,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                 self.hc_ffn_scale,
                 self.hc_ffn_base,
                 norm=self.post_attention_layernorm,
+                forward_batch=forward_batch,
             )
             if not norm_fused:
                 hidden_states = self.post_attention_layernorm(hidden_states)
@@ -1544,7 +1641,14 @@ class DeepseekV4DecoderLayer(nn.Module):
                 get_global_dp_buffer(get_tp_group()),
                 hidden_states,
             )
-            dp_gather_partial(hidden_states, local_hidden_states, forward_batch)
+            if _is_npu:
+                # DSV4 TP-accuracy fix (NPU): hidden_states follow TP_ATTN_FULL
+                # semantics (replicated within an attention-TP group). Use
+                # replicate gather to avoid summing the same activations across
+                # attention-TP ranks before entering MLP/MoE.
+                dp_gather_replicate(hidden_states, local_hidden_states, forward_batch)
+            else:
+                dp_gather_partial(hidden_states, local_hidden_states, forward_batch)
         _a2a_scatter_chunks: Optional[List[torch.Tensor]] = None
         if _use_tp_attn_a2a_scatter:
             s, r = get_attention_tp_size(), get_attention_tp_rank()
@@ -1562,18 +1666,28 @@ class DeepseekV4DecoderLayer(nn.Module):
         if _use_cp and get_moe_a2a_backend().is_none():
             hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
         elif _use_tp_moe_gather:
-            hidden_states, global_hidden_states = (
-                get_local_dp_buffer(get_tp_group()),
-                hidden_states,
-            )
-            if should_use_dp_reduce_scatterv():
-                get_tp_group().reduce_scatterv(
-                    global_hidden_states,
-                    output=hidden_states,
-                    sizes=get_dp_global_num_tokens(),
+            if _is_npu:
+                # DSV4 TP-accuracy fix (NPU): scatter into the attention-TP
+                # group's local buffer (matches the replicate gather above) to
+                # avoid double-summing TP_ATTN_FULL-replicated activations.
+                hidden_states, global_hidden_states = (
+                    get_local_dp_buffer(get_attention_tp_group()),
+                    hidden_states,
                 )
-            else:
                 dp_scatter(hidden_states, global_hidden_states, forward_batch)
+            else:
+                hidden_states, global_hidden_states = (
+                    get_local_dp_buffer(get_tp_group()),
+                    hidden_states,
+                )
+                if should_use_dp_reduce_scatterv():
+                    get_tp_group().reduce_scatterv(
+                        global_hidden_states,
+                        output=hidden_states,
+                        sizes=get_dp_global_num_tokens(),
+                    )
+                else:
+                    dp_scatter(hidden_states, global_hidden_states, forward_batch)
         if _use_tp_attn_a2a_scatter:
             assert _a2a_scatter_chunks is not None
             gathered = [torch.empty_like(t) for t in _a2a_scatter_chunks]
@@ -1709,7 +1823,13 @@ class DeepseekV4Model(nn.Module):
                 dtype=input_ids.dtype,
                 device=input_ids.device,
             )
-            dp_gather_partial(input_ids_global, input_ids[:, None], forward_batch)
+            if _is_npu:
+                # DSV4 TP-accuracy fix (NPU): token ids are replicated within an
+                # attention-TP group. Use replicate gather to avoid summing
+                # duplicated ids when attention_tp_size > 1.
+                dp_gather_replicate(input_ids_global, input_ids[:, None], forward_batch)
+            else:
+                dp_gather_partial(input_ids_global, input_ids[:, None], forward_batch)
             input_ids_global = input_ids_global.squeeze(-1)
         else:
             input_ids_global = input_ids
@@ -1900,6 +2020,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         if self.capture_aux_hidden_states:
             hidden_states, aux_hidden_states = hidden_states
         hidden_states, pre_hc_head = hidden_states
+
         return self.logits_processor(
             input_ids,
             hidden_states,
@@ -1944,7 +2065,10 @@ class DeepseekV4ForCausalLM(nn.Module):
         for layer_id in range(self.model.start_layer, self.model.end_layer):
             layer = self.model.layers[layer_id]
             self_attn = layer.self_attn
-            if self_attn.compress_ratio != 0 and not self_attn.compressor.ape_converted:
+            if (
+                self_attn.compress_ratio in (4, 128)
+                and not self_attn.compressor.ape_converted
+            ):
                 self_attn.compressor.apply_ape_hotfix()
             if (
                 self_attn.compress_ratio == 4
@@ -1955,7 +2079,9 @@ class DeepseekV4ForCausalLM(nn.Module):
 
     @staticmethod
     def remap_weight_name_to_dpsk_hf_format(
-        name: str, is_nextn: bool = False, num_hidden_layers: Optional[int] = None
+        name: str,
+        is_nextn: bool = False,
+        num_hidden_layers: Optional[int] = None,
     ) -> str:
         if name == "embed.weight":
             return "model.embed_tokens.weight"
@@ -2353,8 +2479,10 @@ class DeepseekV4ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        # Hot weight reload (RL workflows). Use the device-agnostic module
+        # accessor so this works on both CUDA/HIP and NPU.
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,7 +1,7 @@
 import logging
 
 from sglang.srt.server_args import ServerArgs, get_global_server_args
-from sglang.srt.utils.common import is_blackwell, is_hip, is_musa
+from sglang.srt.utils.common import is_blackwell, is_hip, is_musa, is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -235,6 +235,11 @@ class DraftBackendFactory:
         )
 
     def _create_dsv4_decode_backend(self):
+        # On NPU the "dsv4" backend resolves to the Ascend V4 subclass; its
+        # draft path reuses the Ascend multi-step draft backend.
+        if is_npu():
+            return self._create_ascend_decode_backend()
+
         if is_hip():
             from sglang.srt.layers.attention.deepseek_v4_backend_hip_radix import (
                 DeepseekV4MultiStepBackend,
@@ -332,6 +337,11 @@ class DraftBackendFactory:
         return None
 
     def _create_dsv4_prefill_backend(self):
+        # On NPU the "dsv4" backend resolves to the Ascend V4 subclass; its
+        # draft-extend path reuses the Ascend prefill draft backend.
+        if is_npu():
+            return self._create_ascend_prefill_backend()
+
         if is_hip():
             from sglang.srt.layers.attention.deepseek_v4_backend_hip_radix import (
                 DeepseekV4HipRadixBackend,


### PR DESCRIPTION
End-to-end Ascend NPU backend for the DeepSeek-V4-Flash architecture, overlaid on the existing CUDA/HIP code via is_npu() device gates so the community code paths are unchanged.

New (NPU):
- hardware_backend/npu/attention/ascend_dsv4_backend.py
- hardware_backend/npu/dsv4_{allocator,common_hooks,memory_pool,req_to_token_pool}.py
- hardware_backend/npu/moe/topk.py
- layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8_moe.py

Modified (is_npu()-gated branches; CUDA/HIP behavior unchanged):
- models/deepseek_v4.py, layers/{deepseek_v4_rope,mhc}.py, layers/attention/dsv4/compressor.py: torch_npu RMS norm + v4_rope_inplace_npu fallbacks (fused CUDA/tvm_ffi kernels are unavailable on Ascend); NPU kv store path; DSV4 TP-accuracy fix
- mem_cache/{common,deepseek_v4_compress_state,deepseek_v4_memory_pool}.py: NPU pool factory hooks
- managers/schedule_batch.py, model_executor/{forward_batch_info,model_runner_kv_cache_mixin}.py: out_cache_loc_dsv4 plumbing
- hardware_backend/npu/{attention/ascend_backend,graph_runner/npu_graph_runner,utils}.py, layers/attention/attention_registry.py, speculative/draft_utils.py: DSV4 device routing
- layers/moe/hash_topk.py, arg_groups/deepseek_v4_hook.py, layers/quantization/modelslim/modelslim.py: NPU topk/EPLB recording, defaults, quant

Accuracy/benchmark on Ascend: pending (to fill in PR description).

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27345759727](https://github.com/sgl-project/sglang/actions/runs/27345759727)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27345759717](https://github.com/sgl-project/sglang/actions/runs/27345759717)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->