### PR TITLE
[AMD] De-register two broken JIT kernel tests from AMD CI

### DIFF
--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -10,11 +10,10 @@ from sglang.jit_kernel.activation import (
     run_activation,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
-register_amd_ci(est_time=20, suite="jit-kernel-unit-test-amd")
 
 
 OPS = SUPPORTED_ACTIVATIONS

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -23,11 +23,10 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
 )
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
-register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 configs = list(
     itertools.product(


### PR DESCRIPTION
## Summary
Drop `register_amd_ci(suite="jit-kernel-unit-test-amd")` from two tests that fail in the AMD `jit-kernel-unit-test-amd` job on MI325 and have been turning it **red on scheduled `main` runs since ~2026-06-10 07:34 UTC**:
- `test_activation.py`
- `test_per_token_group_quant_8bit.py`

CUDA registrations are unchanged — both still run on NV via `base-b-kernel-unit-1-gpu-large` / `nightly-kernel-1-gpu`.

## Why these two fail on AMD (MI325-measured)
- **`test_activation`** — the JIT activation kernel fails to **compile on ROCm** (`hipcc`, gfx942): CUDA-only path in `csrc/elementwise/activation.cuh` (e.g. `cuda_fp16.h`). Hard failure, independent of timeout (`73 failed` in ~72s).
- **`test_per_token_group_quant_8bit`** — parametrizes **~1872 configs** (its `est_time=16` is wildly off for AMD); on MI325 it exceeds the per-file 1200s limit and never completes. A probe that bumped the job timeout 10 → 30 min confirmed **more time does not help** — it still hits the per-file 1200s timeout.

## Effect
After this change the AMD jit suite is the passing set (5 files, ~80s total), restoring the `jit-kernel-unit-test-amd` job to green:
`test_store_cache`, `test_fused_qk_gemma_rmsnorm_gate`, `diffusion/test_flydsl_fused_norm`, `benchmark/bench_clamp_position`, `benchmark/bench_resolve_future_token_ids`.

These two can be re-registered for AMD once their kernels are ROCm-ported / the AMD CI range is trimmed.

## Context
- The breakage is **pre-existing on `main`** (scheduled `jit-kernel-unit-test-amd` flipped green→red between 06-10 00:57 and 07:34 UTC and has failed since).
- Relatedly, #27837 adds 4 *new* MI325-validated JIT tests to the same suite; it currently inherits this red job. This PR unblocks that suite.
- Note for future tuning: NV runs its (larger) JIT suite with a 30-min step budget vs AMD's 10-min; not needed here since the passing AMD set runs in ~80s.

## Test plan
- [x] 30-min timeout probe on MI325 confirmed both tests fail regardless of budget (activation: compile fail; per_token_group_quant: per-file 1200s timeout)
- [x] Local registration parse + sanity check: AMD suite collects the 5-file passing set, no errors
- [ ] `jit-kernel-unit-test-amd` green on MI325 for this branch











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27378770800](https://github.com/sgl-project/sglang/actions/runs/27378770800)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27378770237](https://github.com/sgl-project/sglang/actions/runs/27378770237)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->