### PR TITLE
Support online MXFP8 quantization for ungated MoE

### DIFF
--- a/docs_new/docs/advanced_features/quantization.mdx
+++ b/docs_new/docs/advanced_features/quantization.mdx
@@ -200,7 +200,7 @@ On Ascend, various layers quantization configurations are supported, see [Ascend
 ## GEMM Backends for FP4/FP8 Quantization
 
 <Note>
-Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. When running FP8 or FP4 quantized models, you can select the GEMM backend via `--fp8-gemm-backend` and `--fp4-gemm-backend`.
+Backend selection applies to **blockwise FP8**, **MXFP8** (dense linear), and **NVFP4** GEMM. When running offline or online FP8 or FP4 quantized models, you can select the GEMM backend via `--fp8-gemm-backend` and `--fp4-gemm-backend`.
 </Note>
 
 ### `--fp8-gemm-backend` (Blockwise FP8 GEMM)
@@ -258,6 +258,8 @@ Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. Wh
 </table>
 
 **`auto` selection order:** 1) DeepGEMM (SM90/SM100, installed); 2) FlashInfer TRTLLM (SM100, FlashInfer available); 3) CUTLASS (SM90/SM100/120); 4) AITER (AMD); 5) Triton. **Exception:** SM120 always resolves to Triton.
+
+**MXFP8 dense linear:** `auto` uses `flashinfer_cutlass` on SM100 (else `triton`). `flashinfer_cutlass` is fastest on most shapes; `flashinfer_trtllm` is faster only at small M.
 
 ### `--fp4-gemm-backend` (NVFP4 GEMM)
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -657,11 +657,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
     if TopKOutputChecker.format_is_bypassed(topk_output):
         router_logits = topk_output.router_logits
         topk_config = topk_output.topk_config
-        correction_bias = (
-            None
-            if topk_config.correction_bias is None
-            else topk_config.correction_bias.to(hidden_states.dtype)
-        )
+        correction_bias = topk_config.correction_bias
     else:
         router_logits = None
         topk_config = None
@@ -684,7 +680,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
             assert quant_info.weight_block_k == 32
             from flashinfer import mxfp8_quantize
 
-            a_q, a_sf = mxfp8_quantize(hidden_states, False)
+            a_q, a_sf = mxfp8_quantize(hidden_states, False, backend="cute-dsl")
             # FlashInfer TRT-LLM MxFP8 expects token-major activation scales:
             # [num_tokens, hidden_size // 32] (no transpose).
             a_sf_t = a_sf.view(torch.uint8).reshape(hidden_states.shape[0], -1)

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -322,6 +322,11 @@ def align_mxfp8_moe_weights_for_flashinfer_trtllm(layer: Module) -> None:
     assert w13_scale.dtype == torch.uint8
     assert w2_scale.dtype == torch.uint8
 
+    if not is_gated:
+        intermediate = w2_weight.shape[2]
+        w13_weight = w13_weight[:, :intermediate, :].contiguous()
+        w13_scale = w13_scale[:, :intermediate, :].contiguous()
+
     # Pad for kernel alignment (non-gated needs 128, gated needs 16)
     min_alignment = 16 if is_gated else 128
     w13_weight, w13_scale, w2_weight, w2_scale, _ = _align_mxfp8_moe_weights(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -59,11 +59,11 @@ from sglang.srt.layers.quantization.fp8_utils import (
     cutlass_fp8_supported,
     dispatch_w8a8_block_fp8_linear,
     dispatch_w8a8_mxfp8_linear,
+    get_fp8_gemm_runner_backend,
     input_to_float8,
     mxfp8_group_quantize,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_weight_ue8m0_inplace,
-    resolve_mxfp8_linear_backend,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
@@ -356,10 +356,8 @@ class Fp8LinearMethod(LinearMethodBase):
         )
         self.w8a8_block_fp8_linear = None
         self.w8a8_mxfp8_linear = None
-        self.mxfp8_backend = None
         if self.use_mxfp8:
-            self.mxfp8_backend = resolve_mxfp8_linear_backend()
-            self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear(self.mxfp8_backend)
+            self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear()
         else:
             self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
         self.is_checkpoint_fp8_serialized = (
@@ -589,7 +587,7 @@ class Fp8LinearMethod(LinearMethodBase):
         if not self.use_mxfp8:
             return
 
-        backend = self.mxfp8_backend
+        backend = get_fp8_gemm_runner_backend()
         if backend.is_flashinfer_trtllm():
             from flashinfer import shuffle_matrix_a, shuffle_matrix_sf_a
 
@@ -794,9 +792,10 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
-            if self.mxfp8_backend.is_flashinfer_cutlass():
+            backend = get_fp8_gemm_runner_backend()
+            if backend.is_flashinfer_cutlass():
                 weight_scale = layer.weight_scale_inv_swizzled
-            elif self.mxfp8_backend.is_flashinfer_trtllm():
+            elif backend.is_flashinfer_trtllm():
                 weight_scale = layer.weight_scale_inv_shuffled
             else:
                 weight_scale = layer.weight_scale_inv

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -59,11 +59,11 @@ from sglang.srt.layers.quantization.fp8_utils import (
     cutlass_fp8_supported,
     dispatch_w8a8_block_fp8_linear,
     dispatch_w8a8_mxfp8_linear,
-    get_fp8_gemm_runner_backend,
     input_to_float8,
     mxfp8_group_quantize,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_weight_ue8m0_inplace,
+    resolve_mxfp8_linear_backend,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
@@ -356,8 +356,10 @@ class Fp8LinearMethod(LinearMethodBase):
         )
         self.w8a8_block_fp8_linear = None
         self.w8a8_mxfp8_linear = None
+        self.mxfp8_backend = None
         if self.use_mxfp8:
-            self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear()
+            self.mxfp8_backend = resolve_mxfp8_linear_backend()
+            self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear(self.mxfp8_backend)
         else:
             self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
         self.is_checkpoint_fp8_serialized = (
@@ -587,7 +589,8 @@ class Fp8LinearMethod(LinearMethodBase):
         if not self.use_mxfp8:
             return
 
-        if get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
+        backend = self.mxfp8_backend
+        if backend.is_flashinfer_trtllm():
             from flashinfer import shuffle_matrix_a, shuffle_matrix_sf_a
 
             weight = layer.weight.data
@@ -628,7 +631,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 .reshape_as(scale_u8)
                 .contiguous(),
             )
-        elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
+        elif backend.is_flashinfer_cutlass():
             from flashinfer import block_scale_interleave
 
             scale_u8 = layer.weight_scale_inv.data
@@ -791,9 +794,9 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
-            if get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
+            if self.mxfp8_backend.is_flashinfer_cutlass():
                 weight_scale = layer.weight_scale_inv_swizzled
-            elif get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
+            elif self.mxfp8_backend.is_flashinfer_trtllm():
                 weight_scale = layer.weight_scale_inv_shuffled
             else:
                 weight_scale = layer.weight_scale_inv

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -17,6 +17,7 @@ from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.common import torch_release
 
 if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.server_args import ServerArgs
 
 from sglang.srt.layers.quantization.fp8_kernel import (
@@ -395,7 +396,8 @@ def dispatch_w8a8_block_fp8_linear() -> Callable:
     return _dispatch_auto_backend()
 
 
-def dispatch_w8a8_mxfp8_linear(backend: Fp8GemmRunnerBackend) -> Callable:
+def dispatch_w8a8_mxfp8_linear() -> Callable:
+    backend = get_fp8_gemm_runner_backend()
     if backend.is_flashinfer_cutlass() or backend.is_flashinfer_trtllm():
         return flashinfer_mxfp8_blockscaled_linear
     return triton_mxfp8_blockscaled_linear
@@ -485,7 +487,9 @@ def _dispatch_auto_backend() -> Callable:
         return triton_w8a8_block_fp8_linear
 
 
-def initialize_fp8_gemm_config(server_args: ServerArgs) -> None:
+def initialize_fp8_gemm_config(
+    server_args: ServerArgs, model_config: Optional[ModelConfig] = None
+) -> None:
     """Initialize FP8 GEMM configuration."""
     global FP8_GEMM_RUNNER_BACKEND
 
@@ -494,7 +498,18 @@ def initialize_fp8_gemm_config(server_args: ServerArgs) -> None:
         # TODO(brayden): Verify if CUTLASS can be set by default once SwapAB is supported
         backend = "triton"
 
-    FP8_GEMM_RUNNER_BACKEND = Fp8GemmRunnerBackend(backend)
+    backend = Fp8GemmRunnerBackend(backend)
+
+    is_mxfp8 = model_config is not None and model_config.quantization == "mxfp8"
+    if (
+        backend.is_auto()
+        and is_mxfp8
+        and _is_sm100_supported
+        and is_flashinfer_available()
+    ):
+        backend = Fp8GemmRunnerBackend.FLASHINFER_CUTLASS
+
+    FP8_GEMM_RUNNER_BACKEND = backend
 
 
 def get_fp8_gemm_runner_backend() -> Fp8GemmRunnerBackend:
@@ -503,13 +518,6 @@ def get_fp8_gemm_runner_backend() -> Fp8GemmRunnerBackend:
     if FP8_GEMM_RUNNER_BACKEND is None:
         FP8_GEMM_RUNNER_BACKEND = Fp8GemmRunnerBackend.AUTO
     return FP8_GEMM_RUNNER_BACKEND
-
-
-def resolve_mxfp8_linear_backend() -> Fp8GemmRunnerBackend:
-    backend = get_fp8_gemm_runner_backend()
-    if backend.is_auto() and _is_sm100_supported and is_flashinfer_available():
-        return Fp8GemmRunnerBackend.FLASHINFER_CUTLASS
-    return backend
 
 
 def flashinfer_gemm_w8a8_block_fp8_linear_with_fallback(
@@ -1105,7 +1113,7 @@ def flashinfer_mxfp8_blockscaled_linear(
     # Ensure transposed tensors are contiguous for FlashInfer's internal runner.
     weight_t = weight.contiguous().t()
 
-    if resolve_mxfp8_linear_backend().is_flashinfer_trtllm():
+    if get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
         weight_scale_t = weight_scale.contiguous().view(-1)
         output = flashinfer_mm_mxfp8(
             q_input,
@@ -1116,7 +1124,7 @@ def flashinfer_mxfp8_blockscaled_linear(
             use_8x4_sf_layout=False,
             backend="trtllm",
         )
-    elif resolve_mxfp8_linear_backend().is_flashinfer_cutlass():
+    elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
         weight_scale_t = (
             weight_scale.contiguous().t()
             if weight_scale.ndim == 2

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -395,16 +395,8 @@ def dispatch_w8a8_block_fp8_linear() -> Callable:
     return _dispatch_auto_backend()
 
 
-def dispatch_w8a8_mxfp8_linear() -> Callable:
-    """Dispatch MXFP8 linear kernel by --fp8-gemm-backend.
-
-    For MXFP8, Triton remains the default path. We only route to FlashInfer
-    when backend is explicitly set to flashinfer_cutlass or flashinfer_trtllm.
-    """
-    backend = get_fp8_gemm_runner_backend()
-    if backend.is_flashinfer_trtllm():
-        return flashinfer_mxfp8_blockscaled_linear
-    elif backend.is_flashinfer_cutlass():
+def dispatch_w8a8_mxfp8_linear(backend: Fp8GemmRunnerBackend) -> Callable:
+    if backend.is_flashinfer_cutlass() or backend.is_flashinfer_trtllm():
         return flashinfer_mxfp8_blockscaled_linear
     return triton_mxfp8_blockscaled_linear
 
@@ -511,6 +503,13 @@ def get_fp8_gemm_runner_backend() -> Fp8GemmRunnerBackend:
     if FP8_GEMM_RUNNER_BACKEND is None:
         FP8_GEMM_RUNNER_BACKEND = Fp8GemmRunnerBackend.AUTO
     return FP8_GEMM_RUNNER_BACKEND
+
+
+def resolve_mxfp8_linear_backend() -> Fp8GemmRunnerBackend:
+    backend = get_fp8_gemm_runner_backend()
+    if backend.is_auto() and _is_sm100_supported and is_flashinfer_available():
+        return Fp8GemmRunnerBackend.FLASHINFER_CUTLASS
+    return backend
 
 
 def flashinfer_gemm_w8a8_block_fp8_linear_with_fallback(
@@ -1106,8 +1105,7 @@ def flashinfer_mxfp8_blockscaled_linear(
     # Ensure transposed tensors are contiguous for FlashInfer's internal runner.
     weight_t = weight.contiguous().t()
 
-    if get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
-
+    if resolve_mxfp8_linear_backend().is_flashinfer_trtllm():
         weight_scale_t = weight_scale.contiguous().view(-1)
         output = flashinfer_mm_mxfp8(
             q_input,
@@ -1118,7 +1116,7 @@ def flashinfer_mxfp8_blockscaled_linear(
             use_8x4_sf_layout=False,
             backend="trtllm",
         )
-    elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
+    elif resolve_mxfp8_linear_backend().is_flashinfer_cutlass():
         weight_scale_t = (
             weight_scale.contiguous().t()
             if weight_scale.ndim == 2

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -17,7 +17,6 @@ from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.common import torch_release
 
 if TYPE_CHECKING:
-    from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.server_args import ServerArgs
 
 from sglang.srt.layers.quantization.fp8_kernel import (
@@ -487,9 +486,7 @@ def _dispatch_auto_backend() -> Callable:
         return triton_w8a8_block_fp8_linear
 
 
-def initialize_fp8_gemm_config(
-    server_args: ServerArgs, model_config: Optional[ModelConfig] = None
-) -> None:
+def initialize_fp8_gemm_config(server_args: ServerArgs) -> None:
     """Initialize FP8 GEMM configuration."""
     global FP8_GEMM_RUNNER_BACKEND
 
@@ -500,10 +497,9 @@ def initialize_fp8_gemm_config(
 
     backend = Fp8GemmRunnerBackend(backend)
 
-    is_mxfp8 = model_config is not None and model_config.quantization == "mxfp8"
     if (
         backend.is_auto()
-        and is_mxfp8
+        and server_args.quantization == "mxfp8"
         and _is_sm100_supported
         and is_flashinfer_available()
     ):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -748,7 +748,7 @@ class Scheduler(
             initialize_moe_config(self.server_args)
 
         # Initialize GEMM-related configuration for FP8 and FP4 backends.
-        initialize_fp8_gemm_config(self.server_args)
+        initialize_fp8_gemm_config(self.server_args, self.model_config)
         initialize_fp4_gemm_config(self.server_args)
 
         # This must be called after initialize_moe_config

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -748,7 +748,7 @@ class Scheduler(
             initialize_moe_config(self.server_args)
 
         # Initialize GEMM-related configuration for FP8 and FP4 backends.
-        initialize_fp8_gemm_config(self.server_args, self.model_config)
+        initialize_fp8_gemm_config(self.server_args)
         initialize_fp4_gemm_config(self.server_args)
 
         # This must be called after initialize_moe_config


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

1. Support online MXFP8 quantization for non-gated MoE (Nemotron)
2. Switch defualt backend from Triton to CUTLASS GEMM (on the basis of perf)
3. Use Cute-DSL quantizer on the basis of perf and only use 8x4 layout (bitwise exactness is covered by the next release) (https://github.com/flashinfer-ai/flashinfer/pull/3387)

## Modifications

Profiles are for BS = 128, no DP attention

### BF16

 ```
 python3 -m sglang.launch_server \
    --model-path nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16 \
    --trust-remote-code \
    --tool-call-parser qwen3_coder \
    --reasoning-parser nemotron_3 \
    --tp-size 8 \
    --ep-size 8 \
    --max-running-requests 512 \
```

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 350 --platinum
Loading GSM8K Platinum dataset from HuggingFace...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [00:53<00:00, 22.48it/s]
Accuracy: 0.982
Invalid: 0.000
Latency: 53.778 s
Output throughput: 2462.566 token/s
```

<img width="1692" height="543" alt="Screenshot 2026-06-11 at 9 01 56 AM" src="https://github.com/user-attachments/assets/f6276427-ebdb-4420-9e47-5fc18f12a69b" />

### Online MXFP8

```
python3 -m sglang.launch_server \
    --model-path nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16 \
    --trust-remote-code \
    --tool-call-parser qwen3_coder \
    --reasoning-parser nemotron_3 \
    --tp-size 8 \
    --ep-size 8 \
    --max-running-requests 512 \
    --quantization mxfp8
 ```
 
 ```
 python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 350 --platinum
Loading GSM8K Platinum dataset from HuggingFace...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [00:49<00:00, 24.22it/s]
Accuracy: 0.983
Invalid: 0.000
Latency: 49.928 s
Output throughput: 2662.353 token/s
 ```
 
<img width="1687" height="508" alt="Screenshot 2026-06-11 at 9 02 07 AM" src="https://github.com/user-attachments/assets/97f0d108-579c-4094-952f-f3c453940fa6" />
(A little variance due to EP imbalance, but still faster)

















































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27801386768](https://github.com/sgl-project/sglang/actions/runs/27801386768)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27801386659](https://github.com/sgl-project/sglang/actions/runs/27801386659)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->