### PR TITLE
docs(mlx): correct fused_swiglu docstring bench figure

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/moe/fused_swiglu.py
+++ b/python/sglang/srt/hardware_backend/mlx/moe/fused_swiglu.py
@@ -5,8 +5,9 @@ Why this exists
 The existing `FusedSwitchUpGate` (fused_switch_glu.py) concatenates up_proj
 and gate_proj weights along the output dim and runs one gather_qmm. That saves
 one kernel launch per layer but doubles the matmul's output dim, which pushes
-MLX's quantized GEMV into a worse tile/occupancy config. At bs >= 4 on
-Qwen3-30B-A3B-4bit this is a net regression (~2% slower at bs=32).
+MLX's quantized GEMV into a worse tile/occupancy config. On
+Qwen3-30B-A3B-4bit this measured ~2% slower at bs=8 (within trial variance;
+bs >= 16 unmeasured, OOM on 24GB).
 
 Path B keeps up_proj and gate_proj separate (matmul kernels see their natural
 N — no tile regression) and instead fuses the *activation* into the gate


### PR DESCRIPTION
The docstring cited ~2% slower at bs=32 for the concat (FusedSwitchUpGate) path on Qwen3-30B-A3B-4bit. That figure was never measured: the #24712 benchmark covered bs=1 and bs=8 only (bs>=16 OOM'd on 24GB), and the bs=8 delta was ~2% slower, flagged within trial variance. Correcting the docstring to match what was measured. No code change. Refs #26188, #24712.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27475460320](https://github.com/sgl-project/sglang/actions/runs/27475460320)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27475460210](https://github.com/sgl-project/sglang/actions/runs/27475460210)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->