### PR TITLE
[Test] Add unit tests for entrypoints/openai/streaming_asr.py

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_streaming_asr.py
+++ b/test/registered/unit/entrypoints/openai/test_streaming_asr.py
@@ -1,0 +1,269 @@
+"""Unit tests for entrypoints/openai/streaming_asr.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cpu_ci(est_time=6, suite="base-b-test-cpu")
+
+import io
+import unittest
+import wave
+
+import soundfile as sf
+
+from sglang.srt.entrypoints.openai.streaming_asr import (
+    StreamingASRState,
+    _is_cjk,
+    needs_space,
+    normalize_whitespace,
+    split_audio_chunks,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_wav_bytes(duration_sec=1.0, sample_rate=16000):
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(b"\x00\x00" * int(duration_sec * sample_rate))
+    return buf.getvalue()
+
+
+class TestStreamingASRState(CustomTestCase):
+    def _state(self, unfixed_chunk_num=2, unfixed_token_num=2):
+        return StreamingASRState(
+            chunk_size_sec=1.0,
+            unfixed_chunk_num=unfixed_chunk_num,
+            unfixed_token_num=unfixed_token_num,
+        )
+
+    def test_get_prefix_empty_before_threshold(self):
+        state = self._state(unfixed_chunk_num=3)
+        state.emitted_text = "hello"
+        self.assertEqual(state.get_prefix_text(), "")
+        state.chunk_index = 2
+        self.assertEqual(state.get_prefix_text(), "")
+
+    def test_get_prefix_returns_emitted_after_threshold(self):
+        state = self._state(unfixed_chunk_num=2)
+        state.emitted_text = "hello world"
+        state.chunk_index = 2
+        self.assertEqual(state.get_prefix_text(), "hello world")
+
+    def test_get_prefix_returns_empty_when_no_emitted(self):
+        state = self._state(unfixed_chunk_num=2)
+        state.chunk_index = 5
+        state.emitted_text = ""
+        self.assertEqual(state.get_prefix_text(), "")
+
+    def test_record_emit_first_delta(self):
+        state = self._state()
+        result = state._record_emit("hello")
+        self.assertEqual(result, "hello")
+        self.assertEqual(state.emitted_text, "hello")
+
+    def test_record_emit_appends_with_space(self):
+        state = self._state()
+        state._record_emit("hello")
+        state._record_emit("world")
+        self.assertEqual(state.emitted_text, "hello world")
+
+    def test_record_emit_skips_empty(self):
+        state = self._state()
+        result = state._record_emit("")
+        self.assertEqual(result, "")
+        self.assertEqual(state.emitted_text, "")
+
+    def test_update_normal_growth(self):
+        state = self._state(unfixed_token_num=2)
+        delta = state.update("hello world from asr today")
+        self.assertEqual(state.confirmed_text, "hello world from")
+        self.assertEqual(delta, "hello world from")
+
+    def test_update_second_chunk_emits_only_new_words(self):
+        state = self._state(unfixed_token_num=2)
+        state.update("hello world from asr today")
+        delta = state.update("hello world from asr right now")
+        self.assertEqual(delta, "asr")
+
+    def test_update_short_transcript_confirmed_becomes_empty(self):
+        state = self._state(unfixed_token_num=3)
+        state.update("hello world")
+        self.assertEqual(state.confirmed_text, "")
+
+    def test_update_model_revises_earlier_text(self):
+        state = self._state(unfixed_token_num=2)
+        state.update("hello world foo bar baz")
+        delta = state.update("hello earth foo bar baz")
+        self.assertEqual(state.confirmed_text, "hello earth foo")
+        self.assertNotIn("world", delta)
+
+    def test_update_increments_chunk_index(self):
+        state = self._state(unfixed_token_num=2)
+        self.assertEqual(state.chunk_index, 0)
+        state.update("one two three four")
+        self.assertEqual(state.chunk_index, 1)
+        state.update("one two three five")
+        self.assertEqual(state.chunk_index, 2)
+
+    def test_finalize_exact_match(self):
+        state = self._state(unfixed_token_num=2)
+        state.update("hello world from asr now")
+        state.full_transcript = "hello world from asr now"
+        delta = state.finalize()
+        self.assertEqual(delta, "asr now")
+
+    def test_finalize_with_revision(self):
+        state = self._state(unfixed_token_num=2)
+        state.update("hello world from asr now")
+        state.full_transcript = "hello earth from asr now"
+        delta = state.finalize()
+        self.assertNotIn("world", delta)
+
+    def test_finalize_no_common_prefix(self):
+        state = self._state(unfixed_token_num=2)
+        state.update("hello world foo bar")
+        state.full_transcript = "completely different text here now"
+        delta = state.finalize()
+        self.assertEqual(delta, "completely different text here now")
+
+
+class TestSplitAudioChunks(CustomTestCase):
+    def test_empty_audio_raises(self):
+        with self.assertRaises(ValueError):
+            split_audio_chunks(b"", 1.0)
+
+    def test_nonpositive_chunk_size_raises(self):
+        wav = _make_wav_bytes(duration_sec=1.0)
+        with self.assertRaises(ValueError):
+            split_audio_chunks(wav, 0)
+        with self.assertRaises(ValueError):
+            split_audio_chunks(wav, -1)
+
+    def test_single_chunk_when_chunk_size_equals_duration(self):
+        wav = _make_wav_bytes(duration_sec=1.0, sample_rate=8000)
+        chunks = split_audio_chunks(wav, 1.0)
+        self.assertEqual(len(chunks), 1)
+        self.assertIsInstance(chunks[0], bytes)
+
+    def test_multiple_chunks_when_duration_exceeds_chunk_size(self):
+        wav = _make_wav_bytes(duration_sec=1.0, sample_rate=8000)
+        chunks = split_audio_chunks(wav, 0.3)
+        self.assertEqual(len(chunks), 4)
+
+    def test_chunks_are_growing(self):
+        wav = _make_wav_bytes(duration_sec=1.0, sample_rate=8000)
+        chunks = split_audio_chunks(wav, 0.4)
+        self.assertEqual(len(chunks), 3)
+        prev_size = 0
+        for c in chunks:
+            self.assertGreater(len(c), prev_size)
+            prev_size = len(c)
+
+    def test_chunks_are_valid_wav(self):
+        wav = _make_wav_bytes(duration_sec=1.0, sample_rate=8000)
+        chunks = split_audio_chunks(wav, 0.4)
+        for c in chunks:
+            data, _sr = sf.read(io.BytesIO(c), dtype="float32")
+            self.assertGreater(len(data), 0)
+
+    def test_invalid_audio_raises(self):
+        with self.assertRaises(ValueError):
+            split_audio_chunks(b"not audio data", 1.0)
+
+
+class TestNormalizeWhitespace(CustomTestCase):
+    def test_no_punctuation_no_change(self):
+        self.assertEqual(normalize_whitespace("hello world"), "hello world")
+
+    def test_removes_space_before_comma(self):
+        self.assertEqual(normalize_whitespace("hello , world"), "hello, world")
+
+    def test_removes_space_before_period(self):
+        self.assertEqual(normalize_whitespace("end ."), "end.")
+
+    def test_removes_space_before_question_mark(self):
+        self.assertEqual(normalize_whitespace("what ?"), "what?")
+
+    def test_removes_space_before_cjk_punctuation(self):
+        self.assertEqual(normalize_whitespace("你好 ， 世界"), "你好， 世界")
+        self.assertEqual(normalize_whitespace("真的 ？"), "真的？")
+
+    def test_multiple_punctuation_in_one_string(self):
+        self.assertEqual(
+            normalize_whitespace("x , y . z !"),
+            "x, y. z!",
+        )
+
+
+class TestIsCJK(CustomTestCase):
+    def test_cjk_ideograph(self):
+        self.assertTrue(_is_cjk("世"))
+
+    def test_hiragana(self):
+        self.assertTrue(_is_cjk("あ"))
+
+    def test_katakana(self):
+        self.assertTrue(_is_cjk("ア"))
+
+    def test_cjk_punctuation(self):
+        self.assertTrue(_is_cjk("、"))
+        self.assertTrue(_is_cjk("。"))
+
+    def test_fullwidth_ascii(self):
+        self.assertTrue(_is_cjk("Ａ"))
+
+    def test_latin_letters_are_not_cjk(self):
+        self.assertFalse(_is_cjk("a"))
+        self.assertFalse(_is_cjk("Z"))
+
+    def test_ascii_digit_is_not_cjk(self):
+        self.assertFalse(_is_cjk("5"))
+
+    def test_ascii_space_is_not_cjk(self):
+        self.assertFalse(_is_cjk(" "))
+
+    def test_korean_hangul_is_not_cjk(self):
+        self.assertFalse(_is_cjk("가"))
+
+    def test_devanagari_is_not_cjk(self):
+        self.assertFalse(_is_cjk("अ"))
+
+
+class TestNeedsSpace(CustomTestCase):
+    def test_empty_strings_return_false(self):
+        self.assertFalse(needs_space("", ""))
+        self.assertFalse(needs_space("hello", ""))
+        self.assertFalse(needs_space("", "world"))
+
+    def test_already_has_space_returns_false(self):
+        self.assertFalse(needs_space("hello ", "world"))
+        self.assertFalse(needs_space("hello", " world"))
+
+    def test_all_no_space_before_chars(self):
+        from sglang.srt.entrypoints.openai.streaming_asr import _NO_SPACE_BEFORE
+        for ch in _NO_SPACE_BEFORE:
+            self.assertFalse(needs_space("hello", ch), f"char={ch!r}")
+
+    def test_all_no_space_after_chars(self):
+        from sglang.srt.entrypoints.openai.streaming_asr import _NO_SPACE_AFTER
+        for ch in _NO_SPACE_AFTER:
+            self.assertFalse(needs_space(ch, "world"), f"char={ch!r}")
+
+    def test_adjacent_cjk_no_space(self):
+        self.assertFalse(needs_space("你好", "世界"))
+
+    def test_cjk_to_latin_needs_space(self):
+        self.assertTrue(needs_space("你好", "hello"))
+
+    def test_latin_to_cjk_needs_space(self):
+        self.assertTrue(needs_space("hello", "世界"))
+
+    def test_normal_words_need_space(self):
+        self.assertTrue(needs_space("hello", "world"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
45 test cases covering StreamingASRState, split_audio_chunks, normalize_whitespace, _is_cjk, and needs_space.

No server, no GPU, no model loading.
Ref: #20865


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Added a new test file: `test/registered/unit/entrypoints/openai/test_streaming_asr.py`

`entrypoints/openai/streaming_asr.py` currently has no dedicated unit tests. It contains the `StreamingASRState` state machine for chunk-based streaming ASR with prefix rollback, plus several pure-logic helpers for audio chunk splitting, CJK character classification, whitespace normalization, and inter-delta boundary spacing. These paths can regress silently. This PR adds CPU-only coverage for the current behavior.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
**Coverage (5 components, 45 tests):**

- **`StreamingASRState`** (14 tests) — `get_prefix_text` threshold logic (empty before `unfixed_chunk_num`, returns `emitted_text` after), `_record_emit` accumulation (first delta, space-append, empty skip), `update` chunk-by-chunk growth with `unfixed_token_num` trailing-word trimming, second-chunk delta isolation, model revision via word-level common prefix, and `finalize` exact-match / revision / full-replacement edge cases.
- **`split_audio_chunks`** (7 tests) — real WAV byte generation via stdlib `wave`, empty/non-positive validation, single-chunk exact match, multiple chunks with growing sizes, roundtrip through `soundfile.read` to verify valid WAV output, and corrupt input rejection.
- **`normalize_whitespace`** (6 tests) — ASCII punctuation, CJK punctuation, no-op pass-through, and multiple punctuation in one pass.
- **`_is_cjk`** (10 tests) — CJK ideographs, hiragana/katakana, CJK punctuation, fullwidth ASCII (positive); Latin, digits, spaces, Korean Hangul, Devanagari (negative).
- **`needs_space`** (8 tests) — empty strings, pre-existing space, `_NO_SPACE_BEFORE` and `_NO_SPACE_AFTER` full-set iterated validation, adjacent CJK, CJK↔Latin boundary, and normal word boundary.

The tests are CPU-only and do not start a server or load a model. `split_audio_chunks` uses real WAV bytes generated via `wave` + real `soundfile` read/write (no mock). They are registered via:

```python
register_cpu_ci(est_time=5, suite="base-a-test-cpu")
register_cpu_ci(est_time=6, suite="base-b-test-cpu")
```
**Test plan:**
```shell
pytest test/registered/unit/entrypoints/openai/test_streaming_asr.py -v
======================================================================== test session starts =========================================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/evanderf/sglang/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/evanderf/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, anyio-4.13.0, asyncio-1.4.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 45 items                                                                                                                                                   

test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_finalize_exact_match PASSED                                         [  2%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_finalize_no_common_prefix PASSED                                    [  4%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_finalize_with_revision PASSED                                       [  6%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_get_prefix_empty_before_threshold PASSED                            [  8%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_get_prefix_returns_emitted_after_threshold PASSED                   [ 11%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_get_prefix_returns_empty_when_no_emitted PASSED                     [ 13%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_record_emit_appends_with_space PASSED                               [ 15%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_record_emit_first_delta PASSED                                      [ 17%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_record_emit_skips_empty PASSED                                      [ 20%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_update_increments_chunk_index PASSED                                [ 22%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_update_model_revises_earlier_text PASSED                            [ 24%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_update_normal_growth PASSED                                         [ 26%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_update_second_chunk_emits_only_new_words PASSED                     [ 28%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestStreamingASRState::test_update_short_transcript_confirmed_becomes_empty PASSED              [ 31%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestSplitAudioChunks::test_chunks_are_growing PASSED                                            [ 33%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestSplitAudioChunks::test_chunks_are_valid_wav PASSED                                          [ 35%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestSplitAudioChunks::test_empty_audio_raises PASSED                                            [ 37%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestSplitAudioChunks::test_invalid_audio_raises PASSED                                          [ 40%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestSplitAudioChunks::test_multiple_chunks_when_duration_exceeds_chunk_size PASSED              [ 42%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestSplitAudioChunks::test_nonpositive_chunk_size_raises PASSED                                 [ 44%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestSplitAudioChunks::test_single_chunk_when_chunk_size_equals_duration PASSED                  [ 46%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNormalizeWhitespace::test_multiple_punctuation_in_one_string PASSED                         [ 48%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNormalizeWhitespace::test_no_punctuation_no_change PASSED                                   [ 51%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNormalizeWhitespace::test_removes_space_before_cjk_punctuation PASSED                       [ 53%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNormalizeWhitespace::test_removes_space_before_comma PASSED                                 [ 55%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNormalizeWhitespace::test_removes_space_before_period PASSED                                [ 57%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNormalizeWhitespace::test_removes_space_before_question_mark PASSED                         [ 60%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_ascii_digit_is_not_cjk PASSED                                                   [ 62%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_ascii_space_is_not_cjk PASSED                                                   [ 64%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_cjk_ideograph PASSED                                                            [ 66%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_cjk_punctuation PASSED                                                          [ 68%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_devanagari_is_not_cjk PASSED                                                    [ 71%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_fullwidth_ascii PASSED                                                          [ 73%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_hiragana PASSED                                                                 [ 75%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_katakana PASSED                                                                 [ 77%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_korean_hangul_is_not_cjk PASSED                                                 [ 80%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestIsCJK::test_latin_letters_are_not_cjk PASSED                                                [ 82%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_adjacent_cjk_no_space PASSED                                               [ 84%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_all_no_space_after_chars PASSED                                            [ 86%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_all_no_space_before_chars PASSED                                           [ 88%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_already_has_space_returns_false PASSED                                     [ 91%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_cjk_to_latin_needs_space PASSED                                            [ 93%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_empty_strings_return_false PASSED                                          [ 95%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_latin_to_cjk_needs_space PASSED                                            [ 97%]
test/registered/unit/entrypoints/openai/test_streaming_asr.py::TestNeedsSpace::test_normal_words_need_space PASSED                                             [100%]

========================================================================== warnings summary ==========================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/evanderf/sglang/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 45 passed, 16 warnings in 5.74s ===================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
<!-- Detail the changes made in this pull request. -->
```
## Accuracy Tests
N/A — this is a test-only change. No kernel or model-forward code is touched.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
N/A — this PR only adds unit tests and does not affect the inference path.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27393965531](https://github.com/sgl-project/sglang/actions/runs/27393965531)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27393965448](https://github.com/sgl-project/sglang/actions/runs/27393965448)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->