### PR TITLE
[AMD] Enable shared expert fusion with BF16→MXFP4 online quantization

### DIFF
--- a/python/sglang/jit_kernel/tests/test_fused_qk_gemma_rmsnorm_gate.py
+++ b/python/sglang/jit_kernel/tests/test_fused_qk_gemma_rmsnorm_gate.py
@@ -1,0 +1,151 @@
+import itertools
+import sys
+
+import pytest
+import torch
+
+from sglang.srt.models.utils import fused_qk_gemma_rmsnorm_with_gate
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=20, suite="jit-kernel-unit-test-amd")
+
+
+def reference_qk_gemma_rmsnorm_with_gate(
+    q_gate: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float,
+    head_dim: int,
+    num_heads: int,
+):
+    """Pure-PyTorch reference: deinterleave q/gate, GemmaRMSNorm q and k."""
+    seq_len = q_gate.shape[0]
+
+    # Deinterleave q and gate from [q_h0, gate_h0, q_h1, gate_h1, ...]
+    qg_3d = q_gate.view(seq_len, num_heads, 2 * head_dim)
+    q = qg_3d[:, :, :head_dim].contiguous().view(-1, head_dim)
+    gate = qg_3d[:, :, head_dim:].contiguous().view(-1, head_dim)
+
+    k_flat = k.reshape(-1, head_dim)
+
+    # GemmaRMSNorm: x * rsqrt(mean(x^2) + eps) * (weight + 1)
+    def gemma_rmsnorm(x, w):
+        x_fp32 = x.float()
+        var = x_fp32.pow(2).mean(dim=-1, keepdim=True)
+        normed = x_fp32 * (var + eps).rsqrt() * (w.float() + 1.0)
+        return normed.to(x.dtype)
+
+    q_out = gemma_rmsnorm(q, q_weight)
+    k_out = gemma_rmsnorm(k_flat, k_weight)
+
+    return q_out, k_out, gate
+
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+SEQ_LENS = [1, 2, 4, 7, 16, 128]
+NUM_HEADS_LIST = [8, 16, 32]
+NUM_KV_HEADS_LIST = [2, 4, 8]
+HEAD_DIM_LIST = [64, 128]
+
+
+@pytest.mark.parametrize(
+    "seq_len,num_heads,num_kv_heads,head_dim",
+    list(itertools.product(SEQ_LENS, NUM_HEADS_LIST, NUM_KV_HEADS_LIST, HEAD_DIM_LIST)),
+)
+def test_fused_qk_gemma_rmsnorm_with_gate(
+    seq_len: int, num_heads: int, num_kv_heads: int, head_dim: int
+):
+    if num_kv_heads > num_heads:
+        pytest.skip("num_kv_heads > num_heads is not a valid config")
+
+    eps = 1e-6
+    q_size = num_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+
+    # Build a full qkv buffer and split — this gives non-contiguous k,
+    # which is the real usage pattern
+    qkv = torch.randn(
+        seq_len, q_size * 2 + kv_size + kv_size, device=DEVICE, dtype=DTYPE
+    )
+    q_gate, k, v = qkv.split([q_size * 2, kv_size, kv_size], dim=-1)
+
+    q_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+    k_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+
+    # Reference
+    q_ref, k_ref, gate_ref = reference_qk_gemma_rmsnorm_with_gate(
+        q_gate, k, q_weight, k_weight, eps, head_dim, num_heads
+    )
+
+    # Fused kernel
+    q_out, k_out, gate_out = fused_qk_gemma_rmsnorm_with_gate(
+        q_gate, k, q_weight, k_weight, eps, head_dim, num_heads
+    )
+
+    torch.testing.assert_close(q_out, q_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(k_out, k_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(gate_out, gate_ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+def test_gate_is_exact_copy(head_dim: int):
+    """Gate output must be a bitwise-exact copy of the input gate data."""
+    seq_len = 4
+    num_heads = 16
+    num_kv_heads = 4
+    eps = 1e-6
+    q_size = num_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+
+    qkv = torch.randn(
+        seq_len, q_size * 2 + kv_size + kv_size, device=DEVICE, dtype=DTYPE
+    )
+    q_gate, k, v = qkv.split([q_size * 2, kv_size, kv_size], dim=-1)
+    q_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+    k_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+
+    _, _, gate_out = fused_qk_gemma_rmsnorm_with_gate(
+        q_gate, k, q_weight, k_weight, eps, head_dim, num_heads
+    )
+
+    # Extract gate from interleaved buffer manually
+    qg_3d = q_gate.view(seq_len, num_heads, 2 * head_dim)
+    gate_expected = qg_3d[:, :, head_dim:].contiguous().view(-1, head_dim)
+
+    assert torch.equal(gate_out, gate_expected), "Gate must be bitwise exact"
+
+
+@pytest.mark.parametrize("seq_len", [1, 8])
+def test_contiguous_k_also_works(seq_len: int):
+    """Kernel should work even when k is already contiguous."""
+    num_heads = 16
+    num_kv_heads = 4
+    head_dim = 128
+    eps = 1e-6
+    q_size = num_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+
+    q_gate = torch.randn(seq_len, q_size * 2, device=DEVICE, dtype=DTYPE)
+    k = torch.randn(seq_len, kv_size, device=DEVICE, dtype=DTYPE)
+    assert k.is_contiguous()
+
+    q_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+    k_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+
+    q_ref, k_ref, gate_ref = reference_qk_gemma_rmsnorm_with_gate(
+        q_gate, k, q_weight, k_weight, eps, head_dim, num_heads
+    )
+    q_out, k_out, gate_out = fused_qk_gemma_rmsnorm_with_gate(
+        q_gate, k, q_weight, k_weight, eps, head_dim, num_heads
+    )
+
+    torch.testing.assert_close(q_out, q_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(k_out, k_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(gate_out, gate_ref, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/python/sglang/jit_kernel/tests/test_sigmoid_gate_mul.py
+++ b/python/sglang/jit_kernel/tests/test_sigmoid_gate_mul.py
@@ -1,0 +1,81 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=4, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=4, suite="jit-kernel-unit-test-amd")
+
+DEVICE = "cuda"
+
+
+def reference_sigmoid_gate_mul(x, gate):
+    return x * torch.sigmoid(gate)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 4096),
+        (4, 4096),
+        (8, 4096),
+        (32, 8192),
+        (1, 128),
+        (16, 16384),
+    ],
+)
+def test_sigmoid_gate_mul_correctness(shape, dtype):
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    torch.manual_seed(42)
+    x = torch.randn(shape, dtype=dtype, device=DEVICE)
+    gate = torch.randn(shape, dtype=dtype, device=DEVICE)
+
+    ref = reference_sigmoid_gate_mul(x, gate)
+    out = sigmoid_gate_mul(x, gate)
+
+    rtol = 1e-2 if dtype == torch.bfloat16 else 1e-3
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-3
+    torch.testing.assert_close(out, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("shape", [(4, 4096), (1, 128)])
+def test_sigmoid_gate_mul_does_not_modify_inputs(shape):
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    torch.manual_seed(42)
+    x = torch.randn(shape, dtype=torch.bfloat16, device=DEVICE)
+    gate = torch.randn(shape, dtype=torch.bfloat16, device=DEVICE)
+    x_orig = x.clone()
+    gate_orig = gate.clone()
+
+    sigmoid_gate_mul(x, gate)
+
+    torch.testing.assert_close(x, x_orig, rtol=0, atol=0)
+    torch.testing.assert_close(gate, gate_orig, rtol=0, atol=0)
+
+
+def test_sigmoid_gate_mul_output_dtype():
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    for dtype in [torch.bfloat16, torch.float16, torch.float32]:
+        x = torch.randn(4, 4096, dtype=dtype, device=DEVICE)
+        gate = torch.randn(4, 4096, dtype=dtype, device=DEVICE)
+        out = sigmoid_gate_mul(x, gate)
+        assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
+
+
+def test_sigmoid_gate_mul_contiguous_output():
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import sigmoid_gate_mul
+
+    x = torch.randn(4, 4096, dtype=torch.bfloat16, device=DEVICE)
+    gate = torch.randn(4, 4096, dtype=torch.bfloat16, device=DEVICE)
+    out = sigmoid_gate_mul(x, gate)
+    assert out.is_contiguous()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/python/sglang/jit_kernel/tests/test_sigmoid_gate_mul.py
+++ b/python/sglang/jit_kernel/tests/test_sigmoid_gate_mul.py
@@ -15,6 +15,9 @@ def reference_sigmoid_gate_mul(x, gate):
     return x * torch.sigmoid(gate)
 
 
+# ── element-wise variant ──
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize(
     "shape",
@@ -74,6 +77,81 @@ def test_sigmoid_gate_mul_contiguous_output():
     x = torch.randn(4, 4096, dtype=torch.bfloat16, device=DEVICE)
     gate = torch.randn(4, 4096, dtype=torch.bfloat16, device=DEVICE)
     out = sigmoid_gate_mul(x, gate)
+    assert out.is_contiguous()
+
+
+# ── broadcast variant ──
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 4096),
+        (4, 4096),
+        (8, 4096),
+        (32, 8192),
+        (1, 128),
+        (16, 16384),
+    ],
+)
+def test_sigmoid_gate_mul_broadcast_correctness(shape, dtype):
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+        sigmoid_gate_mul_broadcast,
+    )
+
+    torch.manual_seed(42)
+    bs, hidden_dim = shape
+    x = torch.randn(shape, dtype=dtype, device=DEVICE)
+    gate = torch.randn(bs, 1, dtype=dtype, device=DEVICE)
+
+    ref = x * torch.sigmoid(gate.float()).to(dtype)
+    out = sigmoid_gate_mul_broadcast(x, gate)
+
+    rtol = 1e-2 if dtype == torch.bfloat16 else 1e-3
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-3
+    torch.testing.assert_close(out, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("shape", [(4, 4096), (1, 128)])
+def test_sigmoid_gate_mul_broadcast_does_not_modify_inputs(shape):
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+        sigmoid_gate_mul_broadcast,
+    )
+
+    torch.manual_seed(42)
+    bs, hidden_dim = shape
+    x = torch.randn(shape, dtype=torch.bfloat16, device=DEVICE)
+    gate = torch.randn(bs, 1, dtype=torch.bfloat16, device=DEVICE)
+    x_orig = x.clone()
+    gate_orig = gate.clone()
+
+    sigmoid_gate_mul_broadcast(x, gate)
+
+    torch.testing.assert_close(x, x_orig, rtol=0, atol=0)
+    torch.testing.assert_close(gate, gate_orig, rtol=0, atol=0)
+
+
+def test_sigmoid_gate_mul_broadcast_output_dtype():
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+        sigmoid_gate_mul_broadcast,
+    )
+
+    for dtype in [torch.bfloat16, torch.float16, torch.float32]:
+        x = torch.randn(4, 4096, dtype=dtype, device=DEVICE)
+        gate = torch.randn(4, 1, dtype=dtype, device=DEVICE)
+        out = sigmoid_gate_mul_broadcast(x, gate)
+        assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
+
+
+def test_sigmoid_gate_mul_broadcast_contiguous_output():
+    from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+        sigmoid_gate_mul_broadcast,
+    )
+
+    x = torch.randn(4, 4096, dtype=torch.bfloat16, device=DEVICE)
+    gate = torch.randn(4, 1, dtype=torch.bfloat16, device=DEVICE)
+    out = sigmoid_gate_mul_broadcast(x, gate)
     assert out.is_contiguous()
 
 

--- a/python/sglang/jit_kernel/triton/sigmoid_gate_mul.py
+++ b/python/sglang/jit_kernel/triton/sigmoid_gate_mul.py
@@ -1,0 +1,29 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _sigmoid_gate_mul_kernel(
+    x_ptr,
+    gate_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask).to(tl.float32)
+    g = tl.load(gate_ptr + offsets, mask=mask).to(tl.float32)
+    out = x * tl.sigmoid(g)
+    tl.store(out_ptr + offsets, out.to(x_ptr.dtype.element_ty), mask=mask)
+
+
+def sigmoid_gate_mul(x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+    """Compute x * sigmoid(gate) in a single fused kernel."""
+    out = torch.empty_like(x)
+    n = x.numel()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+    _sigmoid_gate_mul_kernel[grid](x, gate, out, n, BLOCK_SIZE=1024)
+    return out

--- a/python/sglang/jit_kernel/triton/sigmoid_gate_mul.py
+++ b/python/sglang/jit_kernel/triton/sigmoid_gate_mul.py
@@ -1,6 +1,21 @@
+"""Fused sigmoid-gate-multiply Triton kernels.
+
+Two variants:
+- ``sigmoid_gate_mul``: element-wise ``x * sigmoid(gate)`` when x and gate
+  have identical shapes.
+- ``sigmoid_gate_mul_broadcast``: broadcast ``x * sigmoid(gate)`` when gate
+  is ``(N, 1)`` and x is ``(N, D)``.
+"""
+
+from __future__ import annotations
+
 import torch
 import triton
 import triton.language as tl
+
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
 
 
 @triton.jit
@@ -21,9 +36,52 @@ def _sigmoid_gate_mul_kernel(
 
 
 def sigmoid_gate_mul(x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
-    """Compute x * sigmoid(gate) in a single fused kernel."""
+    """Compute ``x * sigmoid(gate)`` in a single fused kernel (same-shape)."""
     out = torch.empty_like(x)
     n = x.numel()
     grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
     _sigmoid_gate_mul_kernel[grid](x, gate, out, n, BLOCK_SIZE=1024)
+    return out
+
+
+@triton.jit
+def _sigmoid_gate_mul_broadcast_kernel(
+    out_ptr,
+    gate_ptr,
+    x_ptr,
+    hidden_dim: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    g = tl.load(gate_ptr + row).to(tl.float32)
+    g = tl.sigmoid(g)
+
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < hidden_dim
+    x = tl.load(x_ptr + row * hidden_dim + offs, mask=mask).to(tl.float32)
+    out = x * g
+    tl.store(
+        out_ptr + row * hidden_dim + offs,
+        out.to(x_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+
+def sigmoid_gate_mul_broadcast(x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+    """Compute ``x * sigmoid(gate)`` where gate is (N, 1) and x is (N, D)."""
+    bs, hidden_dim = x.shape
+    out = torch.empty_like(x)
+    BLOCK_SIZE = triton.next_power_of_2(hidden_dim)
+    max_warps = 16 if _is_hip else 32
+    num_warps = max(
+        min(triton.next_power_of_2(triton.cdiv(hidden_dim, 8 * 32)), max_warps), 4
+    )
+    _sigmoid_gate_mul_broadcast_kernel[(bs,)](
+        out,
+        gate,
+        x,
+        hidden_dim=hidden_dim,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=num_warps,
+    )
     return out

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -18,7 +18,7 @@ from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.utils import is_cpu, is_cuda, is_npu
+from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_npu
 from sglang.srt.utils.common import rank0_log
 
 if not is_cpu():
@@ -26,7 +26,7 @@ if not is_cpu():
         CHUNK_SIZE as FLA_CHUNK_SIZE,
     )
 
-if is_cuda():
+if is_cuda() or is_hip():
     from sglang.jit_kernel.triton.gdn_fused_proj import fused_qkv_split_gdn_prefill
 
 MAX_FUSED_QKV_SPLIT_DIM = 8192
@@ -451,7 +451,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
 
         actual_seq_len = mixed_qkv.shape[0]
         qkv_dim = layer.q_dim + layer.k_dim + layer.v_dim
-        if is_cuda() and qkv_dim <= MAX_FUSED_QKV_SPLIT_DIM:
+        if (is_cuda() or is_hip()) and qkv_dim <= MAX_FUSED_QKV_SPLIT_DIM:
             query, key, value = fused_qkv_split_gdn_prefill(
                 mixed_qkv,
                 layer.num_q_heads,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -123,6 +123,21 @@ _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
+def _shared_expert_excluded_from_quant(
+    quant_config: Optional[QuantizationConfig],
+) -> bool:
+    """True when the checkpoint excludes shared-expert weights from quantization."""
+    if quant_config is None:
+        return False
+    exclude_layers = getattr(quant_config, "exclude_layers", [])
+    return any(
+        "shared_expert" in layer
+        and "shared_expert_gate" not in layer
+        and not layer.startswith("mtp.")
+        for layer in exclude_layers
+    )
+
+
 def can_fuse_shared_expert(
     config: PretrainedConfig,
     quant_config: Optional[QuantizationConfig],
@@ -130,6 +145,10 @@ def can_fuse_shared_expert(
     """Whether the shared expert may be fused as an extra MoE expert (Qwen3.5 + Aiter).
 
     Caller must still gate on ``support_shared_expert_fusion`` and ``_use_aiter``.
+
+    When the shared expert is excluded from quantization (BF16 in an MXFP4
+    checkpoint), fusion is still allowed on AMD/HIP because the BF16 weights
+    are online-quantized to FP4 during ``load_weights()``.
     """
     if (
         get_global_server_args().disable_shared_experts_fusion is True
@@ -139,17 +158,8 @@ def can_fuse_shared_expert(
     ):
         return False
 
-    # If the shared expert is excluded from quantization (stored as FP32 in the
-    # checkpoint), fusing it into the quantized MoE weight tensor requires online
-    # quantization which is not supported. Disable fusion in this case.
-    if quant_config is not None:
-        exclude_layers = getattr(quant_config, "exclude_layers", [])
-        if any(
-            "shared_expert" in layer
-            and "shared_expert_gate" not in layer
-            and not layer.startswith("mtp.")
-            for layer in exclude_layers
-        ):
+    if _shared_expert_excluded_from_quant(quant_config):
+        if not _use_aiter:
             return False
 
     return True
@@ -953,6 +963,13 @@ class Qwen2MoeForCausalLM(nn.Module):
             use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
         )
         self.logits_processor = LogitsProcessor(config)
+
+        self._needs_shared_expert_online_quant = (
+            _use_aiter
+            and _shared_expert_excluded_from_quant(quant_config)
+            and self._has_fused_shared_experts()
+        )
+
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
 
@@ -1025,6 +1042,34 @@ class Qwen2MoeForCausalLM(nn.Module):
 
         return result
 
+    def _has_fused_shared_experts(self):
+        """Check if any layer has fused shared experts enabled."""
+        if not hasattr(self.model, "layers"):
+            return False
+        for layer in self.model.layers:
+            if (
+                layer is not None
+                and hasattr(layer, "mlp")
+                and hasattr(layer.mlp, "num_fused_shared_experts")
+                and layer.mlp.num_fused_shared_experts > 0
+            ):
+                return True
+        return False
+
+    def _online_quant_bf16_to_mxfp4(
+        self, weight: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Quantize a BF16 weight to MXFP4 (packed uint8) + E8M0 scales."""
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+        orig_shape = weight.shape
+        w = weight.view(-1, orig_shape[-1]) if weight.dim() != 2 else weight
+        w_quant, scales = dynamic_mxfp4_quant(w)
+        if weight.dim() != 2:
+            w_quant = w_quant.view(orig_shape[:-1] + (w_quant.shape[-1],))
+            scales = scales.view(orig_shape[:-1] + (scales.shape[-1],))
+        return w_quant, scales
+
     @property
     def start_layer(self):
         return self.model.start_layer
@@ -1043,11 +1088,14 @@ class Qwen2MoeForCausalLM(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
+        num_experts = self.config.num_experts
+        needs_online_quant = self._needs_shared_expert_online_quant
+
         expert_params_mapping = FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.num_experts,
+            num_experts=num_experts,
         )
 
         params_dict = dict(self.named_parameters())
@@ -1063,6 +1111,52 @@ class Qwen2MoeForCausalLM(nn.Module):
             ):
                 continue
             if "rotary_emb.inv_freq" in name:
+                continue
+
+            # Redirect shared_expert weights into the fused expert slot.
+            # BF16 weights are online-quantized to MXFP4 before storage.
+            # The shared_expert_gate is NOT redirected; it stays standalone.
+            if (
+                needs_online_quant
+                and "mlp.shared_expert." in name
+                and "shared_expert_gate" not in name
+            ):
+                if "gate_proj" in name:
+                    shard_id = "w1"
+                elif "up_proj" in name:
+                    shard_id = "w3"
+                elif "down_proj" in name:
+                    shard_id = "w2"
+                else:
+                    continue
+
+                w_quant, w_scales = self._online_quant_bf16_to_mxfp4(
+                    loaded_weight
+                )
+
+                # Build the FusedMoE param name (e.g., model.layers.0.mlp.experts.w13_weight)
+                layer_prefix = name.split("mlp.shared_expert.")[0]
+                if shard_id in ("w1", "w3"):
+                    w_param_name = layer_prefix + "mlp.experts.w13_weight"
+                    s_param_name = layer_prefix + "mlp.experts.w13_weight_scale"
+                else:
+                    w_param_name = layer_prefix + "mlp.experts.w2_weight"
+                    s_param_name = layer_prefix + "mlp.experts.w2_weight_scale"
+
+                shared_expert_id = num_experts
+
+                if w_param_name in params_dict:
+                    param = params_dict[w_param_name]
+                    param.weight_loader(
+                        param, w_quant, w_param_name,
+                        shard_id=shard_id, expert_id=shared_expert_id,
+                    )
+                if s_param_name in params_dict:
+                    scale_param = params_dict[s_param_name]
+                    scale_param.weight_loader(
+                        scale_param, w_scales, s_param_name,
+                        shard_id=shard_id, expert_id=shared_expert_id,
+                    )
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -402,6 +402,13 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                         True,
                         shared_output,
                     )
+                elif _use_aiter:
+                    from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+                        sigmoid_gate_mul_broadcast,
+                    )
+
+                    gate = self.shared_expert_gate(hidden_states)
+                    shared_output = sigmoid_gate_mul_broadcast(shared_output, gate)
                 else:
                     shared_output = (
                         F.sigmoid(self.shared_expert_gate(hidden_states))

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -930,8 +930,15 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            gate = torch.sigmoid(gate)
-            attn_output = attn_output * gate
+            if _use_aiter:
+                from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+                    sigmoid_gate_mul,
+                )
+
+                attn_output = sigmoid_gate_mul(attn_output, gate)
+            else:
+                gate = torch.sigmoid(gate)
+                attn_output = attn_output * gate
 
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -79,7 +79,10 @@ from sglang.srt.models.qwen2_moe import Qwen2MoeMLP, Qwen2MoeSparseMoeBlock
 
 # Models
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
-from sglang.srt.models.utils import fused_qk_gemma_rmsnorm
+from sglang.srt.models.utils import (
+    fused_qk_gemma_rmsnorm,
+    fused_qk_gemma_rmsnorm_with_gate,
+)
 from sglang.srt.server_args import get_global_server_args
 
 # Utils
@@ -884,6 +887,33 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         q, k = self.rotary_emb(positions, q, k)
         return q, k, v, gate
 
+    def forward_prepare_hip(self, positions, hidden_states):
+        qkv, _ = self.qkv_proj(hidden_states)
+        if self.attn_output_gate:
+            q_gate, k, v = qkv.split(
+                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
+            )
+            seq_len = q_gate.shape[0]
+            q_flat, k_flat, gate_flat = fused_qk_gemma_rmsnorm_with_gate(
+                q_gate,
+                k,
+                self.q_norm.weight.data,
+                self.k_norm.weight.data,
+                self.q_norm.variance_epsilon,
+                self.head_dim,
+                self.num_heads,
+            )
+            q = q_flat.view(seq_len, -1)
+            k = k_flat.view(seq_len, -1)
+            gate = gate_flat.view(seq_len, -1)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            gate = None
+            q, k = self._apply_qk_norm(q, k)
+
+        q, k = self.rotary_emb(positions, q, k)
+        return q, k, v, gate
+
     def forward_prepare_npu(self, positions, hidden_states, forward_batch):
         qkv, _ = self.qkv_proj(hidden_states)
         # Calculate first full attention layer ID based on config
@@ -911,7 +941,12 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        if (
+        if _is_hip and self.attn_output_gate:
+            q, k, v, gate = self.forward_prepare_hip(
+                positions=positions,
+                hidden_states=hidden_states,
+            )
+        elif (
             not _is_npu
             or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
             or not self.attn_output_gate
@@ -1514,7 +1549,6 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
 
 
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
-
     packed_modules_mapping = Qwen3_5ForCausalLM.packed_modules_mapping
     hf_to_sglang_mapper = None
 

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -930,7 +930,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            if _use_aiter:
+            if _is_hip:
                 from sglang.jit_kernel.triton.sigmoid_gate_mul import (
                     sigmoid_gate_mul,
                 )

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -54,7 +54,6 @@ from sglang.srt.utils import (
     make_layers,
     set_weight_attrs,
 )
-from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +65,6 @@ _is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu = is_cpu()
 _is_amx_available = cpu_has_amx_support()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
 if _is_npu:
@@ -823,7 +821,7 @@ class Qwen3HybridAttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            if _use_aiter:
+            if _is_hip:
                 from sglang.jit_kernel.triton.sigmoid_gate_mul import (
                     sigmoid_gate_mul,
                 )

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -49,10 +49,12 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
+    is_hip,
     is_npu,
     make_layers,
     set_weight_attrs,
 )
+from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +62,11 @@ from sglang.jit_kernel.triton.gdn_fused_proj import fused_qkvzba_split_reshape_c
 from sglang.srt.layers.attention.fla.fused_norm_gate import FusedRMSNormGated
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu = is_cpu()
 _is_amx_available = cpu_has_amx_support()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
 if _is_npu:
@@ -819,8 +823,15 @@ class Qwen3HybridAttentionDecoderLayer(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
-            gate = torch.sigmoid(gate)
-            attn_output = attn_output * gate
+            if _use_aiter:
+                from sglang.jit_kernel.triton.sigmoid_gate_mul import (
+                    sigmoid_gate_mul,
+                )
+
+                attn_output = sigmoid_gate_mul(attn_output, gate)
+            else:
+                gate = torch.sigmoid(gate)
+                attn_output = attn_output * gate
 
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -154,9 +154,12 @@ class AutoWeightsLoader:
             for weight_name, weight_data in weights
         )
         for prefix, group in itertools.groupby(weights_by_parts, key=lambda x: x[0][0]):
-            yield prefix, (
-                ("" if len(parts) == 1 else parts[1], weight_data)
-                for parts, weight_data in group
+            yield (
+                prefix,
+                (
+                    ("" if len(parts) == 1 else parts[1], weight_data)
+                    for parts, weight_data in group
+                ),
             )
 
     @staticmethod
@@ -375,7 +378,6 @@ def compute_cu_seqlens_from_grid_numpy(grid_thw: torch.Tensor) -> torch.Tensor:
 
 
 class RotaryPosMixin:
-
     @staticmethod
     @lru_cache(maxsize=1024)
     def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
@@ -590,6 +592,127 @@ def fused_qk_gemma_rmsnorm(
     )
 
     return q_out, k_out
+
+
+# ---------------------------------------------------------------------------
+# Fused QK GemmaRMSNorm + gate extraction kernel
+# For models with attn_output_gate (e.g. Qwen3.5) where q and gate are
+# interleaved per head: [q_h0, gate_h0, q_h1, gate_h1, ...].
+# Reads q from the interleaved buffer, normalizes it, and copies gate to a
+# contiguous output — all in a single kernel launch.  Eliminates two
+# elementwise copy kernels that would otherwise be needed to deinterleave.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _fused_qk_gemma_rmsnorm_gate_kernel(
+    QG_ptr,
+    K_ptr,
+    Q_out_ptr,
+    K_out_ptr,
+    Gate_out_ptr,
+    QW_ptr,
+    KW_ptr,
+    qg_token_stride,
+    qg_head_stride,
+    k_token_stride,
+    k_head_stride,
+    num_heads,
+    num_kv_heads,
+    k_rows,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_HD: tl.constexpr,
+    EPS: tl.constexpr,
+    FP16: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_HD)
+    mask = cols < HEAD_DIM
+    out_dtype = tl.float16 if FP16 else tl.bfloat16
+
+    token_idx = pid // num_heads
+    head_idx = pid % num_heads
+
+    base = token_idx * qg_token_stride + head_idx * qg_head_stride
+
+    # Q norm
+    q = tl.load(QG_ptr + base + cols, mask=mask, other=0.0).to(tl.float32)
+    w_q = tl.load(QW_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    q_var = tl.sum(q * q, axis=0) / HEAD_DIM
+    q_normed = (q * tl.rsqrt(q_var + EPS) * (w_q + 1.0)).to(out_dtype)
+    out_off = pid * HEAD_DIM + cols
+    tl.store(Q_out_ptr + out_off, q_normed, mask=mask)
+
+    # Gate copy
+    gate = tl.load(QG_ptr + base + HEAD_DIM + cols, mask=mask, other=0.0)
+    tl.store(Gate_out_ptr + out_off, gate, mask=mask)
+
+    # K norm (first k_rows blocks only)
+    if pid < k_rows:
+        token_idx_k = pid // num_kv_heads
+        head_idx_k = pid % num_kv_heads
+        k_off = token_idx_k * k_token_stride + head_idx_k * k_head_stride + cols
+        k = tl.load(K_ptr + k_off, mask=mask, other=0.0).to(tl.float32)
+        w_k = tl.load(KW_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        k_var = tl.sum(k * k, axis=0) / HEAD_DIM
+        k_normed = (k * tl.rsqrt(k_var + EPS) * (w_k + 1.0)).to(out_dtype)
+        k_out_off = pid * HEAD_DIM + cols
+        tl.store(K_out_ptr + k_out_off, k_normed, mask=mask)
+
+
+def fused_qk_gemma_rmsnorm_with_gate(
+    q_gate: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float,
+    head_dim: int,
+    num_heads: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused QK GemmaRMSNorm + gate extraction from interleaved q_gate buffer.
+
+    q_gate: (seq, q_size*2) where q and gate are interleaved per head,
+            i.e. [q_h0, gate_h0, q_h1, gate_h1, ...] with q_size = num_heads * head_dim.
+            Can be a non-contiguous view from qkv.split().
+    k: (seq, kv_size) — same as fused_qk_gemma_rmsnorm.
+
+    Returns (q_out, k_out, gate_out) all contiguous with shape
+    (seq*num_heads, head_dim), (seq*num_kv_heads, head_dim), (seq*num_heads, head_dim).
+    """
+    seq_len = q_gate.shape[0]
+    qg_3d = q_gate.view(seq_len, num_heads, 2 * head_dim)
+    num_kv_heads = k.shape[-1] // head_dim
+    k_3d = k.view(seq_len, num_kv_heads, head_dim)
+
+    q_rows = seq_len * num_heads
+    k_rows = seq_len * num_kv_heads
+
+    q_out = torch.empty(q_rows, head_dim, dtype=q_gate.dtype, device=q_gate.device)
+    k_out = torch.empty(k_rows, head_dim, dtype=k.dtype, device=k.device)
+    gate_out = torch.empty(q_rows, head_dim, dtype=q_gate.dtype, device=q_gate.device)
+
+    BLOCK_HD = triton.next_power_of_2(head_dim)
+
+    _fused_qk_gemma_rmsnorm_gate_kernel[(q_rows,)](
+        qg_3d,
+        k_3d,
+        q_out,
+        k_out,
+        gate_out,
+        q_weight,
+        k_weight,
+        qg_3d.stride(0),
+        qg_3d.stride(1),
+        k_3d.stride(0),
+        k_3d.stride(1),
+        num_heads,
+        num_kv_heads,
+        k_rows,
+        HEAD_DIM=head_dim,
+        BLOCK_HD=BLOCK_HD,
+        EPS=eps,
+        FP16=(q_gate.dtype == torch.float16),
+    )
+
+    return q_out, k_out, gate_out
 
 
 # Register the inplace op


### PR DESCRIPTION
## Summary
For MXFP4 checkpoints (e.g., Qwen3.5-397B-A17B-MXFP4) where shared expert weights are excluded from quantization (BF16 in `quantization_config.exclude`) while routed experts are FP4, enable fusion by online-quantizing the BF16 weights to MXFP4 during `load_weights()`.

**Previous approach (closed #27936):** Redirected BF16 weights directly into FP4 slots without quantization → accuracy dropped to 0.81.

**This approach:**
1. `_shared_expert_excluded_from_quant()` detects when shared expert is excluded from quant
2. `can_fuse_shared_expert()` now allows fusion on AMD/HIP even when shared expert is excluded (because online quant is available)
3. `_online_quant_bf16_to_mxfp4()` calls aiter's `dynamic_mxfp4_quant` to convert BF16 → packed FP4 + E8M0 scales
4. `load_weights()` intercepts shared expert BF16 weights, quantizes them, and stores both quantized weights and scales into the fused expert slot

Reference: ATOM commit `02d13056` (per-layer quant comparison logic).

## Changes
- `python/sglang/srt/models/qwen2_moe.py` — 106 insertions, 12 deletions

## Test plan
- [ ] Accuracy validation (>= 0.85 on mgsm_en, Qwen3.5-397B-A17B-MXFP4, TP=2)
- [ ] Benchmark ITL regression check
- [ ] Server log confirms shared expert fusion enabled
- [ ] Verify fused kernel visible in profiling trace

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->