### PR TITLE
Fix MiMo-V2 expert routing on TopK-bypassing MoE backends

### DIFF
--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -56,6 +56,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
 from sglang.srt.layers.moe.topk import TopK, TopKOutputFormat
+from sglang.srt.layers.moe.utils import RoutingMethodType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -263,6 +264,14 @@ class MiMoV2MoE(nn.Module):
             layer_id=self.layer_id,
             quant_config=quant_config,
             routed_scaling_factor=1.0,
+            # MiMo-V2 routes like DeepSeek-V3 (noaux_tc: sigmoid scoring +
+            # e_score_correction_bias + grouped top-k). Backends that bypass
+            # the host-side TopK (e.g. flashinfer_trtllm) route inside the
+            # kernel using this type; without it the kernel falls back to
+            # softmax-style routing and selects the wrong experts.
+            routing_method_type=getattr(
+                config, "routing_method_type", RoutingMethodType.DeepSeekV3
+            ),
             prefix=add_prefix("experts", prefix),
         )
 

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -269,8 +269,9 @@ class MiMoV2MoE(nn.Module):
             # the host-side TopK (e.g. flashinfer_trtllm) route inside the
             # kernel using this type; without it the kernel falls back to
             # softmax-style routing and selects the wrong experts.
-            routing_method_type=getattr(
-                config, "routing_method_type", RoutingMethodType.DeepSeekV3
+            routing_method_type=(
+                getattr(config, "routing_method_type", None)
+                or RoutingMethodType.DeepSeekV3
             ),
             prefix=add_prefix("experts", prefix),
         )


### PR DESCRIPTION
## Motivation

While digging into #24321 (MiMo-V2.5-NVFP4 garbage output), I found that `MiMoV2MoE` constructs its `FusedMoE` **without** `routing_method_type`. MiMo-V2 routes like DeepSeek-V3 (`topk_method: noaux_tc`: sigmoid scoring + `e_score_correction_bias` + grouped top-k), and on backends that **bypass the host-side TopK and route inside the kernel** — `flashinfer_trtllm`, which is the auto default for NVFP4 on ≥SM100 (`modelopt_quant.py`) — the kernel receives `routing_method_type=None` via `getattr(layer, "routing_method_type", RoutingMethodType.Default)` (the attribute exists as `None`, so the getattr default never applies) and does not perform sigmoid/bias routing → wrong experts on every token.

The host-side TopK path (`flashinfer_cutlass`, triton, etc.) is unaffected because `biased_grouped_topk` routes correctly there — so this does **not** fully resolve #24321 (the SM120 report used `flashinfer_cutlass`); it fixes the B200-class default-backend path for this model. Analysis notes posted on the issue.

## Modifications

Pass `routing_method_type=getattr(config, "routing_method_type", RoutingMethodType.DeepSeekV3)` in `MiMoV2MoE`, mirroring `deepseek_v2.py`.

Verified MiMo's routing config (`num_experts=256, top_k=8, n_group=1, topk_group=1`) satisfies every DeepSeekV3-routing constraint in flashinfer's `trtllm_fused_moe_kernel_launcher.cu` (`num_experts % n_group == 0`, `top_k ≤ 8` for ≤384 experts, `topk_group ≤ 4`, `topk_group ≤ n_group`, `top_k < topk_group·num_experts/n_group`).

Possible follow-up (not in this PR): `modelopt_quant.py`'s `getattr(layer, "routing_method_type", …)` never applies its default because `FusedMoE` always sets the attribute (possibly `None`) — an `… or RoutingMethodType.Default` would make the fallback real.

## Accuracy Tests

No SM100-class GPU on hand to run the trtllm-gen path end-to-end; the change is config plumbing identical to the deepseek_v2 pattern and is a no-op for all backends that use host-side TopK. Syntax/pre-commit pass.

## Checklist

- [x] Format your code with pre-commit
- [x] Add unit tests — N/A (config plumbing; covered by existing MiMo CI once it runs trtllm backend)
- [x] Update documentation — N/A

AI assistance (Claude Code) was used for the investigation; I reviewed and understand the change.

 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27342136877](https://github.com/sgl-project/sglang/actions/runs/27342136877)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27342136914](https://github.com/sgl-project/sglang/actions/runs/27342136914)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->