### PR TITLE
[CI] Fix GB300 TestDummyWithSBO crash: disable NaN assert and coredump for dummy weights

### DIFF
--- a/test/registered/4-gpu-models/test_deepseek_v3_cutedsl_4gpu.py
+++ b/test/registered/4-gpu-models/test_deepseek_v3_cutedsl_4gpu.py
@@ -141,6 +141,16 @@ class TestDummyWithSBO(CustomTestCase):
                 **os.environ,
                 "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
                 "SGLANG_MOE_NVFP4_DISPATCH": "0",
+                # Dummy random weights legitimately produce NaN logits; turn
+                # off the CI crash machinery (async assert, coredump on GPU
+                # exception, crash-time coredump) so NaN is sanitized with a
+                # warning instead of killing the scheduler.
+                "SGLANG_ENABLE_ASYNC_ASSERT": "0",
+                "SGLANG_CUDA_COREDUMP": "0",
+                # Already injected into os.environ by the test process when
+                # SGLANG_CUDA_COREDUMP=1, so it must be overridden explicitly.
+                "CUDA_ENABLE_COREDUMP_ON_EXCEPTION": "0",
+                "SGLANG_CUDA_COREDUMP_BEFORE_CRASH": "0",
             },
         )
 


### PR DESCRIPTION
Dummy random weights legitimately produce NaN logits, which now trip the CI async NaN assert added in #27883 and kill the scheduler during warmup. Disable the crash machinery (async assert, CUDA coredump) for this test so NaN is sanitized with a throttled warning instead.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27377259551](https://github.com/sgl-project/sglang/actions/runs/27377259551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27377259029](https://github.com/sgl-project/sglang/actions/runs/27377259029)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->