### PR TITLE
feat(hicache): shared L2 KV cache pool for MLA models (SharedMLA)

### DIFF
--- a/docs_new/docs/advanced_features/server_arguments.mdx
+++ b/docs_new/docs/advanced_features/server_arguments.mdx
@@ -1740,6 +1740,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-shared-mla`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>For MLA models, share a single host (L2) KV cache slab across the TP ranks of one node instead of storing one identical copy per rank, saving (TP-1)/TP of L2 DRAM. Requires `--enable-hierarchical-cache` and a single-node deployment (`nnodes=1`); works with any `--hicache-write-policy`.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -496,6 +496,8 @@ class HiCacheController:
             # todo: load balancing
             and self.storage_config.tp_rank != 0
         )
+        # SharedMLA non-owner ranks reuse rank 0's slab; skip the real L3 IO.
+        self.prefetch_skip = getattr(self.mem_pool_host, "is_owner", True) is False
 
         # Use storage backend factory for dynamic backend creation
         from sglang.srt.mem_cache.storage import StorageBackendFactory
@@ -938,6 +940,10 @@ class HiCacheController:
     def _page_get_zero_copy(
         self, operation, hash_values, host_indices, extra_info=None
     ):
+        if self.prefetch_skip:
+            # SharedMLA non-owner: see _generic_page_get for rationale.
+            operation.increment(len(hash_values) * self.page_size)
+            return
         results = self.storage_backend.batch_get_v1(
             hash_values, host_indices, extra_info
         )
@@ -953,6 +959,12 @@ class HiCacheController:
 
     # todo: deprecate
     def _generic_page_get(self, operation, hash_values, host_indices, extra_info=None):
+        if self.prefetch_skip:
+            # SharedMLA non-owner: advance completed_tokens; MIN converges to rank 0.
+            for _ in range(len(hash_values)):
+                if not operation.increment(self.page_size):
+                    break
+            return
         dummy_page_dst = [
             self.mem_pool_host.get_dummy_flat_data_page() for _ in hash_values
         ]
@@ -1051,7 +1063,13 @@ class HiCacheController:
                 )
                 batch_hashes.append(last_hash)
             extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
-            hit_page_num = self.storage_backend.batch_exists(batch_hashes, extra_info)
+            if self.prefetch_skip:
+                # SharedMLA non-owner: assume full hit; MIN clamps to rank 0.
+                hit_page_num = len(batch_hashes)
+            else:
+                hit_page_num = self.storage_backend.batch_exists(
+                    batch_hashes, extra_info
+                )
             hash_value.extend(batch_hashes[:hit_page_num])
             storage_query_count += hit_page_num * self.page_size
             if hit_page_num < len(batch_hashes):

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -90,14 +90,31 @@ class HiRadixCache(RadixCache):
             # Filled by attach_hybrid_dsa_pool_to_hiradix_cache after storage extra_config is parsed.
             self.token_to_kv_pool_host = None
         elif isinstance(self.kv_cache, MLATokenToKVPool):
-            self.token_to_kv_pool_host = MLATokenToKVPoolHost(
-                self.kv_cache,
-                server_args.hicache_ratio,
-                server_args.hicache_size,
-                self.page_size,
-                server_args.hicache_mem_layout,
-                allocator_type=server_args.hicache_storage_backend,
-            )
+            if server_args.enable_shared_mla:
+                from sglang.srt.mem_cache.shared_mla_host_kv_cache import (
+                    SharedMLATokenToKVPoolHost,
+                )
+
+                tp_rank = torch.distributed.get_rank(group=params.tp_cache_group)
+                tp_size = torch.distributed.get_world_size(group=params.tp_cache_group)
+                self.token_to_kv_pool_host = SharedMLATokenToKVPoolHost(
+                    self.kv_cache,
+                    server_args.hicache_ratio,
+                    server_args.hicache_size,
+                    self.page_size,
+                    server_args.hicache_mem_layout,
+                    tp_rank=tp_rank,
+                    tp_size=tp_size,
+                )
+            else:
+                self.token_to_kv_pool_host = MLATokenToKVPoolHost(
+                    self.kv_cache,
+                    server_args.hicache_ratio,
+                    server_args.hicache_size,
+                    self.page_size,
+                    server_args.hicache_mem_layout,
+                    allocator_type=server_args.hicache_storage_backend,
+                )
         else:
             raise ValueError("HiRadixCache only supports MHA, MLA, and DSA models")
 

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -263,6 +263,17 @@ class HostKVCache(abc.ABC):
         ), "The host memory should be larger than the device memory with the current protocol"
 
         # Verify there is enough available host memory.
+        self._check_host_memory()
+
+        self.kv_buffer = self.init_kv_buffer()
+
+        # A lock for synchronized operations on memory allocation and state transitions.
+        self.lock = threading.RLock()
+        self.clear()
+
+    def _check_host_memory(self):
+        # Subclasses that attach to a shared slab instead of allocating per-rank
+        # host memory may override this (e.g. SharedMLA followers).
         host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
         available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
@@ -277,12 +288,6 @@ class HostKVCache(abc.ABC):
             logger.info(
                 f"Allocating {requested_bytes / 1e9:.2f} GB host memory for hierarchical KV cache."
             )
-
-        self.kv_buffer = self.init_kv_buffer()
-
-        # A lock for synchronized operations on memory allocation and state transitions.
-        self.lock = threading.RLock()
-        self.clear()
 
     @abc.abstractmethod
     def get_size_per_token(self):

--- a/python/sglang/srt/mem_cache/shared_mla_host_kv_cache.py
+++ b/python/sglang/srt/mem_cache/shared_mla_host_kv_cache.py
@@ -1,0 +1,347 @@
+"""
+SharedMLA: a single host (L2) KV cache slab shared across the TP ranks of one node.
+
+For MLA models every TP rank produces an identical compressed KV cache, so the
+default per-rank host pool stores TP copies of the same bytes. Here rank 0 owns a
+POSIX shm slab (cudaHostRegister) and the others attach read-only; every rank runs
+the same deterministic allocator, so all derive identical slot indices with no
+cross-rank broadcast. Single-node only (the slab is visible on one host).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+import platform
+from multiprocessing import shared_memory
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+import psutil
+import torch
+
+from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
+from sglang.srt.mem_cache.memory_pool_host import MLATokenToKVPoolHost
+from sglang.srt.utils import is_cuda
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.cache_controller import LayerDoneCounter
+
+_is_cuda = is_cuda()
+
+logger = logging.getLogger(__name__)
+
+
+def _mbind_interleave(addr: int, length: int) -> bool:
+    """Interleave a range's physical pages across all NUMA nodes via mbind(2).
+
+    The slab is read fan-out by all GPUs; interleaving spreads reads over both
+    UPI directions (measured ~212 -> ~281 GB/s for 8 GPUs). Must run before
+    first-touch. Returns False on any failure (caller falls back to default
+    first-touch placement, still correct).
+    """
+    try:
+        with open("/sys/devices/system/node/online") as f:
+            online = f.read().strip()
+    except OSError:
+        return False
+
+    node_ids = []
+    for part in online.split(","):
+        if "-" in part:
+            lo, hi = part.split("-")
+            node_ids.extend(range(int(lo), int(hi) + 1))
+        else:
+            node_ids.append(int(part))
+    if len(node_ids) < 2:
+        return False  # single NUMA node: interleave is a no-op
+
+    max_node = max(node_ids)
+    nodemask = 0
+    for n in node_ids:
+        nodemask |= 1 << n
+
+    MPOL_INTERLEAVE = 3
+    maxnode = max_node + 2
+
+    page_size = os.sysconf("SC_PAGESIZE")
+    aligned_addr = addr & ~(page_size - 1)
+    aligned_len = length + (addr - aligned_addr)
+
+    # glibc may not export mbind as a symbol, so invoke the raw syscall.
+    machine = platform.machine()
+    if machine == "x86_64":
+        NR_mbind = 237
+    elif machine in ("aarch64", "arm64"):
+        NR_mbind = 235
+    else:
+        return False
+
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        mask_arr = ctypes.c_ulong(nodemask)
+        libc.syscall.restype = ctypes.c_long
+        rc = libc.syscall(
+            ctypes.c_long(NR_mbind),
+            ctypes.c_void_p(aligned_addr),
+            ctypes.c_ulong(aligned_len),
+            ctypes.c_int(MPOL_INTERLEAVE),
+            ctypes.byref(mask_arr),
+            ctypes.c_ulong(maxnode),
+            ctypes.c_uint(0),
+        )
+    except Exception as e:
+        logger.warning(f"SharedMLA: mbind raised ({e}), using default placement")
+        return False
+    if rc != 0:
+        logger.warning(
+            f"SharedMLA: mbind failed (errno={ctypes.get_errno()}), "
+            f"using default placement"
+        )
+        return False
+    return True
+
+
+class SharedMLATokenToKVPoolHost(MLATokenToKVPoolHost):
+    """MLA shared L2 host pool: rank 0 owns a POSIX shm slab, the others read it.
+
+    Subclasses MLATokenToKVPoolHost and only overrides where the KV bytes come
+    from: rank 0 creates a NUMA-interleaved shm slab + cudaHostRegister, the other
+    ranks attach read-only. All layout/transfer/data-page logic is inherited, so
+    every hicache mem layout and IO backend works unchanged. Every rank runs the
+    same deterministic allocator, so slot indices match with no cross-rank
+    broadcast. Single-node only (the slab is visible on one host).
+    """
+
+    def __init__(
+        self,
+        device_pool: MLATokenToKVPool,
+        host_to_device_ratio: float,
+        host_size: int,
+        page_size: int,
+        layout: str,
+        tp_rank: int,
+        tp_size: int,
+        pin_memory: bool = True,
+        device: str = "cpu",
+        allocator_type: str = "default",
+        override_kv_cache_dim: Optional[int] = None,
+    ):
+        # Shared-only state must be set before super().__init__, which calls
+        # init_kv_buffer() / _check_host_memory() below.
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.is_owner = tp_rank == 0
+        self._registered_ptr = None
+        self._shm = None
+        self._shm_name = None
+
+        super().__init__(
+            device_pool,
+            host_to_device_ratio,
+            host_size,
+            page_size,
+            layout,
+            pin_memory,
+            device,
+            allocator_type,
+            override_kv_cache_dim=override_kv_cache_dim,
+        )
+
+        self.layer_transfer_counter = None
+        self.enable_custom_mem_pool = False
+        self.custom_mem_pool = None
+        self.mem_usage = self.get_kv_size_bytes() / (1024**3)
+        logger.info(
+            f"SharedMLA rank {self.tp_rank}: ready, size={self.size} tokens, "
+            f"{self.mem_usage:.2f} GB "
+            f"({'owns' if self.is_owner else 'reads'} the slab "
+            f"shared across all {self.tp_size} ranks)"
+        )
+
+    def _check_host_memory(self):
+        # Only the owner allocates the slab; followers attach to it, so the
+        # base per-rank availability check would double-count and misfire.
+        if not self.is_owner:
+            return
+        total_bytes = self.size * self.size_per_token
+        host_mem = psutil.virtual_memory()
+        safety_margin = 10 * (1024**3)
+        if total_bytes > host_mem.available:
+            raise ValueError(
+                f"Not enough host memory for SharedMLA. "
+                f"Need {total_bytes / 1e9:.2f} GB, "
+                f"have {host_mem.available / 1e9:.2f} GB available."
+            )
+        if total_bytes > host_mem.available - safety_margin:
+            logger.warning(
+                f"SharedMLA slab ({total_bytes / 1e9:.2f} GB) leaves less "
+                f"than {safety_margin / 1e9:.0f} GB of host memory free "
+                f"({host_mem.available / 1e9:.2f} GB available)."
+            )
+
+    def init_kv_buffer(self):
+        # Same layout dims as the parent MLATokenToKVPoolHost, but the buffer is
+        # backed by a shared shm slab (owner creates, others attach) instead of a
+        # per-rank pinned allocation.
+        if self.layout == "layer_first":
+            dims = (self.layer_num, self.size, 1, self.kv_cache_dim)
+        elif self.layout == "page_first":
+            dims = (self.size, self.layer_num, 1, self.kv_cache_dim)
+        elif self.layout == "page_first_direct":
+            dims = (self.page_num, self.layer_num, self.page_size, 1, self.kv_cache_dim)
+        else:
+            raise ValueError(f"SharedMLA unsupported layout: {self.layout}")
+        self.token_stride_size = self.kv_cache_dim * self.dtype.itemsize
+        self.layout_dim = self.token_stride_size * self.layer_num
+        total_bytes = self.size * self.layer_num * self.token_stride_size
+
+        owner_pid = os.getpid() if self.is_owner else 0
+        pid_tensor = torch.tensor(
+            [owner_pid], dtype=torch.int64, device=self.device_pool.device
+        )
+        if torch.distributed.is_initialized():
+            torch.distributed.broadcast(pid_tensor, src=0)
+        self._shm_name = f"shared_mla_tp{self.tp_size}_p{pid_tensor.item()}"
+
+        if self.is_owner:
+            logger.info(
+                f"SharedMLA rank 0: creating shared slab "
+                f"{total_bytes / 1e9:.2f} GB (name={self._shm_name})"
+            )
+            # Reclaim multi-GB slabs leaked by a crashed run (dead owner PID).
+            self._reclaim_stale_slabs()
+            try:
+                stale = shared_memory.SharedMemory(name=self._shm_name)
+                stale.close()
+                stale.unlink()
+                logger.warning(f"SharedMLA rank 0: removed stale slab {self._shm_name}")
+            except FileNotFoundError:
+                pass
+            self._shm = shared_memory.SharedMemory(
+                name=self._shm_name, create=True, size=total_bytes
+            )
+            # Interleave pages across NUMA nodes before first-touch (mbind only
+            # governs future faults), then touch them to realize the placement.
+            owner_np = np.ndarray((total_bytes,), dtype=np.uint8, buffer=self._shm.buf)
+            interleaved = _mbind_interleave(
+                torch.from_numpy(owner_np).data_ptr(), total_bytes
+            )
+            owner_np[:] = 0
+            logger.info(
+                f"SharedMLA rank 0: slab pages "
+                f"{'interleaved across NUMA nodes' if interleaved else 'default (first-touch) placement'}"
+            )
+
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+        if not self.is_owner:
+            self._shm = shared_memory.SharedMemory(name=self._shm_name)
+            logger.info(f"SharedMLA rank {self.tp_rank}: attached to shared slab")
+
+        np_array = np.ndarray((total_bytes,), dtype=np.uint8, buffer=self._shm.buf)
+        shm_tensor = torch.from_numpy(np_array)
+        if _is_cuda:
+            self._cuda_host_register(shm_tensor.data_ptr(), total_bytes)
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+
+        return shm_tensor.view(self.dtype).view(*dims)
+
+    def _cuda_host_register(self, ptr: int, total_bytes: int):
+        cudart = torch.cuda.cudart()
+        rc = cudart.cudaHostRegister(ptr, total_bytes, 1)  # portable
+        if int(rc) == 712:
+            # Already registered by a leaked slab at this address: retry once.
+            cudart.cudaHostUnregister(ptr)
+            rc = cudart.cudaHostRegister(ptr, total_bytes, 1)
+        if int(rc) != 0:
+            raise RuntimeError(
+                f"cudaHostRegister failed on rank {self.tp_rank} (rc={int(rc)}). "
+                f"This often means the locked-memory limit is too low; try "
+                f"raising it with `ulimit -l unlimited`."
+            )
+        self._registered_ptr = ptr
+
+    @staticmethod
+    def _reclaim_stale_slabs():
+        """Unlink shared_mla_* slabs in /dev/shm whose owner PID is dead."""
+        try:
+            names = os.listdir("/dev/shm")
+        except OSError:
+            return
+        for name in names:
+            if not name.startswith("shared_mla_tp") or "_p" not in name:
+                continue
+            try:
+                pid = int(name.rsplit("_p", 1)[1])
+            except ValueError:
+                continue
+            if psutil.pid_exists(pid):
+                continue
+            try:
+                stale = shared_memory.SharedMemory(name=name)
+                stale.close()
+                stale.unlink()
+                logger.warning(
+                    f"SharedMLA rank 0: reclaimed stale slab {name} (dead pid {pid})"
+                )
+            except Exception:
+                pass
+
+    def backup_from_device_all_layer(
+        self, device_pool, host_indices, device_indices, io_backend
+    ):
+        # Only rank 0 writes the shared slab; the parent handles all layouts.
+        if not self.is_owner:
+            return
+        return super().backup_from_device_all_layer(
+            device_pool, host_indices, device_indices, io_backend
+        )
+
+    def load_to_device_per_layer(
+        self, device_pool, host_indices, device_indices, layer_id, io_backend
+    ):
+        # All ranks read the shared slab into their own L1. Gate on the transfer
+        # counter (the parent does not) so loads observe completed backups.
+        if self.layer_transfer_counter is not None:
+            self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
+        return super().load_to_device_per_layer(
+            device_pool, host_indices, device_indices, layer_id, io_backend
+        )
+
+    def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:
+        # L3 prefetch fill; only rank 0 writes the slab (defensive: followers are
+        # already short-circuited by the controller's prefetch_skip).
+        if not self.is_owner:
+            return
+        return super().set_from_flat_data_page(index, data_page)
+
+    def get_kv_size_bytes(self):
+        return self.size * self.layer_num * self.token_stride_size
+
+    def register_layer_transfer_counter(self, layer_transfer_counter: LayerDoneCounter):
+        self.layer_transfer_counter = layer_transfer_counter
+
+    def maybe_get_custom_mem_pool(self):
+        return None
+
+    def shutdown(self):
+        # __init__ may fail before these are assigned; guard against that.
+        registered_ptr = getattr(self, "_registered_ptr", None)
+        if registered_ptr is not None and _is_cuda:
+            try:
+                torch.cuda.cudart().cudaHostUnregister(registered_ptr)
+            except Exception:
+                pass
+            self._registered_ptr = None
+        shm = getattr(self, "_shm", None)
+        if shm is not None:
+            shm.close()
+            if self.is_owner:
+                try:
+                    shm.unlink()
+                except Exception:
+                    pass
+            self._shm = None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -699,6 +699,8 @@ class ServerArgs:
     enable_hierarchical_cache: bool = False
     hicache_ratio: float = 2.0
     hicache_size: int = 0
+    # Shared L2 pool for MLA models (rank 0 owns the slab, other ranks read).
+    enable_shared_mla: bool = False
     hicache_write_policy: str = "write_through"
     hicache_io_backend: str = "kernel"
     hicache_mem_layout: str = "layer_first"
@@ -4408,6 +4410,24 @@ class ServerArgs:
                 "and cannot be used at the same time. Please use only one of them."
             )
 
+        if self.enable_shared_mla and not self.enable_hierarchical_cache:
+            raise ValueError(
+                "The argument enable-shared-mla requires enable-hierarchical-cache "
+                "(SharedMLA is a host-pool implementation for the hierarchical cache)."
+            )
+
+        if self.enable_shared_mla and self.nnodes > 1:
+            # TODO(SharedMLA): multi-node can still share with one slab per node
+            # (owner = node-local rank 0, a node-local TP subgroup for the
+            # broadcasts, node-tagged shm names). Single-node only for now.
+            raise ValueError(
+                "The argument enable-shared-mla requires a single-node deployment "
+                f"(nnodes=1, got nnodes={self.nnodes}). The shared L2 slab is a POSIX "
+                "shared-memory segment plus a per-process cudaHostRegister, visible "
+                "only to processes on the same physical host, so a multi-node TP group "
+                "(e.g. TP16 across two 8-GPU hosts) cannot attach to rank 0's slab."
+            )
+
         if self.disaggregation_decode_enable_offload_kvcache:
             if self.disaggregation_mode != "decode":
                 raise ValueError(
@@ -6516,6 +6536,12 @@ class ServerArgs:
             type=int,
             default=ServerArgs.hicache_size,
             help="The size of host KV cache memory pool in gigabytes, which will override the hicache_ratio if set.",
+        )
+        parser.add_argument(
+            "--enable-shared-mla",
+            action="store_true",
+            default=ServerArgs.enable_shared_mla,
+            help="Enable shared L2 KV cache pool for MLA models. Rank 0 owns the shared slab, other ranks read-only. Saves (TP-1)/TP of L2 DRAM. Requires --enable-hierarchical-cache.",
         )
         parser.add_argument(
             "--hicache-write-policy",

--- a/test/registered/unit/mem_cache/test_shared_mla_host_unit.py
+++ b/test/registered/unit/mem_cache/test_shared_mla_host_unit.py
@@ -1,0 +1,170 @@
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
+from sglang.srt.mem_cache.shared_mla_host_kv_cache import SharedMLATokenToKVPoolHost
+from sglang.srt.utils import is_cuda, is_hip
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestSharedMLAHost(unittest.TestCase):
+    """Single-process (TP=1, owner) coverage of SharedMLATokenToKVPoolHost.
+
+    Multi-rank behaviour (follower attach, deterministic allocator lockstep) and
+    NUMA interleave (Linux, >=2 nodes) are validated by end-to-end / micro-
+    benchmarks, not here, since they need multiple processes.
+    """
+
+    PAGE_SIZE = 1
+    LAYER_NUM = 2
+    KV_LORA_RANK = 512
+    QK_ROPE_HEAD_DIM = 64
+
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required for SharedMLA host tests.")
+        if not (is_cuda() or is_hip()):
+            self.skipTest("CUDA/ROCm not available.")
+        self.host = None
+
+    def tearDown(self):
+        if self.host is not None:
+            self.host.shutdown()
+            self.host = None
+
+    def _make_device_pool(self, size):
+        return MLATokenToKVPool(
+            size=size,
+            page_size=self.PAGE_SIZE,
+            dtype=torch.bfloat16,
+            kv_lora_rank=self.KV_LORA_RANK,
+            qk_rope_head_dim=self.QK_ROPE_HEAD_DIM,
+            layer_num=self.LAYER_NUM,
+            device="cuda",
+            enable_memory_saver=False,
+        )
+
+    def _make_host(self, device_pool, host_size=1):
+        return SharedMLATokenToKVPoolHost(
+            device_pool=device_pool,
+            host_to_device_ratio=2.0,
+            host_size=host_size,
+            page_size=self.PAGE_SIZE,
+            layout="layer_first",
+            tp_rank=0,
+            tp_size=1,
+        )
+
+    def test_construction(self):
+        device_pool = self._make_device_pool(size=256)
+        self.host = self._make_host(device_pool)
+        self.assertEqual(
+            tuple(self.host.kv_buffer.shape),
+            (self.LAYER_NUM, self.host.size, 1, self.host.kv_cache_dim),
+        )
+        self.assertGreater(self.host.mem_usage, 0)
+        self.assertEqual(self.host.available_size(), self.host.size)
+
+    def test_alloc_free_clear(self):
+        device_pool = self._make_device_pool(size=256)
+        self.host = self._make_host(device_pool)
+        total = self.host.available_size()
+
+        indices = self.host.alloc(8)
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), 8)
+        self.assertEqual(self.host.available_size(), total - 8)
+
+        self.host.free(indices)
+        self.assertEqual(self.host.available_size(), total)
+
+        self.host.clear()
+        self.assertEqual(self.host.available_size(), self.host.size)
+
+    def test_round_trip_transfer(self):
+        size = 256
+        device_pool = self._make_device_pool(size=size)
+        self.host = self._make_host(device_pool)
+
+        # Fill the device pool with known per-layer values.
+        for layer_id in range(self.LAYER_NUM):
+            buf = device_pool.kv_buffer[layer_id]
+            data = torch.arange(
+                buf.numel(), device=buf.device, dtype=buf.dtype
+            ).view_as(buf)
+            buf.copy_(data + layer_id)
+
+        n = 16
+        host_indices = self.host.alloc(n)
+        device_indices = torch.arange(n, device="cuda", dtype=torch.int64)
+
+        # The transfer kernels need both index tensors on the GPU (the cache
+        # controller moves host_indices to the device before calling these);
+        # mirror that here.
+        host_indices_dev = host_indices.to("cuda", non_blocking=True)
+
+        # device -> shared slab
+        self.host.backup_from_device_all_layer(
+            device_pool, host_indices_dev, device_indices, io_backend="kernel"
+        )
+
+        # zero the device pool, then shared slab -> device
+        for layer_id in range(self.LAYER_NUM):
+            device_pool.kv_buffer[layer_id].zero_()
+        for layer_id in range(self.LAYER_NUM):
+            self.host.load_to_device_per_layer(
+                device_pool,
+                host_indices_dev,
+                device_indices,
+                layer_id,
+                io_backend="kernel",
+            )
+        torch.cuda.synchronize()
+
+        for layer_id in range(self.LAYER_NUM):
+            buf = device_pool.kv_buffer[layer_id]
+            expected = (
+                torch.arange(buf.numel(), device=buf.device, dtype=buf.dtype).view_as(
+                    buf
+                )
+                + layer_id
+            )
+            got = buf[device_indices]
+            self.assertTrue(torch.equal(got, expected[device_indices]))
+
+    def test_stale_slab_is_reclaimed(self):
+        # Construct once, leak the slab (skip shutdown), then construct again
+        # with the same computed name and assert it succeeds (stale unlinked)
+        # rather than raising FileExistsError.
+        device_pool = self._make_device_pool(size=256)
+        first = self._make_host(device_pool)
+        shm_name = first._shm_name
+        # Drop the python handle without unlinking (simulate a crash).
+        first._shm.close()
+        first._shm = None
+
+        self.host = self._make_host(device_pool)
+        self.assertEqual(self.host._shm_name, shm_name)
+        self.assertEqual(self.host.available_size(), self.host.size)
+
+    def test_buffer_meta_lengths(self):
+        device_pool = self._make_device_pool(size=256)
+        self.host = self._make_host(device_pool)
+
+        data_ptrs, data_lens, item_lens = self.host.get_contiguous_buf_infos()
+        self.assertEqual(len(data_ptrs), self.LAYER_NUM)
+        self.assertEqual(len(data_lens), self.LAYER_NUM)
+        self.assertEqual(len(item_lens), self.LAYER_NUM)
+
+        indices = self.host.alloc(self.PAGE_SIZE * 4)
+        ptr_list, size_list = self.host.get_page_buffer_meta(indices)
+        expected = (len(indices) // self.PAGE_SIZE) * self.LAYER_NUM
+        self.assertEqual(len(ptr_list), expected)
+        self.assertEqual(len(size_list), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

For MLA models (DeepSeek V2/V3, Kimi, GLM-4, ...), every TP rank produces an **identical** compressed KV cache. With hierarchical cache enabled, the default host (L2) pool therefore stores `TP` copies of the same bytes — at TP8 that is 8× the necessary host DRAM.

**SharedMLA** keeps a single copy of the L2 cache shared across the TP ranks of one node:
- rank 0 allocates a POSIX shared-memory slab and registers it with `cudaHostRegister`; the other ranks attach read-only and read it over PCIe
- every rank runs the same deterministic slot allocator, so all ranks derive byte-identical host indices from the lockstep request stream with no cross-rank broadcast
- the slab is **topology-aware**: pages are NUMA-interleaved across sockets so reads spread over balanced PCIe/UPI paths instead of hammering one socket's memory controller

### Benefits
- **Host DRAM saving**: one shared copy instead of `TP` copies cuts the L2 footprint by `(TP-1)/TP` — **87.5% at TP8**.
- **Single L3 read per node**: the MLA L3 object is rank-identical, so only rank 0 reads it and fills the shared slab; the other ranks reuse those slots instead of each re-reading the same file.
- **No latency cost**: followers read from the shared slab over PCIe with no measurable load-path overhead vs. a local copy (see Speed Tests).

## Modifications

- **`mem_cache/shared_mla_host_kv_cache.py`** (new): `SharedMLATokenToKVPoolHost` — subclasses `MLATokenToKVPoolHost` and only overrides the memory source (POSIX shm + `cudaHostRegister`, NUMA-interleaved, rank 0 writes / others read-only) and the rank-0 owner gates. All layout/transfer logic is inherited, so every hicache mem layout and IO backend works unchanged.
- **`mem_cache/memory_pool_host.py`**: extract `HostKVCache._check_host_memory` into an overridable method so the shared subclass (whose followers attach instead of allocating) can skip the per-rank host-memory check. No behavior change for existing pools.
- **`mem_cache/hiradix_cache.py`**: route the MLA host pool to `SharedMLATokenToKVPoolHost` when enabled.
- **`managers/cache_controller.py`**: add `prefetch_skip` (mirrors `backup_skip`) so non-owner ranks skip the real L3 read and slab write but still run the full prefetch control flow — the deterministic allocator keeps every rank's indices in lockstep.
- **`server_args.py`**: add `--enable-shared-mla`; validate it requires `--enable-hierarchical-cache` and a single-node deployment (`nnodes=1`).
- **`docs_new/docs/advanced_features/server_arguments.mdx`**: document the flag.
- **`test/registered/unit/mem_cache/test_shared_mla_host_unit.py`** (new): single-process unit tests.

### Constraints
- MLA models only (the shared-bytes property only holds for MLA).
- Single node only — the slab is POSIX shm + `cudaHostRegister`, visible only on one physical host. A multi-node TP group (e.g. TP16 over two hosts) is rejected at startup.

### Future work
- **Multi-node**: one slab per node (node-local owner + broadcast subgroup) — still saves `(per_node_TP-1)/per_node_TP`.

### Related work

- **PR #26691** (HZY-Wade) targets the same problem with NCCL broadcast (rank 0 reads host, broadcasts over NVLink). We instead share a POSIX shm slab via `cudaHostRegister` and let all ranks read it concurrently over PCIe — on par with a local host read in our benchmarks.
- **PR #27370** (xz-keg) applies the same shared-memory idea to the HiSparse (DSA/CSA) decode-stage CPU offload.

Welcome to discuss!

## Accuracy Tests

Correctness is about cross-rank consistency, not model math. Verified on **DeepSeek-V3.1, TP8** (H20×8):

- **Eviction sync**: forced L1+L2 to fill (small pools) and hit evicted prefixes. All 8 ranks run the identical `evict_host` and free the same slots — eviction fires symmetrically.
- **No dirty read**: re-requesting evicted prefixes returns byte-identical greedy (temp=0) output vs. a golden capture; 0 mismatches.
- **L3 round-trip**: with `--hicache-storage-backend file`, flushed L1+L2 and re-requested so prefixes are restored from L3. SharedMLA output is byte-identical to a baseline (non-shared) run on the same L3-hit path.
- **Long-run**: 30 min, 24-concurrent, realistic mixed workload — variable prompt lengths (2k–9k tokens), real decode lengths (32–512 output tokens), and a mix of L1/L2 hits, hits on already-evicted prefixes, shared-prefix split/cascade eviction, fresh prompts that force eviction, and L2↔L3 backup/prefetch, against a small L2 so eviction fires continuously. Zero hang / dirty-read / error.
- Verified with all three `--hicache-write-policy` values (`write_through`, `write_through_selective`, `write_back`).

## Speed Tests

We don't benchmark cache hit rate here — it's entirely workload-dependent. The focus is the only thing SharedMLA could regress: **load latency**. Followers read KV from the shared slab instead of a local copy, inside the prefill forward (attention layers block on it per-layer), so it lands on TTFT. Does the shared read make `load_back` slower?

Answer: no. Measured with the standard `sglang.bench_serving` on **DeepSeek-V3.1, TP8, H20×8** at equal L2 capacity (`--hicache-size 40`), with a 3-step method that forces an L2 hit on the TTFT path. Requests are sent **serially (`--max-concurrency 1`)** so the number reflects the per-request `load_back` cost itself, not queueing delay. 15k-token prompts, 3 rounds each:

| layout / IO backend | cold TTFT | L2-hit TTFT (base) | L2-hit TTFT (SharedMLA) |
|---|---|---|---|
| layer_first / direct | ~1.36 s | 177 ms | 174 ms |
| page_first_direct / direct | ~1.36 s | 187 ms | 186 ms |

L2-hit TTFT is on par across every layout / backend (within run-to-run noise, e.g. layer_first per-round base 175/176/181 ms, shared 172/179/172 ms), and the L2 hit is a ~7.7× speedup over cold. **SharedMLA's shared-slab read carries no latency penalty vs. a local copy, while cutting L2 DRAM by 87.5% at TP8.** (The `load_back` itself — moving the hit KV from host to GPU over PCIe — dominates the 174 ms; only the unaligned tail tokens are recomputed.)

### Confirming the hit is really L2 (not L1)

With `--enable-metrics`, we read `sglang:load_back_tokens_total` (the L2→L1 reload counter, only incremented when an evicted node is restored from the host pool) before and after each step. In every round, on both builds:

| step | load_back_tokens delta |
|---|---|
| step 1 (cold write) | 0 |
| step 2 (evict L1) | 0 |
| step 3 (re-read) | **843776** |

The counter is flat through steps 1–2 and only jumps on step 3 — proof that step 2 evicted the prompts from L1 and step 3 served them via an L2→L1 `load_back`, i.e. a genuine L2 hit.

### Reproduce

1. Build two custom datasets (set A is re-read to hit L2; set B is large junk to flush L1). `~6.8 tokens/word`, so ~2200 words ≈ 15k tokens, just under the 16k context:

```python
# gen_custom.py
import json, random

def write_set(path, prefix, count, n_words, seed):
    rng = random.Random(seed)
    with open(path, "w") as f:
        for i in range(count):
            words = [f"{prefix}{i}w{rng.randint(0, 10**9)}" for _ in range(n_words)]
            p = f"SETID-{prefix}{i} " + " ".join(words)
            f.write(json.dumps({"conversations": [{"content": p}, {"content": "ok"}]}) + "\n")

write_set("/tmp/custom_setA.jsonl", "A", 8, 2200, seed=1001)   # 8 prompts, re-read to hit L2
write_set("/tmp/custom_setB.jsonl", "B", 64, 2200, seed=2002)  # 64 prompts, flush L1
```

2. Launch the server (drop `--enable-shared-mla` for the baseline):

```bash
python3 -m sglang.launch_server --model-path <DeepSeek-V3.1> --tp 8 --port 30001 \
  --trust-remote-code --context-length 16000 --max-total-tokens 18000 \
  --chunked-prefill-size 8192 --mem-fraction-static 0.88 \
  --enable-hierarchical-cache --hicache-size 40 --hicache-write-policy write_through \
  --page-size 64 --hicache-io-backend direct \
  --enable-shared-mla --enable-metrics
# page_first_direct variant: add --hicache-mem-layout page_first_direct
# baseline: drop --enable-shared-mla
```

3. Run the 3-step method (repeat 3 rounds; `load_back` delta on step 3 confirms the L2 hit):

```bash
BENCH="python3 -m sglang.bench_serving --backend sglang --port 30001 \
  --tokenizer <DeepSeek-V3.1> --dataset-name custom --sharegpt-output-len 8"
lb() { curl -s http://127.0.0.1:30001/metrics | grep '^sglang:load_back_tokens_total' | awk '{print $2}'; }

curl -s -X POST http://127.0.0.1:30001/flush_cache; sleep 2
$BENCH --dataset-path /tmp/custom_setA.jsonl --num-prompts 8  --max-concurrency 1 --seed 1  # step1 cold write
$BENCH --dataset-path /tmp/custom_setB.jsonl --num-prompts 64 --max-concurrency 8 --seed 2  # step2 evict L1
echo "load_back before step3: $(lb)"
$BENCH --dataset-path /tmp/custom_setA.jsonl --num-prompts 8  --max-concurrency 1 --seed 1  # step3 L2 hit
echo "load_back after step3:  $(lb)   # delta > 0 => served from L2"
```

Send step 3 serially (`--max-concurrency 1`) so its TTFT is the pure L2-read latency rather than queueing; compare it between the baseline and `--enable-shared-mla` runs.

<details>
<summary>Raw serial logs — standard hicache (base)</summary>

```
# layer_first / direct
===== SERIAL (concurrency=1) L2 REPRO: base_lf_direct  Tue Jun 16 08:14:51 PM CST 2026 =====

################## RUN 1 ##################
[step1 COLD serial]  Median TTFT (ms):                        1357.47   
Benchmark duration (s):                  43.91     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        174.71    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 2 ##################
[step1 COLD serial]  Median TTFT (ms):                        1361.66   
Benchmark duration (s):                  43.95     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        176.28    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 3 ##################
[step1 COLD serial]  Median TTFT (ms):                        1360.16   
Benchmark duration (s):                  44.02     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        181.12    
[load_back] step3 delta = 843776  <<< L2 HIT proof

===== DONE Tue Jun 16 08:19:16 PM CST 2026 =====

# page_first_direct / direct
===== SERIAL (concurrency=1) L2 REPRO: base_pfd  Tue Jun 16 08:45:30 PM CST 2026 =====

################## RUN 1 ##################
[step1 COLD serial]  Median TTFT (ms):                        1362.31   
Benchmark duration (s):                  44.45     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        187.20    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 2 ##################
[step1 COLD serial]  Median TTFT (ms):                        1363.67   
Benchmark duration (s):                  44.52     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        188.46    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 3 ##################
[step1 COLD serial]  Median TTFT (ms):                        1362.25   
Benchmark duration (s):                  44.45     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        186.74    
[load_back] step3 delta = 843776  <<< L2 HIT proof

===== DONE Tue Jun 16 08:49:58 PM CST 2026 =====
```
</details>

<details>
<summary>Raw serial logs — SharedMLA</summary>

```
# layer_first / direct
===== SERIAL (concurrency=1) L2 REPRO: shared_lf_direct  Tue Jun 16 08:32:30 PM CST 2026 =====

################## RUN 1 ##################
[step1 COLD serial]  Median TTFT (ms):                        1352.32   
Benchmark duration (s):                  43.70     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        172.29    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 2 ##################
[step1 COLD serial]  Median TTFT (ms):                        1353.09   
Benchmark duration (s):                  43.67     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        178.78    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 3 ##################
[step1 COLD serial]  Median TTFT (ms):                        1351.39   
Benchmark duration (s):                  43.61     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        172.20    
[load_back] step3 delta = 843776  <<< L2 HIT proof

===== DONE Tue Jun 16 08:36:53 PM CST 2026 =====

# page_first_direct / direct
===== SERIAL (concurrency=1) L2 REPRO: shared_pfd  Tue Jun 16 08:56:06 PM CST 2026 =====

################## RUN 1 ##################
[step1 COLD serial]  Median TTFT (ms):                        1352.94   
Benchmark duration (s):                  43.93     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        189.75    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 2 ##################
[step1 COLD serial]  Median TTFT (ms):                        1356.20   
Benchmark duration (s):                  43.96     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        185.63    
[load_back] step3 delta = 843776  <<< L2 HIT proof

################## RUN 3 ##################
[step1 COLD serial]  Median TTFT (ms):                        1358.19   
Benchmark duration (s):                  43.83     
[load_back] step2 delta = 0
[step3 L2-HIT serial] Median TTFT (ms):                        186.10    
[load_back] step3 delta = 843776  <<< L2 HIT proof

===== DONE Tue Jun 16 09:00:31 PM CST 2026 =====
```
</details>


## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [x] Update documentation
- [x] Provide accuracy and speed benchmark results
- [x] Follow the SGLang code style
