### PR TITLE
fix: handle missing Mooncake transfer status

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1701,6 +1701,15 @@ class MooncakeKVSender(CommonKVSender):
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:
+            if self.bootstrap_room not in self.kv_mgr.request_status:
+                self.kv_mgr.record_failure(
+                    self.bootstrap_room,
+                    "KV transfer status disappeared before Mooncake sender completed",
+                )
+                self.conclude_state = KVPoll.Failed
+                self.trace_ctx.trace_req_finish()
+                return self.conclude_state
+
             status = self.kv_mgr.check_status(self.bootstrap_room)
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status

--- a/test/srt/cpu/test_mooncake_disaggregation.py
+++ b/test/srt/cpu/test_mooncake_disaggregation.py
@@ -1,0 +1,42 @@
+import threading
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVSender
+
+
+class _FakeMooncakeManager:
+    def __init__(self):
+        self.is_dummy_cp_rank = False
+        self.enable_all_cp_ranks_for_transfer = False
+        self.enable_trace = False
+        self.bootstrap_timeout = 60
+        self.kv_item_lens_sum = 0
+        self.state_item_lens_sum = 0
+        self.attn_dp_rank = 0
+        self.server_args = SimpleNamespace(dp_size=1, load_balance_method=None)
+        self.request_status = {}
+        self.req_to_decode_prefix_len = {}
+        self.transfer_infos = {}
+        self.failure_records = {}
+        self.failure_lock = threading.Lock()
+
+    def update_status(self, bootstrap_room, status):
+        self.request_status[bootstrap_room] = status
+
+    def check_status(self, bootstrap_room):
+        return self.request_status[bootstrap_room]
+
+    def record_failure(self, bootstrap_room, failure_reason):
+        with self.failure_lock:
+            self.failure_records[bootstrap_room] = failure_reason
+
+
+def test_mooncake_sender_poll_handles_missing_request_status():
+    mgr = _FakeMooncakeManager()
+    sender = MooncakeKVSender(mgr, "127.0.0.1:30000", 42, [0], 0)
+    mgr.request_status.pop(42)
+
+    assert sender.poll() == KVPoll.Failed
+    assert sender.poll() == KVPoll.Failed
+    assert "status disappeared" in mgr.failure_records[42]


### PR DESCRIPTION
## Summary

Fixes #27643.

`MooncakeKVSender.poll()` currently assumes the bootstrap room is still present in `kv_mgr.request_status` and calls `check_status()` unconditionally. If the room has already been cleared or lost on another path, `check_status()` raises `KeyError` and the scheduler process dies.

Mori's sender already treats a missing room as a failed transfer. This patch gives the Mooncake sender the same defensive behavior: record a failure reason, conclude the sender as `KVPoll.Failed`, finish tracing, and return a normal failure status instead of throwing out of the scheduler loop.

## Validation

- `git diff --check`
- `python -m py_compile python\sglang\srt\disaggregation\mooncake\conn.py test\srt\cpu\test_mooncake_disaggregation.py`
- `python -m ruff check python\sglang\srt\disaggregation\mooncake\conn.py test\srt\cpu\test_mooncake_disaggregation.py`

I also attempted the focused pytest locally:

- `PYTHONPATH=python python -m pytest -q test\srt\cpu\test_mooncake_disaggregation.py`

That cannot collect on this Windows machine because SGLang's import path requires Linux/GPU dependencies (`resource`, then `triton`). The added test is a lightweight fake-manager regression and should run in the normal Linux test environment.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27397991895](https://github.com/sgl-project/sglang/actions/runs/27397991895)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27397991738](https://github.com/sgl-project/sglang/actions/runs/27397991738)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->