### PR TITLE
Fix ModelOpt NVFP4 MoE silently mis-serving parameterized-SwiGLU models

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -59,6 +59,11 @@ class FlashInferCutlassMoeQuantInfo(MoeQuantInfo):
     moe_ep_rank: int = 0
     apply_routed_scaling_factor: bool = True
 
+    # Optional per-expert SwiGLU overrides, fp32 [E].
+    swiglu_alpha: Optional[torch.Tensor] = None
+    swiglu_beta: Optional[torch.Tensor] = None
+    swiglu_limit: Optional[torch.Tensor] = None
+
 
 @dataclass
 class FlashInferCutlassMxfp4MoeQuantInfo(MoeQuantInfo):
@@ -235,6 +240,9 @@ def _run_flashinfer_cutlass(
         tune_max_num_tokens=next_power_of_2(x.shape[0]),
         activation_type=_activation_type(runner_config),
         enable_alltoall=enable_alltoall,
+        swiglu_alpha=quant_info.swiglu_alpha,
+        swiglu_beta=quant_info.swiglu_beta,
+        swiglu_limit=quant_info.swiglu_limit,
     )[0]
 
     if quant_info.quant_type in ("bf16", "fp8"):

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2337,6 +2337,43 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                     (1.0 / layer.g1_alphas).to(torch.float32),
                 )
 
+        if layer.moe_runner_config.is_gated and self.enable_flashinfer_cutlass_moe:
+            swiglu_alpha = layer.moe_runner_config.gemm1_alpha
+            swiglu_limit = (
+                layer.moe_runner_config.gemm1_clamp_limit
+                or layer.moe_runner_config.swiglu_limit
+            )
+            if swiglu_alpha is not None and swiglu_limit is None:
+                raise ValueError("gemm1_alpha requires gemm1_clamp_limit")
+            # Real-domain values (cutlass dequantizes before the activation); beta=1.0 only for the GPT-OSS-style +1 shift (gemm1_alpha set), else 0.0 for clamp-limit-only models.
+            if swiglu_alpha is not None or swiglu_limit is not None:
+                copy_or_rebind_param(
+                    layer,
+                    "swiglu_alpha",
+                    torch.full_like(
+                        layer.g1_alphas,
+                        swiglu_alpha if swiglu_alpha is not None else 1.0,
+                        dtype=torch.float32,
+                    ),
+                )
+                copy_or_rebind_param(
+                    layer,
+                    "swiglu_beta",
+                    torch.full_like(
+                        layer.g1_alphas,
+                        1.0 if swiglu_alpha is not None else 0.0,
+                        dtype=torch.float32,
+                    ),
+                )
+                if swiglu_limit is not None:
+                    copy_or_rebind_param(
+                        layer,
+                        "swiglu_limit",
+                        torch.full_like(
+                            layer.g1_alphas, swiglu_limit, dtype=torch.float32
+                        ),
+                    )
+
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         layer.dispatcher.set_quant_config(
             {
@@ -2709,6 +2746,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 moe_tp_size=layer.moe_tp_size,
                 moe_tp_rank=layer.moe_tp_rank,
                 apply_routed_scaling_factor=False,
+                swiglu_alpha=getattr(layer, "swiglu_alpha", None),
+                swiglu_beta=getattr(layer, "swiglu_beta", None),
+                swiglu_limit=getattr(layer, "swiglu_limit", None),
             )
             return self.runner.run(dispatch_output, quant_info)
 


### PR DESCRIPTION
## Motivation

`MoeRunnerConfig` carries `gemm1_alpha` / `gemm1_clamp_limit` for models whose experts use a parameterized clamped SwiGLU (GPT-OSS family: `(up + 1) * glu(alpha * gate)` with clamping; MiniMax-M3 uses the same form with `alpha=1.702`, `limit=7.0`). On the flashinfer_cutlass NVFP4 MoE path these values are silently dropped, so such models load fine but generate garbage.

This PR originally also covered the flashinfer_trtllm path with a fail-fast (flashinfer 0.6.12 ignored the params there); #31989 added real support on that path, so this is now rescoped to cutlass only (see discussion below).

## Modifications

1. `FlashInferCutlassMoeQuantInfo` gets optional per-expert `swiglu_alpha/beta/limit` (same convention as the mxfp4 quant info) and `_run_flashinfer_cutlass` forwards them to `cutlass_fused_moe`. Also covers the flashinfer-a2a fused func. Unset fields stay `None` — no behavior change for other models.
2. `ModelOptNvFp4FusedMoEMethod`: build the per-expert tensors at weight processing when the runner config sets `gemm1_alpha` / `gemm1_clamp_limit` and the cutlass backend is enabled, and pass them via the quant info. Real-domain values (the cutlass kernel dequantizes before the activation), unlike the trtllm path's `1/g1_alphas`-scaled ones. `swiglu_beta=1.0` (the `+1` shift on the linear branch) only when `gemm1_alpha` is set.

## Test / verification

End-to-end with a MiniMax-M3 NVFP4 checkpoint (NVFP4 experts, BF16 attention; modelopt 0.44.0 PTQ), TP=2 on B300, with the pre-refactor version of this fix (same values, passed at the old direct `flashinfer_cutlass_fused_moe` call site):

- cutlass path without the fix: loads, generates garbage.
- cutlass path with the fix: coherent generations; GSM8K (5-shot, strict) **93.6** vs **93.9** for the official MXFP8 checkpoint, same engine and sampling (model-card settings, temp 1.0 / top-p 0.95).

The rebased version routes the same per-expert tensors through the new moe_runner structure.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31001069767](https://github.com/sgl-project/sglang/actions/runs/31001069767)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31001069333](https://github.com/sgl-project/sglang/actions/runs/31001069333)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
