### PR TITLE
[Core] Reduce RoPE cache size for shorter context length

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/factory.py
+++ b/python/sglang/srt/layers/rotary_embedding/factory.py
@@ -60,6 +60,27 @@ if _use_aiter:
 _ROPE_DICT: Dict[Tuple, RotaryEmbedding] = {}
 
 
+def _get_runtime_model_config():
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        server_args = get_global_server_args()
+    except ValueError:
+        return None
+
+    model_config = getattr(server_args, "model_config", None)
+    if model_config is None:
+        get_model_config = getattr(server_args, "get_model_config", None)
+        if get_model_config is None:
+            return None
+        try:
+            model_config = get_model_config()
+        except Exception:
+            return None
+
+    return model_config
+
+
 def get_rope(
     head_size: int,
     rotary_dim: int,
@@ -93,6 +114,40 @@ def get_rope(
 
     if partial_rotary_factor < 1.0:
         rotary_dim = int(rotary_dim * partial_rotary_factor)
+
+    max_position_before_clamp = max_position
+    if dual_chunk_attention_config is not None:
+        scaling_type = "default"
+    elif rope_scaling is None:
+        scaling_type = "default"
+    elif "rope_type" in rope_scaling:
+        scaling_type = rope_scaling["rope_type"]
+    elif "type" in rope_scaling:
+        scaling_type = rope_scaling["type"]
+    else:
+        raise ValueError(f"Unknown RoPE scaling type, rope_scaling is {rope_scaling}")
+
+    runtime_model_config = _get_runtime_model_config()
+    runtime_context_len = (
+        int(runtime_model_config.context_len)
+        if runtime_model_config is not None
+        and getattr(runtime_model_config, "context_len", None) is not None
+        else None
+    )
+    is_multimodal_model = bool(getattr(runtime_model_config, "is_multimodal", False))
+    rope_scaling_dict = rope_scaling or {}
+    can_clamp_max_position = scaling_type in ("default", "llama3", "proportional")
+    if (
+        runtime_context_len is not None
+        and dual_chunk_attention_config is None
+        and can_clamp_max_position
+        and not (is_multimodal_model and rope_scaling is None)
+        and "mrope_section" not in rope_scaling_dict
+        and not rope_scaling_dict.get("use_fope", False)
+        and max_position > runtime_context_len
+    ):
+        max_position = runtime_context_len
+
     key = (
         head_size,
         rotary_dim,
@@ -126,15 +181,6 @@ def get_rope(
             head_size, rotary_dim, max_position, base, is_neox_style, dtype
         )
     else:
-        if "rope_type" in rope_scaling:
-            scaling_type = rope_scaling["rope_type"]
-        elif "type" in rope_scaling:
-            scaling_type = rope_scaling["type"]
-        else:
-            raise ValueError(
-                f"Unknown RoPE scaling type, rope_scaling is {rope_scaling}"
-            )
-
         if scaling_type == "llama3":
             scaling_factor = _get_rope_param(rope_scaling, "factor", 1.0, scaling_type)
             low_freq_factor = _get_rope_param(
@@ -146,7 +192,7 @@ def get_rope(
             original_max_position = _get_rope_param(
                 rope_scaling,
                 "original_max_position_embeddings",
-                max_position,
+                max_position_before_clamp,
                 scaling_type,
             )
             rotary_emb = Llama3RotaryEmbedding(
@@ -236,7 +282,7 @@ def get_rope(
             original_max_position = _get_rope_param(
                 rope_scaling,
                 "original_max_position_embeddings",
-                max_position,
+                max_position_before_clamp,
                 scaling_type,
             )
             extra_kwargs = {
@@ -275,7 +321,7 @@ def get_rope(
             original_max_position = _get_rope_param(
                 rope_scaling,
                 "original_max_position_embeddings",
-                max_position,
+                max_position_before_clamp,
                 scaling_type,
             )
             extra_kwargs = {
@@ -307,7 +353,7 @@ def get_rope(
             original_max_position = _get_rope_param(
                 rope_scaling,
                 "original_max_position_embeddings",
-                max_position,
+                max_position_before_clamp,
                 scaling_type,
             )
             extra_kwargs = {
@@ -364,6 +410,7 @@ def get_rope_cpu(
         rope_scaling_args = None
     if partial_rotary_factor < 1.0:
         rotary_dim = int(rotary_dim * partial_rotary_factor)
+    max_position_before_clamp = max_position
     key = (
         head_size,
         rotary_dim,
@@ -384,7 +431,10 @@ def get_rope_cpu(
 
     scaling_factor = _get_rope_param(rope_scaling, "factor", 1.0, scaling_type)
     original_max_position = _get_rope_param(
-        rope_scaling, "original_max_position_embeddings", max_position, scaling_type
+        rope_scaling,
+        "original_max_position_embeddings",
+        max_position_before_clamp,
+        scaling_type,
     )
     extra_kwargs = {
         k: v


### PR DESCRIPTION
## Motivation

Some models define very large `max_position_embeddings`, but users often serve
them with a smaller `--context-length`. In those cases, `get_rope()` still builds
cos/sin caches for the full model config length, which increases model
initialization memory usage without benefiting the configured runtime context.

## Changes

- Clamp selected RoPE cache construction to runtime `model_config.context_len`
  when it is smaller than `max_position`.
- Apply the optimization only to RoPE variants whose cache can be safely
  truncated and later expanded:
  - `default`
  - `llama3`
  - `proportional`
- Skip cases that need full/custom position cache behavior:
  - multimodal models with `rope_scaling is None`
  - mRoPE
  - FOPE
  - dual chunk attention
  - other RoPE scaling variants such as dynamic/yarn/deepseek/longrope

## Validation

Ran a remote config smoke test locally:
[test_sgalng_remote_rope_configs.py](https://github.com/user-attachments/files/28909578/test_sgalng_remote_rope_configs.py)


```bash
python test_sgalng_remote_rope_configs.py --context-len 32768 --dtype bfloat16
```
### RoPE cache memory summary

| Model | Case | RoPE | Cache len | Memory MiB | Saved | Prefix |
|---|---|---|---:|---:|---:|---|
| Qwen/Qwen3-4B-Instruct-2507 | text | default | 262,144 -> 32,768 | 64.00 -> 8.00 | 56.00 (87.5%) | PASS |
| LLM-Research/Llama-4-Scout-17B-16E-Instruct | text | llama3 | 10,485,760 -> 32,768 | 2560.00 -> 8.00 | 2552.00 (99.7%) | PASS |
| ZhipuAI/GLM-5.1 | text | default | 202,752 -> 32,768 | 24.75 -> 4.00 | 20.75 (83.8%) | PASS |
| XiaomiMiMo/MiMo-V2.5 | text | default | 1,048,576 -> 32,768 | 128.00 -> 4.00 | 124.00 (96.9%) | PASS |
| MiniMax/MiniMax-M2.7 | text | default | 204,800 -> 32,768 | 50.00 -> 8.00 | 42.00 (84.0%) | PASS |
| google/gemma-4-31B-it | text-sliding_attention | default | 262,144 -> 32,768 | 128.00 -> 16.00 | 112.00 (87.5%) | PASS |
| google/gemma-4-31B-it | text-full_attention | proportional | 262,144 -> 32,768 | 256.00 -> 32.00 | 224.00 (87.5%) | PASS |
| **Total** | - | - | - | 3210.75 -> 80.00 | 3130.75 (97.5%) | - |


Summary:

- Total RoPE cache memory: `3210.75 MiB -> 80.00 MiB`
- Saved: `3130.75 MiB (97.5%)`
- Prefix comparison: all tested cases `PASS`

Also verified that cache expansion via `_ensure_cos_sin_cache_length()` matches
direct full-cache construction for `default`, `llama3`, and `proportional`.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27461850431](https://github.com/sgl-project/sglang/actions/runs/27461850431)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27461850376](https://github.com/sgl-project/sglang/actions/runs/27461850376)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->