### PR TITLE
[Test] Add unit tests for entrypoints/openai/usage_processor.py

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -1,0 +1,162 @@
+"""Unit tests for entrypoints/openai/usage_processor.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="base-b-test-cpu")
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import PromptTokensDetails
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.test.test_utils import CustomTestCase
+
+
+def _resp(prompt_tokens=0, completion_tokens=0, reasoning_tokens=0, cached_tokens=0):
+    meta = {}
+    if prompt_tokens:
+        meta["prompt_tokens"] = prompt_tokens
+    if completion_tokens:
+        meta["completion_tokens"] = completion_tokens
+    if reasoning_tokens:
+        meta["reasoning_tokens"] = reasoning_tokens
+    if cached_tokens:
+        meta["cached_tokens"] = cached_tokens
+    return {"meta_info": meta}
+
+
+class TestDetailsIfCached(CustomTestCase):
+    def test_positive_count_returns_details(self):
+        details = UsageProcessor._details_if_cached(5)
+        self.assertIsInstance(details, PromptTokensDetails)
+        self.assertEqual(details.cached_tokens, 5)
+
+    def test_zero_or_negative_returns_none(self):
+        self.assertIsNone(UsageProcessor._details_if_cached(0))
+        self.assertIsNone(UsageProcessor._details_if_cached(-1))
+
+
+class TestCalculateResponseUsage(CustomTestCase):
+    def test_n_choices_1_every_response_counts_for_prompt(self):
+        responses = [
+            _resp(prompt_tokens=100, completion_tokens=10),
+            _resp(prompt_tokens=200, completion_tokens=20),
+            _resp(prompt_tokens=300, completion_tokens=30),
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=1)
+        self.assertEqual(usage.prompt_tokens, 600)
+        self.assertEqual(usage.completion_tokens, 60)
+
+    def test_n_choices_2_prompt_skipped_on_odd_indices(self):
+        responses = [
+            _resp(prompt_tokens=100, completion_tokens=10),
+            _resp(prompt_tokens=100, completion_tokens=10),
+            _resp(prompt_tokens=200, completion_tokens=10),
+            _resp(prompt_tokens=200, completion_tokens=10),
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+        self.assertEqual(usage.prompt_tokens, 300)
+        self.assertEqual(usage.completion_tokens, 40)
+
+    def test_cache_report_enabled(self):
+        responses = [
+            _resp(prompt_tokens=100, completion_tokens=10, cached_tokens=50),
+            _resp(prompt_tokens=100, completion_tokens=10, cached_tokens=50),
+        ]
+        usage = UsageProcessor.calculate_response_usage(
+            responses, n_choices=2, enable_cache_report=True
+        )
+        self.assertEqual(usage.prompt_tokens, 100)
+        self.assertIsNotNone(usage.prompt_tokens_details)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 50)
+
+    def test_cache_report_disabled_ignores_cached_tokens(self):
+        responses = [
+            _resp(cached_tokens=999),
+            _resp(cached_tokens=999),
+        ]
+        usage = UsageProcessor.calculate_response_usage(
+            responses, n_choices=1, enable_cache_report=False
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_reasoning_tokens_sum_all_regardless_of_stride(self):
+        responses = [
+            _resp(reasoning_tokens=50),
+            _resp(reasoning_tokens=50),
+            _resp(reasoning_tokens=50),
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=3)
+        self.assertEqual(usage.reasoning_tokens, 150)
+
+    def test_n_choices_greater_than_response_count(self):
+        responses = [
+            _resp(prompt_tokens=100, completion_tokens=10),
+            _resp(prompt_tokens=100, completion_tokens=10),
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=5)
+        self.assertEqual(usage.prompt_tokens, 100)
+
+    def test_missing_meta_keys_default_to_zero(self):
+        responses = [{"meta_info": {}}, {"meta_info": {}}]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=1)
+        self.assertEqual(usage.prompt_tokens, 0)
+        self.assertEqual(usage.completion_tokens, 0)
+
+    def test_n_choices_zero_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            UsageProcessor.calculate_response_usage(
+                [_resp(prompt_tokens=100)], n_choices=0
+            )
+
+
+class TestCalculateStreamingUsage(CustomTestCase):
+    def test_prompt_tokens_stride(self):
+        prompt = {0: 100, 1: 100, 2: 200, 3: 200}
+        reasoning = {0: 10, 1: 10, 2: 10, 3: 10}
+        completion = {0: 5, 1: 5, 2: 5, 3: 5}
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt, reasoning, completion, {}, n_choices=2
+        )
+        self.assertEqual(usage.prompt_tokens, 300)
+        self.assertEqual(usage.reasoning_tokens, 40)
+        self.assertEqual(usage.completion_tokens, 20)
+
+    def test_cache_report_enabled(self):
+        prompt = {0: 100}
+        completion = {0: 10}
+        reasoning = {0: 0}
+        cached = {0: 60, 1: 60}
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt, reasoning, completion, cached, n_choices=2, enable_cache_report=True
+        )
+        self.assertEqual(usage.prompt_tokens, 100)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 60)
+
+    def test_cache_report_disabled_ignores_cached(self):
+        cached = {0: 60}
+        usage = UsageProcessor.calculate_streaming_usage(
+            {0: 100}, {0: 0}, {0: 10}, cached, n_choices=1, enable_cache_report=False
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_sparse_keys(self):
+        prompt = {0: 100, 5: 200}
+        completion = {2: 10, 7: 20}
+        reasoning = {3: 5}
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt, reasoning, completion, {}, n_choices=2
+        )
+        self.assertEqual(usage.prompt_tokens, 100)
+        self.assertEqual(usage.completion_tokens, 30)
+        self.assertEqual(usage.reasoning_tokens, 5)
+
+    def test_n_choices_zero_raises_zerodivisionerror(self):
+        with self.assertRaises(ZeroDivisionError):
+            UsageProcessor.calculate_streaming_usage(
+                {0: 100}, {0: 0}, {0: 10}, {}, n_choices=0
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
15 test cases covering:
- _details_if_cached (count > 0 guard)
- calculate_response_usage (n_choices stride, cache_report, reasoning)
- calculate_streaming_usage (same stride with dict keys, sparse keys)

No server, no GPU, no model loading.
Ref: #20865

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Added a new test file: `test/registered/unit/entrypoints/openai/test_usage_processor.py`

`entrypoints/openai/usage_processor.py` currently has no dedicated unit tests. It contains the `UsageProcessor` class with three static helpers that aggregate raw token counts into `UsageInfo` structures. The n_choices stride pattern — where only every n_choices-th response contributes prompt tokens (the rest share the prompt) — is non-trivial and can regress silently. This PR adds CPU-only coverage for the current behavior.

## Modifications
**Coverage (3 helpers, 15 tests):**

- **`_details_if_cached`** — positive count creates `PromptTokensDetails`; zero and negative values return `None` (the `count > 0` guard).
- **`calculate_response_usage`** (7 tests) — n_choices=1 stride (every response counts), n_choices=2 stride (odd indices skipped), n_choices > len(responses), cache_report on/off toggle, reasoning tokens exempt from stride, missing meta_info keys default to zero, and n_choices=0 defense.
- **`calculate_streaming_usage`** (5 tests) — same n_choices stride pattern but operating on dict keys instead of list indices, cache_report parity with the list path, sparse (non-contiguous) dict keys, and n_choices=0 raises `ZeroDivisionError`.

The tests are CPU-only and do not start a server or load a model. They are registered via:
<!-- Describe the purpose and goals of this pull request. -->

```python
register_cpu_ci(est_time=6, suite="base-a-test-cpu")
register_cpu_ci(est_time=7, suite="base-b-test-cpu")
```

**Test plan:**
```shell
pytest test/registered/unit/entrypoints/openai/test_usage_processor.py -v
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/evanderf/sglang/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/evanderf/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, anyio-4.13.0
collected 15 items                                                                                                                                                         

test/registered/unit/entrypoints/openai/test_usage_processor.py::TestDetailsIfCached::test_positive_count_returns_details PASSED                                     [  6%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestDetailsIfCached::test_zero_or_negative_returns_none PASSED                                      [ 13%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_cache_report_disabled_ignores_cached_tokens PASSED                 [ 20%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_cache_report_enabled PASSED                                        [ 26%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_missing_meta_keys_default_to_zero PASSED                           [ 33%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_n_choices_1_every_response_counts_for_prompt PASSED                [ 40%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_n_choices_2_prompt_skipped_on_odd_indices PASSED                   [ 46%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_n_choices_greater_than_response_count PASSED                       [ 53%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_n_choices_zero_raises_valueerror PASSED                            [ 60%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_reasoning_tokens_sum_all_regardless_of_stride PASSED               [ 66%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_cache_report_disabled_ignores_cached PASSED                       [ 73%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_cache_report_enabled PASSED                                       [ 80%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_n_choices_zero_raises_zerodivisionerror PASSED                    [ 86%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_prompt_tokens_stride PASSED                                       [ 93%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_sparse_keys PASSED                                                [100%]

============================================================================= warnings summary =============================================================================
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1434
  /home/evanderf/sglang/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================== 15 passed, 3 warnings in 7.42s ======================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
N/A — this is a test-only change. No kernel or model-forward code is touched.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
N/A — this PR only adds unit tests and does not affect the inference path.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27359134677](https://github.com/sgl-project/sglang/actions/runs/27359134677)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27359133447](https://github.com/sgl-project/sglang/actions/runs/27359133447)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->