### PR TITLE
[DeepSeek-V4-Flash][SM120] FlashInfer MXFP4 path with custom SM120 FlashMLA

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -763,6 +763,13 @@ class Envs:
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
     SGLANG_OPT_USE_COMPRESSOR_V2 = EnvBool(True)
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
+    # SM120 long-context speedup: shard the paged-MQA logits scan across
+    # (batch, num_splits) CTAs. The base kernel is latency-bound on per-row scan
+    # depth (flat vs batch up to the SM count), off by default.
+    SGLANG_SM120_INDEXER_SPLIT = EnvBool(False)
+    SGLANG_SM120_INDEXER_SPLIT_COUNT = EnvInt(128)
+    # Upper batch bound for the split: the captured-graph batch ceiling.
+    SGLANG_SM120_INDEXER_SPLIT_MAX_BS = EnvInt(128)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)
     SGLANG_OPT_FLASHMLA_SPARSE_PREFILL = EnvBool(False)
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -767,7 +767,8 @@ class Envs:
     # (batch, num_splits) CTAs. The base kernel is latency-bound on per-row scan
     # depth (flat vs batch up to the SM count), off by default.
     SGLANG_SM120_INDEXER_SPLIT = EnvBool(False)
-    SGLANG_SM120_INDEXER_SPLIT_COUNT = EnvInt(128)
+    # KV-splits per row. More = shallower per-CTA scan
+    SGLANG_SM120_INDEXER_SPLIT_COUNT = EnvInt(256)
     # Upper batch bound for the split: the captured-graph batch ceiling.
     SGLANG_SM120_INDEXER_SPLIT_MAX_BS = EnvInt(128)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1191,10 +1191,6 @@ class DeepseekV4AttnBackend(
         indices. Chunk-invariant scaffolding lives in
         ``self.forward_metadata.sparse_prefill_cache``.
         """
-        from sglang.srt.layers.attention.flash_mla_sparse_prefill_sm120 import (
-            flash_mla_sparse_fwd_sm120,
-        )
-
         # q is (b, 1, h_q, d_qk); flash_mla_sparse_fwd takes (s_q, h_q, d_qk).
         q_flat = q.squeeze(1)
 
@@ -1265,15 +1261,34 @@ class DeepseekV4AttnBackend(
         )
         kv = workspace
 
-        o, _, _ = flash_mla_sparse_fwd_sm120(
-            q=q_flat,
-            kv=kv,
-            indices=combined_indices.unsqueeze(1),
-            sm_scale=self.softmax_scale,
-            d_v=self.head_dim_v,
-            attn_sink=attn_sink,
-            topk_length=combined_lens,
-        )
+        if _is_sm120:
+            # Stock flash_mla_sparse_fwd is SM90a/SM100f-only and raises on SM120;
+            # route through the SM120 selector (SGLANG_SM120_SPARSE_PREFILL).
+            from sglang.srt.layers.attention.flash_mla_sparse_prefill_sm120 import (
+                flash_mla_sparse_fwd_sm120,
+            )
+
+            o, _, _ = flash_mla_sparse_fwd_sm120(
+                q=q_flat,
+                kv=kv,
+                indices=combined_indices.unsqueeze(1),
+                sm_scale=self.softmax_scale,
+                d_v=self.head_dim_v,
+                attn_sink=attn_sink,
+                topk_length=combined_lens,
+            )
+        else:
+            from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+            o, _, _ = flash_mla_sparse_fwd(
+                q=q_flat,
+                kv=kv,
+                indices=combined_indices.unsqueeze(1),
+                sm_scale=self.softmax_scale,
+                d_v=self.head_dim_v,
+                attn_sink=attn_sink,
+                topk_length=combined_lens,
+            )
         return o
 
     def expand_prefill_casually(

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1191,7 +1191,9 @@ class DeepseekV4AttnBackend(
         indices. Chunk-invariant scaffolding lives in
         ``self.forward_metadata.sparse_prefill_cache``.
         """
-        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+        from sglang.srt.layers.attention.flash_mla_sparse_prefill_sm120 import (
+            flash_mla_sparse_fwd_sm120,
+        )
 
         # q is (b, 1, h_q, d_qk); flash_mla_sparse_fwd takes (s_q, h_q, d_qk).
         q_flat = q.squeeze(1)
@@ -1263,7 +1265,7 @@ class DeepseekV4AttnBackend(
         )
         kv = workspace
 
-        o, _, _ = flash_mla_sparse_fwd(
+        o, _, _ = flash_mla_sparse_fwd_sm120(
             q=q_flat,
             kv=kv,
             indices=combined_indices.unsqueeze(1),

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -510,9 +510,26 @@ class C4IndexerBackendMixin:
                 # SM120: the dsa/ kernel allocs k_smem as 1-D ((B*D,) uint8 +
                 # view), which CUDA-graph capture rejects. Use the dsv4/ kernel
                 # that allocs 2-D shared K directly.
-                from sglang.srt.layers.attention.dsv4.tilelang_kernel import (
-                    tilelang_fp8_paged_mqa_logits as fn,
-                )
+                if envs.SGLANG_SM120_INDEXER_SPLIT.get() and (
+                    weights.shape[0] <= envs.SGLANG_SM120_INDEXER_SPLIT_MAX_BS.get()
+                ):
+                    # Split-KV: shard each row's scan across (batch, num_splits)
+                    # CTAs (bit-exact, big win at long ctx); MAX_BS caps it at
+                    # the graph ceiling. See the kernel for why it always wins.
+                    import functools
+
+                    from sglang.srt.layers.attention.dsv4.tilelang_kernel import (
+                        tilelang_fp8_paged_mqa_logits_split,
+                    )
+
+                    fn = functools.partial(
+                        tilelang_fp8_paged_mqa_logits_split,
+                        num_splits=envs.SGLANG_SM120_INDEXER_SPLIT_COUNT.get(),
+                    )
+                else:
+                    from sglang.srt.layers.attention.dsv4.tilelang_kernel import (
+                        tilelang_fp8_paged_mqa_logits as fn,
+                    )
             else:
                 from sglang.srt.layers.attention.dsa.tilelang_kernel import (
                     tilelang_fp8_paged_mqa_logits as fn,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -506,9 +506,17 @@ class C4IndexerBackendMixin:
                 raise RuntimeError("DeepSeek V4 FP4 indexer requires DeepGEMM indexer.")
             from deep_gemm import fp8_fp4_paged_mqa_logits as fn
         elif envs.SGLANG_OPT_USE_TILELANG_INDEXER.get():
-            from sglang.srt.layers.attention.dsa.tilelang_kernel import (
-                tilelang_fp8_paged_mqa_logits as fn,
-            )
+            if is_sm120_supported():
+                # SM120: the dsa/ kernel allocs k_smem as 1-D ((B*D,) uint8 +
+                # view), which CUDA-graph capture rejects. Use the dsv4/ kernel
+                # that allocs 2-D shared K directly.
+                from sglang.srt.layers.attention.dsv4.tilelang_kernel import (
+                    tilelang_fp8_paged_mqa_logits as fn,
+                )
+            else:
+                from sglang.srt.layers.attention.dsa.tilelang_kernel import (
+                    tilelang_fp8_paged_mqa_logits as fn,
+                )
         elif envs.SGLANG_OPT_USE_AITER_INDEXER.get():
             fn = _aiter_fp8_paged_mqa_logits
         elif envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():

--- a/python/sglang/srt/layers/attention/dsv4/tilelang_kernel.py
+++ b/python/sglang/srt/layers/attention/dsv4/tilelang_kernel.py
@@ -121,3 +121,132 @@ def tilelang_fp8_paged_mqa_logits(
     kvcache_scale = kvcache_fp8[..., block_size * head_dim :].view(dtype=torch.float32)
     kernel(q_fp8, kvcache, kvcache_scale, weight, seq_lens, page_table, logits)
     return logits
+
+
+@functools.cache
+def fp8_paged_mqa_logits_split_kernel(
+    head_dim: int = 128,
+    num_heads: int = 64,
+    block_size: int = 64,
+    num_splits: int = 64,
+    clear_accum: bool = True,
+) -> Any:
+    """Split-KV variant of fp8_paged_mqa_logits.
+
+    Each logit depends on one KV block (no cross-block reduction), so the scan
+    shards cleanly: each (batch, split) CTA owns a block range and writes its own
+    o[] slice — no atomics. Fills the SMs a (batch,)-only grid leaves idle.
+    """
+    N = T.symbolic("batch_size")
+    L = T.symbolic("max_table_length")
+    S = T.symbolic("max_seq_len")
+    C = T.symbolic("num_blocks")
+    B = block_size
+    D = head_dim
+    H = num_heads
+    SP = num_splits
+    d_0, d_1 = T.dynamic("d_0, d_1")
+
+    assert D % 4 == 0
+    assert H % 4 == 0
+    assert D == 128
+
+    @tilelang.jit
+    def fp8_paged_mqa_logits_split(
+        q: T.Tensor[(N, H, D), FP8],
+        kvcache: T.StridedTensor[(C, B, D), (d_0, D, 1), FP8],
+        kvcache_scale: T.StridedTensor[(C, B), (d_1, 1), FP32],
+        weight: T.Tensor[(N, H), FP32],
+        seq_lens: T.Tensor[(N,), INT32],
+        page_table: T.Tensor[(N, L), INT32],
+        o: T.Tensor[(N, S), FP32],
+    ) -> None:
+        _ = N, L, S, C, D, H, B, SP, d_0, d_1
+        with T.Kernel(N, SP) as (bx, sx):
+            seq_len = seq_lens[bx]
+            num_blocks = T.ceildiv(seq_len, B)
+            # Balance on the live seq_len, not the padded S: with a big context
+            # window S >> seq_len, so ceildiv(S, B*SP) would dump every block on
+            # CTA 0 and collapse back to a 1-CTA scan. ceil over num_blocks
+            # covers [0, num_blocks) once each; spare CTAs get trip count 0
+            # (dynamic, like the base kernel -> still capture-safe).
+            blk_per_split = T.ceildiv(num_blocks, SP)
+            blk_start = sx * blk_per_split
+            blk_end = T.min((sx + 1) * blk_per_split, num_blocks)
+
+            q_smem = T.alloc_shared((H, D), FP8)
+            q_s_frag = T.alloc_fragment((H,), FP32)
+            T.copy(q[bx, 0, 0], q_smem)
+            T.copy(weight[bx, 0], q_s_frag)
+
+            for i in T.Pipelined(T.max(blk_end - blk_start, 0), num_stages=2):
+                blk = blk_start + i
+                page = page_table[bx, blk]
+                k_smem = T.alloc_shared((B, D), FP8)
+                k_s_frag = T.alloc_fragment((B,), FP32)
+                T.copy(kvcache[page, 0, 0], k_smem)
+                T.copy(kvcache_scale[page, 0], k_s_frag)
+
+                logits = T.alloc_fragment((B, H), FP32)
+                if not clear_accum:
+                    T.fill(logits, 0.0)
+                T.gemm(
+                    k_smem,
+                    q_smem,
+                    logits,
+                    transpose_A=False,
+                    transpose_B=True,
+                    clear_accum=clear_accum,
+                )
+
+                for h, j in T.Parallel(H, B):
+                    logits[j, h] = T.max(logits[j, h], 0.0) * q_s_frag[h]
+                logits_sum = T.alloc_fragment((B,), FP32)
+                T.reduce_sum(logits, logits_sum, dim=1)
+                for j in T.Parallel(B):
+                    logits_sum[j] *= k_s_frag[j]
+                T.copy(logits_sum, o[bx, blk * B])
+
+    return fp8_paged_mqa_logits_split
+
+
+def tilelang_fp8_paged_mqa_logits_split(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata: Any,
+    max_seq_len: int,
+    clean_logits: bool = True,
+    num_splits: int = 64,
+) -> torch.Tensor:
+    """Split-KV drop-in for tilelang_fp8_paged_mqa_logits (same signature +
+    num_splits). Grid is (batch, num_splits) instead of (batch,)."""
+    _ = deep_gemm_metadata
+    batch_size, _, num_heads, head_dim = q_fp8.shape
+    block_size = kvcache_fp8.shape[1]
+    assert head_dim == 128, "TODO"
+    assert block_size == 64, "TODO"
+    assert q_fp8.shape == (batch_size, 1, num_heads, head_dim)
+    assert kvcache_fp8.shape[1:] == (block_size, 1, head_dim + 4)
+    assert weight.shape == (batch_size, num_heads)
+    assert seq_lens.shape == (batch_size,)
+    assert page_table.shape[0] == batch_size
+    assert clean_logits == False
+
+    logits = page_table.new_empty((batch_size, max_seq_len), dtype=torch.float32)
+    kernel = fp8_paged_mqa_logits_split_kernel(
+        head_dim=head_dim,
+        num_heads=num_heads,
+        block_size=block_size,
+        num_splits=num_splits,
+        clear_accum=clean_logits,
+    )
+    q_fp8 = q_fp8.view(batch_size, num_heads, head_dim)
+    kvcache_fp8 = kvcache_fp8.view(-1, block_size * (head_dim + 4))
+    kvcache = kvcache_fp8[..., : block_size * head_dim].view(dtype=FP8_)
+    kvcache = kvcache.view(-1, block_size, head_dim)
+    kvcache_scale = kvcache_fp8[..., block_size * head_dim :].view(dtype=torch.float32)
+    kernel(q_fp8, kvcache, kvcache_scale, weight, seq_lens, page_table, logits)
+    return logits

--- a/python/sglang/srt/layers/attention/flash_mla_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sm120.py
@@ -4,7 +4,7 @@ On SM120 (Blackwell Desktop / RTX PRO 6000) the flash_mla CUDA kernel
 is not available, so this module provides alternative implementations,
 selected by ``SGLANG_SM120_SPARSE_DECODE`` (default ``triton``):
 
-- ``hmma``   -- out-of-tree deepseek_v4_kernel tensor-core .so (opt-in)
+- ``hmma``   -- custom SM120 sparse-decode kernel (``deepseek_v4_kernel.ops.sparse_decode_fwd``)
 - ``triton`` -- in-tree Triton kernel (default)
 - ``torch``  -- pure-PyTorch fallback
 
@@ -195,12 +195,9 @@ def _sm120_sparse_decode_fwd(
     return out.to(torch.bfloat16), lse.permute(0, 2, 1)
 
 
-# SM120 FlashMLA sparse-decode backend: "hmma" | "triton" | "torch".
-# Controlled by SGLANG_SM120_SPARSE_DECODE (default "triton", the in-tree kernel).
-#   hmma   -> out-of-tree deepseek_v4_kernel tensor-core .so (opt-in); downgraded
-#            to "triton" if the package is not installed.
-#   triton -> in-tree Triton kernel.
-#   torch  -> pure-PyTorch fallback.
+# SM120 sparse-decode backend (SGLANG_SM120_SPARSE_DECODE, default "triton"):
+#   hmma   -> custom SM120 kernel; downgraded to "triton" if not installed.
+#   triton -> in-tree Triton kernel.  torch -> pure-PyTorch fallback.
 def _resolve_sm120_sparse_decode_backend() -> str:
     backend = os.environ.get("SGLANG_SM120_SPARSE_DECODE", "triton").lower()
     if backend not in ("hmma", "triton", "torch"):

--- a/python/sglang/srt/layers/attention/flash_mla_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sm120.py
@@ -69,7 +69,9 @@ def _gather_and_dequant(k_cache, indices, page_size):
     raw_pages = k_cache.as_strided(
         (num_pages, page_bytes),
         (page_bytes, 1),
-    ).view(torch.uint8)  # (num_pages, page_bytes) uint8
+    ).view(
+        torch.uint8
+    )  # (num_pages, page_bytes) uint8
     # Note: float8_e4m3fn and uint8 are both 1 byte, view is safe
 
     # Compute byte offsets within each page

--- a/python/sglang/srt/layers/attention/flash_mla_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sm120.py
@@ -1,10 +1,12 @@
 """SM120 FlashMLA sparse decode implementation.
 
 On SM120 (Blackwell Desktop / RTX PRO 6000) the flash_mla CUDA kernel
-is not available, so this module provides alternative implementations:
+is not available, so this module provides alternative implementations,
+selected by ``SGLANG_SM120_SPARSE_DECODE`` (default ``triton``):
 
-- A fused Triton kernel (default, ``SGLANG_SM120_TRITON_FLASHMLA=1``)
-- A pure-PyTorch fallback (``SGLANG_SM120_TRITON_FLASHMLA=0``)
+- ``hmma``   -- out-of-tree deepseek_v4_kernel tensor-core .so (opt-in)
+- ``triton`` -- in-tree Triton kernel (default)
+- ``torch``  -- pure-PyTorch fallback
 
 The FP8 KV cache uses a page-internal layout where NOPE+ROPE data has
 stride (nope_dim + rope_dim*2) per token, and scales are stored in a
@@ -15,6 +17,8 @@ import logging
 import os
 
 import torch
+
+from sglang.srt.utils.common import is_deepseek_v4_kernel_available
 
 logger = logging.getLogger(__name__)
 
@@ -65,9 +69,7 @@ def _gather_and_dequant(k_cache, indices, page_size):
     raw_pages = k_cache.as_strided(
         (num_pages, page_bytes),
         (page_bytes, 1),
-    ).view(
-        torch.uint8
-    )  # (num_pages, page_bytes) uint8
+    ).view(torch.uint8)  # (num_pages, page_bytes) uint8
     # Note: float8_e4m3fn and uint8 are both 1 byte, view is safe
 
     # Compute byte offsets within each page
@@ -193,17 +195,36 @@ def _sm120_sparse_decode_fwd(
     return out.to(torch.bfloat16), lse.permute(0, 2, 1)
 
 
-# Default SM120 FlashMLA backend: "triton" (optimized) or "torch" (pure-PyTorch fallback).
-# Controlled by SGLANG_SM120_TRITON_FLASHMLA env var (1=triton, 0=torch).
-_sm120_default_backend = (
-    "triton" if os.environ.get("SGLANG_SM120_TRITON_FLASHMLA", "1") == "1" else "torch"
-)
+# SM120 FlashMLA sparse-decode backend: "hmma" | "triton" | "torch".
+# Controlled by SGLANG_SM120_SPARSE_DECODE (default "triton", the in-tree kernel).
+#   hmma   -> out-of-tree deepseek_v4_kernel tensor-core .so (opt-in); downgraded
+#            to "triton" if the package is not installed.
+#   triton -> in-tree Triton kernel.
+#   torch  -> pure-PyTorch fallback.
+def _resolve_sm120_sparse_decode_backend() -> str:
+    backend = os.environ.get("SGLANG_SM120_SPARSE_DECODE", "triton").lower()
+    if backend not in ("hmma", "triton", "torch"):
+        raise ValueError(
+            "SGLANG_SM120_SPARSE_DECODE must be 'hmma', 'triton', or 'torch' "
+            f"(got {backend!r})."
+        )
+    if backend == "hmma" and not is_deepseek_v4_kernel_available():
+        logger.info(
+            "SGLANG_SM120_SPARSE_DECODE=hmma but deepseek_v4_kernel is not "
+            "installed; using the in-tree Triton sparse-decode kernel."
+        )
+        backend = "triton"
+    return backend
+
+
+_sm120_sparse_decode_backend = _resolve_sm120_sparse_decode_backend()
 
 
 def flash_mla_with_kvcache_sm120(**kwargs):
     """SM120 FlashMLA sparse decode entry point.
 
-    Dispatches to the Triton kernel (default) or PyTorch fallback.
+    Dispatches to the resolved backend (see _sm120_sparse_decode_backend): the
+    HMMA tensor-core kernel, the in-tree Triton kernel, or the PyTorch fallback.
     """
     q = kwargs["q"]
     k_cache = kwargs["k_cache"]
@@ -218,7 +239,26 @@ def flash_mla_with_kvcache_sm120(**kwargs):
     extra_indices = kwargs.get("extra_indices_in_kvcache")
     extra_topk_length = kwargs.get("extra_topk_length")
 
-    if _sm120_default_backend == "triton":
+    if _sm120_sparse_decode_backend == "hmma" and indices is not None:
+        from deepseek_v4_kernel.ops import sparse_decode_fwd
+
+        out, lse, _, _ = sparse_decode_fwd(
+            q,
+            k_cache,
+            indices,
+            topk_length,
+            attn_sink,
+            None,  # tile_scheduler_metadata
+            None,  # num_splits
+            extra_k_cache,
+            extra_indices,
+            extra_topk_length,
+            head_dim_v,
+            float(softmax_scale),
+        )
+        return (out, lse)
+
+    if _sm120_sparse_decode_backend == "triton":
         from sglang.srt.layers.attention.flash_mla_sm120_triton import (
             flash_mla_sparse_decode_triton,
         )

--- a/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
@@ -1,0 +1,239 @@
+"""SM120 FlashMLA sparse *prefill* dispatch.
+
+DeepSeek's ``sgl_kernel.flash_mla.flash_mla_sparse_fwd`` is compiled only for
+SM90a (WGMMA) and SM100f (tcgen05); on SM120 (Blackwell workstation / RTX PRO
+6000) it raises ``RuntimeError: Sparse Attention Forward Kernel is only
+supported on SM90a and SM100f architectures``. That path is reached whenever a
+single prefill forward batches more than ``_LARGE_INDEXER_QUERY_THRESHOLD``
+(=11673) query tokens, which a high-concurrency / long-context sweep trips.
+
+This module mirrors ``flash_mla_sm120.py`` (the sparse-*decode* selector) for
+the prefill op, selected by ``SGLANG_SM120_SPARSE_PREFILL``:
+
+- ``hmma``      -- out-of-tree deepseek_v4_kernel tensor-core .so (opt-in), a
+                   drop-in for ``flash_mla_sparse_fwd``.
+- ``sglkernel`` -- the stock ``sgl_kernel.flash_mla.flash_mla_sparse_fwd``
+                   (works on SM90a / SM100f; crashes on SM120).
+- ``torch``     -- a chunked pure-PyTorch reference (always correct, slow).
+
+Default resolution is *safe*: on SM120 the default is ``hmma`` when the package
+is installed, else ``torch`` -- never ``sglkernel`` (which would crash). Off
+SM120 the default is ``sglkernel`` (the working stock kernel). An explicit
+``sglkernel`` on SM120 is downgraded to ``torch`` with a warning so the server
+never crashes on the >11673-token prefill path.
+
+All three branches honour the ``flash_mla_sparse_fwd`` contract::
+
+    flash_mla_sparse_fwd(q[s_q,h_q,d_qk] bf16,
+                         kv[s_kv,(h_kv=1,)d_qk] bf16,
+                         indices[s_q,(h_kv=1,)topk] int32,
+                         sm_scale, d_v=512,
+                         attn_sink[h_q]|None, topk_length[s_q]|None)
+        -> (out[s_q,h_q,d_v] bf16, max_logits[s_q,h_q] f32, lse[s_q,h_q] f32)
+
+Only ``out`` is consumed by the callers (``o, _, _ = ...``); ``max_logits`` and
+``lse`` are returned for parity.
+"""
+
+import logging
+import os
+
+import torch
+
+from sglang.srt.utils.common import (
+    is_deepseek_v4_kernel_available,
+    is_sm120_supported,
+)
+
+logger = logging.getLogger(__name__)
+
+_is_sm120 = is_sm120_supported()
+
+
+def _resolve_sm120_sparse_prefill_backend() -> str:
+    """Resolve ``SGLANG_SM120_SPARSE_PREFILL`` once at import.
+
+    Unset -> a safe per-arch default (``hmma``/``torch`` on SM120, never the
+    crashing stock kernel; ``sglkernel`` elsewhere). An explicit value is
+    validated and, when it cannot run on this device, downgraded (never to a
+    backend that would crash).
+    """
+    raw = os.environ.get("SGLANG_SM120_SPARSE_PREFILL")
+    if raw is None:
+        if not _is_sm120:
+            return "sglkernel"
+        if is_deepseek_v4_kernel_available():
+            return "hmma"
+        logger.info(
+            "SM120 sparse-prefill: deepseek_v4_kernel is not installed and the "
+            "stock sgl_kernel sparse-prefill is SM90a/SM100f-only; using the "
+            "pure-PyTorch reference. Install deepseek_v4_kernel or set "
+            "SGLANG_SM120_SPARSE_PREFILL=hmma for the tensor-core kernel."
+        )
+        return "torch"
+
+    backend = raw.lower()
+    if backend not in ("hmma", "sglkernel", "torch"):
+        raise ValueError(
+            "SGLANG_SM120_SPARSE_PREFILL must be 'hmma', 'sglkernel', or "
+            f"'torch' (got {raw!r})."
+        )
+    if backend == "hmma" and not is_deepseek_v4_kernel_available():
+        fallback = "torch" if _is_sm120 else "sglkernel"
+        logger.info(
+            "SGLANG_SM120_SPARSE_PREFILL=hmma but deepseek_v4_kernel is not "
+            "installed; using %r.",
+            fallback,
+        )
+        return fallback
+    if backend == "sglkernel" and _is_sm120:
+        logger.warning(
+            "SGLANG_SM120_SPARSE_PREFILL=sglkernel on SM120, but the stock "
+            "sparse-prefill kernel only supports SM90a/SM100f and would crash; "
+            "using the pure-PyTorch reference instead."
+        )
+        return "torch"
+    return backend
+
+
+_sm120_sparse_prefill_backend = _resolve_sm120_sparse_prefill_backend()
+
+
+def _normalize_kv_indices(kv: torch.Tensor, indices: torch.Tensor):
+    """Accept the [s_kv,1,d] / [s_q,1,topk] (h_kv=1) shapes the callers pass and
+    the flat [s_kv,d] / [s_q,topk] shapes, returning the flat forms."""
+    if kv.dim() == 3:
+        # [s_kv, h_kv=1, d_qk] -> [s_kv, d_qk]
+        kv = kv.squeeze(1)
+    if indices.dim() == 3:
+        # [s_q, h_kv=1, topk] -> [s_q, topk]
+        indices = indices.squeeze(1)
+    return kv, indices
+
+
+def _torch_sparse_prefill_fwd(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    d_v: int = 512,
+    attn_sink=None,
+    topk_length=None,
+    row_chunk: int = 1024,
+):
+    """Chunked pure-PyTorch reference mirroring DeepSeek's ``ref_sparse_attn_fwd``.
+
+    Chunked over the query dimension so the dense ``[chunk,topk,d_qk]`` gather
+    stays bounded (a single-shot gather at s_q=16384, topk=2048 is ~64 GiB).
+    Natural-log ``max_logits`` / ``lse``; lonely query -> out 0 / mx -inf /
+    lse +inf, matching the HMMA kernel and the stock op.
+    """
+    kv, indices = _normalize_kv_indices(kv, indices)
+    s_q, h_q, d_qk = q.shape
+    s_kv = kv.size(0)
+    topk = indices.size(-1)
+    dev = q.device
+
+    out = torch.empty(s_q, h_q, d_v, dtype=torch.bfloat16, device=dev)
+    max_logits = torch.empty(s_q, h_q, dtype=torch.float32, device=dev)
+    lse = torch.empty(s_q, h_q, dtype=torch.float32, device=dev)
+
+    sink = attn_sink.float() if attn_sink is not None else None
+    ar_topk = torch.arange(topk, device=dev)
+    kv_f = kv.float()
+
+    for start in range(0, s_q, row_chunk):
+        end = min(start + row_chunk, s_q)
+        n = end - start
+        idx = indices[start:end].clone()
+        if topk_length is not None:
+            len_mask = ar_topk.unsqueeze(0).broadcast_to(n, topk) >= topk_length[
+                start:end
+            ].unsqueeze(1)
+            idx[len_mask] = -1
+        invalid = (idx < 0) | (idx >= s_kv)  # [n, topk]
+        idx_safe = torch.where(invalid, torch.zeros_like(idx), idx)
+
+        gathered = kv_f.index_select(0, idx_safe.flatten().long()).reshape(
+            n, topk, d_qk
+        )
+        qf = q[start:end].float()
+        P = (qf @ gathered.transpose(1, 2)) * sm_scale  # [n, h_q, topk]
+        P[invalid.unsqueeze(1).broadcast_to(P.shape)] = float("-inf")
+
+        orig_lse = torch.logsumexp(P, dim=-1)  # [n, h_q]
+        mx = P.max(dim=-1).values  # [n, h_q]
+
+        if sink is not None:
+            lse_for_o = torch.logsumexp(
+                torch.stack(
+                    [orig_lse, sink.broadcast_to(n, h_q)], dim=0
+                ),
+                dim=0,
+            )
+        else:
+            lse_for_o = orig_lse.clone()
+        lse_for_o[lse_for_o == float("-inf")] = float("+inf")  # -> O row 0
+        s_for_o = torch.exp(P - lse_for_o.unsqueeze(-1))
+        o = s_for_o @ gathered[..., :d_v]  # [n, h_q, d_v]
+
+        lonely = orig_lse == float("-inf")
+        orig_lse = orig_lse.clone()
+        orig_lse[lonely] = float("+inf")
+
+        out[start:end] = o.to(torch.bfloat16)
+        max_logits[start:end] = mx
+        lse[start:end] = orig_lse
+
+    return out, max_logits, lse
+
+
+def flash_mla_sparse_fwd_sm120(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    d_v: int = 512,
+    attn_sink=None,
+    topk_length=None,
+):
+    """SM120 sparse-prefill entry point; dispatches to the resolved backend.
+
+    Drop-in for ``sgl_kernel.flash_mla.flash_mla_sparse_fwd``. Returns
+    ``(out, max_logits, lse)``.
+    """
+    if _sm120_sparse_prefill_backend == "hmma":
+        from deepseek_v4_kernel.ops import sparse_prefill_fwd
+
+        return sparse_prefill_fwd(
+            q,
+            kv,
+            indices,
+            float(sm_scale),
+            int(d_v),
+            attn_sink,
+            topk_length,
+        )
+
+    if _sm120_sparse_prefill_backend == "sglkernel":
+        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+        return flash_mla_sparse_fwd(
+            q=q,
+            kv=kv,
+            indices=indices,
+            sm_scale=sm_scale,
+            d_v=d_v,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+        )
+
+    return _torch_sparse_prefill_fwd(
+        q,
+        kv,
+        indices,
+        sm_scale,
+        d_v=d_v,
+        attn_sink=attn_sink,
+        topk_length=topk_length,
+    )

--- a/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
@@ -140,7 +140,7 @@ def _torch_sparse_prefill_fwd(
         )
         qf = q[start:end].float()
         P = (qf @ gathered.transpose(1, 2)) * sm_scale  # [n, h_q, topk]
-        P[invalid.unsqueeze(1).broadcast_to(P.shape)] = float("-inf")
+        P.masked_fill_(invalid.unsqueeze(1), float("-inf"))
 
         orig_lse = torch.logsumexp(P, dim=-1)  # [n, h_q]
         mx = P.max(dim=-1).values  # [n, h_q]
@@ -157,7 +157,6 @@ def _torch_sparse_prefill_fwd(
         o = s_for_o @ gathered[..., :d_v]  # [n, h_q, d_v]
 
         lonely = orig_lse == float("-inf")
-        orig_lse = orig_lse.clone()
         orig_lse[lonely] = float("+inf")
 
         out[start:end] = o.to(torch.bfloat16)

--- a/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
@@ -147,9 +147,7 @@ def _torch_sparse_prefill_fwd(
 
         if sink is not None:
             lse_for_o = torch.logsumexp(
-                torch.stack(
-                    [orig_lse, sink.broadcast_to(n, h_q)], dim=0
-                ),
+                torch.stack([orig_lse, sink.broadcast_to(n, h_q)], dim=0),
                 dim=0,
             )
         else:

--- a/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
+++ b/python/sglang/srt/layers/attention/flash_mla_sparse_prefill_sm120.py
@@ -1,38 +1,21 @@
 """SM120 FlashMLA sparse *prefill* dispatch.
 
-DeepSeek's ``sgl_kernel.flash_mla.flash_mla_sparse_fwd`` is compiled only for
-SM90a (WGMMA) and SM100f (tcgen05); on SM120 (Blackwell workstation / RTX PRO
-6000) it raises ``RuntimeError: Sparse Attention Forward Kernel is only
-supported on SM90a and SM100f architectures``. That path is reached whenever a
-single prefill forward batches more than ``_LARGE_INDEXER_QUERY_THRESHOLD``
-(=11673) query tokens, which a high-concurrency / long-context sweep trips.
+Stock ``sgl_kernel.flash_mla.flash_mla_sparse_fwd`` is SM90a/SM100f-only and raises on
+SM120; that path is hit when a prefill batches > ``_LARGE_INDEXER_QUERY_THRESHOLD`` (=11673)
+query tokens. Mirrors ``flash_mla_sm120.py`` for the prefill op, selected by
+``SGLANG_SM120_SPARSE_PREFILL``:
 
-This module mirrors ``flash_mla_sm120.py`` (the sparse-*decode* selector) for
-the prefill op, selected by ``SGLANG_SM120_SPARSE_PREFILL``:
+- ``hmma``      -- custom SM120 sparse-prefill kernel (``deepseek_v4_kernel.ops.sparse_prefill_fwd``),
+                   a drop-in for ``flash_mla_sparse_fwd``.
+- ``sglkernel`` -- stock kernel (SM90a/SM100f; crashes on SM120).
+- ``torch``     -- chunked pure-PyTorch reference (correct, slow).
 
-- ``hmma``      -- out-of-tree deepseek_v4_kernel tensor-core .so (opt-in), a
-                   drop-in for ``flash_mla_sparse_fwd``.
-- ``sglkernel`` -- the stock ``sgl_kernel.flash_mla.flash_mla_sparse_fwd``
-                   (works on SM90a / SM100f; crashes on SM120).
-- ``torch``     -- a chunked pure-PyTorch reference (always correct, slow).
+Default is *safe*: SM120 → ``hmma`` if installed else ``torch`` (never ``sglkernel``); off
+SM120 → ``sglkernel``. An explicit ``sglkernel`` on SM120 is downgraded to ``torch`` so the
+server never crashes on the > 11673-token path.
 
-Default resolution is *safe*: on SM120 the default is ``hmma`` when the package
-is installed, else ``torch`` -- never ``sglkernel`` (which would crash). Off
-SM120 the default is ``sglkernel`` (the working stock kernel). An explicit
-``sglkernel`` on SM120 is downgraded to ``torch`` with a warning so the server
-never crashes on the >11673-token prefill path.
-
-All three branches honour the ``flash_mla_sparse_fwd`` contract::
-
-    flash_mla_sparse_fwd(q[s_q,h_q,d_qk] bf16,
-                         kv[s_kv,(h_kv=1,)d_qk] bf16,
-                         indices[s_q,(h_kv=1,)topk] int32,
-                         sm_scale, d_v=512,
-                         attn_sink[h_q]|None, topk_length[s_q]|None)
-        -> (out[s_q,h_q,d_v] bf16, max_logits[s_q,h_q] f32, lse[s_q,h_q] f32)
-
-Only ``out`` is consumed by the callers (``o, _, _ = ...``); ``max_logits`` and
-``lse`` are returned for parity.
+Contract: ``flash_mla_sparse_fwd(q, kv, indices, sm_scale, d_v=512, attn_sink, topk_length)
+-> (out, max_logits, lse)``. Callers use only ``out`` (``o, _, _ = ...``).
 """
 
 import logging
@@ -53,10 +36,8 @@ _is_sm120 = is_sm120_supported()
 def _resolve_sm120_sparse_prefill_backend() -> str:
     """Resolve ``SGLANG_SM120_SPARSE_PREFILL`` once at import.
 
-    Unset -> a safe per-arch default (``hmma``/``torch`` on SM120, never the
-    crashing stock kernel; ``sglkernel`` elsewhere). An explicit value is
-    validated and, when it cannot run on this device, downgraded (never to a
-    backend that would crash).
+    Unset -> safe per-arch default (``hmma``/``torch`` on SM120, ``sglkernel`` elsewhere).
+    An explicit value that can't run on this device is downgraded — never to one that crashes.
     """
     raw = os.environ.get("SGLANG_SM120_SPARSE_PREFILL")
     if raw is None:
@@ -65,10 +46,10 @@ def _resolve_sm120_sparse_prefill_backend() -> str:
         if is_deepseek_v4_kernel_available():
             return "hmma"
         logger.info(
-            "SM120 sparse-prefill: deepseek_v4_kernel is not installed and the "
-            "stock sgl_kernel sparse-prefill is SM90a/SM100f-only; using the "
-            "pure-PyTorch reference. Install deepseek_v4_kernel or set "
-            "SGLANG_SM120_SPARSE_PREFILL=hmma for the tensor-core kernel."
+            "SM120 sparse-prefill: deepseek_v4_kernel not installed and stock "
+            "sgl_kernel is SM90a/SM100f-only; using the pure-PyTorch reference. "
+            "Install deepseek_v4_kernel or set SGLANG_SM120_SPARSE_PREFILL=hmma "
+            "for the custom kernel."
         )
         return "torch"
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -115,6 +115,25 @@ _use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 
 
+def _has_flashinfer_sm120_mxfp4_moe() -> bool:
+    """True when FlashInfer exposes the SM120 MXFP4 fused-MoE path.
+
+    Probes FlashInfer's public capability API rather than a version string;
+    returns False (dormant) on builds that predate SM120 MXFP4 MoE support.
+    """
+    try:
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import (
+            sm120_moe_supported_quant_modes,
+        )
+    except Exception:
+        return False
+    return "mxfp4" in sm120_moe_supported_quant_modes()
+
+
+
+
+
+
 def _require_fp4_dtype():
     fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
     if fp4_dtype is None:
@@ -271,6 +290,20 @@ class Fp8Config(QuantizationConfig):
                 )
 
             fp8_method = Fp8MoEMethod(self)
+
+            # SM120 (RTX PRO 6000 / 5090): MXFP4 x MXFP4 fused MoE. Load the
+            # MXFP4 experts as-is and run FlashInfer's fused CuTe-DSL kernels.
+            # Feature-probed; NVFP4/Marlin paths are untouched.
+            if (
+                self.is_fp4_experts
+                and is_sm120_supported()
+                and _has_flashinfer_sm120_mxfp4_moe()
+            ):
+                from sglang.srt.layers.quantization.mxfp4_w4a4_moe import (
+                    Mxfp4W4A4MoEMethod,
+                )
+
+                return Mxfp4W4A4MoEMethod(fp8_method, prefix=prefix)
 
             if self.is_fp4_experts and get_moe_runner_backend().is_marlin():
                 from sglang.srt.layers.quantization.mxfp4_marlin_moe import (

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -130,10 +130,6 @@ def _has_flashinfer_sm120_mxfp4_moe() -> bool:
     return "mxfp4" in sm120_moe_supported_quant_modes()
 
 
-
-
-
-
 def _require_fp4_dtype():
     fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
     if fp4_dtype is None:

--- a/python/sglang/srt/layers/quantization/mxfp4_sm120_common.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_sm120_common.py
@@ -1,0 +1,49 @@
+"""Shared SM120 MXFP4 weight-scale swizzle helpers.
+
+The MXFP4 MoE methods (W4A4 fused and W4A8 grouped-GEMM) load DeepSeek-V4
+experts with E8M0 32-element block scales and must move those scales into the
+128x4 block layout the FlashInfer kernels consume. This module holds the
+load-time swizzle shared by both methods.
+"""
+
+from __future__ import annotations
+
+import torch
+
+# MXFP4/MXFP8 block size (E8M0 32-element block scale).
+_MXFP4_BLOCK = 32
+
+
+def _flashinfer_scale_helpers():
+    """FlashInfer scale-factor padding + the device fp4 quantization module."""
+    from flashinfer.fp4_quantization import (
+        _pad_scale_factors,
+        get_fp4_quantization_module,
+    )
+
+    return _pad_scale_factors, get_fp4_quantization_module
+
+
+def swizzle_weight_scale_mxf4(
+    scale_u8: torch.Tensor, b: int, m: int, n: int
+) -> torch.Tensor:
+    """Swizzle a batched E8M0 weight-scale tensor into the 128x4 block layout.
+
+    Mirrors the FlashInfer reference path: per-expert ``_pad_scale_factors``
+    then a single ``block_scale_interleave_sm100``.
+
+    scale_u8 : ``[B, M, n // 32]`` uint8 (unswizzled E8M0)
+    Returns  : ``[B, M_pad128, ceil(n/32 to mult-4)]`` uint8 swizzled.
+
+    Done once at load time (not under CUDA graph), so a per-expert Python loop
+    is fine.
+    """
+    pad_scale_factors, get_fp4_mod = _flashinfer_scale_helpers()
+    fp4_mod = get_fp4_mod(
+        "".join(str(c) for c in torch.cuda.get_device_capability(scale_u8.device))
+    )
+    padded = torch.stack(
+        [pad_scale_factors(scale_u8[i], m, n, _MXFP4_BLOCK) for i in range(b)]
+    )
+    out = fp4_mod.block_scale_interleave_sm100(padded)
+    return out.view(padded.shape)

--- a/python/sglang/srt/layers/quantization/mxfp4_w4a4_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_w4a4_moe.py
@@ -1,0 +1,323 @@
+"""MXFP4 x MXFP4 fused MoE method for SM120.
+
+DeepSeek-V4-Flash ships routed experts as MXFP4 (E2M1 packed int8 weights +
+E8M0 32-element block scales). This method loads them as-is and runs the experts
+with FlashInfer's fused SwiGLU CuTe-DSL MoE kernels
+(``launch_sm120_moe(quant_mode="mxfp4")``): MXFP4 weights x MXFP4 activations,
+E8M0 self-scaling.
+
+Weight loading is shared with the W4A8 method (``mxfp4_w4a8_moe.py``); only the
+weight-scale swizzle target differs: W4A4 swizzles into the 128x4 layout then
+converts to the MMA layout the fused kernel's ``_get_weight_views`` expects.
+
+Selected by ``fp8.py`` on SM120 + MXFP4 experts + FlashInfer exposing
+``launch_sm120_moe``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import torch
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
+from sglang.srt.utils import log_info_on_rank0, set_weight_attrs
+from sglang.srt.utils.common import is_sm120_supported
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
+
+logger = logging.getLogger(__name__)
+
+_FP4_BLOCK_K = 32  # E8M0 block size
+
+
+class Mxfp4W4A4MoEMethod:
+    """MXFP4 weights x MXFP4 activations MoE (SM120 fused CuTe-DSL)."""
+
+    def __init__(self, fp8_method, prefix: str):
+        self._fp8 = fp8_method
+        self.prefix = prefix
+
+    def create_moe_runner(self, layer, moe_runner_config):
+        # The fused launch runs in apply(); the runner only carries MoE config
+        # (routed_scaling_factor / swiglu_limit).
+        from sglang.srt.layers.moe.moe_runner import MoeRunner
+
+        self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+
+    def create_weights(
+        self,
+        layer: Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        from sglang.srt.layers.moe.fused_moe_triton import (
+            FusedMoeWeightScaleSupported,
+        )
+
+        w13_weight = Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // 2,
+                dtype=torch.int8,
+            ),
+            requires_grad=False,
+        )
+        w2_weight = Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // 2,
+                dtype=torch.int8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+        layer.register_parameter("w2_weight", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+        # float32 placeholder scales; E8M0 are exact powers of two, so the HF
+        # loader casts losslessly. process_weights_after_loading re-encodes them.
+        w13_weight_scale = Parameter(
+            torch.ones(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // _FP4_BLOCK_K,
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        w2_weight_scale = Parameter(
+            torch.ones(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // _FP4_BLOCK_K,
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        w13_weight_scale.format_ue8m0 = False
+        w2_weight_scale.format_ue8m0 = False
+        scale_attrs = dict(extra_weight_attrs)
+        scale_attrs["quant_method"] = FusedMoeWeightScaleSupported.BLOCK.value
+        layer.register_parameter("w13_weight_scale_inv", w13_weight_scale)
+        set_weight_attrs(w13_weight_scale, scale_attrs)
+        layer.register_parameter("w2_weight_scale_inv", w2_weight_scale)
+        set_weight_attrs(w2_weight_scale, scale_attrs)
+
+    @staticmethod
+    def _to_e8m0_u8(scale_f32: torch.Tensor) -> torch.Tensor:
+        """float32 scale magnitude -> E8M0 byte (uint8)."""
+        return scale_f32.to(torch.float8_e8m0fnu).view(torch.uint8)
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if not is_sm120_supported():
+            raise RuntimeError(
+                "Mxfp4W4A4MoEMethod requires SM120 (RTX PRO 6000 Blackwell)."
+            )
+        if getattr(layer, "_w4a4_weights_built", False):
+            return
+
+        # 128x4 weight-scale swizzle (shared with W4A8), then convert to the MMA
+        # layout the fused kernel's _get_weight_views expects.
+        from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+        from sglang.srt.layers.quantization.mxfp4_sm120_common import (
+            swizzle_weight_scale_mxf4,
+        )
+
+        w13 = layer.w13_weight.data  # (E, 2I, H/2) int8, checkpoint [w1|w3]
+        w2 = layer.w2_weight.data  # (E, H, I/2)  int8
+        w13_s = layer.w13_weight_scale_inv.data
+        w2_s = layer.w2_weight_scale_inv.data
+
+        E = w13.shape[0]
+        twoI = w13.shape[1]
+        Hhalf = w13.shape[2]
+        H = Hhalf * 2
+        Ihalf = w2.shape[2]
+        interm = Ihalf * 2
+
+        # Fused kernel expects gate/up as [w3, w1] (up, gate), but the checkpoint
+        # loads W13 as [w1, w3]; swap the I-row halves of weights and 3D scales.
+        Irows = twoI // 2
+        w13 = torch.cat([w13[:, Irows:, :], w13[:, :Irows, :]], dim=1).contiguous()
+        w13_s = torch.cat(
+            [w13_s[:, Irows:, :], w13_s[:, :Irows, :]], dim=1
+        ).contiguous()
+
+        w13_s_u8 = self._to_e8m0_u8(w13_s.to(torch.float32))
+        w2_s_u8 = self._to_e8m0_u8(w2_s.to(torch.float32))
+
+        # 128x4 block-scale swizzle (per expert), then convert to the MMA layout
+        # the fused kernel reads (experts flattened into the leading row dim).
+        w13_s_sw = swizzle_weight_scale_mxf4(w13_s_u8, E, twoI, H)
+        w2_s_sw = swizzle_weight_scale_mxf4(w2_s_u8, E, H, interm)
+        w13_sf_mma = convert_sf_to_mma_layout(
+            w13_s_sw.reshape(E * w13_s_sw.shape[1], w13_s_sw.shape[2]),
+            m=twoI,
+            k=H,
+            num_groups=E,
+            sf_vec_size=_FP4_BLOCK_K,
+        )
+        w2_sf_mma = convert_sf_to_mma_layout(
+            w2_s_sw.reshape(E * w2_s_sw.shape[1], w2_s_sw.shape[2]),
+            m=H,
+            k=interm,
+            num_groups=E,
+            sf_vec_size=_FP4_BLOCK_K,
+        )
+
+        layer.w13_weight = Parameter(
+            w13.view(torch.uint8).contiguous(), requires_grad=False
+        )
+        layer.w2_weight = Parameter(
+            w2.view(torch.uint8).contiguous(), requires_grad=False
+        )
+        layer.w13_weight_scale_inv = Parameter(
+            w13_sf_mma.contiguous(), requires_grad=False
+        )
+        layer.w2_weight_scale_inv = Parameter(
+            w2_sf_mma.contiguous(), requires_grad=False
+        )
+        layer._w4a4_H = H
+        layer._w4a4_I = interm
+        layer._w4a4_E = E
+        layer._w4a4_weights_built = True
+
+        # Build the FlashInfer weight views now (load time), not lazily under
+        # CUDA-graph capture, so the ~48 MB/layer scale storage stays out of the
+        # graph-private pool.
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
+            _get_weight_views,
+        )
+
+        ones_e = torch.ones(E, device=layer.w13_weight.device, dtype=torch.float32)
+        layer._w4a4_alpha = ones_e  # GEMM alpha = 1 (MXFP4 self-scales)
+        layer._w4a4_weight_views = _get_weight_views(
+            w1_fp4=layer.w13_weight,
+            w1_blockscale=layer.w13_weight_scale_inv,
+            w2_fp4=layer.w2_weight,
+            w2_blockscale=layer.w2_weight_scale_inv,
+            w1_alphas=ones_e,
+            w2_alphas=ones_e,
+            n=interm,
+            k=H,
+            activation_precision="fp4",
+            quant_mode="mxfp4",
+        )
+
+        # Free the per-layer transients; the final Parameters hold contiguous
+        # copies. Without this the allocator's reserve starves CUDA-graph capture.
+        del w13, w2, w13_s, w2_s
+        del w13_s_u8, w2_s_u8, w13_s_sw, w2_s_sw, w13_sf_mma, w2_sf_mma
+        torch.cuda.empty_cache()
+
+        log_info_on_rank0(
+            logger,
+            f"SM120 MXFP4 W4A4 experts ready "
+            f"(E={E}, H={H}, I={interm}; layer: {self.prefix})",
+        )
+
+    def apply(
+        self,
+        layer: Module,
+        dispatch_output: "DispatchOutput",
+    ) -> "CombineInput":
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
+            launch_sm120_moe,
+            _get_cached_workspace,
+            select_sm120_moe_backend,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.standard import (
+            StandardCombineInput,
+        )
+        from sglang.srt.layers.moe.topk import TopKOutputChecker
+
+        topk_output = dispatch_output.topk_output
+        if not TopKOutputChecker.format_is_standard(topk_output):
+            raise ValueError(f"Unsupported topk output format: {topk_output.format}")
+
+        hidden_states = dispatch_output.hidden_states
+        M = hidden_states.shape[0]
+        H = layer._w4a4_H
+        interm = layer._w4a4_I
+        E_local = layer._w4a4_E
+        # Global expert count bounds topk-id range; local count sizes the expert
+        # buffers. Under EP global > local and the kernel remaps global->local.
+        E_global = int(getattr(layer, "num_experts", E_local))
+        top_k = topk_output.topk_ids.shape[1]
+        dev = hidden_states.device
+
+        cfg = getattr(self.runner, "config", None)
+
+        # MXFP4 self-scales: no activation global scale (GEMM alpha = 1).
+        ones = layer._w4a4_alpha
+
+        # One capped static workspace per (layer, top_k), allocated outside
+        # CUDA-graph capture so decode never grows it. Larger batches pass
+        # _workspace=None and let launch_sm120_moe size the right one.
+        ws_cap = int(os.environ.get("SGLANG_MXFP4_STATIC_WS_CAP", "640"))
+        routed_rows = M * top_k
+        ws_key = getattr(layer, "_w4a4_ws_key", None)
+        if ws_key != top_k:
+            layer._w4a4_static_ws = _get_cached_workspace(
+                backend="static",
+                state_E=E_local,
+                weight_E=E_global,
+                routed_rows=ws_cap,
+                k=H,
+                n=interm,
+                num_topk=top_k,
+                device=dev,
+                quant_mode="mxfp4",
+                activation="silu",
+            )
+            layer._w4a4_ws_key = top_k
+
+        backend = select_sm120_moe_backend(
+            num_tokens=M, num_topk=top_k, quant_mode="mxfp4"
+        )
+        # EP forces static (kernel needs global->local remap); match the launcher.
+        use_static = backend == "static" and routed_rows <= ws_cap
+        workspace = layer._w4a4_static_ws if use_static else None
+
+        output = torch.empty(M, H, dtype=hidden_states.dtype, device=dev)
+        launch_sm120_moe(
+            a=hidden_states,
+            topk_ids=topk_output.topk_ids,
+            topk_weights=topk_output.topk_weights,
+            w1_weight=layer.w13_weight,
+            w1_weight_sf=layer.w13_weight_scale_inv,
+            w1_alpha=ones,
+            fc2_input_scale=ones,
+            w2_weight=layer.w2_weight,
+            w2_weight_sf=layer.w2_weight_scale_inv,
+            w2_alpha=ones,
+            num_experts=E_global,
+            top_k=top_k,
+            num_local_experts=E_local,
+            scatter_output=output,
+            input_scales_are_reciprocal=False,
+            fast_math=True,
+            activation="silu",
+            quant_mode="mxfp4",
+            _weight_views=layer._w4a4_weight_views,
+            _workspace=workspace,
+        )
+
+        routed_scaling_factor = (
+            getattr(cfg, "routed_scaling_factor", None) if cfg else None
+        )
+        if routed_scaling_factor is not None and routed_scaling_factor != 1.0:
+            output = output * routed_scaling_factor
+        return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/mxfp4_w4a4_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_w4a4_moe.py
@@ -131,6 +131,7 @@ class Mxfp4W4A4MoEMethod:
         # 128x4 weight-scale swizzle (shared with W4A8), then convert to the MMA
         # layout the fused kernel's _get_weight_views expects.
         from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+
         from sglang.srt.layers.quantization.mxfp4_sm120_common import (
             swizzle_weight_scale_mxf4,
         )
@@ -145,7 +146,7 @@ class Mxfp4W4A4MoEMethod:
         Hhalf = w13.shape[2]
         H = Hhalf * 2
         Ihalf = w2.shape[2]
-        interm = Ihalf * 2
+        intermediate = Ihalf * 2
 
         # Fused kernel expects gate/up as [w3, w1] (up, gate), but the checkpoint
         # loads W13 as [w1, w3]; swap the I-row halves of weights and 3D scales.
@@ -161,7 +162,7 @@ class Mxfp4W4A4MoEMethod:
         # 128x4 block-scale swizzle (per expert), then convert to the MMA layout
         # the fused kernel reads (experts flattened into the leading row dim).
         w13_s_sw = swizzle_weight_scale_mxf4(w13_s_u8, E, twoI, H)
-        w2_s_sw = swizzle_weight_scale_mxf4(w2_s_u8, E, H, interm)
+        w2_s_sw = swizzle_weight_scale_mxf4(w2_s_u8, E, H, intermediate)
         w13_sf_mma = convert_sf_to_mma_layout(
             w13_s_sw.reshape(E * w13_s_sw.shape[1], w13_s_sw.shape[2]),
             m=twoI,
@@ -172,7 +173,7 @@ class Mxfp4W4A4MoEMethod:
         w2_sf_mma = convert_sf_to_mma_layout(
             w2_s_sw.reshape(E * w2_s_sw.shape[1], w2_s_sw.shape[2]),
             m=H,
-            k=interm,
+            k=intermediate,
             num_groups=E,
             sf_vec_size=_FP4_BLOCK_K,
         )
@@ -190,7 +191,7 @@ class Mxfp4W4A4MoEMethod:
             w2_sf_mma.contiguous(), requires_grad=False
         )
         layer._w4a4_H = H
-        layer._w4a4_I = interm
+        layer._w4a4_I = intermediate
         layer._w4a4_E = E
         layer._w4a4_weights_built = True
 
@@ -210,7 +211,7 @@ class Mxfp4W4A4MoEMethod:
             w2_blockscale=layer.w2_weight_scale_inv,
             w1_alphas=ones_e,
             w2_alphas=ones_e,
-            n=interm,
+            n=intermediate,
             k=H,
             activation_precision="fp4",
             quant_mode="mxfp4",
@@ -225,7 +226,7 @@ class Mxfp4W4A4MoEMethod:
         log_info_on_rank0(
             logger,
             f"SM120 MXFP4 W4A4 experts ready "
-            f"(E={E}, H={H}, I={interm}; layer: {self.prefix})",
+            f"(E={E}, H={H}, I={intermediate}; layer: {self.prefix})",
         )
 
     def apply(
@@ -234,10 +235,11 @@ class Mxfp4W4A4MoEMethod:
         dispatch_output: "DispatchOutput",
     ) -> "CombineInput":
         from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
-            launch_sm120_moe,
             _get_cached_workspace,
+            launch_sm120_moe,
             select_sm120_moe_backend,
         )
+
         from sglang.srt.layers.moe.token_dispatcher.standard import (
             StandardCombineInput,
         )
@@ -250,7 +252,7 @@ class Mxfp4W4A4MoEMethod:
         hidden_states = dispatch_output.hidden_states
         M = hidden_states.shape[0]
         H = layer._w4a4_H
-        interm = layer._w4a4_I
+        intermediate = layer._w4a4_I
         E_local = layer._w4a4_E
         # Global expert count bounds topk-id range; local count sizes the expert
         # buffers. Under EP global > local and the kernel remaps global->local.
@@ -276,7 +278,7 @@ class Mxfp4W4A4MoEMethod:
                 weight_E=E_global,
                 routed_rows=ws_cap,
                 k=H,
-                n=interm,
+                n=intermediate,
                 num_topk=top_k,
                 device=dev,
                 quant_mode="mxfp4",

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -344,6 +344,16 @@ def is_flashinfer_available():
     return importlib.util.find_spec("flashinfer") is not None and is_cuda()
 
 
+def is_deepseek_v4_kernel_available() -> bool:
+    """Check whether the out-of-tree deepseek_v4_kernel is installed.
+
+    Provides the SM120 HMMA tensor-core sparse-decode kernel
+    (``deepseek_v4_kernel.ops.sparse_decode_fwd``), a drop-in for FlashMLA's
+    sparse decode. Optional; when absent the in-tree Triton kernel is used.
+    """
+    return importlib.util.find_spec("deepseek_v4_kernel") is not None
+
+
 @lru_cache(maxsize=1)
 def is_tokenspeed_mla_available():
     """

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -345,11 +345,11 @@ def is_flashinfer_available():
 
 
 def is_deepseek_v4_kernel_available() -> bool:
-    """Check whether the out-of-tree deepseek_v4_kernel is installed.
+    """Whether the custom SM120 deepseek_v4_kernel is installed.
 
-    Provides the SM120 HMMA tensor-core sparse-decode kernel
-    (``deepseek_v4_kernel.ops.sparse_decode_fwd``), a drop-in for FlashMLA's
-    sparse decode. Optional; when absent the in-tree Triton kernel is used.
+    Provides the SM120 sparse decode + prefill kernels
+    (``deepseek_v4_kernel.ops.{sparse_decode_fwd, sparse_prefill_fwd}``), drop-ins
+    for FlashMLA. Optional; when absent the in-tree Triton/torch paths are used.
     """
     return importlib.util.find_spec("deepseek_v4_kernel") is not None
 


### PR DESCRIPTION
## Motivation

Native reference path for SM120 for dsv4-flash with:

1. **FlashInfer native MXFP4 W4A4 fused MoE:** https://github.com/flashinfer-ai/flashinfer/pull/3541
2. custom [sparse_decode_kernel.cuh](https://github.com/ambientlight/deepseek-v4-flash-sm120/blob/feat/hmma-tensor-core-sparse-decode/csrc/sm120/decode/sparse_decode_kernel.cuh) + [sparse_prefill_kernel.cuh](https://github.com/ambientlight/deepseek-v4-flash-sm120/blob/feat/hmma-tensor-core-sparse-decode/csrc/sm120/prefill/sparse_prefill_kernel.cuh) HMMA kernels from [deepseek-v4-flash-sm120](https://github.com/ambientlight/deepseek-v4-flash-sm120) as a drop-in replacement to DSv4 stock FlashMLA kernels unavailable for SM120

Not sure if there is way to check this in but putting this out as a practical reference for 4x RTX6000 pro max-q blackwell box. Reference setup per [DEPLOY-MXFP4-W4A4-DEEPSEEK-V4-FLASH-SM120.md](https://github.com/ambientlight/rtx-pro-6000-bench/blob/main/docs/DEPLOY-MXFP4-W4A4-DEEPSEEK-V4-FLASH-SM120.md) (assembled via hillclimbling with 4.8 opus max against [OxSero/deepseek-v4-flash-sm120 fork](https://github.com/ambientlight/deepseek-v4-flash-sm120))

## Modifications

1. MXFP4 W4A4 fused MoE: loads the checkpoint's MXFP4 experts as-is and runs the fused SwiGLU GEMM through FlashInfer's SM120 CuTe-DSL path ([flashinfer-ai#3541](https://github.com/flashinfer-ai/flashinfer/pull/3541)).
2. Selectable SM120 sparse decode: `SGLANG_SM120_SPARSE_DECODE` toggle (hmma, triton, torch; default triton). hmma is our custom [sparse_decode_kernel.cuh](https://github.com/ambientlight/deepseek-v4-flash-sm120/blob/feat/hmma-tensor-core-sparse-decode/csrc/sm120/decode/sparse_decode_kernel.cuh). If the custom kernel package isn't installed, hmma falls back to triton
3. Selectable SM120 sparse prefill: same idea for [sparse_prefill_kernel.cuh](https://github.com/ambientlight/deepseek-v4-flash-sm120/blob/feat/hmma-tensor-core-sparse-decode/csrc/sm120/prefill/sparse_prefill_kernel.cuh): a `SGLANG_SM120_SPARSE_PREFILL` toggle (hmma, sglkernel, torch). 
4. Add a split-KV variant d1c590ffc5f461ac2491bcc59a47dd282dfc4b7b of the SM120 tilelang paged-MQA-logits indexer kernel that shards each row's KV scan across (batch, num_splits) CTAs allowing to push long-context decode at `256K / 512K / 1M` from `20.7 / 12.4 / 6.9` to `27.4 / 17.7 / 10.4` tok/s

Both selectors share a small `is_deepseek_v4_kernel_available()` probe that decides whether hmma is reachable.

**also:** SM120 bugfix https://github.com/sgl-project/sglang/commit/e1ca8d9672d8ef2efe7b97c21d572e702054ee98 routes the tilelang FP8 paged-MQA-logits indexer to dsv4 instead of dsa kernel, fixing an illegal memory access under CUDA-graph capture

## Accuracy Tests

SWE-Bench Verified scores 76% on mini-swe-agent 2.4.2 harness per https://github.com/ambientlight/rtx-pro-6000-bench/tree/main/evals/swebench-verified/deepseek-v4-flash-2026-06-20

```
python3 -m sglang.test.few_shot_gsm8k --num-questions 200
# Accuracy: 0.980   Invalid: 0.000
```

The HMMA kernels are checked [deepseek-v4-flash-sm120/tests](https://github.com/ambientlight/deepseek-v4-flash-sm120/tree/feat/hmma-tensor-core-sparse-decode/tests) against a torch port of `ref_sparse_attn_fwd`:

```
python -m pytest tests/test_sparse_decode.py tests/test_sparse_prefill.py -v -p no:cacheprovider

shape (s_q,h_q,topk)           out_cosine  max|out-ref|
(64,64,64)                      0.9999976      1.95e-03
(1024,128,256)                  0.9999976      9.77e-04
(64,128,2048)                   0.9999977      2.44e-04
(1024,64,256)                   0.9999977      9.77e-04
```

## Speed Tests and Profiling (4x RTX6000 pro blackwell max-q)

See [DEPLOY-MXFP4-W4A4-DEEPSEEK-V4-FLASH-SM120.md#performance](https://github.com/ambientlight/rtx-pro-6000-bench/blob/main/docs/DEPLOY-MXFP4-W4A4-DEEPSEEK-V4-FLASH-SM120.md#performance)

[bench/deepseek-v4-flash_W300_TP4_sglang](https://github.com/ambientlight/rtx-pro-6000-bench/tree/main/bench/deepseek-v4-flash_W300_TP4_sglang): single-stream decode scales to the **full 1M context**: `64K / 128K / 256K / 512K / 1M` token prompts sustain `46 / 38 / 27 / 18 / 10 tok/s`, the 1M prompt peaking at 95% VRAM [bench_sweep_single.chunk8192.log](https://github.com/ambientlight/rtx-pro-6000-bench/blob/main/bench/deepseek-v4-flash_W300_TP4_sglang/bench_sweep_single.chunk8192.log), concurrency sweep at W300/TP4 [bench_sweep.log](https://github.com/ambientlight/rtx-pro-6000-bench/blob/main/bench/deepseek-v4-flash_W300_TP4_sglang/bench_sweep.log): **8576/8576 requests, 0 failed over ~27 h continuous load**, best sustained 756 tok/s @ 2K (c64)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27441191956](https://github.com/sgl-project/sglang/actions/runs/27441191956)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27441191771](https://github.com/sgl-project/sglang/actions/runs/27441191771)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->