### PR TITLE
[DSV4] Use int64 for compressor out_loc tensors

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/fused_norm_rope_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/fused_norm_rope_v2.cuh
@@ -44,7 +44,7 @@ struct FusedNormRopeStoreParams {
   const void* __restrict__ handle;  // plan decode / compress
   const void* __restrict__ weight;
   const float* __restrict__ freqs_cis;
-  const int32_t* __restrict__ out_loc;
+  const int64_t* __restrict__ out_loc;
   uint8_t* __restrict__ kvcache;
   float eps;
   uint32_t compress_ratio;
@@ -90,7 +90,7 @@ INDEXER_KERNEL void fused_norm_rope_indexer(const __grid_constant__ FusedNormRop
 
   const auto input = static_cast<DType*>(params.input) + work_id * kHeadDim;
   int32_t position;
-  int32_t out_loc;
+  int64_t out_loc;
   if constexpr (kMode == CompressExtend) {
     const auto plan = static_cast<const PlanC*>(params.handle)[work_id];
     if (plan.is_invalid()) return;
@@ -204,8 +204,8 @@ INDEXER_KERNEL void fused_norm_rope_indexer(const __grid_constant__ FusedNormRop
     const auto abs_max = warp::reduce_max(local_max);
     const auto scale = fmaxf(1e-4f, abs_max) / math::FP8_E4M3_MAX;
     const auto inv_scale = 1.0f / scale;
-    const int32_t page = out_loc >> kPageBits;
-    const int32_t offset = out_loc & ((1 << kPageBits) - 1);
+    const int64_t page = out_loc >> kPageBits;
+    const int64_t offset = out_loc & ((1 << kPageBits) - 1);
     const auto page_ptr = params.kvcache + page * kPageBytes;
     const auto value_ptr = page_ptr + offset * 128;
     const auto scale_ptr = page_ptr + (128 << kPageBits) + offset * 4;
@@ -244,7 +244,7 @@ INDEXER_KERNEL void fused_norm_rope_indexer_fp4(const __grid_constant__ FusedNor
 
   const auto input = static_cast<DType*>(params.input) + work_id * kHeadDim;
   int32_t position;
-  int32_t out_loc;
+  int64_t out_loc;
   if constexpr (kMode == CompressExtend) {
     const auto plan = static_cast<const PlanC*>(params.handle)[work_id];
     if (plan.is_invalid()) return;
@@ -351,8 +351,8 @@ INDEXER_KERNEL void fused_norm_rope_indexer_fp4(const __grid_constant__ FusedNor
     const uint8_t packed1 = quant_fp4_e2m1(data[2] * inv_scale) | (quant_fp4_e2m1(data[3] * inv_scale) << 4);
     const uint16_t packed = static_cast<uint16_t>(packed0) | (static_cast<uint16_t>(packed1) << 8);
 
-    const int32_t page = out_loc >> kPageBits;
-    const int32_t offset = out_loc & ((1 << kPageBits) - 1);
+    const int64_t page = out_loc >> kPageBits;
+    const int64_t offset = out_loc & ((1 << kPageBits) - 1);
     const auto page_ptr = params.kvcache + page * kPageBytes;
     const auto value_ptr = page_ptr + offset * 64;
     const auto scale_ptr = page_ptr + (64 << kPageBits) + offset * 4;
@@ -398,7 +398,7 @@ FLASHMLA_KERNEL void fused_norm_rope_flashmla(const __grid_constant__ FusedNormR
 
   const auto input = static_cast<DType*>(params.input) + work_id * kHeadDim;
   int32_t position;
-  int32_t out_loc;
+  int64_t out_loc;
   if constexpr (kMode == CompressExtend) {
     const auto plan = static_cast<const PlanC*>(params.handle)[work_id];
     if (plan.is_invalid()) return;
@@ -450,8 +450,8 @@ FLASHMLA_KERNEL void fused_norm_rope_flashmla(const __grid_constant__ FusedNormR
     }
   }
 
-  const int32_t page = out_loc >> kPageBits;
-  const int32_t offset = out_loc & ((1 << kPageBits) - 1);
+  const int64_t page = out_loc >> kPageBits;
+  const int64_t offset = out_loc & ((1 << kPageBits) - 1);
   const auto page_ptr = params.kvcache + page * kPageBytes;
   const auto value_ptr = page_ptr + offset * (kBf16Store ? (kHeadDim * 2) : 576);
 
@@ -560,7 +560,7 @@ struct FusedNormRopeKernel {
         .with_device(device_)
         .verify(freqs_cis);
     TensorMatcher({-1})  // out_loc
-        .with_dtype<int32_t>()
+        .with_dtype<int64_t>()
         .with_device(device_)
         .verify(out_loc);
     TensorMatcher({-1, -1})  // cache
@@ -587,7 +587,7 @@ struct FusedNormRopeKernel {
         .handle = plan.data_ptr(),
         .weight = weight.data_ptr(),
         .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
-        .out_loc = static_cast<const int32_t*>(out_loc.data_ptr()),
+        .out_loc = static_cast<const int64_t*>(out_loc.data_ptr()),
         .kvcache = static_cast<uint8_t*>(kvcache.data_ptr()),
         .eps = eps,
         .compress_ratio = compress_ratio,
@@ -625,7 +625,7 @@ struct FusedNormRopeKernel {
     TensorMatcher({N, kHeadDim}).with_dtype<DType>().with_device(device_).verify(input);
     TensorMatcher({kHeadDim}).with_dtype<DType>().with_device(device_).verify(weight);
     TensorMatcher({-1, kRopeDim}).with_dtype<float>().with_device(device_).verify(freqs_cis);
-    TensorMatcher({-1}).with_dtype<int32_t>().with_device(device_).verify(out_loc);
+    TensorMatcher({-1}).with_dtype<int64_t>().with_device(device_).verify(out_loc);
     TensorMatcher({-1, -1}).with_strides({kFp4PageBytes, 1}).with_dtype<uint8_t>().with_device(device_).verify(kvcache);
 
     switch (mode) {
@@ -646,7 +646,7 @@ struct FusedNormRopeKernel {
         .handle = plan.data_ptr(),
         .weight = weight.data_ptr(),
         .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
-        .out_loc = static_cast<const int32_t*>(out_loc.data_ptr()),
+        .out_loc = static_cast<const int64_t*>(out_loc.data_ptr()),
         .kvcache = static_cast<uint8_t*>(kvcache.data_ptr()),
         .eps = eps,
         .compress_ratio = compress_ratio,

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -519,9 +519,6 @@ class CompressorBackendMixin:
                 kv_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
                 page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
                 if hasattr(compress_kv_pool, "translate_loc_to_hisparse_device"):
-                    # The v2 compressor writes directly into the raw C4 KV tensor,
-                    # so HiSparse C4 needs the physical C4 location here. Use the
-                    # int64 (no-narrowing) translation; the store kernel takes int64.
                     out_loc = compress_kv_pool._translate_loc_to_hisparse_device(
                         out_loc
                     )

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -519,12 +519,12 @@ class CompressorBackendMixin:
                 kv_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
                 page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
                 if hasattr(compress_kv_pool, "translate_loc_to_hisparse_device"):
-                    # The v2 compressor writes directly into the raw C4 KV tensor.
-                    # HiSparse C4 therefore needs the physical C4 location here.
-                    # The compress kernel requires an int32 write location.
-                    out_loc = compress_kv_pool.translate_loc_to_hisparse_device(
+                    # The v2 compressor writes directly into the raw C4 KV tensor,
+                    # so HiSparse C4 needs the physical C4 location here. Use the
+                    # int64 (no-narrowing) translation; the store kernel takes int64.
+                    out_loc = compress_kv_pool._translate_loc_to_hisparse_device(
                         out_loc
-                    ).to(torch.int32)
+                    )
             self._forward_compress_all_in_one(
                 kv_score_buffer=state_pool.kv_score_buffer.kv_score,
                 kv_score_input=kv_score_input,

--- a/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
@@ -107,12 +107,12 @@ def _init_compressed_attn_metadata_triton(
     bs = seq_lens.shape[0]
     device = seq_lens.device
 
-    c4_out_loc = torch.empty(bs, dtype=torch.int32, device=device)
+    c4_out_loc = torch.empty(bs, dtype=torch.int64, device=device)
     c4_positions = torch.empty(bs, dtype=torch.int32, device=device)
     c4_seq_lens_raw = torch.empty(bs, dtype=torch.int32, device=device)
     c4_seq_lens_clamp1 = torch.empty(bs, dtype=torch.int32, device=device)
 
-    c128_out_loc = torch.empty(bs, dtype=torch.int32, device=device)
+    c128_out_loc = torch.empty(bs, dtype=torch.int64, device=device)
     c128_positions = torch.empty(bs, dtype=torch.int32, device=device)
     c128_seq_lens_raw = torch.empty(bs, dtype=torch.int32, device=device)
     c128_seq_lens_clamp1 = torch.empty(bs, dtype=torch.int32, device=device)

--- a/test/registered/jit/deepseek_v4/test_fp4_indexer.py
+++ b/test/registered/jit/deepseek_v4/test_fp4_indexer.py
@@ -195,51 +195,6 @@ def test_fp4_fused_norm_rope_store_layout(num_tokens: int) -> None:
     torch.testing.assert_close(cache, expected)
 
 
-@pytest.mark.parametrize("num_tokens", [1, 16, 96])
-def test_flashmla_fused_norm_rope_store_int64_loc(num_tokens: int) -> None:
-    # head_dim=512 (non-fp4) is the HiSparse C4 store path. Validate that an int64
-    # out_loc routes token i to slot loc[i] without narrowing: storing into a
-    # permuted slot set and gathering back must match a contiguous-slot store.
-    torch.manual_seed(num_tokens + 400)
-    head_dim = 512
-    page_size = 1
-    page_bytes = ((584 * page_size + 575) // 576) * 576
-    num_slots = 4 * num_tokens
-    compress_ratio = 4
-    kv = torch.randn(num_tokens, head_dim, device="cuda", dtype=torch.bfloat16)
-    norm_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
-    seq_lens = (
-        torch.arange(1, num_tokens + 1, device="cuda", dtype=torch.int64)
-        * compress_ratio
-    )
-    req_pool_indices = torch.arange(num_tokens, device="cuda", dtype=torch.int64)
-    plan = CompressorDecodePlan.generate_legacy(
-        compress_ratio, req_pool_indices, seq_lens
-    )
-    freqs_cis = precompute_freqs_cis(
-        64, int(seq_lens.max().item()) + 1, 0, 10000, 1, 32, 1
-    ).to("cuda")
-
-    def _store(loc: torch.Tensor) -> torch.Tensor:
-        cache = torch.zeros(num_slots, page_bytes, device="cuda", dtype=torch.uint8)
-        compress_norm_rope_store(
-            kv.clone(),
-            plan,
-            norm_weight=norm_weight,
-            norm_eps=1.0e-6,
-            freq_cis=freqs_cis,
-            out_loc=loc,
-            kvcache=cache,
-            page_size=page_size,
-        )
-        return cache
-
-    ref = _store(torch.arange(num_tokens, device="cuda", dtype=torch.int64))
-    perm = torch.randperm(num_slots, device="cuda")[:num_tokens].to(torch.int64)
-    out = _store(perm)
-    torch.testing.assert_close(out[perm], ref[:num_tokens])
-
-
 @pytest.mark.parametrize("batch_size", [1, 5, 17])
 def test_fp4_fused_q_indexer_rope_hadamard_quant(batch_size: int) -> None:
     torch.manual_seed(batch_size + 200)

--- a/test/registered/jit/deepseek_v4/test_fp4_indexer.py
+++ b/test/registered/jit/deepseek_v4/test_fp4_indexer.py
@@ -148,7 +148,7 @@ def test_fp4_fused_norm_rope_store_layout(num_tokens: int) -> None:
     plan = CompressorDecodePlan.generate_legacy(
         compress_ratio, req_pool_indices, seq_lens
     )
-    loc = torch.arange(num_tokens, device="cuda", dtype=torch.int32)
+    loc = torch.arange(num_tokens, device="cuda", dtype=torch.int64)
     freqs_cis = precompute_freqs_cis(
         64, int(seq_lens.max().item()) + 1, 0, 10000, 1, 32, 1
     ).to("cuda")
@@ -193,6 +193,51 @@ def test_fp4_fused_norm_rope_store_layout(num_tokens: int) -> None:
         num_pages,
     )
     torch.testing.assert_close(cache, expected)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 16, 96])
+def test_flashmla_fused_norm_rope_store_int64_loc(num_tokens: int) -> None:
+    # head_dim=512 (non-fp4) is the HiSparse C4 store path. Validate that an int64
+    # out_loc routes token i to slot loc[i] without narrowing: storing into a
+    # permuted slot set and gathering back must match a contiguous-slot store.
+    torch.manual_seed(num_tokens + 400)
+    head_dim = 512
+    page_size = 1
+    page_bytes = ((584 * page_size + 575) // 576) * 576
+    num_slots = 4 * num_tokens
+    compress_ratio = 4
+    kv = torch.randn(num_tokens, head_dim, device="cuda", dtype=torch.bfloat16)
+    norm_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+    seq_lens = (
+        torch.arange(1, num_tokens + 1, device="cuda", dtype=torch.int64)
+        * compress_ratio
+    )
+    req_pool_indices = torch.arange(num_tokens, device="cuda", dtype=torch.int64)
+    plan = CompressorDecodePlan.generate_legacy(
+        compress_ratio, req_pool_indices, seq_lens
+    )
+    freqs_cis = precompute_freqs_cis(
+        64, int(seq_lens.max().item()) + 1, 0, 10000, 1, 32, 1
+    ).to("cuda")
+
+    def _store(loc: torch.Tensor) -> torch.Tensor:
+        cache = torch.zeros(num_slots, page_bytes, device="cuda", dtype=torch.uint8)
+        compress_norm_rope_store(
+            kv.clone(),
+            plan,
+            norm_weight=norm_weight,
+            norm_eps=1.0e-6,
+            freq_cis=freqs_cis,
+            out_loc=loc,
+            kvcache=cache,
+            page_size=page_size,
+        )
+        return cache
+
+    ref = _store(torch.arange(num_tokens, device="cuda", dtype=torch.int64))
+    perm = torch.randperm(num_slots, device="cuda")[:num_tokens].to(torch.int64)
+    out = _store(perm)
+    torch.testing.assert_close(out[perm], ref[:num_tokens])
 
 
 @pytest.mark.parametrize("batch_size", [1, 5, 17])


### PR DESCRIPTION
## Motivation

Follow-up to #27091. @merrymercy noted on `compressor_v2.py` that we should **prefer int64 for any indices**. The HiSparse C4 store target was computed as `translate_loc_to_hisparse_device(out_loc).to(torch.int32)`, narrowing the *physical* device slot to int32 — a latent truncation risk once the device pool exceeds 2^31 slots.

## Modifications

Make the DSV4 compressor write-location (`out_loc`) tensors **int64 end-to-end**:

- **`metadata_kernel.py`**: build `c4_out_loc` / `c128_out_loc` as int64. The in-kernel arithmetic was already int64 (`raw_out_loc` = `out_cache_loc` is int64); only the output buffer dtype changes, which just removes the final downcast.
- **`fused_norm_rope_v2.cuh`** (`compress_norm_rope_store`): `out_loc` is int64; `page`/`offset` arithmetic widened to int64 across all three kernel variants (indexer, indexer-fp4, flashmla).
- **`compressor_v2.py`**: the HiSparse C4 direct-write path uses the no-cast int64 `_translate_loc_to_hisparse_device` instead of `translate_loc_to_hisparse_device(...).to(torch.int32)`.

Every **other** store kernel reachable from `c4`/`c128_out_loc` is already int64-tolerant, so no further kernel changes are needed:
- `_set_k_and_s` (V1 non-fused / index-scale) asserts `int32` **or** `int64`;
- the fused-store CUDA kernel (`store.cuh`) is templated on `IndicesT` (index dtype taken from `indices.dtype`);
- the fp4 index-cache store kernel is dtype-agnostic;
- HIP fused-store paths re-cast to int32 internally;
- HiSparse `set_*` pool methods translate to int32 before their underlying kernel.

(`fused_k_norm_rope_flashmla`, the only int32-hard store kernel, is fed `swa_loc`, **not** `c4`/`c128_out_loc`, so it is out of scope.)

## Accuracy Tests

On H200:
- `test/registered/jit/deepseek_v4/test_fp4_indexer.py` — **15 passed**. Updated the fused-norm-rope-store layout test to int64 `loc`; added a head_dim=512 / non-fp4 **int64 loc-routing** test that exercises the HiSparse store path (token `i` must land at slot `loc[i]` with no narrowing).
- `test/registered/attention/unittests/dsv4/test_deepseek_v4.py` — **16 passed, 31 subtests** (cuda-graph decode, SWA, eagle verify / draft / draft-extend, compress attention, breakable-cuda-graph metadata contract, `swa_out_cache_loc` resolver). `test_compress_attention_cases` compares attention output against a reference, so it confirms the int64 metadata values are correct.

## Speed Tests and Profiling

No perf impact: only index dtype widens (int32→int64) for small per-token location tensors; arithmetic and store layouts are unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27382173914](https://github.com/sgl-project/sglang/actions/runs/27382173914)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27382173790](https://github.com/sgl-project/sglang/actions/runs/27382173790)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->