### PR TITLE
[Mamba] Fix spec-v2 + extra_buffer crash (guard None mamba_next_track_idx)

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1573,9 +1573,15 @@ def set_mamba_track_indices_from_reqs(batch):
     all_buffers = req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
         batch.req_pool_indices
     ]  # (bs, ping_pong_size), int64, on device
+    # Guard: mamba_next_track_idx may be None for requests that haven't
+    # gone through _alloc_ping_pong_buffer yet (e.g., spec v2 verify path).
+    # Default to 0 (first ping-pong slot) to avoid TypeError.
     idx = (
         torch.tensor(
-            [req.mamba_next_track_idx for req in batch.reqs],
+            [
+                req.mamba_next_track_idx if req.mamba_next_track_idx is not None else 0
+                for req in batch.reqs
+            ],
             dtype=torch.int64,
             pin_memory=True,
         )


### PR DESCRIPTION
set_mamba_track_indices_from_reqs assumes every req has a valid
mamba_next_track_idx, but on the Spec-v2 verify path some reqs never went
through _alloc_ping_pong_buffer, so it is None -> TypeError on the first
cache-eligible request (extra_buffer + spec decoding). Guard None -> 0.

Fixes #27325 (also hit in production on Qwen3.5; same one-line fix as #27324).
Last piece gating NemotronH MTP + radix cache upstream — the enabling refactors
(#27418 auto-resolver, #15829 extra_buffer + conv_states_shape) already merged.
Fix https://github.com/sgl-project/sglang/issues/31249
Validated on GB10 (NemotronH-NVFP4, MTP): cached spec requests no longer crash,
~95% prefix reuse.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28556695824](https://github.com/sgl-project/sglang/actions/runs/28556695824)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28556695626](https://github.com/sgl-project/sglang/actions/runs/28556695626)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->