### PR TITLE
[MoE Refactor] Add torch_native MoE runner backend

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -63,6 +63,10 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer CuteDSL only supports fused path
         elif runner_backend.is_flashinfer_mxfp4():
             self.runner_core = None  # FlashInfer MXFP4 only supports fused path
+        elif runner_backend.is_torch_native():
+            import sglang.srt.layers.moe.moe_runner.torch_native  # noqa: F401
+
+            self.runner_core = None  # Torch native only supports fused path
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -109,6 +109,10 @@ class MoeRunner:
             # Import here (not at module top, to avoid a circular import) to
             # register the hpc_ops fused func before the pool lookup.
             from sglang.srt.layers.moe.moe_runner import hpc_ops  # noqa: F401
+        elif runner_backend.is_torch_native():
+            import sglang.srt.layers.moe.moe_runner.torch_native  # noqa: F401
+
+            self.runner_core = None  # Torch native only supports fused path
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 

--- a/python/sglang/srt/layers/moe/moe_runner/torch_native.py
+++ b/python/sglang/srt/layers/moe/moe_runner/torch_native.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import types
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    register_fused_func,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+@dataclass
+class TorchNativeMoeQuantInfo(MoeQuantInfo):
+    w13_weight: torch.Tensor = None
+    w2_weight: torch.Tensor = None
+    w13_bias: Optional[torch.Tensor] = None
+    w2_bias: Optional[torch.Tensor] = None
+
+
+@register_fused_func("none", "torch_native")
+def fused_experts_none_to_torch_native(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: TorchNativeMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    from sglang.srt.layers.moe.fused_moe_native import moe_forward_native
+    from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+    hidden_states = dispatch_output.hidden_states
+    topk_output = dispatch_output.topk_output
+
+    proxy = types.SimpleNamespace(
+        w13_weight=quant_info.w13_weight,
+        w2_weight=quant_info.w2_weight,
+        w13_weight_bias=quant_info.w13_bias,
+        w2_weight_bias=quant_info.w2_bias,
+        num_experts=quant_info.w13_weight.shape[0],
+    )
+
+    output = moe_forward_native(proxy, hidden_states, topk_output, runner_config)
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -99,6 +99,7 @@ class MoeRunnerBackend(Enum):
     CUTLASS = "cutlass"
     MARLIN = "marlin"
     AITER = "aiter"
+    TORCH_NATIVE = "torch_native"
 
     def is_auto(self):
         return self == MoeRunnerBackend.AUTO
@@ -143,6 +144,9 @@ class MoeRunnerBackend(Enum):
 
     def is_aiter(self):
         return self == MoeRunnerBackend.AITER
+
+    def is_torch_native(self):
+        return self == MoeRunnerBackend.TORCH_NATIVE
 
 
 class DeepEPMode(Enum):

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -111,6 +111,7 @@ class MoeRunnerBackend(Enum):
     EXPERIMENTAL_SGL_MARLIN = "experimental_sgl_marlin"
     AITER = "aiter"
     HPC_OPS = "hpc_ops"
+    TORCH_NATIVE = "torch_native"
 
     def is_auto(self):
         return self == MoeRunnerBackend.AUTO
@@ -173,6 +174,9 @@ class MoeRunnerBackend(Enum):
 
     def is_aiter(self):
         return self == MoeRunnerBackend.AITER
+
+    def is_torch_native(self):
+        return self == MoeRunnerBackend.TORCH_NATIVE
 
 
 class DeepEPMode(Enum):

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -410,6 +410,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
+        if get_moe_runner_backend().is_torch_native():
+            self.runner = MoeRunner(MoeRunnerBackend.TORCH_NATIVE, moe_runner_config)
+            self._aiter_runner = None
+            return
         if self.use_flashinfer_trtllm_moe:
             backend = (
                 MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED
@@ -603,15 +607,28 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             )
             return StandardCombineInput(hidden_states=output)
         else:
-            from sglang.srt.layers.moe.fused_moe_native import moe_forward_native
+            if get_moe_runner_backend().is_torch_native():
+                from sglang.srt.layers.moe.moe_runner.torch_native import (
+                    TorchNativeMoeQuantInfo,
+                )
 
-            output = moe_forward_native(
-                layer,
-                x,
-                topk_output,
-                moe_runner_config,
-            )
-            return StandardCombineInput(hidden_states=output)
+                quant_info = TorchNativeMoeQuantInfo(
+                    w13_weight=layer.w13_weight,
+                    w2_weight=layer.w2_weight,
+                    w13_bias=getattr(layer, "w13_weight_bias", None),
+                    w2_bias=getattr(layer, "w2_weight_bias", None),
+                )
+                return self.runner.run(dispatch_output, quant_info)
+            else:
+                from sglang.srt.layers.moe.fused_moe_native import moe_forward_native
+
+                output = moe_forward_native(
+                    layer,
+                    x,
+                    topk_output,
+                    moe_runner_config,
+                )
+                return StandardCombineInput(hidden_states=output)
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         return TritonMoeQuantInfo(

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -701,6 +701,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, BaseFusedOp):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
+        if get_moe_runner_backend().is_torch_native():
+            self.runner = MoeRunner(MoeRunnerBackend.TORCH_NATIVE, moe_runner_config)
+            self._aiter_runner = None
+            return
         if self.use_flashinfer_trtllm_moe:
             backend = (
                 MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED
@@ -906,15 +910,28 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, BaseFusedOp):
             )
             return StandardCombineInput(hidden_states=output)
         else:
-            from sglang.srt.layers.moe.fused_moe_native import moe_forward_native
+            if get_moe_runner_backend().is_torch_native():
+                from sglang.srt.layers.moe.moe_runner.torch_native import (
+                    TorchNativeMoeQuantInfo,
+                )
 
-            output = moe_forward_native(
-                layer,
-                x,
-                topk_output,
-                moe_runner_config,
-            )
-            return StandardCombineInput(hidden_states=output)
+                quant_info = TorchNativeMoeQuantInfo(
+                    w13_weight=layer.w13_weight,
+                    w2_weight=layer.w2_weight,
+                    w13_bias=getattr(layer, "w13_weight_bias", None),
+                    w2_bias=getattr(layer, "w2_weight_bias", None),
+                )
+                return self.runner.run(dispatch_output, quant_info)
+            else:
+                from sglang.srt.layers.moe.fused_moe_native import moe_forward_native
+
+                output = moe_forward_native(
+                    layer,
+                    x,
+                    topk_output,
+                    moe_runner_config,
+                )
+                return StandardCombineInput(hidden_states=output)
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         return TritonMoeQuantInfo(

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -804,6 +804,18 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, BaseFusedOp):
                 w2_bias=getattr(layer, "w2_weight_bias", None),
             )
             return self.runner.run(dispatch_output, quant_info)
+        elif backend.is_torch_native():
+            from sglang.srt.layers.moe.moe_runner.torch_native import (
+                TorchNativeMoeQuantInfo,
+            )
+
+            quant_info = TorchNativeMoeQuantInfo(
+                w13_weight=layer.w13_weight,
+                w2_weight=layer.w2_weight,
+                w13_bias=getattr(layer, "w13_weight_bias", None),
+                w2_bias=getattr(layer, "w2_weight_bias", None),
+            )
+            return self.runner.run(dispatch_output, quant_info)
         elif self.runner.runner_backend.is_deep_gemm():
             w13_weight = layer.w13_weight
             w2_weight = layer.w2_weight

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -242,6 +242,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "cutlass",
     "aiter",
     "marlin",
+    "torch_native",
 ]
 
 MOE_A2A_BACKEND_CHOICES = [

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -265,6 +265,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "cutlass",
     "aiter",
     "marlin",
+    "torch_native",
     "humming",
     "experimental_sgl_marlin",
     "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), FP8 MoE on Hopper (SM90) only

--- a/test/registered/unit/layers/quantization/test_unquant_torch_native.py
+++ b/test/registered/unit/layers/quantization/test_unquant_torch_native.py
@@ -1,0 +1,72 @@
+"""Regression tests for unquantized torch-native MoE dispatch."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe.fused_moe_native import fused_moe_forward_native
+from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.quantization import unquant
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestUnquantizedTorchNativeMoE(CustomTestCase):
+    def test_cuda_forward_matches_native_forward(self):
+        config = MoeRunnerConfig(
+            num_experts=4,
+            num_local_experts=4,
+            hidden_size=16,
+            intermediate_size_per_partition=32,
+            top_k=2,
+            params_dtype=torch.bfloat16,
+            activation="silu",
+            is_gated=True,
+        )
+        generator = torch.Generator(device="cuda").manual_seed(0)
+        layer = SimpleNamespace(
+            w13_weight=torch.randn(
+                4, 64, 16, dtype=torch.bfloat16, device="cuda", generator=generator
+            ),
+            w2_weight=torch.randn(
+                4, 16, 32, dtype=torch.bfloat16, device="cuda", generator=generator
+            ),
+            moe_runner_config=config,
+        )
+        dispatch_output = StandardDispatchOutput(
+            hidden_states=torch.randn(
+                3, 16, dtype=torch.bfloat16, device="cuda", generator=generator
+            ),
+            hidden_states_scale=None,
+            topk_output=StandardTopKOutput(
+                topk_weights=torch.tensor(
+                    [[0.7, 0.3], [0.6, 0.4], [0.8, 0.2]],
+                    dtype=torch.float32,
+                    device="cuda",
+                ),
+                topk_ids=torch.tensor([[0, 1], [2, 3], [1, 2]], device="cuda"),
+                router_logits=torch.zeros(3, 4, device="cuda"),
+            ),
+        )
+        expected = fused_moe_forward_native(layer, dispatch_output).hidden_states
+
+        with patch.object(
+            unquant,
+            "get_moe_runner_backend",
+            return_value=MoeRunnerBackend.TORCH_NATIVE,
+        ):
+            method = unquant.UnquantizedFusedMoEMethod()
+            method.create_moe_runner(layer, config)
+            actual = method.forward_cuda(layer, dispatch_output).hidden_states
+
+        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Wraps the existing `moe_forward_native` implementation into the `MoeRunner` framework using the `@register_fused_func` pattern (same as `marlin.py`)
- Adds `TORCH_NATIVE` to the `MoeRunnerBackend` enum and `--moe-runner-backend torch_native` CLI option
- Wires it through `UnquantizedFusedMoEMethod` so the CPU fallback path can optionally go through `MoeRunner`

Part of the Stage 3 adoption work in #8715 — specifically the **Torch native backend** task under `unquant.py` → `torch_native.py`.

## Test plan
- [ ] Verify `FusedOpPool.get_fused_func("none", "torch_native")` returns a callable after import
- [ ] Run a small MoE model with `--moe-runner-backend torch_native` and compare output against `--moe-runner-backend triton`
- [ ] Run existing MoE tests without `--moe-runner-backend` flag to confirm backward compatibility

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32439478627](https://github.com/sgl-project/sglang/actions/runs/32439478627)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32439478376](https://github.com/sgl-project/sglang/actions/runs/32439478376)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32439478476](https://github.com/sgl-project/sglang/actions/runs/32439478476)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->