### PR TITLE
fix(gateway): make sgl-model-gateway a cargo workspace so maturin 1.14 accepts the parent README

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["bindings/python"]
+exclude = ["bindings/golang", "examples"]
+
 [package]
 name = "sgl-model-gateway"
 version = "0.3.2"

--- a/sgl-model-gateway/bindings/python/Cargo.toml
+++ b/sgl-model-gateway/bindings/python/Cargo.toml
@@ -19,10 +19,3 @@ default-features = true
 [features]
 default = ["pyo3/extension-module"]
 vendored-openssl = ["sgl-model-gateway/vendored-openssl"]
-
-[profile.ci]
-inherits = "release"
-opt-level = 2       # Lighter optimization (still fast runtime, much faster compile)
-lto = "thin"        # Thin LTO - good balance
-codegen-units = 16  # More parallelization for faster builds
-strip = true

--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
+
+use once_cell::sync::OnceCell;
 use pyo3::prelude::*;
 use smg::*;
-use once_cell::sync::OnceCell;
-use std::collections::HashMap;
 
 // Define the enums with PyO3 bindings
 #[pyclass(eq)]
@@ -69,7 +70,12 @@ impl PyApiKeyEntry {
     #[new]
     #[pyo3(signature = (id, name, key, role = PyRole::User))]
     fn new(id: String, name: String, key: String, role: PyRole) -> Self {
-        PyApiKeyEntry { id, name, key, role }
+        PyApiKeyEntry {
+            id,
+            name,
+            key,
+            role,
+        }
     }
 }
 
@@ -166,11 +172,7 @@ impl PyControlPlaneAuthConfig {
         api_keys = vec![],
         audit_enabled = true,
     ))]
-    fn new(
-        jwt: Option<PyJwtConfig>,
-        api_keys: Vec<PyApiKeyEntry>,
-        audit_enabled: bool,
-    ) -> Self {
+    fn new(jwt: Option<PyJwtConfig>, api_keys: Vec<PyApiKeyEntry>, audit_enabled: bool) -> Self {
         PyControlPlaneAuthConfig {
             jwt,
             api_keys,
@@ -183,7 +185,11 @@ impl PyControlPlaneAuthConfig {
     pub fn to_auth_control_plane_config(&self) -> auth::ControlPlaneAuthConfig {
         auth::ControlPlaneAuthConfig {
             jwt: self.jwt.as_ref().map(|j| j.to_auth_jwt_config()),
-            api_keys: self.api_keys.iter().map(|k| k.to_auth_api_key_entry()).collect(),
+            api_keys: self
+                .api_keys
+                .iter()
+                .map(|k| k.to_auth_api_key_entry())
+                .collect(),
             audit_enabled: self.audit_enabled,
         }
     }
@@ -576,9 +582,7 @@ impl Router {
         };
 
         let redis_config = if matches!(self.history_backend, HistoryBackendType::Redis) {
-            self.redis_config
-                .as_ref()
-                .map(|cfg| cfg.to_config_redis())
+            self.redis_config.as_ref().map(|cfg| cfg.to_config_redis())
         } else {
             None
         };


### PR DESCRIPTION
## Motivation

The dev docker image build [recently started failing](https://github.com/sgl-project/sglang/actions/runs/27393198276) on **both** `build-x86` and `build-arm64`:

```
💥 maturin failed
  Caused by: `project.readme` path `../../README.md` resolves outside
             allowed metadata root `/build/sgl-model-gateway/bindings/python`
```

**Root cause:** maturin **1.14.0** added [PyO3/maturin#3182 "Support parent-relative pyproject metadata in sdists"](https://github.com/PyO3/maturin/pull/3182), which bounds a parent-relative `project.readme` to the **cargo workspace root** (see [`project_layout.rs`](https://github.com/PyO3/maturin/blob/main/src/project_layout.rs): `allowed_metadata_root = if pyproject_dir.starts_with(workspace_root) { workspace_root } else { pyproject_dir }`). The Dockerfiles install maturin unpinned, so they picked up 1.14.0.

`sgl-model-gateway` has no `[workspace]` — the root crate and `bindings/python` are independent packages — so `cargo metadata` reports each crate's own directory as its workspace root. `bindings/python/pyproject.toml` then has `readme = "../../README.md"`, which resolves to `sgl-model-gateway/README.md`, outside `bindings/python/`, and maturin rejects it.

Because that `pyproject.toml` is shared by every maturin build path, this is not limited to the dev image — it also affects `docker/gateway.Dockerfile`, `docker/rocm.Dockerfile`, `.github/workflows/pr-test-rust.yml`, the PyPI release, and `sgl-model-gateway/Makefile`.

## Modification

Declare `sgl-model-gateway` as the **cargo workspace root** with `bindings/python` as a member (the golang bindings and wasm examples stay standalone via `exclude`):

```toml
[workspace]
members = ["bindings/python"]
exclude = ["bindings/golang", "examples"]
```

Now `cargo metadata` from `bindings/python` reports `sgl-model-gateway/` as the workspace root, which contains `README.md`, so the existing `readme = "../../README.md"` resolves inside the allowed metadata root. This is exactly the layout maturin #3182 is designed for.

- **No change to which README ships on PyPI** — the `readme` field is untouched, still the repo-root gateway README.
- **Version-agnostic** — fixes every maturin build path in one place rather than pinning maturin in 6+ scripts.
- Build profiles (`release`/`ci`/`dev`) already exist at the workspace root, so the now-redundant `[profile.ci]` in `bindings/python/Cargo.toml` (byte-identical to the root one) is dropped — cargo ignores profile tables in workspace members anyway.

### Why the `lib.rs` formatting changes?

`bindings/python` was previously its own standalone crate, so the `rustfmt sgl-model-gateway` pre-commit hook (`cd sgl-model-gateway && cargo +nightly fmt -- --check`) never reached `bindings/python/src/lib.rs`. Making it a workspace member brings it under the gateway's [`rustfmt.toml`](https://github.com/sgl-project/sglang/blob/main/sgl-model-gateway/rustfmt.toml) (`group_imports = "StdExternalCrate"`, `imports_granularity = "Crate"`) for the first time, which is what the Lint job flagged. The `lib.rs` change is purely that one-time `cargo +nightly fmt` normalization (import grouping + chain/struct wrapping) — **no logic change**.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] `[profile.ci]` (used by `pr-test-rust.yml --profile ci`) is preserved at the workspace root, identical to the dropped member copy.



## Testing: https://github.com/sgl-project/sglang/actions/runs/27394688617/job/80959410404



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27395362207](https://github.com/sgl-project/sglang/actions/runs/27395362207)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27395362141](https://github.com/sgl-project/sglang/actions/runs/27395362141)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->