### PR TITLE
[diffusion] Improve server warmup coverage

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -36,7 +36,10 @@ from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import sync_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import PortArgs, ServerArgs
-from sglang.multimodal_gen.runtime.server_warmup import prepare_warmup_image_path_sync
+from sglang.multimodal_gen.runtime.server_warmup import (
+    run_sync_client_warmup,
+    should_run_explicit_client_warmup,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     GREEN,
     RESET,
@@ -47,10 +50,6 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import (
 from sglang.multimodal_gen.runtime.utils.trace_wrapper import (
     init_diffusion_tracing,
     trace_req,
-)
-from sglang.multimodal_gen.runtime.warmup_request_builder import (
-    build_warmup_reqs,
-    should_include_warmup_image,
 )
 
 logger = init_logger(__name__)
@@ -156,26 +155,10 @@ class DiffGenerator:
         return processes
 
     def _run_client_warmup_if_needed(self) -> None:
-        if not self.server_args.warmup or self.server_args.warmup_resolutions is None:
+        if not should_run_explicit_client_warmup(self.server_args):
             return
 
-        warmup_input_path = None
-        if should_include_warmup_image(self.server_args, server_based_warmup=True):
-            warmup_input_path = prepare_warmup_image_path_sync(self.server_args)
-
-        warmup_reqs = build_warmup_reqs(
-            self.server_args,
-            warmup_resolutions=self.server_args.warmup_resolutions,
-            warmup_input_path=warmup_input_path,
-            return_warmup_result=True,
-            server_based_warmup=True,
-        )
-        warmup_total = len(warmup_reqs)
-        for req in warmup_reqs:
-            req.extra["warmup_total"] = warmup_total
-            response = sync_scheduler_client.forward(req)
-            if response.error is not None:
-                raise RuntimeError(response.error)
+        run_sync_client_warmup(self.server_args, sync_scheduler_client.forward)
 
     def _check_remote_scheduler(self):
         """Check if the remote scheduler is accessible."""

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -36,6 +36,7 @@ from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import sync_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import PortArgs, ServerArgs
+from sglang.multimodal_gen.runtime.server_warmup import prepare_warmup_image_path_sync
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     GREEN,
     RESET,
@@ -46,6 +47,10 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import (
 from sglang.multimodal_gen.runtime.utils.trace_wrapper import (
     init_diffusion_tracing,
     trace_req,
+)
+from sglang.multimodal_gen.runtime.warmup_request_builder import (
+    build_warmup_reqs,
+    should_include_warmup_image,
 )
 
 logger = init_logger(__name__)
@@ -130,13 +135,13 @@ class DiffGenerator:
         logger.info(f"Local mode: {local_mode}")
         if local_mode:
             instance.local_scheduler_process = instance._start_local_server_if_needed()
+            instance.owns_scheduler_client = True
+            instance._run_client_warmup_if_needed()
         else:
             # In remote mode, we just need to connect and check.
             sync_scheduler_client.initialize(server_args)
             instance._check_remote_scheduler()
-
-        # In both modes, this DiffGenerator instance is responsible for the client's lifecycle.
-        instance.owns_scheduler_client = True
+            instance.owns_scheduler_client = True
         return instance
 
     def _start_local_server_if_needed(
@@ -149,6 +154,28 @@ class DiffGenerator:
         processes = launch_server(self.server_args, launch_http_server=False)
 
         return processes
+
+    def _run_client_warmup_if_needed(self) -> None:
+        if not self.server_args.warmup or self.server_args.warmup_resolutions is None:
+            return
+
+        warmup_input_path = None
+        if should_include_warmup_image(self.server_args, server_based_warmup=True):
+            warmup_input_path = prepare_warmup_image_path_sync(self.server_args)
+
+        warmup_reqs = build_warmup_reqs(
+            self.server_args,
+            warmup_resolutions=self.server_args.warmup_resolutions,
+            warmup_input_path=warmup_input_path,
+            return_warmup_result=True,
+            server_based_warmup=True,
+        )
+        warmup_total = len(warmup_reqs)
+        for req in warmup_reqs:
+            req.extra["warmup_total"] = warmup_total
+            response = sync_scheduler_client.forward(req)
+            if response.error is not None:
+                raise RuntimeError(response.error)
 
     def _check_remote_scheduler(self):
         """Check if the remote scheduler is accessible."""

--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -82,7 +82,11 @@ async def _run_server_warmup_after_http_ready(
 
         await _wait_until_http_ready(server_args)
 
-        await run_async_client_warmup(server_args, async_scheduler_client.forward)
+        await run_async_client_warmup(
+            server_args,
+            async_scheduler_client.forward,
+            fail_open=server_args.warmup_resolutions is None,
+        )
         logger.info("The server is fired up and ready to roll!")
         warmup_done.set()
     except asyncio.CancelledError:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -35,12 +35,11 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 )
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
-from sglang.multimodal_gen.runtime.server_warmup import prepare_warmup_image_path
-from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.runtime.warmup_request_builder import (
-    build_warmup_reqs,
-    should_include_warmup_image,
+from sglang.multimodal_gen.runtime.server_warmup import (
+    run_async_client_warmup,
+    should_run_synthetic_server_warmup,
 )
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.srt.utils.json_response import orjson_response
 from sglang.version import __version__
 
@@ -73,54 +72,17 @@ async def _wait_until_http_ready(server_args: ServerArgs) -> None:
     raise RuntimeError(f"HTTP server did not become ready at {health_url}")
 
 
-def _is_realtime_serving(server_args: ServerArgs) -> bool:
-    """A realtime pipeline establishes per-session state over the WebSocket, so
-    the synthetic server-warmup request (which has no session) cannot run — it
-    would fail in the realtime stage and abort startup. Detect it via the
-    realtime-adapter registry and skip server warmup."""
-    try:
-        from sglang.multimodal_gen.runtime.entrypoints.openai.realtime.registry import (
-            get_realtime_model_adapter,
-        )
-
-        get_realtime_model_adapter(server_args)
-        return True
-    except Exception:
-        return False
-
-
 async def _run_server_warmup_after_http_ready(
     server_args: ServerArgs, warmup_done: asyncio.Event
 ) -> None:
     try:
-        if (
-            not server_args.warmup
-            or not server_args.server_warmup
-            or _is_realtime_serving(server_args)
-        ):
+        if not should_run_synthetic_server_warmup(server_args):
             warmup_done.set()
             return
 
         await _wait_until_http_ready(server_args)
 
-        warmup_input_path = None
-        if should_include_warmup_image(server_args, server_based_warmup=True):
-            warmup_input_path = await prepare_warmup_image_path(server_args)
-
-        warmup_reqs = build_warmup_reqs(
-            server_args,
-            warmup_resolutions=server_args.warmup_resolutions,
-            warmup_input_path=warmup_input_path,
-            return_warmup_result=True,
-            server_based_warmup=True,
-        )
-        warmup_total = len(warmup_reqs)
-        for req in warmup_reqs:
-            req.extra["warmup_total"] = warmup_total
-            response = await async_scheduler_client.forward(req)
-            if response.error is not None:
-                raise RuntimeError(response.error)
-
+        await run_async_client_warmup(server_args, async_scheduler_client.forward)
         logger.info("The server is fired up and ready to roll!")
         warmup_done.set()
     except asyncio.CancelledError:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -96,7 +96,6 @@ async def _run_server_warmup_after_http_ready(
         if (
             not server_args.warmup
             or not server_args.server_warmup
-            or server_args.warmup_resolutions is not None
             or _is_realtime_serving(server_args)
         ):
             warmup_done.set()
@@ -110,11 +109,10 @@ async def _run_server_warmup_after_http_ready(
 
         warmup_reqs = build_warmup_reqs(
             server_args,
-            warmup_resolutions=None,
+            warmup_resolutions=server_args.warmup_resolutions,
             warmup_input_path=warmup_input_path,
             return_warmup_result=True,
             server_based_warmup=True,
-            use_model_sampling_defaults=True,
         )
         warmup_total = len(warmup_reqs)
         for req in warmup_reqs:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -1,10 +1,8 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
 import asyncio
-import base64
 import inspect
 import json
 import os
-import re
 import shutil
 import tempfile
 import time
@@ -30,6 +28,8 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
 from sglang.multimodal_gen.runtime.server_args import get_global_server_args
+from sglang.multimodal_gen.runtime.utils.common import parse_size
+from sglang.multimodal_gen.runtime.utils.image_io import save_base64_image_to_path
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     init_logger,
     log_batch_completion,
@@ -95,17 +95,6 @@ def temp_dir_if_disabled(
             shutil.rmtree(tmp, ignore_errors=True)
 
 
-def _parse_size(size: str) -> tuple[int, int] | tuple[None, None]:
-    try:
-        parts = size.lower().replace(" ", "").split("x")
-        if len(parts) != 2:
-            raise ValueError
-        w, h = int(parts[0]), int(parts[1])
-        return w, h
-    except Exception:
-        return None, None
-
-
 def choose_output_image_ext(
     output_format: Optional[str], background: Optional[str]
 ) -> str:
@@ -135,7 +124,7 @@ def build_sampling_params(request_id: str, **kwargs) -> SamplingParams:
     # parse "WxH" size string if provided
     size = kwargs.pop("size", None)
     if size:
-        w, h = _parse_size(size)
+        w, h = parse_size(size)
         if w is not None:
             # treat None dimensions as unset so parsed size can fill them
             if kwargs.get("width") is None:
@@ -227,7 +216,7 @@ async def _maybe_url_image(
         if prefer_remote_source:
             return img_url
         # encode image base64 url and persist on disk
-        input_path = await _save_base64_image_to_path(img_url, target_path)
+        input_path = save_base64_image_to_path(img_url, target_path)
         return input_path
     else:
         raise ValueError("Unsupported image url format")
@@ -322,46 +311,6 @@ async def _save_url_image_to_path(image_url: str, target_path: str) -> str:
         raise Exception(
             f"Failed to download image from URL {image_url}: {str(final_error)}"
         )
-
-
-async def _save_base64_image_to_path(base64_data: str, target_path: str) -> str:
-    """Decode base64 image data and save to target path."""
-
-    _B64_FMT_HINT = (
-        "Failed to decode base64 image. "
-        "Expected format: `data:[<media-type>];base64,<data>`"
-    )
-
-    # split `data:[<media-type>][;base64],<data>` to media-type base64 data
-    pattern = r"data:(.*?)(;base64)?,(.*)"
-    match = re.match(pattern, base64_data)
-    if not match:
-        raise ValueError(_B64_FMT_HINT)
-    media_type = match.group(1)
-    is_base64 = match.group(2)
-    if not is_base64:
-        raise ValueError(f"{_B64_FMT_HINT} (missing ;base64 marker)")
-    data = match.group(3)
-    if not data:
-        raise ValueError(f"{_B64_FMT_HINT} (empty data payload)")
-    # get ext from url
-    if media_type.startswith("image/"):
-        ext = media_type.split("/")[-1].lower()
-        if ext == "jpeg":
-            ext = "jpg"
-    else:
-        ext = "jpg"
-    target_path = f"{target_path}.{ext}"
-    os.makedirs(os.path.dirname(target_path), exist_ok=True)
-
-    try:
-        image_data = base64.b64decode(data)
-        with open(target_path, "wb") as f:
-            f.write(image_data)
-
-        return target_path
-    except Exception as e:
-        raise Exception(f"Failed to decode base64 image: {str(e)}")
 
 
 async def process_generation_batch(

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -17,7 +17,6 @@ from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
 from sglang.multimodal_gen.runtime.disaggregation.scheduler_mixin import (
     SchedulerDisaggMixin,
 )
-from sglang.multimodal_gen.runtime.distributed import get_world_group
 from sglang.multimodal_gen.runtime.entrypoints.post_training.io_struct import (
     GetWeightsChecksumReqInput,
     UpdateWeightFromDiskReqInput,
@@ -59,17 +58,12 @@ from sglang.multimodal_gen.runtime.server_warmup import (
     get_first_generation_req,
     is_server_based_warmup,
     is_warmup_req,
-    prepare_warmup_image_path_sync,
     should_return_warmup_result,
 )
 from sglang.multimodal_gen.runtime.utils.common import get_zmq_socket
 from sglang.multimodal_gen.runtime.utils.distributed import broadcast_pyobj
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.trace_wrapper import DiffStage, trace_slice
-from sglang.multimodal_gen.runtime.warmup_request_builder import (
-    build_warmup_reqs,
-    should_include_warmup_image,
-)
 
 logger = init_logger(__name__)
 
@@ -159,15 +153,13 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         if self.receiver is not None:
             self._poller.register(self.receiver, zmq.POLLIN)
 
-        # whether we've send the necessary warmup reqs
+        # whether lazy req-based warmup has already been scheduled
         self.warmed_up = False
         # warmup progress tracking
         self._warmup_total = 0
         self._warmup_processed = 0
         self._warmup_progress_bar: Any | None = None
         self._logged_server_ready_after_warmup = False
-
-        self.prepare_internal_warmup_reqs()
 
         # Maximum consecutive errors before terminating the event loop
         self._max_consecutive_errors = 3
@@ -963,69 +955,6 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             stop_reason=stop_reason,
         )
         return batch_items
-
-    def prepare_internal_warmup_reqs(self):
-        if (
-            not self.server_args.warmup
-            or self.warmed_up
-            or self.server_args.server_warmup
-            or self.server_args.warmup_resolutions is None
-        ):
-            return
-
-        self._warmup_total = len(self.server_args.warmup_resolutions)
-        self._warmup_processed = 0
-
-        warmup_input_path = None
-        if should_include_warmup_image(self.server_args, server_based_warmup=False):
-            warmup_input_path = self._prepare_shared_warmup_image_path()
-
-        warmup_reqs = build_warmup_reqs(
-            self.server_args,
-            warmup_resolutions=self.server_args.warmup_resolutions,
-            warmup_input_path=warmup_input_path,
-        )
-        for req in warmup_reqs:
-            self.waiting_queue.append((None, req, time.monotonic()))
-
-        # if server is warmed-up, set this flag to avoid req-based warmup
-        self.warmed_up = True
-
-    def _prepare_shared_warmup_image_path(self) -> str:
-        world_group = get_world_group()
-        src_rank = world_group.ranks[0]
-
-        warmup_sync: dict[str, str | None]
-        if world_group.rank == src_rank:
-            try:
-                input_path = prepare_warmup_image_path_sync(self.server_args)
-                warmup_sync = {"input_path": input_path, "error": None}
-            except Exception as e:
-                warmup_sync = {"input_path": None, "error": str(e)}
-        else:
-            warmup_sync = {}
-
-        # Sync rank 0's warmup-image write result (path or error) to all ranks.
-        warmup_sync = broadcast_pyobj(
-            warmup_sync,
-            world_group.rank,
-            world_group.cpu_group,
-            src=src_rank,
-        )
-        if not isinstance(warmup_sync, dict):
-            raise RuntimeError("Invalid warmup sync payload received across ranks")
-
-        error = warmup_sync.get("error")
-        if error is not None:
-            raise RuntimeError(
-                f"Warmup image preparation failed on rank {src_rank}: {error}"
-            )
-
-        input_path = warmup_sync.get("input_path")
-        if not isinstance(input_path, str) or not input_path:
-            raise RuntimeError("Warmup image preparation returned empty input path")
-
-        return input_path
 
     def process_received_reqs_with_req_based_warmup(
         self, recv_reqs: List[tuple[bytes, Any]]

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -1029,6 +1029,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
     def process_received_reqs_with_req_based_warmup(
         self, recv_reqs: List[tuple[bytes, Any]]
     ) -> List[tuple[bytes, Any]]:
+        """maybe insert a cloend req before actual req to avoid compile/cold-start"""
         if (
             self.warmed_up
             or not self.server_args.warmup

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -151,8 +151,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         if self.receiver is not None:
             self._poller.register(self.receiver, zmq.POLLIN)
 
-        # whether lazy req-based warmup has already been scheduled
-        self.warmed_up = False
+        self.req_based_warmup_scheduled = False
         # warmup progress tracking
         self._warmup_total = 0
         self._warmup_processed = 0

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -167,7 +167,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         self._warmup_progress_bar: Any | None = None
         self._logged_server_ready_after_warmup = False
 
-        self.prepare_server_warmup_reqs()
+        self.prepare_internal_warmup_reqs()
 
         # Maximum consecutive errors before terminating the event loop
         self._max_consecutive_errors = 3
@@ -964,10 +964,11 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         )
         return batch_items
 
-    def prepare_server_warmup_reqs(self):
+    def prepare_internal_warmup_reqs(self):
         if (
             not self.server_args.warmup
             or self.warmed_up
+            or self.server_args.server_warmup
             or self.server_args.warmup_resolutions is None
         ):
             return

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -11,7 +11,6 @@ from enum import Enum
 from typing import Any, Iterator, List
 
 import zmq
-from tqdm.auto import tqdm
 
 from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
 from sglang.multimodal_gen.runtime.disaggregation.scheduler_mixin import (
@@ -55,8 +54,7 @@ from sglang.multimodal_gen.runtime.server_args import (
     set_global_server_args,
 )
 from sglang.multimodal_gen.runtime.server_warmup import (
-    get_first_generation_req,
-    is_server_based_warmup,
+    SchedulerWarmupMixin,
     is_warmup_req,
     should_return_warmup_result,
 )
@@ -71,7 +69,7 @@ _MAX_RECV_REQS_PER_POLL = 1024
 _BATCH_METRICS_LOG_INTERVAL = 5
 
 
-class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
+class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisaggMixin):
     """
     Runs the main event loop for the rank 0 worker.
     It listens for external requests via ZMQ and coordinates with other workers.
@@ -246,103 +244,6 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         if len(reqs) > 1:
             return [self._dispatch_single_request(req) for req in reqs]
         return self._dispatch_single_request(reqs[0])
-
-    @staticmethod
-    def _format_warmup_req(req_or_group: Any) -> str:
-        req = get_first_generation_req(req_or_group)
-        prefix = (
-            "server warmup req"
-            if is_server_based_warmup(req_or_group)
-            else "warmup req"
-        )
-        if req is None:
-            return prefix
-
-        shape = f"{req.width}x{req.height}"
-        if req.num_frames is not None and req.num_frames > 1:
-            shape += f"x{req.num_frames}f"
-
-        default_steps = req.extra.get("cache_dit_num_inference_steps")
-        if default_steps is not None and default_steps != req.num_inference_steps:
-            steps = f"{req.num_inference_steps}/{default_steps} steps"
-        else:
-            steps = f"{req.num_inference_steps} step"
-            if req.num_inference_steps != 1:
-                steps += "s"
-
-        return f"{prefix} ({shape}, {steps})"
-
-    def _warmup_progress_total(self, req_or_group: Any | None = None) -> int:
-        req = get_first_generation_req(req_or_group)
-        if req is not None:
-            warmup_total = req.extra.get("warmup_total")
-            if warmup_total is not None:
-                return warmup_total
-
-        return max(self._warmup_total, 1)
-
-    def _ensure_warmup_progress_bar(self, req_or_group: Any) -> None:
-        if not self._show_warmup_progress:
-            return
-
-        if self._warmup_progress_bar is None:
-            self._warmup_progress_bar = tqdm(
-                total=self._warmup_progress_total(req_or_group),
-                desc="Warmup requests",
-                unit="req",
-            )
-        self._warmup_progress_bar.set_postfix_str(
-            self._format_warmup_req(req_or_group), refresh=False
-        )
-
-    def _advance_warmup_progress_bar(
-        self, req_or_group: Any, output_batch: OutputBatch
-    ) -> None:
-        if not self._show_warmup_progress:
-            return
-
-        if self._warmup_progress_bar is None:
-            self._ensure_warmup_progress_bar(req_or_group)
-
-        if output_batch.metrics is not None:
-            last_duration_s = output_batch.metrics.total_duration_s
-            self._warmup_progress_bar.set_postfix_str(
-                f"{self._format_warmup_req(req_or_group)}, last={last_duration_s:.2f}s",
-                refresh=False,
-            )
-        self._warmup_progress_bar.update(1)
-
-        if self._warmup_progress_bar.n >= self._warmup_progress_bar.total:
-            self._warmup_progress_bar.close()
-            self._warmup_progress_bar = None
-
-    def _log_warmup_result(
-        self,
-        output_batch: OutputBatch,
-        req_or_group: Any,
-        is_warmup: bool,
-    ) -> None:
-        if not is_warmup:
-            return
-
-        server_based_warmup = is_server_based_warmup(req_or_group)
-        self._warmup_processed += 1
-        self._advance_warmup_progress_bar(req_or_group, output_batch)
-
-        if output_batch.error is None:
-            if (
-                not server_based_warmup
-                and not self._logged_server_ready_after_warmup
-                and (
-                    self._warmup_total <= 0
-                    or self._warmup_processed >= self._warmup_total
-                )
-            ):
-                logger.info("The server is fired up and ready to roll!")
-                self._logged_server_ready_after_warmup = True
-        else:
-            warmup_desc = self._format_warmup_req(req_or_group)
-            logger.info(f"{warmup_desc} processing failed")
 
     def _handle_generation(
         self, reqs: list[Any], *, allow_dynamic_batching: bool = True
@@ -955,29 +856,6 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             stop_reason=stop_reason,
         )
         return batch_items
-
-    def process_received_reqs_with_req_based_warmup(
-        self, recv_reqs: List[tuple[bytes, Any]]
-    ) -> List[tuple[bytes, Any]]:
-        """maybe insert a cloend req before actual req to avoid compile/cold-start"""
-        if (
-            self.warmed_up
-            or not self.server_args.warmup
-            or not recv_reqs
-            or self.server_args.warmup_resolutions is not None
-            or self.server_args.server_warmup
-        ):
-            return recv_reqs
-
-        identity, req_or_group = recv_reqs[0]
-        req = get_first_generation_req(req_or_group)
-        if req is not None:
-            warmup_req = req.copy_as_warmup(self.server_args.warmup_steps)
-            recv_reqs.insert(0, (identity, warmup_req))
-            self._warmup_total = 1
-            self._warmup_processed = 0
-            self.warmed_up = True
-        return recv_reqs
 
     @staticmethod
     def _normalize_received_payload(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
@@ -67,6 +67,7 @@ class PipelineStage(StageDedupMixin, ABC):
     # Class-level default so subclasses that override __init__ without
     # calling super().__init__() still see a consistent explicit-range gate.
     _current_use_nvtx: bool = False
+    _current_batch_is_warmup: bool = False
 
     def __init__(self):
         self.server_args = get_global_server_args()
@@ -76,7 +77,7 @@ class PipelineStage(StageDedupMixin, ABC):
 
     def log_info(self, msg, *args):
         """Logs an informational message with the stage name as a prefix."""
-        if self.server_args.comfyui_mode:
+        if self.server_args.comfyui_mode or self._current_batch_is_warmup:
             return
         logger.info(f"[{self.__class__.__name__}] {msg}", *args)
 
@@ -355,6 +356,8 @@ class PipelineStage(StageDedupMixin, ABC):
         self._apply_nvtx_gate(batch.is_warmup)
 
         # Execute the actual stage logic with unified profiling.
+        previous_batch_is_warmup = self._current_batch_is_warmup
+        self._current_batch_is_warmup = batch.is_warmup
         try:
             with StageProfiler(
                 stage_name,
@@ -366,6 +369,7 @@ class PipelineStage(StageDedupMixin, ABC):
             ):
                 result = self.forward(batch, server_args)
         finally:
+            self._current_batch_is_warmup = previous_batch_is_warmup
             self._current_use_nvtx = False
 
         # Post-execution output verification

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -1258,11 +1258,12 @@ class ServerArgs(DisaggServerArgsMixin):
             help=(
                 "Perform warmup before normal traffic. `sglang serve` runs a "
                 "server warmup through the scheduler client after HTTP is ready. "
-                "Other entrypoints use request-based warmup unless "
-                "`--warmup-resolutions` is specified. Recommended to enable when "
-                "benchmarking to ensure fair comparison and best performance. "
-                "When enabled, look for the line ending with `(with warmup "
-                "excluded)` for actual processing time."
+                "Other client entrypoints run explicit `--warmup-resolutions` "
+                "through the scheduler client, otherwise they use request-based "
+                "warmup. Recommended to enable when benchmarking to ensure fair "
+                "comparison and best performance. When enabled, look for the "
+                "line ending with `(with warmup excluded)` for actual processing "
+                "time."
             ),
         )
         parser.add_argument(
@@ -1270,7 +1271,7 @@ class ServerArgs(DisaggServerArgsMixin):
             type=str,
             nargs="+",
             default=ServerArgs.warmup_resolutions,
-            help="Specify resolutions for server to warmup. e.g., `--warmup-resolutions 256x256, 720x720`",
+            help="Specify explicit warmup resolutions. e.g., `--warmup-resolutions 256x256 720x720`",
         )
         parser.add_argument(
             "--warmup-steps",

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -691,7 +691,6 @@ class ServerArgs(DisaggServerArgsMixin):
     def _adjust_warmup(self):
         if self.warmup_resolutions is not None:
             self.warmup = True
-            self.server_warmup = False
 
         if self.disagg_role != RoleType.MONOLITHIC:
             self.server_warmup = False
@@ -1258,12 +1257,12 @@ class ServerArgs(DisaggServerArgsMixin):
             default=ServerArgs.warmup,
             help=(
                 "Perform warmup before normal traffic. `sglang serve` runs a "
-                "lightweight server warmup after HTTP is ready; other entrypoints "
-                "use request-based warmup unless `--warmup-resolutions` is "
-                "specified. Recommended to enable when benchmarking to ensure fair "
-                "comparison and best performance. When enabled with "
-                "`--warmup-resolutions` unspecified, look for the line ending with "
-                "`(with warmup excluded)` for actual processing time."
+                "server warmup through the scheduler client after HTTP is ready. "
+                "Other entrypoints use request-based warmup unless "
+                "`--warmup-resolutions` is specified. Recommended to enable when "
+                "benchmarking to ensure fair comparison and best performance. "
+                "When enabled, look for the line ending with `(with warmup "
+                "excluded)` for actual processing time."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/runtime/server_warmup.py
+++ b/python/sglang/multimodal_gen/runtime/server_warmup.py
@@ -145,9 +145,7 @@ async def run_async_client_warmup(
                 raise RuntimeError(response.error)
     except Exception as e:
         if fail_open:
-            logger.warning(
-                "Synthetic server warmup failed; continuing startup: %s", e
-            )
+            logger.warning("Synthetic server warmup failed; continuing startup: %s", e)
             return
         raise
 

--- a/python/sglang/multimodal_gen/runtime/server_warmup.py
+++ b/python/sglang/multimodal_gen/runtime/server_warmup.py
@@ -129,17 +129,27 @@ def build_client_warmup_reqs(
 async def run_async_client_warmup(
     server_args: ServerArgs,
     forward: Callable[[Req], Awaitable[OutputBatch]],
+    *,
+    fail_open: bool = False,
 ) -> None:
-    warmup_input_path = None
-    if should_include_warmup_image(server_args, server_based_warmup=True):
-        warmup_input_path = prepare_warmup_image_path(server_args)
+    try:
+        warmup_input_path = None
+        if should_include_warmup_image(server_args, server_based_warmup=True):
+            warmup_input_path = prepare_warmup_image_path(server_args)
 
-    for req in build_client_warmup_reqs(
-        server_args, warmup_input_path=warmup_input_path
-    ):
-        response = await forward(req)
-        if response.error is not None:
-            raise RuntimeError(response.error)
+        for req in build_client_warmup_reqs(
+            server_args, warmup_input_path=warmup_input_path
+        ):
+            response = await forward(req)
+            if response.error is not None:
+                raise RuntimeError(response.error)
+    except Exception as e:
+        if fail_open:
+            logger.warning(
+                "Synthetic server warmup failed; continuing startup: %s", e
+            )
+            return
+        raise
 
 
 def run_sync_client_warmup(

--- a/python/sglang/multimodal_gen/runtime/server_warmup.py
+++ b/python/sglang/multimodal_gen/runtime/server_warmup.py
@@ -1,19 +1,18 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
 
 # SPDX-License-Identifier: Apache-2.0
-import asyncio
 import os
 import tempfile
 from typing import Any, Awaitable, Callable
 
 from tqdm.auto import tqdm
 
-from sglang.multimodal_gen.runtime.entrypoints.openai.utils import save_image_to_path
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
     OutputBatch,
     Req,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.image_io import save_base64_image_to_path
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.warmup_request_builder import (
     build_warmup_reqs,
@@ -133,7 +132,7 @@ async def run_async_client_warmup(
 ) -> None:
     warmup_input_path = None
     if should_include_warmup_image(server_args, server_based_warmup=True):
-        warmup_input_path = await prepare_warmup_image_path(server_args)
+        warmup_input_path = prepare_warmup_image_path(server_args)
 
     for req in build_client_warmup_reqs(
         server_args, warmup_input_path=warmup_input_path
@@ -149,7 +148,7 @@ def run_sync_client_warmup(
 ) -> None:
     warmup_input_path = None
     if should_include_warmup_image(server_args, server_based_warmup=True):
-        warmup_input_path = prepare_warmup_image_path_sync(server_args)
+        warmup_input_path = prepare_warmup_image_path(server_args)
 
     for req in build_client_warmup_reqs(
         server_args, warmup_input_path=warmup_input_path
@@ -159,7 +158,7 @@ def run_sync_client_warmup(
             raise RuntimeError(response.error)
 
 
-async def prepare_warmup_image_path(server_args: ServerArgs) -> str:
+def prepare_warmup_image_path(server_args: ServerArgs) -> str:
     if server_args.input_save_path is not None:
         uploads_dir = server_args.input_save_path
         os.makedirs(uploads_dir, exist_ok=True)
@@ -167,13 +166,9 @@ async def prepare_warmup_image_path(server_args: ServerArgs) -> str:
         uploads_dir = tempfile.mkdtemp(prefix="sglang_input_")
 
     warmup_image_base = os.path.join(uploads_dir, "warmup_image")
-    return await save_image_to_path(
+    return save_base64_image_to_path(
         MINIMUM_PICTURE_BASE64_FOR_WARMUP, warmup_image_base
     )
-
-
-def prepare_warmup_image_path_sync(server_args: ServerArgs) -> str:
-    return asyncio.run(prepare_warmup_image_path(server_args))
 
 
 class SchedulerWarmupMixin:
@@ -257,7 +252,7 @@ class SchedulerWarmupMixin:
         self, recv_reqs: list[tuple[bytes, Any]]
     ) -> list[tuple[bytes, Any]]:
         if (
-            self.warmed_up
+            self.req_based_warmup_scheduled
             or not self.server_args.warmup
             or not recv_reqs
             or self.server_args.warmup_resolutions is not None
@@ -272,5 +267,5 @@ class SchedulerWarmupMixin:
             recv_reqs.insert(0, (identity, warmup_req))
             self._warmup_total = 1
             self._warmup_processed = 0
-            self.warmed_up = True
+            self.req_based_warmup_scheduled = True
         return recv_reqs

--- a/python/sglang/multimodal_gen/runtime/server_warmup.py
+++ b/python/sglang/multimodal_gen/runtime/server_warmup.py
@@ -4,12 +4,21 @@
 import asyncio
 import os
 import tempfile
-from typing import Any
+from typing import Any, Awaitable, Callable
+
+from tqdm.auto import tqdm
 
 from sglang.multimodal_gen.runtime.entrypoints.openai.utils import save_image_to_path
-from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+    OutputBatch,
+    Req,
+)
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.warmup_request_builder import (
+    build_warmup_reqs,
+    should_include_warmup_image,
+)
 
 logger = init_logger(__name__)
 
@@ -50,6 +59,106 @@ def should_return_warmup_result(req_or_group: Any) -> bool:
     )
 
 
+def should_run_server_warmup(server_args: ServerArgs) -> bool:
+    return server_args.warmup and server_args.server_warmup
+
+
+def is_realtime_serving(server_args: ServerArgs) -> bool:
+    """Synthetic warmup has no realtime session state."""
+    try:
+        from sglang.multimodal_gen.runtime.entrypoints.openai.realtime.registry import (
+            get_realtime_model_adapter,
+        )
+
+        get_realtime_model_adapter(server_args)
+        return True
+    except Exception:
+        return False
+
+
+def should_run_synthetic_server_warmup(server_args: ServerArgs) -> bool:
+    return should_run_server_warmup(server_args) and not is_realtime_serving(
+        server_args
+    )
+
+
+def should_run_explicit_client_warmup(server_args: ServerArgs) -> bool:
+    return server_args.warmup and server_args.warmup_resolutions is not None
+
+
+def format_warmup_req(req_or_group: Any) -> str:
+    req = get_first_generation_req(req_or_group)
+    prefix = (
+        "server warmup req" if is_server_based_warmup(req_or_group) else "warmup req"
+    )
+    if req is None:
+        return prefix
+
+    shape = f"{req.width}x{req.height}"
+    if req.num_frames is not None and req.num_frames > 1:
+        shape += f"x{req.num_frames}f"
+
+    default_steps = req.extra.get("cache_dit_num_inference_steps")
+    if default_steps is not None and default_steps != req.num_inference_steps:
+        steps = f"{req.num_inference_steps}/{default_steps} steps"
+    else:
+        steps = f"{req.num_inference_steps} step"
+        if req.num_inference_steps != 1:
+            steps += "s"
+
+    return f"{prefix} ({shape}, {steps})"
+
+
+def build_client_warmup_reqs(
+    server_args: ServerArgs,
+    *,
+    warmup_input_path: str | None = None,
+) -> list[Req]:
+    warmup_reqs = build_warmup_reqs(
+        server_args,
+        warmup_resolutions=server_args.warmup_resolutions,
+        warmup_input_path=warmup_input_path,
+        return_warmup_result=True,
+        server_based_warmup=True,
+    )
+    warmup_total = len(warmup_reqs)
+    for req in warmup_reqs:
+        req.extra["warmup_total"] = warmup_total
+    return warmup_reqs
+
+
+async def run_async_client_warmup(
+    server_args: ServerArgs,
+    forward: Callable[[Req], Awaitable[OutputBatch]],
+) -> None:
+    warmup_input_path = None
+    if should_include_warmup_image(server_args, server_based_warmup=True):
+        warmup_input_path = await prepare_warmup_image_path(server_args)
+
+    for req in build_client_warmup_reqs(
+        server_args, warmup_input_path=warmup_input_path
+    ):
+        response = await forward(req)
+        if response.error is not None:
+            raise RuntimeError(response.error)
+
+
+def run_sync_client_warmup(
+    server_args: ServerArgs,
+    forward: Callable[[Req], OutputBatch],
+) -> None:
+    warmup_input_path = None
+    if should_include_warmup_image(server_args, server_based_warmup=True):
+        warmup_input_path = prepare_warmup_image_path_sync(server_args)
+
+    for req in build_client_warmup_reqs(
+        server_args, warmup_input_path=warmup_input_path
+    ):
+        response = forward(req)
+        if response.error is not None:
+            raise RuntimeError(response.error)
+
+
 async def prepare_warmup_image_path(server_args: ServerArgs) -> str:
     if server_args.input_save_path is not None:
         uploads_dir = server_args.input_save_path
@@ -65,3 +174,103 @@ async def prepare_warmup_image_path(server_args: ServerArgs) -> str:
 
 def prepare_warmup_image_path_sync(server_args: ServerArgs) -> str:
     return asyncio.run(prepare_warmup_image_path(server_args))
+
+
+class SchedulerWarmupMixin:
+    @staticmethod
+    def _format_warmup_req(req_or_group: Any) -> str:
+        return format_warmup_req(req_or_group)
+
+    def _warmup_progress_total(self, req_or_group: Any | None = None) -> int:
+        req = get_first_generation_req(req_or_group)
+        if req is not None:
+            warmup_total = req.extra.get("warmup_total")
+            if warmup_total is not None:
+                return warmup_total
+
+        return max(self._warmup_total, 1)
+
+    def _ensure_warmup_progress_bar(self, req_or_group: Any) -> None:
+        if not self._show_warmup_progress:
+            return
+
+        if self._warmup_progress_bar is None:
+            self._warmup_progress_bar = tqdm(
+                total=self._warmup_progress_total(req_or_group),
+                desc="Warmup requests",
+                unit="req",
+            )
+        self._warmup_progress_bar.set_postfix_str(
+            self._format_warmup_req(req_or_group), refresh=False
+        )
+
+    def _advance_warmup_progress_bar(
+        self, req_or_group: Any, output_batch: OutputBatch
+    ) -> None:
+        if not self._show_warmup_progress:
+            return
+
+        if self._warmup_progress_bar is None:
+            self._ensure_warmup_progress_bar(req_or_group)
+
+        if output_batch.metrics is not None:
+            last_duration_s = output_batch.metrics.total_duration_s
+            self._warmup_progress_bar.set_postfix_str(
+                f"{self._format_warmup_req(req_or_group)}, last={last_duration_s:.2f}s",
+                refresh=False,
+            )
+        self._warmup_progress_bar.update(1)
+
+        if self._warmup_progress_bar.n >= self._warmup_progress_bar.total:
+            self._warmup_progress_bar.close()
+            self._warmup_progress_bar = None
+
+    def _log_warmup_result(
+        self,
+        output_batch: OutputBatch,
+        req_or_group: Any,
+        is_warmup: bool,
+    ) -> None:
+        if not is_warmup:
+            return
+
+        server_based_warmup = is_server_based_warmup(req_or_group)
+        self._warmup_processed += 1
+        self._advance_warmup_progress_bar(req_or_group, output_batch)
+
+        if output_batch.error is None:
+            if (
+                not server_based_warmup
+                and not self._logged_server_ready_after_warmup
+                and (
+                    self._warmup_total <= 0
+                    or self._warmup_processed >= self._warmup_total
+                )
+            ):
+                logger.info("The server is fired up and ready to roll!")
+                self._logged_server_ready_after_warmup = True
+        else:
+            warmup_desc = self._format_warmup_req(req_or_group)
+            logger.info(f"{warmup_desc} processing failed")
+
+    def process_received_reqs_with_req_based_warmup(
+        self, recv_reqs: list[tuple[bytes, Any]]
+    ) -> list[tuple[bytes, Any]]:
+        if (
+            self.warmed_up
+            or not self.server_args.warmup
+            or not recv_reqs
+            or self.server_args.warmup_resolutions is not None
+            or self.server_args.server_warmup
+        ):
+            return recv_reqs
+
+        identity, req_or_group = recv_reqs[0]
+        req = get_first_generation_req(req_or_group)
+        if req is not None:
+            warmup_req = req.copy_as_warmup(self.server_args.warmup_steps)
+            recv_reqs.insert(0, (identity, warmup_req))
+            self._warmup_total = 1
+            self._warmup_processed = 0
+            self.warmed_up = True
+        return recv_reqs

--- a/python/sglang/multimodal_gen/runtime/utils/common.py
+++ b/python/sglang/multimodal_gen/runtime/utils/common.py
@@ -110,6 +110,16 @@ def normalize_gpu_ids(gpu_ids: Any) -> list[int] | None:
     return parsed
 
 
+def parse_size(size: str) -> tuple[int | None, int | None]:
+    try:
+        parts = size.lower().replace(" ", "").split("x")
+        if len(parts) != 2:
+            raise ValueError
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None, None
+
+
 def parse_tcp_host_port(value: str | None, field_name: str) -> tuple[str, int]:
     if value is None or not str(value).strip():
         raise ValueError(f"{field_name} is required")

--- a/python/sglang/multimodal_gen/runtime/utils/image_io.py
+++ b/python/sglang/multimodal_gen/runtime/utils/image_io.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+import base64
+import os
+import re
+
+
+def save_base64_image_to_path(base64_data: str, target_path: str) -> str:
+    b64_format_hint = (
+        "Failed to decode base64 image. "
+        "Expected format: `data:[<media-type>];base64,<data>`"
+    )
+
+    match = re.match(r"data:(.*?)(;base64)?,(.*)", base64_data)
+    if not match:
+        raise ValueError(b64_format_hint)
+    media_type = match.group(1)
+    is_base64 = match.group(2)
+    if not is_base64:
+        raise ValueError(f"{b64_format_hint} (missing ;base64 marker)")
+    data = match.group(3)
+    if not data:
+        raise ValueError(f"{b64_format_hint} (empty data payload)")
+
+    if media_type.startswith("image/"):
+        ext = media_type.split("/")[-1].lower()
+        if ext == "jpeg":
+            ext = "jpg"
+    else:
+        ext = "jpg"
+    target_path = f"{target_path}.{ext}"
+    os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+    try:
+        image_data = base64.b64decode(data)
+    except Exception as exc:
+        raise Exception(f"Failed to decode base64 image: {str(exc)}") from exc
+
+    with open(target_path, "wb") as f:
+        f.write(image_data)
+
+    return target_path

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -6,8 +6,11 @@ first real request, without copying user traffic. It starts from the model's
 sampling defaults, then keeps startup bounded by choosing common low-cost
 resolution/frame buckets and trimming the denoising step count.
 
-Explicit request-based warmup remains a scheduler-level legacy path and is not
-constructed here.
+Image models may run a tiny second step because first/last step paths often
+initialize different kernels or scheduler state. Video models cap frames and
+steps to keep startup bounded. Explicit warmup resolutions share this builder;
+online serving sends them through the scheduler client after HTTP is ready,
+while non-server entrypoints can still enqueue them internally.
 """
 
 from copy import copy
@@ -62,9 +65,8 @@ def _resolve_default_warmup_resolution(
     sampling_defaults: SamplingParams,
     *,
     server_based_warmup: bool,
-    use_model_sampling_defaults: bool,
 ) -> tuple[int, int]:
-    if server_based_warmup and use_model_sampling_defaults:
+    if server_based_warmup:
         return _resolve_representative_warmup_resolution(
             server_args, sampling_defaults
         )
@@ -168,13 +170,12 @@ def _resolve_warmup_num_frames(
     sampling_defaults: SamplingParams,
     *,
     server_based_warmup: bool,
-    use_model_sampling_defaults: bool,
 ) -> int:
     num_frames = sampling_defaults.num_frames
     if (
         not server_based_warmup
-        or not use_model_sampling_defaults
         or not _is_video_warmup_task(server_args)
+        or num_frames is None
     ):
         return num_frames
 
@@ -192,10 +193,9 @@ def _resolve_warmup_steps(
     sampling_defaults: SamplingParams,
     *,
     server_based_warmup: bool,
-    use_model_sampling_defaults: bool,
 ) -> int:
     warmup_steps = server_args.warmup_steps
-    if not server_based_warmup or not use_model_sampling_defaults:
+    if not server_based_warmup:
         return warmup_steps
 
     default_steps = sampling_defaults.num_inference_steps
@@ -231,42 +231,31 @@ def build_warmup_reqs(
     warmup_input_path: str | None = None,
     return_warmup_result: bool = False,
     server_based_warmup: bool = False,
-    use_model_sampling_defaults: bool = False,
 ) -> list[Req]:
     task_type = server_args.pipeline_config.task_type
-    if warmup_resolutions is None or use_model_sampling_defaults:
-        sampling_defaults = get_model_sampling_defaults(server_args)
-    else:
-        sampling_defaults = SamplingParams()
+    sampling_defaults = get_model_sampling_defaults(server_args)
 
     if warmup_resolutions is None:
         width, height = _resolve_default_warmup_resolution(
             server_args,
             sampling_defaults,
             server_based_warmup=server_based_warmup,
-            use_model_sampling_defaults=use_model_sampling_defaults,
         )
         resolutions: list[tuple[int, int]] = [(width, height)]
     else:
         resolutions = [_parse_size(resolution) for resolution in warmup_resolutions]
 
-    negative_prompt: Any = (
-        sampling_defaults.negative_prompt if use_model_sampling_defaults else None
-    )
-    cfg_scale = (
-        _effective_cfg_scale(sampling_defaults) if use_model_sampling_defaults else None
-    )
+    negative_prompt: Any = sampling_defaults.negative_prompt
+    cfg_scale = _effective_cfg_scale(sampling_defaults)
     warmup_steps = _resolve_warmup_steps(
         server_args,
         sampling_defaults,
         server_based_warmup=server_based_warmup,
-        use_model_sampling_defaults=use_model_sampling_defaults,
     )
     warmup_num_frames = _resolve_warmup_num_frames(
         server_args,
         sampling_defaults,
         server_based_warmup=server_based_warmup,
-        use_model_sampling_defaults=use_model_sampling_defaults,
     )
 
     warmup_reqs = []
@@ -278,24 +267,21 @@ def build_warmup_reqs(
             height=height,
             prompt=DEFAULT_PLACEHOLDER_PROMPT,
         )
-        if use_model_sampling_defaults:
-            req_kwargs["sampling_params"] = copy(sampling_defaults)
-            req_kwargs.update(
-                negative_prompt=negative_prompt,
-                guidance_scale=sampling_defaults.guidance_scale,
-                guidance_scale_2=sampling_defaults.guidance_scale_2,
-                true_cfg_scale=sampling_defaults.true_cfg_scale,
-                num_inference_steps=sampling_defaults.num_inference_steps,
-                num_frames=warmup_num_frames,
-            )
+        req_kwargs["sampling_params"] = copy(sampling_defaults)
+        req_kwargs.update(
+            negative_prompt=negative_prompt,
+            guidance_scale=sampling_defaults.guidance_scale,
+            guidance_scale_2=sampling_defaults.guidance_scale_2,
+            true_cfg_scale=sampling_defaults.true_cfg_scale,
+            num_inference_steps=sampling_defaults.num_inference_steps,
+            num_frames=warmup_num_frames,
+        )
         if include_warmup_image:
             if warmup_input_path is None:
                 raise RuntimeError(
                     "Warmup image path is required for image-input model"
                 )
             req_kwargs["prompt"] = DEFAULT_PLACEHOLDER_PROMPT
-            if not use_model_sampling_defaults:
-                req_kwargs["negative_prompt"] = ""
             req_kwargs["image_path"] = [warmup_input_path]
         if (
             server_args.enable_cfg_parallel
@@ -303,12 +289,7 @@ def build_warmup_reqs(
         ):
             req_kwargs["negative_prompt"] = DEFAULT_PLACEHOLDER_PROMPT
             req_kwargs["do_classifier_free_guidance"] = True
-        elif (
-            use_model_sampling_defaults
-            and negative_prompt is not None
-            and cfg_scale is not None
-            and cfg_scale > 1.0
-        ):
+        elif negative_prompt is not None and cfg_scale is not None and cfg_scale > 1.0:
             req_kwargs["do_classifier_free_guidance"] = True
 
         req = Req(**req_kwargs)

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -40,21 +40,17 @@ SERVER_WARMUP_VIDEO_STEPS = 2
 
 def get_model_sampling_defaults(server_args: ServerArgs) -> SamplingParams:
     pipeline_class_name = server_args.pipeline_class_name
-    try:
-        if pipeline_class_name:
-            config_classes = get_pipeline_config_classes(pipeline_class_name)
-            if config_classes is not None:
-                _, sampling_params_cls = config_classes
-                return sampling_params_cls()
+    if pipeline_class_name:
+        config_classes = get_pipeline_config_classes(pipeline_class_name)
+        if config_classes is not None:
+            _, sampling_params_cls = config_classes
+            return sampling_params_cls()
 
-        return SamplingParams.from_pretrained(
-            server_args.model_path,
-            backend=server_args.backend,
-            model_id=server_args.model_id,
-        )
-    except Exception:
-        logger.debug("Falling back to base SamplingParams for server warmup")
-        return SamplingParams()
+    return SamplingParams.from_pretrained(
+        server_args.model_path,
+        backend=server_args.backend,
+        model_id=server_args.model_id,
+    )
 
 
 def _resolve_default_warmup_resolution(
@@ -64,10 +60,9 @@ def _resolve_default_warmup_resolution(
     server_based_warmup: bool,
     use_model_sampling_defaults: bool,
 ) -> tuple[int, int]:
+    """returns a default resolution to warmup"""
     if server_based_warmup and use_model_sampling_defaults:
-        return _resolve_representative_warmup_resolution(
-            server_args, sampling_defaults
-        )
+        return _resolve_representative_warmup_resolution(server_args, sampling_defaults)
 
     width = sampling_defaults.width
     height = sampling_defaults.height
@@ -152,6 +147,7 @@ def _select_supported_warmup_resolution(
 def _fit_resolution_to_area(
     width: int, height: int, target_area: int
 ) -> tuple[int, int]:
+    """adjust the warmup resolution to balance between warmup time and warmup effect"""
     area = width * height
     if area <= target_area:
         return width, height
@@ -176,6 +172,7 @@ def _resolve_warmup_num_frames(
         or not use_model_sampling_defaults
         or not _is_video_warmup_task(server_args)
     ):
+        # use default num frames
         return num_frames
 
     return min(num_frames, SERVER_WARMUP_MAX_VIDEO_FRAMES)
@@ -269,6 +266,7 @@ def build_warmup_reqs(
         use_model_sampling_defaults=use_model_sampling_defaults,
     )
 
+    # build warmup reqs
     warmup_reqs = []
     include_warmup_image = should_include_warmup_image(server_args, server_based_warmup)
     for width, height in resolutions:

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -281,11 +281,9 @@ def build_warmup_reqs(
                 )
             req_kwargs["prompt"] = DEFAULT_PLACEHOLDER_PROMPT
             req_kwargs["image_path"] = [warmup_input_path]
-        if (
-            server_args.enable_cfg_parallel
-            and req_kwargs.get("negative_prompt") is None
-        ):
-            req_kwargs["negative_prompt"] = DEFAULT_PLACEHOLDER_PROMPT
+        if server_args.enable_cfg_parallel:
+            if not req_kwargs.get("negative_prompt"):
+                req_kwargs["negative_prompt"] = DEFAULT_PLACEHOLDER_PROMPT
             req_kwargs["do_classifier_free_guidance"] = True
         elif negative_prompt is not None and cfg_scale is not None and cfg_scale > 1.0:
             req_kwargs["do_classifier_free_guidance"] = True

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -9,8 +9,8 @@ resolution/frame buckets and trimming the denoising step count.
 Image models may run a tiny second step because first/last step paths often
 initialize different kernels or scheduler state. Video models cap frames and
 steps to keep startup bounded. Explicit warmup resolutions share this builder;
-online serving sends them through the scheduler client after HTTP is ready,
-while non-server entrypoints can still enqueue them internally.
+callers send them through the scheduler client so warmup exercises the same
+request transport path as real generation.
 """
 
 from copy import copy
@@ -22,9 +22,9 @@ from sglang.multimodal_gen.configs.sample.sampling_params import (
     SamplingParams,
 )
 from sglang.multimodal_gen.registry import get_pipeline_config_classes
-from sglang.multimodal_gen.runtime.entrypoints.openai.utils import _parse_size
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.common import parse_size
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
@@ -240,7 +240,7 @@ def build_warmup_reqs(
         )
         resolutions: list[tuple[int, int]] = [(width, height)]
     else:
-        resolutions = [_parse_size(resolution) for resolution in warmup_resolutions]
+        resolutions = [parse_size(resolution) for resolution in warmup_resolutions]
 
     negative_prompt: Any = sampling_defaults.negative_prompt
     cfg_scale = _effective_cfg_scale(sampling_defaults)

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -23,7 +23,10 @@ from sglang.multimodal_gen.configs.sample.sampling_params import (
 )
 from sglang.multimodal_gen.registry import get_pipeline_config_classes
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
-from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.server_args import (
+    ServerArgs,
+    is_ltx2_two_stage_pipeline_name,
+)
 from sglang.multimodal_gen.runtime.utils.common import parse_size
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
@@ -89,9 +92,10 @@ def _resolve_representative_warmup_resolution(
     sampling_defaults: SamplingParams,
 ) -> tuple[int, int]:
     target_area = _target_warmup_area(server_args)
+    alignment = _warmup_resolution_alignment(server_args)
 
     supported_resolution = _select_supported_warmup_resolution(
-        sampling_defaults.supported_resolutions, target_area
+        sampling_defaults.supported_resolutions, target_area, alignment
     )
     if supported_resolution is not None:
         return supported_resolution
@@ -99,9 +103,10 @@ def _resolve_representative_warmup_resolution(
     width = sampling_defaults.width
     height = sampling_defaults.height
     if width is not None and height is not None:
-        return _fit_resolution_to_area(width, height, target_area)
+        return _fit_resolution_to_area(width, height, target_area, alignment)
 
-    return _fallback_warmup_resolution(server_args)
+    width, height = _fallback_warmup_resolution(server_args)
+    return _fit_resolution_to_area(width, height, target_area, alignment)
 
 
 def _target_warmup_area(server_args: ServerArgs) -> int:
@@ -129,9 +134,17 @@ def _is_video_warmup_task(server_args: ServerArgs) -> bool:
     return server_args.pipeline_config.task_type.data_type() == DataType.VIDEO
 
 
+def _warmup_resolution_alignment(server_args: ServerArgs) -> int:
+    if is_ltx2_two_stage_pipeline_name(server_args.pipeline_class_name):
+        vae_scale_factor = server_args.pipeline_config.vae_scale_factor
+        return max(64, int(vae_scale_factor) * 2)
+    return 16
+
+
 def _select_supported_warmup_resolution(
     supported_resolutions: list[tuple[int, int]] | None,
     target_area: int,
+    alignment: int,
 ) -> tuple[int, int] | None:
     if not supported_resolutions:
         return None
@@ -140,25 +153,40 @@ def _select_supported_warmup_resolution(
         resolution
         for resolution in supported_resolutions
         if resolution[0] * resolution[1] <= target_area
+        and _is_resolution_aligned(resolution, alignment)
     ]
     if candidates:
         return max(candidates, key=lambda size: size[0] * size[1])
-    return min(supported_resolutions, key=lambda size: size[0] * size[1])
+
+    aligned_resolutions = [
+        resolution
+        for resolution in supported_resolutions
+        if _is_resolution_aligned(resolution, alignment)
+    ]
+    if aligned_resolutions:
+        return min(aligned_resolutions, key=lambda size: size[0] * size[1])
+    return None
 
 
 def _fit_resolution_to_area(
-    width: int, height: int, target_area: int
+    width: int, height: int, target_area: int, alignment: int
 ) -> tuple[int, int]:
     """adjust the warmup resolution to balance between warmup time and warmup effect"""
     area = width * height
-    if area <= target_area:
-        return width, height
+    if area > target_area:
+        scale = (target_area / area) ** 0.5
+        width = int(width * scale)
+        height = int(height * scale)
 
-    scale = (target_area / area) ** 0.5
     return (
-        max(16, int(width * scale) // 16 * 16),
-        max(16, int(height * scale) // 16 * 16),
+        max(alignment, width // alignment * alignment),
+        max(alignment, height // alignment * alignment),
     )
+
+
+def _is_resolution_aligned(resolution: tuple[int, int], alignment: int) -> bool:
+    width, height = resolution
+    return width % alignment == 0 and height % alignment == 0
 
 
 def _resolve_warmup_num_frames(

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -28,10 +28,6 @@ logger = init_logger(__name__)
 
 DEFAULT_PLACEHOLDER_PROMPT = "warmup"
 DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION = (64, 64)
-DEFAULT_REPRESENTATIVE_PROMPT = (
-    "A detailed cinematic scene with a clear subject, natural lighting, "
-    "and rich background details"
-)
 SERVER_WARMUP_IMAGE_FALLBACK_RESOLUTION = (512, 512)
 SERVER_WARMUP_VIDEO_FALLBACK_RESOLUTION = (832, 480)
 SERVER_WARMUP_IMAGE_MAX_AREA = 768 * 768
@@ -167,16 +163,6 @@ def _fit_resolution_to_area(
     )
 
 
-def _resolve_warmup_prompt(
-    *,
-    server_based_warmup: bool,
-    use_model_sampling_defaults: bool,
-) -> str:
-    if server_based_warmup and use_model_sampling_defaults:
-        return DEFAULT_REPRESENTATIVE_PROMPT
-    return DEFAULT_PLACEHOLDER_PROMPT
-
-
 def _resolve_warmup_num_frames(
     server_args: ServerArgs,
     sampling_defaults: SamplingParams,
@@ -282,10 +268,6 @@ def build_warmup_reqs(
         server_based_warmup=server_based_warmup,
         use_model_sampling_defaults=use_model_sampling_defaults,
     )
-    warmup_prompt = _resolve_warmup_prompt(
-        server_based_warmup=server_based_warmup,
-        use_model_sampling_defaults=use_model_sampling_defaults,
-    )
 
     warmup_reqs = []
     include_warmup_image = should_include_warmup_image(server_args, server_based_warmup)
@@ -294,7 +276,7 @@ def build_warmup_reqs(
             data_type=task_type.data_type(),
             width=width,
             height=height,
-            prompt=warmup_prompt,
+            prompt=DEFAULT_PLACEHOLDER_PROMPT,
         )
         if use_model_sampling_defaults:
             req_kwargs["sampling_params"] = copy(sampling_defaults)
@@ -311,7 +293,7 @@ def build_warmup_reqs(
                 raise RuntimeError(
                     "Warmup image path is required for image-input model"
                 )
-            req_kwargs["prompt"] = warmup_prompt
+            req_kwargs["prompt"] = DEFAULT_PLACEHOLDER_PROMPT
             if not use_model_sampling_defaults:
                 req_kwargs["negative_prompt"] = ""
             req_kwargs["image_path"] = [warmup_input_path]

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -1,22 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """Build synthetic diffusion warmup requests.
 
-Default server warmup should cover the model's normal serving path before the
-first real request, without copying user traffic. It therefore starts from the
-model's sampling defaults, keeps default resolution/frame semantics, and trims
-only the denoising step count.
+Default server warmup should cover a representative serving path before the
+first real request, without copying user traffic. It starts from the model's
+sampling defaults, then keeps startup bounded by choosing common low-cost
+resolution/frame buckets and trimming the denoising step count.
 
-Image models may run a tiny second step because first/last step paths often
-initialize different kernels or scheduler state. Video models stay at
-`warmup_steps` to keep startup bounded. Explicit request-based warmup remains a
-scheduler-level legacy path and is not constructed here.
+Explicit request-based warmup remains a scheduler-level legacy path and is not
+constructed here.
 """
 
 from copy import copy
 from typing import Any
 
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
-from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.configs.sample.sampling_params import (
+    DataType,
+    SamplingParams,
+)
 from sglang.multimodal_gen.registry import get_pipeline_config_classes
 from sglang.multimodal_gen.runtime.entrypoints.openai.utils import _parse_size
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
@@ -27,7 +28,18 @@ logger = init_logger(__name__)
 
 DEFAULT_PLACEHOLDER_PROMPT = "warmup"
 DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION = (64, 64)
+DEFAULT_REPRESENTATIVE_PROMPT = (
+    "A detailed cinematic scene with a clear subject, natural lighting, "
+    "and rich background details"
+)
+SERVER_WARMUP_IMAGE_FALLBACK_RESOLUTION = (512, 512)
+SERVER_WARMUP_VIDEO_FALLBACK_RESOLUTION = (832, 480)
+SERVER_WARMUP_IMAGE_MAX_AREA = 768 * 768
+SERVER_WARMUP_DIFFUSERS_IMAGE_MAX_AREA = 512 * 512
+SERVER_WARMUP_VIDEO_MAX_AREA = 832 * 480
+SERVER_WARMUP_MAX_VIDEO_FRAMES = 17
 SERVER_WARMUP_IMAGE_STEPS = 2
+SERVER_WARMUP_VIDEO_STEPS = 2
 
 
 def get_model_sampling_defaults(server_args: ServerArgs) -> SamplingParams:
@@ -52,7 +64,15 @@ def get_model_sampling_defaults(server_args: ServerArgs) -> SamplingParams:
 def _resolve_default_warmup_resolution(
     server_args: ServerArgs,
     sampling_defaults: SamplingParams,
+    *,
+    server_based_warmup: bool,
+    use_model_sampling_defaults: bool,
 ) -> tuple[int, int]:
+    if server_based_warmup and use_model_sampling_defaults:
+        return _resolve_representative_warmup_resolution(
+            server_args, sampling_defaults
+        )
+
     width = sampling_defaults.width
     height = sampling_defaults.height
     if width is not None and height is not None:
@@ -69,6 +89,110 @@ def _resolve_default_warmup_resolution(
         width or DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION[0],
         height or DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION[1],
     )
+
+
+def _resolve_representative_warmup_resolution(
+    server_args: ServerArgs,
+    sampling_defaults: SamplingParams,
+) -> tuple[int, int]:
+    target_area = _target_warmup_area(server_args)
+
+    supported_resolution = _select_supported_warmup_resolution(
+        sampling_defaults.supported_resolutions, target_area
+    )
+    if supported_resolution is not None:
+        return supported_resolution
+
+    width = sampling_defaults.width
+    height = sampling_defaults.height
+    if width is not None and height is not None:
+        return _fit_resolution_to_area(width, height, target_area)
+
+    return _fallback_warmup_resolution(server_args)
+
+
+def _target_warmup_area(server_args: ServerArgs) -> int:
+    if server_args.pipeline_config.task_type.is_image_gen():
+        if getattr(server_args, "backend", None) == "diffusers":
+            return SERVER_WARMUP_DIFFUSERS_IMAGE_MAX_AREA
+        return SERVER_WARMUP_IMAGE_MAX_AREA
+    if _is_video_warmup_task(server_args):
+        return SERVER_WARMUP_VIDEO_MAX_AREA
+    return (
+        DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION[0]
+        * DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION[1]
+    )
+
+
+def _fallback_warmup_resolution(server_args: ServerArgs) -> tuple[int, int]:
+    if server_args.pipeline_config.task_type.is_image_gen():
+        return SERVER_WARMUP_IMAGE_FALLBACK_RESOLUTION
+    if _is_video_warmup_task(server_args):
+        return SERVER_WARMUP_VIDEO_FALLBACK_RESOLUTION
+    return DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION
+
+
+def _is_video_warmup_task(server_args: ServerArgs) -> bool:
+    return server_args.pipeline_config.task_type.data_type() == DataType.VIDEO
+
+
+def _select_supported_warmup_resolution(
+    supported_resolutions: list[tuple[int, int]] | None,
+    target_area: int,
+) -> tuple[int, int] | None:
+    if not supported_resolutions:
+        return None
+
+    candidates = [
+        resolution
+        for resolution in supported_resolutions
+        if resolution[0] * resolution[1] <= target_area
+    ]
+    if candidates:
+        return max(candidates, key=lambda size: size[0] * size[1])
+    return min(supported_resolutions, key=lambda size: size[0] * size[1])
+
+
+def _fit_resolution_to_area(
+    width: int, height: int, target_area: int
+) -> tuple[int, int]:
+    area = width * height
+    if area <= target_area:
+        return width, height
+
+    scale = (target_area / area) ** 0.5
+    return (
+        max(16, int(width * scale) // 16 * 16),
+        max(16, int(height * scale) // 16 * 16),
+    )
+
+
+def _resolve_warmup_prompt(
+    *,
+    server_based_warmup: bool,
+    use_model_sampling_defaults: bool,
+) -> str:
+    if server_based_warmup and use_model_sampling_defaults:
+        return DEFAULT_REPRESENTATIVE_PROMPT
+    return DEFAULT_PLACEHOLDER_PROMPT
+
+
+def _resolve_warmup_num_frames(
+    server_args: ServerArgs,
+    sampling_defaults: SamplingParams,
+    *,
+    server_based_warmup: bool,
+    use_model_sampling_defaults: bool,
+) -> int:
+    num_frames = sampling_defaults.num_frames
+    if (
+        not server_based_warmup
+        or not use_model_sampling_defaults
+        or not _is_video_warmup_task(server_args)
+    ):
+        return num_frames
+
+    return min(num_frames, SERVER_WARMUP_MAX_VIDEO_FRAMES)
 
 
 def _effective_cfg_scale(sampling_defaults: SamplingParams) -> float | None:
@@ -92,10 +216,13 @@ def _resolve_warmup_steps(
     if default_steps is None or default_steps <= warmup_steps:
         return warmup_steps
 
-    if not server_args.pipeline_config.task_type.is_image_gen():
-        return warmup_steps
+    if _is_video_warmup_task(server_args):
+        return min(default_steps, max(warmup_steps, SERVER_WARMUP_VIDEO_STEPS))
 
-    return min(default_steps, max(warmup_steps, SERVER_WARMUP_IMAGE_STEPS))
+    if server_args.pipeline_config.task_type.is_image_gen():
+        return min(default_steps, max(warmup_steps, SERVER_WARMUP_IMAGE_STEPS))
+
+    return warmup_steps
 
 
 def should_include_warmup_image(
@@ -128,7 +255,10 @@ def build_warmup_reqs(
 
     if warmup_resolutions is None:
         width, height = _resolve_default_warmup_resolution(
-            server_args, sampling_defaults
+            server_args,
+            sampling_defaults,
+            server_based_warmup=server_based_warmup,
+            use_model_sampling_defaults=use_model_sampling_defaults,
         )
         resolutions: list[tuple[int, int]] = [(width, height)]
     else:
@@ -146,6 +276,16 @@ def build_warmup_reqs(
         server_based_warmup=server_based_warmup,
         use_model_sampling_defaults=use_model_sampling_defaults,
     )
+    warmup_num_frames = _resolve_warmup_num_frames(
+        server_args,
+        sampling_defaults,
+        server_based_warmup=server_based_warmup,
+        use_model_sampling_defaults=use_model_sampling_defaults,
+    )
+    warmup_prompt = _resolve_warmup_prompt(
+        server_based_warmup=server_based_warmup,
+        use_model_sampling_defaults=use_model_sampling_defaults,
+    )
 
     warmup_reqs = []
     include_warmup_image = should_include_warmup_image(server_args, server_based_warmup)
@@ -154,7 +294,7 @@ def build_warmup_reqs(
             data_type=task_type.data_type(),
             width=width,
             height=height,
-            prompt=DEFAULT_PLACEHOLDER_PROMPT,
+            prompt=warmup_prompt,
         )
         if use_model_sampling_defaults:
             req_kwargs["sampling_params"] = copy(sampling_defaults)
@@ -164,14 +304,14 @@ def build_warmup_reqs(
                 guidance_scale_2=sampling_defaults.guidance_scale_2,
                 true_cfg_scale=sampling_defaults.true_cfg_scale,
                 num_inference_steps=sampling_defaults.num_inference_steps,
-                num_frames=sampling_defaults.num_frames,
+                num_frames=warmup_num_frames,
             )
         if include_warmup_image:
             if warmup_input_path is None:
                 raise RuntimeError(
                     "Warmup image path is required for image-input model"
                 )
-            req_kwargs["prompt"] = DEFAULT_PLACEHOLDER_PROMPT
+            req_kwargs["prompt"] = warmup_prompt
             if not use_model_sampling_defaults:
                 req_kwargs["negative_prompt"] = ""
             req_kwargs["image_path"] = [warmup_input_path]

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -141,9 +141,7 @@ def _warmup_resolution_alignment(server_args: ServerArgs) -> int:
     vae_stride = getattr(pipeline_config, "vae_stride", None)
     if vae_stride is not None:
         spatial_stride = (
-            vae_stride[-2:]
-            if isinstance(vae_stride, (tuple, list))
-            else (vae_stride,)
+            vae_stride[-2:] if isinstance(vae_stride, (tuple, list)) else (vae_stride,)
         )
         for stride in spatial_stride:
             alignment = max(alignment, int(stride))

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -135,10 +135,36 @@ def _is_video_warmup_task(server_args: ServerArgs) -> bool:
 
 
 def _warmup_resolution_alignment(server_args: ServerArgs) -> int:
+    pipeline_config = server_args.pipeline_config
+    alignment = 16
+
+    vae_stride = getattr(pipeline_config, "vae_stride", None)
+    if vae_stride is not None:
+        spatial_stride = (
+            vae_stride[-2:]
+            if isinstance(vae_stride, (tuple, list))
+            else (vae_stride,)
+        )
+        for stride in spatial_stride:
+            alignment = max(alignment, int(stride))
+
+    vae_scale_factor = getattr(pipeline_config, "vae_scale_factor", None)
+    if vae_scale_factor is not None:
+        alignment = max(alignment, int(vae_scale_factor))
+
+    arch_config = getattr(
+        getattr(pipeline_config, "vae_config", None), "arch_config", None
+    )
+    for attr in ("vae_scale_factor", "spatial_compression_ratio"):
+        value = getattr(arch_config, attr, None)
+        if value is not None:
+            alignment = max(alignment, int(value))
+
     if is_ltx2_two_stage_pipeline_name(server_args.pipeline_class_name):
-        vae_scale_factor = server_args.pipeline_config.vae_scale_factor
-        return max(64, int(vae_scale_factor) * 2)
-    return 16
+        vae_scale_factor = pipeline_config.vae_scale_factor
+        alignment = max(alignment, 64, int(vae_scale_factor) * 2)
+
+    return alignment
 
 
 def _select_supported_warmup_resolution(

--- a/python/sglang/multimodal_gen/test/unit/sana_wm/test_streaming_cached.py
+++ b/python/sglang/multimodal_gen/test/unit/sana_wm/test_streaming_cached.py
@@ -241,7 +241,9 @@ HFFN, WFFN = S, 1  # S spatial tokens per frame
 
 def _ffn():
     m = GLUMBConvTemp(C_FFN, HID, t_kernel_size=3).double().eval()
-    with torch.no_grad():  # zero-init t_conv -> randomize for a non-trivial temporal filter
+    with (
+        torch.no_grad()
+    ):  # zero-init t_conv -> randomize for a non-trivial temporal filter
         m.t_conv.weight.copy_(torch.randn_like(m.t_conv.weight))
     return m
 

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -33,8 +33,9 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.input_validation import
     InputValidationStage,
 )
 from sglang.multimodal_gen.runtime.warmup_request_builder import (
-    DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION,
     DEFAULT_PLACEHOLDER_PROMPT,
+    DEFAULT_REPRESENTATIVE_PROMPT,
+    SERVER_WARMUP_IMAGE_FALLBACK_RESOLUTION,
     build_warmup_reqs,
     should_include_warmup_image,
 )
@@ -183,6 +184,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertEqual(req.num_inference_steps, 2)
         self.assertEqual(req.extra["cache_dit_num_inference_steps"], 20)
         self.assertEqual(req.negative_prompt, "model default negative")
+        self.assertEqual(req.prompt, DEFAULT_REPRESENTATIVE_PROMPT)
         self.assertIs(req.do_classifier_free_guidance, True)
         self.assertTrue(req.extra["return_warmup_result"])
         self.assertTrue(req.extra["server_based_warmup"])
@@ -215,7 +217,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertEqual(req.width, 640)
         self.assertEqual(req.height, 640)
 
-    def test_server_based_warmup_prefers_default_resolution_over_supported_min(self):
+    def test_server_based_warmup_uses_supported_resolution_within_budget(self):
         server_args = MagicMock()
         server_args.warmup_steps = 1
         server_args.enable_cfg_parallel = False
@@ -243,7 +245,61 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
                 server_based_warmup=True,
             )
 
-        self.assertEqual((reqs[0].width, reqs[0].height), (1024, 1024))
+        self.assertEqual((reqs[0].width, reqs[0].height), (512, 512))
+
+    def test_server_based_warmup_scales_large_image_default(self):
+        server_args = MagicMock()
+        server_args.warmup_steps = 1
+        server_args.enable_cfg_parallel = False
+        server_args.backend = "auto"
+
+        task_type = MagicMock()
+        task_type.requires_image_input.return_value = False
+        task_type.accepts_image_input.return_value = False
+        task_type.is_image_gen.return_value = True
+        task_type.data_type.return_value = ModelTaskType.T2I.data_type()
+        server_args.pipeline_config.task_type = task_type
+
+        sampling_defaults = SamplingParams(width=1024, height=1024)
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=sampling_defaults,
+        ):
+            reqs = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=None,
+                use_model_sampling_defaults=True,
+                server_based_warmup=True,
+            )
+
+        self.assertEqual((reqs[0].width, reqs[0].height), (768, 768))
+
+    def test_server_based_warmup_uses_diffusers_image_budget(self):
+        server_args = MagicMock()
+        server_args.warmup_steps = 1
+        server_args.enable_cfg_parallel = False
+        server_args.backend = "diffusers"
+
+        task_type = MagicMock()
+        task_type.requires_image_input.return_value = False
+        task_type.accepts_image_input.return_value = False
+        task_type.is_image_gen.return_value = True
+        task_type.data_type.return_value = ModelTaskType.T2I.data_type()
+        server_args.pipeline_config.task_type = task_type
+
+        sampling_defaults = SamplingParams(width=1024, height=1024)
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=sampling_defaults,
+        ):
+            reqs = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=None,
+                use_model_sampling_defaults=True,
+                server_based_warmup=True,
+            )
+
+        self.assertEqual((reqs[0].width, reqs[0].height), (512, 512))
 
     def test_server_based_warmup_keeps_video_warmup_lightweight(self):
         server_args = MagicMock()
@@ -274,10 +330,50 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
                 server_based_warmup=True,
             )
 
-        self.assertEqual(reqs[0].num_inference_steps, 1)
-        self.assertEqual(reqs[0].num_frames, 81)
+        self.assertEqual(reqs[0].num_inference_steps, 2)
+        self.assertEqual(reqs[0].num_frames, 17)
 
-    def test_server_based_warmup_keeps_lightweight_image_fallback(self):
+    def test_server_based_warmup_uses_video_supported_resolution_budget(self):
+        server_args = MagicMock()
+        server_args.warmup_steps = 1
+        server_args.enable_cfg_parallel = False
+
+        task_type = MagicMock()
+        task_type.requires_image_input.return_value = False
+        task_type.accepts_image_input.return_value = False
+        task_type.is_image_gen.return_value = False
+        task_type.data_type.return_value = ModelTaskType.T2V.data_type()
+        server_args.pipeline_config.task_type = task_type
+
+        sampling_defaults = SamplingParams(
+            width=1280,
+            height=720,
+            num_frames=81,
+            num_inference_steps=35,
+            supported_resolutions=[
+                (1280, 720),
+                (720, 1280),
+                (832, 480),
+                (480, 832),
+                (1024, 1024),
+            ],
+        )
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=sampling_defaults,
+        ):
+            reqs = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=None,
+                use_model_sampling_defaults=True,
+                server_based_warmup=True,
+            )
+
+        self.assertEqual((reqs[0].width, reqs[0].height), (832, 480))
+        self.assertEqual(reqs[0].num_frames, 17)
+        self.assertEqual(reqs[0].num_inference_steps, 2)
+
+    def test_server_based_warmup_uses_representative_image_fallback(self):
         server_args = MagicMock()
         server_args.warmup_steps = 1
         server_args.enable_cfg_parallel = False
@@ -303,7 +399,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         req = reqs[0]
         self.assertEqual(
             (req.width, req.height),
-            DEFAULT_LIGHTWEIGHT_IMAGE_RESOLUTION,
+            SERVER_WARMUP_IMAGE_FALLBACK_RESOLUTION,
         )
 
     def test_warmup_image_inclusion_policy_all_task_types(self):

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -67,7 +67,7 @@ def _make_bare_scheduler(enable_cfg_parallel: bool) -> Scheduler:
     server_args.pipeline_config.task_type = task_type
 
     scheduler.server_args = server_args
-    scheduler.warmed_up = False
+    scheduler.req_based_warmup_scheduled = False
     scheduler.waiting_queue = deque()
     return scheduler
 
@@ -160,7 +160,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertTrue(processed[0][1].metrics.suppress_stage_breakdown)
         self.assertEqual(processed[0][1].num_inference_steps, 1)
         self.assertEqual(processed[0][1].extra["cache_dit_num_inference_steps"], 20)
-        self.assertTrue(scheduler.warmed_up)
+        self.assertTrue(scheduler.req_based_warmup_scheduled)
 
     def test_req_based_warmup_skips_default_server_warmup_path(self):
         scheduler = _make_bare_scheduler(enable_cfg_parallel=False)
@@ -172,7 +172,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
 
         self.assertIs(processed, recv_reqs)
         self.assertEqual(len(processed), 1)
-        self.assertFalse(scheduler.warmed_up)
+        self.assertFalse(scheduler.req_based_warmup_scheduled)
 
     def test_diff_generator_runs_explicit_warmup_through_scheduler_client(self):
         generator = object.__new__(DiffGenerator)

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -34,7 +34,6 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.input_validation import
 )
 from sglang.multimodal_gen.runtime.warmup_request_builder import (
     DEFAULT_PLACEHOLDER_PROMPT,
-    DEFAULT_REPRESENTATIVE_PROMPT,
     SERVER_WARMUP_IMAGE_FALLBACK_RESOLUTION,
     build_warmup_reqs,
     should_include_warmup_image,
@@ -184,7 +183,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertEqual(req.num_inference_steps, 2)
         self.assertEqual(req.extra["cache_dit_num_inference_steps"], 20)
         self.assertEqual(req.negative_prompt, "model default negative")
-        self.assertEqual(req.prompt, DEFAULT_REPRESENTATIVE_PROMPT)
+        self.assertEqual(req.prompt, DEFAULT_PLACEHOLDER_PROMPT)
         self.assertIs(req.do_classifier_free_guidance, True)
         self.assertTrue(req.extra["return_warmup_result"])
         self.assertTrue(req.extra["server_based_warmup"])

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -98,11 +98,15 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
 
     def test_warmup_req_cfg_parallel_sets_do_cfg(self):
         server_args = _make_bare_scheduler(enable_cfg_parallel=True).server_args
-        req = build_warmup_reqs(
-            server_args,
-            warmup_resolutions=["512x512"],
-            server_based_warmup=True,
-        )[0]
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=SamplingParams(),
+        ):
+            req = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=["512x512"],
+                server_based_warmup=True,
+            )[0]
         self.assertIs(req.do_classifier_free_guidance, True)
         self.assertEqual(req.negative_prompt, DEFAULT_PLACEHOLDER_PROMPT)
 
@@ -113,11 +117,15 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         # "warmup" placeholder for negative_prompt (which would indicate
         # the fix's kwargs leaked into this branch).
         server_args = _make_bare_scheduler(enable_cfg_parallel=False).server_args
-        req = build_warmup_reqs(
-            server_args,
-            warmup_resolutions=["512x512"],
-            server_based_warmup=True,
-        )[0]
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=SamplingParams(),
+        ):
+            req = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=["512x512"],
+                server_based_warmup=True,
+            )[0]
         self.assertIs(req.do_classifier_free_guidance, False)
         self.assertNotEqual(req.negative_prompt, DEFAULT_PLACEHOLDER_PROMPT)
 
@@ -185,7 +193,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertTrue(req.is_warmup)
         self.assertEqual((req.width, req.height), (832, 480))
         self.assertEqual(req.num_frames, 17)
-        self.assertEqual(req.num_inference_steps, 1)
+        self.assertEqual(req.num_inference_steps, 2)
         self.assertTrue(req.extra["return_warmup_result"])
         self.assertTrue(req.extra["server_based_warmup"])
         self.assertEqual(req.extra["warmup_total"], 1)
@@ -289,7 +297,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         req = reqs[0]
         self.assertEqual((req.width, req.height), (832, 480))
         self.assertEqual(req.num_frames, 17)
-        self.assertEqual(req.num_inference_steps, 1)
+        self.assertEqual(req.num_inference_steps, 2)
         self.assertEqual(req.extra["cache_dit_num_inference_steps"], 50)
         self.assertEqual(req.negative_prompt, "model default negative")
         self.assertIs(req.do_classifier_free_guidance, True)

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -468,6 +468,40 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertEqual(reqs[0].num_frames, 17)
         self.assertEqual(reqs[0].num_inference_steps, 2)
 
+    def test_ltx2_two_stage_warmup_uses_pipeline_alignment(self):
+        server_args = MagicMock()
+        server_args.warmup_steps = 1
+        server_args.enable_cfg_parallel = False
+        server_args.pipeline_class_name = "LTX2TwoStageHQPipeline"
+
+        task_type = MagicMock()
+        task_type.requires_image_input.return_value = False
+        task_type.accepts_image_input.return_value = False
+        task_type.is_image_gen.return_value = False
+        task_type.data_type.return_value = ModelTaskType.T2V.data_type()
+        server_args.pipeline_config.task_type = task_type
+        server_args.pipeline_config.vae_scale_factor = 32
+
+        sampling_defaults = SamplingParams(
+            width=1920,
+            height=1088,
+            num_frames=121,
+            num_inference_steps=15,
+        )
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=sampling_defaults,
+        ):
+            reqs = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=None,
+                server_based_warmup=True,
+            )
+
+        self.assertEqual((reqs[0].width, reqs[0].height), (832, 448))
+        self.assertEqual(reqs[0].width % 64, 0)
+        self.assertEqual(reqs[0].height % 64, 0)
+
     def test_server_based_warmup_uses_representative_image_fallback(self):
         server_args = MagicMock()
         server_args.warmup_steps = 1

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -1,7 +1,7 @@
 """Unit tests for the --enable-cfg-parallel warmup fix and guard.
 
 Covers warmup and cfg-parallel guard paths introduced alongside this file:
-- Scheduler.prepare_server_warmup_reqs synthesizes warmup Reqs that
+- Scheduler.prepare_internal_warmup_reqs synthesizes fallback warmup Reqs that
   actually enable classifier-free guidance when cfg-parallel is on.
 - InputValidationStage.forward rejects non-CFG requests when the server
   has cfg-parallel on.
@@ -44,7 +44,7 @@ def _make_bare_scheduler(enable_cfg_parallel: bool) -> Scheduler:
     """
     Build a minimal Scheduler without calling __init__ (which requires
     distributed init, ZMQ sockets, pipeline load, etc.). Populates only
-    the attributes prepare_server_warmup_reqs reads/writes for a
+    the attributes prepare_internal_warmup_reqs reads/writes for a
     text-only task so _prepare_shared_warmup_image_path is skipped.
     """
     scheduler = object.__new__(Scheduler)
@@ -54,6 +54,7 @@ def _make_bare_scheduler(enable_cfg_parallel: bool) -> Scheduler:
     server_args.warmup_steps = 1
     server_args.warmup_resolutions = ["512x512"]
     server_args.enable_cfg_parallel = enable_cfg_parallel
+    server_args.server_warmup = False
 
     # Text-only task — accepts_image_input() False skips the image-path
     # branch entirely, so we don't need to mock
@@ -92,11 +93,11 @@ def _make_validation_server_args(enable_cfg_parallel: bool) -> MagicMock:
 
 
 class TestWarmupReqCfgParallel(unittest.TestCase):
-    """Commit 1 regression: prepare_server_warmup_reqs."""
+    """Commit 1 regression: prepare_internal_warmup_reqs."""
 
     def test_warmup_req_cfg_parallel_sets_do_cfg(self):
         scheduler = _make_bare_scheduler(enable_cfg_parallel=True)
-        scheduler.prepare_server_warmup_reqs()
+        scheduler.prepare_internal_warmup_reqs()
 
         self.assertEqual(len(scheduler.waiting_queue), 1)
         _, req, _ = scheduler.waiting_queue[0]
@@ -110,12 +111,21 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         # "warmup" placeholder for negative_prompt (which would indicate
         # the fix's kwargs leaked into this branch).
         scheduler = _make_bare_scheduler(enable_cfg_parallel=False)
-        scheduler.prepare_server_warmup_reqs()
+        scheduler.prepare_internal_warmup_reqs()
 
         self.assertEqual(len(scheduler.waiting_queue), 1)
         _, req, _ = scheduler.waiting_queue[0]
         self.assertIs(req.do_classifier_free_guidance, False)
         self.assertNotEqual(req.negative_prompt, DEFAULT_PLACEHOLDER_PROMPT)
+
+    def test_server_warmup_skips_internal_warmup_queue(self):
+        scheduler = _make_bare_scheduler(enable_cfg_parallel=False)
+        scheduler.server_args.server_warmup = True
+
+        scheduler.prepare_internal_warmup_reqs()
+
+        self.assertEqual(len(scheduler.waiting_queue), 0)
+        self.assertFalse(scheduler.warmed_up)
 
     def test_req_based_warmup_remains_explicit_legacy_entry(self):
         scheduler = _make_bare_scheduler(enable_cfg_parallel=False)
@@ -171,7 +181,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 return_warmup_result=True,
                 server_based_warmup=True,
             )
@@ -208,13 +217,49 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
         req = reqs[0]
         self.assertEqual(req.width, 640)
         self.assertEqual(req.height, 640)
+
+    def test_server_based_warmup_resolutions_keep_sampling_defaults_and_caps(self):
+        server_args = MagicMock()
+        server_args.warmup_steps = 1
+        server_args.enable_cfg_parallel = False
+
+        task_type = MagicMock()
+        task_type.requires_image_input.return_value = False
+        task_type.accepts_image_input.return_value = False
+        task_type.is_image_gen.return_value = False
+        task_type.data_type.return_value = ModelTaskType.T2V.data_type()
+        server_args.pipeline_config.task_type = task_type
+
+        sampling_defaults = SamplingParams(
+            negative_prompt="model default negative",
+            guidance_scale=3.5,
+            num_frames=81,
+            num_inference_steps=50,
+        )
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=sampling_defaults,
+        ):
+            reqs = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=["832x480"],
+                return_warmup_result=True,
+                server_based_warmup=True,
+            )
+
+        req = reqs[0]
+        self.assertEqual((req.width, req.height), (832, 480))
+        self.assertEqual(req.num_frames, 17)
+        self.assertEqual(req.num_inference_steps, 1)
+        self.assertEqual(req.extra["cache_dit_num_inference_steps"], 50)
+        self.assertEqual(req.negative_prompt, "model default negative")
+        self.assertIs(req.do_classifier_free_guidance, True)
 
     def test_server_based_warmup_uses_supported_resolution_within_budget(self):
         server_args = MagicMock()
@@ -240,7 +285,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -267,7 +311,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -294,7 +337,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -325,7 +367,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -364,7 +405,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -391,7 +431,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
             reqs = build_warmup_reqs(
                 server_args,
                 warmup_resolutions=None,
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -441,7 +480,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
                 server_args,
                 warmup_resolutions=None,
                 warmup_input_path="/tmp/warmup.png",
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -461,7 +499,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
                 server_args,
                 warmup_resolutions=None,
                 warmup_input_path="/tmp/warmup.png",
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 
@@ -481,7 +518,6 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
                 server_args,
                 warmup_resolutions=None,
                 warmup_input_path="/tmp/warmup.png",
-                use_model_sampling_defaults=True,
                 server_based_warmup=True,
             )
 

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -1,13 +1,14 @@
 """Unit tests for the --enable-cfg-parallel warmup fix and guard.
 
 Covers warmup and cfg-parallel guard paths introduced alongside this file:
-- Scheduler.prepare_internal_warmup_reqs synthesizes fallback warmup Reqs that
-  actually enable classifier-free guidance when cfg-parallel is on.
+- build_warmup_reqs synthesizes warmup Reqs that actually enable
+  classifier-free guidance when cfg-parallel is on.
+- DiffGenerator sends explicit warmup resolutions through the scheduler client.
 - InputValidationStage.forward rejects non-CFG requests when the server
   has cfg-parallel on.
 - Server-based warmup can opt into model-default negative prompts so warmup
   populates the negative text embedding cache.
-- Req-based warmup remains available only through the explicit legacy path.
+- Req-based warmup remains available only through the lazy legacy path.
 
 All tests are CPU-only; no model loading, no distributed init.
 """
@@ -24,8 +25,12 @@ from sglang.multimodal_gen.configs.pipeline_configs.flux_finetuned import (
     Flux2FinetunedPipelineConfig,
 )
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import DiffGenerator
 from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
-from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+    OutputBatch,
+    Req,
+)
 from sglang.multimodal_gen.runtime.pipelines_core.stages.image_encoding import (
     ImageVAEEncodingStage,
 )
@@ -44,8 +49,7 @@ def _make_bare_scheduler(enable_cfg_parallel: bool) -> Scheduler:
     """
     Build a minimal Scheduler without calling __init__ (which requires
     distributed init, ZMQ sockets, pipeline load, etc.). Populates only
-    the attributes prepare_internal_warmup_reqs reads/writes for a
-    text-only task so _prepare_shared_warmup_image_path is skipped.
+    the attributes req-based warmup reads/writes.
     """
     scheduler = object.__new__(Scheduler)
 
@@ -56,9 +60,6 @@ def _make_bare_scheduler(enable_cfg_parallel: bool) -> Scheduler:
     server_args.enable_cfg_parallel = enable_cfg_parallel
     server_args.server_warmup = False
 
-    # Text-only task — accepts_image_input() False skips the image-path
-    # branch entirely, so we don't need to mock
-    # _prepare_shared_warmup_image_path.
     task_type = MagicMock()
     task_type.requires_image_input.return_value = False
     task_type.accepts_image_input.return_value = False
@@ -93,14 +94,15 @@ def _make_validation_server_args(enable_cfg_parallel: bool) -> MagicMock:
 
 
 class TestWarmupReqCfgParallel(unittest.TestCase):
-    """Commit 1 regression: prepare_internal_warmup_reqs."""
+    """Warmup request construction and req-based warmup guards."""
 
     def test_warmup_req_cfg_parallel_sets_do_cfg(self):
-        scheduler = _make_bare_scheduler(enable_cfg_parallel=True)
-        scheduler.prepare_internal_warmup_reqs()
-
-        self.assertEqual(len(scheduler.waiting_queue), 1)
-        _, req, _ = scheduler.waiting_queue[0]
+        server_args = _make_bare_scheduler(enable_cfg_parallel=True).server_args
+        req = build_warmup_reqs(
+            server_args,
+            warmup_resolutions=["512x512"],
+            server_based_warmup=True,
+        )[0]
         self.assertIs(req.do_classifier_free_guidance, True)
         self.assertEqual(req.negative_prompt, DEFAULT_PLACEHOLDER_PROMPT)
 
@@ -110,22 +112,14 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         # AND the synthesized Req is not using the cfg-parallel-specific
         # "warmup" placeholder for negative_prompt (which would indicate
         # the fix's kwargs leaked into this branch).
-        scheduler = _make_bare_scheduler(enable_cfg_parallel=False)
-        scheduler.prepare_internal_warmup_reqs()
-
-        self.assertEqual(len(scheduler.waiting_queue), 1)
-        _, req, _ = scheduler.waiting_queue[0]
+        server_args = _make_bare_scheduler(enable_cfg_parallel=False).server_args
+        req = build_warmup_reqs(
+            server_args,
+            warmup_resolutions=["512x512"],
+            server_based_warmup=True,
+        )[0]
         self.assertIs(req.do_classifier_free_guidance, False)
         self.assertNotEqual(req.negative_prompt, DEFAULT_PLACEHOLDER_PROMPT)
-
-    def test_server_warmup_skips_internal_warmup_queue(self):
-        scheduler = _make_bare_scheduler(enable_cfg_parallel=False)
-        scheduler.server_args.server_warmup = True
-
-        scheduler.prepare_internal_warmup_reqs()
-
-        self.assertEqual(len(scheduler.waiting_queue), 0)
-        self.assertFalse(scheduler.warmed_up)
 
     def test_req_based_warmup_remains_explicit_legacy_entry(self):
         scheduler = _make_bare_scheduler(enable_cfg_parallel=False)
@@ -156,6 +150,45 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertIs(processed, recv_reqs)
         self.assertEqual(len(processed), 1)
         self.assertFalse(scheduler.warmed_up)
+
+    def test_diff_generator_runs_explicit_warmup_through_scheduler_client(self):
+        generator = object.__new__(DiffGenerator)
+        server_args = MagicMock()
+        server_args.warmup = True
+        server_args.warmup_resolutions = ["832x480"]
+        server_args.warmup_steps = 1
+        server_args.enable_cfg_parallel = False
+
+        task_type = MagicMock()
+        task_type.requires_image_input.return_value = False
+        task_type.accepts_image_input.return_value = False
+        task_type.is_image_gen.return_value = False
+        task_type.data_type.return_value = ModelTaskType.T2V.data_type()
+        server_args.pipeline_config.task_type = task_type
+        generator.server_args = server_args
+
+        sampling_defaults = SamplingParams(num_frames=81, num_inference_steps=50)
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+                return_value=sampling_defaults,
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.diffusion_generator.sync_scheduler_client.forward",
+                return_value=OutputBatch(error=None),
+            ) as forward,
+        ):
+            generator._run_client_warmup_if_needed()
+
+        forward.assert_called_once()
+        req = forward.call_args.args[0]
+        self.assertTrue(req.is_warmup)
+        self.assertEqual((req.width, req.height), (832, 480))
+        self.assertEqual(req.num_frames, 17)
+        self.assertEqual(req.num_inference_steps, 1)
+        self.assertTrue(req.extra["return_warmup_result"])
+        self.assertTrue(req.extra["server_based_warmup"])
+        self.assertEqual(req.extra["warmup_total"], 1)
 
     def test_server_based_warmup_uses_model_default_negative_prompt(self):
         server_args = MagicMock()

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -98,9 +98,24 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
 
     def test_warmup_req_cfg_parallel_sets_do_cfg(self):
         server_args = _make_bare_scheduler(enable_cfg_parallel=True).server_args
+        sampling_defaults = SamplingParams()
         with patch(
             "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
-            return_value=SamplingParams(),
+            return_value=sampling_defaults,
+        ):
+            req = build_warmup_reqs(
+                server_args,
+                warmup_resolutions=["512x512"],
+                server_based_warmup=True,
+            )[0]
+        self.assertIs(req.do_classifier_free_guidance, True)
+        self.assertEqual(req.negative_prompt, sampling_defaults.negative_prompt)
+
+    def test_warmup_req_cfg_parallel_fills_missing_negative_prompt(self):
+        server_args = _make_bare_scheduler(enable_cfg_parallel=True).server_args
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=SamplingParams(negative_prompt=None),
         ):
             req = build_warmup_reqs(
                 server_args,


### PR DESCRIPTION
## Summary

Improve diffusion server-based warmup coverage while keeping startup cost bounded:

- choose representative low-cost image/video resolution buckets for default server warmup
- use `512x512` image fallback instead of `64x64`
- cap default image warmup by backend (`768x768` area for native, `512x512` area for diffusers)
- cap video warmup to `17` frames and up to `2` warmup steps
- keep the warmup prompt lightweight as `"warmup"` to avoid extra text encoding startup cost

## Motivation

The existing server-based warmup can miss common CI/user workload paths, especially image requests that fall back to `64x64`, video requests that use full default frame counts, and diffusers/cache-DiT paths that never see a realistic image shape before the first real request.

This keeps the synthetic warmup request generic, but makes it closer to common serving shapes without copying user traffic.

## Validation

Targeted remote GitHub Actions runs:

- `zimage_image_t2i_multi_lora`: warmup `4.98s -> 4.61s`
- `qwen_image_t2i_cache_dit_scm_config_diffusers_1gpu`: warmup `46.56s -> 46.76s`
- `wan2_1_i2v_14b_480P_2gpu`: warmup `32.82s -> 33.68s`
- `flux1_modelopt_nvfp4_t2i`: final patch warmup `7.13s`, compared with base repeats `7.50s` / `8.03s`

An intermediate variant with a longer representative prompt regressed Flux warmup. This PR intentionally keeps the placeholder prompt and only changes resolution/frame/step coverage.

No local tests were run.













































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27487958425](https://github.com/sgl-project/sglang/actions/runs/27487958425)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27487958337](https://github.com/sgl-project/sglang/actions/runs/27487958337)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->