### PR TITLE
[Fix] bench image dataset: fix VLChatProcessor (Janus) and MiniCPMOProcessor (MiniCPM-o) token counting

### DIFF
--- a/python/sglang/benchmark/datasets/image.py
+++ b/python/sglang/benchmark/datasets/image.py
@@ -114,8 +114,6 @@ def create_mm_data_row(
     except Exception as e:
         # Note (Xinyuan): This is a workaround for an issue where some tokenizers do not support content as a list. (e.g. InternVL)
         print(f"Error applying chat template: {e}, fallback to <image> tag")
-        # Use the model-specific image placeholder token when no chat template is available.
-        # MiniCPM-o (MiniCPMOProcessor) expects (<image>./</image>); others use <image>.
         if type(processor).__name__ == "MiniCPMOProcessor":
             prompt_str = f"(<image>./</image>){text_prompt}"
         else:
@@ -130,8 +128,6 @@ def create_mm_data_row(
             return_tensors="pt",
         )["input_ids"].numel()
     elif type(processor).__name__ == "VLChatProcessor":
-        # Janus processor: __call__ expects prompt= kwarg, not text=; text= is silently
-        # ignored via **kwargs which leaves prompt=None and causes tokenizer.encode(None).
         prompt_len = processor(
             prompt=prompt_str,
             images=images,

--- a/python/sglang/benchmark/datasets/image.py
+++ b/python/sglang/benchmark/datasets/image.py
@@ -114,6 +114,7 @@ def create_mm_data_row(
     except Exception as e:
         # Note (Xinyuan): This is a workaround for an issue where some tokenizers do not support content as a list. (e.g. InternVL)
         print(f"Error applying chat template: {e}, fallback to <image> tag")
+        # Some tokenizers do not support list content; fall back to a placeholder in the text
         if type(processor).__name__ == "MiniCPMOProcessor":
             prompt_str = f"(<image>./</image>){text_prompt}"
         else:

--- a/python/sglang/benchmark/datasets/image.py
+++ b/python/sglang/benchmark/datasets/image.py
@@ -114,8 +114,12 @@ def create_mm_data_row(
     except Exception as e:
         # Note (Xinyuan): This is a workaround for an issue where some tokenizers do not support content as a list. (e.g. InternVL)
         print(f"Error applying chat template: {e}, fallback to <image> tag")
-        # Some tokenizers do not support list content; fall back to a placeholder in the text
-        prompt_str = f"<image>{text_prompt}"
+        # Use the model-specific image placeholder token when no chat template is available.
+        # MiniCPM-o (MiniCPMOProcessor) expects (<image>./</image>); others use <image>.
+        if type(processor).__name__ == "MiniCPMOProcessor":
+            prompt_str = f"(<image>./</image>){text_prompt}"
+        else:
+            prompt_str = f"<image>{text_prompt}"
 
     # Calculate total tokens (text + vision)
     if type(processor).__name__ == "KimiK25Processor":
@@ -124,6 +128,14 @@ def create_mm_data_row(
             text=prompt_str,
             medias=medias,
             return_tensors="pt",
+        )["input_ids"].numel()
+    elif type(processor).__name__ == "VLChatProcessor":
+        # Janus processor: __call__ expects prompt= kwarg, not text=; text= is silently
+        # ignored via **kwargs which leaves prompt=None and causes tokenizer.encode(None).
+        prompt_len = processor(
+            prompt=prompt_str,
+            images=images,
+            force_batchify=False,
         )["input_ids"].numel()
     else:
         prompt_len = processor(


### PR DESCRIPTION
## Motivation

`benchmark/datasets/image.py`'s `create_mm_data_row` uses a local processor call purely to **count tokens** before sending requests to the server. Two VLM processors do not follow the generic calling convention assumed by the fallback path, causing the image benchmark to crash before any server request is made:

- **deepseek-ai/Janus** models use `VLChatProcessor` whose `__call__` takes `prompt=` (not `text=`). The generic fallback path passes `text=[prompt_str]`, which silently enters `**kwargs` and leaves `prompt=None` → `tokenizer.encode(None)` → `ValueError`.
- **openbmb/MiniCPM-o** models use `MiniCPMOProcessor` whose `_convert()` searches for the model-specific `(<image>./</image>)` placeholder. The generic `<image>` fallback tag is not recognised → zero image bounds found → `torch.hstack([])` → `RuntimeError: sizes must match`.

Note: accuracy benchmarking (via `lmms-eval`) is not affected because it uses its own per-task prompt formatters and never calls `create_mm_data_row`. Only throughput benchmarking with `--dataset-name image` is affected.

## Modifications

### 1. `benchmark/datasets/image.py` — `ValueError` for `deepseek-ai/Janus-*`

When `apply_chat_template` fails, the fallback calls `processor(text=[prompt_str], ...)`. `VLChatProcessor.__call__` signature is `(self, *, prompt=None, conversations=None, images=None, ...)` — `text=` goes into `**kwargs` and is ignored, leaving `prompt=None`.

**Fix:** add a `VLChatProcessor` branch that passes `prompt=prompt_str` directly.

### 2. `benchmark/datasets/image.py` — `RuntimeError` for `openbmb/MiniCPM-o-*`

When `apply_chat_template` fails, the fallback sets `prompt_str = f"<image>{text_prompt}"`. `MiniCPMOProcessor._convert()` looks for `(<image>./</image>)` tokens; finding none, it returns empty image-bounds tensors → `torch.hstack` crash.

**Fix:** detect `MiniCPMOProcessor` in the fallback and use `(<image>./</image>)` as the placeholder instead of the generic `<image>` tag.

Both changes are class-name-gated (`type(processor).__name__ == ...`) and are strictly additive — the existing `else` branch for all other processors is unchanged.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer/development_tips.html#format-code-with-pre-commit) guide
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer/development_tips.html#run-and-add-unit-tests) guide
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.ai/developer/development_tips.html#write-documentations) guide
- [ ] Provide accuracy and speed benchmark results if applicable





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27399903307](https://github.com/sgl-project/sglang/actions/runs/27399903307)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27399903177](https://github.com/sgl-project/sglang/actions/runs/27399903177)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->