### PR TITLE
Fix TRTLLM MHA FP8 KV cache scale handling

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.attention.triton_ops.trtllm_fp8_kv_kernel import (
     fused_fp8_set_kv_buffer,
 )
 from sglang.srt.layers.attention.utils import canonicalize_stride
+from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -232,6 +233,56 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             if is_swa:
                 return swa_pt
         return self.forward_metadata.page_table
+
+    @staticmethod
+    def _get_scalar_scale(
+        layer: RadixAttention,
+        float_attr: str,
+        scale_attr: str,
+    ) -> float:
+        scale = getattr(layer, float_attr, None)
+        if scale is None:
+            scale = getattr(layer, scale_attr, None)
+        if scale is None:
+            return 1.0
+        if isinstance(scale, torch.Tensor):
+            logger.warning_once(
+                "Ignoring tensor %s for TRT-LLM MHA FP8 KV cache scale. "
+                "Expected %s to be populated with a Python scalar.",
+                scale_attr,
+                float_attr,
+            )
+            return 1.0
+        scale = float(scale)
+        return scale if scale > 0.0 else 1.0
+
+    def _get_bmm_scales(
+        self, layer: RadixAttention, q_scale: float | torch.Tensor = 1.0
+    ) -> tuple[float | torch.Tensor, float]:
+        """Return FlashInfer TRT-LLM MHA BMM scales.
+
+        The FP8 paths store Q/K/V as values divided by their per-tensor scales.
+        FlashInfer applies bmm1_scale to QK and bmm2_scale to PV, so FP8 reads
+        need Q and K descales in BMM1 and V descale in BMM2. Non-FP8 KV cache
+        entries are already in model dtype.
+        """
+        if self.data_type != torch.float8_e4m3fn:
+            return layer.scaling, 1.0
+
+        k_scale = self._get_scalar_scale(layer, "k_scale_float", "k_scale")
+        v_scale = self._get_scalar_scale(layer, "v_scale_float", "v_scale")
+        return q_scale * k_scale * layer.scaling, v_scale
+
+    def _maybe_quantize_q(
+        self, q: torch.Tensor, *, force_fp8: bool = False
+    ) -> tuple[torch.Tensor, float | torch.Tensor]:
+        if self.data_type != torch.float8_e4m3fn:
+            return q, 1.0
+        if self.is_xqa_impl and not force_fp8:
+            return q, 1.0
+
+        q_2d, q_scale = scaled_fp8_quant(q.reshape(-1, q.shape[-1]).contiguous(), None)
+        return q_2d.reshape(q.shape), q_scale
 
     def init_cuda_graph_state(
         self,
@@ -801,9 +852,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     layer.v_scale,
                 )
 
-        # For XQA, q_dtype should be bf16
-        if self.data_type == torch.float8_e4m3fn and (not self.is_xqa_impl):
-            q = q.to(torch.float8_e4m3fn)
+        # For XQA, q_dtype should be bf16. TRT-LLM-GEN uses FP8 Q; dynamically
+        # quantize it and pass the descale into BMM1 instead of unscaled casting.
+        q, q_scale = self._maybe_quantize_q(q)
         q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
         k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
         # shape conversion:
@@ -822,15 +873,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         kv_cache = (k_cache, v_cache)
 
-        # TODO: add support for quantization
-        q_scale = 1.0
-        k_scale = (
-            layer.k_scale_float
-            if getattr(layer, "k_scale_float", None) is not None
-            else 1.0
-        )
-        bmm1_scale = q_scale * k_scale * layer.scaling
-        bmm2_scale = 1.0
+        bmm1_scale, bmm2_scale = self._get_bmm_scales(layer, q_scale)
         # sink: additional value per head in the denominator of the softmax.
         attention_sink = kwargs.get("sinks", None)
 
@@ -892,8 +935,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     layer.v_scale,
                 )
 
-        if self.data_type == torch.float8_e4m3fn:
-            q = q.to(torch.float8_e4m3fn)
+        q, q_scale = self._maybe_quantize_q(
+            q, force_fp8=not forward_batch.forward_mode.is_target_verify()
+        )
         q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
         # [num_pages, page_size, num_kv_heads, head_dim] -> [num_pages, num_kv_heads, page_size, head_dim]
         k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
@@ -913,15 +957,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         # sink: additional value per head in the denominator of the softmax.
         attention_sink = kwargs.get("sinks", None)
-        # TODO: add support for quantization
-        q_scale = 1.0
-        k_scale = (
-            layer.k_scale_float
-            if getattr(layer, "k_scale_float", None) is not None
-            else 1.0
-        )
-        bmm1_scale = q_scale * k_scale * layer.scaling
-        bmm2_scale = 1.0
+        bmm1_scale, bmm2_scale = self._get_bmm_scales(layer, q_scale)
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 


### PR DESCRIPTION
## Summary

The TRTLLM MHA FP8 KV-cache path was missing part of the scale handoff to FlashInfer. In the TRTLLM-GEN path, Q was being cast directly to FP8, but the matching dynamic `q_scale` was not computed or passed into the attention BMM scale. That means the kernel saw FP8 Q with `q_scale = 1.0`, which can hurt accuracy.

This patch makes the decode and extend paths carry the FP8 scales they need:

- dynamically quantize Q with `scaled_fp8_quant()` when TRTLLM-GEN needs FP8 Q
- pass `q_scale * k_scale * layer.scaling` as `bmm1_scale`
- pass `v_scale` as `bmm2_scale`
- keep XQA decode on BF16 Q
- use scalar K/V scale attrs for TRTLLM MHA BMM scales and fall back to `1.0`

This is a general TRTLLM MHA FP8 KV-cache scale fix. It also addresses the Gemma-4-26B-A4B-NVFP4 quality drop reported in https://github.com/sgl-project/sglang/issues/26518.

## Details

FP8 KV cache stores K/V as quantized values divided by their scales. FlashInfer applies the compensation through its BMM scale arguments:

```text
bmm1_scale = q_scale * k_scale * softmax_scale
bmm2_scale = v_scale
```

That matches the FlashInfer TRTLLM-GEN path: FP8 KV-cache attention uses FP8 Q, accepts tensor `bmm1_scale`, and applies that scale in the QK BMM. XQA decode is the exception, so it stays on BF16 Q.

When a checkpoint does not provide scalar K/V cache scales, `k_scale` and `v_scale` stay at `1.0`. The Q side is still handled dynamically, so TRTLLM-GEN gets an FP8 Q tensor together with the matching `q_scale` in `bmm1_scale`.

## Accuracy check

Server:

```bash
CUDA_VISIBLE_DEVICES=3 sglang serve \
  --model-path nvidia/Gemma-4-26B-A4B-NVFP4 \
  --attention-backend trtllm_mha \
  --reasoning-parser gemma4 \
  --tool-call-parser gemma4 \
  --trust-remote-code
```

GSM8K:

```bash
python -m sglang.test.run_eval \
  --base-url http://127.0.0.1:30000 \
  --model nvidia/Gemma-4-26B-A4B-NVFP4 \
  --eval-name gsm8k \
  --max-tokens 131072 \
  --repeat 1 \
  --num-threads 1299 \
  --num-shots 20 \
  --temperature 1.0 \
  --top-p 0.95 \
  --chat-template-kwargs '{"enable_thinking": true}'

Score: 0.968
Total latency: 223.839 s
Output throughput: 9754.789 token/s
[METRIC] gsm8k_score=0.9676674364896074
```

GPQA:

```bash
python -m sglang.test.run_eval \
  --base-url http://127.0.0.1:30000 \
  --model nvidia/Gemma-4-26B-A4B-NVFP4 \
  --eval-name gpqa \
  --max-tokens 131072 \
  --repeat 1 \
  --num-threads 198 \
  --temperature 1.0 \
  --top-p 0.95 \
  --chat-template-kwargs '{"enable_thinking": true}'

Score: 0.798
Total latency: 655.967 s
Output throughput: 3813.635 token/s
[METRIC] gpqa_score=0.797979797979798
```

AIME25:

```bash
python -m sglang.test.run_eval \
  --base-url http://127.0.0.1:30000 \
  --model nvidia/Gemma-4-26B-A4B-NVFP4 \
  --eval-name aime25 \
  --max-tokens 131072 \
  --repeat 1 \
  --num-threads 30 \
  --temperature 1.0 \
  --top-p 0.95 \
  --chat-template-kwargs '{"enable_thinking": true}'

Score: 0.867
Total latency: 547.061 s
Output throughput: 1025.345 token/s
[METRIC] aime25_score=0.8666666666666667
```































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27490352276](https://github.com/sgl-project/sglang/actions/runs/27490352276)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27490352218](https://github.com/sgl-project/sglang/actions/runs/27490352218)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->