### PR TITLE
[CI] Kernel benchmark regression gate (draft / RFC)

### DIFF
--- a/.github/workflows/nightly-kernel-bench-gt.yml
+++ b/.github/workflows/nightly-kernel-bench-gt.yml
@@ -1,0 +1,90 @@
+name: Nightly Kernel Bench Ground Truth
+
+# Generates the performance ground truth for the kernel benchmark regression
+# suite and publishes it to sgl-project/ci-data. PR runs (pr-test-kernel-bench.yml)
+# pull this ground truth back and compare their fresh numbers against it with a
+# relative tolerance.
+#
+# One ground-truth file is produced per GPU SKU (sm90 = Hopper, sm100 = Blackwell)
+# so that the comparison only ever happens against numbers measured on the same
+# hardware class.
+
+on:
+  schedule:
+    # 09:30 UTC daily, after the nightly NVIDIA tests have settled.
+    - cron: '30 9 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        required: false
+        default: ''
+        type: string
+      publish:
+        description: 'Publish the generated ground truth to sgl-project/ci-data'
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: nightly-kernel-bench-gt-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  SGLANG_IS_IN_CI: true
+  SGLANG_CUDA_COREDUMP: "1"
+
+jobs:
+  generate-gt:
+    if: github.repository == 'sgl-project/sglang'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sku: sm90
+            runner: 1-gpu-h100
+          - sku: sm100
+            runner: 1-gpu-b200
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install dependencies
+        timeout-minutes: 20
+        run: |
+          bash scripts/ci/cuda/ci_install_dependency.sh
+
+      - name: Generate ground truth
+        timeout-minutes: 45
+        run: |
+          mkdir -p kernel-bench-gt
+          cd sgl-kernel/benchmark
+          python3 -m kernel_bench_regression generate \
+            --out "$GITHUB_WORKSPACE/kernel-bench-gt/${{ matrix.sku }}.json" \
+            --repeat 5 \
+            --commit "$GITHUB_SHA"
+          echo "----- generated ${{ matrix.sku }}.json -----"
+          cat "$GITHUB_WORKSPACE/kernel-bench-gt/${{ matrix.sku }}.json"
+
+      - name: Upload ground-truth artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-bench-gt-${{ matrix.sku }}
+          path: kernel-bench-gt/${{ matrix.sku }}.json
+          retention-days: 14
+
+      - name: Publish ground truth to sgl-project/ci-data
+        if: ${{ inputs.publish != false }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          python3 scripts/ci/utils/kernel/publish_kernel_bench_gt.py \
+            --source-dir kernel-bench-gt \
+            --target-dir kernel-bench

--- a/.github/workflows/pr-test-kernel-bench.yml
+++ b/.github/workflows/pr-test-kernel-bench.yml
@@ -1,0 +1,95 @@
+name: PR Test - Kernel Bench Regression
+
+# Runs the registered kernel benchmark subset on a PR and compares the fresh
+# numbers against the nightly ground truth in sgl-project/ci-data with a relative
+# tolerance (default 5%).
+#
+# CI GPUs are NOT isolated, so an occasional regression here may be noise --
+# this gate is safe to simply re-run. A persistent failure across re-runs is a
+# real kernel performance regression.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Tracked kernel sources
+      - "sgl-kernel/csrc/gemm/dsv3_**"
+      - "sgl-kernel/csrc/elementwise/dsv4_**"
+      - "sgl-kernel/csrc/attention/cutlass_mla**"
+      - "sgl-kernel/csrc/gemm/per_token_group_quant_8bit**"
+      - "sgl-kernel/csrc/moe/moe_fused_gate**"
+      # Benchmark files + the regression harness itself
+      - "sgl-kernel/benchmark/bench_dsv3_**"
+      - "sgl-kernel/benchmark/bench_dsv4_**"
+      - "sgl-kernel/benchmark/bench_cutlass_mla**"
+      - "sgl-kernel/benchmark/bench_moe_fused_gate**"
+      - "sgl-kernel/benchmark/bench_per_token_group_quant_8bit**"
+      - "sgl-kernel/benchmark/kernel_bench_regression/**"
+      - ".github/workflows/pr-test-kernel-bench.yml"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        required: false
+        default: ''
+        type: string
+      gt_ref:
+        description: 'ci-data ref to pull ground truth from'
+        required: false
+        default: 'main'
+        type: string
+      tolerance:
+        description: 'Relative regression tolerance (e.g. 0.05 == 5%)'
+        required: false
+        default: '0.05'
+        type: string
+
+concurrency:
+  group: pr-test-kernel-bench-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  SGLANG_IS_IN_CI: true
+  SGLANG_CUDA_COREDUMP: "1"
+
+jobs:
+  kernel-bench-compare:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: 1-gpu-h100
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Install dependencies
+        timeout-minutes: 20
+        run: |
+          bash scripts/ci/cuda/ci_install_dependency.sh
+
+      - name: Compare against nightly ground truth (sm90)
+        timeout-minutes: 30
+        env:
+          GT_REF: ${{ inputs.gt_ref || 'main' }}
+          TOLERANCE: ${{ inputs.tolerance || '0.05' }}
+        run: |
+          cd sgl-kernel/benchmark
+          GT_URL="https://raw.githubusercontent.com/sgl-project/ci-data/${GT_REF}/kernel-bench/sm90.json"
+          python3 -m kernel_bench_regression compare \
+            --gt-url "$GT_URL" \
+            --tolerance "$TOLERANCE" \
+            --repeat 5 \
+            --measured-out "$GITHUB_WORKSPACE/kernel-bench-measured.json" \
+            --commit "$GITHUB_SHA"
+
+      - name: Upload measured results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-bench-measured
+          path: kernel-bench-measured.json
+          retention-days: 7

--- a/scripts/ci/utils/kernel/publish_kernel_bench_gt.py
+++ b/scripts/ci/utils/kernel/publish_kernel_bench_gt.py
@@ -1,0 +1,174 @@
+"""Publish kernel-benchmark ground-truth JSON to sgl-project/ci-data.
+
+Mirrors ``scripts/ci/utils/diffusion/publish_diffusion_gt.py`` (same GitHub-API
+commit-with-retry pattern, same ``GH_PAT_FOR_NIGHTLY_CI_DATA`` token) but for small
+JSON ground-truth files instead of images. The nightly workflow generates a results
+JSON per GPU SKU and this script commits it under ``kernel-bench/`` so PR runs can
+pull it back and compare.
+
+Usage:
+    GITHUB_TOKEN=... python scripts/ci/utils/kernel/publish_kernel_bench_gt.py \\
+        --source-dir kernel-bench-gt \\
+        --target-dir kernel-bench
+"""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.error import HTTPError
+
+# Reuse the GitHub-API helpers from publish_traces (same approach as the diffusion
+# publisher). Support both package-style and direct-script execution.
+if __package__:
+    from ..publish_traces import (
+        create_blobs,
+        create_commit,
+        create_tree,
+        get_branch_sha,
+        get_tree_sha,
+        is_permission_error,
+        is_rate_limit_error,
+        update_branch_ref,
+        verify_token_permissions,
+    )
+else:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from publish_traces import (
+        create_blobs,
+        create_commit,
+        create_tree,
+        get_branch_sha,
+        get_tree_sha,
+        is_permission_error,
+        is_rate_limit_error,
+        update_branch_ref,
+        verify_token_permissions,
+    )
+
+REPO_OWNER = "sgl-project"
+REPO_NAME = "ci-data"
+BRANCH = "main"
+DEFAULT_TARGET_DIR = "kernel-bench"
+
+
+def collect_json_files(source_dir, target_dir):
+    """Return list of ``(repo_path, content_bytes)`` for every .json in source_dir."""
+    files = []
+    for entry in sorted(os.listdir(source_dir)):
+        if not entry.endswith(".json"):
+            continue
+        local_path = os.path.join(source_dir, entry)
+        if not os.path.isfile(local_path):
+            continue
+        with open(local_path, "rb") as f:
+            content = f.read()
+        files.append((f"{target_dir}/{entry}", content))
+    return files
+
+
+def publish(source_dir, target_dir):
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+
+    files_to_upload = collect_json_files(source_dir, target_dir)
+    if not files_to_upload:
+        print(f"No .json files found in {source_dir}")
+        return
+
+    print(
+        f"Found {len(files_to_upload)} ground-truth file(s) to publish to "
+        f"{REPO_OWNER}/{REPO_NAME}/{target_dir}"
+    )
+
+    perm = verify_token_permissions(REPO_OWNER, REPO_NAME, token)
+    if perm == "rate_limited":
+        print("GitHub API rate-limited, skipping upload.")
+        return
+    if not perm:
+        print("Token permission verification failed.")
+        sys.exit(1)
+
+    # Commit-with-retry to tolerate concurrent pushes to ci-data main.
+    max_retries = 5
+    for attempt in range(max_retries):
+        try:
+            branch_sha = get_branch_sha(REPO_OWNER, REPO_NAME, BRANCH, token)
+            tree_sha = get_tree_sha(REPO_OWNER, REPO_NAME, branch_sha, token)
+
+            tree_items = create_blobs(REPO_OWNER, REPO_NAME, files_to_upload, token)
+            new_tree_sha = create_tree(
+                REPO_OWNER, REPO_NAME, tree_sha, tree_items, token
+            )
+            if new_tree_sha == tree_sha:
+                print("Ground truth unchanged, nothing to publish.")
+                return
+
+            commit_msg = (
+                f"kernel-bench: update ground truth in {target_dir} "
+                f"({len(files_to_upload)} file(s)) [automated]"
+            )
+            commit_sha = create_commit(
+                REPO_OWNER, REPO_NAME, new_tree_sha, branch_sha, commit_msg, token
+            )
+            update_branch_ref(REPO_OWNER, REPO_NAME, BRANCH, commit_sha, token)
+            print(
+                f"Successfully published {len(files_to_upload)} file(s) "
+                f"(commit {commit_sha[:10]})"
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            if is_rate_limit_error(e):
+                print("Rate-limited, skipping.")
+                return
+            if is_permission_error(e):
+                print(
+                    f"ERROR: Token lacks write permission to {REPO_OWNER}/{REPO_NAME}. "
+                    "Update GH_PAT_FOR_NIGHTLY_CI_DATA with a token that has "
+                    "contents:write."
+                )
+                sys.exit(1)
+
+            retryable = False
+            if hasattr(e, "error_body"):
+                if "Update is not a fast forward" in e.error_body:
+                    retryable = True
+                elif "Object does not exist" in e.error_body:
+                    retryable = True
+            if isinstance(e, HTTPError) and e.code in [422, 500, 502, 503, 504]:
+                retryable = True
+
+            if retryable and attempt < max_retries - 1:
+                wait = 2**attempt
+                print(
+                    f"Attempt {attempt + 1}/{max_retries} failed, retrying in {wait}s..."
+                )
+                time.sleep(wait)
+            else:
+                print(f"Failed after {attempt + 1} attempts: {e}")
+                raise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Publish kernel-bench ground truth to sgl-project/ci-data"
+    )
+    parser.add_argument(
+        "--source-dir",
+        required=True,
+        help="Local directory containing the GT .json files",
+    )
+    parser.add_argument(
+        "--target-dir",
+        default=DEFAULT_TARGET_DIR,
+        help=f"Target directory in ci-data (default: {DEFAULT_TARGET_DIR})",
+    )
+    args = parser.parse_args()
+    publish(args.source_dir, args.target_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/sgl-kernel/benchmark/kernel_bench_regression/README.md
+++ b/sgl-kernel/benchmark/kernel_bench_regression/README.md
@@ -1,0 +1,105 @@
+# Kernel benchmark regression CI
+
+A lightweight, **model-agnostic** performance-regression gate for SGLang CUDA/Triton
+kernels.
+
+It reuses the existing `sgl-kernel/benchmark/bench_*.py` benchmarks (no kernel
+launch logic is duplicated), captures their throughput / latency into a structured
+JSON, and compares a fresh run against a **nightly-generated ground truth** with a
+relative tolerance (default **±5%**).
+
+The suite is seeded with the kernels that dominate current decode/prefill paths and
+is designed to **grow across model families** — adding a kernel is one line in
+`registry.py`.
+
+## Why
+
+Many `bench_*.py` files are not wired into any CI suite, so a code change can
+silently regress a kernel's performance. This harness closes that gap with the same
+ground-truth pattern the diffusion CI already uses.
+
+CI GPUs are **not isolated**, so absolute numbers drift run to run. The design
+accounts for that:
+
+- **Ground truth comes from the nightly job**, not a value committed in-tree.
+- The PR run pulls that ground truth and compares with a **relative tolerance**.
+- A regression **fails the job but is safe to re-run** — transient noise passes on
+  retry; a real regression keeps failing.
+- Each config is measured **best-of-N** (`--repeat`) to suppress jitter.
+
+## Flow
+
+```
+   nightly-kernel-bench-gt.yml                     pr-test-kernel-bench.yml
+   (schedule, sm90 + sm100 runners)                (pull_request, sm90 runner)
+            |                                                  |
+   generate <sku>.json  ──publish──>  sgl-project/ci-data  ──pull (raw URL)──> compare
+                                      kernel-bench/                             ±tolerance
+                                          sm90.json                                |
+                                          sm100.json                          pass / fail (re-runnable)
+```
+
+One ground-truth file per GPU SKU (`sm90` = Hopper, `sm100` = Blackwell). Cases
+whose `min_compute_capability` exceeds the current GPU (e.g. CUTLASS MLA needs
+Blackwell) are skipped, so the sm90 PR job only compares sm90-capable kernels.
+
+## CLI
+
+```bash
+# From sgl-kernel/benchmark/
+
+# List the registered cases (no GPU required).
+python3 -m kernel_bench_regression list
+
+# Generate a ground-truth JSON (run on the target GPU).
+python3 -m kernel_bench_regression generate --out gt.json --repeat 5
+
+# Compare a fresh run against a local or remote ground truth.
+python3 -m kernel_bench_regression compare --gt-file gt.json
+python3 -m kernel_bench_regression compare \
+    --gt-url https://raw.githubusercontent.com/sgl-project/ci-data/main/kernel-bench/sm90.json \
+    --tolerance 0.05
+```
+
+`compare` exits non-zero when any shared config is more than `--tolerance` worse
+than the ground truth (lower latency / higher throughput is never a regression).
+Configs present on only one side are reported but never fail the run.
+
+## Adding a kernel
+
+Append one `BenchCase` to `KERNEL_BENCH_CASES` in [`registry.py`](registry.py):
+
+```python
+BenchCase(
+    case_id="my_kernel",            # stable key in the ground truth — never rename
+    bench_file="bench_my_kernel.py",
+    mark_attr="benchmark",          # the triton.testing.perf_report object
+    provider="sgl-kernel",          # the line_arg VALUE of the kernel under test
+    metric="TFLOPs",                # "us" | "TFLOPs" | "GB/s"
+    higher_is_better=True,
+    tags=("gemm",),                 # kernel categories for grouping (model-agnostic)
+    component="what it computes",
+    # min_compute_capability=(10, 0),  # for Blackwell-only kernels
+    # extra_args={...},                # constant kwargs for the bench function
+    # configs_override=[(1,), (16,)],  # pin a small, deterministic config set
+)
+```
+
+The next nightly run regenerates the ground truth to include it.
+
+## Bootstrapping
+
+The very first time, run the nightly workflow manually
+(`workflow_dispatch`) so `kernel-bench/sm90.json` and `sm100.json` exist in
+`sgl-project/ci-data` before the PR gate can pull them.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `registry.py` | Declarative list of tracked kernel cases. |
+| `runner.py` | Imports each bench, drives the kernel provider, captures metrics. |
+| `compare.py` | Pure, GPU-free tolerance comparison + report formatting. |
+| `__main__.py` | `list` / `generate` / `compare` CLI. |
+| `test_compare.py` | CPU-only unit tests for the comparison math. |
+| `../../scripts/ci/utils/kernel/publish_kernel_bench_gt.py` | Publishes GT JSON to ci-data. |

--- a/sgl-kernel/benchmark/kernel_bench_regression/__init__.py
+++ b/sgl-kernel/benchmark/kernel_bench_regression/__init__.py
@@ -1,0 +1,14 @@
+"""SGLang kernel benchmark regression harness.
+
+This package wraps the existing ``sgl-kernel/benchmark/bench_*.py`` benchmarks,
+captures their throughput / latency into a structured JSON, and compares a fresh
+run against a nightly-generated ground truth with a relative tolerance.
+
+The suite is model-agnostic -- it tracks whatever kernels are registered in
+``registry.py`` and is meant to grow across model families. See ``README.md`` for
+the full ground-truth flow.
+"""
+
+from .registry import KERNEL_BENCH_CASES, BenchCase
+
+__all__ = ["KERNEL_BENCH_CASES", "BenchCase"]

--- a/sgl-kernel/benchmark/kernel_bench_regression/__main__.py
+++ b/sgl-kernel/benchmark/kernel_bench_regression/__main__.py
@@ -1,0 +1,193 @@
+"""CLI for the SGLang kernel benchmark regression harness.
+
+Examples
+--------
+Generate a ground-truth file (run on the nightly GPU):
+
+    python -m kernel_bench_regression generate --out ground_truth.json
+
+Compare a fresh run on a PR against a ground truth, failing on >5% regression:
+
+    python -m kernel_bench_regression compare --gt-file ground_truth.json
+
+    python -m kernel_bench_regression compare \\
+        --gt-url https://raw.githubusercontent.com/sgl-project/ci-data/main/kernel-bench/sm90.json
+
+List the registered cases (no GPU required):
+
+    python -m kernel_bench_regression list
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+# Allow both ``python -m kernel_bench_regression`` (run from the benchmark dir)
+# and package-style execution.
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from kernel_bench_regression import compare as compare_mod
+    from kernel_bench_regression import registry
+else:
+    from . import compare as compare_mod
+    from . import registry
+
+
+def _load_ground_truth(args) -> dict:
+    if args.gt_file:
+        with open(args.gt_file, "r", encoding="utf-8") as f:
+            return json.load(f)
+    if args.gt_url:
+        print(f"Fetching ground truth from {args.gt_url}")
+        with urllib.request.urlopen(args.gt_url, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    raise SystemExit("compare requires --gt-file or --gt-url")
+
+
+def _cmd_list(args) -> int:
+    cases = registry.get_cases(args.cases)
+    print(f"{len(cases)} kernel benchmark case(s):\n")
+    for c in cases:
+        cap = ".".join(map(str, c.min_compute_capability))
+        direction = "higher=better" if c.higher_is_better else "lower=better"
+        tags = ",".join(c.tags)
+        print(f"  {c.case_id}  [{tags}]")
+        print(f"          {c.component}")
+        print(
+            f"          file={c.bench_file} provider={c.provider!r} "
+            f"metric={c.metric} ({direction}) min_cc={cap}"
+        )
+    return 0
+
+
+def _cmd_generate(args) -> int:
+    from kernel_bench_regression import runner  # noqa: WPS433 (lazy: needs torch)
+
+    cases = registry.get_cases(args.cases)
+    payload = runner.generate(
+        cases, repeat=args.repeat, tolerance=args.tolerance, commit=args.commit
+    )
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+    n_meas = sum(len(c["measurements"]) for c in payload["cases"].values())
+    print(
+        f"\nWrote {len(payload['cases'])} case(s), {n_meas} measurement(s) to {out_path}"
+    )
+    return 0
+
+
+def _cmd_compare(args) -> int:
+    from kernel_bench_regression import runner  # noqa: WPS433 (lazy: needs torch)
+
+    ground_truth = _load_ground_truth(args)
+    tolerance = (
+        args.tolerance
+        if args.tolerance is not None
+        else ground_truth.get("tolerance", 0.05)
+    )
+    cases = registry.get_cases(args.cases)
+    measured = runner.generate(
+        cases, repeat=args.repeat, tolerance=tolerance, commit=args.commit
+    )
+
+    if args.measured_out:
+        with open(args.measured_out, "w", encoding="utf-8") as f:
+            json.dump(measured, f, indent=2, sort_keys=True)
+            f.write("\n")
+        print(f"Wrote measured results to {args.measured_out}")
+
+    report = compare_mod.compare_results(ground_truth, measured, tolerance)
+    print("\n" + compare_mod.format_report(report, tolerance))
+
+    if not report.passed and not args.warn_only:
+        print(
+            "\nThis gate is allowed to be flaky on non-isolated CI GPUs: "
+            "if you believe the regression is noise, simply re-run the job.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="kernel_bench_regression")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def _add_common(p):
+        p.add_argument(
+            "--cases",
+            nargs="*",
+            default=None,
+            help="Subset of case_ids to run (default: all).",
+        )
+        p.add_argument(
+            "--repeat",
+            type=int,
+            default=3,
+            help="Best-of-N repeats per config to suppress noise (default: 3).",
+        )
+        p.add_argument(
+            "--commit", default="", help="Commit SHA to stamp into the results meta."
+        )
+        p.add_argument(
+            "--no-ci-config",
+            action="store_true",
+            help="Do NOT force SGLANG_IS_IN_CI=true (use each benchmark's full "
+            "config set). Ground truth and PR runs must use the same setting.",
+        )
+
+    p_list = sub.add_parser("list", help="List registered cases (no GPU needed).")
+    p_list.add_argument("--cases", nargs="*", default=None)
+
+    p_gen = sub.add_parser("generate", help="Run benchmarks and write a results JSON.")
+    _add_common(p_gen)
+    p_gen.add_argument("--out", required=True, help="Output JSON path.")
+    p_gen.add_argument("--tolerance", type=float, default=0.05)
+
+    p_cmp = sub.add_parser(
+        "compare", help="Run benchmarks and compare to ground truth."
+    )
+    _add_common(p_cmp)
+    p_cmp.add_argument("--gt-file", default=None, help="Local ground-truth JSON path.")
+    p_cmp.add_argument("--gt-url", default=None, help="Remote ground-truth JSON URL.")
+    p_cmp.add_argument(
+        "--tolerance",
+        type=float,
+        default=None,
+        help="Relative tolerance (default: value stored in the ground truth, or 0.05).",
+    )
+    p_cmp.add_argument(
+        "--measured-out", default=None, help="Optional path to dump the fresh run."
+    )
+    p_cmp.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Report regressions but always exit 0.",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        return _cmd_list(args)
+
+    # Force the benchmarks' CI config path unless explicitly disabled, so that the
+    # ground truth and the PR run measure identical config keys.
+    if not getattr(args, "no_ci_config", False):
+        os.environ.setdefault("SGLANG_IS_IN_CI", "true")
+
+    if args.command == "generate":
+        return _cmd_generate(args)
+    if args.command == "compare":
+        return _cmd_compare(args)
+    parser.error(f"unknown command {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sgl-kernel/benchmark/kernel_bench_regression/compare.py
+++ b/sgl-kernel/benchmark/kernel_bench_regression/compare.py
@@ -1,0 +1,166 @@
+"""Pure ground-truth comparison logic (no torch / CUDA dependency).
+
+Kept import-light on purpose so the regression math can be unit-tested on any
+machine (see ``test_compare.py``) without a GPU.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Delta:
+    case_id: str
+    config: str
+    metric: str
+    higher_is_better: bool
+    gt_value: float
+    measured_value: float
+    # Signed regression ratio: > 0 means measured is WORSE than ground truth.
+    regression_ratio: float
+
+
+@dataclass
+class CompareReport:
+    regressions: List[Delta]
+    improvements: List[Delta]
+    within_tolerance: List[Delta]
+    missing: List[str]  # "case_id::config" present in GT but not measured
+    new_measurements: List[str]  # present in measured but not in GT (informational)
+
+    @property
+    def passed(self) -> bool:
+        return not self.regressions
+
+
+def _regression_ratio(
+    gt_value: float, measured_value: float, higher_is_better: bool
+) -> float:
+    """Fraction by which ``measured`` is worse than ``gt``. Positive == worse.
+
+    For throughput (higher_is_better) a drop is worse: (gt - measured) / gt.
+    For latency a rise is worse: (measured - gt) / gt.
+    """
+    if gt_value == 0:
+        # Degenerate ground truth -- treat any nonzero measurement as matching to
+        # avoid a divide-by-zero false alarm.
+        return 0.0
+    if higher_is_better:
+        return (gt_value - measured_value) / gt_value
+    return (measured_value - gt_value) / gt_value
+
+
+def compare_results(
+    ground_truth: dict,
+    measured: dict,
+    tolerance: float,
+) -> CompareReport:
+    """Compare a fresh ``measured`` run against ``ground_truth`` with ``tolerance``.
+
+    A config regresses when its kernel is more than ``tolerance`` (e.g. 0.05 == 5%)
+    worse than the ground truth in the metric's "good" direction. Configs that are
+    missing on either side are reported but never fail the run -- config sets evolve,
+    and the goal is to catch *regressions on shared configs*, not enforce identical
+    coverage.
+    """
+    regressions: List[Delta] = []
+    improvements: List[Delta] = []
+    within: List[Delta] = []
+    missing: List[str] = []
+    new_measurements: List[str] = []
+
+    gt_cases: Dict[str, dict] = ground_truth.get("cases", {})
+    m_cases: Dict[str, dict] = measured.get("cases", {})
+
+    for case_id, gt_case in gt_cases.items():
+        higher_is_better = gt_case["higher_is_better"]
+        metric = gt_case["metric"]
+        gt_meas: Dict[str, Optional[float]] = gt_case.get("measurements", {})
+        m_case = m_cases.get(case_id)
+        m_meas: Dict[str, Optional[float]] = (m_case or {}).get("measurements", {})
+
+        for config, gt_value in gt_meas.items():
+            if gt_value is None:
+                continue
+            measured_value = m_meas.get(config)
+            if measured_value is None:
+                missing.append(f"{case_id}::{config}")
+                continue
+            ratio = _regression_ratio(gt_value, measured_value, higher_is_better)
+            delta = Delta(
+                case_id=case_id,
+                config=config,
+                metric=metric,
+                higher_is_better=higher_is_better,
+                gt_value=gt_value,
+                measured_value=measured_value,
+                regression_ratio=ratio,
+            )
+            if ratio > tolerance:
+                regressions.append(delta)
+            elif ratio < -tolerance:
+                improvements.append(delta)
+            else:
+                within.append(delta)
+
+    # Informational: configs measured this run that the ground truth doesn't know.
+    for case_id, m_case in m_cases.items():
+        gt_meas = gt_cases.get(case_id, {}).get("measurements", {})
+        for config, value in m_case.get("measurements", {}).items():
+            if value is not None and config not in gt_meas:
+                new_measurements.append(f"{case_id}::{config}")
+
+    return CompareReport(
+        regressions=regressions,
+        improvements=improvements,
+        within_tolerance=within,
+        missing=missing,
+        new_measurements=new_measurements,
+    )
+
+
+def format_report(report: CompareReport, tolerance: float) -> str:
+    """Render a human-readable summary for CI logs."""
+    lines: List[str] = []
+    pct = f"{tolerance * 100:.1f}%"
+    lines.append(f"Kernel benchmark regression report (tolerance ±{pct})")
+    lines.append("=" * 72)
+
+    def _row(d: Delta) -> str:
+        arrow = "↑good" if d.higher_is_better else "↓good"
+        return (
+            f"  {d.case_id}::{d.config}\n"
+            f"      gt={d.gt_value:.4g} {d.metric}  measured={d.measured_value:.4g} {d.metric} "
+            f"({arrow})  delta={d.regression_ratio * 100:+.2f}% worse"
+        )
+
+    if report.regressions:
+        lines.append(f"\nREGRESSIONS ({len(report.regressions)}):")
+        for d in report.regressions:
+            lines.append(_row(d))
+    if report.improvements:
+        lines.append(f"\nImprovements ({len(report.improvements)}):")
+        for d in report.improvements:
+            lines.append(_row(d))
+    lines.append(
+        f"\nWithin tolerance: {len(report.within_tolerance)}  |  "
+        f"Regressions: {len(report.regressions)}  |  "
+        f"Improvements: {len(report.improvements)}"
+    )
+    if report.missing:
+        lines.append(
+            f"\nMissing this run ({len(report.missing)}) -- not counted as regressions:"
+        )
+        for key in report.missing:
+            lines.append(f"  {key}")
+    if report.new_measurements:
+        lines.append(
+            f"\nNew configs not in ground truth ({len(report.new_measurements)}):"
+        )
+        for key in report.new_measurements:
+            lines.append(f"  {key}")
+
+    verdict = "PASS" if report.passed else "FAIL"
+    lines.append("\n" + "=" * 72)
+    lines.append(f"VERDICT: {verdict}")
+    return "\n".join(lines)

--- a/sgl-kernel/benchmark/kernel_bench_regression/registry.py
+++ b/sgl-kernel/benchmark/kernel_bench_regression/registry.py
@@ -1,0 +1,156 @@
+"""Registry of kernel benchmark cases tracked for performance regression.
+
+Each :class:`BenchCase` points at an existing ``bench_*.py`` file under
+``sgl-kernel/benchmark/`` and the ``triton.testing.perf_report`` object inside it.
+The runner imports that object, drives the kernel-under-test provider directly, and
+records the median metric for every config. We deliberately reuse the existing
+benchmarks instead of duplicating kernel-launch logic so the regression suite stays
+in sync with whatever the benchmark authors maintain.
+
+The suite is model-agnostic: adding a kernel is a one-line edit here. Tag each case
+with the kernel categories it belongs to (``mla``, ``moe``, ``gemm``, ``fp8``,
+``attention``, ...) so the suite can grow across model families without renaming.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class BenchCase:
+    """One kernel benchmark tracked for performance regression.
+
+    Attributes:
+        case_id: Stable identifier used as the key in the ground-truth JSON. Never
+            rename an existing one or the ground truth stops matching. By convention
+            this mirrors the kernel's own name (e.g. the bench function it wraps).
+        bench_file: File name (relative to ``sgl-kernel/benchmark/``) to import.
+        mark_attr: Name of the ``triton.testing.perf_report`` object in that module.
+        provider: The ``line_arg`` value of the kernel under test (NOT the display
+            ``line_name``). The benchmark function branches on this string, e.g.
+            ``"sgl-kernel"`` or ``"sglang"``.
+        metric: Unit string for reporting, e.g. ``"us"``, ``"TFLOPs"``, ``"GB/s"``.
+        higher_is_better: ``True`` for throughput (TFLOPs/GB-s), ``False`` for
+            latency (us). Drives which direction counts as a regression.
+        tags: Kernel categories for grouping/filtering, e.g. ``("mla", "gemm")``.
+            Documentation/selection only -- never affects the comparison.
+        component: Human-readable description of what the kernel computes.
+        min_compute_capability: Skip the case when the current GPU is older than
+            this ``(major, minor)``. e.g. CUTLASS MLA needs ``(10, 0)`` (Blackwell).
+        extra_args: Constant keyword args forwarded to the benchmark function for
+            every config (e.g. CUTLASS MLA's ``block_size`` / ``num_kv_splits``).
+        configs_override: Optional explicit list of x-value tuples to override the
+            benchmark's own ``x_vals``. Used to pin a small, representative and
+            deterministic config set independent of the benchmark's CI shortcuts.
+            Each tuple must line up with the benchmark's ``x_names`` order.
+    """
+
+    case_id: str
+    bench_file: str
+    mark_attr: str
+    provider: str
+    metric: str
+    higher_is_better: bool
+    tags: Tuple[str, ...]
+    component: str
+    min_compute_capability: Tuple[int, int] = (9, 0)
+    extra_args: dict = field(default_factory=dict)
+    configs_override: Optional[List[tuple]] = None
+
+
+# NOTE: Keep this list small and high-signal. The goal is a fast regression gate
+# over the kernels that dominate decode/prefill, not exhaustive coverage. More
+# cases (and more model families) can be added incrementally; just append a
+# BenchCase pointing at any existing bench_*.py perf_report object.
+KERNEL_BENCH_CASES: List[BenchCase] = [
+    BenchCase(
+        case_id="dsv3_fused_a_gemm",
+        bench_file="bench_dsv3_fused_a_gemm.py",
+        mark_attr="benchmark",
+        provider="sgl-kernel",
+        metric="TFLOPs",
+        higher_is_better=True,
+        tags=("mla", "gemm"),
+        component="MLA fused down-proj 'A' GEMM (7168x2112)",
+        configs_override=[(1,), (8,), (16,)],
+    ),
+    BenchCase(
+        case_id="dsv3_router_gemm_bf16_out",
+        bench_file="bench_dsv3_router_gemm.py",
+        mark_attr="benchmark_bf16_output",
+        provider="sgl-kernel-256",
+        metric="TFLOPs",
+        higher_is_better=True,
+        tags=("moe", "gemm"),
+        component="MoE router GEMM, 256 experts, bf16 output",
+        configs_override=[(1,), (8,), (16,)],
+    ),
+    BenchCase(
+        case_id="dsv3_router_gemm_float_out",
+        bench_file="bench_dsv3_router_gemm.py",
+        mark_attr="benchmark_float_output",
+        provider="sgl-kernel-256",
+        metric="TFLOPs",
+        higher_is_better=True,
+        tags=("moe", "gemm"),
+        component="MoE router GEMM, 256 experts, fp32 output",
+        configs_override=[(1,), (8,), (16,)],
+    ),
+    BenchCase(
+        case_id="moe_fused_gate",
+        bench_file="bench_moe_fused_gate.py",
+        mark_attr="benchmark",
+        provider="kernel",
+        metric="us",
+        higher_is_better=False,
+        tags=("moe", "gate"),
+        component="MoE fused gate + grouped top-k selector",
+    ),
+    BenchCase(
+        case_id="per_token_group_quant_8bit",
+        bench_file="bench_per_token_group_quant_8bit.py",
+        mark_attr="benchmark",
+        provider="sglang",
+        metric="us",
+        higher_is_better=False,
+        tags=("fp8", "quant"),
+        component="FP8 blockwise per-token-group quant (blockwise GEMM input)",
+    ),
+    BenchCase(
+        case_id="dsv4_q_norm_rope",
+        bench_file="bench_dsv4_norm_rope.py",
+        mark_attr="benchmark_q_norm_rope",
+        provider="sglang",
+        metric="us",
+        higher_is_better=False,
+        tags=("attention", "norm", "rope"),
+        component="Fused Q RMSNorm + RoPE",
+        configs_override=[(1, 8, 192), (16, 8, 192), (64, 16, 192)],
+    ),
+    BenchCase(
+        case_id="cutlass_mla_decode",
+        bench_file="bench_cutlass_mla.py",
+        mark_attr="benchmark",
+        provider="128 heads",
+        metric="GB/s",
+        higher_is_better=True,
+        tags=("mla", "attention", "decode"),
+        component="CUTLASS MLA decode attention (TP=1, 128 heads)",
+        min_compute_capability=(10, 0),
+        extra_args={"block_size": 128, "num_kv_splits": 1},
+        configs_override=[(1, 1024), (8, 2048), (32, 4096)],
+    ),
+]
+
+
+def get_cases(case_ids: Optional[List[str]] = None) -> List[BenchCase]:
+    """Return all cases, or only those whose ``case_id`` is in ``case_ids``."""
+    if not case_ids:
+        return list(KERNEL_BENCH_CASES)
+    wanted = set(case_ids)
+    selected = [c for c in KERNEL_BENCH_CASES if c.case_id in wanted]
+    known = {c.case_id for c in KERNEL_BENCH_CASES}
+    unknown = sorted(wanted - known)
+    if unknown:
+        raise SystemExit(f"unknown case id(s): {' '.join(unknown)}")
+    return selected

--- a/sgl-kernel/benchmark/kernel_bench_regression/runner.py
+++ b/sgl-kernel/benchmark/kernel_bench_regression/runner.py
@@ -1,0 +1,182 @@
+"""Run kernel benchmarks and capture their metrics into a results dict.
+
+The runner imports each benchmark module by file path, grabs its
+``triton.testing.perf_report`` object, and calls the underlying benchmark function
+directly for the kernel-under-test provider on each config. Driving ``mark.fn``
+directly (instead of relying on the printed table or ``return_df``) is robust across
+triton versions and skips the slow reference (torch) provider entirely.
+"""
+
+import importlib.util
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .registry import BenchCase
+
+# sgl-kernel/benchmark/ -- the directory that holds the bench_*.py files.
+BENCH_DIR = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION = 1
+
+
+def _load_mark(bench_file: str, mark_attr: str):
+    """Import ``bench_file`` from the benchmark dir and return its perf_report mark.
+
+    Each bench file must already see ``SGLANG_IS_IN_CI`` in the environment (it reads
+    it at import time), so callers set that before invoking the runner.
+    """
+    path = BENCH_DIR / bench_file
+    if not path.exists():
+        raise FileNotFoundError(f"benchmark file not found: {path}")
+    module_name = f"_dsbench_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    # Make the benchmark dir importable in case the file uses sibling imports.
+    if str(BENCH_DIR) not in sys.path:
+        sys.path.insert(0, str(BENCH_DIR))
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    mark = getattr(module, mark_attr)
+    return mark
+
+
+def _benchmark_obj(mark):
+    """Return the single ``triton.testing.Benchmark`` backing a perf_report mark."""
+    benchmarks = getattr(mark, "benchmarks", None)
+    if benchmarks is None:
+        raise AttributeError("perf_report object has no .benchmarks attribute")
+    if isinstance(benchmarks, (list, tuple)):
+        if len(benchmarks) != 1:
+            raise ValueError(
+                "regression harness only supports single-Benchmark perf_report objects"
+            )
+        return benchmarks[0]
+    return benchmarks
+
+
+def _config_key(x_names: List[str], x_val) -> str:
+    """Stable string key for one config, e.g. ``num_tokens=1,num_heads=8``."""
+    values = x_val if isinstance(x_val, (list, tuple)) else (x_val,)
+    return ",".join(f"{name}={value}" for name, value in zip(x_names, values))
+
+
+def _median_metric(result) -> float:
+    """Benchmark fns return either a scalar metric or a (median, max, min) tuple."""
+    if isinstance(result, (list, tuple)):
+        return float(result[0])
+    return float(result)
+
+
+def _device_capability() -> Optional[Tuple[int, int]]:
+    import torch
+
+    if not torch.cuda.is_available():
+        return None
+    return torch.cuda.get_device_capability()
+
+
+def _device_name() -> str:
+    import torch
+
+    if not torch.cuda.is_available():
+        return "cpu"
+    return torch.cuda.get_device_name(0)
+
+
+def run_case(case: BenchCase, repeat: int = 3) -> Dict[str, Optional[float]]:
+    """Run every config of one case and return ``{config_key: best_metric}``.
+
+    ``best_metric`` is the best-of-``repeat`` value (max for throughput, min for
+    latency) to suppress noise from non-isolated CI GPUs. A config that raises is
+    recorded as ``None`` so a single bad shape never aborts the whole run.
+    """
+    import torch  # noqa: F401  (ensures CUDA context errors surface here)
+
+    mark = _load_mark(case.bench_file, case.mark_attr)
+    bench = _benchmark_obj(mark)
+    x_names = bench.x_names
+    line_arg = bench.line_arg
+    const_args = dict(getattr(bench, "args", {}) or {})
+    const_args.update(case.extra_args)
+
+    x_vals = (
+        case.configs_override if case.configs_override is not None else bench.x_vals
+    )
+
+    measurements: Dict[str, Optional[float]] = {}
+    for x_val in x_vals:
+        key = _config_key(x_names, x_val)
+        values = x_val if isinstance(x_val, (list, tuple)) else (x_val,)
+        kwargs = dict(zip(x_names, values))
+        kwargs.update(const_args)
+        kwargs[line_arg] = case.provider
+
+        best: Optional[float] = None
+        for _ in range(max(1, repeat)):
+            try:
+                metric = _median_metric(mark.fn(**kwargs))
+            except Exception as exc:  # noqa: BLE001
+                print(f"  [warn] {case.case_id}::{key} raised: {exc}")
+                best = None
+                break
+            if best is None:
+                best = metric
+            elif case.higher_is_better:
+                best = max(best, metric)
+            else:
+                best = min(best, metric)
+        measurements[key] = best
+        if best is not None:
+            print(f"  {case.case_id}::{key} = {best:.4g} {case.metric}")
+    return measurements
+
+
+def generate(
+    cases: List[BenchCase],
+    repeat: int = 3,
+    tolerance: float = 0.05,
+    commit: str = "",
+) -> dict:
+    """Run all ``cases`` (skipping ones the current GPU can't run) and build a
+    results dict ready to serialize as ground truth or to compare against one."""
+    capability = _device_capability()
+    cap_tuple = capability if capability is not None else (0, 0)
+
+    results: Dict[str, dict] = {}
+    skipped: List[str] = []
+    for case in cases:
+        if cap_tuple < case.min_compute_capability:
+            need = ".".join(map(str, case.min_compute_capability))
+            have = ".".join(map(str, cap_tuple))
+            print(
+                f"[skip] {case.case_id}: needs compute capability >= {need}, have {have}"
+            )
+            skipped.append(case.case_id)
+            continue
+        tag_str = ",".join(case.tags)
+        print(f"[run] {case.case_id} ({tag_str}: {case.component})")
+        measurements = run_case(case, repeat=repeat)
+        results[case.case_id] = {
+            "metric": case.metric,
+            "higher_is_better": case.higher_is_better,
+            "tags": list(case.tags),
+            "component": case.component,
+            "measurements": measurements,
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "meta": {
+            "device_name": _device_name(),
+            "compute_capability": ".".join(map(str, cap_tuple)),
+            "commit": commit or os.environ.get("GITHUB_SHA", ""),
+            "generated_at_unix": int(time.time()),
+            "repeat": repeat,
+            "skipped_cases": skipped,
+        },
+        "tolerance": tolerance,
+        "cases": results,
+    }

--- a/sgl-kernel/benchmark/kernel_bench_regression/test_compare.py
+++ b/sgl-kernel/benchmark/kernel_bench_regression/test_compare.py
@@ -1,0 +1,149 @@
+"""CPU-only unit tests for the regression comparison math.
+
+These intentionally have no torch/CUDA dependency so they run anywhere:
+
+    python -m pytest sgl-kernel/benchmark/kernel_bench_regression/test_compare.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from kernel_bench_regression import compare as compare_mod
+else:
+    from . import compare as compare_mod
+
+
+def _gt():
+    return {
+        "tolerance": 0.05,
+        "cases": {
+            "latency_kernel": {
+                "metric": "us",
+                "higher_is_better": False,
+                "measurements": {"n=1": 100.0, "n=16": 200.0},
+            },
+            "throughput_kernel": {
+                "metric": "TFLOPs",
+                "higher_is_better": True,
+                "measurements": {"n=1": 50.0, "n=16": 80.0},
+            },
+        },
+    }
+
+
+def _measured(cases):
+    return {"cases": cases}
+
+
+class CompareTest(unittest.TestCase):
+    def test_within_tolerance_passes(self):
+        measured = _measured(
+            {
+                "latency_kernel": {
+                    "metric": "us",
+                    "higher_is_better": False,
+                    "measurements": {"n=1": 103.0, "n=16": 196.0},
+                },
+                "throughput_kernel": {
+                    "metric": "TFLOPs",
+                    "higher_is_better": True,
+                    "measurements": {"n=1": 49.0, "n=16": 82.0},
+                },
+            }
+        )
+        report = compare_mod.compare_results(_gt(), measured, tolerance=0.05)
+        self.assertTrue(report.passed)
+        self.assertEqual(report.regressions, [])
+
+    def test_latency_regression_fails(self):
+        # 200 -> 220 is +10% latency == worse than 5% tolerance.
+        measured = _measured(
+            {
+                "latency_kernel": {
+                    "metric": "us",
+                    "higher_is_better": False,
+                    "measurements": {"n=1": 100.0, "n=16": 220.0},
+                },
+            }
+        )
+        report = compare_mod.compare_results(_gt(), measured, tolerance=0.05)
+        self.assertFalse(report.passed)
+        self.assertEqual(len(report.regressions), 1)
+        d = report.regressions[0]
+        self.assertEqual(d.case_id, "latency_kernel")
+        self.assertEqual(d.config, "n=16")
+        self.assertAlmostEqual(d.regression_ratio, 0.10, places=6)
+
+    def test_throughput_regression_fails(self):
+        # 80 -> 70 is a 12.5% throughput drop == regression.
+        measured = _measured(
+            {
+                "throughput_kernel": {
+                    "metric": "TFLOPs",
+                    "higher_is_better": True,
+                    "measurements": {"n=1": 50.0, "n=16": 70.0},
+                },
+            }
+        )
+        report = compare_mod.compare_results(_gt(), measured, tolerance=0.05)
+        self.assertFalse(report.passed)
+        self.assertEqual(len(report.regressions), 1)
+        self.assertAlmostEqual(report.regressions[0].regression_ratio, 0.125, places=6)
+
+    def test_improvement_is_not_a_regression(self):
+        measured = _measured(
+            {
+                "latency_kernel": {
+                    "metric": "us",
+                    "higher_is_better": False,
+                    "measurements": {"n=1": 80.0, "n=16": 150.0},
+                },
+            }
+        )
+        report = compare_mod.compare_results(_gt(), measured, tolerance=0.05)
+        self.assertTrue(report.passed)
+        self.assertEqual(len(report.improvements), 2)
+
+    def test_missing_config_is_reported_not_failed(self):
+        measured = _measured(
+            {
+                "latency_kernel": {
+                    "metric": "us",
+                    "higher_is_better": False,
+                    "measurements": {"n=1": 100.0},  # n=16 missing
+                },
+            }
+        )
+        report = compare_mod.compare_results(_gt(), measured, tolerance=0.05)
+        self.assertTrue(report.passed)
+        self.assertIn("latency_kernel::n=16", report.missing)
+
+    def test_zero_ground_truth_does_not_divide_by_zero(self):
+        gt = {
+            "tolerance": 0.05,
+            "cases": {
+                "k": {
+                    "metric": "us",
+                    "higher_is_better": False,
+                    "measurements": {"n=1": 0.0},
+                }
+            },
+        }
+        measured = _measured(
+            {
+                "k": {
+                    "metric": "us",
+                    "higher_is_better": False,
+                    "measurements": {"n=1": 5.0},
+                }
+            }
+        )
+        report = compare_mod.compare_results(gt, measured, tolerance=0.05)
+        self.assertTrue(report.passed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Follow-up to the JIT-kernel cleanup discussion — we want an **advanced CI to prevent silent performance regressions** in SGLang kernels. Today many `sgl-kernel/benchmark/bench_*.py` files are **not wired into any CI suite**, so a refactor can regress a kernel's perf and nobody notices.

This draft implements the **nightly-ground-truth + per-PR-compare with tolerance** approach: nightly CI is the ground truth, each PR run pulls it down and compares with a `±5%` tolerance. Because CI GPUs aren't isolated, the gate is **safe to re-run** (transient noise passes on retry; a real regression keeps failing).

It deliberately mirrors the existing **diffusion** ground-truth pattern (`diffusion-ci-gt-gen.yml` + `publish_diffusion_gt.py` → `sgl-project/ci-data`).

The suite is **model-agnostic** — it tracks whatever kernels are registered and is meant to grow across model families. Cases are tagged by kernel category (`mla` / `moe` / `gemm` / `fp8` / `attention` / …) rather than by model.

## What's here

| Piece | File |
| --- | --- |
| Registry-driven harness (reuses existing `perf_report` objects, no kernel logic duplicated) | `sgl-kernel/benchmark/kernel_bench_regression/{registry,runner,compare,__main__}.py` |
| GPU-free comparison math + unit tests | `compare.py`, `test_compare.py` |
| GT publisher to `sgl-project/ci-data` (GitHub API, same token as diffusion) | `scripts/ci/utils/kernel/publish_kernel_bench_gt.py` |
| Nightly GT generation (sm90 + sm100) | `.github/workflows/nightly-kernel-bench-gt.yml` |
| PR regression gate (paths-filtered) | `.github/workflows/pr-test-kernel-bench.yml` |

```
nightly (sm90/sm100 runners)                   PR (sm90 runner)
  generate <sku>.json ──publish──> ci-data ──pull──> compare ±5% ──> pass/fail (re-runnable)
                                   kernel-bench/{sm90,sm100}.json
```

The harness drives each bench's kernel-under-test provider directly (`mark.fn(...)`), so it's robust across triton versions and skips the slow torch reference. Throughput→higher-better, latency→lower-better; only shared configs that are worse by `>tolerance` fail. Blackwell-only cases (CUTLASS MLA) carry a `min_compute_capability` and are auto-skipped on the sm90 PR runner.

## Initial registered subset

`dsv3_fused_a_gemm`, `dsv3_router_gemm` (bf16/fp32 out), `dsv4_q_norm_rope`, `moe_fused_gate`, `per_token_group_quant_8bit`, `cutlass_mla_decode` (sm100). (`case_id`s mirror the upstream kernel/bench names.) Adding a kernel is a one-line `BenchCase` in `registry.py`.

## Status / open questions (RFC)

- [ ] **Not yet run on GPU** — opening as draft to let CI exercise it and gauge the pass-rate / noise under non-isolated runners. May need to tune `--repeat` (best-of-N) and the `5%` tolerance per kernel.
- [ ] **Bootstrap**: the nightly workflow must run once (`workflow_dispatch`) to seed `kernel-bench/{sm90,sm100}.json` in `ci-data` before the PR gate can pull.
- [ ] Should the PR gate be a standalone workflow (as here) or fold into the existing `pr-test-sgl-kernel` reusable workflow with the prebuilt kernel wheel?
- [ ] Per-kernel tolerance overrides if 5% global proves too tight/loose.

CPU-checkable locally: `python -m pytest sgl-kernel/benchmark/kernel_bench_regression/test_compare.py` and `python -m kernel_bench_regression list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)