### PR TITLE
fix: preserve GLM string ids with underscores

### DIFF
--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -130,6 +130,8 @@ def parse_arguments(
     # Strategy 3: ast.literal_eval
     try:
         parsed_value = ast.literal_eval(json_value)
+        if arg_type == "string" and not isinstance(parsed_value, (str, dict, list)):
+            return json_value, True
         return parsed_value, True
     except (ValueError, SyntaxError):
         pass

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -119,6 +119,8 @@ def parse_arguments(
     # Strategy 3: ast.literal_eval
     try:
         parsed_value = ast.literal_eval(json_value)
+        if arg_type == "string" and not isinstance(parsed_value, (str, dict, list)):
+            return json_value, True
         return parsed_value, True
     except (ValueError, SyntaxError):
         pass

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2764,6 +2764,31 @@ class TestGlm4MoeDetector(unittest.TestCase):
         )
         self.assertEqual(result.normal_text, "")
 
+    def test_string_argument_preserves_bare_underscore_id(self):
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="lookup",
+                    description="Lookup by identifier",
+                    parameters={
+                        "type": "object",
+                        "properties": {"item_id": {"type": "string"}},
+                        "required": ["item_id"],
+                    },
+                ),
+            ),
+        ]
+        text = (
+            "<tool_call>lookup\n"
+            "<arg_key>item_id</arg_key>\n<arg_value>10220_3939392</arg_value>\n"
+            "</tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["item_id"], "10220_3939392")
+
     def test_multiple_tool_calls(self):
         text = (
             "<tool_call>get_weather\n"
@@ -3087,6 +3112,31 @@ class TestGlm47MoeDetector(unittest.TestCase):
             result.calls[0].parameters, '{"city": "Beijing", "date": "2024-06-27"}'
         )
         self.assertEqual(result.normal_text, "")
+
+    def test_string_argument_preserves_bare_underscore_id(self):
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="lookup",
+                    description="Lookup by identifier",
+                    parameters={
+                        "type": "object",
+                        "properties": {"item_id": {"type": "string"}},
+                        "required": ["item_id"],
+                    },
+                ),
+            ),
+        ]
+        text = (
+            "<tool_call>lookup"
+            "<arg_key>item_id</arg_key><arg_value>10220_3939392</arg_value>"
+            "</tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["item_id"], "10220_3939392")
 
     def test_multiple_tool_calls(self):
         text = (


### PR DESCRIPTION
## Summary

- preserve bare underscore IDs for GLM string arguments when JSON parsing falls through to `ast.literal_eval`
- keep numeric parsing unchanged for arguments declared as `number`
- add regression coverage for the GLM-4 and GLM-4.7 MoE detectors

Fixes #28111.

## To verify

- `python -m py_compile python\sglang\srt\function_call\glm4_moe_detector.py python\sglang\srt\function_call\glm47_moe_detector.py test\registered\unit\function_call\test_function_call_parser.py`
- `git diff --check`
- `python -m ruff check --select=F401,F821,UP037 python\sglang\srt\function_call\glm4_moe_detector.py python\sglang\srt\function_call\glm47_moe_detector.py test\registered\unit\function_call\test_function_call_parser.py`
- parser smoke test loading the two detector modules directly and checking `parse_arguments("10220_3939392", "string")`

I could not run the full targeted pytest module on this Windows checkout because importing SGLang fails on POSIX/CUDA-only dependencies (`resource`, then `triton`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34895953960](https://github.com/sgl-project/sglang/actions/runs/34895953960)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34895953116](https://github.com/sgl-project/sglang/actions/runs/34895953116)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34895953544](https://github.com/sgl-project/sglang/actions/runs/34895953544)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->