### PR TITLE
fix(sampling): reject non-finite temperature in SamplingParams.verify

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -14,6 +14,7 @@
 """Sampling parameters for text generation."""
 
 import logging
+import math
 from typing import Any, Dict, List, Optional, Union
 
 # sre_parse is deprecated in Python 3.11+, use re._parser instead
@@ -118,9 +119,9 @@ class SamplingParams:
             self.top_k = TOP_K_ALL  # whole vocabulary
 
     def verify(self, vocab_size):
-        if self.temperature < 0.0:
+        if not math.isfinite(self.temperature) or self.temperature < 0.0:
             raise ValueError(
-                f"temperature must be non-negative, got {self.temperature}."
+                f"temperature must be a non-negative finite number, got {self.temperature}."
             )
         if not 0.0 < self.top_p <= 1.0:
             raise ValueError(f"top_p must be in (0, 1], got {self.top_p}.")

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -92,6 +92,18 @@ class TestSamplingParamsVerify(CustomTestCase):
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
+    def test_nan_temperature_raises(self):
+        """verify() must reject NaN temperature; the bare < 0.0 check alone lets it through."""
+        sp = self._make(temperature=float("nan"))
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_inf_temperature_raises(self):
+        """verify() must reject non-finite (inf) temperature."""
+        sp = self._make(temperature=float("inf"))
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
     # --- top_p ---
     def test_top_p_negative_raises(self):
         """Test that verify() rejects negative top_p (valid range is (0, 1])."""


### PR DESCRIPTION

## Motivation

A single user request with `temperature` set to NaN (or +/-Inf) crashes the whole server.

`SamplingParams.verify()` guards temperature with `if self.temperature < 0.0`. Under IEEE-754, `nan < 0.0` and `inf < 0.0` are both `False`, so a non-finite temperature passes admission. It then scales the logits into a probability tensor containing NaN/Inf, and the sampler calls `torch.multinomial`, which triggers a CUDA device-side assert (`probability tensor contains either inf, nan or element < 0`). That poisons the CUDA context, the scheduler dies, and every later request gets connection-refused until the server is restarted. This is a request-level denial of service.

`temperature` is a public sampling parameter, so any client can send it. A literal `NaN`/`Infinity` in the JSON body is accepted by the default parser. It is reachable from the native `/generate` endpoint (`sampling_params.temperature`) and from the OpenAI-compatible `/v1/chat/completions` and `/v1/completions` endpoints (top-level `temperature`), so mainstream OpenAI clients can trigger it too.

temperature is the only float sampling field that uses a one-sided comparison; the others (`top_p`, `min_p`, the penalties, `repetition_penalty`) use closed-interval checks like `not 0.0 < x <= 1.0`, which already reject NaN because every comparison with NaN is `False`.

## Modifications

- In `SamplingParams.verify()`, reject temperature when it is not finite, in addition to the existing negative check: `if not math.isfinite(self.temperature) or self.temperature < 0.0`. The serving layer maps the raised `ValueError` to HTTP 400.
- Add two minimal regression cases (NaN and Inf temperature) to the existing `TestSamplingParamsVerify` unit class.

## Testing

Reproduced on current upstream main (`a3fd5c24b`, 2026-06-14) with a real server. Applying this patch to the same main checkout changes the same request from a process-killing DoS to HTTP 400, while a valid request after it remains HTTP 200.

| case | without fix | with fix |
|---|---|---|
| `/generate` `temperature=NaN` | server RemoteDisconnected, then exit -9 | HTTP 400 |
| valid `/generate` after that request | Connection refused | HTTP 200 |

<details>
<summary>repro environment, command, and output</summary>

Environment:

- GPU: A800-80GB
- Model: `Qwen3-0.6B`
- Runtime: current upstream main `a3fd5c24b` through an isolated `PYTHONPATH` clone
- PyTorch 2.11.0+cu130, CUDA 13.0, sgl-kernel 0.4.2.post2

```bash
python -m sglang.launch_server \
  --model-path Qwen3-0.6B \
  --host 127.0.0.1 --port 31027 \
  --attention-backend triton --sampling-backend pytorch \
  --disable-cuda-graph --disable-piecewise-cuda-graph \
  --mem-fraction-static 0.4 --dtype bfloat16 --max-running-requests 8

# attack (raw body, literal NaN)
curl -s -X POST http://127.0.0.1:31027/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"Hello","sampling_params":{"temperature":NaN,"max_new_tokens":8}}'
```

Current main, unpatched, native `/generate` temperature=NaN:

```text
MARKER_MAIN_COMMIT a3fd5c24b
MARKER_MODEL /root/autodl-tmp/models/Qwen3-0.6B
MARKER_BASELINE_OK
MARKER_ATTACK_RESULT status=None dt=5.1s body=RemoteDisconnected: Remote end closed connection without response
MARKER_NORMAL_AFTER status=None dt=0.0s body=URLError: <urlopen error [Errno 111] Connection refused>
MARKER_SERVER_EXIT -9
MARKER_DOS_CONFIRMED
```

Server log root cause:

```text
sglang/srt/layers/sampler.py:656, in sampling_from_probs_torch
sampled_index = torch.multinomial(probs, num_samples=1)
torch.AcceleratorError: CUDA error: device-side assert triggered
kill_process_tree called: parent_pid=231206, include_parent=True
```

Same main checkout with this patch applied:

```text
MARKER_MAIN_COMMIT a3fd5c24b-fixed
MARKER_MODEL /root/autodl-tmp/models/Qwen3-0.6B
MARKER_BASELINE_OK
MARKER_ATTACK_RESULT status=400 dt=0.0s body={"error":{"message":"temperature must be a non-negative finite number, got nan."}}
MARKER_NORMAL_AFTER status=200 dt=0.1s body={"text":" Answer! I'm", ...}
MARKER_SERVER_EXIT running
MARKER_NO_DOS
```

</details>

Unit tests and static checks on the clone:

- `pytest test/registered/unit/sampling/test_sampling_params.py -k temperature` -> 7 passed
- `black --check` / `isort --check-only` / `ruff check` on `python/sglang/srt/sampling/sampling_params.py` -> clean

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed for admission validation.
- [ ] Provide accuracy and speed benchmark results. Not needed because this does not change model outputs or the decode hot path.
- [x] Follow the SGLang code style guidance.

cc @hnyls2002 @merrymercy

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27474793738](https://github.com/sgl-project/sglang/actions/runs/27474793738)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27474793692](https://github.com/sgl-project/sglang/actions/runs/27474793692)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->