### PR TITLE
[DSV4][Perf] Use unflattened DeepGEMM next-n layout on SM100

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -44,6 +44,7 @@ from sglang.srt.layers.attention.dsv4.metadata import (
     PagedIndexerMetadata,
     copy_metadata,
     maybe_copy_inplace,
+    use_deep_gemm_fp8_indexer,
 )
 from sglang.srt.layers.attention.dsv4.metadata_kernel import (
     init_compression_metadata as _init_compression_metadata_triton,
@@ -62,7 +63,7 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.utils import ceil_align
-from sglang.srt.utils.common import is_sm120_supported
+from sglang.srt.utils.common import is_sm100_supported, is_sm120_supported
 
 if TYPE_CHECKING:
     from sgl_kernel.flash_mla import FlashMLASchedMeta
@@ -477,11 +478,35 @@ class DeepseekV4AttnBackend(
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
         return pin_tensor.to(self.device, non_blocking=True)
 
-    def init_forward_metadata_indexer(self, core_attn_metadata: DSV4AttnMetadata):
+    def init_forward_metadata_indexer(
+        self,
+        core_attn_metadata: DSV4AttnMetadata,
+        unflattened_next_n: Optional[int] = None,
+    ):
+        c4_seq_lens_unflattened = None
+        c4_page_table_unflattened = None
+        use_unflattened_deep_gemm_indexer = (
+            unflattened_next_n is not None
+            and unflattened_next_n >= 2
+            and is_sm100_supported()
+            and (self.enable_deepseek_v4_fp4_indexer or use_deep_gemm_fp8_indexer())
+        )
+        if use_unflattened_deep_gemm_indexer:
+            c4_seq_lens = core_attn_metadata.c4_topk_lengths_raw
+            assert c4_seq_lens is not None
+            assert c4_seq_lens.numel() % unflattened_next_n == 0
+            c4_seq_lens_unflattened = c4_seq_lens.view(
+                -1, unflattened_next_n
+            ).contiguous()
+            c4_page_table = core_attn_metadata.page_table
+            assert c4_page_table.shape[0] % unflattened_next_n == 0
+            c4_page_table_unflattened = c4_page_table[::unflattened_next_n].contiguous()
         return PagedIndexerMetadata(
             page_size=self.page_size,
             page_table=core_attn_metadata.page_table,
             c4_seq_lens=core_attn_metadata.c4_topk_lengths_raw,
+            c4_seq_lens_unflattened=c4_seq_lens_unflattened,
+            c4_page_table_unflattened=c4_page_table_unflattened,
         )
 
     def init_forward_metadata_decode(
@@ -542,6 +567,7 @@ class DeepseekV4AttnBackend(
         extend_start_loc: Optional[torch.Tensor] = None,
         need_compress: bool = True,
         use_prefill_cuda_graph: bool = False,
+        indexer_unflattened_next_n: Optional[int] = None,
     ) -> DSV4Metadata:
         seq_lens_casual, req_pool_indices_repeated = self.expand_prefill_casually(
             num_tokens=num_tokens,
@@ -563,7 +589,9 @@ class DeepseekV4AttnBackend(
             is_prefill=True,
         )
         indexer_metadata = (
-            self.init_forward_metadata_indexer(core_attn_metadata)
+            self.init_forward_metadata_indexer(
+                core_attn_metadata, unflattened_next_n=indexer_unflattened_next_n
+            )
             if need_compress
             else None
         )
@@ -676,6 +704,7 @@ class DeepseekV4AttnBackend(
             extend_start_loc=None,
             need_compress=True,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
+            indexer_unflattened_next_n=self.speculative_num_draft_tokens,
         )
 
     def make_forward_metadata_from_raw_verify(
@@ -702,7 +731,9 @@ class DeepseekV4AttnBackend(
             out_loc=out_cache_loc,
             need_compress=True,
         )
-        indexer_metadata = self.init_forward_metadata_indexer(core_attn_metadata)
+        indexer_metadata = self.init_forward_metadata_indexer(
+            core_attn_metadata, unflattened_next_n=num_draft_tokens
+        )
         create = functools.partial(
             create_paged_compressor_data,
             is_prefill=True,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -17,7 +17,10 @@ from sglang.jit_kernel.dsv4 import (
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsv4.compressor import Compressor
-from sglang.srt.layers.attention.dsv4.metadata import PagedIndexerMetadata
+from sglang.srt.layers.attention.dsv4.metadata import (
+    PagedIndexerMetadata,
+    use_deep_gemm_fp8_indexer,
+)
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.utils import add_prefix, is_hip
@@ -495,14 +498,38 @@ class C4IndexerBackendMixin:
         use_fp4_indexer = c4_indexer.use_fp4_indexer
         head_dim_with_sf = 68 if use_fp4_indexer else 132
 
+        query_rows = q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
+        c4_seq_lens_unflattened = getattr(
+            indexer_metadata, "c4_seq_lens_unflattened", None
+        )
+        use_unflattened_deep_gemm_indexer = (
+            (use_fp4_indexer or use_deep_gemm_fp8_indexer())
+            and c4_seq_lens_unflattened is not None
+            and c4_seq_lens_unflattened.dim() == 2
+            and query_rows == c4_seq_lens_unflattened.numel()
+        )
+
         if use_fp4_indexer:
             q_fp4, q_sf = q_indexer
             assert len(q_fp4.shape) == 3
             assert len(q_sf.shape) == 2
-            q = (q_fp4.unsqueeze(1), q_sf.unsqueeze(1))
+            if use_unflattened_deep_gemm_indexer:
+                batch_size, next_n = c4_seq_lens_unflattened.shape
+                q = (
+                    q_fp4.view(batch_size, next_n, q_fp4.shape[1], q_fp4.shape[2]),
+                    q_sf.view(batch_size, next_n, q_sf.shape[1]),
+                )
+            else:
+                q = (q_fp4.unsqueeze(1), q_sf.unsqueeze(1))
         else:
             assert len(q_indexer.shape) == 3
-            q = q_indexer.unsqueeze(1)
+            if use_unflattened_deep_gemm_indexer:
+                batch_size, next_n = c4_seq_lens_unflattened.shape
+                q = q_indexer.view(
+                    batch_size, next_n, q_indexer.shape[1], q_indexer.shape[2]
+                )
+            else:
+                q = q_indexer.unsqueeze(1)
 
         c4_indexer_kv_cache = c4_indexer_kv_cache.view(
             c4_indexer_kv_cache.shape[0], block_kv, num_heads_kv, head_dim_with_sf
@@ -528,8 +555,6 @@ class C4IndexerBackendMixin:
         else:
             from deep_gemm import fp8_paged_mqa_logits as fn
 
-        query_rows = q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
-
         def match_num_queries(tensor: torch.Tensor, value: int) -> torch.Tensor:
             if tensor.shape[0] == query_rows:
                 return tensor
@@ -541,6 +566,19 @@ class C4IndexerBackendMixin:
         c4_seq_lens = match_num_queries(indexer_metadata.c4_seq_lens, value=1)
         _c4sl = c4_seq_lens
         page_table = match_num_queries(indexer_metadata.page_table, value=0)
+        logits_page_table = page_table
+        if use_unflattened_deep_gemm_indexer:
+            assert c4_seq_lens_unflattened is not None
+            next_n = c4_seq_lens_unflattened.shape[1]
+            _c4sl = c4_seq_lens_unflattened
+            page_table_unflattened = getattr(
+                indexer_metadata, "c4_page_table_unflattened", None
+            )
+            logits_page_table = (
+                page_table_unflattened
+                if page_table_unflattened is not None
+                else page_table[::next_n].contiguous()
+            )
         c4_sparse_page_indices = match_num_queries(
             core_metadata.c4_sparse_page_indices, value=-1
         )
@@ -550,12 +588,24 @@ class C4IndexerBackendMixin:
         _use_aiter = envs.SGLANG_OPT_USE_AITER_INDEXER.get() and not use_fp4_indexer
         if _c4sl.dim() == 1 and not _use_tilelang and not _use_aiter:
             _c4sl = _c4sl.unsqueeze(-1)
+        if use_unflattened_deep_gemm_indexer:
+            batch_size, next_n = _c4sl.shape
+            assert logits_page_table.shape[0] == batch_size
+            assert page_table.shape[0] == batch_size * next_n
+            assert weights.shape[0] == batch_size * next_n
+            if use_fp4_indexer:
+                assert isinstance(q, tuple)
+                assert q[0].shape[:2] == (batch_size, next_n)
+                assert q[1].shape[:2] == (batch_size, next_n)
+            else:
+                assert isinstance(q, torch.Tensor)
+                assert q.shape[:2] == (batch_size, next_n)
         logits = fn(
             q,
             c4_indexer_kv_cache,
             weights,
             _c4sl,
-            page_table,
+            logits_page_table,
             indexer_metadata.deep_gemm_metadata,
             indexer_metadata.max_c4_seq_len,
             False,

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -13,6 +13,14 @@ if TYPE_CHECKING:
     pass
 
 
+def use_deep_gemm_fp8_indexer() -> bool:
+    return not (
+        envs.SGLANG_OPT_USE_TILELANG_INDEXER.get()
+        or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
+        or envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
+    )
+
+
 """
 Some comments on the common terms used in DeepSeekV4Backend:
 
@@ -100,28 +108,34 @@ class PagedIndexerMetadata:
     page_size: int
     page_table: torch.Tensor
     c4_seq_lens: torch.Tensor
+    c4_seq_lens_unflattened: Optional[torch.Tensor] = None
+    c4_page_table_unflattened: Optional[torch.Tensor] = None
     deep_gemm_metadata: Any = field(init=False, repr=False)
     topk_metadata: torch.Tensor = field(init=False, repr=False)
 
     def __post_init__(self):
-        if (
-            envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
-            or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
-        ):
+        if not use_deep_gemm_fp8_indexer():
             self.deep_gemm_metadata = None
         else:
             import deep_gemm
 
-            use_jit_indexer = (
+            schedule_c4_seq_lens = (
+                self.c4_seq_lens_unflattened
+                if self.c4_seq_lens_unflattened is not None
+                else self.c4_seq_lens
+            )
+            # The local SGLang JIT metadata kernel is flat-only; unflattened
+            # DeepGEMM next-n scheduling needs the 2D context-lens contract.
+            use_jit_indexer = self.c4_seq_lens_unflattened is None and (
                 envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get()
-                or self.c4_seq_lens.numel() > _LARGE_INDEXER_QUERY_THRESHOLD
+                or schedule_c4_seq_lens.numel() > _LARGE_INDEXER_QUERY_THRESHOLD
             )
             if use_jit_indexer:
                 from sglang.jit_kernel.dsv4 import get_paged_mqa_logits_metadata
             else:
                 from deep_gemm import get_paged_mqa_logits_metadata
 
-            _c4 = self.c4_seq_lens.to(torch.int32)
+            _c4 = schedule_c4_seq_lens.to(torch.int32)
             if _c4.dim() == 1:
                 _c4 = _c4.unsqueeze(-1)
             self.deep_gemm_metadata = get_paged_mqa_logits_metadata(
@@ -155,10 +169,21 @@ class PagedIndexerMetadata:
 
     def copy_(self, other: PagedIndexerMetadata):
         if is_hip():
-            copy_fields = ["page_table", "c4_seq_lens"]
+            copy_fields = [
+                "page_table",
+                "c4_seq_lens",
+                "c4_seq_lens_unflattened",
+                "c4_page_table_unflattened",
+            ]
             assign_fields = ["deep_gemm_metadata"]
         else:
-            copy_fields = ["page_table", "c4_seq_lens", "deep_gemm_metadata"]
+            copy_fields = [
+                "page_table",
+                "c4_seq_lens",
+                "c4_seq_lens_unflattened",
+                "c4_page_table_unflattened",
+                "deep_gemm_metadata",
+            ]
             assign_fields = []
         copy_fields += ["topk_metadata"]
         copy_metadata(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4392,6 +4392,16 @@ class ServerArgs:
                 "--enable-deepseek-v4-fp4-indexer requires SM100 GPUs with "
                 "DeepGEMM FP4 indexer support."
             )
+        if self.enable_deepseek_v4_fp4_indexer and (
+            envs.SGLANG_OPT_USE_TILELANG_INDEXER.get()
+            or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
+            or envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
+        ):
+            raise ValueError(
+                "--enable-deepseek-v4-fp4-indexer requires the DeepGEMM indexer "
+                "path and cannot be combined with FP8 TileLang, AITER, or torch "
+                "paged MQA logits fallback envs."
+            )
         # FP8 W_o GEMM requires Blackwell (sm100+). Auto-disable on Hopper.
         if is_cuda() and envs.SGLANG_OPT_FP8_WO_A_GEMM.get() and get_device_sm() < 100:
             if envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set():


### PR DESCRIPTION
## Motivation

DeepGEMM's SM100 paged MQA logits kernels can consume the `next_n` dimension directly. For DSV4 speculative target verify, SGLang already supported `next_n=4`, but the DeepGEMM indexer call was still flattened from `(B, next_n)` into `(B * next_n, 1)`. This PR keeps the target verify layout as `(B, next_n)` for the DeepGEMM FP8 and FP4 indexer paths on SM100-family GPUs.

| Version | DeepGEMM input layout |
| --- | --- |
| Before | `(B * next_n, 1, ...)` |
| After | `(B, next_n, ...)` |

## Modifications

- Add DSV4 C4 indexer metadata for the unflattened speculative target verify DeepGEMM path on SM100-family GPUs.
- Reshape FP8 and FP4 indexer queries from `(B * next_n, ...)` back to `(B, next_n, ...)` before calling DeepGEMM when `next_n >= 2`.
- Build DeepGEMM schedule metadata from the matching `(B, next_n)` C4 context lengths for this path.
- Keep the flattened page table for the top-k transform, and pass the matching unflattened page table to the DeepGEMM logits call.
- Keep the existing flattened path for non-SM100-family GPUs and for FP8 TileLang/AITER/torch fallback indexers.

## Accuracy Tests

GSM8K:

| Indexer | Before | After |
| --- | ---: | ---: |
| FP8 | 96.51% | 96.97% |
| FP4 | 96.36% | 96.66% |

## Speed Tests and Profiling

Benchmark setup:

| Setting | Value |
| --- | --- |
| Model | `deepseek-ai/DeepSeek-V4-Flash` |
| Batch size | 32 |
| Input / output len | 8192 / 1024 |
| Speculative config | steps=3, eagle top-k=1, draft tokens=4 |

### Profiler trace

FP8 before:

<img width="1631" height="747" alt="Screenshot 2026-06-12 193313" src="https://github.com/user-attachments/assets/a44eb439-a712-4f23-8364-687097ad730e" />

FP8 after:

<img width="1632" height="748" alt="Screenshot 2026-06-12 192549" src="https://github.com/user-attachments/assets/898d9c37-d537-48db-8477-8db9d5c95145" />

FP4 before:

<img width="1632" height="747" alt="Screenshot 2026-06-12 193058" src="https://github.com/user-attachments/assets/980c9cd2-f0ca-42d9-9cdd-bc3abc423005" />

FP4 after:

<img width="1632" height="747" alt="Screenshot 2026-06-12 192740" src="https://github.com/user-attachments/assets/9240ea4c-5518-4338-be87-5641cfaf1bd4" />

The FP8 and FP4 kernel names change from `<1u, ...>` to `<4u, ...>`, confirming that DeepGEMM sees `next_n=4` in the patched path.

### E2E numbers

| Indexer | Before out tok/s | After out tok/s | Diff | Accept len |
| --- | ---: | ---: | ---: | ---: |
| FP8 | 2902.38 | 3036.07 | +4.6% | 2.80 -> 2.78 |
| FP4 | 2934.26 | 3073.79 | +4.8% | 2.77 -> 2.77 |















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27462414589](https://github.com/sgl-project/sglang/actions/runs/27462414589)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27462414528](https://github.com/sgl-project/sglang/actions/runs/27462414528)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->