### PR TITLE
[Need to test on Node] Fix Responses API review follow-ups from #25881

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import time
+from collections import OrderedDict
 from contextlib import AsyncExitStack
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Optional, Union
@@ -80,6 +81,40 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _BoundedResponseStore(OrderedDict):
+    """LRU-bounded ``dict`` for the in-process /v1/responses stores.
+
+    Both the response objects and the input-message history are retained only
+    to serve ``store=true`` retrieval and ``previous_response_id`` continuation.
+    Without a bound these grow without limit under default-configured traffic
+    (``store`` defaults to ``True``). Reads and writes refresh recency so that
+    actively-referenced multi-turn conversations survive while idle ones are
+    evicted first. ``max_size <= 0`` disables eviction (legacy behavior).
+    """
+
+    def __init__(self, max_size: int):
+        super().__init__()
+        self._max_size = max_size
+
+    def __getitem__(self, key):
+        value = super().__getitem__(key)
+        self.move_to_end(key)
+        return value
+
+    def get(self, key, default=None):
+        if key in self:
+            return self[key]
+        return default
+
+    def __setitem__(self, key, value):
+        if key in self:
+            super().__delitem__(key)
+        super().__setitem__(key, value)
+        if self._max_size > 0:
+            while len(self) > self._max_size:
+                self.popitem(last=False)
+
+
 class OpenAIServingResponses(OpenAIServingChat):
     """Handler for /v1/responses requests"""
 
@@ -122,18 +157,21 @@ class OpenAIServingResponses(OpenAIServingChat):
                 get_stop_tokens_for_assistant_actions()
             )
 
-        # Response storage for background and retrieval operations
-        # Note: In production, this should use a proper storage backend (Redis, database)
-        # with TTL/expiration to prevent memory leaks
-        self.response_store: dict[str, ResponsesResponse] = {}
+        # Response/message storage for background, retrieval, and
+        # ``previous_response_id`` continuation. These are LRU-bounded
+        # (--responses-store-max-size) to cap memory under default
+        # ``store=true`` traffic; in production a shared backend (Redis,
+        # database) with TTL would be preferable, and high-QPS deployments
+        # should send ``store: false`` to avoid retaining inputs/outputs.
+        store_max_size = self.tokenizer_manager.server_args.responses_store_max_size
+        self.response_store: dict[str, ResponsesResponse] = _BoundedResponseStore(
+            store_max_size
+        )
         self.response_store_lock = asyncio.Lock()
 
-        # Message storage for conversation continuity
-        # Note: In production, this should use a proper storage backend (Redis, database)
-        # with TTL/expiration to prevent memory leaks
         self.msg_store: dict[
             str, Union[list[ChatCompletionMessageParam], list[OpenAIMessage]]
-        ] = {}
+        ] = _BoundedResponseStore(store_max_size)
 
         self.background_tasks: dict[str, asyncio.Task] = {}
 
@@ -270,11 +308,23 @@ class OpenAIServingResponses(OpenAIServingChat):
                     assert len(tool_list) == 0
                     tool_sessions = {}
                 for i, engine_prompt in enumerate(engine_prompts):
-                    # Calculate default max tokens from context length minus prompt length
+                    # Derive prompt length for default_max_tokens. Prefer the
+                    # already-tokenized ids: the multimodal path sets
+                    # ``engine_prompt`` to ``tokenizer.decode(prompt_ids)``, so
+                    # re-encoding the string here would be a redundant second
+                    # tokenization run synchronously on the event loop, blocking
+                    # all concurrent requests. Fall back to an off-loop encode
+                    # only when token ids are unavailable.
                     if isinstance(engine_prompt, list):
                         prompt_length = len(engine_prompt)
+                    elif processed_messages is not None and isinstance(
+                        processed_messages.prompt_ids, list
+                    ):
+                        prompt_length = len(processed_messages.prompt_ids)
                     elif isinstance(engine_prompt, str):
-                        prompt_length = len(tokenizer.encode(engine_prompt))
+                        prompt_length = len(
+                            await asyncio.to_thread(tokenizer.encode, engine_prompt)
+                        )
                     else:
                         prompt_length = 0
 
@@ -725,6 +775,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 if isinstance(tool_call_data, dict):
                     tool_call_data = [tool_call_data]
                 if isinstance(tool_call_data, list):
+                    appended_any = False
                     for tool in tool_call_data:
                         if not isinstance(tool, dict) or "name" not in tool:
                             continue
@@ -741,7 +792,14 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 status="completed",
                             )
                         )
-                    content = ""
+                        appended_any = True
+                    # Only consume ``content`` once it has actually been parsed
+                    # into tool calls. If every entry lacked "name" (or the JSON
+                    # was a list of non-dicts), keep the model text so it is
+                    # still surfaced as an output message below instead of being
+                    # silently dropped.
+                    if appended_any:
+                        content = ""
             except Exception as e:
                 logger.error("Required tool JSON parse error: %s", e)
 
@@ -1034,15 +1092,35 @@ class OpenAIServingResponses(OpenAIServingChat):
 
         # Prepend the conversation history
         if prev_response is not None:
-            # Add the previous messages
-            prev_msg = self.msg_store[prev_response.id]
+            # Add the previous messages (best-effort: the bounded store may have
+            # evicted an idle conversation, in which case the response output
+            # replayed below is still available).
+            prev_msg = self.msg_store.get(prev_response.id, [])
             messages.extend(prev_msg)
 
             for output_item in prev_response.output:
+                # Replay assistant text from ``message`` items.
                 assistant_text = self._output_message_text(output_item)
-                if assistant_text is None:
+                if assistant_text is not None:
+                    messages.append({"role": "assistant", "content": assistant_text})
                     continue
-                messages.append({"role": "assistant", "content": assistant_text})
+                # Replay ``function_call`` items as a proper assistant
+                # ``tool_calls`` message. Dropping them (the previous behavior)
+                # orphaned any client-supplied ``function_call_output`` in the
+                # next turn, breaking multi-turn tool use. The subsequent
+                # ``_merge_consecutive_assistant_messages`` folds this into the
+                # preceding assistant text block. Reasoning items remain
+                # skipped (``_normalize_response_message_for_chat`` returns None
+                # for them here).
+                item_type = (
+                    output_item.get("type")
+                    if isinstance(output_item, dict)
+                    else getattr(output_item, "type", None)
+                )
+                if item_type == "function_call":
+                    normalized = self._normalize_response_message_for_chat(output_item)
+                    if normalized is not None:
+                        messages.append(normalized)
 
         # Append the new input
         # Responses API supports simple text inputs without chat format
@@ -1119,7 +1197,9 @@ class OpenAIServingResponses(OpenAIServingChat):
             # Continue the previous conversation.
             # FIXME: Currently, request params like reasoning and
             # instructions are ignored.
-            prev_msgs = self.msg_store[prev_response.id]
+            # ``.get`` (not ``[]``) since the bounded store may have evicted an
+            # idle conversation.
+            prev_msgs = self.msg_store.get(prev_response.id, [])
             # Remove the previous chain-of-thoughts if there is a new "final"
             # message.
             if (
@@ -1781,6 +1861,7 @@ class OpenAIServingResponses(OpenAIServingChat):
         tool_parser: Optional[Union[FunctionCallParser, JsonArrayParser]] = None
         if chat_tools and request.tool_choice != "none":
             native_supports_structural_tag = False
+            probe: Optional[FunctionCallParser] = None
             if self.tool_call_parser:
                 probe = FunctionCallParser(chat_tools, self.tool_call_parser)
                 native_supports_structural_tag = (
@@ -1789,7 +1870,9 @@ class OpenAIServingResponses(OpenAIServingChat):
             if is_required and not native_supports_structural_tag:
                 tool_parser = JsonArrayParser()
             elif self.tool_call_parser:
-                tool_parser = FunctionCallParser(chat_tools, self.tool_call_parser)
+                # Reuse the probe instead of constructing a second identical
+                # parser for the native path.
+                tool_parser = probe
         reasoning_parser_obj: Optional[ReasoningParser] = None
         if self.reasoning_parser:
             reasoning_parser_obj = ReasoningParser(

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -244,6 +244,7 @@ class Qwen3Detector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        tool_start_token: Optional[str] = "<tool_call>",
     ):
         think_excluded_tokens = [
             "<tool_call>",
@@ -251,15 +252,23 @@ class Qwen3Detector(BaseReasoningFormatDetector):
             "<|im_end|>",
             "<|endoftext|>",
         ]
+        # ``tool_start_token`` makes the base detector treat ``<tool_call>`` as
+        # an implicit reasoning close when the model opens a tool call before
+        # emitting ``</think>`` — the Qwen3.5 behavior. The non-streaming path
+        # only does this when ``</think>`` is absent, so a literal ``<tool_call>``
+        # inside reasoning that later closes ``</think>`` is still parsed
+        # normally; the streaming path closes eagerly on the first ``<tool_call>``
+        # seen while reasoning. Subclasses that only reuse Qwen3 *tokens*
+        # (DeepSeek-V3/V4, MIMO, Poolside) pass ``None`` so the heuristic does
+        # not leak to families where the unclosed-``</think>`` quirk was never
+        # observed.
         super().__init__(
             "<think>",
             "</think>",
             think_excluded_tokens=think_excluded_tokens,
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
-            # Qwen3.5 sometimes opens ``<tool_call>`` without closing
-            # ``</think>``; treat it as an implicit reasoning close.
-            tool_start_token="<tool_call>",
+            tool_start_token=tool_start_token,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
             thinks_internally=True,
@@ -579,6 +588,9 @@ class _DeepSeekV3Detector(Qwen3Detector):
     """DeepSeek-V3 reuses Qwen3 tokens but requires explicit thinking=True to enable."""
 
     def __init__(self, **kwargs):
+        # Only reuses Qwen3 *tokens*; the Qwen3.5 unclosed-``</think>`` quirk
+        # was never observed here, so keep ``<tool_call>`` inert in reasoning.
+        kwargs.setdefault("tool_start_token", None)
         super().__init__(**kwargs)
         self.reasoning_default = "explicit_thinking"
 
@@ -587,6 +599,7 @@ class _MimoDetector(Qwen3Detector):
     """MIMO reuses Qwen3 tokens but requires explicit enable_thinking=True to enable."""
 
     def __init__(self, **kwargs):
+        kwargs.setdefault("tool_start_token", None)
         super().__init__(**kwargs)
         self.reasoning_default = "explicit_enable_thinking"
 
@@ -596,6 +609,7 @@ class _PoolsideV1Detector(Qwen3Detector):
     defaults `enable_thinking=False`; reasoning is opt-in via `enable_thinking=True`."""
 
     def __init__(self, **kwargs):
+        kwargs.setdefault("tool_start_token", None)
         super().__init__(**kwargs)
         self.reasoning_default = "explicit_enable_thinking"
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -550,6 +550,7 @@ class ServerArgs:
     sampling_defaults: str = "model"
     asr_max_buffer_seconds: int = 60
     asr_max_concurrent_sessions: int = 32
+    responses_store_max_size: int = 10000
 
     # Data parallelism
     dp_size: int = 1
@@ -5663,6 +5664,17 @@ class ServerArgs:
             "--enable-cache-report",
             action="store_true",
             help="Return number of cached tokens in usage.prompt_tokens_details for each openai request.",
+        )
+        parser.add_argument(
+            "--responses-store-max-size",
+            type=int,
+            default=ServerArgs.responses_store_max_size,
+            help="Maximum number of conversations retained in the in-process "
+            "/v1/responses stores that back store=true retrieval and "
+            "previous_response_id continuation. The least-recently-used entries "
+            "are evicted past this size; set <= 0 to disable eviction (unbounded). "
+            "For high-QPS serving prefer store=false per request to avoid "
+            "retaining inputs/outputs at all.",
         )
         reasoning_parser_choices = list(ReasoningParser.DetectorMap.keys())
         parser.add_argument(

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1546,5 +1546,39 @@ class TestPoolsideV1Registered(CustomTestCase):
         self.assertTrue(rp.detector.thinks_internally)
 
 
+class TestQwen3ToolCallThinkClose(CustomTestCase):
+    """The Qwen3 detector treats ``<tool_call>`` inside a still-open ``<think>``
+    block as an implicit reasoning close (the Qwen3.5 behavior). That heuristic
+    must stay scoped: subclasses that only reuse Qwen3 *tokens* keep the token
+    inert, and (non-streaming) it only fires when ``</think>`` is absent, so a
+    literal ``<tool_call>`` inside genuine reasoning is not mis-parsed."""
+
+    def test_qwen3_default_enables_tool_call_think_close(self):
+        self.assertEqual(Qwen3Detector().tool_start_token, "<tool_call>")
+        # No ``</think>``: the tool call implicitly closes reasoning.
+        text = "<think>deliberating<tool_call>{}"
+        result = Qwen3Detector(force_reasoning=True).detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "deliberating")
+        self.assertEqual(result.normal_text, "<tool_call>{}")
+
+    def test_non_streaming_gated_on_think_close(self):
+        # When ``</think>`` is present, a literal ``<tool_call>`` inside
+        # reasoning is NOT treated as an implicit close: it stays in
+        # reasoning_text and the split happens at ``</think>``.
+        text = "<think>maybe <tool_call> here</think>the answer"
+        result = Qwen3Detector(force_reasoning=True).detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "maybe <tool_call> here")
+        self.assertEqual(result.normal_text, "the answer")
+
+    def test_token_only_subclasses_do_not_inherit_think_close(self):
+        # DeepSeek-V3/V4, MIMO, and Poolside reuse Qwen3 tokens, but the
+        # unclosed-``</think>`` quirk was only observed on Qwen3.5, so they keep
+        # ``<tool_call>`` inert rather than force-closing reasoning.
+        for model_type in ("deepseek-v3", "deepseek-v4", "mimo", "poolside_v1"):
+            detector_cls = ReasoningParser.DetectorMap[model_type]
+            self.assertTrue(issubclass(detector_cls, Qwen3Detector))
+            self.assertIsNone(detector_cls().tool_start_token, model_type)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[Need to test on Node]

## Summary

Follow-up to #25881, which was merged with my review comments unaddressed. @hnyls2002 asked me to submit the fixes (the gemini-bot and @Kontinuation comments were already resolved in #25881; these were not). This is the single consolidated PR for all of them.

### Correctness
- **`previous_response_id` replay dropped tool calls.** `_output_message_text` returns `None` for `function_call` items, so the replay loop skipped them. A prior turn that ended in a tool call replayed as nothing — and since clients continuing via `previous_response_id` typically send only `{type: function_call_output, ...}`, that produced a `role: tool` message with no preceding assistant `tool_calls`, breaking multi-turn tool use. `function_call` items are now replayed as a proper assistant `tool_calls` message (via the existing `_normalize_response_message_for_chat`), which `_merge_consecutive_assistant_messages` folds into the preceding text block.
- **Required-tool JSON path blanked model output when nothing parsed.** `content = ""` ran unconditionally after the parse loop, so a list of non-dicts (or entries all missing `"name"`) silently discarded the model text *and* emitted no tool call. Now only cleared when at least one tool call was actually appended.
- **Qwen3 `<tool_call>` implicit-think-close is now scoped.** The `tool_start_token="<tool_call>"` added in #25881 lives on the shared `Qwen3Detector`, so it force-closed reasoning on `<tool_call>` for the whole family (`qwen3`, `qwen3-thinking`, `minimax`, `interns1`) **and** the token-reuse subclasses (`DeepSeek-V3/V4`, `MIMO`, `Poolside`). The quirk is Qwen3.5-specific, so those subclasses now keep the token inert via a parameterized `tool_start_token`. Note the non-streaming path already only fires when `</think>` is absent (so a literal `<tool_call>` inside genuine reasoning that later closes `</think>` is parsed normally); the streaming path closes eagerly on the first `<tool_call>` seen while reasoning. Adds regression tests.

### Performance
- **`default_max_tokens` no longer re-tokenizes on the event loop.** The multimodal path sets `engine_prompt = tokenizer.decode(prompt_ids)` and then re-encoded that string *synchronously on the asyncio loop* (blocking all concurrent requests, hurting TTFT) purely to count tokens. Now reuses the already-computed `prompt_ids`, falling back to an off-loop `asyncio.to_thread` encode only when ids aren't available.
- **Streaming tool path reuses the `FunctionCallParser` probe** instead of constructing a second identical parser per request.

### Memory
- **`response_store` / `msg_store` are now LRU-bounded** via a new **`--responses-store-max-size`** server arg (default 10000) instead of growing without limit under default `store=true` traffic; `<= 0` keeps the legacy unbounded behavior. Store reads are made eviction-safe, and the flag help recommends `store=false` for high-QPS serving. (Pre-existing issue, but #25881 is what makes `/v1/responses` actually usable.)

## Test plan
- New `TestQwen3ToolCallThinkClose` in `test/registered/unit/parser/test_reasoning_parser.py` covers the default heuristic, the `</think>`-gated non-streaming safety, and the scoped subclasses.
- Verified the replay fix and `_BoundedResponseStore` LRU/eviction/unbounded semantics against the real code, and the `--responses-store-max-size` arg parsing.
- `black` / `isort` / `ruff` / `codespell` (pre-commit) all pass.

> Note: full `test/registered/unit/entrypoints/openai/test_serving_responses.py` couldn't be executed in my local (un-synced) environment; the `serving_responses.py` fixes rely on that existing suite plus the manual verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27454123065](https://github.com/sgl-project/sglang/actions/runs/27454123065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27454122984](https://github.com/sgl-project/sglang/actions/runs/27454122984)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->