### PR TITLE
Add weireweire to CI permissions

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1203,6 +1203,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "weireweire": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "wenscarl": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Summary
- Add GitHub user `weireweire` to CI permissions with a custom override and zero cooldown.

## Testing
- `jq -e '.weireweire.cooldown_interval_minutes == 0 and .weireweire.reason == "custom override" and .weireweire.can_tag_run_ci_label == true and .weireweire.can_rerun_failed_ci == true and .weireweire.can_rerun_stage == true' .github/CI_PERMISSIONS.json`\n- `git diff --check`\n- Commit hooks, including `sort CI_PERMISSIONS.json`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27377520407](https://github.com/sgl-project/sglang/actions/runs/27377520407)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27377519772](https://github.com/sgl-project/sglang/actions/runs/27377519772)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->