### PR TITLE
fix(attention): sm120 shared-memory-safe block size in context_attention_fwd

### DIFF
--- a/python/sglang/kernels/ops/attention/prefill_attention.py
+++ b/python/sglang/kernels/ops/attention/prefill_attention.py
@@ -177,7 +177,13 @@ def context_attention_fwd(
     out: [b * s, head, head_dim]
     sm_scale: softmax scale, defaults to 1/sqrt(head_dim)
     """
-    if (_is_cuda or _is_hip) and CUDA_CAPABILITY[0] > 8:
+    if _is_cuda and CUDA_CAPABILITY[0] == 12:
+        # sm120 workstation/consumer Blackwell (RTX PRO 6000, RTX 50xx) has a
+        # much smaller shared memory size (~100KB) than sm90/sm100; BLOCK=128
+        # needs 128KB+ and raises triton OutOfResources (same class of issue
+        # as the extend_attention fix in #14311).
+        BLOCK = 64
+    elif (_is_cuda or _is_hip) and CUDA_CAPABILITY[0] > 8:
         BLOCK = 128
     else:
         BLOCK = 64


### PR DESCRIPTION
## Motivation

`context_attention_fwd` (`python/sglang/kernels/ops/attention/prefill_attention.py` after the kernel-tree move, the vision-attention / prefill path) picks `BLOCK = 128` for every CUDA capability > 8, but sm120 workstation/consumer Blackwell (RTX PRO 6000 / RTX 50xx) has only ~100KB shared memory per SM. The kernel fails to launch with:

```
triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 131072, Hardware limit: 101376
```

crashing every caller of this path on sm120. This is the same bug class #14311 already fixed in `extend_attention.py` (sm120 carve-out with a smaller block size); `prefill_attention.py` was missed.

## Modifications

Add the capability-12 branch mirroring #14311: `BLOCK = 64` on sm120, unchanged elsewhere (sm9x/sm10x keep 128, pre-sm90 keeps 64).

## Accuracy Tests

Verified on RTX PRO 6000 Blackwell (SM 12.0, torch 2.11+cu128, triton 3.6.0):

```
PYTHONPATH=python python -m unittest test.registered.attention.test_triton_attention_kernels.TestTritonAttention.test_context_attention
# main:      ERROR — OutOfResources (Required: 131072, Hardware limit: 101376)
# this PR:   OK (Ran 1 test, 3.6s) — existing test compares against torch SDPA reference
```

No numerics change on other architectures (block-size selection only).

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests. (Covered by the existing registered `test_context_attention`, which goes from crash to pass on sm120.)
- [ ] Update documentation according to Write documentations. (N/A)
- [x] Provide accuracy and speed benchmark results. (Accuracy above; speed N/A — launch-failure fix.)
- [x] Follow the SGLang code style guidance.

AI-assisted (Claude Code); change reviewed and validated by me on hardware.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29642170051](https://github.com/sgl-project/sglang/actions/runs/29642170051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29642170000](https://github.com/sgl-project/sglang/actions/runs/29642170000)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


Rebased onto the kernel-tree refactor (the file moved to `python/sglang/kernels/ops/attention/`). Re-verified on an RTX PRO 6000 (SM120): on current main `test_context_attention` and `test_extend_attention` both fail with the shared-memory `OutOfResources` this fixes; with this one-hunk change both pass. (`test_extend_attention_sliding_window` fails on main too, but that's a separate numerics mismatch, unrelated to the launch failure fixed here.)