### PR TITLE
fix(multimodal): return 400 for corrupt image inputs

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -917,6 +917,8 @@ class BaseMultimodalProcessor(ABC):
         for modality, idx, future in futures:
             try:
                 result = await asyncio.wrap_future(future)
+            except ValueError:
+                raise
             except Exception as e:
                 logger.exception(
                     "[load_mm_data(simple)] error loading %s data at index=%d",
@@ -1058,6 +1060,8 @@ class BaseMultimodalProcessor(ABC):
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"
                 )
+            except ValueError:
+                raise
             except Exception as e:
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -946,7 +946,13 @@ def _load_image(
             logger.warning(
                 f"Failed to decode JPEG on GPU, falling back to CPU. Error: {e}"
             )
-    return Image.open(BytesIO(image_bytes))
+    try:
+        image = Image.open(BytesIO(image_bytes))
+        # Force decode so corrupt/truncated bytes fail here as a client error
+        image.load()
+        return image
+    except (OSError, SyntaxError, Image.UnidentifiedImageError) as e:
+        raise ValueError(f"Failed to load image: {e}") from e
 
 
 def load_image(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -951,7 +951,7 @@ def _load_image(
         # Force decode so corrupt/truncated bytes fail here as a client error
         image.load()
         return image
-    except (OSError, SyntaxError, Image.UnidentifiedImageError) as e:
+    except (OSError, SyntaxError) as e:
         raise ValueError(f"Failed to load image: {e}") from e
 
 

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -1,16 +1,20 @@
+import io
 import unittest
 from array import array
 
 import torch
+from PIL import Image
 
 from sglang.srt.utils.common import (
+    _load_image,
     flatten_arrays_to_int64_tensor,
     get_device_sm_nvidia_smi,
     get_nvidia_driver_version_str,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
 
 
@@ -141,6 +145,34 @@ class TestGetDeviceSmNvidiaSmi(CustomTestCase):
             self.assertEqual(get_device_sm_nvidia_smi(), (0, 0))
         finally:
             subprocess.run = original
+
+
+class TestLoadImage(CustomTestCase):
+    def test_corrupt_image_bytes_raise_value_error(self):
+        buf = io.BytesIO()
+        Image.new("RGB", (16, 16), (10, 120, 200)).save(buf, format="PNG")
+        valid_png = buf.getvalue()
+
+        broken_chunk_png = bytearray(valid_png)
+        idat_pos = broken_chunk_png.index(b"IDAT")
+        broken_chunk_png[idat_pos - 1] -= 6
+
+        img = _load_image(image_bytes=valid_png, gpu_image_decode=False)
+        self.assertEqual(img.size, (16, 16))
+
+        cases = [
+            b"not an image",
+            b"",
+            valid_png[: len(valid_png) // 2],
+            bytes(broken_chunk_png),
+        ]
+        for image_bytes in cases:
+            with self.subTest(length=len(image_bytes)):
+                with self.assertRaisesRegex(ValueError, "Failed to load image"):
+                    _load_image(
+                        image_bytes=image_bytes,
+                        gpu_image_decode=False,
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Corrupt, truncated, or non-image bytes in an OpenAI-compatible VLM request are client input errors, but the CPU PIL fallback currently can surface them as HTTP 500. `_load_image` returns a lazy `Image.open(...)` result without forcing decode or translating PIL decode failures; when that failure reaches the multimodal loader, the fast and legacy paths wrap it as `RuntimeError`, which serving treats as internal.

SGLang #27451 already keeps malformed base64 as a 400 in `_load_single_item`; this patch closes the remaining corrupt image-byte path. It also complements #26995: that PR proposes eager decode for throughput, but it does not translate PIL decode errors into `ValueError` or preserve them through the fast and legacy aggregation paths. The behavior matches vllm-project/vllm#38253.

## Modifications

- `python/sglang/srt/utils/common.py`: force `image.load()` in `_load_image`, then translate `OSError` / `SyntaxError` / `PIL.UnidentifiedImageError` into `ValueError("Failed to load image: ...")`.
- `python/sglang/srt/multimodal/processors/base_processor.py`: let `ValueError` propagate through `fast_load_mm_data` and `legacy_load_mm_data` before the generic `Exception -> RuntimeError` wrapping.
- `test/registered/unit/utils/test_common.py`: add one CPU-registered test method that covers valid, garbage, empty, truncated-PNG, and broken-PNG-chunk inputs.

Serving already maps `ValueError` to 400. The forced decode does not add a new happy-path decode; valid images are decoded by preprocessing anyway, and this just moves the failure point before the heavier path runs.

## Testing

Real server E2E on A800-80GB with `Qwen2.5-VL-3B-Instruct`, baseline without the fix vs fixed:

| input | baseline | fixed |
|---|---|---|
| valid PNG, valid JPEG, two valid images | 200 | 200 |
| non-image bytes | 500 | 400 `Failed to load image: cannot identify image file` |
| truncated PNG | 500 | 400 `Failed to load image: image file is truncated` |
| truncated JPEG | 500 | 400 `Failed to load image: Truncated File Read` |
| garbage bytes | 500 | 400 |
| two images, one corrupt | 500 | 400 |
| 12 concurrent, 6 valid and 6 corrupt | 6x200 + 6x500 | 6x200 + 6x400 |

Valid requests are unaffected, and `/health` stays 200 after the corrupt-input burst. The same matrix was also reproduced across six processor families covering both loader paths: `Qwen2.5-VL-3B`, `InternVL2-1B`, `Gemma-3-4B`, `GLM-4.1V-9B`, `Pixtral-12B` on the fast path and `MiniCPM-V-2_6` on the legacy path.

The GPU nvJPEG fast path stays correct. A truncated JPEG without the trailing marker does not enter `decode_jpeg`; a marker-valid but corrupt JPEG makes `decode_jpeg` raise, falls back to the CPU path, and returns 400 after this fix.

Current `upstream/main` branch checks:

- `CUDA_VISIBLE_DEVICES=9 python -m pytest test/registered/unit/utils/test_common.py::TestLoadImage::test_corrupt_image_bytes_raise_value_error -q`: 1 passed, 4 subtests passed.
- `CUDA_VISIBLE_DEVICES=9 python -m pytest test/registered/unit/utils/test_common.py -q`: 1 passed, 2 skipped, 4 subtests passed.
- `pre-commit run --files python/sglang/srt/multimodal/processors/base_processor.py python/sglang/srt/utils/common.py test/registered/unit/utils/test_common.py`: passed.
- `python -m py_compile python/sglang/srt/utils/common.py python/sglang/srt/multimodal/processors/base_processor.py test/registered/unit/utils/test_common.py`: passed.
- `git diff --check`: passed.

<details><summary>repro command and client</summary>

```bash
python -m sglang.launch_server --model-path Qwen/Qwen2.5-VL-3B-Instruct \
  --port 30000 --trust-remote-code \
  --sampling-backend pytorch --attention-backend triton \
  --disable-cuda-graph --mem-fraction-static 0.7 --dtype bfloat16

# base64("not an image") = bm90IGFuIGltYWdl
curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST \
  http://127.0.0.1:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"x","messages":[{"role":"user","content":[
        {"type":"text","text":"describe"},
        {"type":"image_url","image_url":{"url":"data:image/jpeg;base64,bm90IGFuIGltYWdl"}}]}],
       "max_tokens":4}'
```

The server E2E above was run in the release-pinned validation environment (`sglang==0.5.12.post1`) before adapting the same fix onto current `upstream/main`. The current-main branch passes the focused unit and pre-commit checks listed above.
</details>

## Checklist

- [x] Format the code according to the format/pre-commit checks.
- [x] Add unit tests according to the unit-test guidance.
- [x] Follow the SGLang code style guidance.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35595795353](https://github.com/sgl-project/sglang/actions/runs/35595795353)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35595795132](https://github.com/sgl-project/sglang/actions/runs/35595795132)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35595795451](https://github.com/sgl-project/sglang/actions/runs/35595795451)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->