### PR TITLE
Lingbot World: VAE NHWC

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/usp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/usp.py
@@ -154,6 +154,14 @@ def _usp_input_all_to_all_varlen(
         len(seq_lens) == world_size
     ), f"seq_lens must have length {world_size}, got {len(seq_lens)}"
 
+    # Fast path: when every rank holds the same local sequence length, the
+    # variable-length all-to-all degenerates to a fixed-size one. The fixed-size
+    # path avoids the per-rank ``.contiguous()`` slice loop and the two
+    # ``torch.cat`` calls below, cutting the number of layout-copy kernels
+    # (``direct_copy``) launched per attention layer by ~3x. Output is identical.
+    if len(set(seq_lens)) == 1:
+        return _usp_input_all_to_all(x, head_dim=head_dim)
+
     rank = get_ulysses_parallel_rank()
 
     # Move the dimension to be split (h_global) to dim 0 for all_to_all_single
@@ -286,6 +294,12 @@ def _usp_output_all_to_all_varlen(
     assert (
         len(seq_lens) == world_size
     ), f"seq_lens must have length {world_size}, got {len(seq_lens)}"
+
+    # Fast path: equal local sequence lengths -> the fixed-size inverse all-to-all
+    # is identical and avoids the per-rank slice/contiguous loop + torch.cat. See
+    # the matching note in ``_usp_input_all_to_all_varlen``.
+    if len(set(seq_lens)) == 1:
+        return _usp_output_all_to_all(x, head_dim=head_dim)
 
     rank = get_ulysses_parallel_rank()
 

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -6,6 +6,9 @@ import torch.nn as nn
 from safetensors.torch import load_file as safetensors_load_file
 
 from sglang.multimodal_gen.configs.models import ModelConfig
+from sglang.multimodal_gen.configs.pipeline_configs.lingbot_world import (
+    LingBotWorldI2VConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import LTX2PipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
     QwenImagePipelineConfig,
@@ -88,6 +91,11 @@ def _should_use_channels_last_3d(
         isinstance(pipeline_config, (WanT2V480PConfig, LTX2PipelineConfig))
         and server_args.num_gpus == 1
     ):
+        return True
+    # LingBot-World realtime decode: the distributed (height-sharded, halo)
+    # WanDist* conv path is channels_last_3d-aware, so NHWC is safe and removes
+    # the per-block nchwToNhwc layout round-trips even at num_gpus > 1.
+    if isinstance(pipeline_config, LingBotWorldI2VConfig):
         return True
     return False
 

--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
@@ -195,14 +195,24 @@ class WanRMS_norm(nn.Module):
         self.scale = dim**0.5
         self.gamma = nn.Parameter(torch.ones(shape))
         self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.0
+        self._eps = 1e-12
 
     def forward(self, x):
-        return (
-            F.normalize(x, dim=(1 if self.channel_first else -1))
-            * self.scale
-            * self.gamma
-            + self.bias
-        )
+        # Manual RMS normalization, mathematically equivalent to the original
+        #     F.normalize(x, dim) * sqrt(dim) * gamma + bias.
+        # rsqrt(mean(x^2)) already equals F.normalize(x) * sqrt(dim) (== scale),
+        # so the scale must NOT be reapplied here -- only gamma/bias.
+        #
+        # The rewrite uses broadcasting elementwise ops so the output KEEPS the
+        # input memory format (esp. channels_last_3d / NDHWC). F.normalize
+        # materializes a contiguous NCDHW result, which forces the following
+        # WanCausalConv3d to convert the activation back to channels_last every
+        # block (the nchwToNhwc kernels seen in the profile). Reducing over the
+        # contiguous-in-NHWC channel dim is also coalesced.
+        norm_dim = 1 if self.channel_first else -1
+        variance = x.pow(2).mean(dim=norm_dim, keepdim=True)
+        normed = x * torch.rsqrt(variance + self._eps)
+        return normed * self.gamma + self.bias
 
 
 class WanUpsample(nn.Upsample):


### PR DESCRIPTION
…VAE decode

Two precision-neutral optimizations for LingBot-World realtime causal decode on multi-GPU Ulysses sequence parallelism (measured on 8xH200, ulysses-degree 8, 832x480, 4-step DMD).

1) Ulysses all-to-all equal-split fast path (usp.py)
   When every rank holds the same local sequence length (true at 832x480/sp=8:
   3*240*416=299520 divisible by 8), the variable-length all-to-all degenerates
   to the fixed-size one. Delegating to _usp_input/output_all_to_all skips the
   per-rank slice/.contiguous() loop (x world_size) and two torch.cat per output
   A2A, cutting direct_copy(bf16) layout-copy launches ~2.7x (541,824 -> 197,952
   over a 20-chunk capture). Element-exact equivalent to the varlen path.

2) End-to-end NHWC (channels_last_3d) VAE decode
   - Enable channels_last_3d for LingBot pipelines (vae_loader): the distributed height-sharded conv path is already channels_last-aware, so NHWC is safe at num_gpus > 1 and activates the existing match_conv3d_input_format path.
   - Rewrite WanRMS_norm from F.normalize (which materializes a contiguous NCDHW result and breaks channels_last) to an equivalent manual RMS using broadcasting elementwise ops that preserve the input memory format. Removes ~95% of nchwToNhwc/nhwcToNchw layout kernels (64,120 -> 3,528 launches over a 20-chunk capture).

Combined: end-to-end steady-state median -9.4% / fps +10.7% on 8xH200.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27352630328](https://github.com/sgl-project/sglang/actions/runs/27352630328)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27352629205](https://github.com/sgl-project/sglang/actions/runs/27352629205)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->