### PR TITLE
Clamp default fused-MoE Triton configs to the device shared memory limit (SM120/SM121)

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -143,6 +143,83 @@ def get_moe_configs(
     return None
 
 
+@functools.lru_cache(maxsize=1)
+def _get_max_shared_mem_bytes() -> Optional[int]:
+    """Per-block shared memory limit of the current device, or None if
+    it cannot be determined (non-CUDA platforms, mocked drivers, ...)."""
+    try:
+        index = torch.cuda.current_device()
+        return triton.runtime.driver.active.utils.get_device_properties(index)[
+            "max_shared_mem"
+        ]
+    except Exception:
+        return None
+
+
+def _estimate_fused_moe_smem_bytes(config: Dict[str, int], dtype: Optional[str]) -> int:
+    """Estimate the shared memory the fused-MoE Triton kernel needs for a
+    config: (num_stages - 1) double-buffered (BLOCK_M x BLOCK_K) A-tiles and
+    (BLOCK_K x BLOCK_N) B-tiles. Matches the requirement Triton reports in
+    OutOfResources (e.g. 147456 = (4-1) * (128 + 256) * 128 for fp8).
+    """
+    elem_bytes = 1 if dtype in ("fp8_w8a8", "int8_w8a8", "int8_w8a16") else 2
+    num_stages = config.get("num_stages", 2)
+    return (
+        max(num_stages - 1, 1)
+        * config["BLOCK_SIZE_K"]
+        * (config["BLOCK_SIZE_M"] + config["BLOCK_SIZE_N"])
+        * elem_bytes
+    )
+
+
+def clamp_config_to_shared_mem(
+    config: Dict[str, int],
+    dtype: Optional[str],
+    block_shape: Optional[List[int]] = None,
+) -> Dict[str, int]:
+    """Degrade a default fused-MoE config until it fits the device's
+    per-block shared memory limit (issue #28019).
+
+    Default configs are tuned for >=160KB-smem datacenter parts; SM120/SM121
+    (RTX 5090 / RTX PRO 6000 / GB10) expose only ~99KB per block, so e.g. the
+    fp8_w8a8 prefill default (128x256x128, 4 stages -> 147456B) aborts the
+    first forward pass with triton OutOfResources. Degrade num_stages first
+    (cheapest perf-wise), then halve BLOCK_SIZE_N / BLOCK_SIZE_K. For
+    block-quantized weights (block_shape set), BLOCK_SIZE_N/K are tied to the
+    quant block geometry, so only num_stages is degraded.
+    """
+    limit = _get_max_shared_mem_bytes()
+    if limit is None or _estimate_fused_moe_smem_bytes(config, dtype) <= limit:
+        return config
+    original = dict(config)
+    config = dict(config)
+    while (
+        _estimate_fused_moe_smem_bytes(config, dtype) > limit
+        and config.get("num_stages", 2) > 2
+    ):
+        config["num_stages"] -= 1
+    if block_shape is None:
+        while (
+            _estimate_fused_moe_smem_bytes(config, dtype) > limit
+            and config["BLOCK_SIZE_N"] > 64
+        ):
+            config["BLOCK_SIZE_N"] //= 2
+        while (
+            _estimate_fused_moe_smem_bytes(config, dtype) > limit
+            and config["BLOCK_SIZE_K"] > 64
+        ):
+            config["BLOCK_SIZE_K"] //= 2
+    logger.warning(
+        "Default fused-MoE Triton config %s needs more shared memory than the "
+        "device provides (%d bytes); degraded to %s. Consider contributing a "
+        "tuned config for this device (see benchmark/kernels/fused_moe_triton).",
+        original,
+        limit,
+        config,
+    )
+    return config
+
+
 def get_default_config(
     M: int,
     E: int,
@@ -246,9 +323,15 @@ def try_get_optimal_moe_config(
             # optimal config
             config = configs[min(configs.keys(), key=lambda x: abs(x - M))]
         else:
-            # Else use the default config
-            config = get_default_config(
-                M, E, N, w1_shape[2], top_k, dtype, is_marlin, block_shape
+            # Else use the default config, degraded if it would exceed the
+            # device's shared memory limit (issue #28019; tuned JSON configs
+            # are per-device and thus already fit).
+            config = clamp_config_to_shared_mem(
+                get_default_config(
+                    M, E, N, w1_shape[2], top_k, dtype, is_marlin, block_shape
+                ),
+                dtype,
+                block_shape,
             )
         if return_down_config:
             down_configs = get_moe_configs(

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -145,15 +145,33 @@ def get_moe_configs(
 
 @functools.lru_cache(maxsize=1)
 def _get_max_shared_mem_bytes() -> Optional[int]:
-    """Per-block shared memory limit of the current device, or None if
-    it cannot be determined (non-CUDA platforms, mocked drivers, ...)."""
+    """Per-block (opt-in) shared memory limit of the current device, or None
+    if it cannot be determined (non-CUDA platforms, mocked drivers, ...)."""
     try:
         index = torch.cuda.current_device()
+        props = torch.cuda.get_device_properties(index)
+        # Stable public API first (cudaDeviceProp.sharedMemPerBlockOptin).
+        opt_in_bytes = getattr(props, "shared_memory_per_block_optin", None)
+        if opt_in_bytes:
+            return opt_in_bytes
+        # Fallback for torch builds without that field: Triton's internal
+        # driver API (subject to change across Triton versions, hence the
+        # broad except below).
         return triton.runtime.driver.active.utils.get_device_properties(index)[
             "max_shared_mem"
         ]
     except Exception:
         return None
+
+
+# Per-tile element sizes (activation A-tile, weight B-tile) by config dtype
+# string. Mixed-precision dtypes have differently-sized operands.
+_SMEM_ELEM_BYTES: Dict[Optional[str], Tuple[float, float]] = {
+    "fp8_w8a8": (1, 1),
+    "int8_w8a8": (1, 1),
+    "int8_w8a16": (2, 1),
+    "int4_w4a16": (2, 0.5),
+}
 
 
 def _estimate_fused_moe_smem_bytes(config: Dict[str, int], dtype: Optional[str]) -> int:
@@ -162,13 +180,12 @@ def _estimate_fused_moe_smem_bytes(config: Dict[str, int], dtype: Optional[str])
     (BLOCK_K x BLOCK_N) B-tiles. Matches the requirement Triton reports in
     OutOfResources (e.g. 147456 = (4-1) * (128 + 256) * 128 for fp8).
     """
-    elem_bytes = 1 if dtype in ("fp8_w8a8", "int8_w8a8", "int8_w8a16") else 2
+    a_bytes, b_bytes = _SMEM_ELEM_BYTES.get(dtype, (2, 2))
     num_stages = config.get("num_stages", 2)
-    return (
+    return int(
         max(num_stages - 1, 1)
         * config["BLOCK_SIZE_K"]
-        * (config["BLOCK_SIZE_M"] + config["BLOCK_SIZE_N"])
-        * elem_bytes
+        * (config["BLOCK_SIZE_M"] * a_bytes + config["BLOCK_SIZE_N"] * b_bytes)
     )
 
 

--- a/test/registered/moe/test_fused_moe_smem_clamp.py
+++ b/test/registered/moe/test_fused_moe_smem_clamp.py
@@ -1,0 +1,100 @@
+"""Regression tests for issue #28019.
+
+The default fused-MoE Triton configs are tuned for >=160KB-smem datacenter
+GPUs; SM120/SM121 (RTX 5090 / RTX PRO 6000 / GB10) expose only ~99KB
+(101376 B) per block, so the fp8_w8a8 prefill default (128x256x128, 4
+stages -> 147456 B) aborted the first forward pass with
+``triton OutOfResources: shared memory, Required: 147456, Hardware limit:
+101376``. ``clamp_config_to_shared_mem`` degrades such configs until they
+fit. Pure config logic; no GPU kernels invoked (the limit is mocked).
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config import (
+    _estimate_fused_moe_smem_bytes,
+    clamp_config_to_shared_mem,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+
+SM12X_LIMIT = 101376  # bytes/block on SM120 and SM121
+
+# The exact config from the #28019 crash (fp8_w8a8, block_shape=None, M > E).
+FP8_PREFILL_DEFAULT = {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 8,
+    "num_stages": 4,
+}
+
+_LIMIT_PATH = (
+    "sglang.srt.layers.moe.moe_runner.triton_utils."
+    "fused_moe_triton_config._get_max_shared_mem_bytes"
+)
+
+
+class TestFusedMoeSmemClamp(CustomTestCase):
+    def test_estimate_matches_triton_reported_requirement(self):
+        # triton reported exactly 147456 bytes for this config in #28019.
+        self.assertEqual(
+            _estimate_fused_moe_smem_bytes(FP8_PREFILL_DEFAULT, "fp8_w8a8"), 147456
+        )
+
+    def test_crash_config_clamped_under_sm12x_limit(self):
+        with patch(_LIMIT_PATH, return_value=SM12X_LIMIT):
+            clamped = clamp_config_to_shared_mem(FP8_PREFILL_DEFAULT, "fp8_w8a8")
+        self.assertLessEqual(
+            _estimate_fused_moe_smem_bytes(clamped, "fp8_w8a8"), SM12X_LIMIT
+        )
+        # num_stages is degraded first (cheapest perf-wise): 4 stages over
+        # the limit -> 3 stages = 2 * 384 * 128 = 98304 <= 101376 fits.
+        self.assertEqual(clamped["num_stages"], 3)
+        self.assertEqual(clamped["BLOCK_SIZE_N"], 256)
+
+    def test_fitting_config_untouched(self):
+        small = {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        }
+        with patch(_LIMIT_PATH, return_value=SM12X_LIMIT):
+            self.assertIs(clamp_config_to_shared_mem(small, None), small)
+
+    def test_unknown_limit_is_a_noop(self):
+        with patch(_LIMIT_PATH, return_value=None):
+            self.assertIs(
+                clamp_config_to_shared_mem(FP8_PREFILL_DEFAULT, "fp8_w8a8"),
+                FP8_PREFILL_DEFAULT,
+            )
+
+    def test_block_shape_only_degrades_stages(self):
+        config = {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 32,
+            "num_warps": 4,
+            "num_stages": 6,
+        }
+        with patch(_LIMIT_PATH, return_value=49152):
+            clamped = clamp_config_to_shared_mem(config, "fp8_w8a8", [128, 128])
+        # Quant-block geometry must be preserved.
+        self.assertEqual(clamped["BLOCK_SIZE_N"], 128)
+        self.assertEqual(clamped["BLOCK_SIZE_K"], 128)
+        self.assertEqual(clamped["num_stages"], 3)
+
+    def test_tiny_limit_degrades_blocks_too(self):
+        with patch(_LIMIT_PATH, return_value=24576):
+            clamped = clamp_config_to_shared_mem(FP8_PREFILL_DEFAULT, "fp8_w8a8")
+        self.assertLessEqual(_estimate_fused_moe_smem_bytes(clamped, "fp8_w8a8"), 24576)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_fused_moe_smem_clamp.py
+++ b/test/registered/moe/test_fused_moe_smem_clamp.py
@@ -95,6 +95,35 @@ class TestFusedMoeSmemClamp(CustomTestCase):
             clamped = clamp_config_to_shared_mem(FP8_PREFILL_DEFAULT, "fp8_w8a8")
         self.assertLessEqual(_estimate_fused_moe_smem_bytes(clamped, "fp8_w8a8"), 24576)
 
+    def test_mixed_precision_w8a16_byte_sizes(self):
+        # int8_w8a16: 2-byte activations (A-tile), 1-byte weights (B-tile).
+        config = {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 256,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 32,
+            "num_warps": 8,
+            "num_stages": 4,
+        }
+        # (4-1) * 128 * (128*2 + 256*1) = 3 * 128 * 512 = 196608
+        self.assertEqual(_estimate_fused_moe_smem_bytes(config, "int8_w8a16"), 196608)
+        with patch(_LIMIT_PATH, return_value=SM12X_LIMIT):
+            clamped = clamp_config_to_shared_mem(config, "int8_w8a16")
+        self.assertLessEqual(
+            _estimate_fused_moe_smem_bytes(clamped, "int8_w8a16"), SM12X_LIMIT
+        )
+
+    def test_w4a16_half_byte_weights(self):
+        # int4_w4a16: 2-byte activations, 0.5-byte weights.
+        config = {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "num_stages": 3,
+        }
+        # (3-1) * 128 * (64*2 + 128*0.5) = 2 * 128 * 192 = 49152
+        self.assertEqual(_estimate_fused_moe_smem_bytes(config, "int4_w4a16"), 49152)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #28019. `RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic` crashes on GB10/SM121 (and any SM120/SM121 part) during the scheduler's first forward pass:

```
triton.runtime.errors.OutOfResources: shared memory, Required: 147456, Hardware limit: 101376
```

The default fused-MoE Triton configs assume ≥160KB-smem datacenter GPUs. The fp8_w8a8 prefill default (`BLOCK 128x256x128, num_warps=8, num_stages=4`) needs `(4-1) × (128+256) × 128 × 1B = 147456` bytes — over the ~99KB (101376B) per-block limit shared by SM120 and SM121. Whenever no tuned JSON exists for the device (none do for Gemma-4 MoE shapes on these archs), the default is selected and the first forward aborts. There is no smem-aware fallback anywhere in `try_get_optimal_moe_config`.

## Modifications

`fused_moe_triton_config.py`:
- `_get_max_shared_mem_bytes()` — cached query of `triton.runtime.driver.active.utils.get_device_properties(...)["max_shared_mem"]` (same mechanism as `srt/layers/attention/fla/utils.py`); returns None on non-CUDA/mocked platforms (clamp becomes a no-op).
- `_estimate_fused_moe_smem_bytes()` — `(num_stages-1)` double-buffered A/B tiles; matches the requirement Triton reports byte-for-byte (147456 for the crash config).
- `clamp_config_to_shared_mem()` — degrades `num_stages` first (cheapest perf-wise), then halves `BLOCK_SIZE_N`/`BLOCK_SIZE_K`; block-quantized configs (`block_shape` set) only degrade `num_stages` since block geometry is tied to the quant layout. Logs a warning with a pointer to the tuning benchmark.
- Wired into the **default-config path only** of `try_get_optimal_moe_config` — tuned JSON configs are per-device and already fit.

## Verification (RTX PRO 6000 Blackwell, SM120 — same 101376B limit as the reporter's GB10)

1. **Exact repro**: launching the fused-MoE Triton kernel with the pre-fix 4-stage default reproduces the reported error byte-for-byte (`Required: 147456, Hardware limit: 101376`).
2. **Fix**: the clamp degrades it to `num_stages=3` (98304B ≤ 101376) — the kernel launches and completes. Minimal perf impact (stage count only; block shape preserved).
3. **End-to-end selection**: `try_get_optimal_moe_config` on a shape with no tuned JSON now returns the degraded config with a warning, instead of handing the crash config to the kernel.

## Checklist

- [x] Format your code: `pre-commit run` passes on both files
- [x] Add unit tests: `test/registered/moe/test_fused_moe_smem_clamp.py` — 6 tests (estimate formula matches Triton's reported 147456; crash config clamped under the SM12x limit via stages-first; fitting/no-limit no-ops; block-shape geometry preservation; tiny-limit block degradation):

```
PYTHONPATH=python .venv/bin/python -m pytest test/registered/moe/test_fused_moe_smem_clamp.py -q
6 passed
```

AI assistance disclosure: prepared with AI assistance (Claude); reviewed and validated on real SM120 hardware by the submitter.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27407557666](https://github.com/sgl-project/sglang/actions/runs/27407557666)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27407557552](https://github.com/sgl-project/sglang/actions/runs/27407557552)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->