### PR TITLE
[AMD] Cache unified_kv swa_loc once per step instead of per layer

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -184,7 +184,6 @@ class DSV4AttnMetadata:
                 "c4_sparse_topk_lengths_raw",
                 "c4_sparse_page_indices",
                 "c4_sparse_raw_indices",
-                "unified_swa_loc",
                 "unified_swa_indices",
                 "unified_swa_indptr",
                 "unified_hca_indices",
@@ -200,6 +199,7 @@ class DSV4AttnMetadata:
                 # Recomputed by the recorded init_forward_metadata_in_graph op
                 # each forward; not copied across replays.
                 "swa_out_cache_loc",
+                "unified_swa_loc",
                 "c1_flashmla_metadata",
                 "c4_flashmla_metadata",
                 "c128_flashmla_metadata",

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -123,6 +123,9 @@ class DSV4AttnMetadata:
     c128_topk_lengths_raw: Optional[torch.Tensor] = None
 
     # unified_kv: per-forward prebuilt ragged decode index
+    # SWA ring write target (req_slot*ring + pos%ring), computed once per
+    # forward in _attach_unified_kv_decode_streams, read by every layer's store.
+    unified_swa_loc: Optional[torch.Tensor] = None
     unified_swa_indices: Optional[torch.Tensor] = None
     unified_swa_indptr: Optional[torch.Tensor] = None
     unified_hca_indices: Optional[torch.Tensor] = None
@@ -181,6 +184,7 @@ class DSV4AttnMetadata:
                 "c4_sparse_topk_lengths_raw",
                 "c4_sparse_page_indices",
                 "c4_sparse_raw_indices",
+                "unified_swa_loc",
                 "unified_swa_indices",
                 "unified_swa_indptr",
                 "unified_hca_indices",
@@ -1028,6 +1032,13 @@ class DeepseekV4HipRadixBackend(
             ring_stride=pool.unified_swa_ring_size,
             swa_pages=pool.unified_swa_pages,
         )
+        # SWA ring write target, same value for every layer this forward.
+        # Decode: N tokens == N reqs, positions already aligned (no repeat).
+        req_slot = req_pool_indices[:N].to(torch.int64)
+        core.unified_swa_loc = (
+            req_slot * pool.unified_swa_ring_size
+            + core.positions_casual.to(torch.int64) % pool.unified_swa_ring_size
+        ).to(torch.int32)
 
     def _attach_unified_kv_prefill_meta(
         self,
@@ -1205,6 +1216,32 @@ class DeepseekV4HipRadixBackend(
         return self.token_to_kv_pool.translate_loc_from_full_to_swa(out_cache_loc).to(
             torch.int32
         )
+
+    def get_unified_swa_loc(self, forward_batch: ForwardBatch) -> torch.Tensor:
+        """SWA ring write target for unified_kv, shared by all layers.
+
+        Fast path: the per-forward value cached in _attach_unified_kv_decode_streams
+        (recorded inside cuda graphs, so replay re-reads live buffers). Fallback:
+        recompute at store time, matching the pre-cache per-layer behavior, for
+        paths that never ran the decode-stream init (eager prefill/extend, idle,
+        or a batch re-padded after init -> shape mismatch).
+        """
+        positions = forward_batch.positions
+        core = getattr(self.forward_metadata, "core_attn_metadata", None)
+        cached = core.unified_swa_loc if core is not None else None
+        if (
+            cached is not None
+            and not forward_batch.forward_mode.is_idle()
+            and cached.shape[0] == positions.shape[0]
+        ):
+            return cached
+        ring = self.token_to_kv_pool.unified_swa_ring_size
+        req_slot = forward_batch.req_pool_indices.to(torch.int64)
+        if req_slot.shape[0] != positions.shape[0]:
+            req_slot = req_slot.repeat_interleave(
+                positions.shape[0] // req_slot.shape[0]
+            )
+        return (req_slot * ring + positions.to(torch.int64) % ring).to(torch.int32)
 
     def store_cache(
         self, layer_id: int, swa_k: torch.Tensor, forward_batch: ForwardBatch

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -765,18 +765,10 @@ class MQALayer(nn.Module):
 
             token_to_kv_pool = get_token_to_kv_pool()
             if unified:
-                swa_ring_size = token_to_kv_pool.unified_swa_ring_size
                 swa_cache = token_to_kv_pool.get_unified_kv(self.layer_id)
-                # ring slot = req_slot * ring + pos % ring, per token.
-                # positions is per-token; req_pool_indices is per-req.
-                req_slot = forward_batch.req_pool_indices.to(torch.int64)
-                if req_slot.shape[0] != positions.shape[0]:
-                    req_slot = req_slot.repeat_interleave(
-                        positions.shape[0] // req_slot.shape[0]
-                    )
-                swa_loc = (
-                    req_slot * swa_ring_size + positions.to(torch.int64) % swa_ring_size
-                ).to(torch.int32)
+                # swa_loc is layer-independent; computed once per forward by the
+                # backend and cached on the metadata (read here by every layer).
+                swa_loc = attn_backend.get_unified_swa_loc(forward_batch)
                 swa_page_size, bf16_store = 1, True
             else:
                 swa_cache = token_to_kv_pool.swa_kv_pool.kv_buffer[self.layer_id]


### PR DESCRIPTION
Co-authored-by: @1am9trash 
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In the unified_kv decode path, `swa_loc` (the SWA ring write target, `req_slot * ring + pos % ring`) was recomputed inside every layer's KV store. This value is layer-independent — it depends only on the request slots and token positions of the current forward, not on `layer_id` — so recomputing it per layer is redundant work on the decode hot path.

## Modifications

**`python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py`**
- Add a `unified_swa_loc` field to `DSV4AttnMetadata`, placed in `assign_fields`: it is recomputed by the recorded in-graph op each forward, matching `swa_out_cache_loc`.
- In `_attach_unified_kv_decode_streams`, compute swa_loc once per forward and cache it on the metadata.
- Add `DeepseekV4HipRadixBackend.get_unified_swa_loc()`: returns the cached value on the fast path (shape-matched, non-idle), and falls back to recomputing it for paths that never ran the decode-stream init (eager prefill/extend, idle, or a batch re-padded after init).

**`python/sglang/srt/models/deepseek_v4.py`**
- In `MQALayer._forward_prepare`, replace the per-layer swa_loc computation in the unified branch with a call to `attn_backend.get_unified_swa_loc(...)`. 
## Accuracy Tests
gsm8k Accuracy: 0.945
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
round 2.5% increase in Total token throughput.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27386530531](https://github.com/sgl-project/sglang/actions/runs/27386530531)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27396179998](https://github.com/sgl-project/sglang/actions/runs/27396179998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->