### PR TITLE
【bugfix】The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -1556,12 +1556,9 @@ class AscendAttnBackend(AttentionBackend):
                 q, k, v = [
                     data[: forward_batch.num_token_non_padded_cpu] for data in [q, k, v]
                 ]
-                if q_rope is not None:
-                    q_nope = q
-                else:
-                    q_nope, q_rope = q.split(
-                        [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
-                    )
+                q_nope, q_rope = q.split(
+                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
+                )
                 k_nope, k_rope = k.split(
                     [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
                 )
@@ -1723,12 +1720,9 @@ class AscendAttnBackend(AttentionBackend):
                     data[: forward_batch.num_token_non_padded_cpu] for data in [q, k, v]
                 ]
 
-                if q_rope is not None:
-                    q_nope = q
-                else:
-                    q_nope, q_rope = q.split(
-                        [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
-                    )
+                q_nope, q_rope = q.split(
+                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
+                )
                 k_nope, k_rope = k.split(
                     [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
                 )

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -1556,9 +1556,12 @@ class AscendAttnBackend(AttentionBackend):
                 q, k, v = [
                     data[: forward_batch.num_token_non_padded_cpu] for data in [q, k, v]
                 ]
-                q_nope, q_rope = q.split(
-                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
-                )
+                if q_rope is not None:
+                    q_nope = q
+                else:
+                    q_nope, q_rope = q.split(
+                        [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
+                    )
                 k_nope, k_rope = k.split(
                     [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
                 )
@@ -1720,9 +1723,12 @@ class AscendAttnBackend(AttentionBackend):
                     data[: forward_batch.num_token_non_padded_cpu] for data in [q, k, v]
                 ]
 
-                q_nope, q_rope = q.split(
-                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
-                )
+                if q_rope is not None:
+                    q_nope = q
+                else:
+                    q_nope, q_rope = q.split(
+                        [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
+                    )
                 k_nope, k_rope = k.split(
                     [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
                 )

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -403,9 +403,7 @@ def forward_dsa_prepare_npu(
                 latent_cache, forward_batch, k_nope, k_pe
             )
 
-    if m.skip_topk:
-        topk_indices = prev_topk_indices
-    else:
+    if not m.skip_topk or (m.is_nextn and prev_topk_indices is None):
         topk_indices = m.indexer(
             hidden_states,
             q_lora,
@@ -415,6 +413,8 @@ def forward_dsa_prepare_npu(
             layer_scatter_modes,
             dynamic_scale,
         )
+    else:
+        topk_indices = prev_topk_indices
 
     return (
         q_pe,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Fixed the bug caused by 393d0e169e8e1bab59a85e35392078ce0c684d9b on the NPU platform

The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn

```shell
RuntimeError: split_with_sizes expects split_sizes to sum exactly to 512 (input tensor's size at dimension -1), but got split_sizes=[512, 64]

[2026-06-12 08:28:30 DP11 TP22 EP22] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 4064, in run_scheduler_process
    scheduler.run_event_loop()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1418, in run_event_loop
    dispatch_event_loop(self)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3929, in dispatch_event_loop
    scheduler.event_loop_overlap()
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1482, in event_loop_overlap
    batch_result = self.run_batch(batch)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3041, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/eagle_worker_v2.py", line 957, in forward_batch_generation
    self.draft_worker._draft_extend_for_prefill(
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/eagle_worker_v2.py", line 694, in _draft_extend_for_prefill
    logits_output = self.draft_runner.forward(forward_batch).logits_output
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 3462, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 3589, in _forward_raw
    ret, can_run_graph = self.forward_extend(
                         ^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 3347, in forward_extend
    ret = self.model.forward(
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_nextn.py", line 350, in forward
    hidden_states = self.model(input_ids, positions, forward_batch)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_nextn.py", line 227, in forward
    hidden_states, residual, topk_indices = self.decoder(
                                            ^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 2105, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 1760, in forward
    return self.forward_core(s)
           ^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 1881, in forward_core
    return forward_dsa_core_npu(self, *inner_state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py", line 442, in forward_dsa_core_npu
    attn_output = m.attn_mqa(
                  ^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/radix_attention.py", line 145, in forward
    return get_attn_backend().forward(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/base_attn_backend.py", line 189, in forward
    return self.forward_extend(
           ^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py", line 1587, in forward_extend
    q_nope, q_rope = q.split(
                     ^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/_tensor.py", line 1066, in split
    return torch._VF.split_with_sizes(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: split_with_sizes expects split_sizes to sum exactly to 512 (input tensor's size at dimension -1), but got split_sizes=[512, 64]

```


```shell

  tensor_data = torch.ByteTensor(
[2026-06-13 03:13:47 DP7 TP14 EP14] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP2 TP5 EP5] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP3 TP7 EP7] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP4 TP9 EP9] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP6 TP12 EP12] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP4 TP8 EP8] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP7 TP15 EP15] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP5 TP10 EP10] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP5 TP11 EP11] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP3 TP6 EP6] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP6 TP13 EP13] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP1 TP2 EP2] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP1 TP3 EP3] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP0 TP0 EP0] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP0 TP1 EP1] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:47 DP2 TP4 EP4] get env HOSTNAME = ubuntu-docker
[2026-06-13 03:13:52 DP2 TP4 EP4] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 17.62
[2026-06-13 03:13:52 DP1 TP2 EP2] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 17.64
[2026-06-13 03:13:52 DP0 TP0 EP0] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 17.61
[2026-06-13 03:13:52 DP5 TP10 EP10] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 16.86
[2026-06-13 03:13:52 DP4 TP8 EP8] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 16.71
[2026-06-13 03:13:53 DP7 TP14 EP14] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 15.04
[2026-06-13 03:13:53 DP6 TP12 EP12] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 15.37
[2026-06-13 03:13:53 DP3 TP6 EP6] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 15.17
[2026-06-13 03:13:59] INFO:     61.47.19.66:59860 - "POST /generate HTTP/1.1" 200 OK
[2026-06-13 03:13:59] The server is fired up and ready to roll!
```
sript:
```shell
# cpu高性能
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl -w kernel.sched_migration_cost_ns=50000
# 绑核
export SGLANG_SET_CPU_AFFINITY=1

unset https_proxy
unset http_proxy
unset HTTPS_PROXY
unset HTTP_PROXY
unset ASCEND_LAUNCH_BLOCKING

source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh

# export PYTHONPATH=/home/luochen/glm/sglang_3_17_poc/sglang/python:$PYTHONPATH
#export PYTHONPATH=/home/luochen/glm/sglang_4_15_poc/sglang/python:$PYTHONPATH
# export PYTHONPATH=/home/luochen/sglang/python:$PYTHONPATH

# cd /home/l00890003/codes/sglang-npu-nn-blue-1
# export PYTHONPATH=${PWD}/python:$PYTHONPATH
# 内存碎片
# export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32
# 网卡
export HCCL_SOCKET_IFNAME=enp196s0f0
export GLOO_SOCKET_IFNAME=enp196s0f0
# model path

# 最新w4a8权重-mlp未量化
# MODEL_PATH=/home/weights/GLM-5-w4a8
#MODEL_PATH=/home/weights/GLM-5-w4a8-new
MODEL_PATH=/home/weights/GLM-5.1-w4a8
export DEEP_NORMAL_MODE_USE_INT8_QUANT=1

P_IP=('61.47.19.71' '61.47.19.69')
P_MASTER=""${P_IP[0]}:4567""
export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600

# mtp环境变量
export SGLANG_ENABLE_SPEC_V2=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1

LOCAL_HOST1=`hostname -I|awk  '{print$1}'`
LOCAL_HOST2=`hostname -I|awk  '{print$2}'`
export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=32

# export SGLANG_NPU_USE_MULTI_STREAM=1

# export SGLANG_USE_AG_AFTER_QLORA=1

### 调度优化
# export SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE=1

for i in ""${!P_IP[@]}"";
do
    if [[ ""$LOCAL_HOST1"" == ""${P_IP[$i]}"" || ""$LOCAL_HOST2"" == ""${P_IP[$i]}"" ]];
    then
################################### profiling
        echo ""${P_IP[$i]}""
        export HCCL_BUFFSIZE=2500
        python3 -m sglang.launch_server \
        --model-path $MODEL_PATH \
        --attention-backend ascend \
        --device npu \
        --dist-init-addr 61.47.19.71:5000 \
        --tp-size 32 --nnodes 2 --node-rank $i \
        --dp-size 16 --enable-dp-attention \
        --chunked-prefill-size 65536 --max-prefill-tokens 280000 \
        --trust-remote-code \
        --host 61.47.19.71 \
        --mem-fraction-static 0.65 \
        --port 8001 \
        --served-model-name glm-5 \
        --cuda-graph-max-bs 8 \
        --max-running-requests 256 \
        --quantization modelslim \
        --speculative-draft-model-quantization unquant \
        --moe-a2a-backend deepep --deepep-mode auto \
        --load-balance-method round_robin \
        --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
        NODE_RANK=$i
        break
    fi
done

```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
```shell
# nextn reuses the topk_indices from the previous layer, the first layer needs to create topk_indices
python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
```

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [√ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27537081991](https://github.com/sgl-project/sglang/actions/runs/27537081991)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27537081804](https://github.com/sgl-project/sglang/actions/runs/27537081804)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->