### PR TITLE
[sglang-miles] weight checker: ULP-based quant error tolerance via allow_quant_error

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1714,6 +1714,7 @@ class ResumeMemoryOccupationReqOutput(BaseReq):
 @dataclass
 class CheckWeightsReqInput(BaseReq):
     action: str = "checksum"
+    allow_quant_error: bool = False
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -155,7 +155,9 @@ class SchedulerWeightUpdaterManager:
         success, message = self.tp_worker.destroy_weights_update_group(recv_req)
         return DestroyWeightsUpdateGroupReqOutput(success, message)
 
-    def iter_weight_update_workers(self, selector: str = "all") -> List[Tuple[str, Any]]:
+    def iter_weight_update_workers(
+        self, selector: str = "all"
+    ) -> List[Tuple[str, Any]]:
         """Resolve a {target, draft, all} selector to (role, worker) pairs, target
         first: the target worker and, when present, the draft worker. This is the
         worker-level inclusion decision; each worker then contributes its own runners
@@ -366,12 +368,17 @@ class SchedulerWeightUpdaterManager:
 
     def check_weights(self, recv_req: CheckWeightsReqInput):
         try:
-            payload = self.tp_worker.model_runner.check_weights(action=recv_req.action)
+            payload = self.tp_worker.model_runner.check_weights(
+                action=recv_req.action, allow_quant_error=recv_req.allow_quant_error
+            )
 
             if self.draft_worker is not None:
                 draft_runner = _get_draft_model_runner(self.draft_worker)
                 if draft_runner is not None:
-                    draft_payload = draft_runner.check_weights(action=recv_req.action)
+                    draft_payload = draft_runner.check_weights(
+                        action=recv_req.action,
+                        allow_quant_error=recv_req.allow_quant_error,
+                    )
                     if payload is not None and draft_payload is not None:
                         payload = _merge_checksum_payloads(payload, draft_payload)
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3816,8 +3816,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
         ShardedStateLoader.save_model(self.model, path, pattern, max_size)
 
-    def check_weights(self, action: str):
-        return self._weight_checker.handle(action=action)
+    def check_weights(self, action: str, allow_quant_error: bool = False):
+        return self._weight_checker.handle(
+            action=action, allow_quant_error=allow_quant_error
+        )
 
     def update_weights_from_ipc(self, recv_req):
         """Update weights from IPC for checkpoint-engine integration."""

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -243,11 +243,8 @@ def _random_like(t: torch.Tensor):
 
 
 def _build_quantized_set(model) -> Dict[str, Tuple[type, str]]:
-    """Apply the router across the model: {weight_name: (ComparableWeight subclass,
-    scale_name)} for each weight in a module routed to a ComparableWeight. Weights
-    absent from the set (int4, mxfp8, unquantized, ...) compare raw.
-    select_comparable_weight raises for an unsupported quant format (e.g. nvfp4).
-    """
+    """Run the router over the model: {weight_name: (ComparableWeight subclass,
+    scale_name)} for each quantized weight; weights absent from the set compare raw."""
     quantized_set = {}
     for module_name, module in model.named_modules():
         comparable_cls = select_comparable_weight(getattr(module, "quant_method", None))
@@ -267,8 +264,8 @@ def _build_entries(
     skip_compare_names: Set[str],
     quantized_set: Optional[Dict[str, Tuple[type, str]]] = None,
 ) -> Iterable[Tuple[str, bool, ComparableWeight]]:
-    """Yields (name, should_compare, ComparableWeight): quantized weights become a
-    dequant-aware comparable (consuming their scale), everything else is raw."""
+    """Yields (name, should_compare, ComparableWeight); quantized weights consume
+    their scale, everything else is raw."""
     skip_compare_names = set(skip_compare_names)
     quantized_set = quantized_set or {}
     scale_names = {scale for _, scale in quantized_set.values()}

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -10,10 +10,10 @@ from pydantic import BaseModel, ConfigDict
 from sglang.srt.managers.mm_utils import tensor_hash
 from sglang.srt.utils.weight_checker_comparator import (
     _CHUNK_NUMEL,
+    ComparableWeight,
     RawReference,
-    ReferenceWeight,
     _compare_references,
-    select_quantization_method,
+    select_reference_weight,
 )
 
 logger = logging.getLogger(__name__)
@@ -90,18 +90,18 @@ class WeightChecker:
     def _compare(self, allow_quant_error: bool = False):
         assert self._snapshot_tensors is not None
 
-        quant_plan = _build_quant_plan(self._model_runner.model)
+        reference_plan = _build_reference_plan(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
             if getattr(param, "_skip_weight_check", False)
         }
-        _check_tensors(
-            expect_tensors=_postprocess_tensors(
-                self._snapshot_tensors, skip_compare_names, quant_plan
+        _compare_entries(
+            expect_entries=_build_entries(
+                self._snapshot_tensors, skip_compare_names, reference_plan
             ),
-            actual_tensors=_postprocess_tensors(
-                dict(self._model_state()), skip_compare_names, quant_plan
+            actual_entries=_build_entries(
+                dict(self._model_state()), skip_compare_names, reference_plan
             ),
             allow_quant_error=allow_quant_error,
         )
@@ -110,7 +110,7 @@ class WeightChecker:
         torch.cuda.synchronize()
         start = time.perf_counter()
 
-        quant_plan = _build_quant_plan(self._model_runner.model)
+        reference_plan = _build_reference_plan(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
@@ -120,8 +120,8 @@ class WeightChecker:
         # Hash the dequantized weight so two (qweight, scale) pairs with the same
         # bf16 hash equal.
         checksums = {}
-        for name, should_compare, ref in _postprocess_tensors(
-            dict(self._model_state()), skip_compare_names, quant_plan
+        for name, should_compare, ref in _build_entries(
+            dict(self._model_state()), skip_compare_names, reference_plan
         ):
             if should_compare:
                 checksums[name] = _hash_tensor(ref.dequantize().data)
@@ -167,9 +167,9 @@ def _hash_tensor(t: torch.Tensor) -> str:
     return f"{tensor_hash(t):016x}"
 
 
-def _check_tensors(
-    expect_tensors: Iterable[Tuple[str, bool, ReferenceWeight]],
-    actual_tensors: Iterable[Tuple[str, bool, ReferenceWeight]],
+def _compare_entries(
+    expect_entries: Iterable[Tuple[str, bool, ComparableWeight]],
+    actual_entries: Iterable[Tuple[str, bool, ComparableWeight]],
     allow_quant_error: bool = False,
 ):
     good_names = []
@@ -180,7 +180,7 @@ def _check_tensors(
         actual_name,
         actual_should_compare,
         actual_ref,
-    ) in zip(expect_tensors, actual_tensors, strict=True):
+    ) in zip(expect_entries, actual_entries, strict=True):
         assert expect_name == actual_name, f"{expect_name=} {actual_name=}"
         assert (
             should_compare == actual_should_compare
@@ -242,15 +242,15 @@ def _random_like(t: torch.Tensor):
     )
 
 
-def _build_quant_plan(model) -> Dict[str, Tuple[type, str]]:
-    """Apply the router across the model: {weight_name: (ReferenceWeight subclass,
-    scale_name)} for each weight in a module routed to a ReferenceWeight. Weights
+def _build_reference_plan(model) -> Dict[str, Tuple[type, str]]:
+    """Apply the router across the model: {weight_name: (ComparableWeight subclass,
+    scale_name)} for each weight in a module routed to a ComparableWeight. Weights
     absent from the plan (int4, mxfp8, unquantized, ...) compare raw.
-    select_quantization_method raises for an unsupported quant format (e.g. nvfp4).
+    select_reference_weight raises for an unsupported quant format (e.g. nvfp4).
     """
     plan = {}
     for module_name, module in model.named_modules():
-        rw_cls = select_quantization_method(getattr(module, "quant_method", None))
+        rw_cls = select_reference_weight(getattr(module, "quant_method", None))
         if rw_cls is None:
             continue
         prefix = f"{module_name}." if module_name else ""
@@ -262,22 +262,22 @@ def _build_quant_plan(model) -> Dict[str, Tuple[type, str]]:
     return plan
 
 
-def _postprocess_tensors(
+def _build_entries(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
-    quant_plan: Optional[Dict[str, Tuple[type, str]]] = None,
-) -> Iterable[Tuple[str, bool, ReferenceWeight]]:
-    """Yields (name, should_compare, ReferenceWeight): quant_plan weights become a
+    reference_plan: Optional[Dict[str, Tuple[type, str]]] = None,
+) -> Iterable[Tuple[str, bool, ComparableWeight]]:
+    """Yields (name, should_compare, ComparableWeight): planned weights become a
     dequant-aware reference (consuming their scale), everything else is raw."""
     skip_compare_names = set(skip_compare_names)
-    quant_plan = quant_plan or {}
-    scale_names = {scale for _, scale in quant_plan.values()}
+    reference_plan = reference_plan or {}
+    scale_names = {scale for _, scale in reference_plan.values()}
 
     for name, tensor in raw.items():
         if name in scale_names:
             continue  # compared via its weight's reference
-        if name in quant_plan:
-            rw_cls, s_name = quant_plan[name]
+        if name in reference_plan:
+            rw_cls, s_name = reference_plan[name]
             yield name, True, rw_cls(tensor, raw[s_name])
         else:
             should_compare = name not in skip_compare_names and (

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -54,14 +54,16 @@ class WeightChecker:
         self._model_runner = model_runner
         self._snapshot_tensors = None
 
-    def handle(self, action: str) -> Optional[Dict]:
-        logger.info(f"[WeightChecker] handle action={action}")
+    def handle(self, action: str, allow_quant_error: bool = False) -> Optional[Dict]:
+        logger.info(
+            f"[WeightChecker] handle action={action} allow_quant_error={allow_quant_error}"
+        )
         if action == "snapshot":
             return self._snapshot()
         elif action == "reset_tensors":
             return self._reset_tensors()
         elif action == "compare":
-            return self._compare()
+            return self._compare(allow_quant_error=allow_quant_error)
         elif action == "checksum":
             return self._compute_checksum()
         else:
@@ -82,7 +84,7 @@ class WeightChecker:
                 continue
             param.copy_(_random_like(param))
 
-    def _compare(self):
+    def _compare(self, allow_quant_error: bool = False):
         assert self._snapshot_tensors is not None
 
         skip_compare_names = {
@@ -97,6 +99,7 @@ class WeightChecker:
             actual_tensors=_postprocess_tensors(
                 dict(self._model_state()), skip_compare_names
             ),
+            allow_quant_error=allow_quant_error,
         )
 
     def _compute_checksum(self) -> Dict:
@@ -112,13 +115,21 @@ class WeightChecker:
         # Reuse the snapshot/compare postprocess pipeline so fp8 weights are
         # dequantized to bf16 before hashing — two (qweight, scale) pairs that
         # produce the same bf16 must produce the same checksum.
-        checksums = {
-            name: _hash_tensor(tensor.data)
-            for name, should_compare, tensor in _postprocess_tensors(
-                dict(self._model_state()), skip_compare_names
-            )
-            if should_compare
-        }
+        checksums = {}
+        for name, should_compare, entry in _postprocess_tensors(
+            dict(self._model_state()), skip_compare_names
+        ):
+            if not should_compare:
+                continue
+            if entry[0] == "quant":
+                _, w_q, w_s = entry
+                w_s = _normalize_scale(w_q, w_s)
+                tensor = block_quant_dequant(
+                    w_q, w_s, block_size=_block_size_of(w_q, w_s), dtype=torch.bfloat16
+                )
+            else:
+                tensor = entry[1]
+            checksums[name] = _hash_tensor(tensor.data)
 
         h = hashlib.sha256()
         for name in sorted(checksums):
@@ -162,42 +173,84 @@ def _hash_tensor(t: torch.Tensor) -> str:
 
 
 def _check_tensors(
-    expect_tensors: Iterable[Tuple[str, bool, torch.Tensor]],
-    actual_tensors: Iterable[Tuple[str, bool, torch.Tensor]],
+    expect_tensors: Iterable[Tuple[str, bool, Tuple]],
+    actual_tensors: Iterable[Tuple[str, bool, Tuple]],
+    allow_quant_error: bool = False,
 ):
-    from sglang.srt.debug_utils.dumper import get_tensor_info
-
     good_names = []
     error_messages = []
     info_messages = []
 
-    for (expect_name, expect_should_compare, expect), (
+    for (expect_name, expect_should_compare, expect_entry), (
         actual_name,
         actual_should_compare,
-        actual,
+        actual_entry,
     ) in zip(expect_tensors, actual_tensors, strict=True):
         assert expect_name == actual_name, f"{expect_name=} {actual_name=}"
         assert (
             expect_should_compare == actual_should_compare
         ), f"{expect_should_compare=} {actual_should_compare=}"
+        assert expect_entry[0] == actual_entry[0]
         name = expect_name
         should_compare = expect_should_compare
 
-        expect = expect.cuda()
-        actual = actual.cuda()
-
-        if torch.all(expect == actual):
-            good_names.append(name)
-        else:
-            abs_diff = (actual.float() - expect.float()).abs()
+        if expect_entry[0] == "quant":
+            _, expect_q, expect_s = expect_entry
+            _, actual_q, actual_s = actual_entry
+            try:
+                equal, max_abs_err, mean_abs_err, num_exceed = _compare_quant_pair(
+                    expect_q, expect_s, actual_q, actual_s
+                )
+            except Exception as e:
+                e.add_note(
+                    f"when handling {name=} "
+                    f"expect: shape={tuple(expect_q.shape)} dtype={expect_q.dtype} "
+                    f"actual: shape={tuple(actual_q.shape)} dtype={actual_q.dtype}"
+                )
+                raise
+            if equal:
+                good_names.append(name)
+                continue
             msg = (
                 f"name={name} "
-                f"max_abs_err={abs_diff.max()} "
-                f"mean_abs_err={abs_diff.mean()} "
-                f"{get_tensor_info(expect)=} "
-                f"{get_tensor_info(actual)=} "
+                f"max_abs_err={max_abs_err} "
+                f"mean_abs_err={mean_abs_err} "
+                f"num_exceed_quant_ulp_tolerance={num_exceed} "
+                f"expect_quant: shape={tuple(expect_q.shape)} dtype={expect_q.dtype} "
+                f"actual_quant: shape={tuple(actual_q.shape)} dtype={actual_q.dtype} "
             )
-            (error_messages if should_compare else info_messages).append(msg)
+            if not should_compare:
+                info_messages.append(msg)
+            elif allow_quant_error and num_exceed == 0:
+                # Each side is one quantization of the same weight, so they may
+                # disagree by up to 1 ULP of each quantized representation.
+                info_messages.append(msg + "(within quantization ULP tolerance)")
+            else:
+                error_messages.append(msg)
+            continue
+
+        expect = expect_entry[1]
+        actual = actual_entry[1]
+        equal, max_abs_err, mean_abs_err = _compare_raw_pair(
+            expect, actual, compute_stats=should_compare
+        )
+        if equal:
+            good_names.append(name)
+        elif not should_compare:
+            info_messages.append(
+                f"name={name} differs (not compared) "
+                f"shape={tuple(actual.shape)} dtype={actual.dtype} "
+            )
+        else:
+            error_messages.append(
+                f"name={name} "
+                f"max_abs_err={max_abs_err} "
+                f"mean_abs_err={mean_abs_err} "
+                f"shape={tuple(actual.shape)} "
+                f"expect_dtype={expect.dtype} actual_dtype={actual.dtype} "
+                f"expect_head={expect.reshape(-1)[:5].float().tolist()} "
+                f"actual_head={actual.reshape(-1)[:5].float().tolist()} "
+            )
 
     logger.info(f"[check_tensors] equal tensors: {good_names}")
     if len(info_messages) > 0:
@@ -206,13 +259,25 @@ def _check_tensors(
         raise Exception(f"check tensor equality failed:\n" + "\n".join(error_messages))
 
 
+# Bounds GPU transients during chunked randomize/compare: full-size fp32
+# intermediates of large MoE weights do not fit next to the KV-cache pool.
+_CHUNK_NUMEL = 64 * 1024 * 1024
+
+
 def _random_like(t: torch.Tensor):
     device = t.device
     shape = t.shape
     dtype = t.dtype
 
     if dtype.is_floating_point:
-        return torch.rand(shape, device=device, dtype=torch.float32).to(dtype)
+        # Generate chunked: a full-size fp32 rand of a large weight does not
+        # fit next to the KV-cache pool.
+        out = torch.empty(shape, device=device, dtype=dtype)
+        for chunk in out.view(-1).split(_CHUNK_NUMEL):
+            chunk.copy_(
+                torch.rand(chunk.shape, device=device, dtype=torch.float32).to(dtype)
+            )
+        return out
 
     if dtype == torch.bool:
         return torch.rand(shape, device=device) > 0.5
@@ -223,12 +288,138 @@ def _random_like(t: torch.Tensor):
     )
 
 
+def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
+    """Per-element ULP (spacing to the next representable magnitude) of w_q in its own dtype."""
+    finfo = torch.finfo(w_q.dtype)
+    x = w_q.to(torch.float32).abs()
+    # frexp: x = m * 2^e with m in [0.5, 1), so 2^(e-1) is the binade base of x.
+    _, exponent = torch.frexp(x)
+    binade = torch.exp2((exponent - 1).to(torch.float32))
+    # Zeros and subnormals share the spacing of the smallest normal binade.
+    binade = binade.masked_fill(x < finfo.smallest_normal, finfo.smallest_normal)
+    return binade * finfo.eps
+
+
+def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
+    if w_s.dtype == torch.int32:
+        # UE8M0 packed format (Blackwell DeepGEMM)
+        w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
+    return w_s.to(torch.float32)
+
+
+def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
+    # fp8 block quant uses square blocks. The output (row) dim can have a partial
+    # last block (e.g. fused_qkv_a_proj_with_mqa out-dim 2112 = 16*128 + 64), and
+    # then neither ceil(n/s_n) nor n//s_n recovers the true block size (2112/17
+    # rounds to 125/124, not 128). The contraction (column) dim is 128-aligned,
+    # so column // num_col_blocks gives the true block size exactly; reuse it for
+    # rows (square blocks). block_quant_dequant handles the partial row block via
+    # its repeat_interleave + slice.
+    k, s_k = w_q.shape[-1], w_s.shape[-1]
+    assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
+    block = k // s_k
+    return [block, block]
+
+
+def _iter_quant_chunks(w_q: torch.Tensor, w_s: torch.Tensor, block_n: int):
+    """Yields block-row-aligned (q_slice, s_slice) pairs of bounded size."""
+    q3 = w_q.reshape(-1, *w_q.shape[-2:])
+    s3 = w_s.reshape(-1, *w_s.shape[-2:])
+    n, k = q3.shape[-2:]
+    rows = max(block_n, _CHUNK_NUMEL // k // block_n * block_n)
+    for b in range(q3.shape[0]):
+        for r0 in range(0, n, rows):
+            r1 = min(r0 + rows, n)
+            yield q3[b, r0:r1], s3[b, r0 // block_n : -(-r1 // block_n)]
+
+
+def _compare_quant_pair(
+    expect_q: torch.Tensor,
+    expect_s: torch.Tensor,
+    actual_q: torch.Tensor,
+    actual_s: torch.Tensor,
+) -> Tuple[bool, float, float, int]:
+    """Chunked compare of two block-quantized tensors in dequantized space.
+
+    Returns (equal, max_abs_err, mean_abs_err, num_exceed) where num_exceed
+    counts elements differing by more than 1 ULP of each side's quantized
+    representation (NaN counts as exceeding).
+    """
+    assert expect_q.shape == actual_q.shape, f"{expect_q.shape=} {actual_q.shape=}"
+    expect_s = _normalize_scale(expect_q, expect_s)
+    actual_s = _normalize_scale(actual_q, actual_s)
+    block_n = _block_size_of(actual_q, actual_s)[0]
+
+    equal = True
+    max_abs_err = torch.zeros((), dtype=torch.float32)
+    sum_abs_err = 0.0
+    num_exceed = 0
+    for (e_q, e_s), (a_q, a_s) in zip(
+        _iter_quant_chunks(expect_q, expect_s, block_n),
+        _iter_quant_chunks(actual_q, actual_s, block_n),
+        strict=True,
+    ):
+        e_q, e_s = e_q.cuda(), e_s.cuda()
+        a_q, a_s = a_q.cuda(), a_s.cuda()
+        if e_q.dtype == a_q.dtype and torch.equal(e_q, a_q) and torch.equal(e_s, a_s):
+            continue
+        block_size = _block_size_of(e_q, e_s)
+        e_dequant = block_quant_dequant(e_q, e_s, block_size, dtype=torch.bfloat16)
+        a_dequant = block_quant_dequant(a_q, a_s, block_size, dtype=torch.bfloat16)
+        abs_diff = (a_dequant.float() - e_dequant.float()).abs()
+        if torch.all(abs_diff == 0):
+            continue
+        equal = False
+        tolerance = block_quant_dequant(
+            _quant_ulp(e_q), e_s, block_size, dtype=torch.float32
+        ) + block_quant_dequant(_quant_ulp(a_q), a_s, block_size, dtype=torch.float32)
+        # torch.maximum propagates NaN, unlike builtin max().
+        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
+        sum_abs_err += abs_diff.sum().item()
+        # `~(diff <= tol)` instead of `diff > tol` so NaN counts as exceeding.
+        num_exceed += int((~(abs_diff <= tolerance)).sum())
+    return equal, max_abs_err.item(), sum_abs_err / expect_q.numel(), num_exceed
+
+
+def _compare_raw_pair(
+    expect: torch.Tensor, actual: torch.Tensor, compute_stats: bool
+) -> Tuple[bool, float, float]:
+    """Chunked exact-compare of two raw tensors; optionally accumulates
+    abs-diff stats without materializing full-size fp32 intermediates.
+
+    Returns (equal, max_abs_err, mean_abs_err).
+    """
+    assert expect.shape == actual.shape, f"{expect.shape=} {actual.shape=}"
+    expect_flat = expect.reshape(-1)
+    actual_flat = actual.reshape(-1)
+
+    equal = True
+    max_abs_err = torch.zeros((), dtype=torch.float32)
+    sum_abs_err = 0.0
+    for start in range(0, expect_flat.numel(), _CHUNK_NUMEL):
+        e = expect_flat[start : start + _CHUNK_NUMEL].cuda()
+        a = actual_flat[start : start + _CHUNK_NUMEL].cuda()
+        if torch.all(e == a):
+            continue
+        equal = False
+        if not compute_stats:
+            break
+        abs_diff = (a.float() - e.float()).abs()
+        # torch.maximum propagates NaN, unlike builtin max().
+        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
+        sum_abs_err += abs_diff.sum().item()
+    return equal, max_abs_err.item(), sum_abs_err / max(expect_flat.numel(), 1)
+
+
 def _postprocess_tensors(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
-) -> Iterable[Tuple[str, bool, torch.Tensor]]:
-    from sglang.srt.debug_utils.dumper import get_tensor_info
+) -> Iterable[Tuple[str, bool, Tuple]]:
+    """Yields (name, should_compare, entry).
 
+    entry is ("quant", w_q, w_s) for block-quantized pairs — compared/hashed in
+    dequantized space without materializing the full dequant — or ("raw", tensor).
+    """
     skip_compare_names = set(skip_compare_names)
 
     # Skip non-persistent buffers (registered with persistent=False; recomputed
@@ -251,30 +442,12 @@ def _postprocess_tensors(
     skip_compare_names.update(quant_names)
     skip_compare_names.update(quant_scale_names)
     for name in quant_names:
-        w_q = raw[name]
-        w_s = raw[name.replace("weight", "weight_scale_inv")]
-
-        try:
-            if w_s.dtype == torch.int32:
-                # UE8M0 packed format (Blackwell DeepGEMM)
-                w_s_for_dequant = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
-            else:
-                w_s_for_dequant = w_s
-
-            w_dequant = block_quant_dequant(
-                w_q,
-                w_s_for_dequant,
-                # TODO do not hardcode
-                block_size=[128, 128],
-                dtype=torch.bfloat16,
-            )
-            yield name, True, w_dequant
-        except Exception as e:
-            e.add_note(
-                f"when handling {name=} {get_tensor_info(w_q)=} {get_tensor_info(w_s)=}"
-            )
-            raise
+        yield name, True, (
+            "quant",
+            raw[name],
+            raw[name.replace("weight", "weight_scale_inv")],
+        )
 
     for name in raw:
         should_compare = name not in skip_compare_names
-        yield name, should_compare, raw[name]
+        yield name, should_compare, ("raw", raw[name])

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -7,11 +7,12 @@ import torch
 import torch.distributed as dist
 from pydantic import BaseModel, ConfigDict
 
-from sglang.srt.layers.quantization.fp8_utils import (
-    block_quant_dequant,
-    inverse_transform_scale_ue8m0,
-)
 from sglang.srt.managers.mm_utils import tensor_hash
+from sglang.srt.utils.weight_checker_quant import (
+    _CHUNK_NUMEL,
+    Fp8BlockReference,
+    _compare_references,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,11 +123,7 @@ class WeightChecker:
             if not should_compare:
                 continue
             if entry[0] == "quant":
-                _, w_q, w_s = entry
-                w_s = _normalize_scale(w_q, w_s)
-                tensor = block_quant_dequant(
-                    w_q, w_s, block_size=_block_size_of(w_q, w_s), dtype=torch.bfloat16
-                )
+                tensor = entry[1].dequantize(dtype=torch.bfloat16)
             else:
                 tensor = entry[1]
             checksums[name] = _hash_tensor(tensor.data)
@@ -195,17 +192,14 @@ def _check_tensors(
         should_compare = expect_should_compare
 
         if expect_entry[0] == "quant":
-            _, expect_q, expect_s = expect_entry
-            _, actual_q, actual_s = actual_entry
+            expect_ref, actual_ref = expect_entry[1], actual_entry[1]
             try:
-                equal, max_abs_err, mean_abs_err, num_exceed = _compare_quant_pair(
-                    expect_q, expect_s, actual_q, actual_s
+                equal, max_abs_err, mean_abs_err, num_exceed = _compare_references(
+                    expect_ref, actual_ref
                 )
             except Exception as e:
                 e.add_note(
-                    f"when handling {name=} "
-                    f"expect: shape={tuple(expect_q.shape)} dtype={expect_q.dtype} "
-                    f"actual: shape={tuple(actual_q.shape)} dtype={actual_q.dtype}"
+                    f"when handling {name=} expect={expect_ref!r} actual={actual_ref!r}"
                 )
                 raise
             if equal:
@@ -216,13 +210,11 @@ def _check_tensors(
                 f"max_abs_err={max_abs_err} "
                 f"mean_abs_err={mean_abs_err} "
                 f"num_exceed_quant_ulp_tolerance={num_exceed} "
-                f"expect_quant: shape={tuple(expect_q.shape)} dtype={expect_q.dtype} "
-                f"actual_quant: shape={tuple(actual_q.shape)} dtype={actual_q.dtype} "
+                f"expect={expect_ref!r} actual={actual_ref!r} "
             )
             if not should_compare:
                 info_messages.append(msg)
             elif allow_quant_error and num_exceed == 0:
-                # Two faithful quantizations may differ by up to 1 ULP each.
                 info_messages.append(msg + "(within quantization ULP tolerance)")
             else:
                 error_messages.append(msg)
@@ -258,10 +250,6 @@ def _check_tensors(
         raise Exception(f"check tensor equality failed:\n" + "\n".join(error_messages))
 
 
-# Bound GPU memory: a full-size fp32 intermediate won't fit beside the KV-cache pool.
-_CHUNK_NUMEL = 64 * 1024 * 1024
-
-
 def _random_like(t: torch.Tensor):
     device = t.device
     shape = t.shape
@@ -282,91 +270,6 @@ def _random_like(t: torch.Tensor):
     return torch.randint(
         low=int(info.min), high=int(info.max), size=shape, device=device, dtype=dtype
     )
-
-
-def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
-    """Per-element ULP of w_q in its own dtype."""
-    finfo = torch.finfo(w_q.dtype)
-    x = w_q.to(torch.float32).abs()
-    # frexp: x = m * 2^e, m in [0.5, 1), so 2^(e-1) is x's binade base.
-    _, exponent = torch.frexp(x)
-    binade = torch.exp2((exponent - 1).to(torch.float32))
-    # Zeros and subnormals share the spacing of the smallest normal binade.
-    binade = binade.masked_fill(x < finfo.smallest_normal, finfo.smallest_normal)
-    return binade * finfo.eps
-
-
-def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
-    if w_s.dtype == torch.int32:
-        # UE8M0 packed format (Blackwell DeepGEMM)
-        w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
-    return w_s.to(torch.float32)
-
-
-def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
-    # Square blocks. The row dim may have a partial last block (so n//s_n is wrong),
-    # but the K dim is block-aligned, so k//s_k recovers the true block size exactly.
-    k, s_k = w_q.shape[-1], w_s.shape[-1]
-    assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
-    block = k // s_k
-    return [block, block]
-
-
-def _iter_quant_chunks(w_q: torch.Tensor, w_s: torch.Tensor, block_n: int):
-    """Yields block-row-aligned (q_slice, s_slice) pairs of bounded size."""
-    q3 = w_q.reshape(-1, *w_q.shape[-2:])
-    s3 = w_s.reshape(-1, *w_s.shape[-2:])
-    n, k = q3.shape[-2:]
-    rows = max(block_n, _CHUNK_NUMEL // k // block_n * block_n)
-    for b in range(q3.shape[0]):
-        for r0 in range(0, n, rows):
-            r1 = min(r0 + rows, n)
-            yield q3[b, r0:r1], s3[b, r0 // block_n : -(-r1 // block_n)]
-
-
-def _compare_quant_pair(
-    expect_q: torch.Tensor,
-    expect_s: torch.Tensor,
-    actual_q: torch.Tensor,
-    actual_s: torch.Tensor,
-) -> Tuple[bool, float, float, int]:
-    """Chunked compare of two block-quant tensors in dequant space. Returns
-    (equal, max_abs_err, mean_abs_err, num_exceed); num_exceed counts elements
-    off by >1 ULP per side (NaN counts as exceeding)."""
-    assert expect_q.shape == actual_q.shape, f"{expect_q.shape=} {actual_q.shape=}"
-    expect_s = _normalize_scale(expect_q, expect_s)
-    actual_s = _normalize_scale(actual_q, actual_s)
-    block_n = _block_size_of(actual_q, actual_s)[0]
-
-    equal = True
-    max_abs_err = torch.zeros((), dtype=torch.float32)
-    sum_abs_err = 0.0
-    num_exceed = 0
-    for (e_q, e_s), (a_q, a_s) in zip(
-        _iter_quant_chunks(expect_q, expect_s, block_n),
-        _iter_quant_chunks(actual_q, actual_s, block_n),
-        strict=True,
-    ):
-        e_q, e_s = e_q.cuda(), e_s.cuda()
-        a_q, a_s = a_q.cuda(), a_s.cuda()
-        if e_q.dtype == a_q.dtype and torch.equal(e_q, a_q) and torch.equal(e_s, a_s):
-            continue
-        block_size = _block_size_of(e_q, e_s)
-        e_dequant = block_quant_dequant(e_q, e_s, block_size, dtype=torch.bfloat16)
-        a_dequant = block_quant_dequant(a_q, a_s, block_size, dtype=torch.bfloat16)
-        abs_diff = (a_dequant.float() - e_dequant.float()).abs()
-        if torch.all(abs_diff == 0):
-            continue
-        equal = False
-        tolerance = block_quant_dequant(
-            _quant_ulp(e_q), e_s, block_size, dtype=torch.float32
-        ) + block_quant_dequant(_quant_ulp(a_q), a_s, block_size, dtype=torch.float32)
-        # torch.maximum propagates NaN, unlike builtin max().
-        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
-        sum_abs_err += abs_diff.sum().item()
-        # `~(diff <= tol)` instead of `diff > tol` so NaN counts as exceeding.
-        num_exceed += int((~(abs_diff <= tolerance)).sum())
-    return equal, max_abs_err.item(), sum_abs_err / expect_q.numel(), num_exceed
 
 
 def _compare_raw_pair(
@@ -400,8 +303,8 @@ def _postprocess_tensors(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
 ) -> Iterable[Tuple[str, bool, Tuple]]:
-    """Yields (name, should_compare, entry); entry is ("quant", w_q, w_s) for
-    block-quant pairs (dequantized lazily) or ("raw", tensor)."""
+    """Yields (name, should_compare, entry); entry is ("quant", ReferenceWeight)
+    for block-quant pairs or ("raw", tensor)."""
     skip_compare_names = set(skip_compare_names)
 
     # Skip non-persistent buffers (registered with persistent=False; recomputed
@@ -426,8 +329,9 @@ def _postprocess_tensors(
     for name in quant_names:
         yield name, True, (
             "quant",
-            raw[name],
-            raw[name.replace("weight", "weight_scale_inv")],
+            Fp8BlockReference(
+                raw[name], raw[name.replace("weight", "weight_scale_inv")]
+            ),
         )
 
     for name in raw:

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -12,6 +12,7 @@ from sglang.srt.utils.weight_checker_quant import (
     _CHUNK_NUMEL,
     Fp8BlockReference,
     _compare_references,
+    select_quantization_method,
 )
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,7 @@ class WeightChecker:
 
     def _compare(self, allow_quant_error: bool = False):
         assert self._snapshot_tensors is not None
+        self._assert_quant_supported()
 
         skip_compare_names = {
             name
@@ -106,6 +108,7 @@ class WeightChecker:
     def _compute_checksum(self) -> Dict:
         torch.cuda.synchronize()
         start = time.perf_counter()
+        self._assert_quant_supported()
 
         skip_compare_names = {
             name
@@ -163,6 +166,10 @@ class WeightChecker:
     def _model_state(self):
         yield from self._model_runner.model.named_parameters()
         yield from self._model_runner.model.named_buffers()
+
+    def _assert_quant_supported(self):
+        for _, module in self._model_runner.model.named_modules():
+            select_quantization_method(getattr(module, "quant_method", None))
 
 
 def _hash_tensor(t: torch.Tensor) -> str:

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -96,11 +96,11 @@ class WeightChecker:
             for name, param in self._model_state()
             if getattr(param, "_skip_weight_check", False)
         }
-        _compare_entries(
-            expect_entries=_build_entries(
+        _check_tensors(
+            expect_tensors=_build_entries(
                 self._snapshot_tensors, skip_compare_names, reference_plan
             ),
-            actual_entries=_build_entries(
+            actual_tensors=_build_entries(
                 dict(self._model_state()), skip_compare_names, reference_plan
             ),
             allow_quant_error=allow_quant_error,
@@ -167,9 +167,9 @@ def _hash_tensor(t: torch.Tensor) -> str:
     return f"{tensor_hash(t):016x}"
 
 
-def _compare_entries(
-    expect_entries: Iterable[Tuple[str, bool, ComparableWeight]],
-    actual_entries: Iterable[Tuple[str, bool, ComparableWeight]],
+def _check_tensors(
+    expect_tensors: Iterable[Tuple[str, bool, ComparableWeight]],
+    actual_tensors: Iterable[Tuple[str, bool, ComparableWeight]],
     allow_quant_error: bool = False,
 ):
     good_names = []
@@ -180,7 +180,7 @@ def _compare_entries(
         actual_name,
         actual_should_compare,
         actual_ref,
-    ) in zip(expect_entries, actual_entries, strict=True):
+    ) in zip(expect_tensors, actual_tensors, strict=True):
         assert expect_name == actual_name, f"{expect_name=} {actual_name=}"
         assert (
             should_compare == actual_should_compare

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -222,8 +222,7 @@ def _check_tensors(
             if not should_compare:
                 info_messages.append(msg)
             elif allow_quant_error and num_exceed == 0:
-                # Each side is one quantization of the same weight, so they may
-                # disagree by up to 1 ULP of each quantized representation.
+                # Two faithful quantizations may differ by up to 1 ULP each.
                 info_messages.append(msg + "(within quantization ULP tolerance)")
             else:
                 error_messages.append(msg)
@@ -259,8 +258,7 @@ def _check_tensors(
         raise Exception(f"check tensor equality failed:\n" + "\n".join(error_messages))
 
 
-# Bounds GPU transients during chunked randomize/compare: full-size fp32
-# intermediates of large MoE weights do not fit next to the KV-cache pool.
+# Bound GPU memory: a full-size fp32 intermediate won't fit beside the KV-cache pool.
 _CHUNK_NUMEL = 64 * 1024 * 1024
 
 
@@ -270,8 +268,6 @@ def _random_like(t: torch.Tensor):
     dtype = t.dtype
 
     if dtype.is_floating_point:
-        # Generate chunked: a full-size fp32 rand of a large weight does not
-        # fit next to the KV-cache pool.
         out = torch.empty(shape, device=device, dtype=dtype)
         for chunk in out.view(-1).split(_CHUNK_NUMEL):
             chunk.copy_(
@@ -289,10 +285,10 @@ def _random_like(t: torch.Tensor):
 
 
 def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
-    """Per-element ULP (spacing to the next representable magnitude) of w_q in its own dtype."""
+    """Per-element ULP of w_q in its own dtype."""
     finfo = torch.finfo(w_q.dtype)
     x = w_q.to(torch.float32).abs()
-    # frexp: x = m * 2^e with m in [0.5, 1), so 2^(e-1) is the binade base of x.
+    # frexp: x = m * 2^e, m in [0.5, 1), so 2^(e-1) is x's binade base.
     _, exponent = torch.frexp(x)
     binade = torch.exp2((exponent - 1).to(torch.float32))
     # Zeros and subnormals share the spacing of the smallest normal binade.
@@ -308,13 +304,8 @@ def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
 
 
 def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
-    # fp8 block quant uses square blocks. The output (row) dim can have a partial
-    # last block (e.g. fused_qkv_a_proj_with_mqa out-dim 2112 = 16*128 + 64), and
-    # then neither ceil(n/s_n) nor n//s_n recovers the true block size (2112/17
-    # rounds to 125/124, not 128). The contraction (column) dim is 128-aligned,
-    # so column // num_col_blocks gives the true block size exactly; reuse it for
-    # rows (square blocks). block_quant_dequant handles the partial row block via
-    # its repeat_interleave + slice.
+    # Square blocks. The row dim may have a partial last block (so n//s_n is wrong),
+    # but the K dim is block-aligned, so k//s_k recovers the true block size exactly.
     k, s_k = w_q.shape[-1], w_s.shape[-1]
     assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
     block = k // s_k
@@ -339,12 +330,9 @@ def _compare_quant_pair(
     actual_q: torch.Tensor,
     actual_s: torch.Tensor,
 ) -> Tuple[bool, float, float, int]:
-    """Chunked compare of two block-quantized tensors in dequantized space.
-
-    Returns (equal, max_abs_err, mean_abs_err, num_exceed) where num_exceed
-    counts elements differing by more than 1 ULP of each side's quantized
-    representation (NaN counts as exceeding).
-    """
+    """Chunked compare of two block-quant tensors in dequant space. Returns
+    (equal, max_abs_err, mean_abs_err, num_exceed); num_exceed counts elements
+    off by >1 ULP per side (NaN counts as exceeding)."""
     assert expect_q.shape == actual_q.shape, f"{expect_q.shape=} {actual_q.shape=}"
     expect_s = _normalize_scale(expect_q, expect_s)
     actual_s = _normalize_scale(actual_q, actual_s)
@@ -384,11 +372,8 @@ def _compare_quant_pair(
 def _compare_raw_pair(
     expect: torch.Tensor, actual: torch.Tensor, compute_stats: bool
 ) -> Tuple[bool, float, float]:
-    """Chunked exact-compare of two raw tensors; optionally accumulates
-    abs-diff stats without materializing full-size fp32 intermediates.
-
-    Returns (equal, max_abs_err, mean_abs_err).
-    """
+    """Chunked exact-compare of two raw tensors, optionally accumulating
+    abs-diff stats. Returns (equal, max_abs_err, mean_abs_err)."""
     assert expect.shape == actual.shape, f"{expect.shape=} {actual.shape=}"
     expect_flat = expect.reshape(-1)
     actual_flat = actual.reshape(-1)
@@ -415,11 +400,8 @@ def _postprocess_tensors(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
 ) -> Iterable[Tuple[str, bool, Tuple]]:
-    """Yields (name, should_compare, entry).
-
-    entry is ("quant", w_q, w_s) for block-quantized pairs — compared/hashed in
-    dequantized space without materializing the full dequant — or ("raw", tensor).
-    """
+    """Yields (name, should_compare, entry); entry is ("quant", w_q, w_s) for
+    block-quant pairs (dequantized lazily) or ("raw", tensor)."""
     skip_compare_names = set(skip_compare_names)
 
     # Skip non-persistent buffers (registered with persistent=False; recomputed

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -10,7 +10,8 @@ from pydantic import BaseModel, ConfigDict
 from sglang.srt.managers.mm_utils import tensor_hash
 from sglang.srt.utils.weight_checker_comparator import (
     _CHUNK_NUMEL,
-    _compare_raw_pair,
+    RawReference,
+    ReferenceWeight,
     _compare_references,
     select_quantization_method,
 )
@@ -116,20 +117,14 @@ class WeightChecker:
             if getattr(param, "_skip_weight_check", False)
         }
 
-        # Reuse the snapshot/compare postprocess pipeline so fp8 weights are
-        # dequantized to bf16 before hashing — two (qweight, scale) pairs that
-        # produce the same bf16 must produce the same checksum.
+        # Hash the dequantized weight so two (qweight, scale) pairs with the same
+        # bf16 hash equal.
         checksums = {}
-        for name, should_compare, entry in _postprocess_tensors(
+        for name, should_compare, ref in _postprocess_tensors(
             dict(self._model_state()), skip_compare_names, quant_plan
         ):
-            if not should_compare:
-                continue
-            if entry[0] == "quant":
-                tensor = entry[1].dequantize(dtype=torch.bfloat16)
-            else:
-                tensor = entry[1]
-            checksums[name] = _hash_tensor(tensor.data)
+            if should_compare:
+                checksums[name] = _hash_tensor(ref.dequantize().data)
 
         h = hashlib.sha256()
         for name in sorted(checksums):
@@ -173,78 +168,50 @@ def _hash_tensor(t: torch.Tensor) -> str:
 
 
 def _check_tensors(
-    expect_tensors: Iterable[Tuple[str, bool, Tuple]],
-    actual_tensors: Iterable[Tuple[str, bool, Tuple]],
+    expect_tensors: Iterable[Tuple[str, bool, ReferenceWeight]],
+    actual_tensors: Iterable[Tuple[str, bool, ReferenceWeight]],
     allow_quant_error: bool = False,
 ):
     good_names = []
     error_messages = []
     info_messages = []
 
-    for (expect_name, expect_should_compare, expect_entry), (
+    for (expect_name, should_compare, expect_ref), (
         actual_name,
         actual_should_compare,
-        actual_entry,
+        actual_ref,
     ) in zip(expect_tensors, actual_tensors, strict=True):
         assert expect_name == actual_name, f"{expect_name=} {actual_name=}"
         assert (
-            expect_should_compare == actual_should_compare
-        ), f"{expect_should_compare=} {actual_should_compare=}"
-        assert expect_entry[0] == actual_entry[0]
+            should_compare == actual_should_compare
+        ), f"{should_compare=} {actual_should_compare=}"
         name = expect_name
-        should_compare = expect_should_compare
 
-        if expect_entry[0] == "quant":
-            expect_ref, actual_ref = expect_entry[1], actual_entry[1]
-            try:
-                equal, max_abs_err, mean_abs_err, num_exceed = _compare_references(
-                    expect_ref, actual_ref
-                )
-            except Exception as e:
-                e.add_note(
-                    f"when handling {name=} expect={expect_ref!r} actual={actual_ref!r}"
-                )
-                raise
-            if equal:
-                good_names.append(name)
-                continue
-            msg = (
-                f"name={name} "
-                f"max_abs_err={max_abs_err} "
-                f"mean_abs_err={mean_abs_err} "
-                f"num_exceed_quant_ulp_tolerance={num_exceed} "
-                f"expect={expect_ref!r} actual={actual_ref!r} "
+        try:
+            equal, max_abs_err, mean_abs_err, num_exceed = _compare_references(
+                expect_ref, actual_ref
             )
-            if not should_compare:
-                info_messages.append(msg)
-            elif allow_quant_error and num_exceed == 0:
-                info_messages.append(msg + "(within quantization ULP tolerance)")
-            else:
-                error_messages.append(msg)
-            continue
-
-        expect = expect_entry[1]
-        actual = actual_entry[1]
-        equal, max_abs_err, mean_abs_err = _compare_raw_pair(
-            expect, actual, compute_stats=should_compare
-        )
+        except Exception as e:
+            e.add_note(
+                f"when handling {name=} expect={expect_ref!r} actual={actual_ref!r}"
+            )
+            raise
         if equal:
             good_names.append(name)
-        elif not should_compare:
-            info_messages.append(
-                f"name={name} differs (not compared) "
-                f"shape={tuple(actual.shape)} dtype={actual.dtype} "
-            )
+            continue
+        msg = (
+            f"name={name} "
+            f"max_abs_err={max_abs_err} "
+            f"mean_abs_err={mean_abs_err} "
+            f"num_exceed={num_exceed} "
+            f"expect={expect_ref!r} actual={actual_ref!r} "
+        )
+        if not should_compare:
+            info_messages.append(msg)
+        elif allow_quant_error and num_exceed == 0:
+            info_messages.append(msg + "(within quantization ULP tolerance)")
         else:
-            error_messages.append(
-                f"name={name} "
-                f"max_abs_err={max_abs_err} "
-                f"mean_abs_err={mean_abs_err} "
-                f"shape={tuple(actual.shape)} "
-                f"expect_dtype={expect.dtype} actual_dtype={actual.dtype} "
-                f"expect_head={expect.reshape(-1)[:5].float().tolist()} "
-                f"actual_head={actual.reshape(-1)[:5].float().tolist()} "
-            )
+            error_messages.append(msg)
 
     logger.info(f"[check_tensors] equal tensors: {good_names}")
     if len(info_messages) > 0:
@@ -299,23 +266,21 @@ def _postprocess_tensors(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
     quant_plan: Optional[Dict[str, Tuple[type, str]]] = None,
-) -> Iterable[Tuple[str, bool, Tuple]]:
-    """Yields (name, should_compare, entry); entry is ("quant", ReferenceWeight)
-    for the weight pairs in quant_plan (empty => all raw) or ("raw", tensor)."""
+) -> Iterable[Tuple[str, bool, ReferenceWeight]]:
+    """Yields (name, should_compare, ReferenceWeight): quant_plan weights become a
+    dequant-aware reference (consuming their scale), everything else is raw."""
     skip_compare_names = set(skip_compare_names)
     quant_plan = quant_plan or {}
+    scale_names = {scale for _, scale in quant_plan.values()}
 
-    # Skip non-persistent buffers (registered with persistent=False; recomputed
-    # after weight load and not part of the synced payload).
-    for name in raw:
-        if _is_non_persistent_buffer_name(name):
-            skip_compare_names.add(name)
-            logger.info(f"[check_tensors] Skipping non-persistent buffer: {name}")
-
-    for w_name, (rw_cls, s_name) in quant_plan.items():
-        skip_compare_names.update((w_name, s_name))
-        yield w_name, True, ("quant", rw_cls(raw[w_name], raw[s_name]))
-
-    for name in raw:
-        should_compare = name not in skip_compare_names
-        yield name, should_compare, ("raw", raw[name])
+    for name, tensor in raw.items():
+        if name in scale_names:
+            continue  # compared via its weight's reference
+        if name in quant_plan:
+            rw_cls, s_name = quant_plan[name]
+            yield name, True, rw_cls(tensor, raw[s_name])
+        else:
+            should_compare = name not in skip_compare_names and (
+                not _is_non_persistent_buffer_name(name)
+            )
+            yield name, should_compare, RawReference(tensor)

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -8,9 +8,9 @@ import torch.distributed as dist
 from pydantic import BaseModel, ConfigDict
 
 from sglang.srt.managers.mm_utils import tensor_hash
-from sglang.srt.utils.weight_checker_quant import (
+from sglang.srt.utils.weight_checker_comparator import (
     _CHUNK_NUMEL,
-    Fp8BlockReference,
+    _compare_raw_pair,
     _compare_references,
     select_quantization_method,
 )
@@ -88,8 +88,8 @@ class WeightChecker:
 
     def _compare(self, allow_quant_error: bool = False):
         assert self._snapshot_tensors is not None
-        self._assert_quant_supported()
 
+        quant_plan = _build_quant_plan(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
@@ -97,10 +97,10 @@ class WeightChecker:
         }
         _check_tensors(
             expect_tensors=_postprocess_tensors(
-                self._snapshot_tensors, skip_compare_names
+                self._snapshot_tensors, skip_compare_names, quant_plan
             ),
             actual_tensors=_postprocess_tensors(
-                dict(self._model_state()), skip_compare_names
+                dict(self._model_state()), skip_compare_names, quant_plan
             ),
             allow_quant_error=allow_quant_error,
         )
@@ -108,8 +108,8 @@ class WeightChecker:
     def _compute_checksum(self) -> Dict:
         torch.cuda.synchronize()
         start = time.perf_counter()
-        self._assert_quant_supported()
 
+        quant_plan = _build_quant_plan(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
@@ -121,7 +121,7 @@ class WeightChecker:
         # produce the same bf16 must produce the same checksum.
         checksums = {}
         for name, should_compare, entry in _postprocess_tensors(
-            dict(self._model_state()), skip_compare_names
+            dict(self._model_state()), skip_compare_names, quant_plan
         ):
             if not should_compare:
                 continue
@@ -166,10 +166,6 @@ class WeightChecker:
     def _model_state(self):
         yield from self._model_runner.model.named_parameters()
         yield from self._model_runner.model.named_buffers()
-
-    def _assert_quant_supported(self):
-        for _, module in self._model_runner.model.named_modules():
-            select_quantization_method(getattr(module, "quant_method", None))
 
 
 def _hash_tensor(t: torch.Tensor) -> str:
@@ -279,40 +275,35 @@ def _random_like(t: torch.Tensor):
     )
 
 
-def _compare_raw_pair(
-    expect: torch.Tensor, actual: torch.Tensor, compute_stats: bool
-) -> Tuple[bool, float, float]:
-    """Chunked exact-compare of two raw tensors, optionally accumulating
-    abs-diff stats. Returns (equal, max_abs_err, mean_abs_err)."""
-    assert expect.shape == actual.shape, f"{expect.shape=} {actual.shape=}"
-    expect_flat = expect.reshape(-1)
-    actual_flat = actual.reshape(-1)
-
-    equal = True
-    max_abs_err = torch.zeros((), dtype=torch.float32)
-    sum_abs_err = 0.0
-    for start in range(0, expect_flat.numel(), _CHUNK_NUMEL):
-        e = expect_flat[start : start + _CHUNK_NUMEL].cuda()
-        a = actual_flat[start : start + _CHUNK_NUMEL].cuda()
-        if torch.all(e == a):
+def _build_quant_plan(model) -> Dict[str, Tuple[type, str]]:
+    """Apply the router across the model: {weight_name: (ReferenceWeight subclass,
+    scale_name)} for each weight in a module routed to a ReferenceWeight. Weights
+    absent from the plan (int4, mxfp8, unquantized, ...) compare raw.
+    select_quantization_method raises for an unsupported quant format (e.g. nvfp4).
+    """
+    plan = {}
+    for module_name, module in model.named_modules():
+        rw_cls = select_quantization_method(getattr(module, "quant_method", None))
+        if rw_cls is None:
             continue
-        equal = False
-        if not compute_stats:
-            break
-        abs_diff = (a.float() - e.float()).abs()
-        # torch.maximum propagates NaN, unlike builtin max().
-        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
-        sum_abs_err += abs_diff.sum().item()
-    return equal, max_abs_err.item(), sum_abs_err / max(expect_flat.numel(), 1)
+        prefix = f"{module_name}." if module_name else ""
+        own = {name for name, _ in module.named_parameters(recurse=False)}
+        for name in own:
+            scale = name.replace("weight", "weight_scale_inv")
+            if name.endswith("weight") and scale in own:
+                plan[prefix + name] = (rw_cls, prefix + scale)
+    return plan
 
 
 def _postprocess_tensors(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
+    quant_plan: Optional[Dict[str, Tuple[type, str]]] = None,
 ) -> Iterable[Tuple[str, bool, Tuple]]:
     """Yields (name, should_compare, entry); entry is ("quant", ReferenceWeight)
-    for block-quant pairs or ("raw", tensor)."""
+    for the weight pairs in quant_plan (empty => all raw) or ("raw", tensor)."""
     skip_compare_names = set(skip_compare_names)
+    quant_plan = quant_plan or {}
 
     # Skip non-persistent buffers (registered with persistent=False; recomputed
     # after weight load and not part of the synced payload).
@@ -321,25 +312,9 @@ def _postprocess_tensors(
             skip_compare_names.add(name)
             logger.info(f"[check_tensors] Skipping non-persistent buffer: {name}")
 
-    # dequant fp8
-    quant_names = [
-        name
-        for name in raw
-        # Match: `something.weight`, `something.experts.w2_weight`
-        if name.endswith("weight") and name.replace("weight", "weight_scale_inv") in raw
-    ]
-    quant_scale_names = [
-        name.replace("weight", "weight_scale_inv") for name in quant_names
-    ]
-    skip_compare_names.update(quant_names)
-    skip_compare_names.update(quant_scale_names)
-    for name in quant_names:
-        yield name, True, (
-            "quant",
-            Fp8BlockReference(
-                raw[name], raw[name.replace("weight", "weight_scale_inv")]
-            ),
-        )
+    for w_name, (rw_cls, s_name) in quant_plan.items():
+        skip_compare_names.update((w_name, s_name))
+        yield w_name, True, ("quant", rw_cls(raw[w_name], raw[s_name]))
 
     for name in raw:
         should_compare = name not in skip_compare_names

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -13,7 +13,7 @@ from sglang.srt.utils.weight_checker_comparator import (
     ComparableWeight,
     RawReference,
     _compare_references,
-    select_reference_weight,
+    select_comparable_weight,
 )
 
 logger = logging.getLogger(__name__)
@@ -246,11 +246,11 @@ def _build_reference_plan(model) -> Dict[str, Tuple[type, str]]:
     """Apply the router across the model: {weight_name: (ComparableWeight subclass,
     scale_name)} for each weight in a module routed to a ComparableWeight. Weights
     absent from the plan (int4, mxfp8, unquantized, ...) compare raw.
-    select_reference_weight raises for an unsupported quant format (e.g. nvfp4).
+    select_comparable_weight raises for an unsupported quant format (e.g. nvfp4).
     """
     plan = {}
     for module_name, module in model.named_modules():
-        rw_cls = select_reference_weight(getattr(module, "quant_method", None))
+        rw_cls = select_comparable_weight(getattr(module, "quant_method", None))
         if rw_cls is None:
             continue
         prefix = f"{module_name}." if module_name else ""

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -11,8 +11,8 @@ from sglang.srt.managers.mm_utils import tensor_hash
 from sglang.srt.utils.weight_checker_comparator import (
     _CHUNK_NUMEL,
     ComparableWeight,
-    RawReference,
-    _compare_references,
+    RawComparable,
+    _compare_weights,
     select_comparable_weight,
 )
 
@@ -90,7 +90,7 @@ class WeightChecker:
     def _compare(self, allow_quant_error: bool = False):
         assert self._snapshot_tensors is not None
 
-        reference_plan = _build_reference_plan(self._model_runner.model)
+        quantized_set = _build_quantized_set(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
@@ -98,10 +98,10 @@ class WeightChecker:
         }
         _check_tensors(
             expect_tensors=_build_entries(
-                self._snapshot_tensors, skip_compare_names, reference_plan
+                self._snapshot_tensors, skip_compare_names, quantized_set
             ),
             actual_tensors=_build_entries(
-                dict(self._model_state()), skip_compare_names, reference_plan
+                dict(self._model_state()), skip_compare_names, quantized_set
             ),
             allow_quant_error=allow_quant_error,
         )
@@ -110,7 +110,7 @@ class WeightChecker:
         torch.cuda.synchronize()
         start = time.perf_counter()
 
-        reference_plan = _build_reference_plan(self._model_runner.model)
+        quantized_set = _build_quantized_set(self._model_runner.model)
         skip_compare_names = {
             name
             for name, param in self._model_state()
@@ -121,7 +121,7 @@ class WeightChecker:
         # bf16 hash equal.
         checksums = {}
         for name, should_compare, ref in _build_entries(
-            dict(self._model_state()), skip_compare_names, reference_plan
+            dict(self._model_state()), skip_compare_names, quantized_set
         ):
             if should_compare:
                 checksums[name] = _hash_tensor(ref.dequantize().data)
@@ -188,7 +188,7 @@ def _check_tensors(
         name = expect_name
 
         try:
-            equal, max_abs_err, mean_abs_err, num_exceed = _compare_references(
+            equal, max_abs_err, mean_abs_err, num_exceed = _compare_weights(
                 expect_ref, actual_ref
             )
         except Exception as e:
@@ -242,45 +242,45 @@ def _random_like(t: torch.Tensor):
     )
 
 
-def _build_reference_plan(model) -> Dict[str, Tuple[type, str]]:
+def _build_quantized_set(model) -> Dict[str, Tuple[type, str]]:
     """Apply the router across the model: {weight_name: (ComparableWeight subclass,
     scale_name)} for each weight in a module routed to a ComparableWeight. Weights
-    absent from the plan (int4, mxfp8, unquantized, ...) compare raw.
+    absent from the set (int4, mxfp8, unquantized, ...) compare raw.
     select_comparable_weight raises for an unsupported quant format (e.g. nvfp4).
     """
-    plan = {}
+    quantized_set = {}
     for module_name, module in model.named_modules():
-        rw_cls = select_comparable_weight(getattr(module, "quant_method", None))
-        if rw_cls is None:
+        comparable_cls = select_comparable_weight(getattr(module, "quant_method", None))
+        if comparable_cls is None:
             continue
         prefix = f"{module_name}." if module_name else ""
         own = {name for name, _ in module.named_parameters(recurse=False)}
         for name in own:
             scale = name.replace("weight", "weight_scale_inv")
             if name.endswith("weight") and scale in own:
-                plan[prefix + name] = (rw_cls, prefix + scale)
-    return plan
+                quantized_set[prefix + name] = (comparable_cls, prefix + scale)
+    return quantized_set
 
 
 def _build_entries(
     raw: Dict[str, torch.Tensor],
     skip_compare_names: Set[str],
-    reference_plan: Optional[Dict[str, Tuple[type, str]]] = None,
+    quantized_set: Optional[Dict[str, Tuple[type, str]]] = None,
 ) -> Iterable[Tuple[str, bool, ComparableWeight]]:
-    """Yields (name, should_compare, ComparableWeight): planned weights become a
-    dequant-aware reference (consuming their scale), everything else is raw."""
+    """Yields (name, should_compare, ComparableWeight): quantized weights become a
+    dequant-aware comparable (consuming their scale), everything else is raw."""
     skip_compare_names = set(skip_compare_names)
-    reference_plan = reference_plan or {}
-    scale_names = {scale for _, scale in reference_plan.values()}
+    quantized_set = quantized_set or {}
+    scale_names = {scale for _, scale in quantized_set.values()}
 
     for name, tensor in raw.items():
         if name in scale_names:
-            continue  # compared via its weight's reference
-        if name in reference_plan:
-            rw_cls, s_name = reference_plan[name]
-            yield name, True, rw_cls(tensor, raw[s_name])
+            continue  # compared via its weight's comparable
+        if name in quantized_set:
+            comparable_cls, s_name = quantized_set[name]
+            yield name, True, comparable_cls(tensor, raw[s_name])
         else:
             should_compare = name not in skip_compare_names and (
                 not _is_non_persistent_buffer_name(name)
             )
-            yield name, should_compare, RawReference(tensor)
+            yield name, should_compare, RawComparable(tensor)

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -38,7 +38,7 @@ class ComparableWeight:
         raise NotImplementedError
 
 
-class Fp8BlockReference(ComparableWeight):
+class Fp8BlockComparable(ComparableWeight):
     """Deepseek-style FP8 quantization."""
 
     def __init__(self, w_q: torch.Tensor, w_s: torch.Tensor):
@@ -93,7 +93,7 @@ class Fp8BlockReference(ComparableWeight):
         return block_quant_dequant(self.w_q, s, block_size, dtype=dtype)
 
 
-class RawReference(ComparableWeight):
+class RawComparable(ComparableWeight):
     """Unquantized tensor: identity dequant, exact (no-tolerance) compare."""
 
     def __init__(self, tensor: torch.Tensor):
@@ -111,7 +111,7 @@ class RawReference(ComparableWeight):
         return self.tensor
 
 
-def _compare_references(
+def _compare_weights(
     expect: ComparableWeight, actual: ComparableWeight
 ) -> Tuple[bool, float, float, int]:
     """Chunked compare of two ComparableWeights in dequant space. Returns
@@ -143,7 +143,7 @@ def _compare_references(
 def select_comparable_weight(quant_method) -> Optional[type]:
     """Single router: map a module's quant_method to its ComparableWeight subclass.
 
-    - fp8 block quant -> Fp8BlockReference: its scale is requantized to ue8m0 on
+    - fp8 block quant -> Fp8BlockComparable: its scale is requantized to ue8m0 on
       load, so the same weight lands as two different fp8 encodings; compare in
       dequant space with ULP tolerance.
     - nvfp4 -> raise: e4m3 fractional block scale + max-recomputed global scale is
@@ -157,7 +157,7 @@ def select_comparable_weight(quant_method) -> Optional[type]:
         and quant_method.block_quant
         and not quant_method.use_mxfp8
     ):
-        return Fp8BlockReference
+        return Fp8BlockComparable
     if isinstance(quant_method, (ModelOptFp4LinearMethod, ModelOptNvFp4FusedMoEMethod)):
         raise NotImplementedError(
             f"weight checker has no ComparableWeight for {type(quant_method).__name__}"

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -140,7 +140,7 @@ def _compare_references(
     return equal, max_abs_err.item(), sum_abs_err / max(numel, 1), num_exceed
 
 
-def select_reference_weight(quant_method) -> Optional[type]:
+def select_comparable_weight(quant_method) -> Optional[type]:
     """Single router: map a module's quant_method to its ComparableWeight subclass.
 
     - fp8 block quant -> Fp8BlockReference: its scale is requantized to ue8m0 on

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -114,9 +114,8 @@ class RawComparable(ComparableWeight):
 def _compare_weights(
     expect: ComparableWeight, actual: ComparableWeight
 ) -> Tuple[bool, float, float, int]:
-    """Chunked compare of two ComparableWeights in dequant space. Returns
-    (equal, max_abs_err, mean_abs_err, num_exceed); num_exceed counts elements
-    off by more than the combined per-side tolerance."""
+    """Chunked dequant-space compare; returns (equal, max_abs_err, mean_abs_err,
+    num_exceed), num_exceed counting elements past the combined per-side tolerance."""
     equal = True
     max_abs_err = torch.zeros((), dtype=torch.float32)
     sum_abs_err = 0.0
@@ -141,16 +140,11 @@ def _compare_weights(
 
 
 def select_comparable_weight(quant_method) -> Optional[type]:
-    """Single router: map a module's quant_method to its ComparableWeight subclass.
-
-    - fp8 block quant -> Fp8BlockComparable: its scale is requantized to ue8m0 on
-      load, so the same weight lands as two different fp8 encodings; compare in
-      dequant space with ULP tolerance.
-    - nvfp4 -> raise: e4m3 fractional block scale + max-recomputed global scale is
-      likewise non-bit-exact, but has no ComparableWeight yet.
-    - everything else -> None (raw exact compare): int4 (fixed integer scale) and
-      mxfp8/mxfp4 (e8m0, same quantizer on both sides, no load-time requant) all
-      transfer bit-exact.
+    """Map a module's quant_method to its ComparableWeight subclass; None means raw
+    (bit-exact) compare. fp8 block quant -> Fp8BlockComparable: load-time ue8m0
+    requant yields two valid fp8 encodings, so compare in dequant space with ULP
+    tolerance. nvfp4 -> raise (non-bit-exact, unsupported). int4/mxfp8/mxfp4 and
+    unquantized -> None.
     """
     if (
         isinstance(quant_method, (Fp8LinearMethod, Fp8MoEMethod))

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -2,18 +2,14 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 
-from sglang.srt.layers.quantization.base_config import (
-    FusedMoEMethodBase,
-    LinearMethodBase,
-)
 from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod, Fp8MoEMethod
 from sglang.srt.layers.quantization.fp8_utils import (
     block_quant_dequant,
     inverse_transform_scale_ue8m0,
 )
-from sglang.srt.layers.quantization.unquant import (
-    UnquantizedFusedMoEMethod,
-    UnquantizedLinearMethod,
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptFp4LinearMethod,
+    ModelOptNvFp4FusedMoEMethod,
 )
 
 # chunk to avoid too high GPU memory peak
@@ -126,17 +122,53 @@ def _compare_references(
     return equal, max_abs_err.item(), sum_abs_err / max(numel, 1), num_exceed
 
 
+def _compare_raw_pair(
+    expect: torch.Tensor, actual: torch.Tensor, compute_stats: bool
+) -> Tuple[bool, float, float]:
+    """Chunked exact-compare of two raw tensors, optionally accumulating
+    abs-diff stats. Returns (equal, max_abs_err, mean_abs_err)."""
+    assert expect.shape == actual.shape, f"{expect.shape=} {actual.shape=}"
+    expect_flat = expect.reshape(-1)
+    actual_flat = actual.reshape(-1)
+
+    equal = True
+    max_abs_err = torch.zeros((), dtype=torch.float32)
+    sum_abs_err = 0.0
+    for start in range(0, expect_flat.numel(), _CHUNK_NUMEL):
+        e = expect_flat[start : start + _CHUNK_NUMEL].cuda()
+        a = actual_flat[start : start + _CHUNK_NUMEL].cuda()
+        if torch.all(e == a):
+            continue
+        equal = False
+        if not compute_stats:
+            break
+        abs_diff = (a.float() - e.float()).abs()
+        # torch.maximum propagates NaN, unlike builtin max().
+        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
+        sum_abs_err += abs_diff.sum().item()
+    return equal, max_abs_err.item(), sum_abs_err / max(expect_flat.numel(), 1)
+
+
 def select_quantization_method(quant_method) -> Optional[type]:
-    if not isinstance(quant_method, (LinearMethodBase, FusedMoEMethodBase)):
-        return None
-    if isinstance(quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)):
-        return None
+    """Single router: map a module's quant_method to a comparison strategy.
+
+    - fp8 block quant -> Fp8BlockReference: its scale is requantized to ue8m0 on
+      load, so the same weight lands as two different fp8 encodings; compare in
+      dequant space with ULP tolerance.
+    - nvfp4 -> raise: e4m3 fractional block scale + max-recomputed global scale is
+      likewise non-bit-exact, but has no ReferenceWeight yet.
+    - everything else -> None (raw exact compare): int4 (fixed integer scale) and
+      mxfp8/mxfp4 (e8m0, same quantizer on both sides, no load-time requant) all
+      transfer bit-exact.
+    """
     if (
         isinstance(quant_method, (Fp8LinearMethod, Fp8MoEMethod))
         and quant_method.block_quant
         and not quant_method.use_mxfp8
     ):
         return Fp8BlockReference
-    raise NotImplementedError(
-        f"weight checker has no ReferenceWeight for {type(quant_method).__name__}"
-    )
+    if isinstance(quant_method, (ModelOptFp4LinearMethod, ModelOptNvFp4FusedMoEMethod)):
+        raise NotImplementedError(
+            f"weight checker has no ReferenceWeight for {type(quant_method).__name__}"
+        )
+    return None

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -93,6 +93,24 @@ class Fp8BlockReference(ReferenceWeight):
         return block_quant_dequant(self.w_q, s, block_size, dtype=dtype)
 
 
+class RawReference(ReferenceWeight):
+    """Unquantized tensor: identity dequant, exact (no-tolerance) compare."""
+
+    def __init__(self, tensor: torch.Tensor):
+        self.tensor = tensor
+
+    def __repr__(self) -> str:
+        return f"raw(shape={tuple(self.tensor.shape)} dtype={self.tensor.dtype})"
+
+    def iter_chunks(self):
+        flat = self.tensor.reshape(-1)
+        for start in range(0, flat.numel(), _CHUNK_NUMEL):
+            yield flat[start : start + _CHUNK_NUMEL].cuda(), None
+
+    def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        return self.tensor
+
+
 def _compare_references(
     expect: ReferenceWeight, actual: ReferenceWeight
 ) -> Tuple[bool, float, float, int]:
@@ -120,33 +138,6 @@ def _compare_references(
         # `~(diff <= tol)` instead of `diff > tol` so NaN counts as exceeding.
         num_exceed += int((~(abs_diff <= tol)).sum())
     return equal, max_abs_err.item(), sum_abs_err / max(numel, 1), num_exceed
-
-
-def _compare_raw_pair(
-    expect: torch.Tensor, actual: torch.Tensor, compute_stats: bool
-) -> Tuple[bool, float, float]:
-    """Chunked exact-compare of two raw tensors, optionally accumulating
-    abs-diff stats. Returns (equal, max_abs_err, mean_abs_err)."""
-    assert expect.shape == actual.shape, f"{expect.shape=} {actual.shape=}"
-    expect_flat = expect.reshape(-1)
-    actual_flat = actual.reshape(-1)
-
-    equal = True
-    max_abs_err = torch.zeros((), dtype=torch.float32)
-    sum_abs_err = 0.0
-    for start in range(0, expect_flat.numel(), _CHUNK_NUMEL):
-        e = expect_flat[start : start + _CHUNK_NUMEL].cuda()
-        a = actual_flat[start : start + _CHUNK_NUMEL].cuda()
-        if torch.all(e == a):
-            continue
-        equal = False
-        if not compute_stats:
-            break
-        abs_diff = (a.float() - e.float()).abs()
-        # torch.maximum propagates NaN, unlike builtin max().
-        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
-        sum_abs_err += abs_diff.sum().item()
-    return equal, max_abs_err.item(), sum_abs_err / max(expect_flat.numel(), 1)
 
 
 def select_quantization_method(quant_method) -> Optional[type]:

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -16,8 +16,8 @@ from sglang.srt.layers.quantization.modelopt_quant import (
 _CHUNK_NUMEL = 64 * 1024 * 1024
 
 
-class ReferenceWeight:
-    """Base class to get reference weight for all precisions."""
+class ComparableWeight:
+    """Base class: a weight in comparable (dequantized) form, for all precisions."""
 
     @staticmethod
     def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
@@ -38,7 +38,7 @@ class ReferenceWeight:
         raise NotImplementedError
 
 
-class Fp8BlockReference(ReferenceWeight):
+class Fp8BlockReference(ComparableWeight):
     """Deepseek-style FP8 quantization."""
 
     def __init__(self, w_q: torch.Tensor, w_s: torch.Tensor):
@@ -55,7 +55,7 @@ class Fp8BlockReference(ReferenceWeight):
         return w_s.to(torch.float32)
 
     @staticmethod
-    def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
+    def _infer_block_size(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
         k, s_k = w_q.shape[-1], w_s.shape[-1]
         assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
         block = k // s_k
@@ -73,12 +73,12 @@ class Fp8BlockReference(ReferenceWeight):
                 r1 = min(r0 + rows, n)
                 yield q3[b, r0:r1], s3[b, r0 // block_n : -(-r1 // block_n)]
 
-    def _normalized(self):
+    def _scale_and_block_size(self):
         s = self._normalize_scale(self.w_q, self.w_s)
-        return s, self._block_size_of(self.w_q, s)
+        return s, self._infer_block_size(self.w_q, s)
 
     def iter_chunks(self):
-        s, block_size = self._normalized()
+        s, block_size = self._scale_and_block_size()
         for q, s_chunk in self._iter_quant_chunks(self.w_q, s, block_size[0]):
             q, s_chunk = q.cuda(), s_chunk.cuda()
             yield (
@@ -89,11 +89,11 @@ class Fp8BlockReference(ReferenceWeight):
             )
 
     def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
-        s, block_size = self._normalized()
+        s, block_size = self._scale_and_block_size()
         return block_quant_dequant(self.w_q, s, block_size, dtype=dtype)
 
 
-class RawReference(ReferenceWeight):
+class RawReference(ComparableWeight):
     """Unquantized tensor: identity dequant, exact (no-tolerance) compare."""
 
     def __init__(self, tensor: torch.Tensor):
@@ -112,9 +112,9 @@ class RawReference(ReferenceWeight):
 
 
 def _compare_references(
-    expect: ReferenceWeight, actual: ReferenceWeight
+    expect: ComparableWeight, actual: ComparableWeight
 ) -> Tuple[bool, float, float, int]:
-    """Chunked compare of two ReferenceWeights in dequant space. Returns
+    """Chunked compare of two ComparableWeights in dequant space. Returns
     (equal, max_abs_err, mean_abs_err, num_exceed); num_exceed counts elements
     off by more than the combined per-side tolerance."""
     equal = True
@@ -140,14 +140,14 @@ def _compare_references(
     return equal, max_abs_err.item(), sum_abs_err / max(numel, 1), num_exceed
 
 
-def select_quantization_method(quant_method) -> Optional[type]:
-    """Single router: map a module's quant_method to a comparison strategy.
+def select_reference_weight(quant_method) -> Optional[type]:
+    """Single router: map a module's quant_method to its ComparableWeight subclass.
 
     - fp8 block quant -> Fp8BlockReference: its scale is requantized to ue8m0 on
       load, so the same weight lands as two different fp8 encodings; compare in
       dequant space with ULP tolerance.
     - nvfp4 -> raise: e4m3 fractional block scale + max-recomputed global scale is
-      likewise non-bit-exact, but has no ReferenceWeight yet.
+      likewise non-bit-exact, but has no ComparableWeight yet.
     - everything else -> None (raw exact compare): int4 (fixed integer scale) and
       mxfp8/mxfp4 (e8m0, same quantizer on both sides, no load-time requant) all
       transfer bit-exact.
@@ -160,6 +160,6 @@ def select_quantization_method(quant_method) -> Optional[type]:
         return Fp8BlockReference
     if isinstance(quant_method, (ModelOptFp4LinearMethod, ModelOptNvFp4FusedMoEMethod)):
         raise NotImplementedError(
-            f"weight checker has no ReferenceWeight for {type(quant_method).__name__}"
+            f"weight checker has no ComparableWeight for {type(quant_method).__name__}"
         )
     return None

--- a/python/sglang/srt/utils/weight_checker_quant.py
+++ b/python/sglang/srt/utils/weight_checker_quant.py
@@ -23,48 +23,20 @@ from sglang.srt.layers.quantization.unquant import (
 _CHUNK_NUMEL = 64 * 1024 * 1024
 
 
-def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
-    """Per-element ULP of w_q in its own dtype."""
-    finfo = torch.finfo(w_q.dtype)
-    x = w_q.to(torch.float32).abs()
-    # frexp: x = m * 2^e, m in [0.5, 1), so 2^(e-1) is x's binade base.
-    _, exponent = torch.frexp(x)
-    binade = torch.exp2((exponent - 1).to(torch.float32))
-    # Zeros and subnormals share the spacing of the smallest normal binade.
-    binade = binade.masked_fill(x < finfo.smallest_normal, finfo.smallest_normal)
-    return binade * finfo.eps
-
-
-def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
-    if w_s.dtype == torch.int32:
-        # UE8M0 packed format (Blackwell DeepGEMM)
-        w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
-    return w_s.to(torch.float32)
-
-
-def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
-    # Square blocks. The row dim may have a partial last block (so n//s_n is wrong),
-    # but the K dim is block-aligned, so k//s_k recovers the true block size exactly.
-    k, s_k = w_q.shape[-1], w_s.shape[-1]
-    assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
-    block = k // s_k
-    return [block, block]
-
-
-def _iter_quant_chunks(w_q: torch.Tensor, w_s: torch.Tensor, block_n: int):
-    """Yields block-row-aligned (q_slice, s_slice) pairs of bounded size."""
-    q3 = w_q.reshape(-1, *w_q.shape[-2:])
-    s3 = w_s.reshape(-1, *w_s.shape[-2:])
-    n, k = q3.shape[-2:]
-    rows = max(block_n, _CHUNK_NUMEL // k // block_n * block_n)
-    for b in range(q3.shape[0]):
-        for r0 in range(0, n, rows):
-            r1 = min(r0 + rows, n)
-            yield q3[b, r0:r1], s3[b, r0 // block_n : -(-r1 // block_n)]
-
-
 class ReferenceWeight:
     """A logical weight in encoding-invariant (dequantized) form."""
+
+    @staticmethod
+    def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
+        """Per-element ULP of w_q in its own dtype."""
+        finfo = torch.finfo(w_q.dtype)
+        x = w_q.to(torch.float32).abs()
+        # frexp: x = m * 2^e, m in [0.5, 1), so 2^(e-1) is x's binade base.
+        _, exponent = torch.frexp(x)
+        binade = torch.exp2((exponent - 1).to(torch.float32))
+        # Zeros and subnormals share the spacing of the smallest normal binade.
+        binade = binade.masked_fill(x < finfo.smallest_normal, finfo.smallest_normal)
+        return binade * finfo.eps
 
     def iter_chunks(self) -> Iterable[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
         """Yield (dequant, tolerance) cuda chunks bounded by _CHUNK_NUMEL. tolerance
@@ -88,18 +60,46 @@ class Fp8BlockReference(ReferenceWeight):
     def __repr__(self) -> str:
         return f"fp8_block(shape={tuple(self.w_q.shape)} dtype={self.w_q.dtype})"
 
+    @staticmethod
+    def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
+        if w_s.dtype == torch.int32:
+            # UE8M0 packed format (Blackwell DeepGEMM)
+            w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
+        return w_s.to(torch.float32)
+
+    @staticmethod
+    def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
+        # Square blocks. The row dim may have a partial last block (so n//s_n is wrong),
+        # but the K dim is block-aligned, so k//s_k recovers the true block size exactly.
+        k, s_k = w_q.shape[-1], w_s.shape[-1]
+        assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
+        block = k // s_k
+        return [block, block]
+
+    @staticmethod
+    def _iter_quant_chunks(w_q: torch.Tensor, w_s: torch.Tensor, block_n: int):
+        """Yields block-row-aligned (q_slice, s_slice) pairs of bounded size."""
+        q3 = w_q.reshape(-1, *w_q.shape[-2:])
+        s3 = w_s.reshape(-1, *w_s.shape[-2:])
+        n, k = q3.shape[-2:]
+        rows = max(block_n, _CHUNK_NUMEL // k // block_n * block_n)
+        for b in range(q3.shape[0]):
+            for r0 in range(0, n, rows):
+                r1 = min(r0 + rows, n)
+                yield q3[b, r0:r1], s3[b, r0 // block_n : -(-r1 // block_n)]
+
     def _normalized(self):
-        s = _normalize_scale(self.w_q, self.w_s)
-        return s, _block_size_of(self.w_q, s)
+        s = self._normalize_scale(self.w_q, self.w_s)
+        return s, self._block_size_of(self.w_q, s)
 
     def iter_chunks(self):
         s, block_size = self._normalized()
-        for q, s_chunk in _iter_quant_chunks(self.w_q, s, block_size[0]):
+        for q, s_chunk in self._iter_quant_chunks(self.w_q, s, block_size[0]):
             q, s_chunk = q.cuda(), s_chunk.cuda()
             yield (
                 block_quant_dequant(q, s_chunk, block_size, dtype=torch.bfloat16),
                 block_quant_dequant(
-                    _quant_ulp(q), s_chunk, block_size, dtype=torch.float32
+                    self._quant_ulp(q), s_chunk, block_size, dtype=torch.float32
                 ),
             )
 

--- a/python/sglang/srt/utils/weight_checker_quant.py
+++ b/python/sglang/srt/utils/weight_checker_quant.py
@@ -1,0 +1,134 @@
+"""Quantization-aware reference weights for the weight checker.
+
+A ReferenceWeight presents a logical weight in encoding-invariant (dequantized)
+form. weight_checker compares and checksums only through this seam, so a new
+precision is a new ReferenceWeight subclass — _check_tensors / _compute_checksum
+never change. Each subclass reuses sglang's per-format dequant logic.
+"""
+
+from typing import Iterable, Optional, Tuple
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_utils import (
+    block_quant_dequant,
+    inverse_transform_scale_ue8m0,
+)
+
+# Bound GPU memory: a full-size fp32 intermediate won't fit beside the KV-cache pool.
+_CHUNK_NUMEL = 64 * 1024 * 1024
+
+
+def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
+    """Per-element ULP of w_q in its own dtype."""
+    finfo = torch.finfo(w_q.dtype)
+    x = w_q.to(torch.float32).abs()
+    # frexp: x = m * 2^e, m in [0.5, 1), so 2^(e-1) is x's binade base.
+    _, exponent = torch.frexp(x)
+    binade = torch.exp2((exponent - 1).to(torch.float32))
+    # Zeros and subnormals share the spacing of the smallest normal binade.
+    binade = binade.masked_fill(x < finfo.smallest_normal, finfo.smallest_normal)
+    return binade * finfo.eps
+
+
+def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
+    if w_s.dtype == torch.int32:
+        # UE8M0 packed format (Blackwell DeepGEMM)
+        w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
+    return w_s.to(torch.float32)
+
+
+def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
+    # Square blocks. The row dim may have a partial last block (so n//s_n is wrong),
+    # but the K dim is block-aligned, so k//s_k recovers the true block size exactly.
+    k, s_k = w_q.shape[-1], w_s.shape[-1]
+    assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
+    block = k // s_k
+    return [block, block]
+
+
+def _iter_quant_chunks(w_q: torch.Tensor, w_s: torch.Tensor, block_n: int):
+    """Yields block-row-aligned (q_slice, s_slice) pairs of bounded size."""
+    q3 = w_q.reshape(-1, *w_q.shape[-2:])
+    s3 = w_s.reshape(-1, *w_s.shape[-2:])
+    n, k = q3.shape[-2:]
+    rows = max(block_n, _CHUNK_NUMEL // k // block_n * block_n)
+    for b in range(q3.shape[0]):
+        for r0 in range(0, n, rows):
+            r1 = min(r0 + rows, n)
+            yield q3[b, r0:r1], s3[b, r0 // block_n : -(-r1 // block_n)]
+
+
+class ReferenceWeight:
+    """A logical weight in encoding-invariant (dequantized) form."""
+
+    def iter_chunks(self) -> Iterable[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
+        """Yield (dequant, tolerance) cuda chunks bounded by _CHUNK_NUMEL. tolerance
+        is this side's per-element abs tolerance (ULP in dequant space), or None
+        when the format requires exact equality."""
+        raise NotImplementedError
+
+    def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        """Full dequantized tensor, for checksum hashing."""
+        raise NotImplementedError
+
+
+class Fp8BlockReference(ReferenceWeight):
+    """fp8 block quant: a (weight, weight_scale_inv) pair, scale optionally
+    UE8M0-packed. Square blocks with a possibly-partial last row block."""
+
+    def __init__(self, w_q: torch.Tensor, w_s: torch.Tensor):
+        self.w_q = w_q
+        self.w_s = w_s
+
+    def __repr__(self) -> str:
+        return f"fp8_block(shape={tuple(self.w_q.shape)} dtype={self.w_q.dtype})"
+
+    def _normalized(self):
+        s = _normalize_scale(self.w_q, self.w_s)
+        return s, _block_size_of(self.w_q, s)
+
+    def iter_chunks(self):
+        s, block_size = self._normalized()
+        for q, s_chunk in _iter_quant_chunks(self.w_q, s, block_size[0]):
+            q, s_chunk = q.cuda(), s_chunk.cuda()
+            yield (
+                block_quant_dequant(q, s_chunk, block_size, dtype=torch.bfloat16),
+                block_quant_dequant(
+                    _quant_ulp(q), s_chunk, block_size, dtype=torch.float32
+                ),
+            )
+
+    def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        s, block_size = self._normalized()
+        return block_quant_dequant(self.w_q, s, block_size, dtype=dtype)
+
+
+def _compare_references(
+    expect: ReferenceWeight, actual: ReferenceWeight
+) -> Tuple[bool, float, float, int]:
+    """Chunked compare of two ReferenceWeights in dequant space. Returns
+    (equal, max_abs_err, mean_abs_err, num_exceed); num_exceed counts elements
+    off by more than the combined per-side tolerance (NaN counts as exceeding)."""
+    equal = True
+    max_abs_err = torch.zeros((), dtype=torch.float32)
+    sum_abs_err = 0.0
+    num_exceed = 0
+    numel = 0
+    for (e_dq, e_tol), (a_dq, a_tol) in zip(
+        expect.iter_chunks(), actual.iter_chunks(), strict=True
+    ):
+        assert e_dq.shape == a_dq.shape, f"{e_dq.shape=} {a_dq.shape=}"
+        numel += e_dq.numel()
+        abs_diff = (a_dq.float() - e_dq.float()).abs()
+        if torch.all(abs_diff == 0):
+            continue
+        equal = False
+        # Each side may deviate from the shared source weight by its own tolerance.
+        tol = 0.0 if e_tol is None or a_tol is None else e_tol + a_tol
+        # torch.maximum propagates NaN, unlike builtin max().
+        max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
+        sum_abs_err += abs_diff.sum().item()
+        # `~(diff <= tol)` instead of `diff > tol` so NaN counts as exceeding.
+        num_exceed += int((~(abs_diff <= tol)).sum())
+    return equal, max_abs_err.item(), sum_abs_err / max(numel, 1), num_exceed

--- a/python/sglang/srt/utils/weight_checker_quant.py
+++ b/python/sglang/srt/utils/weight_checker_quant.py
@@ -50,9 +50,6 @@ class ReferenceWeight:
 
 
 class Fp8BlockReference(ReferenceWeight):
-    """fp8 block quant: a (weight, weight_scale_inv) pair, scale optionally
-    UE8M0-packed. Square blocks with a possibly-partial last row block."""
-
     def __init__(self, w_q: torch.Tensor, w_s: torch.Tensor):
         self.w_q = w_q
         self.w_s = w_s
@@ -63,14 +60,11 @@ class Fp8BlockReference(ReferenceWeight):
     @staticmethod
     def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
         if w_s.dtype == torch.int32:
-            # UE8M0 packed format (Blackwell DeepGEMM)
             w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
         return w_s.to(torch.float32)
 
     @staticmethod
     def _block_size_of(w_q: torch.Tensor, w_s: torch.Tensor) -> list:
-        # Square blocks. The row dim may have a partial last block (so n//s_n is wrong),
-        # but the K dim is block-aligned, so k//s_k recovers the true block size exactly.
         k, s_k = w_q.shape[-1], w_s.shape[-1]
         assert k % s_k == 0, f"cannot infer block size from {w_q.shape=} {w_s.shape=}"
         block = k // s_k
@@ -140,15 +134,11 @@ def _compare_references(
 
 def select_quantization_method(quant_method) -> Optional[type]:
     """Select the ReferenceWeight subclass for a module's quant_method: None if the
-    module is not a quantized weight layer, the subclass for a supported format,
-    else raise. Dispatching on quant_method (not param names) is robust to
-    swizzled scales and per-format naming."""
+    module is not a quantized weight layer, the subclass for a supported format."""
     if not isinstance(quant_method, (LinearMethodBase, FusedMoEMethodBase)):
         return None
     if isinstance(quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)):
         return None
-    # fp8 block quant has square blocks; mxfp8 ([1, 32]) is non-square and
-    # per-tensor fp8 has no block scale, so neither is supported.
     if (
         isinstance(quant_method, (Fp8LinearMethod, Fp8MoEMethod))
         and quant_method.block_quant

--- a/python/sglang/srt/utils/weight_checker_quant.py
+++ b/python/sglang/srt/utils/weight_checker_quant.py
@@ -1,18 +1,22 @@
-"""Quantization-aware reference weights for the weight checker.
-
-A ReferenceWeight presents a logical weight in encoding-invariant (dequantized)
-form. weight_checker compares and checksums only through this seam, so a new
-precision is a new ReferenceWeight subclass — _check_tensors / _compute_checksum
-never change. Each subclass reuses sglang's per-format dequant logic.
-"""
+"""Reference weights for the weight checker: a quantized weight in dequantized,
+encoding-invariant form. A new precision is a new ReferenceWeight subclass."""
 
 from typing import Iterable, Optional, Tuple
 
 import torch
 
+from sglang.srt.layers.quantization.base_config import (
+    FusedMoEMethodBase,
+    LinearMethodBase,
+)
+from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod, Fp8MoEMethod
 from sglang.srt.layers.quantization.fp8_utils import (
     block_quant_dequant,
     inverse_transform_scale_ue8m0,
+)
+from sglang.srt.layers.quantization.unquant import (
+    UnquantizedFusedMoEMethod,
+    UnquantizedLinearMethod,
 )
 
 # Bound GPU memory: a full-size fp32 intermediate won't fit beside the KV-cache pool.
@@ -132,3 +136,25 @@ def _compare_references(
         # `~(diff <= tol)` instead of `diff > tol` so NaN counts as exceeding.
         num_exceed += int((~(abs_diff <= tol)).sum())
     return equal, max_abs_err.item(), sum_abs_err / max(numel, 1), num_exceed
+
+
+def select_quantization_method(quant_method) -> Optional[type]:
+    """Select the ReferenceWeight subclass for a module's quant_method: None if the
+    module is not a quantized weight layer, the subclass for a supported format,
+    else raise. Dispatching on quant_method (not param names) is robust to
+    swizzled scales and per-format naming."""
+    if not isinstance(quant_method, (LinearMethodBase, FusedMoEMethodBase)):
+        return None
+    if isinstance(quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)):
+        return None
+    # fp8 block quant has square blocks; mxfp8 ([1, 32]) is non-square and
+    # per-tensor fp8 has no block scale, so neither is supported.
+    if (
+        isinstance(quant_method, (Fp8LinearMethod, Fp8MoEMethod))
+        and quant_method.block_quant
+        and not quant_method.use_mxfp8
+    ):
+        return Fp8BlockReference
+    raise NotImplementedError(
+        f"weight checker has no ReferenceWeight for {type(quant_method).__name__}"
+    )

--- a/python/sglang/srt/utils/weight_checker_quant.py
+++ b/python/sglang/srt/utils/weight_checker_quant.py
@@ -1,6 +1,3 @@
-"""Reference weights for the weight checker: a quantized weight in dequantized,
-encoding-invariant form. A new precision is a new ReferenceWeight subclass."""
-
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -19,12 +16,12 @@ from sglang.srt.layers.quantization.unquant import (
     UnquantizedLinearMethod,
 )
 
-# Bound GPU memory: a full-size fp32 intermediate won't fit beside the KV-cache pool.
+# chunk to avoid too high GPU memory peak
 _CHUNK_NUMEL = 64 * 1024 * 1024
 
 
 class ReferenceWeight:
-    """A logical weight in encoding-invariant (dequantized) form."""
+    """Base class to get reference weight for all precisions."""
 
     @staticmethod
     def _quant_ulp(w_q: torch.Tensor) -> torch.Tensor:
@@ -39,17 +36,15 @@ class ReferenceWeight:
         return binade * finfo.eps
 
     def iter_chunks(self) -> Iterable[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
-        """Yield (dequant, tolerance) cuda chunks bounded by _CHUNK_NUMEL. tolerance
-        is this side's per-element abs tolerance (ULP in dequant space), or None
-        when the format requires exact equality."""
         raise NotImplementedError
 
     def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
-        """Full dequantized tensor, for checksum hashing."""
         raise NotImplementedError
 
 
 class Fp8BlockReference(ReferenceWeight):
+    """Deepseek-style FP8 quantization."""
+
     def __init__(self, w_q: torch.Tensor, w_s: torch.Tensor):
         self.w_q = w_q
         self.w_s = w_s
@@ -107,7 +102,7 @@ def _compare_references(
 ) -> Tuple[bool, float, float, int]:
     """Chunked compare of two ReferenceWeights in dequant space. Returns
     (equal, max_abs_err, mean_abs_err, num_exceed); num_exceed counts elements
-    off by more than the combined per-side tolerance (NaN counts as exceeding)."""
+    off by more than the combined per-side tolerance."""
     equal = True
     max_abs_err = torch.zeros((), dtype=torch.float32)
     sum_abs_err = 0.0
@@ -122,9 +117,8 @@ def _compare_references(
         if torch.all(abs_diff == 0):
             continue
         equal = False
-        # Each side may deviate from the shared source weight by its own tolerance.
+        # |a_dq - e_dq| ≤ |a_dq - w| + |e_dq - w| ≤ a_tol + e_tol
         tol = 0.0 if e_tol is None or a_tol is None else e_tol + a_tol
-        # torch.maximum propagates NaN, unlike builtin max().
         max_abs_err = torch.maximum(max_abs_err, abs_diff.max().cpu())
         sum_abs_err += abs_diff.sum().item()
         # `~(diff <= tol)` instead of `diff > tol` so NaN counts as exceeding.
@@ -133,8 +127,6 @@ def _compare_references(
 
 
 def select_quantization_method(quant_method) -> Optional[type]:
-    """Select the ReferenceWeight subclass for a module's quant_method: None if the
-    module is not a quantized weight layer, the subclass for a supported format."""
     if not isinstance(quant_method, (LinearMethodBase, FusedMoEMethodBase)):
         return None
     if isinstance(quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)):

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -29,7 +29,7 @@ from sglang.srt.utils.weight_checker import (
     ParallelismInfo,
     WeightChecker,
     _build_entries,
-    _build_reference_plan,
+    _build_quantized_set,
     _check_tensors,
     _hash_tensor,
     _is_non_persistent_buffer_name,
@@ -37,9 +37,9 @@ from sglang.srt.utils.weight_checker import (
 )
 from sglang.srt.utils.weight_checker_comparator import (
     ComparableWeight,
-    Fp8BlockReference,
-    RawReference,
-    _compare_references,
+    Fp8BlockComparable,
+    RawComparable,
+    _compare_weights,
     select_comparable_weight,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -69,7 +69,7 @@ def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) ->
         assert a_name == e_name, f"[{i}] name: {a_name!r} != {e_name!r}"
         assert a_flag == e_flag, f"[{i}] should_compare: {a_flag} != {e_flag}"
         assert type(a_ref) is type(e_ref), f"[{i}] kind mismatch for {a_name!r}"
-        if isinstance(a_ref, Fp8BlockReference):
+        if isinstance(a_ref, Fp8BlockComparable):
             torch.testing.assert_close(
                 a_ref.w_q, e_ref.w_q, msg=f"[{i}] w_q {a_name!r}"
             )
@@ -83,9 +83,9 @@ def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) ->
 
 
 def _compare_quant_pair(expect_q, expect_s, actual_q, actual_s):
-    """Test shim: wrap fp8 (q, s) pairs as references and compare them."""
-    return _compare_references(
-        Fp8BlockReference(expect_q, expect_s), Fp8BlockReference(actual_q, actual_s)
+    """Test shim: wrap fp8 (q, s) pairs as comparables and compare them."""
+    return _compare_weights(
+        Fp8BlockComparable(expect_q, expect_s), Fp8BlockComparable(actual_q, actual_s)
     )
 
 
@@ -222,14 +222,14 @@ class TestPostprocessTensors(CustomTestCase):
         raw = {"a.weight": a, "b.bias": b}
         _assert_entries_close(
             _build_entries(raw, set()),
-            [("a.weight", True, RawReference(a)), ("b.bias", True, RawReference(b))],
+            [("a.weight", True, RawComparable(a)), ("b.bias", True, RawComparable(b))],
         )
 
     def test_weight_alone_without_scale_inv_does_not_trigger_dequant(self):
         w = torch.randn(4)
         raw = {"x.weight": w}
         _assert_entries_close(
-            _build_entries(raw, set()), [("x.weight", True, RawReference(w))]
+            _build_entries(raw, set()), [("x.weight", True, RawComparable(w))]
         )
 
     # --- non-persistent buffer skip ---
@@ -244,8 +244,8 @@ class TestPostprocessTensors(CustomTestCase):
         _assert_entries_close(
             _build_entries(raw, set()),
             [
-                ("model.rotary_emb.cos_sin_cache", False, RawReference(cache)),
-                ("model.layers.0.weight", True, RawReference(plain)),
+                ("model.rotary_emb.cos_sin_cache", False, RawComparable(cache)),
+                ("model.layers.0.weight", True, RawComparable(plain)),
             ],
         )
 
@@ -253,14 +253,14 @@ class TestPostprocessTensors(CustomTestCase):
         t = torch.randn(4)
         _assert_entries_close(
             _build_entries({"model.rotary_emb.inv_freq": t}, set()),
-            [("model.rotary_emb.inv_freq", False, RawReference(t))],
+            [("model.rotary_emb.inv_freq", False, RawComparable(t))],
         )
 
     def test_skips_weight_fp32_substring(self):
         t = torch.randn(4)
         _assert_entries_close(
             _build_entries({"model.layers.0.mlp.gate._weight_fp32": t}, set()),
-            [("model.layers.0.mlp.gate._weight_fp32", False, RawReference(t))],
+            [("model.layers.0.mlp.gate._weight_fp32", False, RawComparable(t))],
         )
 
     def test_substring_match_not_endswith(self):
@@ -268,7 +268,7 @@ class TestPostprocessTensors(CustomTestCase):
         t = torch.randn(4)
         _assert_entries_close(
             _build_entries({"weird.cos_sin_cache.foo.bar": t}, set()),
-            [("weird.cos_sin_cache.foo.bar", False, RawReference(t))],
+            [("weird.cos_sin_cache.foo.bar", False, RawComparable(t))],
         )
 
     # --- fp8 quant pair (real dequant on real fp8 tensors) ---
@@ -277,10 +277,10 @@ class TestPostprocessTensors(CustomTestCase):
         qweight, sf_fp32, sf_packed_int32 = _build_fp8_quant_pair()
         raw = {"x.weight": qweight, "x.weight_scale_inv": sf_packed_int32}
 
-        ref = Fp8BlockReference(qweight, sf_packed_int32)
-        plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
+        ref = Fp8BlockComparable(qweight, sf_packed_int32)
+        quantized_set = {"x.weight": (Fp8BlockComparable, "x.weight_scale_inv")}
         _assert_entries_close(
-            _build_entries(raw, set(), plan),
+            _build_entries(raw, set(), quantized_set),
             [("x.weight", True, ref)],
         )
 
@@ -292,14 +292,14 @@ class TestPostprocessTensors(CustomTestCase):
             "x.weight_scale_inv": sf_fp32,
             "y.bias": bias,
         }
-        # scale_inv is consumed by its weight's reference; y.bias stays raw.
-        ref = Fp8BlockReference(qweight, sf_fp32)
-        plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
+        # scale_inv is consumed by its weight's comparable; y.bias stays raw.
+        ref = Fp8BlockComparable(qweight, sf_fp32)
+        quantized_set = {"x.weight": (Fp8BlockComparable, "x.weight_scale_inv")}
         _assert_entries_close(
-            _build_entries(raw, set(), plan),
+            _build_entries(raw, set(), quantized_set),
             [
                 ("x.weight", True, ref),
-                ("y.bias", True, RawReference(bias)),
+                ("y.bias", True, RawComparable(bias)),
             ],
         )
 
@@ -309,7 +309,7 @@ class TestPostprocessTensors(CustomTestCase):
         s = torch.zeros(1, 1, dtype=torch.int32)
         _assert_entries_close(
             _build_entries({"x.weight_scale_inv": s}, set()),
-            [("x.weight_scale_inv", True, RawReference(s))],
+            [("x.weight_scale_inv", True, RawComparable(s))],
         )
 
 
@@ -323,18 +323,18 @@ class TestCheckTensors(CustomTestCase):
     def test_passes_when_all_equal(self):
         t = torch.ones(2, 2)
         expect = [
-            ("a", True, RawReference(t.clone())),
-            ("b", True, RawReference(t.clone())),
+            ("a", True, RawComparable(t.clone())),
+            ("b", True, RawComparable(t.clone())),
         ]
         actual = [
-            ("a", True, RawReference(t.clone())),
-            ("b", True, RawReference(t.clone())),
+            ("a", True, RawComparable(t.clone())),
+            ("b", True, RawComparable(t.clone())),
         ]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_raises_when_should_compare_true_and_diff(self):
-        expect = [("a", True, RawReference(torch.ones(2, 2)))]
-        actual = [("a", True, RawReference(torch.zeros(2, 2)))]
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", True, RawComparable(torch.zeros(2, 2)))]
         with self.assertRaises(Exception) as ctx:
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
         msg = str(ctx.exception)
@@ -343,25 +343,25 @@ class TestCheckTensors(CustomTestCase):
 
     def test_passes_when_should_compare_false_even_if_diff(self):
         # should_compare=False -> diff is logged, not raised.
-        expect = [("a", False, RawReference(torch.ones(2, 2)))]
-        actual = [("a", False, RawReference(torch.zeros(2, 2)))]
+        expect = [("a", False, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", False, RawComparable(torch.zeros(2, 2)))]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_name_mismatch(self):
-        expect = [("a", True, RawReference(torch.ones(2, 2)))]
-        actual = [("b", True, RawReference(torch.ones(2, 2)))]
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("b", True, RawComparable(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_should_compare_mismatch(self):
-        expect = [("a", True, RawReference(torch.ones(2, 2)))]
-        actual = [("a", False, RawReference(torch.ones(2, 2)))]
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", False, RawComparable(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_chunked_raw_stats_match_unchunked(self):
-        expect = [("a", True, RawReference(torch.zeros(10)))]
-        actual = [("a", True, RawReference(torch.arange(10.0)))]
+        expect = [("a", True, RawComparable(torch.zeros(10)))]
+        actual = [("a", True, RawComparable(torch.arange(10.0)))]
         with patch("sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 3):
             with self.assertRaises(Exception) as ctx:
                 _check_tensors(expect_tensors=expect, actual_tensors=actual)
@@ -371,10 +371,10 @@ class TestCheckTensors(CustomTestCase):
     def test_zip_strict_raises_on_length_mismatch(self):
         t = torch.ones(2, 2)
         expect = [
-            ("a", True, RawReference(t.clone())),
-            ("b", True, RawReference(t.clone())),
+            ("a", True, RawComparable(t.clone())),
+            ("b", True, RawComparable(t.clone())),
         ]
-        actual = [("a", True, RawReference(t.clone()))]
+        actual = [("a", True, RawComparable(t.clone()))]
         with self.assertRaises(ValueError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
@@ -482,7 +482,7 @@ class TestCompareQuantPair(CustomTestCase):
         e_q, e_s = self._quantize_partial(weight, 1.0)
         a_q, a_s = self._quantize_partial(weight, 1.001)
         self.assertEqual(list(e_s.shape), [4, 2])  # ceil(448/128)=4, 256/128=2
-        self.assertEqual(Fp8BlockReference._infer_block_size(e_q, e_s), [128, 128])
+        self.assertEqual(Fp8BlockComparable._infer_block_size(e_q, e_s), [128, 128])
         equal, _, _, num_exceed = _compare_quant_pair(e_q, e_s, a_q, a_s)
         self.assertFalse(equal)
         self.assertEqual(num_exceed, 0)
@@ -507,10 +507,10 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
         return {"x.weight": q, "x.weight_scale_inv": s}
 
     def _check(self, expect_raw, actual_raw, **kwargs):
-        plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
+        quantized_set = {"x.weight": (Fp8BlockComparable, "x.weight_scale_inv")}
         _check_tensors(
-            expect_tensors=_build_entries(expect_raw, set(), plan),
-            actual_tensors=_build_entries(actual_raw, set(), plan),
+            expect_tensors=_build_entries(expect_raw, set(), quantized_set),
+            actual_tensors=_build_entries(actual_raw, set(), quantized_set),
             **kwargs,
         )
 
@@ -533,8 +533,8 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
         self.assertIn("num_exceed", str(ctx.exception))
 
     def test_flag_does_not_relax_non_quant_tensors(self):
-        expect = [("a", True, RawReference(torch.ones(2, 2)))]
-        actual = [("a", True, RawReference(torch.ones(2, 2) + 0.5))]
+        expect = [("a", True, RawComparable(torch.ones(2, 2)))]
+        actual = [("a", True, RawComparable(torch.ones(2, 2) + 0.5))]
         with self.assertRaises(Exception):
             _check_tensors(
                 expect_tensors=expect, actual_tensors=actual, allow_quant_error=True
@@ -569,7 +569,7 @@ class TestSelectComparableWeight(CustomTestCase):
             select_comparable_weight(fake)
 
 
-class TestBuildReferencePlan(CustomTestCase):
+class TestBuildQuantizedSet(CustomTestCase):
 
     def test_fp8_block_module_pairs_weight_and_scale(self):
         from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
@@ -587,12 +587,12 @@ class TestBuildReferencePlan(CustomTestCase):
             "weight_scale_inv", nn.Parameter(torch.zeros(1, 1), requires_grad=False)
         )
         self.assertEqual(
-            _build_reference_plan(model),
-            {"proj.weight": (Fp8BlockReference, "proj.weight_scale_inv")},
+            _build_quantized_set(model),
+            {"proj.weight": (Fp8BlockComparable, "proj.weight_scale_inv")},
         )
 
     def test_no_quant_method_yields_empty_plan(self):
-        self.assertEqual(_build_reference_plan(_TinyModel()), {})
+        self.assertEqual(_build_quantized_set(_TinyModel()), {})
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -37,6 +37,7 @@ from sglang.srt.utils.weight_checker import (
 )
 from sglang.srt.utils.weight_checker_comparator import (
     Fp8BlockReference,
+    RawReference,
     ReferenceWeight,
     _compare_references,
     select_quantization_method,
@@ -52,34 +53,32 @@ register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
 # ---------------------------------------------------------------------------
 
 
-Entry = Tuple[str, bool, Tuple]
+Entry = Tuple[str, bool, ReferenceWeight]
 
 
 def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) -> None:
-    """Compare two streams of (name, should_compare, entry) where entry is
-    ("raw", tensor) or ("quant", Fp8BlockReference)."""
+    """Compare two streams of (name, should_compare, ReferenceWeight)."""
     actual_list: List[Entry] = list(actual)
     expected_list: List[Entry] = list(expected)
     assert len(actual_list) == len(
         expected_list
     ), f"length mismatch: actual={len(actual_list)} expected={len(expected_list)}"
-    for i, ((a_name, a_flag, a_entry), (e_name, e_flag, e_entry)) in enumerate(
+    for i, ((a_name, a_flag, a_ref), (e_name, e_flag, e_ref)) in enumerate(
         zip(actual_list, expected_list)
     ):
         assert a_name == e_name, f"[{i}] name: {a_name!r} != {e_name!r}"
         assert a_flag == e_flag, f"[{i}] should_compare: {a_flag} != {e_flag}"
-        assert a_entry[0] == e_entry[0], f"[{i}] entry kind mismatch for {a_name!r}"
-        if a_entry[0] == "quant":
-            a_ref, e_ref = a_entry[1], e_entry[1]
+        assert type(a_ref) is type(e_ref), f"[{i}] kind mismatch for {a_name!r}"
+        if isinstance(a_ref, Fp8BlockReference):
             torch.testing.assert_close(
-                a_ref.w_q, e_ref.w_q, msg=f"[{i}] w_q mismatch for {a_name!r}"
+                a_ref.w_q, e_ref.w_q, msg=f"[{i}] w_q {a_name!r}"
             )
             torch.testing.assert_close(
-                a_ref.w_s, e_ref.w_s, msg=f"[{i}] w_s mismatch for {a_name!r}"
+                a_ref.w_s, e_ref.w_s, msg=f"[{i}] w_s {a_name!r}"
             )
         else:
             torch.testing.assert_close(
-                a_entry[1], e_entry[1], msg=f"[{i}] tensor mismatch for {a_name!r}"
+                a_ref.tensor, e_ref.tensor, msg=f"[{i}] tensor {a_name!r}"
             )
 
 
@@ -223,14 +222,14 @@ class TestPostprocessTensors(CustomTestCase):
         raw = {"a.weight": a, "b.bias": b}
         _assert_entries_close(
             _postprocess_tensors(raw, set()),
-            [("a.weight", True, ("raw", a)), ("b.bias", True, ("raw", b))],
+            [("a.weight", True, RawReference(a)), ("b.bias", True, RawReference(b))],
         )
 
     def test_weight_alone_without_scale_inv_does_not_trigger_dequant(self):
         w = torch.randn(4)
         raw = {"x.weight": w}
         _assert_entries_close(
-            _postprocess_tensors(raw, set()), [("x.weight", True, ("raw", w))]
+            _postprocess_tensors(raw, set()), [("x.weight", True, RawReference(w))]
         )
 
     # --- non-persistent buffer skip ---
@@ -245,8 +244,8 @@ class TestPostprocessTensors(CustomTestCase):
         _assert_entries_close(
             _postprocess_tensors(raw, set()),
             [
-                ("model.rotary_emb.cos_sin_cache", False, ("raw", cache)),
-                ("model.layers.0.weight", True, ("raw", plain)),
+                ("model.rotary_emb.cos_sin_cache", False, RawReference(cache)),
+                ("model.layers.0.weight", True, RawReference(plain)),
             ],
         )
 
@@ -254,14 +253,14 @@ class TestPostprocessTensors(CustomTestCase):
         t = torch.randn(4)
         _assert_entries_close(
             _postprocess_tensors({"model.rotary_emb.inv_freq": t}, set()),
-            [("model.rotary_emb.inv_freq", False, ("raw", t))],
+            [("model.rotary_emb.inv_freq", False, RawReference(t))],
         )
 
     def test_skips_weight_fp32_substring(self):
         t = torch.randn(4)
         _assert_entries_close(
             _postprocess_tensors({"model.layers.0.mlp.gate._weight_fp32": t}, set()),
-            [("model.layers.0.mlp.gate._weight_fp32", False, ("raw", t))],
+            [("model.layers.0.mlp.gate._weight_fp32", False, RawReference(t))],
         )
 
     def test_substring_match_not_endswith(self):
@@ -269,7 +268,7 @@ class TestPostprocessTensors(CustomTestCase):
         t = torch.randn(4)
         _assert_entries_close(
             _postprocess_tensors({"weird.cos_sin_cache.foo.bar": t}, set()),
-            [("weird.cos_sin_cache.foo.bar", False, ("raw", t))],
+            [("weird.cos_sin_cache.foo.bar", False, RawReference(t))],
         )
 
     # --- fp8 quant pair (real dequant on real fp8 tensors) ---
@@ -282,11 +281,7 @@ class TestPostprocessTensors(CustomTestCase):
         plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
         _assert_entries_close(
             _postprocess_tensors(raw, set(), plan),
-            [
-                ("x.weight", True, ("quant", ref)),
-                ("x.weight", False, ("raw", qweight)),
-                ("x.weight_scale_inv", False, ("raw", sf_packed_int32)),
-            ],
+            [("x.weight", True, ref)],
         )
 
     def test_fp8_quant_pair_yield_order_alongside_other_entries(self):
@@ -297,16 +292,14 @@ class TestPostprocessTensors(CustomTestCase):
             "x.weight_scale_inv": sf_fp32,
             "y.bias": bias,
         }
-        # All quant entries come first, then a raw pass over every key.
+        # scale_inv is consumed by its weight's reference; y.bias stays raw.
         ref = Fp8BlockReference(qweight, sf_fp32)
         plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
         _assert_entries_close(
             _postprocess_tensors(raw, set(), plan),
             [
-                ("x.weight", True, ("quant", ref)),
-                ("x.weight", False, ("raw", qweight)),
-                ("x.weight_scale_inv", False, ("raw", sf_fp32)),
-                ("y.bias", True, ("raw", bias)),
+                ("x.weight", True, ref),
+                ("y.bias", True, RawReference(bias)),
             ],
         )
 
@@ -316,7 +309,7 @@ class TestPostprocessTensors(CustomTestCase):
         s = torch.zeros(1, 1, dtype=torch.int32)
         _assert_entries_close(
             _postprocess_tensors({"x.weight_scale_inv": s}, set()),
-            [("x.weight_scale_inv", True, ("raw", s))],
+            [("x.weight_scale_inv", True, RawReference(s))],
         )
 
 
@@ -329,13 +322,19 @@ class TestCheckTensors(CustomTestCase):
 
     def test_passes_when_all_equal(self):
         t = torch.ones(2, 2)
-        expect = [("a", True, ("raw", t.clone())), ("b", True, ("raw", t.clone()))]
-        actual = [("a", True, ("raw", t.clone())), ("b", True, ("raw", t.clone()))]
+        expect = [
+            ("a", True, RawReference(t.clone())),
+            ("b", True, RawReference(t.clone())),
+        ]
+        actual = [
+            ("a", True, RawReference(t.clone())),
+            ("b", True, RawReference(t.clone())),
+        ]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_raises_when_should_compare_true_and_diff(self):
-        expect = [("a", True, ("raw", torch.ones(2, 2)))]
-        actual = [("a", True, ("raw", torch.zeros(2, 2)))]
+        expect = [("a", True, RawReference(torch.ones(2, 2)))]
+        actual = [("a", True, RawReference(torch.zeros(2, 2)))]
         with self.assertRaises(Exception) as ctx:
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
         msg = str(ctx.exception)
@@ -344,25 +343,25 @@ class TestCheckTensors(CustomTestCase):
 
     def test_passes_when_should_compare_false_even_if_diff(self):
         # should_compare=False -> diff is logged, not raised.
-        expect = [("a", False, ("raw", torch.ones(2, 2)))]
-        actual = [("a", False, ("raw", torch.zeros(2, 2)))]
+        expect = [("a", False, RawReference(torch.ones(2, 2)))]
+        actual = [("a", False, RawReference(torch.zeros(2, 2)))]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_name_mismatch(self):
-        expect = [("a", True, ("raw", torch.ones(2, 2)))]
-        actual = [("b", True, ("raw", torch.ones(2, 2)))]
+        expect = [("a", True, RawReference(torch.ones(2, 2)))]
+        actual = [("b", True, RawReference(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_should_compare_mismatch(self):
-        expect = [("a", True, ("raw", torch.ones(2, 2)))]
-        actual = [("a", False, ("raw", torch.ones(2, 2)))]
+        expect = [("a", True, RawReference(torch.ones(2, 2)))]
+        actual = [("a", False, RawReference(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_chunked_raw_stats_match_unchunked(self):
-        expect = [("a", True, ("raw", torch.zeros(10)))]
-        actual = [("a", True, ("raw", torch.arange(10.0)))]
+        expect = [("a", True, RawReference(torch.zeros(10)))]
+        actual = [("a", True, RawReference(torch.arange(10.0)))]
         with patch("sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 3):
             with self.assertRaises(Exception) as ctx:
                 _check_tensors(expect_tensors=expect, actual_tensors=actual)
@@ -371,8 +370,11 @@ class TestCheckTensors(CustomTestCase):
 
     def test_zip_strict_raises_on_length_mismatch(self):
         t = torch.ones(2, 2)
-        expect = [("a", True, ("raw", t.clone())), ("b", True, ("raw", t.clone()))]
-        actual = [("a", True, ("raw", t.clone()))]
+        expect = [
+            ("a", True, RawReference(t.clone())),
+            ("b", True, RawReference(t.clone())),
+        ]
+        actual = [("a", True, RawReference(t.clone()))]
         with self.assertRaises(ValueError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
@@ -528,11 +530,11 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
         )
         with self.assertRaises(Exception) as ctx:
             self._check(self.e_raw, bad, allow_quant_error=True)
-        self.assertIn("num_exceed_quant_ulp_tolerance", str(ctx.exception))
+        self.assertIn("num_exceed", str(ctx.exception))
 
     def test_flag_does_not_relax_non_quant_tensors(self):
-        expect = [("a", True, ("raw", torch.ones(2, 2)))]
-        actual = [("a", True, ("raw", torch.ones(2, 2) + 0.5))]
+        expect = [("a", True, RawReference(torch.ones(2, 2)))]
+        actual = [("a", True, RawReference(torch.ones(2, 2) + 0.5))]
         with self.assertRaises(Exception):
             _check_tensors(
                 expect_tensors=expect, actual_tensors=actual, allow_quant_error=True

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -36,9 +36,8 @@ from sglang.srt.utils.weight_checker import (
 )
 from sglang.srt.utils.weight_checker_quant import (
     Fp8BlockReference,
-    _block_size_of,
+    ReferenceWeight,
     _compare_references,
-    _quant_ulp,
     select_quantization_method,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -391,7 +390,7 @@ class TestQuantUlp(CustomTestCase):
             # (the largest magnitude reuses the spacing below it).
             spacing = magnitudes[1:] - magnitudes[:-1]
             expected = torch.cat([spacing, spacing[-1:]])
-            got = _quant_ulp(magnitudes.to(dtype))
+            got = ReferenceWeight._quant_ulp(magnitudes.to(dtype))
             torch.testing.assert_close(got, expected, rtol=0, atol=0)
 
 
@@ -476,7 +475,7 @@ class TestCompareQuantPair(CustomTestCase):
         e_q, e_s = self._quantize_partial(weight, 1.0)
         a_q, a_s = self._quantize_partial(weight, 1.001)
         self.assertEqual(list(e_s.shape), [4, 2])  # ceil(448/128)=4, 256/128=2
-        self.assertEqual(_block_size_of(e_q, e_s), [128, 128])
+        self.assertEqual(Fp8BlockReference._block_size_of(e_q, e_s), [128, 128])
         equal, _, _, num_exceed = _compare_quant_pair(e_q, e_s, a_q, a_s)
         self.assertFalse(equal)
         self.assertEqual(num_exceed, 0)

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -21,7 +21,6 @@ import torch
 from torch import nn
 
 from sglang.srt.layers.quantization.fp8_utils import (
-    block_quant_dequant,
     quant_weight_ue8m0,
     transform_scale_ue8m0,
 )
@@ -29,10 +28,13 @@ from sglang.srt.utils.weight_checker import (
     ChecksumInfo,
     ParallelismInfo,
     WeightChecker,
+    _block_size_of,
     _check_tensors,
+    _compare_quant_pair,
     _hash_tensor,
     _is_non_persistent_buffer_name,
     _postprocess_tensors,
+    _quant_ulp,
     _random_like,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -46,24 +48,27 @@ register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
 # ---------------------------------------------------------------------------
 
 
-Triple = Tuple[str, bool, torch.Tensor]
+Entry = Tuple[str, bool, Tuple]
 
 
-def _assert_triples_close(actual: Iterable[Triple], expected: Iterable[Triple]) -> None:
-    """Compare two streams of (name, should_compare, tensor); element-wise tensor close."""
-    actual_list: List[Triple] = list(actual)
-    expected_list: List[Triple] = list(expected)
+def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) -> None:
+    """Compare two streams of (name, should_compare, entry) where entry is
+    ("raw", tensor) or ("quant", w_q, w_s)."""
+    actual_list: List[Entry] = list(actual)
+    expected_list: List[Entry] = list(expected)
     assert len(actual_list) == len(
         expected_list
     ), f"length mismatch: actual={len(actual_list)} expected={len(expected_list)}"
-    for i, ((a_name, a_flag, a_t), (e_name, e_flag, e_t)) in enumerate(
+    for i, ((a_name, a_flag, a_entry), (e_name, e_flag, e_entry)) in enumerate(
         zip(actual_list, expected_list)
     ):
         assert a_name == e_name, f"[{i}] name: {a_name!r} != {e_name!r}"
         assert a_flag == e_flag, f"[{i}] should_compare: {a_flag} != {e_flag}"
-        torch.testing.assert_close(
-            a_t, e_t, msg=f"[{i}] tensor mismatch for {a_name!r}"
-        )
+        assert a_entry[0] == e_entry[0], f"[{i}] entry kind mismatch for {a_name!r}"
+        for a_t, e_t in zip(a_entry[1:], e_entry[1:], strict=True):
+            torch.testing.assert_close(
+                a_t, e_t, msg=f"[{i}] tensor mismatch for {a_name!r}"
+            )
 
 
 def _build_fp8_quant_pair(device: str = "cuda"):
@@ -173,6 +178,16 @@ class TestRandomLike(CustomTestCase):
         _random_like(t)
         torch.testing.assert_close(t, before)
 
+    def test_floating_point_chunked_generation(self):
+        with patch("sglang.srt.utils.weight_checker._CHUNK_NUMEL", 8):
+            out = _random_like(torch.zeros(64, dtype=torch.bfloat16))
+        self.assertEqual(out.dtype, torch.bfloat16)
+        self.assertEqual(out.shape, (64,))
+        self.assertGreater(out.unique().numel(), 8)
+        self.assertGreaterEqual(out.float().min().item(), 0.0)
+        # bf16 rounding may carry values just below 1.0 up to exactly 1.0
+        self.assertLessEqual(out.float().max().item(), 1.0)
+
 
 # ---------------------------------------------------------------------------
 # _postprocess_tensors
@@ -187,15 +202,17 @@ class TestPostprocessTensors(CustomTestCase):
         a = torch.randn(4)
         b = torch.randn(4)
         raw = {"a.weight": a, "b.bias": b}
-        _assert_triples_close(
+        _assert_entries_close(
             _postprocess_tensors(raw, set()),
-            [("a.weight", True, a), ("b.bias", True, b)],
+            [("a.weight", True, ("raw", a)), ("b.bias", True, ("raw", b))],
         )
 
     def test_weight_alone_without_scale_inv_does_not_trigger_dequant(self):
         w = torch.randn(4)
         raw = {"x.weight": w}
-        _assert_triples_close(_postprocess_tensors(raw, set()), [("x.weight", True, w)])
+        _assert_entries_close(
+            _postprocess_tensors(raw, set()), [("x.weight", True, ("raw", w))]
+        )
 
     # --- non-persistent buffer skip ---
 
@@ -206,69 +223,48 @@ class TestPostprocessTensors(CustomTestCase):
             "model.rotary_emb.cos_sin_cache": cache,
             "model.layers.0.weight": plain,
         }
-        _assert_triples_close(
+        _assert_entries_close(
             _postprocess_tensors(raw, set()),
             [
-                ("model.rotary_emb.cos_sin_cache", False, cache),
-                ("model.layers.0.weight", True, plain),
+                ("model.rotary_emb.cos_sin_cache", False, ("raw", cache)),
+                ("model.layers.0.weight", True, ("raw", plain)),
             ],
         )
 
     def test_skips_inv_freq_substring(self):
         t = torch.randn(4)
-        _assert_triples_close(
+        _assert_entries_close(
             _postprocess_tensors({"model.rotary_emb.inv_freq": t}, set()),
-            [("model.rotary_emb.inv_freq", False, t)],
+            [("model.rotary_emb.inv_freq", False, ("raw", t))],
         )
 
     def test_skips_weight_fp32_substring(self):
         t = torch.randn(4)
-        _assert_triples_close(
+        _assert_entries_close(
             _postprocess_tensors({"model.layers.0.mlp.gate._weight_fp32": t}, set()),
-            [("model.layers.0.mlp.gate._weight_fp32", False, t)],
+            [("model.layers.0.mlp.gate._weight_fp32", False, ("raw", t))],
         )
 
     def test_substring_match_not_endswith(self):
         # Pattern can appear anywhere in the name, not just at the end.
         t = torch.randn(4)
-        _assert_triples_close(
+        _assert_entries_close(
             _postprocess_tensors({"weird.cos_sin_cache.foo.bar": t}, set()),
-            [("weird.cos_sin_cache.foo.bar", False, t)],
+            [("weird.cos_sin_cache.foo.bar", False, ("raw", t))],
         )
 
     # --- fp8 quant pair (real dequant on real fp8 tensors) ---
 
-    def test_fp8_quant_pair_with_int32_scale_dequants_via_ue8m0(self):
+    def test_fp8_quant_pair_yields_lazy_pair(self):
         qweight, sf_fp32, sf_packed_int32 = _build_fp8_quant_pair()
         raw = {"x.weight": qweight, "x.weight_scale_inv": sf_packed_int32}
 
-        # Reference: ue8m0 path inside _postprocess_tensors should eventually
-        # call block_quant_dequant with the unpacked fp32 scale.
-        expected_dequant = block_quant_dequant(
-            qweight, sf_fp32, block_size=[128, 128], dtype=torch.bfloat16
-        )
-        _assert_triples_close(
+        _assert_entries_close(
             _postprocess_tensors(raw, set()),
             [
-                ("x.weight", True, expected_dequant),
-                ("x.weight", False, qweight),
-                ("x.weight_scale_inv", False, sf_packed_int32),
-            ],
-        )
-
-    def test_fp8_quant_pair_with_fp32_scale_dequants_directly(self):
-        qweight, sf_fp32, _ = _build_fp8_quant_pair()
-        raw = {"x.weight": qweight, "x.weight_scale_inv": sf_fp32}
-
-        expected_dequant = block_quant_dequant(
-            qweight, sf_fp32, block_size=[128, 128], dtype=torch.bfloat16
-        )
-        _assert_triples_close(
-            _postprocess_tensors(raw, set()),
-            [
-                ("x.weight", True, expected_dequant),
-                ("x.weight", False, qweight),
-                ("x.weight_scale_inv", False, sf_fp32),
+                ("x.weight", True, ("quant", qweight, sf_packed_int32)),
+                ("x.weight", False, ("raw", qweight)),
+                ("x.weight_scale_inv", False, ("raw", sf_packed_int32)),
             ],
         )
 
@@ -280,17 +276,14 @@ class TestPostprocessTensors(CustomTestCase):
             "x.weight_scale_inv": sf_fp32,
             "y.bias": bias,
         }
-        expected_dequant = block_quant_dequant(
-            qweight, sf_fp32, block_size=[128, 128], dtype=torch.bfloat16
-        )
-        # All dequant entries come first, then a raw pass over every key.
-        _assert_triples_close(
+        # All quant entries come first, then a raw pass over every key.
+        _assert_entries_close(
             _postprocess_tensors(raw, set()),
             [
-                ("x.weight", True, expected_dequant),
-                ("x.weight", False, qweight),
-                ("x.weight_scale_inv", False, sf_fp32),
-                ("y.bias", True, bias),
+                ("x.weight", True, ("quant", qweight, sf_fp32)),
+                ("x.weight", False, ("raw", qweight)),
+                ("x.weight_scale_inv", False, ("raw", sf_fp32)),
+                ("y.bias", True, ("raw", bias)),
             ],
         )
 
@@ -298,9 +291,9 @@ class TestPostprocessTensors(CustomTestCase):
         # Without the matching `.weight`, no quant pair forms; the scale_inv flows
         # through as a normal entry with should_compare=True.
         s = torch.zeros(1, 1, dtype=torch.int32)
-        _assert_triples_close(
+        _assert_entries_close(
             _postprocess_tensors({"x.weight_scale_inv": s}, set()),
-            [("x.weight_scale_inv", True, s)],
+            [("x.weight_scale_inv", True, ("raw", s))],
         )
 
 
@@ -313,13 +306,13 @@ class TestCheckTensors(CustomTestCase):
 
     def test_passes_when_all_equal(self):
         t = torch.ones(2, 2)
-        expect = [("a", True, t.clone()), ("b", True, t.clone())]
-        actual = [("a", True, t.clone()), ("b", True, t.clone())]
+        expect = [("a", True, ("raw", t.clone())), ("b", True, ("raw", t.clone()))]
+        actual = [("a", True, ("raw", t.clone())), ("b", True, ("raw", t.clone()))]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_raises_when_should_compare_true_and_diff(self):
-        expect = [("a", True, torch.ones(2, 2))]
-        actual = [("a", True, torch.zeros(2, 2))]
+        expect = [("a", True, ("raw", torch.ones(2, 2)))]
+        actual = [("a", True, ("raw", torch.zeros(2, 2)))]
         with self.assertRaises(Exception) as ctx:
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
         msg = str(ctx.exception)
@@ -328,28 +321,196 @@ class TestCheckTensors(CustomTestCase):
 
     def test_passes_when_should_compare_false_even_if_diff(self):
         # should_compare=False -> diff is logged, not raised.
-        expect = [("a", False, torch.ones(2, 2))]
-        actual = [("a", False, torch.zeros(2, 2))]
+        expect = [("a", False, ("raw", torch.ones(2, 2)))]
+        actual = [("a", False, ("raw", torch.zeros(2, 2)))]
         _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_name_mismatch(self):
-        expect = [("a", True, torch.ones(2, 2))]
-        actual = [("b", True, torch.ones(2, 2))]
+        expect = [("a", True, ("raw", torch.ones(2, 2)))]
+        actual = [("b", True, ("raw", torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_should_compare_mismatch(self):
-        expect = [("a", True, torch.ones(2, 2))]
-        actual = [("a", False, torch.ones(2, 2))]
+        expect = [("a", True, ("raw", torch.ones(2, 2)))]
+        actual = [("a", False, ("raw", torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
+    def test_chunked_raw_stats_match_unchunked(self):
+        expect = [("a", True, ("raw", torch.zeros(10)))]
+        actual = [("a", True, ("raw", torch.arange(10.0)))]
+        with patch("sglang.srt.utils.weight_checker._CHUNK_NUMEL", 3):
+            with self.assertRaises(Exception) as ctx:
+                _check_tensors(expect_tensors=expect, actual_tensors=actual)
+        self.assertIn("max_abs_err=9.0", str(ctx.exception))
+        self.assertIn("mean_abs_err=4.5", str(ctx.exception))
+
     def test_zip_strict_raises_on_length_mismatch(self):
         t = torch.ones(2, 2)
-        expect = [("a", True, t.clone()), ("b", True, t.clone())]
-        actual = [("a", True, t.clone())]
+        expect = [("a", True, ("raw", t.clone())), ("b", True, ("raw", t.clone()))]
+        actual = [("a", True, ("raw", t.clone()))]
         with self.assertRaises(ValueError):
             _check_tensors(expect_tensors=expect, actual_tensors=actual)
+
+
+# ---------------------------------------------------------------------------
+# _quant_ulp + allow_quant_error
+# ---------------------------------------------------------------------------
+
+
+class TestQuantUlp(CustomTestCase):
+
+    def test_matches_bruteforce_spacing_for_fp8(self):
+        for dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            all_bits = torch.arange(256, dtype=torch.uint8).view(dtype)
+            vals = all_bits.to(torch.float32)
+            magnitudes = torch.unique(vals[torch.isfinite(vals) & (vals >= 0)])
+            # Brute-force ULP: spacing to the next representable magnitude
+            # (the largest magnitude reuses the spacing below it).
+            spacing = magnitudes[1:] - magnitudes[:-1]
+            expected = torch.cat([spacing, spacing[-1:]])
+            got = _quant_ulp(magnitudes.to(dtype))
+            torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+
+class TestCompareQuantPair(CustomTestCase):
+    """Chunked dequantized-space comparison of block-quantized pairs."""
+
+    @staticmethod
+    def _quantize(weight: torch.Tensor, scale_margin: float):
+        """Blockwise 128x128 fp8 quantization with a tweakable scale convention."""
+        n, k = weight.shape
+        blocks = weight.float().view(n // 128, 128, k // 128, 128).permute(0, 2, 1, 3)
+        scale = blocks.abs().amax(dim=(-1, -2)) / 448.0 * scale_margin
+        q = (blocks / scale[:, :, None, None]).to(torch.float8_e4m3fn)
+        q = q.permute(0, 2, 1, 3).reshape(n, k)
+        return q, scale
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.weight = torch.randn(256, 256, device="cuda") * 0.02
+        self.e_q, self.e_s = self._quantize(self.weight, 1.0)
+        self.a_q, self.a_s = self._quantize(self.weight, 1.001)
+
+    def test_identical_pair_is_equal(self):
+        equal, max_err, mean_err, num_exceed = _compare_quant_pair(
+            self.e_q, self.e_s, self.e_q.clone(), self.e_s.clone()
+        )
+        self.assertTrue(equal)
+        self.assertEqual((max_err, mean_err, num_exceed), (0.0, 0.0, 0))
+
+    def test_ue8m0_packed_scale_equals_unpacked_scale(self):
+        qweight, sf_fp32, sf_packed_int32 = _build_fp8_quant_pair()
+        equal, *_ = _compare_quant_pair(qweight, sf_packed_int32, qweight, sf_fp32)
+        self.assertTrue(equal)
+
+    def test_two_quantizations_stay_within_ulp_tolerance(self):
+        equal, max_err, mean_err, num_exceed = _compare_quant_pair(
+            self.e_q, self.e_s, self.a_q, self.a_s
+        )
+        self.assertFalse(equal)
+        self.assertGreater(max_err, 0.0)
+        self.assertEqual(num_exceed, 0)
+
+    def test_corruption_and_fp8_nan_exceed_tolerance(self):
+        bad_q = self.a_q.clone().view(torch.uint8)
+        bad_q[::50] += 8  # jumps a full binade; some bytes become fp8 NaN
+        equal, max_err, mean_err, num_exceed = _compare_quant_pair(
+            self.e_q, self.e_s, bad_q.view(torch.float8_e4m3fn), self.a_s
+        )
+        self.assertFalse(equal)
+        self.assertGreater(num_exceed, 0)
+
+    def test_chunked_result_matches_unchunked(self):
+        reference = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
+        with patch("sglang.srt.utils.weight_checker._CHUNK_NUMEL", 128 * 128):
+            chunked = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
+        self.assertEqual(chunked, reference)
+
+    @staticmethod
+    def _quantize_partial(weight: torch.Tensor, scale_margin: float):
+        """128x128 block quant where the last block per dim may be partial."""
+        n, k = weight.shape
+        s_n, s_k = -(-n // 128), -(-k // 128)
+        q = torch.empty(n, k, dtype=torch.float8_e4m3fn, device=weight.device)
+        scale = torch.empty(s_n, s_k, device=weight.device)
+        for i in range(s_n):
+            for j in range(s_k):
+                blk = weight[i * 128 : (i + 1) * 128, j * 128 : (j + 1) * 128].float()
+                s = blk.abs().amax() / 448.0 * scale_margin
+                s = s if s > 0 else weight.new_ones(())
+                scale[i, j] = s
+                q[i * 128 : (i + 1) * 128, j * 128 : (j + 1) * 128] = (blk / s).to(
+                    torch.float8_e4m3fn
+                )
+        return q, scale
+
+    def test_partial_last_block_infers_true_block_size(self):
+        # fused_qkv_a_proj_with_mqa out-dim is not a multiple of 128 (e.g. 2112 =
+        # 16*128 + 64), so the last row-block is partial. ceil(dim/num_blocks)
+        # would infer 125, misaligning scales; the true block size is 128.
+        n, k = 3 * 128 + 64, 256  # 448 rows = partial last block, 256 cols
+        weight = torch.randn(n, k, device="cuda") * 0.02
+        e_q, e_s = self._quantize_partial(weight, 1.0)
+        a_q, a_s = self._quantize_partial(weight, 1.001)
+        self.assertEqual(list(e_s.shape), [4, 2])  # ceil(448/128)=4, 256/128=2
+        self.assertEqual(_block_size_of(e_q, e_s), [128, 128])
+        equal, _, _, num_exceed = _compare_quant_pair(e_q, e_s, a_q, a_s)
+        self.assertFalse(equal)
+        self.assertEqual(num_exceed, 0)
+
+    def test_3d_expert_tensor(self):
+        q3 = self.e_q.reshape(2, 128, 256).contiguous()
+        s3 = self.e_s.reshape(2, 1, 2)
+        equal, *_ = _compare_quant_pair(q3, s3, q3.clone(), s3.clone())
+        self.assertTrue(equal)
+
+
+class TestCheckTensorsAllowQuantError(CustomTestCase):
+
+    def setUp(self):
+        torch.manual_seed(0)
+        weight = torch.randn(256, 256, device="cuda") * 0.02
+        self.e_raw = self._as_raw(*TestCompareQuantPair._quantize(weight, 1.0))
+        self.a_raw = self._as_raw(*TestCompareQuantPair._quantize(weight, 1.001))
+
+    @staticmethod
+    def _as_raw(q, s):
+        return {"x.weight": q, "x.weight_scale_inv": s}
+
+    def _check(self, expect_raw, actual_raw, **kwargs):
+        _check_tensors(
+            expect_tensors=_postprocess_tensors(expect_raw, set()),
+            actual_tensors=_postprocess_tensors(actual_raw, set()),
+            **kwargs,
+        )
+
+    def test_within_tolerance_passes_with_flag(self):
+        self._check(self.e_raw, self.a_raw, allow_quant_error=True)
+
+    def test_within_tolerance_fails_without_flag(self):
+        with self.assertRaises(Exception) as ctx:
+            self._check(self.e_raw, self.a_raw)
+        self.assertIn("name=x.weight", str(ctx.exception))
+
+    def test_exceeding_tolerance_fails_with_flag(self):
+        bad_q = self.a_raw["x.weight"].clone().view(torch.uint8)
+        bad_q[::50] += 8
+        bad = self._as_raw(
+            bad_q.view(torch.float8_e4m3fn), self.a_raw["x.weight_scale_inv"]
+        )
+        with self.assertRaises(Exception) as ctx:
+            self._check(self.e_raw, bad, allow_quant_error=True)
+        self.assertIn("num_exceed_quant_ulp_tolerance", str(ctx.exception))
+
+    def test_flag_does_not_relax_non_quant_tensors(self):
+        expect = [("a", True, ("raw", torch.ones(2, 2)))]
+        actual = [("a", True, ("raw", torch.ones(2, 2) + 0.5))]
+        with self.assertRaises(Exception):
+            _check_tensors(
+                expect_tensors=expect, actual_tensors=actual, allow_quant_error=True
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -40,7 +40,7 @@ from sglang.srt.utils.weight_checker_comparator import (
     Fp8BlockReference,
     RawReference,
     _compare_references,
-    select_reference_weight,
+    select_comparable_weight,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -542,21 +542,21 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
 
 
 # ---------------------------------------------------------------------------
-# select_reference_weight
+# select_comparable_weight
 # ---------------------------------------------------------------------------
 
 
-class TestSelectReferenceWeight(CustomTestCase):
+class TestSelectComparableWeight(CustomTestCase):
 
     def test_returns_none_when_not_a_quant_method(self):
-        self.assertIsNone(select_reference_weight(None))
+        self.assertIsNone(select_comparable_weight(None))
 
     def test_returns_none_for_raw_safe_method(self):
         from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 
         # unquantized / int4 / mxfp8 all route to raw (None).
         fake = UnquantizedLinearMethod.__new__(UnquantizedLinearMethod)
-        self.assertIsNone(select_reference_weight(fake))
+        self.assertIsNone(select_comparable_weight(fake))
 
     def test_raises_on_nvfp4(self):
         from sglang.srt.layers.quantization.modelopt_quant import (
@@ -566,7 +566,7 @@ class TestSelectReferenceWeight(CustomTestCase):
         # nvfp4 has no ComparableWeight yet -> must raise, not silently raw-compare.
         fake = ModelOptFp4LinearMethod.__new__(ModelOptFp4LinearMethod)
         with self.assertRaises(NotImplementedError):
-            select_reference_weight(fake)
+            select_comparable_weight(fake)
 
 
 class TestBuildReferencePlan(CustomTestCase):

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -28,19 +28,19 @@ from sglang.srt.utils.weight_checker import (
     ChecksumInfo,
     ParallelismInfo,
     WeightChecker,
-    _build_quant_plan,
-    _check_tensors,
+    _build_entries,
+    _build_reference_plan,
+    _compare_entries,
     _hash_tensor,
     _is_non_persistent_buffer_name,
-    _postprocess_tensors,
     _random_like,
 )
 from sglang.srt.utils.weight_checker_comparator import (
+    ComparableWeight,
     Fp8BlockReference,
     RawReference,
-    ReferenceWeight,
     _compare_references,
-    select_quantization_method,
+    select_reference_weight,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -53,11 +53,11 @@ register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
 # ---------------------------------------------------------------------------
 
 
-Entry = Tuple[str, bool, ReferenceWeight]
+Entry = Tuple[str, bool, ComparableWeight]
 
 
 def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) -> None:
-    """Compare two streams of (name, should_compare, ReferenceWeight)."""
+    """Compare two streams of (name, should_compare, ComparableWeight)."""
     actual_list: List[Entry] = list(actual)
     expected_list: List[Entry] = list(expected)
     assert len(actual_list) == len(
@@ -93,7 +93,7 @@ def _build_fp8_quant_pair(device: str = "cuda"):
     """Construct a real fp8-quantized weight + matching fp32 + ue8m0-packed scales.
 
     Returns (qweight, sf_fp32, sf_packed_int32) so callers can pick which scale dtype
-    drives the _postprocess_tensors branch under test.
+    drives the _build_entries branch under test.
     """
     weight_bf16 = torch.randn((256, 128), dtype=torch.bfloat16, device=device)
     block_size = [128, 128]
@@ -110,7 +110,7 @@ def _build_fp8_quant_pair(device: str = "cuda"):
 
 
 class _TinyModel(nn.Module):
-    """Mimics the buffer naming patterns _reset_tensors / _postprocess_tensors care about."""
+    """Mimics the buffer naming patterns _reset_tensors / _build_entries care about."""
 
     def __init__(self):
         super().__init__()
@@ -208,7 +208,7 @@ class TestRandomLike(CustomTestCase):
 
 
 # ---------------------------------------------------------------------------
-# _postprocess_tensors
+# _build_entries
 # ---------------------------------------------------------------------------
 
 
@@ -221,7 +221,7 @@ class TestPostprocessTensors(CustomTestCase):
         b = torch.randn(4)
         raw = {"a.weight": a, "b.bias": b}
         _assert_entries_close(
-            _postprocess_tensors(raw, set()),
+            _build_entries(raw, set()),
             [("a.weight", True, RawReference(a)), ("b.bias", True, RawReference(b))],
         )
 
@@ -229,7 +229,7 @@ class TestPostprocessTensors(CustomTestCase):
         w = torch.randn(4)
         raw = {"x.weight": w}
         _assert_entries_close(
-            _postprocess_tensors(raw, set()), [("x.weight", True, RawReference(w))]
+            _build_entries(raw, set()), [("x.weight", True, RawReference(w))]
         )
 
     # --- non-persistent buffer skip ---
@@ -242,7 +242,7 @@ class TestPostprocessTensors(CustomTestCase):
             "model.layers.0.weight": plain,
         }
         _assert_entries_close(
-            _postprocess_tensors(raw, set()),
+            _build_entries(raw, set()),
             [
                 ("model.rotary_emb.cos_sin_cache", False, RawReference(cache)),
                 ("model.layers.0.weight", True, RawReference(plain)),
@@ -252,14 +252,14 @@ class TestPostprocessTensors(CustomTestCase):
     def test_skips_inv_freq_substring(self):
         t = torch.randn(4)
         _assert_entries_close(
-            _postprocess_tensors({"model.rotary_emb.inv_freq": t}, set()),
+            _build_entries({"model.rotary_emb.inv_freq": t}, set()),
             [("model.rotary_emb.inv_freq", False, RawReference(t))],
         )
 
     def test_skips_weight_fp32_substring(self):
         t = torch.randn(4)
         _assert_entries_close(
-            _postprocess_tensors({"model.layers.0.mlp.gate._weight_fp32": t}, set()),
+            _build_entries({"model.layers.0.mlp.gate._weight_fp32": t}, set()),
             [("model.layers.0.mlp.gate._weight_fp32", False, RawReference(t))],
         )
 
@@ -267,7 +267,7 @@ class TestPostprocessTensors(CustomTestCase):
         # Pattern can appear anywhere in the name, not just at the end.
         t = torch.randn(4)
         _assert_entries_close(
-            _postprocess_tensors({"weird.cos_sin_cache.foo.bar": t}, set()),
+            _build_entries({"weird.cos_sin_cache.foo.bar": t}, set()),
             [("weird.cos_sin_cache.foo.bar", False, RawReference(t))],
         )
 
@@ -280,7 +280,7 @@ class TestPostprocessTensors(CustomTestCase):
         ref = Fp8BlockReference(qweight, sf_packed_int32)
         plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
         _assert_entries_close(
-            _postprocess_tensors(raw, set(), plan),
+            _build_entries(raw, set(), plan),
             [("x.weight", True, ref)],
         )
 
@@ -296,7 +296,7 @@ class TestPostprocessTensors(CustomTestCase):
         ref = Fp8BlockReference(qweight, sf_fp32)
         plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
         _assert_entries_close(
-            _postprocess_tensors(raw, set(), plan),
+            _build_entries(raw, set(), plan),
             [
                 ("x.weight", True, ref),
                 ("y.bias", True, RawReference(bias)),
@@ -308,13 +308,13 @@ class TestPostprocessTensors(CustomTestCase):
         # through as a normal entry with should_compare=True.
         s = torch.zeros(1, 1, dtype=torch.int32)
         _assert_entries_close(
-            _postprocess_tensors({"x.weight_scale_inv": s}, set()),
+            _build_entries({"x.weight_scale_inv": s}, set()),
             [("x.weight_scale_inv", True, RawReference(s))],
         )
 
 
 # ---------------------------------------------------------------------------
-# _check_tensors  (implementation moves both sides via .cuda())
+# _compare_entries  (implementation moves both sides via .cuda())
 # ---------------------------------------------------------------------------
 
 
@@ -330,13 +330,13 @@ class TestCheckTensors(CustomTestCase):
             ("a", True, RawReference(t.clone())),
             ("b", True, RawReference(t.clone())),
         ]
-        _check_tensors(expect_tensors=expect, actual_tensors=actual)
+        _compare_entries(expect_entries=expect, actual_entries=actual)
 
     def test_raises_when_should_compare_true_and_diff(self):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("a", True, RawReference(torch.zeros(2, 2)))]
         with self.assertRaises(Exception) as ctx:
-            _check_tensors(expect_tensors=expect, actual_tensors=actual)
+            _compare_entries(expect_entries=expect, actual_entries=actual)
         msg = str(ctx.exception)
         self.assertIn("name=a", msg)
         self.assertIn("max_abs_err", msg)
@@ -345,26 +345,26 @@ class TestCheckTensors(CustomTestCase):
         # should_compare=False -> diff is logged, not raised.
         expect = [("a", False, RawReference(torch.ones(2, 2)))]
         actual = [("a", False, RawReference(torch.zeros(2, 2)))]
-        _check_tensors(expect_tensors=expect, actual_tensors=actual)
+        _compare_entries(expect_entries=expect, actual_entries=actual)
 
     def test_asserts_on_name_mismatch(self):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("b", True, RawReference(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
-            _check_tensors(expect_tensors=expect, actual_tensors=actual)
+            _compare_entries(expect_entries=expect, actual_entries=actual)
 
     def test_asserts_on_should_compare_mismatch(self):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("a", False, RawReference(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
-            _check_tensors(expect_tensors=expect, actual_tensors=actual)
+            _compare_entries(expect_entries=expect, actual_entries=actual)
 
     def test_chunked_raw_stats_match_unchunked(self):
         expect = [("a", True, RawReference(torch.zeros(10)))]
         actual = [("a", True, RawReference(torch.arange(10.0)))]
         with patch("sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 3):
             with self.assertRaises(Exception) as ctx:
-                _check_tensors(expect_tensors=expect, actual_tensors=actual)
+                _compare_entries(expect_entries=expect, actual_entries=actual)
         self.assertIn("max_abs_err=9.0", str(ctx.exception))
         self.assertIn("mean_abs_err=4.5", str(ctx.exception))
 
@@ -376,7 +376,7 @@ class TestCheckTensors(CustomTestCase):
         ]
         actual = [("a", True, RawReference(t.clone()))]
         with self.assertRaises(ValueError):
-            _check_tensors(expect_tensors=expect, actual_tensors=actual)
+            _compare_entries(expect_entries=expect, actual_entries=actual)
 
 
 # ---------------------------------------------------------------------------
@@ -395,7 +395,7 @@ class TestQuantUlp(CustomTestCase):
             # (the largest magnitude reuses the spacing below it).
             spacing = magnitudes[1:] - magnitudes[:-1]
             expected = torch.cat([spacing, spacing[-1:]])
-            got = ReferenceWeight._quant_ulp(magnitudes.to(dtype))
+            got = ComparableWeight._quant_ulp(magnitudes.to(dtype))
             torch.testing.assert_close(got, expected, rtol=0, atol=0)
 
 
@@ -482,7 +482,7 @@ class TestCompareQuantPair(CustomTestCase):
         e_q, e_s = self._quantize_partial(weight, 1.0)
         a_q, a_s = self._quantize_partial(weight, 1.001)
         self.assertEqual(list(e_s.shape), [4, 2])  # ceil(448/128)=4, 256/128=2
-        self.assertEqual(Fp8BlockReference._block_size_of(e_q, e_s), [128, 128])
+        self.assertEqual(Fp8BlockReference._infer_block_size(e_q, e_s), [128, 128])
         equal, _, _, num_exceed = _compare_quant_pair(e_q, e_s, a_q, a_s)
         self.assertFalse(equal)
         self.assertEqual(num_exceed, 0)
@@ -508,9 +508,9 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
 
     def _check(self, expect_raw, actual_raw, **kwargs):
         plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
-        _check_tensors(
-            expect_tensors=_postprocess_tensors(expect_raw, set(), plan),
-            actual_tensors=_postprocess_tensors(actual_raw, set(), plan),
+        _compare_entries(
+            expect_entries=_build_entries(expect_raw, set(), plan),
+            actual_entries=_build_entries(actual_raw, set(), plan),
             **kwargs,
         )
 
@@ -536,40 +536,40 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("a", True, RawReference(torch.ones(2, 2) + 0.5))]
         with self.assertRaises(Exception):
-            _check_tensors(
-                expect_tensors=expect, actual_tensors=actual, allow_quant_error=True
+            _compare_entries(
+                expect_entries=expect, actual_entries=actual, allow_quant_error=True
             )
 
 
 # ---------------------------------------------------------------------------
-# select_quantization_method
+# select_reference_weight
 # ---------------------------------------------------------------------------
 
 
-class TestSelectQuantizationMethod(CustomTestCase):
+class TestSelectReferenceWeight(CustomTestCase):
 
     def test_returns_none_when_not_a_quant_method(self):
-        self.assertIsNone(select_quantization_method(None))
+        self.assertIsNone(select_reference_weight(None))
 
     def test_returns_none_for_raw_safe_method(self):
         from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 
         # unquantized / int4 / mxfp8 all route to raw (None).
         fake = UnquantizedLinearMethod.__new__(UnquantizedLinearMethod)
-        self.assertIsNone(select_quantization_method(fake))
+        self.assertIsNone(select_reference_weight(fake))
 
     def test_raises_on_nvfp4(self):
         from sglang.srt.layers.quantization.modelopt_quant import (
             ModelOptFp4LinearMethod,
         )
 
-        # nvfp4 has no ReferenceWeight yet -> must raise, not silently raw-compare.
+        # nvfp4 has no ComparableWeight yet -> must raise, not silently raw-compare.
         fake = ModelOptFp4LinearMethod.__new__(ModelOptFp4LinearMethod)
         with self.assertRaises(NotImplementedError):
-            select_quantization_method(fake)
+            select_reference_weight(fake)
 
 
-class TestBuildQuantPlan(CustomTestCase):
+class TestBuildReferencePlan(CustomTestCase):
 
     def test_fp8_block_module_pairs_weight_and_scale(self):
         from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
@@ -587,12 +587,12 @@ class TestBuildQuantPlan(CustomTestCase):
             "weight_scale_inv", nn.Parameter(torch.zeros(1, 1), requires_grad=False)
         )
         self.assertEqual(
-            _build_quant_plan(model),
+            _build_reference_plan(model),
             {"proj.weight": (Fp8BlockReference, "proj.weight_scale_inv")},
         )
 
     def test_no_quant_method_yields_empty_plan(self):
-        self.assertEqual(_build_quant_plan(_TinyModel()), {})
+        self.assertEqual(_build_reference_plan(_TinyModel()), {})
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -28,13 +28,14 @@ from sglang.srt.utils.weight_checker import (
     ChecksumInfo,
     ParallelismInfo,
     WeightChecker,
+    _build_quant_plan,
     _check_tensors,
     _hash_tensor,
     _is_non_persistent_buffer_name,
     _postprocess_tensors,
     _random_like,
 )
-from sglang.srt.utils.weight_checker_quant import (
+from sglang.srt.utils.weight_checker_comparator import (
     Fp8BlockReference,
     ReferenceWeight,
     _compare_references,
@@ -278,8 +279,9 @@ class TestPostprocessTensors(CustomTestCase):
         raw = {"x.weight": qweight, "x.weight_scale_inv": sf_packed_int32}
 
         ref = Fp8BlockReference(qweight, sf_packed_int32)
+        plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
         _assert_entries_close(
-            _postprocess_tensors(raw, set()),
+            _postprocess_tensors(raw, set(), plan),
             [
                 ("x.weight", True, ("quant", ref)),
                 ("x.weight", False, ("raw", qweight)),
@@ -297,8 +299,9 @@ class TestPostprocessTensors(CustomTestCase):
         }
         # All quant entries come first, then a raw pass over every key.
         ref = Fp8BlockReference(qweight, sf_fp32)
+        plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
         _assert_entries_close(
-            _postprocess_tensors(raw, set()),
+            _postprocess_tensors(raw, set(), plan),
             [
                 ("x.weight", True, ("quant", ref)),
                 ("x.weight", False, ("raw", qweight)),
@@ -360,7 +363,7 @@ class TestCheckTensors(CustomTestCase):
     def test_chunked_raw_stats_match_unchunked(self):
         expect = [("a", True, ("raw", torch.zeros(10)))]
         actual = [("a", True, ("raw", torch.arange(10.0)))]
-        with patch("sglang.srt.utils.weight_checker._CHUNK_NUMEL", 3):
+        with patch("sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 3):
             with self.assertRaises(Exception) as ctx:
                 _check_tensors(expect_tensors=expect, actual_tensors=actual)
         self.assertIn("max_abs_err=9.0", str(ctx.exception))
@@ -444,7 +447,9 @@ class TestCompareQuantPair(CustomTestCase):
 
     def test_chunked_result_matches_unchunked(self):
         reference = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
-        with patch("sglang.srt.utils.weight_checker_quant._CHUNK_NUMEL", 128 * 128):
+        with patch(
+            "sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 128 * 128
+        ):
             chunked = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
         self.assertEqual(chunked, reference)
 
@@ -500,9 +505,10 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
         return {"x.weight": q, "x.weight_scale_inv": s}
 
     def _check(self, expect_raw, actual_raw, **kwargs):
+        plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
         _check_tensors(
-            expect_tensors=_postprocess_tensors(expect_raw, set()),
-            actual_tensors=_postprocess_tensors(actual_raw, set()),
+            expect_tensors=_postprocess_tensors(expect_raw, set(), plan),
+            actual_tensors=_postprocess_tensors(actual_raw, set(), plan),
             **kwargs,
         )
 
@@ -543,15 +549,48 @@ class TestSelectQuantizationMethod(CustomTestCase):
     def test_returns_none_when_not_a_quant_method(self):
         self.assertIsNone(select_quantization_method(None))
 
-    def test_raises_on_unsupported_quant_method(self):
-        from sglang.srt.layers.quantization.base_config import LinearMethodBase
+    def test_returns_none_for_raw_safe_method(self):
+        from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 
-        class _Unsupported(LinearMethodBase):
-            def apply(self, *args, **kwargs):
-                return None
+        # unquantized / int4 / mxfp8 all route to raw (None).
+        fake = UnquantizedLinearMethod.__new__(UnquantizedLinearMethod)
+        self.assertIsNone(select_quantization_method(fake))
 
+    def test_raises_on_nvfp4(self):
+        from sglang.srt.layers.quantization.modelopt_quant import (
+            ModelOptFp4LinearMethod,
+        )
+
+        # nvfp4 has no ReferenceWeight yet -> must raise, not silently raw-compare.
+        fake = ModelOptFp4LinearMethod.__new__(ModelOptFp4LinearMethod)
         with self.assertRaises(NotImplementedError):
-            select_quantization_method(_Unsupported())
+            select_quantization_method(fake)
+
+
+class TestBuildQuantPlan(CustomTestCase):
+
+    def test_fp8_block_module_pairs_weight_and_scale(self):
+        from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+
+        method = Fp8LinearMethod.__new__(Fp8LinearMethod)
+        method.block_quant = True
+        method.use_mxfp8 = False
+        model = nn.Module()
+        model.proj = nn.Module()
+        model.proj.quant_method = method
+        model.proj.register_parameter(
+            "weight", nn.Parameter(torch.zeros(4, 4), requires_grad=False)
+        )
+        model.proj.register_parameter(
+            "weight_scale_inv", nn.Parameter(torch.zeros(1, 1), requires_grad=False)
+        )
+        self.assertEqual(
+            _build_quant_plan(model),
+            {"proj.weight": (Fp8BlockReference, "proj.weight_scale_inv")},
+        )
+
+    def test_no_quant_method_yields_empty_plan(self):
+        self.assertEqual(_build_quant_plan(_TinyModel()), {})
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -30,7 +30,7 @@ from sglang.srt.utils.weight_checker import (
     WeightChecker,
     _build_entries,
     _build_reference_plan,
-    _compare_entries,
+    _check_tensors,
     _hash_tensor,
     _is_non_persistent_buffer_name,
     _random_like,
@@ -314,7 +314,7 @@ class TestPostprocessTensors(CustomTestCase):
 
 
 # ---------------------------------------------------------------------------
-# _compare_entries  (implementation moves both sides via .cuda())
+# _check_tensors  (implementation moves both sides via .cuda())
 # ---------------------------------------------------------------------------
 
 
@@ -330,13 +330,13 @@ class TestCheckTensors(CustomTestCase):
             ("a", True, RawReference(t.clone())),
             ("b", True, RawReference(t.clone())),
         ]
-        _compare_entries(expect_entries=expect, actual_entries=actual)
+        _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_raises_when_should_compare_true_and_diff(self):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("a", True, RawReference(torch.zeros(2, 2)))]
         with self.assertRaises(Exception) as ctx:
-            _compare_entries(expect_entries=expect, actual_entries=actual)
+            _check_tensors(expect_tensors=expect, actual_tensors=actual)
         msg = str(ctx.exception)
         self.assertIn("name=a", msg)
         self.assertIn("max_abs_err", msg)
@@ -345,26 +345,26 @@ class TestCheckTensors(CustomTestCase):
         # should_compare=False -> diff is logged, not raised.
         expect = [("a", False, RawReference(torch.ones(2, 2)))]
         actual = [("a", False, RawReference(torch.zeros(2, 2)))]
-        _compare_entries(expect_entries=expect, actual_entries=actual)
+        _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_name_mismatch(self):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("b", True, RawReference(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
-            _compare_entries(expect_entries=expect, actual_entries=actual)
+            _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_asserts_on_should_compare_mismatch(self):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("a", False, RawReference(torch.ones(2, 2)))]
         with self.assertRaises(AssertionError):
-            _compare_entries(expect_entries=expect, actual_entries=actual)
+            _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
     def test_chunked_raw_stats_match_unchunked(self):
         expect = [("a", True, RawReference(torch.zeros(10)))]
         actual = [("a", True, RawReference(torch.arange(10.0)))]
         with patch("sglang.srt.utils.weight_checker_comparator._CHUNK_NUMEL", 3):
             with self.assertRaises(Exception) as ctx:
-                _compare_entries(expect_entries=expect, actual_entries=actual)
+                _check_tensors(expect_tensors=expect, actual_tensors=actual)
         self.assertIn("max_abs_err=9.0", str(ctx.exception))
         self.assertIn("mean_abs_err=4.5", str(ctx.exception))
 
@@ -376,7 +376,7 @@ class TestCheckTensors(CustomTestCase):
         ]
         actual = [("a", True, RawReference(t.clone()))]
         with self.assertRaises(ValueError):
-            _compare_entries(expect_entries=expect, actual_entries=actual)
+            _check_tensors(expect_tensors=expect, actual_tensors=actual)
 
 
 # ---------------------------------------------------------------------------
@@ -508,9 +508,9 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
 
     def _check(self, expect_raw, actual_raw, **kwargs):
         plan = {"x.weight": (Fp8BlockReference, "x.weight_scale_inv")}
-        _compare_entries(
-            expect_entries=_build_entries(expect_raw, set(), plan),
-            actual_entries=_build_entries(actual_raw, set(), plan),
+        _check_tensors(
+            expect_tensors=_build_entries(expect_raw, set(), plan),
+            actual_tensors=_build_entries(actual_raw, set(), plan),
             **kwargs,
         )
 
@@ -536,8 +536,8 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
         expect = [("a", True, RawReference(torch.ones(2, 2)))]
         actual = [("a", True, RawReference(torch.ones(2, 2) + 0.5))]
         with self.assertRaises(Exception):
-            _compare_entries(
-                expect_entries=expect, actual_entries=actual, allow_quant_error=True
+            _check_tensors(
+                expect_tensors=expect, actual_tensors=actual, allow_quant_error=True
             )
 
 

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -28,14 +28,17 @@ from sglang.srt.utils.weight_checker import (
     ChecksumInfo,
     ParallelismInfo,
     WeightChecker,
-    _block_size_of,
     _check_tensors,
-    _compare_quant_pair,
     _hash_tensor,
     _is_non_persistent_buffer_name,
     _postprocess_tensors,
-    _quant_ulp,
     _random_like,
+)
+from sglang.srt.utils.weight_checker_quant import (
+    Fp8BlockReference,
+    _block_size_of,
+    _compare_references,
+    _quant_ulp,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -53,7 +56,7 @@ Entry = Tuple[str, bool, Tuple]
 
 def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) -> None:
     """Compare two streams of (name, should_compare, entry) where entry is
-    ("raw", tensor) or ("quant", w_q, w_s)."""
+    ("raw", tensor) or ("quant", Fp8BlockReference)."""
     actual_list: List[Entry] = list(actual)
     expected_list: List[Entry] = list(expected)
     assert len(actual_list) == len(
@@ -65,10 +68,25 @@ def _assert_entries_close(actual: Iterable[Entry], expected: Iterable[Entry]) ->
         assert a_name == e_name, f"[{i}] name: {a_name!r} != {e_name!r}"
         assert a_flag == e_flag, f"[{i}] should_compare: {a_flag} != {e_flag}"
         assert a_entry[0] == e_entry[0], f"[{i}] entry kind mismatch for {a_name!r}"
-        for a_t, e_t in zip(a_entry[1:], e_entry[1:], strict=True):
+        if a_entry[0] == "quant":
+            a_ref, e_ref = a_entry[1], e_entry[1]
             torch.testing.assert_close(
-                a_t, e_t, msg=f"[{i}] tensor mismatch for {a_name!r}"
+                a_ref.w_q, e_ref.w_q, msg=f"[{i}] w_q mismatch for {a_name!r}"
             )
+            torch.testing.assert_close(
+                a_ref.w_s, e_ref.w_s, msg=f"[{i}] w_s mismatch for {a_name!r}"
+            )
+        else:
+            torch.testing.assert_close(
+                a_entry[1], e_entry[1], msg=f"[{i}] tensor mismatch for {a_name!r}"
+            )
+
+
+def _compare_quant_pair(expect_q, expect_s, actual_q, actual_s):
+    """Test shim: wrap fp8 (q, s) pairs as references and compare them."""
+    return _compare_references(
+        Fp8BlockReference(expect_q, expect_s), Fp8BlockReference(actual_q, actual_s)
+    )
 
 
 def _build_fp8_quant_pair(device: str = "cuda"):
@@ -259,10 +277,11 @@ class TestPostprocessTensors(CustomTestCase):
         qweight, sf_fp32, sf_packed_int32 = _build_fp8_quant_pair()
         raw = {"x.weight": qweight, "x.weight_scale_inv": sf_packed_int32}
 
+        ref = Fp8BlockReference(qweight, sf_packed_int32)
         _assert_entries_close(
             _postprocess_tensors(raw, set()),
             [
-                ("x.weight", True, ("quant", qweight, sf_packed_int32)),
+                ("x.weight", True, ("quant", ref)),
                 ("x.weight", False, ("raw", qweight)),
                 ("x.weight_scale_inv", False, ("raw", sf_packed_int32)),
             ],
@@ -277,10 +296,11 @@ class TestPostprocessTensors(CustomTestCase):
             "y.bias": bias,
         }
         # All quant entries come first, then a raw pass over every key.
+        ref = Fp8BlockReference(qweight, sf_fp32)
         _assert_entries_close(
             _postprocess_tensors(raw, set()),
             [
-                ("x.weight", True, ("quant", qweight, sf_fp32)),
+                ("x.weight", True, ("quant", ref)),
                 ("x.weight", False, ("raw", qweight)),
                 ("x.weight_scale_inv", False, ("raw", sf_fp32)),
                 ("y.bias", True, ("raw", bias)),
@@ -424,7 +444,7 @@ class TestCompareQuantPair(CustomTestCase):
 
     def test_chunked_result_matches_unchunked(self):
         reference = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
-        with patch("sglang.srt.utils.weight_checker._CHUNK_NUMEL", 128 * 128):
+        with patch("sglang.srt.utils.weight_checker_quant._CHUNK_NUMEL", 128 * 128):
             chunked = _compare_quant_pair(self.e_q, self.e_s, self.a_q, self.a_s)
         self.assertEqual(chunked, reference)
 

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -39,6 +39,7 @@ from sglang.srt.utils.weight_checker_quant import (
     _block_size_of,
     _compare_references,
     _quant_ulp,
+    select_quantization_method,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -531,6 +532,27 @@ class TestCheckTensorsAllowQuantError(CustomTestCase):
             _check_tensors(
                 expect_tensors=expect, actual_tensors=actual, allow_quant_error=True
             )
+
+
+# ---------------------------------------------------------------------------
+# select_quantization_method
+# ---------------------------------------------------------------------------
+
+
+class TestSelectQuantizationMethod(CustomTestCase):
+
+    def test_returns_none_when_not_a_quant_method(self):
+        self.assertIsNone(select_quantization_method(None))
+
+    def test_raises_on_unsupported_quant_method(self):
+        from sglang.srt.layers.quantization.base_config import LinearMethodBase
+
+        class _Unsupported(LinearMethodBase):
+            def apply(self, *args, **kwargs):
+                return None
+
+        with self.assertRaises(NotImplementedError):
+            select_quantization_method(_Unsupported())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Replaces the manually-tuned threshold approach from #21521 (closed). A hand-picked `dequant_mean_err_threshold` (e.g. `2e-4`) is both too loose (a mean threshold lets per-element corruption hide in a large tensor) and arbitrary per model/precision.

miles-side PR: radixark/miles#1336 (stacked on radixark/miles#1329)

Stacked on #28001 (begin/end_weight_update API, required by the miles base PR); targets its branch so the diff shows only this PR's changes. Retarget to sglang-miles after #28001 merges.

## Modifications

`CheckWeightsReqInput` gains `allow_quant_error: bool = False`, plumbed through scheduler/model_runner into `WeightChecker`.

In `weight_checker.py`:
- `_postprocess_tensors` now yields `(name, should_compare, quant_ulp, tensor)`. For block-quantized pairs (`weight` + `weight_scale_inv`), `quant_ulp` is the per-element ULP of the quantized dtype at each element's magnitude, scaled into dequantized space via `block_quant_dequant`.
- With `allow_quant_error`, dequantized tensors may differ per element by `expect_ulp + actual_ulp`: each side is one faithful quantization of the same source weight, so each may deviate from it by up to 1 ULP of its own representation. Without the flag, exact equality is required as before.
- The exceed-check uses `~(diff <= tol)` so NaN counts as a failure instead of silently passing.
- Block size is derived from weight/scale shapes instead of the hardcoded `[128, 128]` (removes the TODO; also makes non-128-block formats dequantable).

## Accuracy Tests

- `_quant_ulp` brute-force verified against the true spacing of all 256 bit patterns of `float8_e4m3fn` and `float8_e5m2` — exact match (added as a unit test).
- Integration: two independent quantizations of the same weight (different scale conventions, ~14k differing elements out of 64k) pass with the flag and fail without it; bit-flip corruption and NaN are caught even with the flag.
- Updated `test/registered/unit/utils/test_weight_checker.py` to the new yield format and added `TestQuantUlp` + `TestCheckTensorsAllowQuantError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















































































































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28005289536](https://github.com/sgl-project/sglang/actions/runs/28005289536)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28005289450](https://github.com/sgl-project/sglang/actions/runs/28005289450)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


