### PR TITLE
Add SGLANG_ENABLE_WAR_BARRIER to force-enable the overlap scheduler WAR barrier on non-CUDA (e.g. AMD)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -309,6 +309,10 @@ class Envs:
     # Scheduler: others:
     SGLANG_EMPTY_CACHE_INTERVAL = EnvFloat(-1)  # in seconds. Set if you observe high memory accumulation over a long serving period.
     SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP = EnvBool(False)
+    # Force-enable the WAR (write-after-read) barrier for the overlap scheduler
+    # even when is_cuda() is False (e.g. AMD/ROCm). On CUDA the barrier is
+    # already enabled regardless of this flag (see start_event_loop).
+    SGLANG_ENABLE_WAR_BARRIER = EnvBool(False)
     # PP: skip output send/recv when the entire batch consists of non-final chunked prefill requests,
     # since process_batch_result_prefill discards next_token_ids for those anyway.
     SGLANG_PP_SKIP_PURE_CHUNKED_OUTPUT_COMM = EnvBool(False)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1424,7 +1424,9 @@ class Scheduler(
         # DFLASH fences its shared req_to_token writes with verify_done /
         # plan-stream deps, so the global WAR barrier only serializes plan
         # overlap. TODO: generalize this global-barrier enablement policy.
-        self._war_barrier_enabled = is_cuda() and not self.spec_algorithm.is_dflash()
+        self._war_barrier_enabled = (
+            is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
+        ) and not self.spec_algorithm.is_dflash()
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)
 


### PR DESCRIPTION
## Motivation

The overlap scheduler uses a WAR (write-after-read) barrier so that an iteration's
schedule-stream writes to shared GPU buffers (`req_to_token_pool` / SWA mapping)
wait on the previous forward's reads. Today this barrier is gated on `is_cuda()`,
so it never engages on AMD/ROCm even though the same hazard exists there.

This PR adds `SGLANG_ENABLE_WAR_BARRIER` to force-enable the barrier on non-CUDA
platforms (the immediate goal is AMD).

## Changes

- Add `SGLANG_ENABLE_WAR_BARRIER` env var (`environ.py`), default `False`.
- Fold it into `_war_barrier_enabled` in `Scheduler.start_event_loop`:
  `(is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()) and not spec_algorithm.is_dflash()`.

The flag overrides only the `is_cuda()` requirement; the DFLASH guard is preserved
(DFLASH already fences these writes via `verify_done` / plan-stream deps).

## Behavior

| Flag | Platform | Barrier | Note |
|---|---|---|---|
| `False` (default) | CUDA | on (unless DFLASH) | unchanged from main |
| `False` (default) | AMD / non-CUDA | off | unchanged from main |
| `True` | AMD / non-CUDA | on (unless DFLASH) | new |
| `True` | CUDA | on (unless DFLASH) | same as CUDA default |

Default `False` keeps existing behavior on `main` when the flag is unset.

## Test

- `environ.py` / `scheduler.py` compile; descriptor defaults to `False` and
  flips to `True` under override.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27380965405](https://github.com/sgl-project/sglang/actions/runs/27380965405)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27380965283](https://github.com/sgl-project/sglang/actions/runs/27380965283)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->