### PR TITLE
[diffusion] Enable channels_last_3d for Cosmos3 VAE

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 from safetensors.torch import load_file as safetensors_load_file
 
 from sglang.multimodal_gen.configs.models import ModelConfig
+from sglang.multimodal_gen.configs.pipeline_configs.cosmos3 import Cosmos3Config
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import LTX2PipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
     QwenImagePipelineConfig,
@@ -84,8 +85,14 @@ def _should_use_channels_last_3d(
     pipeline_config = server_args.pipeline_config
     if isinstance(pipeline_config, QwenImagePipelineConfig):
         return True
+    # Cosmos3 reuses the Wan VAE (AutoencoderKLWan), so the same Conv3d
+    # channels_last_3d transform applies. Gated on single-GPU like Wan/LTX
+    # since the parallel-decode path is not yet validated with channels_last.
     if (
-        isinstance(pipeline_config, (WanT2V480PConfig, LTX2PipelineConfig))
+        isinstance(
+            pipeline_config,
+            (WanT2V480PConfig, LTX2PipelineConfig, Cosmos3Config),
+        )
         and server_args.num_gpus == 1
     ):
         return True

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -85,9 +85,6 @@ def _should_use_channels_last_3d(
     pipeline_config = server_args.pipeline_config
     if isinstance(pipeline_config, QwenImagePipelineConfig):
         return True
-    # Cosmos3 reuses the Wan VAE (AutoencoderKLWan), so the same Conv3d
-    # channels_last_3d transform applies. Gated on single-GPU like Wan/LTX
-    # since the parallel-decode path is not yet validated with channels_last.
     if (
         isinstance(
             pipeline_config,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Cosmos3 reuses the Wan VAE, but Cosmos3Config was excluded from the Conv3d channels_last_3d transform that Wan-T2V-480P / LTX2 / Qwen-Image already use.

```bash
root@node # python -c "from huggingface_hub import hf_hub_download; import json; print(json.load(open(hf_hub_download('nvidia/Cosmos3-Nano','vae/config.json')))['_class_name'])"
AutoencoderKLWan
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Add Cosmos to the gate.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

cl3d could affect numerics but should be well-tested in other codepaths and should be handled by cudnn/cutlass

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

Measured on GB300 (ONLY warmed VAE decode part, no DiT, bf16):
  480p 81f:  1015 -> 869 ms  (1.17x)
  720p 81f:  2283 -> 2000 ms (1.14x)
  720p 121f: 3410 -> 2980 ms (1.14x)

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27401075627](https://github.com/sgl-project/sglang/actions/runs/27401075627)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27401075495](https://github.com/sgl-project/sglang/actions/runs/27401075495)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->