### PR TITLE
[dsv4] Pad MLA decode q-heads to 64 (not full n_heads) for FlashMLA head64 kernel

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -382,6 +382,9 @@ class MQALayer(nn.Module):
                 )
 
         self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
+        self._attn_sink_local: Optional[torch.Tensor] = (
+            self.attn_sink if attn_tp_size == 1 else None
+        )
         self.fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get()
         if self.fuse_wqa_wkv:
             self.wqkv_a = ReplicatedLinear(
@@ -897,7 +900,6 @@ class MQALayer(nn.Module):
         )
 
         tp_slice, q_padded, q_out = slice(None), None, None
-        attn_sink_local = self.attn_sink
         if self.tp_size > 1:
             # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
             # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
@@ -905,13 +907,17 @@ class MQALayer(nn.Module):
             # this rank and padded to match.
             padded_num_heads = 64 if self.n_local_heads <= 64 else self.n_heads
             q_padded = x.new_empty(x.shape[0], padded_num_heads, self.head_dim)
-            rank = self.tp_rank
             tp_slice = slice(0, self.n_local_heads)
             q_out = q_padded[:, tp_slice, :]
-            attn_sink_local = self.attn_sink.new_zeros(padded_num_heads)
-            attn_sink_local[: self.n_local_heads] = self.attn_sink[
-                rank * self.n_local_heads : (rank + 1) * self.n_local_heads
-            ]
+            if self._attn_sink_local is None:
+                # Build once on the first forward (post weight load); a per-call
+                # rebuild would replay a fill+copy per layer in the decode graph.
+                rank = self.tp_rank
+                sink = self.attn_sink.new_zeros(padded_num_heads)
+                sink[: self.n_local_heads] = self.attn_sink[
+                    rank * self.n_local_heads : (rank + 1) * self.n_local_heads
+                ]
+                self._attn_sink_local = sink
 
         if enable_multi_stream:
             # Multi-stream path always fuses cache write into the K kernel,
@@ -978,7 +984,7 @@ class MQALayer(nn.Module):
                     o,
                     self.attn_mqa.layer_id,
                     self.compress_ratio,
-                    attn_sink_local,
+                    self._attn_sink_local,
                     save_kv_cache,
                 )
             else:
@@ -989,7 +995,7 @@ class MQALayer(nn.Module):
                     layer=self.attn_mqa,
                     forward_batch=forward_batch,
                     compress_ratio=self.compress_ratio,
-                    attn_sink=attn_sink_local,
+                    attn_sink=self._attn_sink_local,
                     save_kv_cache=save_kv_cache,
                 )
             o = o[:, tp_slice, :]

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -897,11 +897,21 @@ class MQALayer(nn.Module):
         )
 
         tp_slice, q_padded, q_out = slice(None), None, None
+        attn_sink_local = self.attn_sink
         if self.tp_size > 1:
-            q_padded = x.new_empty(x.shape[0], self.n_heads, self.head_dim)
+            # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
+            # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
+            # dispatch the cheaper decode::head64 variant; attn_sink is sliced to
+            # this rank and padded to match.
+            padded_num_heads = 64 if self.n_local_heads <= 64 else self.n_heads
+            q_padded = x.new_empty(x.shape[0], padded_num_heads, self.head_dim)
             rank = self.tp_rank
-            tp_slice = slice(rank * self.n_local_heads, (rank + 1) * self.n_local_heads)
+            tp_slice = slice(0, self.n_local_heads)
             q_out = q_padded[:, tp_slice, :]
+            attn_sink_local = self.attn_sink.new_zeros(padded_num_heads)
+            attn_sink_local[: self.n_local_heads] = self.attn_sink[
+                rank * self.n_local_heads : (rank + 1) * self.n_local_heads
+            ]
 
         if enable_multi_stream:
             # Multi-stream path always fuses cache write into the K kernel,
@@ -968,7 +978,7 @@ class MQALayer(nn.Module):
                     o,
                     self.attn_mqa.layer_id,
                     self.compress_ratio,
-                    self.attn_sink,
+                    attn_sink_local,
                     save_kv_cache,
                 )
             else:
@@ -979,7 +989,7 @@ class MQALayer(nn.Module):
                     layer=self.attn_mqa,
                     forward_batch=forward_batch,
                     compress_ratio=self.compress_ratio,
-                    attn_sink=self.attn_sink,
+                    attn_sink=attn_sink_local,
                     save_kv_cache=save_kv_cache,
                 )
             o = o[:, tp_slice, :]


### PR DESCRIPTION
## Motivation

On DeepSeek-V4-Pro, MLA decode attention dispatches FlashMLA's slow `fwd_for_small_topk::head128` kernel even under tensor parallelism. With attention-TP the per-rank query-head count is `n_heads // attn_tp` (128 / TP4 = 32), but `MQALayer.forward` pads it to the full global `n_heads` before the kernel, so each rank computes `n_heads - n_local` wasted heads. FlashMLA only specializes `h_q` for {64, 128}; padding to 64 dispatches the ~2x cheaper `decode::head64` variant instead of `head128`.

## Modifications

`MQALayer.forward` (`models/deepseek_v4.py`): when `n_local_heads <= 64`, size the padded query buffer to 64 instead of `n_heads`, place the rank's heads at `[:n_local_heads]`, and slice the unsharded `attn_sink` to this rank padded to match. The unified-kv-triton path is untouched. The per-rank padded `attn_sink` is built once on the first forward and cached (it is a constant; rebuilding it per call replayed a fill+copy per layer inside the decode CUDA graph).

## Accuracy Tests

GSM8K (1319, 5-shot, chat, `max_tokens=16384`), DeepSeek-V4-Pro fp4, B300 TP4, via `sglang.test.run_eval --eval-name gsm8k`:

| | accuracy |
|---|---|
| head128 (before) | 0.962 |
| head64 (this PR) | 0.963 |

No regression — the kept heads compute identically; the padded heads are sliced off the output.

## Speed Tests and Profiling

**Setup.** DeepSeek-V4-Pro fp4, B300, TP4, 8k1k (ISL 8192 / OSL 1024), fp8 KV cache, mixed-chunk, breakable/piecewise CUDA graph, swa-full-tokens-ratio 0.15, mem-fraction-static 0.85, chunked-prefill 8192. sa-bench concurrency sweep; baseline and this PR are the same build/container with the model file as the only difference. Median latencies.

**Kernel.** The MLA decode attention dispatch changes from `fwd_for_small_topk::head128` to `decode::head64` (per-rank 32 q-heads padded to 64 instead of 128):

| | us / launch |
|---|---|
| `fwd_for_small_topk::head128` (before) | 58.1 |
| `decode::head64` (this PR) | 17.1 |

~3.4x on the decode attention kernel.

**End-to-end** (head128 baseline -> this PR):

| conc | Total TPS/GPU | TPS/user | median TTFT (s) | median TPOT (ms) |
|---|---|---|---|---|
| 8 | 946 -> 967 (+2.2%) | 55.8 -> 56.8 | 0.45 -> 0.40 | 17.9 -> 17.6 |
| 16 | 1456 -> 1507 (+3.5%) | 42.5 -> 43.9 | 0.44 -> 0.40 | 23.5 -> 22.8 |
| 32 | 2116 -> 2218 (+4.8%) | 30.9 -> 32.3 | 0.47 -> 0.42 | 32.4 -> 31.0 |
| 64 | 2795 -> 2980 (+6.6%) | 19.9 -> 21.3 | 0.56 -> 0.64 | 50.2 -> 47.0 |

**Where the gain comes from** (e2e server-log analysis at running-req ~32). The fix accelerates prefill, where MLA attention is on the critical path (the extend path also dispatches this decode kernel for chunks below FlashMLA's large-query threshold); decode iteration time is unchanged because the decode attention overlaps off the critical path, and the cached `attn_sink` only removes a per-layer fill+copy launch (not on the critical path). Consistent with the gain landing in prefill:

| metric | head128 | this PR | delta |
|---|---|---|---|
| prefill input throughput | 13,027 tok/s | 13,941 tok/s | +7.0% |
| prefill per-step time | 571 ms | 545 ms | -4.6% |
| decode iter time | 20.30 ms | 20.35 ms | ~0 |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Provide accuracy and speed benchmark results.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27451918291](https://github.com/sgl-project/sglang/actions/runs/27451918291)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27578117742](https://github.com/sgl-project/sglang/actions/runs/27578117742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->