### PR TITLE
[AMD] Keep basic sanity fwd occupancy threshold

### DIFF
--- a/test/registered/core/test_basic_sanity.py
+++ b/test/registered/core/test_basic_sanity.py
@@ -17,6 +17,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    is_in_amd_ci,
     popen_launch_server,
 )
 
@@ -36,7 +37,7 @@ class TestBasicSanity(
     # 5090 + Llama-3.1-8B single-batch decode with overlap scheduler +
     # cuda graph measured ~99 median in CI; async-assert probes are off in
     # base-a, so the threshold can sit right under the measured median.
-    fwd_occupancy_threshold = 99.0
+    fwd_occupancy_threshold = 97.0 if is_in_amd_ci() else 99.0
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Summary
- Keep the raised fwd occupancy threshold for CUDA/other backends.
- Preserve AMD's previous `97.0` threshold for `test_basic_sanity.py`, matching current MI325 measurements.

## Test plan
- Not run locally; GPU CI coverage required.


Made with [Cursor](https://cursor.com)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27409529663](https://github.com/sgl-project/sglang/actions/runs/27409529663)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27409529536](https://github.com/sgl-project/sglang/actions/runs/27409529536)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->