### PR TITLE
[Spec] Centralize dummy verify-input capture; add `carries_draft_hidden_states`

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1067,12 +1067,12 @@ class Scheduler(
                 buffer_size,
                 hidden_size=(
                     model_config.spec_hidden_size
-                    if self.spec_algorithm.is_eagle()
+                    if self.spec_algorithm.carries_draft_hidden_states()
                     else 16  # minimal padding size for RDMA
                 ),
                 hidden_states_dtype=(
                     model_config.dtype
-                    if self.spec_algorithm.is_eagle()
+                    if self.spec_algorithm.carries_draft_hidden_states()
                     else torch.float32
                 ),
                 custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),
@@ -1120,14 +1120,12 @@ class Scheduler(
                 buffer_size,
                 hidden_size=(
                     model_config.spec_hidden_size
-                    if self.spec_algorithm.is_eagle()
-                    or self.spec_algorithm.is_standalone()
+                    if self.spec_algorithm.carries_draft_hidden_states()
                     else 16  # minimal padding size for RDMA
                 ),
                 hidden_states_dtype=(
                     model_config.dtype
-                    if self.spec_algorithm.is_eagle()
-                    or self.spec_algorithm.is_standalone()
+                    if self.spec_algorithm.carries_draft_hidden_states()
                     else torch.float32
                 ),
                 custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -191,7 +191,10 @@ from sglang.srt.server_args import (
     get_global_server_args,
     set_global_server_args_for_scheduler,
 )
-from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_info import (
+    SpeculativeAlgorithm,
+    create_capture_spec_info,
+)
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 from sglang.srt.state_capturer.indexer_topk import (
     create_indexer_capturer,
@@ -2683,62 +2686,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             global_dp_buffer_len = None
             global_num_tokens_cpu = None
 
-        def get_spec_info():
-            spec_info = None
-            if self.spec_algorithm.is_eagle() or self.spec_algorithm.is_standalone():
-                from sglang.srt.speculative.eagle_info import EagleVerifyInput
-
-                if self.is_draft_worker:
-                    raise RuntimeError("This should not happen.")
-                else:
-                    spec_info = EagleVerifyInput(
-                        draft_token=None,
-                        custom_mask=buffers.custom_mask,
-                        positions=None,
-                        retrieve_index=None,
-                        retrieve_next_token=None,
-                        retrieve_next_sibling=None,
-                        retrieve_cum_len=None,
-                        spec_steps=self.server_args.speculative_num_steps,
-                        topk=self.server_args.speculative_eagle_topk,
-                        draft_token_num=self.server_args.speculative_num_draft_tokens,
-                        capture_hidden_mode=CaptureHiddenMode.FULL,
-                        seq_lens_sum=None,
-                        seq_lens_cpu=None,
-                    )
-            elif self.spec_algorithm.is_dflash():
-                from sglang.srt.speculative.dflash_info import DFlashVerifyInput
-
-                # Dummy warmup only needs shape metadata; avoid forcing custom-mask mode.
-                spec_info = DFlashVerifyInput(
-                    draft_token=None,
-                    positions=None,
-                    draft_token_num=self.server_args.speculative_num_draft_tokens,
-                    custom_mask=None,
-                    capture_hidden_mode=(
-                        CaptureHiddenMode.NULL
-                        if self.is_draft_worker
-                        else CaptureHiddenMode.FULL
-                    ),
-                )
-
-            elif self.spec_algorithm.is_ngram():
-                from sglang.srt.speculative.ngram_info import NgramVerifyInput
-
-                spec_info = NgramVerifyInput(
-                    draft_token=None,
-                    custom_mask=buffers.custom_mask,
-                    positions=None,
-                    retrieve_index=None,
-                    retrieve_next_token=None,
-                    retrieve_next_sibling=None,
-                    draft_token_num=num_tokens_per_bs,
-                )
-                spec_info.capture_hidden_mode = CaptureHiddenMode.NULL
-
-            return spec_info
-
-        spec_info = get_spec_info()
+        spec_info = create_capture_spec_info(
+            self.spec_algorithm,
+            self.server_args,
+            buffers.custom_mask,
+            num_tokens_per_bs,
+            self.is_draft_worker,
+        )
         if capture_hidden_mode != CaptureHiddenMode.FULL:
             capture_hidden_mode = (
                 spec_info.capture_hidden_mode if spec_info else CaptureHiddenMode.NULL

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -193,7 +193,7 @@ from sglang.srt.server_args import (
 )
 from sglang.srt.speculative.spec_info import (
     SpeculativeAlgorithm,
-    create_capture_spec_info,
+    create_dummy_verify_input,
 )
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 from sglang.srt.state_capturer.indexer_topk import (
@@ -2686,7 +2686,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             global_dp_buffer_len = None
             global_num_tokens_cpu = None
 
-        spec_info = create_capture_spec_info(
+        spec_info = create_dummy_verify_input(
             self.spec_algorithm,
             self.server_args,
             buffers.custom_mask,

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -273,7 +273,7 @@ class SpecInput(ABC):
         return global_num_tokens, global_num_tokens_for_logprob
 
 
-def create_capture_spec_info(
+def create_dummy_verify_input(
     spec_algorithm: SpeculativeAlgorithm,
     server_args: ServerArgs,
     custom_mask: torch.Tensor,

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -124,6 +124,15 @@ class SpeculativeAlgorithm(Enum):
         per-topk page rounding; see get_alloc_len_per_decode."""
         return not self.is_ngram()
 
+    def carries_draft_hidden_states(self) -> bool:
+        """Whether the prefill->decode disaggregation transfer carries target
+        hidden states for the draft. Only EAGLE-family drafts read transferred
+        hidden states; STANDALONE runs a vanilla LLM draft that ignores them
+        (build_disagg_draft_input returns None and prefill never collects them),
+        so its metadata buffer needs only minimal RDMA padding. Sizes the disagg
+        MetadataBuffers hidden-states buffer."""
+        return self.is_eagle()
+
     def create_future_map(
         self,
         device: torch.device,
@@ -266,3 +275,68 @@ class SpecInput(ABC):
             x * c2 for x in batch.global_num_tokens_for_logprob
         ]
         return global_num_tokens, global_num_tokens_for_logprob
+
+
+def create_capture_spec_info(
+    spec_algorithm: SpeculativeAlgorithm,
+    server_args: ServerArgs,
+    custom_mask: torch.Tensor,
+    num_tokens_per_bs: int,
+    is_draft_worker: bool,
+) -> Optional[SpecInput]:
+    """Build the shape-only dummy verify ``SpecInput`` used during CUDA-graph
+    capture. Centralizes the per-algorithm dispatch so the model runner stays
+    algorithm-agnostic (mirrors ``SpeculativeAlgorithm.create_worker``)."""
+    from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+    spec_info = None
+    if spec_algorithm.is_eagle() or spec_algorithm.is_standalone():
+        from sglang.srt.speculative.eagle_info import EagleVerifyInput
+
+        if is_draft_worker:
+            raise RuntimeError("This should not happen.")
+        else:
+            spec_info = EagleVerifyInput(
+                draft_token=None,
+                custom_mask=custom_mask,
+                positions=None,
+                retrieve_index=None,
+                retrieve_next_token=None,
+                retrieve_next_sibling=None,
+                retrieve_cum_len=None,
+                spec_steps=server_args.speculative_num_steps,
+                topk=server_args.speculative_eagle_topk,
+                draft_token_num=server_args.speculative_num_draft_tokens,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+                seq_lens_sum=None,
+                seq_lens_cpu=None,
+            )
+    elif spec_algorithm.is_dflash():
+        from sglang.srt.speculative.dflash_info import DFlashVerifyInput
+
+        # Dummy warmup only needs shape metadata; avoid forcing custom-mask mode.
+        spec_info = DFlashVerifyInput(
+            draft_token=None,
+            positions=None,
+            draft_token_num=server_args.speculative_num_draft_tokens,
+            custom_mask=None,
+            capture_hidden_mode=(
+                CaptureHiddenMode.NULL if is_draft_worker else CaptureHiddenMode.FULL
+            ),
+        )
+
+    elif spec_algorithm.is_ngram():
+        from sglang.srt.speculative.ngram_info import NgramVerifyInput
+
+        spec_info = NgramVerifyInput(
+            draft_token=None,
+            custom_mask=custom_mask,
+            positions=None,
+            retrieve_index=None,
+            retrieve_next_token=None,
+            retrieve_next_sibling=None,
+            draft_token_num=num_tokens_per_bs,
+        )
+        spec_info.capture_hidden_mode = CaptureHiddenMode.NULL
+
+    return spec_info

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -125,12 +125,8 @@ class SpeculativeAlgorithm(Enum):
         return not self.is_ngram()
 
     def carries_draft_hidden_states(self) -> bool:
-        """Whether the prefill->decode disaggregation transfer carries target
-        hidden states for the draft. Only EAGLE-family drafts read transferred
-        hidden states; STANDALONE runs a vanilla LLM draft that ignores them
-        (build_disagg_draft_input returns None and prefill never collects them),
-        so its metadata buffer needs only minimal RDMA padding. Sizes the disagg
-        MetadataBuffers hidden-states buffer."""
+        """Whether the disagg prefill->decode transfer carries draft hidden
+        states (EAGLE-family only; STANDALONE's vanilla draft ignores them)."""
         return self.is_eagle()
 
     def create_future_map(
@@ -284,9 +280,7 @@ def create_capture_spec_info(
     num_tokens_per_bs: int,
     is_draft_worker: bool,
 ) -> Optional[SpecInput]:
-    """Build the shape-only dummy verify ``SpecInput`` used during CUDA-graph
-    capture. Centralizes the per-algorithm dispatch so the model runner stays
-    algorithm-agnostic (mirrors ``SpeculativeAlgorithm.create_worker``)."""
+    """Dummy verify ``SpecInput`` for CUDA-graph capture (per-algorithm dispatch)."""
     from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 
     spec_info = None


### PR DESCRIPTION
- Factor the CUDA-graph dummy verify-input construction into `create_dummy_verify_input`, so `ModelRunner` no longer hardcodes the per-algorithm `EagleVerifyInput` / `DFlashVerifyInput` / `NgramVerifyInput` classes for capture warmup. (Draft-side capture stays inline in the EAGLE draft runners — it builds a single hardcoded class, no per-algorithm dispatch to factor.)
- Add `SpeculativeAlgorithm.carries_draft_hidden_states()` and use it to size the disaggregation `MetadataBuffers` hidden-states buffer. This also makes the prefill and decode buffers consistent for `STANDALONE`: its vanilla-LLM draft never reads transferred hidden states (prefill never collects them, `build_disagg_draft_input` returns `None`), so it only needs the minimal RDMA padding the decode side already used.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27442738616](https://github.com/sgl-project/sglang/actions/runs/27442738616)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27442738458](https://github.com/sgl-project/sglang/actions/runs/27442738458)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
