### PR TITLE
fix(fp8/moe): raise clear error for unsupported MoE runner backend (#27951)

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1784,9 +1784,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             or moe_runner_backend.is_flashinfer_trtllm_routed()
         ):
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
-        else:
+        elif moe_runner_backend.is_cutlass():
+            # `cutlass` is handled by a dedicated branch in `apply()` and
+            # intentionally does not allocate a `MoeRunner`.
             # TODO(cwan): refactor other backends
             pass
+        else:
+            # Any other backend (e.g. `flashinfer_cutlass`) has no FP8 MoE
+            # implementation here. Fail fast at startup with an actionable message
+            # instead of a later, opaque
+            # `AttributeError: 'Fp8MoEMethod' object has no attribute 'runner'`.
+            raise ValueError(
+                f"MoE runner backend '{moe_runner_backend.value}' is not supported "
+                f"for FP8 MoE models. Supported backends: deep_gemm, triton, aiter, "
+                f"cutlass, flashinfer_trtllm, flashinfer_trtllm_routed. For FP8 "
+                f"expert weights with FlashInfer, use '--moe-runner-backend cutlass' "
+                f"instead."
+            )
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         return TritonMoeQuantInfo(


### PR DESCRIPTION
## Motivation

Closes #27951.

When launching an FP8 MoE model with an unsupported MoE runner backend such as `--moe-runner-backend flashinfer_cutlass`, the server passes startup and CUDA-graph capture cleanly and only crashes on the **first forward pass** with an opaque error:

```
AttributeError: 'Fp8MoEMethod' object has no attribute 'runner'
```

Root cause: `Fp8MoEMethod.create_moe_runner` only allocates `self.runner` for the `deep_gemm` / `triton` / `aiter` / `flashinfer_trtllm` / `flashinfer_trtllm_routed` backends. `apply()` has a dedicated, runner-less branch for `cutlass`, but `flashinfer_cutlass` (and any other unsupported value) falls through both: `self.runner` is never set, yet `apply()` eventually dereferences `self.runner.runner_backend`.

## Modification

Make `create_moe_runner` fail fast for unsupported backends instead of leaving `self.runner` unset:

- `cutlass` keeps its existing no-runner behavior (handled in `apply()`).
- Any other unsupported backend now raises a clear `ValueError` that names the backend and points users to `--moe-runner-backend cutlass` for FP8 expert weights.

`create_moe_runner` is invoked from `FusedMoE.__init__`, so the error now surfaces at **server startup** rather than as a cryptic `AttributeError` on the first request — matching the behavior requested in the issue.

## Checklist

- [x] Minimal, targeted change (1 file, +15/-1)
- [x] Preserves the existing `cutlass` path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27381134216](https://github.com/sgl-project/sglang/actions/runs/27381134216)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27381134056](https://github.com/sgl-project/sglang/actions/runs/27381134056)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->