### PR TITLE
fix(pd): disable overlap for spec+grammar in disagg decode loop

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1750,6 +1750,10 @@ class SchedulerDisaggregationDecodeMixin:
         self.result_queue = deque()
         self.last_batch: Optional[ScheduleBatch] = None
 
+        def pop_and_process():
+            tmp_batch, tmp_result = self.result_queue.popleft()
+            self.process_batch_result(tmp_batch, tmp_result)
+
         while True:
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
@@ -1765,6 +1769,11 @@ class SchedulerDisaggregationDecodeMixin:
             # Get the next batch to run
             batch = self.get_next_disagg_decode_batch_to_run()
             self.cur_batch = batch
+            # overlap + spec + grammar is unsupported (would desync DP ranks).
+            disable_overlap_for_batch = self.is_disable_overlap_for_batch(batch)
+
+            if disable_overlap_for_batch and self.last_batch:
+                pop_and_process()
 
             # Launch the current batch
             if batch:
@@ -1775,8 +1784,8 @@ class SchedulerDisaggregationDecodeMixin:
 
             # Process the last batch
             if self.last_batch:
-                tmp_batch, tmp_result = self.result_queue.popleft()
-                self.process_batch_result(tmp_batch, tmp_result)
+                if not disable_overlap_for_batch:
+                    pop_and_process()
             elif batch is None:
                 self.on_idle()
 

--- a/test/registered/disaggregation/test_disaggregation_basic.py
+++ b/test/registered/disaggregation/test_disaggregation_basic.py
@@ -10,6 +10,7 @@ import requests
 from transformers import AutoTokenizer
 
 from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
 from sglang.test.kits.pause_generation_kit import PauseResumeInPlaceMixin
 from sglang.test.run_eval import run_eval
 from sglang.test.server_fixtures.disaggregation_fixture import (
@@ -21,7 +22,7 @@ from sglang.test.test_utils import (
     DEFAULT_TARGET_MODEL_EAGLE3,
 )
 
-register_cuda_ci(est_time=509, stage="base-b", runner_config="2-gpu-large")
+register_cuda_ci(est_time=560, stage="base-b", runner_config="2-gpu-large")
 
 
 class TestDisaggregationAccuracy(PauseResumeInPlaceMixin, PDDisaggregationServerBase):
@@ -215,7 +216,7 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
                 raise e from health_check_error
 
 
-class TestDisaggregationMooncakeSpec(PDDisaggregationServerBase):
+class TestDisaggregationMooncakeSpec(JSONConstrainedMixin, PDDisaggregationServerBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
# Summary

In PD-disaggregation decode mode, event_loop_overlap_disagg_decode never applied the overlap + spec + grammar guard that the non-disaggregation event_loop_overlap has via is_disable_overlap_for_batch (the need_grammar_sync branch, added in #13425). This loop unconditionally overlapped every batch.

## Root cause

The guard is gated on batch.is_spec_v2. Previously EAGLE/MTP ran on the spec V1 worker, so is_spec_v2 was False and this code path was never reached — the bug stayed dormant.

After #25464 (Deprecate Spec V1) and #27607 (remove V1 worker), EAGLE/MTP now always run on spec V2. Grammar tokens are accepted through the spec-V2 path (_apply_decode_grammar, accepting a list of speculated tokens). Because the disagg decode loop lacks the guard, a grammar rejection that triggers an abort makes one DP rank diverge under overlap (it issues a different number of forward/collective ops than its peers). That rank never returns to the top of the loop, so the remaining DP ranks deadlock in the per-iteration request broadcast (_broadcast_reqs_across_ranks → broadcast_pyobj, gloo). The whole engine hangs; /health stops responding and the pod is killed by the liveness probe.

## Trigger conditions

disaggregation_mode=decode + EAGLE/MTP (spec V2) + grammar/constrained decoding (xgrammar) + DP attention. Other combinations don't reach the diverging path.

## Fix

Apply is_disable_overlap_for_batch in event_loop_overlap_disagg_decode, mirroring event_loop_overlap: when spec + grammar is active, process the previous batch before launching the current one so all DP ranks make the same overlap decision and stay in lockstep.

---


CC @hnyls2002 @ShangmingCai 













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27441929435](https://github.com/sgl-project/sglang/actions/runs/27441929435)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27441929257](https://github.com/sgl-project/sglang/actions/runs/27441929257)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->