### PR TITLE
[session] Fix reaper closing sessions mid-decode; forward session_params in /v1/completions

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -132,6 +132,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             custom_labels=custom_labels,
             custom_logit_processor=request.custom_logit_processor,
             images_config=getattr(request, "images_config", None),
+            session_params=request.session_params,
         )
 
         return adapted_request, request

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -138,6 +138,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             custom_labels=custom_labels,
             custom_logit_processor=request.custom_logit_processor,
             images_config=getattr(request, "images_config", None),
+            session_params=request.session_params,
         )
 
         return adapted_request, request

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4826,6 +4826,13 @@ class Scheduler(
             # This only works for requests that have not started anything.
             # We still need to send something back to TokenizerManager to clean up the state.
             req = self.waiting_queue.pop(i)
+            if req.session is not None:
+                # A popped queued request never reaches check_finished, so
+                # mark it finished here; otherwise the session's idle reaper
+                # and deferred close wait on it forever.
+                req.finished_reason = FINISH_ABORT("Aborted from the waiting queue.")
+                if req.session.streaming:
+                    req.session.abort_req()
             self.beam_coordinator.retire_group(req)
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -390,15 +390,13 @@ class SessionController:
 
     def _close(self, session_id: str):
         session = self.sessions[session_id]
-        req = None
         has_unfinished_request = False
         if session.streaming and session._inflight:
             has_unfinished_request = True
-        elif session.streaming and session.req_nodes:
-            assert len(session.req_nodes) == 1
-            [last_node] = session.req_nodes.values()
-            req = last_node.req
-            if not req.finished():
+        elif session.req_nodes:
+            if session.streaming:
+                assert len(session.req_nodes) == 1
+            if not self._all_requests_finished(session):
                 has_unfinished_request = True
 
         if has_unfinished_request:
@@ -455,9 +453,16 @@ class SessionController:
                 self.sessions[sid].close_on_finish = False
                 self._close(sid)
 
-            timed_out = [
-                sid for sid, session in self.sessions.items() if session.is_timed_out()
-            ]
+            timed_out = []
+            for sid, session in self.sessions.items():
+                if (session.streaming and session._inflight) or (
+                    not self._all_requests_finished(session)
+                ):
+                    # The session is busy decoding, not idle: keep the idle
+                    # timeout clock from expiring underneath an active request.
+                    session.last_active_time = now
+                elif session.is_timed_out():
+                    timed_out.append(sid)
             for sid in timed_out:
                 log_info_on_rank0(logger, f"Session {sid} timed out, closing.")
                 self._close(sid)

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -392,15 +392,13 @@ class SessionController:
 
     def _close(self, session_id: str):
         session = self.sessions[session_id]
-        req = None
         has_unfinished_request = False
         if session.streaming and session._inflight:
             has_unfinished_request = True
-        elif session.streaming and session.req_nodes:
-            assert len(session.req_nodes) == 1
-            [last_node] = session.req_nodes.values()
-            req = last_node.req
-            if not req.finished():
+        elif session.req_nodes:
+            if session.streaming:
+                assert len(session.req_nodes) == 1
+            if not self._all_requests_finished(session):
                 has_unfinished_request = True
 
         if has_unfinished_request:
@@ -458,9 +456,16 @@ class SessionController:
                 self.sessions[sid].close_on_finish = False
                 self._close(sid)
 
-            timed_out = [
-                sid for sid, session in self.sessions.items() if session.is_timed_out()
-            ]
+            timed_out = []
+            for sid, session in self.sessions.items():
+                if (session.streaming and session._inflight) or (
+                    not self._all_requests_finished(session)
+                ):
+                    # The session is busy decoding, not idle: keep the idle
+                    # timeout clock from expiring underneath an active request.
+                    session.last_active_time = now
+                elif session.is_timed_out():
+                    timed_out.append(sid)
             for sid in timed_out:
                 log_info_on_rank0(logger, f"Session {sid} timed out, closing.")
                 self._close(sid)

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -95,6 +95,10 @@ class Session:
         self.req_nodes: Dict[str, SessionReqNode] = {}
         self.close_on_finish: bool = False
         self._inflight: bool = False
+        # True while the reaper observes an unfinished request; lets the
+        # tick after the request finishes restart the idle clock from
+        # (approximately) completion time instead of the previous tick.
+        self._busy_at_last_reap: bool = False
         # Token-array lengths of last_req as of its finish_req. The share path
         # appends speculatively beyond these; only finish_req confirms them, so
         # _share_token_arrays trims back first (heals aborted turns).
@@ -464,6 +468,12 @@ class SessionController:
                     # The session is busy decoding, not idle: keep the idle
                     # timeout clock from expiring underneath an active request.
                     session.last_active_time = now
+                    session._busy_at_last_reap = True
+                elif session._busy_at_last_reap:
+                    # The last request finished between reap ticks: restart
+                    # the idle clock from completion, not the previous tick.
+                    session.last_active_time = now
+                    session._busy_at_last_reap = False
                 elif session.is_timed_out():
                     timed_out.append(sid)
             for sid in timed_out:

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -76,6 +76,14 @@ class ServingCompletionTestCase(unittest.TestCase):
         internal, _ = self.sc._convert_to_internal_request(req)
         self.assertEqual(internal.input_ids, [1, 2, 3, 4])
 
+    def test_session_params_forwarded(self):
+        # Regression test for #23579: session_params was silently dropped.
+        req = CompletionRequest(
+            model="x", prompt="Hello", max_tokens=100, session_params={"id": "s1"}
+        )
+        internal, _ = self.sc._convert_to_internal_request(req)
+        self.assertEqual(internal.session_params, {"id": "s1"})
+
     # ---------- echo-handling ----------
     def test_echo_with_string_prompt_streaming(self):
         req = CompletionRequest(model="x", prompt="Hello", max_tokens=1, echo=True)

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -101,6 +101,14 @@ class ServingCompletionTestCase(unittest.TestCase):
         self.assertEqual(internal.cache_salt, "tenant-a")
         self.assertEqual(internal.extra_key, "classification")
 
+    def test_session_params_forwarded(self):
+        # Regression test for #23579: session_params was silently dropped.
+        req = CompletionRequest(
+            model="x", prompt="Hello", max_tokens=100, session_params={"id": "s1"}
+        )
+        internal, _ = self.sc._convert_to_internal_request(req)
+        self.assertEqual(internal.session_params, {"id": "s1"})
+
     def test_single_request_rejects_batched_cache_salt(self):
         req = CompletionRequest(
             model="x",

--- a/test/registered/unit/session/test_session_controller.py
+++ b/test/registered/unit/session/test_session_controller.py
@@ -1,0 +1,143 @@
+"""Unit tests for srt/session/session_controller — no server, no model loading.
+
+Regression tests for https://github.com/sgl-project/sglang/issues/23579:
+the idle-timeout reaper must never tear down a session while one of its
+requests is still decoding.
+"""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+import time
+import unittest
+
+from sglang.srt.managers.io_struct import CloseSessionReqInput, OpenSessionReqInput
+from sglang.srt.session.session_controller import SessionController, SessionReqNode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_TIMEOUT = 0.05
+
+
+class _FakeTreeCache:
+    def __init__(self):
+        self.released = []
+
+    def release_session(self, session_id):
+        self.released.append(session_id)
+
+
+class _FakeReq:
+    """Mimics the bits of Req that SessionController touches."""
+
+    def __init__(self, rid, is_finished=False):
+        self.rid = rid
+        self.finished_reason = None
+        self.multimodal_inputs = None
+        self.is_finished = is_finished
+
+    def finished(self):
+        return self.is_finished
+
+
+class TestSessionControllerReaper(CustomTestCase):
+    def setUp(self):
+        self.tree_cache = _FakeTreeCache()
+        self.controller = SessionController(self.tree_cache)
+
+    def _open(self, streaming=False):
+        out = self.controller.open(
+            OpenSessionReqInput(
+                capacity_of_str_len=32768,
+                session_id="s1",
+                streaming=streaming,
+                timeout=_TIMEOUT,
+            )
+        )
+        self.assertTrue(out.success)
+        return self.controller.get("s1")
+
+    def _expire_timeout(self, session):
+        """Backdate the session past its idle timeout and force a reap tick."""
+        session.last_active_time = time.monotonic() - 10 * _TIMEOUT
+        self.controller._last_reap_time = 0.0
+
+    def test_reaper_skips_non_streaming_session_with_unfinished_request(self):
+        session = self._open(streaming=False)
+        req = _FakeReq("r1", is_finished=False)
+        session.req_nodes["r1"] = SessionReqNode(req)
+
+        # Simulate a decode that runs longer than the idle timeout.
+        self._expire_timeout(session)
+        now = time.monotonic()
+        self.controller.maybe_reap(now)
+
+        self.assertIn("s1", self.controller)
+        self.assertEqual(self.tree_cache.released, [])
+        # The reaper must not even schedule a deferred close: the session is
+        # busy, not idle, so follow-up requests should still be accepted.
+        self.assertFalse(session.close_on_finish)
+        # The timeout clock is refreshed so it restarts after the decode.
+        self.assertEqual(session.last_active_time, now)
+
+    def test_reaper_skips_streaming_session_with_inflight_request(self):
+        session = self._open(streaming=True)
+        session._inflight = True
+
+        self._expire_timeout(session)
+        self.controller.maybe_reap(time.monotonic())
+
+        self.assertIn("s1", self.controller)
+        self.assertEqual(self.tree_cache.released, [])
+        self.assertFalse(session.close_on_finish)
+
+    def test_reaper_reaps_idle_session_after_requests_finish(self):
+        session = self._open(streaming=False)
+        req = _FakeReq("r1", is_finished=False)
+        session.req_nodes["r1"] = SessionReqNode(req)
+
+        self._expire_timeout(session)
+        self.controller.maybe_reap(time.monotonic())
+        self.assertIn("s1", self.controller)
+
+        req.is_finished = True
+        self._expire_timeout(session)
+        self.controller.maybe_reap(time.monotonic())
+
+        self.assertNotIn("s1", self.controller)
+        self.assertEqual(self.tree_cache.released, ["s1"])
+
+    def test_reaper_reaps_idle_session_without_requests(self):
+        session = self._open(streaming=False)
+
+        self._expire_timeout(session)
+        self.controller.maybe_reap(time.monotonic())
+
+        self.assertNotIn("s1", self.controller)
+        self.assertEqual(self.tree_cache.released, ["s1"])
+
+    def test_explicit_close_defers_until_request_finishes(self):
+        session = self._open(streaming=False)
+        req = _FakeReq("r1", is_finished=False)
+        session.req_nodes["r1"] = SessionReqNode(req)
+
+        self.controller.close(CloseSessionReqInput(session_id="s1"))
+
+        # The close is deferred while the request is still decoding.
+        self.assertIn("s1", self.controller)
+        self.assertEqual(self.tree_cache.released, [])
+        self.assertTrue(session.close_on_finish)
+
+        req.is_finished = True
+        self.controller._last_reap_time = 0.0
+        self.controller.maybe_reap(time.monotonic())
+
+        self.assertNotIn("s1", self.controller)
+        self.assertEqual(self.tree_cache.released, ["s1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/session/test_session_controller.py
+++ b/test/registered/unit/session/test_session_controller.py
@@ -29,6 +29,9 @@ class _FakeTreeCache:
     def release_session(self, session_id):
         self.released.append(session_id)
 
+    def release_radix_session(self, session_id):
+        pass
+
 
 class _FakeReq:
     """Mimics the bits of Req that SessionController touches."""
@@ -103,7 +106,18 @@ class TestSessionControllerReaper(CustomTestCase):
         self.controller.maybe_reap(time.monotonic())
         self.assertIn("s1", self.controller)
 
+        # The request finished between reap ticks with a stale idle clock:
+        # the first idle tick must restart the clock from completion, not
+        # reap based on the previous tick's timestamp.
         req.is_finished = True
+        self._expire_timeout(session)
+        now = time.monotonic()
+        self.controller.maybe_reap(now)
+        self.assertIn("s1", self.controller)
+        self.assertEqual(self.tree_cache.released, [])
+        self.assertEqual(session.last_active_time, now)
+
+        # Only a full idle timeout after that reaps the session.
         self._expire_timeout(session)
         self.controller.maybe_reap(time.monotonic())
 


### PR DESCRIPTION
## Motivation

Fixes #23579.

The idle-timeout reaper releases non-streaming sessions while a request is still decoding, and `/v1/completions` accepts but drops `session_params`.

## Modifications

Generalizing the `_close()` unfinished-request guard alone is not enough: the reaper would then mark the busy session `close_on_finish`, and the scheduler rejects new requests for sessions in that state, so the follow-up request still fails. The real invariant is that an idle timeout must not expire underneath an active request — `maybe_reap` now refreshes `last_active_time` for busy sessions and only reaps idle ones, while explicit `/close_session` keeps deferred-close semantics through the generalized guard. This also stops `release_features()` from firing on a request's multimodal inputs mid-decode.

The refresh covers streaming sessions too: previously a streaming session whose request outlived the timeout got `close_on_finish=True` from the reaper and died the instant the request finished, with the same "session id does not exist" outcome for follow-ups.

Both fixes have CPU unit tests in `base-a-test-cpu`: a new `test/registered/unit/session/test_session_controller.py` and `test_session_params_forwarded` in the existing completions unit suite. `serving_chat.py` has the same `session_params` drop; left out to keep this issue-scoped — happy to follow up.

## Accuracy Tests

Not applicable — no changes to kernels or model forward code; this is a session-lifecycle and request-plumbing bugfix.

## Speed Tests and Profiling

Not applicable — no inference-speed-impacting changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33380582845](https://github.com/sgl-project/sglang/actions/runs/33380582845)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33380582630](https://github.com/sgl-project/sglang/actions/runs/33380582630)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33380582775](https://github.com/sgl-project/sglang/actions/runs/33380582775)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->