### PR TITLE
fix(mis): reject items exceeding FlashInfer uint16 position metadata limit

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -38,6 +38,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
+from sglang.srt.server_args import MIS_MAX_ITEM_LEN
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
@@ -105,6 +106,18 @@ if is_flashinfer_available():
 class WrapperDispatch(Enum):
     SLIDING_WINDOW = auto()
     CROSS_ATTENTION = auto()
+
+
+def _mis_max_item_position(delimiter_indices_cpu: torch.Tensor, seq_len: int) -> int:
+    """Return the largest pos_within_item for any single scored item."""
+    if delimiter_indices_cpu.numel() == 0:
+        return 0
+    max_pos = 0
+    for j in range(delimiter_indices_cpu.numel() - 1):
+        gap = delimiter_indices_cpu[j + 1].item() - delimiter_indices_cpu[j].item()
+        max_pos = max(max_pos, gap - 1)
+    tail = seq_len - delimiter_indices_cpu[-1].item() - 1
+    return max(max_pos, tail)
 
 
 @dataclass
@@ -419,6 +432,16 @@ class FlashInferAttnBackend(AttentionBackend):
                 seq_start = seq_end
                 continue
 
+            # Backstop for requests that bypass TokenizerManager validation:
+            # FlashInfer MIS metadata is uint16, so longer items would wrap.
+            max_item_pos = _mis_max_item_position(delimiter_indices_cpu, seq_len)
+            if max_item_pos > MIS_MAX_ITEM_LEN:
+                raise ValueError(
+                    f"Multi-item scoring item length {max_item_pos} exceeds "
+                    f"FlashInfer uint16 metadata limit ({MIS_MAX_ITEM_LEN}). "
+                    f"Shorten the scored item or disable --enable-mis."
+                )
+
             first_delim = delimiter_indices_cpu[0].item()  # CPU .item(), no GPU sync
             delimiter_indices = delimiter_indices_cpu.to(device, non_blocking=True)
             prefix_len = first_delim + (
@@ -441,6 +464,7 @@ class FlashInferAttnBackend(AttentionBackend):
             last_delim = relative_positions[torch.clamp(bucket_idx - 1, min=0)]
             pos_within_item = suffix_range - last_delim
 
+            # Safe: per-item length validated against MIS_MAX_ITEM_LEN above.
             token_pos_in_items_ptr.append(pos_within_item.to(torch.uint16))
 
             forward_batch.positions[seq_start + first_delim : seq_end] = (

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -101,6 +101,7 @@ from sglang.srt.observability.request_metrics_exporter import (
 from sglang.srt.observability.trace import SpanAttributes, extract_trace_headers
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import (
+    MIS_MAX_ITEM_LEN,
     PortArgs,
     ServerArgs,
     set_global_server_args_for_tokenizer,
@@ -232,6 +233,20 @@ class InputFormat(Enum):
     SINGLE_STRING = 1  # Regular single text like "Hello world"
     BATCH_STRINGS = 2  # Regular batch like ["Hello", "World"]
     CROSS_ENCODER_PAIRS = 3  # Cross-encoder pairs like [["query", "document"]]
+
+
+def _validate_mis_item_lengths(delimiter_indices: List[int], num_tokens: int) -> None:
+    """Reject MIS requests whose longest item would overflow uint16 metadata."""
+    boundaries = [*delimiter_indices, num_tokens]
+    max_item_len = max(
+        (b - a - 1 for a, b in zip(boundaries, boundaries[1:])), default=0
+    )
+    if max_item_len > MIS_MAX_ITEM_LEN:
+        raise ValueError(
+            f"Multi-item scoring item length {max_item_len} exceeds FlashInfer "
+            f"uint16 metadata limit ({MIS_MAX_ITEM_LEN} tokens). Use shorter "
+            f"items or disable multi-item scoring (--enable-mis)."
+        )
 
 
 class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
@@ -1003,6 +1018,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     "The server is not configured to enable custom logit processor. "
                     "Please set `--enable-custom-logit-processor` to enable this feature."
                 )
+
+        # FlashInfer MIS metadata is uint16. Reject over-limit items here so
+        # the request fails cleanly before entering the scheduler forward path.
+        if obj.multi_item_delimiter_indices and input_ids:
+            _validate_mis_item_lengths(obj.multi_item_delimiter_indices, len(input_ids))
 
     def _validate_mm_limits(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -228,6 +228,12 @@ GRAMMAR_BACKEND_CHOICES = ["xgrammar", "outlines", "llguidance", "none"]
 # attention backend supports position-only MIS.
 MIS_DELIMITER_TOKEN_ID = 9999
 
+# FlashInfer MIS kernels read item-position metadata (token_pos_in_items_ptr /
+# max_item_len_ptr) as uint16: the delimiter occupies position 0 and item
+# tokens occupy positions 1..len, so no single scored item may exceed this
+# many tokens. Longer items would silently wrap modulo 2^16 (issue #26629).
+MIS_MAX_ITEM_LEN = (1 << 16) - 1
+
 MOE_RUNNER_BACKEND_CHOICES = [
     "auto",
     "deep_gemm",

--- a/test/registered/unit/layers/attention/test_flashinfer_mis_uint16_limit.py
+++ b/test/registered/unit/layers/attention/test_flashinfer_mis_uint16_limit.py
@@ -1,0 +1,117 @@
+"""Unit tests for FlashInfer MIS uint16 item-position metadata limits."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.attention.flashinfer_backend import (
+    FlashInferAttnBackend,
+    _mis_max_item_position,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_forward_batch(seq_len: int, delimiter_indices):
+    return SimpleNamespace(
+        forward_mode=ForwardMode.EXTEND,
+        multi_item_delimiter_indices=[
+            torch.tensor(delimiter_indices, dtype=torch.int64)
+        ],
+        extend_prefix_lens_cpu=None,
+        extend_seq_lens_cpu=[seq_len],
+        input_ids=torch.arange(seq_len, dtype=torch.int64),
+        positions=torch.arange(seq_len, dtype=torch.int64),
+    )
+
+
+def _make_backend():
+    backend = FlashInferAttnBackend.__new__(FlashInferAttnBackend)
+    backend.enable_mis = True
+    return backend
+
+
+class TestFlashInferMISUint16Limit(CustomTestCase):
+    def test_below_boundary_succeeds(self):
+        params = _make_backend()._process_multi_item_scoring(
+            _make_forward_batch(seq_len=65006, delimiter_indices=[4, 65005])
+        )
+
+        self.assertTrue(params.is_enabled())
+        self.assertEqual(
+            params.max_item_len_ptr.to(torch.int32).max().item(),
+            65000,
+        )
+
+    def test_at_boundary_succeeds(self):
+        params = _make_backend()._process_multi_item_scoring(
+            _make_forward_batch(seq_len=65541, delimiter_indices=[4, 65540])
+        )
+
+        self.assertTrue(params.is_enabled())
+        self.assertEqual(
+            params.max_item_len_ptr.to(torch.int32).max().item(),
+            65535,
+        )
+
+    def test_above_boundary_raises(self):
+        with self.assertRaisesRegex(ValueError, "uint16 metadata limit"):
+            _make_backend()._process_multi_item_scoring(
+                _make_forward_batch(seq_len=70006, delimiter_indices=[4, 70005])
+            )
+
+    def test_multi_item_total_suffix_large_but_items_ok(self):
+        params = _make_backend()._process_multi_item_scoring(
+            _make_forward_batch(
+                seq_len=70015,
+                delimiter_indices=[
+                    4,
+                    7005,
+                    14006,
+                    21007,
+                    28008,
+                    35009,
+                    42010,
+                    49011,
+                    56012,
+                    63013,
+                    70014,
+                ],
+            )
+        )
+
+        self.assertTrue(params.is_enabled())
+        self.assertEqual(
+            params.max_item_len_ptr.to(torch.int32).max().item(),
+            7000,
+        )
+
+    def test_multi_item_with_one_long_item_raises(self):
+        with self.assertRaisesRegex(ValueError, "uint16 metadata limit"):
+            _make_backend()._process_multi_item_scoring(
+                _make_forward_batch(
+                    seq_len=70040, delimiter_indices=[4, 21, 70022, 70039]
+                )
+            )
+
+    def test_helper_single_long_item(self):
+        self.assertEqual(
+            _mis_max_item_position(torch.tensor([4, 70005], dtype=torch.int64), 70006),
+            70000,
+        )
+
+    def test_helper_multi_item_short_segments(self):
+        self.assertEqual(
+            _mis_max_item_position(
+                torch.tensor([4, 21, 7022, 7039], dtype=torch.int64), 7040
+            ),
+            7000,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_tokenizer_manager_mis_item_length.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_mis_item_length.py
@@ -1,0 +1,54 @@
+"""Unit tests for tokenizer-level MIS item length validation."""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.tokenizer_manager import _validate_mis_item_lengths
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestTokenizerManagerMISItemLength(CustomTestCase):
+    def test_below_boundary_passes(self):
+        _validate_mis_item_lengths([4, 65005], 65006)
+
+    def test_at_boundary_passes(self):
+        _validate_mis_item_lengths([4, 65540], 65541)
+
+    def test_above_boundary_raises(self):
+        with self.assertRaisesRegex(ValueError, "uint16 metadata limit"):
+            _validate_mis_item_lengths([4, 70005], 70006)
+
+    def test_long_tail_item_raises(self):
+        with self.assertRaisesRegex(ValueError, "uint16 metadata limit"):
+            _validate_mis_item_lengths([4], 70005)
+
+    def test_multi_item_total_large_but_each_item_ok(self):
+        _validate_mis_item_lengths(
+            [
+                4,
+                7005,
+                14006,
+                21007,
+                28008,
+                35009,
+                42010,
+                49011,
+                56012,
+                63013,
+                70014,
+            ],
+            70015,
+        )
+
+    def test_multi_item_with_one_long_item_raises(self):
+        with self.assertRaisesRegex(ValueError, "uint16 metadata limit"):
+            _validate_mis_item_lengths([4, 21, 70022, 70039], 70040)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #26629.

When `--enable-mis` is used, FlashInfer MIS metadata stores per-item token positions in `uint16` buffers (`token_pos_in_items_ptr` / `max_item_len_ptr`). A scored item longer than 65,535 tokens silently wraps during `.to(torch.uint16)`, so the request can return HTTP 200 with corrupted MIS metadata and materially wrong scores.

This PR makes that failure mode explicit: we reject oversized MIS items before the uint16 casts can happen.

## Modifications

- Add a shared `MIS_MAX_ITEM_LEN = 65535` constant next to `MIS_DELIMITER_TOKEN_ID`.
- Validate MIS item lengths in `TokenizerManager._validate_one_request`, where request validation errors surface cleanly per request.
- Add a FlashInfer backend backstop in `_process_multi_item_scoring` before `pos_within_item.to(torch.uint16)`.
- Keep the check per item, not total suffix length, so requests with many individually safe items are still accepted even if the combined scored suffix exceeds 65,535 tokens.
- Add CPU unit tests for:
  - below-boundary item length
  - exact 65,535 boundary
  - over-boundary rejection
  - long tail item after a single delimiter
  - large total suffix with individually safe items
  - reporter-shaped mixed long-item cases
  - backend helper math and backend guard behavior

## Accuracy Tests

This PR affects output behavior only for invalid MIS requests that would previously produce silently corrupted uint16 metadata and wrong scores. Valid MIS requests at or below the 65,535-token per-item limit are unchanged.

Focused unit tests:

test/registered/unit/layers/attention/test_flashinfer_mis_uint16_limit.py
Ran 7 tests in 0.003s

✅

test/registered/unit/managers/test_tokenizer_manager_mis_item_length.py
Ran 6 tests in 0.000s

✅


## Speed Tests and Profiling
No speed benchmark was run. This change adds a lightweight CPU-side delimiter-gap validation for MIS requests and does not change FlashInfer kernels or valid-request attention computation.

The backend guard runs before GPU metadata construction and only computes the max inter-delimiter gap from already-available CPU delimiter indices.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27377794109](https://github.com/sgl-project/sglang/actions/runs/27377794109)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27377794046](https://github.com/sgl-project/sglang/actions/runs/27377794046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->