### PR TITLE
docs(minimax-m3): add high-concurrency throughput tip for H200 bf16

### DIFF
--- a/docs_new/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
+++ b/docs_new/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
@@ -152,6 +152,8 @@ The MXFP8 kernels are Blackwell-only, so Hopper (H200) serves the full-precision
 - **Attention**: FlashAttention-3 with page size 1. MSA (§2.1) is a Blackwell kernel, so M3's sparse step runs on the built-in Triton path here.
 - **CUDA graph**: on, with full decode-graph capture.
 
+**High-concurrency throughput (optional).** On Hopper the sparse prefill runs on the Triton path as a separate eager forward, which briefly stalls the in-flight decode batch under heavy concurrent load. Adding `--enable-mixed-chunk --chunked-prefill-size 2048` merges the running decodes into the prefill step instead of preempting them, which recovers roughly **+10% output throughput** and **~10% lower median TPOT** at high concurrency on 8×H200, with no change in accuracy. Leave it off for latency-sensitive low-concurrency serving.
+
 Validated on 8×H200 — reasoning and tool-call auto-detection plus long-context generation. For prefill/decode disaggregation on Hopper, see §3.4.
 
 ## 3. Advanced Usage


### PR DESCRIPTION
Docs-only. Adds a 'High-concurrency throughput' note to §2.4 (Serving on Hopper with the bf16 build) of the MiniMax-M3 cookbook page: `--enable-mixed-chunk --chunked-prefill-size 2048` merges running decodes into the prefill step instead of letting the eager sparse-prefill forward preempt them. Measured on 8×H200 bf16 (random in1024/out512, conc 64): +10.1% output throughput (1318→1451 tok/s), −9.5% median TPOT (43.5→39.4 ms), no GSM8K accuracy change. Leave off for latency-sensitive low-concurrency serving.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27470210603](https://github.com/sgl-project/sglang/actions/runs/27470210603)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27470210521](https://github.com/sgl-project/sglang/actions/runs/27470210521)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->