### PR TITLE
[Fix] Unquote ResponseTool annotation breaking lint on all PRs

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1320,7 +1320,7 @@ class ResponseTool(BaseModel):
     tools: Optional[List[Dict[str, Any]]] = None
 
     @model_validator(mode="after")
-    def validate_function_tool(self) -> "ResponseTool":
+    def validate_function_tool(self) -> ResponseTool:
         if self.type == "function" and not self.name:
             raise ValueError("Function tools must include a name.")
         return self


### PR DESCRIPTION
## Motivation

#25881 (merged ~30 min ago) introduced a quoted return annotation:

```python
def validate_function_tool(self) -> "ResponseTool":
```

ruff auto-fixes this (UP037, quoted annotation), so the `lint` job — which runs pre-commit on the PR merged with latest main — now ends with "files were modified by this hook" and **fails for every open PR** (first seen on #28089, which doesn't touch this file).

## Modifications

Unquote the annotation (one line). `pre-commit run` on the file passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27446139689](https://github.com/sgl-project/sglang/actions/runs/27446139689)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27446139491](https://github.com/sgl-project/sglang/actions/runs/27446139491)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->