### PR TITLE
Use the correct wrapper for `fp4_quantize`

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -286,8 +286,7 @@ class DeepseekV2MLP(nn.Module):
             and self.swiglu_limit is None
             and not isinstance(x, tuple)
         ):
-            from flashinfer import fp4_quantize
-
+            from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
             from sglang.srt.layers.quantization.nvfp4_gemm_swiglu_nvfp4_quant import (
                 nvfp4_gemm_swiglu_nvfp4_quant,
             )


### PR DESCRIPTION
Make sure to select backend = cute-dsl, compare to the CUDA one. Otherwise, it will use quantize_with_block_size, which is not the correct option

<img width="1644" height="1477" alt="image" src="https://github.com/user-attachments/assets/2f13d247-89fa-4fcc-9aea-cfc1ceb07923" />

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27377527693](https://github.com/sgl-project/sglang/actions/runs/27377527693)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27377528197](https://github.com/sgl-project/sglang/actions/runs/27377528197)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->