### PR TITLE
fix: avoid blocking the event loop with requests.get in async route

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1144,7 +1144,8 @@ async def remote_instance_transfer_engine_info(rank: int = None):
 
     server_args = _global_state.tokenizer_manager.server_args
     try:
-        resp = requests.get(
+        resp = await asyncio.to_thread(
+            requests.get,
             f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
             params={"rank": rank},
             timeout=5,


### PR DESCRIPTION
## Motivation

`remote_instance_transfer_engine_info` (`srt/entrypoints/http_server.py`) is an `async` FastAPI route, but it makes a **synchronous** `requests.get(..., timeout=5)` call:

```python
async def remote_instance_transfer_engine_info(rank: int = None):
    ...
    resp = requests.get(..., timeout=5)
```

A blocking call inside an async handler blocks the **entire event loop** for its duration — up to 5s here. While it waits, every other in-flight request the server is handling is frozen (no concurrency, no health checks). On a busy serving endpoint that's a real latency/availability hit.

## Modifications

Offload the blocking call to a worker thread with `asyncio.to_thread`, so the event loop stays free while the request is in flight:

```python
resp = await asyncio.to_thread(
    requests.get,
    f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
    params={"rank": rank},
    timeout=5,
)
```

`asyncio` is already imported; no new dependency. Behavior is otherwise identical.

## Checklist

- [x] Compiles cleanly (`python -m py_compile`).
- [x] Minimal, single-file change.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27403070264](https://github.com/sgl-project/sglang/actions/runs/27403070264)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27403070181](https://github.com/sgl-project/sglang/actions/runs/27403070181)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->