### PR TITLE
[Bugfix] MiMo-V2: support plain [Q;K;V] fused qkv_proj checkpoints

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -71,6 +71,48 @@ def get_mimo_v2_fused_qkv_expected_tp_size(hf_config):
     return num_key_value_heads
 
 
+def is_mimo_v2_fused_qkv_plain_layout(hf_config) -> bool:
+    """Whether a MiMoV2 fused qkv_proj checkpoint stores rows in plain
+    [Q;K;V] order rather than the TP-interleaved order of the original
+    Pro release.
+
+    Both layouts declare attention_projection_layout='fused_qkv' and have
+    identical tensor shapes, so the row order cannot be inferred from the
+    weights. Checkpoints re-exported through transformers + ModelOpt (the
+    community quantization path) load the original weights with HF modeling
+    code, which de-interleaves qkv_proj in memory, and then serialize it in
+    plain [Q;K;V] order. Sharding such a checkpoint by blind row-chunking
+    assigns Q rows to K/V slots and produces degenerate output (issue
+    sgl-project/sglang#24321).
+
+    An explicit `fused_qkv_weight_order` config field ('plain' or
+    'interleaved', settable via --json-model-override-args) takes precedence
+    over the ModelOpt-provenance heuristic.
+    """
+    order = getattr(hf_config, "fused_qkv_weight_order", None)
+    if order is None:
+        text_config = getattr(hf_config, "text_config", None)
+        if text_config is not None:
+            order = getattr(text_config, "fused_qkv_weight_order", None)
+    if order is not None:
+        if order not in ("plain", "interleaved"):
+            raise ValueError(
+                f"MiMoV2 hf_config has unsupported fused_qkv_weight_order="
+                f"{order!r}; expected 'plain', 'interleaved', or unset."
+            )
+        return order == "plain"
+
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    if quantization_config is not None:
+        if isinstance(quantization_config, dict):
+            quant_method = quantization_config.get("quant_method")
+        else:
+            quant_method = getattr(quantization_config, "quant_method", None)
+        if quant_method == "modelopt":
+            return True
+    return False
+
+
 class AttentionArch(IntEnum):
     MLA = auto()
     MHA = auto()

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -20,7 +20,10 @@ import torch.nn.functional as F
 from torch import nn
 
 from sglang.srt.batch_overlap.two_batch_overlap import model_forward_maybe_tbo
-from sglang.srt.configs.model_config import get_mimo_v2_fused_qkv_expected_tp_size
+from sglang.srt.configs.model_config import (
+    get_mimo_v2_fused_qkv_expected_tp_size,
+    is_mimo_v2_fused_qkv_plain_layout,
+)
 from sglang.srt.distributed import (
     get_moe_expert_parallel_world_size,
     get_pp_group,
@@ -94,7 +97,11 @@ logger = logging.getLogger(__name__)
 
 
 def load_mimo_v2_qkv_proj_weight(
-    name, param, loaded_weight, expected_fused_tp_size: Optional[int] = None
+    name,
+    param,
+    loaded_weight,
+    expected_fused_tp_size: Optional[int] = None,
+    plain_layout: bool = False,
 ):
     if loaded_weight.shape == param.shape:
         # The checkpoint already stores this rank's qkv_proj shard.
@@ -106,6 +113,22 @@ def load_mimo_v2_qkv_proj_weight(
             f"qkv_proj weight {name}: unexpected shape {tuple(loaded_weight.shape)}; "
             f"expected sharded {tuple(param.shape)}"
         )
+
+    if plain_layout:
+        # The checkpoint stores fused qkv rows in plain [Q;K;V] order
+        # (transformers/ModelOpt re-exports). Blind row-chunking would assign
+        # Q rows to K/V slots on every rank (issue #24321); delegate to the
+        # QKVParallelLinear weight loader, which splits the fused tensor by
+        # section and shards each section per rank. This also lifts the
+        # attention-TP restriction of the interleaved format.
+        weight_loader = getattr(param, "weight_loader", None)
+        if weight_loader is None or weight_loader is default_weight_loader:
+            raise ValueError(
+                f"qkv_proj weight {name} is in plain [Q;K;V] layout but the "
+                "parameter has no QKVParallelLinear weight loader to shard it."
+            )
+        weight_loader(param, loaded_weight)
+        return
 
     tp_size = get_attention_tp_size()
     tp_rank = get_attention_tp_rank()
@@ -1385,7 +1408,11 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
                         self.config
                     )
                     load_mimo_v2_qkv_proj_weight(
-                        name, param, loaded_weight, expected_fused_tp_size
+                        name,
+                        param,
+                        loaded_weight,
+                        expected_fused_tp_size,
+                        plain_layout=is_mimo_v2_fused_qkv_plain_layout(self.config),
                     )
                 continue
 

--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -19,7 +19,10 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig
 
-from sglang.srt.configs.model_config import get_mimo_v2_fused_qkv_expected_tp_size
+from sglang.srt.configs.model_config import (
+    get_mimo_v2_fused_qkv_expected_tp_size,
+    is_mimo_v2_fused_qkv_plain_layout,
+)
 from sglang.srt.distributed import get_tensor_model_parallel_world_size
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.layers.communicator import (
@@ -318,6 +321,7 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
                         expected_fused_tp_size=get_mimo_v2_fused_qkv_expected_tp_size(
                             self.config
                         ),
+                        plain_layout=is_mimo_v2_fused_qkv_plain_layout(self.config),
                     )
                 continue
 

--- a/test/registered/unit/configs/test_mimo_v2_qkv_layout.py
+++ b/test/registered/unit/configs/test_mimo_v2_qkv_layout.py
@@ -1,0 +1,109 @@
+"""Unit tests for MiMoV2 fused qkv_proj layout detection
+(srt/configs/model_config.py: is_mimo_v2_fused_qkv_plain_layout) and the
+plain-layout delegation in load_mimo_v2_qkv_proj_weight."""
+
+import unittest
+
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from sglang.srt.configs.model_config import is_mimo_v2_fused_qkv_plain_layout
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMiMoV2QkvLayoutDetection(CustomTestCase):
+    def test_default_is_interleaved(self):
+        # Original Pro release: fused_qkv, no quantization_config.
+        config = PretrainedConfig(attention_projection_layout="fused_qkv")
+        self.assertFalse(is_mimo_v2_fused_qkv_plain_layout(config))
+
+    def test_modelopt_quantization_config_implies_plain(self):
+        # Community re-exports through transformers + ModelOpt serialize
+        # qkv_proj in plain [Q;K;V] order (e.g. lukealonso/MiMo-V2.5-NVFP4).
+        config = PretrainedConfig(
+            attention_projection_layout="fused_qkv",
+            quantization_config={"quant_method": "modelopt"},
+        )
+        self.assertTrue(is_mimo_v2_fused_qkv_plain_layout(config))
+
+    def test_non_modelopt_quantization_config_stays_interleaved(self):
+        config = PretrainedConfig(
+            attention_projection_layout="fused_qkv",
+            quantization_config={"quant_method": "fp8"},
+        )
+        self.assertFalse(is_mimo_v2_fused_qkv_plain_layout(config))
+
+    def test_explicit_order_overrides_heuristic(self):
+        # An explicit field wins over ModelOpt provenance, in both directions.
+        config = PretrainedConfig(
+            fused_qkv_weight_order="interleaved",
+            quantization_config={"quant_method": "modelopt"},
+        )
+        self.assertFalse(is_mimo_v2_fused_qkv_plain_layout(config))
+
+        config = PretrainedConfig(fused_qkv_weight_order="plain")
+        self.assertTrue(is_mimo_v2_fused_qkv_plain_layout(config))
+
+    def test_explicit_order_on_text_config(self):
+        config = PretrainedConfig(
+            text_config=PretrainedConfig(fused_qkv_weight_order="plain")
+        )
+        self.assertTrue(is_mimo_v2_fused_qkv_plain_layout(config))
+
+    def test_invalid_order_raises(self):
+        config = PretrainedConfig(fused_qkv_weight_order="zigzag")
+        with self.assertRaises(ValueError):
+            is_mimo_v2_fused_qkv_plain_layout(config)
+
+
+class TestPlainLayoutLoaderDelegation(CustomTestCase):
+    """load_mimo_v2_qkv_proj_weight must hand plain-layout fused tensors to
+    the parameter's QKVParallelLinear weight loader instead of row-chunking."""
+
+    @classmethod
+    def setUpClass(cls):
+        mimo_v2 = pytest.importorskip(
+            "sglang.srt.models.mimo_v2",
+            reason="mimo_v2 model module not importable in this environment",
+        )
+        cls.load_qkv = staticmethod(mimo_v2.load_mimo_v2_qkv_proj_weight)
+
+    @staticmethod
+    def _make_param(shape, loader=None):
+        param = torch.nn.Parameter(torch.zeros(shape), requires_grad=False)
+        if loader is not None:
+            param.weight_loader = loader
+        return param
+
+    def test_plain_layout_delegates_full_tensor(self):
+        calls = []
+        param = self._make_param((10, 4), loader=lambda p, w: calls.append(w))
+        fused = torch.randn(40, 4)  # rank shard 10 rows, fused 4x
+        self.load_qkv("layer.qkv_proj.weight", param, fused, plain_layout=True)
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(torch.equal(calls[0], fused))
+
+    def test_plain_layout_without_loader_raises(self):
+        param = self._make_param((10, 4))
+        with self.assertRaisesRegex(ValueError, "plain \\[Q;K;V\\]"):
+            self.load_qkv(
+                "layer.qkv_proj.weight",
+                param,
+                torch.randn(40, 4),
+                plain_layout=True,
+            )
+
+    def test_presharded_weight_short_circuits(self):
+        # Already-sharded tensors copy directly regardless of layout flag.
+        param = self._make_param((10, 4))
+        shard = torch.randn(10, 4)
+        self.load_qkv("layer.qkv_proj.weight", param, shard, plain_layout=True)
+        self.assertTrue(torch.equal(param.data, shard))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #24321. Also fixes the EAGLE draft-loading failure in #24322 for these checkpoints.

The original MiMo-V2.5 Pro release stores fused `qkv_proj` rows **TP-interleaved**, so `load_mimo_v2_qkv_proj_weight` shards it with blind row chunking (`loaded_weight.chunk(tp_size, dim=0)[tp_rank]`).

Checkpoints re-exported through transformers + ModelOpt — the community quantization path, e.g. `lukealonso/MiMo-V2.5-NVFP4` and `shadowlilac/MiMo-V2.5-NVFP4` — load the original weights with HF modeling code, which de-interleaves `qkv_proj` in memory, and then serialize **plain `[Q;K;V]`** rows. Both layouts declare `attention_projection_layout: "fused_qkv"` and have identical tensor shapes, so the difference is invisible to the loader. Blind chunking then assigns Q rows to K/V slots on every rank:

- target model: degenerate output (`++++...`) on every attention/MoE backend — the actual root cause of #24321, previously suspected to be an SM100 kernel gap or checkpoint `input_scale` pathology;
- EAGLE MTP draft: the same shared loader path breaks draft loading for these checkpoints (#24322).

Blind chunking cannot simply be removed: it is correct for the published interleaved Pro format, and the section-aware loader would mis-shard *that*. The layout must be selected.

## Modifications

1. `is_mimo_v2_fused_qkv_plain_layout(hf_config)` in `model_config.py`: an explicit `fused_qkv_weight_order` config field (`"plain"` / `"interleaved"`, settable per-deployment via `--json-model-override-args`) takes precedence; otherwise fall back to ModelOpt provenance (`quantization_config.quant_method == "modelopt"` -> plain), since these exports are produced by transformers serialization and are plain-ordered.
2. `load_mimo_v2_qkv_proj_weight(..., plain_layout=False)`: when plain, delegate to the parameter's bound `QKVParallelLinear` weight loader (`loaded_shard_id=None` fused path), which splits the tensor into Q/K/V sections — including MiMo's asymmetric `v_head_size` — and shards each per rank. This also lifts the interleaved format's `attention TP == num_key_value_heads` restriction for plain checkpoints. Interleaved behavior is unchanged; per-rank-presharded checkpoints still short-circuit before any layout handling.
3. Both call sites pass the flag: `mimo_v2.py` and `mimo_v2_nextn.py` (MTP draft).

If a ModelOpt re-export with preserved interleaving ever appears, `fused_qkv_weight_order: "interleaved"` overrides the heuristic.

## Accuracy Tests

E2E on B200 (SGLang nightly, `lukealonso/MiMo-V2.5-NVFP4`, TP4; MXFP8 dense tensors dequantized offline to bf16 and MIXED_PRECISION routing fixed per #28099):

- Before: `++++...` degenerate output on all backends. After: coherent output.
- Isolation ladder: `flashinfer_cutlass` alone FAIL -> + per-token activation env FAIL -> **+ this fix PASS**; `flashinfer_trtllm` also coherent with this fix.
- GSM8K-200 greedy: **0.990** (original FP8 checkpoint on the same stack: 0.995).
- EAGLE multi-layer MTP (steps=3, draft=4): draft loads and runs, accept length 3.95-4.0, matching FP8+MTP; no #24322 crash.
- Sustained 2x TP4 saturation benches (25-31 concurrent agentic sessions/replica), zero request errors.

New unit test `test/registered/unit/configs/test_mimo_v2_qkv_layout.py` (registered `base-a-test-cpu`), 9/9 passing: layout detection (default interleaved; ModelOpt provenance -> plain; non-ModelOpt quant config -> interleaved; explicit field overrides both ways; `text_config` honored; invalid value raises) and loader behavior (plain delegates full fused tensor to the bound loader; plain without bound loader raises; presharded short-circuits).

## Speed Tests and Profiling

No change to the interleaved path. Plain path: single-stream 1024/1024 conc-1 on 4x B200 TP4 with MTP: 500 tok/s, median TPOT 1.91 ms, accept length 3.90.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27446830320](https://github.com/sgl-project/sglang/actions/runs/27446830320)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27446830232](https://github.com/sgl-project/sglang/actions/runs/27446830232)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->