### PR TITLE
Disable dsr1 prefill cudagraphs by default

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1009,6 +1009,9 @@ class ServerArgs:
         # deterministic backend is set before auto-detection fills it in.
         self._handle_deterministic_inference()
         self._handle_attention_backend_compatibility()
+        # Must run after the attention backend is resolved so the trtllm_mla
+        # default (auto-selected for DeepseekV3ForCausalLM on sm100) is visible.
+        self._disable_prefill_cuda_graph_for_deepseek_trtllm_mla()
         self._handle_mamba_backend()
         self._handle_linear_attn_backend()
         self._handle_kv4_compatibility()
@@ -1545,6 +1548,34 @@ class ServerArgs:
                 )
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
                 return
+
+    def _disable_prefill_cuda_graph_for_deepseek_trtllm_mla(self):
+        """Disable prefill CUDA graph for dsr1 by default when using the trtllm_mla
+        attention backend. Under any captured prefill CUDA graph (tc_piecewise or
+        breakable) trtllm_mla falls back to FlashAttention for prefill and regresses
+        performance, so disable whichever prefill graph backend is in effect.
+        """
+
+        if (Phase.PREFILL, "backend") in self._cuda_graph_config_locked:
+            return
+        if self.cuda_graph_config.prefill.backend == Backend.DISABLED:
+            return
+        if (
+            "DeepseekV3ForCausalLM"
+            not in self.get_model_config().hf_config.architectures
+        ):
+            return
+        prefill_attention_backend, _ = self.get_attention_backends()
+        if prefill_attention_backend != "trtllm_mla":
+            return
+        logger.warning(
+            "Disabling prefill CUDA graph (%s) by default for the DeepSeek-V3 arch on "
+            "the trtllm_mla attention backend (a captured prefill graph forces a "
+            "FlashAttention fallback that regresses prefill). Set the prefill cuda graph "
+            "backend explicitly (e.g. --cuda-graph-backend-prefill tc_piecewise) to override.",
+            self.cuda_graph_config.prefill.backend,
+        )
+        self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
     def _validate_cuda_graph_config(self):
         if self.cuda_graph_config is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DSR1 + trtllm_mla attention backend fallbacks to FlashAttention under prefill cudagraphs, which regresses performance a lot.
Disable it by default.

Regression at 1k1k conc=64 is ~13% TPOT. Full results of PCG off
```
============ Serving Benchmark Result ============
Successful requests:                     640       
Benchmark duration (s):                  209.60    
Total input tokens:                      590227    
Total generated tokens:                  589961    
Request throughput (req/s):              3.05      
Output token throughput (tok/s):         2814.72   
Total Token throughput (tok/s):          5630.71   
---------------Time to First Token----------------
Mean TTFT (ms):                          654.26    
Median TTFT (ms):                        524.50    
P90 TTFT (ms):                           1030.20   
P99 TTFT (ms):                           2158.66   
P99.9 TTFT (ms):                         2160.71   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.46     
Median TPOT (ms):                        21.65     
P90 TPOT (ms):                           22.89     
P99 TPOT (ms):                           23.47     
P99.9 TPOT (ms):                         23.62     
---------------Inter-token Latency----------------
Mean ITL (ms):                           634.52    
Median ITL (ms):                         569.32    
P90 ITL (ms):                            788.06    
P99 ITL (ms):                            994.26    
P99.9 ITL (ms):                          1150.51   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          20428.53  
Median E2EL (ms):                        20580.11  
P90 E2EL (ms):                           22634.90  
P99 E2EL (ms):                           23986.83  
P99.9 E2EL (ms):                         24347.97  
==================================================
```

PCG on
```
============ Serving Benchmark Result ============
Successful requests:                     640       
Benchmark duration (s):                  238.59    
Total input tokens:                      590227    
Total generated tokens:                  589961    
Request throughput (req/s):              2.68      
Output token throughput (tok/s):         2472.71   
Total Token throughput (tok/s):          4946.53   
---------------Time to First Token----------------
Mean TTFT (ms):                          766.11    
Median TTFT (ms):                        602.10    
P90 TTFT (ms):                           1356.78   
P99 TTFT (ms):                           2642.74   
P99.9 TTFT (ms):                         2644.19   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.49     
Median TPOT (ms):                        24.49     
P90 TPOT (ms):                           27.95     
P99 TPOT (ms):                           29.94     
P99.9 TPOT (ms):                         30.33     
---------------Inter-token Latency----------------
Mean ITL (ms):                           724.03    
Median ITL (ms):                         570.25    
P90 ITL (ms):                            1130.24   
P99 ITL (ms):                            1612.48   
P99.9 ITL (ms):                          1793.82   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          23329.72  
Median E2EL (ms):                        23283.00  
P90 E2EL (ms):                           26920.38  
P99 E2EL (ms):                           30180.09  
P99.9 E2EL (ms):                         31263.80  
==================================================
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27413427468](https://github.com/sgl-project/sglang/actions/runs/27413427468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27413427384](https://github.com/sgl-project/sglang/actions/runs/27413427384)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->