### PR TITLE
feat: add --disable-cuda-perf-boost to recover idle GPU power

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -783,6 +783,7 @@ class ServerArgs:
     disable_tokenizer_batch_decode: bool = False
     disable_outlines_disk_cache: bool = False
     disable_custom_all_reduce: bool = False
+    disable_cuda_perf_boost: bool = False
     enable_mscclpp: bool = False
     enable_torch_symm_mem: bool = False
     pre_warm_nccl: bool = dataclasses.field(
@@ -940,6 +941,11 @@ class ServerArgs:
         self._handle_ssl_validation()
         # Validate transcription/ASR-specific server args (model-independent).
         self._handle_asr_validation()
+
+        # Propagate --disable-cuda-perf-boost into the process env early so the
+        # NVIDIA driver picks it up at CUDA context creation (must happen before
+        # any torch/CUDA init and before scheduler subprocess fork).
+        self._handle_disable_cuda_perf_boost()
 
         # Validate PD disaggregation flags early (before dummy-model short-circuit).
         from sglang.srt.arg_groups.pd_disaggregation_hook import (
@@ -1232,6 +1238,20 @@ class ServerArgs:
             raise ValueError(
                 f"SGLANG_GRPC_PORT ({self.grpc_port}) must be between 1 and 65535"
             )
+
+    def _handle_disable_cuda_perf_boost(self):
+        # CUDA_DISABLE_PERF_BOOST is an NVIDIA driver env var (added in the 580
+        # driver series; older drivers silently ignore it). setdefault so an
+        # explicit user-set value (including "0") wins over the CLI flag.
+        if not self.disable_cuda_perf_boost:
+            return
+        if is_hip():
+            logger.warning(
+                "--disable-cuda-perf-boost has no effect on AMD/HIP devices; "
+                "CUDA_DISABLE_PERF_BOOST is an NVIDIA driver env var. Ignoring."
+            )
+            return
+        os.environ.setdefault("CUDA_DISABLE_PERF_BOOST", "1")
 
     def _handle_prefill_delayer_env_compat(self):
         if envs.SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE.get():
@@ -6965,6 +6985,17 @@ class ServerArgs:
             "--disable-custom-all-reduce",
             action="store_true",
             help="Disable the custom all-reduce kernel and fall back to NCCL.",
+        )
+        parser.add_argument(
+            "--disable-cuda-perf-boost",
+            action="store_true",
+            help="Set CUDA_DISABLE_PERF_BOOST=1 in the process environment before "
+            "CUDA context creation. Lets the NVIDIA DVFS governor drop idle SM "
+            "clocks instead of locking them at boost when a context is loaded, "
+            "saving ~26-66 W/GPU at 0%% utilization on Hopper/Ampere/Ada. "
+            "Adds a one-time ~150 ms ramp on the first request after idle; "
+            "steady-state latency is unchanged. Requires an NVIDIA driver "
+            "from the 580 series (older drivers silently ignore the env var).",
         )
         parser.add_argument(
             "--enable-mscclpp",

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -265,6 +265,50 @@ class TestContextParallelServerArgs(CustomTestCase):
                 )
 
 
+class TestDisableCudaPerfBoost(CustomTestCase):
+    """Cover the --disable-cuda-perf-boost CLI flag and its env propagation."""
+
+    _ENV_KEY = "CUDA_DISABLE_PERF_BOOST"
+
+    def setUp(self):
+        self._prev = os.environ.pop(self._ENV_KEY, None)
+
+    def tearDown(self):
+        os.environ.pop(self._ENV_KEY, None)
+        if self._prev is not None:
+            os.environ[self._ENV_KEY] = self._prev
+
+    def test_default_is_false_and_env_unset(self):
+        ServerArgs(model_path="dummy")
+        self.assertNotIn(self._ENV_KEY, os.environ)
+
+    def test_cli_flag_parses_and_sets_env(self):
+        server_args = prepare_server_args(
+            ["--model-path", "dummy", "--disable-cuda-perf-boost"]
+        )
+        self.assertTrue(server_args.disable_cuda_perf_boost)
+        self.assertEqual(os.environ.get(self._ENV_KEY), "1")
+
+    def test_field_true_sets_env(self):
+        ServerArgs(model_path="dummy", disable_cuda_perf_boost=True)
+        self.assertEqual(os.environ.get(self._ENV_KEY), "1")
+
+    def test_respects_existing_user_value(self):
+        os.environ[self._ENV_KEY] = "0"
+        ServerArgs(model_path="dummy", disable_cuda_perf_boost=True)
+        self.assertEqual(os.environ[self._ENV_KEY], "0")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_amd_hip_skips_env_set_and_warns(self, _mock_is_hip):
+        with self.assertLogs("sglang.srt.server_args", level="WARNING") as cm:
+            ServerArgs(model_path="dummy", disable_cuda_perf_boost=True)
+        self.assertNotIn(self._ENV_KEY, os.environ)
+        self.assertTrue(
+            any("AMD/HIP" in msg for msg in cm.output),
+            f"expected AMD/HIP warning, got {cm.output}",
+        )
+
+
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.get_free_port")
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")


### PR DESCRIPTION
## Motivation

Loading a model into VRAM forces the NVIDIA driver to lock SM clocks at boost even at 0% utilization, costing roughly 26-66 W per idle GPU (Hopper/Ampere/Ada) and scaling linearly under TP/DP. NVIDIA shipped `CUDA_DISABLE_PERF_BOOST` in the 580 driver series (CUDA Toolkit 13.2) so the DVFS governor can drop idle SM clocks back to bare-idle.

Full background, per-architecture measurements, and the driver-level repro are in #27567.

Closes #27567

## Modifications

- New `disable_cuda_perf_boost: bool = False` field on `ServerArgs` (default off, so behavior is unchanged for users on older drivers, which silently ignore the env var anyway).
- New `--disable-cuda-perf-boost` CLI flag in `add_cli_args`.
- New `_handle_disable_cuda_perf_boost` handler in `ServerArgs.__post_init__`, matching the existing `_handle_prefill_delayer_env_compat` pattern. The handler fires for both CLI users (`prepare_server_args` -> `__post_init__`) and programmatic users (`Engine(...)` -> `ServerArgs(...).__post_init__`), with no launcher edits.
- `os.environ.setdefault("CUDA_DISABLE_PERF_BOOST", "1")` so an explicit user-set value (including `=0`) wins over the CLI flag.
- AMD/HIP path: logs a warning and skips the env-set, since `CUDA_DISABLE_PERF_BOOST` is an NVIDIA driver var and would be a silent no-op on ROCm otherwise. The flag is named `--disable-cuda-perf-boost` (rather than the more generic `--disable-gpu-perf-boost`) to make the NVIDIA scope explicit at the call site.
- Unit tests in `test/registered/unit/server_args/test_server_args.py` covering: default off (env unset), CLI flag parses and sets env, direct `field=True` sets env, pre-existing user value respected, AMD/HIP path skips env-set and emits the expected warning.

## Accuracy Tests

N/A — does not affect any model output path.

## Speed Tests and Profiling

Validated through vLLM serving Qwen2.5-7B (driver-level repro and per-GPU numbers in #27567):
- Warm-request p50/p95/p99 latency unchanged.
- One-time ~150 ms ramp on the first request after idle (DVFS step back up to boost).
- Idle power drops scale linearly per GPU under TP/DP.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27403288950](https://github.com/sgl-project/sglang/actions/runs/27403288950)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27403288741](https://github.com/sgl-project/sglang/actions/runs/27403288741)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->