### PR TITLE
Fix DP attention + EP mode of Nemotron

### DIFF
--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -55,7 +55,10 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
-from sglang.srt.layers.moe.utils import RoutingMethodType
+from sglang.srt.layers.moe.utils import (
+    RoutingMethodType,
+    should_skip_post_experts_all_reduce,
+)
 from sglang.srt.layers.quantization import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
@@ -129,10 +132,10 @@ class NemotronHMLP(nn.Module):
         )
         self.act_fn = ReLU2()
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor, use_reduce_scatter: bool = False):
         x, _ = self.up_proj(x)
         x = self.act_fn(x)
-        x, _ = self.down_proj(x)
+        x, _ = self.down_proj(x, skip_all_reduce=use_reduce_scatter)
         return x
 
 
@@ -296,7 +299,9 @@ class NemotronHMoE(nn.Module):
 
         return final_hidden_states, shared_output
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor, use_reduce_scatter: bool = False
+    ) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         # routed_scaling_factor is fused into the experts call (applied by the
         # MoE runner / topk), so final_hidden_states is already scaled.
@@ -308,7 +313,10 @@ class NemotronHMoE(nn.Module):
         if shared_output is not None:
             final_hidden_states += shared_output
 
-        if self.tp_size > 1:
+        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
+            is_tp_path=True,
+            use_reduce_scatter=use_reduce_scatter,
+        ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         return final_hidden_states.view(num_tokens, hidden_dim)
@@ -328,7 +336,12 @@ class NemotronHMLPLikeDecoderLayer(nn.Module):
             hidden_states, residual = self.layer_communicator.prepare_mlp(
                 hidden_states, residual, forward_batch
             )
-            hidden_states = self.mixer.forward(hidden_states)
+            use_reduce_scatter = self.layer_communicator.should_use_reduce_scatter(
+                forward_batch
+            )
+            hidden_states = self.mixer.forward(
+                hidden_states, use_reduce_scatter=use_reduce_scatter
+            )
             hidden_states, residual = self.layer_communicator.postprocess_layer(
                 hidden_states, residual, forward_batch
             )
@@ -375,7 +388,9 @@ class NemotronHMLPDecoderLayer(NemotronHMLPLikeDecoderLayer):
         )
 
         self.norm = RMSNorm(config.hidden_size, eps=config.layer_norm_epsilon)
-        self.layer_communicator = make_layer_communicator(self.norm, for_attn=False)
+        self.layer_communicator = make_layer_communicator(
+            self.norm, for_attn=False, allow_reduce_scatter=True
+        )
 
 
 class NemotronHMoEDecoderLayer(NemotronHMLPLikeDecoderLayer):
@@ -398,7 +413,9 @@ class NemotronHMoEDecoderLayer(NemotronHMLPLikeDecoderLayer):
         )
 
         self.norm = RMSNorm(config.hidden_size, eps=config.layer_norm_epsilon)
-        self.layer_communicator = make_layer_communicator(self.norm, for_attn=False)
+        self.layer_communicator = make_layer_communicator(
+            self.norm, for_attn=False, allow_reduce_scatter=True
+        )
 
 
 class NemotronHAttnLikeDecoderLayer(nn.Module):

--- a/python/sglang/srt/models/nemotron_h_utils.py
+++ b/python/sglang/srt/models/nemotron_h_utils.py
@@ -57,11 +57,12 @@ def _build_layer_scatter_modes() -> LayerScatterModes:
 
 
 def make_layer_communicator(
-    layer_norm: RMSNorm, *, for_attn: bool
+    layer_norm: RMSNorm, *, for_attn: bool, allow_reduce_scatter: bool = False
 ) -> LayerCommunicator:
     return LayerCommunicator(
         layer_scatter_modes=_build_layer_scatter_modes(),
         input_layernorm=layer_norm if for_attn else nn.Identity(),
         post_attention_layernorm=nn.Identity() if for_attn else layer_norm,
         force_layernorm_before_dp_gather=True,
+        allow_reduce_scatter=allow_reduce_scatter,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
It's spotted through profiling:

```
SGLANG_FLASHINFER_WORKSPACE_SIZE=1073741824 python3 -m sglang.launch_server \
    --model-path nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
    --trust-remote-code \
    --tool-call-parser qwen3_coder \
    --reasoning-parser nemotron_3 \
    --tp-size 8 \
    --dp-size 8 \
    --enable-dp-attention \
    --ep-size 8 \
    --max-running-requests 1024 \
    --mamba-full-memory-ratio 5.0 \
    --mem-fraction-static 0.9
 ```
 
<img width="1685" height="862" alt="Screenshot 2026-06-12 at 3 48 36 PM" src="https://github.com/user-attachments/assets/9fd7fa31-b9e5-4790-91f3-6c6cc2b12aa1" />

It will perform AR + RS, which the only necessary comm op after the experts should be RS here.
<img width="1678" height="463" alt="Screenshot 2026-06-12 at 3 52 33 PM" src="https://github.com/user-attachments/assets/d90cf488-5647-405d-93b1-34b8661ceea9" />

<!-- Describe the purpose and goals of this pull request. -->

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

Before:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 128 --platinum
Loading GSM8K Platinum dataset from HuggingFace...
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [01:49<00:00, 11.08it/s]
Accuracy: 0.000
Invalid: 1.000
Latency: 109.131 s
Output throughput: 5672.169 token/s
```

After:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 128 --platinum
Loading GSM8K Platinum dataset from HuggingFace...
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [01:11<00:00, 16.86it/s]
Accuracy: 0.983
Invalid: 0.000
Latency: 71.723 s
Output throughput: 1838.485 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27447696428](https://github.com/sgl-project/sglang/actions/runs/27447696428)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27447696311](https://github.com/sgl-project/sglang/actions/runs/27447696311)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->