### PR TITLE
fix(quant): dispatch compressed-tensors ParallelLMHead

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -195,9 +195,18 @@ class CompressedTensorsConfig(QuantizationConfig):
                 scheme = self.get_linear_scheme(layer=layer, layer_name=prefix)
             except ValueError:
                 scheme = None
-            if scheme is not None:
+            # Only WNA16 registers weight_packed; others (W8A8-fp8/int8,
+            # W8A16-fp8) register `weight` and would be silently miscomputed
+            # by _compute_lm_head's hasattr("weight") matmul short-circuit.
+            if isinstance(scheme, CompressedTensorsWNA16):
                 layer.scheme = scheme
                 return CompressedTensorsLinearMethod(self)
+            elif scheme is not None:
+                logger.warning_once(
+                    f"ParallelLMHead quantization with {type(scheme).__name__} is "
+                    "not supported (lm_head would be computed without weight_scale); "
+                    "loading lm_head unquantized."
+                )
         return None
 
     def _add_fused_moe_to_target_scheme_map(self):

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -188,6 +188,16 @@ class CompressedTensorsConfig(QuantizationConfig):
                     use_triton_kernels, use_flashinfer_trtllm_moe, use_deep_gemm
                 )
             return CompressedTensorsFusedMoEMethod(self)
+        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+
+        if isinstance(layer, ParallelLMHead):
+            try:
+                scheme = self.get_linear_scheme(layer=layer, layer_name=prefix)
+            except ValueError:
+                scheme = None
+            if scheme is not None:
+                layer.scheme = scheme
+                return CompressedTensorsLinearMethod(self)
         return None
 
     def _add_fused_moe_to_target_scheme_map(self):
@@ -715,7 +725,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return NPUCompressedTensorsW8A8Int8DynamicMoE(weight_quant, input_quant)
             else:
                 raise NotImplementedError(
-                    f"The W8A8Int8 Fused MoE scheme is implemented only for NPU for now."
+                    "The W8A8Int8 Fused MoE scheme is implemented only for NPU for now."
                 )
         elif self._is_dynamic_token_w4a8(weight_quant, input_quant):
             if _is_npu:
@@ -723,7 +733,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return NPUCompressedTensorsW4A8Int8DynamicMoE(self)
             else:
                 raise NotImplementedError(
-                    f"The W4A8Int8 Fused MoE scheme is implemented only for NPU for now."
+                    "The W4A8Int8 Fused MoE scheme is implemented only for NPU for now."
                 )
         else:
             raise RuntimeError(

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -6,6 +6,10 @@ from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import
     CompressedTensorsConfig,
     CompressedTensorsLinearMethod,
 )
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsW8A8Fp8,
+    CompressedTensorsWNA16,
+)
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -85,7 +89,7 @@ class TestQuantLogString(CustomTestCase):
             sparsity_scheme_map={},
             sparsity_ignore_list=[],
         )
-        sentinel = object()
+        sentinel = MagicMock(spec=CompressedTensorsWNA16)
         cfg.get_linear_scheme = MagicMock(return_value=sentinel)
         layer = ParallelLMHead.__new__(ParallelLMHead)
 
@@ -94,6 +98,23 @@ class TestQuantLogString(CustomTestCase):
         self.assertIsInstance(method, CompressedTensorsLinearMethod)
         self.assertIs(layer.scheme, sentinel)
         cfg.get_linear_scheme.assert_called_once_with(layer=layer, layer_name="lm_head")
+
+        w8a8_cfg = CompressedTensorsConfig(
+            target_scheme_map={"lm_head": {"weights": None, "input_activations": None}},
+            ignore=[],
+            quant_format="pack-quantized",
+            sparsity_scheme_map={},
+            sparsity_ignore_list=[],
+        )
+        w8a8_cfg.get_linear_scheme = MagicMock(
+            return_value=MagicMock(spec=CompressedTensorsW8A8Fp8)
+        )
+        w8a8_layer = ParallelLMHead.__new__(ParallelLMHead)
+
+        w8a8_method = w8a8_cfg.get_quant_method(w8a8_layer, prefix="lm_head")
+
+        self.assertIsNone(w8a8_method)
+        self.assertFalse(hasattr(w8a8_layer, "scheme"))
 
         fallback_cfg = CompressedTensorsConfig(
             target_scheme_map={},

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -85,13 +85,33 @@ class TestQuantLogString(unittest.TestCase):
             sparsity_ignore_list=[],
         )
         sentinel = object()
-        cfg.get_linear_scheme = lambda **_: sentinel
+        cfg.get_linear_scheme = MagicMock(return_value=sentinel)
         layer = ParallelLMHead.__new__(ParallelLMHead)
 
         method = cfg.get_quant_method(layer, prefix="lm_head")
 
         self.assertIsInstance(method, CompressedTensorsLinearMethod)
         self.assertIs(layer.scheme, sentinel)
+        cfg.get_linear_scheme.assert_called_once_with(layer=layer, layer_name="lm_head")
+
+        fallback_cfg = CompressedTensorsConfig(
+            target_scheme_map={},
+            ignore=[],
+            quant_format="pack-quantized",
+            sparsity_scheme_map={},
+            sparsity_ignore_list=[],
+        )
+        fallback_cfg.get_linear_scheme = MagicMock(
+            side_effect=ValueError("Not targeted")
+        )
+        fallback_layer = ParallelLMHead.__new__(ParallelLMHead)
+
+        fallback_method = fallback_cfg.get_quant_method(
+            fallback_layer, prefix="lm_head"
+        )
+
+        self.assertIsNone(fallback_method)
+        self.assertFalse(hasattr(fallback_layer, "scheme"))
 
 
 if __name__ == "__main__":

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -2,14 +2,18 @@ import unittest
 from unittest.mock import MagicMock
 
 from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
+)
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="base-b-test-cpu")
 
 
-class TestQuantLogString(CustomTestCase):
+class TestQuantLogString(unittest.TestCase):
     def test_qwen_fp8_config(self):
         # Example from Qwen/Qwen3-4B-Thinking-2507-FP8
         quant_config = {
@@ -71,6 +75,23 @@ class TestQuantLogString(CustomTestCase):
         result = model_config.get_quantization_config_log_str()
         print(f"\n[Test No Quant] Result: {result}")
         self.assertIsNone(result)
+
+    def test_compressed_tensors_parallel_lm_head_dispatch(self):
+        cfg = CompressedTensorsConfig(
+            target_scheme_map={"lm_head": {"weights": None, "input_activations": None}},
+            ignore=[],
+            quant_format="pack-quantized",
+            sparsity_scheme_map={},
+            sparsity_ignore_list=[],
+        )
+        sentinel = object()
+        cfg.get_linear_scheme = lambda **_: sentinel
+        layer = ParallelLMHead.__new__(ParallelLMHead)
+
+        method = cfg.get_quant_method(layer, prefix="lm_head")
+
+        self.assertIsInstance(method, CompressedTensorsLinearMethod)
+        self.assertIs(layer.scheme, sentinel)
 
 
 if __name__ == "__main__":

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -8,12 +8,13 @@ from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import
 )
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="base-b-test-cpu")
 
 
-class TestQuantLogString(unittest.TestCase):
+class TestQuantLogString(CustomTestCase):
     def test_qwen_fp8_config(self):
         # Example from Qwen/Qwen3-4B-Thinking-2507-FP8
         quant_config = {


### PR DESCRIPTION
## Motivation

`CompressedTensorsConfig.get_quant_method()` currently dispatches `LinearBase` and `FusedMoE` only. `ParallelLMHead` is a `VocabParallelEmbedding` subclass, so a compressed-tensors checkpoint that targets `lm_head` falls through to `return None` and loads the packed head with `UnquantizedEmbeddingMethod`.

On a checkpoint with a pack-quantized `lm_head`, the server can load but generation becomes empty or garbage because the packed head is never routed to the existing compressed-tensors linear method. This ports the same gap fixed in vLLM [#37291](https://github.com/vllm-project/vllm/pull/37291).

## Modifications

- Add a `ParallelLMHead` branch in `CompressedTensorsConfig.get_quant_method()`.
- Reuse `get_linear_scheme(prefix)` and return `CompressedTensorsLinearMethod` when the prefix matches a compressed-tensors target.
- Treat `ValueError` from target matching as unquantized, so ignored or untargeted `lm_head` stays unchanged.
- Add one registered CPU test method to the existing `test_quant_config_parsing.py`.

## Accuracy Tests

A800-SXM4-80GB. The server E2E uses an isolated SGLang clone with `PYTHONPATH` pointing at the patched tree. The test checkpoint is TinyLlama with `tie_word_embeddings=false` and a genuinely pack-quantized `lm_head`, synthesized from real weights with compressed-tensors `quantize` and `pack_to_int32`, matching the llmcompressor packed format.

<details>
<summary>server E2E: quantized lm_head before and after</summary>

```bash
export PATH=/root/autodl-tmp/conda_envs/sglang/bin:$PATH
export PYTHONPATH=/root/autodl-tmp/code/sglang-A12/python
python -m sglang.launch_server \
  --model-path /root/autodl-tmp/models/tinyllama-w4a16-lmhead \
  --host 127.0.0.1 --port 31024 \
  --dtype float16 \
  --sampling-backend pytorch \
  --attention-backend triton \
  --disable-cuda-graph \
  --disable-piecewise-cuda-graph \
  --mem-fraction-static 0.6 \
  --max-running-requests 8

curl -s http://127.0.0.1:31024/generate \
  -H 'Content-Type: application/json' \
  -d '{"text":"The capital of France is","sampling_params":{"temperature":0,"max_new_tokens":14}}'

curl -s http://127.0.0.1:31024/generate \
  -H 'Content-Type: application/json' \
  -d '{"text":"Q: What is 2+2? A:","sampling_params":{"temperature":0,"max_new_tokens":14}}'
```

```text
before:
  "The capital of France is" -> ''
  "Q: What is 2+2? A:" -> ''

after:
  "The capital of France is" -> ' Paris. The capital of France is Paris. The capital of France is'
  "Q: What is 2+2? A:" -> ' 2+2 = 4\n\nA'
```

The same before/after also holds for a separate W4A16 group-128 `lm_head` config.
</details>

<details>
<summary>extended matrix</summary>

| checkpoint | scheme | after | before |
|---|---|---|---|
| TinyLlama | `lm_head` W4A16 channel | coherent, gold-token logprob about -1.0 | `''`, logprob about -10 |
| TinyLlama | `lm_head` W4A16 group-32 / 64 / 128 | coherent | `''` |
| TinyLlama | `lm_head` W8A16 channel | coherent, logprob -1.04 | `''`, logprob -10.37 |
| Qwen3-0.6B | `lm_head` W4A16 channel | logprob -1.34 | repeated `!`, logprob -11.93 |
| Qwen3-4B | `lm_head` W4A16 channel | coherent, logprob -0.65 | repeated `!`, logprob -11.93 |

No-regression control: an ordinary compressed-tensors TinyLlama checkpoint with `lm_head` in `ignore` produced identical output before and after the patch.

Target matching control: both exact `lm_head` and regex `re:.*lm_head.*` targets dispatch and generate correctly after the patch.
</details>

<details>
<summary>current-main unit before and after</summary>

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD/python \
  python -m pytest test/registered/quant/test_quant_config_parsing.py::TestQuantLogString::test_compressed_tensors_parallel_lm_head_dispatch -q
```

```text
upstream main 95867f093:
FAILED test_quant_config_parsing.py::TestQuantLogString::test_compressed_tensors_parallel_lm_head_dispatch
AssertionError: None is not an instance of CompressedTensorsLinearMethod

this patch:
1 passed, 24 warnings in 7.19s
```
</details>

## Speed Tests and Profiling

Not run. This is a correctness-only dispatch change; it only routes an `lm_head` that the checkpoint already marks as quantized to the existing `CompressedTensorsLinearMethod`.

## Checklist

- [x] Added one unit test method to an existing test file (`test_quant_config_parsing.py`).
- [x] Ran server E2E before and after on a quantized-`lm_head` checkpoint.
- [x] Ran changed-file formatting and lint checks (`black`, `isort`, `ruff`, `git diff --check`).
- [x] Ran the three SGLang local pre-commit CI scripts directly after `pre-commit` could not install one external hook environment from the configured PyPI mirror.




















## Motivation

`CompressedTensorsConfig.get_quant_method()` currently dispatches `LinearBase` and `FusedMoE` only. `ParallelLMHead` is a `VocabParallelEmbedding` subclass, so a compressed-tensors checkpoint that targets `lm_head` falls through to `return None` and loads the packed head with `UnquantizedEmbeddingMethod`.

On a checkpoint with a pack-quantized `lm_head`, the server can load but generation becomes empty or garbage because the packed head is never routed to the existing compressed-tensors linear method. This ports the same gap fixed in vLLM [#37291](https://github.com/vllm-project/vllm/pull/37291).

## Modifications

- Add a `ParallelLMHead` branch in `CompressedTensorsConfig.get_quant_method()`.
- Reuse `get_linear_scheme(prefix)` and return `CompressedTensorsLinearMethod` when the prefix matches a compressed-tensors target.
- Treat `ValueError` from target matching as unquantized, so ignored or untargeted `lm_head` stays unchanged.
- Add one registered CPU test method to the existing `test_quant_config_parsing.py`.

## Accuracy Tests

A800-SXM4-80GB. The server E2E uses an isolated SGLang clone with `PYTHONPATH` pointing at the patched tree. The test checkpoint is TinyLlama with `tie_word_embeddings=false` and a genuinely pack-quantized `lm_head`, synthesized from real weights with compressed-tensors `quantize` and `pack_to_int32`, matching the llmcompressor packed format.

<details>
<summary>server E2E: quantized lm_head before and after</summary>

```bash
export PATH=/root/autodl-tmp/conda_envs/sglang/bin:$PATH
export PYTHONPATH=/root/autodl-tmp/code/sglang-A12/python
python -m sglang.launch_server \
  --model-path /root/autodl-tmp/models/tinyllama-w4a16-lmhead \
  --host 127.0.0.1 --port 31024 \
  --dtype float16 \
  --sampling-backend pytorch \
  --attention-backend triton \
  --disable-cuda-graph \
  --disable-piecewise-cuda-graph \
  --mem-fraction-static 0.6 \
  --max-running-requests 8

curl -s http://127.0.0.1:31024/generate \
  -H 'Content-Type: application/json' \
  -d '{"text":"The capital of France is","sampling_params":{"temperature":0,"max_new_tokens":14}}'

curl -s http://127.0.0.1:31024/generate \
  -H 'Content-Type: application/json' \
  -d '{"text":"Q: What is 2+2? A:","sampling_params":{"temperature":0,"max_new_tokens":14}}'
```

```text
before:
  "The capital of France is" -> ''
  "Q: What is 2+2? A:" -> ''

after:
  "The capital of France is" -> ' Paris. The capital of France is Paris. The capital of France is'
  "Q: What is 2+2? A:" -> ' 2+2 = 4\n\nA'
```

The same before/after also holds for a separate W4A16 group-128 `lm_head` config.
</details>

<details>
<summary>extended matrix</summary>

| checkpoint | scheme | after | before |
|---|---|---|---|
| TinyLlama | `lm_head` W4A16 channel | coherent, gold-token logprob about -1.0 | `''`, logprob about -10 |
| TinyLlama | `lm_head` W4A16 group-32 / 64 / 128 | coherent | `''` |
| TinyLlama | `lm_head` W8A16 channel | coherent, logprob -1.04 | `''`, logprob -10.37 |
| Qwen3-0.6B | `lm_head` W4A16 channel | logprob -1.34 | repeated `!`, logprob -11.93 |
| Qwen3-4B | `lm_head` W4A16 channel | coherent, logprob -0.65 | repeated `!`, logprob -11.93 |

No-regression control: an ordinary compressed-tensors TinyLlama checkpoint with `lm_head` in `ignore` produced identical output before and after the patch.

Target matching control: both exact `lm_head` and regex `re:.*lm_head.*` targets dispatch and generate correctly after the patch.
</details>

<details>
<summary>current-main unit before and after</summary>

```bash
CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD/python \
  python -m pytest test/registered/quant/test_quant_config_parsing.py::TestQuantLogString::test_compressed_tensors_parallel_lm_head_dispatch -q
```

```text
upstream main 95867f093:
FAILED test_quant_config_parsing.py::TestQuantLogString::test_compressed_tensors_parallel_lm_head_dispatch
AssertionError: None is not an instance of CompressedTensorsLinearMethod

this patch:
1 passed, 24 warnings in 7.19s
```
</details>

## Speed Tests and Profiling

Not run. This is a correctness-only dispatch change; it only routes an `lm_head` that the checkpoint already marks as quantized to the existing `CompressedTensorsLinearMethod`.

## Checklist

- [x] Added one unit test method to an existing test file (`test_quant_config_parsing.py`).
- [x] Ran server E2E before and after on a quantized-`lm_head` checkpoint.
- [x] Ran changed-file formatting and lint checks (`black`, `isort`, `ruff`, `git diff --check`).
- [x] Ran the three SGLang local pre-commit CI scripts directly after `pre-commit` could not install one external hook environment from the configured PyPI mirror.
























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28189998004](https://github.com/sgl-project/sglang/actions/runs/28189998004)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28189998048](https://github.com/sgl-project/sglang/actions/runs/28189998048)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->