### PR TITLE
fix(health): make health-check rid unique across tokenizer workers

### DIFF
--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -11,6 +11,7 @@ import pickle
 import threading
 import time
 import traceback
+import uuid
 from collections import defaultdict
 from http import HTTPStatus
 from typing import Dict, List, Optional, Set, Tuple, Union
@@ -2550,7 +2551,8 @@ async def _dp_worker_health_encode(enc: MMEncoder) -> None:
         # No processor → can't functionally probe; liveness alone is healthy.
         return None
 
-    req_id = f"{HEALTH_CHECK_RID_PREFIX}_{time.time()}"
+    # uuid keeps rids unique across workers; a bare time.time() can collide.
+    req_id = f"{HEALTH_CHECK_RID_PREFIX}_{uuid.uuid4().hex}"
     try:
         _, _, _, error_msg, error_code = await enc.encode(
             mm_items=mm_items,
@@ -3757,7 +3759,8 @@ async def health_generate():
         return Response(status_code=200)
 
     try:
-        req_id = f"{HEALTH_CHECK_RID_PREFIX}_{time.time()}"
+        # uuid keeps rids unique across workers; a bare time.time() can collide.
+        req_id = f"{HEALTH_CHECK_RID_PREFIX}_{uuid.uuid4().hex}"
 
         dummy_request = {
             "mm_items": mm_items,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -24,6 +24,7 @@ import os
 import tempfile
 import threading
 import time
+import uuid
 from contextlib import asynccontextmanager
 from http import HTTPStatus
 from typing import (
@@ -607,9 +608,9 @@ async def health_generate(request: Request) -> Response:
         return Response(status_code=200)
 
     sampling_params = {"max_new_tokens": 1, "temperature": 0.0}
-    # pid keeps rids unique across tokenizer workers (a bare time.time() can
+    # uuid keeps rids unique across tokenizer workers (a bare time.time() can
     # collide and crash the shared DetokenizerManager decode_status).
-    rid = f"{HEALTH_CHECK_RID_PREFIX}_{os.getpid()}_{time.time()}"
+    rid = f"{HEALTH_CHECK_RID_PREFIX}_{uuid.uuid4().hex}"
 
     if _global_state.tokenizer_manager.is_generation:
         gri = GenerateReqInput(

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -607,7 +607,9 @@ async def health_generate(request: Request) -> Response:
         return Response(status_code=200)
 
     sampling_params = {"max_new_tokens": 1, "temperature": 0.0}
-    rid = f"{HEALTH_CHECK_RID_PREFIX}_{time.time()}"
+    # pid keeps rids unique across tokenizer workers (a bare time.time() can
+    # collide and crash the shared DetokenizerManager decode_status).
+    rid = f"{HEALTH_CHECK_RID_PREFIX}_{os.getpid()}_{time.time()}"
 
     if _global_state.tokenizer_manager.is_generation:
         gri = GenerateReqInput(


### PR DESCRIPTION
Use os.getpid() in the health-check rid so concurrent /health_generate probes from multiple tokenizer workers (--tokenizer-worker-num > 1) cannot collide. A bare time.time() rid could repeat across worker processes, producing duplicate rids in one BatchTokenIDOutput and crashing the shared DetokenizerManager with 'Decode status not found'.

 may fix https://github.com/sgl-project/sglang/issues/28142
 
 cc @hnyls2002 @merrymercy 





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27491057450](https://github.com/sgl-project/sglang/actions/runs/27491057450)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27491057393](https://github.com/sgl-project/sglang/actions/runs/27491057393)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->