### PR TITLE
[AMD][bugfix] Gate TBO dual-stream a2a to graph capture and drop record_stream

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -634,14 +634,13 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
     ):
         done_event: Optional[torch.cuda.Event] = None
 
-        if self._comm_stream:
+        # Only overlap the a2a on the comm stream during CUDA graph capture
+        # (decode). In eager mode (e.g. prefill) the dual-stream path lets the
+        # MoRI a2a contend with the other microbatch's compute for the same
+        # intra-node CUs and can stall forward progress, so run inline instead.
+        if self._comm_stream and torch.cuda.is_current_stream_capturing():
             compute_stream = torch.cuda.current_stream()
             comm_stream = self._comm_stream  # comm stream
-
-            for t in (hidden_states, topk_weights, topk_ids):
-                t.record_stream(comm_stream)
-            if scale is not None:
-                scale.record_stream(comm_stream)
 
             with torch.cuda.stream(comm_stream):
                 # if (previous_event) stream_wait(comm_stream, previous_event)
@@ -678,15 +677,6 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
                     done_event.record(comm_stream)
                 else:
                     compute_stream.wait_stream(comm_stream)
-
-            for t in (
-                packed_recv_hidden,
-                recv_topk_weights,
-                recv_scales,
-                recv_topk_ids,
-            ):
-                if t is not None:
-                    t.record_stream(comm_stream)
         else:
 
             (
@@ -749,12 +739,12 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
     ):
         done_event: Optional[torch.cuda.Event] = None
 
-        if self._comm_stream:
+        # See _dispatch_core: only overlap on the comm stream during CUDA graph
+        # capture (decode); run inline in eager mode to avoid a2a/compute CU
+        # contention that can stall forward progress.
+        if self._comm_stream and torch.cuda.is_current_stream_capturing():
             compute_stream = torch.cuda.current_stream()
             comm_stream = self._comm_stream
-
-            for t in (hidden_states, topk_ids, topk_weights):
-                t.record_stream(comm_stream)
 
             with torch.cuda.stream(comm_stream):
                 if previous_event is not None:
@@ -776,8 +766,6 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
                     done_event.record(comm_stream)
                 else:
                     compute_stream.wait_stream(comm_stream)
-
-            combined_hidden_states.record_stream(comm_stream)
 
         else:
             combined_hidden_states = self.mori_op.combine(


### PR DESCRIPTION
## Motivation

The MoRI two-batch-overlap (TBO) dispatcher ran the all-to-all dispatch/combine on a separate comm stream whenever dual-stream was enabled. In eager mode (e.g. prefill) this lets the intra-node, CU-driven a2a contend with the other microbatch's compute for the same CUs, which can stall forward progress and hang.

## Modifications

Gate the comm-stream overlap on torch.cuda.is_current_stream_capturing() so it only runs during decode CUDA graph capture; eager runs inline.

Also remove the tensor.record_stream(comm_stream) calls in the dual-stream path. During graph capture these pin caching-allocator blocks to comm events that never complete within the captured graph, inflating the capture private pool by tens of GB. They are unnecessary because the capture path's stream ordering is already enforced via events / wait_stream.

## Accuracy Tests

TBD

## Speed Tests and Profiling

TBD

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27437314290](https://github.com/sgl-project/sglang/actions/runs/27437314290)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27437314201](https://github.com/sgl-project/sglang/actions/runs/27437314201)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->