### PR TITLE
[WIP] Enable FlashInfer GDN pool-indexed decode and bf16 state on SM90

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
 )
@@ -103,7 +104,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             raise RuntimeError("FlashInfer GDN decode kernel is unavailable.")
 
         sm_major = torch.cuda.get_device_capability()[0]
-        self.use_state_pool = sm_major >= 10
+        self.use_state_pool = sm_major >= 9
         self.supports_target_verify = sm_major in (9, 10)
 
         if sm_major == 9 and self._prefill_fn is None:
@@ -111,8 +112,11 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         if self._mtp_fn is None:
             raise RuntimeError("FlashInfer GDN MTP (verify) kernel is unavailable.")
 
-        if self.use_state_pool and mtp_bf16_fn is not None:
-            # Adapt bf16 kernel to fp32 kernel interface so target_verify needs no branching.
+        # Select MTP kernel based on state dtype. The fp32 MTP kernel only
+        # accepts fp32 state, while the bf16 kernel only accepts bf16 state.
+        self._use_bf16_state = envs.SGLANG_MAMBA_SSM_DTYPE.get() == "bfloat16"
+        if self._use_bf16_state and mtp_bf16_fn is not None:
+
             def _mtp_bf16_adapted(
                 q,
                 k,
@@ -191,8 +195,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 initial_state_indices=cache_indices,
             )
         else:
-            # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
-            # will no longer be needed here.
             state_batch = ssm_states[cache_indices]
             output_fi, new_state = self._decode_fn(
                 q=query_fi,
@@ -259,7 +261,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 scale=None,
                 initial_state=initial_state_fi,
                 output_final_state=True,
-                cu_seqlens=query_start_loc,  # already int32
+                cu_seqlens=query_start_loc,
                 use_qk_l2norm_in_kernel=False,
                 output_state=output_state_fi,
             )
@@ -270,7 +272,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 cache_indices,
                 ssm_states.shape[0] - 1,
             ).to(torch.int64)
-            # State must be float32; kernel requires int64 cu_seqlens.
             initial_state_fi = ssm_states[ssm_cache_indices].to(torch.float32)
             output_fi, output_state_fi = self._prefill_fn(
                 q=q_fi,
@@ -281,7 +282,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 scale=None,
                 initial_state=initial_state_fi,
                 output_final_state=True,
-                cu_seqlens=query_start_loc.to(torch.int64),
+                cu_seqlens=query_start_loc,
                 use_qk_l2norm_in_kernel=False,
             )
 
@@ -349,8 +350,8 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         b_mtp = b.view(batch_size, draft_token_num, num_v_heads)
 
         intermediate_states_buffer_mtp = intermediate_states_buffer
-        if self.use_state_pool and intermediate_states_buffer is not None:
-            # The SM100 bf16 MTP kernel indexes this scratch buffer by the
+        if self._use_bf16_state and intermediate_states_buffer is not None:
+            # The bf16 MTP kernel indexes this scratch buffer by the
             # per-call batch id, while SGLang's speculative state cache is
             # pool-scoped and may include an extra dummy slot.
             intermediate_states_buffer_mtp = intermediate_states_buffer[:batch_size]

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -177,7 +177,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         query_fi = q.view(batch_size, 1, num_heads, head_k_dim)
         key_fi = k.view(batch_size, 1, num_heads, head_k_dim)
         value_fi = v.view(batch_size, 1, num_v_heads, head_v_dim)
-        a_fi = a.view(batch_size, 1, num_v_heads)
+        a_fi = a.view(batch_size, 1, num_v_heads).clone()
         b_fi = b.view(batch_size, 1, num_v_heads)
 
         if self.use_state_pool:

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -180,36 +180,24 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         a_fi = a.view(batch_size, 1, num_v_heads)
         b_fi = b.view(batch_size, 1, num_v_heads)
 
-        if self.use_state_pool:
-            output_fi, _ = self._decode_fn(
-                q=query_fi,
-                k=key_fi,
-                v=value_fi,
-                state=None,
-                A_log=A_log.detach().float(),
-                a=a_fi,
-                dt_bias=dt_bias.detach(),
-                b=b_fi,
-                use_qk_l2norm=True,
-                initial_state=ssm_states,
-                initial_state_indices=cache_indices,
-            )
-        else:
-            state_batch = ssm_states[cache_indices]
-            output_fi, new_state = self._decode_fn(
-                q=query_fi,
-                k=key_fi,
-                v=value_fi,
-                state=state_batch,
-                A_log=A_log.detach(),
-                a=a_fi,
-                dt_bias=dt_bias.detach(),
-                b=b_fi,
-                scale=None,
-                output=None,
-                use_qk_l2norm=True,
-            )
-            ssm_states[cache_indices] = new_state
+        # Always use manual gather/scatter for decode. The pool-indexed
+        # path (initial_state + initial_state_indices) uses CuTe DSL which
+        # requires 16/32-byte aligned tensor data_ptr. With high TP the a/b
+        # tensors can be too small for PyTorch's allocator to guarantee
+        # alignment, causing RuntimeError on both SM90 and SM100.
+        state_batch = ssm_states[cache_indices]
+        output_fi, new_state = self._decode_fn(
+            q=query_fi,
+            k=key_fi,
+            v=value_fi,
+            state=state_batch,
+            A_log=A_log.detach().float(),
+            a=a_fi,
+            dt_bias=dt_bias.detach(),
+            b=b_fi,
+            use_qk_l2norm=True,
+        )
+        ssm_states[cache_indices] = new_state
 
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)
 

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -180,24 +180,36 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         a_fi = a.view(batch_size, 1, num_v_heads)
         b_fi = b.view(batch_size, 1, num_v_heads)
 
-        # Always use manual gather/scatter for decode. The pool-indexed
-        # path (initial_state + initial_state_indices) uses CuTe DSL which
-        # requires 16/32-byte aligned tensor data_ptr. With high TP the a/b
-        # tensors can be too small for PyTorch's allocator to guarantee
-        # alignment, causing RuntimeError on both SM90 and SM100.
-        state_batch = ssm_states[cache_indices]
-        output_fi, new_state = self._decode_fn(
-            q=query_fi,
-            k=key_fi,
-            v=value_fi,
-            state=state_batch,
-            A_log=A_log.detach().float(),
-            a=a_fi,
-            dt_bias=dt_bias.detach(),
-            b=b_fi,
-            use_qk_l2norm=True,
-        )
-        ssm_states[cache_indices] = new_state
+        if self.use_state_pool:
+            output_fi, _ = self._decode_fn(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=None,
+                A_log=A_log.detach().float(),
+                a=a_fi,
+                dt_bias=dt_bias.detach(),
+                b=b_fi,
+                use_qk_l2norm=True,
+                initial_state=ssm_states,
+                initial_state_indices=cache_indices,
+            )
+        else:
+            state_batch = ssm_states[cache_indices]
+            output_fi, new_state = self._decode_fn(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=state_batch,
+                A_log=A_log.detach(),
+                a=a_fi,
+                dt_bias=dt_bias.detach(),
+                b=b_fi,
+                scale=None,
+                output=None,
+                use_qk_l2norm=True,
+            )
+            ssm_states[cache_indices] = new_state
 
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3385,20 +3385,6 @@ class ServerArgs:
                 "defaulting --linear-attn-decode-backend to flashinfer."
             )
 
-        # SM100+ FlashInfer GDN decode requires bf16 state; SM90 uses float32.
-        decode = self.linear_attn_decode_backend or self.linear_attn_backend
-        if (
-            decode == "flashinfer"
-            and self.mamba_ssm_dtype != "bfloat16"
-            and torch.cuda.is_available()
-            and torch.cuda.get_device_capability()[0] >= 10
-        ):
-            raise ValueError(
-                "--linear-attn-decode-backend flashinfer on SM100+ requires "
-                "--mamba-ssm-dtype bfloat16, "
-                f"got {self.mamba_ssm_dtype!r}"
-            )
-
         # SM100+ FlashInfer GDN prefill requires CUDA 13+ (CuTe DSL kernel)
         # for correctness and best performance.
         prefill = self.linear_attn_prefill_backend or self.linear_attn_backend

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -14,6 +14,7 @@ from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner i
 )
 from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import NPUGraphRunner
 from sglang.srt.kv_canary.runner.canary_manager import context_tuple
+from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
 from sglang.srt.layers.attention.tokenspeed_mla_backend import TokenspeedMLABackend
 from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
 from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
@@ -376,6 +377,7 @@ class EagleDraftWorker(BaseDraftWorker):
         supports_cuda_draft_extend_graph = (_is_cuda or _is_musa) and isinstance(
             self.draft_extend_attn_backend,
             (
+                FlashAttentionBackend,
                 TritonAttnBackend,
                 TRTLLMMLABackend,
                 TRTLLMHAAttnBackend,


### PR DESCRIPTION
## Summary

FlashInfer's GDN kernels now fully support SM90 (Hopper), but sglang still gates several features behind `sm_major >= 10`. This PR updates the conditions to match FlashInfer's actual capabilities.

### Changes

**1. Enable pool-indexed decode on SM90** (`use_state_pool`: `>= 10` → `>= 9`)

The decode path previously used manual gather/scatter on SM90, passing a batched state tensor to the kernel. FlashInfer PR [flashinfer-ai/flashinfer#2521](https://github.com/flashinfer-ai/flashinfer/pull/2521) (merged 2026-03-09) added pool-indexed state access (`initial_state` + `initial_state_indices`) to the SM90 decode kernel, eliminating the gather/scatter overhead. The TODO referencing this PR is now removed.

**2. Enable bf16 state path on SM90**

FlashInfer's bf16 CuTe DSL decode kernel (`gdn_decode_bf16_state.py`) includes SM90 compatibility — it uses scalar FMA wrappers instead of SM100-only packed FMA intrinsics. There is no SM version gate blocking SM90 in FlashInfer. The previous `sm_major >= 10` restriction in sglang was a leftover from when the bf16 kernel hadn't been adapted for SM90 yet.

**3. Select MTP kernel by state dtype instead of SM version**

Previously, the bf16 MTP kernel adapter was installed unconditionally when `use_state_pool=True` (i.e., SM100+). This worked because a separate validation in `server_args.py` enforced that SM100 + FlashInfer decode must use bf16 state. Now that both SM90 and SM100 can use either fp32 or bf16 state with FlashInfer, the MTP kernel selection is based on `SGLANG_MAMBA_SSM_DTYPE` at init time:
- `bfloat16` → bf16 MTP kernel (`gdn_decode_bf16_state.gated_delta_rule_mtp`)
- otherwise → fp32 MTP kernel (`gdn_decode.gated_delta_rule_mtp`)

The `intermediate_states_buffer` slicing in `target_verify` is also gated on `_use_bf16_state` (bf16 MTP kernel indexes by batch id, fp32 kernel uses pool-scoped indices).

**4. Remove SM100+ bf16 state requirement for FlashInfer decode** (`server_args.py`)

FlashInfer's `gated_delta_rule_decode_pretranspose` auto-dispatches based on state dtype: bf16 state → CuTe DSL kernel, fp32 state → C++ JIT kernel. Both paths work on both SM90 and SM100. The validation that forced `mamba_ssm_dtype=bfloat16` on SM100+ was unnecessarily restrictive.

**5. Remove redundant `cu_seqlens` dtype conversions** (`gdn_flashinfer.py`)

FlashInfer's `chunk_gated_delta_rule` prefill function internally converts `cu_seqlens` to the correct dtype per architecture (int32 for SM100 CuTe DSL path, int64 for SM90 C++ JIT path). The caller-side `.to(torch.int64)` on SM90 was redundant.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27340989216](https://github.com/sgl-project/sglang/actions/runs/27340989216)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27340989045](https://github.com/sgl-project/sglang/actions/runs/27340989045)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->