### PR TITLE
chore: bump tokenspeed_mla 0.1.1 -> 0.1.6

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
   "tiktoken",
   "tilelang==0.1.8",
   "timm==1.0.16",
-  "tokenspeed_mla==0.1.1",
+  "tokenspeed_mla==0.1.6",
   "torch_memory_saver>=0.0.9.post1",
   "torch==2.11.0",
   "torchao==0.17.0",


### PR DESCRIPTION
## Summary

Bumps the `tokenspeed_mla` dependency pin from **0.1.1 → 0.1.6** (latest on PyPI) in `python/pyproject.toml`.

The MLA prefill FMHA kernel (`tokenspeed_mla_prefill`, used by the `tokenspeed_mla` attention backend on Blackwell) was substantially reworked between 0.1.1 and 0.1.5:
- **FP8 `P` pre-scale**: an exp2-exponent offset so the softmax probabilities fill more of E4M3's `[0, 448]` range before the `P·V` matmul.
- A rewritten softmax/exp reduction inner loop (`compute_row_sum` / `apply_exp_and_cvt`).

SGLang is currently pinned to **0.1.1**, so the `tokenspeed_mla` backend leaves ~12% of MLA extend/prefill attention time on the table on B200. This is a pure dependency bump — no code changes (the backend API is unchanged; 0.1.6's prefill kernel is identical to 0.1.5, the rest are decode/packaging changes).

## Benchmark — our workload (Kimi-K2.5-NVFP4, TP8, B200)

Microbenchmarked `tokenspeed_mla_prefill` directly on the exact extend shapes (per TP rank: `h=8`, `d_qk=192`, `d_v=128`, fp8 e4m3 Q/K/V, `bs=1`, `return_lse=True`, `q=6797`). Durations are **pure GPU kernel time** read from `torch.profiler` (same methodology as our serving traces), p50 over 40 iters, warm clocks.

| FMHA config | 0.1.1 | 0.1.6 | speedup |
|---|---|---|---|
| self (causal, kv=6797) | 143.3 µs | 124.8 µs | **1.15×** |
| prefix chunk (non-causal, kv=32768) | 816.6 µs | 720.6 µs | **1.13×** |
| monolithic prefix (non-causal, kv=75000) | 1854.5 µs | 1632.6 µs | **1.14×** |

Per-MLA-layer extend attention (self + monolithic prefix): **1998 µs → 1757 µs** (−240 µs/layer), i.e. **≈ −14.6 ms per prefill step** across 61 layers, purely from the kernel bump.

## Validation

The isolated kernel numbers reproduce real serving captures on both engines, which cross-validates the measurement:
- 0.1.1 `mono75k` = 1854 µs ≈ captured SGLang (default-cap) prefix FMHA ≈ 1867 µs.
- 0.1.6 `chunk32k` = 721 µs ≈ captured TokenSpeed prefix chunk ≈ 711–757 µs (TokenSpeed already ships ≈0.1.5/0.1.6).

So the speedup brings the SGLang `tokenspeed_mla` backend's per-kernel FMHA cost in line with the faster reference.

## End-to-end correctness (DeepSeek-V3-0324-FP4)

Ran the registered e2e accuracy test `TestDeepseekV3FP4SymmetricMemory` (`test/registered/models_e2e/test_deepseek_v3_fp4.py`) with **the only change being `--attention-backend trtllm_mla` → `tokenspeed_mla`**, against **0.1.6** (the version this PR pins). Everything else identical: `nvidia/DeepSeek-V3-0324-FP4`, TP4, `flashinfer_trtllm` MoE, `modelopt_fp4`, `--kv-cache-dtype fp8_e4m3`, `--enable-symm-mem`; GSM8K 1319 questions, 8-shot, threshold ≥ 0.93.

| backend | GSM8K (1319q, 8-shot) | threshold | result |
|---|---|---|---|
| `tokenspeed_mla` (0.1.6) | **0.9550** | ≥ 0.93 | ✅ passed |

```
1 passed in 303.51s (0:05:03)
metrics={'score': 0.9550, 'score:std': 0.2073, 'latency': 43.23s, 'output_throughput': 3260.9 tok/s}
```

`tokenspeed_mla` (0.1.6) is a correct drop-in for `trtllm_mla` on the full NVFP4 e2e eval, clearing the same 0.93 bar with margin. Backend activation confirmed in the server log (`attention_backend='tokenspeed_mla'`, page_size auto-set to 64). The MLA attention unit suite (`test/registered/attention/unittests/mla/test_tokenspeed_mla.py`) also passes on both 0.1.1 and 0.1.6.

## Notes / risk

- Dependency-only change; no API or behavior change in the backend.
- 0.1.5 → 0.1.6 is a no-op for the prefill FMHA specifically; 0.1.6 is pinned simply because it is the latest release.
- Gains above are isolated, warm-clock kernel times; end-to-end prefill improvement depends on attention being on the critical path (it is for eager extend/prefill).

## Test plan

- [ ] CI dependency resolution / install with `tokenspeed_mla==0.1.6`.
- [x] Smoke test `--attention-backend tokenspeed_mla` on a Blackwell (SM100) box with `--kv-cache-dtype fp8_e4m3` (e.g. the Kimi-K2.5-NVFP4 TP8 config).
- [x] e2e GSM8K accuracy on DeepSeek-V3-0324-FP4 with `tokenspeed_mla` (0.1.6): **0.9550 ≥ 0.93**.
- [ ] Confirm per-layer prefix FMHA drops to ~1.63 ms in a re-profile.

Made with [Cursor](https://cursor.com)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27453829210](https://github.com/sgl-project/sglang/actions/runs/27453829210)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27453829138](https://github.com/sgl-project/sglang/actions/runs/27453829138)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
