### PR TITLE
fix(quant): support block FP8 strategy for CompressedTensorsW8A16Fp8

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -451,6 +451,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         is_per_tensor_or_channel_weight = weight_quant.strategy in [
             QuantizationStrategy.TENSOR,
             QuantizationStrategy.CHANNEL,
+            QuantizationStrategy.BLOCK,
         ]
         if not (
             is_symmetric_weight
@@ -593,6 +594,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                     return CompressedTensorsW8A16Fp8(
                         strategy=weight_quant.strategy,
                         is_static_input_scheme=not input_quant.dynamic,
+                        weight_block_size=weight_quant.block_structure,
                     )
 
             # note: input_quant can be None
@@ -601,6 +603,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return CompressedTensorsW8A16Fp8(
                     strategy=weight_quant.strategy,
                     is_static_input_scheme=is_static_input_scheme,
+                    weight_block_size=weight_quant.block_structure,
                 )
 
             if self._is_static_tensor_w8a8(weight_quant, input_quant):
@@ -715,7 +718,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return NPUCompressedTensorsW8A8Int8DynamicMoE(weight_quant, input_quant)
             else:
                 raise NotImplementedError(
-                    f"The W8A8Int8 Fused MoE scheme is implemented only for NPU for now."
+                    "The W8A8Int8 Fused MoE scheme is implemented only for NPU for now."
                 )
         elif self._is_dynamic_token_w4a8(weight_quant, input_quant):
             if _is_npu:
@@ -723,7 +726,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return NPUCompressedTensorsW4A8Int8DynamicMoE(self)
             else:
                 raise NotImplementedError(
-                    f"The W4A8Int8 Fused MoE scheme is implemented only for NPU for now."
+                    "The W4A8Int8 Fused MoE scheme is implemented only for NPU for now."
                 )
         else:
             raise RuntimeError(

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -8,6 +8,7 @@ import torch
 from compressed_tensors.quantization import QuantizationStrategy
 
 from sglang.srt.layers.parameter import (
+    BlockQuantScaleParameter,
     ChannelQuantScaleParameter,
     ModelWeightParameter,
     PerTensorScaleParameter,
@@ -23,13 +24,23 @@ from sglang.srt.layers.quantization.utils import convert_to_channelwise
 
 __all__ = ["CompressedTensorsW8A16Fp8"]
 
-SUPPORTED_STRATEGIES = [QuantizationStrategy.CHANNEL, QuantizationStrategy.TENSOR]
+SUPPORTED_STRATEGIES = [
+    QuantizationStrategy.CHANNEL,
+    QuantizationStrategy.TENSOR,
+    QuantizationStrategy.BLOCK,
+]
 
 
 class CompressedTensorsW8A16Fp8(CompressedTensorsLinearScheme):
-    def __init__(self, strategy: str, is_static_input_scheme: bool):
+    def __init__(
+        self,
+        strategy: str,
+        is_static_input_scheme: bool,
+        weight_block_size: Optional[List[int]] = None,
+    ):
         self.strategy = strategy
         self.is_static_input_scheme = is_static_input_scheme
+        self.weight_block_size = weight_block_size
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -40,6 +51,22 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsLinearScheme):
     # So if we have a fused module (QKV, MLP) with per tensor scales,
     # we expand each scale to its shard's channels.
     def process_weights_after_loading(self, layer) -> None:
+        if self.strategy == QuantizationStrategy.BLOCK:
+            # compressed-tensors stores block scales as "weight_scale", while
+            # the Marlin FP8 block path reads "weight_scale_inv". Rename it and
+            # leave the weight in [output, input] layout (size_k_first=False),
+            # mirroring the Fp8 block-quant path.
+            assert not self.is_static_input_scheme
+            layer.weight = torch.nn.Parameter(layer.weight.data, requires_grad=False)
+            weight_scale = layer.weight_scale.data
+            del layer._parameters["weight_scale"]
+            layer.register_parameter(
+                "weight_scale_inv",
+                torch.nn.Parameter(weight_scale, requires_grad=False),
+            )
+            prepare_fp8_layer_for_marlin(layer, size_k_first=False)
+            return
+
         if self.strategy == QuantizationStrategy.TENSOR:
             ws_channelwise = convert_to_channelwise(
                 layer.weight_scale, layer.logical_widths
@@ -76,6 +103,11 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsLinearScheme):
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
         layer.orig_dtype = params_dtype
+        layer.weight_block_size = (
+            self.weight_block_size
+            if self.strategy == QuantizationStrategy.BLOCK
+            else None
+        )
 
         # WEIGHT
         weight = ModelWeightParameter(
@@ -100,6 +132,28 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsLinearScheme):
         elif self.strategy == QuantizationStrategy.TENSOR:
             weight_scale = PerTensorScaleParameter(
                 data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+                weight_loader=weight_loader,
+            )
+        elif self.strategy == QuantizationStrategy.BLOCK:
+            assert self.weight_block_size is not None
+            block_n, block_k = self.weight_block_size
+            for output_partition_size in output_partition_sizes:
+                assert output_partition_size % block_n == 0, (
+                    f"output_partition_size={output_partition_size} is not "
+                    f"divisible by block_n={block_n}"
+                )
+            assert input_size_per_partition % block_k == 0, (
+                f"input_size_per_partition={input_size_per_partition} is not "
+                f"divisible by block_k={block_k}"
+            )
+            weight_scale = BlockQuantScaleParameter(
+                data=torch.empty(
+                    (output_size_per_partition + block_n - 1) // block_n,
+                    (input_size_per_partition + block_k - 1) // block_k,
+                    dtype=torch.float32,
+                ),
+                input_dim=1,
+                output_dim=0,
                 weight_loader=weight_loader,
             )
         else:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -56,7 +56,10 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsLinearScheme):
             # the Marlin FP8 block path reads "weight_scale_inv". Rename it and
             # leave the weight in [output, input] layout (size_k_first=False),
             # mirroring the Fp8 block-quant path.
-            assert not self.is_static_input_scheme
+            if self.is_static_input_scheme:
+                layer.input_scale = torch.nn.Parameter(
+                    layer.input_scale.data, requires_grad=False
+                )
             layer.weight = torch.nn.Parameter(layer.weight.data, requires_grad=False)
             weight_scale = layer.weight_scale.data
             del layer._parameters["weight_scale"]

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from compressed_tensors.quantization import QuantizationStrategy
@@ -42,6 +42,29 @@ class TestCompressedTensorsW8A16Fp8(CustomTestCase):
         self.assertIsInstance(layer.weight_scale, BlockQuantScaleParameter)
         self.assertEqual(tuple(layer.weight_scale.shape), (16, 8))
         self.assertEqual(layer.weight.dtype, torch.float8_e4m3fn)
+
+        static_block_scheme = CompressedTensorsW8A16Fp8(
+            strategy=QuantizationStrategy.BLOCK,
+            is_static_input_scheme=True,
+            weight_block_size=[128, 128],
+        )
+        static_layer = torch.nn.Module()
+        static_block_scheme.create_weights(
+            layer=static_layer,
+            input_size=1024,
+            output_partition_sizes=[2048],
+            input_size_per_partition=1024,
+            params_dtype=torch.bfloat16,
+            weight_loader=noop_loader,
+        )
+        with patch(
+            "sglang.srt.layers.quantization.compressed_tensors.schemes."
+            "compressed_tensors_w8a16_fp8.prepare_fp8_layer_for_marlin"
+        ):
+            static_block_scheme.process_weights_after_loading(static_layer)
+
+        self.assertIsInstance(static_layer.input_scale, torch.nn.Parameter)
+        self.assertTrue(hasattr(static_layer, "weight_scale_inv"))
 
         channel_scheme = CompressedTensorsW8A16Fp8(
             strategy=QuantizationStrategy.CHANNEL,

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -1,12 +1,63 @@
 import unittest
 from unittest.mock import MagicMock
 
+import torch
+from compressed_tensors.quantization import QuantizationStrategy
+
 from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.layers.parameter import BlockQuantScaleParameter
+from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a16_fp8 import (
+    SUPPORTED_STRATEGIES,
+    CompressedTensorsW8A16Fp8,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="base-b-test-cpu")
+
+
+class TestCompressedTensorsW8A16Fp8(CustomTestCase):
+    def test_block_strategy_registers_block_scale(self):
+        def noop_loader(*args, **kwargs):
+            pass
+
+        block_scheme = CompressedTensorsW8A16Fp8(
+            strategy=QuantizationStrategy.BLOCK,
+            is_static_input_scheme=False,
+            weight_block_size=[128, 128],
+        )
+        layer = torch.nn.Module()
+        block_scheme.create_weights(
+            layer=layer,
+            input_size=1024,
+            output_partition_sizes=[2048],
+            input_size_per_partition=1024,
+            params_dtype=torch.bfloat16,
+            weight_loader=noop_loader,
+        )
+
+        self.assertIn(QuantizationStrategy.BLOCK, SUPPORTED_STRATEGIES)
+        self.assertEqual(layer.weight_block_size, [128, 128])
+        self.assertIsInstance(layer.weight_scale, BlockQuantScaleParameter)
+        self.assertEqual(tuple(layer.weight_scale.shape), (16, 8))
+        self.assertEqual(layer.weight.dtype, torch.float8_e4m3fn)
+
+        channel_scheme = CompressedTensorsW8A16Fp8(
+            strategy=QuantizationStrategy.CHANNEL,
+            is_static_input_scheme=False,
+        )
+        channel_layer = torch.nn.Module()
+        channel_scheme.create_weights(
+            layer=channel_layer,
+            input_size=1024,
+            output_partition_sizes=[2048],
+            input_size_per_partition=1024,
+            params_dtype=torch.bfloat16,
+            weight_loader=noop_loader,
+        )
+
+        self.assertIsNone(channel_layer.weight_block_size)
 
 
 class TestQuantLogString(CustomTestCase):


### PR DESCRIPTION

## Motivation

`CompressedTensorsW8A16Fp8` only accepts the `per-tensor` and `per-channel` weight strategies. Block-quantized FP8 compressed-tensors checkpoints such as `RedHatAI/Qwen3-0.6B-FP8-BLOCK` fail to load on GPUs without native FP8 support because the W8A8 FP8 path falls back to the W8A16 Marlin path, which rejects `strategy=block`.

SGLang already has the Marlin block-scale machinery: `prepare_fp8_layer_for_marlin` handles `weight_block_size` / `weight_scale_inv` and block-to-group scale expansion. This PR wires `CompressedTensorsW8A16Fp8` into that path.

Before this change, the real engine load fails at weight creation:

```
ValueError: Unsupported weight strategy=block, supported strategies are
[<QuantizationStrategy.CHANNEL: 'channel'>, <QuantizationStrategy.TENSOR: 'tensor'>]
```

This is the same compatibility gap vLLM closed in vllm-project/vllm#33280.

## Modifications

- Accept `QuantizationStrategy.BLOCK` in `CompressedTensorsW8A16Fp8`.
- Thread `weight_quant.block_structure` into W8A16 FP8 scheme construction.
- Register block scales as `BlockQuantScaleParameter` with shape `(ceil(out / block_n), ceil(in / block_k))`, and validate partition divisibility.
- For block strategy, keep weight layout as `[output, input]`, rename `weight_scale` to `weight_scale_inv`, and call `prepare_fp8_layer_for_marlin(..., size_k_first=False)`.
- Keep tensor and channel strategy behavior unchanged.
- Remove two stale f-string prefixes in the touched `compressed_tensors.py` file so scoped `ruff` is clean.

## Accuracy Tests

Validated on a single A800-SXM4-80GB (SM80, no native FP8) with `RedHatAI/Qwen3-0.6B-FP8-BLOCK`.

Before this change:

```text
ValueError: Unsupported weight strategy=block, supported strategies are [<QuantizationStrategy.CHANNEL: 'channel'>, <QuantizationStrategy.TENSOR: 'tensor'>]
```

After this change:

```text
GEN_OK:  Paris. The capital of France is also [12095, 13, 576, 6722, 315, 9625, 374, 1083]
```

<details><summary>repro script and output</summary>

```python
import multiprocessing

import sglang


def main():
    eng = None
    try:
        eng = sglang.Engine(
            model_path="RedHatAI/Qwen3-0.6B-FP8-BLOCK",
            attention_backend="triton",
            disable_cuda_graph=True,
            mem_fraction_static=0.05,
        )
    except Exception as e:
        print("ENGINE_INIT_EXC:", type(e).__name__, repr(str(e))[:1500], flush=True)
        raise
    print("=== ENGINE UP ===", flush=True)
    try:
        out = eng.generate(
            ["The capital of France is"],
            {"temperature": 0, "max_new_tokens": 8},
        )
        print("GEN_OK:", out[0]["text"], out[0]["output_ids"], flush=True)
    finally:
        if eng:
            eng.shutdown()


if __name__ == "__main__":
    multiprocessing.freeze_support()
    main()
```

Baseline output:

```text
ENGINE_INIT_EXC: ValueError "Unsupported weight strategy=block, supported strategies are [<QuantizationStrategy.CHANNEL: 'channel'>, <QuantizationStrategy.TENSOR: 'tensor'>]"
```

Fixed output:

```text
=== ENGINE UP ===
GEN_OK:  Paris. The capital of France is also [12095, 13, 576, 6722, 315, 9625, 374, 1083]
```

Local rerun note: the shared A800 env had `sglang-kernel==0.4.2.post2`, so I used `SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK=1` for the rerun. This only bypasses the local version gate; the failing and fixed paths above both execute the real SGLang engine and model loader.

</details>

Added one focused CPU unit test in the existing `test/registered/quant/test_quant_config_parsing.py`: block strategy is supported, `create_weights` registers a `BlockQuantScaleParameter` of the expected `(16, 8)` shape for a `2048x1024` weight with `[128, 128]` blocks, and the channel path leaves `weight_block_size` unset.

```text
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD/python python -m pytest test/registered/quant/test_quant_config_parsing.py::TestCompressedTensorsW8A16Fp8::test_block_strategy_registers_block_scale -q
1 passed

CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD/python python -m pytest test/registered/quant/test_quant_config_parsing.py -q
6 passed

CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD/python python -m ruff check python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py test/registered/quant/test_quant_config_parsing.py
All checks passed!

CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD/python python -m black --check python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py test/registered/quant/test_quant_config_parsing.py
3 files would be left unchanged.

CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD/python python -m isort --check-only python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py test/registered/quant/test_quant_config_parsing.py
```

## Speed Tests and Profiling

Not applicable. This only changes weight creation and post-load processing for the block strategy; it reuses the existing Marlin FP8 forward path.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests.
- [x] Update documentation / docstrings as needed.
- [x] Follow the SGLang code style guidance.

cc @Fridge003 @BBuf















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27461209627](https://github.com/sgl-project/sglang/actions/runs/27461209627)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27461209553](https://github.com/sgl-project/sglang/actions/runs/27461209553)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->