### PR TITLE
fix(frontend): return 400 for missing completions json_schema

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -164,9 +164,13 @@ class OpenAIServingCompletion(OpenAIServingBase):
 
         # Handle response_format constraints
         if request.response_format and request.response_format.type == "json_schema":
-            sampling_params["json_schema"] = convert_json_schema_to_str(
-                request.response_format.json_schema.schema_
-            )
+            json_schema = request.response_format.json_schema
+            schema = getattr(json_schema, "schema_", None)
+            if schema is None:
+                raise ValueError(
+                    "schema_ is required for json_schema response format request."
+                )
+            sampling_params["json_schema"] = convert_json_schema_to_str(schema)
         elif request.response_format and request.response_format.type == "json_object":
             sampling_params["json_schema"] = '{"type": "object"}'
         elif (

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -140,6 +140,17 @@ class ServingCompletionTestCase(unittest.TestCase):
         self.assertIn("json_schema", sampling_params)
         self.assertIsInstance(sampling_params["json_schema"], str)
 
+    def test_response_format_json_schema_missing_schema(self):
+        """Test that json_schema response_format without a schema raises a ValueError."""
+        req = CompletionRequest(
+            model="x",
+            prompt="Generate a JSON object:",
+            max_tokens=100,
+            response_format={"type": "json_schema"},
+        )
+        with self.assertRaises(ValueError):
+            self.sc._build_sampling_params(req)
+
     def test_response_format_structural_tag(self):
         """Test that response_format structural_tag is correctly processed in sampling params."""
         req = CompletionRequest(


### PR DESCRIPTION

## Motivation

`/v1/completions` returns HTTP 500 for a malformed `response_format: {"type": "json_schema"}` request with no `json_schema` field. The same malformed input is already treated as a client error on the chat path, so this makes the completions path return the same 400 error message instead of surfacing an internal `AttributeError`.

## Modifications

- Reuse the chat path validation shape with `getattr(..., "schema_", None)`.
- Raise `ValueError("schema_ is required for json_schema response format request.")` before passing the schema into constrained decoding.

## Testing

Real server before/after on A800-80GB with `Qwen/Qwen3-0.6B`:

| Request | Current main | This patch |
|---|---:|---:|
| missing `json_schema` | 500 | 400 |
| valid `json_schema` | 200 | 200 |

<details><summary>repro (server command, client payloads, full output)</summary>

Setting:

- Hardware: NVIDIA A800-SXM4-80GB, CUDA SM80
- Model: `Qwen/Qwen3-0.6B`
- SGLang: current main plus this patch
- Runtime: Python 3.12, PyTorch 2.11.0+cu130, `sglang-kernel==0.4.3`
- Server flags: `--sampling-backend pytorch --attention-backend triton --disable-cuda-graph --disable-piecewise-cuda-graph --dtype float16`

Server:

```bash
python -m sglang.launch_server \
  --model-path "$QWEN3_0_6B_MODEL" \
  --host 127.0.0.1 \
  --port 31046 \
  --dtype float16 \
  --sampling-backend pytorch \
  --attention-backend triton \
  --disable-cuda-graph \
  --disable-piecewise-cuda-graph \
  --mem-fraction-static 0.5
```

Client payloads:

```bash
curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:31046/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"x","prompt":"hi","max_tokens":8,"response_format":{"type":"json_schema"}}'

curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:31046/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"x","prompt":"hi","max_tokens":8,"response_format":{"type":"json_schema","json_schema":{"name":"obj","schema":{"type":"object","properties":{"a":{"type":"string"}}}}}}'
```

Output on current main:

```text
missing-schema: got HTTP 500, expected HTTP 500
{"object":"error","message":"Internal server error: 'NoneType' object has no attribute 'schema_'","type":"InternalServerError","param":null,"code":500}
valid-schema: got HTTP 200, expected HTTP 200
```

Output with this patch:

```text
missing-schema: got HTTP 400, expected HTTP 400
{"object":"error","message":"schema_ is required for json_schema response format request.","type":"BadRequest","param":null,"code":400}
valid-schema: got HTTP 200, expected HTTP 200
```

</details>

Formatting checks:

```bash
black --check python/sglang/srt/entrypoints/openai/serving_completions.py
isort --check-only python/sglang/srt/entrypoints/openai/serving_completions.py
ruff check --select=F401,F821 python/sglang/srt/entrypoints/openai/serving_completions.py
git diff --check
```

## Checklist

- [x] Format the code according to SGLang style.
- [x] Validate the behavior through a real server before/after repro.
- [x] Documentation is not needed for this frontend error-classification fix.
- [x] Accuracy and speed benchmarks are not needed because this does not change model outputs or inference code.

cc @hnyls2002 

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27504315387](https://github.com/sgl-project/sglang/actions/runs/27504315387)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27504315278](https://github.com/sgl-project/sglang/actions/runs/27504315278)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->