### PR TITLE
Add --mamba-ssm-enable-stochastic-rounding for GDN and Mamba1/2 decode

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -655,6 +655,8 @@ class Envs:
     # Mamba
     SGLANG_MAMBA_CONV_DTYPE = EnvStr("bfloat16")
     SGLANG_MAMBA_SSM_DTYPE = EnvStr(None)
+    SGLANG_MAMBA_SSM_ENABLE_STOCHASTIC_ROUNDING = EnvBool(False)
+    SGLANG_MAMBA_SSM_PHILOX_ROUNDS = EnvInt(10)
 
     # Unified Radix Tree
     SGLANG_ENABLE_UNIFIED_RADIX_TREE = EnvBool(False)

--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -13,7 +13,9 @@ from sglang.srt.layers.attention.fla.index import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
 )
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.fla.op import exp, safe_exp
+from sglang.srt.layers.attention.fla.stochastic_round import rs_round_state
 from sglang.srt.layers.attention.fla.utils import (
     autotune_cache_kwargs,
     is_nvidia_hopper,
@@ -76,6 +78,9 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     NT_BUCKET: tl.constexpr,
+    rand_seed=None,
+    USE_RS_ROUNDING: tl.constexpr = False,
+    PHILOX_ROUNDS: tl.constexpr = 10,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -271,25 +276,72 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             b_k = tl.load(p_k, boundary_check=(0, 1))
             b_h4 += tl.trans(tl.dot(b_k, b_v))
 
-    # epilogue
+    # epilogue: write the final recurrent state back to the in-place cache. With
+    # USE_RS_ROUNDING, stochastically round the fp32 state into the narrow cache
+    # dtype (per-element Philox counters decorrelate lanes; per-call seed loaded
+    # from device memory).
     if INPLACE_UPDATE:
+        if USE_RS_ROUNDING:
+            rs_seed = tl.load(rand_seed)
+            rs_o_v = i_v * BV + tl.arange(0, BV)
+            rs_base = (i_n * H + i_h) * V * K + rs_o_v[:, None] * K
         p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if USE_RS_ROUNDING:
+            b_o = rs_round_state(
+                b_h1,
+                rs_seed,
+                rs_base + tl.arange(0, 64)[None, :],
+                ht.dtype.element_ty,
+                PHILOX_ROUNDS,
+            )
+        else:
+            b_o = b_h1.to(p_ht.dtype.element_ty)
+        tl.store(p_ht, b_o, boundary_check=(0, 1))
         if K > 64:
             p_ht = tl.make_block_ptr(
                 ht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
             )
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if USE_RS_ROUNDING:
+                b_o = rs_round_state(
+                    b_h2,
+                    rs_seed,
+                    rs_base + (64 + tl.arange(0, 64))[None, :],
+                    ht.dtype.element_ty,
+                    PHILOX_ROUNDS,
+                )
+            else:
+                b_o = b_h2.to(p_ht.dtype.element_ty)
+            tl.store(p_ht, b_o, boundary_check=(0, 1))
         if K > 128:
             p_ht = tl.make_block_ptr(
                 ht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
             )
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if USE_RS_ROUNDING:
+                b_o = rs_round_state(
+                    b_h3,
+                    rs_seed,
+                    rs_base + (128 + tl.arange(0, 64))[None, :],
+                    ht.dtype.element_ty,
+                    PHILOX_ROUNDS,
+                )
+            else:
+                b_o = b_h3.to(p_ht.dtype.element_ty)
+            tl.store(p_ht, b_o, boundary_check=(0, 1))
         if K > 192:
             p_ht = tl.make_block_ptr(
                 ht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
             )
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if USE_RS_ROUNDING:
+                b_o = rs_round_state(
+                    b_h4,
+                    rs_seed,
+                    rs_base + (192 + tl.arange(0, 64))[None, :],
+                    ht.dtype.element_ty,
+                    PHILOX_ROUNDS,
+                )
+            else:
+                b_o = b_h4.to(p_ht.dtype.element_ty)
+            tl.store(p_ht, b_o, boundary_check=(0, 1))
 
 
 def chunk_gated_delta_rule_fwd_h(
@@ -325,6 +377,15 @@ def chunk_gated_delta_rule_fwd_h(
 
     v_new = torch.empty_like(u) if save_new_value else None
 
+    # GDN cache stochastic rounding (--mamba-ssm-enable-stochastic-rounding):
+    # the kernel rounds the fp32 final state into the narrow ssm_dtype cache.
+    use_rs = envs.SGLANG_MAMBA_SSM_ENABLE_STOCHASTIC_ROUNDING.get()
+    rand_seed = (
+        torch.randint(0, 2**31 - 1, (1,), device=k.device, dtype=torch.int64)
+        if use_rs
+        else None
+    )
+
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), N * H)
 
@@ -353,5 +414,8 @@ def chunk_gated_delta_rule_fwd_h(
         SAVE_NEW_VALUE=v_new is not None,
         IS_VARLEN=cu_seqlens is not None,
         NT_BUCKET=(0 if NT <= 32 else (1 if NT <= 128 else 2)),
+        rand_seed=rand_seed,
+        USE_RS_ROUNDING=use_rs,
+        PHILOX_ROUNDS=envs.SGLANG_MAMBA_SSM_PHILOX_ROUNDS.get(),
     )
     return h, v_new

--- a/python/sglang/srt/layers/attention/fla/fused_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_recurrent.py
@@ -9,6 +9,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.attention.fla.op import exp
+from sglang.srt.layers.attention.fla.stochastic_round import rs_round_state
 from sglang.srt.layers.attention.fla.utils import input_guard
 
 
@@ -193,6 +194,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     h0,
     ht,
     ssm_state_indices,
+    rand_seed,
     scale,
     stride_mixed_qkv_tok: tl.constexpr,
     stride_a_tok: tl.constexpr,
@@ -208,6 +210,8 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     BV: tl.constexpr,
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    USE_RS_ROUNDING: tl.constexpr,
+    PHILOX_ROUNDS: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -262,7 +266,17 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
 
     p_ht = ht + state_idx * stride_final_state_token
     p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
-    tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+    if USE_RS_ROUNDING:
+        # Stochastic rounding of the fp32 state into the narrow cache dtype.
+        # Per-element Philox counters (unique per request/head/v/k) decorrelate
+        # lanes; the per-call seed (device tensor) advances each step/replay.
+        rs_offs = (i_n * HV + i_hv) * V * K + o_v[:, None] * K + o_k[None, :]
+        b_ht = rs_round_state(
+            b_h, tl.load(rand_seed), rs_offs, p_ht.dtype.element_ty, PHILOX_ROUNDS
+        )
+    else:
+        b_ht = b_h.to(p_ht.dtype.element_ty)
+    tl.store(p_ht, b_ht, mask=mask_h)
 
 
 def fused_recurrent_gated_delta_rule_packed_decode(
@@ -276,6 +290,9 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     out: torch.Tensor,
     ssm_state_indices: torch.Tensor,
     use_qk_l2norm_in_kernel: bool = False,
+    rand_seed: Optional[torch.Tensor] = None,
+    use_rs_rounding: bool = False,
+    philox_rounds: int = 10,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if mixed_qkv.ndim != 2:
         raise ValueError(
@@ -381,6 +398,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         h0=initial_state,
         ht=initial_state,
         ssm_state_indices=ssm_state_indices,
+        rand_seed=rand_seed,
         scale=scale,
         stride_mixed_qkv_tok=stride_mixed_qkv_tok,
         stride_a_tok=stride_a_tok,
@@ -396,6 +414,8 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         BV=BV,
         SOFTPLUS_THRESHOLD=20.0,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        USE_RS_ROUNDING=use_rs_rounding,
+        PHILOX_ROUNDS=philox_rounds,
         num_warps=num_warps,
         num_stages=num_stages,
     )

--- a/python/sglang/srt/layers/attention/fla/stochastic_round.py
+++ b/python/sglang/srt/layers/attention/fla/stochastic_round.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Hardware stochastic rounding for the native narrow SSM/GDN state store.
+
+When ``--mamba-ssm-enable-stochastic-rounding`` is set, the fla recurrence kernels
+round the fp32 accumulated recurrent state to the narrow storage dtype
+(fp16 / bf16) **stochastically** instead of round-to-nearest, at the final-state
+store. This is the lossy fp32->narrow step for ``--mamba-ssm-dtype``.
+
+Hardware path only: ``cvt.rs.{f16x2,bf16x2}.f32`` (PTX stochastic-rounding convert,
+SM100+ / Blackwell), fed by per-element Philox random bits.
+
+There is **no software fallback**: if ``cvt.rs`` is unsupported on the GPU arch the
+kernel simply fails to compile (the combination is rejected at startup in
+``ServerArgs``; see ``--mamba-ssm-enable-stochastic-rounding``).
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def convert_rs_fp16x2(x, rand):
+    """fp32 -> fp16 with hardware stochastic rounding (``cvt.rs.f16x2.f32``).
+
+    Processes two f32 lanes -> one f16x2 per asm invocation (``pack=2``); the
+    random bits drive the stochastic rounding decision.
+    """
+    return tl.inline_asm_elementwise(
+        asm="""{
+        cvt.rs.f16x2.f32 $0, $2, $1, $3;
+        }""",
+        constraints=("=r,r,r,r,r"),
+        args=(x, rand),
+        dtype=tl.float16,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def convert_rs_bf16x2(x, rand):
+    """fp32 -> bf16 with hardware stochastic rounding (``cvt.rs.bf16x2.f32``)."""
+    return tl.inline_asm_elementwise(
+        asm="""{
+        cvt.rs.bf16x2.f32 $0, $2, $1, $3;
+        }""",
+        constraints=("=r,r,r,r,r"),
+        args=(x, rand),
+        dtype=tl.bfloat16,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def rs_round_state(b_h, seed, offsets, DTYPE: tl.constexpr, PHILOX_ROUNDS: tl.constexpr):
+    """Stochastically round fp32 tile ``b_h`` to ``DTYPE`` (fp16 or bf16).
+
+    ``seed`` is a scalar per-call Philox seed (loaded from a device tensor so it is
+    CUDA-graph capturable and advances per replay); ``offsets`` are per-element
+    Philox counters that decorrelate lanes. ``DTYPE`` is the destination
+    (cache) element type, passed as ``ptr.dtype.element_ty``.
+    """
+    rand = tl.randint(seed, offsets, PHILOX_ROUNDS)
+    if DTYPE == tl.float16:
+        return convert_rs_fp16x2(b_h, rand)
+    else:
+        tl.static_assert(
+            DTYPE == tl.bfloat16,
+            "GDN stochastic rounding requires the SSM cache dtype to be fp16 or bf16",
+        )
+        return convert_rs_bf16x2(b_h, rand)

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
@@ -1,5 +1,6 @@
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
 )
@@ -78,6 +79,17 @@ class TritonGDNKernel(LinearAttnKernelBase):
         # Packed kernel expects output shape [B, 1, HV, V]
         out = mixed_qkv.new_empty(B, 1, num_v_heads, head_v_dim)
 
+        # GDN cache stochastic rounding (--mamba-ssm-enable-stochastic-rounding):
+        # round the fp32 state into the narrow ssm_dtype cache stochastically. The
+        # per-call seed is drawn from the default CUDA RNG (capturable; advances on
+        # each CUDA-graph replay so every decode step gets fresh rounding noise).
+        use_rs = envs.SGLANG_MAMBA_SSM_ENABLE_STOCHASTIC_ROUNDING.get()
+        rand_seed = (
+            torch.randint(0, 2**31 - 1, (1,), device=mixed_qkv.device, dtype=torch.int64)
+            if use_rs
+            else None
+        )
+
         fused_recurrent_gated_delta_rule_packed_decode(
             mixed_qkv=mixed_qkv,
             a=a,
@@ -89,6 +101,9 @@ class TritonGDNKernel(LinearAttnKernelBase):
             out=out,
             ssm_state_indices=cache_indices,
             use_qk_l2norm_in_kernel=True,
+            rand_seed=rand_seed,
+            use_rs_rounding=use_rs,
+            philox_rounds=envs.SGLANG_MAMBA_SSM_PHILOX_ROUNDS.get(),
         )
 
         # Convert [B, 1, HV, V] → [1, B, HV, V] to match existing output

--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Optional, Tuple
 import torch
 import torch.nn as nn
 
+from sglang.srt.environ import envs
 from sglang.srt.configs.mamba_utils import (
     Mamba2CacheParams,
     extra_groups_for_head_shards,
@@ -717,6 +718,12 @@ class MambaMixer2(torch.nn.Module):
                     intermediate_state_indices=self.intermediate_state_indices,
                 )
             else:
+                use_rs = envs.SGLANG_MAMBA_SSM_ENABLE_STOCHASTIC_ROUNDING.get()
+                rand_seed = (
+                    torch.randint(0, 2**31 - 1, (1,), device=ssm_state.device, dtype=torch.int64)
+                    if use_rs
+                    else None
+                )
                 selective_state_update(
                     ssm_state,
                     hidden_states_d,
@@ -730,6 +737,9 @@ class MambaMixer2(torch.nn.Module):
                     dt_softplus=True,
                     state_batch_indices=state_indices_tensor_d,
                     out=preallocated_ssm_out_d.view(num_decodes, -1, self.head_dim),
+                    rand_seed=rand_seed,
+                    use_rs_rounding=use_rs,
+                    philox_rounds=envs.SGLANG_MAMBA_SSM_PHILOX_ROUNDS.get(),
                 )
 
         # 4. gated MLP

--- a/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
@@ -12,6 +12,7 @@ import triton.language as tl
 from packaging import version
 
 from sglang.jit_kernel.utils import is_arch_support_pdl
+from sglang.srt.layers.attention.fla.stochastic_round import rs_round_state
 
 PAD_SLOT_ID = -1
 
@@ -144,6 +145,9 @@ def _selective_scan_update_kernel(
     HAS_INTERMEDIATE_STATE_INDICES: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
     USE_GDC: tl.constexpr = False,
+    rand_seed=None,
+    USE_RS_ROUNDING: tl.constexpr = False,
+    PHILOX_ROUNDS: tl.constexpr = 10,
 ):
     if USE_GDC:
         tl.extra.cuda.gdc_wait()
@@ -300,7 +304,20 @@ def _selective_scan_update_kernel(
             z_ptr += stride_z_T
 
     if not DISABLE_STATE_UPDATE:
-        tl.store(state_ptrs, state.to(state_ptrs.dtype.element_ty), mask=mask)
+        if USE_RS_ROUNDING:
+            rs_offs = (
+                pid_b * nheads * dim * dstate
+                + pid_h * dim * dstate
+                + offs_m[:, None] * dstate
+                + offs_n[None, :]
+            )
+            state_q = rs_round_state(
+                state, tl.load(rand_seed), rs_offs,
+                state_ptrs.dtype.element_ty, PHILOX_ROUNDS,
+            )
+        else:
+            state_q = state.to(state_ptrs.dtype.element_ty)
+        tl.store(state_ptrs, state_q, mask=mask)
 
     if USE_GDC:
         tl.extra.cuda.gdc_launch_dependents()
@@ -325,6 +342,9 @@ def selective_state_update(
     cache_steps=None,
     retrieve_parent_token=None,
     intermediate_state_indices=None,
+    rand_seed=None,
+    use_rs_rounding=False,
+    philox_rounds=10,
 ):
     """
     Argument:
@@ -502,5 +522,8 @@ def selective_state_update(
             BLOCK_SIZE_M,
             DISABLE_STATE_UPDATE=disable_state_update,
             num_warps=num_warps,
+            rand_seed=rand_seed,
+            USE_RS_ROUNDING=use_rs_rounding,
+            PHILOX_ROUNDS=philox_rounds,
             **pdl_kwargs,
         )

--- a/python/sglang/srt/layers/attention/mamba/ops/ssu_dispatch.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssu_dispatch.py
@@ -39,6 +39,9 @@ class MambaSSUBackend(ABC):
         cache_steps: int | None = None,
         retrieve_parent_token: torch.Tensor | None = None,
         intermediate_state_indices: torch.Tensor | None = None,
+        rand_seed: torch.Tensor | None = None,
+        use_rs_rounding: bool = False,
+        philox_rounds: int = 10,
     ) -> None: ...
 
 
@@ -76,6 +79,9 @@ class TritonSSUBackend(MambaSSUBackend):
         cache_steps: int | None = None,
         retrieve_parent_token: torch.Tensor | None = None,
         intermediate_state_indices: torch.Tensor | None = None,
+        rand_seed: torch.Tensor | None = None,
+        use_rs_rounding: bool = False,
+        philox_rounds: int = 10,
     ) -> None:
         self._kernel(
             state,
@@ -96,6 +102,9 @@ class TritonSSUBackend(MambaSSUBackend):
             cache_steps=cache_steps,
             retrieve_parent_token=retrieve_parent_token,
             intermediate_state_indices=intermediate_state_indices,
+            rand_seed=rand_seed,
+            use_rs_rounding=use_rs_rounding,
+            philox_rounds=philox_rounds,
         )
 
 
@@ -131,6 +140,9 @@ class FlashInferSSUBackend(MambaSSUBackend):
         cache_steps: int | None = None,
         retrieve_parent_token: torch.Tensor | None = None,
         intermediate_state_indices: torch.Tensor | None = None,
+        rand_seed: torch.Tensor | None = None,
+        use_rs_rounding: bool = False,
+        philox_rounds: int = 10,
     ) -> None:
         if retrieve_parent_token is not None:
             raise ValueError(
@@ -223,6 +235,9 @@ def selective_state_update(
     cache_steps: int | None = None,
     retrieve_parent_token: torch.Tensor | None = None,
     intermediate_state_indices: torch.Tensor | None = None,
+    rand_seed: torch.Tensor | None = None,
+    use_rs_rounding: bool = False,
+    philox_rounds: int = 10,
 ) -> None:
     """Dispatch selective-state-update to the configured backend.
 
@@ -274,4 +289,7 @@ def selective_state_update(
         cache_steps=cache_steps,
         retrieve_parent_token=retrieve_parent_token,
         intermediate_state_indices=intermediate_state_indices,
+        rand_seed=rand_seed,
+        use_rs_rounding=use_rs_rounding,
+        philox_rounds=philox_rounds,
     )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -688,6 +688,8 @@ class ServerArgs:
     # Mamba cache
     max_mamba_cache_size: Optional[int] = None
     mamba_ssm_dtype: Optional[str] = None
+    mamba_ssm_enable_stochastic_rounding: bool = False
+    mamba_ssm_philox_rounds: int = 10
     mamba_full_memory_ratio: float = 0.9
     mamba_scheduler_strategy: str = "auto"
     mamba_track_interval: int = 256
@@ -3385,6 +3387,8 @@ class ServerArgs:
             self.linear_attn_decode_backend is None
             and is_sm100_supported()
             and self.mamba_ssm_dtype == "bfloat16"
+            and self.speculative_algorithm is None
+            and not self.mamba_ssm_enable_stochastic_rounding
         ):
             self.linear_attn_decode_backend = "flashinfer"
             logger.info(
@@ -3404,6 +3408,56 @@ class ServerArgs:
                 "--linear-attn-decode-backend flashinfer on SM100+ requires "
                 "--mamba-ssm-dtype bfloat16, "
                 f"got {self.mamba_ssm_dtype!r}"
+            )
+
+        # --mamba-ssm-enable-stochastic-rounding: SR of the fp32 recurrent state
+        # into the narrow cache dtype, done in the Triton kernels via hardware
+        # cvt.rs (GDN decode/prefill, Mamba1/2 decode). No software fallback.
+        if self.mamba_ssm_enable_stochastic_rounding:
+            if self.speculative_algorithm is not None:
+                raise ValueError(
+                    "--mamba-ssm-enable-stochastic-rounding is not supported with "
+                    "speculative decoding: under MTP the recurrent state is advanced "
+                    "via the target-verify path + state scatter, neither SR-wired, so "
+                    "SR would be silently skipped on decode. Disable speculative "
+                    "decoding to use SR. Got --speculative-algorithm="
+                    f"{self.speculative_algorithm!r}."
+                )
+            if self.mamba_ssm_dtype not in ("float16", "bfloat16"):
+                raise ValueError(
+                    "--mamba-ssm-enable-stochastic-rounding requires --mamba-ssm-dtype "
+                    "float16 or bfloat16 (nothing to round at float32); got "
+                    f"{self.mamba_ssm_dtype!r}."
+                )
+            if self.mamba_ssm_philox_rounds < 1:
+                raise ValueError(
+                    "--mamba-ssm-philox-rounds must be >= 1, got "
+                    f"{self.mamba_ssm_philox_rounds}."
+                )
+            for _bk in (
+                self.linear_attn_decode_backend,
+                self.linear_attn_prefill_backend,
+            ):
+                if _bk is not None and _bk != "triton":
+                    raise ValueError(
+                        "--mamba-ssm-enable-stochastic-rounding requires the Triton "
+                        f"backend for GDN linear attention; got {_bk!r}. Use the Triton "
+                        "backend (omit --linear-attn-*-backend or set 'triton')."
+                    )
+            if (
+                not torch.cuda.is_available()
+                or torch.cuda.get_device_capability()[0] < 10
+            ):
+                raise ValueError(
+                    "--mamba-ssm-enable-stochastic-rounding requires an SM100+ GPU "
+                    "(hardware cvt.rs stochastic-rounding convert); this GPU does not "
+                    "support it and there is no software fallback."
+                )
+            logger.info(
+                "SSM stochastic rounding ENABLED: dtype=%s, philox_rounds=%d "
+                "(hardware cvt.rs, Triton kernels)",
+                self.mamba_ssm_dtype,
+                self.mamba_ssm_philox_rounds,
             )
 
         # SM100+ FlashInfer GDN prefill requires CUDA 13+ (CuTe DSL kernel)
@@ -4357,6 +4411,9 @@ class ServerArgs:
         envs.SGLANG_ENABLE_TORCH_COMPILE.set("1" if self.enable_torch_compile else "0")
         if self.mamba_ssm_dtype is not None:
             envs.SGLANG_MAMBA_SSM_DTYPE.set(self.mamba_ssm_dtype)
+        if self.mamba_ssm_enable_stochastic_rounding:
+            envs.SGLANG_MAMBA_SSM_ENABLE_STOCHASTIC_ROUNDING.set(True)
+            envs.SGLANG_MAMBA_SSM_PHILOX_ROUNDS.set(self.mamba_ssm_philox_rounds)
         envs.SGLANG_DISABLE_OUTLINES_DISK_CACHE.set(
             "1" if self.disable_outlines_disk_cache else "0"
         )
@@ -6445,6 +6502,21 @@ class ServerArgs:
             choices=["float32", "bfloat16", "float16"],
             help="The data type of the SSM states in mamba cache. "
             "If not set, will be read from model config (mamba_ssm_dtype).",
+        )
+        parser.add_argument(
+            "--mamba-ssm-enable-stochastic-rounding",
+            action="store_true",
+            help="Stochastically round the fp32 recurrent state to the narrow "
+            "--mamba-ssm-dtype (fp16/bf16) at the kernel store, instead of "
+            "round-to-nearest. Supports GDN and Mamba1/Mamba2 decode kernels "
+            "(Triton backend). Requires an SM100+ GPU (hardware cvt.rs).",
+        )
+        parser.add_argument(
+            "--mamba-ssm-philox-rounds",
+            type=int,
+            default=ServerArgs.mamba_ssm_philox_rounds,
+            help="Philox round count for the SSM stochastic-rounding RNG "
+            "(default 10; only used with --mamba-ssm-enable-stochastic-rounding).",
         )
         parser.add_argument(
             "--mamba-full-memory-ratio",

--- a/test/registered/attention/test_gdn_stochastic_round.py
+++ b/test/registered/attention/test_gdn_stochastic_round.py
@@ -1,0 +1,172 @@
+"""GPU unit tests for GDN stochastic rounding (--mamba-ssm-enable-stochastic-rounding).
+
+Covers the hardware cvt.rs SR helper (fp16/bf16: unbiased, on-grid, seed-controlled,
+differs from RTN), the packed_decode kernel's in-place SR store, and the prefill
+(chunk_delta_h) SR store. cvt.rs requires SM100+; tests skip otherwise.
+Run: ``python -m pytest test/registered/attention/test_gdn_stochastic_round.py``.
+"""
+
+import unittest
+
+import torch
+
+_HAS_SM100 = (
+    torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10
+)
+
+if _HAS_SM100:
+    import triton
+    import triton.language as tl
+
+    from sglang.srt.environ import envs
+    from sglang.srt.layers.attention.fla.chunk import chunk_gated_delta_rule
+    from sglang.srt.layers.attention.fla.fused_recurrent import (
+        fused_recurrent_gated_delta_rule_packed_decode,
+    )
+    from sglang.srt.layers.attention.fla.stochastic_round import rs_round_state
+
+    @triton.jit
+    def _sr_test_kernel(
+        x_ptr, seed_ptr, out_ptr, n, DTYPE: tl.constexpr, ROUNDS: tl.constexpr, BLOCK: tl.constexpr
+    ):
+        offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < n
+        x = tl.load(x_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+        y = rs_round_state(x, tl.load(seed_ptr), offs, DTYPE, ROUNDS)
+        tl.store(out_ptr + offs, y, mask=mask)
+
+    def _sr_round(x_f32, dtype, rounds=10, seed_val=12345):
+        n = x_f32.numel()
+        seed = torch.tensor([seed_val], device="cuda", dtype=torch.int64)
+        out = torch.empty(n, device="cuda", dtype=dtype)
+        tl_dtype = tl.float16 if dtype == torch.float16 else tl.bfloat16
+        BLOCK = 1024
+        _sr_test_kernel[(triton.cdiv(n, BLOCK),)](
+            x_f32.contiguous().view(-1), seed, out, n,
+            DTYPE=tl_dtype, ROUNDS=rounds, BLOCK=BLOCK,
+        )
+        return out.view(x_f32.shape)
+
+
+@unittest.skipUnless(_HAS_SM100, "SSM SR needs an SM100+ GPU (hardware cvt.rs)")
+class TestSSMStochasticRoundHelper(unittest.TestCase):
+    def _unbiased_on_grid(self, dtype, spacing):
+        lower, upper = 1.0, 1.0 + spacing
+        x_val = 1.0 + 0.3 * spacing  # 30% toward `upper`
+        x = torch.full((1_000_000,), x_val, device="cuda", dtype=torch.float32)
+        y = _sr_round(x, dtype, seed_val=7).to(torch.float32)
+        self.assertTrue(((y == lower) | (y == upper)).all().item())  # on grid
+        self.assertAlmostEqual((y == upper).float().mean().item(), 0.3, delta=0.02)
+        self.assertAlmostEqual(y.mean().item(), x_val, delta=1e-3)  # unbiased
+
+    def test_fp16_unbiased_on_grid(self):
+        self._unbiased_on_grid(torch.float16, 2.0 ** -10)
+
+    def test_bf16_unbiased_on_grid(self):
+        self._unbiased_on_grid(torch.bfloat16, 2.0 ** -7)
+
+    def test_seed_controls_rounding(self):
+        torch.manual_seed(0)
+        x = torch.randn(8192, device="cuda", dtype=torch.float32)
+        for dtype in (torch.float16, torch.bfloat16):
+            a = _sr_round(x, dtype, seed_val=1)
+            a2 = _sr_round(x, dtype, seed_val=1)
+            b = _sr_round(x, dtype, seed_val=2)
+            self.assertTrue(torch.equal(a, a2))  # same seed -> deterministic
+            self.assertFalse(torch.equal(a, b))  # different seed -> different noise
+
+    def test_differs_from_rtn_but_brackets_input(self):
+        torch.manual_seed(0)
+        x = torch.randn(8192, device="cuda", dtype=torch.float32)
+        for dtype in (torch.float16, torch.bfloat16):
+            sr = _sr_round(x, dtype, seed_val=3).to(torch.float32)
+            rtn = x.to(dtype).to(torch.float32)
+            self.assertFalse(torch.equal(sr, rtn))  # SR generally != RTN
+            self.assertTrue(torch.isfinite(sr).all().item())
+            self.assertLessEqual((sr - x).abs().max().item(), (rtn - x).abs().max().item() * 4 + 1e-3)
+
+
+@unittest.skipUnless(_HAS_SM100, "SSM SR needs an SM100+ GPU (hardware cvt.rs)")
+class TestPackedDecodeSR(unittest.TestCase):
+    def _run(self, ssm_in, use_rs, seed_val, dtype):
+        B, H, HV, K, V = 4, 2, 4, 8, 8
+        torch.manual_seed(0)
+        mixed_qkv = torch.randn(B, 2 * H * K + HV * V, device="cuda", dtype=torch.float32)
+        a = torch.randn(B, HV, device="cuda", dtype=torch.float32)
+        b = torch.randn(B, HV, device="cuda", dtype=torch.float32)
+        A_log = torch.randn(HV, device="cuda", dtype=torch.float32)
+        dt_bias = torch.randn(HV, device="cuda", dtype=torch.float32)
+        out = torch.empty(B, 1, HV, V, device="cuda", dtype=torch.float32)
+        idx = torch.arange(B, device="cuda", dtype=torch.int64)
+        state = ssm_in.clone()
+        seed = torch.tensor([seed_val], device="cuda", dtype=torch.int64) if use_rs else None
+        fused_recurrent_gated_delta_rule_packed_decode(
+            mixed_qkv=mixed_qkv, a=a, b=b, A_log=A_log, dt_bias=dt_bias, scale=K ** -0.5,
+            initial_state=state, out=out, ssm_state_indices=idx,
+            use_qk_l2norm_in_kernel=True,
+            rand_seed=seed, use_rs_rounding=use_rs, philox_rounds=10,
+        )
+        return state
+
+    def test_sr_store_differs_from_rtn_and_varies(self):
+        for dtype in (torch.float16, torch.bfloat16):
+            ssm_in = torch.randn(4, 4, 8, 8, device="cuda", dtype=dtype)
+            rtn = self._run(ssm_in, use_rs=False, seed_val=0, dtype=dtype)
+            sr1 = self._run(ssm_in, use_rs=True, seed_val=1, dtype=dtype)
+            sr2 = self._run(ssm_in, use_rs=True, seed_val=2, dtype=dtype)
+            self.assertTrue(torch.isfinite(sr1.float()).all().item())
+            self.assertFalse(torch.equal(sr1, rtn))
+            self.assertFalse(torch.equal(sr1, sr2))
+            self.assertEqual(sr1.dtype, dtype)
+
+
+@unittest.skipUnless(_HAS_SM100, "SSM SR needs an SM100+ GPU (hardware cvt.rs)")
+class TestChunkPrefillSR(unittest.TestCase):
+    """Regression guard for the prefill (chunk_delta_h) SR store."""
+
+    def _inputs(self, cache_dtype):
+        N, H, K, V, Tseq = 2, 2, 128, 64, 64
+        total_T = N * Tseq
+        torch.manual_seed(0)
+        act = torch.bfloat16
+        q = torch.randn(1, total_T, H, K, device="cuda", dtype=act)
+        k = torch.nn.functional.normalize(
+            torch.randn(1, total_T, H, K, device="cuda", dtype=act), p=2, dim=-1
+        )
+        v = torch.randn(1, total_T, H, V, device="cuda", dtype=act)
+        g = torch.nn.functional.logsigmoid(
+            torch.rand(1, total_T, H, device="cuda", dtype=torch.float32)
+        ).to(act)
+        beta = torch.rand(1, total_T, H, device="cuda", dtype=act).sigmoid()
+        cu = torch.tensor([0, Tseq, total_T], device="cuda", dtype=torch.int64)
+        idx = torch.arange(N, device="cuda", dtype=torch.int64)
+        ssm = torch.randn(N, H, V, K, device="cuda", dtype=cache_dtype)
+        return q, k, v, g, beta, cu, idx, ssm
+
+    def _run(self, inputs, use_rs, rng_seed):
+        q, k, v, g, beta, cu, idx, ssm = inputs
+        state = ssm.clone()
+        torch.manual_seed(rng_seed)
+        with envs.SGLANG_MAMBA_SSM_ENABLE_STOCHASTIC_ROUNDING.override(use_rs):
+            chunk_gated_delta_rule(
+                q, k, v, g, beta, initial_state=state, initial_state_indices=idx,
+                cu_seqlens=cu, head_first=False, use_qk_l2norm_in_kernel=True,
+            )
+        return state
+
+    def test_chunk_sr_compiles_and_rounds(self):
+        for cache_dtype in (torch.float16, torch.bfloat16):
+            inp = self._inputs(cache_dtype)
+            rtn = self._run(inp, use_rs=False, rng_seed=0)
+            sr1 = self._run(inp, use_rs=True, rng_seed=1)
+            sr1b = self._run(inp, use_rs=True, rng_seed=1)
+            sr2 = self._run(inp, use_rs=True, rng_seed=2)
+            self.assertTrue(torch.isfinite(sr1.float()).all().item())
+            self.assertFalse(torch.equal(sr1, rtn))
+            self.assertTrue(torch.equal(sr1, sr1b))
+            self.assertFalse(torch.equal(sr1, sr2))
+            self.assertEqual(sr1.dtype, cache_dtype)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/layers/mamba/test_mamba_ssm_sr.py
+++ b/test/registered/layers/mamba/test_mamba_ssm_sr.py
@@ -1,0 +1,76 @@
+"""GPU unit tests for Mamba1/Mamba2 stochastic rounding (selective_state_update).
+
+Tests the hardware cvt.rs SR store in the selective_state_update kernel
+(--mamba-ssm-enable-stochastic-rounding with --mamba-ssm-dtype float16/bfloat16).
+cvt.rs requires SM100+; tests skip otherwise.
+Run: ``python -m pytest test/registered/layers/mamba/test_mamba_ssm_sr.py``.
+"""
+
+import unittest
+
+import torch
+
+_HAS_SM100 = (
+    torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10
+)
+
+
+@unittest.skipUnless(_HAS_SM100, "SSM SR needs an SM100+ GPU (hardware cvt.rs)")
+class TestSelectiveStateUpdateSR(unittest.TestCase):
+    """SR for the Mamba1/Mamba2 decode kernel (selective_state_update)."""
+
+    def _run(self, state_in, use_rs, seed_val, dtype):
+        batch, nheads, dim, dstate = 4, 2, 32, 16
+        torch.manual_seed(0)
+        x = torch.randn(batch, nheads, dim, device="cuda", dtype=torch.float32)
+        dt = torch.randn(batch, nheads, dim, device="cuda", dtype=torch.float32)
+        A = torch.randn(nheads, dim, dstate, device="cuda", dtype=torch.float32)
+        B = torch.randn(batch, 1, dstate, device="cuda", dtype=torch.float32)
+        C = torch.randn(batch, 1, dstate, device="cuda", dtype=torch.float32)
+        D = torch.randn(nheads, dim, device="cuda", dtype=torch.float32)
+        dt_bias = torch.randn(nheads, dim, device="cuda", dtype=torch.float32)
+        out = torch.empty_like(x)
+        state = state_in.clone()
+        seed = (
+            torch.tensor([seed_val], device="cuda", dtype=torch.int64)
+            if use_rs
+            else None
+        )
+        from sglang.srt.layers.attention.mamba.ops.mamba_ssm import (
+            selective_state_update,
+        )
+
+        selective_state_update(
+            state,
+            x,
+            dt,
+            A,
+            B,
+            C,
+            D=D,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            out=out,
+            rand_seed=seed,
+            use_rs_rounding=use_rs,
+            philox_rounds=10,
+        )
+        return state
+
+    def test_sr_store_differs_from_rtn_and_varies(self):
+        for dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                state_in = torch.randn(
+                    4, 2, 32, 16, device="cuda", dtype=dtype
+                )
+                rtn = self._run(state_in, use_rs=False, seed_val=0, dtype=dtype)
+                sr1 = self._run(state_in, use_rs=True, seed_val=1, dtype=dtype)
+                sr2 = self._run(state_in, use_rs=True, seed_val=2, dtype=dtype)
+                self.assertTrue(torch.isfinite(sr1.float()).all().item())
+                self.assertFalse(torch.equal(sr1, rtn))
+                self.assertFalse(torch.equal(sr1, sr2))
+                self.assertEqual(sr1.dtype, dtype)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add hardware stochastic rounding (PTX cvt.rs, SM100+/Blackwell) for the recurrent state store in GDN (gated delta network) and Mamba1/Mamba2 decode kernels. When --mamba-ssm-dtype is float16 or bfloat16, the fp32 accumulated state is rounded stochastically instead of round-to-nearest, reducing systematic quantization bias in the recurrent state cache.

## Motivation

Enable stochastic rounding for GDN and Mamaba1/Mamba2 float16/bfloat16 state cache to improve model accuracy.

## Modifications

New module stochastic_round.py: Triton inline-asm helpers for cvt.rs.{f16x2,bf16x2}.f32 + rs_round_state wrapper. Seed loaded from device memory for CUDA-graph capturability.

Kernel changes (decode store epilogue):
- fused_recurrent.py: GDN packed decode
- chunk_delta_h.py: GDN prefill (INPLACE_UPDATE epilogue)
- gdn_triton.py: GDN decode dispatch (seed generation)
- mamba_ssm.py: Mamba1/Mamba2 selective_state_update
- ssu_dispatch.py: SR params threaded through dispatch layer
- mamba.py: seed generation in Mamba decode path

Flags: --mamba-ssm-enable-stochastic-rounding (store_true), --mamba-ssm-philox-rounds (default 10). Guards: requires SM100+, Triton, --mamba-ssm-dtype float16/bfloat16, no speculative decoding.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27383212210](https://github.com/sgl-project/sglang/actions/runs/27383212210)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27383212128](https://github.com/sgl-project/sglang/actions/runs/27383212128)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->