### PR TITLE
[Bugfix] Detect ModelOpt MIXED_PRECISION checkpoints by content, not architecture

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1038,10 +1038,18 @@ class ModelConfig:
         quant_algo = json_quant_configs.get("quant_algo", None)
 
         if quant_algo == "MIXED_PRECISION":
-            architectures = getattr(self.hf_config, "architectures", []) or []
-            if getattr(self.hf_config, "model_type", None) == "nemotron_h" or any(
-                arch.startswith("NemotronH") for arch in architectures
-            ):
+            # Two distinct checkpoint families use quant_algo=MIXED_PRECISION:
+            #  - ModelOpt per-layer mixed-precision exports (e.g. NVFP4 experts
+            #    + FP8 dense). These always carry a non-empty
+            #    `quantized_layers` map, which ModelOptMixedPrecisionConfig
+            #    requires to dispatch per-layer quant methods.
+            #  - DeepSeek-style W4AFP8 exports, whose hf_quant_config.json is
+            #    bare ({"quant_algo": "MIXED_PRECISION",
+            #    "kv_cache_quant_algo": ...}) with no per-layer map.
+            # Detect by content instead of architecture so any model with a
+            # ModelOpt mixed-precision export (MiMo-V2, NemotronH, ...) loads
+            # without a per-arch allowlist.
+            if json_quant_configs.get("quantized_layers"):
                 return {"quant_method": "modelopt_mixed", "quant_algo": quant_algo}
             return {"quant_method": "w4afp8", "quant_algo": quant_algo}
         elif quant_algo and ("FP4" in quant_algo or "NVFP4" in quant_algo):

--- a/test/registered/unit/configs/test_modelopt_mixed_precision_detection.py
+++ b/test/registered/unit/configs/test_modelopt_mixed_precision_detection.py
@@ -1,0 +1,63 @@
+"""Unit tests for ModelOpt MIXED_PRECISION quant-method detection in
+srt/configs/model_config.py (_parse_modelopt_quant_config)."""
+
+import unittest
+
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _parse(quantization: dict) -> dict:
+    # _parse_modelopt_quant_config only reads the passed dict; bypass the
+    # heavyweight ModelConfig constructor.
+    model_config = ModelConfig.__new__(ModelConfig)
+    return model_config._parse_modelopt_quant_config({"quantization": quantization})
+
+
+class TestModelOptMixedPrecisionDetection(CustomTestCase):
+    def test_mixed_precision_with_quantized_layers_is_modelopt_mixed(self):
+        # ModelOpt per-layer mixed export (e.g. MiMo-V2.5 NVFP4: MXFP8/FP8
+        # dense + NVFP4 experts; NemotronH mixed exports have the same shape).
+        result = _parse(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.layers.0.self_attn.qkv_proj": {"quant_algo": "FP8"},
+                    "model.layers.1.mlp.experts.0.gate_proj": {
+                        "quant_algo": "NVFP4",
+                        "group_size": 16,
+                    },
+                },
+            }
+        )
+        self.assertEqual(result["quant_method"], "modelopt_mixed")
+
+    def test_mixed_precision_without_quantized_layers_is_w4afp8(self):
+        # DeepSeek-style W4AFP8 export: bare MIXED_PRECISION config
+        # (e.g. nvidia/DeepSeek-R1-0528-W4AFP8 hf_quant_config.json).
+        result = _parse({"quant_algo": "MIXED_PRECISION", "kv_cache_quant_algo": None})
+        self.assertEqual(result["quant_method"], "w4afp8")
+
+    def test_mixed_precision_with_empty_quantized_layers_is_w4afp8(self):
+        # An empty map can't drive per-layer dispatch
+        # (ModelOptMixedPrecisionConfig.from_config would reject it).
+        result = _parse({"quant_algo": "MIXED_PRECISION", "quantized_layers": {}})
+        self.assertEqual(result["quant_method"], "w4afp8")
+
+    def test_nvfp4_is_modelopt_fp4(self):
+        result = _parse({"quant_algo": "NVFP4"})
+        self.assertEqual(result["quant_method"], "modelopt_fp4")
+
+    def test_fp8_is_modelopt_fp8(self):
+        result = _parse({"quant_algo": "FP8"})
+        self.assertEqual(result["quant_method"], "modelopt_fp8")
+
+    def test_unknown_algo_returns_none(self):
+        self.assertIsNone(_parse({"quant_algo": "INT42"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`quant_algo: "MIXED_PRECISION"` in `hf_quant_config.json` / `quantization_config` is used by two unrelated checkpoint families:

1. **ModelOpt per-layer mixed-precision exports** (e.g. NVFP4 experts + FP8/MXFP8 dense). These always carry a non-empty `quantized_layers` map — which `ModelOptMixedPrecisionConfig.from_config` *requires* to dispatch per-layer quant methods.
2. **DeepSeek-style W4AFP8 exports** (e.g. `nvidia/DeepSeek-R1-0528-W4AFP8`, `novita/Deepseek-V3.1-W4AFP8`), whose quant config is bare: `{"quant_algo": "MIXED_PRECISION", "kv_cache_quant_algo": null}` — no per-layer map.

`ModelConfig._parse_modelopt_quant_config` currently routes everything except NemotronH to `w4afp8`. Loading a ModelOpt mixed export of any other model fails hard:

```
ValueError: Quantization method specified in the model config (w4afp8) does not
match the quantization method specified in the `quantization` argument (modelopt_fp4).
```

Observed with `lukealonso/MiMo-V2.5-NVFP4` on 4x B200 (related: #24321) — even though `ModelOptMixedPrecisionConfig` handles this checkpoint correctly once routing is fixed.

## Modifications

Route on checkpoint content instead of an architecture allowlist: MIXED_PRECISION with a non-empty `quantized_layers` map -> `modelopt_mixed`; bare MIXED_PRECISION -> `w4afp8` (unchanged).

This subsumes the NemotronH special case: `ModelOptMixedPrecisionConfig.from_config` raises on an empty/missing `quantized_layers` map, so any NemotronH checkpoint that worked before necessarily carries the map and routes identically. Conversely, `W4AFp8Config` never reads `quantized_layers`, and published W4AFP8 checkpoints don't ship one.

No behavior change for: bare-MIXED_PRECISION (DeepSeek W4AFP8), NemotronH, FP4/FP8/other ModelOpt algos. Behavior change only for MIXED_PRECISION + `quantized_layers` on non-NemotronH archs — previously a guaranteed launch failure, now routed to the existing handler.

## Accuracy Tests

E2E on 4x B200 (TP4, nightly): `lukealonso/MiMo-V2.5-NVFP4` (with its 63 MXFP8 dense tensors dequantized offline to bf16) launches via `modelopt_mixed` and produces coherent output. GSM8K-200 greedy: **0.990** vs 0.995 for the original FP8 checkpoint. Note full serving of this checkpoint also needs the plain-[Q;K;V] qkv loader fix (separate PR) — this PR fixes the launch-time routing failure.

New CPU unit test `test/registered/unit/configs/test_modelopt_mixed_precision_detection.py` (registered `base-a-test-cpu`): ModelOpt-mixed shape -> `modelopt_mixed`; bare DeepSeek W4AFP8 shape -> `w4afp8`; empty map -> `w4afp8`; NVFP4/FP8/unknown algos unchanged. 6/6 passing.

## Speed Tests and Profiling

N/A — config parsing only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27446810291](https://github.com/sgl-project/sglang/actions/runs/27446810291)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27446810168](https://github.com/sgl-project/sglang/actions/runs/27446810168)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->