### PR TITLE
Fix multi-tokenizer batch IPC routing

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -3219,10 +3219,13 @@ class SignalHandler:
 def stamp_http_worker_ipc(obj: Any, ipc_name: str) -> None:
     if isinstance(obj, BaseReq):
         obj.http_worker_ipc = ipc_name
-    elif isinstance(
-        obj, (BatchTokenizedGenerateReqInput, BatchTokenizedEmbeddingReqInput)
-    ):
-        for req in obj:
-            req.http_worker_ipc = ipc_name
     elif isinstance(obj, BaseBatchReq):
-        obj.http_worker_ipcs = [ipc_name] * len(obj.rids)
+        batch = getattr(obj, "batch", None)
+        if batch is not None:
+            if obj.rids is None:
+                obj.rids = [req.rid for req in batch]
+            for req in batch:
+                req.http_worker_ipc = ipc_name
+
+        batch_size = len(obj.rids) if obj.rids is not None else len(obj)
+        obj.http_worker_ipcs = [ipc_name] * batch_size

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -1,16 +1,22 @@
 import unittest
+from types import SimpleNamespace
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import BatchStrOutput
+from sglang.srt.managers.io_struct import (
+    BatchStrOutput,
+    BatchTokenizedEmbeddingReqInput,
+    BatchTokenizedGenerateReqInput,
+)
 from sglang.srt.managers.multi_tokenizer_mixin import (
     TokenizerWorker,
     _handle_output_by_index,
     get_tokenizer_worker_class,
 )
+from sglang.srt.managers.tokenizer_manager import stamp_http_worker_ipc
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -91,6 +97,31 @@ class TestMultiTokenizerMixin(unittest.TestCase):
             single_output.cached_tokens_details,
             [{"device": 1, "host": 3}],
         )
+
+    def test_stamp_http_worker_ipc_populates_tokenized_batch_metadata(self):
+        for batch_cls in (
+            BatchTokenizedGenerateReqInput,
+            BatchTokenizedEmbeddingReqInput,
+        ):
+            with self.subTest(batch_cls=batch_cls):
+                batch_req = batch_cls(
+                    batch=[
+                        SimpleNamespace(rid="rid-0", http_worker_ipc=None),
+                        SimpleNamespace(rid="rid-1", http_worker_ipc=None),
+                    ]
+                )
+
+                stamp_http_worker_ipc(batch_req, "ipc://tokenizer-0")
+
+                self.assertEqual(batch_req.rids, ["rid-0", "rid-1"])
+                self.assertEqual(
+                    batch_req.http_worker_ipcs,
+                    ["ipc://tokenizer-0", "ipc://tokenizer-0"],
+                )
+                self.assertEqual(
+                    [item.http_worker_ipc for item in batch_req.batch],
+                    ["ipc://tokenizer-0", "ipc://tokenizer-0"],
+                )
 
     def test_get_tokenizer_worker_class_uses_default(self):
         self.assertIs(get_tokenizer_worker_class(DefaultServerArgs()), TokenizerWorker)


### PR DESCRIPTION
## Summary
- populate `rids` and `http_worker_ipcs` when stamping tokenized batched requests in multi-tokenizer mode
- keep item-level `http_worker_ipc` on each request inside `BatchTokenizedGenerateReqInput` / `BatchTokenizedEmbeddingReqInput`
- add unit coverage for tokenized batch IPC stamping with `rids=None`

Fixes #29024

## Investigation
The original regression was narrowed down by comparing the multi-tokenizer routing path across release tags. The relevant failure mode is native batched `/generate` requests with tokenizer batch encoding enabled and multiple tokenizer workers.

`v0.5.11` does not have the new multi-detokenizer routing path. `v0.5.12` introduced `MultiDetokenizerRouter` in `e028556db0` / #24944 (`Add multi-detokenizer support`). The routing regression is still present in `v0.5.12.post1`, `v0.5.13`, and current `main`. There was an older related `v0.5.4` `__getitem__` IPC propagation issue, but that was fixed in `v0.5.4.post1` by `e15b63a182` / #12053, so it is separate from this patch.

After #29214, `SenderWrapper` was removed and the IPC stamping moved into `tokenizer_manager.stamp_http_worker_ipc()`. On current `main`, tokenized batch requests enter the `BaseBatchReq` path with `rids=None`, so `[ipc_name] * len(obj.rids)` raises `TypeError: object of type 'NoneType' has no len()`. This also affects default server warmup when `--tokenizer-worker-num > 1`, because warmup uses the batched path.

This patch makes `stamp_http_worker_ipc()` derive `rids` from `obj.batch` when needed, stamps each item in the batch with the originating tokenizer IPC, and fills the wrapper-level `http_worker_ipcs` list for downstream routing.

## Test Plan
- pre-commit run --files python/sglang/srt/managers/tokenizer_manager.py test/registered/unit/managers/test_multi_tokenizer_mixin.py
- python3 -m py_compile python/sglang/srt/managers/tokenizer_manager.py test/registered/unit/managers/test_multi_tokenizer_mixin.py
- python -m pytest test/registered/unit/managers/test_multi_tokenizer_mixin.py -q



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29445567708](https://github.com/sgl-project/sglang/actions/runs/29445567708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29445567444](https://github.com/sgl-project/sglang/actions/runs/29445567444)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->