### PR TITLE
[HiSparse] fix: populate req_pool_indices_cpu in staging-to-decode batch

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2436,8 +2436,11 @@ class Scheduler(
             spec_algorithm=self.spec_algorithm,
         )
 
-        batch.req_pool_indices = torch.tensor(
-            [r.req_pool_idx for r in reqs], dtype=torch.int64, device=device
+        batch.req_pool_indices_cpu = torch.tensor(
+            [r.req_pool_idx for r in reqs], dtype=torch.int64
+        )
+        batch.req_pool_indices = batch.req_pool_indices_cpu.to(
+            device, non_blocking=True
         )
         seq_lens = [len(r.origin_input_ids) + len(r.output_ids) - 1 for r in reqs]
         batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=device)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2437,7 +2437,7 @@ class Scheduler(
         )
 
         batch.req_pool_indices_cpu = torch.tensor(
-            [r.req_pool_idx for r in reqs], dtype=torch.int64
+            [r.req_pool_idx for r in reqs], dtype=torch.int64, device="cpu"
         )
         batch.req_pool_indices = batch.req_pool_indices_cpu.to(
             device, non_blocking=True


### PR DESCRIPTION
## Background

HiSparse does not put a request into normal decode immediately after prefill. Instead, a prefilled request is admitted into HiSparse staging, asynchronously staged into host/device buffers, and later collected and turned into a decode `ScheduleBatch` by `_build_hisparse_decode_batch()`.

That hand-built decode batch only initialized the GPU-side `req_pool_indices` and left `req_pool_indices_cpu` as `None`. `prepare_for_decode()` then passes that `None` into HiSparse:

```
prepare_for_decode
  -> hisparse_coordinator.map_last_loc_to_buffer(..., req_pool_indices_cpu)
  -> _eager_backup_previous_token()
  -> req_idx = int(req_pool_indices_cpu[i])   # req_pool_indices_cpu is None
```

so the scheduler crashes with:

```
TypeError: 'NoneType' object is not subscriptable
```

Every DP scheduler process hits the same error, the server becomes unhealthy (`/health_generate` returns 503), the parent kills the children (exit code -9), and CI fails before any GSM8K assertion runs. The first staged request entering decode is enough to trigger it.

## Fix

- `_build_hisparse_decode_batch()`: build the CPU tensor first and derive the GPU tensor from it, so both `req_pool_indices` and `req_pool_indices_cpu` are populated (matching the normal prefill allocation path).
- `ScheduleBatch.copy()`: also copy `req_pool_indices_cpu`, so the scheduler-side CPU mirror survives overlap-scheduling result queueing (`result_queue.append((batch.copy(), ...))`).

## Reproduce / Verify

Failing config (8-GPU GLM-5 FP8 DSA, dp-attention, flashmla_sparse, HiSparse):

```bash
python test/registered/8-gpu-models/test_dsa_models_hisparse.py
```

Before the fix the server dies right after the first prefill batch transitions into decode. After the fix the staged request enters decode without `req_pool_indices_cpu=None`, no `TypeError` from `_eager_backup_previous_token()`, and the eval proceeds to the GSM8K assertions.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27461547020](https://github.com/sgl-project/sglang/actions/runs/27461547020)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27461546936](https://github.com/sgl-project/sglang/actions/runs/27461546936)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->