### PR TITLE
fix(moe): make FlashInfer A2A robust to collapsed global_num_tokens (moe_dense_tp_size NaN)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1320,7 +1320,7 @@ class ResponseTool(BaseModel):
     tools: Optional[List[Dict[str, Any]]] = None
 
     @model_validator(mode="after")
-    def validate_function_tool(self) -> "ResponseTool":
+    def validate_function_tool(self) -> ResponseTool:
         if self.type == "function" and not self.name:
             raise ValueError("Function tools must include a name.")
         return self

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import get_int_env_var
+from sglang.srt.utils.common import require_mlp_tp_gather
 
 try:
     from flashinfer import nvfp4_block_scale_interleave
@@ -210,6 +211,12 @@ class FlashinferDispatcher(BaseDispatcher):
             # DP attention: multiple DP ranks with different token counts.
             # Use the max across ranks so the A2A workspace fits the fattest.
             self.runtime_max_tokens_per_rank = max(dp_global)
+        elif self.ep_size > 1 and not require_mlp_tp_gather(get_global_server_args()):
+            # require_mlp_tp_gather is False, so the scheduler collapsed
+            # global_num_tokens to the local count; x.shape[0] then differs
+            # across EP ranks and breaks the fixed-geometry MoeAlltoAll. Use
+            # the static all-rank capacity instead.
+            self.runtime_max_tokens_per_rank = self.max_num_tokens
         else:
             # dp_size=1 or SP: use the actual input tensor size (post-scatter
             # in SP mode, full batch otherwise).  Avoids the pre-scatter


### PR DESCRIPTION
## Motivation

`--moe-a2a-backend flashinfer` with `--enable-dp-attention` silently produces NaN/inf logits (gsm8k ~0, or a `probability tensor contains inf/nan` device-side assert under sampling) when `--moe-dense-tp-size 1` is set. The FlashInfer CuteDSL/Cutlass MoE kernels are correct on their own; the corruption comes from per-rank A2A dispatch sizing.

Root cause: `moe_dense_tp_size` set makes `require_mlp_tp_gather()` return `False`, so the scheduler stores only the local rank count in `batch.global_num_tokens` instead of the all-gathered list (see the existing `TODO: handle the case when moe_dense_tp_size != 1` in `scheduler_components/dp_attn.py`). `FlashinferDispatcher.dispatch()` then sees `len(dp_global) > 1 == False` and takes the `else` branch (intended for `dp_size=1` / SP), setting `runtime_max_tokens_per_rank = x.shape[0]`. Under EP this local count differs across ranks, so the fixed-geometry `MoeAlltoAll` (combine reshapes to `[ep_size, runtime_max_tokens_per_rank, hidden]`) disagrees across ranks and reads/writes mismatched slots, producing NaN.

Only the FlashInfer dispatcher reads `get_dp_global_num_tokens()`; DeepEP / Mooncake / MoRI / NIXL size dispatch from a static `num_max_dispatch_tokens_per_rank` and are unaffected (so `moe_dense_tp_size=1` already works with them, e.g. DeepSeek).

## Modifications

`python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py`: in `dispatch()`, when `ep_size > 1` and `moe_dense_tp_size` is set (the exact condition that collapses `global_num_tokens`), fall back to `self.max_num_tokens` (the static per-rank dispatch capacity, identical on every rank and bounding the workspace) instead of the per-rank-inconsistent `x.shape[0]`. CUDA-graph safe (fixed at init, no device sync). The normal multi-rank path (`max(dp_global)`) and the `dp_size=1` / SP path are unchanged.

## Accuracy Tests

Qwen3.5-397B-A17B-NVFP4, 4x Blackwell, `tp4 / dp4 / ep4` + dp-attention + `flashinfer_cutedsl` + flashinfer A2A, full gsm8k (1319 examples, 8-shot):

| Config | Before | After |
| --- | --- | --- |
| `--moe-dense-tp-size 1` | crash (`probability tensor contains inf/nan`) / 0.0 | **0.977** |

Reproduce:

```bash
python3 -m sglang.launch_server \
  --model-path nvidia/Qwen3.5-397B-A17B-NVFP4 --trust-remote-code \
  --quantization modelopt_fp4 --tp 4 --dp 4 --ep-size 4 \
  --enable-dp-attention --enable-dp-lm-head \
  --moe-runner-backend flashinfer_cutedsl --moe-a2a-backend flashinfer \
  --moe-dense-tp-size 1 --disable-radix-cache --disable-flashinfer-autotune

python3 -m sglang.test.run_eval --eval-name gsm8k --num-examples 1319 --num-shots 8
```

## Speed Tests and Profiling

No impact on existing paths. The fallback triggers only for the previously-broken `moe_dense_tp_size=1` case.

## Checklist

- [x] Provided accuracy results above.
- [x] Format code with pre-commit.
- [ ] Add unit tests.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27447271856](https://github.com/sgl-project/sglang/actions/runs/27447271856)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27447271821](https://github.com/sgl-project/sglang/actions/runs/27447271821)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->