### PR TITLE
fix(frontend): return HTTP 400 for out-of-vocabulary token_ids_logprob

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -985,7 +985,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if isinstance(obj, EmbeddingReqInput):
             self._validate_for_matryoshka_dim(obj)
 
-        # Validate custom logit processor
+        # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
             if (
@@ -1049,24 +1049,24 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             )
 
     def _validate_token_ids_logprob(self, obj: GenerateReqInput) -> None:
+        # Batch requests are split into per-request sub-objects before this
+        # runs (normalize_batch_and_arguments + __getitem__), so the only
+        # legal shape here is the per-request contract of
+        # TokenizedGenerateReqInput.token_ids_logprob: a flat list of ints.
         token_ids_logprob = obj.token_ids_logprob
         if not token_ids_logprob:
             return
+        if not isinstance(token_ids_logprob, list):
+            raise ValueError("token_ids_logprob must be a flat list of integers.")
         vocab_size = self.model_config.vocab_size
-        for token_id in self._iter_token_ids_logprob(token_ids_logprob):
+        for token_id in token_ids_logprob:
+            if not isinstance(token_id, int):
+                raise ValueError("token_ids_logprob must be a flat list of integers.")
             if token_id < 0 or token_id >= vocab_size:
                 raise ValueError(
                     f"token_ids_logprob contains out-of-vocabulary token id "
                     f"{token_id}; valid range is [0, {vocab_size})."
                 )
-
-    @staticmethod
-    def _iter_token_ids_logprob(token_ids_logprob):
-        if isinstance(token_ids_logprob[0], list):
-            for token_ids in token_ids_logprob:
-                yield from token_ids
-        else:
-            yield from token_ids_logprob
 
     def _validate_input_ids_in_vocab(
         self, input_ids: Union[List[int], List[List[int]]], vocab_size: int

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -987,6 +987,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Validate custom logit processor
         if isinstance(obj, GenerateReqInput):
+            self._validate_token_ids_logprob(obj)
             if (
                 obj.return_hidden_states
                 and not self.server_args.enable_return_hidden_states
@@ -1046,6 +1047,26 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             raise ValueError(
                 f"Provided dimensions are greater than max embedding dimension: {self.model_config.hidden_size}"
             )
+
+    def _validate_token_ids_logprob(self, obj: GenerateReqInput) -> None:
+        token_ids_logprob = obj.token_ids_logprob
+        if not token_ids_logprob:
+            return
+        vocab_size = self.model_config.vocab_size
+        for token_id in self._iter_token_ids_logprob(token_ids_logprob):
+            if token_id < 0 or token_id >= vocab_size:
+                raise ValueError(
+                    f"token_ids_logprob contains out-of-vocabulary token id "
+                    f"{token_id}; valid range is [0, {vocab_size})."
+                )
+
+    @staticmethod
+    def _iter_token_ids_logprob(token_ids_logprob):
+        if isinstance(token_ids_logprob[0], list):
+            for token_ids in token_ids_logprob:
+                yield from token_ids
+        else:
+            yield from token_ids_logprob
 
     def _validate_input_ids_in_vocab(
         self, input_ids: Union[List[int], List[List[int]]], vocab_size: int

--- a/test/registered/openai_server/validation/test_request_length_validation.py
+++ b/test/registered/openai_server/validation/test_request_length_validation.py
@@ -121,6 +121,54 @@ class TestRequestLengthValidation(CustomTestCase):
             self.assertEqual(response.status_code, 400)
             self.assertIn("out-of-vocabulary", response.text)
 
+    def test_token_ids_logprob_rejects_nested_list(self):
+        # Nested lists are a batch-level wire format; a single request must
+        # pass a flat list of ints. A ragged nested list with in-vocab ids
+        # would otherwise crash the scheduler in the sampler gather.
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([[0]], [[0], [1, 2]]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("flat list of integers", response.text)
+
+    def test_token_ids_logprob_batch_with_one_oov(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(
+            f"{self.base_url}/generate",
+            headers=headers,
+            json={
+                "text": ["hi", "hi"],
+                "sampling_params": {"max_new_tokens": 1},
+                "return_logprob": True,
+                "token_ids_logprob": [[0], [2_000_000_000]],
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("out-of-vocabulary", response.text)
+
+    def test_token_ids_logprob_valid(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(
+            f"{self.base_url}/generate",
+            headers=headers,
+            json={
+                "text": "hi",
+                "sampling_params": {"max_new_tokens": 1},
+                "return_logprob": True,
+                "token_ids_logprob": [0],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/openai_server/validation/test_request_length_validation.py
+++ b/test/registered/openai_server/validation/test_request_length_validation.py
@@ -1,6 +1,7 @@
 import unittest
 
 import openai
+import requests
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -103,6 +104,22 @@ class TestRequestLengthValidation(CustomTestCase):
             "max_completion_tokens is too large",
             str(cm.exception),
         )
+
+    def test_token_ids_logprob_out_of_vocabulary(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for token_ids_logprob in ([-1], [2_000_000_000]):
+            response = requests.post(
+                f"{self.base_url}/generate",
+                headers=headers,
+                json={
+                    "text": "hi",
+                    "sampling_params": {"max_new_tokens": 1},
+                    "return_logprob": True,
+                    "token_ids_logprob": token_ids_logprob,
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("out-of-vocabulary", response.text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Motivation

`/generate` accepts user-supplied `token_ids_logprob`, but `TokenizerManager._validate_one_request` does not validate those ids before the request reaches GPU logprob gather.

I reproduced two bad paths on a real server. An id `>= vocab_size` causes a CUDA device-side assert and kills the engine; later valid requests fail too. A negative id is accepted by PyTorch indexing and returns the logprob for the wrong token. This is the same input class fixed in vllm-project/vllm#44042.

## Modifications

- Add `_validate_token_ids_logprob` in `TokenizerManager`.
- Call it at the start of the `GenerateReqInput` validation path.
- Reject flat or nested `token_ids_logprob` values below 0 or at least `vocab_size`; the serving layer maps the `ValueError` to HTTP 400.
- Validate the field even when `return_logprob=false`, matching the existing vLLM behavior for caller-supplied logprob token ids.
- Add one minimal native `/generate` regression guard to the existing request validation server test. It covers the two admission failures that matter for this bug: a negative id and a far above-vocab id.

## Testing

Runtime repro was done with native `/generate` and an isolated SGLang v0.5.12.post1 clone through `PYTHONPATH`. The same patch applies cleanly to current main; the static checks below pass on that clone.

| case | without validation | with validation |
|---|---|---|
| `token_ids_logprob=[999999999]` | HTTP 000, engine dies | HTTP 400 |
| valid request after that OOV request | HTTP 000 | HTTP 200 |
| `token_ids_logprob=[-1]` | HTTP 200, reverse-index logprob | HTTP 400 |
| `return_logprob=false` with above-vocab id | HTTP 200 | HTTP 400 |

The fixed path also returns HTTP 400 for single-request nested OOV and for a batch containing one OOV request.

<details>
<summary>repro environment, command, and output</summary>

Environment:

- GPU: A800-80GB
- Model: `Qwen/Qwen3-0.6B`, vocab size 151936
- Runtime: SGLang v0.5.12.post1 through an isolated `PYTHONPATH` clone
- Python: 3.12.13
- PyTorch: 2.11.0+cu130
- CUDA: 13.0
- `sglang-kernel`: 0.4.2.post2

```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3-0.6B \
  --host 127.0.0.1 \
  --port 31033 \
  --sampling-backend pytorch \
  --attention-backend triton \
  --disable-cuda-graph \
  --disable-piecewise-cuda-graph \
  --mem-fraction-static 0.6 \
  --dtype bfloat16

curl -s -o /tmp/oov.out -w "HTTP %{http_code}\n" \
  -X POST http://127.0.0.1:31033/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"hi","sampling_params":{"max_new_tokens":1},"return_logprob":true,"token_ids_logprob":[999999999]}'

curl -s -o /tmp/valid.out -w "HTTP %{http_code}\n" \
  -X POST http://127.0.0.1:31033/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"hi","sampling_params":{"max_new_tokens":1},"return_logprob":true,"token_ids_logprob":[0,5]}'
```

```text
########## BASELINE ##########
baseline up
[baseline] A3 OOV token_ids_logprob[-1,999999] -> HTTP 000
curl-failed(conn?)
[baseline] A3 valid token_ids_logprob[0,5] -> HTTP 000
curl-failed

server log:
RuntimeError: Triton Error [CUDA]: device-side assert triggered

baseline negative id response:
{"text":"Created","output_ids":[11694],"meta_info":{"id":"db91c4fc5d3540e590844801bcac5b42","finish_reason":{"type":"length","length":1},"prompt_tokens":1,"weight_version":"default","num_retractions":0,"input_token_logprobs":[],"output_token_logprobs":[[-7.654629707336426,11694,null]],"output_token_logprobs_length":1,"input_token_ids_logprobs":[],"output_token_ids_logprobs":[[[-11.178067207336426,-1,null]]],"reasoning_tokens":0,"completion_tokens":1,"cached_tokens":0,"cached_tokens_details":null,"dp_rank":null,"e2e_latency":0.14054013788700104,"response_sent_to_client_ts":1781253393.0250933}}

########## FIXED ##########
fixed up
[fixed] A3 OOV token_ids_logprob[-1,999999] -> HTTP 400
[fixed] A3 valid token_ids_logprob[0,5] -> HTTP 200

fixed above-vocab response:
{"error":{"message":"token_ids_logprob contains out-of-vocabulary token id 999999999; valid range is [0, 151936)."}}

fixed negative response:
{"error":{"message":"token_ids_logprob contains out-of-vocabulary token id -1; valid range is [0, 151936)."}}

fixed valid response:
{"text":"Army","output_ids":[91895],"meta_info":{"id":"ea6da7d247fe49fb8a57be422aa746ce","finish_reason":{"type":"length","length":1},"prompt_tokens":1,"weight_version":"default","num_retractions":0,"input_token_logprobs":[],"output_token_logprobs":[[-10.123379707336426,91895,null]],"output_token_logprobs_length":1,"input_token_ids_logprobs":[],"output_token_ids_logprobs":[[[-7.904629707336426,0,null],[-9.404629707336426,5,null]]],"reasoning_tokens":0,"completion_tokens":1,"cached_tokens":0,"cached_tokens_details":null,"dp_rank":null,"e2e_latency":0.14027650095522404,"response_sent_to_client_ts":1781253419.4206583}}
```

</details>

<details>
<summary>additional runtime sweep</summary>

Every model below reproduced the same baseline pattern: `[-1]` returned HTTP 200, `[1e9]` returned HTTP 000, and the follow-up valid request also returned HTTP 000. With the validation patch, each model passed the 11-case matrix: negative, exactly `vocab_size`, valid boundary, far above vocab, mixed valid/OOV, empty, valid multi-id, batch one-OOV, batch valid, parallel valid, and parallel OOV.

| model | vocab size | fixed matrix |
|---|---:|---|
| TinyLlama-W4A16 | 32000 | 11/11 |
| LFM2-1.2B | 65536 | 11/11 |
| Qwen3-0.6B | 151936 | 11/11 |
| Qwen3-4B | 151936 | 11/11 |
| Qwen3-8B-AWQ | 151936 | 11/11 |
| Qwen2.5-VL-3B | 151936 | 11/11 |
| gpt-oss-20b | 201088 | 11/11 |

</details>

Additional checks on the current-main PR clone:

- `black --check python/sglang/srt/managers/tokenizer_manager.py test/registered/openai_server/validation/test_request_length_validation.py`
- `isort --check-only python/sglang/srt/managers/tokenizer_manager.py test/registered/openai_server/validation/test_request_length_validation.py`
- `ruff check python/sglang/srt/managers/tokenizer_manager.py test/registered/openai_server/validation/test_request_length_validation.py`
- `python -m py_compile python/sglang/srt/managers/tokenizer_manager.py test/registered/openai_server/validation/test_request_length_validation.py`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed for admission validation.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not needed because this does not change model outputs or the decode hot path.
- [x] Follow the SGLang code style guidance.

cc @hnyls2002 @merrymercy

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27449765117](https://github.com/sgl-project/sglang/actions/runs/27449765117)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27449765016](https://github.com/sgl-project/sglang/actions/runs/27449765016)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->