### PR TITLE
[EPD][BugFix] Fix encode_with_global_cache_mooncake

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -1182,7 +1182,7 @@ class WaitingImageRDMARequest(WaitingImageRequest):
             self.embeddings_buffer = None
             self._buffer_from_pool = False
         self.recv_req.mm_inputs = mm_inputs
-        self.recv_req.input_ids = mm_inputs.input_ids
+        self.recv_req.input_ids = array("q", mm_inputs.input_ids)
         self.status = WaitingImageRequestStatus.SUCCESS
         self._cleanup_gpu_buffer()
         self.recv_socket.close()

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -1071,6 +1071,7 @@ class MMEncoder:
                     )
                 else:
                     mm_hashes = hashes
+                str_mm_hashes = [str(h) for h in mm_hashes]
 
             # All ranks: launch background task for cache check + VIT forward.
             # Do NOT use run_in_executor: get_feature_fn relies on a session
@@ -1082,7 +1083,7 @@ class MMEncoder:
                     # Step 1: Rank 0 checks cache, broadcast mask if TP > 1
                     if self.rank == 0:
                         exist_mask = await self.mm_global_cache.batch_is_exist(
-                            mm_hashes
+                            str_mm_hashes
                         )
                         mask_tensor = torch.tensor(
                             [1 if e else 0 for e in exist_mask],
@@ -1122,7 +1123,7 @@ class MMEncoder:
                     cached_slices = []
 
                     if self.rank == 0 and hit_indices:
-                        hit_hashes = [mm_hashes[i] for i in hit_indices]
+                        hit_hashes = [str_mm_hashes[i] for i in hit_indices]
                         hit_tokens = [
                             self.get_num_tokens(grid_thw[i], modality)
                             for i in hit_indices
@@ -1224,7 +1225,7 @@ class MMEncoder:
                         # Release cache refs after data is copied to GPU
                         if cached_slices:
                             loaded_hashes = [
-                                mm_hashes[idx]
+                                str_mm_hashes[idx]
                                 for idx in hit_indices
                                 if fallback_mask[idx].item() == 0
                             ]
@@ -1233,10 +1234,10 @@ class MMEncoder:
 
                         # Background insert: store newly computed embeddings into global cache.
                         # Includes both original misses and fallback-recomputed hits.
-                        all_new_hashes = [mm_hashes[i] for i in missing_indices]
+                        all_new_hashes = [str_mm_hashes[i] for i in missing_indices]
                         all_new_slices = list(new_slices)
                         if fallback_slices is not None:
-                            all_new_hashes += [mm_hashes[i] for i in fallback_indices]
+                            all_new_hashes += [str_mm_hashes[i] for i in fallback_indices]
                             all_new_slices += list(fallback_slices)
                         if all_new_hashes:
 

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -1210,9 +1210,11 @@ class MMEncoder:
                         # Move cached CPU slices to GPU and match model dtype
                         device = torch.device(f"cuda:{self.gpu_id}")
                         final_slices = [
-                            s.to(device=device, dtype=self._embedding_dtype)
-                            if s.device.type == "cpu"
-                            else s
+                            (
+                                s.to(device=device, dtype=self._embedding_dtype)
+                                if s.device.type == "cpu"
+                                else s
+                            )
                             for s in final_slices
                         ]
                         mm_embedding = torch.cat(final_slices, dim=0)
@@ -1237,7 +1239,9 @@ class MMEncoder:
                         all_new_hashes = [str_mm_hashes[i] for i in missing_indices]
                         all_new_slices = list(new_slices)
                         if fallback_slices is not None:
-                            all_new_hashes += [str_mm_hashes[i] for i in fallback_indices]
+                            all_new_hashes += [
+                                str_mm_hashes[i] for i in fallback_indices
+                            ]
                             all_new_slices += list(fallback_slices)
                         if all_new_hashes:
 

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -1116,12 +1116,11 @@ class MMEncoder:
                             grid_thw,
                             keep_on_gpu=True,
                         )
-                        if self.rank == 0:
-                            for i, idx in enumerate(missing_indices):
-                                final_slices[idx] = new_slices[i]
 
-                    # Step 3: Rank 0 prefetches cache-hit embeddings
-                    prefetch_status = torch.tensor([1], dtype=torch.int32)
+                    # Step 3: Rank 0 prefetches cache-hit embeddings and builds fallback_mask.
+                    fallback_mask = torch.zeros(num_items, dtype=torch.int32)
+                    cached_slices = []
+
                     if self.rank == 0 and hit_indices:
                         hit_hashes = [mm_hashes[i] for i in hit_indices]
                         hit_tokens = [
@@ -1140,46 +1139,81 @@ class MMEncoder:
                                     await asyncio.sleep(0.005)
 
                             await asyncio.wait_for(_wait_prefetch(), timeout=60.0)
+
                             cached_slices = self.mm_global_cache.get_embeddings(
                                 hit_hashes
                             )
                             for i, idx in enumerate(hit_indices):
-                                final_slices[idx] = cached_slices[i]
+                                if cached_slices[i] is None:
+                                    fallback_mask[idx] = 1
+                            num_partial_fail = int(fallback_mask.sum().item())
+                            if num_partial_fail > 0:
+                                logger.warning(
+                                    f"Req {req_id}: {num_partial_fail}/{len(hit_indices)} "
+                                    f"cache-hit items failed to load (pool full), "
+                                    f"falling back to ViT"
+                                )
                         except (asyncio.TimeoutError, Exception) as e:
                             logger.error(
                                 f"Prefetch failed for {req_id}: {e}. "
                                 f"Falling back to ViT for "
                                 f"{len(hit_indices)} hit items."
                             )
-                            prefetch_status[0] = 0
+                            for idx in hit_indices:
+                                fallback_mask[idx] = 1
 
-                    # Broadcast prefetch result if TP > 1
+                    # Step 4: Broadcast fallback_mask to all ranks so they stay in sync.
                     if self.server_args.tp_size > 1:
                         torch.distributed.broadcast(
-                            prefetch_status,
+                            fallback_mask,
                             src=0,
                             group=self.mm_global_cache.prefetch_tp_group,
                         )
 
-                    # Step 4: All ranks fallback VIT for failed prefetch
-                    # (runs in event loop to preserve session context)
+                    # Step 5: All ranks run ViT for items that need fallback recomputation.
+                    fallback_indices = [
+                        i for i in range(num_items) if fallback_mask[i].item() == 1
+                    ]
                     fallback_slices = None
-                    if prefetch_status.item() == 0 and hit_indices:
+                    if fallback_indices:
+                        logger.info(
+                            f"Req {req_id}: All ranks running ViT fallback "
+                            f"for {len(fallback_indices)} items."
+                        )
                         fallback_slices = self._encode_missing(
                             mm_feature,
                             mm_inputs,
-                            hit_indices,
+                            fallback_indices,
                             modality,
                             get_feature_fn,
                             grid_thw,
                             keep_on_gpu=True,
                         )
-                        if self.rank == 0:
+
+                    # Step 6: Rank 0 assembles final embedding.
+                    if self.rank == 0:
+                        for i, idx in enumerate(missing_indices):
+                            final_slices[idx] = new_slices[i]
+
+                        # Fill in successfully loaded cache-hit embeddings
+                        if cached_slices:
                             for i, idx in enumerate(hit_indices):
+                                if cached_slices[i] is not None:
+                                    final_slices[idx] = cached_slices[i]
+
+                        # Fill in ViT fallback results for failed items
+                        if fallback_slices is not None:
+                            for i, idx in enumerate(fallback_indices):
                                 final_slices[idx] = fallback_slices[i]
 
-                    # Step 5: Rank 0 assembles and stores result
-                    if self.rank == 0:
+                        # Move cached CPU slices to GPU and match model dtype
+                        device = torch.device(f"cuda:{self.gpu_id}")
+                        final_slices = [
+                            s.to(device=device, dtype=self._embedding_dtype)
+                            if s.device.type == "cpu"
+                            else s
+                            for s in final_slices
+                        ]
                         mm_embedding = torch.cat(final_slices, dim=0)
                         # Wait for any pending VIT / cat kernels to finish
                         # before publishing to /send: mooncake transfer_sync
@@ -1187,11 +1221,22 @@ class MMEncoder:
                         # and would otherwise race with in-flight kernels.
                         torch.cuda.current_stream(mm_embedding.device).synchronize()
 
-                        # Background insert new embeddings into cache
+                        # Release cache refs after data is copied to GPU
+                        if cached_slices:
+                            loaded_hashes = [
+                                mm_hashes[idx]
+                                for idx in hit_indices
+                                if fallback_mask[idx].item() == 0
+                            ]
+                            if loaded_hashes:
+                                self.mm_global_cache.release_embeddings(loaded_hashes)
+
+                        # Background insert: store newly computed embeddings into global cache.
+                        # Includes both original misses and fallback-recomputed hits.
                         all_new_hashes = [mm_hashes[i] for i in missing_indices]
                         all_new_slices = list(new_slices)
                         if fallback_slices is not None:
-                            all_new_hashes += [mm_hashes[i] for i in hit_indices]
+                            all_new_hashes += [mm_hashes[i] for i in fallback_indices]
                             all_new_slices += list(fallback_slices)
                         if all_new_hashes:
 


### PR DESCRIPTION
Fix encode_with_global_cache_mooncake prefetch fallback, CPU→GPU transfer, and input_ids type mismatch


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
PR #22587 (`[EPD] Optimize the Mooncake backend`) introduced `encode_with_global_cache_mooncake` and `WaitingImageRDMARequest` to support Mooncake RDMA-based embedding transfer. However, several issues exist in this code path:

1. **All-or-nothing prefetch fallback**: The function uses a scalar `prefetch_status` (0/1) to represent the entire batch's prefetch result. When any single cache-hit item fails to load (e.g., pool memory pressure), all cache-hit items are discarded and recomputed by ViT — even those that loaded successfully. This wastes GPU compute and increases latency.

2. **Missing `None` check on `get_embeddings()` return and CPU→GPU device mismatch**: `get_embeddings()` returns views into a pinned CPU memory pool and can return `None` for items that failed to load. The code does not handle either case — `None` entries crash `torch.cat()`, and mixing CPU cache tensors with GPU ViT tensors causes a device mismatch error.

3. **`WaitingImageRDMARequest.finalize()` missing `array("q", ...)` wrapper**: PR #25098 migrated `Req.origin_input_ids` from `List[int]` to `array.array('q')`. It updated the base class `WaitingImageRequest.finalize()`, but `WaitingImageRDMARequest` overrides `finalize()` with its own RDMA-specific implementation that was not updated. This causes a `TypeError` (`list + array.array`) when the scheduler concatenates `origin_input_ids + output_ids`.

   **Why only the Mooncake RDMA path is affected:**
   - `zmq_to_tokenizer` (E-only): `input_ids` is wrapped by `tokenizer_manager._create_tokenized_req()` — OK
   - `zmq_to_scheduler` (non-Mooncake): inherits base `WaitingImageRequest.finalize()` (updated by #25098) — OK
   - `grpc` (EPD full disagg): `WaitingImageRequestGrpc` inherits base `finalize()` — OK
   - **`mooncake` (RDMA)**: `WaitingImageRDMARequest.finalize()` overrides base — **missed by #25098, `TypeError`**

## Modifications

<!-- Detail the changes made in this pull request. -->
### `encode_server.py` — `encode_with_global_cache_mooncake`

Adapt the per-item fallback logic from `encode_with_global_cache` (as fixed in the `LRU_eviction` branch / PR #25954):

- Replace scalar `prefetch_status` with per-item `fallback_mask` tensor (`torch.zeros(num_items, dtype=torch.int32)`).
- After `get_embeddings()`, check each `cached_slices[i]`: mark `fallback_mask[idx] = 1` if `None` (partial load failure); on full exception, mark all hit items.
- Broadcast `fallback_mask` (instead of `prefetch_status`) to all TP ranks.
- Compute `fallback_indices` from `fallback_mask`; only these items run ViT fallback. Successfully loaded cache-hit embeddings are preserved.
- After `torch.cat`, use `fallback_indices` (not `hit_indices`) for background insert of recomputed embeddings.
- Add `s.to(device)` for CPU cache tensor slices before `torch.cat()` to ensure device consistency.

### `encode_receiver.py` — `WaitingImageRDMARequest.finalize()`

- Wrap `mm_inputs.input_ids` with `array("q", mm_inputs.input_ids)`, consistent with the base class `WaitingImageRequest.finalize()`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
End-to-end tests were run to ensure that requests could be output correctly.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27414310565](https://github.com/sgl-project/sglang/actions/runs/27414310565)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27414310336](https://github.com/sgl-project/sglang/actions/runs/27414310336)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->