### PR TITLE
[Quantization] Native mxfp4 expert runtime for the MiMo-V2.5 Pro FP4 target (stacked on #27638)

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -131,11 +131,6 @@ def handle_speculative_decoding(server_args: "ServerArgs") -> None:
 
 
 def _handle_dflash(server_args: "ServerArgs") -> None:
-    if server_args.enable_dp_attention:
-        raise ValueError(
-            "Currently DFLASH speculative decoding does not support dp attention."
-        )
-
     if server_args.pp_size != 1:
         raise ValueError(
             "Currently DFLASH speculative decoding only supports pp_size == 1."

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -249,6 +249,19 @@ class ModelConfig:
         # Other FP8 MoE models (for example DeepSeek V3.2) must keep the normal
         # FP8 expert tensor layout.
         self.is_fp4_experts: bool = False
+        if (
+            "MiMoV2ForCausalLM"
+            in (getattr(self.hf_config, "architectures", None) or [])
+            and (getattr(self.hf_config, "quantization_config", None) or {}).get(
+                "store_dtype"
+            )
+            == "mxfp4"
+        ):
+            self.is_fp4_experts = envs.SGLANG_MIMO_V2_FP4_EXPERTS.get()
+            if self.is_fp4_experts:
+                logger.info(
+                    "MiMoV2 store_dtype=mxfp4: keeping native fp4 expert layout"
+                )
         if is_deepseek_v4(self.hf_config):
             self.is_fp4_experts = envs.SGLANG_DSV4_FP4_EXPERTS.get()
             if not envs.SGLANG_DSV4_FP4_EXPERTS.is_set():

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -745,6 +745,9 @@ class Envs:
 
     # Set False when using FP4-to-FP8 converted DeepSeek V4 checkpoint.
     SGLANG_DSV4_FP4_EXPERTS = EnvBool(True)
+    # Keep MiMo-V2 mxfp4-stored experts packed (W4 runtime via flashinfer_mxfp4)
+    # instead of dequantizing them to block-FP8 at load.
+    SGLANG_MIMO_V2_FP4_EXPERTS = EnvBool(False)
     # Default reasoning_effort for dsv4 chat encoder when request doesn't set it.
     # Accepts "", "max", "high" (empty string means unset); other values filtered to None.
     SGLANG_DSV4_REASONING_EFFORT = EnvStr("")

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -837,7 +837,14 @@ class FlashAttentionBackend(AttentionBackend):
         is_swa_layer = (
             layer.sliding_window_size is not None and layer.sliding_window_size > -1
         )
-        window_size = (layer.sliding_window_size, 0) if is_swa_layer else (-1, -1)
+        if is_swa_layer and layer.attn_type == AttentionType.ENCODER_ONLY:
+            # Non-causal attention (e.g. DFlash draft block) needs a symmetric
+            # window so each token can attend to both sides within the window.
+            window_size = (layer.sliding_window_size, layer.sliding_window_size)
+        elif is_swa_layer:
+            window_size = (layer.sliding_window_size, 0)
+        else:
+            window_size = (-1, -1)
         k_descale, v_descale = None, None
         # only use kv scaling if: 1) fp8 kv is explicitly enabled, 2) RadixAttention
         # has corresponding quantization method so that layer.k_scale is not None,
@@ -1303,7 +1310,14 @@ class FlashAttentionBackend(AttentionBackend):
         is_swa_layer = (
             layer.sliding_window_size is not None and layer.sliding_window_size > -1
         )
-        window_size = (layer.sliding_window_size, 0) if is_swa_layer else (-1, -1)
+        if is_swa_layer and layer.attn_type == AttentionType.ENCODER_ONLY:
+            # Non-causal attention (e.g. DFlash draft block) needs a symmetric
+            # window so each token can attend to both sides within the window.
+            window_size = (layer.sliding_window_size, layer.sliding_window_size)
+        elif is_swa_layer:
+            window_size = (layer.sliding_window_size, 0)
+        else:
+            window_size = (-1, -1)
 
         causal = True
         if layer.is_cross_attention or layer.attn_type == AttentionType.ENCODER_ONLY:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -156,6 +156,7 @@ class Fp8Config(QuantizationConfig):
         packed_modules_mapping: Optional[Dict[str, List[str]]] = None,
         use_mxfp8: bool = False,
         is_fp4_experts: bool = False,
+        store_dtype: str = "fp8",
     ) -> None:
         super().__init__()
         # DSV4 mxfp4-packed (True) vs converted FP8 (False); injected by
@@ -178,6 +179,12 @@ class Fp8Config(QuantizationConfig):
             )
         self.packed_modules_mapping = packed_modules_mapping or {}
         self.use_mxfp8 = use_mxfp8
+        assert store_dtype in ("fp8", "mxfp4")
+        if store_dtype == "mxfp4":
+            assert is_checkpoint_fp8_serialized and activation_scheme == "dynamic"
+            if weight_block_size is None:
+                weight_block_size = [128, 128]
+        self.store_dtype = store_dtype
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
                 raise ValueError(
@@ -236,6 +243,7 @@ class Fp8Config(QuantizationConfig):
                 normalized.append(f"model.{base}")
             ignored_layers = normalized
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
+        store_dtype = cls.get_from_keys_or(config, ["store_dtype"], "fp8")
         if use_mxfp8 and weight_block_size is not None:
             logger.warning(
                 "MXFP8 ignoring incoming weight_block_size in config.json; it is fixed to [1, 32]."
@@ -248,6 +256,7 @@ class Fp8Config(QuantizationConfig):
             weight_block_size=weight_block_size,
             packed_modules_mapping=packed_modules_mapping,
             use_mxfp8=use_mxfp8,
+            store_dtype=store_dtype,
         )
 
     def get_quant_method(
@@ -927,6 +936,65 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                         )
 
         # WEIGHTS
+        if self.quant_config.store_dtype == "mxfp4":
+            mx_block = 32
+            assert (
+                hidden_size % mx_block == 0
+            ), f"mxfp4 requires hidden_size divisible by {mx_block}, got {hidden_size}"
+            assert intermediate_size_per_partition % mx_block == 0, (
+                f"mxfp4 requires intermediate_size_per_partition divisible by {mx_block}, "
+                f"got {intermediate_size_per_partition}"
+            )
+            w13_weight = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    2 * intermediate_size_per_partition,
+                    hidden_size // 2,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            w2_weight = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    hidden_size,
+                    intermediate_size_per_partition // 2,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_weight", w13_weight)
+            set_weight_attrs(w13_weight, extra_weight_attrs)
+            layer.register_parameter("w2_weight", w2_weight)
+            set_weight_attrs(w2_weight, extra_weight_attrs)
+            w13_weight_scale = torch.nn.Parameter(
+                torch.ones(
+                    num_experts,
+                    2 * intermediate_size_per_partition,
+                    hidden_size // mx_block,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            w2_weight_scale = torch.nn.Parameter(
+                torch.ones(
+                    num_experts,
+                    hidden_size,
+                    intermediate_size_per_partition // mx_block,
+                    dtype=torch.uint8,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_weight_scale", w13_weight_scale)
+            layer.register_parameter("w2_weight_scale", w2_weight_scale)
+            extra_weight_attrs.update(
+                {"quant_method": FusedMoeWeightScaleSupported.BLOCK.value}
+            )
+            set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+            set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+            layer.w13_input_scale = None
+            layer.w2_input_scale = None
+            return
         if self.is_fp4_expert:
             w13_weight = torch.nn.Parameter(
                 torch.empty(
@@ -1546,7 +1614,70 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             align_mxfp8_moe_weights_for_flashinfer_trtllm(layer)
 
+    def _mxfp4_dequant_to_block_fp8(self, layer: Module) -> None:
+        """Convert mxfp4 storage (uint8 packed e2m1 + uint8 e8m0 block scales)
+        to block-wise fp8 (e4m3 + fp32 scale_inv) once at load time so the
+        runtime forward path is identical to a regular fp8 block-quant MoE."""
+        from sglang.srt.layers.quantization.fp8_utils import per_block_cast_to_fp8
+        from sglang.srt.layers.quantization.mxfp4_tensor import MXFP4QuantizeUtil
+
+        mx_block = 32
+        logger.info(
+            "mxfp4->fp8: converting MoE weights. w13=%s w2=%s",
+            getattr(layer, "w13_weight", None) is not None,
+            getattr(layer, "w2_weight", None) is not None,
+        )
+
+        def _convert(weight_name: str, scale_name: str):
+            packed = getattr(layer, weight_name).data
+            scale = getattr(layer, scale_name).data
+            num_experts = packed.shape[0]
+            fp8_chunks = []
+            scale_chunks = []
+            for e in range(num_experts):
+                w_bf16 = MXFP4QuantizeUtil.dequantize(
+                    packed[e].cuda(),
+                    dtype=torch.bfloat16,
+                    scale=scale[e].cuda(),
+                    block_sizes=[mx_block],
+                )
+                w_fp8, w_scale = per_block_cast_to_fp8(w_bf16)
+                fp8_chunks.append(w_fp8)
+                scale_chunks.append(w_scale)
+            return (
+                torch.stack(fp8_chunks, dim=0).contiguous(),
+                torch.stack(scale_chunks, dim=0).contiguous(),
+            )
+
+        w13_fp8, w13_scale_inv = _convert("w13_weight", "w13_weight_scale")
+        w2_fp8, w2_scale_inv = _convert("w2_weight", "w2_weight_scale")
+
+        del layer.w13_weight, layer.w13_weight_scale
+        del layer.w2_weight, layer.w2_weight_scale
+
+        layer.register_parameter(
+            "w13_weight", torch.nn.Parameter(w13_fp8, requires_grad=False)
+        )
+        layer.register_parameter(
+            "w13_weight_scale_inv",
+            torch.nn.Parameter(w13_scale_inv, requires_grad=False),
+        )
+        layer.register_parameter(
+            "w2_weight", torch.nn.Parameter(w2_fp8, requires_grad=False)
+        )
+        layer.register_parameter(
+            "w2_weight_scale_inv",
+            torch.nn.Parameter(w2_scale_inv, requires_grad=False),
+        )
+
     def process_weights_after_loading(self, layer: Module) -> None:
+        if self.quant_config.store_dtype == "mxfp4":
+            logger.info("store_dtype=mxfp4: dispatching to _mxfp4_dequant_to_block_fp8")
+            self._mxfp4_dequant_to_block_fp8(layer)
+            # Fall through to block_quant post-processing (deep_gemm ue8m0,
+            # triton swizzle, etc.) since the converted weights are now
+            # standard fp8 block-quant.
+
         if _is_hip and _use_hip_int4:
             self.process_weights_hip_int4(layer)
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1671,7 +1671,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
 
     def process_weights_after_loading(self, layer: Module) -> None:
-        if self.quant_config.store_dtype == "mxfp4":
+        if (
+            self.quant_config.store_dtype == "mxfp4"
+            and not self.quant_config.is_fp4_experts
+        ):
             logger.info("store_dtype=mxfp4: dispatching to _mxfp4_dequant_to_block_fp8")
             self._mxfp4_dequant_to_block_fp8(layer)
             # Fall through to block_quant post-processing (deep_gemm ue8m0,

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -135,9 +135,6 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         self.moe_runner_config = moe_runner_config
 
         swiglu_limit = moe_runner_config.swiglu_limit
-        assert (
-            swiglu_limit is not None
-        ), f"swiglu_limit must be non-None for DeepSeek V4 (got {swiglu_limit!r})"
         self._gemm1_clamp_limit_tensor = (
             torch.full(
                 (layer.num_local_experts,),

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -516,7 +516,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
     def can_run(self, forward_batch: ForwardBatch):
         if forward_batch.replace_embeds is not None:
             return False
-        if self.require_mlp_tp_gather:
+        if (
+            self.require_mlp_tp_gather
+            and forward_batch.global_num_tokens_cpu is not None
+        ):
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
                 if self.model_runner.spec_algorithm.is_eagle()

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -12,7 +12,10 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from sglang.srt.distributed import get_tensor_model_parallel_world_size
+from sglang.srt.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
@@ -109,9 +112,27 @@ class DFlashAttention(nn.Module):
             base=rope_theta,
             rope_scaling=rope_scaling,
             is_neox_style=rope_is_neox_style,
+            partial_rotary_factor=float(getattr(config, "partial_rotary_factor", 1.0)),
         )
 
         self.scaling = head_dim**-0.5
+
+        # MiMo DFlash draft extras from dflash_config: a sliding window over the
+        # draft block, a per-head attention sink bias, and a value scale. Defaults
+        # preserve the generic (sink-less, non-windowed, unscaled) draft behavior.
+        draft_cfg = parse_dflash_draft_config(draft_hf_config=config)
+        swa_window = None
+        if draft_cfg.use_swa:
+            swa_window = draft_cfg.swa_window_size
+            if swa_window is None:
+                swa_window = getattr(config, "sliding_window", None)
+        self.v_scale: Optional[float] = draft_cfg.attention_value_scale
+        self.attention_sink_bias = (
+            nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
+            if draft_cfg.attention_sink_bias
+            else None
+        )
+
         # DFlash uses non-causal attention over the draft block.
         self.attn = RadixAttention(
             num_heads=self.num_heads,
@@ -120,6 +141,7 @@ class DFlashAttention(nn.Module):
             num_kv_heads=self.num_kv_heads,
             layer_id=layer_id,
             attn_type=AttentionType.ENCODER_ONLY,
+            sliding_window_size=int(swa_window) if swa_window else -1,
         )
 
     def forward_prepare_npu(self, positions, hidden_states):
@@ -155,7 +177,16 @@ class DFlashAttention(nn.Module):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
             q, k = apply_qk_norm(q, k, self.q_norm, self.k_norm, self.head_dim)
             q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v, forward_batch)
+        if self.v_scale is not None:
+            v = v * self.v_scale
+        # Forward the attention sink bias only when this draft has one; backends
+        # without sink support (e.g. FlashInfer) reject the `sinks=` kwarg.
+        if self.attention_sink_bias is not None:
+            attn_output = self.attn(
+                q, k, v, forward_batch, sinks=self.attention_sink_bias
+            )
+        else:
+            attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
 
@@ -419,6 +450,12 @@ class DFlashDraftModel(nn.Module):
                         f"(num_context_features={self.num_context_features}, hidden_size={int(self.config.hidden_size)}), "
                         f"but got {tuple(loaded_weight.shape)} for weight '{name}'."
                     )
+                if resolved_name.endswith("attention_sink_bias"):
+                    # The checkpoint stores the sink bias for all heads; copy the
+                    # slice owned by this TP rank (matching self.num_heads).
+                    start = get_tensor_model_parallel_rank() * param.numel()
+                    param.data.copy_(loaded_weight[start : start + param.numel()])
+                    continue
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -733,11 +733,22 @@ class MiMoV2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Self Attention
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states, residual, forward_batch
-        )
+        if captured_last_layer_outputs is not None:
+            hidden_states, residual = (
+                self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                    hidden_states,
+                    residual,
+                    forward_batch,
+                    captured_last_layer_outputs=captured_last_layer_outputs,
+                )
+            )
+        else:
+            hidden_states, residual = self.layer_communicator.prepare_attn(
+                hidden_states, residual, forward_batch
+            )
 
         if hidden_states.shape[0] != 0:
             hidden_states = self.self_attn(
@@ -883,6 +894,9 @@ class MiMoV2Model(nn.Module):
         else:
             self.norm = PPMissingLayer(return_tuple=True)
 
+        # For EAGLE3 / DFLASH aux hidden state capture.
+        self.layers_to_capture: List[int] = []
+
     def get_input_embedding(self, input_ids: torch.Tensor) -> torch.Tensor:
         if hasattr(self.config, "scale_emb"):
             return self.get_input_embeddings()(input_ids) * self.config.scale_emb
@@ -910,6 +924,9 @@ class MiMoV2Model(nn.Module):
             assert pp_proxy_tensors is not None
             hidden_states = pp_proxy_tensors["hidden_states"]
             residual = pp_proxy_tensors["residual"]
+
+        # TBO path skips per-layer capture; DFLASH+TBO is unsupported.
+        aux_hidden_states: List[torch.Tensor] = []
 
         if forward_batch.can_run_tbo:
             tbo_start_layer = self.start_layer
@@ -941,11 +958,29 @@ class MiMoV2Model(nn.Module):
         else:
             for i in range(self.start_layer, self.end_layer):
                 layer = self.layers[i]
+                # Capture the residual stream entering this layer (= output of the
+                # previous target layer) via the layer communicator, which records
+                # it at the attention scatter mode (TP_ATTN_FULL). This keeps every
+                # captured tensor in one consistent layout under DP attention, where
+                # the per-layer residual stream alternates scattered/gathered.
+                capture_buf = aux_hidden_states if i in self.layers_to_capture else None
                 hidden_states, residual = layer(
                     positions,
                     hidden_states,
                     forward_batch,
                     residual,
+                    captured_last_layer_outputs=capture_buf,
+                )
+            # DFLASH may also request capture *after* the final layer (e.g.
+            # target_layer_ids ends at num_hidden_layers-1, so layers_to_capture
+            # contains end_layer). The final residual stream is already at the
+            # model-output scatter mode (TP_ATTN_FULL), matching the in-loop
+            # captures; clone to avoid the post-loop norm mutating it in place.
+            if self.end_layer in self.layers_to_capture:
+                aux_hidden_states.append(
+                    (hidden_states + residual).clone()
+                    if residual is not None
+                    else hidden_states.clone()
                 )
 
         hidden_states_before_norm = None
@@ -967,7 +1002,10 @@ class MiMoV2Model(nn.Module):
                 else:
                     hidden_states, _ = self.norm(hidden_states, residual)
 
-        return hidden_states, hidden_states_before_norm
+        if len(aux_hidden_states) == 0:
+            return hidden_states, hidden_states_before_norm
+
+        return hidden_states, hidden_states_before_norm, aux_hidden_states
 
     # If this function is called, it should always initialize KV cache scale
     # factors (or else raise an exception). Thus, handled exceptions should
@@ -1052,6 +1090,9 @@ class MiMoV2ForCausalLM(nn.Module):
         self.logits_processor = (
             LogitsProcessor(config) if not self.config.encoder_only else None
         )
+
+        # For DFLASH aux hidden state capture (target model side).
+        self.capture_aux_hidden_states = False
 
         vision_config = getattr(config, "vision_config", None)
         audio_config = getattr(config, "audio_config", None)
@@ -1214,7 +1255,7 @@ class MiMoV2ForCausalLM(nn.Module):
         ), "forward() should not be called in encoder_only mode"
 
         if self._is_multimodal:
-            hidden_states, hidden_states_before_norm = general_mm_embed_routine(
+            model_out = general_mm_embed_routine(
                 input_ids=input_ids,
                 forward_batch=forward_batch,
                 language_model=self.model,
@@ -1223,7 +1264,7 @@ class MiMoV2ForCausalLM(nn.Module):
                 pp_proxy_tensors=pp_proxy_tensors,
             )
         else:
-            hidden_states, hidden_states_before_norm = self.model(
+            model_out = self.model(
                 input_ids,
                 positions,
                 forward_batch,
@@ -1231,12 +1272,19 @@ class MiMoV2ForCausalLM(nn.Module):
                 pp_proxy_tensors=pp_proxy_tensors,
             )
 
+        aux_hidden_states = None
+        if isinstance(model_out, tuple) and len(model_out) == 3:
+            hidden_states, hidden_states_before_norm, aux_hidden_states = model_out
+        else:
+            hidden_states, hidden_states_before_norm = model_out
+
         if self.pp_group.is_last_rank:
             return self.logits_processor(
                 input_ids,
                 hidden_states,
                 self.lm_head,
                 forward_batch,
+                aux_hidden_states=aux_hidden_states,
                 hidden_states_before_norm=hidden_states_before_norm,
             )
         else:
@@ -1508,6 +1556,20 @@ class MiMoV2ForCausalLM(nn.Module):
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         if self.model is not None:
             self.model.load_kv_cache_scales(quantization_param_path)
+
+    def set_dflash_layers_to_capture(self, layer_ids: List[int]):
+        if not self.pp_group.is_last_rank:
+            return
+
+        if layer_ids is None:
+            raise ValueError(
+                "DFLASH requires explicit layer_ids for aux hidden capture."
+            )
+
+        self.capture_aux_hidden_states = True
+        # SGLang captures "before layer i". To capture the hidden state after target
+        # layer `k` (HF-style), we capture before layer `k + 1`.
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -273,6 +273,7 @@ class MiMoV2MoE(nn.Module):
             num_expert_group=config.n_group,
             topk_group=config.topk_group,
             correction_bias=self.gate.e_score_correction_bias,
+            is_fp4_experts=getattr(quant_config, "is_fp4_experts", False),
             quant_config=quant_config,
             routed_scaling_factor=1.0,
             apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
@@ -1466,6 +1467,16 @@ class MiMoV2ForCausalLM(nn.Module):
                     )
                     skipped_mtp_weights = True
                 continue
+
+            # Native mxfp4 experts (is_fp4_experts): checkpoint ships uint8
+            # e2m1 nibbles + uint8 e8m0 block scales per expert, while the
+            # fp4-expert params are int8 nibbles + float32 *_weight_scale_inv.
+            if ".mlp.experts." in name and loaded_weight.dtype == torch.uint8:
+                if name.endswith(".weight_scale"):
+                    name = name + "_inv"
+                    loaded_weight = torch.exp2(loaded_weight.to(torch.float32) - 127.0)
+                elif name.endswith(".weight"):
+                    loaded_weight = loaded_weight.view(torch.int8)
 
             # Support fused qkv_proj checkpoint (Pro format)
             if "qkv_proj" in name:

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from numbers import Integral
 from typing import Any, List, Optional, Tuple
@@ -267,6 +268,11 @@ class DFlashDraftConfig:
     target_layer_ids: Optional[List[int]]
     mask_token: str
     mask_token_id: Optional[int]
+    attention_sink_bias: bool = False
+    attention_value_scale: Optional[float] = None
+    use_swa: bool = False
+    swa_window_size: Optional[int] = None
+    backbone_rotary_base: Optional[float] = None
 
     def require_num_layers(self) -> int:
         if self.num_hidden_layers is None:
@@ -385,6 +391,66 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
                 f"got {mask_token_id}."
             )
 
+    raw_attention_sink_bias = dflash_cfg.get("attention_sink_bias", False)
+    if not isinstance(raw_attention_sink_bias, bool):
+        raise ValueError(
+            "DFLASH dflash_config.attention_sink_bias must be a bool, "
+            f"got {raw_attention_sink_bias!r} (type={type(raw_attention_sink_bias).__name__})."
+        )
+    attention_sink_bias = bool(raw_attention_sink_bias)
+
+    raw_attention_value_scale = dflash_cfg.get("attention_value_scale", None)
+    if raw_attention_value_scale is None:
+        attention_value_scale: Optional[float] = None
+    else:
+        if isinstance(raw_attention_value_scale, bool) or not isinstance(
+            raw_attention_value_scale, (int, float)
+        ):
+            raise ValueError(
+                "DFLASH dflash_config.attention_value_scale must be int|float|None, "
+                f"got {raw_attention_value_scale!r} "
+                f"(type={type(raw_attention_value_scale).__name__})."
+            )
+        attention_value_scale = float(raw_attention_value_scale)
+        if not math.isfinite(attention_value_scale):
+            raise ValueError(
+                "DFLASH dflash_config.attention_value_scale must be finite, "
+                f"got {attention_value_scale}."
+            )
+
+    raw_use_swa = dflash_cfg.get("use_swa", False)
+    if not isinstance(raw_use_swa, bool):
+        raise ValueError(
+            "DFLASH dflash_config.use_swa must be a bool, "
+            f"got {raw_use_swa!r} (type={type(raw_use_swa).__name__})."
+        )
+    use_swa = bool(raw_use_swa)
+
+    swa_window_size = _parse_optional_int(
+        dflash_cfg.get("swa_window_size", None),
+        field_name="DFLASH swa_window_size",
+        min_value=1,
+    )
+
+    raw_backbone_rotary_base = dflash_cfg.get("backbone_rotary_base", None)
+    if raw_backbone_rotary_base is None:
+        backbone_rotary_base: Optional[float] = None
+    else:
+        if isinstance(raw_backbone_rotary_base, bool) or not isinstance(
+            raw_backbone_rotary_base, (int, float)
+        ):
+            raise ValueError(
+                "DFLASH dflash_config.backbone_rotary_base must be int|float|None, "
+                f"got {raw_backbone_rotary_base!r} "
+                f"(type={type(raw_backbone_rotary_base).__name__})."
+            )
+        backbone_rotary_base = float(raw_backbone_rotary_base)
+        if not math.isfinite(backbone_rotary_base) or backbone_rotary_base <= 0:
+            raise ValueError(
+                "DFLASH dflash_config.backbone_rotary_base must be a positive finite number, "
+                f"got {backbone_rotary_base}."
+            )
+
     return DFlashDraftConfig(
         num_hidden_layers=num_hidden_layers,
         num_target_layers=num_target_layers,
@@ -392,6 +458,11 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
         target_layer_ids=parsed_target_layer_ids,
         mask_token=mask_token,
         mask_token_id=mask_token_id,
+        attention_sink_bias=attention_sink_bias,
+        attention_value_scale=attention_value_scale,
+        use_swa=use_swa,
+        swa_window_size=swa_window_size,
+        backbone_rotary_base=backbone_rotary_base,
     )
 
 

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -1,9 +1,11 @@
 import logging
-import math
+import os
+from contextlib import nullcontext
 from copy import deepcopy
 from typing import Optional
 
 import torch
+import torch.nn.functional as F
 
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.managers.schedule_batch import ScheduleBatch
@@ -22,32 +24,21 @@ from sglang.srt.server_args import (
 )
 from sglang.srt.speculative.dflash_info import DFlashDraftInput, DFlashVerifyInput
 from sglang.srt.speculative.dflash_utils import (
-    can_dflash_use_fused_qkv_proj,
     is_dflash_sampling_verify_available,
     parse_dflash_draft_config,
     resolve_dflash_verify_mask_policy,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
-from sglang.srt.utils import is_cuda, is_npu
+from sglang.srt.speculative.spec_utils import (
+    assign_req_to_token_pool_func,
+    draft_tp_context,
+)
+from sglang.srt.utils import empty_context, is_npu
 
 _is_npu = is_npu()
 
 
 logger = logging.getLogger(__name__)
-
-_FusedKVMaterializeHelper = None
-
-
-def _get_fused_kv_materialize_helper():
-    global _FusedKVMaterializeHelper
-    if _FusedKVMaterializeHelper is None:
-        from sglang.srt.speculative.triton_ops.fused_kv_materialize import (
-            FusedKVMaterializeHelper,
-        )
-
-        _FusedKVMaterializeHelper = FusedKVMaterializeHelper
-    return _FusedKVMaterializeHelper
 
 
 class DFlashWorker:
@@ -82,6 +73,16 @@ class DFlashWorker:
         )
         self.use_compact_draft_cache = self.draft_window_size is not None
         self.device = target_worker.device
+
+        # DP attention support: wrap any draft model collective in the attention
+        # TP group so DP groups don't deadlock on each other's collectives. When
+        # DP attention is off this is a no-op contextmanager.
+        self._enable_dp_attention = bool(server_args.enable_dp_attention)
+        if self._enable_dp_attention:
+            self._draft_tp_context = draft_tp_context
+        else:
+            # Match the draft_tp_context call signature (takes one positional arg).
+            self._draft_tp_context = lambda _tp_group: empty_context()
 
         self._warned_sampling_fallback = False
         self._logged_first_verify = False
@@ -142,21 +143,28 @@ class DFlashWorker:
             target_worker.model_runner.model_config.context_len
         )
         saved_server_args = get_global_server_args()
-        self.draft_worker = TpModelWorker(
-            server_args=draft_server_args,
-            gpu_id=gpu_id,
-            tp_rank=tp_rank,
-            moe_ep_rank=moe_ep_rank,
-            pp_rank=0,
-            attn_cp_rank=attn_cp_rank,
-            moe_dp_rank=moe_dp_rank,
-            dp_rank=dp_rank,
-            nccl_port=nccl_port,
-            is_draft_worker=True,
-            req_to_token_pool=shared_req_to_token_pool,
-            token_to_kv_pool_allocator=target_token_to_kv_pool_allocator,
-            memory_pool_config=target_worker.model_runner.memory_pool_config,
-        )
+        if self._enable_dp_attention:
+            from sglang.srt.layers.dp_attention import get_attention_tp_group
+
+            _init_ctx = draft_tp_context(get_attention_tp_group())
+        else:
+            _init_ctx = nullcontext()
+        with _init_ctx:
+            self.draft_worker = TpModelWorker(
+                server_args=draft_server_args,
+                gpu_id=gpu_id,
+                tp_rank=tp_rank,
+                moe_ep_rank=moe_ep_rank,
+                pp_rank=0,
+                attn_cp_rank=attn_cp_rank,
+                moe_dp_rank=moe_dp_rank,
+                dp_rank=dp_rank,
+                nccl_port=nccl_port,
+                is_draft_worker=True,
+                req_to_token_pool=shared_req_to_token_pool,
+                token_to_kv_pool_allocator=target_token_to_kv_pool_allocator,
+                memory_pool_config=target_worker.model_runner.memory_pool_config,
+            )
         set_global_server_args_for_scheduler(saved_server_args)
         self.draft_model_runner = self.draft_worker.model_runner
         self.draft_model = self.draft_model_runner.model
@@ -186,6 +194,13 @@ class DFlashWorker:
             mask_token=self._mask_token,
             mask_token_id=self._mask_token_id_override,
         )
+        # Merge the trained mask embedding from mask_embedding.pt (if present) into
+        # the target embedding table. Must run after _mask_token_id is set and
+        # before any draft forward (or the embed CPU cache) consumes it.
+        self._maybe_merge_trained_mask_embedding()
+        # Cache full embed/lm_head on CPU once (all ranks sync) so the per-block
+        # draft embedding lookup and greedy sampling avoid DP-mismatched collectives.
+        self._cache_full_embed_weight()
         if self.tp_rank == 0:
             logger.info(
                 "Initialized DFLASH draft runner. attention_backend=%s, model=%s, block_size=%s, draft_window_size=%s, compact_cache=%s",
@@ -228,90 +243,6 @@ class DFlashWorker:
         self._draft_greedy_rank_index_buf: Optional[torch.Tensor] = None
         self._draft_greedy_selected_ids_buf: Optional[torch.Tensor] = None
         self._draft_greedy_index_cap: int = 0
-
-        self._use_fused_kv_materialize = is_cuda()
-        self._fused_kv_helper: Optional[object] = None
-        if self._use_fused_kv_materialize:
-            self._init_fused_kv_helper()
-
-    def _init_fused_kv_helper(self) -> None:
-        """Initialize the fused KV materialization helper with pre-stacked weights."""
-        try:
-            layers = self.draft_model.layers
-            fused_disable_reason: Optional[str] = None
-
-            if len(layers) == 0:
-                fused_disable_reason = "no layers found"
-
-            for layer_idx, layer in enumerate(layers):
-                attn = layer.self_attn
-                eligible, reason = can_dflash_use_fused_qkv_proj(attn.qkv_proj)
-                if not eligible:
-                    fused_disable_reason = f"{reason}: layer={layer_idx}"
-                    break
-
-                # Keep semantics aligned with set_kv_buffer scaling behavior.
-                k_scale = getattr(attn.attn, "k_scale", None)
-                v_scale = getattr(attn.attn, "v_scale", None)
-                if k_scale is not None and not math.isclose(float(k_scale), 1.0):
-                    fused_disable_reason = (
-                        "non-unit k_scale is not supported for fused KV path: "
-                        f"layer={layer_idx}, k_scale={k_scale}"
-                    )
-                    break
-                if v_scale is not None and not math.isclose(float(v_scale), 1.0):
-                    fused_disable_reason = (
-                        "non-unit v_scale is not supported for fused KV path: "
-                        f"layer={layer_idx}, v_scale={v_scale}"
-                    )
-                    break
-
-                rope_is_neox_style = bool(
-                    getattr(attn.rotary_emb, "is_neox_style", True)
-                )
-                if not rope_is_neox_style:
-                    fused_disable_reason = (
-                        "non-neox RoPE is not supported for fused KV path: "
-                        f"layer={layer_idx}, rope_is_neox_style={rope_is_neox_style}"
-                    )
-                    break
-
-            if fused_disable_reason is not None:
-                if self.tp_rank == 0:
-                    logger.info(
-                        "DFLASH fused KV materialization disabled: %s",
-                        fused_disable_reason,
-                    )
-                self._use_fused_kv_materialize = False
-                self._fused_kv_helper = None
-                return
-
-            FusedKVMaterializeHelper = _get_fused_kv_materialize_helper()
-            first_attn = layers[0].self_attn
-            rotary_emb = first_attn.rotary_emb
-
-            self._fused_kv_helper = FusedKVMaterializeHelper(
-                layers=layers,
-                rotary_emb=rotary_emb,
-                num_kv_heads=first_attn.num_kv_heads,
-                head_dim=first_attn.head_dim,
-                device=self.device,
-            )
-            if self.tp_rank == 0:
-                logger.info(
-                    "DFLASH fused KV materialization enabled. "
-                    "n_layers=%d, num_kv_heads=%d, head_dim=%d",
-                    len(layers),
-                    first_attn.num_kv_heads,
-                    first_attn.head_dim,
-                )
-        except Exception as e:
-            logger.warning(
-                "DFLASH fused KV initialization failed, falling back to sequential path: %s",
-                e,
-            )
-            self._use_fused_kv_materialize = False
-            self._fused_kv_helper = None
 
     def _ensure_draft_block_buffers(self, bs: int) -> None:
         cap = (
@@ -522,6 +453,163 @@ class DFlashWorker:
 
         return int(resolved_id)
 
+    def _maybe_merge_trained_mask_embedding(self) -> None:
+        """Merge a trained mask embedding into the target model's embedding table.
+
+        During DFlash training, the mask token embedding can be trained separately
+        and saved as ``mask_embedding.pt`` in the draft checkpoint directory.
+        This method checks for that file and, if found, overwrites the
+        corresponding row in the target model's embedding table so that
+        inference uses the learned representation.
+
+        For per-position mask embeddings (``per_position=True`` in the saved
+        file), the embeddings are stored on the worker and applied per-block-
+        offset during drafting instead of being merged into the embedding table.
+
+        Handles VocabParallelEmbedding TP sharding: each rank only updates
+        the row if the mask token falls within its local shard range.
+        """
+        self._per_position_mask_embeddings = None
+
+        draft_model_path = self.server_args.speculative_draft_model_path
+        if draft_model_path is None:
+            return
+
+        mask_emb_path = os.path.join(draft_model_path, "mask_embedding.pt")
+        if not os.path.exists(mask_emb_path):
+            return
+
+        saved = torch.load(mask_emb_path, map_location=self.device, weights_only=True)
+        embedding_tensor = saved["embedding"]
+        saved_token_id = int(saved["mask_token_id"])
+
+        if saved_token_id != self._mask_token_id:
+            raise ValueError(
+                f"DFLASH mask_embedding.pt was trained with mask_token_id={saved_token_id}, "
+                f"but the current resolved mask_token_id={self._mask_token_id}. "
+                "These must match."
+            )
+
+        if saved.get("per_position"):
+            target_model = self.target_worker.model_runner.model
+            embed_module = target_model.get_input_embeddings()
+            self._per_position_mask_embeddings = embedding_tensor.to(
+                embed_module.weight.dtype
+            )
+            if self.tp_rank == 0:
+                logger.info(
+                    "Loaded per-position mask embeddings (shape=%s, source=%s)",
+                    list(self._per_position_mask_embeddings.shape),
+                    mask_emb_path,
+                )
+            return
+
+        target_model = self.target_worker.model_runner.model
+        embed_module = target_model.get_input_embeddings()
+
+        token_id = self._mask_token_id
+        shard_indices = getattr(embed_module, "shard_indices", None)
+
+        with torch.no_grad():
+            if shard_indices is not None:
+                # VocabParallelEmbedding: check if this token falls in our shard.
+                start = shard_indices.org_vocab_start_index
+                end = shard_indices.org_vocab_end_index
+                if start <= token_id < end:
+                    local_idx = token_id - start
+                    embed_module.weight[local_idx].copy_(
+                        embedding_tensor.to(embed_module.weight.dtype)
+                    )
+            else:
+                # Standard nn.Embedding (no TP sharding).
+                embed_module.weight[token_id].copy_(
+                    embedding_tensor.to(embed_module.weight.dtype)
+                )
+
+        if self.tp_rank == 0:
+            logger.info(
+                "Merged trained mask embedding into target model "
+                "(mask_token_id=%s, source=%s)",
+                self._mask_token_id,
+                mask_emb_path,
+            )
+
+    def _cache_full_embed_weight(self) -> None:
+        """Cache full embedding and lm_head weights on CPU during init.
+
+        With DP attention the active and idle groups run different code
+        paths, so the full-TP all_reduce inside VocabParallelEmbedding
+        gets mismatched calls and corrupts results.  Similarly, the
+        attention-TP greedy sampling only covers part of the vocabulary.
+
+        Fix: gather full weights once during init (all ranks sync) and
+        store on CPU.  At runtime, use F.embedding from CPU (embed) and
+        chunked matmul (lm_head) with no TP collectives.
+        """
+        self._full_embed_cpu = None
+        self._full_lm_head_cpu = None
+
+        if not self._enable_dp_attention:
+            return
+
+        target_model = self.target_worker.model_runner.model
+        tp_group = get_tp_group()
+        tp_size = int(tp_group.world_size)
+        if tp_size <= 1:
+            return
+
+        def _broadcast_gather_cpu(local_shard, tp_group, tp_size, tp_rank):
+            """Gather shards via sequential broadcast (one shard on GPU at a time)."""
+            import torch.distributed as dist
+
+            parts = []
+            for r in range(tp_size):
+                if r == tp_rank:
+                    buf = local_shard.contiguous()
+                else:
+                    buf = torch.empty_like(local_shard)
+                dist.broadcast(buf, src=tp_group.ranks[r], group=tp_group.device_group)
+                parts.append(buf.cpu())
+                if r != tp_rank:
+                    del buf
+            return torch.cat(parts, dim=0)
+
+        # --- 1) Full embed_tokens on CPU ---
+        embed_module = target_model.get_input_embeddings()
+        local_w = embed_module.weight.data
+        shard = getattr(embed_module, "shard_indices", None)
+        num_org = int(shard.num_org_elements) if shard else local_w.shape[0]
+        vocab_size = int(self.target_worker.model_runner.model_config.vocab_size)
+        self._full_embed_cpu = _broadcast_gather_cpu(
+            local_w[:num_org], tp_group, tp_size, self.tp_rank
+        )[:vocab_size]
+        if self.tp_rank == 0:
+            logger.info(
+                "DFLASH cached embed on CPU: shape=%s, mask_norm=%.4f",
+                list(self._full_embed_cpu.shape),
+                self._full_embed_cpu[self._mask_token_id].float().norm().item(),
+            )
+
+        # --- 2) Full lm_head on CPU (only needed when enable_dp_lm_head is off) ---
+        lm_head = getattr(target_model, "lm_head", None)
+        if (
+            not self.server_args.enable_dp_lm_head
+            and lm_head is not None
+            and hasattr(lm_head, "weight")
+            and hasattr(lm_head, "shard_indices")
+        ):
+            lm_w = lm_head.weight.data
+            lm_shard = lm_head.shard_indices
+            lm_num_org = int(lm_shard.num_org_elements)
+            self._full_lm_head_cpu = _broadcast_gather_cpu(
+                lm_w[:lm_num_org], tp_group, tp_size, self.tp_rank
+            )[:vocab_size].float()
+            if self.tp_rank == 0:
+                logger.info(
+                    "DFLASH cached lm_head on CPU: shape=%s",
+                    list(self._full_lm_head_cpu.shape),
+                )
+
     def _prepare_for_speculative_decoding(
         self, batch: ScheduleBatch, draft_input: DFlashDraftInput
     ):
@@ -574,7 +662,21 @@ class DFlashWorker:
         block_ids.fill_(int(self._mask_token_id))
         block_ids[:, 0].copy_(draft_input.bonus_tokens.to(torch.long))
 
-        noise_embedding = embed_module(block_ids)
+        if self._full_embed_cpu is not None:
+            noise_embedding = F.embedding(block_ids.cpu(), self._full_embed_cpu).to(
+                device=block_ids.device
+            )
+        else:
+            noise_embedding = embed_module(block_ids)
+
+        if self._per_position_mask_embeddings is not None:
+            is_mask = block_ids == self._mask_token_id
+            pos_in_block = torch.arange(self.block_size, device=block_ids.device)
+            pos_embeds = self._per_position_mask_embeddings[pos_in_block]
+            noise_embedding[is_mask] = pos_embeds.unsqueeze(0).expand(bs, -1, -1)[
+                is_mask
+            ]
+
         input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
 
         # For spec-v1, the draft KV cache is always materialized before drafting the
@@ -655,7 +757,9 @@ class DFlashWorker:
                 capture_hidden_mode=CaptureHiddenMode.NULL,
             )
 
-            with torch.inference_mode():
+            with torch.inference_mode(), self._draft_tp_context(
+                self.draft_model_runner.tp_group
+            ):
                 draft_logits_output = self.draft_model_runner.forward(
                     forward_batch
                 ).logits_output
@@ -667,10 +771,13 @@ class DFlashWorker:
         if draft_hidden is None:
             raise RuntimeError("DFLASH draft model returned no hidden states.")
         draft_hidden = draft_hidden.view(bs, self.block_size, -1)
-        draft_next = self._greedy_sample_from_vocab_parallel_head(
-            hidden_states=draft_hidden[:, 1:, :].reshape(-1, draft_hidden.shape[-1]),
-            lm_head=lm_head,
-        ).view(bs, self.block_size - 1)
+        with self._draft_tp_context(self.draft_model_runner.tp_group):
+            draft_next = self._greedy_sample_from_vocab_parallel_head(
+                hidden_states=draft_hidden[:, 1:, :].reshape(
+                    -1, draft_hidden.shape[-1]
+                ),
+                lm_head=lm_head,
+            ).view(bs, self.block_size - 1)
         draft_tokens = self._draft_block_tokens_buf[:bs]
         draft_tokens[:, 0].copy_(block_ids[:, 0])
         draft_tokens[:, 1:].copy_(draft_next)
@@ -714,6 +821,13 @@ class DFlashWorker:
 
         if hidden_states.numel() == 0:
             return torch.empty((0,), dtype=torch.long, device=hidden_states.device)
+
+        # Full-vocab path: use cached full lm_head (no TP collective needed).
+        if self._full_lm_head_cpu is not None:
+            device = hidden_states.device
+            hs_cpu = hidden_states.float().cpu()
+            logits = torch.matmul(hs_cpu, self._full_lm_head_cpu.T)
+            return torch.argmax(logits, dim=-1).to(torch.long).to(device)
 
         tp_group = get_tp_group()
         tp_size = int(tp_group.world_size)
@@ -905,6 +1019,40 @@ class DFlashWorker:
             draft_input.target_hidden = draft_input.target_hidden[:0]
             return
 
+        # With --enable-dp-attention, prepare_mlp_sync_batch rounds each DP rank's
+        # global_num_tokens up to a multiple of attn_tp_size for reduce-scatter
+        # alignment, so target_hidden can carry trailing padding rows that are not
+        # real tokens. Drop them before materializing into the draft KV, or the
+        # padding rows write into slots that don't belong to this request and
+        # silently corrupt other requests' cache (invariant: target_hidden row
+        # count must equal sum(ctx_lens)).
+        expected_ctx = int(draft_input.ctx_lens.sum())
+        if total_ctx > expected_ctx:
+            if not getattr(self, "_logged_dp_padding_trim", False):
+                logger.warning(
+                    "DFLASH target_hidden has %d trailing DP-padding row(s); trimming "
+                    "to sum(ctx_lens)=%d. (target_hidden=%d, ctx_lens=%s, forward_mode=%s, "
+                    "is_extend_in_batch=%s, bs=%d) Logged once per worker.",
+                    total_ctx - expected_ctx,
+                    expected_ctx,
+                    total_ctx,
+                    draft_input.ctx_lens.tolist(),
+                    batch.forward_mode,
+                    getattr(batch, "is_extend_in_batch", None),
+                    bs,
+                )
+                self._logged_dp_padding_trim = True
+            draft_input.target_hidden = draft_input.target_hidden[:expected_ctx]
+            total_ctx = expected_ctx
+        elif total_ctx < expected_ctx:
+            raise RuntimeError(
+                "DFLASH target_hidden has fewer rows than sum(ctx_lens) — "
+                f"target_hidden={total_ctx}, sum(ctx_lens)={expected_ctx}, "
+                f"ctx_lens={draft_input.ctx_lens.tolist()}, forward_mode={batch.forward_mode}, "
+                f"is_extend_in_batch={getattr(batch, 'is_extend_in_batch', None)}, bs={bs}. "
+                "This indicates upstream hidden capture lost rows."
+            )
+
         target_req_to_token = batch.req_to_token_pool.req_to_token
         draft_req_to_token = self.draft_model_runner.req_to_token_pool.req_to_token
 
@@ -957,7 +1105,9 @@ class DFlashWorker:
             )  # [sum(ctx_lens)]
             ctx_positions = pos2d[mask]  # [sum(ctx_lens)]
 
-        with torch.inference_mode():
+        with torch.inference_mode(), self._draft_tp_context(
+            self.draft_model_runner.tp_group
+        ):
             ctx_hidden = self.draft_model.project_target_hidden(
                 draft_input.target_hidden
             )  # [sum(ctx), hidden]
@@ -966,25 +1116,9 @@ class DFlashWorker:
                     f"DFLASH ctx_hidden/cache_loc mismatch: {ctx_hidden.shape[0]} vs {ctx_cache_loc.numel()}."
                 )
 
-            if self._use_fused_kv_materialize and self._fused_kv_helper is not None:
-                try:
-                    self._append_target_hidden_fused(
-                        ctx_hidden, ctx_positions, ctx_cache_loc
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "DFLASH fused KV append failed; falling back to sequential path: %s",
-                        e,
-                    )
-                    self._use_fused_kv_materialize = False
-                    self._fused_kv_helper = None
-                    self._append_target_hidden_sequential(
-                        ctx_hidden, ctx_positions, ctx_cache_loc
-                    )
-            else:
-                self._append_target_hidden_sequential(
-                    ctx_hidden, ctx_positions, ctx_cache_loc
-                )
+            self._append_target_hidden_sequential(
+                ctx_hidden, ctx_positions, ctx_cache_loc
+            )
 
         if self.use_compact_draft_cache:
             new_draft_seq_lens = self._compute_compact_draft_seq_lens(batch.seq_lens)
@@ -1035,35 +1169,6 @@ class DFlashWorker:
                 attn.attn.k_scale,
                 attn.attn.v_scale,
             )
-
-    def _append_target_hidden_fused(
-        self,
-        ctx_hidden: torch.Tensor,
-        ctx_positions: torch.Tensor,
-        ctx_cache_loc: torch.Tensor,
-    ) -> None:
-        """Fused KV materialization using batched projection + Triton kernel."""
-        token_to_kv_pool = self.draft_model_runner.token_to_kv_pool
-        layers = self.draft_model.layers
-
-        def _write_layer_kv(
-            layer_idx: int, cache_k: torch.Tensor, cache_v: torch.Tensor
-        ) -> None:
-            attn = layers[layer_idx].self_attn.attn
-            token_to_kv_pool.set_kv_buffer(
-                attn,
-                ctx_cache_loc,
-                cache_k,
-                cache_v,
-                attn.k_scale,
-                attn.v_scale,
-            )
-
-        self._fused_kv_helper.materialize(
-            ctx_hidden=ctx_hidden,
-            positions=ctx_positions,
-            write_layer_kv=_write_layer_kv,
-        )
 
     def _update_target_mamba_state_after_verify(
         self,
@@ -1119,6 +1224,22 @@ class DFlashWorker:
                 "Invariant broken: DFLASH batch requested return_logprob, but scheduler should have rejected this request."
             )
 
+        _fm = batch.forward_mode
+        _bs = batch.batch_size()
+        _eib = batch.is_extend_in_batch
+
+        # Idle DP rank during an extend-in-batch step: still issue the target extend
+        # forward so the active and idle DP groups stay in collective lockstep.
+        if self._enable_dp_attention and (_fm.is_idle() or _bs == 0) and _eib:
+            batch.capture_hidden_mode = CaptureHiddenMode.FULL
+            batch_result = self.target_worker.forward_batch_generation(batch, **kwargs)
+            return GenerationBatchResult(
+                logits_output=batch_result.logits_output,
+                next_token_ids=batch_result.next_token_ids,
+                num_correct_drafts=0,
+                can_run_cuda_graph=batch_result.can_run_cuda_graph,
+            )
+
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             batch.capture_hidden_mode = CaptureHiddenMode.FULL
             batch_result = self.target_worker.forward_batch_generation(batch, **kwargs)
@@ -1170,6 +1291,28 @@ class DFlashWorker:
             )
 
         # Decode / target-verify stage.
+        # Idle DP rank during decode: build an empty verify input and run the target
+        # verify forward so collectives match the active DP group.
+        _is_idle_decode_sync = (
+            self._enable_dp_attention and (_fm.is_idle() or _bs == 0) and not _eib
+        )
+        if _is_idle_decode_sync:
+            batch.spec_info = DFlashVerifyInput(
+                draft_token=torch.empty((0,), dtype=torch.long, device=self.device),
+                positions=torch.empty((0,), dtype=torch.int64, device=self.device),
+                draft_token_num=self.block_size,
+            )
+            batch.capture_hidden_mode = CaptureHiddenMode.FULL
+            batch_result = self.target_worker.forward_batch_generation(
+                batch, is_verify=True, **kwargs
+            )
+            return GenerationBatchResult(
+                logits_output=batch_result.logits_output,
+                next_token_ids=batch_result.next_token_ids,
+                num_correct_drafts=0,
+                can_run_cuda_graph=batch_result.can_run_cuda_graph,
+            )
+
         draft_input = batch.spec_info
         if not isinstance(draft_input, DFlashDraftInput):
             raise RuntimeError(

--- a/test/registered/spec/dflash/test_dflash_mimo_v2_fp4.py
+++ b/test/registered/spec/dflash/test_dflash_mimo_v2_fp4.py
@@ -1,0 +1,103 @@
+import os
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=1800, suite="nightly-8-gpu-common", nightly=True)
+
+# Public checkpoints: target = https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash
+# (the FP4 mxfp4 target at the repo root), draft = the repo's `dflash/` subfolder. Because
+# the draft is a subfolder (not its own repo id), download the repo and point
+# MIMO_V2_DFLASH_DRAFT at the local `<repo>/dflash` path:
+#   hf download XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash --local-dir /models/mimo-fp4-dflash
+#   export MIMO_V2_FP4_TARGET=/models/mimo-fp4-dflash
+#   export MIMO_V2_DFLASH_DRAFT=/models/mimo-fp4-dflash/dflash
+MIMO_V2_FP4_TARGET = os.environ.get(
+    "MIMO_V2_FP4_TARGET", "XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash"
+)
+MIMO_V2_DFLASH_DRAFT = os.environ.get("MIMO_V2_DFLASH_DRAFT", "")
+
+
+@unittest.skipUnless(
+    MIMO_V2_DFLASH_DRAFT,
+    "Set MIMO_V2_DFLASH_DRAFT to the local DFlash draft subfolder "
+    "(<repo>/dflash) to run. Needs a 16-GPU (TP16/DP2) runner.",
+)
+class TestMiMoV2FP4DFlash(CustomTestCase, GSM8KMixin):
+    """GSM8K + accept-length check for the FP4 MiMo-V2-Pro target with its DFlash draft.
+
+    Mirrors the internal v0.5.10 deployment eval (TP16/DP2/EP16, dp-attention, fa3),
+    which scored AIME25 28/30 at accept-length ~4. The 1T FP4 target cannot fit a
+    single device, so this needs a 16-GPU (TP16/DP2 => attn_tp=8) runner.
+    """
+
+    model = MIMO_V2_FP4_TARGET
+    draft_model = MIMO_V2_DFLASH_DRAFT
+    gsm8k_accuracy_thres = 0.85
+    gsm8k_accept_length_thres = 3.5
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        launch_args = [
+            "--trust-remote-code",
+            "--speculative-algorithm",
+            "DFLASH",
+            "--speculative-draft-model-path",
+            cls.draft_model,
+            "--speculative-num-draft-tokens",
+            "8",
+            "--quantization",
+            "fp8",
+            "--attention-backend",
+            "fa3",
+            "--tensor-parallel-size",
+            "16",
+            "--data-parallel-size",
+            "2",
+            "--ep-size",
+            "16",
+            "--enable-dp-attention",
+            "--enable-dp-lm-head",
+            "--moe-dense-tp-size",
+            "1",
+            "--reasoning-parser",
+            "qwen3",
+            "--tool-call-parser",
+            "mimo",
+            "--page-size",
+            "1",
+            "--disable-overlap-schedule",
+        ]
+        old_value = os.environ.get("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN")
+        os.environ["SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN"] = "1"
+        try:
+            with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1):
+                cls.process = popen_launch_server(
+                    cls.model,
+                    cls.base_url,
+                    timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                    other_args=launch_args,
+                )
+        finally:
+            if old_value is None:
+                del os.environ["SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN"]
+            else:
+                os.environ["SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN"] = old_value
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a **native W4 runtime path** for `XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash` (`MiMoV2ForCausalLM` with `quantization_config.store_dtype == "mxfp4"`): the mxfp4-packed expert weights (uint8 e2m1 nibbles + uint8 e8m0 block scales) stay packed in VRAM and run through the existing `is_fp4_experts` lane (`Mxfp4FlashinferTrtllmMoEMethod`, trtllm-gen W4 kernels via `--moe-runner-backend flashinfer_mxfp4`), instead of being dequantized to block-FP8 at load.

**Stacked on #27638** — the first two commits here are that PR's DFlash + dequant support (authorship preserved); the last commit is this change. Happy to rebase once #27638 lands.

Opt-in and default-off: `SGLANG_MIMO_V2_FP4_EXPERTS=1` + `--moe-runner-backend flashinfer_mxfp4`. Without the env, behavior is identical to #27638 (dequant-to-FP8).

## Why

The dequant path doubles expert weight bytes in VRAM (1.02T model: **122 GB/GPU on 8xB200 TP8/EP8**). Keeping experts packed halves that to **~61 GB/GPU**, which we cashed in as KV: context length raised from 65536 to **131072** at `mem-fraction-static 0.8`, verified with a live 118k-token prompt (prefill ~28.9k tok/s, TTFT 4.3 s cold).

## Changes

- `environ.py`: new `SGLANG_MIMO_V2_FP4_EXPERTS` (default False).
- `model_config.py`: set `is_fp4_experts` for MiMoV2 + `store_dtype=mxfp4` when the env is set (carried into `Fp8Config` by the existing loader injection).
- `fp8.py`: skip `_mxfp4_dequant_to_block_fp8` when `is_fp4_experts` is set.
- `mimo_v2.py`: pass `is_fp4_experts` into `TopK` (mirrors `deepseek_v2.py`; without it the mxfp4 runner receives a BYPASSED-format TopK output and raises `NotImplementedError`); in `load_weights`, map per-expert checkpoint tensors onto the fp4-expert params — rename `*.weight_scale` to `*.weight_scale_inv` with e8m0→float32 decode (`2^(x-127)`), and reinterpret uint8 nibble weights as int8.
- `mxfp4_flashinfer_trtllm_moe.py`: drop the DSv4-only `swiglu_limit is not None` assert — the clamp tensor construction already handles `None`, and MiMoV2 has no swiglu clamp.

## Validation (8xB200, TP8/EP8, fa4, DFLASH spec decode, draft tokens 8)

Output is coherent (greedy QA, essays, code) and DFlash acceptance is unchanged vs the dequant path.

| | dequant→FP8 (#27638) + `flashinfer_trtllm` | native W4 (this PR) + `flashinfer_mxfp4` |
|---|---|---|
| expert weights VRAM | 122 GB/GPU | **61 GB/GPU** |
| max context @ mem-frac 0.8 | 65536 | **131072** |
| decode, prose (C=1, greedy) | 126 tok/s | 130 tok/s |
| decode, code (C=1, greedy) | 230 tok/s | 196 tok/s |
| prefill (118k-token prompt) | n/a (over ctx cap) | ~28.9k tok/s |
| DFlash accept length | 2.3–6.8 | 2.85–6.03 |

Decode is roughly on par — the W4 mixed-input kernel's in-kernel unpack offsets the halved HBM reads at decode batch sizes — so the practical win of this path is memory (context / concurrency), not raw decode speed.

Re: #27924 — with this stack (and with #27638's dequant path alike) the released `dflash/` drafter reproduces the advertised acceptance on coding prompts (observed up to 6.8 vs the advertised 6.30), so the checkpoint artifact appears fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->