### PR TITLE
[Spec] Support topk > 1 (EAGLE tree) in the trtllm_mha attention backend

### DIFF
--- a/docs_new/docs/advanced_features/attention_backend.mdx
+++ b/docs_new/docs/advanced_features/attention_backend.mdx
@@ -108,7 +108,7 @@ The support matrix is split into two parts: MHA (standard attention) and MLA (mu
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
     </tr>
@@ -490,8 +490,8 @@ Hybrid attention also works with speculative decoding. The backend used for draf
 
 Constraints when combining hybrid attention with speculative decoding:
 
-- If any attention backend is `trtllm_mha`, speculative decoding supports only `--speculative-eagle-topk 1`.
-- For paged MHA backends with `--page-size > 1` and `--speculative-eagle-topk > 1`, only `flashinfer` is supported.
+- `trtllm_mha` supports `--speculative-eagle-topk > 1` on the trtllm-gen kernels (SM100/SM103); the XQA path (SM90/SM120) supports only `--speculative-eagle-topk 1`.
+- For paged MHA backends with `--page-size > 1` and `--speculative-eagle-topk > 1`, only `flashinfer` and `trtllm_mha` are supported.
 - CUDA Graph: the decode backend is always captured; the prefill backend is captured only when `--speculative-attention-mode prefill`.
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -806,8 +806,9 @@ def _qwen3_5_hybrid_overrides(server_args: Any, hf_config: Any) -> dict:
     if not is_sm100_supported() or server_args.attention_backend is not None:
         return {}
     sm100_default_attn_backend = "triton"
-    # trtllm_mha requires speculative_eagle_topk == 1 and page_size > 1.
-    # _get_default_attn_backend handles the eagle_topk check.
+    # trtllm_mha requires page_size > 1; topk > 1 (tree spec decoding) is
+    # supported but not yet default-selected. _get_default_attn_backend
+    # handles the eagle_topk check.
     # There is only one case where page_size=1 is required,
     # which is when radix cache is enabled and both extra_buffer
     # and spec decoding are disabled.

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -323,7 +323,6 @@ def _handle_frozen_kv_mtp(server_args: ServerArgs) -> None:
 
 def _handle_eagle_family(server_args: ServerArgs) -> None:
     from sglang.srt.arg_groups.overrides import (
-        attention_backends_of,
         resolved_view,
     )
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -399,12 +399,6 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             server_args.speculative_num_draft_tokens,
         ) = _auto_choose_speculative_params(server_args, model_arch)
 
-    if "trtllm_mha" in attention_backends_of(resolved_view(server_args)):
-        if server_args.speculative_eagle_topk > 1:
-            raise ValueError(
-                "trtllm_mha backend only supports topk = 1 for speculative decoding."
-            )
-
     if server_args.speculative_use_rejection_sampling:
         # Resolved alias by now: NEXTN -> EAGLE, Gemma4 draft -> FROZEN_KV_MTP.
         # Only the EAGLE/EAGLE3 draft workers emit a target-vocab proposal that
@@ -463,10 +457,10 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         )
         server_args.speculative_num_draft_tokens = server_args.speculative_num_steps + 1
 
-    # topk > 1 + page_size > 1 needs the two-pass cascade draft-decode (shared prefix
-    # pass + per-branch expand pass with prefix-tail dup). Only these backends implement
-    # it; flashmla / trtllm_mla / cutlass_mla can't express the per-branch tree, so reject.
-    _PAGE_TREE_SPEC_BACKENDS = ("flashinfer", "fa3", "triton")
+    # topk > 1 + page_size > 1 needs the page-aligned per-branch draft layout
+    # (per-branch pages with prefix-tail dup). Only these backends implement it;
+    # flashmla / trtllm_mla / cutlass_mla can't express the per-branch tree, so reject.
+    _PAGE_TREE_SPEC_BACKENDS = ("flashinfer", "fa3", "triton", "trtllm_mha")
     view = resolved_view(server_args)
     if (
         server_args.speculative_eagle_topk > 1

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -134,6 +134,11 @@ class TRTLLMMHAMetadata:
     # Draft tree mask for target verify with topk > 1, shape
     # [bs, draft_token_num, draft_token_num] (QLEN_ONLY layout view)
     tree_mask: torch.Tensor = None
+    # Tree verify on SWA layers: page-trimmed swa_page_table and clamped
+    # seqlens presenting only the in-window KV (lazily built once per
+    # forward by _swa_verify_views)
+    swa_verify_page_table: torch.Tensor = None
+    swa_verify_seqlens: torch.Tensor = None
 
 
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
@@ -232,6 +237,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # backends through these attributes.
         self.draft_branch_page_tables: Optional[torch.Tensor] = None
         self.draft_branch_page_table_buf: Optional[torch.Tensor] = None
+        # SWA hybrid + topk > 1: tree verify on SWA layers folds the sliding
+        # window into the packed custom mask (the trtllm-gen custom-mask
+        # cubins have no SlidingWindow+Custom mask type), presenting only the
+        # in-window KV via a page-trimmed SWA table so the mask region stays
+        # ~window-sized. See _swa_verify_views.
+        self.sliding_window_size = model_runner.sliding_window_size
 
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
@@ -393,6 +404,54 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         v_scale = self._get_scalar_scale(layer, "v_scale_float", "v_scale")
         return q_scale * k_scale * layer.scaling, v_scale
 
+    def _layer_is_swa(self, layer: RadixAttention) -> bool:
+        if self._swa_kv_pool is None:
+            return False
+        _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
+        return is_swa
+
+    def _swa_verify_max_pages(self) -> int:
+        """Static page bound for the trimmed SWA verify table: window + draft
+        tail + one page of trim alignment slack. Constant per server config
+        (window, draft tokens, page size), so CUDA-graph safe."""
+        nv = self.speculative_num_draft_tokens
+        return (
+            self.sliding_window_size + nv + self.page_size - 1
+        ) // self.page_size + 1
+
+    def _fill_swa_verify_views(self, metadata: TRTLLMMHAMetadata):
+        """Fill the trimmed (page_table, seqlens) for tree verify on SWA layers.
+
+        The window is folded into flashinfer's packed custom mask, whose
+        region covers the whole presented KV range, so present only the pages
+        from the window start of the shallowest draft row onward. Runs in the
+        metadata init/apply paths (NOT inside the captured forward): the
+        CUDA-graph capture warmup would otherwise pre-populate a lazy cache
+        and leave the gather out of the captured graph, replaying stale
+        capture-time trims.
+        """
+        if self._swa_kv_pool is None or self.topk <= 1:
+            return
+        window = self.sliding_window_size
+        nv = metadata.max_seq_len_q
+        seqlens_full = metadata.cache_seqlens_int32
+        first_keep_page = (
+            torch.clamp(seqlens_full - nv - window, min=0) // self.page_size
+        )
+        seqlens = (seqlens_full - first_keep_page * self.page_size).to(torch.int32)
+        cols = first_keep_page.to(torch.int64).unsqueeze(1) + torch.arange(
+            self._swa_verify_max_pages(), device=seqlens_full.device
+        )
+        cols.clamp_(max=metadata.swa_page_table.shape[1] - 1)
+        trimmed = torch.gather(metadata.swa_page_table, 1, cols)
+        if metadata.swa_verify_page_table is not None:
+            # CUDA-graph mode: write into the bound fixed-address buffers.
+            metadata.swa_verify_page_table.copy_(trimmed)
+            metadata.swa_verify_seqlens.copy_(seqlens)
+        else:
+            metadata.swa_verify_page_table = trimmed
+            metadata.swa_verify_seqlens = seqlens
+
     def init_cuda_graph_state(
         self,
         max_bs: int,
@@ -478,6 +537,18 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
             }
+            if self._swa_kv_pool is not None and self.topk > 1:
+                # Trimmed SWA verify views; refilled before each replay in
+                # the apply path (see _fill_swa_verify_views).
+                self.target_verify_metadata["swa_verify_page_table"] = torch.zeros(
+                    max_bs,
+                    self._swa_verify_max_pages(),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self.target_verify_metadata["swa_verify_seqlens"] = torch.zeros(
+                    max_bs, dtype=torch.int32, device=self.device
+                )
 
             if self.topk > 1 and not self.skip_prefill:
                 # QLEN_ONLY tree mask written in place by the eagle worker
@@ -598,6 +669,13 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 "swa_page_table",
                 bs,
             )
+            if "swa_verify_page_table" in self.target_verify_metadata:
+                metadata.swa_verify_page_table = self.target_verify_metadata[
+                    "swa_verify_page_table"
+                ][:bs, :]
+                metadata.swa_verify_seqlens = self.target_verify_metadata[
+                    "swa_verify_seqlens"
+                ][:bs]
             self.target_verify_metadata[bs] = metadata
         elif forward_mode.is_draft_extend_v2():
             num_tokens_per_bs = num_tokens // bs
@@ -728,6 +806,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             q_stride=q_stride,
             q_mode=q_mode,
         )
+
+        if forward_mode.is_target_verify():
+            # Reads the cache_seqlens and swa_page_table the fused kernel just
+            # rebuilt, so it must run after it.
+            self._fill_swa_verify_views(metadata)
 
         self.forward_metadata = metadata
 
@@ -983,6 +1066,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 )
             )
 
+        if forward_batch.forward_mode.is_target_verify():
+            self._fill_swa_verify_views(metadata)
+
         self.forward_metadata = metadata
 
     def forward_decode(
@@ -1140,13 +1226,29 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             forward_batch.forward_mode.is_target_verify()
             or forward_batch.forward_mode.is_draft_extend_v2()
         ):
+            seq_lens_arg = self.forward_metadata.cache_seqlens_int32
+            max_seq_len_arg = self.max_context_len
+            if (
+                forward_batch.forward_mode.is_target_verify()
+                and self.forward_metadata.tree_mask is not None
+                and self._layer_is_swa(layer)
+            ):
+                # Tree verify on a SWA layer: flashinfer folds the window
+                # into the packed custom mask (no SlidingWindow+Custom cubin;
+                # proper kernel support is a planned follow-up), and the mask
+                # region covers all presented KV, so present only the
+                # in-window pages (filled by _fill_swa_verify_views in the
+                # metadata init/apply paths).
+                page_table = self.forward_metadata.swa_verify_page_table
+                seq_lens_arg = self.forward_metadata.swa_verify_seqlens
+                max_seq_len_arg = self._swa_verify_max_pages() * self.page_size
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,
                 workspace_buffer=self.workspace_buffer,
                 block_tables=page_table,
-                seq_lens=self.forward_metadata.cache_seqlens_int32,
-                max_seq_len=self.max_context_len,
+                seq_lens=seq_lens_arg,
+                max_seq_len=max_seq_len_arg,
                 bmm1_scale=bmm1_scale,
                 bmm2_scale=bmm2_scale,
                 window_left=layer.sliding_window_size,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -238,7 +238,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.draft_branch_page_tables: Optional[torch.Tensor] = None
         self.draft_branch_page_table_buf: Optional[torch.Tensor] = None
         # SWA hybrid + topk > 1: tree verify on SWA layers folds the sliding
-        # window into the packed custom mask (the trtllm-gen custom-mask
+        # window into the packed custom mask (the trtllm custom-mask
         # cubins have no SlidingWindow+Custom mask type), presenting only the
         # in-window KV via a page-trimmed SWA table so the mask region stays
         # ~window-sized. See _swa_verify_views.

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -209,6 +209,13 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.speculative_num_draft_tokens = (
             model_runner.server_args.speculative_num_draft_tokens
         )
+        self.supports_untrimmed_swa_spec_dec_tree = bool(
+            getattr(
+                flashinfer.decode,
+                "trtllm_gen_supports_untrimmed_swa_spec_dec_tree",
+                False,
+            )
+        )
 
         # SWA hybrid models split the KV cache into full and SWA pools with
         # separate index spaces; SWA layers need a translated page_table.
@@ -237,11 +244,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # backends through these attributes.
         self.draft_branch_page_tables: Optional[torch.Tensor] = None
         self.draft_branch_page_table_buf: Optional[torch.Tensor] = None
-        # SWA hybrid + topk > 1: tree verify on SWA layers folds the sliding
-        # window into the packed custom mask (the trtllm custom-mask
-        # cubins have no SlidingWindow+Custom mask type), presenting only the
-        # in-window KV via a page-trimmed SWA table so the mask region stays
-        # ~window-sized. See _swa_verify_views.
+        # Older FlashInfer versions fold the sliding window into the packed
+        # custom mask and need a page-trimmed SWA table. Newer versions own
+        # native-versus-folded selection and consume the full SWA metadata.
         self.sliding_window_size = model_runner.sliding_window_size
 
         # Forward metadata
@@ -420,7 +425,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         ) // self.page_size + 1
 
     def _fill_swa_verify_views(self, metadata: TRTLLMMHAMetadata):
-        """Fill the trimmed (page_table, seqlens) for tree verify on SWA layers.
+        """Fill fallback trimmed metadata for tree verify on SWA layers.
 
         The window is folded into flashinfer's packed custom mask, whose
         region covers the whole presented KV range, so present only the pages
@@ -430,7 +435,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         and leave the gather out of the captured graph, replaying stale
         capture-time trims.
         """
-        if self._swa_kv_pool is None or self.topk <= 1:
+        if (
+            self.supports_untrimmed_swa_spec_dec_tree
+            or self._swa_kv_pool is None
+            or self.topk <= 1
+        ):
             return
         window = self.sliding_window_size
         nv = metadata.max_seq_len_q
@@ -537,7 +546,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
             }
-            if self._swa_kv_pool is not None and self.topk > 1:
+            if (
+                not self.supports_untrimmed_swa_spec_dec_tree
+                and self._swa_kv_pool is not None
+                and self.topk > 1
+            ):
                 # Trimmed SWA verify views; refilled before each replay in
                 # the apply path (see _fill_swa_verify_views).
                 self.target_verify_metadata["swa_verify_page_table"] = torch.zeros(
@@ -1232,13 +1245,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 forward_batch.forward_mode.is_target_verify()
                 and self.forward_metadata.tree_mask is not None
                 and self._layer_is_swa(layer)
+                and not self.supports_untrimmed_swa_spec_dec_tree
             ):
-                # Tree verify on a SWA layer: flashinfer folds the window
-                # into the packed custom mask (no SlidingWindow+Custom cubin;
-                # proper kernel support is a planned follow-up), and the mask
-                # region covers all presented KV, so present only the
-                # in-window pages (filled by _fill_swa_verify_views in the
-                # metadata init/apply paths).
+                # Compatibility path for FlashInfer versions that fold the
+                # window into the packed custom mask: present only in-window
+                # pages filled by _fill_swa_verify_views.
                 page_table = self.forward_metadata.swa_verify_page_table
                 seq_lens_arg = self.forward_metadata.swa_verify_seqlens
                 max_seq_len_arg = self._swa_verify_max_pages() * self.page_size

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -1383,7 +1383,7 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
             # per-step _apply only refreshes the per-step sequence lengths.
             seq_lens_cpu = (
                 forward_batch.seq_lens.cpu()
-                if in_capture
+                if in_capture or forward_batch.seq_lens_cpu is None
                 else forward_batch.seq_lens_cpu
             )
             self._update_draft_branch_page_tables(

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -777,8 +777,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif forward_mode.is_target_verify():
             metadata = self.target_verify_metadata[bs]
             seqlen_offset = metadata.max_seq_len_q
-            if self.topk > 1:
-                self._sync_verify_tree_mask(spec_info, metadata)
+            # Do NOT sync the tree mask here: this body is recorded into the
+            # CUDA graph, so a capture-time pointer-guarded copy would replay
+            # forever and clobber the producer's mask. The host-side hook
+            # update_verify_buffers_to_fill_after_draft owns the sync.
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
             # Static per-request query width, fixed by the captured graph shape.
@@ -827,48 +829,34 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         self.forward_metadata = metadata
 
-    def _sync_verify_tree_mask(
-        self, spec_info: Optional[SpecInput], metadata: TRTLLMMHAMetadata
-    ) -> None:
-        """Copy the QLEN_ONLY tree mask into the CUDA-graph buffer unless the
-        producer already wrote it there in place (the eagle worker writes
-        through get_verify_buffers_to_fill_after_draft)."""
-        mask = getattr(spec_info, "custom_mask", None)
-        if mask is None or metadata.tree_mask is None:
-            return
-        if mask.data_ptr() != self.cuda_graph_custom_mask.data_ptr():
-            numel = metadata.tree_mask.numel()
-            self.cuda_graph_custom_mask[:numel].copy_(mask.reshape(-1)[:numel])
-
     def get_verify_buffers_to_fill_after_draft(self):
         return [self.cuda_graph_custom_mask, None]
 
     def update_verify_buffers_to_fill_after_draft(
         self, spec_info: SpecInput, cuda_graph_bs: Optional[int]
     ):
-        """Re-sync mask-dependent state after the draft output is known.
+        """Sync the QLEN_ONLY tree mask after the draft output is known.
 
-        The packed-mask conversion runs inside the captured verify forward and
-        reads the persistent QLEN_ONLY buffer at replay, so the CUDA-graph
-        path only needs a copy when the producer wrote a different tensor.
+        Runs on the host every verify step (never recorded into a CUDA
+        graph). The captured verify forward reads the persistent
+        cuda_graph_custom_mask buffer at replay; the eagle worker normally
+        writes the mask there in place (get_verify_buffers_to_fill_after_draft),
+        so a copy is only needed when the producer used a different tensor.
+        Must not depend on self.forward_metadata: at this point it still
+        holds the draft-decode metadata, and the verify metadata body is
+        graph-recorded so it cannot do this sync itself.
         """
-        if self.topk <= 1:
+        if self.topk <= 1 or self.cuda_graph_custom_mask is None:
             return
-        metadata = self.forward_metadata
-        if metadata is None or metadata.tree_mask is None:
+        mask = getattr(spec_info, "custom_mask", None)
+        if mask is None:
             return
         if cuda_graph_bs is not None:
-            self._sync_verify_tree_mask(spec_info, metadata)
-        else:
-            mask = getattr(spec_info, "custom_mask", None)
-            if mask is not None:
-                bs, num_draft_tokens = (
-                    metadata.tree_mask.shape[0],
-                    metadata.tree_mask.shape[1],
-                )
-                metadata.tree_mask = mask[
-                    : bs * num_draft_tokens * num_draft_tokens
-                ].view(bs, num_draft_tokens, num_draft_tokens)
+            if mask.data_ptr() != self.cuda_graph_custom_mask.data_ptr():
+                numel = min(mask.numel(), self.cuda_graph_custom_mask.numel())
+                self.cuda_graph_custom_mask[:numel].copy_(mask.reshape(-1)[:numel])
+        # Eager verify builds metadata.tree_mask directly from
+        # spec_info.custom_mask in init_forward_metadata; nothing to sync.
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:
         """Get the fill value for sequence lengths in CUDA graph."""
@@ -964,9 +952,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                         .repeat_interleave(self.topk)
                         .to(torch.int32)
                     )
-                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
-                        self.speculative_step_id + 1
-                    )
                     metadata.cu_seqlens_q = torch.arange(
                         0,
                         batch_size * self.topk + 1,
@@ -1013,9 +998,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 torch.int32
             )
             metadata.max_seq_len_q = tokens_per_req
-            metadata.max_seq_len_k = (
-                forward_batch.seq_lens_cpu.max().item() + tokens_per_req
-            )
             if self.topk > 1:
                 metadata.tree_mask = forward_batch.spec_info.custom_mask[
                     : batch_size * tokens_per_req * tokens_per_req
@@ -1347,9 +1329,13 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
             and not forward_batch.forward_mode.is_idle()
             and forward_batch.spec_info is not None
         ):
-            self._update_draft_branch_page_tables(
-                forward_batch, forward_batch.seq_lens_cpu
-            )
+            # The backend opts out of CPU seq lens (needs_cpu_seq_lens=False),
+            # so eager mode may not carry them; the page-count bound needs a
+            # host value, so sync explicitly in that case.
+            seq_lens_cpu = forward_batch.seq_lens_cpu
+            if seq_lens_cpu is None:
+                seq_lens_cpu = forward_batch.seq_lens.cpu()
+            self._update_draft_branch_page_tables(forward_batch, seq_lens_cpu)
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_forward_metadata(forward_batch)
 

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -131,6 +131,9 @@ class TRTLLMMHAMetadata:
     swa_page_table: torch.Tensor = None
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: torch.Tensor = None
+    # Draft tree mask for target verify with topk > 1, shape
+    # [bs, draft_token_num, draft_token_num] (QLEN_ONLY layout view)
+    tree_mask: torch.Tensor = None
 
 
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
@@ -242,6 +245,23 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         #   KV bf16: q_type = bf16, out_type=model_runner.dtype
         #   KV fp8: q_type = fp8, out_type=model_runner.dtype
         self.is_xqa_impl = is_sm90_supported() or is_sm120_supported()
+
+        # Tree spec decoding (topk > 1): target verify consumes a draft-only
+        # QLEN_ONLY tree mask. The eagle workers read tree_mask_mode to pick
+        # the layout build_tree_kernel_efficient writes, and fill
+        # cuda_graph_custom_mask in place via
+        # get_verify_buffers_to_fill_after_draft.
+        self.cuda_graph_custom_mask: Optional[torch.Tensor] = None
+        if self.topk > 1:
+            if self.is_xqa_impl:
+                raise NotImplementedError(
+                    "trtllm_mha tree speculative decoding (topk > 1) requires "
+                    "the trtllm-gen kernels (SM100/SM103); the XQA path "
+                    "expects a different packed mask format"
+                )
+            from sglang.srt.speculative.eagle_utils import TreeMaskMode
+
+            self.tree_mask_mode = TreeMaskMode.QLEN_ONLY
 
     @staticmethod
     def _resolve_swa_kv_pool(model_runner: ModelRunner) -> Optional[SWAKVPool]:
@@ -459,6 +479,17 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
             }
 
+            if self.topk > 1 and not self.skip_prefill:
+                # QLEN_ONLY tree mask written in place by the eagle worker
+                # after draft (see get_verify_buffers_to_fill_after_draft);
+                # the captured verify forward reads it at replay.
+                num_draft_tokens = self.speculative_num_draft_tokens
+                self.cuda_graph_custom_mask = torch.zeros(
+                    max_bs * num_draft_tokens * num_draft_tokens,
+                    dtype=torch.bool,
+                    device=self.device,
+                )
+
             self.draft_extend_metadata = {
                 "cache_seqlens": torch.zeros(
                     max_bs, dtype=torch.int32, device=self.device
@@ -544,7 +575,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 )
                 self.decode_cuda_graph_metadata[bs] = metadata
         elif forward_mode.is_target_verify():
-            # Target Verify (topk = 1)
+            # Target Verify (chain for topk = 1, tree mask for topk > 1)
             tokens_per_req = num_tokens // bs
             metadata.cache_seqlens_int32 = self.target_verify_metadata["cache_seqlens"][
                 :bs
@@ -557,6 +588,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ]
             metadata.max_seq_len_q = tokens_per_req
             metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
+            if self.topk > 1:
+                metadata.tree_mask = self.cuda_graph_custom_mask[
+                    : bs * tokens_per_req * tokens_per_req
+                ].view(bs, tokens_per_req, tokens_per_req)
             self._bind_swa_page_table(
                 metadata,
                 self.target_verify_metadata,
@@ -649,9 +684,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
         elif forward_mode.is_target_verify():
-            # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
             seqlen_offset = metadata.max_seq_len_q
+            if self.topk > 1:
+                self._sync_verify_tree_mask(spec_info, metadata)
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
             # Static per-request query width, fixed by the captured graph shape.
@@ -695,10 +731,48 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         self.forward_metadata = metadata
 
+    def _sync_verify_tree_mask(
+        self, spec_info: Optional[SpecInput], metadata: TRTLLMMHAMetadata
+    ) -> None:
+        """Copy the QLEN_ONLY tree mask into the CUDA-graph buffer unless the
+        producer already wrote it there in place (the eagle worker writes
+        through get_verify_buffers_to_fill_after_draft)."""
+        mask = getattr(spec_info, "custom_mask", None)
+        if mask is None or metadata.tree_mask is None:
+            return
+        if mask.data_ptr() != self.cuda_graph_custom_mask.data_ptr():
+            numel = metadata.tree_mask.numel()
+            self.cuda_graph_custom_mask[:numel].copy_(mask.reshape(-1)[:numel])
+
+    def get_verify_buffers_to_fill_after_draft(self):
+        return [self.cuda_graph_custom_mask, None]
+
     def update_verify_buffers_to_fill_after_draft(
         self, spec_info: SpecInput, cuda_graph_bs: Optional[int]
     ):
-        pass
+        """Re-sync mask-dependent state after the draft output is known.
+
+        The packed-mask conversion runs inside the captured verify forward and
+        reads the persistent QLEN_ONLY buffer at replay, so the CUDA-graph
+        path only needs a copy when the producer wrote a different tensor.
+        """
+        if self.topk <= 1:
+            return
+        metadata = self.forward_metadata
+        if metadata is None or metadata.tree_mask is None:
+            return
+        if cuda_graph_bs is not None:
+            self._sync_verify_tree_mask(spec_info, metadata)
+        else:
+            mask = getattr(spec_info, "custom_mask", None)
+            if mask is not None:
+                bs, num_draft_tokens = (
+                    metadata.tree_mask.shape[0],
+                    metadata.tree_mask.shape[1],
+                )
+                metadata.tree_mask = mask[
+                    : bs * num_draft_tokens * num_draft_tokens
+                ].view(bs, num_draft_tokens, num_draft_tokens)
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:
         """Get the fill value for sequence lengths in CUDA graph."""
@@ -836,12 +910,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
                 )
         elif forward_batch.forward_mode.is_target_verify():
-            # Only support topk = 1 for now.
+            # Chain verify for topk = 1; tree verify (topk > 1) additionally
+            # carries the QLEN_ONLY draft tree mask.
             tokens_per_req = forward_batch.input_ids.shape[0] // batch_size
             metadata.cache_seqlens_int32 = (forward_batch.seq_lens + tokens_per_req).to(
                 torch.int32
             )
             metadata.max_seq_len_q = tokens_per_req
+            metadata.max_seq_len_k = (
+                forward_batch.seq_lens_cpu.max().item() + tokens_per_req
+            )
+            if self.topk > 1:
+                metadata.tree_mask = forward_batch.spec_info.custom_mask[
+                    : batch_size * tokens_per_req * tokens_per_req
+                ].view(batch_size, tokens_per_req, tokens_per_req)
             metadata.cu_seqlens_q = torch.arange(
                 0,
                 batch_size * tokens_per_req + 1,
@@ -1072,6 +1154,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
                 out_dtype=self.q_data_type,  # model_runner.dtype
                 q_len_per_req=self.forward_metadata.max_seq_len_q,
+                # Tree verify (topk > 1): draft tree mask over the KV tail;
+                # None selects the causal chain-verify path.
+                mask=self.forward_metadata.tree_mask,
             )
         else:
             o = flashinfer.prefill.trtllm_batch_context_with_kv_cache(

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -53,6 +53,68 @@ DEFAULT_WORKSPACE_SIZE_MB = 512
 # Reuse this workspace buffer across all TRTLLM MHA wrappers
 
 
+def draft_branch_num_pages(
+    seq_lens_cpu: torch.Tensor, num_steps: int, page_size: int
+) -> int:
+    """Max pages per (request, branch) row in the spec-v2 draft tree layout:
+    the request's full prefix pages plus the branch's private page run."""
+    seq_lens_cpu = seq_lens_cpu.to(torch.int64)
+    last_page_lens = seq_lens_cpu % page_size
+    branch_pages = (last_page_lens + num_steps + page_size - 1) // page_size
+    return int((seq_lens_cpu // page_size + branch_pages).max().item())
+
+
+def build_draft_branch_page_tables(
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    num_pages: int,
+    topk: int,
+    num_steps: int,
+    page_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Expanded (bs*topk, num_pages) page table for draft decode with topk > 1.
+
+    Branch b of request r attends to the request's full prefix pages followed
+    by the branch's private page run at req_to_token row offset
+    prefix_base + b * num_new_pages * page_size — the layout written by
+    eagle_info_v2.prepare_for_v2_draft. The private first page duplicates the
+    prefix tail page, so the per-branch KV length at draft step i stays
+    seq_lens + i + 1 and the table is identical for all draft steps.
+    """
+    bs = seq_lens.numel()
+    device = seq_lens.device
+    seq_lens = seq_lens.to(torch.int64)
+    last_page_lens = seq_lens % page_size
+    prefix_bases = seq_lens - last_page_lens
+    num_prefix_pages = prefix_bases // page_size
+    branch_strides = (
+        (last_page_lens + num_steps + page_size - 1) // page_size
+    ) * page_size
+    cols = torch.arange(num_pages, device=device, dtype=torch.int64)
+    branch_ids = torch.arange(topk, device=device, dtype=torch.int64)
+    pages_into_branch = cols.view(1, 1, -1) - num_prefix_pages.view(bs, 1, 1)
+    branch_pos = (
+        prefix_bases.view(bs, 1, 1)
+        + branch_ids.view(1, topk, 1) * branch_strides.view(bs, 1, 1)
+        + pages_into_branch * page_size
+    )
+    token_pos = torch.where(
+        pages_into_branch >= 0, branch_pos, (cols * page_size).view(1, 1, -1)
+    )
+    token_pos.clamp_(min=0, max=req_to_token.shape[1] - 1)
+    rows = req_to_token[req_pool_indices.long()]
+    page_tables = (
+        torch.gather(rows.unsqueeze(1).expand(bs, topk, -1), 2, token_pos) // page_size
+    ).to(torch.int32)
+    page_tables = page_tables.reshape(bs * topk, num_pages)
+    if out is None:
+        return page_tables
+    out[: bs * topk, :num_pages].copy_(page_tables)
+    return out[: bs * topk, :num_pages]
+
+
 @dataclass
 class TRTLLMMHAMetadata:
     # Sequence lengths for the forward batch
@@ -129,7 +191,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.decode_cuda_graph_metadata = {}
 
         # Speculative decoding
-        # Only support topk <= 1 for now.
+        # Draft decode supports topk > 1 (tree draft, batch-expanded to
+        # bs*topk rows); target verify still requires topk <= 1 until the
+        # tree-mask path lands.
         self.topk = model_runner.server_args.speculative_eagle_topk or 0
         self.speculative_step_id = speculative_step_id
         self.target_verify_metadata = {}
@@ -158,6 +222,13 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.max_num_pages = (
             self.max_context_len + self.page_size - 1
         ) // self.page_size
+
+        # topk > 1 draft decode runs as a bs*topk batch over per-branch page
+        # tables. The multi-step wrapper owns the shared table (it is
+        # identical for every draft step) and hands it to the per-step
+        # backends through these attributes.
+        self.draft_branch_page_tables: Optional[torch.Tensor] = None
+        self.draft_branch_page_table_buf: Optional[torch.Tensor] = None
 
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
@@ -333,21 +404,37 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             self.speculative_num_draft_tokens is not None
             and self.speculative_num_draft_tokens > 0
         ):
+            # Draft tree decode (topk > 1) expands to one row per
+            # (request, branch).
+            max_draft_rows = max_bs * self.topk if self.topk > 1 else max_bs
+            if max_draft_rows > max_bs:
+                self.decode_cuda_graph_metadata["cache_seqlens"] = torch.zeros(
+                    max_draft_rows, dtype=torch.int32, device=self.device
+                )
             self.decode_cuda_graph_metadata["cu_seqlens_q"] = torch.arange(
-                0, max_bs + 1, dtype=torch.int32, device=self.device
+                0, max_draft_rows + 1, dtype=torch.int32, device=self.device
             )
             self.decode_cuda_graph_metadata["cu_seqlens_k"] = torch.zeros(
-                max_bs + 1, dtype=torch.int32, device=self.device
+                max_draft_rows + 1, dtype=torch.int32, device=self.device
             )
-            self.decode_cuda_graph_metadata["page_table_draft_decode"] = torch.zeros(
-                max_bs,
-                max_num_pages,
-                dtype=torch.int32,
-                device=self.device,
-            )
-            self.decode_cuda_graph_metadata["swa_page_table_draft_decode"] = (
-                self._alloc_swa_page_table(max_bs, max_num_pages)
-            )
+            if self.topk > 1:
+                # The per-branch page table buffer is shared across the
+                # per-step backends; the multi-step wrapper allocates and
+                # fills it (see TRTLLMHAAttnMultiStepDraftBackend).
+                self.decode_cuda_graph_metadata["page_table_draft_decode"] = None
+                self.decode_cuda_graph_metadata["swa_page_table_draft_decode"] = None
+            else:
+                self.decode_cuda_graph_metadata["page_table_draft_decode"] = (
+                    torch.zeros(
+                        max_bs,
+                        max_num_pages,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                )
+                self.decode_cuda_graph_metadata["swa_page_table_draft_decode"] = (
+                    self._alloc_swa_page_table(max_bs, max_num_pages)
+                )
 
             self.target_verify_metadata = {
                 "cache_seqlens": torch.zeros(
@@ -406,25 +493,34 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:
-                # Draft Decode (topk = 1)
+                # Draft Decode (one row per request, or per (request, branch)
+                # for tree draft with topk > 1)
+                rows = bs * self.topk if self.topk > 1 else bs
                 metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
                     "cache_seqlens"
-                ][:bs]
+                ][:rows]
                 metadata.cu_seqlens_q = self.decode_cuda_graph_metadata["cu_seqlens_q"][
-                    : bs + 1
+                    : rows + 1
                 ]
                 metadata.cu_seqlens_k = self.decode_cuda_graph_metadata["cu_seqlens_k"][
-                    : bs + 1
+                    : rows + 1
                 ]
-                metadata.page_table = self.decode_cuda_graph_metadata[
-                    "page_table_draft_decode"
-                ][:bs, :]
-                self._bind_swa_page_table(
-                    metadata,
-                    self.decode_cuda_graph_metadata,
-                    "swa_page_table_draft_decode",
-                    bs,
-                )
+                if self.topk > 1:
+                    assert self.draft_branch_page_table_buf is not None, (
+                        "topk > 1 draft decode requires the multi-step wrapper "
+                        "to allocate the shared per-branch page table buffer"
+                    )
+                    metadata.page_table = self.draft_branch_page_table_buf[:rows, :]
+                else:
+                    metadata.page_table = self.decode_cuda_graph_metadata[
+                        "page_table_draft_decode"
+                    ][:bs, :]
+                    self._bind_swa_page_table(
+                        metadata,
+                        self.decode_cuda_graph_metadata,
+                        "swa_page_table_draft_decode",
+                        bs,
+                    )
                 self.decode_cuda_graph_metadata[bs] = metadata
             else:
                 # Normal Decode
@@ -527,8 +623,27 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:
                 # Draft Decode
-                # Here we only support topk = 1 for now.
                 metadata = self.decode_cuda_graph_metadata[bs]
+                if self.topk > 1:
+                    # Tree draft: one row per (request, branch). The shared
+                    # per-branch page table is filled once per draft phase by
+                    # the multi-step wrapper and the decode kernel bounds KV
+                    # reads by cache_seqlens (max_seq_len is the static
+                    # max_context_len), so only the per-step sequence lengths
+                    # and cu_seqlens_k are updated here - no fused rebuild and
+                    # no host sync.
+                    metadata.cache_seqlens_int32.copy_(
+                        (seq_lens + self.speculative_step_id + 1).repeat_interleave(
+                            self.topk
+                        )
+                    )
+                    metadata.cu_seqlens_k[1:].copy_(
+                        torch.cumsum(
+                            metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
+                        )
+                    )
+                    self.forward_metadata = metadata
+                    return
                 seqlen_offset = self.speculative_step_id + 1
             else:
                 # Normal Decode
@@ -666,7 +781,39 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if forward_batch.forward_mode.is_decode_or_idle():
             if forward_batch.spec_info is not None:
                 # Draft Decode
-                # Here we only support topk = 1 for now.
+                if self.topk > 1:
+                    # Tree draft: one row per (request, branch) over the
+                    # per-branch page tables built by the multi-step wrapper
+                    # (they are identical for every draft step).
+                    assert self.draft_branch_page_tables is not None, (
+                        "topk > 1 draft decode requires the multi-step wrapper "
+                        "to build the per-branch page tables first"
+                    )
+                    metadata.cache_seqlens_int32 = (
+                        (seqlens_in_batch + (self.speculative_step_id + 1))
+                        .repeat_interleave(self.topk)
+                        .to(torch.int32)
+                    )
+                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
+                        self.speculative_step_id + 1
+                    )
+                    metadata.cu_seqlens_q = torch.arange(
+                        0,
+                        batch_size * self.topk + 1,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                    metadata.cu_seqlens_k = torch.nn.functional.pad(
+                        torch.cumsum(
+                            metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
+                        ),
+                        (1, 0),
+                    )
+                    # Already in page units; skip the strided token->page
+                    # conversion below.
+                    metadata.page_table = self.draft_branch_page_tables
+                    self.forward_metadata = metadata
+                    return
                 metadata.cache_seqlens_int32 = (
                     seqlens_in_batch + (self.speculative_step_id + 1)
                 ).to(torch.int32)
@@ -968,12 +1115,61 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
                 kv_last_page_len_buf=self.kv_last_page_len,
                 speculative_step_id=i,
             )
+        # Shared (max bs*topk, num_pages) per-branch page table for tree
+        # draft decode; identical across draft steps, so it is built once per
+        # draft phase and bound by every per-step backend.
+        self.draft_branch_page_table_buf: Optional[torch.Tensor] = None
+
+    def _update_draft_branch_page_tables(
+        self,
+        forward_batch: ForwardBatch,
+        seq_lens_cpu: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+    ):
+        bs = forward_batch.batch_size
+        num_pages = draft_branch_num_pages(
+            seq_lens_cpu[:bs], self.speculative_num_steps, self.page_size
+        )
+        page_tables = build_draft_branch_page_tables(
+            self.req_to_token_pool.req_to_token,
+            forward_batch.req_pool_indices[:bs],
+            forward_batch.seq_lens[:bs],
+            num_pages,
+            self.topk,
+            self.speculative_num_steps,
+            self.page_size,
+            out=out,
+        )
+        for backend in self.attn_backends:
+            backend.draft_branch_page_tables = page_tables
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
+        if (
+            self.topk > 1
+            and not forward_batch.forward_mode.is_idle()
+            and forward_batch.spec_info is not None
+        ):
+            self._update_draft_branch_page_tables(
+                forward_batch, forward_batch.seq_lens_cpu
+            )
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_forward_metadata(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+        if self.topk > 1:
+            max_num_pages = (
+                self.max_context_len + self.page_size - 1
+            ) // self.page_size + (
+                2 * (self.page_size - 1) + self.speculative_num_steps
+            ) // self.page_size
+            self.draft_branch_page_table_buf = torch.zeros(
+                max_num_tokens,
+                max_num_pages,
+                dtype=torch.int32,
+                device=self.kv_indptr.device,
+            )
+            for backend in self.attn_backends:
+                backend.draft_branch_page_table_buf = self.draft_branch_page_table_buf
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
 
@@ -995,6 +1191,19 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
             forward_mode=ForwardMode.DECODE,
             encoder_lens=forward_batch.encoder_lens,
         )
+        if self.topk > 1:
+            # Fill the shared per-branch page table once per draft phase;
+            # per-step _apply only refreshes the per-step sequence lengths.
+            seq_lens_cpu = (
+                forward_batch.seq_lens.cpu()
+                if in_capture
+                else forward_batch.seq_lens_cpu
+            )
+            self._update_draft_branch_page_tables(
+                forward_batch,
+                seq_lens_cpu,
+                out=self.draft_branch_page_table_buf,
+            )
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_forward_metadata_out_graph(
                 inner_fb, in_capture=in_capture

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -153,6 +153,13 @@ def default_tree_mask_mode() -> TreeMaskMode:
     return TreeMaskMode.QLEN_ONLY if _is_cpu else TreeMaskMode.FULL_MASK
 
 
+def resolve_tree_mask_mode(target_attn_backend) -> TreeMaskMode:
+    """The verify tree-mask layout is a property of the target attention
+    backend (e.g. trtllm_mha consumes the draft-only QLEN_ONLY layout for
+    tree verify); otherwise fall back to the platform default."""
+    return getattr(target_attn_backend, "tree_mask_mode", default_tree_mask_mode())
+
+
 def build_tree_kernel_efficient(
     bonus_tokens: torch.Tensor,
     parent_list: List[torch.Tensor],

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -66,7 +66,6 @@ from sglang.srt.speculative.eagle_info import (
     EagleVerifyInput,
 )
 from sglang.srt.speculative.eagle_utils import (
-    TreeMaskMode,
     _eagle_prefill_tail_tokens,
     build_tree_kernel_efficient,
     default_tree_mask_mode,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -75,6 +75,7 @@ from sglang.srt.speculative.eagle_utils import (
     organize_draft_results,
     per_step_draft_out_cache_loc,
     resolve_tree_mask_mode,
+    TreeMaskMode,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -66,6 +66,7 @@ from sglang.srt.speculative.eagle_info import (
     EagleVerifyInput,
 )
 from sglang.srt.speculative.eagle_utils import (
+    TreeMaskMode,
     _eagle_prefill_tail_tokens,
     build_tree_kernel_efficient,
     default_tree_mask_mode,
@@ -75,7 +76,6 @@ from sglang.srt.speculative.eagle_utils import (
     organize_draft_results,
     per_step_draft_out_cache_loc,
     resolve_tree_mask_mode,
-    TreeMaskMode,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -74,6 +74,7 @@ from sglang.srt.speculative.eagle_utils import (
     get_draft_recurrent_hidden_state_spec,
     organize_draft_results,
     per_step_draft_out_cache_loc,
+    resolve_tree_mask_mode,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
@@ -396,7 +397,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_runner.draft_attn_backend = self.draft_attn_backend
         if self.draft_extend_attn_backend is not None:
             self.draft_runner.attn_backend = self.draft_extend_attn_backend
-        self.tree_mask_mode = default_tree_mask_mode()
+        self.tree_mask_mode = resolve_tree_mask_mode(
+            self.target_worker.model_runner.attn_backend
+        )
 
     def _capture_cuda_graphs(self):
         """Capture the draft worker's own cuda graphs (decode + draft-extend)."""

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -54,6 +54,7 @@ from sglang.srt.speculative.eagle_utils import (
     eagle_prepare_for_verify,
     eagle_sample,
     get_draft_recurrent_hidden_state_spec,
+    resolve_tree_mask_mode,
 )
 from sglang.srt.speculative.multi_layer_eagle_draft_extend_cuda_graph_runner import (
     MultiLayerEagleMultiStepDraftExtendCudaGraphRunner,
@@ -195,6 +196,10 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
             speculative_moe_backend_context(),
         ):
             super().init_attention_backends()
+
+        self.tree_mask_mode = resolve_tree_mask_mode(
+            self.target_worker.model_runner.attn_backend
+        )
 
     def init_cuda_graphs(self):
         with (

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -78,6 +78,9 @@ class DenseAttentionCase:
     prefix_lens: tuple[int, ...]
     extend_lens: tuple[int, ...] = ()
     sliding_window_size: int | None = None
+    # Tree spec decoding: backends read this at construction time (e.g. the
+    # trtllm_mha verify path keys its tree-mask handling on topk > 1).
+    speculative_eagle_topk: int = 0
 
     @property
     def batch_size(self) -> int:
@@ -363,7 +366,7 @@ class MockModelRunner(ModelRunner):
             pp_size=1,
             revision=None,
             speculative_algorithm=None,
-            speculative_eagle_topk=0,
+            speculative_eagle_topk=case.speculative_eagle_topk,
             speculative_num_draft_tokens=speculative_num_draft_tokens,
             speculative_num_steps=max(0, speculative_num_draft_tokens - 1),
             tp_size=1,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -757,19 +757,78 @@ def _prepare_dense_draft_replay_state(
         {"prefix_hidden": fixture.prefix_hidden},
         max_context_len=settings.max_context_len,
     )
+    # Fill the whole draft footprint (branch page runs included), mirroring
+    # the production allocator which assigns the full reserved range.
     for req_idx, prefix_len in enumerate(case.prefix_lens):
-        for branch in range(settings.topk):
-            for step in range(settings.speculative_num_steps):
-                position = prefix_len + branch * settings.speculative_num_steps + step
-                fixture.runner.req_to_token_pool.req_to_token[
+        footprint = _dense_draft_footprint(
+            prefix_len=prefix_len,
+            topk=settings.topk,
+            speculative_num_steps=settings.speculative_num_steps,
+            page_size=case.page_size,
+        )
+        for position in range(prefix_len, footprint):
+            fixture.runner.req_to_token_pool.req_to_token[
+                req_idx,
+                position,
+            ] = _dense_token_loc(
+                req_idx,
+                position,
+                page_size=case.page_size,
+                max_context_len=settings.max_context_len,
+            )
+    _duplicate_dense_prefix_tail_to_branches(fixture, case, settings)
+
+
+def _duplicate_dense_prefix_tail_to_branches(
+    fixture,
+    case: DenseAttentionCase,
+    settings: EagleDraftRunnerSettings,
+) -> None:
+    """Mirror eagle_info_v2.duplicate_prefix_tail_to_draft_branches: with
+    page_size > 1 and topk > 1, branch b >= 1's first page starts with
+    `last_page` hole slots that must hold the real prefix tail KV."""
+    page_size = case.page_size
+    if settings.topk <= 1 or page_size == 1:
+        return
+    pool = fixture.runner.token_to_kv_pool
+    device = fixture.runner.device
+    for req_idx, prefix_len in enumerate(case.prefix_lens):
+        last_page = prefix_len % page_size
+        if last_page == 0:
+            continue
+        prefix_base = prefix_len - last_page
+        num_new_pages = (
+            last_page + settings.speculative_num_steps + page_size - 1
+        ) // page_size
+        src_slots = [
+            _dense_token_loc(
+                req_idx,
+                prefix_base + offset,
+                page_size=page_size,
+                max_context_len=settings.max_context_len,
+            )
+            for offset in range(last_page)
+        ]
+        src = torch.tensor(src_slots, dtype=torch.int64, device=device)
+        for branch in range(1, settings.topk):
+            branch_base = prefix_base + branch * num_new_pages * page_size
+            tgt_slots = [
+                _dense_token_loc(
                     req_idx,
-                    position,
-                ] = _dense_token_loc(
-                    req_idx,
-                    position,
-                    page_size=case.page_size,
+                    branch_base + offset,
+                    page_size=page_size,
                     max_context_len=settings.max_context_len,
                 )
+                for offset in range(last_page)
+            ]
+            tgt = torch.tensor(tgt_slots, dtype=torch.int64, device=device)
+            # Direct buffer copy: the fixture pool is built without
+            # enable_kv_cache_copy, so move_kv_cache is unavailable.
+            for layer_id in range(pool.start_layer, pool.start_layer + pool.layer_num):
+                k_buffer = pool.get_key_buffer(layer_id)
+                v_buffer = pool.get_value_buffer(layer_id)
+                k_buffer[tgt] = k_buffer[src]
+                v_buffer[tgt] = v_buffer[src]
 
 
 def _dense_draft_cache_position(
@@ -779,30 +838,52 @@ def _dense_draft_cache_position(
     step: int,
     topk: int,
     speculative_num_steps: int,
+    page_size: int,
 ) -> int:
     if topk == 1:
         return prefix_len + step
-    return prefix_len + branch * speculative_num_steps + step
+    if page_size == 1:
+        return prefix_len + branch * speculative_num_steps + step
+    # spec-v2 paged tree layout (eagle_info_v2.prepare_for_v2_draft): each
+    # branch owns a page-aligned page run after the full prefix pages; the
+    # run's first `last_page` slots duplicate the prefix tail page.
+    last_page = prefix_len % page_size
+    prefix_base = prefix_len - last_page
+    num_new_pages = (last_page + speculative_num_steps + page_size - 1) // page_size
+    return prefix_base + branch * num_new_pages * page_size + last_page + step
+
+
+def _dense_draft_footprint(
+    *,
+    prefix_len: int,
+    topk: int,
+    speculative_num_steps: int,
+    page_size: int,
+) -> int:
+    """req_to_token row positions used by a request's prefix + draft tree."""
+    if topk == 1:
+        return prefix_len + speculative_num_steps
+    if page_size == 1:
+        return prefix_len + topk * speculative_num_steps
+    last_page = prefix_len % page_size
+    prefix_base = prefix_len - last_page
+    num_new_pages = (last_page + speculative_num_steps + page_size - 1) // page_size
+    return prefix_base + topk * num_new_pages * page_size
 
 
 def _check_dense_draft_cache_layout(
     case: DenseAttentionCase,
     settings: EagleDraftRunnerSettings,
 ) -> None:
-    if settings.topk > 1 and case.page_size != 1:
-        raise ValueError(
-            "The dense EAGLE draft runner fixture covers tree draft with "
-            "page_size=1, where branch cache slots are laid out linearly."
+    for prefix_len in case.prefix_lens:
+        footprint = _dense_draft_footprint(
+            prefix_len=prefix_len,
+            topk=settings.topk,
+            speculative_num_steps=settings.speculative_num_steps,
+            page_size=case.page_size,
         )
-    if settings.topk > 1:
-        for prefix_len in case.prefix_lens:
-            if (
-                prefix_len + settings.topk * settings.speculative_num_steps
-                > settings.max_context_len
-            ):
-                raise ValueError(
-                    "Draft cache layout exceeds the configured context len."
-                )
+        if footprint > settings.max_context_len:
+            raise ValueError("Draft cache layout exceeds the configured context len.")
 
 
 def _make_dense_eagle_draft_forward_batch(
@@ -820,6 +901,7 @@ def _make_dense_eagle_draft_forward_batch(
                     step=step,
                     topk=settings.topk,
                     speculative_num_steps=settings.speculative_num_steps,
+                    page_size=case.page_size,
                 )
                 out_cache_locs.append(
                     _dense_token_loc(
@@ -1112,6 +1194,7 @@ def _prepare_mla_draft_replay_state(
                     step=step,
                     topk=settings.topk,
                     speculative_num_steps=settings.speculative_num_steps,
+                    page_size=case.page_size,
                 )
                 fixture.runner.req_to_token_pool.req_to_token[
                     req_idx,
@@ -1159,6 +1242,7 @@ def _make_mla_eagle_draft_forward_batch(
                     step=step,
                     topk=settings.topk,
                     speculative_num_steps=settings.speculative_num_steps,
+                    page_size=case.page_size,
                 )
                 out_cache_locs.append(
                     _mla_token_loc(

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
@@ -7,6 +7,7 @@ from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.eagle_info import EagleVerifyInput
+from sglang.srt.speculative.eagle_utils import TreeMaskMode
 from sglang.srt.speculative.frozen_kv_mtp_info import FrozenKVMTPVerifyInput
 from sglang.srt.speculative.ngram_info import NgramVerifyInput
 
@@ -228,6 +229,16 @@ def _draft_tree_mask(
     return mask
 
 
+def _verify_tree_mask_mode(case, topk: int) -> TreeMaskMode:
+    """Mirror the production workers: the verify mask layout is a property of
+    the target attention backend (see `tree_mask_mode` resolution in
+    eagle_worker_v2). trtllm_mha consumes the draft-only QLEN_ONLY layout for
+    tree verify; everything else takes the dense FULL_MASK layout."""
+    if topk > 1 and case.backend == "trtllm_mha":
+        return TreeMaskMode.QLEN_ONLY
+    return TreeMaskMode.FULL_MASK
+
+
 def _make_custom_masks(
     case,
     *,
@@ -240,6 +251,7 @@ def _make_custom_masks(
         topk=topk,
         device=device,
     )
+    tree_mask_mode = _verify_tree_mask_mode(case, topk)
     masks_by_req = []
     flattened_masks = []
     for prefix_len in case.prefix_lens:
@@ -253,9 +265,13 @@ def _make_custom_masks(
         reference_mask[:, prefix_len:] = draft_mask
         masks_by_req.append(reference_mask)
 
-        backend_mask = torch.zeros_like(reference_mask)
-        backend_mask[:, :seq_len] = reference_mask
-        flattened_masks.append(backend_mask.reshape(-1))
+        if tree_mask_mode == TreeMaskMode.QLEN_ONLY:
+            # Draft-only mask, flat (bs, draft_token_num, draft_token_num).
+            flattened_masks.append(draft_mask.reshape(-1))
+        else:
+            backend_mask = torch.zeros_like(reference_mask)
+            backend_mask[:, :seq_len] = reference_mask
+            flattened_masks.append(backend_mask.reshape(-1))
 
     return masks_by_req, torch.cat(flattened_masks, dim=0)
 

--- a/test/registered/attention/unittests/dense/test_trtllm_mha.py
+++ b/test/registered/attention/unittests/dense/test_trtllm_mha.py
@@ -275,6 +275,40 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
             ),
             2,  # topk
         ),
+        # SWA + tree verify: the window is folded into flashinfer's packed
+        # custom mask over a page-trimmed SWA table. Prefixes cover window
+        # entirely inside the prefix (trim > 0), window spanning the whole
+        # sequence (trim == 0), and a page-boundary prefix.
+        (
+            DenseAttentionCase(
+                name="runner_trtllm_mha_eagle_verify_tree_swa",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                num_kv_heads=4,
+                page_size=16,
+                prefix_lens=(3, 14, 17, 32),
+                extend_lens=(3, 3, 3, 3),
+                sliding_window_size=4,
+                speculative_eagle_topk=2,
+            ),
+            2,  # topk
+        ),
+        (
+            DenseAttentionCase(
+                name="runner_trtllm_mha_eagle_verify_tree_swa_gqa_page32",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                num_kv_heads=2,
+                page_size=32,
+                prefix_lens=(30, 60),
+                extend_lens=(3, 3),
+                sliding_window_size=5,
+                speculative_eagle_topk=2,
+            ),
+            2,  # topk
+        ),
     )
 
     SPEC_VERIFY_CUDA_GRAPH_CASES = (
@@ -288,6 +322,21 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
                 page_size=16,
                 prefix_lens=(14, 15, 16),
                 extend_lens=(3, 3, 3),
+                speculative_eagle_topk=2,
+            ),
+            2,  # topk
+        ),
+        (
+            DenseAttentionCase(
+                name="runner_cuda_graph_trtllm_mha_eagle_verify_tree_swa",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                num_kv_heads=4,
+                page_size=16,
+                prefix_lens=(3, 17, 32),
+                extend_lens=(3, 3, 3),
+                sliding_window_size=4,
                 speculative_eagle_topk=2,
             ),
             2,  # topk

--- a/test/registered/attention/unittests/dense/test_trtllm_mha.py
+++ b/test/registered/attention/unittests/dense/test_trtllm_mha.py
@@ -6,7 +6,11 @@ import torch
 
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.utils import is_flashinfer_available
-from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
+from sglang.srt.utils.common import (
+    is_sm90_supported,
+    is_sm100_supported,
+    is_sm120_supported,
+)
 from sglang.test.test_utils import CustomTestCase
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -31,7 +35,7 @@ register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
 @unittest.skipIf(
     not torch.cuda.is_available()
     or not is_flashinfer_available()
-    or not (is_sm90_supported() or is_sm120_supported()),
+    or not (is_sm90_supported() or is_sm100_supported() or is_sm120_supported()),
     "CUDA + FlashInfer TRT-LLM MHA decode support are required",
 )
 class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
@@ -121,13 +125,13 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
         ),
     )
 
-    # EAGLE draft CG runner — chain only (topk=1). trtllm_mha is constrained
-    # to topk=1 via `trtllm_mha_backend.py:459,492` so tree-mode tests don't
-    # apply. This test exercises the draft-decode CG capture/replay path
-    # (`init_forward_metadata_capture_cuda_graph` line 320 and
-    # `init_forward_metadata_replay_cuda_graph` line 460) — the same path
-    # patched by PR #26521 (capture-time NaN fix) and PR #26655 (replay-time
-    # slice rebind).
+    # EAGLE draft CG runner — chain (topk=1) plus tree (topk>1) cases. Tree
+    # draft decode expands the batch to bs*topk rows with per-branch page
+    # tables over the spec-v2 page-aligned branch layout
+    # (`eagle_info_v2.prepare_for_v2_draft`). Tuples are
+    # (case, topk, num_draft_tokens, max_context_len); prefix_lens straddle
+    # page boundaries so branch regions start mid-page (last_page > 0) and
+    # exactly on a page boundary (last_page == 0).
     EAGLE_DRAFT_RUNNER_CASES = (
         (
             DenseAttentionCase(
@@ -141,6 +145,49 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
             ),
             1,  # topk
             3,  # num_draft_tokens
+            64,  # max_context_len
+        ),
+        (
+            DenseAttentionCase(
+                name="runner_eagle_draft_decode_trtllm_mha_cuda_graph_tree_page16",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.DECODE,
+                num_heads=4,
+                num_kv_heads=4,
+                page_size=16,
+                prefix_lens=(14, 15, 16),
+            ),
+            2,  # topk
+            4,  # num_draft_tokens
+            64,  # max_context_len
+        ),
+        (
+            DenseAttentionCase(
+                name="runner_eagle_draft_decode_trtllm_mha_cuda_graph_tree_gqa_topk4",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.DECODE,
+                num_heads=4,
+                num_kv_heads=2,
+                page_size=16,
+                prefix_lens=(14, 15, 16),
+            ),
+            4,  # topk
+            6,  # num_draft_tokens
+            128,  # max_context_len
+        ),
+        (
+            DenseAttentionCase(
+                name="runner_eagle_draft_decode_trtllm_mha_cuda_graph_tree_page32",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.DECODE,
+                num_heads=4,
+                num_kv_heads=4,
+                page_size=32,
+                prefix_lens=(31, 32),
+            ),
+            2,  # topk
+            4,  # num_draft_tokens
+            128,  # max_context_len
         ),
     )
 
@@ -179,7 +226,12 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
                 )
 
     def test_runner_mode_eagle_draft_cuda_graph_runner_cases(self):
-        for case, topk, num_draft_tokens in self.EAGLE_DRAFT_RUNNER_CASES:
+        for (
+            case,
+            topk,
+            num_draft_tokens,
+            max_context_len,
+        ) in self.EAGLE_DRAFT_RUNNER_CASES:
             with self.subTest(case=case.name, backend=case.backend, topk=topk):
                 run_dense_eagle_draft_cuda_graph_runner_case(
                     self,
@@ -188,6 +240,7 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
                     speculative_num_draft_tokens=num_draft_tokens,
                     head_dim=self.HEAD_DIM,
                     hidden_size=self.HIDDEN_SIZE,
+                    max_context_len=max_context_len,
                 )
 
     def test_runner_mode_frozen_kv_mtp_cuda_graph_runner_cases(self):
@@ -199,6 +252,151 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
                     head_dim=self.HEAD_DIM,
                     hidden_size=self.HIDDEN_SIZE,
                 )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestTRTLLMMHADraftBranchPageTables(CustomTestCase):
+    """Validate build_draft_branch_page_tables against (a) a direct python
+    re-derivation of the spec-v2 branch layout and (b) the production
+    generate_draft_decode_kv_indices triton kernel (independent code path):
+    every token that kernel emits must live in the page the table points at,
+    at the matching in-page offset."""
+
+    CASES = (
+        # (page_size, topk, num_steps, prefix_lens)
+        (16, 2, 3, (14, 15, 16)),
+        (16, 4, 3, (1, 14, 31, 32)),
+        (32, 2, 4, (31, 32, 33)),
+        (64, 8, 5, (63, 64, 130)),
+        (1, 2, 3, (5, 9)),
+    )
+
+    def test_matches_layout_and_kv_indices(self):
+        from sglang.srt.layers.attention.trtllm_mha_backend import (
+            build_draft_branch_page_tables,
+            draft_branch_num_pages,
+        )
+        from sglang.srt.speculative.triton_ops.cache_locs import (
+            generate_draft_decode_kv_indices,
+        )
+        from sglang.srt.utils import next_power_of_2
+
+        device = "cuda"
+        # Row width; multiple of every tested page size and large enough for
+        # the widest branch footprint (page 64, topk 8: 128 + 8*64 = 640).
+        ctx = 1024
+        for page_size, topk, num_steps, prefix_lens in self.CASES:
+            with self.subTest(page_size=page_size, topk=topk, steps=num_steps):
+                bs = len(prefix_lens)
+                pos = torch.arange(ctx, dtype=torch.int32, device=device)
+                req_to_token = (
+                    page_size
+                    + torch.arange(bs, dtype=torch.int32, device=device).view(-1, 1)
+                    * ctx
+                    + pos.view(1, -1)
+                )
+                req_pool_indices = torch.arange(bs, dtype=torch.int32, device=device)
+                seq_lens = torch.tensor(prefix_lens, dtype=torch.int32, device=device)
+                num_pages = draft_branch_num_pages(seq_lens.cpu(), num_steps, page_size)
+                page_tables = build_draft_branch_page_tables(
+                    req_to_token,
+                    req_pool_indices,
+                    seq_lens,
+                    num_pages,
+                    topk,
+                    num_steps,
+                    page_size,
+                ).cpu()
+
+                # (a) direct python re-derivation of the branch layout.
+                rows_cpu = req_to_token.cpu()
+                for req_idx, prefix_len in enumerate(prefix_lens):
+                    last_page = prefix_len % page_size
+                    prefix_base = prefix_len - last_page
+                    num_prefix_pages = prefix_base // page_size
+                    if topk == 1 or page_size == 1:
+                        branch_stride = num_steps
+                    else:
+                        branch_stride = (
+                            (last_page + num_steps + page_size - 1) // page_size
+                        ) * page_size
+                    branch_pages = (last_page + num_steps + page_size - 1) // page_size
+                    for branch in range(topk):
+                        row = page_tables[req_idx * topk + branch]
+                        for col in range(num_prefix_pages):
+                            self.assertEqual(
+                                int(row[col]),
+                                int(rows_cpu[req_idx, col * page_size]) // page_size,
+                            )
+                        for j in range(branch_pages):
+                            position = (
+                                prefix_base + branch * branch_stride + j * page_size
+                            )
+                            self.assertEqual(
+                                int(row[num_prefix_pages + j]),
+                                int(rows_cpu[req_idx, position]) // page_size,
+                            )
+
+                # (b) cross-check against the production kv-indices kernel.
+                width = (sum(prefix_lens) + bs * num_steps) * topk + 64
+                kv_indices = torch.zeros(
+                    (num_steps, width), dtype=torch.int32, device=device
+                )
+                kv_indptr = torch.zeros(
+                    (num_steps, bs * topk + 1), dtype=torch.int32, device=device
+                )
+                positions = (
+                    seq_lens.repeat_interleave(topk).to(torch.int64).contiguous()
+                )
+                generate_draft_decode_kv_indices[(num_steps, bs, topk)](
+                    req_pool_indices,
+                    req_to_token,
+                    seq_lens,
+                    kv_indices,
+                    kv_indptr,
+                    positions,
+                    ctx,
+                    width,
+                    kv_indptr.shape[1],
+                    next_power_of_2(bs),
+                    next_power_of_2(num_steps),
+                    next_power_of_2(bs * topk),
+                    page_size,
+                )
+                kv_indices_cpu = kv_indices.cpu()
+                seq_lens_cpu = [int(s) for s in prefix_lens]
+                for step in range(num_steps):
+                    iters = step + 1
+                    for req_idx, prefix_len in enumerate(prefix_lens):
+                        cum_seq_len = sum(seq_lens_cpu[:req_idx])
+                        last_page = prefix_len % page_size
+                        prefix_base = prefix_len - last_page
+                        for branch in range(topk):
+                            offset = (
+                                cum_seq_len * topk
+                                + req_idx * iters * topk
+                                + branch * (prefix_len + iters)
+                            )
+                            branch_kv = kv_indices_cpu[
+                                step, offset : offset + prefix_len + iters
+                            ]
+                            row = page_tables[req_idx * topk + branch]
+                            # Full prefix pages must match token-by-token.
+                            for j in range(prefix_base):
+                                self.assertEqual(
+                                    int(branch_kv[j]) // page_size,
+                                    int(row[j // page_size]),
+                                )
+                            # Draft tokens land in the branch's private pages
+                            # at the matching in-page offsets.
+                            for s in range(iters):
+                                token = int(branch_kv[prefix_len + s])
+                                page_col = (prefix_base + last_page + s) // page_size
+                                self.assertEqual(token // page_size, int(row[page_col]))
+                                self.assertEqual(
+                                    token % page_size,
+                                    (last_page + s) % page_size,
+                                )
 
 
 if __name__ == "__main__":

--- a/test/registered/attention/unittests/dense/test_trtllm_mha.py
+++ b/test/registered/attention/unittests/dense/test_trtllm_mha.py
@@ -27,6 +27,10 @@ from sglang.test.kits.attention_unittest.runner_modes.speculative_draft_runner i
     run_dense_eagle_draft_cuda_graph_runner_case,
     run_dense_frozen_kv_mtp_cuda_graph_runner_case,
 )
+from sglang.test.kits.attention_unittest.runner_modes.speculative_target_verify_runner import (
+    run_dense_spec_verify_case,
+    run_dense_spec_verify_cuda_graph_case,
+)
 
 register_cuda_ci(est_time=20, stage="base-b", runner_config="4-gpu-b200")
 register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
@@ -221,6 +225,93 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
                 run_dense_cuda_graph_decode_case(
                     self,
                     case,
+                    head_dim=self.HEAD_DIM,
+                    hidden_size=self.HIDDEN_SIZE,
+                )
+
+    # EAGLE verify: chain (topk=1) goes through the causal q_len_per_req
+    # path; tree (topk=2) passes the QLEN_ONLY tree mask to the trtllm-gen
+    # custom-mask kernels. The kit hardcodes draft_token_num=3 with parent
+    # indices (-1, 0, 0) for topk>1. prefix_lens straddle page boundaries.
+    SPEC_VERIFY_CASES = (
+        (
+            DenseAttentionCase(
+                name="runner_trtllm_mha_eagle_verify_chain",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                num_kv_heads=4,
+                page_size=16,
+                prefix_lens=(4, 7),
+                extend_lens=(3, 3),
+            ),
+            1,  # topk
+        ),
+        (
+            DenseAttentionCase(
+                name="runner_trtllm_mha_eagle_verify_tree",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                num_kv_heads=4,
+                page_size=16,
+                prefix_lens=(14, 15, 16),
+                extend_lens=(3, 3, 3),
+                speculative_eagle_topk=2,
+            ),
+            2,  # topk
+        ),
+        (
+            DenseAttentionCase(
+                name="runner_trtllm_mha_eagle_verify_tree_gqa_page32",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                num_kv_heads=2,
+                page_size=32,
+                prefix_lens=(30, 31),
+                extend_lens=(3, 3),
+                speculative_eagle_topk=2,
+            ),
+            2,  # topk
+        ),
+    )
+
+    SPEC_VERIFY_CUDA_GRAPH_CASES = (
+        (
+            DenseAttentionCase(
+                name="runner_cuda_graph_trtllm_mha_eagle_verify_tree",
+                backend="trtllm_mha",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                num_kv_heads=4,
+                page_size=16,
+                prefix_lens=(14, 15, 16),
+                extend_lens=(3, 3, 3),
+                speculative_eagle_topk=2,
+            ),
+            2,  # topk
+        ),
+    )
+
+    def test_runner_mode_spec_verify_cases(self):
+        for case, topk in self.SPEC_VERIFY_CASES:
+            with self.subTest(case=case.name, backend=case.backend, topk=topk):
+                run_dense_spec_verify_case(
+                    self,
+                    case,
+                    topk=topk,
+                    head_dim=self.HEAD_DIM,
+                    hidden_size=self.HIDDEN_SIZE,
+                )
+
+    def test_runner_mode_spec_verify_cuda_graph_cases(self):
+        for case, topk in self.SPEC_VERIFY_CUDA_GRAPH_CASES:
+            with self.subTest(case=case.name, backend=case.backend, topk=topk):
+                run_dense_spec_verify_cuda_graph_case(
+                    self,
+                    case,
+                    topk=topk,
                     head_dim=self.HEAD_DIM,
                     hidden_size=self.HIDDEN_SIZE,
                 )

--- a/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
+++ b/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
@@ -117,7 +117,9 @@ class TestTRTLLMMHASpecDecode(unittest.TestCase):
 
         metadata = backend.decode_cuda_graph_metadata[bs]
         expected_seqlens = torch.tensor([12] * topk + [22] * topk, dtype=torch.int32)
-        self.assertEqual(metadata.cache_seqlens_int32.tolist(), expected_seqlens.tolist())
+        self.assertEqual(
+            metadata.cache_seqlens_int32.tolist(), expected_seqlens.tolist()
+        )
         self.assertEqual(metadata.max_seq_len_k, 22)
         self.assertEqual(
             metadata.cu_seqlens_k[1:].tolist(),

--- a/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
+++ b/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
@@ -1,0 +1,175 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.trtllm_mha_backend import (
+    TRTLLMHAAttnBackend,
+    TRTLLMHAAttnMultiStepDraftBackend,
+    TRTLLMMHAMetadata,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative.eagle_utils import TreeMaskMode, resolve_tree_mask_mode
+from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+def _make_backend_factory(decode_backend, draft_extend_backend):
+    class FakeDraftBackendFactory:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def create_decode_backend(self):
+            return decode_backend
+
+        def create_draft_extend_backend(self):
+            return draft_extend_backend
+
+    return FakeDraftBackendFactory
+
+
+class TestTRTLLMMHASpecDecode(unittest.TestCase):
+    def test_tree_spec_backend_reports_qlen_only_mask_mode(self):
+        model_runner = SimpleNamespace(
+            model_config=SimpleNamespace(context_len=1024, hidden_size=128),
+            kv_cache_dtype=torch.bfloat16,
+            dtype=torch.bfloat16,
+            page_size=64,
+            req_to_token_pool=SimpleNamespace(
+                req_to_token=torch.empty(1, 1024, dtype=torch.int32)
+            ),
+            device="cpu",
+            server_args=SimpleNamespace(
+                speculative_eagle_topk=8,
+                speculative_num_draft_tokens=32,
+            ),
+            token_to_kv_pool=object(),
+            token_to_kv_pool_allocator=SimpleNamespace(get_kvcache=lambda: object()),
+            is_draft_worker=False,
+            spec_algorithm=SpeculativeAlgorithm.EAGLE,
+            sliding_window_size=None,
+        )
+
+        with patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend."
+            "FlashInferAttnBackend.__init__",
+            return_value=None,
+        ), patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend.is_sm90_supported",
+            return_value=False,
+        ), patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend.is_sm120_supported",
+            return_value=False,
+        ):
+            backend = TRTLLMHAAttnBackend(model_runner)
+
+        self.assertEqual(backend.tree_mask_mode, TreeMaskMode.QLEN_ONLY)
+        self.assertEqual(resolve_tree_mask_mode(backend), TreeMaskMode.QLEN_ONLY)
+
+    def test_worker_resolves_target_tree_mask_mode_after_backend_init(self):
+        worker = object.__new__(EagleDraftWorker)
+        target_backend = SimpleNamespace(tree_mask_mode=TreeMaskMode.QLEN_ONLY)
+        decode_backend = object()
+        draft_extend_backend = object()
+        worker.server_args = SimpleNamespace()
+        worker.draft_runner = SimpleNamespace(attn_backend=object())
+        worker.target_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(attn_backend=target_backend)
+        )
+        worker.topk = 8
+        worker.speculative_num_steps = 5
+
+        with patch(
+            "sglang.srt.speculative.eagle_worker_v2.DraftBackendFactory",
+            _make_backend_factory(decode_backend, draft_extend_backend),
+        ):
+            worker.init_attention_backend()
+
+        self.assertIs(worker.draft_attn_backend, decode_backend)
+        self.assertIs(worker.draft_extend_attn_backend, draft_extend_backend)
+        self.assertIs(worker.draft_runner.attn_backend, draft_extend_backend)
+        self.assertEqual(worker.tree_mask_mode, TreeMaskMode.QLEN_ONLY)
+
+    def test_topk_draft_cuda_graph_metadata_uses_seq_lens_tensor(self):
+        bs = 2
+        topk = 4
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        backend.topk = topk
+        backend.speculative_step_id = 1
+        backend.decode_cuda_graph_metadata = {
+            bs: TRTLLMMHAMetadata(
+                cache_seqlens_int32=torch.empty(bs * topk, dtype=torch.int32),
+                cu_seqlens_k=torch.zeros(bs * topk + 1, dtype=torch.int32),
+            )
+        }
+
+        backend._apply_cuda_graph_metadata(
+            bs=bs,
+            req_pool_indices=torch.arange(bs, dtype=torch.int32),
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            spec_info=object(),
+        )
+
+        metadata = backend.decode_cuda_graph_metadata[bs]
+        expected_seqlens = torch.tensor([12] * topk + [22] * topk, dtype=torch.int32)
+        self.assertEqual(metadata.cache_seqlens_int32.tolist(), expected_seqlens.tolist())
+        self.assertEqual(metadata.max_seq_len_k, 22)
+        self.assertEqual(
+            metadata.cu_seqlens_k[1:].tolist(),
+            torch.cumsum(expected_seqlens, dim=0, dtype=torch.int32).tolist(),
+        )
+        self.assertIs(backend.forward_metadata, metadata)
+
+    def test_multistep_draft_falls_back_to_seq_lens_when_cpu_copy_missing(self):
+        backend = object.__new__(TRTLLMHAAttnMultiStepDraftBackend)
+        backend.topk = 8
+        backend.speculative_num_steps = 3
+        backend.draft_branch_page_table_buf = torch.empty(1, 1, dtype=torch.int32)
+        inner_fb = object()
+        step_backends = [SimpleNamespace(calls=[]) for _ in range(2)]
+        for step_backend in step_backends:
+            step_backend.init_forward_metadata_out_graph = (
+                lambda fb, in_capture=False, step_backend=step_backend: (
+                    step_backend.calls.append((fb, in_capture))
+                )
+            )
+        backend.attn_backends = step_backends
+
+        forward_batch = SimpleNamespace(
+            batch_size=2,
+            encoder_lens=torch.tensor([0, 0], dtype=torch.int32),
+            seq_lens=torch.tensor([64, 127], dtype=torch.int32),
+            seq_lens_cpu=None,
+            spec_info=SimpleNamespace(is_draft_input=lambda: True),
+        )
+
+        with patch(
+            "sglang.srt.model_executor.forward_batch_info.build_inner_fb_view",
+            return_value=inner_fb,
+        ) as build_inner_fb_view, patch.object(
+            backend, "_update_draft_branch_page_tables"
+        ) as update_tables:
+            backend.init_forward_metadata_out_graph(forward_batch)
+
+        build_inner_fb_view.assert_called_once_with(
+            forward_batch,
+            bs=forward_batch.batch_size,
+            forward_mode=ForwardMode.DECODE,
+            encoder_lens=forward_batch.encoder_lens,
+        )
+        update_tables.assert_called_once()
+        args, kwargs = update_tables.call_args
+        self.assertIs(args[0], forward_batch)
+        self.assertEqual(args[1].tolist(), forward_batch.seq_lens.cpu().tolist())
+        self.assertIs(kwargs["out"], backend.draft_branch_page_table_buf)
+        for step_backend in step_backends:
+            self.assertEqual(step_backend.calls, [(inner_fb, False)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
+++ b/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
@@ -267,6 +267,30 @@ class TestTRTLLMMHASpecDecode(unittest.TestCase):
         )
         self.assertIs(backend.forward_metadata, metadata)
 
+    def test_verify_mask_sync_ignores_stale_draft_forward_metadata(self):
+        """Bug regression: the verify tree-mask sync must run in the host-side
+        update_verify_buffers_to_fill_after_draft hook without depending on
+        self.forward_metadata. At hook time forward_metadata still holds the
+        draft-decode metadata (tree_mask=None), and the verify metadata body
+        is recorded into the CUDA graph, so a sync gated on forward_metadata
+        never copies the producer's mask; the capture-time all-true dummy then
+        replays into every verify, inflating accept length and corrupting
+        outputs (observed E2E as GSM8K 0.04 vs 0.77 baseline)."""
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        backend.topk = 8
+        backend.cuda_graph_custom_mask = torch.ones(2 * 4 * 4, dtype=torch.bool)
+        # Hook fires right after draft: forward_metadata is the draft's.
+        backend.forward_metadata = TRTLLMMHAMetadata()
+
+        producer_mask = torch.zeros(2 * 4 * 4, dtype=torch.bool)
+        spec_info = SimpleNamespace(custom_mask=producer_mask)
+
+        backend.update_verify_buffers_to_fill_after_draft(spec_info, cuda_graph_bs=2)
+
+        self.assertEqual(
+            backend.cuda_graph_custom_mask.tolist(), producer_mask.tolist()
+        )
+
     def test_multistep_draft_falls_back_to_seq_lens_when_cpu_copy_missing(self):
         backend = object.__new__(TRTLLMHAAttnMultiStepDraftBackend)
         backend.topk = 8

--- a/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
+++ b/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
@@ -122,10 +122,6 @@ class TestTRTLLMMHASpecDecode(unittest.TestCase):
                 )
 
                 with patch.object(
-                    backend,
-                    "_maybe_quantize_q",
-                    return_value=(torch.zeros(2, 2), 1.0),
-                ), patch.object(
                     backend, "_get_bmm_scales", return_value=(1.0, 1.0)
                 ), patch.object(
                     backend, "_get_layer_page_table", return_value=full_page_table
@@ -265,7 +261,6 @@ class TestTRTLLMMHASpecDecode(unittest.TestCase):
         self.assertEqual(
             metadata.cache_seqlens_int32.tolist(), expected_seqlens.tolist()
         )
-        self.assertEqual(metadata.max_seq_len_k, 22)
         self.assertEqual(
             metadata.cu_seqlens_k[1:].tolist(),
             torch.cumsum(expected_seqlens, dim=0, dtype=torch.int32).tolist(),

--- a/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
+++ b/test/registered/unit/spec/test_trtllm_mha_spec_decode.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import torch
 
+import sglang.srt.layers.attention.trtllm_mha_backend as trtllm_mha_backend
 from sglang.srt.layers.attention.trtllm_mha_backend import (
     TRTLLMHAAttnBackend,
     TRTLLMHAAttnMultiStepDraftBackend,
@@ -33,6 +34,150 @@ def _make_backend_factory(decode_backend, draft_extend_backend):
 
 
 class TestTRTLLMMHASpecDecode(unittest.TestCase):
+    @staticmethod
+    def _model_runner():
+        return SimpleNamespace(
+            model_config=SimpleNamespace(context_len=1024, hidden_size=128),
+            kv_cache_dtype=torch.bfloat16,
+            dtype=torch.bfloat16,
+            page_size=64,
+            req_to_token_pool=SimpleNamespace(
+                req_to_token=torch.empty(1, 1024, dtype=torch.int32)
+            ),
+            device="cpu",
+            server_args=SimpleNamespace(
+                speculative_eagle_topk=8,
+                speculative_num_draft_tokens=32,
+            ),
+            token_to_kv_pool=object(),
+            token_to_kv_pool_allocator=SimpleNamespace(get_kvcache=lambda: object()),
+            is_draft_worker=False,
+            spec_algorithm=SpeculativeAlgorithm.EAGLE,
+            sliding_window_size=128,
+        )
+
+    def test_backend_caches_untrimmed_swa_capability(self):
+        for capability in (False, True):
+            with self.subTest(capability=capability), patch.object(
+                trtllm_mha_backend.flashinfer.decode,
+                "trtllm_gen_supports_untrimmed_swa_spec_dec_tree",
+                capability,
+                create=True,
+            ), patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend."
+                "FlashInferAttnBackend.__init__",
+                return_value=None,
+            ), patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_sm90_supported",
+                return_value=False,
+            ), patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_sm120_supported",
+                return_value=False,
+            ):
+                backend = TRTLLMHAAttnBackend(self._model_runner())
+
+            self.assertEqual(backend.supports_untrimmed_swa_spec_dec_tree, capability)
+
+    def test_swa_tree_verify_selects_native_or_fallback_metadata(self):
+        full_page_table = torch.tensor([[1, 2, 3]], dtype=torch.int32)
+        fallback_page_table = torch.tensor([[2, 3]], dtype=torch.int32)
+        full_seq_lens = torch.tensor([6], dtype=torch.int32)
+        fallback_seq_lens = torch.tensor([4], dtype=torch.int32)
+
+        for capability in (False, True):
+            with self.subTest(capability=capability):
+                backend = object.__new__(TRTLLMHAAttnBackend)
+                backend.data_type = torch.bfloat16
+                backend.is_xqa_impl = False
+                backend.q_data_type = torch.bfloat16
+                backend.page_size = 2
+                backend.workspace_buffer = torch.empty(1)
+                backend.max_context_len = 16
+                backend.sliding_window_size = 4
+                backend.speculative_num_draft_tokens = 2
+                backend.supports_untrimmed_swa_spec_dec_tree = capability
+                backend.forward_metadata = TRTLLMMHAMetadata(
+                    cache_seqlens_int32=full_seq_lens,
+                    max_seq_len_q=2,
+                    swa_page_table=full_page_table,
+                    swa_verify_page_table=fallback_page_table,
+                    swa_verify_seqlens=fallback_seq_lens,
+                    tree_mask=torch.ones(1, 2, 2, dtype=torch.bool),
+                )
+                cache = torch.zeros(3, 2, 1, 2)
+                backend.token_to_kv_pool = SimpleNamespace(
+                    get_kv_buffer=lambda _layer_id: (cache, cache)
+                )
+                layer = SimpleNamespace(
+                    layer_id=0,
+                    tp_q_head_num=1,
+                    tp_k_head_num=1,
+                    tp_v_head_num=1,
+                    head_dim=2,
+                    sliding_window_size=4,
+                )
+                forward_batch = SimpleNamespace(
+                    forward_mode=ForwardMode.TARGET_VERIFY,
+                    out_cache_loc=torch.empty(0, dtype=torch.int64),
+                )
+
+                with patch.object(
+                    backend,
+                    "_maybe_quantize_q",
+                    return_value=(torch.zeros(2, 2), 1.0),
+                ), patch.object(
+                    backend, "_get_bmm_scales", return_value=(1.0, 1.0)
+                ), patch.object(
+                    backend, "_get_layer_page_table", return_value=full_page_table
+                ), patch.object(
+                    backend, "_layer_is_swa", return_value=True
+                ), patch.object(
+                    trtllm_mha_backend.flashinfer.decode,
+                    "trtllm_batch_decode_with_kv_cache",
+                    return_value=torch.zeros(2, 1, 2),
+                ) as decode:
+                    backend.forward_extend(
+                        torch.zeros(2, 2),
+                        None,
+                        None,
+                        layer,
+                        forward_batch,
+                        save_kv_cache=False,
+                    )
+
+                kwargs = decode.call_args.kwargs
+                expected_page_table = (
+                    full_page_table if capability else fallback_page_table
+                )
+                expected_seq_lens = full_seq_lens if capability else fallback_seq_lens
+                expected_max_seq_len = 16 if capability else 8
+                self.assertIs(kwargs["block_tables"], expected_page_table)
+                self.assertIs(kwargs["seq_lens"], expected_seq_lens)
+                self.assertEqual(kwargs["max_seq_len"], expected_max_seq_len)
+
+    def test_native_swa_tree_verify_skips_fallback_trim(self):
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        backend._swa_kv_pool = object()
+        backend.topk = 8
+        backend.sliding_window_size = 4
+        backend.speculative_num_draft_tokens = 2
+        backend.page_size = 2
+        metadata = TRTLLMMHAMetadata(
+            cache_seqlens_int32=torch.tensor([6], dtype=torch.int32),
+            max_seq_len_q=2,
+            swa_page_table=torch.tensor([[1, 2, 3]], dtype=torch.int32),
+        )
+
+        backend.supports_untrimmed_swa_spec_dec_tree = True
+        backend._fill_swa_verify_views(metadata)
+        self.assertIsNone(metadata.swa_verify_page_table)
+        self.assertIsNone(metadata.swa_verify_seqlens)
+
+        backend.supports_untrimmed_swa_spec_dec_tree = False
+        backend._fill_swa_verify_views(metadata)
+        self.assertIsNotNone(metadata.swa_verify_page_table)
+        self.assertIsNotNone(metadata.swa_verify_seqlens)
+
     def test_tree_spec_backend_reports_qlen_only_mask_mode(self):
         model_runner = SimpleNamespace(
             model_config=SimpleNamespace(context_len=1024, hidden_size=128),


### PR DESCRIPTION
> **Depends on flashinfer-ai/flashinfer#3585** (spec-dec tree custom-mask
> support in `trtllm_batch_decode_with_kv_cache`). This PR needs a flashinfer
> release containing that change before the pinned `flashinfer_python` can be
> bumped and this can merge.
>
> Further trtllm_mha kernel updates in flashinfer (native SlidingWindow+Custom
> mask support, SwapsMmaAb custom-mask tiles for small batches) are planned as
> future updates; this PR's sglang-side interface does not change for them.

## Motivation

The trtllm_mha backend rejected `speculative_eagle_topk > 1`, excluding
EAGLE/EAGLE3 tree speculation on the trtllm-gen FMHA path. This PR adds tree
draft decode, tree target verify, and SWA hybrid model support (gpt-oss).

## Modifications

- Draft decode: tree draft runs as a bs*topk batch over per-branch page
  tables built from the spec-v2 page-aligned branch layout. The table is
  step-invariant: built once per draft phase (pure torch gather, no new
  kernel) and shared across per-step backends for CUDA graph capture/replay.
- Verify: backend exposes `tree_mask_mode = QLEN_ONLY` when topk > 1; v2
  eagle workers resolve the tree mask mode from the target attention backend
  instead of hardcoding FULL_MASK. A persistent (max_bs * nv * nv) bool mask
  buffer is exposed through `get_verify_buffers_to_fill_after_draft`;
  flashinfer's packed-mask conversion is captured inside the verify forward
  and reads that fixed address at replay.
- SWA hybrid models: tree verify on sliding-window layers passes the layer's
  `window_left` to flashinfer (which folds it into the packed custom mask)
  and presents only the in-window KV via a page-trimmed view of the
  translated SWA table, filled into fixed-address buffers in the metadata
  init/apply paths so CUDA-graph replay recomputes it.
- Server args: the blanket "trtllm_mha only supports topk = 1" check is
  removed; trtllm_mha joins the page_size > 1 tree-spec backend list. The
  SM100 auto-default still excludes topk > 1 (explicit opt-in; flipping the
  default is a separate follow-up). XQA (SM90/SM120) with topk > 1 raises
  NotImplementedError (different packed mask format).
- Attention-unittest kit: paged tree draft layout, tree verify cases
  (chain/tree, eager/CUDA graph, SWA windows incl. trim > 0 and GQA), and a
  cross-check of the page-table builder against the production
  `generate_draft_decode_kv_indices` kernel.
- Docs: attention backend support matrix and hybrid spec constraints updated
  (`docs_new/docs/advanced_features/attention_backend.mdx`).

## Accuracy Tests

- Kit suites green: full trtllm_mha (chain + tree, eager + CUDA graph, SWA),
  triton/flashinfer dense verify+draft, MLA, DSA, SWA regressions.
- Llama-3.1-8B + lmsys EAGLE3 draft, topk=8 (1x B200), vs flashinfer
  backend: GSM8K 5-shot 0.7703/0.7005 vs 0.7779/0.7096 (within 1 stderr),
  accept_length 2.782 vs 2.784, greedy outputs identical.
- Llama-3.3-70B TP4 (4x B300): GSM8K 0.9371/0.7544 vs 0.9363/0.7650,
  accept_length 1.573 vs 1.572, greedy outputs identical.
- gpt-oss-120b TP4 (SWA + sinks), vs triton backend: accept_length 2.945 vs
  2.950, greedy outputs identical.

## Speed Tests and Profiling

bench_serving sharegpt output tok/s (c=1/8/32), trtllm_mha vs baseline:

- Llama-3.1-8B vs flashinfer: 395/1591/2746 vs 303/1267/2318
  (geomean 1.25x).
- Llama-3.3-70B TP4 vs flashinfer: 135/651/1008 vs 107/529/909
  (geomean 1.20x).
- gpt-oss-120b TP4 vs triton: 383/1382/2242 vs 396/1209/2118
  (geomean 1.05x).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->