### PR TITLE
Add prajjwal1 to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -993,6 +993,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "prajjwal1": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "pranavm-nvidia": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Add `prajjwal1` to `.github/CI_PERMISSIONS.json` with a 60-minute cooldown, inserted in alphabetical order.

```json
"prajjwal1": {
    "can_tag_run_ci_label": true,
    "can_rerun_failed_ci": true,
    "can_rerun_stage": true,
    "cooldown_interval_minutes": 60,
    "reason": "custom override"
}
```











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27455074129](https://github.com/sgl-project/sglang/actions/runs/27455074129)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27455074094](https://github.com/sgl-project/sglang/actions/runs/27455074094)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->