### PR TITLE
refactor weight processing in RL weight update 

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -61,9 +61,11 @@ from sglang.srt.managers.data_parallel_controller import (
 )
 from sglang.srt.managers.detokenizer_manager import run_detokenizer_process
 from sglang.srt.managers.io_struct import (
+    BeginWeightUpdateReqInput,
     CloseSessionReqInput,
     DestroyWeightsUpdateGroupReqInput,
     EmbeddingReqInput,
+    EndWeightUpdateReqInput,
     GenerateReqInput,
     GetWeightsByNameReqInput,
     InitWeightsUpdateGroupReqInput,
@@ -72,7 +74,6 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqInput,
     MultimodalDataInputFormat,
     OpenSessionReqInput,
-    PostProcessWeightsReqInput,
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
     RpcReqInput,
@@ -1112,31 +1113,20 @@ class Engine(EngineScoreMixin, EngineBase):
             self.tokenizer_manager.update_weights_from_ipc(obj, None)
         )
 
-    def post_process_weights(
-        self,
-        restore_weights_before_load: bool = False,
-        post_process_quantization: bool = False,
-        post_load_weights: bool = False,
-    ):
+    def begin_weight_update(self):
+        """Open a weight-update session.
+        Must be called before update_weights_from_*; pair with end_weight_update.
         """
-        Optional post-processing for updated weights (e.g., Marlin conversion).
-        Should be called after weight update is finished.
-
-        Args:
-            restore_weights_before_load: Restore weights to pre-quantization state.
-            post_process_quantization: Re-apply quantization post-processing.
-            post_load_weights: Call model.post_load_weights() for models that
-                need post-load decomposition (e.g., DeepSeek MLA kv_b_proj
-                decomposition into w_kc/w_vc tensors after RDMA weight transfer).
-        """
-        obj = PostProcessWeightsReqInput(
-            restore_weights_before_load=restore_weights_before_load,
-            post_process_quantization=post_process_quantization,
-            post_load_weights=post_load_weights,
+        obj = BeginWeightUpdateReqInput()
+        return self.loop.run_until_complete(
+            self.tokenizer_manager.begin_weight_update(obj, None)
         )
 
+    def end_weight_update(self):
+        """Close the weight-update session."""
+        obj = EndWeightUpdateReqInput()
         return self.loop.run_until_complete(
-            self.tokenizer_manager.post_process_weights(obj, None)
+            self.tokenizer_manager.end_weight_update(obj, None)
         )
 
     def get_weights_by_name(self, name: str, truncate_size: int = 100):

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -111,6 +111,7 @@ from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.managers.io_struct import (
     AbortReq,
     AttachHiCacheStorageReqInput,
+    BeginWeightUpdateReqInput,
     CheckWeightsReqInput,
     CloseSessionReqInput,
     ConfigureLoggingReq,
@@ -118,6 +119,7 @@ from sglang.srt.managers.io_struct import (
     DestroyWeightsUpdateGroupReqInput,
     DumperControlReqInput,
     EmbeddingReqInput,
+    EndWeightUpdateReqInput,
     GenerateReqInput,
     GetWeightsByNameReqInput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
@@ -128,7 +130,6 @@ from sglang.srt.managers.io_struct import (
     OpenSessionReqInput,
     ParseFunctionCallReq,
     PauseGenerationReqInput,
-    PostProcessWeightsReqInput,
     ProfileReqInput,
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
@@ -1277,13 +1278,23 @@ async def update_weights_from_ipc(obj: UpdateWeightsFromIPCReqInput, request: Re
         return ORJSONResponse(content, status_code=HTTPStatus.BAD_REQUEST)
 
 
-@app.post("/post_process_weights")
-async def post_process_weights(req: PostProcessWeightsReqInput, request: Request):
-    """
-    Optional post-processing for updated weights (e.g., Marlin conversion).
-    This should be called selectively after `update_weights_from_distributed/update_weights_from_tensor`.
-    """
-    success, message = await _global_state.tokenizer_manager.post_process_weights(
+@app.post("/begin_weight_update")
+async def begin_weight_update(req: BeginWeightUpdateReqInput, request: Request):
+    """Open a weight-update session on all rollout engines (restore packed weights)."""
+    success, message = await _global_state.tokenizer_manager.begin_weight_update(
+        req, request
+    )
+
+    content = {"success": success, "message": message}
+    return ORJSONResponse(
+        content, status_code=200 if success else HTTPStatus.BAD_REQUEST
+    )
+
+
+@app.post("/end_weight_update")
+async def end_weight_update(req: EndWeightUpdateReqInput, request: Request):
+    """End the weight update session: optionally post_load_weights, then quant finalize."""
+    success, message = await _global_state.tokenizer_manager.end_weight_update(
         req, request
     )
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1580,18 +1580,23 @@ class InitWeightsSendGroupForRemoteInstanceReqOutput(BaseReq):
 
 
 @dataclass
-class PostProcessWeightsReqInput(BaseReq):
-    # Whether to restore weights before loading new weights
-    restore_weights_before_load: bool = False
-    # Whether to enable quantization post-processing
-    post_process_quantization: bool = False
-    # Whether to call model.post_load_weights() after weight update
-    # (e.g., DeepSeek MLA kv_b_proj decomposition into w_kc/w_vc tensors)
-    post_load_weights: bool = False
+class BeginWeightUpdateReqInput(BaseReq):
+    pass
 
 
 @dataclass
-class PostProcessWeightsReqOutput(BaseReq):
+class BeginWeightUpdateReqOutput(BaseReq):
+    success: bool
+    message: str
+
+
+@dataclass
+class EndWeightUpdateReqInput(BaseReq):
+    pass
+
+
+@dataclass
+class EndWeightUpdateReqOutput(BaseReq):
     success: bool
     message: str
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1714,6 +1714,7 @@ class ResumeMemoryOccupationReqOutput(BaseReq):
 @dataclass
 class CheckWeightsReqInput(BaseReq):
     action: str = "checksum"
+    allow_quant_error: bool = False
 
 
 @dataclass

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1583,7 +1583,10 @@ class InitWeightsSendGroupForRemoteInstanceReqOutput(BaseReq):
 
 @dataclass
 class BeginWeightUpdateReqInput(BaseReq):
-    pass
+    # Which model runners this update session covers: "target" (main model only),
+    # "draft" (draft worker(s) only), or "all" (default). The selector is fixed for
+    # the whole begin -> update -> end session; end finalizes the same set.
+    selector: Literal["target", "draft", "all"] = "all"
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -92,6 +92,7 @@ from sglang.srt.managers.io_struct import (
     AttachHiCacheStorageReqOutput,
     BatchTokenizedEmbeddingReqInput,
     BatchTokenizedGenerateReqInput,
+    BeginWeightUpdateReqInput,
     CheckWeightsReqInput,
     ClearHiCacheReqInput,
     ClearHiCacheReqOutput,
@@ -103,6 +104,7 @@ from sglang.srt.managers.io_struct import (
     DetachHiCacheStorageReqOutput,
     DumperControlReqInput,
     DumperControlReqOutput,
+    EndWeightUpdateReqInput,
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
@@ -126,7 +128,6 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqOutput,
     OpenSessionReqInput,
     PauseGenerationReqInput,
-    PostProcessWeightsReqInput,
     ProfileReq,
     ReleaseMemoryOccupationReqInput,
     RemoveExternalCorpusReqInput,
@@ -1339,8 +1340,12 @@ class Scheduler(
                     self.weight_updater.check_weights,
                 ),
                 (
-                    PostProcessWeightsReqInput,
-                    self.weight_updater.post_process_weights,
+                    BeginWeightUpdateReqInput,
+                    self.weight_updater.begin_weight_update,
+                ),
+                (
+                    EndWeightUpdateReqInput,
+                    self.weight_updater.end_weight_update,
                 ),
                 (SlowDownReqInput, self.slow_down),
                 (

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -103,6 +103,9 @@ class SchedulerWeightUpdaterManager:
     stashed_model_static_state: Any = None
     _weight_update_in_progress: bool = False
     _weight_update_loaded: bool = False
+    # Runner selector for the open session, recorded at begin_weight_update and
+    # reused by end_weight_update so the same set is restored and finalized.
+    _weight_update_selector: str = "all"
 
     @contextmanager
     def _observe_weight_load(self, source: str) -> Iterator[None]:
@@ -152,16 +155,27 @@ class SchedulerWeightUpdaterManager:
         success, message = self.tp_worker.destroy_weights_update_group(recv_req)
         return DestroyWeightsUpdateGroupReqOutput(success, message)
 
-    def get_model_runners(self, selector: str = "all") -> List[Tuple[str, Any]]:
-        """Resolve a {target, draft} selector to (role, ModelRunner) pairs, target
-        first. role is "" for the target runner; draft roles come from the draft
-        worker's iter_draft_runners()."""
+    def iter_weight_update_workers(self, selector: str = "all") -> List[Tuple[str, Any]]:
+        """Resolve a {target, draft, all} selector to (role, worker) pairs, target
+        first: the target worker and, when present, the draft worker. This is the
+        worker-level inclusion decision; each worker then contributes its own runners
+        via iter_runners()."""
         parsed = _parse_runner_selector(selector)
-        runners: List[Tuple[str, Any]] = []
+        workers: List[Tuple[str, Any]] = []
         if "target" in parsed:
-            runners.append(("", self.tp_worker.model_runner))
+            workers.append(("target", self.tp_worker))
         if "draft" in parsed and self.draft_worker is not None:
-            runners += self.draft_worker.iter_draft_runners()
+            workers.append(("draft", self.draft_worker))
+        return workers
+
+    def get_model_runners(self, selector: str = "all") -> List[Tuple[str, Any]]:
+        """Resolve a {target, draft, all} selector to (role, ModelRunner) pairs, target
+        first. Derived from iter_weight_update_workers: each selected worker yields its
+        own runners via iter_runners() — role "" for the target runner, draft roles
+        from the draft worker."""
+        runners: List[Tuple[str, Any]] = []
+        for _, worker in self.iter_weight_update_workers(selector):
+            runners += worker.iter_runners()
         return runners
 
     def update_weights_from_distributed(
@@ -245,26 +259,35 @@ class SchedulerWeightUpdaterManager:
         return GetWeightsByNameReqOutput(parameter)
 
     def begin_weight_update(self, recv_req: BeginWeightUpdateReqInput):
-        """Begin a weight-update session: restore in-place-packed weights to a loadable state."""
-        success, message = self.tp_worker.begin_weight_update()
+        """Begin a weight-update session: restore in-place-packed weights to a
+        loadable state on the selected runners (target and/or draft), so the draft
+        model is prepared identically to the target. The selector is recorded and
+        reused by end_weight_update so the same set is finalized."""
+        assert (
+            not self._weight_update_in_progress
+        ), "begin_weight_update called while a weight-update session is already open"
+        self._weight_update_selector = recv_req.selector
+        for _, runner in self.get_model_runners(recv_req.selector):
+            runner.begin_weight_update()
         self._weight_update_in_progress = True
         self._weight_update_loaded = False
         torch.distributed.barrier(group=self.tp_cpu_group)
-        return BeginWeightUpdateReqOutput(success, message)
+        return BeginWeightUpdateReqOutput(True, "Success")
 
     def end_weight_update(self, recv_req: EndWeightUpdateReqInput):
-        """End the weight-update session: quant finalize on the full model, plus
-        model.post_load_weights only when load_weights was bypassed this session (e.g. P2P/RDMA).
+        """End the weight-update session on the runners begin_weight_update opened
+        (its recorded selector): quant finalize on each, plus model.post_load_weights
+        only when load_weights was bypassed this session (e.g. P2P/RDMA).
         """
         assert (
             self._weight_update_in_progress
         ), "end_weight_update called without begin_weight_update"
-        success, message = self.tp_worker.end_weight_update(
-            run_post_load=not self._weight_update_loaded
-        )
+        run_post_load = not self._weight_update_loaded
+        for _, runner in self.get_model_runners(self._weight_update_selector):
+            runner.end_weight_update(run_post_load=run_post_load)
         self._weight_update_in_progress = False
         torch.distributed.barrier(group=self.tp_cpu_group)
-        return EndWeightUpdateReqOutput(success, message)
+        return EndWeightUpdateReqOutput(True, "Success")
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
         assert (

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -18,16 +18,18 @@ from sglang.srt.constants import (
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import (
+    BeginWeightUpdateReqInput,
+    BeginWeightUpdateReqOutput,
     CheckWeightsReqInput,
     CheckWeightsReqOutput,
     DestroyWeightsUpdateGroupReqInput,
     DestroyWeightsUpdateGroupReqOutput,
+    EndWeightUpdateReqInput,
+    EndWeightUpdateReqOutput,
     GetWeightsByNameReqInput,
     GetWeightsByNameReqOutput,
     InitWeightsUpdateGroupReqInput,
     InitWeightsUpdateGroupReqOutput,
-    PostProcessWeightsReqInput,
-    PostProcessWeightsReqOutput,
     ReleaseMemoryOccupationReqInput,
     ReleaseMemoryOccupationReqOutput,
     ResumeMemoryOccupationReqInput,
@@ -86,6 +88,8 @@ class SchedulerWeightUpdaterManager:
     metrics_collector: Optional[Any] = None
     offload_tags: set = field(default_factory=set)
     stashed_model_static_state: Any = None
+    _weight_update_in_progress: bool = False
+    _weight_update_loaded: bool = False
 
     @contextmanager
     def _observe_weight_load(self, source: str) -> Iterator[None]:
@@ -140,6 +144,9 @@ class SchedulerWeightUpdaterManager:
         recv_req: UpdateWeightsFromDistributedReqInput,
     ) -> Tuple[bool, str]:
         """Update the online model parameter."""
+        assert (
+            self._weight_update_in_progress
+        ), "update_weights_from_distributed requires an open begin_weight_update session"
         with self._observe_weight_load("distributed"):
             if recv_req.disable_draft_model:
                 worker = self.tp_worker
@@ -147,6 +154,7 @@ class SchedulerWeightUpdaterManager:
                 worker = self.draft_worker or self.tp_worker
             success, message = worker.update_weights_from_distributed(recv_req)
             if success:
+                self._weight_update_loaded = True
                 self.flush_cache_after_weight_update(recv_req)
             else:
                 logger.error(message)
@@ -154,6 +162,9 @@ class SchedulerWeightUpdaterManager:
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
         """Update the online model parameter from tensors."""
+        assert (
+            self._weight_update_in_progress
+        ), "update_weights_from_tensor requires an open begin_weight_update session"
         with self._observe_weight_load("tensor"):
             if recv_req.disable_draft_model:
                 worker = self.tp_worker
@@ -161,6 +172,7 @@ class SchedulerWeightUpdaterManager:
                 worker = self.draft_worker or self.tp_worker
             success, message = worker.update_weights_from_tensor(recv_req)
             if success:
+                self._weight_update_loaded = True
                 self.flush_cache_after_weight_update(recv_req)
             else:
                 logger.error(message)
@@ -185,10 +197,27 @@ class SchedulerWeightUpdaterManager:
         parameter = self.tp_worker.get_weights_by_name(recv_req)
         return GetWeightsByNameReqOutput(parameter)
 
-    def post_process_weights(self, recv_req: PostProcessWeightsReqInput):
-        """Optional post-processing for updated weights (e.g., Marlin conversion)."""
-        success, message = self.tp_worker.post_process_weights(recv_req)
-        return PostProcessWeightsReqOutput(success, message)
+    def begin_weight_update(self, recv_req: BeginWeightUpdateReqInput):
+        """Begin a weight-update session: restore in-place-packed weights to a loadable state."""
+        success, message = self.tp_worker.begin_weight_update()
+        self._weight_update_in_progress = True
+        self._weight_update_loaded = False
+        torch.distributed.barrier(group=self.tp_cpu_group)
+        return BeginWeightUpdateReqOutput(success, message)
+
+    def end_weight_update(self, recv_req: EndWeightUpdateReqInput):
+        """End the weight-update session: quant finalize on the full model, plus
+        model.post_load_weights only when load_weights was bypassed this session (e.g. P2P/RDMA).
+        """
+        assert (
+            self._weight_update_in_progress
+        ), "end_weight_update called without begin_weight_update"
+        success, message = self.tp_worker.end_weight_update(
+            run_post_load=not self._weight_update_loaded
+        )
+        self._weight_update_in_progress = False
+        torch.distributed.barrier(group=self.tp_cpu_group)
+        return EndWeightUpdateReqOutput(success, message)
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
         assert (

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -155,7 +155,9 @@ class SchedulerWeightUpdaterManager:
         success, message = self.tp_worker.destroy_weights_update_group(recv_req)
         return DestroyWeightsUpdateGroupReqOutput(success, message)
 
-    def iter_weight_update_workers(self, selector: str = "all") -> List[Tuple[str, Any]]:
+    def iter_weight_update_workers(
+        self, selector: str = "all"
+    ) -> List[Tuple[str, Any]]:
         """Resolve a {target, draft, all} selector to (role, worker) pairs, target
         first: the target worker and, when present, the draft worker. This is the
         worker-level inclusion decision; each worker then contributes its own runners
@@ -366,12 +368,17 @@ class SchedulerWeightUpdaterManager:
 
     def check_weights(self, recv_req: CheckWeightsReqInput):
         try:
-            payload = self.tp_worker.model_runner.check_weights(action=recv_req.action)
+            payload = self.tp_worker.model_runner.check_weights(
+                action=recv_req.action, allow_quant_error=recv_req.allow_quant_error
+            )
 
             if self.draft_worker is not None:
                 draft_runner = _get_draft_model_runner(self.draft_worker)
                 if draft_runner is not None:
-                    draft_payload = draft_runner.check_weights(action=recv_req.action)
+                    draft_payload = draft_runner.check_weights(
+                        action=recv_req.action,
+                        allow_quant_error=recv_req.allow_quant_error,
+                    )
                     if payload is not None and draft_payload is not None:
                         payload = _merge_checksum_payloads(payload, draft_payload)
 

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import time
 import uuid
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import fastapi
@@ -15,6 +16,8 @@ from sglang.srt.managers.io_struct import (
     AddExternalCorpusReqOutput,
     AttachHiCacheStorageReqInput,
     AttachHiCacheStorageReqOutput,
+    BeginWeightUpdateReqInput,
+    BeginWeightUpdateReqOutput,
     CheckWeightsReqInput,
     CheckWeightsReqOutput,
     ClearHiCacheReqInput,
@@ -26,6 +29,8 @@ from sglang.srt.managers.io_struct import (
     DetachHiCacheStorageReqOutput,
     DumperControlReqInput,
     DumperControlReqOutput,
+    EndWeightUpdateReqInput,
+    EndWeightUpdateReqOutput,
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
@@ -50,8 +55,6 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqOutput,
     LoRAUpdateOutput,
     OpenSessionReqInput,
-    PostProcessWeightsReqInput,
-    PostProcessWeightsReqOutput,
     ProfileReq,
     ProfileReqOutput,
     ProfileReqType,
@@ -100,7 +103,8 @@ _COMMUNICATOR_SPECS = [
     ("send_weights_to_remote_instance", SendWeightsToRemoteInstanceReqOutput),
     ("update_weights_from_tensor", UpdateWeightsFromTensorReqOutput),
     ("update_weights_from_ipc", UpdateWeightsFromIPCReqOutput),
-    ("post_process_weights", PostProcessWeightsReqOutput),
+    ("begin_weight_update", BeginWeightUpdateReqOutput),
+    ("end_weight_update", EndWeightUpdateReqOutput),
     ("get_weights_by_name", GetWeightsByNameReqOutput),
     ("release_memory_occupation", ReleaseMemoryOccupationReqOutput),
     ("resume_memory_occupation", ResumeMemoryOccupationReqOutput),
@@ -530,16 +534,41 @@ class TokenizerControlMixin:
 
         return success, message
 
-    async def post_process_weights(
+    async def begin_weight_update(
         self: TokenizerManager,
-        obj: PostProcessWeightsReqInput,
+        obj: BeginWeightUpdateReqInput,
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
-        """Trigger post-processing hooks for weights after loading."""
+        """Begin a new weight update session: restore packed weights to a loadable state."""
         self.auto_create_handle_loop()
-        async with self.model_update_lock.writer_lock:
-            results = await self.post_process_weights_communicator(obj)
-        return FanOutCommunicator.merge_results(results)
+
+        async with self.is_pause_cond:
+            is_paused = self.is_pause
+
+        lock_context = (
+            self.model_update_lock.writer_lock if not is_paused else nullcontext()
+        )
+        async with lock_context:
+            results = await self.begin_weight_update_communicator(obj)
+            return FanOutCommunicator.merge_results(results)
+
+    async def end_weight_update(
+        self: TokenizerManager,
+        obj: EndWeightUpdateReqInput,
+        request: Optional[fastapi.Request] = None,
+    ) -> Tuple[bool, str]:
+        """End the weight update session: optionally post_load_weights, then quant finalize."""
+        self.auto_create_handle_loop()
+
+        async with self.is_pause_cond:
+            is_paused = self.is_pause
+
+        lock_context = (
+            self.model_update_lock.writer_lock if not is_paused else nullcontext()
+        )
+        async with lock_context:
+            results = await self.end_weight_update_communicator(obj)
+            return FanOutCommunicator.merge_results(results)
 
     async def _unload_lora_adapter_locked(
         self: TokenizerManager,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -30,7 +30,6 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterFromDistributedReqInput,
     LoadLoRAAdapterFromTensorsReqInput,
     LoadLoRAAdapterReqInput,
-    PostProcessWeightsReqInput,
     SendWeightsToRemoteInstanceReqInput,
     UnloadLoRAAdapterReqInput,
     UpdateWeightFromDiskReqInput,
@@ -44,6 +43,11 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
+from sglang.srt.model_loader.loader import (
+    post_load_weights,
+    postprocess_weight,
+    restore_weight,
+)
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import MultiprocessingSerializer, broadcast_pyobj, set_random_seed
 from sglang.srt.utils.hf_transformers_utils import (
@@ -173,10 +177,18 @@ class BaseTpWorker(ABC):
         success, message = self.model_runner.update_weights_from_ipc(recv_req)
         return success, message
 
-    def post_process_weights(self, recv_req: PostProcessWeightsReqInput):
-        """Perform optional post-processing on the updated model weights (e.g., Marlin conversion)."""
-        success, message = self.model_runner.post_process_weights(recv_req)
-        return success, message
+    def begin_weight_update(self):
+        """Begin a new weight update session: restore packed weights to a loadable state."""
+        restore_weight(self.model_runner.model, torch.device(self.device))
+        return True, "Success"
+
+    def end_weight_update(self, run_post_load: bool):
+        """End the weight update session: optionally post_load_weights, then quant finalize."""
+        model = self.model_runner.model
+        if run_post_load:
+            post_load_weights(model)
+        postprocess_weight(model, torch.device(self.device))
+        return True, "Success"
 
     def get_weights_by_name(self, recv_req: GetWeightsByNameReqInput):
         parameter = self.model_runner.get_weights_by_name(

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -41,11 +41,6 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.model_loader.loader import (
-    post_load_weights,
-    postprocess_weight,
-    restore_weight,
-)
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import MultiprocessingSerializer, broadcast_pyobj, set_random_seed
 from sglang.srt.utils.hf_transformers_utils import (
@@ -151,19 +146,6 @@ class BaseTpWorker(ABC):
         """Update weights from IPC for checkpoint-engine integration."""
         success, message = self.model_runner.update_weights_from_ipc(recv_req)
         return success, message
-
-    def begin_weight_update(self):
-        """Begin a new weight update session: restore packed weights to a loadable state."""
-        restore_weight(self.model_runner.model, torch.device(self.device))
-        return True, "Success"
-
-    def end_weight_update(self, run_post_load: bool):
-        """End the weight update session: optionally post_load_weights, then quant finalize."""
-        model = self.model_runner.model
-        if run_post_load:
-            post_load_weights(model)
-        postprocess_weight(model, torch.device(self.device))
-        return True, "Success"
 
     def get_weights_by_name(self, recv_req: GetWeightsByNameReqInput):
         parameter = self.model_runner.get_weights_by_name(
@@ -415,10 +397,12 @@ class TpModelWorker(BaseTpWorker):
     def model_runner(self) -> "ModelRunner":
         return self._model_runner
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
-        # The target worker shares this class (is_draft_worker=False) and returns [].
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        # All (role, ModelRunner) pairs this worker contributes to a weight update.
+        # The target (is_draft_worker=False) yields its own runner under the empty
+        # role; a draft worker yields its draft runner(s).
         if not self.is_draft_worker:
-            return []
+            return [("", self.model_runner)]
         if self.model_runner_list:
             return [
                 (f"draft_step_{i}", r) for i, r in enumerate(self.model_runner_list)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3900,51 +3900,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
         return output
 
-    def post_process_weights(self, recv_req):
-        """
-        Execute post-processing logic for model weights, such as Marlin quantization format conversion
-        and model-specific post_load_weights hooks (e.g., DeepSeek MLA kv_b_proj decomposition).
-        """
-        from sglang.srt.model_loader.loader import device_loading_context
-
-        target_device = torch.device("cuda", torch.cuda.current_device())
-
-        if recv_req.post_load_weights:
-            # Call model.post_load_weights() if available (e.g., for DeepSeek MLA
-            # models that need to decompose kv_b_proj.weight into w_kc/w_vc tensors
-            # after RDMA weight transfer)
-            if hasattr(self.model, "post_load_weights"):
-                self.model.post_load_weights()
-
-        # LoRA wrappers forward `quant_method` for forward-path dispatch but
-        # don't own the packed params; skip them here so the inner base layer
-        # (yielded separately by `named_modules`) handles post-processing.
-        from sglang.srt.lora.layers import BaseLayerWithLoRA
-
-        if recv_req.restore_weights_before_load:
-            for _, module in self.model.named_modules():
-                if isinstance(module, BaseLayerWithLoRA):
-                    continue
-                quant_method = getattr(module, "quant_method", None)
-                if quant_method is not None and hasattr(
-                    quant_method, "restore_weights_before_loading"
-                ):
-                    with device_loading_context(module, target_device):
-                        quant_method.restore_weights_before_loading(module)
-
-        if recv_req.post_process_quantization:
-            for _, module in self.model.named_modules():
-                if isinstance(module, BaseLayerWithLoRA):
-                    continue
-                quant_method = getattr(module, "quant_method", None)
-                if quant_method is not None and hasattr(
-                    quant_method, "process_weights_after_loading"
-                ):
-                    with device_loading_context(module, target_device):
-                        quant_method.process_weights_after_loading(module)
-
-        return True, "Success"
-
 
 def _model_load_weights_direct(model, named_tensors: List[Tuple[str, torch.Tensor]]):
     params_dict = dict(model.named_parameters())

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3816,8 +3816,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
         ShardedStateLoader.save_model(self.model, path, pattern, max_size)
 
-    def check_weights(self, action: str):
-        return self._weight_checker.handle(action=action)
+    def check_weights(self, action: str, allow_quant_error: bool = False):
+        return self._weight_checker.handle(
+            action=action, allow_quant_error=allow_quant_error
+        )
 
     def update_weights_from_ipc(self, recv_req):
         """Update weights from IPC for checkpoint-engine integration."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -177,7 +177,13 @@ from sglang.srt.model_executor.piecewise_cuda_graph_runner import (
     PiecewiseCudaGraphRunner,
 )
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
+from sglang.srt.model_loader.loader import (
+    DefaultModelLoader,
+    get_model_loader,
+    post_load_weights,
+    postprocess_weight,
+    restore_weight,
+)
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
     register_memory_region,
@@ -1947,6 +1953,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def load_weights(self, weights) -> None:
         """Load an in-memory list of (name, tensor) weights into this runner's model."""
         self.model.load_weights(weights)
+
+    def begin_weight_update(self) -> None:
+        """Begin a weight-update session: restore in-place-packed weights to a
+        loadable state (no-op for schemes that don't repack)."""
+        restore_weight(self.model, torch.device(self.device))
+
+    def end_weight_update(self, run_post_load: bool) -> None:
+        """End the weight-update session: optionally run model.post_load_weights
+        (when load_weights was bypassed this session, e.g. P2P/RDMA), then finalize
+        quantized weights into kernel layout."""
+        if run_post_load:
+            post_load_weights(self.model)
+        postprocess_weight(self.model, torch.device(self.device))
 
     def receive_weights_from_distributed(
         self,

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -296,13 +296,43 @@ def _initialize_model(
     return model_class(**kwargs)
 
 
-def _post_load_weights(model: nn.Module) -> None:
+def post_load_weights(model: nn.Module) -> None:
     # Loaders that bypass `model.load_weights()` (dummy / sharded state / remote instance /
     # remote fs) must trigger the model's post-load fixup explicitly; `model.load_weights()`
     # would normally do it internally. NextN subclasses override the method to fill in
     # `is_nextn=True`, so the loader doesn't need to know.
     if hasattr(model, "post_load_weights"):
         model.post_load_weights()
+
+
+def _apply_quant_method_hook(model: nn.Module, target_device, hook_name: str) -> None:
+    """Run a quant_method hook (restore/process) on every quantized module.
+
+    LoRA wrappers forward `quant_method` for forward-path dispatch but don't own
+    the packed params; skip them so the inner base layer (yielded separately by
+    `named_modules`) handles it.
+    """
+    from sglang.srt.lora.layers import BaseLayerWithLoRA
+
+    for _, module in model.named_modules():
+        if isinstance(module, BaseLayerWithLoRA):
+            continue
+        quant_method = getattr(module, "quant_method", None)
+        if quant_method is not None and hasattr(quant_method, hook_name):
+            with device_loading_context(module, target_device):
+                getattr(quant_method, hook_name)(module)
+
+
+def restore_weight(model: nn.Module, target_device) -> None:
+    """Undo in-place quant packing so fresh weights can be loaded
+    (no-op for schemes that don't repack, e.g. plain fp8)."""
+    _apply_quant_method_hook(model, target_device, "restore_weights_before_loading")
+
+
+def postprocess_weight(model: nn.Module, target_device) -> None:
+    """Finalize quantized weights into kernel layout (Marlin repack, UE8M0 requant,
+    transpose, ...)."""
+    _apply_quant_method_hook(model, target_device, "process_weights_after_loading")
 
 
 class BaseModelLoader(ABC):
@@ -1382,7 +1412,7 @@ class DummyModelLoader(BaseModelLoader):
             # random values to the weights.
             initialize_dummy_weights(model)
 
-            _post_load_weights(model)
+            post_load_weights(model)
 
         return model.eval()
 
@@ -1525,7 +1555,7 @@ class ShardedStateLoader(BaseModelLoader):
             if state_dict:
                 raise ValueError(f"Missing keys {tuple(state_dict)} in loaded state!")
 
-            _post_load_weights(model)
+            post_load_weights(model)
 
         return model.eval()
 
@@ -2296,7 +2326,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
                 )
             current_platform.synchronize()
 
-            _post_load_weights(model)
+            post_load_weights(model)
         end_get_weights_tic = time.time()
         logger.debug(
             f"finish getting all weights from remote instance, time used: {(end_get_weights_tic - start_get_weights_tic):.4f}s"
@@ -2359,7 +2389,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             logger.error(f"batch transfer failed, error: {ret}")
             return False
 
-        _post_load_weights(model)
+        post_load_weights(model)
 
         return True
 
@@ -2449,7 +2479,7 @@ class RemoteModelLoader(BaseModelLoader):
         if state_dict:
             raise ValueError(f"Missing keys {tuple(state_dict)} in loaded state!")
 
-        _post_load_weights(model)
+        post_load_weights(model)
 
     def _load_model_from_remote_fs(
         self, model, client, model_config: ModelConfig, device_config: DeviceConfig

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -356,7 +356,7 @@ class DFlashWorker:
         # to flush here.
         pass
 
-    def iter_draft_runners(self) -> list[tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> list[tuple[str, "ModelRunner"]]:
         # Explicit so DFlash's __getattr__ doesn't delegate this to the target
         # (whose model_runner is aliased here) and miss the real draft.
         return [("draft", self.draft_model_runner)]

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -922,7 +922,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
         return [("draft", self.draft_worker.draft_runner)]
 
     def forward_batch_generation(self, batch: ScheduleBatch, on_publish=None):

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -203,7 +203,7 @@ class FrozenKVMTPWorker(TpModelWorker):
     def clear_cache_pool(self):
         pass
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
         return [("draft", self.draft_model_runner)]
 
     def _resolve_draft_backend_type(self) -> str:

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -699,7 +699,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
         return [(f"draft_step_{i}", r) for i, r in enumerate(self.draft_runner_list)]
 
     def forward_batch_generation(self, batch: ScheduleBatch, on_publish=None):

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -86,8 +86,9 @@ class NGRAMWorker:
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
 
-    def iter_draft_runners(self) -> list[tuple[str, "ModelRunner"]]:
-        # NGRAM shares the target's model_runner — no independent draft.
+    def iter_runners(self) -> list[tuple[str, "ModelRunner"]]:
+        # NGRAM shares the target's model_runner — no independent draft runner of its
+        # own (the target worker contributes its runner).
         return []
 
     def add_external_corpus(self, corpus_id: str, token_chunks: list[list[int]]) -> int:

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -7,11 +7,14 @@ import torch
 import torch.distributed as dist
 from pydantic import BaseModel, ConfigDict
 
-from sglang.srt.layers.quantization.fp8_utils import (
-    block_quant_dequant,
-    inverse_transform_scale_ue8m0,
-)
 from sglang.srt.managers.mm_utils import tensor_hash
+from sglang.srt.utils.weight_checker_comparator import (
+    _CHUNK_NUMEL,
+    ComparableWeight,
+    RawComparable,
+    _compare_weights,
+    select_comparable_weight,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,14 +57,16 @@ class WeightChecker:
         self._model_runner = model_runner
         self._snapshot_tensors = None
 
-    def handle(self, action: str) -> Optional[Dict]:
-        logger.info(f"[WeightChecker] handle action={action}")
+    def handle(self, action: str, allow_quant_error: bool = False) -> Optional[Dict]:
+        logger.info(
+            f"[WeightChecker] handle action={action} allow_quant_error={allow_quant_error}"
+        )
         if action == "snapshot":
             return self._snapshot()
         elif action == "reset_tensors":
             return self._reset_tensors()
         elif action == "compare":
-            return self._compare()
+            return self._compare(allow_quant_error=allow_quant_error)
         elif action == "checksum":
             return self._compute_checksum()
         else:
@@ -82,43 +87,44 @@ class WeightChecker:
                 continue
             param.copy_(_random_like(param))
 
-    def _compare(self):
+    def _compare(self, allow_quant_error: bool = False):
         assert self._snapshot_tensors is not None
 
+        quantized_set = _build_quantized_set(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
             if getattr(param, "_skip_weight_check", False)
         }
         _check_tensors(
-            expect_tensors=_postprocess_tensors(
-                self._snapshot_tensors, skip_compare_names
+            expect_tensors=_build_entries(
+                self._snapshot_tensors, skip_compare_names, quantized_set
             ),
-            actual_tensors=_postprocess_tensors(
-                dict(self._model_state()), skip_compare_names
+            actual_tensors=_build_entries(
+                dict(self._model_state()), skip_compare_names, quantized_set
             ),
+            allow_quant_error=allow_quant_error,
         )
 
     def _compute_checksum(self) -> Dict:
         torch.cuda.synchronize()
         start = time.perf_counter()
 
+        quantized_set = _build_quantized_set(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
             if getattr(param, "_skip_weight_check", False)
         }
 
-        # Reuse the snapshot/compare postprocess pipeline so fp8 weights are
-        # dequantized to bf16 before hashing — two (qweight, scale) pairs that
-        # produce the same bf16 must produce the same checksum.
-        checksums = {
-            name: _hash_tensor(tensor.data)
-            for name, should_compare, tensor in _postprocess_tensors(
-                dict(self._model_state()), skip_compare_names
-            )
-            if should_compare
-        }
+        # Hash the dequantized weight so two (qweight, scale) pairs with the same
+        # bf16 hash equal.
+        checksums = {}
+        for name, should_compare, ref in _build_entries(
+            dict(self._model_state()), skip_compare_names, quantized_set
+        ):
+            if should_compare:
+                checksums[name] = _hash_tensor(ref.dequantize().data)
 
         h = hashlib.sha256()
         for name in sorted(checksums):
@@ -162,42 +168,50 @@ def _hash_tensor(t: torch.Tensor) -> str:
 
 
 def _check_tensors(
-    expect_tensors: Iterable[Tuple[str, bool, torch.Tensor]],
-    actual_tensors: Iterable[Tuple[str, bool, torch.Tensor]],
+    expect_tensors: Iterable[Tuple[str, bool, ComparableWeight]],
+    actual_tensors: Iterable[Tuple[str, bool, ComparableWeight]],
+    allow_quant_error: bool = False,
 ):
-    from sglang.srt.debug_utils.dumper import get_tensor_info
-
     good_names = []
     error_messages = []
     info_messages = []
 
-    for (expect_name, expect_should_compare, expect), (
+    for (expect_name, should_compare, expect_ref), (
         actual_name,
         actual_should_compare,
-        actual,
+        actual_ref,
     ) in zip(expect_tensors, actual_tensors, strict=True):
         assert expect_name == actual_name, f"{expect_name=} {actual_name=}"
         assert (
-            expect_should_compare == actual_should_compare
-        ), f"{expect_should_compare=} {actual_should_compare=}"
+            should_compare == actual_should_compare
+        ), f"{should_compare=} {actual_should_compare=}"
         name = expect_name
-        should_compare = expect_should_compare
 
-        expect = expect.cuda()
-        actual = actual.cuda()
-
-        if torch.all(expect == actual):
-            good_names.append(name)
-        else:
-            abs_diff = (actual.float() - expect.float()).abs()
-            msg = (
-                f"name={name} "
-                f"max_abs_err={abs_diff.max()} "
-                f"mean_abs_err={abs_diff.mean()} "
-                f"{get_tensor_info(expect)=} "
-                f"{get_tensor_info(actual)=} "
+        try:
+            equal, max_abs_err, mean_abs_err, num_exceed = _compare_weights(
+                expect_ref, actual_ref
             )
-            (error_messages if should_compare else info_messages).append(msg)
+        except Exception as e:
+            e.add_note(
+                f"when handling {name=} expect={expect_ref!r} actual={actual_ref!r}"
+            )
+            raise
+        if equal:
+            good_names.append(name)
+            continue
+        msg = (
+            f"name={name} "
+            f"max_abs_err={max_abs_err} "
+            f"mean_abs_err={mean_abs_err} "
+            f"num_exceed={num_exceed} "
+            f"expect={expect_ref!r} actual={actual_ref!r} "
+        )
+        if not should_compare:
+            info_messages.append(msg)
+        elif allow_quant_error and num_exceed == 0:
+            info_messages.append(msg + "(within quantization ULP tolerance)")
+        else:
+            error_messages.append(msg)
 
     logger.info(f"[check_tensors] equal tensors: {good_names}")
     if len(info_messages) > 0:
@@ -212,7 +226,12 @@ def _random_like(t: torch.Tensor):
     dtype = t.dtype
 
     if dtype.is_floating_point:
-        return torch.rand(shape, device=device, dtype=torch.float32).to(dtype)
+        out = torch.empty(shape, device=device, dtype=dtype)
+        for chunk in out.view(-1).split(_CHUNK_NUMEL):
+            chunk.copy_(
+                torch.rand(chunk.shape, device=device, dtype=torch.float32).to(dtype)
+            )
+        return out
 
     if dtype == torch.bool:
         return torch.rand(shape, device=device) > 0.5
@@ -223,58 +242,42 @@ def _random_like(t: torch.Tensor):
     )
 
 
-def _postprocess_tensors(
+def _build_quantized_set(model) -> Dict[str, Tuple[type, str]]:
+    """Run the router over the model: {weight_name: (ComparableWeight subclass,
+    scale_name)} for each quantized weight; weights absent from the set compare raw."""
+    quantized_set = {}
+    for module_name, module in model.named_modules():
+        comparable_cls = select_comparable_weight(getattr(module, "quant_method", None))
+        if comparable_cls is None:
+            continue
+        prefix = f"{module_name}." if module_name else ""
+        own = {name for name, _ in module.named_parameters(recurse=False)}
+        for name in own:
+            scale = name.replace("weight", "weight_scale_inv")
+            if name.endswith("weight") and scale in own:
+                quantized_set[prefix + name] = (comparable_cls, prefix + scale)
+    return quantized_set
+
+
+def _build_entries(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
-) -> Iterable[Tuple[str, bool, torch.Tensor]]:
-    from sglang.srt.debug_utils.dumper import get_tensor_info
-
+    quantized_set: Optional[Dict[str, Tuple[type, str]]] = None,
+) -> Iterable[Tuple[str, bool, ComparableWeight]]:
+    """Yields (name, should_compare, ComparableWeight); quantized weights consume
+    their scale, everything else is raw."""
     skip_compare_names = set(skip_compare_names)
+    quantized_set = quantized_set or {}
+    scale_names = {scale for _, scale in quantized_set.values()}
 
-    # Skip non-persistent buffers (registered with persistent=False; recomputed
-    # after weight load and not part of the synced payload).
-    for name in raw:
-        if _is_non_persistent_buffer_name(name):
-            skip_compare_names.add(name)
-            logger.info(f"[check_tensors] Skipping non-persistent buffer: {name}")
-
-    # dequant fp8
-    quant_names = [
-        name
-        for name in raw
-        # Match: `something.weight`, `something.experts.w2_weight`
-        if name.endswith("weight") and name.replace("weight", "weight_scale_inv") in raw
-    ]
-    quant_scale_names = [
-        name.replace("weight", "weight_scale_inv") for name in quant_names
-    ]
-    skip_compare_names.update(quant_names)
-    skip_compare_names.update(quant_scale_names)
-    for name in quant_names:
-        w_q = raw[name]
-        w_s = raw[name.replace("weight", "weight_scale_inv")]
-
-        try:
-            if w_s.dtype == torch.int32:
-                # UE8M0 packed format (Blackwell DeepGEMM)
-                w_s_for_dequant = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
-            else:
-                w_s_for_dequant = w_s
-
-            w_dequant = block_quant_dequant(
-                w_q,
-                w_s_for_dequant,
-                # TODO do not hardcode
-                block_size=[128, 128],
-                dtype=torch.bfloat16,
+    for name, tensor in raw.items():
+        if name in scale_names:
+            continue  # compared via its weight's comparable
+        if name in quantized_set:
+            comparable_cls, s_name = quantized_set[name]
+            yield name, True, comparable_cls(tensor, raw[s_name])
+        else:
+            should_compare = name not in skip_compare_names and (
+                not _is_non_persistent_buffer_name(name)
             )
-            yield name, True, w_dequant
-        except Exception as e:
-            e.add_note(
-                f"when handling {name=} {get_tensor_info(w_q)=} {get_tensor_info(w_s)=}"
-            )
-            raise
-
-    for name in raw:
-        should_compare = name not in skip_compare_names
-        yield name, should_compare, raw[name]
+            yield name, should_compare, RawComparable(tensor)

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -1,0 +1,159 @@
+from typing import Iterable, Optional, Tuple
+
+import torch
+
+from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod, Fp8MoEMethod
+from sglang.srt.layers.quantization.fp8_utils import (
+    block_quant_dequant,
+    inverse_transform_scale_ue8m0,
+)
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptFp4LinearMethod,
+    ModelOptNvFp4FusedMoEMethod,
+)
+
+# chunk to avoid too high GPU memory peak
+_CHUNK_NUMEL = 64 * 1024 * 1024
+
+
+class ComparableWeight:
+    """Base class: a weight in comparable (dequantized) form, for all precisions."""
+
+    @staticmethod
+    def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
+        """Per-element ULP of w_q in its own dtype."""
+        finfo = torch.finfo(w_q.dtype)
+        x = w_q.to(torch.float32).abs()
+        # frexp: x = m * 2^e, m in [0.5, 1), so 2^(e-1) is x's binade base.
+        _, exponent = torch.frexp(x)
+        binade = torch.exp2((exponent - 1).to(torch.float32))
+        # Zeros and subnormals share the spacing of the smallest normal binade.
+        binade = binade.masked_fill(x < finfo.smallest_normal, finfo.smallest_normal)
+        return binade * finfo.eps
+
+    def iter_chunks(self) -> Iterable[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
+        raise NotImplementedError
+
+    def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class Fp8BlockComparable(ComparableWeight):
+    """Deepseek-style FP8 quantization."""
+
+    def __init__(self, w_q: torch.Tensor, w_s: torch.Tensor):
+        self.w_q = w_q
+        self.w_s = w_s
+
+    def __repr__(self) -> str:
+        return f"fp8_block(shape={tuple(self.w_q.shape)} dtype={self.w_q.dtype})"
+
+    @staticmethod
+    def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
+        if w_s.dtype == torch.int32:
+            w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
+        return w_s.to(torch.float32)
+
+    @staticmethod
+    def _infer_block_size(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
+        k, s_k = w_q.shape[-1], w_s.shape[-1]
+        assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
+        block = k // s_k
+        return [block, block]
+
+    @staticmethod
+    def _iter_quant_chunks(w_q: torch.Tensor, w_s: torch.Tensor, block_n: int):
+        """Yields block-row-aligned (q_slice, s_slice) pairs of bounded size."""
+        q3 = w_q.reshape(-1, *w_q.shape[-2:])
+        s3 = w_s.reshape(-1, *w_s.shape[-2:])
+        n, k = q3.shape[-2:]
+        rows = max(block_n, _CHUNK_NUMEL // k // block_n * block_n)
+        for b in range(q3.shape[0]):
+            for r0 in range(0, n, rows):
+                r1 = min(r0 + rows, n)
+                yield q3[b, r0:r1], s3[b, r0 // block_n : -(-r1 // block_n)]
+
+    def _scale_and_block_size(self):
+        s = self._normalize_scale(self.w_q, self.w_s)
+        return s, self._infer_block_size(self.w_q, s)
+
+    def iter_chunks(self):
+        s, block_size = self._scale_and_block_size()
+        for q, s_chunk in self._iter_quant_chunks(self.w_q, s, block_size[0]):
+            q, s_chunk = q.cuda(), s_chunk.cuda()
+            yield (
+                block_quant_dequant(q, s_chunk, block_size, dtype=torch.bfloat16),
+                block_quant_dequant(
+                    self._quant_ulp(q), s_chunk, block_size, dtype=torch.float32
+                ),
+            )
+
+    def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        s, block_size = self._scale_and_block_size()
+        return block_quant_dequant(self.w_q, s, block_size, dtype=dtype)
+
+
+class RawComparable(ComparableWeight):
+    """Unquantized tensor: identity dequant, exact (no-tolerance) compare."""
+
+    def __init__(self, tensor: torch.Tensor):
+        self.tensor = tensor
+
+    def __repr__(self) -> str:
+        return f"raw(shape={tuple(self.tensor.shape)} dtype={self.tensor.dtype})"
+
+    def iter_chunks(self):
+        flat = self.tensor.reshape(-1)
+        for start in range(0, flat.numel(), _CHUNK_NUMEL):
+            yield flat[start : start + _CHUNK_NUMEL].cuda(), None
+
+    def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        return self.tensor
+
+
+def _compare_weights(
+    expect: ComparableWeight, actual: ComparableWeight
+) -> Tuple[bool, float, float, int]:
+    """Chunked dequant-space compare; returns (equal, max_abs_err, mean_abs_err,
+    num_exceed), num_exceed counting elements past the combined per-side tolerance."""
+    equal = True
+    max_abs_err = torch.zeros((), dtype=torch.float32)
+    sum_abs_err = 0.0
+    num_exceed = 0
+    numel = 0
+    for (e_dq, e_tol), (a_dq, a_tol) in zip(
+        expect.iter_chunks(), actual.iter_chunks(), strict=True
+    ):
+        assert e_dq.shape == a_dq.shape, f"{e_dq.shape=} {a_dq.shape=}"
+        numel += e_dq.numel()
+        abs_diff = (a_dq.float() - e_dq.float()).abs()
+        if torch.all(abs_diff == 0):
+            continue
+        equal = False
+        # |a_dq - e_dq| ≤ |a_dq - w| + |e_dq - w| ≤ a_tol + e_tol
+        tol = 0.0 if e_tol is None or a_tol is None else e_tol + a_tol
+        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
+        sum_abs_err += abs_diff.sum().item()
+        # `~(diff <= tol)` instead of `diff > tol` so NaN counts as exceeding.
+        num_exceed += int((~(abs_diff <= tol)).sum())
+    return equal, max_abs_err.item(), sum_abs_err / max(numel, 1), num_exceed
+
+
+def select_comparable_weight(quant_method) -> Optional[type]:
+    """Map a module's quant_method to its ComparableWeight subclass; None means raw
+    (bit-exact) compare. fp8 block quant -> Fp8BlockComparable: load-time ue8m0
+    requant yields two valid fp8 encodings, so compare in dequant space with ULP
+    tolerance. nvfp4 -> raise (non-bit-exact, unsupported). int4/mxfp8/mxfp4 and
+    unquantized -> None.
+    """
+    if (
+        isinstance(quant_method, (Fp8LinearMethod, Fp8MoEMethod))
+        and quant_method.block_quant
+        and not quant_method.use_mxfp8
+    ):
+        return Fp8BlockComparable
+    if isinstance(quant_method, (ModelOptFp4LinearMethod, ModelOptNvFp4FusedMoEMethod)):
+        raise NotImplementedError(
+            f"weight checker has no ComparableWeight for {type(quant_method).__name__}"
+        )
+    return None

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -21,7 +21,6 @@ import torch
 from torch import nn
 
 from sglang.srt.layers.quantization.fp8_utils import (
-    block_quant_dequant,
     quant_weight_ue8m0,
     transform_scale_ue8m0,
 )
@@ -29,11 +28,19 @@ from sglang.srt.utils.weight_checker import (
     ChecksumInfo,
     ParallelismInfo,
     WeightChecker,
+    _build_entries,
+    _build_quantized_set,
     _check_tensors,
     _hash_tensor,
     _is_non_persistent_buffer_name,
-    _postprocess_tensors,
     _random_like,
+)
+from sglang.srt.utils.weight_checker_comparator import (
+    ComparableWeight,
+    Fp8BlockComparable,
+    RawComparable,
+    _compare_weights,
+    select_comparable_weight,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -46,31 +53,47 @@ register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
 # ---------------------------------------------------------------------------
 
 
-Triple = Tuple[str, bool, torch.Tensor]
+Entry = Tuple[str, bool, ComparableWeight]
 
 
-def _assert_triples_close(actual: Iterable[Triple], expected: Iterable[Triple]) -> None:
-    """Compare two streams of (name, should_compare, tensor); element-wise tensor close."""
-    actual_list: List[Triple] = list(actual)
-    expected_list: List[Triple] = list(expected)
+def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) -> None:
+    """Compare two streams of (name, should_compare, ComparableWeight)."""
+    actual_list: List[Entry] = list(actual)
+    expected_list: List[Entry] = list(expected)
     assert len(actual_list) == len(
         expected_list
     ), f"length mismatch: actual={len(actual_list)} expected={len(expected_list)}"
-    for i, ((a_name, a_flag, a_t), (e_name, e_flag, e_t)) in enumerate(
+    for i, ((a_name, a_flag, a_ref), (e_name, e_flag, e_ref)) in enumerate(
         zip(actual_list, expected_list)
     ):
         assert a_name == e_name, f"[{i}] name: {a_name!r} != {e_name!r}"
         assert a_flag == e_flag, f"[{i}] should_compare: {a_flag} != {e_flag}"
-        torch.testing.assert_close(
-            a_t, e_t, msg=f"[{i}] tensor mismatch for {a_name!r}"
-        )
+        assert type(a_ref) is type(e_ref), f"[{i}] kind mismatch for {a_name!r}"
+        if isinstance(a_ref, Fp8BlockComparable):
+            torch.testing.assert_close(
+                a_ref.w_q, e_ref.w_q, msg=f"[{i}] w_q {a_name!r}"
+            )
+            torch.testing.assert_close(
+                a_ref.w_s, e_ref.w_s, msg=f"[{i}] w_s {a_name!r}"
+            )
+        else:
+            torch.testing.assert_close(
+                a_ref.tensor, e_ref.tensor, msg=f"[{i}] tensor {a_name!r}"
+            )
+
+
+def _compare_quant_pair(expect_q, expect_s, actual_q, actual_s):
+    """Test shim: wrap fp8 (q, s) pairs as comparables and compare them."""
+    return _compare_weights(
+        Fp8BlockComparable(expect_q, expect_s), Fp8BlockComparable(actual_q, actual_s)
+    )
 
 
 def _build_fp8_quant_pair(device: str = "cuda"):
     """Construct a real fp8-quantized weight + matching fp32 + ue8m0-packed scales.
 
     Returns (qweight, sf_fp32, sf_packed_int32) so callers can pick which scale dtype
-    drives the _postprocess_tensors branch under test.
+    drives the _build_entries branch under test.
     """
     weight_bf16 = torch.randn((256, 128), dtype=torch.bfloat16, device=device)
     block_size = [128, 128]
@@ -87,7 +110,7 @@ def _build_fp8_quant_pair(device: str = "cuda"):
 
 
 class _TinyModel(nn.Module):
-    """Mimics the buffer naming patterns _reset_tensors / _postprocess_tensors care about."""
+    """Mimics the buffer naming patterns _reset_tensors / _build_entries care about."""
 
     def __init__(self):
         super().__init__()
@@ -173,9 +196,19 @@ class TestRandomLike(CustomTestCase):
         _random_like(t)
         torch.testing.assert_close(t, before)
 
+    def test_floating_point_chunked_generation(self):
+        with patch("sglang.srt.utils.weight_checker._CHUNK_NUMEL", 8):
+            out = _random_like(torch.zeros(64, dtype=torch.bfloat16))
+        self.assertEqual(out.dtype, torch.bfloat16)
+        self.assertEqual(out.shape, (64,))
+        self.assertGreater(out.unique().numel(), 8)
+        self.assertGreaterEqual(out.float().min().item(), 0.0)
+        # bf16 rounding may carry values just below 1.0 up to exactly 1.0
+        self.assertLessEqual(out.float().max().item(), 1.0)
+
 
 # ---------------------------------------------------------------------------
-# _postprocess_tensors
+# _build_entries
 # ---------------------------------------------------------------------------
 
 
@@ -187,15 +220,17 @@ class TestPostprocessTensors(CustomTestCase):
         a = torch.randn(4)
         b = torch.randn(4)
         raw = {"a.weight": a, "b.bias": b}
-        _assert_triples_close(
-            _postprocess_tensors(raw, set()),
-            [("a.weight", True, a), ("b.bias", True, b)],
+        _assert_entries_close(
+            _build_entries(raw, set()),
+            [("a.weight", True, RawComparable(a)), ("b.bias", True, RawComparable(b))],
         )
 
     def test_weight_alone_without_scale_inv_does_not_trigger_dequant(self):
         w = torch.randn(4)
         raw = {"x.weight": w}
-        _assert_triples_close(_postprocess_tensors(raw, set()), [("x.weight", True, w)])
+        _assert_entries_close(
+            _build_entries(raw, set()), [("x.weight", True, RawComparable(w))]
+        )
 
     # --- non-persistent buffer skip ---
 
@@ -206,70 +241,47 @@ class TestPostprocessTensors(CustomTestCase):
             "model.rotary_emb.cos_sin_cache": cache,
             "model.layers.0.weight": plain,
         }
-        _assert_triples_close(
-            _postprocess_tensors(raw, set()),
+        _assert_entries_close(
+            _build_entries(raw, set()),
             [
-                ("model.rotary_emb.cos_sin_cache", False, cache),
-                ("model.layers.0.weight", True, plain),
+                ("model.rotary_emb.cos_sin_cache", False, RawComparable(cache)),
+                ("model.layers.0.weight", True, RawComparable(plain)),
             ],
         )
 
     def test_skips_inv_freq_substring(self):
         t = torch.randn(4)
-        _assert_triples_close(
-            _postprocess_tensors({"model.rotary_emb.inv_freq": t}, set()),
-            [("model.rotary_emb.inv_freq", False, t)],
+        _assert_entries_close(
+            _build_entries({"model.rotary_emb.inv_freq": t}, set()),
+            [("model.rotary_emb.inv_freq", False, RawComparable(t))],
         )
 
     def test_skips_weight_fp32_substring(self):
         t = torch.randn(4)
-        _assert_triples_close(
-            _postprocess_tensors({"model.layers.0.mlp.gate._weight_fp32": t}, set()),
-            [("model.layers.0.mlp.gate._weight_fp32", False, t)],
+        _assert_entries_close(
+            _build_entries({"model.layers.0.mlp.gate._weight_fp32": t}, set()),
+            [("model.layers.0.mlp.gate._weight_fp32", False, RawComparable(t))],
         )
 
     def test_substring_match_not_endswith(self):
         # Pattern can appear anywhere in the name, not just at the end.
         t = torch.randn(4)
-        _assert_triples_close(
-            _postprocess_tensors({"weird.cos_sin_cache.foo.bar": t}, set()),
-            [("weird.cos_sin_cache.foo.bar", False, t)],
+        _assert_entries_close(
+            _build_entries({"weird.cos_sin_cache.foo.bar": t}, set()),
+            [("weird.cos_sin_cache.foo.bar", False, RawComparable(t))],
         )
 
     # --- fp8 quant pair (real dequant on real fp8 tensors) ---
 
-    def test_fp8_quant_pair_with_int32_scale_dequants_via_ue8m0(self):
+    def test_fp8_quant_pair_yields_lazy_pair(self):
         qweight, sf_fp32, sf_packed_int32 = _build_fp8_quant_pair()
         raw = {"x.weight": qweight, "x.weight_scale_inv": sf_packed_int32}
 
-        # Reference: ue8m0 path inside _postprocess_tensors should eventually
-        # call block_quant_dequant with the unpacked fp32 scale.
-        expected_dequant = block_quant_dequant(
-            qweight, sf_fp32, block_size=[128, 128], dtype=torch.bfloat16
-        )
-        _assert_triples_close(
-            _postprocess_tensors(raw, set()),
-            [
-                ("x.weight", True, expected_dequant),
-                ("x.weight", False, qweight),
-                ("x.weight_scale_inv", False, sf_packed_int32),
-            ],
-        )
-
-    def test_fp8_quant_pair_with_fp32_scale_dequants_directly(self):
-        qweight, sf_fp32, _ = _build_fp8_quant_pair()
-        raw = {"x.weight": qweight, "x.weight_scale_inv": sf_fp32}
-
-        expected_dequant = block_quant_dequant(
-            qweight, sf_fp32, block_size=[128, 128], dtype=torch.bfloat16
-        )
-        _assert_triples_close(
-            _postprocess_tensors(raw, set()),
-            [
-                ("x.weight", True, expected_dequant),
-                ("x.weight", False, qweight),
-                ("x.weight_scale_inv", False, sf_fp32),
-            ],
+        ref = Fp8BlockComparable(qweight, sf_packed_int32)
+        quantized_set = {"x.weight": (Fp8BlockComparable, "x.weight_scale_inv")}
+        _assert_entries_close(
+            _build_entries(raw, set(), quantized_set),
+            [("x.weight", True, ref)],
         )
 
     def test_fp8_quant_pair_yield_order_alongside_other_entries(self):
@@ -280,17 +292,14 @@ class TestPostprocessTensors(CustomTestCase):
             "x.weight_scale_inv": sf_fp32,
             "y.bias": bias,
         }
-        expected_dequant = block_quant_dequant(
-            qweight, sf_fp32, block_size=[128, 128], dtype=torch.bfloat16
-        )
-        # All dequant entries come first, then a raw pass over every key.
-        _assert_triples_close(
-            _postprocess_tensors(raw, set()),
+        # scale_inv is consumed by its weight's comparable; y.bias stays raw.
+        ref = Fp8BlockComparable(qweight, sf_fp32)
+        quantized_set = {"x.weight": (Fp8BlockComparable, "x.weight_scale_inv")}
+        _assert_entries_close(
+            _build_entries(raw, set(), quantized_set),
             [
-                ("x.weight", True, expected_dequant),
-                ("x.weight", False, qweight),
-                ("x.weight_scale_inv", False, sf_fp32),
-                ("y.bias", True, bias),
+                ("x.weight", True, ref),
+                ("y.bias", True, RawComparable(bias)),
             ],
         )
 
@@ -298,9 +307,9 @@ class TestPostprocessTensors(CustomTestCase):
         # Without the matching `.weight`, no quant pair forms; the scale_inv flows
         # through as a normal entry with should_compare=True.
         s = torch.zeros(1, 1, dtype=torch.int32)
-        _assert_triples_close(
-            _postprocess_tensors({"x.weight_scale_inv": s}, set()),
-            [("x.weight_scale_inv", True, s)],
+        _assert_entries_close(
+            _build_entries({"x.weight_scale_inv": s}, set()),
+            [("x.weight_scale_inv", True, RawComparable(s))],
         )
 
 
@@ -313,13 +322,19 @@ class TestCheckTensors(CustomTestCase):
 
     def test_passes_when_all_equal(self):
         t = torch.ones(2, 2)
-        expect = [("a", True, t.clone()), ("b", True, t.clone())]
-        actual = [("a", True, t.clone()), ("b", True, t.clone())]
+        expect = [
+            ("a", True, RawComparable(t.clone())),
+            ("b", True, RawComparable(t.clone())),
+        ]
+        actual = [
+            ("a", True, RawComparable(t.clone())),
+            ("b", True, RawComparable(t.clone())),
+        ]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_raises_when_should_compare_true_and_diff(self):
-        expect = [("a", True, torch.ones(2, 2))]
-        actual = [("a", True, torch.zeros(2, 2))]
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", True, RawComparable(torch.zeros(2, 2)))]
         with self.assertRaises(Exception) as ctx:
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
         msg = str(ctx.exception)
@@ -328,28 +343,256 @@ class TestCheckTensors(CustomTestCase):
 
     def test_passes_when_should_compare_false_even_if_diff(self):
         # should_compare=False -> diff is logged, not raised.
-        expect = [("a", False, torch.ones(2, 2))]
-        actual = [("a", False, torch.zeros(2, 2))]
+        expect = [("a", False, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", False, RawComparable(torch.zeros(2, 2)))]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_name_mismatch(self):
-        expect = [("a", True, torch.ones(2, 2))]
-        actual = [("b", True, torch.ones(2, 2))]
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("b", True, RawComparable(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_should_compare_mismatch(self):
-        expect = [("a", True, torch.ones(2, 2))]
-        actual = [("a", False, torch.ones(2, 2))]
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", False, RawComparable(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
+    def test_chunked_raw_stats_match_unchunked(self):
+        expect = [("a", True, RawComparable(torch.zeros(10)))]
+        actual = [("a", True, RawComparable(torch.arange(10.0)))]
+        with patch("sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 3):
+            with self.assertRaises(Exception) as ctx:
+                _check_tensors(expect_tensors=expect, actual_tensors=actual)
+        self.assertIn("max_abs_err=9.0", str(ctx.exception))
+        self.assertIn("mean_abs_err=4.5", str(ctx.exception))
+
     def test_zip_strict_raises_on_length_mismatch(self):
         t = torch.ones(2, 2)
-        expect = [("a", True, t.clone()), ("b", True, t.clone())]
-        actual = [("a", True, t.clone())]
+        expect = [
+            ("a", True, RawComparable(t.clone())),
+            ("b", True, RawComparable(t.clone())),
+        ]
+        actual = [("a", True, RawComparable(t.clone()))]
         with self.assertRaises(ValueError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
+
+
+# ---------------------------------------------------------------------------
+# _quant_ulp + allow_quant_error
+# ---------------------------------------------------------------------------
+
+
+class TestQuantUlp(CustomTestCase):
+
+    def test_matches_bruteforce_spacing_for_fp8(self):
+        for dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            all_bits = torch.arange(256, dtype=torch.uint8).view(dtype)
+            vals = all_bits.to(torch.float32)
+            magnitudes = torch.unique(vals[torch.isfinite(vals) & (vals >= 0)])
+            # Brute-force ULP: spacing to the next representable magnitude
+            # (the largest magnitude reuses the spacing below it).
+            spacing = magnitudes[1:] - magnitudes[:-1]
+            expected = torch.cat([spacing, spacing[-1:]])
+            got = ComparableWeight._quant_ulp(magnitudes.to(dtype))
+            torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+
+class TestCompareQuantPair(CustomTestCase):
+    """Chunked dequantized-space comparison of block-quantized pairs."""
+
+    @staticmethod
+    def _quantize(weight: torch.Tensor, scale_margin: float):
+        """Blockwise 128x128 fp8 quantization with a tweakable scale convention."""
+        n, k = weight.shape
+        blocks = weight.float().view(n // 128, 128, k // 128, 128).permute(0, 2, 1, 3)
+        scale = blocks.abs().amax(dim=(-1, -2)) / 448.0 * scale_margin
+        q = (blocks / scale[:, :, None, None]).to(torch.float8_e4m3fn)
+        q = q.permute(0, 2, 1, 3).reshape(n, k)
+        return q, scale
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.weight = torch.randn(256, 256, device="cuda") * 0.02
+        self.e_q, self.e_s = self._quantize(self.weight, 1.0)
+        self.a_q, self.a_s = self._quantize(self.weight, 1.001)
+
+    def test_identical_pair_is_equal(self):
+        equal, max_err, mean_err, num_exceed = _compare_quant_pair(
+            self.e_q, self.e_s, self.e_q.clone(), self.e_s.clone()
+        )
+        self.assertTrue(equal)
+        self.assertEqual((max_err, mean_err, num_exceed), (0.0, 0.0, 0))
+
+    def test_ue8m0_packed_scale_equals_unpacked_scale(self):
+        qweight, sf_fp32, sf_packed_int32 = _build_fp8_quant_pair()
+        equal, *_ = _compare_quant_pair(qweight, sf_packed_int32, qweight, sf_fp32)
+        self.assertTrue(equal)
+
+    def test_two_quantizations_stay_within_ulp_tolerance(self):
+        equal, max_err, mean_err, num_exceed = _compare_quant_pair(
+            self.e_q, self.e_s, self.a_q, self.a_s
+        )
+        self.assertFalse(equal)
+        self.assertGreater(max_err, 0.0)
+        self.assertEqual(num_exceed, 0)
+
+    def test_corruption_and_fp8_nan_exceed_tolerance(self):
+        bad_q = self.a_q.clone().view(torch.uint8)
+        bad_q[::50] += 8  # jumps a full binade; some bytes become fp8 NaN
+        equal, max_err, mean_err, num_exceed = _compare_quant_pair(
+            self.e_q, self.e_s, bad_q.view(torch.float8_e4m3fn), self.a_s
+        )
+        self.assertFalse(equal)
+        self.assertGreater(num_exceed, 0)
+
+    def test_chunked_result_matches_unchunked(self):
+        reference = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
+        with patch(
+            "sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 128 * 128
+        ):
+            chunked = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
+        self.assertEqual(chunked, reference)
+
+    @staticmethod
+    def _quantize_partial(weight: torch.Tensor, scale_margin: float):
+        """128x128 block quant where the last block per dim may be partial."""
+        n, k = weight.shape
+        s_n, s_k = -(-n // 128), -(-k // 128)
+        q = torch.empty(n, k, dtype=torch.float8_e4m3fn, device=weight.device)
+        scale = torch.empty(s_n, s_k, device=weight.device)
+        for i in range(s_n):
+            for j in range(s_k):
+                blk = weight[i * 128 : (i + 1) * 128, j * 128 : (j + 1) * 128].float()
+                s = blk.abs().amax() / 448.0 * scale_margin
+                s = s if s > 0 else weight.new_ones(())
+                scale[i, j] = s
+                q[i * 128 : (i + 1) * 128, j * 128 : (j + 1) * 128] = (blk / s).to(
+                    torch.float8_e4m3fn
+                )
+        return q, scale
+
+    def test_partial_last_block_infers_true_block_size(self):
+        # fused_qkv_a_proj_with_mqa out-dim is not a multiple of 128 (e.g. 2112 =
+        # 16*128 + 64), so the last row-block is partial. ceil(dim/num_blocks)
+        # would infer 125, misaligning scales; the true block size is 128.
+        n, k = 3 * 128 + 64, 256  # 448 rows = partial last block, 256 cols
+        weight = torch.randn(n, k, device="cuda") * 0.02
+        e_q, e_s = self._quantize_partial(weight, 1.0)
+        a_q, a_s = self._quantize_partial(weight, 1.001)
+        self.assertEqual(list(e_s.shape), [4, 2])  # ceil(448/128)=4, 256/128=2
+        self.assertEqual(Fp8BlockComparable._infer_block_size(e_q, e_s), [128, 128])
+        equal, _, _, num_exceed = _compare_quant_pair(e_q, e_s, a_q, a_s)
+        self.assertFalse(equal)
+        self.assertEqual(num_exceed, 0)
+
+    def test_3d_expert_tensor(self):
+        q3 = self.e_q.reshape(2, 128, 256).contiguous()
+        s3 = self.e_s.reshape(2, 1, 2)
+        equal, *_ = _compare_quant_pair(q3, s3, q3.clone(), s3.clone())
+        self.assertTrue(equal)
+
+
+class TestCheckTensorsAllowQuantError(CustomTestCase):
+
+    def setUp(self):
+        torch.manual_seed(0)
+        weight = torch.randn(256, 256, device="cuda") * 0.02
+        self.e_raw = self._as_raw(*TestCompareQuantPair._quantize(weight, 1.0))
+        self.a_raw = self._as_raw(*TestCompareQuantPair._quantize(weight, 1.001))
+
+    @staticmethod
+    def _as_raw(q, s):
+        return {"x.weight": q, "x.weight_scale_inv": s}
+
+    def _check(self, expect_raw, actual_raw, **kwargs):
+        quantized_set = {"x.weight": (Fp8BlockComparable, "x.weight_scale_inv")}
+        _check_tensors(
+            expect_tensors=_build_entries(expect_raw, set(), quantized_set),
+            actual_tensors=_build_entries(actual_raw, set(), quantized_set),
+            **kwargs,
+        )
+
+    def test_within_tolerance_passes_with_flag(self):
+        self._check(self.e_raw, self.a_raw, allow_quant_error=True)
+
+    def test_within_tolerance_fails_without_flag(self):
+        with self.assertRaises(Exception) as ctx:
+            self._check(self.e_raw, self.a_raw)
+        self.assertIn("name=x.weight", str(ctx.exception))
+
+    def test_exceeding_tolerance_fails_with_flag(self):
+        bad_q = self.a_raw["x.weight"].clone().view(torch.uint8)
+        bad_q[::50] += 8
+        bad = self._as_raw(
+            bad_q.view(torch.float8_e4m3fn), self.a_raw["x.weight_scale_inv"]
+        )
+        with self.assertRaises(Exception) as ctx:
+            self._check(self.e_raw, bad, allow_quant_error=True)
+        self.assertIn("num_exceed", str(ctx.exception))
+
+    def test_flag_does_not_relax_non_quant_tensors(self):
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", True, RawComparable(torch.ones(2, 2) + 0.5))]
+        with self.assertRaises(Exception):
+            _check_tensors(
+                expect_tensors=expect, actual_tensors=actual, allow_quant_error=True
+            )
+
+
+# ---------------------------------------------------------------------------
+# select_comparable_weight
+# ---------------------------------------------------------------------------
+
+
+class TestSelectComparableWeight(CustomTestCase):
+
+    def test_returns_none_when_not_a_quant_method(self):
+        self.assertIsNone(select_comparable_weight(None))
+
+    def test_returns_none_for_raw_safe_method(self):
+        from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
+
+        # unquantized / int4 / mxfp8 all route to raw (None).
+        fake = UnquantizedLinearMethod.__new__(UnquantizedLinearMethod)
+        self.assertIsNone(select_comparable_weight(fake))
+
+    def test_raises_on_nvfp4(self):
+        from sglang.srt.layers.quantization.modelopt_quant import (
+            ModelOptFp4LinearMethod,
+        )
+
+        # nvfp4 has no ComparableWeight yet -> must raise, not silently raw-compare.
+        fake = ModelOptFp4LinearMethod.__new__(ModelOptFp4LinearMethod)
+        with self.assertRaises(NotImplementedError):
+            select_comparable_weight(fake)
+
+
+class TestBuildQuantizedSet(CustomTestCase):
+
+    def test_fp8_block_module_pairs_weight_and_scale(self):
+        from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+
+        method = Fp8LinearMethod.__new__(Fp8LinearMethod)
+        method.block_quant = True
+        method.use_mxfp8 = False
+        model = nn.Module()
+        model.proj = nn.Module()
+        model.proj.quant_method = method
+        model.proj.register_parameter(
+            "weight", nn.Parameter(torch.zeros(4, 4), requires_grad=False)
+        )
+        model.proj.register_parameter(
+            "weight_scale_inv", nn.Parameter(torch.zeros(1, 1), requires_grad=False)
+        )
+        self.assertEqual(
+            _build_quantized_set(model),
+            {"proj.weight": (Fp8BlockComparable, "proj.weight_scale_inv")},
+        )
+
+    def test_no_quant_method_yields_empty_plan(self):
+        self.assertEqual(_build_quantized_set(_TinyModel()), {})
 
 
 # ---------------------------------------------------------------------------

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -1,7 +1,13 @@
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
+import pytest
+
+from sglang.srt.managers.io_struct import (
+    BeginWeightUpdateReqInput,
+    EndWeightUpdateReqInput,
+    UpdateWeightsFromDistributedReqInput,
+)
 from sglang.srt.managers.scheduler_components.weight_updater import (
     SchedulerWeightUpdaterManager,
 )
@@ -21,7 +27,7 @@ def _distributed_req(selector="all"):
 def _manager(tp_worker, draft_worker):
     # metrics_collector defaults to None, so _observe_weight_load is a no-op and the
     # unused disagg/memory hooks below are never exercised by these tests.
-    return SchedulerWeightUpdaterManager(
+    manager = SchedulerWeightUpdaterManager(
         tp_worker=tp_worker,
         draft_worker=draft_worker,
         tp_cpu_group=object(),
@@ -32,6 +38,9 @@ def _manager(tp_worker, draft_worker):
         get_disagg_decode_prealloc_queue=Mock(return_value=None),
         get_disagg_prefill_bootstrap_queue=Mock(return_value=None),
     )
+    # update_weights_from_* assert an open begin_weight_update session.
+    manager._weight_update_in_progress = True
+    return manager
 
 
 def test_scheduler_distributed_update_receives_once_on_target_loads_into_each():
@@ -43,10 +52,11 @@ def test_scheduler_distributed_update_receives_once_on_target_loads_into_each():
     target_runner.receive_weights_from_distributed.return_value = weights
     draft_runner = Mock()
     manager = _manager(
-        tp_worker=SimpleNamespace(model_runner=target_runner),
-        draft_worker=SimpleNamespace(
-            iter_draft_runners=lambda: [("draft", draft_runner)]
+        tp_worker=SimpleNamespace(
+            model_runner=target_runner,
+            iter_runners=lambda: [("", target_runner)],
         ),
+        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
     )
 
     output = manager.update_weights_from_distributed(_distributed_req())
@@ -72,7 +82,10 @@ def test_scheduler_distributed_update_target_only_selector_skips_draft():
     target_runner.receive_weights_from_distributed.return_value = weights
     draft_worker = Mock()
     manager = _manager(
-        tp_worker=SimpleNamespace(model_runner=target_runner),
+        tp_worker=SimpleNamespace(
+            model_runner=target_runner,
+            iter_runners=lambda: [("", target_runner)],
+        ),
         draft_worker=draft_worker,
     )
 
@@ -83,4 +96,129 @@ def test_scheduler_distributed_update_target_only_selector_skips_draft():
     assert output.success is True
     target_runner.receive_weights_from_distributed.assert_called_once()
     target_runner.load_weights.assert_called_once_with(weights)
-    draft_worker.iter_draft_runners.assert_not_called()
+    draft_worker.iter_runners.assert_not_called()
+
+
+def _session_manager(target_runner, draft_runner):
+    return _manager(
+        tp_worker=SimpleNamespace(iter_runners=lambda: [("", target_runner)]),
+        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
+    )
+
+
+def test_begin_weight_update_restores_target_and_draft():
+    # The session begins on every runner (target + draft): the draft model is
+    # restored to a loadable state identically to the target.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        output = manager.begin_weight_update(BeginWeightUpdateReqInput())
+
+    assert output.success is True
+    target_runner.begin_weight_update.assert_called_once_with()
+    draft_runner.begin_weight_update.assert_called_once_with()
+    assert manager._weight_update_in_progress is True
+    assert manager._weight_update_loaded is False
+
+
+def test_end_weight_update_runs_post_load_on_both_when_load_was_bypassed():
+    # No load_weights happened this session (e.g. P2P/RDMA), so end runs
+    # post_load_weights then quant finalize on BOTH target and draft.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_loaded = False
+
+    with patch("torch.distributed.barrier"):
+        output = manager.end_weight_update(EndWeightUpdateReqInput())
+
+    assert output.success is True
+    target_runner.end_weight_update.assert_called_once_with(run_post_load=True)
+    draft_runner.end_weight_update.assert_called_once_with(run_post_load=True)
+    assert manager._weight_update_in_progress is False
+
+
+def test_end_weight_update_skips_post_load_on_both_when_weights_loaded():
+    # A distributed/tensor load happened this session, so post_load is skipped on
+    # both runners; only quant finalize runs.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_loaded = True
+
+    with patch("torch.distributed.barrier"):
+        manager.end_weight_update(EndWeightUpdateReqInput())
+
+    target_runner.end_weight_update.assert_called_once_with(run_post_load=False)
+    draft_runner.end_weight_update.assert_called_once_with(run_post_load=False)
+
+
+def test_model_runner_begin_end_wire_to_loader_hooks():
+    # ModelRunner.begin/end delegate to the loader: begin restores; end runs
+    # post_load only when requested, always finalizes quant layout.
+    import sglang.srt.model_executor.model_runner as mr
+
+    runner = SimpleNamespace(model=object(), device="cpu")
+
+    with patch.object(mr, "restore_weight") as restore:
+        mr.ModelRunner.begin_weight_update(runner)
+    restore.assert_called_once()
+
+    with patch.object(mr, "post_load_weights") as post_load, patch.object(
+        mr, "postprocess_weight"
+    ) as postprocess:
+        mr.ModelRunner.end_weight_update(runner, run_post_load=True)
+    post_load.assert_called_once()
+    postprocess.assert_called_once()
+
+    with patch.object(mr, "post_load_weights") as post_load, patch.object(
+        mr, "postprocess_weight"
+    ) as postprocess:
+        mr.ModelRunner.end_weight_update(runner, run_post_load=False)
+    post_load.assert_not_called()
+    postprocess.assert_called_once()
+
+
+def test_begin_weight_update_selector_restores_only_selected_and_is_recorded():
+    # begin(selector="draft") opens the session on the draft only; the target is
+    # untouched, and the selector is recorded for end to reuse.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        manager.begin_weight_update(BeginWeightUpdateReqInput(selector="draft"))
+
+    target_runner.begin_weight_update.assert_not_called()
+    draft_runner.begin_weight_update.assert_called_once_with()
+    assert manager._weight_update_selector == "draft"
+
+
+def test_end_weight_update_reuses_session_selector_from_begin():
+    # end has no selector of its own; it finalizes exactly the set begin opened.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        manager.begin_weight_update(BeginWeightUpdateReqInput(selector="draft"))
+        manager.end_weight_update(EndWeightUpdateReqInput())
+
+    target_runner.end_weight_update.assert_not_called()
+    draft_runner.end_weight_update.assert_called_once()
+
+
+def test_begin_weight_update_rejects_reentry():
+    # A second begin while a session is open would leave the first session's
+    # restored runners unfinalized — reject it loudly.
+    manager = _session_manager(Mock(), Mock())
+    manager._weight_update_in_progress = True
+
+    with patch("torch.distributed.barrier"):
+        with pytest.raises(AssertionError, match="already open"):
+            manager.begin_weight_update(BeginWeightUpdateReqInput())


### PR DESCRIPTION
## Summary

Refactors the online weight-update post-processing on the SGLang side. Training (miles) no longer drives the restore/quantize ordering via a 3-flag `post_process_weights` RPC. Instead the engine owns a **weight-update session**:

- **`begin_weight_update`** — restores in-place-packed weights to a loadable state (no-op for schemes that don't repack, e.g. plain fp8). Sets `_weight_update_in_progress`.
- **`update_weights_from_*`** — assert a session is open (catches silent misuse); record that `model.load_weights()` ran this session.
- **`end_weight_update`** — quant finalize (`process_weights_after_loading`) on the full model, plus `model.post_load_weights()` **only when `load_weights` was bypassed this session** (i.e. P2P/RDMA). The engine decides this itself via `_weight_update_loaded`; no flag crosses the API.

`post_process_weights` (RPC + the `restore/quantize/post_load` boolean dispatcher) is deleted.

## Why

- The restore/quantize/post-load transforms depend on engine-side settings (kernel backend, hardware, quant scheme) — they belong on the engine, not the trainer.
- A `begin`/`end` bracket gives "restore once / finalize once" naturally and works uniformly for tensor / broadcast / P2P (P2P has no per-bucket update RPC, so explicit begin/end is required).
- The open-session assert turns a previously-silent misuse (updating weights without the surrounding prep) into a loud error.

## Changes

- `io_struct.py`: `BeginWeightUpdate*` / `EndWeightUpdate*` req/resp replace `PostProcessWeights*`.
- `model_loader/loader.py`: extracted `restore_weights_before_loading_all` / `process_weights_after_loading_all` as free functions (single canonical definition, alongside the existing post-load helper); renamed `_post_load_weights` → `post_load_weights`.
- `scheduler` / `tp_worker` / `tokenizer_control_mixin` / `http_server` / `engine`: begin/end wiring; removed `post_process_weights`.

## Paired change

Requires the matching miles-side PR (begin/end calls replace `post_process_weights`).

## Notes

- `post_load_weights` is still embedded in `model.load_weights()` for tensor/broadcast (runs per-bucket); pulling it out so all transports run it once at `end_weight_update` is a deliberate follow-up. `_weight_update_loaded` is the seam for it.
- Lint: isort + black applied to the changed files manually (full pre-commit suite not runnable in this partial checkout).



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28138539341](https://github.com/sgl-project/sglang/actions/runs/28138539341)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28138539302](https://github.com/sgl-project/sglang/actions/runs/28138539302)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->