### PR TITLE
[spec-v2] Remove CUDA sync between verify(i) and draft(i+1)

### DIFF
--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -194,6 +194,7 @@ def _build_tbo_child_replay_fb_view(
         seq_lens=fb_view.seq_lens[seq_slice],
         seq_lens_sum=int(child_seq_lens_cpu.sum()),
         seq_lens_cpu=child_seq_lens_cpu,
+        seq_len_cpu_ub=getattr(fb_view, "seq_len_cpu_ub", None),
         encoder_lens=None,
         out_cache_loc=(
             parent_out_cache_loc[tok_slice]

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -45,6 +45,30 @@ DEFAULT_WORKSPACE_SIZE_MB = 512
 global_zero_init_workspace_buffer = None
 
 
+def _max_kv_len(
+    seq_lens_cpu: Optional[torch.Tensor],
+    seq_len_cpu_ub: Optional[int],
+    seq_lens: torch.Tensor,
+) -> int:
+    """Max KV length used to size attention metadata (page-table width)."""
+    assert (
+        seq_lens_cpu is None or seq_len_cpu_ub is None
+    ), "seq_lens_cpu and seq_len_cpu_ub should not be both set"
+    if seq_lens_cpu is not None:
+        # Prefer the host-side ``seq_lens_cpu`` if present, since it carries
+        # the exact value and is sync free
+        return int(seq_lens_cpu.max().item())
+    elif seq_len_cpu_ub is not None:
+        # When the ``seq_lens_cpu`` is absent, prefer the host-side
+        # ``seq_len_cpu_ub`` which is set on the spec-v2 sync-free path
+        # (needs_cpu_seq_lens=False)
+        return seq_len_cpu_ub
+    else:
+        # Fall back to a GPU ``.item()`` sync only when neither is available,
+        # triggers a sync
+        return int(seq_lens.max().item())
+
+
 @dataclass
 class TRTLLMMHAMetadata:
     # Sequence lengths for the forward batch
@@ -67,6 +91,8 @@ class TRTLLMMHAMetadata:
 
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     """TRTLLM MHA attention kernel from flashinfer."""
+
+    needs_cpu_seq_lens: bool = False
 
     def __init__(
         self,
@@ -440,14 +466,18 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
+        seq_len_cpu_ub: Optional[int] = None,
     ):
         """Shared capture+replay body for the cuda-graph init path.
 
         Public entry: :py:meth:`init_forward_metadata_out_graph`.
         """
         seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
+        # seq_lens_cpu is None on the sync-free path (needs_cpu_seq_lens=False);
+        # seq_len_cpu_ub then carries the host upper bound. See _max_kv_len.
+        seq_lens_cpu = seq_lens_cpu[:bs] if seq_lens_cpu is not None else None
         req_pool_indices = req_pool_indices[:bs]
+        max_kv = _max_kv_len(seq_lens_cpu, seq_len_cpu_ub, seq_lens)
         metadata = None
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:
@@ -460,9 +490,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32.copy_(
                     seq_lens + self.speculative_step_id + 1
                 )
-                metadata.max_seq_len_k = seq_lens.max().item() + (
-                    self.speculative_step_id + 1
-                )
+                metadata.max_seq_len_k = max_kv + (self.speculative_step_id + 1)
 
                 max_seq_pages = (
                     metadata.max_seq_len_k + self.page_size - 1
@@ -470,7 +498,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
+                max_len = max_kv
                 max_seq_pages = (max_len + self.page_size - 1) // self.page_size
                 metadata.max_seq_len_k = max_len
 
@@ -492,8 +520,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata = self.target_verify_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
 
-            metadata.max_seq_len_k = seq_lens_cpu.max().item() + metadata.max_seq_len_q
-            max_len = seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = max_kv + metadata.max_seq_len_q
+            max_len = max_kv
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -510,8 +538,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
-            max_len = seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = max_kv
+            max_len = max_kv
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -608,7 +636,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         if in_capture:
             num_tokens = forward_batch.positions.numel()
-            seq_lens_cpu = seq_lens.cpu()
             self._build_cuda_graph_metadata(
                 bs, num_tokens, forward_mode, spec_info, seq_lens.device
             )
@@ -618,7 +645,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 seq_lens=seq_lens,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
-                seq_lens_cpu=seq_lens_cpu,
+                seq_lens_cpu=forward_batch.seq_lens_cpu,
+                seq_len_cpu_ub=forward_batch.seq_len_cpu_ub,
             )
             if forward_mode.is_draft_extend():
                 # CUDA graph bakes max_seq_len_q as a constant. replay() sets it
@@ -634,6 +662,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 forward_mode=forward_mode,
                 spec_info=spec_info,
                 seq_lens_cpu=forward_batch.seq_lens_cpu,
+                seq_len_cpu_ub=forward_batch.seq_len_cpu_ub,
             )
 
         # Refill the SWA write-target buffer from the live out_cache_loc before
@@ -662,9 +691,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32 = (
                     seqlens_in_batch + (self.speculative_step_id + 1)
                 ).to(torch.int32)
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
-                    self.speculative_step_id + 1
-                )
+                metadata.max_seq_len_k = _max_kv_len(
+                    forward_batch.seq_lens_cpu,
+                    forward_batch.seq_len_cpu_ub,
+                    forward_batch.seq_lens,
+                ) + (self.speculative_step_id + 1)
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -680,7 +711,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 # Normal Decode
                 metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = _max_kv_len(
+                    forward_batch.seq_lens_cpu,
+                    forward_batch.seq_len_cpu_ub,
+                    forward_batch.seq_lens,
+                )
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -698,7 +733,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
             metadata.max_seq_len_q = tokens_per_req
             metadata.max_seq_len_k = (
-                forward_batch.seq_lens_cpu.max().item() + tokens_per_req
+                _max_kv_len(
+                    forward_batch.seq_lens_cpu,
+                    forward_batch.seq_len_cpu_ub,
+                    forward_batch.seq_lens,
+                )
+                + tokens_per_req
             )
             metadata.cu_seqlens_q = torch.arange(
                 0,
@@ -717,7 +757,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         else:
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = _max_kv_len(
+                forward_batch.seq_lens_cpu,
+                forward_batch.seq_len_cpu_ub,
+                forward_batch.seq_lens,
+            )
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
             )
@@ -725,8 +769,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 forward_batch.req_pool_indices, : metadata.max_seq_len_k
             ]
 
-            if any(
-                forward_batch.extend_prefix_lens_cpu
+            if (
+                forward_batch.extend_prefix_lens_cpu is not None
+                and any(forward_batch.extend_prefix_lens_cpu)
             ) or forward_batch.forward_mode.is_draft_extend(include_v2=True):
                 extend_seq_lens = forward_batch.extend_seq_lens
                 # NOTE: in piecewise CUDA graph warmup, extend_seq_lens_cpu is a torch.Tensor;
@@ -971,6 +1016,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
 class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
     """Multi-step TRTLLM MHA attention kernel used by EAGLE."""
+
+    needs_cpu_seq_lens: bool = False
 
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Sequence, Union
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.speculative.spec_utils import spec_need_hidden_states
 from sglang.srt.speculative.triton_ops.gather_spec_extras import gather_spec_extras
 from sglang.srt.utils import is_cuda, is_hip, is_npu
@@ -25,18 +24,11 @@ def decide_needs_cpu_seq_lens(
 ) -> bool:
     """Whether FutureMap must publish seq_lens_cpu / sum.
 
-    OR over per-backend needs_cpu_seq_lens; force True under TBO / piecewise CG
-    (they read the CPU mirror outside the backend layer).
+    OR over per-backend needs_cpu_seq_lens; force True under TBO (it reads the
+    CPU mirror outside the backend layer).
     """
     if server_args.enable_two_batch_overlap:
         # FIXME: support TBO without seq lens cpu value
-        return True
-    cuda_graph_config = server_args.cuda_graph_config
-    if (
-        cuda_graph_config is not None
-        and cuda_graph_config.prefill.backend == Backend.TC_PIECEWISE
-    ):
-        # FIXME: support PCG without seq lens cpu value
         return True
     # Skip unset slots (e.g. draft_extend_attn_backend on some spec configs);
     # missing flag -> True so undeclared backends stay on the legacy path.
@@ -285,11 +277,17 @@ class FutureMap:
             # skip the .cpu() D2H. Downstream takes the GPU-only path.
             batch.seq_lens_cpu = None
             batch.seq_lens_sum = None
+            # Host-side upper bound on max(seq_lens) so bound-safe backends can
+            # size attention metadata (max_seq_len_k) without a D2H sync.
+            batch.seq_len_cpu_ub = max(
+                (r.kv_allocated_len for r in batch.reqs), default=0
+            )
             return
 
         if self.fwd_prepare_d2h_stream is None or self.publish_ready is None:
             batch.seq_lens_cpu = batch.seq_lens.cpu()  # bootstrap / non-CUDA
             batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
+            batch.seq_len_cpu_ub = None
             return
 
         # Mechanism: don't sync the schedule stream; gate a private stream on the
@@ -302,6 +300,7 @@ class FutureMap:
         # FIXME: fi == batch.req_pool_indices; unify future_indices and req_pool_indices.
         batch.seq_lens_cpu = self.new_seq_lens_cpu_pinned[batch.req_pool_indices_cpu]
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
+        batch.seq_len_cpu_ub = None
 
     def publish(self, future_indices: torch.Tensor, new_seq_lens: torch.Tensor) -> None:
         indices = future_indices

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1736,6 +1736,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # === Host metadata crossing to ForwardBatch (CPU lists / mirrors) ===
     seq_lens_cpu: torch.Tensor = None  # shape: [b], int64
+    # Host-side scalar upper bound on max(seq_lens). resolve_seq_lens_cpu sets this
+    # (from kv_allocated_len) when a backend skips the seq_lens_cpu D2H sync
+    # (needs_cpu_seq_lens=False), so the backend can size attention metadata without
+    # syncing; None otherwise (seq_lens_cpu carries the exact value instead).
+    seq_len_cpu_ub: Optional[int] = None
 
     # For multimodal inputs
     multimodal_inputs: Optional[List] = None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -354,6 +354,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # === Borrowed from ScheduleBatch: host metadata (CPU lists / mirrors) ===
     # Optional seq_lens on cpu (CPU mirror of seq_lens)
     seq_lens_cpu: Optional[torch.Tensor] = None
+    # Host-side scalar upper bound on max(seq_lens), used by bound-safe attention
+    # backends (needs_cpu_seq_lens=False) to size attention metadata without the
+    # seq_lens_cpu D2H sync. Populated by resolve_seq_lens_cpu only when that sync
+    # is skipped; None otherwise (seq_lens_cpu carries the exact value instead).
+    seq_len_cpu_ub: Optional[int] = None
 
     # For logprob
     top_logprobs_nums: Optional[List[int]] = None
@@ -629,6 +634,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             seq_lens=batch.seq_lens,
             out_cache_loc=batch.out_cache_loc,
             seq_lens_sum=batch.seq_lens_sum,
+            seq_len_cpu_ub=batch.seq_len_cpu_ub,
             # Inputs aliased by reference from ScheduleBatch
             seq_lens_cpu=seq_lens_cpu,
             orig_seq_lens=batch.orig_seq_lens,
@@ -1374,6 +1380,7 @@ def build_inner_fb_view(
         seq_lens=forward_batch.seq_lens,
         seq_lens_sum=forward_batch.seq_lens_sum,
         seq_lens_cpu=forward_batch.seq_lens_cpu,
+        seq_len_cpu_ub=getattr(forward_batch, "seq_len_cpu_ub", None),
         encoder_lens=encoder_lens,
         out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
         spec_info=forward_batch.spec_info,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -153,7 +153,12 @@ def build_replay_fb_view(
             if forward_batch.seq_lens_sum is None
             else forward_batch.seq_lens_sum + (bs - raw_bs) * seq_len_fill_value
         ),
-        seq_lens_cpu=buffers.seq_lens_cpu[:bs],
+        seq_lens_cpu=(
+            buffers.seq_lens_cpu[:bs]
+            if forward_batch.seq_lens_cpu is not None
+            else None
+        ),
+        seq_len_cpu_ub=forward_batch.seq_len_cpu_ub,
         encoder_lens=buffers.encoder_lens[:bs] if is_encoder_decoder else None,
         out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
         spec_info=forward_batch.spec_info,
@@ -712,7 +717,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
-            seq_lens_cpu=seq_lens_cpu,
+            seq_lens_cpu=(seq_lens_cpu if attn_backend.needs_cpu_seq_lens else None),
+            seq_len_cpu_ub=(
+                None if attn_backend.needs_cpu_seq_lens else int(seq_lens.max().item())
+            ),
             next_token_logits_buffer=next_token_logits_buffer,
             orig_seq_lens=seq_lens,
             out_cache_loc=out_cache_loc,

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -539,7 +539,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             req_pool_indices=buffers.req_pool_indices,
             seq_lens=buffers.seq_lens,
             seq_lens_sum=seq_lens_sum,
-            seq_lens_cpu=buffers.seq_lens_cpu,
+            seq_lens_cpu=(
+                buffers.seq_lens_cpu if forward_batch.seq_lens_cpu is not None else None
+            ),
+            seq_len_cpu_ub=forward_batch.seq_len_cpu_ub,
             encoder_lens=None,
             out_cache_loc=forward_batch.out_cache_loc,
             spec_info=forward_batch.spec_info,

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -320,6 +320,7 @@ class FrozenKVMTPDraftWorker(BaseDraftWorker, TpModelWorker):
                 if forward_batch.seq_lens_cpu is not None
                 else None
             ),
+            seq_len_cpu_ub=forward_batch.seq_len_cpu_ub,
             encoder_lens=None,
             out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
             spec_info=None,

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -573,9 +573,16 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             input_ids=getattr(forward_batch, "input_ids", None),
             req_pool_indices=buffers.req_pool_indices,
             seq_lens=buffers.seq_lens,
-            seq_lens_sum=forward_batch.seq_lens_sum
-            + (bs - raw_bs) * self.seq_len_fill_value,
-            seq_lens_cpu=buffers.seq_lens_cpu,
+            seq_lens_sum=(
+                None
+                if forward_batch.seq_lens_sum is None
+                else forward_batch.seq_lens_sum
+                + (bs - raw_bs) * self.seq_len_fill_value
+            ),
+            seq_lens_cpu=(
+                buffers.seq_lens_cpu if forward_batch.seq_lens_cpu is not None else None
+            ),
+            seq_len_cpu_ub=forward_batch.seq_len_cpu_ub,
             encoder_lens=None,
             # per-step write target (advanced in-graph by assign_new_state);
             # forward_batch.out_cache_loc is frozen at step 0.


### PR DESCRIPTION
## Motivation

Currently, every spec-v2 decode step does a CUDA sync to copy the seq_lens back to the host, because the host needs the updated seq_lens to set up the next stage's attention metadata.

Since seq_lens is only final once the current stage's GPU work completes, the CPU blocks on the GPU before it can launch the next stage (GPU verify i -> CPU -> GPU draft i+1). This prevents running CPU work and issuing kernels ahead of GPU execution, causing GPU idle.

## Modifications

<img width="1714" height="724" alt="image" src="https://github.com/user-attachments/assets/a019bcbb-b167-4e64-ab75-8d93b5fee31b" />

We observe the host's only use of the synced lengths is `max(seq_lens)`, and only to set how *wide* the page table is (how many KV-page pointers to gather per request), while the attention kernel reads the exact per-request lengths directly from GPU state. So the host doesn't need the precise max; any **upper bound** suffices.

Such a bound is already on the host for free: `kv_allocated_len` — the scheduler's per-request count of allocated KV slots.

  - Add a `seq_len_cpu_ub` field to `ForwardBatch`/`ScheduleBatch`, populated from `max(kv_allocated_len)` (host-only, no new sync) and plumbed through the CUDA-graph `ForwardBatch` views.
  - Mark `trtllm_mha` (and its multi-step draft wrapper) `needs_cpu_seq_lens=False`: it sizes attention metadata from `seq_len_cpu_ub` when the exact host mirror is absent, falling back to a GPU `.max()` only if neither is present.
  - Relax the publish decision so piecewise-CUDA-graph configs no longer force the sync, since PCG only relays the host seq-len values without consuming them (the real consumers are the attention backends).

The implication is that the page table is sized marginally larger than strictly needed — it points at a few already-allocated KV pages the kernel ignores (no *extra* memory is allocated; the over-allocation already exists in `kv_allocated_len`), a negligible copy cost — but the per-step sync is gone for `trtllm_mha` decode (draft and verify).

The change is general: any spec algorithm on a bound-safe backend benefits, while backends that genuinely consume the exact host values keep `needs_cpu_seq_lens=True` and the sync.

## Accuracy Tests

```
# Start server
LD_PRELOAD=/usr/lib64/libnuma.so.1 TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas \
  uv run --no-project python -m sglang.launch_server \
    --model-path meta-llama/Llama-3.1-8B-Instruct \
    --speculative-algorithm EAGLE3 --speculative-draft-model-path lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B \
    --speculative-num-steps 5 --speculative-eagle-topk 1 --speculative-num-draft-tokens 8 \
    --attention-backend trtllm_mha --tp-size 4 --mem-fraction-static 0.85 \
    --context-length 2048 --dtype bfloat16 --host 127.0.0.1 --port 30000 

# Run GSM8K test
uv run python -m sglang.test.few_shot_gsm8k --num-questions 1319 --num-shots 5 --port 30000
```
* Before: 75.7%
* After: 75.9%

## Speed Tests and Profiling

```
# Start server
SGLANG_SIMULATE_ACC_LEN=4 LD_PRELOAD=/usr/lib64/libnuma.so.1 TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas \
  uv run --no-project python -m sglang.launch_server \
    --model-path meta-llama/Llama-3.1-8B-Instruct \
    --speculative-algorithm EAGLE3 --speculative-draft-model-path lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B \
    --speculative-num-steps 5 --speculative-eagle-topk 1 --speculative-num-draft-tokens 8 \
    --attention-backend trtllm_mha --tp-size 4 --mem-fraction-static 0.85 \
    --context-length 2048 --dtype bfloat16 --host 127.0.0.1 --port 30000

# Run benchmarking
for c in 1 2 4 8 16 32 64; do uv run python -m sglang.bench_serving --backend sglang --host 127.0.0.1 --port 30000 \
    --dataset-name random --random-input-len 1024 --random-output-len 1024 \
    --num-prompts $((c*16)) --max-concurrency $c; done
```

|  | TPOT Before (ms) | TPOT After (ms) | Throughput Before (tok/s) | Throughput After (tok/s) |
| --- | --- | --- | --- | --- |
| BS=1 | 1.22 | 1.09 | 1637.03 | 1827.98 |
| BS=2 | 1.31 | 1.18 | 2797.05 | 3089.43 |
| BS=4 | 1.49 | 1.36 | 5068.00 | 5416.35 |
| BS=8 | 1.78 | 1.60 | 8147.45 | 8885.33 |
| BS=16 | 2.36 | 2.23 | 12785.37 | 13506.70 |
| BS=32 | 3.33 | 3.18 | 17840.23 | 18787.23 |
| BS=64 | 4.55 | 4.31 | 21135.16 | 22243.34 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27400596631](https://github.com/sgl-project/sglang/actions/runs/27400596631)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27400596422](https://github.com/sgl-project/sglang/actions/runs/27400596422)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->