### PR TITLE
Add @alexnails as codeowner for srt/platforms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,7 @@
 /python/sglang/srt/models/transformers.py @adarshxs
 /python/sglang/srt/multimodal @mickqian @JustinTong0323 @yhyang201 @yuan-luo
 /python/sglang/srt/observability @merrymercy @fzyzcjy @sufeng-buaa
-/python/sglang/srt/platforms @merrymercy @whybeyoung
+/python/sglang/srt/platforms @merrymercy @whybeyoung @alexnails
 /python/sglang/srt/ray @Qiaolin-Yu @xyuzh
 /python/sglang/srt/speculative @Ying1123 @merrymercy @hnyls2002 @Qiaolin-Yu
 /sgl-kernel @ispobock @BBuf @yizhang2077 @merrymercy @FlamingoPg @HaiShaw


### PR DESCRIPTION
Add `@alexnails` as a codeowner for `/python/sglang/srt/platforms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27423419061](https://github.com/sgl-project/sglang/actions/runs/27423419061)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27423418844](https://github.com/sgl-project/sglang/actions/runs/27423418844)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->