### PR TITLE
Lingbot World Optimization

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py
@@ -7,6 +7,18 @@ import torch.nn.functional as F
 from sglang.multimodal_gen.runtime.platforms import current_platform
 
 
+def causal_t_pad(x: torch.Tensor, t_pad: int) -> torch.Tensor:
+    """Zero-pad ``t_pad`` frames at the front of the temporal dim (dim 2).
+
+    The symmetric H/W padding is folded into the conv's own ``padding`` argument
+    (see WanCausalConv3d / WanDistCausalConv3d); only this asymmetric causal
+    front-pad on T is applied separately.
+    """
+    if t_pad <= 0:
+        return x
+    return F.pad(x, (0, 0, 0, 0, t_pad, 0))
+
+
 def _channels_last_3d_supported_by_platform() -> bool:
     return hasattr(torch, "channels_last_3d") and (
         current_platform.is_cuda() or current_platform.is_rocm()
@@ -150,24 +162,22 @@ class WanCausalConv3d(nn.Conv3d):
             padding=padding,
         )
         self.padding: tuple[int, int, int]
-        # Set up causal padding
-        self._padding: tuple[int, ...] = (
-            self.padding[2],
-            self.padding[2],
-            self.padding[1],
-            self.padding[1],
-            2 * self.padding[0],
-            0,
-        )
-        self.padding = (0, 0, 0)
+        # Fold the symmetric H/W padding into the conv itself (cuDNN applies it
+        # internally with no tensor materialization and preserves channels_last);
+        # only the causal temporal front-padding is done manually. This removes
+        # the per-conv F.pad that otherwise breaks channels_last and forces a
+        # match_conv3d_input_format .contiguous() copy.
+        pt, ph, pw = self.padding
+        self._t_pad = 2 * pt  # causal: pad 2*pt frames at the front of T
+        self.padding = (0, ph, pw)
 
     def forward(self, x, cache_x=None):
-        padding = list(self._padding)
-        if cache_x is not None and self._padding[4] > 0:
+        t_pad = self._t_pad
+        if cache_x is not None and self._t_pad > 0:
             cache_x = cache_x.to(x.device)
             x = torch.cat([cache_x, x], dim=2)
-            padding[4] -= cache_x.shape[2]
-        x = F.pad(x, padding)
+            t_pad -= cache_x.shape[2]
+        x = causal_t_pad(x, t_pad)
         x = (
             x if current_platform.is_amp_supported() else x.to(self.weight.dtype)
         )  # casting needed if amp isn't supported

--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_dist_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_dist_utils.py
@@ -18,6 +18,7 @@ from sglang.multimodal_gen.runtime.models.vaes.parallel.wan_common_utils import 
     WanRMS_norm,
     WanUpsample,
     attention_block_forward,
+    causal_t_pad,
     match_conv3d_input_format,
     mid_block_forward,
     resample_forward,
@@ -302,39 +303,27 @@ class WanDistCausalConv3d(nn.Conv3d):
         self.height_halo_size = (self.kernel_size[-2] - 1) // 2
 
         self.padding: tuple[int, int, int]
-        # Set up causal padding, let the halo to control height padding
-        if self.height_halo_size > 0:
-            self._padding: tuple[int, ...] = (
-                self.padding[2],
-                self.padding[2],
-                0,
-                0,
-                2 * self.padding[0],
-                0,
-            )
-        else:
-            self._padding: tuple[int, ...] = (
-                self.padding[2],
-                self.padding[2],
-                self.padding[1],
-                self.padding[1],
-                2 * self.padding[0],
-                0,
-            )
-        self.padding = (0, 0, 0)
+        # Fold symmetric W padding (and H when not height-sharded) into the conv;
+        # height padding is controlled by the halo exchange when sharded, and the
+        # causal temporal front-padding is done manually. Avoids the per-conv
+        # F.pad that breaks channels_last and triggers a .contiguous() copy.
+        pt, ph, pw = self.padding
+        self._t_pad = 2 * pt
+        conv_h = 0 if self.height_halo_size > 0 else ph
+        self.padding = (0, conv_h, pw)
         self._halo_recv_top_buf: torch.Tensor | None = None
         self._halo_recv_bottom_buf: torch.Tensor | None = None
         self.rank = get_sp_parallel_rank()
         self.world_size = get_sp_world_size()
 
     def forward(self, x, cache_x=None):
-        padding = list(self._padding)
-        if cache_x is not None and self._padding[4] > 0:
+        t_pad = self._t_pad
+        if cache_x is not None and self._t_pad > 0:
             cache_x = cache_x.to(x.device)
             x = torch.cat([cache_x, x], dim=2)
-            padding[4] -= cache_x.shape[2]
+            t_pad -= cache_x.shape[2]
 
-        x = F.pad(x, padding)
+        x = causal_t_pad(x, t_pad)
 
         x = (
             x if current_platform.is_amp_supported() else x.to(self.weight.dtype)


### PR DESCRIPTION
# perf(diffusion VAE): fold symmetric H/W conv padding into the conv to preserve channels_last

## Summary

`WanCausalConv3d` / `WanDistCausalConv3d` pad all of (W, H, T) with a single
`F.pad` before every `Conv3d`. `F.pad` returns a **plain-contiguous (NCDHW)**
tensor, which destroys the `channels_last_3d` (NDHWC) layout that
`SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D` enables so the convs can run cuDNN's
fast NHWC kernels. `match_conv3d_input_format` then has to re-impose the layout
with a `.contiguous(channels_last_3d)` call — a **full-tensor copy on every
conv**.

This PR folds the **symmetric** W (and H, when not height-sharded) padding into
the conv's own `padding` argument. cuDNN applies it internally with no tensor
materialization and **preserves channels_last**, so the per-conv layout copy is
removed. Only the asymmetric causal temporal front-pad is still applied
manually.

- **Numerically identical** — same zero-padding, just moved from `F.pad` into
  `Conv3d.padding`.
- **No behavior change when channels_last is off** — the change is layout-agnostic;
  it only removes a copy that exists *because of* channels_last.
- Builds directly on the existing upstream `SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D`
  channels_last_3d VAE support — no new flags, no new dependencies.

## Motivation

Upstream already supports channels_last_3d VAE decode
(`SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D`, `_convert_conv3d_weights_to_channels_last_3d`,
`match_conv3d_input_format`). It gives a large speedup by letting Conv3d hit
cuDNN's NHWC kernels instead of the slow NCDHW path.

But the causal conv padding fought against it. The original code:

```python
# WanCausalConv3d.__init__
self._padding = (self.padding[2], self.padding[2],   # W
                 self.padding[1], self.padding[1],   # H
                 2 * self.padding[0], 0)             # T (causal, front)
self.padding = (0, 0, 0)                             # conv does no padding

# WanCausalConv3d.forward
x = F.pad(x, padding)        # <-- returns NCDHW-contiguous, breaks channels_last
...                          #     -> match_conv3d_input_format must copy it back
```

Profiling LingBot-World (Wan2.2-I2V-A14B, DMD 4-step) decode on 8×H200,
ulysses-degree 8, with channels_last on, a torch-profiler `with_stack` trace
attributes a large chunk of the VAE decode's `direct_copy` GPU time to exactly
this `F.pad` → `match_conv3d_input_format.contiguous()` sequence.

## Change

For both `WanCausalConv3d` and `WanDistCausalConv3d`:

```python
# __init__: fold symmetric H/W into the conv; remember the causal T front-pad
pt, ph, pw = self.padding
self._t_pad = 2 * pt
conv_h = 0 if self.height_halo_size > 0 else ph   # dist: H comes from halo exchange
self.padding = (0, conv_h, pw)                     # WanCausalConv3d: self.padding = (0, ph, pw)

# forward: only the causal T front-pad is done manually
t_pad = self._t_pad
if cache_x is not None and self._t_pad > 0:
    cache_x = cache_x.to(x.device)
    x = torch.cat([cache_x, x], dim=2)
    t_pad -= cache_x.shape[2]
x = causal_t_pad(x, t_pad)   # F.pad on T-front only, and a no-op when t_pad == 0
```

`causal_t_pad` is a small shared helper (`wan_common_utils.py`) that zero-pads
only the temporal front. In **streaming decode the feat-cache already supplies
the front frames**, so `t_pad` collapses to 0 and `causal_t_pad` returns the
input untouched — meaning the steady-state conv input stays channels_last and
no copy happens at all. The first chunk (no cache) still does one small T-front
`F.pad`.

For the distributed conv, height padding continues to be provided by the
existing halo exchange when height-sharded (`conv_h = 0` in that case), so only
W (and the non-sharded H) is folded into the conv.

### Files

- `python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_common_utils.py`
  — `causal_t_pad` helper; `WanCausalConv3d` __init__/forward.
- `python/sglang/multimodal_gen/runtime/models/vaes/parallel/wan_dist_utils.py`
  — `WanDistCausalConv3d` __init__/forward.

~37 insertions / 38 deletions, 2 files.

## Correctness

Folding symmetric padding into `Conv3d.padding` is mathematically identical to
zero-padding with `F.pad` and then convolving with `padding=0`; the causal
T-front pad is unchanged. Verified end-to-end on 8×H200, ulysses-degree 8,
832×480, DMD 4-step:

- **channels_last ON**: 285/285 frames produced, decoded video visually clean.
- **channels_last OFF** (`SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D=false`): 285/285
  frames, video clean — confirms the change is layout-agnostic and the
  channels_last-specific code paths fall back correctly.

## Performance

LingBot-World, 8×H200, ulysses-degree 8, 832×480, DMD 4-step, channels_last on.

- VAE-decode `fp32 direct_copy` (cumulative GPU time, nsys): **4710 ms → 4087 ms,
  ≈ −13%** — the per-conv layout copy is the eliminated portion.
- End-to-end per-chunk latency: within noise of baseline (~1%); the VAE-decode
  layout copy is a small fraction of the per-chunk budget, so this is a clean
  targeted win rather than a headline speedup.

(The remaining VAE `direct_copy` is dominated by the distributed height-sharding
halo-exchange `concat`, which is structural to sequence parallelism and out of
scope for this PR.)

## Testing

```bash
# functional + layout-agnostic check
SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D=true  sglang serve --model-path <lingbot-world> \
  --num-gpus 8 --ulysses-degree 8 ...        # -> frames/video normal
SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D=false sglang serve ...   # -> frames/video normal
```

Existing VAE tests under `python/sglang/multimodal_gen/test/` continue to pass;
no new flags or dependencies are introduced.