### PR TITLE
fix: apply rope overrides to text_config for VLM-format models

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -46,6 +46,97 @@ def _set_architectures(config, arch_name):
     config.update({"architectures": [arch_name]})
 
 
+_ROPE_OVERRIDE_KEYS = ("rope_scaling", "rope_parameters")
+
+# Sub-config attributes that may hold the language-model config of a
+# composite (VLM / omni) model. Mirrors the attribute priority of
+# `get_hf_text_config` in common.py.
+_TEXT_SUB_CONFIG_ATTRS = (
+    "thinker_config",
+    "llm_config",
+    "language_config",
+    "text_config",
+)
+
+
+def _resolve_text_sub_config(config) -> Optional[PretrainedConfig]:
+    """Find the language-model sub-config of a composite (VLM/omni) config.
+
+    Follows the same attribute priority as `get_hf_text_config` in common.py.
+    Returns None for pure-text configs (no sub-config).
+    """
+    for attr in _TEXT_SUB_CONFIG_ATTRS:
+        sub = getattr(config, attr, None)
+        if isinstance(sub, dict):
+            sub = PretrainedConfig(**sub)
+            setattr(config, attr, sub)
+        if isinstance(sub, PretrainedConfig):
+            if attr == "thinker_config":
+                inner = getattr(sub, "text_config", None)
+                if isinstance(inner, dict):
+                    inner = PretrainedConfig(**inner)
+                    sub.text_config = inner
+                if isinstance(inner, PretrainedConfig):
+                    return inner
+            return sub
+    return None
+
+
+def _merged_rope_override(config, key: str, value):
+    """Merge a rope override dict over the config's existing rope dict."""
+    existing = getattr(config, key, None)
+    if isinstance(value, dict) and isinstance(existing, dict):
+        return {**existing, **value}
+    return value
+
+
+def apply_model_override_args(config, model_override_args: dict) -> None:
+    """Apply ``--json-model-override-args`` to a (possibly composite) config.
+
+    A flat ``config.update()`` and shallow nested updates are not enough for
+    composite (VLM-format) configs whose language-model settings live in a
+    sub-config such as ``text_config`` (see issue #27974):
+
+    - Nested overrides recurse into existing sub-configs so partial rope
+      mappings merge without replacing the config or dropping checkpoint keys.
+    - Flat rope overrides (``{"rope_scaling": ...}``) would only update the
+      unused parent config while the language model reads rope settings from
+      the text sub-config -- a silent no-op. Mirror them onto the text
+      sub-config as well.
+    """
+    flat_overrides = {}
+    for key, value in model_override_args.items():
+        existing = getattr(config, key, None)
+        if (
+            key in _TEXT_SUB_CONFIG_ATTRS
+            and isinstance(value, dict)
+            and isinstance(existing, dict)
+        ):
+            existing = PretrainedConfig(**existing)
+            setattr(config, key, existing)
+        if isinstance(value, dict) and isinstance(existing, PretrainedConfig):
+            apply_model_override_args(existing, value)
+        elif key in _ROPE_OVERRIDE_KEYS:
+            flat_overrides[key] = _merged_rope_override(config, key, value)
+        else:
+            flat_overrides[key] = value
+    if flat_overrides:
+        config.update(flat_overrides)
+
+    rope_keys = [k for k in _ROPE_OVERRIDE_KEYS if k in flat_overrides]
+    if rope_keys:
+        text_config = _resolve_text_sub_config(config)
+        if text_config is not None:
+            text_config.update(
+                {
+                    key: _merged_rope_override(
+                        text_config, key, model_override_args[key]
+                    )
+                    for key in rope_keys
+                }
+            )
+
+
 def _apply_deepseek_ocr_overrides(config, model):
     _override_v_head_dim_if_zero(config)
     _set_architectures(config, "DeepseekOCRForCausalLM")
@@ -254,15 +345,7 @@ def get_config(
     )
 
     if model_override_args:
-        # A plain update() setattrs a dict-valued override straight onto the
-        # config, so '{"text_config": {...}}' on a VLM would replace the whole
-        # sub-config with a dict and break attribute access downstream.
-        for key, value in model_override_args.items():
-            current = getattr(config, key, None)
-            if isinstance(value, dict) and isinstance(current, PretrainedConfig):
-                current.update(value)
-            else:
-                setattr(config, key, value)
+        apply_model_override_args(config, model_override_args)
 
     if is_gguf:
         if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -26,6 +26,7 @@ from sglang.srt.utils.hf_transformers.common import (
     get_hf_text_config,
     get_rope_config,
 )
+from sglang.srt.utils.hf_transformers.config import apply_model_override_args
 from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
 from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -634,6 +635,91 @@ class TestPatchNemotronHPattern(unittest.TestCase):
             self.assertEqual(result, ["mamba", "moe", "attention"])
         except ImportError:
             self.skipTest("NemotronHConfig not available in this transformers version")
+
+
+# ---------------------------------------------------------------------------
+# apply_model_override_args (issue #27974)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyModelOverrideArgs(unittest.TestCase):
+    YARN = {
+        "rope_type": "yarn",
+        "factor": 4.0,
+        "original_max_position_embeddings": 8192,
+    }
+
+    def _make_composite_config(self, rope_key="rope_parameters"):
+        text_cfg = PretrainedConfig()
+        text_cfg.num_attention_heads = 8
+        rope = {
+            "rope_type": "default",
+            "rope_theta": 1e7,
+            "mrope_section": [11, 11, 10],
+        }
+        setattr(text_cfg, rope_key, rope)
+        cfg = PretrainedConfig()
+        cfg.text_config = text_cfg
+        return cfg, text_cfg
+
+    def test_flat_update_on_pure_text_config(self):
+        cfg = PretrainedConfig()
+        cfg.num_hidden_layers = 2
+        apply_model_override_args(cfg, {"num_hidden_layers": 4})
+        self.assertEqual(cfg.num_hidden_layers, 4)
+
+    def test_flat_rope_scaling_mirrors_rope_parameters(self):
+        # Qwen3.5 v5 keeps checkpoint keys under rope_parameters while the
+        # documented flat override still uses rope_scaling.
+        cfg, text_cfg = self._make_composite_config("rope_parameters")
+        apply_model_override_args(cfg, {"rope_scaling": dict(self.YARN)})
+        self.assertEqual(text_cfg.rope_parameters["rope_type"], "yarn")
+        self.assertEqual(text_cfg.rope_parameters["factor"], 4.0)
+        self.assertEqual(text_cfg.rope_parameters["rope_theta"], 1e7)
+        self.assertEqual(text_cfg.rope_parameters["mrope_section"], [11, 11, 10])
+
+    def test_flat_rope_parameters_mirrors_and_merges(self):
+        cfg, text_cfg = self._make_composite_config("rope_parameters")
+        apply_model_override_args(cfg, {"rope_parameters": dict(self.YARN)})
+        self.assertEqual(text_cfg.rope_parameters["rope_type"], "yarn")
+        self.assertEqual(text_cfg.rope_parameters["factor"], 4.0)
+        self.assertEqual(text_cfg.rope_parameters["rope_theta"], 1e7)
+        self.assertEqual(text_cfg.rope_parameters["mrope_section"], [11, 11, 10])
+
+    def test_nested_override_recurses_into_sub_config(self):
+        # Nested rope updates retain the existing config object and keys.
+        cfg, text_cfg = self._make_composite_config()
+        apply_model_override_args(
+            cfg, {"text_config": {"rope_parameters": dict(self.YARN)}}
+        )
+        self.assertIsInstance(cfg.text_config, PretrainedConfig)
+        self.assertIs(cfg.text_config, text_cfg)
+        self.assertEqual(text_cfg.num_attention_heads, 8)
+        self.assertEqual(text_cfg.rope_parameters["rope_type"], "yarn")
+        self.assertEqual(text_cfg.rope_parameters["rope_theta"], 1e7)
+
+    def test_nested_non_rope_override(self):
+        cfg, text_cfg = self._make_composite_config()
+        apply_model_override_args(cfg, {"text_config": {"num_attention_heads": 16}})
+        self.assertEqual(text_cfg.num_attention_heads, 16)
+        self.assertEqual(text_cfg.rope_parameters["rope_type"], "default")
+
+    def test_flat_rope_update_prefers_dict_llm_config(self):
+        cfg, lower_priority_text_cfg = self._make_composite_config()
+        cfg.llm_config = {
+            "num_attention_heads": 8,
+            "rope_parameters": {
+                "rope_type": "default",
+                "rope_theta": 1e7,
+            },
+        }
+        apply_model_override_args(cfg, {"rope_parameters": dict(self.YARN)})
+        self.assertIsInstance(cfg.llm_config, PretrainedConfig)
+        self.assertEqual(cfg.llm_config.rope_parameters["rope_type"], "yarn")
+        self.assertEqual(cfg.llm_config.rope_parameters["rope_theta"], 1e7)
+        self.assertEqual(
+            lower_priority_text_cfg.rope_parameters["rope_type"], "default"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #27974. For composite (VLM-format) configs whose language-model settings live under a sub-config (for example, `text_config` in Qwen3.5 / Qwen3-VL), two `--json-model-override-args` paths remain incorrect on current main:

- Flat `{"rope_scaling": {...}}` updates only the unused parent config while the language model reads rope settings from its text sub-config, so the override is a silent no-op.
- Current main preserves one-level nested `PretrainedConfig` objects after #33351, but a partial nested rope mapping is still shallowly assigned and drops checkpoint-required keys such as `rope_theta` and `mrope_section`.

## Modifications

Replace the shallow override loop in `get_config` with `apply_model_override_args`:

- Recurse into existing text sub-config objects and normalize known dict-valued text sub-configs before applying nested overrides.
- Mirror flat `rope_scaling` / `rope_parameters` overrides onto the selected language sub-config using `get_hf_text_config` priority: `thinker_config` → `llm_config` → `language_config` → `text_config`.
- Merge partial rope dictionaries over checkpoint values instead of dropping unmentioned keys.
- Preserve ordinary flat overrides and existing sub-config object identity.

## Accuracy Tests

- Exact helper execution with Transformers 5.12.1: 6/6 focused assertions pass for flat aliases, direct rope parameters, nested partial merges, dict-valued priority, thinker nesting, and repeated updates.
- Focused unit module: 66 passed in the verifier environment.
- `py_compile`, Ruff 0.15.1, Black 26.1.0, isort 7.0.0, and `git diff --check`: pass.
- The original Qwen3.5-397B path was independently production-validated. This rebased head was not tested on a running server.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations. (N/A)
- [x] Provide accuracy and speed benchmark results. (Config-path correctness above; no kernel/speed impact.)
- [x] Follow the SGLang code style guidance.

AI-assisted (Claude Code); reviewed line-by-line and validated by me.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35434492661](https://github.com/sgl-project/sglang/actions/runs/35434492661)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35434492634](https://github.com/sgl-project/sglang/actions/runs/35434492634)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35434492869](https://github.com/sgl-project/sglang/actions/runs/35434492869)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
