### PR TITLE
feat(mxfp4): implement Mxfp4MoEMethod.get_triton_quant_info for MoE LoRA

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1096,6 +1096,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             # routes through `apply` without a MoeRunner. TODO(cwan): migrate.
             pass
 
+    def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
+        # Called by FusedMoEWithLoRA when the MoE LoRA runner uses the triton
+        # backend. On the triton path process_weights_after_loading() has already
+        # upcast w13/w2 to bf16, so build the quant info directly from them --
+        # the same tensors apply()'s triton branch uses.
+        return TritonMoeQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            b13=getattr(layer, "w13_weight_bias", None),
+            b2=getattr(layer, "w2_weight_bias", None),
+        )
+
     def _apply_sm90_cutlass(self, layer, dispatch_output):
         """SM90 (Hopper) MXFP4 x BF16 MoE via FlashInfer's cutlass mixed-input
         path (PR #3084). Routed through the unified ``MoeRunner`` -- this


### PR DESCRIPTION
## Motivation

`FusedMoEWithLoRA.__init__` calls `base_layer.quant_method.get_triton_quant_info(base_layer)` when the MoE LoRA runner uses the triton backend (e.g. `--moe-runner-backend triton`). `Mxfp4MoEMethod` did not implement it, so loading a per-expert MoE LoRA on an mxfp4 model such as `openai/gpt-oss-20b` raised:

```
NotImplementedError: Mxfp4MoEMethod must implement get_triton_quant_info()
```

This makes per-expert MoE LoRA unusable for mxfp4 MoE models on the triton runner. (Supersedes the stalled WIP #23218, which proposed the same change but was never updated after 2026-04-20.)

## Modifications

Implement `Mxfp4MoEMethod.get_triton_quant_info(layer)`.

On the triton (non-`triton_kernels`) path, `process_weights_after_loading()` already upcasts `w13`/`w2` to bf16, so the quant info can be built directly from `layer.w13_weight` / `layer.w2_weight` — **the same tensors `apply()`'s triton `else` branch already uses** to build its `TritonMoeQuantInfo`. The new method just exposes that construction:

```python
def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
    return TritonMoeQuantInfo(
        w13_weight=layer.w13_weight,
        w2_weight=layer.w2_weight,
        b13=getattr(layer, "w13_weight_bias", None),
        b2=getattr(layer, "w2_weight_bias", None),
    )
```

- Single file changed: `python/sglang/srt/layers/quantization/mxfp4.py`.
- `TritonMoeQuantInfo` is already imported at module top; no new imports.
- No behavior change for non-LoRA paths (the method is only called by `FusedMoEWithLoRA`).

## Accuracy Tests

Does not change any existing forward/kernel path — it only enables a path that previously crashed at init. Verified manually:

- **Model:** `openai/gpt-oss-20b` (mxfp4 MoE, 24 layers, 32 experts) + a rank-32 per-expert LoRA.
- **Launch:** `--enable-lora --moe-runner-backend triton --lora-backend triton --max-lora-rank 32 --dtype bfloat16`.
- **Before:** server fails to start with the `NotImplementedError` above.
- **After:** server starts, the MoE LoRA loads and is applied; the adapter's fine-tuned output is produced (confirmed via a deterministic `temperature=0` prompt — structured fine-tuned output with the adapter vs. base output without it).
- **Platform:** SM100 (NVIDIA GB10 / Blackwell), CUDA 13. The returned tensors are identical to the existing `apply()` triton branch, so behavior is consistent across SMs.

## Speed Tests and Profiling

No impact on inference speed: the method is called once per MoE layer at LoRA-adapter init to build a lightweight `TritonMoeQuantInfo` (no extra tensor work in the hot path). No changes to any kernel.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27354232302](https://github.com/sgl-project/sglang/actions/runs/27354232302)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27354229697](https://github.com/sgl-project/sglang/actions/runs/27354229697)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->