### PR TITLE
fix(deepgemm): align PP-parallel warmup bs to CP padding

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -463,10 +463,15 @@ def pp_parallel_deep_gemm_warmup(model_runner) -> None:
     # n_splits ~= n_sms / ceil(bs/block_m) with block_m=64; sweep 5 bs to
     # cover the brackets real /generate hits (smallest decode shape,
     # mid-low, two mid, and n_splits=1 for ~5K+ token prefill). Ceil-align
-    # to attn_cp_size for DSA prefill CP's seq_len % cp_size == 0 assert.
+    # bs to the CP padding alignment (cp_size, or 2*cp_size for DSA
+    # in-seq-split). _dummy_run does not pad q/hidden like the real flow, so
+    # an unaligned bs makes DSA's padded num_splits longer than the q tokens
+    # and trips FlashMLA's "num_splits must have shape (b+1)" check.
+    from sglang.srt.layers.utils.cp_utils import get_cp_padding_align_size
+
     n_sms = torch.cuda.get_device_properties(model_runner.device).multi_processor_count
     block_m = 64
-    cp = max(model_runner.attn_cp_size, 1)
+    cp = max(get_cp_padding_align_size(), 1)
     batch_sizes = sorted(
         {
             ceil_align(bs, cp)


### PR DESCRIPTION


The PP-parallel DeepGEMM warmup ran EXTEND dummy forwards with batch sizes aligned only to attn_cp_size. DSA pads dsa_cache_seqlens (and the derived FlashMLA num_splits) to cal_padded_tokens, which uses get_cp_padding_align_size() (cp_size, or 2*cp_size for DSA in-seq-split). The real /generate flow also pads q/hidden to that length, but _dummy_run does not, so an unaligned bs made num_splits longer than the q tokens and tripped FlashMLA's 'num_splits must have shape (b+1)' check.

Align the synthetic warmup batch sizes to get_cp_padding_align_size() so the dummy q tokens match DSA's padded seqlens (no-op when CP is off).

## Fix:

```
  File "/usr/local/src/sglang/python/sglang/srt/models/deepseek_v2.py", line 2426, in forward
    hidden_states, residual, topk_indices = layer(
                                            ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/models/deepseek_v2.py", line 2073, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/models/deepseek_v2.py", line 1728, in forward
    return self.forward_core(s)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/models/deepseek_v2.py", line 1839, in forward_core
    return self.forward_absorb_core(*inner_state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py", line 494, in forward_absorb_core
    attn_output = self.attn_mqa(
                  ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/layers/radix_attention.py", line 139, in forward
    return get_attn_backend().forward(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/layers/attention/base_attn_backend.py", line 159, in forward
    return self.forward_extend(
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/layers/attention/dsa_backend.py", line 1543, in forward_extend
    return self._forward_flashmla_kv(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/src/sglang/python/sglang/srt/layers/attention/dsa_backend.py", line 1867, in _forward_flashmla_kv
    o, _ = flash_mla_with_kvcache(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sgl_kernel/flash_mla.py", line 181, in flash_mla_with_kvcache
    out, softmax_lse = torch.ops.sgl_kernel.fwd_kvcache_mla.default(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 865, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: num_splits must have shape (b+1)

````

This regression was introduced by PR #26911 ("Gate DP-attention even-token padding to CP-enabled configs", merged 2026-06-03). That PR changed cal_padded_tokens() from always aligning to attn_cp_size * 2 to the config-aware get_cp_padding_align_size() (cp_size, or 2 * cp_size only for in-seq-split CP). The FlashMLA kernel itself was not changed.

Before #26911, the warmup's attn_cp_size-aligned batch sizes happened to stay compatible with the padding logic, so SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP ran fine. After #26911, the DSA padding alignment and the warmup's batch-size alignment diverged, surfacing the crash.

## Symptom

With SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP enabled on a DeepSeek-V3.2/V4 (DSA) + CP deployment, every PP rank crashes during startup warmup:

File ".../layers/attention/dsa_backend.py", line 1867, in _forward_flashmla_kv
    o, _ = flash_mla_with_kvcache(...)
RuntimeError: num_splits must have shape (b+1)

The crash is in the EXTEND dummy forward: pp_parallel_deep_gemm_warmup → model_runner._dummy_run(forward_mode_override=EXTEND) → DSA _forward_flashmla_kv.

## Root cause

_forward_flashmla_kv reshapes the query to q_all.view(-1, 1, h, d), so FlashMLA infers batch b = q_tokens and requires num_splits.shape == (b + 1).

num_splits is derived from dsa_cache_seqlens_int32, which DSA pads via pad_dsa_cache_seqlens() to cal_padded_tokens(), aligned to get_cp_padding_align_size().

- Real /generate: ForwardBatch.prepare_mlp_sync_batch pads q/hidden to the same cal_padded_tokens, so q_tokens == len(dsa_cache_seqlens) and the shapes match.
- _dummy_run: the synthetic q length is just num_tokens = batch_size and is not padded to cal_padded_tokens. The PP-parallel warmup only ceil-aligned its batch_sizes to attn_cp_size. When the real alignment is larger (2 * cp_size for in-seq-split CP), the padded dsa_cache_seqlens/num_splits is longer than the unpadded q tokens → the (b+1) check fails.

cc  @Fridge003 @ShangmingCai 









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27346912579](https://github.com/sgl-project/sglang/actions/runs/27346912579)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27346911482](https://github.com/sgl-project/sglang/actions/runs/27346911482)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->