### PR TITLE
Add DFLASH Mamba/GDN reduced-cache replay

### DIFF
--- a/docs_new/docs/advanced_features/speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/speculative_decoding.mdx
@@ -463,6 +463,11 @@ Relevant parameters:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dflash-mamba-cache-steps</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of target-verify draft steps whose Mamba/GDN recurrent states are cached. Values smaller than the DFlash block size reduce recurrent-state memory and enable replay for the uncached tail.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Full block</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dflash-draft-window-size</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Draft KV sliding-window size. Must be <code>&gt;= speculative-num-draft-tokens</code> when set.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -103,7 +103,7 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
             )
 
     if (
-        server_args.speculative_dflash_mamba_cache_steps is not None
+        getattr(server_args, "speculative_dflash_mamba_cache_steps", None) is not None
         and server_args.speculative_algorithm != "DFLASH"
     ):
         raise ValueError(

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -102,6 +102,15 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
                 server_args.speculative_algorithm,
             )
 
+    if (
+        server_args.speculative_dflash_mamba_cache_steps is not None
+        and server_args.speculative_algorithm != "DFLASH"
+    ):
+        raise ValueError(
+            "--speculative-dflash-mamba-cache-steps is only supported with "
+            "--speculative-algorithm DFLASH."
+        )
+
     algo = None
     if server_args.speculative_algorithm is not None:
         from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -228,6 +237,29 @@ def _handle_dflash(server_args: ServerArgs) -> None:
                 "--speculative-num-draft-tokens (block_size). "
                 f"window_size={server_args.speculative_draft_window_size}, block_size={draft_tokens}."
             )
+
+    if server_args.speculative_dflash_mamba_cache_steps is not None:
+        cache_steps = int(server_args.speculative_dflash_mamba_cache_steps)
+        draft_tokens = int(server_args.speculative_num_draft_tokens)
+        if cache_steps < 0:
+            raise ValueError(
+                "DFLASH requires --speculative-dflash-mamba-cache-steps "
+                f"to be non-negative, got {cache_steps}."
+            )
+        if cache_steps > draft_tokens:
+            raise ValueError(
+                "DFLASH --speculative-dflash-mamba-cache-steps must be <= "
+                "--speculative-num-draft-tokens. "
+                f"cache_steps={cache_steps}, draft_tokens={draft_tokens}."
+            )
+        server_args.speculative_dflash_mamba_cache_steps = cache_steps
+
+    if (
+        server_args.speculative_dflash_mamba_cache_steps is not None
+        and server_args.speculative_dflash_mamba_cache_steps
+        < server_args.speculative_num_draft_tokens
+    ):
+        server_args.speculative_dflash_mamba_replay = True
 
     if server_args.max_running_requests is None:
         server_args.max_running_requests = 48

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -711,6 +711,7 @@ class TboForwardBatchPreparer:
             "is_prefill_only",
             "spec_algorithm",
             "capture_hidden_mode",
+            "cuda_graph_key",
             "padded_static_len",
             "split_index",  # for split prefill
             "orig_seq_lens",  # only used by qwen-1m, thus not care

--- a/python/sglang/srt/configs/mamba_utils.py
+++ b/python/sglang/srt/configs/mamba_utils.py
@@ -113,16 +113,20 @@ class BaseLinearStateParams(ABC):
     layers: list[int]
 
     @property
-    def mamba_cache_per_req(self) -> int:
+    def mamba_conv_cache_per_req(self) -> int:
         conv_numel = int(
             np.sum([np.prod(conv_shape) for conv_shape in self.shape.conv])
         )
+        return conv_numel * self.dtype.conv.itemsize * len(self.layers)
 
+    @property
+    def mamba_temporal_cache_per_req(self) -> int:
         ssm_numel = int(np.prod(self.shape.temporal))
-        return (
-            conv_numel * self.dtype.conv.itemsize
-            + ssm_numel * self.dtype.temporal.itemsize
-        ) * len(self.layers)
+        return ssm_numel * self.dtype.temporal.itemsize * len(self.layers)
+
+    @property
+    def mamba_cache_per_req(self) -> int:
+        return self.mamba_conv_cache_per_req + self.mamba_temporal_cache_per_req
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -194,6 +194,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         pre_alloc_size: int,
         enable_overlap_schedule: bool,
         mamba_size: int = None,
+        speculative_mamba_cache_steps: int = None,
         start_layer: int = None,
         speculative_eagle_topk: Optional[int] = None,
     ):
@@ -240,6 +241,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
             enable_mamba_extra_buffer=self.enable_mamba_extra_buffer,
             speculative_num_draft_tokens=speculative_num_draft_tokens,
             speculative_eagle_topk=speculative_eagle_topk,
+            speculative_mamba_cache_steps=speculative_mamba_cache_steps,
         )
 
     def clear(self):

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -76,6 +76,18 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
             device=self.device,
         )
 
+    @staticmethod
+    def _spec_metadata_kwargs(
+        forward_mode: ForwardMode,
+        spec_info: Optional[SpecInput],
+    ):
+        return dict(
+            is_target_verify=forward_mode.is_target_verify(),
+            draft_token_num=(spec_info.draft_token_num if spec_info is not None else 1),
+            mamba_cache_steps=getattr(spec_info, "mamba_cache_steps", None),
+            mamba_replay=bool(getattr(spec_info, "mamba_replay", False)),
+        )
+
     def _capture_metadata(
         self,
         bs: int,
@@ -115,12 +127,14 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
                 retrieve_next_token=self.retrieve_next_token_list[bs - 1],
                 retrieve_next_sibling=self.retrieve_next_sibling_list[bs - 1],
                 retrieve_parent_token=self.retrieve_parent_token_list[bs - 1],
+                **self._spec_metadata_kwargs(forward_mode, spec_info),
             )
         else:
             return ForwardMetadata(
                 query_start_loc=self.query_start_loc_list[bs - 1],
                 mamba_cache_indices=self.state_indices_list[bs - 1],
                 mamba_cache_indices_gdn=self.state_indices_list_gdn[bs - 1],
+                **self._spec_metadata_kwargs(forward_mode, spec_info),
             )
 
     def _replay_metadata(
@@ -192,12 +206,14 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
                 retrieve_next_token=self.retrieve_next_token_list[bs - 1],
                 retrieve_next_sibling=self.retrieve_next_sibling_list[bs - 1],
                 retrieve_parent_token=self.retrieve_parent_token_list[bs - 1],
+                **self._spec_metadata_kwargs(forward_mode, spec_info),
             )
         else:
             return ForwardMetadata(
                 query_start_loc=self.query_start_loc_list[bs - 1],
                 mamba_cache_indices=self.state_indices_list[bs - 1],
                 mamba_cache_indices_gdn=self.state_indices_list_gdn[bs - 1],
+                **self._spec_metadata_kwargs(forward_mode, spec_info),
             )
 
     def get_cuda_graph_seq_len_fill_value(self):
@@ -219,10 +235,12 @@ class AscendHybridLinearAttnBackend(HybridLinearAttnBackend):
 
     def update_mamba_state_after_mtp_verify(
         self,
-        last_correct_step_indices: torch.Tensor,
-        mamba_track_indices: Optional[torch.Tensor],
-        mamba_steps_to_track: Optional[torch.Tensor],
-        model,
+        last_correct_step_indices: Optional[torch.Tensor] = None,
+        mamba_track_indices: Optional[torch.Tensor] = None,
+        mamba_steps_to_track: Optional[torch.Tensor] = None,
+        model=None,
+        accepted_steps: Optional[torch.Tensor] = None,
+        accepted_lengths: Optional[torch.Tensor] = None,
     ):
         """
         Update mamba states after MTP verify using fully fused Triton kernel.
@@ -233,7 +251,32 @@ class AscendHybridLinearAttnBackend(HybridLinearAttnBackend):
         - index_select kernel launches
         - nonzero kernel launches
         """
-        request_number = last_correct_step_indices.shape[0]
+        if accepted_steps is None:
+            if last_correct_step_indices is None:
+                raise ValueError(
+                    "update_mamba_state_after_mtp_verify requires accepted_steps "
+                    "or last_correct_step_indices."
+                )
+            accepted_steps = last_correct_step_indices
+
+        mamba_cache_steps = getattr(
+            self.linear_attn_backend.forward_metadata, "mamba_cache_steps", None
+        )
+        mamba_replay = bool(
+            getattr(self.linear_attn_backend.forward_metadata, "mamba_replay", False)
+        )
+        draft_token_num = int(self.linear_attn_backend.forward_metadata.draft_token_num)
+        if (
+            mamba_replay
+            and mamba_cache_steps is not None
+            and int(mamba_cache_steps) < draft_token_num
+        ):
+            raise NotImplementedError(
+                "DFLASH Mamba replay is only implemented for CUDA hybrid linear "
+                "attention backends."
+            )
+
+        request_number = accepted_steps.shape[0]
 
         state_indices_tensor = (
             self.linear_attn_backend.forward_metadata.mamba_cache_indices[
@@ -254,7 +297,7 @@ class AscendHybridLinearAttnBackend(HybridLinearAttnBackend):
             device=dst_indices_tensor.device,
             dtype=torch.int64,
         )
-        last_steps = last_correct_step_indices.to(torch.int64)  # [N]
+        last_steps = accepted_steps.to(torch.int64)  # [N]
 
         move_intermediate_cache(
             ssm_states,

--- a/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -19,12 +19,18 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     o,
     h0_source,
     h0_indices,
+    h0_output_indices,
     cu_seqlens,
     # Parameters for target_verify support (unused for decode)
     intermediate_states_buffer,
     intermediate_state_indices,
     cache_steps,
     retrieve_parent_token_ptr,
+    input_token_indices,
+    input_sequence_indices,
+    input_sequence_lengths,
+    input_token_start: tl.constexpr,
+    input_token_stride: tl.constexpr,
     stride_retrieve_parent_token_seq: tl.constexpr,
     stride_retrieve_parent_token_token: tl.constexpr,
     # ================================================
@@ -49,8 +55,12 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     IS_KDA: tl.constexpr,
     # Optional flags for target_verify support (default False for decode)
     DISABLE_STATE_UPDATE: tl.constexpr = False,
+    DISABLE_OUTPUT_CALCULATION: tl.constexpr = False,
     CACHE_INTERMEDIATE_STATES: tl.constexpr = False,
     HAS_EAGLE_TREE_CUSTOM_ATTN_MASK: tl.constexpr = False,
+    HAS_INPUT_TOKEN_INDICES: tl.constexpr = False,
+    HAS_INPUT_SEQUENCE_INDICES: tl.constexpr = False,
+    HAS_INPUT_SEQUENCE_LENGTHS: tl.constexpr = False,
 ):
     """
     Fused kernel that combines sigmoid gating computation with recurrent delta rule update.
@@ -59,7 +69,11 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     i_n, i_hv = i_nh // HV, i_nh % HV
     i_h = i_hv // (HV // H)
 
-    if IS_VARLEN:
+    if HAS_INPUT_SEQUENCE_LENGTHS:
+        bos = 0
+        all = T
+        T = tl.load(input_sequence_lengths + i_n).to(tl.int64)
+    elif IS_VARLEN:
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int64),
             tl.load(cu_seqlens + i_n + 1).to(tl.int64),
@@ -73,24 +87,66 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     o_k = i_k * BK + tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
 
-    p_q = q + bos * stride_q + i_h * K + o_k
-    p_k = k + bos * stride_k + i_h * K + o_k
-    p_v = v + bos * stride_v + i_hv * V + o_v
-    p_b = b + bos * stride_b + i_hv
-    p_o = o + ((i_k * all + bos) * HV + i_hv) * V + o_v
+    if not HAS_INPUT_TOKEN_INDICES and not HAS_INPUT_SEQUENCE_INDICES:
+        p_k = k + bos * stride_k + i_h * K + o_k
+        p_v = v + bos * stride_v + i_hv * V + o_v
+        p_b = b + bos * stride_b + i_hv
+    else:
+        p_k = k + i_h * K + o_k
+        p_v = v + i_hv * V + o_v
+        p_b = b + i_hv
+
+    if not DISABLE_OUTPUT_CALCULATION:
+        p_q = q + bos * stride_q + i_h * K + o_k
+        p_o = o + ((i_k * all + bos) * HV + i_hv) * V + o_v
 
     # Gating computation pointers
     p_A_log = A_log + i_hv
     if IS_KDA:
-        p_a = a + bos * stride_a + i_hv * K + o_k
         p_dt_bias = dt_bias + i_hv * K + o_k
+        if not HAS_INPUT_TOKEN_INDICES and not HAS_INPUT_SEQUENCE_INDICES:
+            p_a = a + bos * stride_a + i_hv * K + o_k
+        else:
+            p_a = a + i_hv * K + o_k
     else:
-        p_a = a + bos * stride_a + i_hv
         p_dt_bias = dt_bias + i_hv
+        if not HAS_INPUT_TOKEN_INDICES and not HAS_INPUT_SEQUENCE_INDICES:
+            p_a = a + bos * stride_a + i_hv
+        else:
+            p_a = a + i_hv
 
     mask_k = o_k < K
     mask_v = o_v < V
     mask_h = mask_k[:, None] & mask_v[None, :]
+
+    if T == 0:
+        return
+
+    if HAS_INPUT_SEQUENCE_INDICES:
+        physical_t = (
+            tl.load(input_sequence_indices + i_n).to(tl.int64) * input_token_stride
+            + input_token_start
+        )
+        p_k = k + physical_t * stride_k + i_h * K + o_k
+        p_v = v + physical_t * stride_v + i_hv * V + o_v
+        p_b = b + physical_t * stride_b + i_hv
+        if not DISABLE_OUTPUT_CALCULATION:
+            p_q = q + physical_t * stride_q + i_h * K + o_k
+        if IS_KDA:
+            p_a = a + physical_t * stride_a + i_hv * K + o_k
+        else:
+            p_a = a + physical_t * stride_a + i_hv
+    elif HAS_INPUT_SEQUENCE_LENGTHS:
+        physical_t = i_n * input_token_stride + input_token_start
+        p_k = k + physical_t * stride_k + i_h * K + o_k
+        p_v = v + physical_t * stride_v + i_hv * V + o_v
+        p_b = b + physical_t * stride_b + i_hv
+        if not DISABLE_OUTPUT_CALCULATION:
+            p_q = q + physical_t * stride_q + i_h * K + o_k
+        if IS_KDA:
+            p_a = a + physical_t * stride_a + i_hv * K + o_k
+        else:
+            p_a = a + physical_t * stride_a + i_hv
 
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
@@ -125,6 +181,17 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
 
     step_idx = 0
     for _ in range(0, T):
+        if HAS_INPUT_TOKEN_INDICES:
+            physical_t = tl.load(input_token_indices + bos + step_idx).to(tl.int64)
+            p_q = q + physical_t * stride_q + i_h * K + o_k
+            p_k = k + physical_t * stride_k + i_h * K + o_k
+            p_v = v + physical_t * stride_v + i_hv * V + o_v
+            p_b = b + physical_t * stride_b + i_hv
+            if IS_KDA:
+                p_a = a + physical_t * stride_a + i_hv * K + o_k
+            else:
+                p_a = a + physical_t * stride_a + i_hv
+
         # Tree attention: load parent's cached state
         if HAS_EAGLE_TREE_CUSTOM_ATTN_MASK:
             # step_idx == 0 uses b_h from USE_INITIAL_STATE
@@ -144,7 +211,6 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
                 b_h = tl.load(cache_ptr, mask=mask_h, other=0).to(tl.float32)
 
         # Load inputs
-        b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
         b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
         b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
         b_b = tl.load(p_b).to(tl.float32)
@@ -175,10 +241,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
 
         # Apply L2 normalization if enabled
         if USE_QK_L2NORM_IN_KERNEL:
-            b_q = b_q / (tl.sqrt(tl.sum(b_q * b_q) + 1e-6))
             b_k = b_k / (tl.sqrt(tl.sum(b_k * b_k) + 1e-6))
-
-        b_q = b_q * scale
 
         # Apply gating to hidden state: h *= exp(g)
         if IS_KDA:
@@ -196,12 +259,17 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
         b_h += b_k[:, None] * b_v[None, :]
 
         # Compute output: o = sum(h * q, dim=0)
-        b_o = tl.sum(b_h * b_q[:, None], 0)
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+        if not DISABLE_OUTPUT_CALCULATION:
+            b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
+            if USE_QK_L2NORM_IN_KERNEL:
+                b_q = b_q / (tl.sqrt(tl.sum(b_q * b_q) + 1e-6))
+            b_q = b_q * scale
+            b_o = tl.sum(b_h * b_q[:, None], 0)
+            tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
 
         # Cache intermediate states if enabled
         if CACHE_INTERMEDIATE_STATES:
-            if cache_idx >= 0:
+            if cache_idx >= 0 and step_idx < cache_steps:
                 step_offset = step_idx * HV * K * V
                 cache_ptr = (
                     intermediate_states_buffer
@@ -216,18 +284,21 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
         step_idx += 1
 
         # Update pointers for next timestep
-        p_q += stride_q
-        p_k += stride_k
-        p_v += stride_v
-        p_b += stride_b
-        p_o += HV * V
-        p_a += stride_a
+        if not HAS_INPUT_TOKEN_INDICES:
+            if not DISABLE_OUTPUT_CALCULATION:
+                p_q += stride_q
+            p_k += stride_k
+            p_v += stride_v
+            p_b += stride_b
+            p_a += stride_a
+        if not DISABLE_OUTPUT_CALCULATION:
+            p_o += HV * V
 
     # Store final state back to h0_source with bounds checking
     if not DISABLE_STATE_UPDATE:
         if USE_INITIAL_STATE:
-            idx = tl.load(h0_indices + i_n)
-            if idx >= 0:
+            idx = tl.load(h0_output_indices + i_n)
+            if (idx >= 0) & (T > 0):
                 p_h0 = (
                     h0_source
                     + idx * HV * K * V
@@ -250,18 +321,25 @@ def fused_sigmoid_gating_delta_rule_update(
     b: torch.Tensor,
     initial_state_source: torch.Tensor,
     initial_state_indices: torch.Tensor,
+    output_state_indices: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: Optional[torch.Tensor] = None,
     is_kda: bool = False,
     # Optional parameters for target_verify support
     disable_state_update: bool = False,
+    disable_output_calculation: bool = False,
     intermediate_states_buffer: Optional[torch.Tensor] = None,
     intermediate_state_indices: Optional[torch.Tensor] = None,
     cache_steps: Optional[
         int
     ] = None,  # kept for API compat; stride is derived from ``intermediate_states_buffer.shape[1]``
     retrieve_parent_token: Optional[torch.Tensor] = None,
+    input_token_indices: Optional[torch.Tensor] = None,
+    input_sequence_indices: Optional[torch.Tensor] = None,
+    input_sequence_lengths: Optional[torch.Tensor] = None,
+    input_token_start: int = 0,
+    input_token_stride: int = 0,
 ):
     """
     Fused triton implementation of sigmoid gating delta rule update.
@@ -274,6 +352,31 @@ def fused_sigmoid_gating_delta_rule_update(
                      and optional state update disable
     """
     B, T, H, K, V = *k.shape, v.shape[-1]
+    if input_token_indices is not None:
+        assert cu_seqlens is not None, "input_token_indices requires cu_seqlens"
+        assert (
+            disable_output_calculation
+        ), "input_token_indices is only supported for state-only replay"
+    if input_sequence_indices is not None:
+        assert (
+            cu_seqlens is not None or input_sequence_lengths is not None
+        ), "input_sequence_indices requires cu_seqlens or input_sequence_lengths"
+        assert (
+            input_token_indices is None
+        ), "input_sequence_indices and input_token_indices are mutually exclusive"
+        assert (
+            disable_output_calculation
+        ), "input_sequence_indices is only supported for state-only replay"
+    if input_sequence_lengths is not None:
+        assert input_sequence_indices is not None or input_token_stride > 0, (
+            "input_sequence_lengths requires input_sequence_indices or "
+            "a positive input_token_stride"
+        )
+        assert (
+            disable_output_calculation
+        ), "input_sequence_lengths is only supported for state-only replay"
+    if output_state_indices is None:
+        output_state_indices = initial_state_indices
     stride_q = q.stride()[1]
     stride_k = k.stride()[1]
     stride_v = v.stride()[1]
@@ -283,7 +386,10 @@ def fused_sigmoid_gating_delta_rule_update(
     # Using stride()[-2] covers GDN [T, HV] and KDA layouts ([T, HV*K] / [B, T, HV*K]).
     stride_a = a.stride()[-2]
     HV = v.shape[2]
-    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    if input_sequence_lengths is not None:
+        N = input_sequence_lengths.shape[0]
+    else:
+        N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)
     NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
     assert NK == 1, "NK > 1 is not supported yet"
@@ -295,7 +401,13 @@ def fused_sigmoid_gating_delta_rule_update(
     else:
         assert scale > 0, "scale must be positive"
 
-    o = q.new_empty(NK, *v.shape)
+    if disable_output_calculation:
+        # State-only replay does not read or write the output pointer in the
+        # Triton kernel. Reuse an existing tensor to avoid a tiny allocation for
+        # every replay layer.
+        o = q
+    else:
+        o = q.new_empty(NK, *v.shape)
 
     # Prepare retrieve_parent_token strides
     if retrieve_parent_token is not None:
@@ -330,11 +442,17 @@ def fused_sigmoid_gating_delta_rule_update(
         o=o,
         h0_source=initial_state_source,
         h0_indices=initial_state_indices,
+        h0_output_indices=output_state_indices,
         cu_seqlens=cu_seqlens,
         intermediate_states_buffer=intermediate_states_buffer,
         intermediate_state_indices=intermediate_state_indices,
         cache_steps=cache_stride_steps,
         retrieve_parent_token_ptr=retrieve_parent_token,
+        input_token_indices=input_token_indices,
+        input_sequence_indices=input_sequence_indices,
+        input_sequence_lengths=input_sequence_lengths,
+        input_token_start=input_token_start,
+        input_token_stride=input_token_stride,
         stride_retrieve_parent_token_seq=stride_retrieve_parent_token_seq,
         stride_retrieve_parent_token_token=stride_retrieve_parent_token_token,
         scale=scale,
@@ -357,10 +475,16 @@ def fused_sigmoid_gating_delta_rule_update(
         IS_VARLEN=cu_seqlens is not None,
         IS_KDA=is_kda,
         DISABLE_STATE_UPDATE=disable_state_update,
+        DISABLE_OUTPUT_CALCULATION=disable_output_calculation,
         CACHE_INTERMEDIATE_STATES=intermediate_states_buffer is not None,
         HAS_EAGLE_TREE_CUSTOM_ATTN_MASK=retrieve_parent_token is not None,
+        HAS_INPUT_TOKEN_INDICES=input_token_indices is not None,
+        HAS_INPUT_SEQUENCE_INDICES=input_sequence_indices is not None,
+        HAS_INPUT_SEQUENCE_LENGTHS=input_sequence_lengths is not None,
         num_warps=num_warps,
         num_stages=num_stages,
     )
+    if disable_output_calculation:
+        return None
     o = o.squeeze(0)
     return o

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 class MambaAttnBackendBase(AttentionBackend):
+    supports_dflash_mamba_replay = False
+
     def __init__(self, model_runner: ModelRunner):
         super().__init__()
         self.pad_slot_id = PAD_SLOT_ID
@@ -44,6 +46,15 @@ class MambaAttnBackendBase(AttentionBackend):
         self.cached_cuda_graph_decode_query_start_loc: torch.Tensor = None
         self.cached_cuda_graph_verify_query_start_loc: torch.Tensor = None
         self.conv_states_shape: tuple[int, int] = None
+
+    def replay_mamba_state_after_verify(self, **kwargs) -> None:
+        raise NotImplementedError(
+            "DFLASH reduced Mamba cache replay is only implemented for GDN "
+            "linear attention backends."
+        )
+
+    def clear_mamba_replay_inputs(self) -> None:
+        pass
 
     def _execute_deferred_mamba_cow_and_clear(self, forward_batch: ForwardBatch):
         """Run deferred clear/COW ops on the forward stream to avoid races."""
@@ -160,6 +171,11 @@ class MambaAttnBackendBase(AttentionBackend):
             forward_batch.mamba_track_mask is not None
             and forward_batch.mamba_track_mask.any()
         )
+        draft_token_num = (
+            forward_batch.spec_info.draft_token_num
+            if forward_batch.spec_info is not None
+            else 1
+        )
 
         return ForwardMetadata(
             query_start_loc=query_start_loc,
@@ -173,6 +189,8 @@ class MambaAttnBackendBase(AttentionBackend):
             track_ssm_final_src=track_ssm_final_src,
             track_ssm_final_dst=track_ssm_final_dst,
             has_mamba_track_mask=has_mamba_track_mask,
+            is_target_verify=forward_batch.forward_mode.is_target_verify(),
+            draft_token_num=draft_token_num,
         )
 
     def init_forward_metadata_out_graph(
@@ -418,6 +436,17 @@ class MambaAttnBackendBase(AttentionBackend):
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
         mamba_indices = self.req_to_token_pool.get_mamba_indices(req_pool_indices)
         self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
+        draft_token_num = spec_info.draft_token_num if spec_info is not None else 1
+        mamba_cache_steps = (
+            getattr(spec_info, "mamba_cache_steps", None)
+            if spec_info is not None
+            else None
+        )
+        mamba_replay = (
+            getattr(spec_info, "mamba_replay", False)
+            if spec_info is not None
+            else False
+        )
 
         # If topk > 1, we need to use retrieve_next_token and retrieve_next_sibling to handle the eagle tree custom attention mask
         if forward_mode.is_target_verify() and self.topk > 1:
@@ -430,11 +459,19 @@ class MambaAttnBackendBase(AttentionBackend):
                 retrieve_next_token=self.retrieve_next_token_list[bs - 1],
                 retrieve_next_sibling=self.retrieve_next_sibling_list[bs - 1],
                 retrieve_parent_token=self.retrieve_parent_token_list[bs - 1],
+                is_target_verify=forward_mode.is_target_verify(),
+                draft_token_num=draft_token_num,
+                mamba_cache_steps=mamba_cache_steps,
+                mamba_replay=mamba_replay,
             )
         else:
             return ForwardMetadata(
                 query_start_loc=self.query_start_loc_list[bs - 1],
                 mamba_cache_indices=self.state_indices_list[bs - 1],
+                is_target_verify=forward_mode.is_target_verify(),
+                draft_token_num=draft_token_num,
+                mamba_cache_steps=mamba_cache_steps,
+                mamba_replay=mamba_replay,
             )
 
     def _replay_metadata(
@@ -484,6 +521,17 @@ class MambaAttnBackendBase(AttentionBackend):
                 )
         else:
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
+        draft_token_num = spec_info.draft_token_num if spec_info is not None else 1
+        mamba_cache_steps = (
+            getattr(spec_info, "mamba_cache_steps", None)
+            if spec_info is not None
+            else None
+        )
+        mamba_replay = (
+            getattr(spec_info, "mamba_replay", False)
+            if spec_info is not None
+            else False
+        )
 
         # If topk > 1, we need to use retrieve_next_token and retrieve_next_sibling to handle the eagle tree custom attention mask
         if forward_mode.is_target_verify() and self.topk > 1:
@@ -504,11 +552,19 @@ class MambaAttnBackendBase(AttentionBackend):
                 retrieve_next_token=self.retrieve_next_token_list[bs - 1],
                 retrieve_next_sibling=self.retrieve_next_sibling_list[bs - 1],
                 retrieve_parent_token=self.retrieve_parent_token_list[bs - 1],
+                is_target_verify=forward_mode.is_target_verify(),
+                draft_token_num=draft_token_num,
+                mamba_cache_steps=mamba_cache_steps,
+                mamba_replay=mamba_replay,
             )
         else:
             return ForwardMetadata(
                 query_start_loc=self.query_start_loc_list[bs - 1],
                 mamba_cache_indices=self.state_indices_list[bs - 1],
+                is_target_verify=forward_mode.is_target_verify(),
+                draft_token_num=draft_token_num,
+                mamba_cache_steps=mamba_cache_steps,
+                mamba_replay=mamba_replay,
             )
 
     def get_cuda_graph_seq_len_fill_value(self):
@@ -618,11 +674,23 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
         )
         spec_info = forward_batch.spec_info
         draft_token_num = spec_info.draft_token_num if spec_info is not None else 1
+        mamba_cache_steps = (
+            getattr(spec_info, "mamba_cache_steps", None)
+            if spec_info is not None
+            else None
+        )
+        mamba_replay = (
+            getattr(spec_info, "mamba_replay", False)
+            if spec_info is not None
+            else False
+        )
         self.forward_metadata = Mamba2Metadata.prepare_decode(
             metadata,
             forward_batch.seq_lens,
             is_target_verify=forward_batch.forward_mode.is_target_verify(),
             draft_token_num=draft_token_num,
+            mamba_cache_steps=mamba_cache_steps,
+            mamba_replay=mamba_replay,
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
@@ -706,6 +774,8 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.full_attn_backend = full_attn_backend
         self.linear_attn_backend = linear_attn_backend
         self.attn_backend_list = [full_attn_backend, linear_attn_backend]
+        self._mamba_zero_steps_cache = {}
+        self._mamba_clamped_steps_cache = {}
         # Dispatcher aliases the full-attn backend's pool refs.
         self.token_to_kv_pool = full_attn_backend.token_to_kv_pool
         self.req_to_token_pool = full_attn_backend.req_to_token_pool
@@ -714,6 +784,32 @@ class HybridLinearAttnBackend(AttentionBackend):
             full_attn_backend.needs_cpu_seq_lens
             or linear_attn_backend.needs_cpu_seq_lens
         )
+
+    @staticmethod
+    def _mamba_buffer_cache_key(device: torch.device, size: int):
+        return (device.type, -1 if device.index is None else device.index, size)
+
+    def _get_mamba_zero_steps(self, size: int, device: torch.device) -> torch.Tensor:
+        key = self._mamba_buffer_cache_key(device, size)
+        zero_steps = self._mamba_zero_steps_cache.get(key)
+        if zero_steps is None:
+            zero_steps = torch.zeros((size,), dtype=torch.int32, device=device)
+            self._mamba_zero_steps_cache[key] = zero_steps
+        return zero_steps
+
+    def _clamp_mamba_steps(self, steps: torch.Tensor, max_step: int) -> torch.Tensor:
+        if steps.dtype != torch.int32:
+            return torch.clamp(steps, max=max_step)
+
+        key = self._mamba_buffer_cache_key(steps.device, steps.shape[0])
+        clamped_steps = self._mamba_clamped_steps_cache.get(key)
+        if clamped_steps is None:
+            clamped_steps = torch.empty(
+                (steps.shape[0],), dtype=torch.int32, device=steps.device
+            )
+            self._mamba_clamped_steps_cache[key] = clamped_steps
+        torch.clamp(steps, max=max_step, out=clamped_steps)
+        return clamped_steps
 
     def _is_full_attn(
         self, layer: Optional[RadixAttention], layer_id: Optional[int] = None
@@ -899,10 +995,12 @@ class HybridLinearAttnBackend(AttentionBackend):
 
     def update_mamba_state_after_mtp_verify(
         self,
-        last_correct_step_indices: torch.Tensor,
-        mamba_track_indices: Optional[torch.Tensor],
-        mamba_steps_to_track: Optional[torch.Tensor],
-        model,
+        last_correct_step_indices: Optional[torch.Tensor] = None,
+        mamba_track_indices: Optional[torch.Tensor] = None,
+        mamba_steps_to_track: Optional[torch.Tensor] = None,
+        model=None,
+        accepted_steps: Optional[torch.Tensor] = None,
+        accepted_lengths: Optional[torch.Tensor] = None,
     ):
         """
         Update mamba states after MTP verify using fully fused Triton kernel.
@@ -913,7 +1011,15 @@ class HybridLinearAttnBackend(AttentionBackend):
         - index_select kernel launches
         - nonzero kernel launches
         """
-        request_number = last_correct_step_indices.shape[0]
+        if accepted_steps is None:
+            if last_correct_step_indices is None:
+                raise ValueError(
+                    "update_mamba_state_after_mtp_verify requires accepted_steps "
+                    "or last_correct_step_indices."
+                )
+            accepted_steps = last_correct_step_indices
+
+        request_number = accepted_steps.shape[0]
 
         state_indices_tensor = (
             self.linear_attn_backend.forward_metadata.mamba_cache_indices[
@@ -930,36 +1036,120 @@ class HybridLinearAttnBackend(AttentionBackend):
         intermediate_state_cache = mamba_caches.intermediate_ssm
         intermediate_conv_window_cache = mamba_caches.intermediate_conv_window[0]
 
-        # Use fully fused kernel that handles masking internally
-        # This avoids separate nonzero() and index_select() calls
-        fused_mamba_state_scatter_with_mask(
-            ssm_states,
-            intermediate_state_cache,
-            state_indices_tensor,
-            last_correct_step_indices,
+        mamba_cache_steps = getattr(
+            self.linear_attn_backend.forward_metadata, "mamba_cache_steps", None
         )
-        # conv intermediate uses the deduplicated sliding-window (overlapping)
-        # layout, so it needs the strided-read scatter variant.
+        mamba_replay = bool(
+            getattr(self.linear_attn_backend.forward_metadata, "mamba_replay", False)
+        )
+        draft_token_num = int(self.linear_attn_backend.forward_metadata.draft_token_num)
+        replay_enabled = (
+            mamba_replay
+            and mamba_cache_steps is not None
+            and int(mamba_cache_steps) < draft_token_num
+        )
+        effective_cache_steps = (
+            int(mamba_cache_steps) if mamba_cache_steps is not None else draft_token_num
+        )
+        zero_cache_replay = replay_enabled and effective_cache_steps == 0
+        dense_active_replay = replay_enabled and effective_cache_steps <= 1
+
+        if replay_enabled and not self.linear_attn_backend.supports_dflash_mamba_replay:
+            raise NotImplementedError(
+                "DFLASH reduced Mamba cache replay is only implemented for GDN "
+                "linear attention backends."
+            )
+
+        if replay_enabled:
+            replay_start_step = effective_cache_steps - 1
+            if zero_cache_replay:
+                ssm_accepted_steps = None
+            elif effective_cache_steps == 1:
+                ssm_accepted_steps = self._get_mamba_zero_steps(
+                    request_number, accepted_steps.device
+                )
+            else:
+                ssm_accepted_steps = self._clamp_mamba_steps(
+                    accepted_steps, replay_start_step
+                )
+        else:
+            ssm_accepted_steps = accepted_steps
+
+        # Scatter accepted SSM step from intermediate cache to main buffer
+        if not zero_cache_replay:
+            fused_mamba_state_scatter_with_mask(
+                ssm_states,
+                intermediate_state_cache,
+                state_indices_tensor,
+                ssm_accepted_steps,
+            )
+        # Scatter accepted conv window state (always from intermediate cache)
+        # The conv intermediate may use the deduplicated sliding-window layout,
+        # so it needs the strided-read scatter variant.
         fused_conv_window_scatter_with_mask(
             conv_states,
             intermediate_conv_window_cache,
             state_indices_tensor,
-            last_correct_step_indices,
+            accepted_steps,
         )
 
-        # Track indices used for tracking mamba states for prefix cache
-        if mamba_track_indices is not None:
+        tracked_mamba_state_updated = False
+
+        def update_tracked_mamba_state_after_verify():
             assert mamba_steps_to_track is not None
-            # Use fully fused kernel for track scatter operations
-            fused_mamba_state_scatter_with_mask(
-                ssm_states,
-                intermediate_state_cache,
-                mamba_track_indices,
-                mamba_steps_to_track,
+            if zero_cache_replay:
+                ssm_steps_to_track = mamba_steps_to_track
+            elif replay_enabled:
+                ssm_steps_to_track = self._clamp_mamba_steps(
+                    mamba_steps_to_track, replay_start_step
+                )
+            else:
+                ssm_steps_to_track = mamba_steps_to_track
+            if ssm_steps_to_track is not None:
+                if not zero_cache_replay:
+                    fused_mamba_state_scatter_with_mask(
+                        ssm_states,
+                        intermediate_state_cache,
+                        mamba_track_indices,
+                        ssm_steps_to_track,
+                    )
+                fused_conv_window_scatter_with_mask(
+                    conv_states,
+                    intermediate_conv_window_cache,
+                    mamba_track_indices,
+                    mamba_steps_to_track,
+                )
+            if replay_enabled:
+                self.linear_attn_backend.replay_mamba_state_after_verify(
+                    target_steps=mamba_steps_to_track,
+                    destination_state_indices=mamba_track_indices,
+                    mamba_cache_steps=effective_cache_steps,
+                    replay_raw_requests=zero_cache_replay,
+                    initial_state_indices=(
+                        state_indices_tensor if zero_cache_replay else None
+                    ),
+                )
+
+        # K=0 replay must compute prefix-cache tracking slots before the main
+        # request slots are replayed, because the main slots hold the pre-verify
+        # initial states.
+        if zero_cache_replay and mamba_track_indices is not None:
+            update_tracked_mamba_state_after_verify()
+            tracked_mamba_state_updated = True
+
+        # Replay remaining SSM steps beyond what was cached
+        if replay_enabled:
+            self.linear_attn_backend.replay_mamba_state_after_verify(
+                target_steps=accepted_steps,
+                target_lengths=accepted_lengths if zero_cache_replay else None,
+                destination_state_indices=state_indices_tensor,
+                mamba_cache_steps=effective_cache_steps,
+                replay_all_requests=dense_active_replay,
             )
-            fused_conv_window_scatter_with_mask(
-                conv_states,
-                intermediate_conv_window_cache,
-                mamba_track_indices,
-                mamba_steps_to_track,
-            )
+
+        # Track indices used for tracking mamba states for prefix cache
+        if mamba_track_indices is not None and not tracked_mamba_state_updated:
+            update_tracked_mamba_state_after_verify()
+
+        if replay_enabled:
+            self.linear_attn_backend.clear_mamba_replay_inputs()

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 
@@ -16,8 +16,9 @@ from sglang.srt.layers.attention.mamba.causal_conv1d_triton import (
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_npu
 from sglang.srt.utils.common import rank0_log
 
@@ -128,6 +129,10 @@ class GDNKernelDispatcher:
         else:
             raise ValueError(f"Unsupported GDN prefill backend: {prefill_backend}")
 
+        # Replay after target verify can require multi-step varlen state updates.
+        # Keep this path on Triton even if decode/verify use FlashInfer.
+        self.replay_kernel = triton_kernel
+
         # Verify kernel: use FlashInfer when the selected FlashInfer kernel
         # supports MTP verify. SM90 uses the fp32-state path; SM100 uses the
         # bf16-state adapter in FlashInferGDNKernel.
@@ -194,7 +199,7 @@ class GDNKernelDispatcher:
         dt_bias: torch.Tensor,
         ssm_states: torch.Tensor,
         cache_indices: torch.Tensor,
-        query_start_loc: torch.Tensor,
+        query_start_loc: Optional[torch.Tensor],
         **kwargs,
     ) -> torch.Tensor:
         return self.decode_kernel.decode(
@@ -265,11 +270,51 @@ class GDNKernelDispatcher:
             **kwargs,
         )
 
+    def state_update(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        input_token_indices: Optional[torch.Tensor] = None,
+        input_sequence_indices: Optional[torch.Tensor] = None,
+        input_sequence_lengths: Optional[torch.Tensor] = None,
+        initial_state_indices: Optional[torch.Tensor] = None,
+        input_token_start: int = 0,
+        input_token_stride: int = 0,
+        **kwargs,
+    ) -> None:
+        self.replay_kernel.state_update(
+            k,
+            v,
+            a,
+            b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            ssm_states=ssm_states,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+            input_token_indices=input_token_indices,
+            input_sequence_indices=input_sequence_indices,
+            input_sequence_lengths=input_sequence_lengths,
+            initial_state_indices=initial_state_indices,
+            input_token_start=input_token_start,
+            input_token_stride=input_token_stride,
+            **kwargs,
+        )
+
 
 class GDNAttnBackend(MambaAttnBackendBase):
     """Attention backend for GDN (Gated Delta Network) linear attention."""
 
     needs_cpu_seq_lens: bool = False
+    supports_dflash_mamba_replay = True
 
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
@@ -287,9 +332,61 @@ class GDNAttnBackend(MambaAttnBackendBase):
         self.verify_intermediate_state_indices = torch.arange(
             self.req_to_token_pool.size, dtype=torch.int32, device=model_runner.device
         )
+        self._verify_replay_inputs = {}
+        self._verify_replay_inputs_by_graph_key = {}
+        self._verify_replay_inputs_graph_static = False
+        self._verify_replay_graph_key = None
+        self._replay_req_indices_cache: Dict[Tuple[str, int, int], torch.Tensor] = {}
+        self._replay_tail_lengths_cache: Dict[Tuple[str, int, int], torch.Tensor] = {}
+        self._replay_invalid_mask_cache: Dict[Tuple[str, int, int], torch.Tensor] = {}
+        self._replay_tmp_mask_cache: Dict[Tuple[str, int, int], torch.Tensor] = {}
+
+    @staticmethod
+    def _replay_buffer_cache_key(
+        device: torch.device, size: int
+    ) -> Tuple[str, int, int]:
+        return (device.type, -1 if device.index is None else device.index, size)
+
+    def _get_replay_req_indices(self, size: int, device: torch.device) -> torch.Tensor:
+        key = self._replay_buffer_cache_key(device, size)
+        req_indices = self._replay_req_indices_cache.get(key)
+        if req_indices is None:
+            req_indices = torch.arange(size, dtype=torch.int64, device=device)
+            self._replay_req_indices_cache[key] = req_indices
+        return req_indices
+
+    def _get_replay_tail_lengths(self, size: int, device: torch.device) -> torch.Tensor:
+        key = self._replay_buffer_cache_key(device, size)
+        tail_lengths = self._replay_tail_lengths_cache.get(key)
+        if tail_lengths is None:
+            tail_lengths = torch.empty((size,), dtype=torch.int32, device=device)
+            self._replay_tail_lengths_cache[key] = tail_lengths
+        return tail_lengths
+
+    def _get_replay_invalid_mask(self, size: int, device: torch.device) -> torch.Tensor:
+        key = self._replay_buffer_cache_key(device, size)
+        invalid_mask = self._replay_invalid_mask_cache.get(key)
+        if invalid_mask is None:
+            invalid_mask = torch.empty((size,), dtype=torch.bool, device=device)
+            self._replay_invalid_mask_cache[key] = invalid_mask
+        return invalid_mask
+
+    def _get_replay_tmp_mask(self, size: int, device: torch.device) -> torch.Tensor:
+        key = self._replay_buffer_cache_key(device, size)
+        tmp_mask = self._replay_tmp_mask_cache.get(key)
+        if tmp_mask is None:
+            tmp_mask = torch.empty((size,), dtype=torch.bool, device=device)
+            self._replay_tmp_mask_cache[key] = tmp_mask
+        return tmp_mask
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         super().init_forward_metadata(forward_batch)
+        self._verify_replay_graph_key = None
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            and not self._verify_replay_inputs_graph_static
+        ):
+            self._verify_replay_inputs.clear()
         if self.forward_metadata.has_mamba_track_mask:
             self.forward_metadata.mamba_track_mask_indices = (
                 forward_batch.mamba_track_mask.nonzero(as_tuple=True)[0]
@@ -299,6 +396,68 @@ class GDNAttnBackend(MambaAttnBackendBase):
                     self.forward_metadata.mamba_track_mask_indices
                 ]
             )
+
+    def init_forward_metadata_out_graph(
+        self,
+        forward_batch: ForwardBatch,
+        in_capture: bool = False,
+    ):
+        super().init_forward_metadata_out_graph(forward_batch, in_capture=in_capture)
+        self._verify_replay_graph_key = None
+        if not forward_batch.forward_mode.is_target_verify():
+            return
+        if in_capture:
+            return
+        if self._verify_replay_inputs_graph_static:
+            self._verify_replay_graph_key = getattr(
+                forward_batch, "cuda_graph_key", forward_batch.batch_size
+            )
+        else:
+            self._verify_replay_inputs.clear()
+
+    def init_forward_metadata_capture_cuda_graph(
+        self,
+        bs: int,
+        num_tokens: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: ForwardMode,
+        spec_info: Optional[SpecInput],
+    ):
+        super().init_forward_metadata_capture_cuda_graph(
+            bs,
+            num_tokens,
+            req_pool_indices,
+            seq_lens,
+            encoder_lens,
+            forward_mode,
+            spec_info,
+        )
+        self._verify_replay_graph_key = None
+
+    def init_forward_metadata_replay_cuda_graph(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_sum: int,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: ForwardMode,
+        spec_info: Optional[SpecInput],
+        seq_lens_cpu: Optional[torch.Tensor],
+    ):
+        super().init_forward_metadata_replay_cuda_graph(
+            bs,
+            req_pool_indices,
+            seq_lens,
+            seq_lens_sum,
+            encoder_lens,
+            forward_mode,
+            spec_info,
+            seq_lens_cpu,
+        )
+        self._verify_replay_graph_key = bs if forward_mode.is_target_verify() else None
 
     def forward_decode(
         self,
@@ -474,6 +633,43 @@ class GDNAttnBackend(MambaAttnBackendBase):
             value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
 
         if is_target_verify:
+            mamba_cache_steps = (
+                forward_batch.spec_info.draft_token_num
+                if getattr(forward_batch.spec_info, "mamba_cache_steps", None) is None
+                else forward_batch.spec_info.mamba_cache_steps
+            )
+            if (
+                getattr(forward_batch.spec_info, "mamba_replay", False)
+                and mamba_cache_steps < forward_batch.spec_info.draft_token_num
+            ):
+                replay_inputs = (
+                    key,
+                    value,
+                    a,
+                    b,
+                    layer.A_log,
+                    layer.dt_bias,
+                    forward_batch.spec_info.draft_token_num,
+                )
+                if (
+                    torch.cuda.is_available()
+                    and torch.cuda.is_current_stream_capturing()
+                ):
+                    self._verify_replay_inputs_graph_static = True
+                    graph_key = getattr(forward_batch, "cuda_graph_key", batch_size)
+                    self._verify_replay_inputs_by_graph_key.setdefault(graph_key, {})[
+                        layer.layer_id
+                    ] = replay_inputs
+                else:
+                    self._verify_replay_inputs[layer.layer_id] = replay_inputs
+            cache_intermediate_states = int(mamba_cache_steps) > 0
+            effective_cache_steps = mamba_cache_steps
+            if not cache_intermediate_states and retrieve_parent_token is not None:
+                raise RuntimeError(
+                    "DFLASH Mamba cache_steps=0 replay does not support tree "
+                    "target verify because parent recurrent states are not cached."
+                )
+
             core_attn_out = self.kernel_dispatcher.target_verify(
                 A_log=layer.A_log,
                 dt_bias=layer.dt_bias,
@@ -485,9 +681,13 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 ssm_states=ssm_states,
                 cache_indices=cache_indices,
                 query_start_loc=query_start_loc,
-                intermediate_states_buffer=intermediate_state_cache,
-                intermediate_state_indices=intermediate_state_indices,
-                cache_steps=forward_batch.spec_info.draft_token_num,
+                intermediate_states_buffer=(
+                    intermediate_state_cache if cache_intermediate_states else None
+                ),
+                intermediate_state_indices=(
+                    intermediate_state_indices if cache_intermediate_states else None
+                ),
+                cache_steps=effective_cache_steps,
                 retrieve_parent_token=retrieve_parent_token,
             )
         else:
@@ -515,3 +715,142 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 )
 
         return core_attn_out
+
+    def replay_mamba_state_after_verify(
+        self,
+        *,
+        target_steps: torch.Tensor,
+        target_lengths: Optional[torch.Tensor] = None,
+        destination_state_indices: torch.Tensor,
+        mamba_cache_steps: int,
+        replay_all_requests: bool = False,
+        replay_raw_requests: bool = False,
+        initial_state_indices: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Replay GDN states from cached step K-1 or the pre-verify state.
+
+        If K > 0, the caller must first scatter intermediate_ssm[K-1] into
+        destination_state_indices for requests whose target step is >= K. If K == 0,
+        replay starts from draft step 0. By default the destination slots are also
+        the initial state slots; callers may pass initial_state_indices when replay
+        should read from one cache slot and write the final state to another.
+        """
+        replay_inputs_by_layer = self._verify_replay_inputs
+        if self._verify_replay_graph_key is not None:
+            replay_inputs_by_layer = self._verify_replay_inputs_by_graph_key.get(
+                self._verify_replay_graph_key, {}
+            )
+
+        if not replay_inputs_by_layer:
+            raise RuntimeError(
+                "DFLASH Mamba replay was requested, but no GDN replay inputs "
+                "were captured during target verify."
+            )
+
+        _, _, _, _, _, _, draft_token_num = next(iter(replay_inputs_by_layer.values()))
+        max_tail_len = int(draft_token_num) - int(mamba_cache_steps)
+        if replay_all_requests or replay_raw_requests:
+            request_number = target_steps.shape[0]
+            req_indices = (
+                self._get_replay_req_indices(request_number, target_steps.device)
+                if replay_raw_requests
+                else None
+            )
+            if (
+                target_lengths is not None
+                and int(mamba_cache_steps) == 0
+                and not replay_raw_requests
+            ):
+                if target_lengths.shape[0] != request_number:
+                    raise ValueError(
+                        "target_lengths must match target_steps in GDN replay: "
+                        f"{target_lengths.shape=} {target_steps.shape=}"
+                    )
+                tail_lengths = target_lengths
+                if tail_lengths.dtype != torch.int32:
+                    tail_lengths = tail_lengths.to(torch.int32)
+                if not tail_lengths.is_contiguous():
+                    tail_lengths = tail_lengths.contiguous()
+            elif int(mamba_cache_steps) == 1 and not replay_raw_requests:
+                # Dense K=1 replay starts after cached step 0, so the replay
+                # length is exactly the final accepted step index.
+                tail_lengths = target_steps
+                if tail_lengths.dtype != torch.int32:
+                    tail_lengths = tail_lengths.to(torch.int32)
+                if not tail_lengths.is_contiguous():
+                    tail_lengths = tail_lengths.contiguous()
+            else:
+                tail_lengths = self._get_replay_tail_lengths(
+                    request_number, target_steps.device
+                )
+                torch.add(target_steps, 1 - int(mamba_cache_steps), out=tail_lengths)
+                tail_lengths.clamp_(min=0, max=max_tail_len)
+            if replay_raw_requests:
+                invalid_mask = self._get_replay_invalid_mask(
+                    request_number, target_steps.device
+                )
+                tmp_mask = self._get_replay_tmp_mask(
+                    request_number, target_steps.device
+                )
+                torch.lt(target_steps, int(mamba_cache_steps), out=invalid_mask)
+                torch.ge(target_steps, int(draft_token_num), out=tmp_mask)
+                invalid_mask.logical_or_(tmp_mask)
+                if initial_state_indices is not None:
+                    torch.lt(initial_state_indices, 0, out=tmp_mask)
+                    invalid_mask.logical_or_(tmp_mask)
+                torch.lt(destination_state_indices, 0, out=tmp_mask)
+                invalid_mask.logical_or_(tmp_mask)
+                tail_lengths.masked_fill_(invalid_mask, 0)
+            replay_state_indices = destination_state_indices
+            replay_initial_state_indices = (
+                destination_state_indices
+                if initial_state_indices is None
+                else initial_state_indices
+            )
+        else:
+            tail_mask = (
+                (target_steps >= int(mamba_cache_steps))
+                & (target_steps < int(draft_token_num))
+                & (destination_state_indices >= 0)
+            )
+            if initial_state_indices is not None:
+                tail_mask = tail_mask & (initial_state_indices >= 0)
+            req_indices = tail_mask.nonzero(as_tuple=True)[0]
+            if req_indices.numel() == 0:
+                return
+
+            tail_lengths = (
+                target_steps[req_indices].to(torch.int32) - int(mamba_cache_steps) + 1
+            )
+            replay_state_indices = destination_state_indices[req_indices]
+            replay_initial_state_indices = (
+                replay_state_indices
+                if initial_state_indices is None
+                else initial_state_indices[req_indices]
+            )
+        for layer_id, replay_inputs in replay_inputs_by_layer.items():
+            key, value, a, b, A_log, dt_bias, draft_token_num = replay_inputs
+
+            layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer_id)
+            self.kernel_dispatcher.state_update(
+                k=key,
+                v=value,
+                a=a,
+                b=b,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                ssm_states=layer_cache.temporal,
+                cache_indices=replay_state_indices,
+                query_start_loc=None,
+                input_sequence_indices=req_indices,
+                input_sequence_lengths=tail_lengths,
+                initial_state_indices=replay_initial_state_indices,
+                input_token_start=int(mamba_cache_steps),
+                input_token_stride=int(draft_token_num),
+            )
+
+    def clear_mamba_replay_inputs(self) -> None:
+        if self._verify_replay_inputs_graph_static:
+            self._verify_replay_graph_key = None
+            return
+        self._verify_replay_inputs.clear()

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
@@ -107,7 +109,7 @@ class TritonGDNKernel(LinearAttnKernelBase):
         dt_bias: torch.Tensor,
         ssm_states: torch.Tensor,
         cache_indices: torch.Tensor,
-        query_start_loc: torch.Tensor,
+        query_start_loc: Optional[torch.Tensor],
         **kwargs,
     ) -> torch.Tensor:
         return fused_sigmoid_gating_delta_rule_update(
@@ -124,6 +126,58 @@ class TritonGDNKernel(LinearAttnKernelBase):
             use_qk_l2norm_in_kernel=True,
             softplus_beta=1.0,
             softplus_threshold=20.0,
+        )
+
+    def state_update(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        input_token_indices: Optional[torch.Tensor] = None,
+        input_sequence_indices: Optional[torch.Tensor] = None,
+        input_sequence_lengths: Optional[torch.Tensor] = None,
+        initial_state_indices: Optional[torch.Tensor] = None,
+        input_token_start: int = 0,
+        input_token_stride: int = 0,
+        **kwargs,
+    ) -> None:
+        if is_cpu() or is_npu():
+            raise NotImplementedError(
+                "State-only GDN replay is only implemented for the Triton CUDA kernel."
+            )
+
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            dt_bias=dt_bias,
+            q=k,
+            k=k,
+            v=v,
+            a=a,
+            b=b,
+            initial_state_source=ssm_states,
+            initial_state_indices=(
+                cache_indices
+                if initial_state_indices is None
+                else initial_state_indices
+            ),
+            output_state_indices=cache_indices,
+            cu_seqlens=query_start_loc,
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            disable_output_calculation=True,
+            input_token_indices=input_token_indices,
+            input_sequence_indices=input_sequence_indices,
+            input_sequence_lengths=input_sequence_lengths,
+            input_token_start=input_token_start,
+            input_token_stride=input_token_stride,
         )
 
     def extend(

--- a/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import torch
 
@@ -23,7 +24,7 @@ class LinearAttnKernelBase(ABC):
         dt_bias: torch.Tensor,
         ssm_states: torch.Tensor,
         cache_indices: torch.Tensor,
-        query_start_loc: torch.Tensor,
+        query_start_loc: Optional[torch.Tensor],
         **kwargs,
     ) -> torch.Tensor: ...
 
@@ -59,4 +60,28 @@ class LinearAttnKernelBase(ABC):
     ) -> torch.Tensor:
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support target_verify"
+        )
+
+    def state_update(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        input_token_indices: Optional[torch.Tensor] = None,
+        input_sequence_indices: Optional[torch.Tensor] = None,
+        input_sequence_lengths: Optional[torch.Tensor] = None,
+        initial_state_indices: Optional[torch.Tensor] = None,
+        input_token_start: int = 0,
+        input_token_stride: int = 0,
+        **kwargs,
+    ) -> None:
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support state-only update"
         )

--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -734,7 +734,11 @@ class MambaMixer2(torch.nn.Module):
                     ),
                     disable_state_update=True,
                     intermediate_states_buffer=layer_cache.intermediate_ssm,
-                    cache_steps=draft_token_num,
+                    cache_steps=(
+                        draft_token_num
+                        if getattr(metadata, "mamba_cache_steps", None) is None
+                        else metadata.mamba_cache_steps
+                    ),
                     retrieve_parent_token=metadata.retrieve_parent_token,
                     intermediate_state_indices=self.intermediate_state_indices,
                 )

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -43,6 +43,8 @@ class ForwardMetadata:
 
     is_target_verify: bool = False
     draft_token_num: int = 1
+    mamba_cache_steps: Optional[int] = None
+    mamba_replay: bool = False
 
     has_mamba_track_mask: bool = False
     mamba_track_mask_indices: Optional[torch.Tensor] = None
@@ -164,6 +166,8 @@ class Mamba2Metadata(ForwardMetadata):
         is_target_verify: bool,
         draft_token_num: int,
         num_decodes: Optional[int] = None,
+        mamba_cache_steps: Optional[int] = None,
+        mamba_replay: bool = False,
     ) -> "Mamba2Metadata":
         """This path is run during CUDA graph capture, i.e. decode only, so `num_prefills` is 0"""
         return Mamba2Metadata(
@@ -183,6 +187,8 @@ class Mamba2Metadata(ForwardMetadata):
             num_prefill_tokens=0,
             is_target_verify=is_target_verify,
             draft_token_num=draft_token_num,
+            mamba_cache_steps=mamba_cache_steps,
+            mamba_replay=mamba_replay,
         )
 
     @classmethod
@@ -202,12 +208,24 @@ class Mamba2Metadata(ForwardMetadata):
             num_decodes = getattr(forward_batch, "_original_batch_size", None)
             if num_decodes is None:
                 num_decodes = len(forward_batch.seq_lens)
+            mamba_cache_steps = (
+                getattr(forward_batch.spec_info, "mamba_cache_steps", None)
+                if forward_batch.spec_info is not None
+                else None
+            )
+            mamba_replay = (
+                getattr(forward_batch.spec_info, "mamba_replay", False)
+                if forward_batch.spec_info is not None
+                else False
+            )
             return cls.prepare_decode(
                 forward_metadata,
                 forward_batch.seq_lens,
                 is_target_verify=forward_batch.forward_mode.is_target_verify(),
                 draft_token_num=draft_token_num,
                 num_decodes=num_decodes,
+                mamba_cache_steps=mamba_cache_steps,
+                mamba_replay=mamba_replay,
             )
         extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
         if extend_seq_lens_cpu is None:
@@ -261,6 +279,16 @@ class Mamba2Metadata(ForwardMetadata):
             if forward_batch.spec_info is not None
             else 1
         )
+        mamba_cache_steps = (
+            getattr(forward_batch.spec_info, "mamba_cache_steps", None)
+            if forward_batch.spec_info is not None
+            else None
+        )
+        mamba_replay = (
+            getattr(forward_batch.spec_info, "mamba_replay", False)
+            if forward_batch.spec_info is not None
+            else False
+        )
         return Mamba2Metadata(
             query_start_loc=query_start_loc,
             mamba_cache_indices=forward_metadata.mamba_cache_indices,
@@ -278,6 +306,8 @@ class Mamba2Metadata(ForwardMetadata):
             num_decodes=num_decodes,
             is_target_verify=forward_batch.forward_mode.is_target_verify(),
             draft_token_num=draft_token_num,
+            mamba_cache_steps=mamba_cache_steps,
+            mamba_replay=mamba_replay,
             mixed_metadata=cls.MixedMetadata(
                 has_initial_states=has_initial_states,
                 prep_initial_states=prep_initial_states,

--- a/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
@@ -254,9 +254,16 @@ def fused_mamba_state_scatter_with_mask(
     dst_layer_stride = dst.stride(0)
     dst_req_stride = dst.stride(1)
 
-    # Ensure indices are int32 and contiguous
-    dst_indices_raw = dst_indices_raw.to(torch.int32).contiguous()
-    step_indices_raw = step_indices_raw.to(torch.int32).contiguous()
+    # The verify hot path already supplies int32 contiguous indices. Avoid
+    # paying Python dispatch for no-op conversions on every scatter call.
+    if dst_indices_raw.dtype != torch.int32:
+        dst_indices_raw = dst_indices_raw.to(torch.int32)
+    if not dst_indices_raw.is_contiguous():
+        dst_indices_raw = dst_indices_raw.contiguous()
+    if step_indices_raw.dtype != torch.int32:
+        step_indices_raw = step_indices_raw.to(torch.int32)
+    if not step_indices_raw.is_contiguous():
+        step_indices_raw = step_indices_raw.contiguous()
 
     # Ensure tensors are contiguous
     if not dst.is_contiguous():

--- a/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
@@ -268,7 +268,7 @@ def _selective_scan_update_kernel(
 
         if CACHE_INTERMEDIATE_STATES:
             if HAS_STATE_BATCH_INDICES:
-                if state_batch_idx != pad_slot_id:
+                if state_batch_idx != pad_slot_id and current_step_idx < cache_steps:
                     cache_ptr_base = (
                         intermediate_states_buffer
                         + cache_idx * cache_steps * nheads * dim * dstate

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -337,6 +337,7 @@ class MambaPool:
         enable_memory_saver: bool = False,
         speculative_num_draft_tokens: Optional[int] = None,
         speculative_eagle_topk: Optional[int] = None,
+        speculative_mamba_cache_steps: Optional[int] = None,
     ):
         conv_state_shape = cache_params.shape.conv
         temporal_state_shape = cache_params.shape.temporal
@@ -400,13 +401,18 @@ class MambaPool:
                         temporal_state_shape[-1],
                         temporal_state_shape[-2],
                     )
+                ssm_cache_steps = (
+                    speculative_num_draft_tokens
+                    if speculative_mamba_cache_steps is None
+                    else int(speculative_mamba_cache_steps)
+                )
                 # Cache intermediate SSM states per draft token during target verify
-                # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
+                # Shape: [num_layers, size + 1, ssm_cache_steps, HV, K, V]
                 intermediate_ssm_state_cache = torch.zeros(
                     size=(
                         num_mamba_layers,
                         spec_state_size + 1,
-                        speculative_num_draft_tokens,
+                        ssm_cache_steps,
                         temporal_state_shape[0],
                         temporal_state_shape[1],
                         temporal_state_shape[2],
@@ -505,6 +511,7 @@ class MambaPool:
                     f"max_mamba_cache_size: {size}, "
                     f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
                     f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
+                    f"intermediate_ssm_cache_steps: {ssm_cache_steps}, "
                     f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
                     # Report the deduplicated PHYSICAL conv-window buffers (the view
                     # over-reports its logical, un-deduplicated size).
@@ -661,6 +668,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         enable_mamba_extra_buffer_lazy: bool = False,
         speculative_num_draft_tokens: int = None,
         speculative_eagle_topk: Optional[int] = None,
+        speculative_mamba_cache_steps: int = None,
         enable_overlap_schedule: bool = True,
         start_layer: Optional[int] = None,
     ):
@@ -686,6 +694,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             enable_mamba_extra_buffer=enable_mamba_extra_buffer,
             speculative_num_draft_tokens=speculative_num_draft_tokens,
             speculative_eagle_topk=speculative_eagle_topk,
+            speculative_mamba_cache_steps=speculative_mamba_cache_steps,
         )
 
     def _init_mamba_pool(
@@ -698,6 +707,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         enable_mamba_extra_buffer: bool,
         speculative_num_draft_tokens: int = None,
         speculative_eagle_topk: Optional[int] = None,
+        speculative_mamba_cache_steps: int = None,
     ):
         self.mamba_pool = MambaPool(
             size=mamba_size,
@@ -708,6 +718,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             enable_memory_saver=self.enable_memory_saver,
             speculative_num_draft_tokens=speculative_num_draft_tokens,
             speculative_eagle_topk=speculative_eagle_topk,
+            speculative_mamba_cache_steps=speculative_mamba_cache_steps,
         )
         self.mamba_allocator = MambaSlotAllocator(
             size=mamba_size,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -417,6 +417,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     sampling_info: SamplingBatchInfo = None
     # Speculative decoding
     spec_info: Optional[SpecInput] = None
+    # CUDA graph variant key used by attention backends that keep per-graph buffers.
+    cuda_graph_key: Optional[object] = None
 
     # === Derived from ScheduleBatch.reqs ===
     # For LoRA

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -112,6 +112,24 @@ class ModelRunnerKVCacheMixin:
             assert server_args.speculative_num_draft_tokens is not None
             assert server_args.max_running_requests is not None
 
+        global_params = config.mamba2_cache_params
+        per_req = global_params.mamba_cache_per_req
+        intermediate_cache_per_req = 0
+        if has_spec_dec:
+            draft_tokens = int(server_args.max_speculative_num_draft_tokens)
+            mamba_cache_steps = draft_tokens
+            if (
+                self.spec_algorithm.is_dflash()
+                and server_args.speculative_dflash_mamba_cache_steps is not None
+            ):
+                mamba_cache_steps = int(
+                    server_args.speculative_dflash_mamba_cache_steps
+                )
+            intermediate_cache_per_req = (
+                global_params.mamba_conv_cache_per_req * draft_tokens
+                + global_params.mamba_temporal_cache_per_req * mamba_cache_steps
+            )
+
         if server_args.max_mamba_cache_size is not None:
             # Use explicitly set max_mamba_cache_size
             server_args.max_mamba_cache_size = server_args.max_mamba_cache_size // (
@@ -125,11 +143,7 @@ class ModelRunnerKVCacheMixin:
                     // (self.dp_size if server_args.enable_dp_attention else 1),
                     server_args.max_mamba_cache_size // ratio,
                 )
-                intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
-                    * capped_reqs
-                    * server_args.speculative_num_draft_tokens
-                )
+                intermediate_size = intermediate_cache_per_req * capped_reqs
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         elif (
             server_args.disable_radix_cache
@@ -142,21 +156,20 @@ class ModelRunnerKVCacheMixin:
             # Reserve intermediate memory based on capped max_num_reqs
             if has_spec_dec:
                 intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
-                    * server_args.max_mamba_cache_size
-                    * server_args.speculative_num_draft_tokens
+                    intermediate_cache_per_req * server_args.max_mamba_cache_size
                 )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         else:
             # Use ratio-based calculation to auto-fit available memory
-            assert config.mamba2_cache_params.mamba_cache_per_req > 0
-            per_req = config.mamba2_cache_params.mamba_cache_per_req
+            assert per_req > 0
 
             # Solve jointly for max_mamba_cache_size accounting for intermediate memory.
             # The mamba budget (from the ratio split) must cover both:
             #   1. main mamba state: max_mamba_cache_size * per_req
-            #   2. intermediate states: (max_mamba_cache_size / ratio) * D * per_req
-            # So: max_mamba_cache_size * per_req * (1 + D/ratio) = mamba_budget_bytes
+            #   2. intermediate states:
+            #      (max_mamba_cache_size / ratio) * intermediate_cache_per_req
+            # So: max_mamba_cache_size * (per_req + intermediate_cache_per_req / ratio)
+            #      = mamba_budget_bytes
             mamba_budget = (
                 total_rest_memory
                 * server_args.mamba_full_memory_ratio
@@ -166,10 +179,9 @@ class ModelRunnerKVCacheMixin:
 
             if has_spec_dec:
                 ratio = self._calculate_mamba_ratio()
-                D = server_args.speculative_num_draft_tokens
                 # Joint solve: main_state + intermediate = mamba_budget
                 server_args.max_mamba_cache_size = int(
-                    mamba_budget_bytes // (per_req * (1 + D / ratio))
+                    mamba_budget_bytes // (per_req + intermediate_cache_per_req / ratio)
                 )
                 # Intermediate memory is included in mamba_budget, subtract it
                 # so the return value only has main_state subtracted from total
@@ -178,7 +190,7 @@ class ModelRunnerKVCacheMixin:
                     // (self.dp_size if server_args.enable_dp_attention else 1),
                     server_args.max_mamba_cache_size // ratio,
                 )
-                intermediate_size = per_req * capped_reqs * D
+                intermediate_size = intermediate_cache_per_req * capped_reqs
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
             else:
                 server_args.max_mamba_cache_size = int(mamba_budget_bytes // per_req)
@@ -351,6 +363,11 @@ class ModelRunnerKVCacheMixin:
                         ),
                         speculative_num_draft_tokens=max_spec_draft_tokens,
                         speculative_eagle_topk=self.server_args.speculative_eagle_topk,
+                        speculative_mamba_cache_steps=(
+                            self.server_args.speculative_dflash_mamba_cache_steps
+                            if self.spec_algorithm.is_dflash()
+                            else None
+                        ),
                         enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
                         pre_alloc_size=pre_alloc_size,
                         enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
@@ -387,6 +404,11 @@ class ModelRunnerKVCacheMixin:
                     enable_mamba_extra_buffer_lazy=self.server_args.enable_mamba_extra_buffer_lazy(),
                     speculative_num_draft_tokens=max_spec_draft_tokens,
                     speculative_eagle_topk=self.server_args.speculative_eagle_topk,
+                    speculative_mamba_cache_steps=(
+                        self.server_args.speculative_dflash_mamba_cache_steps
+                        if self.spec_algorithm.is_dflash()
+                        else None
+                    ),
                     enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
                     start_layer=self.start_layer,
                 )

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1059,9 +1059,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.model_runner.hisparse_coordinator.num_real_reqs.fill_(raw_bs)
 
     # -----------------------------------------------------------------
-    # replay
+    # execute
     # -----------------------------------------------------------------
-    def replay(
+    def execute(
         self,
         forward_batch: ForwardBatch,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -160,6 +160,7 @@ def build_replay_fb_view(
         out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
         out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),
         spec_info=forward_batch.spec_info,
+        cuda_graph_key=getattr(forward_batch, "cuda_graph_key", None),
     )
 
 
@@ -853,6 +854,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         forward_batch, attn_backend, pp_proxy_tensors = self.capture_prepare(
             size, stream_idx=stream_idx
         )
+        shape_key = self._make_graph_key(bs, stream_idx, variant_label)
+        forward_batch.cuda_graph_key = shape_key
 
         # All setup hooks below read get_attn_backend() (TboForwardBatchPreparer,
         # DeepEP adapter, …) so they must run inside the same ForwardContext
@@ -910,7 +913,6 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 else contextlib.nullcontext()
             )
             with canary_ctx:
-                shape_key = self._make_graph_key(bs, stream_idx, variant_label)
                 self.backend.capture_one(
                     shape_key,
                     run_once,
@@ -980,6 +982,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self._replay_graph_key = self._make_graph_key(
                 self.bs, stream_idx, variant_label
             )
+            forward_batch.cuda_graph_key = self._replay_graph_key
             return
 
         buffers = self.buffers
@@ -1030,7 +1033,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             stream_idx = get_current_stream_idx()
             attn_backend = self.model_runner.decode_attn_backend_group[stream_idx]
         else:
+            stream_idx = None
             attn_backend = self.attn_backend
+        variant_label = self._resolve_lora_variant(forward_batch)
+        self._replay_graph_key = self._make_graph_key(bs, stream_idx, variant_label)
+        forward_batch.cuda_graph_key = self._replay_graph_key
         fb_view = build_replay_fb_view(
             forward_batch=forward_batch,
             buffers=buffers,
@@ -1051,13 +1058,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if self.model_runner.hisparse_coordinator is not None:
             self.model_runner.hisparse_coordinator.num_real_reqs.fill_(raw_bs)
 
-        variant_label = self._resolve_lora_variant(forward_batch)
-        stream_idx = get_current_stream_idx() if self.enable_pdmux else None
-        self._replay_graph_key = self._make_graph_key(
-            self.bs, stream_idx, variant_label
-        )
-
-    def execute(
+    # -----------------------------------------------------------------
+    # replay
+    # -----------------------------------------------------------------
+    def replay(
         self,
         forward_batch: ForwardBatch,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
@@ -1156,6 +1160,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 draft_token=None,
                 positions=None,
                 draft_token_num=self.model_runner.server_args.speculative_num_draft_tokens,
+                mamba_cache_steps=(
+                    self.model_runner.server_args.speculative_dflash_mamba_cache_steps
+                ),
+                mamba_replay=(
+                    self.model_runner.server_args.speculative_dflash_mamba_replay
+                ),
                 custom_mask=(
                     None
                     if (self.model_runner.is_draft_worker or not build_custom_mask)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -617,6 +617,8 @@ class ServerArgs:
     speculative_eagle_topk: Optional[int] = None
     speculative_num_draft_tokens: Optional[int] = None
     speculative_dflash_block_size: Optional[int] = None
+    speculative_dflash_mamba_cache_steps: Optional[int] = None
+    speculative_dflash_mamba_replay: bool = False
     speculative_accept_threshold_single: float = 1.0
     speculative_accept_threshold_acc: float = 1.0
     speculative_token_map: Optional[str] = None
@@ -6088,6 +6090,15 @@ class ServerArgs:
             type=int,
             help="DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
             default=ServerArgs.speculative_dflash_block_size,
+        )
+        parser.add_argument(
+            "--speculative-dflash-mamba-cache-steps",
+            type=int,
+            help="DFLASH only. Number of target-verify draft steps whose intermediate "
+            "Mamba/GDN SSM states are cached. Defaults to the full verify block size. "
+            "Values smaller than the block size reduce speculative SSM cache memory "
+            "and automatically replay the uncached accepted tail.",
+            default=ServerArgs.speculative_dflash_mamba_cache_steps,
         )
         parser.add_argument(
             "--speculative-accept-threshold-single",

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -30,6 +30,8 @@ class DFlashVerifyInput(SpecInput):
     draft_token: torch.Tensor
     positions: torch.Tensor
     draft_token_num: int
+    mamba_cache_steps: int | None = None
+    mamba_replay: bool = False
     # Kept for compatibility with attention backends that gate tree metadata by `topk > 1`.
     # DFLASH verify is linear (non-tree), so this is always 1.
     topk: int = 1
@@ -49,6 +51,18 @@ class DFlashVerifyInput(SpecInput):
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.draft_token_num, self.draft_token_num
 
+    def check_mamba_replay_config(self) -> None:
+        if (
+            self.mamba_cache_steps is not None
+            and self.mamba_cache_steps < self.draft_token_num
+            and not self.mamba_replay
+        ):
+            raise RuntimeError(
+                "DFLASH reduced Mamba/GDN cache requires replay, but replay was "
+                "not enabled. This should be auto-enabled when "
+                "speculative_dflash_mamba_cache_steps < speculative_num_draft_tokens."
+            )
+
     def prepare_for_verify(
         self,
         batch: ScheduleBatch,
@@ -61,6 +75,7 @@ class DFlashVerifyInput(SpecInput):
         metadata or eager attention metadata so the actual forward can run with
         `skip_attn_backend_init=True`.
         """
+        self.check_mamba_replay_config()
         batch.input_ids = self.draft_token
         batch.spec_info = self
         batch.forward_mode = (

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -225,6 +225,8 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_token=torch.empty((0,), dtype=torch.long, device=self.device),
             positions=torch.empty((0,), dtype=torch.int64, device=self.device),
             draft_token_num=int(self.block_size),
+            mamba_cache_steps=server_args.speculative_dflash_mamba_cache_steps,
+            mamba_replay=server_args.speculative_dflash_mamba_replay,
             custom_mask=None,
             capture_hidden_mode=CaptureHiddenMode.NULL,
         )
@@ -1044,6 +1046,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         *,
         batch: ScheduleBatch,
         seq_lens_pre_verify: torch.Tensor,
+        seq_lens_cpu_pre_verify: Optional[torch.Tensor],
         commit_lens: torch.Tensor,
     ) -> None:
         """Commit Mamba intermediate states for accepted verify steps.
@@ -1056,33 +1059,62 @@ class DFlashWorkerV2(BaseSpecWorker):
         if not hasattr(attn_backend, "update_mamba_state_after_mtp_verify"):
             return
 
-        last_correct_step_indices = commit_lens.to(torch.int64) - 1
+        accepted_steps = commit_lens.to(torch.int32) - 1
+        mamba_track_indices = batch.mamba_track_indices
         mamba_steps_to_track = None
 
-        if batch.mamba_track_indices is not None:
+        if mamba_track_indices is not None:
             mamba_track_interval = self.server_args.mamba_track_interval
-            to_track_mask = (
-                seq_lens_pre_verify // mamba_track_interval
-                != batch.seq_lens // mamba_track_interval
-            )
-            tracking_point = (
-                batch.seq_lens // mamba_track_interval * mamba_track_interval
-            )
-            to_track_ith = torch.clamp(tracking_point - seq_lens_pre_verify - 1, min=0)
-            can_track_mask = to_track_mask & (
-                to_track_ith < commit_lens.to(to_track_ith.dtype)
-            )
-            mamba_steps_to_track = torch.where(
-                can_track_mask,
-                to_track_ith.to(torch.int64),
-                torch.full_like(to_track_ith, -1, dtype=torch.int64),
-            )
+            if seq_lens_cpu_pre_verify is not None:
+                seq_lens_cpu = batch.seq_lens_cpu
+                commit_lens_cpu = seq_lens_cpu - seq_lens_cpu_pre_verify
+                to_track_mask_cpu = (
+                    seq_lens_cpu_pre_verify // mamba_track_interval
+                    != seq_lens_cpu // mamba_track_interval
+                )
+                tracking_point_cpu = (
+                    seq_lens_cpu // mamba_track_interval * mamba_track_interval
+                )
+                to_track_ith_cpu = torch.clamp(
+                    tracking_point_cpu - seq_lens_cpu_pre_verify - 1, min=0
+                )
+                can_track_mask_cpu = to_track_mask_cpu & (
+                    to_track_ith_cpu < commit_lens_cpu.to(to_track_ith_cpu.dtype)
+                )
+                if bool(can_track_mask_cpu.any().item()):
+                    mamba_steps_to_track = torch.where(
+                        can_track_mask_cpu,
+                        to_track_ith_cpu.to(torch.int32),
+                        torch.full_like(to_track_ith_cpu, -1, dtype=torch.int32),
+                    ).to(device=batch.seq_lens.device, non_blocking=True)
+                else:
+                    mamba_track_indices = None
+            else:
+                to_track_mask = (
+                    seq_lens_pre_verify // mamba_track_interval
+                    != batch.seq_lens // mamba_track_interval
+                )
+                tracking_point = (
+                    batch.seq_lens // mamba_track_interval * mamba_track_interval
+                )
+                to_track_ith = torch.clamp(
+                    tracking_point - seq_lens_pre_verify - 1, min=0
+                )
+                can_track_mask = to_track_mask & (
+                    to_track_ith < commit_lens.to(to_track_ith.dtype)
+                )
+                mamba_steps_to_track = torch.where(
+                    can_track_mask,
+                    to_track_ith.to(torch.int32),
+                    torch.full_like(to_track_ith, -1, dtype=torch.int32),
+                )
 
         attn_backend.update_mamba_state_after_mtp_verify(
-            last_correct_step_indices=last_correct_step_indices,
-            mamba_track_indices=batch.mamba_track_indices,
+            accepted_steps=accepted_steps,
+            mamba_track_indices=mamba_track_indices,
             mamba_steps_to_track=mamba_steps_to_track,
             model=self.target_worker.model_runner.model,
+            accepted_lengths=commit_lens,
         )
 
     def _ensure_accept_bonus_buffers(self, bs: int) -> None:
@@ -1503,6 +1535,8 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_token=verify_input_ids,
             positions=positions,
             draft_token_num=int(self.block_size),
+            mamba_cache_steps=self.server_args.speculative_dflash_mamba_cache_steps,
+            mamba_replay=self.server_args.speculative_dflash_mamba_replay,
             custom_mask=custom_mask,
             capture_hidden_mode=CaptureHiddenMode.FULL,
         )
@@ -1516,6 +1550,12 @@ class DFlashWorkerV2(BaseSpecWorker):
         )
         seq_lens_pre_verify = (
             model_worker_batch.seq_lens.clone() if need_mamba_verify_commit else None
+        )
+        seq_lens_cpu_pre_verify = (
+            model_worker_batch.seq_lens_cpu.clone()
+            if need_mamba_verify_commit
+            and model_worker_batch.mamba_track_indices is not None
+            else None
         )
         seq_lens_cpu_backup = model_worker_batch.seq_lens_cpu
         seq_lens_sum_backup = model_worker_batch.seq_lens_sum
@@ -1638,6 +1678,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             self._update_target_mamba_state_after_verify(
                 batch=model_worker_batch,
                 seq_lens_pre_verify=seq_lens_pre_verify,
+                seq_lens_cpu_pre_verify=seq_lens_cpu_pre_verify,
                 commit_lens=commit_lens,
             )
 

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -332,6 +332,8 @@ def create_dummy_verify_input(
             draft_token=None,
             positions=None,
             draft_token_num=server_args.speculative_num_draft_tokens,
+            mamba_cache_steps=server_args.speculative_dflash_mamba_cache_steps,
+            mamba_replay=server_args.speculative_dflash_mamba_replay,
             custom_mask=None,
             capture_hidden_mode=(
                 CaptureHiddenMode.NULL if is_draft_worker else CaptureHiddenMode.FULL

--- a/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
+++ b/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
@@ -67,6 +67,15 @@ class TestTboFilterBatchMarker(CustomTestCase):
         self.assertFalse(child.forward_metadata_ready)
         self.assertFalse(child.forward_metadata_replan_equivalent)
 
+    def test_filter_batch_preserves_cuda_graph_key(self):
+        parent = _make_target_verify_batch(8)
+        graph_key = object()
+        parent.cuda_graph_key = graph_key
+
+        child = _filter(parent, lo=0, hi=4)
+
+        self.assertIs(child.cuda_graph_key, graph_key)
+
 
 def _make_valued_batch(bs: int) -> ForwardBatch:
     # Distinct per-position values so a filtered slice is unambiguous.

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -768,6 +768,106 @@ class TestNgramExternalSamArgs(CustomTestCase):
         self.assertIn("external-corpus-max-tokens", str(context.exception))
 
 
+class TestDFlashMambaReplayArgs(CustomTestCase):
+    def _make_dummy_dflash_args(self, **overrides):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = "DFLASH"
+        args.speculative_draft_model_path = "dummy-draft"
+        args.speculative_num_draft_tokens = 16
+        args.speculative_num_steps = None
+        args.speculative_eagle_topk = None
+        args.max_running_requests = 16
+        args.device = "cuda"
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def _handle_dflash_args(self, args):
+        with patch(
+            "sglang.srt.utils.hf_transformers_utils.get_config",
+            return_value=SimpleNamespace(architectures=[]),
+        ):
+            handle_speculative_decoding(args)
+
+    def test_reduced_mamba_cache_auto_enables_replay(self):
+        args = self._make_dummy_dflash_args(
+            speculative_dflash_mamba_cache_steps=0,
+        )
+
+        self._handle_dflash_args(args)
+
+        self.assertEqual(args.speculative_dflash_mamba_cache_steps, 0)
+        self.assertTrue(args.speculative_dflash_mamba_replay)
+
+    def test_full_mamba_cache_does_not_force_replay(self):
+        args = self._make_dummy_dflash_args(
+            speculative_dflash_mamba_cache_steps=16,
+        )
+
+        self._handle_dflash_args(args)
+
+        self.assertEqual(args.speculative_dflash_mamba_cache_steps, 16)
+        self.assertFalse(args.speculative_dflash_mamba_replay)
+
+    def test_mamba_cache_steps_must_be_non_negative(self):
+        args = self._make_dummy_dflash_args(
+            speculative_dflash_mamba_cache_steps=-1,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            self._handle_dflash_args(args)
+
+        self.assertIn("non-negative", str(context.exception))
+
+    def test_mamba_cache_steps_must_fit_draft_budget(self):
+        args = self._make_dummy_dflash_args(
+            speculative_dflash_mamba_cache_steps=17,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            self._handle_dflash_args(args)
+
+        self.assertIn("must be <=", str(context.exception))
+
+    def test_mamba_cache_steps_requires_dflash(self):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = "EAGLE"
+        args.speculative_dflash_mamba_cache_steps = 0
+        args.device = "cuda"
+
+        with self.assertRaises(ValueError) as context:
+            handle_speculative_decoding(args)
+
+        self.assertIn("only supported", str(context.exception))
+
+    def test_draft_window_must_cover_dflash_block(self):
+        args = self._make_dummy_dflash_args(
+            speculative_draft_window_size=8,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            self._handle_dflash_args(args)
+
+        self.assertIn("must be >=", str(context.exception))
+
+    def test_verify_reduced_mamba_cache_requires_replay(self):
+        import torch
+
+        from sglang.srt.speculative.dflash_info import DFlashVerifyInput
+
+        draft_token_num = 4
+        spec_info = DFlashVerifyInput(
+            draft_token=torch.arange(draft_token_num, dtype=torch.int64),
+            positions=torch.arange(draft_token_num, dtype=torch.int64),
+            draft_token_num=draft_token_num,
+            mamba_cache_steps=0,
+            mamba_replay=False,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "requires replay"):
+            spec_info.check_mamba_replay_config()
+
+
 class TestAdaptiveSpecArgs(CustomTestCase):
     def test_adaptive_defaults_to_config_step_when_spec_params_omitted(self):
         with tempfile.NamedTemporaryFile("w", suffix=".json") as f:


### PR DESCRIPTION
# Add DFLASH Mamba/GDN reduced-cache replay

## Motivation

DFLASH target verification currently reserves recurrent state snapshots for every draft-token position when the target model uses linear attention / GDN / Mamba-style states. For full attention, the analogous verify budget is extra draft-token KV cache. For linear attention / GDN, each position stores a recurrent state snapshot, which is much larger than one token of KV cache.

This PR adds a reduced-cache target-verify path for DFLASH Mamba/GDN layers. Instead of always caching all `block_size` target verify states, the server can cache only the first `K` states and replay the accepted uncached tail after verification. `K=0` is a true zero intermediate SSM snapshot cache path.

## Modifications

- Add `--speculative-dflash-mamba-cache-steps`.
  - DFLASH-only.
  - Defaults to the full DFLASH block size when unset.
  - Values smaller than the block size automatically enable replay.
- Thread reduced-cache metadata through DFLASH V2 target verify, forward metadata, CUDA graph replay inputs, and Mamba/GDN cache allocation.
- Add GDN state-only replay after target verify, including K=0 and K=1 optimized paths.
- Guard unsupported reduced-cache cases:
  - reduced replay requires DFLASH;
  - reduced replay currently requires a linear backend that supports DFLASH Mamba replay;
  - NPU reduced-cache path is guarded instead of silently using the old scatter/rollback path.
- Add server-argument unit coverage for validation and auto-enable behavior.

## Accuracy Tests

Environment:

- Commit: `ddfe42e86`
- Target: Qwen3.5-27B DFLASH target checkpoint
- Draft: Qwen3.5-27B-DFlash draft checkpoint
- Hardware: 2x NVIDIA A100-SXM4-80GB, TP=2
- Runtime: Python 3.11.14, PyTorch 2.11.0+cu129, CUDA 12.9, FlashInfer 0.6.12
- DFLASH path: V2 (`DFlashWorkerV2`)

Static/unit checks:

```text
py_compile selected replay/spec/server-args files: passed
pytest test/registered/unit/server_args/test_server_args.py::TestDFlashMambaReplayArgs -v
7 passed
```

Runtime correctness smoke:

- Fixed prompts, OpenAI completions endpoint, `temperature=0.0`, `ignore_eos=true`, `max_tokens=64`.
- Compared exact generated text against `K=16` full-cache baseline.

```text
K=0: passed, 0 mismatches
K=1: passed, 0 mismatches
K=4: passed, 0 mismatches
K=8: passed, 0 mismatches
```

## Speed Tests and Profiling

Benchmark command shape:

```bash
python -m sglang.launch_server \
  --model-path <target> \
  --speculative-algorithm DFLASH \
  --speculative-draft-model-path <draft> \
  --speculative-dflash-block-size 16 \
  --speculative-dflash-mamba-cache-steps <K> \
  --attention-backend flashinfer \
  --tp-size 2 \
  --dtype bfloat16 \
  --mem-fraction-static 0.72 \
  --max-running-requests 16 \
  --cuda-graph-max-bs-decode 16 \
  --mamba-scheduler-strategy extra_buffer \
  --disable-custom-all-reduce

python -m sglang.bench_serving \
  --backend sglang-oai \
  --dataset-name random \
  --random-input-len 256 \
  --random-output-len 512 \
  --random-range-ratio 1 \
  --num-prompts max(16, 5 * concurrency) \
  --max-concurrency <C> \
  --warmup-requests 16 \
  --extra-request-body '{"ignore_eos": true, "temperature": 0.0}'
```

Output TPS / latency:

| K | C=1 TPS | C=4 TPS | C=16 TPS | C=16 vs K=16 | C=16 TTFT ms | C=16 TPOT ms | Accept length |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 124.43 | 398.44 | 576.78 | baseline | 5811.54 | 13.46 | 4.20 |
| 0 | 123.71 | 403.43 | 825.86 | 1.43x | 767.47 | 16.70 | 4.21 |
| 1 | 126.45 | 405.10 | 805.28 | 1.40x | 775.38 | 17.05 | 4.21 |
| 4 | 119.44 | 360.10 | 732.84 | 1.27x | 820.15 | 18.08 | 4.16 |
| 8 | 121.53 | 364.87 | 719.58 | 1.25x | 1425.04 | 17.95 | 4.19 |

Notes:

- K=0 and K=1 preserve single-concurrency throughput and improve high-concurrency output TPS by 43% and 40% respectively in this setup.
- Accept length remains comparable across K values, so the throughput difference is not caused by a material accept-length change.
- The K=16 C=16 TTFT includes serving queueing under 80 requests and should be read as an end-to-end serving metric, not isolated model-forward TTFT.
- The first C=4 matrix used the SGLang minimum `5 * concurrency` prompt count, i.e. 20 prompts. A follow-up C=4 run with 80 prompts was added because the K=4/K=8 points looked noisier than expected.

Follow-up C=4 run with 80 prompts and K order `16, 8, 4, 1, 0`:

| K | Output TPS | vs K=16 | TTFT ms | TPOT ms | E2E ms | Accept length |
|---:|---:|---:|---:|---:|---:|---:|
| 16 | 433.80 | baseline | 172.00 | 8.74 | 4639.77 | 4.26 |
| 8 | 420.35 | 0.97x | 177.69 | 8.99 | 4773.68 | 4.28 |
| 4 | 411.54 | 0.95x | 182.87 | 9.18 | 4872.54 | 4.26 |
| 1 | 442.77 | 1.02x | 179.04 | 8.51 | 4528.21 | 4.26 |
| 0 | 438.57 | 1.01x | 178.35 | 8.60 | 4570.94 | 4.26 |

Interpretation:

- The original K=4/K=8 C=4 points were too pessimistic; with 80 prompts, K=8 is within 3.1% of K=16 and K=4 is within 5.1%.
- K=0/K=1 remain slightly faster than K=16, which indicates replay itself is not the bottleneck.
- The remaining K=4 gap is consistent with the K>1 partial-cache path using sparse tail selection around the average accepted length boundary. This path does extra `nonzero`/gather bookkeeping and may replay short tails when accepted length exceeds K.

Mamba/GDN intermediate cache allocation, per TP rank from server allocation logs:

| K | max_mamba_cache_size | intermediate steps | intermediate SSM cache GB/TP | intermediate conv GB/TP | max_total_num_tokens |
|---:|---:|---:|---:|---:|---:|
| 16 | 48 | 16 | 11.25 | 0.22 | 419405 |
| 0 | 190 | 0 | 0.00 | 0.37 | 414207 |
| 1 | 160 | 1 | 1.20 | 0.37 | 439812 |
| 4 | 109 | 4 | 4.78 | 0.37 | 446827 |
| 8 | 76 | 8 | 9.00 | 0.35 | 408132 |

The target-verify intermediate SSM snapshot cache is eliminated at K=0 and reduced to 1.20 GB/TP at K=1, compared with 11.25 GB/TP at K=16.

GDN replay microbench, direct fused kernel timing on one A100 rank with Qwen3.5-style GDN dimensions, per layer:

| Batch | K | target_verify ms | replay ms at accepted=4 | replay tail |
|---:|---:|---:|---:|---:|
| 4 | 16 | 0.1105 | n/a | n/a |
| 4 | 8 | 0.0927 | 0.0590 | 0 |
| 4 | 4 | 0.0892 | 0.0576 | 0 |
| 4 | 1 | 0.0917 | 0.0592 | 3 |
| 4 | 0 | 0.0741 | 0.0592 | 4 |
| 16 | 16 | 0.3182 | n/a | n/a |
| 16 | 8 | 0.2360 | 0.0588 | 0 |
| 16 | 4 | 0.2099 | 0.0589 | 0 |
| 16 | 1 | 0.1953 | 0.0603 | 3 |
| 16 | 0 | 0.1764 | 0.0598 | 4 |

The kernel-level result does not show a fundamental K=4/K=8 slowdown. Target verify gets faster as fewer intermediate SSM snapshots are stored. The serving-level K=4 gap is therefore more likely from replay bookkeeping, CUDA graph/scheduling differences, and workload variance than from the fused GDN kernel itself.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Full upstream CI was not run locally.

























































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27836881362](https://github.com/sgl-project/sglang/actions/runs/27836881362)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27836881254](https://github.com/sgl-project/sglang/actions/runs/27836881254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->