### PR TITLE
Add Anthropic Messages API routing for gateway and PD mode

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -120,6 +120,15 @@ class AnthropicMessagesRequest(BaseModel):
     top_k: Optional[int] = None
     top_p: Optional[float] = None
 
+    # SGLang internal PD-disaggregation fields. The gateway injects these
+    # before forwarding Anthropic requests to prefill/decode workers.
+    bootstrap_host: Optional[list[str] | str] = None
+    bootstrap_port: Optional[list[Optional[int]] | int] = None
+    bootstrap_room: Optional[list[int] | int] = None
+    routed_dp_rank: Optional[int] = None
+    disagg_prefill_dp_rank: Optional[int] = None
+    data_parallel_rank: Optional[int] = None
+
     @field_validator("model")
     @classmethod
     def validate_model(cls, v):
@@ -138,9 +147,13 @@ class AnthropicMessagesRequest(BaseModel):
 class AnthropicDelta(BaseModel):
     """Delta for streaming responses"""
 
-    type: Optional[Literal["text_delta", "input_json_delta"]] = None
+    type: Optional[
+        Literal["text_delta", "input_json_delta", "thinking_delta", "signature_delta"]
+    ] = None
     text: Optional[str] = None
     partial_json: Optional[str] = None
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
 
     # Message delta fields
     stop_reason: Optional[

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -272,6 +272,18 @@ class AnthropicServing:
         if anthropic_request.stop_sequences is not None:
             request_data["stop"] = anthropic_request.stop_sequences
 
+        for pd_field in (
+            "bootstrap_host",
+            "bootstrap_port",
+            "bootstrap_room",
+            "routed_dp_rank",
+            "disagg_prefill_dp_rank",
+            "data_parallel_rank",
+        ):
+            value = getattr(anthropic_request, pd_field)
+            if value is not None:
+                request_data[pd_field] = value
+
         # Enable usage in stream so we can report it
         if anthropic_request.stream:
             request_data["stream_options"] = StreamOptions(include_usage=True)
@@ -439,6 +451,7 @@ class AnthropicServing:
         first_chunk = True
         content_block_index = 0
         content_block_open = False
+        content_block_type: Optional[str] = None
         finish_reason: Optional[str] = None
         usage_info: Optional[dict] = None
         message_id = f"msg_{uuid.uuid4().hex}"
@@ -461,6 +474,8 @@ class AnthropicServing:
                         stop_event.model_dump_json(exclude_none=True),
                         "content_block_stop",
                     )
+                    content_block_open = False
+                    content_block_type = None
 
                 # Emit message_delta with stop_reason and usage
                 stop_reason = STOP_REASON_MAP.get(finish_reason or "stop", "end_turn")
@@ -570,6 +585,8 @@ class AnthropicServing:
                                 "content_block_stop",
                             )
                             content_block_index += 1
+                            content_block_open = False
+                            content_block_type = None
 
                         # Start tool_use content block
                         start_event = AnthropicStreamEvent(
@@ -587,6 +604,7 @@ class AnthropicServing:
                             "content_block_start",
                         )
                         content_block_open = True
+                        content_block_type = "tool_use"
 
                         # Stream initial arguments if present
                         if tc_func.arguments:
@@ -619,8 +637,64 @@ class AnthropicServing:
                         )
                 continue
 
+            reasoning_content = getattr(delta, "reasoning_content", None)
+            if reasoning_content:
+                if content_block_open and content_block_type != "thinking":
+                    stop_event = AnthropicStreamEvent(
+                        type="content_block_stop",
+                        index=content_block_index,
+                    )
+                    yield _wrap_sse_event(
+                        stop_event.model_dump_json(exclude_none=True),
+                        "content_block_stop",
+                    )
+                    content_block_index += 1
+                    content_block_open = False
+                    content_block_type = None
+
+                if not content_block_open:
+                    start_event = AnthropicStreamEvent(
+                        type="content_block_start",
+                        index=content_block_index,
+                        content_block=AnthropicContentBlock(
+                            type="thinking", thinking="", signature=""
+                        ),
+                    )
+                    yield _wrap_sse_event(
+                        start_event.model_dump_json(exclude_none=True),
+                        "content_block_start",
+                    )
+                    content_block_open = True
+                    content_block_type = "thinking"
+
+                delta_event = AnthropicStreamEvent(
+                    type="content_block_delta",
+                    index=content_block_index,
+                    delta=AnthropicDelta(
+                        type="thinking_delta",
+                        thinking=reasoning_content,
+                    ),
+                )
+                yield _wrap_sse_event(
+                    delta_event.model_dump_json(exclude_none=True),
+                    "content_block_delta",
+                )
+
             # Handle text content deltas
             if delta.content is not None and delta.content != "":
+                if content_block_open and content_block_type != "text":
+                    stop_event = AnthropicStreamEvent(
+                        type="content_block_stop",
+                        index=content_block_index,
+                    )
+                    yield _wrap_sse_event(
+                        stop_event.model_dump_json(exclude_none=True),
+                        "content_block_stop",
+                    )
+                    content_block_index += 1
+                    content_block_open = False
+                    content_block_type = None
+
                 # Start a text content block if needed
                 if not content_block_open:
                     start_event = AnthropicStreamEvent(
@@ -633,6 +707,7 @@ class AnthropicServing:
                         "content_block_start",
                     )
                     content_block_open = True
+                    content_block_type = "text"
 
                 # Emit text delta
                 delta_event = AnthropicStreamEvent(
@@ -662,6 +737,15 @@ class AnthropicServing:
 
         choice = response.choices[0]
         content: list[AnthropicContentBlock] = []
+
+        if choice.message.reasoning_content:
+            content.append(
+                AnthropicContentBlock(
+                    type="thinking",
+                    thinking=choice.message.reasoning_content,
+                    signature="",
+                )
+            )
 
         # Add text content
         if choice.message.content:

--- a/sgl-model-gateway/src/observability/metrics.rs
+++ b/sgl-model-gateway/src/observability/metrics.rs
@@ -385,6 +385,8 @@ pub mod metrics_labels {
     pub const ENDPOINT_RERANK: &str = "rerank";
     pub const ENDPOINT_EMBEDDINGS: &str = "embeddings";
     pub const ENDPOINT_CLASSIFY: &str = "classify";
+    pub const ENDPOINT_MESSAGES: &str = "messages";
+    pub const ENDPOINT_COUNT_TOKENS: &str = "count_tokens";
 
     // Worker types
     pub const WORKER_REGULAR: &str = "regular";

--- a/sgl-model-gateway/src/routers/anthropic_protocol.rs
+++ b/sgl-model-gateway/src/routers/anthropic_protocol.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::protocols::common::GenerationRequest;
+
+/// Anthropic Messages request with minimal routing metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicMessagesRequest {
+    pub model: String,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default)]
+    pub messages: Vec<Value>,
+    #[serde(default, flatten)]
+    pub extra: Map<String, Value>,
+}
+
+/// Anthropic count_tokens request with minimal routing metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicCountTokensRequest {
+    pub model: String,
+    #[serde(default)]
+    pub messages: Vec<Value>,
+    #[serde(default, flatten)]
+    pub extra: Map<String, Value>,
+}
+
+impl GenerationRequest for AnthropicMessagesRequest {
+    fn is_stream(&self) -> bool {
+        self.stream
+    }
+
+    fn get_model(&self) -> Option<&str> {
+        Some(self.model.as_str())
+    }
+
+    fn extract_text_for_routing(&self) -> String {
+        extract_text_from_messages(&self.messages)
+    }
+}
+
+impl GenerationRequest for AnthropicCountTokensRequest {
+    fn is_stream(&self) -> bool {
+        false
+    }
+
+    fn get_model(&self) -> Option<&str> {
+        Some(self.model.as_str())
+    }
+
+    fn extract_text_for_routing(&self) -> String {
+        extract_text_from_messages(&self.messages)
+    }
+}
+
+fn extract_text_from_messages(messages: &[Value]) -> String {
+    let mut parts = Vec::new();
+
+    for msg in messages {
+        let Some(content) = msg.get("content") else {
+            continue;
+        };
+
+        match content {
+            Value::String(text) => {
+                if !text.is_empty() {
+                    parts.push(text.clone());
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    let Some(kind) = item.get("type").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    if kind == "text" {
+                        if let Some(text) = item.get("text").and_then(Value::as_str) {
+                            if !text.is_empty() {
+                                parts.push(text.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    parts.join(" ")
+}

--- a/sgl-model-gateway/src/routers/grpc/utils.rs
+++ b/sgl-model-gateway/src/routers/grpc/utils.rs
@@ -1026,6 +1026,8 @@ pub(crate) fn route_to_endpoint(route: &str) -> &'static str {
         "/v1/completions" => metrics_labels::ENDPOINT_COMPLETIONS,
         "/v1/rerank" => metrics_labels::ENDPOINT_RERANK,
         "/v1/responses" => metrics_labels::ENDPOINT_RESPONSES,
+        "/v1/messages" => metrics_labels::ENDPOINT_MESSAGES,
+        "/v1/messages/count_tokens" => metrics_labels::ENDPOINT_COUNT_TOKENS,
         _ => "other",
     }
 }

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -31,13 +31,14 @@ use crate::{
     protocols::{
         chat::{ChatCompletionRequest, ChatMessage, MessageContent},
         classify::ClassifyRequest,
-        common::{InputIds, StringOrArray},
+        common::{GenerationRequest, InputIds, StringOrArray},
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
         generate::GenerateRequest,
         rerank::RerankRequest,
     },
     routers::{
+        anthropic_protocol::{AnthropicCountTokensRequest, AnthropicMessagesRequest},
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
         header_utils,
@@ -77,6 +78,71 @@ struct PDRequestContext<'a> {
 struct BreakerOutcomesRecorded;
 
 impl PDRouter {
+    async fn post_to_worker<T: Serialize>(
+        &self,
+        worker: Arc<dyn Worker>,
+        endpoint: &'static str,
+        headers: Option<&HeaderMap>,
+        body: &T,
+    ) -> Response {
+        let mut headers_with_trace = headers.cloned().unwrap_or_default();
+        inject_trace_context_http(&mut headers_with_trace);
+
+        let json_request = match serde_json::to_value(body) {
+            Ok(v) => v,
+            Err(e) => return Self::handle_serialization_error(e),
+        };
+
+        let request = self.build_post_with_headers(
+            &self.client,
+            worker.url(),
+            endpoint,
+            &json_request,
+            Some(&headers_with_trace),
+            false,
+        );
+
+        match request.send().await {
+            Ok(res) => {
+                let status = StatusCode::from_u16(res.status().as_u16())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                let response_headers = header_utils::preserve_response_headers(res.headers());
+
+                match res.bytes().await {
+                    Ok(body) => {
+                        let mut response = Response::new(Body::from(body));
+                        *response.status_mut() = status;
+                        *response.headers_mut() = response_headers;
+                        response
+                    }
+                    Err(e) => {
+                        error!(
+                            "Failed to read response body from worker url={}: {}",
+                            worker.url(),
+                            e
+                        );
+                        error::internal_error(
+                            "read_response_body_failed",
+                            format!("Failed to read response body: {}", e),
+                        )
+                    }
+                }
+            }
+            Err(e) => {
+                error!(
+                    "Failed to proxy POST request to worker url={} endpoint={}: {}",
+                    worker.url(),
+                    endpoint,
+                    e
+                );
+                error::bad_gateway(
+                    "worker_request_failed",
+                    format!("Failed to proxy request to worker: {}", e),
+                )
+            }
+        }
+    }
+
     async fn proxy_to_first_prefill_worker(
         &self,
         endpoint: &str,
@@ -673,6 +739,7 @@ impl PDRouter {
                             prefill_result,
                             prefill.url(),
                             context.return_logprob,
+                            true,
                         )
                         .await
                     {
@@ -682,7 +749,12 @@ impl PDRouter {
                 } else {
                     // Even if we don't need logprobs, we should check prefill status
                     match self
-                        .process_prefill_response(prefill_result, prefill.url(), false)
+                        .process_prefill_response(
+                            prefill_result,
+                            prefill.url(),
+                            false,
+                            !context.is_stream,
+                        )
                         .await
                     {
                         Ok((_, body)) => body,
@@ -1086,6 +1158,7 @@ impl PDRouter {
         prefill_result: Result<reqwest::Response, reqwest::Error>,
         prefill_url: &str,
         return_logprob: bool,
+        consume_body: bool,
     ) -> Result<(StatusCode, Option<bytes::Bytes>), Response> {
         // Check prefill result first - it's critical for disaggregated mode
         let prefill_response = match prefill_result {
@@ -1163,13 +1236,25 @@ impl PDRouter {
                     None
                 }
             }
-        } else {
+        } else if consume_body {
             // For non-logprob requests, just consume the response without storing
             debug!("Consuming prefill response body (non-logprob request)");
             match prefill_response.bytes().await {
                 Ok(_) => debug!("Prefill response consumed successfully"),
                 Err(e) => warn!("Error consuming prefill response: {}", e),
             }
+            None
+        } else {
+            let prefill_url = prefill_url.to_string();
+            tokio::spawn(async move {
+                match prefill_response.bytes().await {
+                    Ok(_) => debug!("Prefill streaming response consumed successfully"),
+                    Err(e) => warn!(
+                        "Error consuming prefill streaming response from {}: {}",
+                        prefill_url, e
+                    ),
+                }
+            });
             None
         };
 
@@ -1540,6 +1625,55 @@ impl RouterTrait for PDRouter {
             "pd_unsupported_classify",
             "PD mode does not support /v1/classify",
         )
+    }
+
+    async fn route_anthropic_messages(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &AnthropicMessagesRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        let request_text = if self.policies_need_request_text() {
+            Some(body.extract_text_for_routing())
+        } else {
+            None
+        };
+
+        let context = PDRequestContext {
+            route: "/v1/messages",
+            batch_size: None,
+            is_stream: body.stream,
+            return_logprob: false,
+            request_text,
+            model_id,
+            headers: headers.cloned(),
+        };
+
+        self.execute_dual_dispatch(headers, body, context).await
+    }
+
+    async fn route_anthropic_count_tokens(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &AnthropicCountTokensRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        let request_text = if self.policies_need_request_text() {
+            Some(body.extract_text_for_routing())
+        } else {
+            None
+        };
+
+        let (prefill, _decode) = match self
+            .select_pd_pair(request_text.as_deref(), model_id, headers)
+            .await
+        {
+            Ok(pair) => pair,
+            Err(e) => return Self::handle_server_selection_error(e),
+        };
+
+        self.post_to_worker(prefill, "/v1/messages/count_tokens", headers, body)
+            .await
     }
 
     fn router_type(&self) -> &'static str {

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -846,6 +846,26 @@ impl RouterTrait for Router {
         }
     }
 
+    async fn route_anthropic_messages(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &crate::routers::anthropic_protocol::AnthropicMessagesRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        self.route_typed_request(headers, body, "/v1/messages", model_id)
+            .await
+    }
+
+    async fn route_anthropic_count_tokens(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &crate::routers::anthropic_protocol::AnthropicCountTokensRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        self.route_typed_request(headers, body, "/v1/messages/count_tokens", model_id)
+            .await
+    }
+
     fn router_type(&self) -> &'static str {
         "regular"
     }

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -10,16 +10,20 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-use crate::protocols::{
-    chat::ChatCompletionRequest,
-    classify::ClassifyRequest,
-    completion::CompletionRequest,
-    embedding::EmbeddingRequest,
-    generate::GenerateRequest,
-    rerank::RerankRequest,
-    responses::{ResponsesGetParams, ResponsesRequest},
+use crate::{
+    protocols::{
+        chat::ChatCompletionRequest,
+        classify::ClassifyRequest,
+        completion::CompletionRequest,
+        embedding::EmbeddingRequest,
+        generate::GenerateRequest,
+        rerank::RerankRequest,
+        responses::{ResponsesGetParams, ResponsesRequest},
+    },
+    routers::anthropic_protocol::{AnthropicCountTokensRequest, AnthropicMessagesRequest},
 };
 
+pub mod anthropic_protocol;
 pub mod conversations;
 pub mod error;
 pub mod factory;
@@ -195,6 +199,34 @@ pub trait RouterTrait: Send + Sync + Debug {
         _model_id: Option<&str>,
     ) -> Response {
         (StatusCode::NOT_IMPLEMENTED, "Rerank not implemented").into_response()
+    }
+
+    /// Route Anthropic Messages API requests
+    async fn route_anthropic_messages(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &AnthropicMessagesRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Anthropic messages not implemented",
+        )
+            .into_response()
+    }
+
+    /// Route Anthropic count_tokens requests
+    async fn route_anthropic_count_tokens(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &AnthropicCountTokensRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Anthropic count_tokens not implemented",
+        )
+            .into_response()
     }
 
     /// Get router type name

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -31,7 +31,10 @@ use crate::{
         rerank::RerankRequest,
         responses::{ResponsesGetParams, ResponsesRequest},
     },
-    routers::RouterTrait,
+    routers::{
+        anthropic_protocol::{AnthropicCountTokensRequest, AnthropicMessagesRequest},
+        RouterTrait,
+    },
     server::ServerConfig,
 };
 
@@ -724,6 +727,76 @@ impl RouterTrait for RouterManager {
             (
                 StatusCode::NOT_FOUND,
                 "No router available for rerank request",
+            )
+                .into_response()
+        }
+    }
+
+    async fn route_anthropic_messages(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &AnthropicMessagesRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        let effective_model_id = if self.enable_igw {
+            let model = model_id.or(Some(&body.model));
+            match self.resolve_model_id(model) {
+                Ok(id) => Some(id),
+                Err(err_response) => return *err_response,
+            }
+        } else {
+            None
+        };
+
+        let selected_model = effective_model_id
+            .as_deref()
+            .or(model_id)
+            .or(Some(&body.model));
+        let router = self.select_router_for_request(headers, selected_model);
+
+        if let Some(router) = router {
+            router
+                .route_anthropic_messages(headers, body, selected_model)
+                .await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Model '{}' not found or no router available", body.model),
+            )
+                .into_response()
+        }
+    }
+
+    async fn route_anthropic_count_tokens(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &AnthropicCountTokensRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        let effective_model_id = if self.enable_igw {
+            let model = model_id.or(Some(&body.model));
+            match self.resolve_model_id(model) {
+                Ok(id) => Some(id),
+                Err(err_response) => return *err_response,
+            }
+        } else {
+            None
+        };
+
+        let selected_model = effective_model_id
+            .as_deref()
+            .or(model_id)
+            .or(Some(&body.model));
+        let router = self.select_router_for_request(headers, selected_model);
+
+        if let Some(router) = router {
+            router
+                .route_anthropic_count_tokens(headers, body, selected_model)
+                .await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Model '{}' not found or no router available", body.model),
             )
                 .into_response()
         }

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -53,6 +53,7 @@ use crate::{
         worker_spec::{WorkerConfigRequest, WorkerUpdateRequest},
     },
     routers::{
+        anthropic_protocol::{AnthropicCountTokensRequest, AnthropicMessagesRequest},
         conversations,
         mesh::{
             get_app_config, get_cluster_status, get_global_rate_limit, get_global_rate_limit_stats,
@@ -245,6 +246,60 @@ async fn v1_classify(
     state
         .router
         .route_classify(Some(&headers), &body, Some(&body.model))
+        .await
+}
+
+async fn v1_anthropic_messages(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let routing: AnthropicMessagesRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "type": "error",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": format!("Invalid request body: {}", e)
+                    }
+                })),
+            )
+                .into_response()
+        }
+    };
+    state
+        .router
+        .route_anthropic_messages(Some(&headers), &routing, Some(&routing.model))
+        .await
+}
+
+async fn v1_anthropic_count_tokens(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let routing: AnthropicCountTokensRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "type": "error",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": format!("Invalid request body: {}", e)
+                    }
+                })),
+            )
+                .into_response()
+        }
+    };
+    state
+        .router
+        .route_anthropic_count_tokens(Some(&headers), &routing, Some(&routing.model))
         .await
 }
 
@@ -549,6 +604,8 @@ pub fn build_app(
         .route("/v1/responses", post(v1_responses))
         .route("/v1/embeddings", post(v1_embeddings))
         .route("/v1/classify", post(v1_classify))
+        .route("/v1/messages", post(v1_anthropic_messages))
+        .route("/v1/messages/count_tokens", post(v1_anthropic_count_tokens))
         .route("/v1/responses/{response_id}", get(v1_responses_get))
         .route(
             "/v1/responses/{response_id}/cancel",

--- a/sgl-model-gateway/tests/api/anthropic_test.rs
+++ b/sgl-model-gateway/tests/api/anthropic_test.rs
@@ -1,0 +1,630 @@
+//! Integration tests for the Anthropic Messages API endpoint (`POST /v1/messages`).
+//!
+//! The gateway forwards Anthropic-format requests to the backend worker's
+//! `/v1/messages` endpoint via the HTTP router.
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header::CONTENT_TYPE, StatusCode},
+};
+use serde_json::json;
+use smg::config::{PolicyConfig, RouterConfig};
+use tower::ServiceExt;
+
+use crate::common::{
+    mock_worker::{HealthStatus, MockWorkerConfig, WorkerType as MockWorkerType},
+    AppTestContext,
+};
+
+/// Build an [`AppTestContext`] whose router is in regular HTTP mode so
+/// that requests are routed through the HTTP router.
+async fn http_mode_ctx(worker_configs: Vec<MockWorkerConfig>) -> AppTestContext {
+    let config = RouterConfig::builder()
+        .regular_mode(vec![])
+        .policy(PolicyConfig::Random)
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(256 * 1024 * 1024)
+        .request_timeout_secs(600)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .max_concurrent_requests(64)
+        .queue_timeout_secs(60)
+        .build_unchecked();
+
+    AppTestContext::new_with_config(config, worker_configs).await
+}
+
+async fn pd_mode_ctx(prefill_port: u16, decode_port: u16) -> AppTestContext {
+    let prefill_url = format!("http://127.0.0.1:{}", prefill_port);
+    let decode_url = format!("http://127.0.0.1:{}", decode_port);
+    let config = RouterConfig::builder()
+        .prefill_decode_mode(vec![(prefill_url, Some(prefill_port))], vec![decode_url])
+        .policy(PolicyConfig::Random)
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(256 * 1024 * 1024)
+        .request_timeout_secs(600)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .max_concurrent_requests(64)
+        .queue_timeout_secs(60)
+        .build_unchecked();
+
+    AppTestContext::new_with_config(
+        config,
+        vec![
+            MockWorkerConfig {
+                port: prefill_port,
+                worker_type: MockWorkerType::Prefill,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+            MockWorkerConfig {
+                port: decode_port,
+                worker_type: MockWorkerType::Decode,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+        ],
+    )
+    .await
+}
+
+fn make_worker_cfg() -> MockWorkerConfig {
+    MockWorkerConfig {
+        port: 0,
+        worker_type: MockWorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    }
+}
+
+async fn assert_status_ok(resp: axum::response::Response) -> axum::response::Response {
+    if resp.status() != StatusCode::OK {
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap_or_default();
+        let body_str = String::from_utf8_lossy(&body);
+        panic!(
+            "unexpected status {} headers={:?} body={}",
+            status, headers, body_str
+        );
+    }
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Non-streaming tests
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_anthropic_messages_basic() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // Response must conform to the Anthropic Messages API schema.
+        assert_eq!(json["type"], "message");
+        assert_eq!(json["role"], "assistant");
+        assert!(json["id"].as_str().unwrap().starts_with("msg_"));
+        assert!(json["content"].is_array());
+        assert!(!json["content"].as_array().unwrap().is_empty());
+        assert_eq!(json["content"][0]["type"], "text");
+        assert!(json["stop_reason"].as_str().is_some());
+        assert!(json["usage"]["input_tokens"].is_number());
+        assert!(json["usage"]["output_tokens"].is_number());
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_messages_with_system_prompt() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 512,
+            "system": "You are a helpful assistant.",
+            "messages": [{"role": "user", "content": "What is 2+2?"}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["type"], "message");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_messages_multi_turn() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user",      "content": "Hello!"},
+                {"role": "assistant", "content": "Hi there! How can I help?"},
+                {"role": "user",      "content": "Tell me a joke."}
+            ]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let _resp = assert_status_ok(resp).await;
+        ctx.shutdown().await;
+    }
+
+    // -------------------------------------------------------------------------
+    // Streaming tests
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_anthropic_messages_streaming() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Count to 3."}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+
+        // Streaming response must use text/event-stream content type.
+        let ct = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("text/event-stream"),
+            "expected text/event-stream, got: {}",
+            ct
+        );
+
+        // Collect and verify SSE events.
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let raw = String::from_utf8_lossy(&bytes);
+
+        // Each data line must carry valid JSON.
+        let data_lines: Vec<&str> = raw.lines().filter(|l| l.starts_with("data:")).collect();
+        assert!(
+            !data_lines.is_empty(),
+            "expected SSE data lines, got:\n{}",
+            raw
+        );
+        for line in &data_lines {
+            let data = line.trim_start_matches("data:").trim();
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(data);
+            assert!(parsed.is_ok(), "invalid JSON in SSE data line: {}", line);
+        }
+
+        // The stream must contain the mandatory Anthropic lifecycle events.
+        assert!(raw.contains("message_start"), "missing message_start");
+        assert!(raw.contains("message_stop"), "missing message_stop");
+
+        ctx.shutdown().await;
+    }
+
+    // -------------------------------------------------------------------------
+    // Error-handling tests
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_anthropic_messages_invalid_json() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from("not valid json"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["type"], "error");
+        assert_eq!(json["error"]["type"], "invalid_request_error");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_messages_missing_model_field() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        // `model` is required for worker selection; omitting it must return 400.
+        let body = json!({
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        ctx.shutdown().await;
+    }
+
+    // -------------------------------------------------------------------------
+    // count_tokens tests
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_anthropic_count_tokens_basic() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "Hello!"}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages/count_tokens")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert!(
+            json["input_tokens"].is_number(),
+            "expected input_tokens to be a number, got: {}",
+            json
+        );
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_count_tokens_with_system_and_tools() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "system": "You are a helpful assistant.",
+            "messages": [{"role": "user", "content": "What time is it?"}],
+            "tools": [{
+                "name": "get_time",
+                "description": "Get current time",
+                "input_schema": {"type": "object", "properties": {}}
+            }]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages/count_tokens")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json["input_tokens"].is_number());
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_count_tokens_invalid_json() {
+        let ctx = http_mode_ctx(vec![make_worker_cfg()]).await;
+        let app = ctx.create_app().await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages/count_tokens")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from("not valid json"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["type"], "error");
+        assert_eq!(json["error"]["type"], "invalid_request_error");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_count_tokens_no_workers() {
+        let ctx = http_mode_ctx(vec![]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages/count_tokens")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            resp.status().is_client_error() || resp.status().is_server_error(),
+            "expected 4xx/5xx without workers, got {}",
+            resp.status()
+        );
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_pd_anthropic_messages_basic() {
+        let ctx = pd_mode_ctx(19801, 19802).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello from PD."}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(json["type"], "message");
+        assert_eq!(json["role"], "assistant");
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_pd_anthropic_messages_streaming() {
+        let ctx = pd_mode_ctx(19803, 19804).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Stream from PD."}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+        let ct = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.contains("text/event-stream"));
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let raw = String::from_utf8_lossy(&bytes);
+        assert!(raw.contains("message_start"), "missing message_start");
+        assert!(
+            raw.contains("content_block_delta"),
+            "missing content block delta"
+        );
+        assert!(raw.contains("message_stop"), "missing message_stop");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_pd_anthropic_count_tokens() {
+        let ctx = pd_mode_ctx(19805, 19806).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "Count me."}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages/count_tokens")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = assert_status_ok(resp).await;
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["input_tokens"], 42);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_messages_no_workers() {
+        // No workers → the router returns a 4xx/5xx.
+        let ctx = http_mode_ctx(vec![]).await;
+        let app = ctx.create_app().await;
+
+        let body = json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            resp.status().is_client_error() || resp.status().is_server_error(),
+            "expected 4xx/5xx without workers, got {}",
+            resp.status()
+        );
+        ctx.shutdown().await;
+    }
+}

--- a/sgl-model-gateway/tests/api/mod.rs
+++ b/sgl-model-gateway/tests/api/mod.rs
@@ -1,5 +1,6 @@
 //! API endpoint integration tests
 
+mod anthropic_test;
 mod api_endpoints_test;
 mod parser_endpoints_test;
 mod request_formats_test;

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -94,6 +94,11 @@ impl MockWorker {
                 "/v1/responses/{response_id}/cancel",
                 post(responses_cancel_handler),
             )
+            .route("/v1/messages", post(anthropic_messages_handler))
+            .route(
+                "/v1/messages/count_tokens",
+                post(anthropic_count_tokens_handler),
+            )
             .route("/flush_cache", post(flush_cache_handler))
             .route("/v1/models", get(v1_models_handler))
             .with_state(config);
@@ -1768,6 +1773,150 @@ async fn rerank_handler(
     });
 
     (StatusCode::OK, Json(mock_results)).into_response()
+}
+
+async fn anthropic_messages_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    Json(payload): Json<serde_json::Value>,
+) -> Response {
+    let config = config.read().await;
+
+    if should_fail(&config).await {
+        return (
+            fail_status_code(config.port),
+            Json(json!({
+                "type": "error",
+                "error": {
+                    "type": "api_error",
+                    "message": "Random failure for testing"
+                }
+            })),
+        )
+            .into_response();
+    }
+
+    if config.response_delay_ms > 0 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(config.response_delay_ms)).await;
+    }
+
+    let model = payload
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("claude-3-5-sonnet-20241022")
+        .to_string();
+    let is_stream = payload
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if is_stream {
+        let msg_id = format!("msg_{}", Uuid::new_v4().simple());
+        let events = vec![
+            Ok::<_, Infallible>(
+                Event::default().event("message_start").data(
+                    json!({
+                        "type": "message_start",
+                        "message": {
+                            "id": msg_id,
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [],
+                            "model": model,
+                            "stop_reason": null,
+                            "stop_sequence": null,
+                            "usage": { "input_tokens": 10, "output_tokens": 0 }
+                        }
+                    })
+                    .to_string(),
+                ),
+            ),
+            Ok(Event::default().event("content_block_start").data(
+                json!({
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": { "type": "text", "text": "" }
+                })
+                .to_string(),
+            )),
+            Ok(Event::default().event("content_block_delta").data(
+                json!({
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {
+                        "type": "text_delta",
+                        "text": "This is a mock Anthropic response."
+                    }
+                })
+                .to_string(),
+            )),
+            Ok(Event::default()
+                .event("content_block_stop")
+                .data(json!({ "type": "content_block_stop", "index": 0 }).to_string())),
+            Ok(Event::default().event("message_delta").data(
+                json!({
+                    "type": "message_delta",
+                    "delta": {
+                        "stop_reason": "end_turn",
+                        "stop_sequence": null
+                    },
+                    "usage": { "output_tokens": 8 }
+                })
+                .to_string(),
+            )),
+            Ok(Event::default()
+                .event("message_stop")
+                .data(json!({ "type": "message_stop" }).to_string())),
+        ];
+
+        Sse::new(stream::iter(events))
+            .keep_alive(KeepAlive::default())
+            .into_response()
+    } else {
+        Json(json!({
+            "id": format!("msg_{}", Uuid::new_v4().simple()),
+            "type": "message",
+            "role": "assistant",
+            "content": [{
+                "type": "text",
+                "text": "This is a mock Anthropic response."
+            }],
+            "model": model,
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 8
+            }
+        }))
+        .into_response()
+    }
+}
+
+async fn anthropic_count_tokens_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    Json(_payload): Json<serde_json::Value>,
+) -> Response {
+    let config = config.read().await;
+
+    if should_fail(&config).await {
+        return (
+            fail_status_code(config.port),
+            Json(json!({
+                "type": "error",
+                "error": {
+                    "type": "api_error",
+                    "message": "Random failure for testing"
+                }
+            })),
+        )
+            .into_response();
+    }
+
+    if config.response_delay_ms > 0 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(config.response_delay_ms)).await;
+    }
+
+    Json(json!({ "input_tokens": 42 })).into_response()
 }
 
 impl Default for MockWorkerConfig {

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -14,6 +14,7 @@ python3 -m unittest openai_server.basic.test_anthropic_server.TestAnthropicServe
 python3 -m unittest openai_server.basic.test_anthropic_server.TestAnthropicServer.test_tool_result_image_content_conversion
 """
 
+import asyncio
 import json
 import unittest
 
@@ -21,6 +22,15 @@ import requests
 
 from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest
 from sglang.srt.entrypoints.anthropic.serving import AnthropicServing
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+    ChatMessage,
+    DeltaMessage,
+    UsageInfo,
+)
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
@@ -33,6 +43,149 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=40, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=140, suite="stage-b-test-1-gpu-small-amd")
+
+
+class TestAnthropicConversion(unittest.TestCase):
+    def test_pd_metadata_conversion(self):
+        anthropic_request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=64,
+            messages=[{"role": "user", "content": "hello"}],
+            bootstrap_host="10.0.0.1",
+            bootstrap_port=8998,
+            bootstrap_room=12345,
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        chat_request = serving._convert_to_chat_completion_request(anthropic_request)
+
+        self.assertEqual(chat_request.bootstrap_host, "10.0.0.1")
+        self.assertEqual(chat_request.bootstrap_port, 8998)
+        self.assertEqual(chat_request.bootstrap_room, 12345)
+
+    def test_non_streaming_reasoning_content_maps_to_thinking_block(self):
+        response = ChatCompletionResponse(
+            id="chatcmpl-test",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        reasoning_content="think first",
+                        content="final answer",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=3, completion_tokens=5, total_tokens=8),
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        anthropic_response = serving._convert_response(response)
+
+        self.assertEqual(anthropic_response.content[0].type, "thinking")
+        self.assertEqual(anthropic_response.content[0].thinking, "think first")
+        self.assertEqual(anthropic_response.content[1].type, "text")
+        self.assertEqual(anthropic_response.content[1].text, "final answer")
+
+    def test_streaming_reasoning_content_maps_to_thinking_delta(self):
+        async def fake_openai_stream():
+            role_chunk = ChatCompletionStreamResponse(
+                id="chatcmpl-test",
+                model="test-model",
+                choices=[
+                    ChatCompletionResponseStreamChoice(
+                        index=0,
+                        delta=DeltaMessage(role="assistant", content=""),
+                    )
+                ],
+            )
+            yield f"data: {role_chunk.model_dump_json()}\n\n"
+
+            reasoning_chunk = ChatCompletionStreamResponse(
+                id="chatcmpl-test",
+                model="test-model",
+                choices=[
+                    ChatCompletionResponseStreamChoice(
+                        index=0,
+                        delta=DeltaMessage(reasoning_content="think first"),
+                    )
+                ],
+            )
+            yield f"data: {reasoning_chunk.model_dump_json()}\n\n"
+
+            text_chunk = ChatCompletionStreamResponse(
+                id="chatcmpl-test",
+                model="test-model",
+                choices=[
+                    ChatCompletionResponseStreamChoice(
+                        index=0,
+                        delta=DeltaMessage(content="final answer"),
+                    )
+                ],
+            )
+            yield f"data: {text_chunk.model_dump_json()}\n\n"
+
+            finish_chunk = ChatCompletionStreamResponse(
+                id="chatcmpl-test",
+                model="test-model",
+                choices=[
+                    ChatCompletionResponseStreamChoice(
+                        index=0,
+                        delta=DeltaMessage(),
+                        finish_reason="stop",
+                    )
+                ],
+            )
+            yield f"data: {finish_chunk.model_dump_json()}\n\n"
+            yield "data: [DONE]\n\n"
+
+        class FakeOpenAIServingChat:
+            def _generate_chat_stream(
+                self, adapted_request, processed_request, raw_request
+            ):
+                return fake_openai_stream()
+
+        async def collect_events():
+            serving = AnthropicServing(openai_serving_chat=FakeOpenAIServingChat())
+            request = AnthropicMessagesRequest(
+                model="test-model",
+                max_tokens=64,
+                stream=True,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            raw_events = []
+            async for event in serving._generate_anthropic_stream(
+                object(), object(), request, object()
+            ):
+                _, data = event.split("data: ", 1)
+                raw_events.append(json.loads(data.strip()))
+            return raw_events
+
+        events = asyncio.run(collect_events())
+
+        thinking_starts = [
+            e
+            for e in events
+            if e["type"] == "content_block_start"
+            and e["content_block"]["type"] == "thinking"
+        ]
+        thinking_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta"
+            and e["delta"]["type"] == "thinking_delta"
+        ]
+        text_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta" and e["delta"]["type"] == "text_delta"
+        ]
+
+        self.assertEqual(len(thinking_starts), 1)
+        self.assertEqual(thinking_deltas[0]["delta"]["thinking"], "think first")
+        self.assertEqual(text_deltas[0]["delta"]["text"], "final answer")
 
 
 class TestAnthropicServer(CustomTestCase):


### PR DESCRIPTION
## Motivation

The Rust model gateway does not currently route Anthropic Messages API requests through the same router abstraction as other generation endpoints. As a result, `/v1/messages` and `/v1/messages/count_tokens` are unavailable in gateway deployments, including PD disaggregation, even though the Python worker already implements Anthropic-compatible APIs.

This PR builds on the direction from #20566 and also covers the PD disaggregation path and Anthropic thinking stream conversion issues found while testing gateway deployments with Claude Code-style clients.

## Modifications

- Add minimal Anthropic routing request structs for the model gateway.
- Wire `POST /v1/messages` and `POST /v1/messages/count_tokens` through `server.rs`, `RouterTrait`, the regular HTTP router, the PD HTTP router, and `RouterManager`.
- In PD mode, route `/v1/messages` through dual prefill/decode dispatch and route `count_tokens` to a prefill worker.
- Avoid synchronously draining the prefill SSE body for streaming PD requests when no logprobs are required.
- Pass gateway-injected PD metadata through the Anthropic-to-OpenAI worker conversion.
- Convert OpenAI `reasoning_content` into Anthropic `thinking` blocks and `thinking_delta` stream events.
- Add gateway Anthropic tests for regular and PD modes, plus conversion tests for PD metadata and reasoning content.

## Accuracy Tests

Not applicable. This PR changes routing/protocol conversion only and does not modify model forward computation.

## Speed Tests and Profiling

Not benchmarked. The changes are in HTTP routing and response protocol conversion; no inference hot path kernels are changed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Tests run:

- `cargo fmt`
- `PROTOC=/Users/xhy/.local/protoc/27.3/bin/protoc cargo test --test api_tests anthropic -- --nocapture`，14 passed
- `python3 -m py_compile python/sglang/srt/entrypoints/anthropic/protocol.py python/sglang/srt/entrypoints/anthropic/serving.py test/registered/openai_server/basic/test_anthropic_server.py`

Not run locally:

- `python3 -m unittest ...TestAnthropicConversion` because the local Python environment is missing `requests`.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27399961628](https://github.com/sgl-project/sglang/actions/runs/27399961628)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27399961475](https://github.com/sgl-project/sglang/actions/runs/27399961475)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->