### PR TITLE
Fix EAGLE3 MLA draft with no lm_head weight (borrow target head)

### DIFF
--- a/python/sglang/srt/models/kimi_k25_eagle3.py
+++ b/python/sglang/srt/models/kimi_k25_eagle3.py
@@ -417,6 +417,7 @@ class Eagle3DeepseekV2ForCausalLM(nn.Module):
             (".gate_up_proj", ".up_proj", 1),
         ]
         cached_a_proj: dict[str, torch.Tensor] = {}
+        lm_head_loaded = False
 
         for name, loaded_weight in weights:
             if name == "d2t" or name.endswith(".d2t"):
@@ -482,6 +483,28 @@ class Eagle3DeepseekV2ForCausalLM(nn.Module):
             param = params_dict[mapped_name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+            if mapped_name.startswith("lm_head."):
+                lm_head_loaded = True
+
+        # Some EAGLE3 checkpoints (e.g. nvidia/Kimi-K2.6-Eagle3) ship no lm_head
+        # weight and expect to reuse the target model's head, but declare
+        # draft_vocab_size (so the draft_vocab_size-is-None heuristic in __init__
+        # does not flag it). Without this, our freshly-allocated ParallelLMHead is
+        # never populated and the draft emits garbage logits -> accept rate 0.00.
+        # Borrow the target head when it is the right shape (full draft vocab).
+        if not self.config.tie_word_embeddings and not lm_head_loaded:
+            draft_vocab_size = getattr(self.config, "draft_vocab_size", None)
+            if draft_vocab_size not in (None, self.config.vocab_size):
+                raise ValueError(
+                    "Eagle3 MLA draft checkpoint provides no lm_head weight and uses "
+                    f"a reduced draft vocab ({draft_vocab_size} != "
+                    f"{self.config.vocab_size}); cannot borrow the target head."
+                )
+            self.load_lm_head_from_target = True
+            logger.info(
+                "Eagle3 MLA: checkpoint has no lm_head weight; loading lm_head from "
+                "the target model."
+            )
 
         self.post_load_weights()
 


### PR DESCRIPTION
## Problem

Fixes #27829.

Some EAGLE3 draft checkpoints ship **no `lm_head` weight** and expect to reuse the target model's head, yet still declare `draft_vocab_size` in their config. `nvidia/Kimi-K2.6-NVFP4` + `nvidia/Kimi-K2.6-Eagle3` is such a case.

In `Eagle3DeepseekV2ForCausalLM` (`models/kimi_k25_eagle3.py`), `load_lm_head_from_target` is only set when `draft_vocab_size is None`. Since this draft declares `draft_vocab_size` (== `vocab_size`, full vocab) and `tie_word_embeddings=false`, a fresh `ParallelLMHead` is allocated and expected to be filled from the checkpoint. With no `lm_head` in the checkpoint, `load_weights` only warns about *unexpected* weights (never *missing* ones), so the draft head is **left at its random init** — the server boots, captures CUDA graphs, and serves HTTP 200, but the draft logits are garbage and no draft token is ever accepted:

```
accept len: 1.00, accept rate: 0.00
```

A sibling checkpoint that *does* ship `lm_head` (`nvidia/Kimi-K2.5-Thinking-Eagle3`) works with a byte-identical config.

## Fix

In `Eagle3DeepseekV2ForCausalLM.load_weights`, track whether an `lm_head` weight was loaded. If none was (and the head isn't tied), set `load_lm_head_from_target = True` so the eagle worker's `init_lm_head` borrows the target model's head — guarded to the full-vocab case (`draft_vocab_size == vocab_size`), otherwise raise instead of silently serving an uninitialized head.

## Precedent

Both vLLM and TRT-LLM already key this decision on **checkpoint contents** (does the draft ship an `lm_head`?) rather than on `draft_vocab_size`, and borrow the target head when the draft doesn't ship one:

- vLLM — `has_own_lm_head` (default `False`, set `True` only if `lm_head` is in the checkpoint), then `_maybe_share_lm_head` borrows the target head.
- TRT-LLM — `Eagle3ForCausalLM` defaults `load_lm_head_from_target = True`, flips it `False` only when an `lm_head` weight is present, then binds `self.lm_head = target_model.lm_head`.

This PR brings SGLang in line with both.

## Verification (8×B200, TP8, EAGLE3 ns=3 topk=1 num_draft=4)

| draft checkpoint | this PR | accept len | accept rate |
|---|---|---|---|
| no `lm_head` | before | 1.00 | 0.00 |
| no `lm_head` | after | 2.59 (max 3.58) | 0.53 |

Acceptance matches a checkpoint that ships its own `lm_head`.

Note: NVIDIA has also updated the `nvidia/Kimi-K2.6-Eagle3` checkpoint to include `lm_head`, which independently resolves the reported case; this PR is defense-in-depth so any full-vocab EAGLE3 draft published without an `lm_head` works rather than silently producing zero acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27336190310](https://github.com/sgl-project/sglang/actions/runs/27336190310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27336190085](https://github.com/sgl-project/sglang/actions/runs/27336190085)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->