### PR TITLE
[Kernel] Add SM120/SM121 dispatch for int8_scaled_mm

### DIFF
--- a/python/sglang/kernels/aot/csrc/gemm/int8_gemm_kernel.cu
+++ b/python/sglang/kernels/aot/csrc/gemm/int8_gemm_kernel.cu
@@ -739,6 +739,14 @@ torch::Tensor int8_scaled_mm(
           out, mat_a, mat_b, scales_a, scales_b, bias);
     }
 #endif
+  } else if (sm_version == 120 || sm_version == 121) {
+    if (out_dtype == torch::kBFloat16) {
+      sm89_dispatch_shape<cutlass::bfloat16_t, cutlass::arch::Sm80, cutlass::gemm::GemmShape<16, 8, 32>>(
+          out, mat_a, mat_b, scales_a, scales_b, bias);
+    } else {
+      sm89_dispatch_shape<cutlass::half_t, cutlass::arch::Sm80, cutlass::gemm::GemmShape<16, 8, 32>>(
+          out, mat_a, mat_b, scales_a, scales_b, bias);
+    }
   } else {
     TORCH_CHECK_NOT_IMPLEMENTED(false, "No implemented int8_scaled_mm for current compute capability.");
   }

--- a/python/sglang/kernels/aot/tests/test_int8_gemm.py
+++ b/python/sglang/kernels/aot/tests/test_int8_gemm.py
@@ -3,7 +3,11 @@ import sys
 import pytest
 import torch
 from sgl_kernel import int8_scaled_mm
-from utils import is_sm10x
+
+
+def _int8_unsupported() -> bool:
+    cap = torch.cuda.get_device_capability()
+    return not ((7, 5) <= cap <= (9, 0) or (12, 0) <= cap <= (12, 1))
 
 
 def to_int8(tensor: torch.Tensor) -> torch.Tensor:
@@ -34,8 +38,8 @@ def _test_accuracy_once(M, N, K, with_bias, out_dtype, device):
 
 
 @pytest.mark.skipif(
-    is_sm10x(),
-    reason="int8_scaled_mm is only supported on sm90 and lower",
+    _int8_unsupported(),
+    reason="int8_scaled_mm supports SM75-SM90 and SM120-SM121",
 )
 @pytest.mark.parametrize("M", [1, 16, 32, 64, 128, 512, 1024, 4096, 8192])
 @pytest.mark.parametrize("N", [16, 128, 512, 1024, 4096, 8192, 16384])


### PR DESCRIPTION
## Motivation

`int8_scaled_mm` supports SM75-SM90 and otherwise falls through to `TORCH_CHECK_NOT_IMPLEMENTED`. Production W8A8 linear callers still reach this registered operation on consumer Blackwell, so SM120 currently aborts instead of producing the layer output.

## Modifications

Route exact SM120/SM121 devices through the existing SM89-compatible tiling (`cutlass::arch::Sm80`, `GemmShape<16, 8, 32>`) for both FP16 and BF16 outputs. Existing SM75-SM90 behavior is unchanged, and unsupported architectures still fail explicitly.

Update `python/sglang/kernels/aot/tests/test_int8_gemm.py` so the accuracy test runs only where the operation has an implemented kernel: SM75-SM90 and SM120/SM121. This keeps SM91 and SM122 excluded instead of using a broad `>= 120` condition.

## Validation

Built current main and the candidate with CUDA 13.0 and PyTorch 2.11.0 from the same bounded-clean AOT cache.

- Current main reproduced `NotImplementedError` on a seeded SM120 BF16 case.
- Candidate passed 33/33 seed-0 SM120 cases against the existing Torch reference with `torch.testing.assert_close`: `M` in `{1, 16, 64, 128, 512, 1024, 4096}` at `N=K=1024`, both output dtypes, bias on/off, plus `(32,128,128)`, `(129,16384,8192)`, and three `N=16384` cases.
- A fresh verifier passed four additional seed-28137 cases covering FP16/BF16, bias on/off, `M=129`, and high-N inputs.
- Candidate wheel SHA256: `6da0d0801565017ebeec95bdd76e0c28ba63e9e444128fd72e37ef98b7cffdd0`; installed SM90/SM100 libraries matched the wheel byte-for-byte.
- An exact Ninja-derived CUDA command produced an `sm_121a` cubin for `int8_gemm_kernel.cu`. This is compile-only evidence; no SM121 runtime or performance claim is made.

## Scope

This is functional enablement, not a performance change. The patch changes only the existing CUDA dispatch and test file; it does not change CUTLASS, tuning, scheduling, or other backends.

## Checklist

- [x] Two-file current-main diff, `git diff --check` clean
- [x] Exact capability-boundary check for SM74/75/90/91/120/121/122
- [x] Real SM120 before/after runtime validation
- [x] AI assistance was used; the author reviewed the patch and ran the hardware validation

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30779033152](https://github.com/sgl-project/sglang/actions/runs/30779033152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30779033073](https://github.com/sgl-project/sglang/actions/runs/30779033073)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
