### PR TITLE
feat: compatibility mode for tool parsers

### DIFF
--- a/docs_new/cookbook/autoregressive/GLM/GLM-4.7.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-4.7.mdx
@@ -127,7 +127,7 @@ Pick a weight format by hardware: **NVFP4** on NVIDIA Blackwell (B200, GB200), *
 - **EAGLE Speculative Decoding:** Supported for GLM-4.7. Add `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`. The spec-v2 overlap scheduler is enabled by default; pass `--disable-overlap-schedule` to disable. Enable via the interactive command generator above.
 - **Thinking Budget:** Use `--enable-custom-logit-processor` flag and pass `Glm4MoeThinkingBudgetLogitProcessor` in requests to cap the model's thinking token count (see section 4.2.3).
 
-For general GLM-4.x family launch guidance (AMD ROCm notes and more), see [Launch GLM-4.5 / GLM-4.6 / GLM-4.7 with SGLang](../../../docs/basic_usage/glm45). Per-hardware bench commands and flags are inline in §5.1 below.
+For general GLM-4.x family launch guidance (AMD ROCm notes and more), see [Launch GLM-4.5 / GLM-4.6 / GLM-4.7 with SGLang](/cookbook/autoregressive/GLM/GLM-4.5). Per-hardware bench commands and flags are inline in §5.1 below.
 
 ## 4. Model Invocation
 

--- a/docs_new/cookbook/autoregressive/NVIDIA/Nemotron3-Nano-Omni.mdx
+++ b/docs_new/cookbook/autoregressive/NVIDIA/Nemotron3-Nano-Omni.mdx
@@ -52,7 +52,7 @@ uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=pytho
 docker pull lmsysorg/sglang:dev-cu13-nemotronh-nano-omni-reasoning-v3
 ```
 
-For the full Docker setup and other installation methods, refer to the [official SGLang installation guide](../../../docs/get-started/installation).
+For the full Docker setup and other installation methods, refer to the [official SGLang installation guide](/docs/get-started/install).
 
 ## 3. Model Deployment
 

--- a/docs_new/docs/advanced_features/tool_parser.mdx
+++ b/docs_new/docs/advanced_features/tool_parser.mdx
@@ -73,6 +73,16 @@ This guide demonstrates how to use SGLang’s [Function calling](https://platfor
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}></td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`minimax-m2`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>MiniMax M2 / M2.5 / M2.7</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Parses the MiniMax XML-style tool-call format.</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`minimax-m3-nom`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>MiniMax M3 NOM</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Parses the namespace-tagged MiniMax M3 NOM format. Use `--reasoning-parser minimax-m3` separately when the model also emits reasoning.</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`pythonic`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Llama-3.2 / Llama-3.3 / Llama-4</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Model outputs function calls as Python code. Requires `--tool-call-parser pythonic` and is recommended to use with a specific chat template.</td>
@@ -117,6 +127,34 @@ wait_for_server(f"http://localhost:{port}")
 ```
 
 Note that `--tool-call-parser` defines the parser used to interpret responses.
+
+### Tool parser compatibility mode
+
+Tool-call parsing is strict by default. If a model emits a known deviation from
+the expected wire format, SGLang fails open and returns the affected output as
+normal text instead of returning a partially parsed tool call.
+
+Use `--enable-tool-call-compatibility-mode` when the deployed model is known to
+produce recoverable tool-call deviations, such as malformed per-call JSON,
+unknown tool names, missing close tags in tag-style formats, or truncated
+streaming arguments.
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path Qwen/Qwen2.5-7B-Instruct \
+  --tool-call-parser qwen25 \
+  --enable-tool-call-compatibility-mode \
+  --host 0.0.0.0
+```
+
+Compatibility mode applies the parser's known recoveries and records the
+recovery events in the detector's compatibility audit trail. In streaming
+responses, if a parser fails after argument fragments have already been sent,
+SGLang closes the streamed JSON arguments when possible and passes the rest of
+the stream through as normal text.
+
+The setting only affects tool-call parsing. It does not change generation
+constraints from `SGLANG_TOOL_STRICT_LEVEL`.
 
 
 ### Define Tools for Function Call
@@ -442,7 +480,11 @@ def convert_dict_to_tool(tool_dict: dict) -> Tool:
 
 tools = [convert_dict_to_tool(raw_tool) for raw_tool in tools]
 
-parser = FunctionCallParser(tools=tools, tool_call_parser="qwen25")
+parser = FunctionCallParser(
+    tools=tools,
+    tool_call_parser="qwen25",
+    enable_compatibility_mode=True,
+)
 normal_text, calls = parser.parse_non_stream(generated_text)
 
 print_highlight("=== Parsing Result ===")

--- a/docs_new/docs/advanced_features/tool_parser.mdx
+++ b/docs_new/docs/advanced_features/tool_parser.mdx
@@ -78,9 +78,9 @@ This guide demonstrates how to use SGLang’s [Function calling](https://platfor
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Parses the MiniMax XML-style tool-call format.</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`minimax-m3-nom`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>MiniMax M3 NOM</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Parses the namespace-tagged MiniMax M3 NOM format. Use `--reasoning-parser minimax-m3` separately when the model also emits reasoning.</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`minimax-m3`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>MiniMax M3</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Parses the namespace-tagged MiniMax M3 format. Use `--reasoning-parser minimax-m3` separately when the model also emits reasoning.</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`pythonic`</td>

--- a/docs_new/docs/hardware-platforms/ascend-npus/ascend_npu_support_new_models.mdx
+++ b/docs_new/docs/hardware-platforms/ascend-npus/ascend_npu_support_new_models.mdx
@@ -157,7 +157,7 @@ launch_server(server_args)
 
 ## Example: Implementing and Serving a Llama Wrapper Model
 
-Below is an introductory, step-by-step walkthrough on how to implement a new model end-to-end in SGLang and then run it via the [Offline Engine](../basic_usage/offline_engine_api).
+Below is an introductory, step-by-step walkthrough on how to implement a new model end-to-end in SGLang and then run it via the [Offline Engine](/docs/basic_usage/offline_engine_api).
 
 ### Implementing Our Model
 
@@ -538,7 +538,7 @@ python -m sglang.launch_server \
 
 ## Documentation
 
-Add to table of supported models in [generative_models.md](./generative_models) or [multimodal_language_models.md](./multimodal_language_models)
+Add to table of supported models in [generative_models.md](/docs/supported-models/generative_models) or [multimodal_language_models.md](/docs/supported-models/multimodal_language_models)
 
 <Tip>
 For NPU-adapted models, also add entries to the NPU support models table in

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1532,7 +1532,12 @@ async def parse_function_call_request(obj: ParseFunctionCallReq, request: Reques
     A native API endpoint to parse function calls from a text.
     """
     # 1) Initialize the parser based on the request body
-    parser = FunctionCallParser(tools=obj.tools, tool_call_parser=obj.tool_call_parser)
+    server_args = _global_state.tokenizer_manager.server_args
+    parser = FunctionCallParser(
+        tools=obj.tools,
+        tool_call_parser=obj.tool_call_parser,
+        enable_compatibility_mode=server_args.enable_tool_call_compatibility_mode,
+    )
 
     # 2) Call the non-stream parsing method (non-stream)
     normal_text, calls = parser.parse_non_stream(obj.text)

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -137,6 +137,9 @@ class OpenAIServingChat(OpenAIServingBase):
         super().__init__(tokenizer_manager)
         self.template_manager = template_manager
         self.tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
+        self.enable_tool_call_compatibility_mode = (
+            self.tokenizer_manager.server_args.enable_tool_call_compatibility_mode
+        )
         self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
         self._reasoning_detector = None
         if self.reasoning_parser:
@@ -588,7 +591,11 @@ class OpenAIServingChat(OpenAIServingBase):
             else:
                 tools = [item.model_dump() for item in request.tools]
             if self.tool_call_parser:
-                parser = FunctionCallParser(request.tools, self.tool_call_parser)
+                parser = FunctionCallParser(
+                    request.tools,
+                    self.tool_call_parser,
+                    enable_compatibility_mode=self.enable_tool_call_compatibility_mode,
+                )
                 tool_call_constraint = parser.get_structure_constraint(
                     request.tool_choice,
                     parallel_tool_calls=request.parallel_tool_calls,
@@ -1409,7 +1416,11 @@ class OpenAIServingChat(OpenAIServingBase):
         # For required/named: only use parser when structural_tag was used
         # as constraint (mirrors the streaming path). For auto: always try.
         if self.tool_call_parser:
-            parser = FunctionCallParser(tools, self.tool_call_parser)
+            parser = FunctionCallParser(
+                tools,
+                self.tool_call_parser,
+                enable_compatibility_mode=self.enable_tool_call_compatibility_mode,
+            )
             should_try_parser = (
                 not is_required or parser.detector.supports_structural_tag()
             )
@@ -1766,26 +1777,29 @@ class OpenAIServingChat(OpenAIServingBase):
                     probe = FunctionCallParser(
                         tools=request.tools,
                         tool_call_parser=self.tool_call_parser,
+                        enable_compatibility_mode=self.enable_tool_call_compatibility_mode,
                     )
                     use_native_parser = probe.detector.supports_structural_tag()
                 if use_native_parser:
                     parser_dict[index] = probe
                 else:
-                    parser_dict[index] = JsonArrayParser()
+                    # The constrained-output JSON parser sits behind the same
+                    # FunctionCallParser boundary as every other detector
+                    # (scope-4 fail-open, streaming latch, compatibility mode).
+                    parser_dict[index] = FunctionCallParser.with_detector(
+                        JsonArrayParser(),
+                        request.tools,
+                        enable_compatibility_mode=self.enable_tool_call_compatibility_mode,
+                    )
             else:
                 parser_dict[index] = FunctionCallParser(
                     tools=request.tools,
                     tool_call_parser=self.tool_call_parser,
+                    enable_compatibility_mode=self.enable_tool_call_compatibility_mode,
                 )
 
         parser = parser_dict[index]
-
-        # Handle both FunctionCallParser and JsonArrayParser
-        if isinstance(parser, JsonArrayParser):
-            result = parser.parse_streaming_increment(delta, request.tools)
-            normal_text, calls = result.normal_text, result.calls
-        else:
-            normal_text, calls = parser.parse_stream_chunk(delta)
+        normal_text, calls = parser.parse_stream_chunk(delta)
 
         # Yield normal text
         if normal_text:
@@ -1868,7 +1882,7 @@ class OpenAIServingChat(OpenAIServingBase):
 
     def _check_for_unstreamed_tool_args(
         self,
-        parser: Union[FunctionCallParser, JsonArrayParser],
+        parser: FunctionCallParser,
         content: Dict[str, Any],
         request: ChatCompletionRequest,
         index: int,
@@ -1878,8 +1892,7 @@ class OpenAIServingChat(OpenAIServingBase):
         when generation finishes. This ensures tool calls are properly completed
         even if the model generates the final arguments in the last chunk.
         """
-        # Get the detector - either from FunctionCallParser or directly if json detector
-        detector = parser.detector if hasattr(parser, "detector") else parser
+        detector = parser.detector
 
         # Only check if we have tool calls and the detector has tracked data
         if (

--- a/python/sglang/srt/function_call/apertus2509_detector.py
+++ b/python/sglang/srt/function_call/apertus2509_detector.py
@@ -1,9 +1,7 @@
 import json
-import logging
 from typing import Any, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -11,9 +9,6 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
-
-logger = logging.getLogger(__name__)
-
 
 class Apertus2509Detector(BaseFormatDetector):
     """
@@ -147,13 +142,7 @@ class Apertus2509Detector(BaseFormatDetector):
                 if args is None:
                     args = {}
 
-                if (
-                    name not in self._tool_indices
-                    and not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
-                ):
-                    logger.warning(
-                        f"Model attempted to call undefined function: {name}"
-                    )
+                if name not in self._tool_indices and self._skip_unknown_tool(name):
                     continue
 
                 tool_id = self.current_tool_id
@@ -232,11 +221,7 @@ class Apertus2509Detector(BaseFormatDetector):
             if args is None:
                 args = {}
 
-            if (
-                name not in self._tool_indices
-                and not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
-            ):
-                logger.warning(f"Model attempted to call undefined function: {name}")
+            if name not in self._tool_indices and self._skip_unknown_tool(name):
                 continue
 
             calls.append(

--- a/python/sglang/srt/function_call/apertus2509_detector.py
+++ b/python/sglang/srt/function_call/apertus2509_detector.py
@@ -10,6 +10,7 @@ from sglang.srt.function_call.core_types import (
     _GetInfoFunc,
 )
 
+
 class Apertus2509Detector(BaseFormatDetector):
     """
     Detector for Apertus 2509 tool/function call format

--- a/python/sglang/srt/function_call/apertus2509_detector.py
+++ b/python/sglang/srt/function_call/apertus2509_detector.py
@@ -3,6 +3,7 @@ from typing import Any, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -53,10 +54,26 @@ class Apertus2509Detector(BaseFormatDetector):
             tool_part = text[start:]
             parsed_arr, json_end = self._try_parse_json_array(tool_part)
             if parsed_arr is None:
+                if self.suffix in tool_part:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=tool_part[:80],
+                    )
+                    cursor = start + tool_part.find(self.suffix) + len(self.suffix)
+                    continue
+                else:
+                    self.compatibility.note(
+                        CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                        detail=tool_part[:80],
+                    )
                 normal_parts.append(tool_part)
                 break
 
             if (suffix_pos := tool_part.find(self.suffix, json_end)) == -1:
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=tool_part[:80],
+                )
                 normal_parts.append(tool_part)
                 break
 
@@ -121,10 +138,14 @@ class Apertus2509Detector(BaseFormatDetector):
             parsed_arr, suffix_pos = self._try_parse_json_array(self._buffer)
             if parsed_arr is None:
                 if self.suffix in self._buffer:
-                    out_normal += self._buffer
-                    self._buffer = ""
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=self._buffer[:80],
+                    )
+                    suffix_end = self._buffer.find(self.suffix) + len(self.suffix)
+                    self._buffer = self._buffer[suffix_end:]
                     self._in_tools_block = False
-                    return StreamingParseResult(normal_text=out_normal, calls=out_calls)
+                    continue
                 return StreamingParseResult(normal_text=out_normal, calls=out_calls)
 
             while suffix_pos < len(self._buffer) and self._buffer[suffix_pos].isspace():
@@ -139,6 +160,10 @@ class Apertus2509Detector(BaseFormatDetector):
             for item in parsed_arr:
                 name, args = self._apertus_obj_to_call(item)
                 if name is None:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=repr(item)[:80],
+                    )
                     continue
                 if args is None:
                     args = {}
@@ -218,6 +243,10 @@ class Apertus2509Detector(BaseFormatDetector):
         for item in arr:
             name, args = self._apertus_obj_to_call(item)
             if name is None:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=repr(item)[:80],
+                )
                 continue
             if args is None:
                 args = {}

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple, Union
 
 import orjson
 from partial_json_parser.core.exceptions import MalformedJSON
@@ -15,6 +15,13 @@ except ImportError:
 
 from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 from sglang.srt.environ import envs
+from sglang.srt.function_call.compatibility import (
+    CompatibilityEvent,
+    CompatibilityMode,
+    CompatibilityRecord,
+    CompatibilityViolation,
+    synthesize_json_close,
+)
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -56,6 +63,86 @@ class BaseFormatDetector(ABC):
         self.eot_token = ""
         self.tool_call_separator = ", "
 
+        # Compatibility-mode policy: the audit trail of tolerances applied to this request.
+        self.compatibility = CompatibilityMode()
+
+    @property
+    def compatibility_records(self) -> List[CompatibilityRecord]:
+        """Tolerances applied to this request so far."""
+        return list(self.compatibility.records)
+
+    def fail_open_stream(
+        self, error: Exception, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        """Recover after ``parse_streaming_increment`` raised exception.
+
+        Called only by ``FunctionCallParser`` — the single recovery boundary —
+        which then passes the rest of the stream through as normal text. The
+        base behavior flushes ``_buffer`` (the accumulated text not yet
+        surfaced; implementations append the chunk to it on entry, so it
+        contains ``new_text``) as content and, when a tool call is mid-stream,
+        closes its already-streamed JSON arguments. Detectors with richer
+        internal state may override to also drain output parsed before the
+        error.
+        """
+        # NOTE: when a call is mid-stream, ``_buffer`` still contains
+        # argument text already emitted as tool-call deltas, so the client
+        # may see it twice (closed tool-call JSON plus raw text). This is the
+        # deliberate no-text-loss trade-off: the buffer cannot be split
+        # reliably after an arbitrary failure.
+        buffered = self._buffer
+        self._buffer = ""
+        return StreamingParseResult(
+            normal_text=buffered if buffered else new_text,
+            calls=self._close_mid_stream_call(),
+        )
+
+    def fail_open_nonstream(
+        self, error: Exception, full_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        """Recover after ``detect_and_parse`` raised (compatibility scope 4).
+
+        Called only by ``FunctionCallParser``. The base behavior surfaces the
+        full original text as content; detectors that can salvage complete
+        calls parsed before the error may override.
+        """
+        return StreamingParseResult(normal_text=full_text)
+
+    def _close_mid_stream_call(self) -> List[ToolCallItem]:
+        """Close the JSON of a mid-stream call so sent fragments stay valid.
+
+        Appends a synthesized closing fragment (see
+        ``compatibility.synthesize_json_close``) when the current tool call's
+        streamed arguments are incomplete JSON, and records the closed
+        arguments in ``prev_tool_call_arr`` so the serving layer's
+        ``_check_for_unstreamed_tool_args`` does not double-send.
+        """
+        calls: List[ToolCallItem] = []
+        tid = self.current_tool_id
+        if not (0 <= tid < len(self.streamed_args_for_tool)):
+            return calls
+        streamed = self.streamed_args_for_tool[tid]
+        if not streamed:
+            return calls
+        args = None
+        try:
+            args = json.loads(streamed)
+        except json.JSONDecodeError:
+            closing = synthesize_json_close(streamed)
+            if closing is not None:
+                if closing:
+                    calls.append(ToolCallItem(tool_index=tid, parameters=closing))
+                    self.streamed_args_for_tool[tid] = streamed + closing
+                try:
+                    args = json.loads(self.streamed_args_for_tool[tid])
+                except json.JSONDecodeError:
+                    args = None
+        if tid < len(self.prev_tool_call_arr):
+            self.prev_tool_call_arr[tid]["arguments"] = (
+                args if args is not None else {}
+            )
+        return calls
+
     def _get_tool_indices(self, tools: List[Tool]) -> Dict[str, int]:
         """
         Get a mapping of tool names to their indices in the tools list.
@@ -74,6 +161,38 @@ class BaseFormatDetector(ABC):
             tool.function.name: i for i, tool in enumerate(tools) if tool.function.name
         }
 
+    def _skip_unknown_tool(self, name: Optional[str]) -> bool:
+        """Drop gate for a tool name absent from the request's tools.
+
+        Returns True (and records ``UNKNOWN_TOOL_DROPPED``) when the call
+        should be dropped; False when ``SGLANG_FORWARD_UNKNOWN_TOOLS`` says
+        to forward it anyway.
+        """
+        logger.warning("Model attempted to call undefined function: %s", name)
+        if envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
+            return False
+        self.compatibility.note(
+            CompatibilityEvent.UNKNOWN_TOOL_DROPPED, detail=repr(name)
+        )
+        return True
+
+    def _note_malformed_tool_call(
+        self, error: Exception, *, detail: str = ""
+    ) -> None:
+        """Record a detector-local parse fallback.
+
+        Detectors that can locally recover from malformed model output call
+        this before returning their legacy fallback. In strict mode the note
+        raises ``CompatibilityViolation`` and the ``FunctionCallParser``
+        boundary performs fail-open recovery.
+        """
+        if isinstance(error, CompatibilityViolation):
+            raise error
+        self.compatibility.note(
+            CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            detail=detail or str(error)[:120],
+        )
+
     def parse_base_json(self, action: Any, tools: List[Tool]) -> List[ToolCallItem]:
         tool_indices = self._get_tool_indices(tools)
         if not isinstance(action, list):
@@ -83,9 +202,8 @@ class BaseFormatDetector(ABC):
         for act in action:
             name = act.get("name")
             if not (name and name in tool_indices):
-                logger.warning(f"Model attempted to call undefined function: {name}")
-                if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
-                    continue  # Skip unknown tools (default legacy behavior)
+                if self._skip_unknown_tool(name):
+                    continue
 
             results.append(
                 ToolCallItem(
@@ -122,6 +240,21 @@ class BaseFormatDetector(ABC):
                 return i
         return 0
 
+    def _hold_back_partial_tokens(
+        self, text: str, tokens: Iterable[str]
+    ) -> Tuple[str, str]:
+        """Split ``text`` into ``(flushable, holdback)``.
+
+        The holdback is the longest suffix that could still grow into one of
+        ``tokens``. Custom streaming implementations use this before flushing
+        buffered text as content, so a marker split across chunk boundaries
+        is neither leaked to the client nor lost to the parser.
+        """
+        partial = max(self._ends_with_partial_token(text, token) for token in tokens)
+        if partial:
+            return text[:-partial], text[-partial:]
+        return text, ""
+
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
     ) -> StreamingParseResult:
@@ -153,16 +286,12 @@ class BaseFormatDetector(ABC):
                 and current_text.startswith(self.tool_call_separator)
             )
         ):
-            # Only clear buffer if we're sure no tool call is starting
-            if not self._ends_with_partial_token(self._buffer, self.bot_token):
-                normal_text = self._buffer
-                self._buffer = ""
-                if self.eot_token in normal_text:
-                    normal_text = normal_text.replace(self.eot_token, "")
-                return StreamingParseResult(normal_text=normal_text)
-            else:
-                # Might be partial bot_token, keep buffering
-                return StreamingParseResult()
+            normal_text, self._buffer = self._hold_back_partial_tokens(
+                current_text, (self.bot_token,)
+            )
+            if self.eot_token in normal_text:
+                normal_text = normal_text.replace(self.eot_token, "")
+            return StreamingParseResult(normal_text=normal_text)
 
         # Build tool indices if not already built
         if not hasattr(self, "_tool_indices"):
@@ -171,177 +300,180 @@ class BaseFormatDetector(ABC):
         flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
 
         try:
-            try:
-                # Priority check: if we're processing a subsequent tool (current_tool_id > 0),
-                # first check if text starts with the tool separator. This is critical for
-                # parallel tool calls because the bot_token (e.g., '[') can also
-                # appear inside array parameters of the current tool, and we must not
-                # mistakenly identify that as the start of a new tool.
-                used_separator_branch = False
-                if self.current_tool_id > 0 and current_text.startswith(
-                    self.tool_call_separator
-                ):
-                    start_idx = len(self.tool_call_separator)
-                    used_separator_branch = True
+            # Priority check: if we're processing a subsequent tool (current_tool_id > 0),
+            # first check if text starts with the tool separator. This is critical for
+            # parallel tool calls because the bot_token (e.g., '[') can also
+            # appear inside array parameters of the current tool, and we must not
+            # mistakenly identify that as the start of a new tool.
+            used_separator_branch = False
+            if self.current_tool_id > 0 and current_text.startswith(
+                self.tool_call_separator
+            ):
+                start_idx = len(self.tool_call_separator)
+                used_separator_branch = True
+            else:
+                tool_call_pos = current_text.find(self.bot_token)
+                if tool_call_pos != -1:
+                    start_idx = tool_call_pos + len(self.bot_token)
                 else:
-                    tool_call_pos = current_text.find(self.bot_token)
-                    if tool_call_pos != -1:
-                        start_idx = tool_call_pos + len(self.bot_token)
-                    else:
-                        start_idx = 0
+                    start_idx = 0
 
-                if start_idx >= len(current_text):
-                    return StreamingParseResult()
+            if start_idx >= len(current_text):
+                return StreamingParseResult()
 
-                try:
-                    obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
-                except (MalformedJSON, json.JSONDecodeError):
-                    # Separator landed on non-JSON markup; fall back to
-                    # bot_token which skips past all inter-object markup.
-                    # e.g. Qwen25: separator "," matches between eot/bot tags.
-                    if used_separator_branch and self.bot_token in current_text:
-                        start_idx = current_text.find(self.bot_token) + len(
-                            self.bot_token
-                        )
-                        if start_idx >= len(current_text):
-                            return StreamingParseResult()
-                        obj, end_idx = _partial_json_loads(
-                            current_text[start_idx:], flags
-                        )
-                    else:
-                        raise
-
-                is_current_complete = _is_complete_json(
-                    current_text[start_idx : start_idx + end_idx]
-                )
-
-                # Validate tool name if present
-                if "name" in obj and obj["name"] not in self._tool_indices:
-                    # Invalid tool name - reset state
-                    self._buffer = ""
-                    self.current_tool_id = -1
-                    self.current_tool_name_sent = False
-                    if self.streamed_args_for_tool:
-                        self.streamed_args_for_tool.pop()
-                    return StreamingParseResult()
-
-                # Handle parameters/arguments consistency
-                # NOTE: we assume here that the obj is always partial of a single tool call
-                if "parameters" in obj:
-                    assert (
-                        "arguments" not in obj
-                    ), "model generated both parameters and arguments"
-                    obj["arguments"] = obj["parameters"]
-
-                current_tool_call = obj
-
+            try:
+                obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
             except (MalformedJSON, json.JSONDecodeError):
+                # Separator landed on non-JSON markup; fall back to
+                # bot_token which skips past all inter-object markup.
+                # e.g. Qwen25: separator "," matches between eot/bot tags.
+                if used_separator_branch and self.bot_token in current_text:
+                    start_idx = current_text.find(self.bot_token) + len(
+                        self.bot_token
+                    )
+                    if start_idx >= len(current_text):
+                        return StreamingParseResult()
+                    obj, end_idx = _partial_json_loads(
+                        current_text[start_idx:], flags
+                    )
+                else:
+                    raise
+
+            is_current_complete = _is_complete_json(
+                current_text[start_idx : start_idx + end_idx]
+            )
+
+            # Validate tool name if present (honoring
+            # SGLANG_FORWARD_UNKNOWN_TOOLS, like the non-streaming path)
+            if (
+                "name" in obj
+                and obj["name"] not in self._tool_indices
+                and self._skip_unknown_tool(obj["name"])
+            ):
+                # Invalid tool name - reset state
+                self._buffer = ""
+                self.current_tool_id = -1
+                self.current_tool_name_sent = False
+                if self.streamed_args_for_tool:
+                    self.streamed_args_for_tool.pop()
                 return StreamingParseResult()
 
-            if not current_tool_call:
-                return StreamingParseResult()
+            # Handle parameters/arguments consistency
+            # NOTE: we assume here that the obj is always partial of a single tool call
+            if "parameters" in obj:
+                assert (
+                    "arguments" not in obj
+                ), "model generated both parameters and arguments"
+                obj["arguments"] = obj["parameters"]
 
-            # Case 1: Handle tool name streaming
-            # This happens when we encounter a tool but haven't sent its name yet
-            if not self.current_tool_name_sent:
-                function_name = current_tool_call.get("name")
+            current_tool_call = obj
 
-                if function_name and function_name in self._tool_indices:
-                    # If this is a new tool (current_tool_id was -1), initialize it
-                    if self.current_tool_id == -1:
-                        self.current_tool_id = 0
+        except (MalformedJSON, json.JSONDecodeError):
+            return StreamingParseResult()
+
+        if not current_tool_call:
+            return StreamingParseResult()
+
+        # Case 1: Handle tool name streaming
+        # This happens when we encounter a tool but haven't sent its name yet
+        if not self.current_tool_name_sent:
+            function_name = current_tool_call.get("name")
+
+            if function_name and (
+                function_name in self._tool_indices
+                or envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+            ):
+                # If this is a new tool (current_tool_id was -1), initialize it
+                if self.current_tool_id == -1:
+                    self.current_tool_id = 0
+                    self.streamed_args_for_tool.append("")
+                # If this is a subsequent tool, ensure streamed_args_for_tool is large enough
+                elif self.current_tool_id >= len(self.streamed_args_for_tool):
+                    while len(self.streamed_args_for_tool) <= self.current_tool_id:
                         self.streamed_args_for_tool.append("")
-                    # If this is a subsequent tool, ensure streamed_args_for_tool is large enough
-                    elif self.current_tool_id >= len(self.streamed_args_for_tool):
-                        while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                            self.streamed_args_for_tool.append("")
 
-                    # Send the tool name with empty parameters
+                # Send the tool name with empty parameters
+                res = StreamingParseResult(
+                    calls=[
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=function_name,
+                            parameters="",
+                        )
+                    ],
+                )
+                self.current_tool_name_sent = True
+            else:
+                res = StreamingParseResult()
+
+        # Case 2: Handle streaming arguments
+        # This happens when we've already sent the tool name and now need to stream arguments incrementally
+        else:
+            cur_arguments = current_tool_call.get("arguments")
+            res = StreamingParseResult()
+
+            if cur_arguments is not None:
+                # Calculate how much of the arguments we've already streamed
+                sent = len(self.streamed_args_for_tool[self.current_tool_id])
+                cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+                prev_arguments = None
+                if self.current_tool_id < len(self.prev_tool_call_arr):
+                    prev_arguments = self.prev_tool_call_arr[
+                        self.current_tool_id
+                    ].get("arguments")
+
+                argument_diff = None
+
+                # If the current tool's JSON is complete, send all remaining arguments
+                if is_current_complete:
+                    argument_diff = cur_args_json[sent:]
+                    completing_tool_id = (
+                        self.current_tool_id
+                    )  # Save the ID of the tool that's completing
+
+                    # Only remove the processed portion, keep unprocessed content
+                    self._buffer = current_text[start_idx + end_idx :]
+
+                # If the tool is still being parsed, send incremental changes
+                elif prev_arguments:
+                    prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
+                    if cur_args_json != prev_args_json:
+                        prefix = _find_common_prefix(prev_args_json, cur_args_json)
+                        argument_diff = prefix[sent:]
+
+                # Update prev_tool_call_arr with current state
+                if self.current_tool_id >= 0:
+                    # Ensure prev_tool_call_arr is large enough
+                    while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                        self.prev_tool_call_arr.append({})
+                    self.prev_tool_call_arr[self.current_tool_id] = (
+                        current_tool_call
+                    )
+
+                # Advance to next tool if complete
+                if is_current_complete:
+                    self.current_tool_name_sent = False
+                    self.current_tool_id += 1
+
+                # Send the argument diff if there's something new
+                if argument_diff is not None:
+                    # Use the correct tool_index: completing_tool_id for completed tools, current_tool_id for ongoing
+                    tool_index_to_use = (
+                        completing_tool_id
+                        if is_current_complete
+                        else self.current_tool_id
+                    )
                     res = StreamingParseResult(
                         calls=[
                             ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=function_name,
-                                parameters="",
+                                tool_index=tool_index_to_use,
+                                parameters=argument_diff,
                             )
                         ],
                     )
-                    self.current_tool_name_sent = True
-                else:
-                    res = StreamingParseResult()
+                    self.streamed_args_for_tool[tool_index_to_use] += argument_diff
 
-            # Case 2: Handle streaming arguments
-            # This happens when we've already sent the tool name and now need to stream arguments incrementally
-            else:
-                cur_arguments = current_tool_call.get("arguments")
-                res = StreamingParseResult()
-
-                if cur_arguments is not None:
-                    # Calculate how much of the arguments we've already streamed
-                    sent = len(self.streamed_args_for_tool[self.current_tool_id])
-                    cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
-                    prev_arguments = None
-                    if self.current_tool_id < len(self.prev_tool_call_arr):
-                        prev_arguments = self.prev_tool_call_arr[
-                            self.current_tool_id
-                        ].get("arguments")
-
-                    argument_diff = None
-
-                    # If the current tool's JSON is complete, send all remaining arguments
-                    if is_current_complete:
-                        argument_diff = cur_args_json[sent:]
-                        completing_tool_id = (
-                            self.current_tool_id
-                        )  # Save the ID of the tool that's completing
-
-                        # Only remove the processed portion, keep unprocessed content
-                        self._buffer = current_text[start_idx + end_idx :]
-
-                    # If the tool is still being parsed, send incremental changes
-                    elif prev_arguments:
-                        prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
-                        if cur_args_json != prev_args_json:
-                            prefix = _find_common_prefix(prev_args_json, cur_args_json)
-                            argument_diff = prefix[sent:]
-
-                    # Update prev_tool_call_arr with current state
-                    if self.current_tool_id >= 0:
-                        # Ensure prev_tool_call_arr is large enough
-                        while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                            self.prev_tool_call_arr.append({})
-                        self.prev_tool_call_arr[self.current_tool_id] = (
-                            current_tool_call
-                        )
-
-                    # Advance to next tool if complete
-                    if is_current_complete:
-                        self.current_tool_name_sent = False
-                        self.current_tool_id += 1
-
-                    # Send the argument diff if there's something new
-                    if argument_diff is not None:
-                        # Use the correct tool_index: completing_tool_id for completed tools, current_tool_id for ongoing
-                        tool_index_to_use = (
-                            completing_tool_id
-                            if is_current_complete
-                            else self.current_tool_id
-                        )
-                        res = StreamingParseResult(
-                            calls=[
-                                ToolCallItem(
-                                    tool_index=tool_index_to_use,
-                                    parameters=argument_diff,
-                                )
-                            ],
-                        )
-                        self.streamed_args_for_tool[tool_index_to_use] += argument_diff
-
-            return res
-
-        except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}")
-            return StreamingParseResult()
+        return res
 
     @abstractmethod
     def has_tool_call(self, text: str) -> bool:

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -138,9 +138,7 @@ class BaseFormatDetector(ABC):
                 except json.JSONDecodeError:
                     args = None
         if tid < len(self.prev_tool_call_arr):
-            self.prev_tool_call_arr[tid]["arguments"] = (
-                args if args is not None else {}
-            )
+            self.prev_tool_call_arr[tid]["arguments"] = args if args is not None else {}
         return calls
 
     def _get_tool_indices(self, tools: List[Tool]) -> Dict[str, int]:
@@ -176,9 +174,7 @@ class BaseFormatDetector(ABC):
         )
         return True
 
-    def _note_malformed_tool_call(
-        self, error: Exception, *, detail: str = ""
-    ) -> None:
+    def _note_malformed_tool_call(self, error: Exception, *, detail: str = "") -> None:
         """Record a detector-local parse fallback.
 
         Detectors that can locally recover from malformed model output call
@@ -328,14 +324,10 @@ class BaseFormatDetector(ABC):
                 # bot_token which skips past all inter-object markup.
                 # e.g. Qwen25: separator "," matches between eot/bot tags.
                 if used_separator_branch and self.bot_token in current_text:
-                    start_idx = current_text.find(self.bot_token) + len(
-                        self.bot_token
-                    )
+                    start_idx = current_text.find(self.bot_token) + len(self.bot_token)
                     if start_idx >= len(current_text):
                         return StreamingParseResult()
-                    obj, end_idx = _partial_json_loads(
-                        current_text[start_idx:], flags
-                    )
+                    obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
                 else:
                     raise
 
@@ -418,9 +410,9 @@ class BaseFormatDetector(ABC):
                 cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
                 prev_arguments = None
                 if self.current_tool_id < len(self.prev_tool_call_arr):
-                    prev_arguments = self.prev_tool_call_arr[
-                        self.current_tool_id
-                    ].get("arguments")
+                    prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
+                        "arguments"
+                    )
 
                 argument_diff = None
 
@@ -446,9 +438,7 @@ class BaseFormatDetector(ABC):
                     # Ensure prev_tool_call_arr is large enough
                     while len(self.prev_tool_call_arr) <= self.current_tool_id:
                         self.prev_tool_call_arr.append({})
-                    self.prev_tool_call_arr[self.current_tool_id] = (
-                        current_tool_call
-                    )
+                    self.prev_tool_call_arr[self.current_tool_id] = current_tool_call
 
                 # Advance to next tool if complete
                 if is_current_complete:

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -16,10 +16,9 @@ except ImportError:
 from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 from sglang.srt.environ import envs
 from sglang.srt.function_call.compatibility import (
+    CompatibilityContext,
     CompatibilityEvent,
-    CompatibilityMode,
     CompatibilityRecord,
-    CompatibilityViolation,
     synthesize_json_close,
 )
 from sglang.srt.function_call.core_types import (
@@ -28,6 +27,7 @@ from sglang.srt.function_call.core_types import (
     _GetInfoFunc,
 )
 from sglang.srt.function_call.utils import (
+    _closed_top_level_json_end,
     _find_common_prefix,
     _is_complete_json,
     _partial_json_loads,
@@ -57,14 +57,19 @@ class BaseFormatDetector(ABC):
         # Critical for serving layer to calculate remaining content when streaming ends.
         # Each index corresponds to a tool_id. Example: ['{"location": "San Francisco"', '{"temp": 72']
         self.streamed_args_for_tool: List[str] = []
+        # True after the detector has accepted the outer tool-call marker and
+        # remains inside the model's multi-call sequence. This lets separator
+        # continuations survive dropped malformed/unknown entries, including
+        # when the separator and next call arrive in different chunks.
+        self._in_tool_call_sequence: bool = False
 
         # Token configuration (override in subclasses)
         self.bot_token = ""
         self.eot_token = ""
         self.tool_call_separator = ", "
 
-        # Compatibility-mode policy: the audit trail of tolerances applied to this request.
-        self.compatibility = CompatibilityMode()
+        # Compatibility-mode policy and audit trail.
+        self.compatibility = CompatibilityContext()
 
     @property
     def compatibility_records(self) -> List[CompatibilityRecord]:
@@ -174,20 +179,74 @@ class BaseFormatDetector(ABC):
         )
         return True
 
-    def _note_malformed_tool_call(self, error: Exception, *, detail: str = "") -> None:
-        """Record a detector-local parse fallback.
+    def _consume_leading_eot_token(self, text: str) -> str:
+        if self.eot_token and text.startswith(self.eot_token):
+            self._in_tool_call_sequence = False
+            return text[len(self.eot_token) :]
+        return text
 
-        Detectors that can locally recover from malformed model output call
-        this before returning their legacy fallback. In strict mode the note
-        raises ``CompatibilityViolation`` and the ``FunctionCallParser``
-        boundary performs fail-open recovery.
-        """
-        if isinstance(error, CompatibilityViolation):
-            raise error
+    def _starts_with_tool_call_separator(self, text: str) -> bool:
+        return bool(
+            self.tool_call_separator and text.startswith(self.tool_call_separator)
+        )
+
+    def _has_tool_call_sequence_context(self) -> bool:
+        """Whether a leading separator can belong to the active tool-call sequence."""
+        return self._in_tool_call_sequence or self.current_tool_name_sent
+
+    def _should_retry_buffer(self, previous_text: str) -> bool:
+        return bool(self._buffer and self._buffer != previous_text)
+
+    def _retry_streaming_tail(
+        self,
+        previous_text: str,
+        calls: List[ToolCallItem],
+        tools: List[Tool],
+    ) -> StreamingParseResult:
+        if not self._should_retry_buffer(previous_text):
+            return StreamingParseResult(calls=calls)
+        tail_result = self.parse_streaming_increment("", tools)
+        return StreamingParseResult(
+            normal_text=tail_result.normal_text,
+            calls=[*calls, *tail_result.calls],
+        )
+
+    def _drop_completed_malformed_entry(
+        self, current_text: str, start_idx: int, end_idx: int, detail: str
+    ) -> bool:
         self.compatibility.note(
             CompatibilityEvent.MALFORMED_JSON_DROPPED,
-            detail=detail or str(error)[:120],
+            detail=detail[:80],
         )
+        self._buffer = self._consume_leading_eot_token(
+            current_text[start_idx + end_idx :]
+        )
+        self.current_tool_name_sent = False
+        return self._should_retry_buffer(current_text)
+
+    def _close_started_malformed_call(self) -> List[ToolCallItem]:
+        """Finish a call whose name was already streamed before its body failed."""
+        if not self.current_tool_name_sent:
+            return []
+
+        tid = self.current_tool_id
+        self.current_tool_name_sent = False
+        if tid < 0:
+            return []
+
+        while len(self.streamed_args_for_tool) <= tid:
+            self.streamed_args_for_tool.append("")
+
+        calls = self._close_mid_stream_call()
+        if not self.streamed_args_for_tool[tid]:
+            calls.append(ToolCallItem(tool_index=tid, parameters="{}"))
+            self.streamed_args_for_tool[tid] = "{}"
+            while len(self.prev_tool_call_arr) <= tid:
+                self.prev_tool_call_arr.append({})
+            self.prev_tool_call_arr[tid]["arguments"] = {}
+
+        self.current_tool_id = tid + 1
+        return calls
 
     def parse_base_json(self, action: Any, tools: List[Tool]) -> List[ToolCallItem]:
         tool_indices = self._get_tool_indices(tools)
@@ -196,7 +255,21 @@ class BaseFormatDetector(ABC):
 
         results = []
         for act in action:
+            if not isinstance(act, dict):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=repr(act)[:80],
+                )
+                continue
+
             name = act.get("name")
+            if not name:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=repr(act)[:80],
+                )
+                continue
+
             if not (name and name in tool_indices):
                 if self._skip_unknown_tool(name):
                     continue
@@ -269,201 +342,300 @@ class BaseFormatDetector(ABC):
 
         For incompatible formats, detectors should override this method with custom logic.
         """
-        # Append new text to buffer
         self._buffer += new_text
-        current_text = self._buffer
+        emitted_calls: List[ToolCallItem] = []
 
-        # The current_text has tool_call if it is the start of a new tool call sequence
-        # or it is the start of a new tool call after a tool call separator, when there is a previous tool call
-        if not (
-            self.has_tool_call(current_text)
-            or (
-                self.current_tool_id > 0
-                and current_text.startswith(self.tool_call_separator)
+        def empty_or_emitted() -> StreamingParseResult:
+            return (
+                StreamingParseResult(calls=emitted_calls)
+                if emitted_calls
+                else StreamingParseResult()
             )
-        ):
-            normal_text, self._buffer = self._hold_back_partial_tokens(
-                current_text, (self.bot_token,)
-            )
-            if self.eot_token in normal_text:
-                normal_text = normal_text.replace(self.eot_token, "")
-            return StreamingParseResult(normal_text=normal_text)
 
-        # Build tool indices if not already built
-        if not hasattr(self, "_tool_indices"):
-            self._tool_indices = self._get_tool_indices(tools)
-
-        flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
-
-        try:
-            # Priority check: if we're processing a subsequent tool (current_tool_id > 0),
-            # first check if text starts with the tool separator. This is critical for
-            # parallel tool calls because the bot_token (e.g., '[') can also
-            # appear inside array parameters of the current tool, and we must not
-            # mistakenly identify that as the start of a new tool.
-            used_separator_branch = False
-            if self.current_tool_id > 0 and current_text.startswith(
-                self.tool_call_separator
+        # A completed bad entry can be consumed without emitting output. Keep
+        # reparsing so a same-chunk tail can still produce the next call:
+        # '<tool_call>{"name":"bad","arguments":{}}, {"name":"get_weather",...}'
+        # becomes ', {"name":"get_weather",...}' after the drop.
+        while True:
+            current_text = self._buffer
+            if (
+                self._in_tool_call_sequence
+                and self.eot_token
+                and current_text.startswith(self.eot_token)
             ):
-                start_idx = len(self.tool_call_separator)
-                used_separator_branch = True
-            else:
-                tool_call_pos = current_text.find(self.bot_token)
-                if tool_call_pos != -1:
-                    start_idx = tool_call_pos + len(self.bot_token)
-                else:
-                    start_idx = 0
+                self._buffer = self._consume_leading_eot_token(current_text)
+                if self._buffer:
+                    continue
+                return StreamingParseResult(calls=emitted_calls)
 
-            if start_idx >= len(current_text):
-                return StreamingParseResult()
+            # If the first entry was dropped, current_tool_id may still be -1
+            # while the buffer starts with ', {"name":"get_weather",...}'.
+            # The outer marker was already accepted, so the comma is sequence
+            # syntax rather than normal text.
+            starts_with_sequence_separator = (
+                self._starts_with_tool_call_separator(current_text)
+                and self._has_tool_call_sequence_context()
+            )
+            has_tool_call = self.has_tool_call(current_text)
+
+            # Parse when a marker starts a sequence, or a leading separator
+            # keeps consuming entries from the current sequence.
+            if not (has_tool_call or starts_with_sequence_separator):
+                normal_text, self._buffer = self._hold_back_partial_tokens(
+                    current_text, (self.bot_token,)
+                )
+                if self.eot_token in normal_text:
+                    normal_text = normal_text.replace(self.eot_token, "")
+                    self._in_tool_call_sequence = False
+                if emitted_calls and normal_text:
+                    # Preserve wire order: callers emit normal_text before calls,
+                    # so text found after recovered calls must wait for the next tick.
+                    self._buffer = normal_text + self._buffer
+                    return StreamingParseResult(calls=emitted_calls)
+                if emitted_calls:
+                    return StreamingParseResult(calls=emitted_calls)
+                return StreamingParseResult(normal_text=normal_text)
+
+            if has_tool_call:
+                self._in_tool_call_sequence = True
+
+            # Build tool indices if not already built
+            if not hasattr(self, "_tool_indices"):
+                self._tool_indices = self._get_tool_indices(tools)
+
+            flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
 
             try:
-                obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
-            except (MalformedJSON, json.JSONDecodeError):
-                # Separator landed on non-JSON markup; fall back to
-                # bot_token which skips past all inter-object markup.
-                # e.g. Qwen25: separator "," matches between eot/bot tags.
-                if used_separator_branch and self.bot_token in current_text:
-                    start_idx = current_text.find(self.bot_token) + len(self.bot_token)
-                    if start_idx >= len(current_text):
-                        return StreamingParseResult()
-                    obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
+                # Priority check: if we're processing a subsequent tool, first
+                # check if text starts with the tool separator. This is critical
+                # for parallel tool calls because the bot_token (e.g., '[') can
+                # also appear inside array parameters of the current tool.
+                used_separator_branch = False
+                if starts_with_sequence_separator:
+                    start_idx = len(self.tool_call_separator)
+                    used_separator_branch = True
                 else:
-                    raise
+                    tool_call_pos = current_text.find(self.bot_token)
+                    if tool_call_pos != -1:
+                        start_idx = tool_call_pos + len(self.bot_token)
+                    else:
+                        start_idx = 0
 
-            is_current_complete = _is_complete_json(
-                current_text[start_idx : start_idx + end_idx]
-            )
+                if start_idx >= len(current_text):
+                    return empty_or_emitted()
 
-            # Validate tool name if present (honoring
-            # SGLANG_FORWARD_UNKNOWN_TOOLS, like the non-streaming path)
-            if (
-                "name" in obj
-                and obj["name"] not in self._tool_indices
-                and self._skip_unknown_tool(obj["name"])
-            ):
-                # Invalid tool name - reset state
-                self._buffer = ""
-                self.current_tool_id = -1
-                self.current_tool_name_sent = False
-                if self.streamed_args_for_tool:
-                    self.streamed_args_for_tool.pop()
-                return StreamingParseResult()
-
-            # Handle parameters/arguments consistency
-            # NOTE: we assume here that the obj is always partial of a single tool call
-            if "parameters" in obj:
-                assert (
-                    "arguments" not in obj
-                ), "model generated both parameters and arguments"
-                obj["arguments"] = obj["parameters"]
-
-            current_tool_call = obj
-
-        except (MalformedJSON, json.JSONDecodeError):
-            return StreamingParseResult()
-
-        if not current_tool_call:
-            return StreamingParseResult()
-
-        # Case 1: Handle tool name streaming
-        # This happens when we encounter a tool but haven't sent its name yet
-        if not self.current_tool_name_sent:
-            function_name = current_tool_call.get("name")
-
-            if function_name and (
-                function_name in self._tool_indices
-                or envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
-            ):
-                # If this is a new tool (current_tool_id was -1), initialize it
-                if self.current_tool_id == -1:
-                    self.current_tool_id = 0
-                    self.streamed_args_for_tool.append("")
-                # If this is a subsequent tool, ensure streamed_args_for_tool is large enough
-                elif self.current_tool_id >= len(self.streamed_args_for_tool):
-                    while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                        self.streamed_args_for_tool.append("")
-
-                # Send the tool name with empty parameters
-                res = StreamingParseResult(
-                    calls=[
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            name=function_name,
-                            parameters="",
+                try:
+                    obj, end_idx = _partial_json_loads(current_text[start_idx:], flags)
+                except (MalformedJSON, json.JSONDecodeError):
+                    # Separator landed on non-JSON markup; fall back to
+                    # bot_token which skips past all inter-object markup.
+                    # e.g. Qwen25: separator "," matches between eot/bot tags.
+                    if used_separator_branch and self.bot_token in current_text:
+                        start_idx = current_text.find(self.bot_token) + len(
+                            self.bot_token
                         )
-                    ],
+                        if start_idx >= len(current_text):
+                            return empty_or_emitted()
+                        obj, end_idx = _partial_json_loads(
+                            current_text[start_idx:], flags
+                        )
+                    else:
+                        raise
+
+                is_current_complete = _is_complete_json(
+                    current_text[start_idx : start_idx + end_idx]
                 )
-                self.current_tool_name_sent = True
-            else:
-                res = StreamingParseResult()
 
-        # Case 2: Handle streaming arguments
-        # This happens when we've already sent the tool name and now need to stream arguments incrementally
-        else:
-            cur_arguments = current_tool_call.get("arguments")
-            res = StreamingParseResult()
+                if not isinstance(obj, dict):
+                    if not is_current_complete:
+                        return empty_or_emitted()
+                    if self._drop_completed_malformed_entry(
+                        current_text,
+                        start_idx,
+                        end_idx,
+                        repr(obj),
+                    ):
+                        continue
+                    return empty_or_emitted()
 
-            if cur_arguments is not None:
-                # Calculate how much of the arguments we've already streamed
-                sent = len(self.streamed_args_for_tool[self.current_tool_id])
-                cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
-                prev_arguments = None
-                if self.current_tool_id < len(self.prev_tool_call_arr):
-                    prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
-                        "arguments"
+                name = obj.get("name")
+                if not name:
+                    if not is_current_complete:
+                        return empty_or_emitted()
+                    if self._drop_completed_malformed_entry(
+                        current_text,
+                        start_idx,
+                        end_idx,
+                        repr(obj),
+                    ):
+                        continue
+                    return empty_or_emitted()
+
+                # Validate tool name if present (honoring
+                # SGLANG_FORWARD_UNKNOWN_TOOLS, like the non-streaming path)
+                if "name" in obj and obj["name"] not in self._tool_indices:
+                    if not is_current_complete:
+                        return empty_or_emitted()
+                    if self._skip_unknown_tool(obj["name"]):
+                        # Consume only this completed unknown call. Retry from
+                        # the remaining buffer so following calls stay parseable
+                        # even when they share the current chunk.
+                        self._buffer = self._consume_leading_eot_token(
+                            current_text[start_idx + end_idx :]
+                        )
+                        self.current_tool_name_sent = False
+                        if self._should_retry_buffer(current_text):
+                            continue
+                        return empty_or_emitted()
+
+                # Handle parameters/arguments consistency
+                # NOTE: we assume here that the obj is always partial of a single tool call
+                if "parameters" in obj:
+                    assert (
+                        "arguments" not in obj
+                    ), "model generated both parameters and arguments"
+                    obj["arguments"] = obj["parameters"]
+
+                current_tool_call = obj
+
+            except (MalformedJSON, json.JSONDecodeError):
+                fragment = current_text[start_idx:]
+                # A parser error alone does not tell us where the bad entry
+                # ends. Wait until the top-level boundary appears; then
+                # '{"arguments":{x}}, {"name":"get_weather",...}' can drop only
+                # the bad entry and retry from the following comma.
+                closed_end = _closed_top_level_json_end(fragment)
+                if closed_end is not None:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=fragment[:closed_end][:80],
                     )
-
-                argument_diff = None
-
-                # If the current tool's JSON is complete, send all remaining arguments
-                if is_current_complete:
-                    argument_diff = cur_args_json[sent:]
-                    completing_tool_id = (
-                        self.current_tool_id
-                    )  # Save the ID of the tool that's completing
-
-                    # Only remove the processed portion, keep unprocessed content
-                    self._buffer = current_text[start_idx + end_idx :]
-
-                # If the tool is still being parsed, send incremental changes
-                elif prev_arguments:
-                    prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
-                    if cur_args_json != prev_args_json:
-                        prefix = _find_common_prefix(prev_args_json, cur_args_json)
-                        argument_diff = prefix[sent:]
-
-                # Update prev_tool_call_arr with current state
-                if self.current_tool_id >= 0:
-                    # Ensure prev_tool_call_arr is large enough
-                    while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                        self.prev_tool_call_arr.append({})
-                    self.prev_tool_call_arr[self.current_tool_id] = current_tool_call
-
-                # Advance to next tool if complete
-                if is_current_complete:
-                    self.current_tool_name_sent = False
-                    self.current_tool_id += 1
-
-                # Send the argument diff if there's something new
-                if argument_diff is not None:
-                    # Use the correct tool_index: completing_tool_id for completed tools, current_tool_id for ongoing
-                    tool_index_to_use = (
-                        completing_tool_id
-                        if is_current_complete
-                        else self.current_tool_id
+                    closing_calls = self._close_started_malformed_call()
+                    self._buffer = self._consume_leading_eot_token(
+                        fragment[closed_end:]
                     )
+                    if closing_calls:
+                        emitted_calls.extend(closing_calls)
+                        if self._should_retry_buffer(current_text):
+                            continue
+                        return StreamingParseResult(calls=emitted_calls)
+                    if self._should_retry_buffer(current_text):
+                        continue
+                return empty_or_emitted()
+
+            if not current_tool_call:
+                return empty_or_emitted()
+
+            # Case 1: Handle tool name streaming
+            # This happens when we encounter a tool but haven't sent its name yet
+            if not self.current_tool_name_sent:
+                function_name = current_tool_call.get("name")
+
+                if function_name and (
+                    function_name in self._tool_indices
+                    or envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+                ):
+                    # If this is a new tool (current_tool_id was -1), initialize it
+                    if self.current_tool_id == -1:
+                        self.current_tool_id = 0
+                        self.streamed_args_for_tool.append("")
+                    # If this is a subsequent tool, ensure streamed_args_for_tool is large enough
+                    elif self.current_tool_id >= len(self.streamed_args_for_tool):
+                        while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                            self.streamed_args_for_tool.append("")
+
+                    # Send the tool name with empty parameters
                     res = StreamingParseResult(
                         calls=[
                             ToolCallItem(
-                                tool_index=tool_index_to_use,
-                                parameters=argument_diff,
+                                tool_index=self.current_tool_id,
+                                name=function_name,
+                                parameters="",
                             )
                         ],
                     )
-                    self.streamed_args_for_tool[tool_index_to_use] += argument_diff
+                    self.current_tool_name_sent = True
+                else:
+                    res = StreamingParseResult()
 
-        return res
+            # Case 2: Handle streaming arguments
+            # This happens when we've already sent the tool name and now need to stream arguments incrementally
+            else:
+                cur_arguments = current_tool_call.get("arguments")
+                res = StreamingParseResult()
+
+                if cur_arguments is not None:
+                    # Calculate how much of the arguments we've already streamed
+                    sent = len(self.streamed_args_for_tool[self.current_tool_id])
+                    cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+                    prev_arguments = None
+                    if self.current_tool_id < len(self.prev_tool_call_arr):
+                        prev_arguments = self.prev_tool_call_arr[
+                            self.current_tool_id
+                        ].get("arguments")
+
+                    argument_diff = None
+
+                    # If the current tool's JSON is complete, send all remaining arguments
+                    if is_current_complete:
+                        argument_diff = cur_args_json[sent:]
+                        completing_tool_id = (
+                            self.current_tool_id
+                        )  # Save the ID of the tool that's completing
+
+                        # Only remove the processed portion, keep unprocessed content
+                        self._buffer = self._consume_leading_eot_token(
+                            current_text[start_idx + end_idx :]
+                        )
+
+                    # If the tool is still being parsed, send incremental changes
+                    elif prev_arguments:
+                        prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
+                        if cur_args_json != prev_args_json:
+                            prefix = _find_common_prefix(prev_args_json, cur_args_json)
+                            argument_diff = prefix[sent:]
+
+                    # Update prev_tool_call_arr with current state
+                    if self.current_tool_id >= 0:
+                        # Ensure prev_tool_call_arr is large enough
+                        while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                            self.prev_tool_call_arr.append({})
+                        self.prev_tool_call_arr[self.current_tool_id] = (
+                            current_tool_call
+                        )
+
+                    # Advance to next tool if complete
+                    if is_current_complete:
+                        self.current_tool_name_sent = False
+                        self.current_tool_id += 1
+
+                    # Send the argument diff if there's something new
+                    if argument_diff is not None:
+                        # Use the correct tool_index: completing_tool_id for completed tools, current_tool_id for ongoing
+                        tool_index_to_use = (
+                            completing_tool_id
+                            if is_current_complete
+                            else self.current_tool_id
+                        )
+                        res = StreamingParseResult(
+                            calls=[
+                                ToolCallItem(
+                                    tool_index=tool_index_to_use,
+                                    parameters=argument_diff,
+                                )
+                            ],
+                        )
+                        self.streamed_args_for_tool[tool_index_to_use] += argument_diff
+
+            if emitted_calls:
+                emitted_calls.extend(res.calls)
+                if res.calls and self._buffer:
+                    continue
+                return StreamingParseResult(
+                    normal_text=res.normal_text, calls=emitted_calls
+                )
+
+            return res
 
     @abstractmethod
     def has_tool_call(self, text: str) -> bool:

--- a/python/sglang/srt/function_call/cohere_command4_detector.py
+++ b/python/sglang/srt/function_call/cohere_command4_detector.py
@@ -78,6 +78,7 @@ class CohereCommand4Detector(BaseFormatDetector):
                     f"Cohere tool-call body did not parse as JSON: {e}; "
                     "returning surrounding text as normal output."
                 )
+                self._note_malformed_tool_call(e, detail=body[:80])
                 return StreamingParseResult(normal_text=normal_text)
 
         normalized = self._normalize_calls(arr)

--- a/python/sglang/srt/function_call/cohere_command4_detector.py
+++ b/python/sglang/srt/function_call/cohere_command4_detector.py
@@ -8,6 +8,7 @@ from partial_json_parser.core.options import Allow
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -32,8 +33,7 @@ class CohereCommand4Detector(BaseFormatDetector):
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
 
-    @staticmethod
-    def _normalize_calls(arr) -> List[dict]:
+    def _normalize_calls(self, arr) -> List[dict]:
         """Translate Cohere's per-item shape ``{tool_call_id, tool_name,
         parameters}`` into the shape ``parse_base_json`` expects (``name`` /
         ``parameters``). Drops ``tool_call_id`` since the OpenAI Chat
@@ -41,14 +41,28 @@ class CohereCommand4Detector(BaseFormatDetector):
         if isinstance(arr, dict):
             arr = [arr]
         if not isinstance(arr, list):
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=repr(arr)[:80],
+            )
             return []
         out: List[dict] = []
         for act in arr:
             if not isinstance(act, dict):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=repr(act)[:80],
+                )
                 continue
             normalized = dict(act)
             if "name" not in normalized and "tool_name" in normalized:
                 normalized["name"] = normalized.pop("tool_name")
+            if "name" not in normalized:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=repr(act)[:80],
+                )
+                continue
             normalized.pop("tool_call_id", None)
             out.append(normalized)
         return out
@@ -58,28 +72,57 @@ class CohereCommand4Detector(BaseFormatDetector):
         idx = text.find(self.bot_token)
         if idx == -1:
             return StreamingParseResult(normal_text=text)
-        normal_text = text[:idx]
         body_start = idx + len(self.bot_token)
         eot_idx = text.find(self.eot_token, body_start)
         body = text[body_start:eot_idx] if eot_idx != -1 else text[body_start:]
+        normal_text = (
+            text[:idx] + text[eot_idx + len(self.eot_token) :]
+            if eot_idx != -1
+            else text[:idx]
+        )
 
         # body should be ``[ {...}, {...} ]`` (with arbitrary whitespace).
         # Prefer the full-text JSON parser when the block is complete; fall
         # back to ``_partial_json_loads`` to be forgiving when generation was
         # truncated before ``<|END_ACTION|>``.
         arr = None
+        used_partial = False
+        parse_error = None
         try:
             arr = orjson.loads(body)
-        except (orjson.JSONDecodeError, TypeError, ValueError):
+        except (orjson.JSONDecodeError, TypeError, ValueError) as e:
+            parse_error = e
             try:
                 arr, _ = _partial_json_loads(body, Allow.ALL)
+                used_partial = True
             except (MalformedJSON, json.JSONDecodeError, ValueError) as e:
                 logger.warning(
                     f"Cohere tool-call body did not parse as JSON: {e}; "
                     "returning surrounding text as normal output."
                 )
-                self._note_malformed_tool_call(e, detail=body[:80])
+                if eot_idx == -1:
+                    self.compatibility.note(
+                        CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                        detail=body[:80],
+                    )
+                else:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=body[:80],
+                    )
                 return StreamingParseResult(normal_text=normal_text)
+        if used_partial:
+            if eot_idx == -1:
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=body[:80],
+                )
+                return StreamingParseResult(normal_text=text, calls=[])
+            elif parse_error is not None:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=body[:80],
+                )
 
         normalized = self._normalize_calls(arr)
         return StreamingParseResult(

--- a/python/sglang/srt/function_call/compatibility/__init__.py
+++ b/python/sglang/srt/function_call/compatibility/__init__.py
@@ -1,0 +1,35 @@
+"""Public compatibility API for function-call parsing.
+
+The implementation is split by responsibility:
+
+- ``mode.py`` defines the compatibility policy, events, records, and strict
+  mode behavior.
+- ``recovery.py`` owns fail-open recovery at the ``FunctionCallParser``
+  boundary.
+- ``param_types.py`` handles schema-driven value conversion.
+
+Importing from ``sglang.srt.function_call.compatibility`` remains the stable
+package-level API for detectors and tests.
+"""
+
+from sglang.srt.function_call.compatibility.mode import (
+    CompatibilityEvent,
+    CompatibilityMode,
+    CompatibilityRecord,
+    CompatibilityViolation,
+)
+from sglang.srt.function_call.compatibility.recovery import (
+    recover_nonstream,
+    recover_stream,
+    synthesize_json_close,
+)
+
+__all__ = [
+    "CompatibilityEvent",
+    "CompatibilityMode",
+    "CompatibilityRecord",
+    "CompatibilityViolation",
+    "recover_nonstream",
+    "recover_stream",
+    "synthesize_json_close",
+]

--- a/python/sglang/srt/function_call/compatibility/__init__.py
+++ b/python/sglang/srt/function_call/compatibility/__init__.py
@@ -2,8 +2,8 @@
 
 The implementation is split by responsibility:
 
-- ``mode.py`` defines the compatibility policy, events, records, and strict
-  mode behavior.
+- ``context.py`` defines the per-request compatibility context, events,
+  records, and strict behavior.
 - ``recovery.py`` owns fail-open recovery at the ``FunctionCallParser``
   boundary.
 - ``param_types.py`` handles schema-driven value conversion.
@@ -12,9 +12,9 @@ Importing from ``sglang.srt.function_call.compatibility`` remains the stable
 package-level API for detectors and tests.
 """
 
-from sglang.srt.function_call.compatibility.mode import (
+from sglang.srt.function_call.compatibility.context import (
+    CompatibilityContext,
     CompatibilityEvent,
-    CompatibilityMode,
     CompatibilityRecord,
     CompatibilityViolation,
 )
@@ -26,7 +26,7 @@ from sglang.srt.function_call.compatibility.recovery import (
 
 __all__ = [
     "CompatibilityEvent",
-    "CompatibilityMode",
+    "CompatibilityContext",
     "CompatibilityRecord",
     "CompatibilityViolation",
     "recover_nonstream",

--- a/python/sglang/srt/function_call/compatibility/context.py
+++ b/python/sglang/srt/function_call/compatibility/context.py
@@ -1,4 +1,4 @@
-"""Compatibility policy and audit records for tool-call parsing."""
+"""Compatibility add-on context and audit records for tool-call parsing."""
 
 import logging
 from contextlib import contextmanager
@@ -93,19 +93,19 @@ class CompatibilityViolation(Exception):
 
 @dataclass(slots=True)
 class _Absorbed:
-    """Outcome of one :meth:`CompatibilityMode.absorb` block, for flow control."""
+    """Outcome of one :meth:`CompatibilityContext.absorb` block, for flow control."""
 
     fired: bool = False
     record: Optional[CompatibilityRecord] = None
 
 
 @dataclass
-class CompatibilityMode:
-    """Per-request tolerance policy plus the audit trail of applied tolerances.
+class CompatibilityContext:
+    """Per-request compatibility add-on shared by detectors and helpers.
 
     ``BaseFormatDetector`` creates one per detector instance (detectors are
     per-request locals); a detector's internal parser shares the detector's
-    policy so all tolerances for a request land on one audit trail.
+    context so policy and audit records stay on one object.
     """
 
     strict: bool = False

--- a/python/sglang/srt/function_call/compatibility/mode.py
+++ b/python/sglang/srt/function_call/compatibility/mode.py
@@ -1,0 +1,163 @@
+"""Compatibility policy and audit records for tool-call parsing."""
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterator, List, Optional, Tuple, Type, Union
+
+logger = logging.getLogger(__name__)
+
+
+class CompatibilityEvent(str, Enum):
+    """One named tolerance.
+
+    Members carry their compatibility scope and whether the deviation is the model's
+    (raises in strict mode) or the caller's / already-failed (never raises).
+    """
+
+    def __new__(cls, value: str, scope: int, strict_raises: bool):
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.scope = scope
+        obj.strict_raises = strict_raises
+        return obj
+
+    # -- Scope 1: wire structure -----------------------------------------
+    #: Unparseable text dropped up to the next recognizable marker.
+    SKIPPED_GARBAGE = ("skipped-garbage", 1, True)
+    #: A block whose JSON (or literal) body failed to parse was dropped;
+    #: surrounding output is preserved.
+    MALFORMED_JSON_DROPPED = ("malformed-json-dropped", 1, True)
+    #: The model called a tool that is not in the request's tools; the call
+    #: was dropped (set SGLANG_FORWARD_UNKNOWN_TOOLS to forward instead).
+    UNKNOWN_TOOL_DROPPED = ("unknown-tool-dropped", 1, True)
+    #: The rest of an invoke was dropped and its streamed arguments closed.
+    DROPPED_INVOKE_TAIL = ("dropped-invoke-tail", 1, True)
+    #: A Step3 tool-call entry whose type part is not ``function``.
+    SKIPPED_NON_FUNCTION_ENTRY = ("skipped-non-function-entry", 1, True)
+    #: A parameter value terminated by the next tag instead of its close tag.
+    MISSING_CLOSE_TAG = ("missing-close-tag", 1, True)
+    #: Generation ended mid-call (e.g. max_tokens); the half-specified call
+    #: was dropped and its raw text re-surfaced as content.
+    TRUNCATED_CALL_DROPPED = ("truncated-call-dropped", 1, True)
+
+    # -- Scope 2: nested parameter structure -----------------------------
+    #: A closing tag closed tags the model never closed itself.
+    MISMATCHED_CLOSING_TAG = ("mismatched-closing-tag", 2, True)
+    #: Tags still open at the end of a parameter body were flushed.
+    UNCLOSED_TAGS_AT_END = ("unclosed-tags-at-end", 2, True)
+    #: A duplicate tag inside an object was collapsed into a list.
+    DUPLICATE_TAG_AS_LIST = ("duplicate-tag-as-list", 2, True)
+    #: Stray text inside an object was captured under ``$text``.
+    MIXED_TEXT_CAPTURED = ("mixed-text-captured", 2, True)
+    #: An array element used a tag other than ``<item>``.
+    NON_ITEM_ARRAY_CHILD = ("non-item-array-child", 2, True)
+    #: Nested tags were parsed as structure although the schema says scalar.
+    STRUCTURE_OVERRODE_SCHEMA = ("structure-overrode-schema", 2, True)
+
+    # -- Scope 3: value conversion ---------------------------------------
+    #: No candidate type could convert the value; the raw string was kept.
+    UNCONVERTIBLE_VALUE_KEPT_RAW = ("unconvertible-value-kept-raw", 3, True)
+    #: The tool's JSON schema is itself invalid and was ignored (caller
+    #: fault -- never raises in strict mode).
+    INVALID_SCHEMA_IGNORED = ("invalid-schema-ignored", 3, False)
+
+    # -- Scope 4: fail-open ----------------------------------------------
+    #: The detector raised; the parse fell open to normal text (recorded at
+    #: the FunctionCallParser boundary after the fact -- never raises).
+    FAIL_OPEN = ("fail-open", 4, False)
+
+
+#: Cap on stored records; pathological inputs degrade to counting only.
+_MAX_RECORDS = 256
+
+
+@dataclass(slots=True)
+class CompatibilityRecord:
+    event: CompatibilityEvent
+    detail: str = ""
+    #: Character offset into the full received text, when known.
+    offset: Optional[int] = None
+
+
+class CompatibilityViolation(Exception):
+    """A model-output deviation hit a strict-mode policy."""
+
+    def __init__(self, record: CompatibilityRecord):
+        self.record = record
+        where = f" at offset {record.offset}" if record.offset is not None else ""
+        detail = f": {record.detail}" if record.detail else ""
+        super().__init__(f"strict mode: {record.event.value}{where}{detail}")
+
+
+@dataclass(slots=True)
+class _Absorbed:
+    """Outcome of one :meth:`CompatibilityMode.absorb` block, for flow control."""
+
+    fired: bool = False
+    record: Optional[CompatibilityRecord] = None
+
+
+@dataclass
+class CompatibilityMode:
+    """Per-request tolerance policy plus the audit trail of applied tolerances.
+
+    ``BaseFormatDetector`` creates one per detector instance (detectors are
+    per-request locals); a detector's internal parser shares the detector's
+    policy so all tolerances for a request land on one audit trail.
+    """
+
+    strict: bool = False
+    records: List[CompatibilityRecord] = field(default_factory=list)
+    #: Records not stored because ``_MAX_RECORDS`` was reached.
+    dropped: int = 0
+
+    def note(
+        self,
+        event: CompatibilityEvent,
+        detail: str = "",
+        *,
+        offset: Optional[int] = None,
+    ) -> Optional[CompatibilityRecord]:
+        """Record (and log) one applied tolerance; raise instead in strict mode."""
+        record = CompatibilityRecord(event=event, detail=detail, offset=offset)
+        if self.strict and event.strict_raises:
+            raise CompatibilityViolation(record)
+        logger.warning("compatibility: %s (%s)", event.value, detail)
+        if len(self.records) >= _MAX_RECORDS:
+            self.dropped += 1
+            return None
+        self.records.append(record)
+        return record
+
+    @contextmanager
+    def absorb(
+        self,
+        event: CompatibilityEvent,
+        exceptions: Union[Type[BaseException], Tuple[Type[BaseException], ...]],
+        detail: str = "",
+    ) -> Iterator[_Absorbed]:
+        """Tolerance as a context: suppress ``exceptions``, record ``event``.
+
+        In strict mode the recording raises ``CompatibilityViolation`` instead
+        of suppressing. Exceptions not listed propagate untouched.
+        """
+        outcome = _Absorbed()
+        try:
+            yield outcome
+        except exceptions as e:
+            outcome.fired = True
+            outcome.record = self.note(event, detail=detail or str(e)[:120])
+
+    def summary(self) -> str:
+        """One-line ``event x count`` summary for logs."""
+        if not self.records and not self.dropped:
+            return "none"
+        counts: dict = {}
+        for record in self.records:
+            counts[record.event.value] = counts.get(record.event.value, 0) + 1
+        parts = [f"{name} x{count}" for name, count in counts.items()]
+        if self.dropped:
+            parts.append(f"(+{self.dropped} dropped)")
+        return ", ".join(parts)

--- a/python/sglang/srt/function_call/compatibility/mode.py
+++ b/python/sglang/srt/function_call/compatibility/mode.py
@@ -24,7 +24,7 @@ class CompatibilityEvent(str, Enum):
         return obj
 
     # -- Scope 1: wire structure -----------------------------------------
-    #: Unparseable text dropped up to the next recognizable marker.
+    #: Unparsable text dropped up to the next recognizable marker.
     SKIPPED_GARBAGE = ("skipped-garbage", 1, True)
     #: A block whose JSON (or literal) body failed to parse was dropped;
     #: surrounding output is preserved.

--- a/python/sglang/srt/function_call/compatibility/param_types.py
+++ b/python/sglang/srt/function_call/compatibility/param_types.py
@@ -236,8 +236,7 @@ class FunctionCallParameterDataType:
     def candidates_allow_structure(self) -> bool:
         """Whether the schema admits nested structure (object/array/unknown)."""
         return any(
-            candidate
-            in (AtomDataType.array, AtomDataType.object, AtomDataType.other)
+            candidate in (AtomDataType.array, AtomDataType.object, AtomDataType.other)
             for candidate in self.candidates
         )
 

--- a/python/sglang/srt/function_call/compatibility/param_types.py
+++ b/python/sglang/srt/function_call/compatibility/param_types.py
@@ -1,0 +1,366 @@
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Iterator, List, Optional, Set
+
+import jsonschema
+import jsonschema.exceptions
+from typing_extensions import Self
+
+from sglang.srt.function_call.compatibility.mode import (
+    CompatibilityEvent,
+    CompatibilityMode,
+)
+
+# fmt: off
+NULL_STRINGS = (
+    "null", "Null", "NULL",
+    # It's bad, especially when we need enum string `none` etc.
+    # "none", "null", "nil",
+    # "None", "Null", "Nil",
+    # "NONE", "NULL", "NIL",
+)
+# fmt: on
+
+
+@dataclass(slots=True)
+class ConversionResult:
+    value: Any
+    confidence: int
+
+
+class AtomDataType(int, Enum):
+    none = auto()
+    string = auto()
+    integer = auto()
+    float = auto()
+    boolean = auto()
+    # complex types:
+    array = auto()
+    object = auto()
+    other = auto()
+
+    @classmethod
+    def from_string(cls, string: Optional[str]) -> Self:
+        if string is None:
+            return cls.string
+        string = string.lower()
+        if string == "none" or string == "null" or string == "nil":
+            return cls.none
+        elif string == "str" or string == "string" or string == "text":
+            return cls.string
+        elif string == "int" or string == "integer":
+            return cls.integer
+        elif string == "float" or string == "number":
+            return cls.float
+        elif string == "bool" or string == "boolean":
+            return cls.boolean
+        elif string == "array" or string == "list":
+            return cls.array
+        elif (
+            string == "object"
+            or string == "dict"
+            or string == "dictionary"
+            or string == "map"
+        ):
+            return cls.object
+        else:
+            return cls.other
+
+    def is_complex_type(self) -> bool:
+        return self == self.array or self == self.object or self == self.other
+
+    @classmethod
+    def from_example(cls, example: Any) -> Self:
+        if example is None:
+            return cls.none
+        elif isinstance(example, str):
+            return cls.string
+        # NOTE: Order matters. True is instance of int.
+        elif isinstance(example, bool):
+            return cls.boolean
+        elif isinstance(example, int):
+            return cls.integer
+        elif isinstance(example, float):
+            return cls.float
+        elif isinstance(example, list):
+            return cls.array
+        elif isinstance(example, dict):
+            return cls.object
+        else:
+            return cls.other
+
+    @classmethod
+    def iter_candidates_from_schema(cls, input: Any) -> Iterator[Self]:
+        if isinstance(input, dict):
+            if "type" in input:
+                type_value = input["type"]
+                if isinstance(type_value, str):
+                    yield cls.from_string(type_value)
+                elif isinstance(type_value, list):
+                    for each in type_value:
+                        yield cls.from_string(each)
+                else:
+                    yield cls.other
+            elif ("properties" in input and isinstance(input["properties"], dict)) or (
+                "additionalProperties" in input
+                and input["additionalProperties"] is not False
+            ):
+                yield cls.object
+            elif "items" in input or "prefixItems" in input:
+                yield cls.array
+            else:
+                nothing_found = True
+                if "const" in input:
+                    nothing_found = False
+                    yield cls.from_example(input["const"])
+                elif (
+                    "enum" in input
+                    and isinstance(input["enum"], list)
+                    and input["enum"]
+                ):
+                    for each in input["enum"]:
+                        nothing_found = False
+                        yield cls.from_example(each)
+                else:
+                    for choice_field in ("anyOf", "oneOf", "allOf"):
+                        if choice_field in input:
+                            choices = input[choice_field]
+                            if isinstance(choices, list):
+                                for choice in choices:
+                                    for each in cls.iter_candidates_from_schema(choice):
+                                        nothing_found = False
+                                        yield each
+                if nothing_found:
+                    yield cls.string
+        else:
+            yield cls.string
+
+    def convert_with_confidence(self, string: str) -> Optional[ConversionResult]:
+        if self == AtomDataType.none:
+            stripped = string.strip()
+            if stripped:
+                if len(stripped) == 4 and stripped.lower() == "null":
+                    return ConversionResult(value=None, confidence=10)
+                return ConversionResult(value=None, confidence=1)
+            else:
+                return ConversionResult(value=None, confidence=3)
+        elif self == AtomDataType.string:
+            return ConversionResult(value=string, confidence=2)
+        elif self == AtomDataType.integer:
+            try:
+                return ConversionResult(value=int(string), confidence=10)
+            except ValueError:
+                return None
+        elif self == AtomDataType.float:
+            try:
+                value = float(string)
+            except ValueError:
+                return None
+            # NOTE: Python is evil.
+            # In Python, we have
+            #     json.dumps(math.nan) -> "NaN"
+            #     json.dumps(math.inf) -> "Infinity"
+            #     json.dumps(-math.inf) -> "-Infinity"
+            # However, in other languages, you cannot deserialize them back.
+            # No perfect solution here.
+            if math.isnan(value):
+                value = "NaN"
+            elif math.isinf(value):
+                value = "Infinity" if value > 0 else "-Infinity"
+            elif value.is_integer() and not any(c in string for c in ".eE"):
+                # Only demote to int when the raw text is written as an
+                # integer (e.g. "3"). Preserve explicit floats like "3.0" or
+                # "1e2" as floats, matching what the model intended.
+                value = int(value)
+            return ConversionResult(value=value, confidence=10)
+        elif self == AtomDataType.boolean:
+            stripped = string.strip()
+            if len(stripped) > 5:
+                return ConversionResult(value=False, confidence=1)
+            lower = stripped.lower()
+            if lower == "true":
+                return ConversionResult(value=True, confidence=10)
+            elif lower == "false":
+                return ConversionResult(value=False, confidence=10)
+            elif lower == "yes" or lower == "on" or lower == "1":
+                return ConversionResult(value=True, confidence=9)
+            elif lower == "no" or lower == "off" or lower == "0":
+                return ConversionResult(value=False, confidence=9)
+            else:
+                return ConversionResult(value=False, confidence=1)
+        else:
+            try:
+                return ConversionResult(value=json.loads(string), confidence=10)
+            except json.JSONDecodeError:
+                return None
+
+
+@dataclass(slots=True)
+class FunctionCallParameterDataType:
+    candidates: List[AtomDataType]
+    schema: Any
+    streaming: bool
+
+    @classmethod
+    def get_schema_of_parameter(cls, schema: Any, parameter_name: str) -> Self:
+        """
+        $ref etc. not supported.
+        """
+        if not isinstance(schema, dict):
+            return cls(candidates=[AtomDataType.string], schema=None, streaming=True)
+        property = None
+        parameters = schema.get("parameters")
+        if isinstance(parameters, dict):
+            properties = parameters.get("properties")
+            if isinstance(properties, dict):
+                property = properties.get(parameter_name)
+        return cls.from_property(property)
+
+    @classmethod
+    def from_property(cls, property: Any) -> Self:
+        candidate_set: Set[AtomDataType] = set()
+        candidates: List[AtomDataType] = []
+        # Guaranteed to be non-empty.
+        for each in AtomDataType.iter_candidates_from_schema(property):
+            if each not in candidate_set:
+                candidate_set.add(each)
+                candidates.append(each)
+        # The parameter is streaming if and only if there is only one candidate, string.
+        # No matter how complicated the schema is, if it can only be a string,
+        streaming = len(candidates) == 1 and candidates[0] == AtomDataType.string
+        return cls(candidates=candidates, schema=property, streaming=streaming)
+
+    @property
+    def candidates_allow_structure(self) -> bool:
+        """Whether the schema admits nested structure (object/array/unknown)."""
+        return any(
+            candidate
+            in (AtomDataType.array, AtomDataType.object, AtomDataType.other)
+            for candidate in self.candidates
+        )
+
+    def get_data_type_of_property(self, key: str) -> Optional[Self]:
+        if isinstance(self.schema, dict):
+            property = self.get_property(self.schema, key)
+            if property:
+                return self.from_property(property)
+            property_choices = []
+            for choice_field in ("anyOf", "oneOf", "allOf"):
+                if choice_field in self.schema:
+                    choices = self.schema[choice_field]
+                    if isinstance(choices, list):
+                        for choice in choices:
+                            property = self.get_property(choice, key)
+                            if property:
+                                property_choices.append(property)
+            if property_choices:
+                return self.from_property(
+                    {
+                        "anyOf": property_choices,
+                    }
+                )
+
+    @staticmethod
+    def get_property(schema: Any, key: str) -> Any:
+        if "properties" in schema:
+            properties = schema["properties"]
+            if isinstance(properties, dict):
+                property = properties.get(key)
+                if property:
+                    return property
+        if "additionalProperties" in schema:
+            additional_properties = schema["additionalProperties"]
+            if isinstance(additional_properties, dict):
+                return additional_properties
+
+    def get_data_type_of_item(self, *, index: int = 0) -> Optional[Self]:
+        if isinstance(self.schema, dict):
+            item = self.get_item(self.schema, index=index)
+            if item:
+                return self.from_property(item)
+            item_choices = []
+            for choice_field in ("anyOf", "oneOf", "allOf"):
+                if choice_field in self.schema:
+                    choices = self.schema[choice_field]
+                    if isinstance(choices, list):
+                        for choice in choices:
+                            item = self.get_item(choice, index=index)
+                            if item:
+                                item_choices.append(item)
+            if item_choices:
+                return self.from_property(
+                    {
+                        "anyOf": item_choices,
+                    }
+                )
+
+    @staticmethod
+    def get_item(schema: Any, *, index: int = 0) -> Any:
+        items = schema.get("items")
+        if items:
+            return items
+        if "prefixItems" in schema:
+            prefix_items = schema["prefixItems"]
+            additional_items = schema.get("additionalItems")
+            if isinstance(prefix_items, list):
+                if index < len(prefix_items):
+                    return prefix_items[index]
+                elif additional_items:
+                    return additional_items
+                elif len(prefix_items):
+                    return prefix_items[-1]
+
+    def convert(
+        self,
+        string: str,
+        *,
+        always_nullable: bool = False,
+        compatibility: Optional[CompatibilityMode] = None,
+    ) -> Any:
+        if always_nullable:
+            stripped = string.strip()
+            if len(stripped) == 4 and stripped.lower() == "null":
+                return None
+        if not string:
+            if AtomDataType.object in self.candidates:
+                return {}
+            elif AtomDataType.array in self.candidates:
+                return []
+            elif AtomDataType.none in self.candidates:
+                return None
+            else:
+                return ""
+        converted_list: List[ConversionResult] = []
+        has_schema = bool(self.schema)
+        for candidate in self.candidates:
+            converted = candidate.convert_with_confidence(string)
+            if converted is None:
+                continue
+            if has_schema:
+                try:
+                    jsonschema.validate(schema=self.schema, instance=converted.value)
+                    # Ensure it beats the invalid ones.
+                    converted.confidence += 10
+                except jsonschema.exceptions.SchemaError:
+                    # The schema is invalid, ignore it.
+                    has_schema = False
+                    if compatibility is not None:
+                        compatibility.note(CompatibilityEvent.INVALID_SCHEMA_IGNORED)
+                except Exception:
+                    # Validation failed.
+                    pass
+            converted_list.append(converted)
+        if len(converted_list) == 1:
+            return converted_list[0].value
+        elif len(converted_list):
+            return max(converted_list, key=lambda x: x.confidence).value
+        else:
+            if compatibility is not None:
+                compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"value {string[:80]!r}, candidates "
+                    f"{[c.name for c in self.candidates]}",
+                )
+            return string

--- a/python/sglang/srt/function_call/compatibility/param_types.py
+++ b/python/sglang/srt/function_call/compatibility/param_types.py
@@ -8,9 +8,9 @@ import jsonschema
 import jsonschema.exceptions
 from typing_extensions import Self
 
-from sglang.srt.function_call.compatibility.mode import (
+from sglang.srt.function_call.compatibility.context import (
+    CompatibilityContext,
     CompatibilityEvent,
-    CompatibilityMode,
 )
 
 # fmt: off
@@ -316,7 +316,7 @@ class FunctionCallParameterDataType:
         string: str,
         *,
         always_nullable: bool = False,
-        compatibility: Optional[CompatibilityMode] = None,
+        compatibility: Optional[CompatibilityContext] = None,
     ) -> Any:
         if always_nullable:
             stripped = string.strip()

--- a/python/sglang/srt/function_call/compatibility/recovery.py
+++ b/python/sglang/srt/function_call/compatibility/recovery.py
@@ -1,0 +1,137 @@
+"""Fail-open recovery helpers for tool-call parsing."""
+
+import json
+import logging
+from typing import TYPE_CHECKING, List, Optional
+
+from sglang.srt.function_call.compatibility.mode import CompatibilityEvent
+from sglang.srt.function_call.core_types import StreamingParseResult
+
+if TYPE_CHECKING:
+    from sglang.srt.entrypoints.openai.protocol import Tool
+    from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+
+logger = logging.getLogger(__name__)
+
+
+def recover_stream(
+    detector: "BaseFormatDetector",
+    error: Exception,
+    chunk_text: str,
+    tools: List["Tool"],
+) -> StreamingParseResult:
+    """Recover after ``parse_streaming_increment`` raised.
+
+    The caller (the boundary) latches afterwards, passing the rest of the
+    stream through as normal text.
+    """
+    detector.compatibility.note(CompatibilityEvent.FAIL_OPEN, detail=str(error))
+    logger.exception(
+        "Tool-call detector %s raised in parse_streaming_increment; "
+        "failing open to normal text (compatibility events: %s).",
+        type(detector).__name__,
+        detector.compatibility.summary(),
+    )
+    try:
+        return detector.fail_open_stream(error, chunk_text, tools)
+    except Exception:
+        logger.exception(
+            "fail_open_stream of %s raised; passing the chunk through.",
+            type(detector).__name__,
+        )
+        return StreamingParseResult(normal_text=chunk_text)
+
+
+def recover_nonstream(
+    detector: "BaseFormatDetector",
+    error: Exception,
+    full_text: str,
+    tools: List["Tool"],
+) -> StreamingParseResult:
+    """Recover after ``detect_and_parse`` raised.
+
+    The detector's hook salvages what it can; when no call survived, the
+    caller falls back to returning the full original text.
+    """
+    detector.compatibility.note(CompatibilityEvent.FAIL_OPEN, detail=str(error))
+    logger.exception(
+        "Tool-call detector %s raised in detect_and_parse; "
+        "failing open to normal text (compatibility events: %s).",
+        type(detector).__name__,
+        detector.compatibility.summary(),
+    )
+    try:
+        return detector.fail_open_nonstream(error, full_text, tools)
+    except Exception:
+        logger.exception(
+            "fail_open_nonstream of %s raised; returning the full text.",
+            type(detector).__name__,
+        )
+        return StreamingParseResult(normal_text=full_text)
+
+
+def synthesize_json_close(partial: str) -> Optional[str]:
+    """Return the minimal suffix that turns ``partial`` into valid JSON.
+
+    Scope-4 mechanism: when a tool call fails mid-stream, the argument
+    fragments already sent to the client cannot be unsent, so
+    ``BaseFormatDetector._close_mid_stream_call`` appends this suffix to keep
+    them concatenating to valid JSON.
+
+    ``partial`` is a prefix of a JSON object as streamed by a detector
+    (object / array nesting, possibly cut inside a string, right after a
+    ``"key": `` separator, or right after a ``,``). Returns ``None`` when no
+    such suffix exists (the caller then falls back to best-effort
+    bookkeeping).
+    """
+    stack: List[str] = []
+    in_string = False
+    escape = False
+    last_significant = ""
+    for ch in partial:
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+                last_significant = ch
+        else:
+            if ch == '"':
+                in_string = True
+                last_significant = ch
+            elif ch == "{":
+                stack.append("}")
+                last_significant = ch
+            elif ch == "[":
+                stack.append("]")
+                last_significant = ch
+            elif ch in "}]":
+                if not stack:
+                    return None
+                stack.pop()
+                last_significant = ch
+            elif not ch.isspace():
+                last_significant = ch
+
+    parts: List[str] = []
+    if in_string:
+        if escape:
+            # A dangling backslash would escape our closing quote.
+            parts.append("\\")
+        parts.append('"')
+    elif last_significant == ":":
+        # Cut right after a `"key": ` separator.
+        parts.append("null")
+    elif last_significant == ",":
+        # Cut right after a separator; emit a placeholder element/entry.
+        parts.append('"": null' if (stack and stack[-1] == "}") else "null")
+    parts.extend(reversed(stack))
+    closing = "".join(parts)
+
+    try:
+        json.loads(partial + closing)
+    except json.JSONDecodeError:
+        return None
+    return closing

--- a/python/sglang/srt/function_call/compatibility/recovery.py
+++ b/python/sglang/srt/function_call/compatibility/recovery.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, List, Optional
 
-from sglang.srt.function_call.compatibility.mode import CompatibilityEvent
+from sglang.srt.function_call.compatibility.context import CompatibilityEvent
 from sglang.srt.function_call.core_types import StreamingParseResult
 
 if TYPE_CHECKING:

--- a/python/sglang/srt/function_call/deepseekv31_detector.py
+++ b/python/sglang/srt/function_call/deepseekv31_detector.py
@@ -84,6 +84,7 @@ class DeepSeekV31Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}")
+            self._note_malformed_tool_call(e)
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
@@ -196,6 +197,7 @@ class DeepSeekV31Detector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=current_text)
 
     def structure_info(self) -> _GetInfoFunc:

--- a/python/sglang/srt/function_call/deepseekv31_detector.py
+++ b/python/sglang/srt/function_call/deepseekv31_detector.py
@@ -5,6 +5,7 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -69,24 +70,40 @@ class DeepSeekV31Detector(BaseFormatDetector):
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=normal_text, calls=[])
+        eot_idx = text.find(self.eot_token, idx + len(self.bot_token))
+        if eot_idx != -1:
+            normal_text = (text[:idx] + text[eot_idx + len(self.eot_token) :]).strip()
         match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        if not match_result_list:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[idx : idx + 80],
+            )
+            return StreamingParseResult(normal_text=text, calls=[])
         calls = []
-        try:
-            for match_result in match_result_list:
-                # Get function name
-                func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
-                func_name = func_detail.group(1)
-                func_args = func_detail.group(2)
-                func_args = json.loads(func_args)
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": func_args}
-                calls.extend(self.parse_base_json(match_result, tools))
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            self._note_malformed_tool_call(e)
-            # return the normal text if parsing fails
-            return StreamingParseResult(normal_text=text)
+        for match_result in match_result_list:
+            # Get function name
+            func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
+            if func_detail is None:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=match_result[:80],
+                )
+                continue
+            func_name = func_detail.group(1)
+            func_args_raw = func_detail.group(2)
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                json.JSONDecodeError,
+                detail=f"{func_name}: {func_args_raw[:80]}",
+            ) as absorbed:
+                func_args = json.loads(func_args_raw)
+            if absorbed.fired:
+                continue
+            # construct match_result for parse_base_json
+            match_result = {"name": func_name, "parameters": func_args}
+            calls.extend(self.parse_base_json(match_result, tools))
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
@@ -103,102 +120,119 @@ class DeepSeekV31Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
-            self._buffer = ""
+            normal_text, self._buffer = self._hold_back_partial_tokens(
+                current_text,
+                (
+                    self.bot_token,
+                    self.eot_token,
+                    "<｜tool▁call▁begin｜>",
+                    "<｜tool▁call▁end｜>",
+                ),
+            )
             for e_token in [self.eot_token, "<｜tool▁call▁end｜>"]:
-                if e_token in new_text:
-                    new_text = new_text.replace(e_token, "")
-            return StreamingParseResult(normal_text=new_text)
+                if e_token in normal_text:
+                    normal_text = normal_text.replace(e_token, "")
+            return StreamingParseResult(normal_text=normal_text)
 
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)
 
         calls: list[ToolCallItem] = []
-        try:
-            partial_match = re.search(
-                pattern=r"<｜tool▁call▁begin｜>(.*)<｜tool▁sep｜>(.*?)(<｜tool▁call▁end｜>|$)",
-                string=current_text,
-                flags=re.DOTALL,
-            )
-            if partial_match:
-                func_name = partial_match.group(1).strip()
-                func_args_raw = partial_match.group(2).strip()
-                is_tool_end = partial_match.group(3)
+        partial_match = re.search(
+            pattern=r"<｜tool▁call▁begin｜>(.*?)<｜tool▁sep｜>(.*?)(<｜tool▁call▁end｜>|$)",
+            string=current_text,
+            flags=re.DOTALL,
+        )
+        if partial_match:
+            func_name = partial_match.group(1).strip()
+            func_args_raw = partial_match.group(2).strip()
+            is_tool_end = partial_match.group(3)
+            if is_tool_end and not _is_complete_json(func_args_raw):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=f"{func_name}: {func_args_raw[:80]}",
+                )
+                calls.extend(self._close_started_malformed_call())
+                self._buffer = current_text[partial_match.end(3) :]
+                self.current_tool_name_sent = False
+                self._last_arguments = ""
+                return self._retry_streaming_tail(current_text, calls, tools)
+            if func_name not in self._tool_indices and self._skip_unknown_tool(
+                func_name
+            ):
+                if _is_complete_json(func_args_raw) and is_tool_end:
+                    self._buffer = current_text[partial_match.end(3) :]
+                    return self._retry_streaming_tail(current_text, calls, tools)
+                return StreamingParseResult(normal_text="", calls=calls)
 
-                # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
-                    self.current_tool_id = 0
-                    self.prev_tool_call_arr = []
-                    self.streamed_args_for_tool = [""]
+            # Initialize state if this is the first tool call
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+                self.prev_tool_call_arr = []
+                self.streamed_args_for_tool = [""]
 
-                # Ensure we have enough entries in our tracking arrays
-                while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                    self.prev_tool_call_arr.append({})
-                while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                    self.streamed_args_for_tool.append("")
+            # Ensure we have enough entries in our tracking arrays
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
 
-                if not self.current_tool_name_sent:
+            if not self.current_tool_name_sent:
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=func_name,
+                        parameters="",
+                    )
+                )
+                self.current_tool_name_sent = True
+                # Store the tool call info for serving layer completions endpoint
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": func_name,
+                    "arguments": {},
+                }
+            else:
+                argument_diff = (
+                    func_args_raw[len(self._last_arguments) :]
+                    if func_args_raw.startswith(self._last_arguments)
+                    else func_args_raw
+                )
+
+                if argument_diff:
                     calls.append(
                         ToolCallItem(
                             tool_index=self.current_tool_id,
-                            name=func_name,
-                            parameters="",
+                            name=None,
+                            parameters=argument_diff,
                         )
                     )
-                    self.current_tool_name_sent = True
-                    # Store the tool call info for serving layer completions endpoint
-                    self.prev_tool_call_arr[self.current_tool_id] = {
-                        "name": func_name,
-                        "arguments": {},
-                    }
-                else:
-                    argument_diff = (
-                        func_args_raw[len(self._last_arguments) :]
-                        if func_args_raw.startswith(self._last_arguments)
-                        else func_args_raw
-                    )
+                    self._last_arguments += argument_diff
+                    self.streamed_args_for_tool[self.current_tool_id] += argument_diff
 
-                    if argument_diff:
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=None,
-                                parameters=argument_diff,
-                            )
-                        )
-                        self._last_arguments += argument_diff
-                        self.streamed_args_for_tool[
-                            self.current_tool_id
-                        ] += argument_diff
+                if _is_complete_json(func_args_raw):
+                    # Update the stored arguments
+                    try:
+                        parsed_args = json.loads(func_args_raw)
+                        self.prev_tool_call_arr[self.current_tool_id][
+                            "arguments"
+                        ] = parsed_args
+                    except json.JSONDecodeError:
+                        pass
 
-                    if _is_complete_json(func_args_raw):
-                        # Update the stored arguments
-                        try:
-                            parsed_args = json.loads(func_args_raw)
-                            self.prev_tool_call_arr[self.current_tool_id][
-                                "arguments"
-                            ] = parsed_args
-                        except json.JSONDecodeError:
-                            pass
+                    # Find the end of the current tool call and remove only that part from buffer
+                    if is_tool_end:
+                        # Remove the completed tool call from buffer, keep any remaining content
+                        self._buffer = current_text[partial_match.end(3) :]
+                    else:
+                        self._buffer = ""
 
-                        # Find the end of the current tool call and remove only that part from buffer
-                        if is_tool_end:
-                            # Remove the completed tool call from buffer, keep any remaining content
-                            self._buffer = current_text[partial_match.end(3) :]
-                        else:
-                            self._buffer = ""
+                    result = StreamingParseResult(normal_text="", calls=calls)
+                    self.current_tool_id += 1
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    return result
 
-                        result = StreamingParseResult(normal_text="", calls=calls)
-                        self.current_tool_id += 1
-                        self._last_arguments = ""
-                        self.current_tool_name_sent = False
-                        return result
-
-            return StreamingParseResult(normal_text="", calls=calls)
-
-        except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}")
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=current_text)
+        return StreamingParseResult(normal_text="", calls=calls)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -223,6 +223,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}")
+            self._note_malformed_tool_call(e)
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
@@ -359,6 +360,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=current_text)
 
     def structure_info(self) -> _GetInfoFunc:

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -2,10 +2,12 @@ import json
 import logging
 import re
 
+from partial_json_parser.core.exceptions import MalformedJSON
 from partial_json_parser.core.options import Allow
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -128,9 +130,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 # Remove incomplete invoke end call prefix in case they are captured by param
                 for token in reversed(self.prefix_invoke_end_call):
                     invoke_content_stripped = invoke_content_stripped.rstrip(token)
-                return invoke_content_stripped
-            elif invoke_content_stripped.endswith("}"):
-                return invoke_content_stripped
+            return invoke_content_stripped
 
         # Fall back to XML parameter tag parsing (original format)
         parameters = {}
@@ -154,12 +154,17 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 try:
                     parameters[param_name] = json.loads(param_value.strip())
                 except (json.JSONDecodeError, ValueError):
+                    if not allow_partial:
+                        self.compatibility.note(
+                            CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                            detail=f"{param_name}: {param_value[:80]}",
+                        )
                     parameters[param_name] = param_value.strip()
+
+        remaining_content = invoke_content[last_match_end:]
 
         # If allowed, try to parse a partial parameter at the end
         if allow_partial:
-            remaining_content = invoke_content[last_match_end:]
-
             # Remove incomplete parameter_end_call prefix in case they are captured by param
             for token in reversed(self.prefix_parameter_end_call):
                 remaining_content = remaining_content.rstrip(token)
@@ -179,8 +184,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
                         parameters[param_name] = _partial_json_loads(
                             param_value, Allow.ALL
                         )[0]
-                    except json.JSONDecodeError:
+                    except (json.JSONDecodeError, MalformedJSON):
                         parameters[param_name] = param_value.strip()
+        elif remaining_content.strip():
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=remaining_content[:80],
+            )
 
         return json.dumps(parameters, ensure_ascii=False)
 
@@ -198,34 +208,66 @@ class DeepSeekV32Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
         calls = []
-        try:
-            # Extract content between function_calls tags
-            function_calls_match = re.search(
-                self.function_calls_regex,
-                text,
-                re.DOTALL,
+        # Extract content between function_calls tags
+        function_calls_match = re.search(
+            self.function_calls_regex,
+            text,
+            re.DOTALL,
+        )
+        if not function_calls_match:
+            if self.eot_token in text:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=text[idx : idx + 80],
+                )
+            else:
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=text[idx : idx + 80],
+                )
+            return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        normal_text = (
+            text[: function_calls_match.start()].removesuffix("\n\n")
+            + text[function_calls_match.end() :]
+        )
+        function_calls_content = function_calls_match.group(1)
+        found_invoke = False
+
+        # Find all invoke blocks
+        for invoke_match in re.finditer(
+            self.invoke_regex, function_calls_content, re.DOTALL
+        ):
+            found_invoke = True
+            func_name, invoke_content, is_complete = self._unpack_invoke_match(
+                invoke_match
             )
-            if not function_calls_match:
-                return StreamingParseResult(normal_text=normal_text, calls=[])
+            if not is_complete:
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=invoke_match.group(0)[:80],
+                )
+                continue
+            func_args = self._parse_parameters_from_xml(invoke_content)
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                json.JSONDecodeError,
+                detail=f"{func_name}: {func_args[:80]}",
+            ) as absorbed:
+                parsed_args = json.loads(func_args)
+            if absorbed.fired:
+                continue
+            # construct match_result for parse_base_json
+            match_result = {"name": func_name, "parameters": parsed_args}
+            calls.extend(self.parse_base_json(match_result, tools))
 
-            function_calls_content = function_calls_match.group(1)
+        if not found_invoke and function_calls_content.strip():
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=function_calls_content[:80],
+            )
 
-            # Find all invoke blocks
-            for invoke_match in re.finditer(
-                self.invoke_regex, function_calls_content, re.DOTALL
-            ):
-                func_name, invoke_content, _ = self._unpack_invoke_match(invoke_match)
-                func_args = self._parse_parameters_from_xml(invoke_content)
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": json.loads(func_args)}
-                calls.extend(self.parse_base_json(match_result, tools))
-
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            self._note_malformed_tool_call(e)
-            # return the normal text if parsing fails
-            return StreamingParseResult(normal_text=text)
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: list[Tool]
@@ -259,109 +301,125 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     current_text = current_text.replace(e_token, "")
             return StreamingParseResult(normal_text=current_text)
 
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
+
         all_calls: list[ToolCallItem] = []
-        try:
-            # Loop to handle multiple consecutive invoke blocks
-            while True:
-                # Try to match an invoke block (may be partial)
-                invoke_match = re.search(
-                    pattern=self.invoke_regex,
-                    string=current_text,
-                    flags=re.DOTALL,
-                )
-                if not invoke_match:
-                    break
+        # Loop to handle multiple consecutive invoke blocks
+        while True:
+            # Try to match an invoke block (may be partial)
+            invoke_match = re.search(
+                pattern=self.invoke_regex,
+                string=current_text,
+                flags=re.DOTALL,
+            )
+            if not invoke_match:
+                break
 
-                func_name, invoke_content, is_tool_end = self._unpack_invoke_match(
-                    invoke_match
-                )
-
-                # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
-                    self.current_tool_id = 0
-                    self.prev_tool_call_arr = []
-                    self.streamed_args_for_tool = [""]
-
-                # Ensure arrays are large enough for current tool
-                while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                    self.prev_tool_call_arr.append({})
-                while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                    self.streamed_args_for_tool.append("")
-
-                # 1. Send tool name if not sent yet
-                if not self.current_tool_name_sent:
-                    all_calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            name=func_name,
-                            parameters="",
-                        )
-                    )
-                    self.current_tool_name_sent = True
-
-                # 2. Parse current parameters (partial or complete)
-                current_params = self._parse_parameters_from_xml(
-                    invoke_content, allow_partial=not is_tool_end
-                )
-
-                # 3. Calculate and send incremental arguments
-                sent_len = len(self.streamed_args_for_tool[self.current_tool_id])
-                prev_params = self.prev_tool_call_arr[self.current_tool_id].get(
-                    "arguments"
-                )
-
-                argument_diff = None
-
+            func_name, invoke_content, is_tool_end = self._unpack_invoke_match(
+                invoke_match
+            )
+            if func_name not in self._tool_indices and self._skip_unknown_tool(
+                func_name
+            ):
                 if is_tool_end:
-                    # If complete, send everything remaining
-                    argument_diff = current_params[sent_len:]
-                elif prev_params is not None:
-                    # If partial, send stable prefix diff
-                    if current_params != prev_params:
-                        prefix = _find_common_prefix(current_params, prev_params)
-                        if len(prefix) > sent_len:
-                            argument_diff = prefix[sent_len:]
-
-                if argument_diff:
-                    all_calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            name=None,
-                            parameters=argument_diff,
-                        )
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += argument_diff
-
-                # Update the stored arguments
-                self.prev_tool_call_arr[self.current_tool_id] = {
-                    "name": func_name,
-                    "arguments": current_params,
-                }
-
-                # Check if tool call is complete (has closing tag)
-                if is_tool_end:
-                    # Remove the completed tool call from buffer
                     self._buffer = current_text[invoke_match.end() :]
-                    current_text = self._buffer  # Update for next iteration
-
-                    # Move to next tool call
-                    self.current_tool_id += 1
-                    self.current_tool_name_sent = False
-
-                    # Continue loop to check for more invoke blocks
+                    current_text = self._buffer
                     continue
-                else:
-                    # Tool call not complete yet, don't return anything
-                    # Wait for more chunks until we see </｜DSML｜invoke>
-                    break
+                break
 
-            # No more invoke blocks found
-            return StreamingParseResult(normal_text="", calls=all_calls)
+            # 1. Parse current parameters (partial or complete)
+            current_params = self._parse_parameters_from_xml(
+                invoke_content, allow_partial=not is_tool_end
+            )
+            if is_tool_end and invoke_content.strip().startswith(("{", "[")):
+                try:
+                    json.loads(current_params)
+                except json.JSONDecodeError:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=current_params[:80],
+                    )
+                    all_calls.extend(self._close_started_malformed_call())
+                    self._buffer = current_text[invoke_match.end() :]
+                    current_text = self._buffer
+                    self.current_tool_name_sent = False
+                    continue
 
-        except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}")
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=current_text)
+            # Initialize state if this is the first tool call
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+                self.prev_tool_call_arr = []
+                self.streamed_args_for_tool = [""]
+
+            # Ensure arrays are large enough for current tool
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
+
+            # 2. Send tool name if not sent yet
+            if not self.current_tool_name_sent:
+                all_calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=func_name,
+                        parameters="",
+                    )
+                )
+                self.current_tool_name_sent = True
+
+            # 3. Calculate and send incremental arguments
+            sent_len = len(self.streamed_args_for_tool[self.current_tool_id])
+            prev_params = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
+
+            argument_diff = None
+
+            if is_tool_end:
+                # If complete, send everything remaining
+                argument_diff = current_params[sent_len:]
+            elif prev_params is not None:
+                # If partial, send stable prefix diff
+                if current_params != prev_params:
+                    prefix = _find_common_prefix(current_params, prev_params)
+                    if len(prefix) > sent_len:
+                        argument_diff = prefix[sent_len:]
+
+            if argument_diff:
+                all_calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=None,
+                        parameters=argument_diff,
+                    )
+                )
+                self.streamed_args_for_tool[self.current_tool_id] += argument_diff
+
+            # Update the stored arguments
+            self.prev_tool_call_arr[self.current_tool_id] = {
+                "name": func_name,
+                "arguments": current_params,
+            }
+
+            # Check if tool call is complete (has closing tag)
+            if is_tool_end:
+                # Remove the completed tool call from buffer
+                self._buffer = current_text[invoke_match.end() :]
+                current_text = self._buffer  # Update for next iteration
+
+                # Move to next tool call
+                self.current_tool_id += 1
+                self.current_tool_name_sent = False
+
+                # Continue loop to check for more invoke blocks
+                continue
+            else:
+                # Tool call not complete yet, don't return anything
+                # Wait for more chunks until we see </｜DSML｜invoke>
+                break
+
+        # No more invoke blocks found
+        return StreamingParseResult(normal_text="", calls=all_calls)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -5,6 +5,7 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -69,21 +70,29 @@ class DeepSeekV3Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=[])
         match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
         calls = []
-        try:
-            for match_result in match_result_list:
-                # Get function name
-                func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
-                func_name = func_detail.group(2)
-                func_args = func_detail.group(3)
-                func_args = json.loads(func_args)
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": func_args}
-                calls.extend(self.parse_base_json(match_result, tools))
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            # return the normal text if parsing fails
-            return StreamingParseResult(normal_text=text)
+
+        for match_result in match_result_list:
+            # Get function name
+            func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
+            if func_detail is None:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=match_result[:80],
+                )
+                continue
+            func_name = func_detail.group(2)
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                json.JSONDecodeError,
+                detail=f"{func_name}: {func_detail.group(3)[:80]}",
+            ) as absorbed:
+                func_args = json.loads(func_detail.group(3))
+            if absorbed.fired:
+                continue
+            # construct match_result for parse_base_json
+            match_result = {"name": func_name, "parameters": func_args}
+            calls.extend(self.parse_base_json(match_result, tools))
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
@@ -100,106 +109,117 @@ class DeepSeekV3Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
-            self._buffer = ""
+            normal_text, self._buffer = self._hold_back_partial_tokens(
+                current_text,
+                (
+                    self.bot_token,
+                    self.eot_token,
+                    "<｜tool▁call▁begin｜>",
+                    "<｜tool▁call▁end｜>",
+                ),
+            )
             for e_token in [self.eot_token, "```", "<｜tool▁call▁end｜>"]:
-                if e_token in new_text:
-                    new_text = new_text.replace(e_token, "")
-            return StreamingParseResult(normal_text=new_text)
+                if e_token in normal_text:
+                    normal_text = normal_text.replace(e_token, "")
+            return StreamingParseResult(normal_text=normal_text)
 
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)
 
         calls: list[ToolCallItem] = []
-        try:
-            partial_match = re.search(
-                pattern=r"<｜tool▁call▁begin｜>(.*)<｜tool▁sep｜>(.*)\n```json\n(.*)\n```.*",
-                string=current_text,
-                flags=re.DOTALL,
-            )
-            if partial_match:
-                func_name = partial_match.group(2).strip()
-                func_args_raw = partial_match.group(3).strip()
 
-                # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
-                    self.current_tool_id = 0
-                    self.prev_tool_call_arr = []
-                    self.streamed_args_for_tool = [""]
+        # Parse only the first complete call currently in the buffer. A chunk
+        # can contain multiple complete calls, so the groups below must be
+        # non-greedy (`.*?`). With greedy `.*`, the match could start at the
+        # first call but bind to the last <｜tool▁sep｜>/JSON block; then the
+        # buffer-removal code would discard the first call while emitting a
+        # later one that remains in the buffer and can be emitted again.
+        partial_match = re.search(
+            pattern=r"<｜tool▁call▁begin｜>(.*?)<｜tool▁sep｜>(.*?)\n```json\n(.*?)\n```",
+            string=current_text,
+            flags=re.DOTALL,
+        )
+        if partial_match:
+            func_name = partial_match.group(2).strip()
+            func_args_raw = partial_match.group(3).strip()
 
-                # Ensure we have enough entries in our tracking arrays
-                while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                    self.prev_tool_call_arr.append({})
-                while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                    self.streamed_args_for_tool.append("")
+            # Initialize state if this is the first tool call
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+                self.prev_tool_call_arr = []
+                self.streamed_args_for_tool = [""]
 
-                if not self.current_tool_name_sent:
+            # Ensure we have enough entries in our tracking arrays
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
+
+            if not self.current_tool_name_sent:
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=func_name,
+                        parameters="",
+                    )
+                )
+                self.current_tool_name_sent = True
+                # Store the tool call info for serving layer completions endpoint
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": func_name,
+                    "arguments": {},
+                }
+            else:
+                argument_diff = (
+                    func_args_raw[len(self._last_arguments) :]
+                    if func_args_raw.startswith(self._last_arguments)
+                    else func_args_raw
+                )
+
+                if argument_diff:
                     calls.append(
                         ToolCallItem(
                             tool_index=self.current_tool_id,
-                            name=func_name,
-                            parameters="",
+                            name=None,
+                            parameters=argument_diff,
                         )
                     )
-                    self.current_tool_name_sent = True
-                    # Store the tool call info for serving layer completions endpoint
-                    self.prev_tool_call_arr[self.current_tool_id] = {
-                        "name": func_name,
-                        "arguments": {},
-                    }
-                else:
-                    argument_diff = (
-                        func_args_raw[len(self._last_arguments) :]
-                        if func_args_raw.startswith(self._last_arguments)
-                        else func_args_raw
+                    self._last_arguments += argument_diff
+                    self.streamed_args_for_tool[
+                        self.current_tool_id
+                    ] += argument_diff
+
+                if _is_complete_json(func_args_raw):
+                    # Update the stored arguments
+                    try:
+                        parsed_args = json.loads(func_args_raw)
+                        self.prev_tool_call_arr[self.current_tool_id][
+                            "arguments"
+                        ] = parsed_args
+                    except json.JSONDecodeError:
+                        pass
+
+                    # Find the end of the current tool call and remove only that part from buffer
+                    tool_call_end_pattern = (
+                        r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
                     )
+                    match = re.search(
+                        tool_call_end_pattern, current_text, re.DOTALL
+                    )
+                    if match:
+                        # Remove the completed tool call from buffer, keep any remaining content
+                        self._buffer = current_text[match.end() :]
+                    else:
+                        self._buffer = ""
 
-                    if argument_diff:
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=None,
-                                parameters=argument_diff,
-                            )
-                        )
-                        self._last_arguments += argument_diff
-                        self.streamed_args_for_tool[
-                            self.current_tool_id
-                        ] += argument_diff
+                    result = StreamingParseResult(normal_text="", calls=calls)
+                    self.current_tool_id += 1
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    return result
 
-                    if _is_complete_json(func_args_raw):
-                        # Update the stored arguments
-                        try:
-                            parsed_args = json.loads(func_args_raw)
-                            self.prev_tool_call_arr[self.current_tool_id][
-                                "arguments"
-                            ] = parsed_args
-                        except json.JSONDecodeError:
-                            pass
+        return StreamingParseResult(normal_text="", calls=calls)
 
-                        # Find the end of the current tool call and remove only that part from buffer
-                        tool_call_end_pattern = (
-                            r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
-                        )
-                        match = re.search(
-                            tool_call_end_pattern, current_text, re.DOTALL
-                        )
-                        if match:
-                            # Remove the completed tool call from buffer, keep any remaining content
-                            self._buffer = current_text[match.end() :]
-                        else:
-                            self._buffer = ""
-
-                        result = StreamingParseResult(normal_text="", calls=calls)
-                        self.current_tool_id += 1
-                        self._last_arguments = ""
-                        self.current_tool_name_sent = False
-                        return result
-
-            return StreamingParseResult(normal_text="", calls=calls)
-
-        except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}")
-            return StreamingParseResult(normal_text=current_text)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -185,9 +185,7 @@ class DeepSeekV3Detector(BaseFormatDetector):
                         )
                     )
                     self._last_arguments += argument_diff
-                    self.streamed_args_for_tool[
-                        self.current_tool_id
-                    ] += argument_diff
+                    self.streamed_args_for_tool[self.current_tool_id] += argument_diff
 
                 if _is_complete_json(func_args_raw):
                     # Update the stored arguments
@@ -203,9 +201,7 @@ class DeepSeekV3Detector(BaseFormatDetector):
                     tool_call_end_pattern = (
                         r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
                     )
-                    match = re.search(
-                        tool_call_end_pattern, current_text, re.DOTALL
-                    )
+                    match = re.search(tool_call_end_pattern, current_text, re.DOTALL)
                     if match:
                         # Remove the completed tool call from buffer, keep any remaining content
                         self._buffer = current_text[match.end() :]
@@ -219,7 +215,6 @@ class DeepSeekV3Detector(BaseFormatDetector):
                     return result
 
         return StreamingParseResult(normal_text="", calls=calls)
-
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -68,7 +68,16 @@ class DeepSeekV3Detector(BaseFormatDetector):
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=normal_text, calls=[])
+        eot_idx = text.find(self.eot_token, idx + len(self.bot_token))
+        if eot_idx != -1:
+            normal_text = (text[:idx] + text[eot_idx + len(self.eot_token) :]).strip()
         match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        if not match_result_list:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[idx : idx + 80],
+            )
+            return StreamingParseResult(normal_text=text, calls=[])
         calls = []
 
         for match_result in match_result_list:
@@ -142,6 +151,31 @@ class DeepSeekV3Detector(BaseFormatDetector):
         if partial_match:
             func_name = partial_match.group(2).strip()
             func_args_raw = partial_match.group(3).strip()
+            tool_call_end_pattern = r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
+            completed_call_match = re.search(
+                tool_call_end_pattern, current_text, re.DOTALL
+            )
+            if completed_call_match and not _is_complete_json(func_args_raw):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=f"{func_name}: {func_args_raw[:80]}",
+                )
+                calls.extend(self._close_started_malformed_call())
+                self._buffer = current_text[completed_call_match.end() :]
+                self.current_tool_name_sent = False
+                self._last_arguments = ""
+                return self._retry_streaming_tail(current_text, calls, tools)
+            if func_name not in self._tool_indices and self._skip_unknown_tool(
+                func_name
+            ):
+                if _is_complete_json(func_args_raw):
+                    tool_call_end_pattern = (
+                        r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
+                    )
+                    match = re.search(tool_call_end_pattern, current_text, re.DOTALL)
+                    self._buffer = current_text[match.end() :] if match else ""
+                    return self._retry_streaming_tail(current_text, calls, tools)
+                return StreamingParseResult(normal_text="", calls=calls)
 
             # Initialize state if this is the first tool call
             if self.current_tool_id == -1:
@@ -198,9 +232,6 @@ class DeepSeekV3Detector(BaseFormatDetector):
                         pass
 
                     # Find the end of the current tool call and remove only that part from buffer
-                    tool_call_end_pattern = (
-                        r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
-                    )
                     match = re.search(tool_call_end_pattern, current_text, re.DOTALL)
                     if match:
                         # Remove the completed tool call from buffer, keep any remaining content

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -33,7 +33,7 @@ from sglang.srt.function_call.llama32_detector import Llama32Detector
 from sglang.srt.function_call.mimo_detector import MiMoDetector
 from sglang.srt.function_call.minicpm5_detector import MiniCPM5Detector
 from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
-from sglang.srt.function_call.minimax_m3_nom import MinimaxM3NomDetector
+from sglang.srt.function_call.minimax_m3 import MinimaxM3Detector
 from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.poolside_v1_detector import PoolsideV1Detector
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
@@ -83,7 +83,7 @@ class FunctionCallParser:
         "step3": Step3Detector,
         "step3p5": Qwen3CoderDetector,
         "minimax-m2": MinimaxM2Detector,
-        "minimax-m3-nom": MinimaxM3NomDetector,
+        "minimax-m3": MinimaxM3Detector,
         "trinity": TrinityDetector,
         "interns1": InternlmDetector,
         "hermes": HermesDetector,

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -13,6 +13,7 @@ from sglang.srt.environ import ToolStrictLevel, envs
 from sglang.srt.function_call.apertus2509_detector import Apertus2509Detector
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.cohere_command4_detector import CohereCommand4Detector
+from sglang.srt.function_call.compatibility import recover_nonstream, recover_stream
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
 from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
@@ -32,6 +33,7 @@ from sglang.srt.function_call.llama32_detector import Llama32Detector
 from sglang.srt.function_call.mimo_detector import MiMoDetector
 from sglang.srt.function_call.minicpm5_detector import MiniCPM5Detector
 from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.srt.function_call.minimax_m3_nom import MinimaxM3NomDetector
 from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.poolside_v1_detector import PoolsideV1Detector
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
@@ -81,6 +83,7 @@ class FunctionCallParser:
         "step3": Step3Detector,
         "step3p5": Qwen3CoderDetector,
         "minimax-m2": MinimaxM2Detector,
+        "minimax-m3-nom": MinimaxM3NomDetector,
         "trinity": TrinityDetector,
         "interns1": InternlmDetector,
         "hermes": HermesDetector,
@@ -89,16 +92,51 @@ class FunctionCallParser:
         "gemma4": Gemma4Detector,
     }
 
-    def __init__(self, tools: List[Tool], tool_call_parser: str):
+    def __init__(
+        self,
+        tools: List[Tool],
+        tool_call_parser: str,
+        enable_compatibility_mode: bool = False,
+    ):
         detector_class = self.ToolCallParserEnum.get(tool_call_parser)
-        if detector_class:
-            detector = detector_class()
-        else:
+        if not detector_class:
             raise ValueError(f"Unsupported tool_call_parser: {tool_call_parser}")
+        self._attach(detector_class(), tools, enable_compatibility_mode)
 
+    @classmethod
+    def with_detector(
+        cls,
+        detector: BaseFormatDetector,
+        tools: List[Tool],
+        enable_compatibility_mode: bool = False,
+    ) -> "FunctionCallParser":
+        """Boundary around an explicitly constructed detector.
+
+        For detectors that are not operator-selectable (the keys of
+        ``ToolCallParserEnum`` double as the ``--tool-call-parser`` CLI
+        choices), e.g. the constrained-output ``JsonArrayParser``. Every
+        detector must sit behind this boundary — it owns scope-4 fail-open
+        and the streaming latch.
+        """
+        parser = cls.__new__(cls)
+        parser._attach(detector, tools, enable_compatibility_mode)
+        return parser
+
+    def _attach(
+        self,
+        detector: BaseFormatDetector,
+        tools: List[Tool],
+        enable_compatibility_mode: bool,
+    ) -> None:
         self.detector = detector
+        detector.compatibility.strict = not enable_compatibility_mode
         self.tools = tools
         self.tool_strict_level = envs.SGLANG_TOOL_STRICT_LEVEL.get()
+        # Fail-open latch: set when the detector raised during streaming, so
+        # the rest of the stream is passed through as normal text instead of
+        # repeatedly calling into a broken detector (or killing the SSE
+        # stream with an uncaught exception).
+        self._detector_failed = False
 
     def has_tool_call(self, text: str) -> bool:
         """
@@ -129,7 +167,13 @@ class FunctionCallParser:
         """
         if not self.tools:
             return full_text, []
-        parsed_result = self.detector.detect_and_parse(full_text, self.tools)
+        try:
+            parsed_result = self.detector.detect_and_parse(full_text, self.tools)
+        except Exception as e:
+            # Fail-open (scope 4): recovery is owned by the compatibility
+            # module; calls it salvaged are returned, otherwise the full
+            # text falls through below.
+            parsed_result = recover_nonstream(self.detector, e, full_text, self.tools)
         tool_call_list = parsed_result.calls
         if tool_call_list:
             return parsed_result.normal_text, tool_call_list
@@ -148,12 +192,21 @@ class FunctionCallParser:
             - The normal text that should be displayed to the user
             - A list of tool calls parsed from the chunk
         """
-        if not self.tools:
+        if (not self.tools) or self._detector_failed:
             return chunk_text, []
         final_normal_text = ""
         final_calls = []
 
-        sp_result = self.detector.parse_streaming_increment(chunk_text, self.tools)
+        try:
+            sp_result = self.detector.parse_streaming_increment(
+                chunk_text, self.tools
+            )
+        except Exception as e:
+            # Fail-open (scope 4): recovery is owned by the compatibility
+            # module; latch so the rest of the stream passes through as text.
+            self._detector_failed = True
+            sp_result = recover_stream(self.detector, e, chunk_text, self.tools)
+            return sp_result.normal_text, list(sp_result.calls)
         if sp_result.normal_text:
             final_normal_text = sp_result.normal_text
         if sp_result.calls:

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -198,9 +198,7 @@ class FunctionCallParser:
         final_calls = []
 
         try:
-            sp_result = self.detector.parse_streaming_increment(
-                chunk_text, self.tools
-            )
+            sp_result = self.detector.parse_streaming_increment(chunk_text, self.tools)
         except Exception as e:
             # Fail-open (scope 4): recovery is owned by the compatibility
             # module; latch so the rest of the stream passes through as text.

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -177,8 +177,9 @@ class FunctionCallParser:
         tool_call_list = parsed_result.calls
         if tool_call_list:
             return parsed_result.normal_text, tool_call_list
-        else:
-            return full_text, []
+        if self.detector.compatibility.records or self.detector.compatibility.dropped:
+            return parsed_result.normal_text, []
+        return full_text, []
 
     def parse_stream_chunk(self, chunk_text: str) -> Tuple[str, list[ToolCallItem]]:
         """

--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -304,6 +304,7 @@ class Gemma4Detector(BaseFormatDetector):
 
         except (ValueError, IndexError, TypeError, KeyError) as e:
             logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=text)
 
     def parse_streaming_increment(
@@ -425,6 +426,7 @@ class Gemma4Detector(BaseFormatDetector):
 
         except (ValueError, IndexError, TypeError, KeyError) as e:
             logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             # Reset parser state to prevent corruption
             self.is_inside_tool_call = False
             self.current_func_name = None

--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -268,7 +269,7 @@ class Gemma4Detector(BaseFormatDetector):
                     args_str = (
                         args_content[:match_idx] if match_idx != -1 else args_content
                     )
-                    results.append((func_name, args_str))
+                    results.append((func_name, args_str, match_idx != -1))
             search_from = end + len(TOOL_CALL_END)
         return results
 
@@ -280,13 +281,48 @@ class Gemma4Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=text)
 
         calls = []
+        content_end = text.find(self.tool_call_start_token)
+        normal_text = text[:content_end] if content_end > 0 else ""
         try:
             matches = self._extract_tool_calls(text)
             if not matches:
-                return StreamingParseResult(normal_text=text)
+                if self.tool_call_end_token in text:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=text[text.find(self.tool_call_start_token) :][:80],
+                    )
+                    end_pos = text.find(
+                        self.tool_call_end_token,
+                        text.find(self.tool_call_start_token),
+                    )
+                    normal_text = (
+                        text[:content_end]
+                        + text[end_pos + len(self.tool_call_end_token) :]
+                    )
+                    return StreamingParseResult(normal_text=normal_text)
+                else:
+                    self.compatibility.note(
+                        CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                        detail=text[text.find(self.tool_call_start_token) :][:80],
+                    )
+                    return StreamingParseResult(normal_text=text)
 
             tool_indices = self._get_tool_indices(tools)
-            for func_name, args_str in matches:
+            for func_name, args_str, args_complete in matches:
+                if not func_name:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=args_str[:80],
+                    )
+                    continue
+                if not args_complete:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=args_str[:80],
+                    )
+                    continue
+                if func_name not in tool_indices and self._skip_unknown_tool(func_name):
+                    continue
                 arguments = _parse_gemma4_args(args_str)
                 calls.append(
                     ToolCallItem(
@@ -296,16 +332,15 @@ class Gemma4Detector(BaseFormatDetector):
                     )
                 )
 
-            # Content = text before first tool call
-            content_end = text.find(self.tool_call_start_token)
-            normal_text = text[:content_end] if content_end > 0 else ""
-
             return StreamingParseResult(normal_text=normal_text, calls=calls)
 
         except (ValueError, IndexError, TypeError, KeyError) as e:
             logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=text)
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=str(e)[:120],
+            )
+            return StreamingParseResult(normal_text=normal_text)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
@@ -372,15 +407,41 @@ class Gemma4Detector(BaseFormatDetector):
                             brace_pos = current_slice.find("{")
                             if brace_pos != -1:
                                 func_name = current_slice[5:brace_pos]
+                                if (
+                                    func_name not in self._tool_indices
+                                    and self._skip_unknown_tool(func_name)
+                                ):
+                                    end_pos = current_slice.find(
+                                        self.tool_call_end_token
+                                    )
+                                    if end_pos == -1:
+                                        break
+                                    self.parsed_pos += end_pos + len(
+                                        self.tool_call_end_token
+                                    )
+                                    self.is_inside_tool_call = False
+                                    self.current_func_name = None
+                                    continue
                                 self.current_tool_id += 1
+                                while (
+                                    len(self.streamed_args_for_tool)
+                                    <= self.current_tool_id
+                                ):
+                                    self.streamed_args_for_tool.append("")
+                                while (
+                                    len(self.prev_tool_call_arr) <= self.current_tool_id
+                                ):
+                                    self.prev_tool_call_arr.append({})
                                 self.current_func_name = func_name
                                 self.current_tool_name_sent = True
+                                self.prev_tool_call_arr[self.current_tool_id] = {
+                                    "name": func_name,
+                                    "arguments": {},
+                                }
 
                                 calls.append(
                                     ToolCallItem(
-                                        tool_index=self._tool_indices.get(
-                                            func_name, -1
-                                        ),
+                                        tool_index=self.current_tool_id,
                                         name=func_name,
                                         parameters="",
                                     )
@@ -388,7 +449,18 @@ class Gemma4Detector(BaseFormatDetector):
                                 self.parsed_pos += brace_pos + 1
                                 continue
                             else:
-                                # Incomplete call:name{
+                                end_pos = current_slice.find(self.tool_call_end_token)
+                                if end_pos != -1:
+                                    self.compatibility.note(
+                                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                                        detail=current_slice[:80],
+                                    )
+                                    self.parsed_pos += end_pos + len(
+                                        self.tool_call_end_token
+                                    )
+                                    self.is_inside_tool_call = False
+                                    self.current_func_name = None
+                                    continue
                                 break
                         else:
                             # Check for partial matches
@@ -397,7 +469,10 @@ class Gemma4Detector(BaseFormatDetector):
                             ) or self.tool_call_end_token.startswith(current_slice):
                                 break
 
-                            # Unexpected content, skip
+                            self.compatibility.note(
+                                CompatibilityEvent.SKIPPED_GARBAGE,
+                                detail=f"inside Gemma4 tool_call: {current_slice[:1]!r}",
+                            )
                             self.parsed_pos += 1
                             continue
                     else:
@@ -406,27 +481,58 @@ class Gemma4Detector(BaseFormatDetector):
                         if match_idx != -1:
                             args_str = current_slice[:match_idx]
                             arguments = _parse_gemma4_args(args_str)
+                            parameters = json.dumps(arguments, ensure_ascii=False)
 
                             calls.append(
                                 ToolCallItem(
-                                    tool_index=self._tool_indices.get(
-                                        self.current_func_name, -1
-                                    ),
-                                    parameters=json.dumps(
-                                        arguments, ensure_ascii=False
-                                    ),
+                                    tool_index=self.current_tool_id,
+                                    parameters=parameters,
                                 )
                             )
+                            self.streamed_args_for_tool[
+                                self.current_tool_id
+                            ] += parameters
+                            self.prev_tool_call_arr[self.current_tool_id] = {
+                                "name": self.current_func_name,
+                                "arguments": arguments,
+                            }
                             self.parsed_pos += match_idx + 1
                             self.current_func_name = None
                             continue
                         else:
-                            # Incomplete arguments block
+                            end_pos = current_slice.find(self.tool_call_end_token)
+                            if end_pos != -1:
+                                self.compatibility.note(
+                                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                                    detail=current_slice[:80],
+                                )
+                                calls.append(
+                                    ToolCallItem(
+                                        tool_index=self.current_tool_id,
+                                        parameters="{}",
+                                    )
+                                )
+                                self.streamed_args_for_tool[
+                                    self.current_tool_id
+                                ] += "{}"
+                                self.prev_tool_call_arr[self.current_tool_id] = {
+                                    "name": self.current_func_name,
+                                    "arguments": {},
+                                }
+                                self.parsed_pos += end_pos + len(
+                                    self.tool_call_end_token
+                                )
+                                self.current_func_name = None
+                                self.is_inside_tool_call = False
+                                continue
                             break
 
         except (ValueError, IndexError, TypeError, KeyError) as e:
             logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=str(e)[:120],
+            )
             # Reset parser state to prevent corruption
             self.is_inside_tool_call = False
             self.current_func_name = None

--- a/python/sglang/srt/function_call/gigachat3_detector.py
+++ b/python/sglang/srt/function_call/gigachat3_detector.py
@@ -76,6 +76,7 @@ class GigaChat3Detector(BaseFormatDetector):
                     function_call = None
             except json.JSONDecodeError as e:
                 logger.warning(f"[GigaChat3] JSON decode error: {e}")
+                self._note_malformed_tool_call(e, detail=m_func.group(1)[:80])
                 return StreamingParseResult(
                     normal_text=model_output,
                     calls=[],

--- a/python/sglang/srt/function_call/gigachat3_detector.py
+++ b/python/sglang/srt/function_call/gigachat3_detector.py
@@ -5,6 +5,7 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -63,36 +64,66 @@ class GigaChat3Detector(BaseFormatDetector):
         if model_output.rstrip().endswith("</s>"):
             model_output = model_output[: model_output.rfind("</s>")]
         m_func = REGEX_FUNCTION_CALL.search(model_output)
+        function_payload = None
+        trailing_content = ""
+        if m_func:
+            prefix = model_output[: m_func.start()]
+            content = (
+                prefix.split("<|message_sep|>", 1)[0]
+                if "<|message_sep|>" in prefix
+                else prefix
+            )
+            function_payload = m_func.group(1)
+            eos_pos = function_payload.find("</s>")
+            if eos_pos != -1:
+                trailing_content = function_payload[eos_pos + len("</s>") :]
+                function_payload = function_payload[:eos_pos]
         if m_func:
             try:
-                function_call = json.loads(m_func.group(1), strict=False)
+                function_call = json.loads(function_payload or "", strict=False)
                 if not (
                     isinstance(function_call, dict)
                     and "name" in function_call
                     and "arguments" in function_call
                 ):
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=(function_payload or "")[:80],
+                    )
                     function_call = None
                 elif not isinstance(function_call["arguments"], dict):
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=(function_payload or "")[:80],
+                    )
                     function_call = None
             except json.JSONDecodeError as e:
                 logger.warning(f"[GigaChat3] JSON decode error: {e}")
-                self._note_malformed_tool_call(e, detail=m_func.group(1)[:80])
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=(function_payload or "")[:80],
+                )
                 return StreamingParseResult(
-                    normal_text=model_output,
+                    normal_text=(content or "") + trailing_content,
                     calls=[],
                 )
-        m_content = REGEX_CONTENT_PATTERN.search(model_output)
-        if m_content:
-            content = m_content.group(1)
-        else:
-            content = model_output
+        if content is None:
+            m_content = REGEX_CONTENT_PATTERN.search(model_output)
+            if m_content:
+                content = m_content.group(1)
+            else:
+                content = model_output
         if not function_call:
-            return StreamingParseResult(normal_text=content, calls=[])
+            return StreamingParseResult(
+                normal_text=(content or "") + trailing_content, calls=[]
+            )
         name = function_call["name"]
         args = function_call["arguments"]
         match_result = {"name": name, "arguments": args}
         calls = self.parse_base_json(match_result, tools)
-        return StreamingParseResult(normal_text=content, calls=calls)
+        return StreamingParseResult(
+            normal_text=(content or "") + trailing_content, calls=calls
+        )
 
     def parse_streaming_increment(
         self,
@@ -103,28 +134,40 @@ class GigaChat3Detector(BaseFormatDetector):
         Streaming parser for incremental text chunks.
         Maintains state across calls to build complete tool calls.
         """
-        if not new_text:
+        if not new_text and not self._buffer:
             return StreamingParseResult()
         logger.debug(f"[GigaChat3] parse_streaming_increment: '{new_text}'")
         self._buffer += new_text
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
         current_text = self._buffer
-        delta_text = new_text
+        delta_text = new_text if new_text else current_text
         content = None
         func_name = None
         cur_args = None
+        args_complete = False
         m_func = REGEX_FUNCTION_CALL.search(current_text)
         if not self.tool_started:
             m_content = REGEX_CONTENT_PATTERN.search(delta_text)
-            if m_content:
-                content = m_content.group(1)
-                self.end_content = True
-            else:
-                if not self.end_content:
-                    content = delta_text
             if m_func:
+                prefix = current_text[: m_func.start()]
+                content = (
+                    prefix.split("<|message_sep|>", 1)[0]
+                    if "<|message_sep|>" in prefix
+                    else (m_content.group(1) if m_content else prefix)
+                )
                 self.tool_started = True
                 logger.debug("[GigaChat3] Tool call started")
-            if content:
+            elif m_content:
+                content = m_content.group(1)
+                self.end_content = True
+            elif not self.end_content:
+                content = delta_text
+            if content and not m_func:
+                if m_content:
+                    self._buffer = current_text[len(content) :]
+                else:
+                    self._buffer = ""
                 return StreamingParseResult(normal_text=content)
         if not m_func:
             return StreamingParseResult()
@@ -135,8 +178,9 @@ class GigaChat3Detector(BaseFormatDetector):
         args_match = ARGS_REGEX.search(json_tail)
         if args_match:
             cur_args = args_match.group(1).strip()
-            if cur_args.endswith("</s>"):
-                cur_args = cur_args[: -len("</s>")]
+            args_complete = "</s>" in cur_args
+            if args_complete:
+                cur_args = cur_args.split("</s>", 1)[0]
             if cur_args.endswith("}"):
                 try:
                     candidate = cur_args[:-1].strip()
@@ -144,26 +188,87 @@ class GigaChat3Detector(BaseFormatDetector):
                     cur_args = candidate
                 except json.JSONDecodeError:
                     pass
+            if args_complete:
+                try:
+                    json.loads(cur_args, strict=False)
+                except json.JSONDecodeError:
+                    calls: List[ToolCallItem] = []
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=cur_args[:80],
+                    )
+                    calls.extend(self._close_started_malformed_call())
+                    end_pos = current_text.find("</s>", m_func.start())
+                    self._buffer = (
+                        current_text[end_pos + len("</s>") :] if end_pos != -1 else ""
+                    )
+                    self.tool_started = False
+                    self.tool_name_sent = False
+                    self.current_tool_name_sent = False
+                    tail = self._retry_streaming_tail(current_text, calls, tools)
+                    tail.normal_text = (content or "") + tail.normal_text
+                    return tail
         calls: List[ToolCallItem] = []
-        if not self.prev_tool_call_arr:
-            self.prev_tool_call_arr.append({})
         if not self.tool_name_sent:
             if not func_name:
-                return StreamingParseResult()
+                if args_complete:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=json_tail[:80],
+                    )
+                    end_pos = current_text.find("</s>", m_func.start())
+                    self._buffer = (
+                        current_text[end_pos + len("</s>") :] if end_pos != -1 else ""
+                    )
+                    self.tool_started = False
+                    self.tool_name_sent = False
+                    self.current_tool_name_sent = False
+                    tail = self._retry_streaming_tail(current_text, [], tools)
+                    tail.normal_text = (content or "") + tail.normal_text
+                    return tail
+                return StreamingParseResult(normal_text=content or "")
+            if func_name not in self._tool_indices and self._skip_unknown_tool(
+                func_name
+            ):
+                if args_complete:
+                    end_pos = current_text.find("</s>", m_func.start())
+                    self._buffer = (
+                        current_text[end_pos + len("</s>") :] if end_pos != -1 else ""
+                    )
+                else:
+                    self._buffer = ""
+                self.tool_started = False
+                self.tool_name_sent = False
+                self.current_tool_name_sent = False
+                self.prev_tool_call_arr = []
+                tail = self._retry_streaming_tail(current_text, [], tools)
+                tail.normal_text = (content or "") + tail.normal_text
+                return tail
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
             self.tool_name_sent = True
-            self.prev_tool_call_arr[0]["name"] = func_name
+            self.current_tool_name_sent = True
+            self.prev_tool_call_arr[self.current_tool_id]["name"] = func_name
+            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = {}
             logger.debug(f"[GigaChat3] Sending tool name: {func_name}")
             calls.append(
                 ToolCallItem(
-                    tool_index=0,
+                    tool_index=self.current_tool_id,
                     name=func_name,
                     parameters="",
                 )
             )
-            return StreamingParseResult(calls=calls)
+            if cur_args is None:
+                return StreamingParseResult(normal_text=content or "", calls=calls)
         if cur_args is None:
             return StreamingParseResult()
-        prev_args = self.prev_tool_call_arr[0].get("arguments_str", "")
+        prev_args = self.prev_tool_call_arr[self.current_tool_id].get(
+            "arguments_str", ""
+        )
         if not prev_args:
             delta_args = cur_args
         elif cur_args.startswith(prev_args):
@@ -175,22 +280,37 @@ class GigaChat3Detector(BaseFormatDetector):
             )
             return StreamingParseResult()
         if not delta_args:
-            return StreamingParseResult()
-        self.prev_tool_call_arr[0]["arguments_str"] = cur_args
+            return StreamingParseResult(normal_text=content or "", calls=calls)
+        self.prev_tool_call_arr[self.current_tool_id]["arguments_str"] = cur_args
         try:
             args_dict = json.loads(cur_args, strict=False)
-            self.prev_tool_call_arr[0]["arguments"] = args_dict
+            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = args_dict
         except json.JSONDecodeError:
-            self.prev_tool_call_arr[0]["arguments"] = {}
+            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = {}
         logger.debug(f"[GigaChat3] Sending args delta: '{delta_args[:100]}...'")
         calls.append(
             ToolCallItem(
-                tool_index=0,
+                tool_index=self.current_tool_id,
                 name=None,
                 parameters=delta_args,
             )
         )
-        return StreamingParseResult(calls=calls)
+        self.streamed_args_for_tool[self.current_tool_id] += delta_args
+
+        if args_complete:
+            end_pos = current_text.find("</s>", m_func.start())
+            self._buffer = (
+                current_text[end_pos + len("</s>") :] if end_pos != -1 else ""
+            )
+            self.tool_started = False
+            self.tool_name_sent = False
+            self.current_tool_name_sent = False
+            self.current_tool_id += 1
+            tail = self._retry_streaming_tail(current_text, calls, tools)
+            tail.normal_text = (content or "") + tail.normal_text
+            return tail
+
+        return StreamingParseResult(normal_text=content or "", calls=calls)
 
     def supports_structural_tag(self) -> bool:
         """GigaChat3 does not use structural tags"""

--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -241,6 +241,7 @@ class Glm47MoeDetector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
@@ -603,6 +604,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                     ] = arguments
             except Exception as e:
                 logger.debug(f"Failed to parse arguments: {e}", exc_info=True)
+                self._note_malformed_tool_call(e, detail=func_args_raw[:80])
 
         # Clean buffer
         self._buffer = current_text[match_end_pos:]
@@ -739,6 +741,7 @@ class Glm47MoeDetector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=current_text)
 
         return StreamingParseResult(normal_text=normal_text, calls=calls)

--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -7,6 +7,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import (
+    CompatibilityEvent,
+    synthesize_json_close,
+)
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -220,30 +224,40 @@ class Glm47MoeDetector(BaseFormatDetector):
 
         # Parse tool calls
         match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        if not match_result_list:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[text.find(self.bot_token) : text.find(self.bot_token) + 80],
+            )
+            return StreamingParseResult(normal_text=text, calls=[])
         calls = []
-        try:
-            for match_result in match_result_list:
-                # Get function name
-                func_detail = self.func_detail_regex.search(match_result)
-                if func_detail is None:
+        for match_result in match_result_list:
+            # Get function name
+            func_detail = self.func_detail_regex.search(match_result)
+            if func_detail is None:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=match_result[:80],
+                )
+                continue
+            func_name = func_detail.group(1) if func_detail.group(1) else ""
+            func_args = func_detail.group(2) if func_detail.group(2) else ""
+            arguments = {}
+            if func_args:
+                pairs = self.func_arg_regex.findall(func_args)
+                if not pairs:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=func_args[:80],
+                    )
                     continue
-                func_name = func_detail.group(1) if func_detail.group(1) else ""
-                func_args = func_detail.group(2) if func_detail.group(2) else ""
-                arguments = {}
-                if func_args:
-                    pairs = self.func_arg_regex.findall(func_args)
-                    # Parse arguments using shared method
-                    arguments = self._parse_argument_pairs(pairs, func_name, tools)
+                # Parse arguments using shared method
+                arguments = self._parse_argument_pairs(pairs, func_name, tools)
 
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": arguments}
-                calls.extend(self.parse_base_json(match_result, tools))
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
-            # return the normal text if parsing fails
-            return StreamingParseResult(normal_text=text)
+            # construct match_result for parse_base_json
+            match_result = {"name": func_name, "parameters": arguments}
+            calls.extend(self.parse_base_json(match_result, tools))
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def _get_value_type(self, func_name: str, key: str, tools: List[Tool]) -> str:
         """Get parameter type from tool definition, with fallback to auto-detection.
@@ -312,15 +326,18 @@ class Glm47MoeDetector(BaseFormatDetector):
             # Ensure proper JSON string formatting with quotes
             return json.dumps(value, ensure_ascii=False)
         elif value_type == "number":
-            try:
-                num = _convert_to_number(value.strip() if value else "")
-                return str(num)
-            except (ValueError, AttributeError):
-                # Fallback to string if not a valid number
+            raw = value.strip() if value else ""
+            num = _convert_to_number(raw)
+            if isinstance(num, str):
                 logger.warning(
                     f"Failed to parse '{value}' as number, treating as string"
                 )
+                self.compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"number: {value[:80]}",
+                )
                 return json.dumps(str(value) if value else "", ensure_ascii=False)
+            return str(num)
         else:
             # For object/array types, return as-is (should already be valid JSON)
             return value
@@ -566,6 +583,13 @@ class Glm47MoeDetector(BaseFormatDetector):
             List of tool call items to add
         """
         calls = []
+        pairs = self.func_arg_regex.findall(func_args_raw)
+        malformed_args = bool(func_args_raw.strip()) and not pairs
+        if malformed_args:
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=func_args_raw[:80],
+            )
 
         # Handle no-arg function or need to close braces
         if self._is_first_param and not self._sent_empty_object:
@@ -579,6 +603,21 @@ class Glm47MoeDetector(BaseFormatDetector):
             )
             self._last_arguments += "{}"
             self.streamed_args_for_tool[self.current_tool_id] += "{}"
+            self._sent_empty_object = True
+        elif malformed_args and not self._sent_empty_object:
+            closing_brace = synthesize_json_close(self._last_arguments)
+            if closing_brace is None:
+                closing_brace = "}"
+            if closing_brace:
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=None,
+                        parameters=closing_brace,
+                    )
+                )
+                self._last_arguments += closing_brace
+                self.streamed_args_for_tool[self.current_tool_id] += closing_brace
             self._sent_empty_object = True
         elif not self._last_arguments.endswith("}") and not self._sent_empty_object:
             # Need to close brace
@@ -596,15 +635,17 @@ class Glm47MoeDetector(BaseFormatDetector):
         # Parse final arguments
         if func_args_raw:
             try:
-                pairs = self.func_arg_regex.findall(func_args_raw)
                 if pairs:
                     arguments = self._parse_argument_pairs(pairs, func_name, tools)
                     self.prev_tool_call_arr[self.current_tool_id][
                         "arguments"
                     ] = arguments
-            except Exception as e:
+            except (json.JSONDecodeError, ValueError) as e:
                 logger.debug(f"Failed to parse arguments: {e}", exc_info=True)
-                self._note_malformed_tool_call(e, detail=func_args_raw[:80])
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=func_args_raw[:80],
+                )
 
         # Clean buffer
         self._buffer = current_text[match_end_pos:]
@@ -668,81 +709,79 @@ class Glm47MoeDetector(BaseFormatDetector):
             self._tool_indices = self._get_tool_indices(tools)
 
         calls: list[ToolCallItem] = []
-        try:
-            # Try to match a partial or complete tool call
-            # Use a single flexible regex pattern that handles all cases
-            partial_match = re.search(
-                r"<tool_call>(.*?)(?:(<arg_key.*?))?(?:(</tool_call>)|$)",
-                current_text,
-                re.DOTALL,
+        # Try to match a partial or complete tool call
+        # Use a single flexible regex pattern that handles all cases
+        partial_match = re.search(
+            r"<tool_call>(.*?)(?:(<arg_key.*?))?(?:(</tool_call>)|$)",
+            current_text,
+            re.DOTALL,
+        )
+
+        if not partial_match:
+            return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        # Extract match groups using helper method
+        func_name, func_args_raw, is_tool_end = self._extract_match_groups(
+            partial_match
+        )
+        if func_name not in self._tool_indices and self._skip_unknown_tool(func_name):
+            if is_tool_end == self.eot_token:
+                self._buffer = current_text[partial_match.end() :]
+            return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+        # Initialize tool call state if needed (keeping existing logic)
+        if self.current_tool_id == -1:
+            self.current_tool_id = 0
+            self.prev_tool_call_arr = []
+            self.streamed_args_for_tool = [""]
+            self._streamed_raw_length = 0
+            self.current_tool_name_sent = False  # Reset for new tool call
+            self._reset_streaming_state()
+        # Check if this is a continuation of an existing tool call or a new one
+        elif not self.current_tool_name_sent:
+            # Only increment tool_id if we're truly starting a NEW tool call
+            # Don't increment if this is just the first time we're processing
+            # a tool call that was received in the buffer
+            # The key insight: only increment when we've COMPLETED a previous tool call
+            # and now see another bot_token in new_text
+            pass  # Remove the problematic auto-increment logic
+
+        # Ensure tracking arrays are large enough (keeping existing logic)
+        while len(self.prev_tool_call_arr) <= self.current_tool_id:
+            self.prev_tool_call_arr.append({})
+        while len(self.streamed_args_for_tool) <= self.current_tool_id:
+            self.streamed_args_for_tool.append("")
+
+        # Determine if function name is complete by checking for <arg_key> in the full text
+        # This is important for streaming scenarios where args come in later chunks
+        has_arg_key = "<arg_key" in current_text
+
+        # Send tool name if needed
+        tool_name_item = self._send_tool_name_if_needed(
+            func_name, has_arg_key, is_tool_end
+        )
+        if tool_name_item:
+            calls.append(tool_name_item)
+
+        # Process streaming arguments if tool name has been sent
+        if self.current_tool_name_sent:
+            arg_item = self._process_arguments_streaming(
+                func_name, func_args_raw, tools
             )
+            if arg_item:
+                calls.append(arg_item)
 
-            if not partial_match:
-                return StreamingParseResult(normal_text=normal_text, calls=[])
-
-            # Extract match groups using helper method
-            func_name, func_args_raw, is_tool_end = self._extract_match_groups(
-                partial_match
-            )
-
-            # Initialize tool call state if needed (keeping existing logic)
-            if self.current_tool_id == -1:
-                self.current_tool_id = 0
-                self.prev_tool_call_arr = []
-                self.streamed_args_for_tool = [""]
-                self._streamed_raw_length = 0
-                self.current_tool_name_sent = False  # Reset for new tool call
-                self._reset_streaming_state()
-            # Check if this is a continuation of an existing tool call or a new one
-            elif not self.current_tool_name_sent:
-                # Only increment tool_id if we're truly starting a NEW tool call
-                # Don't increment if this is just the first time we're processing
-                # a tool call that was received in the buffer
-                # The key insight: only increment when we've COMPLETED a previous tool call
-                # and now see another bot_token in new_text
-                pass  # Remove the problematic auto-increment logic
-
-            # Ensure tracking arrays are large enough (keeping existing logic)
-            while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                self.prev_tool_call_arr.append({})
-            while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                self.streamed_args_for_tool.append("")
-
-            # Determine if function name is complete by checking for <arg_key> in the full text
-            # This is important for streaming scenarios where args come in later chunks
-            has_arg_key = "<arg_key" in current_text
-
-            # Send tool name if needed
-            tool_name_item = self._send_tool_name_if_needed(
-                func_name, has_arg_key, is_tool_end
-            )
-            if tool_name_item:
-                calls.append(tool_name_item)
-
-            # Process streaming arguments if tool name has been sent
-            if self.current_tool_name_sent:
-                arg_item = self._process_arguments_streaming(
-                    func_name, func_args_raw, tools
+            # Finalize tool call if end token is encountered
+            if is_tool_end == self.eot_token and not self._tool_call_completed:
+                finalize_calls = self._finalize_tool_call(
+                    func_name,
+                    func_args_raw,
+                    tools,
+                    partial_match.end(),
+                    current_text,
                 )
-                if arg_item:
-                    calls.append(arg_item)
-
-                # Finalize tool call if end token is encountered
-                if is_tool_end == self.eot_token and not self._tool_call_completed:
-                    finalize_calls = self._finalize_tool_call(
-                        func_name,
-                        func_args_raw,
-                        tools,
-                        partial_match.end(),
-                        current_text,
-                    )
-                    calls.extend(finalize_calls)
-                    return StreamingParseResult(normal_text=normal_text, calls=calls)
-
-        except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=current_text)
+                calls.extend(finalize_calls)
+                return StreamingParseResult(normal_text=normal_text, calls=calls)
 
         return StreamingParseResult(normal_text=normal_text, calls=calls)
 
@@ -778,10 +817,29 @@ class Glm47MoeDetector(BaseFormatDetector):
                 # If type is not defined, keep the parsed value as-is
                 arguments[arg_key] = parsed_value if is_good_json else arg_value
             else:
+                if not self._matches_expected_type(parsed_value, arg_type):
+                    self.compatibility.note(
+                        CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                        detail=f"{func_name}.{arg_key}: {arg_value[:80]}",
+                    )
                 # For other types (number, object, array, etc.), use parsed value
                 arguments[arg_key] = parsed_value if is_good_json else arg_value
 
         return arguments
+
+    @staticmethod
+    def _matches_expected_type(value: Any, arg_type: str) -> bool:
+        if arg_type in ("integer", "int"):
+            return isinstance(value, int) and not isinstance(value, bool)
+        if arg_type == "number":
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        if arg_type in ("boolean", "bool"):
+            return isinstance(value, bool)
+        if arg_type == "object":
+            return isinstance(value, dict)
+        if arg_type in ("array", "list"):
+            return isinstance(value, list)
+        return True
 
     def supports_structural_tag(self) -> bool:
         return False

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -215,6 +215,7 @@ class Glm4MoeDetector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
@@ -579,6 +580,9 @@ class Glm4MoeDetector(BaseFormatDetector):
                             logger.debug(
                                 f"Failed to parse arguments: {e}", exc_info=True
                             )
+                            self._note_malformed_tool_call(
+                                e, detail=func_args_raw[:80]
+                            )
 
                         # Remove the completed tool call from buffer
                         self._buffer = current_text[partial_match.end(3) :]
@@ -595,6 +599,7 @@ class Glm4MoeDetector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=current_text)
 
     def _parse_argument_pairs(

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -580,9 +580,7 @@ class Glm4MoeDetector(BaseFormatDetector):
                             logger.debug(
                                 f"Failed to parse arguments: {e}", exc_info=True
                             )
-                            self._note_malformed_tool_call(
-                                e, detail=func_args_raw[:80]
-                            )
+                            self._note_malformed_tool_call(e, detail=func_args_raw[:80])
 
                         # Remove the completed tool call from buffer
                         self._buffer = current_text[partial_match.end(3) :]

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -7,6 +7,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import (
+    CompatibilityEvent,
+    synthesize_json_close,
+)
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -194,30 +198,50 @@ class Glm4MoeDetector(BaseFormatDetector):
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=normal_text, calls=[])
-        match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        match_result_list = list(re.finditer(self.func_call_regex, text, re.DOTALL))
+        if not match_result_list:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[idx : idx + 80],
+            )
+            return StreamingParseResult(normal_text=text, calls=[])
         calls = []
-        try:
-            for match_result in match_result_list:
-                # Get function name
-                func_detail = self.func_detail_regex.search(match_result)
-                if func_detail is None:
-                    continue
-                func_name = func_detail.group(1) if func_detail.group(1) else ""
-                func_args = func_detail.group(2) if func_detail.group(2) else ""
-                pairs = self.func_arg_regex.findall(func_args)
+        normal_parts = []
+        cursor = 0
+        for match in match_result_list:
+            normal_parts.append(text[cursor : match.start()])
+            match_result = match.group(0)
+            # Get function name
+            func_detail = self.func_detail_regex.search(match_result)
+            if func_detail is None:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=match_result[:80],
+                )
+                cursor = match.end()
+                continue
+            func_name = func_detail.group(1) if func_detail.group(1) else ""
+            func_args = func_detail.group(2) if func_detail.group(2) else ""
+            pairs = self.func_arg_regex.findall(func_args)
+            if func_args.strip() and not pairs:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=func_args[:80],
+                )
+                cursor = match.end()
+                continue
 
-                # Parse arguments using shared method
-                arguments = self._parse_argument_pairs(pairs, func_name, tools)
+            # Parse arguments using shared method
+            arguments = self._parse_argument_pairs(pairs, func_name, tools)
 
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": arguments}
-                calls.extend(self.parse_base_json(match_result, tools))
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
-            # return the normal text if parsing fails
-            return StreamingParseResult(normal_text=text)
+            # construct match_result for parse_base_json
+            match_result = {"name": func_name, "parameters": arguments}
+            calls.extend(self.parse_base_json(match_result, tools))
+            cursor = match.end()
+        normal_parts.append(text[cursor:])
+        return StreamingParseResult(
+            normal_text="".join(normal_parts).strip(), calls=calls
+        )
 
     def _get_value_type(self, func_name: str, key: str, tools: List[Tool]) -> str:
         """Get parameter type from tool definition, with fallback to auto-detection.
@@ -286,15 +310,18 @@ class Glm4MoeDetector(BaseFormatDetector):
             # Ensure proper JSON string formatting with quotes
             return json.dumps(value, ensure_ascii=False)
         elif value_type == "number":
-            try:
-                num = _convert_to_number(value.strip())
-                return str(num)
-            except (ValueError, AttributeError):
-                # Fallback to string if not a valid number
+            raw = value.strip()
+            num = _convert_to_number(raw)
+            if isinstance(num, str):
                 logger.warning(
                     f"Failed to parse '{value}' as number, treating as string"
                 )
+                self.compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"number: {value[:80]}",
+                )
                 return json.dumps(str(value), ensure_ascii=False)
+            return str(num)
         else:
             # For object/array types, return as-is (should already be valid JSON)
             return value
@@ -459,102 +486,121 @@ class Glm4MoeDetector(BaseFormatDetector):
             self._tool_indices = self._get_tool_indices(tools)
 
         calls: list[ToolCallItem] = []
-        try:
-            # Try to match a partial or complete tool call
-            partial_match = re.search(
-                pattern=r"<tool_call>(.*?)(?:\\n|\n)(.*?)(</tool_call>|$)",
-                string=current_text,
-                flags=re.DOTALL,
-            )
-            if partial_match:
-                func_name_raw = partial_match.group(1)
-                func_args_raw = partial_match.group(2)
-                is_tool_end = partial_match.group(3)
+        # Try to match a partial or complete tool call
+        partial_match = re.search(
+            pattern=r"<tool_call>(.*?)(?:\\n|\n)(.*?)(</tool_call>|$)",
+            string=current_text,
+            flags=re.DOTALL,
+        )
+        if partial_match:
+            func_name_raw = partial_match.group(1)
+            func_args_raw = partial_match.group(2)
+            is_tool_end = partial_match.group(3)
 
-                # Only proceed if we have a non-empty function name
-                if func_name_raw is None or not func_name_raw.strip():
-                    # If we only have the start token without a function name,
-                    # continue buffering until we get more content
-                    return StreamingParseResult(normal_text="", calls=[])
+            # Only proceed if we have a non-empty function name
+            if func_name_raw is None or not func_name_raw.strip():
+                # If we only have the start token without a function name,
+                # continue buffering until we get more content
+                return StreamingParseResult(normal_text="", calls=[])
 
-                func_name = func_name_raw.strip()
-                func_args_raw = func_args_raw.strip() if func_args_raw else ""
+            func_name = func_name_raw.strip()
+            func_args_raw = func_args_raw.strip() if func_args_raw else ""
+            if func_name not in self._tool_indices and self._skip_unknown_tool(
+                func_name
+            ):
+                if partial_match.group(3) == self.eot_token:
+                    self._buffer = current_text[partial_match.end(3) :]
+                return StreamingParseResult(normal_text="", calls=calls)
 
-                # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
-                    self.current_tool_id = 0
-                    self.prev_tool_call_arr = []
-                    self.streamed_args_for_tool = [""]
-                    self._streamed_raw_length = 0
-                    self.current_tool_name_sent = False
-                    self._reset_streaming_state()
+            # Initialize state if this is the first tool call
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+                self.prev_tool_call_arr = []
+                self.streamed_args_for_tool = [""]
+                self._streamed_raw_length = 0
+                self.current_tool_name_sent = False
+                self._reset_streaming_state()
 
-                # Ensure we have enough entries in our tracking arrays
-                while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                    self.prev_tool_call_arr.append({})
-                while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                    self.streamed_args_for_tool.append("")
+            # Ensure we have enough entries in our tracking arrays
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
 
-                # Send tool name first if not sent yet
-                if not self.current_tool_name_sent:
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            name=func_name,
-                            parameters="",
-                        )
+            # Send tool name first if not sent yet
+            if not self.current_tool_name_sent:
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=func_name,
+                        parameters="",
                     )
-                    self.current_tool_name_sent = True
-                    self._streamed_raw_length = 0
-                    self._reset_streaming_state()
-                    # Store the tool call info
-                    self.prev_tool_call_arr[self.current_tool_id] = {
-                        "name": func_name,
-                        "arguments": {},
-                    }
-                else:
-                    # Process XML to JSON streaming
-                    current_raw_length = len(func_args_raw)
+                )
+                self.current_tool_name_sent = True
+                self._streamed_raw_length = 0
+                self._reset_streaming_state()
+                # Store the tool call info
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": func_name,
+                    "arguments": {},
+                }
+            else:
+                # Process XML to JSON streaming
+                current_raw_length = len(func_args_raw)
 
-                    if current_raw_length > self._streamed_raw_length:
-                        # Get the new raw XML content
-                        raw_increment = func_args_raw[self._streamed_raw_length :]
+                if current_raw_length > self._streamed_raw_length:
+                    # Get the new raw XML content
+                    raw_increment = func_args_raw[self._streamed_raw_length :]
 
-                        # Convert XML increment to JSON increment using state machine
-                        json_increment = self._process_xml_to_json_streaming(
-                            raw_increment, func_name, tools
+                    # Convert XML increment to JSON increment using state machine
+                    json_increment = self._process_xml_to_json_streaming(
+                        raw_increment, func_name, tools
+                    )
+
+                    # CRITICAL: Update streamed length BEFORE checking json_increment
+                    # Even if json_increment is empty, the input has been consumed by the state machine
+                    self._streamed_raw_length = current_raw_length
+
+                    if json_increment:
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=None,
+                                parameters=json_increment,
+                            )
+                        )
+                        self._last_arguments += json_increment
+                        self.streamed_args_for_tool[
+                            self.current_tool_id
+                        ] += json_increment
+
+                if is_tool_end == self.eot_token:
+                    pairs = self.func_arg_regex.findall(func_args_raw)
+                    malformed_args = bool(func_args_raw.strip()) and not pairs
+                    if malformed_args:
+                        self.compatibility.note(
+                            CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                            detail=func_args_raw[:80],
                         )
 
-                        # CRITICAL: Update streamed length BEFORE checking json_increment
-                        # Even if json_increment is empty, the input has been consumed by the state machine
-                        self._streamed_raw_length = current_raw_length
-
-                        if json_increment:
-                            calls.append(
-                                ToolCallItem(
-                                    tool_index=self.current_tool_id,
-                                    name=None,
-                                    parameters=json_increment,
-                                )
+                    if self._is_first_param:
+                        empty_object = "{}"
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=None,
+                                parameters=empty_object,
                             )
-                            self._last_arguments += json_increment
-                            self.streamed_args_for_tool[
-                                self.current_tool_id
-                            ] += json_increment
-
-                    if is_tool_end == self.eot_token:
-                        if self._is_first_param:
-                            empty_object = "{}"
-                            calls.append(
-                                ToolCallItem(
-                                    tool_index=self.current_tool_id,
-                                    name=None,
-                                    parameters=empty_object,
-                                )
-                            )
-                            self._last_arguments += empty_object
-                        elif not self._last_arguments.endswith("}"):
+                        )
+                        self._last_arguments += empty_object
+                        self.streamed_args_for_tool[
+                            self.current_tool_id
+                        ] += empty_object
+                    elif malformed_args:
+                        closing_brace = synthesize_json_close(self._last_arguments)
+                        if closing_brace is None:
                             closing_brace = "}"
+                        if closing_brace:
                             calls.append(
                                 ToolCallItem(
                                     tool_index=self.current_tool_id,
@@ -566,39 +612,47 @@ class Glm4MoeDetector(BaseFormatDetector):
                             self.streamed_args_for_tool[
                                 self.current_tool_id
                             ] += closing_brace
-
-                        try:
-                            pairs = self.func_arg_regex.findall(func_args_raw)
-                            if pairs:
-                                arguments = self._parse_argument_pairs(
-                                    pairs, func_name, tools
-                                )
-                                self.prev_tool_call_arr[self.current_tool_id][
-                                    "arguments"
-                                ] = arguments
-                        except Exception as e:
-                            logger.debug(
-                                f"Failed to parse arguments: {e}", exc_info=True
+                    elif not self._last_arguments.endswith("}"):
+                        closing_brace = "}"
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=None,
+                                parameters=closing_brace,
                             )
-                            self._note_malformed_tool_call(e, detail=func_args_raw[:80])
+                        )
+                        self._last_arguments += closing_brace
+                        self.streamed_args_for_tool[
+                            self.current_tool_id
+                        ] += closing_brace
 
-                        # Remove the completed tool call from buffer
-                        self._buffer = current_text[partial_match.end(3) :]
+                    try:
+                        if pairs:
+                            arguments = self._parse_argument_pairs(
+                                pairs, func_name, tools
+                            )
+                            self.prev_tool_call_arr[self.current_tool_id][
+                                "arguments"
+                            ] = arguments
+                    except (json.JSONDecodeError, ValueError) as e:
+                        logger.debug(f"Failed to parse arguments: {e}", exc_info=True)
+                        self.compatibility.note(
+                            CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                            detail=func_args_raw[:80],
+                        )
 
-                        result = StreamingParseResult(normal_text="", calls=calls)
-                        self.current_tool_id += 1
-                        self._last_arguments = ""
-                        self.current_tool_name_sent = False
-                        self._streamed_raw_length = 0
-                        self._reset_streaming_state()
-                        return result
+                    # Remove the completed tool call from buffer
+                    self._buffer = current_text[partial_match.end(3) :]
 
-            return StreamingParseResult(normal_text="", calls=calls)
+                    result = StreamingParseResult(normal_text="", calls=calls)
+                    self.current_tool_id += 1
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    self._streamed_raw_length = 0
+                    self._reset_streaming_state()
+                    return result
 
-        except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=current_text)
+        return StreamingParseResult(normal_text="", calls=calls)
 
     def _parse_argument_pairs(
         self, pairs: List[Tuple[str, str]], func_name: str, tools: List[Tool]
@@ -632,10 +686,29 @@ class Glm4MoeDetector(BaseFormatDetector):
                 # If type is not defined, keep the parsed value as-is
                 arguments[arg_key] = parsed_value if is_good_json else arg_value
             else:
+                if not self._matches_expected_type(parsed_value, arg_type):
+                    self.compatibility.note(
+                        CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                        detail=f"{func_name}.{arg_key}: {arg_value[:80]}",
+                    )
                 # For other types (number, object, array, etc.), use parsed value
                 arguments[arg_key] = parsed_value if is_good_json else arg_value
 
         return arguments
+
+    @staticmethod
+    def _matches_expected_type(value: Any, arg_type: str) -> bool:
+        if arg_type in ("integer", "int"):
+            return isinstance(value, int) and not isinstance(value, bool)
+        if arg_type == "number":
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        if arg_type in ("boolean", "bool"):
+            return isinstance(value, bool)
+        if arg_type == "object":
+            return isinstance(value, dict)
+        if arg_type in ("array", "list"):
+            return isinstance(value, list)
+        return True
 
     def supports_structural_tag(self) -> bool:
         return False

--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -4,8 +4,8 @@ import re
 from typing import List, Optional
 
 from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -219,16 +219,19 @@ class GptOssDetector(BaseFormatDetector):
         )
 
         # Check if tool exists
-        if function_name not in tool_indices:
-            logger.debug(f"Function {function_name} not in available tools")
-            if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
-                return None  # Skip unknown tools (default legacy behavior)
+        if function_name not in tool_indices and self._skip_unknown_tool(
+            function_name
+        ):
+            return None
 
         # Parse JSON arguments
-        try:
+        with self.compatibility.absorb(
+            CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            json.JSONDecodeError,
+            detail=f"{function_name}: {json_content[:80]}",
+        ) as absorbed:
             arguments = json.loads(json_content) if json_content.strip() else {}
-        except json.JSONDecodeError as e:
-            logger.debug(f"Failed to parse JSON arguments: {e}")
+        if absorbed.fired:
             return None
 
         return ToolCallItem(

--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -219,9 +219,7 @@ class GptOssDetector(BaseFormatDetector):
         )
 
         # Check if tool exists
-        if function_name not in tool_indices and self._skip_unknown_tool(
-            function_name
-        ):
+        if function_name not in tool_indices and self._skip_unknown_tool(function_name):
             return None
 
         # Parse JSON arguments

--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -206,6 +206,10 @@ class GptOssDetector(BaseFormatDetector):
 
         if not match:
             logger.debug(f"Could not extract tool call from: {content[:100]}")
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=content[:80],
+            )
             return None
 
         full_function_name = match.group(1)

--- a/python/sglang/srt/function_call/hermes_detector.py
+++ b/python/sglang/srt/function_call/hermes_detector.py
@@ -57,6 +57,7 @@ class HermesDetector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}")
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=text)
 
     def _clean_normal_text(self, text: str) -> str:

--- a/python/sglang/srt/function_call/hermes_detector.py
+++ b/python/sglang/srt/function_call/hermes_detector.py
@@ -5,6 +5,7 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -44,21 +45,37 @@ class HermesDetector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
         calls = []
-        try:
-            for match in self.tool_call_regex.findall(text):
-                raw = match[0] or match[1]
-                if not raw:
-                    continue
+        truncated_parts = []
+        for match in self.tool_call_regex.findall(text):
+            raw = match[0] or match[1]
+            if not raw:
+                continue
+            if match[1]:
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=raw[:80],
+                )
+                truncated_parts.append(f"{self.bot_token}{raw}")
+                continue
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                json.JSONDecodeError,
+                detail=raw[:80],
+            ) as absorbed:
                 parsed = json.loads(raw.strip())
-                if isinstance(parsed, list):
-                    calls.extend(self.parse_base_json(parsed, tools))
-                else:
-                    calls.extend(self.parse_base_json(parsed, tools))
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=text)
+            if absorbed.fired:
+                return StreamingParseResult(normal_text=text, calls=[])
+            parsed_items = parsed if isinstance(parsed, list) else [parsed]
+            if not all(isinstance(item, dict) for item in parsed_items):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=raw[:80],
+                )
+                return StreamingParseResult(normal_text=text, calls=[])
+            calls.extend(self.parse_base_json(parsed_items, tools))
+        return StreamingParseResult(
+            normal_text=normal_text + "".join(truncated_parts), calls=calls
+        )
 
     def _clean_normal_text(self, text: str) -> str:
         if not text:

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -4,7 +4,6 @@ import re
 from typing import Any, Dict, List, Optional, Set
 
 from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -225,16 +224,13 @@ class HunyuanDetector(BaseFormatDetector):
         normal_text = text[:idx].strip() if idx > 0 else ""
 
         tool_indices = self._get_tool_indices(tools)
-        forward_unknown = envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
-
         calls: List[ToolCallItem] = []
         try:
             for function_name, function_args in self.tool_call_regex.findall(text):
                 function_name = function_name.strip()
-                if function_name not in tool_indices and not forward_unknown:
-                    logger.warning(
-                        "Model attempted to call undefined function: %s", function_name
-                    )
+                if function_name not in tool_indices and self._skip_unknown_tool(
+                    function_name
+                ):
                     continue
 
                 arg_dict: Dict[str, Any] = {}
@@ -252,6 +248,7 @@ class HunyuanDetector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=text)
 
     # ------------------------------------------------------------------
@@ -270,6 +267,7 @@ class HunyuanDetector(BaseFormatDetector):
             return self._parse_streaming_increment_impl(new_text, tools)
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
+            self._note_malformed_tool_call(e)
             return StreamingParseResult()
 
     def _parse_streaming_increment_impl(
@@ -324,13 +322,17 @@ class HunyuanDetector(BaseFormatDetector):
                     tc_start + len(self.tool_call_start_token) : sep_pos
                 ].strip()
 
-                if (
-                    tool_name not in self._tool_indices
-                    and not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+                if tool_name not in self._tool_indices and self._skip_unknown_tool(
+                    tool_name
                 ):
-                    logger.warning(
-                        "Model attempted to call undefined function: %s", tool_name
-                    )
+                    end_pos = self._buffer.find(self.tool_call_end_token, sep_pos)
+                    if end_pos == -1:
+                        self._buffer = self._buffer[tc_start:]
+                        break
+                    self._buffer = self._buffer[
+                        end_pos + len(self.tool_call_end_token) :
+                    ]
+                    continue
 
                 self._streaming_tool_name = tool_name
                 self.current_tool_id += 1

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -172,8 +173,8 @@ class HunyuanDetector(BaseFormatDetector):
         except (json.JSONDecodeError, ValueError):
             return value
 
-    @staticmethod
     def _parse_value(
+        self,
         value: str,
         function_name: str,
         arg_key: str,
@@ -202,10 +203,19 @@ class HunyuanDetector(BaseFormatDetector):
             try:
                 return json.loads(value)
             except (json.JSONDecodeError, ValueError):
-                pass
+                self.compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"{function_name}.{arg_key}: {value[:80]}",
+                )
 
         if "string" in types:
             return value
+
+        if types & {"boolean", "integer", "number"}:
+            self.compatibility.note(
+                CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                detail=f"{function_name}.{arg_key}: {value[:80]}",
+            )
 
         return HunyuanDetector._deserialize(value)
 
@@ -222,34 +232,62 @@ class HunyuanDetector(BaseFormatDetector):
 
         idx = text.find(self.bot_token)
         normal_text = text[:idx].strip() if idx > 0 else ""
+        section_end = text.find(self.eot_token, idx + len(self.bot_token))
+        if section_end != -1:
+            normal_text = (
+                text[:idx] + text[section_end + len(self.eot_token) :]
+            ).strip()
 
         tool_indices = self._get_tool_indices(tools)
         calls: List[ToolCallItem] = []
-        try:
-            for function_name, function_args in self.tool_call_regex.findall(text):
-                function_name = function_name.strip()
-                if function_name not in tool_indices and self._skip_unknown_tool(
-                    function_name
-                ):
-                    continue
-
-                arg_dict: Dict[str, Any] = {}
-                for key, value in self.func_args_regex.findall(function_args):
-                    key = key.strip()
-                    arg_dict[key] = self._parse_value(value, function_name, key, tools)
-
-                calls.append(
-                    ToolCallItem(
-                        tool_index=tool_indices.get(function_name, -1),
-                        name=function_name,
-                        parameters=json.dumps(arg_dict, ensure_ascii=False),
-                    )
+        matches = self.tool_call_regex.findall(text)
+        if not matches:
+            if self.eot_token in text:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=text[idx : idx + 80],
                 )
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=text)
+                return StreamingParseResult(normal_text=normal_text, calls=[])
+            else:
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=text[idx : idx + 80],
+                )
+                return StreamingParseResult(normal_text=text, calls=[])
+
+        for function_name, function_args in matches:
+            function_name = function_name.strip()
+            if not function_name:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=function_args[:80],
+                )
+                continue
+            if function_name not in tool_indices and self._skip_unknown_tool(
+                function_name
+            ):
+                continue
+
+            arg_dict: Dict[str, Any] = {}
+            arg_pairs = self.func_args_regex.findall(function_args)
+            if function_args.strip() and not arg_pairs:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=function_args[:80],
+                )
+                continue
+            for key, value in arg_pairs:
+                key = key.strip()
+                arg_dict[key] = self._parse_value(value, function_name, key, tools)
+
+            calls.append(
+                ToolCallItem(
+                    tool_index=tool_indices.get(function_name, -1),
+                    name=function_name,
+                    parameters=json.dumps(arg_dict, ensure_ascii=False),
+                )
+            )
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     # ------------------------------------------------------------------
     # Streaming
@@ -263,12 +301,7 @@ class HunyuanDetector(BaseFormatDetector):
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
     ) -> StreamingParseResult:
-        try:
-            return self._parse_streaming_increment_impl(new_text, tools)
-        except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult()
+        return self._parse_streaming_increment_impl(new_text, tools)
 
     def _parse_streaming_increment_impl(
         self, new_text: str, tools: List[Tool]
@@ -399,6 +432,35 @@ class HunyuanDetector(BaseFormatDetector):
                     self._streaming_tool_name or "", partial_key, tools
                 ):
                     partial_value = tail[av_start + len(self.arg_value_start_token) :]
+
+        malformed_tail = bool(is_complete and tail.strip())
+        if malformed_tail:
+            event = (
+                CompatibilityEvent.MISSING_CLOSE_TAG
+                if partial_key is not None and partial_value is not None
+                else CompatibilityEvent.MALFORMED_JSON_DROPPED
+            )
+            self.compatibility.note(
+                event,
+                detail=tail[:80],
+            )
+
+            if (
+                partial_value is not None
+                and 0 <= self.current_tool_id < len(self.streamed_args_for_tool)
+                and self.streamed_args_for_tool[self.current_tool_id]
+            ):
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": self._streaming_tool_name,
+                    "arguments": {},
+                }
+                closing_calls = self._close_mid_stream_call()
+                end_idx = self._buffer.find(self.tool_call_end_token)
+                self._buffer = self._buffer[end_idx + len(self.tool_call_end_token) :]
+                self._reset_streaming_tool_state()
+                return closing_calls
 
         # Avoid emitting a lone "{" before any arg content is knowable.
         if not is_complete and not self._completed_args and partial_value is None:

--- a/python/sglang/srt/function_call/internlm_detector.py
+++ b/python/sglang/srt/function_call/internlm_detector.py
@@ -6,7 +6,6 @@ import re
 from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -119,16 +118,12 @@ class InternlmDetector(BaseFormatDetector):
 
                     # Validate tool name
                     if not (name and name in tool_indices):
-                        logger.warning(
-                            f"[InternLM Tool Call] Model attempted to call undefined function: {name}, "
-                            f"available_tools={list(tool_indices.keys())}"
-                        )
-                        if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
-                            continue  # Skip this tool call
+                        if self._skip_unknown_tool(name):
+                            continue
 
                     # Create tool call item and add to list
                     tool_call = ToolCallItem(
-                        tool_index=tool_indices[name],
+                        tool_index=tool_indices.get(name, -1),
                         name=name,
                         parameters=json.dumps(parameters, ensure_ascii=False),
                     )
@@ -138,6 +133,7 @@ class InternlmDetector(BaseFormatDetector):
                     logger.error(
                         f"[InternLM Tool Call] Failed to parse JSON for tool call #{idx+1}: {e}"
                     )
+                    self._note_malformed_tool_call(e, detail=action_json[:80])
                     continue
 
             logger.info(
@@ -150,6 +146,7 @@ class InternlmDetector(BaseFormatDetector):
             logger.error(
                 f"[InternLM Tool Call] Error in detect_and_parse: {e}", exc_info=True
             )
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=text, calls=[])
 
     def parse_streaming_increment(

--- a/python/sglang/srt/function_call/internlm_detector.py
+++ b/python/sglang/srt/function_call/internlm_detector.py
@@ -7,6 +7,7 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -87,67 +88,86 @@ class InternlmDetector(BaseFormatDetector):
         tool_call_pattern = (
             rf"{re.escape(self.bot_token)}\s*(.*?){re.escape(self.eot_token)}"
         )
-        matches = re.findall(tool_call_pattern, text, re.DOTALL)
+        matches = list(re.finditer(tool_call_pattern, text, re.DOTALL))
 
         if not matches:
             logger.warning("[InternLM Tool Call] No complete tool call blocks found")
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[text.find(self.bot_token) :][:80],
+            )
             return StreamingParseResult(normal_text=text, calls=[])
 
         logger.info(f"[InternLM Tool Call] Found {len(matches)} tool call(s)")
 
         calls = []
         tool_indices = self._get_tool_indices(tools)
+        normal_parts = []
+        cursor = 0
 
-        try:
-            for idx, action_json in enumerate(matches):
-                action_json = action_json.strip()
+        for idx, action_json in enumerate(matches):
+            normal_parts.append(text[cursor : action_json.start()])
+            cursor = action_json.end()
+            action_json = action_json.group(1).strip()
 
-                try:
-                    # Parse the JSON
-                    action_dict = json.loads(action_json)
-                    name = action_dict.get("name")
-                    parameters = self.get_arguments(action_dict)
+            try:
+                # Parse the JSON
+                action_dict = json.loads(action_json)
+            except json.JSONDecodeError as e:
+                logger.error(
+                    f"[InternLM Tool Call] Failed to parse JSON for tool call #{idx+1}: {e}"
+                )
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=action_json[:80],
+                )
+                continue
 
-                    if not parameters:
-                        parameters = {}
+            if not isinstance(action_dict, dict):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=action_json[:80],
+                )
+                continue
 
-                    logger.info(
-                        f"[InternLM Tool Call] Parsed tool call #{idx+1}: name={name}, "
-                        f"parameters={json.dumps(parameters, ensure_ascii=False)}"
-                    )
+            name = action_dict.get("name")
+            parameters = self.get_arguments(action_dict)
 
-                    # Validate tool name
-                    if not (name and name in tool_indices):
-                        if self._skip_unknown_tool(name):
-                            continue
+            if not name:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=action_json[:80],
+                )
+                continue
 
-                    # Create tool call item and add to list
-                    tool_call = ToolCallItem(
-                        tool_index=tool_indices.get(name, -1),
-                        name=name,
-                        parameters=json.dumps(parameters, ensure_ascii=False),
-                    )
-                    calls.append(tool_call)
-
-                except json.JSONDecodeError as e:
-                    logger.error(
-                        f"[InternLM Tool Call] Failed to parse JSON for tool call #{idx+1}: {e}"
-                    )
-                    self._note_malformed_tool_call(e, detail=action_json[:80])
-                    continue
+            if not parameters:
+                parameters = {}
 
             logger.info(
-                f"[InternLM Tool Call] Successfully parsed {len(calls)} tool call(s), "
-                f"normal_text_length={len(normal_text)}"
+                f"[InternLM Tool Call] Parsed tool call #{idx+1}: name={name}, "
+                f"parameters={json.dumps(parameters, ensure_ascii=False)}"
             )
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
 
-        except Exception as e:
-            logger.error(
-                f"[InternLM Tool Call] Error in detect_and_parse: {e}", exc_info=True
+            # Validate tool name
+            if not (name and name in tool_indices):
+                if self._skip_unknown_tool(name):
+                    continue
+
+            # Create tool call item and add to list
+            tool_call = ToolCallItem(
+                tool_index=tool_indices.get(name, -1),
+                name=name,
+                parameters=json.dumps(parameters, ensure_ascii=False),
             )
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=text, calls=[])
+            calls.append(tool_call)
+
+        normal_parts.append(text[cursor:])
+        normal_text = "".join(normal_parts).strip()
+        logger.info(
+            f"[InternLM Tool Call] Successfully parsed {len(calls)} tool call(s), "
+            f"normal_text_length={len(normal_text)}"
+        )
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -9,6 +9,7 @@ from sglang.srt.function_call.base_format_detector import (
     StructuralTag,
     get_model_structural_tag,
 )
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -171,36 +172,42 @@ class KimiK2Detector(BaseFormatDetector):
         """
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=text, calls=[])
-        try:
-            function_call_tuples = self.tool_call_regex.findall(text)
+        function_call_tuples = self.tool_call_regex.findall(text)
 
-            logger.debug("function_call_tuples: %s", function_call_tuples)
+        logger.debug("function_call_tuples: %s", function_call_tuples)
 
-            tool_calls = []
-            for match in function_call_tuples:
-                function_id, function_args = match
-                function_name, function_idx = self._parse_tool_call_id(
-                    function_id, tools, function_args
+        tool_calls = []
+        for match in function_call_tuples:
+            function_id, function_args = match
+            # With a missing <|tool_call_end|> the args capture can span into
+            # the next call; never emit a call whose parameters are not JSON.
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                json.JSONDecodeError,
+                detail=f"{function_id}: {function_args[:80]}",
+            ) as absorbed:
+                json.loads(function_args)
+            if absorbed.fired:
+                continue
+            function_name, function_idx = self._parse_tool_call_id(
+                function_id, tools, function_args
+            )
+            if function_name is None:
+                continue
+
+            logger.debug(f"function_name {function_name}")
+
+            tool_calls.append(
+                ToolCallItem(
+                    tool_index=function_idx,
+                    name=function_name,
+                    parameters=function_args,
                 )
-                if function_name is None:
-                    continue
+            )
 
-                logger.debug(f"function_name {function_name}")
+        content = text[: text.find(self.bot_token)]
+        return StreamingParseResult(normal_text=content, calls=tool_calls)
 
-                tool_calls.append(
-                    ToolCallItem(
-                        tool_index=function_idx,
-                        name=function_name,
-                        parameters=function_args,
-                    )
-                )
-
-            content = text[: text.find(self.bot_token)]
-            return StreamingParseResult(normal_text=content, calls=tool_calls)
-
-        except Exception as e:
-            logger.error("Error in detect_and_parse: %s", e, exc_info=True)
-            return StreamingParseResult(normal_text=text)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
@@ -217,115 +224,119 @@ class KimiK2Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
-            self._buffer = ""
-            normal_text = _strip_special_tokens(new_text)
+            normal_text, self._buffer = self._hold_back_partial_tokens(
+                current_text, _KIMI_K2_SPECIAL_TOKENS
+            )
+            normal_text = _strip_special_tokens(normal_text)
             return StreamingParseResult(normal_text=normal_text)
 
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)
 
         calls: list[ToolCallItem] = []
-        try:
-            match = self.stream_tool_call_portion_regex.search(current_text)
-            if match:
-                function_id = match.group("tool_call_id")
-                function_args = match.group("function_arguments")
+        match = self.stream_tool_call_portion_regex.search(current_text)
+        if match:
+            function_id = match.group("tool_call_id")
+            function_args = match.group("function_arguments")
 
-                # Reuse cached name for current tool call to avoid repeated
-                # json.loads on partial JSON in _infer_tool_name.
-                if self._current_stream_function_name is not None:
-                    function_name = self._current_stream_function_name
-                else:
-                    function_name, _ = self._parse_tool_call_id(
-                        function_id, tools, function_args
+            # Reuse cached name for current tool call to avoid repeated
+            # json.loads on partial JSON in _infer_tool_name.
+            if self._current_stream_function_name is not None:
+                function_name = self._current_stream_function_name
+            else:
+                function_name, _ = self._parse_tool_call_id(
+                    function_id, tools, function_args
+                )
+            if function_name is None:
+                return StreamingParseResult(normal_text="", calls=calls)
+
+            # Initialize state if this is the first tool call
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+                self.prev_tool_call_arr = []
+                self.streamed_args_for_tool = [""]
+
+            # Ensure we have enough entries in our tracking arrays
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
+
+            if not self.current_tool_name_sent:
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=function_name,
+                        parameters="",
                     )
-                if function_name is None:
-                    return StreamingParseResult(normal_text="", calls=calls)
+                )
+                self.current_tool_name_sent = True
+                self._current_stream_function_name = function_name
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": function_name,
+                    "arguments": {},
+                }
+            else:
+                argument_diff = (
+                    function_args[len(self._last_arguments) :]
+                    if function_args.startswith(self._last_arguments)
+                    else function_args
+                )
 
-                # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
-                    self.current_tool_id = 0
-                    self.prev_tool_call_arr = []
-                    self.streamed_args_for_tool = [""]
+                parsed_args_diff = argument_diff.split(self.tool_call_end_token, 1)[
+                    0
+                ]
+                # Hold back a possible partial <|tool_call_end|> at the chunk
+                # boundary: marker text must never leak into streamed
+                # arguments. The next chunk disambiguates and re-emits.
+                parsed_args_diff, _ = self._hold_back_partial_tokens(
+                    parsed_args_diff, (self.tool_call_end_token,)
+                )
 
-                # Ensure we have enough entries in our tracking arrays
-                while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                    self.prev_tool_call_arr.append({})
-                while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                    self.streamed_args_for_tool.append("")
-
-                if not self.current_tool_name_sent:
+                if parsed_args_diff:
                     calls.append(
                         ToolCallItem(
                             tool_index=self.current_tool_id,
-                            name=function_name,
-                            parameters="",
+                            name=None,
+                            parameters=parsed_args_diff,
                         )
                     )
-                    self.current_tool_name_sent = True
-                    self._current_stream_function_name = function_name
-                    self.prev_tool_call_arr[self.current_tool_id] = {
-                        "name": function_name,
-                        "arguments": {},
-                    }
-                else:
-                    argument_diff = (
-                        function_args[len(self._last_arguments) :]
-                        if function_args.startswith(self._last_arguments)
-                        else function_args
+                    self._last_arguments += parsed_args_diff
+                    self.streamed_args_for_tool[
+                        self.current_tool_id
+                    ] += parsed_args_diff
+
+                parsed_args = function_args.split(self.tool_call_end_token, 1)[0]
+                if _is_complete_json(parsed_args):
+                    try:
+                        parsed_args = json.loads(parsed_args)
+                        self.prev_tool_call_arr[self.current_tool_id][
+                            "arguments"
+                        ] = parsed_args
+                    except json.JSONDecodeError:
+                        pass
+
+                    # Find the end of the current tool call and remove only that part from buffer
+                    tool_call_end_pattern = (
+                        r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>"
                     )
+                    end_match = re.search(
+                        tool_call_end_pattern, current_text, re.DOTALL
+                    )
+                    if end_match:
+                        self._buffer = current_text[end_match.end() :]
+                    else:
+                        self._buffer = ""
 
-                    parsed_args_diff = argument_diff.split(self.tool_call_end_token, 1)[
-                        0
-                    ]
+                    result = StreamingParseResult(normal_text="", calls=calls)
+                    self.current_tool_id += 1
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    self._current_stream_function_name = None
+                    return result
 
-                    if parsed_args_diff:
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=None,
-                                parameters=parsed_args_diff,
-                            )
-                        )
-                        self._last_arguments += parsed_args_diff
-                        self.streamed_args_for_tool[
-                            self.current_tool_id
-                        ] += parsed_args_diff
+        return StreamingParseResult(normal_text="", calls=calls)
 
-                    parsed_args = function_args.split(self.tool_call_end_token, 1)[0]
-                    if _is_complete_json(parsed_args):
-                        try:
-                            parsed_args = json.loads(parsed_args)
-                            self.prev_tool_call_arr[self.current_tool_id][
-                                "arguments"
-                            ] = parsed_args
-                        except json.JSONDecodeError:
-                            pass
-
-                        # Find the end of the current tool call and remove only that part from buffer
-                        tool_call_end_pattern = (
-                            r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>"
-                        )
-                        end_match = re.search(
-                            tool_call_end_pattern, current_text, re.DOTALL
-                        )
-                        if end_match:
-                            self._buffer = current_text[end_match.end() :]
-                        else:
-                            self._buffer = ""
-
-                        result = StreamingParseResult(normal_text="", calls=calls)
-                        self.current_tool_id += 1
-                        self._last_arguments = ""
-                        self.current_tool_name_sent = False
-                        self._current_stream_function_name = None
-                        return result
-
-            return StreamingParseResult(normal_text="", calls=calls)
-
-        except Exception as e:
-            logger.error("Error in parse_streaming_increment: %s", e, exc_info=True)
-            return StreamingParseResult(normal_text=_strip_special_tokens(current_text))
 
     def structure_info(self) -> _GetInfoFunc:
         """Return function that creates StructureInfo for guided generation."""

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -208,7 +208,6 @@ class KimiK2Detector(BaseFormatDetector):
         content = text[: text.find(self.bot_token)]
         return StreamingParseResult(normal_text=content, calls=tool_calls)
 
-
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
     ) -> StreamingParseResult:
@@ -283,9 +282,7 @@ class KimiK2Detector(BaseFormatDetector):
                     else function_args
                 )
 
-                parsed_args_diff = argument_diff.split(self.tool_call_end_token, 1)[
-                    0
-                ]
+                parsed_args_diff = argument_diff.split(self.tool_call_end_token, 1)[0]
                 # Hold back a possible partial <|tool_call_end|> at the chunk
                 # boundary: marker text must never leak into streamed
                 # arguments. The next chunk disambiguates and re-emits.
@@ -336,7 +333,6 @@ class KimiK2Detector(BaseFormatDetector):
                     return result
 
         return StreamingParseResult(normal_text="", calls=calls)
-
 
     def structure_info(self) -> _GetInfoFunc:
         """Return function that creates StructureInfo for guided generation."""

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -172,11 +172,32 @@ class KimiK2Detector(BaseFormatDetector):
         """
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=text, calls=[])
+        section_start = text.find(self.bot_token)
+        section_end = text.find(self.eot_token, section_start + len(self.bot_token))
+        normal_text = (
+            text[:section_start] + text[section_end + len(self.eot_token) :]
+            if section_end != -1
+            else text[:section_start]
+        )
         function_call_tuples = self.tool_call_regex.findall(text)
+        if not function_call_tuples:
+            if self.eot_token in text:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=text[text.find(self.bot_token) :][:80],
+                )
+                return StreamingParseResult(normal_text=normal_text, calls=[])
+            else:
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=text[text.find(self.bot_token) :][:80],
+                )
+                return StreamingParseResult(normal_text=text, calls=[])
 
         logger.debug("function_call_tuples: %s", function_call_tuples)
 
         tool_calls = []
+        tool_indices = self._get_tool_indices(tools)
         for match in function_call_tuples:
             function_id, function_args = match
             # With a missing <|tool_call_end|> the args capture can span into
@@ -193,6 +214,14 @@ class KimiK2Detector(BaseFormatDetector):
                 function_id, tools, function_args
             )
             if function_name is None:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=f"{function_id}: {function_args[:80]}",
+                )
+                continue
+            if function_name not in tool_indices and self._skip_unknown_tool(
+                function_name
+            ):
                 continue
 
             logger.debug(f"function_name {function_name}")
@@ -205,8 +234,7 @@ class KimiK2Detector(BaseFormatDetector):
                 )
             )
 
-        content = text[: text.find(self.bot_token)]
-        return StreamingParseResult(normal_text=content, calls=tool_calls)
+        return StreamingParseResult(normal_text=normal_text, calls=tool_calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
@@ -237,6 +265,25 @@ class KimiK2Detector(BaseFormatDetector):
         if match:
             function_id = match.group("tool_call_id")
             function_args = match.group("function_arguments")
+            parsed_args = function_args.split(self.tool_call_end_token, 1)[0]
+            is_tool_end = self.tool_call_end_token in function_args
+
+            if is_tool_end and not _is_complete_json(parsed_args):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=f"{function_id}: {parsed_args[:80]}",
+                )
+                calls.extend(self._close_started_malformed_call())
+                end_match = re.search(
+                    r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>",
+                    current_text,
+                    re.DOTALL,
+                )
+                self._buffer = current_text[end_match.end() :] if end_match else ""
+                self._last_arguments = ""
+                self.current_tool_name_sent = False
+                self._current_stream_function_name = None
+                return self._retry_streaming_tail(current_text, calls, tools)
 
             # Reuse cached name for current tool call to avoid repeated
             # json.loads on partial JSON in _infer_tool_name.
@@ -247,6 +294,33 @@ class KimiK2Detector(BaseFormatDetector):
                     function_id, tools, function_args
                 )
             if function_name is None:
+                if is_tool_end and _is_complete_json(parsed_args):
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=f"{function_id}: {parsed_args[:80]}",
+                    )
+                    end_match = re.search(
+                        r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>",
+                        current_text,
+                        re.DOTALL,
+                    )
+                    self._buffer = current_text[end_match.end() :] if end_match else ""
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    self._current_stream_function_name = None
+                    return self._retry_streaming_tail(current_text, calls, tools)
+                return StreamingParseResult(normal_text="", calls=calls)
+            if function_name not in self._tool_indices and self._skip_unknown_tool(
+                function_name
+            ):
+                if _is_complete_json(parsed_args):
+                    end_match = re.search(
+                        r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>",
+                        current_text,
+                        re.DOTALL,
+                    )
+                    self._buffer = current_text[end_match.end() :] if end_match else ""
+                    return self._retry_streaming_tail(current_text, calls, tools)
                 return StreamingParseResult(normal_text="", calls=calls)
 
             # Initialize state if this is the first tool call
@@ -303,7 +377,6 @@ class KimiK2Detector(BaseFormatDetector):
                         self.current_tool_id
                     ] += parsed_args_diff
 
-                parsed_args = function_args.split(self.tool_call_end_token, 1)[0]
                 if _is_complete_json(parsed_args):
                     try:
                         parsed_args = json.loads(parsed_args)

--- a/python/sglang/srt/function_call/lfm2_detector.py
+++ b/python/sglang/srt/function_call/lfm2_detector.py
@@ -142,7 +142,9 @@ class Lfm2Detector(BaseFormatDetector):
                 arguments[keyword.arg] = self._get_parameter_value(keyword.value)
             except ValueError as e:
                 logger.warning(f"Failed to parse argument {keyword.arg}: {e}")
-                self._note_malformed_tool_call(e, detail=f"{function_name}.{keyword.arg}")
+                self._note_malformed_tool_call(
+                    e, detail=f"{function_name}.{keyword.arg}"
+                )
                 return None
 
         return ToolCallItem(

--- a/python/sglang/srt/function_call/lfm2_detector.py
+++ b/python/sglang/srt/function_call/lfm2_detector.py
@@ -24,7 +24,6 @@ import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -129,12 +128,8 @@ class Lfm2Detector(BaseFormatDetector):
         function_name = call.func.id
 
         # Validate that the function exists in the tools
-        if function_name not in tool_indices:
-            logger.warning(
-                f"Model attempted to call undefined function: {function_name}"
-            )
-            if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
-                return None  # Skip unknown tools (default legacy behavior)
+        if function_name not in tool_indices and self._skip_unknown_tool(function_name):
+            return None  # Skip unknown tools (default legacy behavior)
 
         # Parse arguments
         arguments = {}
@@ -147,6 +142,7 @@ class Lfm2Detector(BaseFormatDetector):
                 arguments[keyword.arg] = self._get_parameter_value(keyword.value)
             except ValueError as e:
                 logger.warning(f"Failed to parse argument {keyword.arg}: {e}")
+                self._note_malformed_tool_call(e, detail=f"{function_name}.{keyword.arg}")
                 return None
 
         return ToolCallItem(
@@ -202,9 +198,11 @@ class Lfm2Detector(BaseFormatDetector):
             return calls, ""
 
         except SyntaxError as e:
+            self._note_malformed_tool_call(e, detail=content[:80])
             return [], f"Python syntax error: {e}"
         except Exception as e:
             logger.exception("Unexpected error in pythonic tool call parsing")
+            self._note_malformed_tool_call(e, detail=content[:80])
             return [], f"Unexpected error: {e}"
 
     def _parse_json_content(
@@ -233,6 +231,7 @@ class Lfm2Detector(BaseFormatDetector):
             return calls, ""
 
         except json.JSONDecodeError as e:
+            self._note_malformed_tool_call(e, detail=content[:80])
             return [], f"JSON parse error: {e}"
 
     def _parse_tool_calls_content(

--- a/python/sglang/srt/function_call/lfm2_detector.py
+++ b/python/sglang/srt/function_call/lfm2_detector.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -123,6 +124,10 @@ class Lfm2Detector(BaseFormatDetector):
             logger.warning(
                 f"Tool call function must be a simple name, got: {type(call.func).__name__}"
             )
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=ast.dump(call)[:80],
+            )
             return None
 
         function_name = call.func.id
@@ -137,13 +142,18 @@ class Lfm2Detector(BaseFormatDetector):
             if keyword.arg is None:
                 # **kwargs unpacking - skip for now
                 logger.warning("Tool call with **kwargs unpacking is not supported")
-                continue
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=function_name,
+                )
+                return None
             try:
                 arguments[keyword.arg] = self._get_parameter_value(keyword.value)
             except ValueError as e:
                 logger.warning(f"Failed to parse argument {keyword.arg}: {e}")
-                self._note_malformed_tool_call(
-                    e, detail=f"{function_name}.{keyword.arg}"
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=f"{function_name}.{keyword.arg}",
                 )
                 return None
 
@@ -171,41 +181,52 @@ class Lfm2Detector(BaseFormatDetector):
 
         try:
             module = ast.parse(content)
-            parsed = getattr(module.body[0], "value", None) if module.body else None
-
-            if parsed is None:
-                return [], "Empty or invalid Python expression"
-
-            # Handle both single call and list of calls
-            if isinstance(parsed, ast.List):
-                call_nodes = parsed.elts
-            elif isinstance(parsed, ast.Call):
-                call_nodes = [parsed]
-            else:
-                return (
-                    [],
-                    f"Expected function call or list, got: {type(parsed).__name__}",
-                )
-
-            # Validate all elements are calls
-            if not all(isinstance(e, ast.Call) for e in call_nodes):
-                return [], "Not all elements in list are function calls"
-
-            calls = []
-            for call_index, call in enumerate(call_nodes):
-                item = self._parse_pythonic_call(call, call_index, tool_indices)
-                if item is not None:
-                    calls.append(item)
-
-            return calls, ""
-
         except SyntaxError as e:
-            self._note_malformed_tool_call(e, detail=content[:80])
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=content[:80],
+            )
             return [], f"Python syntax error: {e}"
-        except Exception as e:
-            logger.exception("Unexpected error in pythonic tool call parsing")
-            self._note_malformed_tool_call(e, detail=content[:80])
-            return [], f"Unexpected error: {e}"
+
+        parsed = getattr(module.body[0], "value", None) if module.body else None
+
+        if parsed is None:
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=content[:80],
+            )
+            return [], "Empty or invalid Python expression"
+
+        # Handle both single call and list of calls
+        if isinstance(parsed, ast.List):
+            call_nodes = parsed.elts
+        elif isinstance(parsed, ast.Call):
+            call_nodes = [parsed]
+        else:
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=content[:80],
+            )
+            return (
+                [],
+                f"Expected function call or list, got: {type(parsed).__name__}",
+            )
+
+        # Validate all elements are calls
+        if not all(isinstance(e, ast.Call) for e in call_nodes):
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=content[:80],
+            )
+            return [], "Not all elements in list are function calls"
+
+        calls = []
+        for call_index, call in enumerate(call_nodes):
+            item = self._parse_pythonic_call(call, call_index, tool_indices)
+            if item is not None:
+                calls.append(item)
+
+        return calls, ""
 
     def _parse_json_content(
         self, content: str, tools: List[Tool]
@@ -227,13 +248,23 @@ class Lfm2Detector(BaseFormatDetector):
 
         try:
             parsed = json.loads(content)
+            parsed_items = parsed if isinstance(parsed, list) else [parsed]
+            if not all(isinstance(item, dict) for item in parsed_items):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=content[:80],
+                )
+                return [], "JSON tool call items must be objects"
             # parse_base_json handles list/dict normalization, tool validation,
             # and SGLANG_FORWARD_UNKNOWN_TOOLS consistently with other detectors
             calls = self.parse_base_json(parsed, tools)
             return calls, ""
 
         except json.JSONDecodeError as e:
-            self._note_malformed_tool_call(e, detail=content[:80])
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=content[:80],
+            )
             return [], f"JSON parse error: {e}"
 
     def _parse_tool_calls_content(
@@ -276,14 +307,27 @@ class Lfm2Detector(BaseFormatDetector):
 
         # Find all <|tool_call_start|>...<|tool_call_end|> blocks
         pattern = rf"{re.escape(self.bot_token)}(.*?){re.escape(self.eot_token)}"
-        match_result_list = re.findall(pattern, text, re.DOTALL)
+        match_result_list = list(re.finditer(pattern, text, re.DOTALL))
+        if not match_result_list:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[idx : idx + 80],
+            )
+            return StreamingParseResult(normal_text=text, calls=[])
 
         calls = []
+        normal_parts = []
+        cursor = 0
         for match_result in match_result_list:
-            parsed_calls = self._parse_tool_calls_content(match_result, tools)
+            normal_parts.append(text[cursor : match_result.start()])
+            parsed_calls = self._parse_tool_calls_content(match_result.group(1), tools)
             calls.extend(parsed_calls)
+            cursor = match_result.end()
 
-        return StreamingParseResult(normal_text=normal_text, calls=calls)
+        normal_parts.append(text[cursor:])
+        return StreamingParseResult(
+            normal_text="".join(normal_parts).strip(), calls=calls
+        )
 
     def _strip_special_tokens(self, text: str) -> str:
         """Remove special tokens from text."""

--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -6,6 +6,7 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityViolation
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -40,7 +41,7 @@ class Llama32Detector(BaseFormatDetector):
             parsed = ast.literal_eval(text.strip())
             if isinstance(parsed, dict):
                 return json.dumps(parsed, ensure_ascii=False)
-        except:
+        except (ValueError, SyntaxError, TypeError):
             pass
         return text
 
@@ -71,7 +72,8 @@ class Llama32Detector(BaseFormatDetector):
                 all_actions.append(obj)
                 idx += end + len(self.tool_call_separator)
                 safe_idx = idx
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as e:
+                parse_error = e
                 # Try Python dict conversion as fallback
                 try:
                     dict_end = idx
@@ -94,12 +96,21 @@ class Llama32Detector(BaseFormatDetector):
                             idx = dict_end + len(self.tool_call_separator)
                             safe_idx = idx
                             continue
-                except:
+                except (ValueError, SyntaxError, TypeError, json.JSONDecodeError) as e:
+                    parse_error = e
                     pass
 
                 next_obj_start = action_text.find('{"name":', idx + 1)
                 if next_obj_start == -1:
+                    if not all_actions and action_text[idx:].strip():
+                        self._note_malformed_tool_call(
+                            parse_error, detail=action_text[idx : idx + 80]
+                        )
                     break
+                if not all_actions:
+                    self._note_malformed_tool_call(
+                        parse_error, detail=action_text[idx:next_obj_start][:80]
+                    )
                 idx = next_obj_start
 
         # Only process if we found valid JSON objects
@@ -131,7 +142,9 @@ class Llama32Detector(BaseFormatDetector):
         try:
             result = super().parse_streaming_increment("", tools)
             return result
-        except:
+        except CompatibilityViolation:
+            raise
+        except (AssertionError, ValueError, TypeError, IndexError, KeyError):
             # Fall back to original buffer
             self._buffer = original_buffer
             return super().parse_streaming_increment(new_text, tools)

--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -6,7 +6,10 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.compatibility import CompatibilityViolation
+from sglang.srt.function_call.compatibility import (
+    CompatibilityEvent,
+    CompatibilityViolation,
+)
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -102,19 +105,30 @@ class Llama32Detector(BaseFormatDetector):
 
                 next_obj_start = action_text.find('{"name":', idx + 1)
                 if next_obj_start == -1:
-                    if not all_actions and action_text[idx:].strip():
-                        self._note_malformed_tool_call(
-                            parse_error, detail=action_text[idx : idx + 80]
+                    if action_text[idx:].strip():
+                        self.compatibility.note(
+                            CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                            detail=action_text[idx : idx + 80],
                         )
                     break
-                if not all_actions:
-                    self._note_malformed_tool_call(
-                        parse_error, detail=action_text[idx:next_obj_start][:80]
+                if action_text[idx:next_obj_start].strip():
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=action_text[idx:next_obj_start][:80],
                     )
                 idx = next_obj_start
 
         # Only process if we found valid JSON objects
-        calls = self.parse_base_json(all_actions, tools) if all_actions else []
+        valid_actions = []
+        for action in all_actions:
+            if not isinstance(action, dict):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=repr(action)[:80],
+                )
+                continue
+            valid_actions.append(action)
+        calls = self.parse_base_json(valid_actions, tools) if valid_actions else []
         # Use safe_idx to avoid idx containing the last part of an invalid JSON object
         trailing_text = (
             action_text[safe_idx:].strip() if safe_idx < action_text_len else ""

--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -20,9 +20,12 @@ import re
 from typing import Any, Dict, List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.core_types import StreamingParseResult, _GetInfoFunc
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -179,14 +182,22 @@ class MiMoDetector(BaseFormatDetector):
             if parsed:
                 func_name = parsed.get("name")
                 if func_name not in tool_indices:
-                    # Unknown function
-                    logger.warning(f"Unknown function: {func_name}")
-                    if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
+                    if self._skip_unknown_tool(func_name):
                         # Return tool call block as normal text
                         normal_text += text[last_end : match.end()]
                         last_end = match.end()
                         continue
-                calls.extend(self.parse_base_json(parsed, tools))
+
+                calls.append(
+                    ToolCallItem(
+                        tool_index=tool_indices.get(func_name, -1),
+                        name=func_name,
+                        parameters=json.dumps(
+                            parsed.get("parameters") or parsed.get("arguments", {}),
+                            ensure_ascii=False,
+                        ),
+                    )
+                )
 
             last_end = match.end()
 

--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -41,7 +42,11 @@ def _get_param_type(func_name: str, param_name: str, tools: List[Tool]) -> str:
 
 
 def _convert_param_value(
-    param_value: str, param_name: str, func_name: str, tools: List[Tool]
+    param_value: str,
+    param_name: str,
+    func_name: str,
+    tools: List[Tool],
+    compatibility=None,
 ) -> Any:
     """
     Convert parameter value based on its type in the schema.
@@ -68,6 +73,11 @@ def _convert_param_value(
         try:
             return int(param_value)
         except (ValueError, TypeError):
+            if compatibility is not None:
+                compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"{func_name}.{param_name}: {param_value[:80]}",
+                )
             logger.warning(
                 "Parsed value '%s' of parameter '%s' is not an "
                 "integer in tool '%s', degenerating to string.",
@@ -85,6 +95,11 @@ def _convert_param_value(
                 else int(float_param_value)
             )
         except (ValueError, TypeError):
+            if compatibility is not None:
+                compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"{func_name}.{param_name}: {param_value[:80]}",
+                )
             logger.warning(
                 "Parsed value '%s' of parameter '%s' is not a float "
                 "in tool '%s', degenerating to string.",
@@ -94,16 +109,22 @@ def _convert_param_value(
             )
             return param_value
     elif param_type in ["boolean", "bool", "binary"]:
+        raw_value = param_value
         param_value = param_value.lower()
         if param_value not in ["true", "false"]:
+            if compatibility is not None:
+                compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"{func_name}.{param_name}: {raw_value[:80]}",
+                )
             logger.warning(
                 "Parsed value '%s' of parameter '%s' is not a boolean "
-                "(`true` or `false`) in tool '%s', degenerating to "
-                "false.",
-                param_value,
+                "(`true` or `false`) in tool '%s', degenerating to string.",
+                raw_value,
                 param_name,
                 func_name,
             )
+            return raw_value
         return param_value == "true"
     else:
         if (
@@ -126,6 +147,11 @@ def _convert_param_value(
         try:
             param_value = ast.literal_eval(param_value)  # safer
         except (ValueError, SyntaxError, TypeError):
+            if compatibility is not None:
+                compatibility.note(
+                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                    detail=f"{func_name}.{param_name}: {param_value[:80]}",
+                )
             logger.warning(
                 "Parsed value '%s' of parameter '%s' cannot be "
                 "converted via Python `ast.literal_eval()` in tool "
@@ -172,9 +198,13 @@ class MiMoDetector(BaseFormatDetector):
         tool_indices = self._get_tool_indices(tools)
 
         calls = []
+        normal_parts = [normal_text]
         last_end = idx
+        saw_block = False
 
         for match in self.tool_call_regex.finditer(text):
+            saw_block = True
+            normal_parts.append(text[last_end : match.start()])
             tool_call_body = match.group(1)
 
             parsed = self._parse_tool_call(tool_call_body, tools)
@@ -183,8 +213,6 @@ class MiMoDetector(BaseFormatDetector):
                 func_name = parsed.get("name")
                 if func_name not in tool_indices:
                     if self._skip_unknown_tool(func_name):
-                        # Return tool call block as normal text
-                        normal_text += text[last_end : match.end()]
                         last_end = match.end()
                         continue
 
@@ -198,10 +226,22 @@ class MiMoDetector(BaseFormatDetector):
                         ),
                     )
                 )
+            else:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=tool_call_body[:80],
+                )
 
             last_end = match.end()
 
-        return StreamingParseResult(normal_text=normal_text, calls=calls)
+        if not saw_block:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[idx : idx + 80],
+            )
+
+        normal_parts.append(text[last_end:])
+        return StreamingParseResult(normal_text="".join(normal_parts), calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
@@ -280,7 +320,11 @@ class MiMoDetector(BaseFormatDetector):
             param_name = param_match.group(1).strip()
             param_value = param_match.group(2)
             params[param_name] = _convert_param_value(
-                param_value, param_name, func_name, tools
+                param_value,
+                param_name,
+                func_name,
+                tools,
+                compatibility=self.compatibility,
             )
 
         return {"name": func_name, "parameters": params}

--- a/python/sglang/srt/function_call/minicpm5_detector.py
+++ b/python/sglang/srt/function_call/minicpm5_detector.py
@@ -105,6 +105,7 @@ class MiniCPM5Detector(BaseFormatDetector):
                 arguments = {}
                 parsed_ok = False
                 param_invalid = False
+                parse_error = None
 
                 # Primary path: XML parsing (lxml preferred, stdlib fallback)
                 try:
@@ -168,7 +169,8 @@ class MiniCPM5Detector(BaseFormatDetector):
                             arguments.clear()
                             param_invalid = True
                     parsed_ok = bool(func_name)
-                except Exception:
+                except Exception as e:
+                    parse_error = e
                     parsed_ok = False
 
                 if not parsed_ok:
@@ -211,10 +213,18 @@ class MiniCPM5Detector(BaseFormatDetector):
                             arguments.clear()
                             param_invalid = True
                         parsed_ok = bool(func_name)
-                    except Exception:
+                        if parsed_ok:
+                            parse_error = None
+                    except Exception as e:
+                        parse_error = e
                         parsed_ok = False
 
-                if not func_name or func_name not in tool_names or param_invalid:
+                if func_name and func_name not in tool_names:
+                    if self._skip_unknown_tool(func_name):
+                        parsed_ok = False
+                    else:
+                        parsed_ok = not param_invalid
+                elif not func_name or param_invalid:
                     parsed_ok = False
                 else:
                     req_props = name_to_required.get(func_name, set())
@@ -225,6 +235,8 @@ class MiniCPM5Detector(BaseFormatDetector):
                     tool_call_obj = {"name": func_name, "parameters": arguments}
                     calls.extend(self.parse_base_json(tool_call_obj, tools))
                 else:
+                    if parse_error is not None:
+                        self._note_malformed_tool_call(parse_error, detail=block[:80])
                     normal_parts.append(block)
 
                 last_end = m.end()
@@ -235,6 +247,7 @@ class MiniCPM5Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text="".join(normal_parts), calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}")
+            self._note_malformed_tool_call(e)
             return StreamingParseResult(normal_text=text)
 
     def _append_tool_call(self, call, all_calls: List) -> None:

--- a/python/sglang/srt/function_call/minicpm5_detector.py
+++ b/python/sglang/srt/function_call/minicpm5_detector.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     _GetInfoFunc,
@@ -52,6 +53,14 @@ def parse_arguments(json_value):
         return json_value, False
 
 
+def _should_record_unconvertible(arg_type, parsed_ok: bool) -> bool:
+    if parsed_ok or arg_type is None:
+        return False
+    if isinstance(arg_type, list):
+        return "string" not in arg_type
+    return arg_type != "string"
+
+
 class MiniCPM5Detector(BaseFormatDetector):
     """
     Detector for MiniCPM-4 models (V3 schema) adapted to the new chat template.
@@ -91,164 +100,194 @@ class MiniCPM5Detector(BaseFormatDetector):
             req = params.get("required", []) if isinstance(params, dict) else []
             try:
                 name_to_required[name] = set(req)
-            except Exception:
+            except TypeError:
                 name_to_required[name] = set()
 
-        try:
-            last_end = 0
-            for m in re.finditer(self.func_call_regex, text, re.DOTALL):
-                if m.start() > last_end:
-                    normal_parts.append(text[last_end : m.start()])
+        last_end = 0
+        saw_block = False
+        for m in re.finditer(self.func_call_regex, text, re.DOTALL):
+            saw_block = True
+            if m.start() > last_end:
+                normal_parts.append(text[last_end : m.start()])
 
-                block = m.group(0)
-                func_name = None
-                arguments = {}
+            block = m.group(0)
+            func_name = None
+            arguments = {}
+            parsed_ok = False
+            param_invalid = False
+            parse_error = None
+            invalid_reason = ""
+
+            # Primary path: XML parsing (lxml preferred, stdlib fallback)
+            try:
+                if _HAS_LXML:
+                    try:
+                        parser = ET.XMLParser(**{"strip_cdata": False})  # type: ignore[call-arg]
+                    except TypeError:
+                        parser = ET.XMLParser()
+                    root = ET.fromstring(block, parser=parser)
+                else:
+                    root = ET.fromstring(block)
+
+                if root.tag == "function":
+                    func_node = root
+                else:
+                    func_node = root.find("function") if hasattr(root, "find") else None
+
+                if func_node is not None:
+                    func_name = (func_node.attrib.get("name") or "").strip()
+
+                args_node = (
+                    func_node.find("arguments") if func_node is not None else None
+                )
+                param_nodes = []
+                if func_node is not None:
+                    param_nodes = list(func_node.findall("param"))
+                    if args_node is not None and not param_nodes:
+                        param_nodes = list(args_node.findall("param"))
+
+                if func_node is not None:
+                    seen_keys = set()
+                    allowed_props = set()
+                    if func_name in tool_names:
+                        allowed_props = name_to_allowed_props.get(func_name, set())
+                    has_invalid_param = False
+                    for param in param_nodes:
+                        key = param.attrib.get("name")
+                        if not key:
+                            has_invalid_param = True
+                            invalid_reason = "parameter missing name"
+                            break
+                        if allowed_props and key not in allowed_props:
+                            has_invalid_param = True
+                            invalid_reason = f"unknown parameter {key!r}"
+                            break
+                        if key in seen_keys:
+                            has_invalid_param = True
+                            invalid_reason = f"duplicate parameter {key!r}"
+                            break
+                        seen_keys.add(key)
+                        val_text = param.text or ""
+                        val_text = val_text.strip()
+                        arg_type = get_argument_type(func_name or "", key, name_to_tool)
+                        if arg_type != "string":
+                            parsed_val, parsed_ok = parse_arguments(val_text)
+                            if _should_record_unconvertible(arg_type, parsed_ok):
+                                self.compatibility.note(
+                                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                                    detail=f"{func_name}.{key}: {val_text[:80]}",
+                                )
+                            arguments[key] = parsed_val
+                        else:
+                            arguments[key] = val_text
+                    if has_invalid_param:
+                        arguments.clear()
+                        param_invalid = True
+                parsed_ok = bool(func_name)
+            except (ET.ParseError, TypeError, ValueError) as e:
+                parse_error = e
                 parsed_ok = False
-                param_invalid = False
-                parse_error = None
 
-                # Primary path: XML parsing (lxml preferred, stdlib fallback)
+            if not parsed_ok:
+                # Fallback path: regex extraction
                 try:
-                    if _HAS_LXML:
-                        try:
-                            parser = ET.XMLParser(**{"strip_cdata": False})  # type: ignore[call-arg]
-                        except TypeError:
-                            parser = ET.XMLParser()
-                        root = ET.fromstring(block, parser=parser)
-                    else:
-                        root = ET.fromstring(block)
-
-                    if root.tag == "function":
-                        func_node = root
-                    else:
-                        func_node = (
-                            root.find("function") if hasattr(root, "find") else None
-                        )
-
-                    if func_node is not None:
-                        func_name = (func_node.attrib.get("name") or "").strip()
-
-                    args_node = (
-                        func_node.find("arguments") if func_node is not None else None
+                    m_fn = _FUNC_NAME_V1_REGEX.search(block)
+                    if m_fn:
+                        func_name = (m_fn.group(1) or "").strip()
+                    has_invalid_param = (
+                        _PARAM_MISSING_NAME_REGEX.search(block) is not None
                     )
-                    param_nodes = []
-                    if func_node is not None:
-                        param_nodes = list(func_node.findall("param"))
-                        if args_node is not None and not param_nodes:
-                            param_nodes = list(args_node.findall("param"))
-
-                    if func_node is not None:
-                        seen_keys = set()
-                        allowed_props = set()
-                        if func_name in tool_names:
-                            allowed_props = name_to_allowed_props.get(func_name, set())
-                        has_invalid_param = False
-                        for param in param_nodes:
-                            key = param.attrib.get("name")
-                            if not key:
-                                has_invalid_param = True
-                                break
-                            if allowed_props and key not in allowed_props:
-                                has_invalid_param = True
-                                break
-                            if key in seen_keys:
-                                has_invalid_param = True
-                                break
-                            seen_keys.add(key)
-                            val_text = param.text or ""
-                            val_text = val_text.strip()
-                            arg_type = get_argument_type(
-                                func_name or "", key, name_to_tool
-                            )
-                            if arg_type != "string":
-                                parsed_val, _ = parse_arguments(val_text)
-                                arguments[key] = parsed_val
-                            else:
-                                arguments[key] = val_text
-                        if has_invalid_param:
-                            arguments.clear()
-                            param_invalid = True
+                    seen_keys = set()
+                    allowed_props = set()
+                    if func_name in tool_names:
+                        allowed_props = name_to_allowed_props.get(func_name, set())
+                    for pm in _PARAM_WITH_NAME_REGEX.finditer(block):
+                        key = pm.group(1).strip()
+                        if allowed_props and key not in allowed_props:
+                            has_invalid_param = True
+                            invalid_reason = f"unknown parameter {key!r}"
+                            break
+                        if key in seen_keys:
+                            has_invalid_param = True
+                            invalid_reason = f"duplicate parameter {key!r}"
+                            break
+                        seen_keys.add(key)
+                        val_text = pm.group(2) or ""
+                        if val_text.startswith("<![CDATA[") and val_text.endswith(
+                            "]]>"
+                        ):
+                            val_text = val_text[len("<![CDATA[") : -len("]]>")]
+                        val_text = val_text.strip()
+                        arg_type = get_argument_type(func_name or "", key, name_to_tool)
+                        if arg_type != "string":
+                            parsed_val, parsed_ok = parse_arguments(val_text)
+                            if _should_record_unconvertible(arg_type, parsed_ok):
+                                self.compatibility.note(
+                                    CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                                    detail=f"{func_name}.{key}: {val_text[:80]}",
+                                )
+                            arguments[key] = parsed_val
+                        else:
+                            arguments[key] = val_text
+                    if has_invalid_param:
+                        arguments.clear()
+                        param_invalid = True
                     parsed_ok = bool(func_name)
-                except Exception as e:
+                    if parsed_ok:
+                        parse_error = None
+                except (IndexError, TypeError, ValueError) as e:
                     parse_error = e
                     parsed_ok = False
 
-                if not parsed_ok:
-                    # Fallback path: regex extraction
-                    try:
-                        m_fn = _FUNC_NAME_V1_REGEX.search(block)
-                        if m_fn:
-                            func_name = (m_fn.group(1) or "").strip()
-                        has_invalid_param = (
-                            _PARAM_MISSING_NAME_REGEX.search(block) is not None
-                        )
-                        seen_keys = set()
-                        allowed_props = set()
-                        if func_name in tool_names:
-                            allowed_props = name_to_allowed_props.get(func_name, set())
-                        for pm in _PARAM_WITH_NAME_REGEX.finditer(block):
-                            key = pm.group(1).strip()
-                            if allowed_props and key not in allowed_props:
-                                has_invalid_param = True
-                                break
-                            if key in seen_keys:
-                                has_invalid_param = True
-                                break
-                            seen_keys.add(key)
-                            val_text = pm.group(2) or ""
-                            if val_text.startswith("<![CDATA[") and val_text.endswith(
-                                "]]>"
-                            ):
-                                val_text = val_text[len("<![CDATA[") : -len("]]>")]
-                            val_text = val_text.strip()
-                            arg_type = get_argument_type(
-                                func_name or "", key, name_to_tool
-                            )
-                            if arg_type != "string":
-                                parsed_val, _ = parse_arguments(val_text)
-                                arguments[key] = parsed_val
-                            else:
-                                arguments[key] = val_text
-                        if has_invalid_param:
-                            arguments.clear()
-                            param_invalid = True
-                        parsed_ok = bool(func_name)
-                        if parsed_ok:
-                            parse_error = None
-                    except Exception as e:
-                        parse_error = e
-                        parsed_ok = False
-
-                if func_name and func_name not in tool_names:
-                    if self._skip_unknown_tool(func_name):
-                        parsed_ok = False
-                    else:
-                        parsed_ok = not param_invalid
-                elif not func_name or param_invalid:
+            if func_name and func_name not in tool_names:
+                if self._skip_unknown_tool(func_name):
                     parsed_ok = False
+                    invalid_reason = ""
                 else:
-                    req_props = name_to_required.get(func_name, set())
-                    if req_props and not req_props.issubset(arguments.keys()):
-                        parsed_ok = False
+                    parsed_ok = not param_invalid
+            elif not func_name or param_invalid:
+                if not invalid_reason:
+                    invalid_reason = (
+                        "missing function name"
+                        if not func_name
+                        else "invalid parameter"
+                    )
+                parsed_ok = False
+            else:
+                req_props = name_to_required.get(func_name, set())
+                if req_props and not req_props.issubset(arguments.keys()):
+                    missing = sorted(req_props - set(arguments.keys()))
+                    invalid_reason = f"missing required parameters {missing!r}"
+                    parsed_ok = False
 
-                if parsed_ok:
-                    tool_call_obj = {"name": func_name, "parameters": arguments}
-                    calls.extend(self.parse_base_json(tool_call_obj, tools))
-                else:
-                    if parse_error is not None:
-                        self._note_malformed_tool_call(parse_error, detail=block[:80])
-                    normal_parts.append(block)
+            if parsed_ok:
+                tool_call_obj = {"name": func_name, "parameters": arguments}
+                calls.extend(self.parse_base_json(tool_call_obj, tools))
+            else:
+                if parse_error is not None:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=block[:80],
+                    )
+                elif invalid_reason:
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=block[:80],
+                    )
+                normal_parts.append(block)
 
-                last_end = m.end()
+            last_end = m.end()
 
-            if last_end < len(text):
-                normal_parts.append(text[last_end:])
+        if not saw_block:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[idx : idx + 80],
+            )
 
-            return StreamingParseResult(normal_text="".join(normal_parts), calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            self._note_malformed_tool_call(e)
-            return StreamingParseResult(normal_text=text)
+        if last_end < len(text):
+            normal_parts.append(text[last_end:])
+
+        return StreamingParseResult(normal_text="".join(normal_parts), calls=calls)
 
     def _append_tool_call(self, call, all_calls: List) -> None:
         if self.current_tool_id == -1:

--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -1,519 +1,111 @@
-import json
-import logging
-import re
-from typing import Any, Dict, List, Tuple
+from typing import Dict, Generator, Optional
 
-from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.core_types import (
-    StreamingParseResult,
-    ToolCallItem,
-    _GetInfoFunc,
-)
-
-logger = logging.getLogger(__name__)
+from sglang.srt.function_call.compatibility import CompatibilityMode
+from sglang.srt.function_call.core_types import _GetInfoFunc
+from sglang.srt.function_call.parsing import TagToolCallParser
+from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
 
 
-class MinimaxM2Detector(BaseFormatDetector):
-    """
-    Detector for MiniMax M2 models.
-    Assumes function call format:
-        <minimax:tool_call>
-        <invoke name="func1">
-        <parameter name="param1">value1</parameter>
-        <parameter name="param2">value2</parameter>
-        </invoke>
-        </minimax:tool_call>
+class M2TextParser(TagToolCallParser):
+    BLOCK_OPEN = "<minimax:tool_call>"
+    BLOCK_CLOSE = "</minimax:tool_call>"
+    INVOKE_PREFIX = '<invoke name="'
+    INVOKE_SUFFIX = '">'
+    INVOKE_END = "</invoke>"
+    PARAM_PREFIX = '<parameter name="'
+    PARAM_NAME_SUFFIX = '">'
+    PARAM_END = "</parameter>"
+
+    def _process(self) -> Generator:
+        tool_call_index = 0
+        while True:
+            # Content before / between / after blocks.
+            yield from self._content_until(self.BLOCK_OPEN)
+            while True:
+                yield from self._whitespace()
+                tried = yield from self._literal(
+                    (self.INVOKE_PREFIX, self.BLOCK_CLOSE),
+                    should_raise=False,
+                )
+                if tried is None:
+                    # Unparseable text inside the block: skip to the next
+                    # invoke or to the block close.
+                    yield from self._skip_garbage(
+                        until=(self.INVOKE_PREFIX, self.BLOCK_CLOSE),
+                        detail="inside <minimax:tool_call>",
+                    )
+                    continue
+                if tried == self.BLOCK_CLOSE:
+                    break
+
+                function_name = yield from self._take_any(until=self.INVOKE_SUFFIX)
+                dropped = yield from self._drop_unknown_invoke(
+                    function_name, self.INVOKE_END
+                )
+                if dropped:
+                    continue
+                self._emit_name(tool_call_index, function_name)
+                function = self._get_function(function_name)
+
+                is_first_parameter = True
+                while True:
+                    yield from self._whitespace()
+                    tried = yield from self._literal(
+                        (self.INVOKE_END, self.PARAM_PREFIX),
+                        should_raise=False,
+                    )
+                    if tried == self.INVOKE_END:
+                        self._emit_call_close(tool_call_index)
+                        break
+                    if tried is None:
+                        # Unparseable text inside the invoke: skip to the
+                        # next parameter or to the end of the invoke.
+                        yield from self._skip_garbage(
+                            until=(self.PARAM_PREFIX, self.INVOKE_END),
+                            detail="inside <invoke>",
+                        )
+                        continue
+
+                    parameter_name = yield from self._take_any(
+                        until=self.PARAM_NAME_SUFFIX
+                    )
+                    self._emit_param_key(
+                        tool_call_index, parameter_name, is_first_parameter
+                    )
+                    data_type = self._param_data_type(function, parameter_name)
+                    # One newline on each side of the value is structural,
+                    # not part of the value.
+                    yield from self._literal("\n", should_raise=False)
+                    yield from self._param_value(
+                        tool_call_index=tool_call_index,
+                        until=("\n" + self.PARAM_END, self.PARAM_END),
+                        data_type=data_type,
+                        always_nullable=True,
+                    )
+                    is_first_parameter = False
+
+                tool_call_index += 1
+
+class MinimaxM2Detector(TagToolCallDetector):
+    """Detector for MiniMax M2 models; the wire format is documented above.
+
+    Parsing is implemented by ``M2TextParser``; streaming bookkeeping comes
+    from ``TagToolCallDetector`` and error recovery from the package
+    compatibility mode (the ``compatibility`` package).
     """
 
     def __init__(self):
         super().__init__()
         self.tool_call_start_token: str = "<minimax:tool_call>"
         self.tool_call_end_token: str = "</minimax:tool_call>"
-        self.tool_call_prefix: str = '<invoke name="'
-        self.tool_call_function_end_token: str = "</invoke>"
-        self.tool_call_regex = re.compile(
-            r"<minimax:tool_call>(.*?)</minimax:tool_call>|<minimax:tool_call>(.*?)$",
-            re.DOTALL,
-        )
-        self.tool_call_function_regex = re.compile(
-            r"<invoke name=\"(.*?)</invoke>|<invoke name=\"(.*)$", re.DOTALL
-        )
-        self.tool_call_parameter_regex = re.compile(
-            r"<parameter name=\"(.*?)</parameter>|<parameter name=\"(.*?)$", re.DOTALL
-        )
-        self._buf: str = ""
-
-        # Streaming state variables
-        self._current_function_name: str = ""
-        self._current_parameters: Dict[str, Any] = {}
-        self._streamed_parameters: Dict[str, str] = (
-            {}
-        )  # Track what parameter content we've streamed
-        self._in_tool_call: bool = False
-        self._function_name_sent: bool = False
 
     def has_tool_call(self, text: str) -> bool:
         return self.tool_call_start_token in text
 
-    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
-        normal, calls = self._extract(text, tools)
-        return StreamingParseResult(normal_text=normal, calls=calls)
-
-    def _convert_param_value(self, value: str, param_type: str) -> Any:
-        """Convert parameter value to the correct type (legacy single-type version)."""
-        return self._convert_param_value_with_types(value, [param_type])
-
-    def _extract_types_from_schema(self, schema: Any) -> list[str]:
-        """
-        Extract all possible types from a JSON schema definition.
-        Handles anyOf, oneOf, allOf, type arrays, and enum fields.
-
-        Args:
-            schema: The JSON schema definition for a parameter
-
-        Returns:
-            List of type strings (e.g., ["string", "integer", "null"])
-        """
-        if schema is None:
-            return ["string"]
-
-        if not isinstance(schema, dict):
-            return ["string"]
-
-        types: set[str] = set()
-
-        # Handle direct "type" field
-        if "type" in schema:
-            type_value = schema["type"]
-            if isinstance(type_value, str):
-                types.add(type_value)
-            elif isinstance(type_value, list):
-                for t in type_value:
-                    if isinstance(t, str):
-                        types.add(t)
-
-        # Handle enum - infer types from enum values
-        if "enum" in schema and isinstance(schema["enum"], list) and schema["enum"]:
-            for value in schema["enum"]:
-                if value is None:
-                    types.add("null")
-                elif isinstance(value, bool):
-                    types.add("boolean")
-                elif isinstance(value, int):
-                    types.add("integer")
-                elif isinstance(value, float):
-                    types.add("number")
-                elif isinstance(value, str):
-                    types.add("string")
-                elif isinstance(value, list):
-                    types.add("array")
-                elif isinstance(value, dict):
-                    types.add("object")
-
-        # Handle anyOf, oneOf, allOf - recursively extract types
-        for choice_field in ("anyOf", "oneOf", "allOf"):
-            if choice_field in schema and isinstance(schema[choice_field], list):
-                for choice in schema[choice_field]:
-                    extracted = self._extract_types_from_schema(choice)
-                    types.update(extracted)
-
-        # If no types found, default to string
-        if not types:
-            return ["string"]
-
-        return list(types)
-
-    def _convert_param_value_with_types(
-        self, value: str, param_types: list[str]
-    ) -> Any:
-        """
-        Convert parameter value to the correct type based on a list of possible types.
-        Tries each type in order until one succeeds.
-
-        Args:
-            value: The string value to convert
-            param_types: List of possible type strings
-
-        Returns:
-            The converted value
-        """
-        if value.lower() == "null":
-            return None
-
-        # Normalize types
-        normalized_types = [t.lower() for t in param_types]
-
-        # Try null first if it's in the list
-        if "null" in normalized_types or value.lower() in ("null", "none", "nil"):
-            return None
-
-        # Try each type in order of preference (most specific first, string as fallback)
-        # Priority: integer > number > boolean > object > array > string
-        type_priority = [
-            "integer",
-            "int",
-            "number",
-            "float",
-            "boolean",
-            "bool",
-            "object",
-            "array",
-            "string",
-            "str",
-            "text",
-        ]
-
-        for param_type in type_priority:
-            if param_type not in normalized_types:
-                continue
-
-            if param_type in ["string", "str", "text"]:
-                return value
-            elif param_type in ["integer", "int"]:
-                try:
-                    return int(value)
-                except (ValueError, TypeError):
-                    continue
-            elif param_type in ["number", "float"]:
-                try:
-                    val = float(value)
-                    return val if val != int(val) else int(val)
-                except (ValueError, TypeError):
-                    continue
-            elif param_type in ["boolean", "bool"]:
-                lower_val = value.lower().strip()
-                if lower_val in ["true", "1", "yes", "on"]:
-                    return True
-                elif lower_val in ["false", "0", "no", "off"]:
-                    return False
-                continue
-            elif param_type in ["object", "array"]:
-                try:
-                    return json.loads(value)
-                except json.JSONDecodeError:
-                    continue
-
-        # Fallback: try JSON parse, then return as string
-        try:
-            return json.loads(value)
-        except json.JSONDecodeError:
-            return value
-
-    def _get_param_types_from_config(
-        self, param_name: str, param_config: dict
-    ) -> list[str]:
-        """
-        Get parameter types from parameter configuration.
-        Handles anyOf, oneOf, allOf, and direct type definitions.
-
-        Args:
-            param_name: The name of the parameter
-            param_config: The properties dict from the tool schema
-
-        Returns:
-            List of type strings
-        """
-        if param_name not in param_config:
-            return ["string"]
-
-        param_schema = param_config[param_name]
-        if not isinstance(param_schema, dict):
-            return ["string"]
-
-        return self._extract_types_from_schema(param_schema)
-
-    def parse_streaming_increment(
-        self, new_text: str, tools: List[Tool]
-    ) -> StreamingParseResult:
-        self._buf += new_text
-        normal = ""
-        calls: List[ToolCallItem] = []
-
-        # Build tool indices for validation
-        if not hasattr(self, "_tool_indices"):
-            self._tool_indices = self._get_tool_indices(tools)
-
-        while True:
-            # If we're not in a tool call and don't see a start token, return normal text
-            if not self._in_tool_call and self.tool_call_start_token not in self._buf:
-                normal += self._buf
-                self._buf = ""
-                break
-
-            # Look for tool call start
-            if not self._in_tool_call:
-                s = self._buf.find(self.tool_call_start_token)
-                if s == -1:
-                    normal += self._buf
-                    self._buf = ""
-                    break
-
-                normal += self._buf[:s]
-                self._buf = self._buf[s:]
-
-                self._in_tool_call = True
-                self._function_name_sent = False
-                self._current_function_name = ""
-                self._current_parameters = {}
-                self._streamed_parameters = {}
-
-                # Remove the start token
-                self._buf = self._buf[len(self.tool_call_start_token) :]
-                continue
-
-            # We're in a tool call, try to parse function name if not sent yet
-            if not self._function_name_sent:
-                # Look for function name pattern: <invoke name=name>
-                function_match = re.search(r"<invoke name=\"([^>]+)\">", self._buf)
-                if function_match:
-                    function_name = function_match.group(1).strip()
-
-                    # Validate function name
-                    if function_name in self._tool_indices:
-                        self._current_function_name = function_name
-                        self._function_name_sent = True
-
-                        # Initialize tool call tracking
-                        if self.current_tool_id == -1:
-                            self.current_tool_id = 0
-
-                        # Ensure tracking arrays are large enough
-                        while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                            self.prev_tool_call_arr.append({})
-                        while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                            self.streamed_args_for_tool.append("")
-
-                        # Store tool call info
-                        self.prev_tool_call_arr[self.current_tool_id] = {
-                            "name": function_name,
-                            "arguments": {},
-                        }
-
-                        # Send tool name with empty parameters
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=function_name,
-                                parameters="",
-                            )
-                        )
-
-                        # Remove the processed function declaration
-                        self._buf = self._buf[function_match.end() :]
-                        continue
-                    else:
-                        # Invalid function name, reset state
-                        logger.warning(f"Invalid function name: {function_name}")
-                        self._reset_streaming_state()
-                        normal += self._buf
-                        self._buf = ""
-                        break
-                else:
-                    # Function name not complete yet, wait for more text
-                    break
-
-            # Parse parameters incrementally
-            if self._function_name_sent:
-                # Process parameters and get any calls to emit
-                parameter_calls = self._parse_and_stream_parameters(self._buf, tools)
-                calls.extend(parameter_calls)
-
-                # Check if tool call is complete
-                if self.tool_call_function_end_token in self._buf:
-                    end_pos = self._buf.find(self.tool_call_function_end_token)
-
-                    # Add closing brace to complete the JSON object
-                    current_streamed = self.streamed_args_for_tool[self.current_tool_id]
-                    if current_streamed:
-                        # Count opening and closing braces to check if JSON is complete
-                        open_braces = current_streamed.count("{")
-                        close_braces = current_streamed.count("}")
-                        if open_braces > close_braces:
-                            calls.append(
-                                ToolCallItem(
-                                    tool_index=self.current_tool_id,
-                                    name=None,
-                                    parameters="}",
-                                )
-                            )
-                            self.streamed_args_for_tool[self.current_tool_id] = (
-                                current_streamed + "}"
-                            )
-
-                    # Complete the tool call
-                    self._buf = self._buf[
-                        end_pos + len(self.tool_call_function_end_token) :
-                    ]
-                    self._reset_streaming_state(True)
-                    self.current_tool_id += 1
-                    continue
-                else:
-                    # Tool call not complete yet, wait for more text
-                    break
-
-        return StreamingParseResult(normal_text=normal, calls=calls)
-
-    def _parse_and_stream_parameters(
-        self, text_to_parse: str, tools: List[Tool]
-    ) -> List[ToolCallItem]:
-        """
-        Parse complete parameter blocks from text and return any tool call items to emit.
-
-        This method:
-        1. Finds all complete <parameter> blocks
-        2. Parses them into a dictionary
-        3. Compares with current parameters and generates diff if needed
-        4. Updates internal state
-
-        Args:
-            text_to_parse: The text to search for parameter blocks
-
-        Returns:
-            List of ToolCallItem objects to emit (may be empty)
-        """
-        calls: List[ToolCallItem] = []
-
-        # Find all complete parameter patterns
-        param_matches = list(
-            re.finditer(
-                r"<parameter name=\"([^>]+)\">(.*?)</parameter>",
-                text_to_parse,
-                re.DOTALL,
-            )
-        )
-
-        # Build new parameters dictionary
-        new_params = {}
-        for match in param_matches:
-            param_name = match.group(1).strip()
-            param_value = match.group(2)
-            new_params[param_name] = self._parse_parameter(
-                self._current_function_name, param_name, param_value, tools
-            )
-
-        # Calculate parameter diff to stream with proper incremental JSON building
-        if new_params != self._current_parameters:
-            previous_args_json = self.streamed_args_for_tool[self.current_tool_id]
-
-            # Build incremental JSON properly
-            if not self._current_parameters:
-                # First parameter(s) - start JSON object but don't close it yet
-                items = []
-                for key, value in new_params.items():
-                    items.append(
-                        f"{json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}"
-                    )
-                json_fragment = "{" + ", ".join(items)
-
-                calls.append(
-                    ToolCallItem(
-                        tool_index=self.current_tool_id,
-                        name=None,
-                        parameters=json_fragment,
-                    )
-                )
-                self.streamed_args_for_tool[self.current_tool_id] = json_fragment
-
-            else:
-                # Additional parameters - add them incrementally
-                new_keys = set(new_params.keys()) - set(self._current_parameters.keys())
-                if new_keys:
-                    # Build the continuation part (no closing brace yet)
-                    continuation_parts = []
-                    for key in new_keys:
-                        value = new_params[key]
-                        continuation_parts.append(
-                            f"{json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}"
-                        )
-
-                    json_fragment = ", " + ", ".join(continuation_parts)
-
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            name=None,
-                            parameters=json_fragment,
-                        )
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] = (
-                        previous_args_json + json_fragment
-                    )
-
-            # Update current state
-            self._current_parameters = new_params
-            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = new_params
-
-        return calls
-
-    def _reset_streaming_state(self, still_in_tool_call: bool = False):
-        """Reset streaming state for the next tool call"""
-        self._in_tool_call = still_in_tool_call
-        self._function_name_sent = False
-        self._current_function_name = ""
-        self._current_parameters = {}
-        self._streamed_parameters = {}
-        self.current_tool_name_sent = False
-
-    def _extract(self, text: str, tools: List[Tool]) -> Tuple[str, List[ToolCallItem]]:
-        normal_parts: List[str] = []
-        calls: List[ToolCallItem] = []
-        cursor = 0
-        while True:
-            s = text.find(self.tool_call_start_token, cursor)
-            if s == -1:
-                normal_parts.append(text[cursor:])
-                break
-            normal_parts.append(text[cursor:s])
-            e = text.find(self.tool_call_end_token, s)
-            if e == -1:
-                normal_parts.append(text[s:])
-                break
-            block = text[s : e + len(self.tool_call_end_token)]
-            cursor = e + len(self.tool_call_end_token)
-            calls.extend(self._parse_block(block, tools))
-        return "".join(normal_parts), calls
-
-    def _parse_block(self, block: str, tools: List[Tool]) -> List[ToolCallItem]:
-        res: List[ToolCallItem] = []
-        for m in self.tool_call_function_regex.findall(block):
-            txt = m[0] if m[0] else m[1]
-            if '">' not in txt:
-                continue
-            idx = txt.index('">')
-            fname = txt[:idx].strip()
-            body = txt[idx + 2 :]
-            params: Dict[str, Any] = {}
-            for pm in self.tool_call_parameter_regex.findall(body):
-                ptxt = pm[0] if pm[0] else pm[1]
-                if '">' not in ptxt:
-                    continue
-                pidx = ptxt.index('">')
-                pname = ptxt[:pidx].strip()
-                pval = ptxt[pidx + 2 :].lstrip("\n").rstrip("\n")
-                params[pname] = self._parse_parameter(fname, pname, pval, tools)
-            raw = {"name": fname, "arguments": params}
-            try:
-                # TODO: fix idx in function call, the index for a function
-                # call will always be -1 in parse_base_json
-                res.extend(self.parse_base_json(raw, tools))
-            except Exception:
-                logger.warning("invalid tool call for %s dropped", fname)
-        return res
-
-    def _parse_parameter(
-        self, fname: str, pname: str, pval: str, tools: List[Tool]
-    ) -> Any:
-        param_config = {}
-        for tool in tools:
-            if tool.function.name == fname and tool.function.parameters is not None:
-                parameters = tool.function.parameters
-                if isinstance(parameters, dict) and "properties" in parameters:
-                    param_config = parameters["properties"]
-                    break
-
-        param_type = self._get_param_types_from_config(pname, param_config)
-        return self._convert_param_value_with_types(pval, param_type)
+    def _make_grammar(
+        self, functions: Optional[Dict], compatibility: CompatibilityMode
+    ) -> M2TextParser:
+        return M2TextParser(functions=functions, compatibility=compatibility)
 
     def supports_structural_tag(self) -> bool:
         return False

--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -28,7 +28,7 @@ class M2TextParser(TagToolCallParser):
                     should_raise=False,
                 )
                 if tried is None:
-                    # Unparseable text inside the block: skip to the next
+                    # Unparsable text inside the block: skip to the next
                     # invoke or to the block close.
                     yield from self._skip_garbage(
                         until=(self.INVOKE_PREFIX, self.BLOCK_CLOSE),
@@ -58,7 +58,7 @@ class M2TextParser(TagToolCallParser):
                         self._emit_call_close(tool_call_index)
                         break
                     if tried is None:
-                        # Unparseable text inside the invoke: skip to the
+                        # Unparsable text inside the invoke: skip to the
                         # next parameter or to the end of the invoke.
                         yield from self._skip_garbage(
                             until=(self.PARAM_PREFIX, self.INVOKE_END),
@@ -85,6 +85,7 @@ class M2TextParser(TagToolCallParser):
                     is_first_parameter = False
 
                 tool_call_index += 1
+
 
 class MinimaxM2Detector(TagToolCallDetector):
     """Detector for MiniMax M2 models; the wire format is documented above.

--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -1,6 +1,6 @@
 from typing import Dict, Generator, Optional
 
-from sglang.srt.function_call.compatibility import CompatibilityMode
+from sglang.srt.function_call.compatibility import CompatibilityContext
 from sglang.srt.function_call.core_types import _GetInfoFunc
 from sglang.srt.function_call.parsing import TagToolCallParser
 from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
@@ -104,7 +104,7 @@ class MinimaxM2Detector(TagToolCallDetector):
         return self.tool_call_start_token in text
 
     def _make_grammar(
-        self, functions: Optional[Dict], compatibility: CompatibilityMode
+        self, functions: Optional[Dict], compatibility: CompatibilityContext
     ) -> M2TextParser:
         return M2TextParser(functions=functions, compatibility=compatibility)
 

--- a/python/sglang/srt/function_call/minimax_m3.py
+++ b/python/sglang/srt/function_call/minimax_m3.py
@@ -389,7 +389,7 @@ class _StackItem:
                 return None
 
 
-class MinimaxM3NomDetector(TagToolCallDetector):
+class MinimaxM3Detector(TagToolCallDetector):
     """Detector for the MiniMax M3 namespace-tagged tool-call format.
 
     Parsing is implemented by ``M3TextParser``; streaming bookkeeping comes

--- a/python/sglang/srt/function_call/minimax_m3.py
+++ b/python/sglang/srt/function_call/minimax_m3.py
@@ -3,7 +3,10 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Union
 
 from typing_extensions import Self
 
-from sglang.srt.function_call.compatibility import CompatibilityEvent, CompatibilityMode
+from sglang.srt.function_call.compatibility import (
+    CompatibilityContext,
+    CompatibilityEvent,
+)
 from sglang.srt.function_call.compatibility.param_types import (
     AtomDataType,
     FunctionCallParameterDataType,
@@ -36,7 +39,7 @@ class M3TextParser(TagToolCallParser):
     def __init__(
         self,
         *,
-        compatibility: CompatibilityMode,
+        compatibility: CompatibilityContext,
         functions: Optional[Dict] = None,
         tool_call_xml_tag_name: str = "tool_call",
         tool_call_namespace_token: str = "]<]minimax[>[",
@@ -85,8 +88,7 @@ class M3TextParser(TagToolCallParser):
             # PatternMismatched (pattern exhausted).
             tool_call_index = 0
             while True:
-                if tool_call_index:
-                    yield from self._literal("\n", should_raise=False)
+                yield from self._literal("\n", should_raise=False)
                 tried = yield from self._literal(
                     (self._invoke_prefix, self._tool_call_end),
                     should_raise=False,
@@ -305,7 +307,7 @@ class _StackItem:
     value: Optional[Union[Dict, List]]
     texts: Optional[List[str]]
     data_type: Optional[FunctionCallParameterDataType]
-    compatibility: CompatibilityMode
+    compatibility: CompatibilityContext
 
     def _note(self, event: CompatibilityEvent, detail: str = "") -> None:
         self.compatibility.note(event, detail)
@@ -403,7 +405,7 @@ class MinimaxM3Detector(TagToolCallDetector):
         return "]<]minimax[>[<tool_call>" in text
 
     def _make_grammar(
-        self, functions: Optional[Dict], compatibility: CompatibilityMode
+        self, functions: Optional[Dict], compatibility: CompatibilityContext
     ) -> M3TextParser:
         return M3TextParser(functions=functions, compatibility=compatibility)
 

--- a/python/sglang/srt/function_call/minimax_m3_nom.py
+++ b/python/sglang/srt/function_call/minimax_m3_nom.py
@@ -1,0 +1,414 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Generator, List, Optional, Union
+
+from typing_extensions import Self
+
+from sglang.srt.function_call.compatibility import CompatibilityEvent, CompatibilityMode
+from sglang.srt.function_call.core_types import _GetInfoFunc
+from sglang.srt.function_call.compatibility.param_types import (
+    AtomDataType,
+    FunctionCallParameterDataType,
+)
+from sglang.srt.function_call.parsing import (
+    TagToolCallParser,
+    default_tool_call_output_key,
+    json_dumps,
+)
+from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
+
+
+class M3TextParser(TagToolCallParser):
+    """
+    Parser for MiniMax M3 models.
+
+    M3 uses a namespace token `]<]minimax[>[` as delimiter before each tag.
+    Parameters use actual XML tag names (not `<parameter name="...">`), and can be nested.
+    Complex arguments, as nested XML tags, are buffered and emitted as complete JSON;
+    Simple arguments, are streamed character-by-character if possible.
+
+    Example raw output::
+
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="func1">]<]minimax[>[<p1>value1]<]minimax[>[</p1>]<]minimax[>[<p2>]<]minimax[>[<item>]<]minimax[>[<k>val]<]minimax[>[</k>]<]minimax[>[</item>]<]minimax[>[</p2>]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    """
+
+    def __init__(
+        self,
+        *,
+        compatibility: CompatibilityMode,
+        functions: Optional[Dict] = None,
+        tool_call_xml_tag_name: str = "tool_call",
+        tool_call_namespace_token: str = "]<]minimax[>[",
+        content_field: str = "content",
+        tool_call_output_key: Callable[
+            [int, Dict], Dict
+        ] = default_tool_call_output_key,
+    ):
+        self._tool_call_namespace_token = tool_call_namespace_token
+        self._tool_call_start = (
+            f"{self._tool_call_namespace_token}<{tool_call_xml_tag_name}>"
+        )
+        self._tool_call_end = (
+            f"{self._tool_call_namespace_token}</{tool_call_xml_tag_name}>"
+        )
+        self._invoke_prefix = f'{self._tool_call_namespace_token}<invoke name="'
+        self._invoke_suffix = '">'
+        self._end_of_invoke = f"{self._tool_call_namespace_token}</invoke>"
+        self._parameter_prefix = f"{self._tool_call_namespace_token}<"
+        self._parameter_suffix = f"{self._tool_call_namespace_token}</"
+        super().__init__(
+            functions=functions,
+            content_field=content_field,
+            tool_call_output_key=tool_call_output_key,
+            compatibility=compatibility,
+        )
+
+    def _process(self) -> Generator[dict, None, None]:
+        if not self._functions:
+            yield from self._take_any(key=self._content_field, commit_each=True)
+        else:
+            yield from self._take_any(
+                until=self._tool_call_start,
+                key=self._content_field,
+                should_consume_suffix=False,
+                commit_each=True,
+            )
+            self._commit()
+            yield from self._literal(self._tool_call_start)
+            yield from self._literal("\n", should_raise=False)
+
+            # NOTE: Only ONE `<tool_call>` block is supported by design.
+            # Multiple parallel calls must share a single wrapper and use
+            # multiple `<invoke>` tags inside it. A second `<tool_call>` after
+            # the first `</tool_call>` will cause `update()` to raise
+            # PatternMismatched (pattern exhausted).
+            tool_call_index = 0
+            while True:
+                if tool_call_index:
+                    yield from self._literal("\n", should_raise=False)
+                tried = yield from self._literal(
+                    (self._invoke_prefix, self._tool_call_end),
+                    should_raise=False,
+                )
+                if tried == self._tool_call_end:
+                    # Block closed cleanly: text up to here is accounted for;
+                    # anything later that makes ``update()`` raise (e.g. a
+                    # second block) is re-surfaced from this point.
+                    self._commit()
+                    break
+                if tried is None:
+                    # Unrecognizable text: leave it uncommitted so the
+                    # imminent pattern-exhausted failure re-surfaces the whole
+                    # unparsed region (including this block's markers).
+                    break
+
+                function_name = yield from self._take_any(until=self._invoke_suffix)
+                dropped = yield from self._drop_unknown_invoke(
+                    function_name, self._end_of_invoke
+                )
+                if dropped:
+                    continue
+                self._emit_name(tool_call_index, function_name)
+                function = self._get_function(function_name)
+                is_first_parameter = True
+                while True:
+                    tried = yield from self._literal(
+                        (self._end_of_invoke, self._parameter_prefix),
+                        should_raise=False,
+                    )
+                    if tried == self._end_of_invoke:
+                        self._emit_call_close(tool_call_index)
+                        break
+                    if tried is None:
+                        # Unparseable text: drop the rest of this invoke and
+                        # close its arguments, hoping the format recovers
+                        # after the invoke ends.
+                        yield from self._recover_invoke(
+                            tool_call_index, self._end_of_invoke
+                        )
+                        break
+                    parameter_name = yield from self._take_any(until=">")
+                    self._emit_param_key(
+                        tool_call_index, parameter_name, is_first_parameter
+                    )
+                    parameter_suffix = "{}{}>".format(
+                        self._parameter_suffix, parameter_name
+                    )
+                    parameter_data_type = (
+                        FunctionCallParameterDataType.get_schema_of_parameter(
+                            function, parameter_name
+                        )
+                    )
+                    tried = yield from self._literal(
+                        self._parameter_prefix,
+                        should_raise=False,
+                        should_consume=False,
+                    )
+                    if tried is not None:
+                        param_body_str = yield from self._take_any(
+                            until=parameter_suffix
+                        )
+                        if param_body_str:
+                            # nested XML -> object
+                            # NOTE: The namespace token has the highest semantic
+                            # priority. Once the model emits `]<]minimax[>[<` here,
+                            # we MUST treat the body as nested XML, even if the
+                            # schema says this parameter should be a primitive.
+                            # The model is asserting "this is a JSON level
+                            # transition" — schema mismatches are reported back via
+                            # the agent loop, not silently rewritten here.
+                            if not parameter_data_type.candidates_allow_structure:
+                                self._note(
+                                    CompatibilityEvent.STRUCTURE_OVERRODE_SCHEMA,
+                                    detail=f"parameter {parameter_name[:40]!r}",
+                                )
+                            param = self._parse_parameter(
+                                param_body_str, parameter_data_type
+                            )
+                        else:
+                            param = parameter_data_type.convert(
+                                "", compatibility=self.compatibility
+                            )
+                        self._emit_args(tool_call_index, json_dumps(param))
+                    else:
+                        # no more nested XML -> string / number / boolean
+                        yield from self._take_data_type_as_json(
+                            until=parameter_suffix,
+                            key=lambda value: self._tool_call_output_key(
+                                tool_call_index, {"arguments": value}
+                            ),
+                            data_type=parameter_data_type,
+                            always_nullable=False,
+                            should_consume_suffix=True,
+                        )
+                    is_first_parameter = False
+                tool_call_index += 1
+
+    def _parse_parameter(
+        self, body: str, parameter_data_type: FunctionCallParameterDataType
+    ) -> dict:
+        chunks = body.split(self._tool_call_namespace_token)
+        # NOTE: Array detection is intentionally a strict "schema says array
+        # AND first child is <item>" check. We do NOT promote a uniform
+        # `<x><x>...` body to an array on schema mismatch — leave it as
+        # `{"x": [...]}` so the agent loop can spot and correct the model.
+        if (
+            AtomDataType.array in parameter_data_type.candidates
+            and len(chunks) > 1
+            and chunks[1].startswith("<item>")
+        ):
+            root = []
+        else:
+            root = {}
+        stack: List[_StackItem] = [
+            _StackItem(
+                tag=None,
+                value=root,
+                texts=None,
+                data_type=parameter_data_type,
+                compatibility=self.compatibility,
+            )
+        ]
+
+        # Ignore the first chunk inside the parameter.
+        # It should be empty, since we've tried `self._parameter_prefix` and failed before entering this function.
+        for chunk_index in range(1, len(chunks)):
+            chunk = chunks[chunk_index]
+            # There are 7 = 3 + 3 + 1 non-empty categories of chunks.
+            if chunk.startswith("</"):
+                gt_offset = chunk.find(">", 2)
+                if gt_offset == -1:
+                    # 1. `</tag`
+                    tag = chunk[2:]
+                    value = None
+                elif gt_offset == len(chunk) - 1:
+                    # 2. `</tag>`
+                    tag = chunk[2:-1]
+                    value = None
+                else:
+                    # 3. `</tag>value`
+                    tag = chunk[2:gt_offset]
+                    value = chunk[gt_offset + 1 :]
+                matched = False
+                while len(stack) > 1:
+                    item = stack.pop()
+                    stack[-1].append(item)
+                    if item.tag == tag:
+                        matched = True
+                        break
+                    self._note(
+                        CompatibilityEvent.MISMATCHED_CLOSING_TAG,
+                        detail=f"</{tag[:40]}> closed open <{str(item.tag)[:40]}>",
+                    )
+                if not matched:
+                    self._note(
+                        CompatibilityEvent.MISMATCHED_CLOSING_TAG,
+                        detail=f"</{tag[:40]}> matched no open tag",
+                    )
+                if value:
+                    stack[-1].append_text(value)
+            elif chunk.startswith("<"):
+                gt_offset = chunk.find(">", 1)
+                if gt_offset == -1:
+                    # 4. `<tag`
+                    tag = chunk[1:]
+                    value = None
+                elif gt_offset == len(chunk) - 1:
+                    # 5. `<tag>`
+                    tag = chunk[1:-1]
+                    value = None
+                else:
+                    # 6. `<tag>value`
+                    tag = chunk[1:gt_offset]
+                    value = chunk[gt_offset + 1 :]
+                sub_data_type = stack[-1].get_data_type_of_property(tag)
+                if (
+                    sub_data_type
+                    and AtomDataType.array in sub_data_type.candidates
+                    and len(chunks) > chunk_index + 1
+                    and chunks[chunk_index + 1].startswith("<item>")
+                ):
+                    sub = []
+                elif sub_data_type and AtomDataType.object in sub_data_type.candidates:
+                    sub = {}
+                else:
+                    sub = None
+                stack.append(
+                    _StackItem(
+                        tag=tag,
+                        value=sub,
+                        texts=[value] if value else None,
+                        data_type=sub_data_type,
+                        compatibility=self.compatibility,
+                    )
+                )
+            elif chunk:
+                # 7. `value`
+                stack[-1].append_text(chunk)
+
+        if len(stack) > 1:
+            self._note(
+                CompatibilityEvent.UNCLOSED_TAGS_AT_END,
+                detail=f"{len(stack) - 1} unclosed tag(s)",
+            )
+        while len(stack) > 1:
+            item = stack.pop()
+            stack[-1].append(item)
+
+        return stack[0].get_value()
+
+
+@dataclass(slots=True)
+class _StackItem:
+    tag: Optional[str]
+    value: Optional[Union[Dict, List]]
+    texts: Optional[List[str]]
+    data_type: Optional[FunctionCallParameterDataType]
+    compatibility: CompatibilityMode
+
+    def _note(self, event: CompatibilityEvent, detail: str = "") -> None:
+        self.compatibility.note(event, detail)
+
+    def get_value(self) -> Any:
+        if self.value is None:
+            if self.texts:
+                value = "".join(self.texts)
+            else:
+                value = ""
+            if self.data_type:
+                value = self.data_type.convert(value, compatibility=self.compatibility)
+            return value
+        elif self.texts and isinstance(self.value, dict):
+            extra_text_key = "$text"
+            while extra_text_key in self.value:
+                extra_text_key = "$" + extra_text_key
+            self._note(
+                CompatibilityEvent.MIXED_TEXT_CAPTURED,
+                detail=f"under {extra_text_key!r} in <{str(self.tag)[:40]}>",
+            )
+            self.value[extra_text_key] = "".join(self.texts)
+            return self.value
+        else:
+            return self.value
+
+    def append(self, item: Self) -> None:
+        if self.value is None:
+            self.value = {item.tag: item.get_value()}
+        elif isinstance(self.value, dict):
+            if item.tag in self.value:
+                # NOTE: Duplicate tag inside an object is collapsed into a
+                # list to preserve all values, even if the schema declares
+                # the key as a singleton. We don't drop the data and we
+                # don't try to "fix" the schema mismatch silently — the agent
+                # loop should surface the inconsistency back to the model.
+                self._note(
+                    CompatibilityEvent.DUPLICATE_TAG_AS_LIST,
+                    detail=f"tag <{str(item.tag)[:40]}>",
+                )
+                value = self.value[item.tag]
+                if isinstance(value, list):
+                    value.append(item.get_value())
+                else:
+                    self.value[item.tag] = [value, item.get_value()]
+            else:
+                self.value[item.tag] = item.get_value()
+        elif isinstance(self.value, list):
+            # We expect `item.tag` to be `"item"`, but if it's not, we should still accept it.
+            if item.tag != "item":
+                self._note(
+                    CompatibilityEvent.NON_ITEM_ARRAY_CHILD,
+                    detail=f"tag <{str(item.tag)[:40]}>",
+                )
+            self.value.append(item.get_value())
+        else:
+            raise NotImplementedError()
+
+    def append_text(self, value: str) -> None:
+        if isinstance(self.value, list):
+            if self.data_type:
+                data_type = self.data_type.get_data_type_of_item(index=len(self.value))
+                if data_type:
+                    value = data_type.convert(value, compatibility=self.compatibility)
+            self.value.append(value)
+        elif self.texts is None:
+            self.texts = [value]
+        else:
+            self.texts.append(value)
+
+    def get_data_type_of_property(
+        self, tag: str
+    ) -> Optional[FunctionCallParameterDataType]:
+        if self.data_type:
+            if isinstance(self.value, list):
+                # We expect `tag` to be `"item"`, but if it's not, we should still accept it.
+                return self.data_type.get_data_type_of_item(index=len(self.value))
+            elif isinstance(self.value, dict):
+                return self.data_type.get_data_type_of_property(tag)
+            else:
+                return None
+
+
+class MinimaxM3NomDetector(TagToolCallDetector):
+    """Detector for the MiniMax M3 namespace-tagged tool-call format.
+
+    Parsing is implemented by ``M3TextParser``; streaming bookkeeping comes
+    from ``TagToolCallDetector`` and error recovery from the package
+    compatibility mode (the ``compatibility`` package). Reasoning is handled by SGLang's
+    separate ``--reasoning-parser minimax-m3`` stage, so the parser emits only
+    ``content`` / ``tool_calls`` deltas.
+    """
+
+    def has_tool_call(self, text: str) -> bool:
+        return "]<]minimax[>[<tool_call>" in text
+
+    def _make_grammar(
+        self, functions: Optional[Dict], compatibility: CompatibilityMode
+    ) -> M3TextParser:
+        return M3TextParser(functions=functions, compatibility=compatibility)
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError

--- a/python/sglang/srt/function_call/minimax_m3_nom.py
+++ b/python/sglang/srt/function_call/minimax_m3_nom.py
@@ -4,11 +4,11 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Union
 from typing_extensions import Self
 
 from sglang.srt.function_call.compatibility import CompatibilityEvent, CompatibilityMode
-from sglang.srt.function_call.core_types import _GetInfoFunc
 from sglang.srt.function_call.compatibility.param_types import (
     AtomDataType,
     FunctionCallParameterDataType,
 )
+from sglang.srt.function_call.core_types import _GetInfoFunc
 from sglang.srt.function_call.parsing import (
     TagToolCallParser,
     default_tool_call_output_key,
@@ -121,7 +121,7 @@ class M3TextParser(TagToolCallParser):
                         self._emit_call_close(tool_call_index)
                         break
                     if tried is None:
-                        # Unparseable text: drop the rest of this invoke and
+                        # Unparsable text: drop the rest of this invoke and
                         # close its arguments, hoping the format recovers
                         # after the invoke ends.
                         yield from self._recover_invoke(

--- a/python/sglang/srt/function_call/mistral_detector.py
+++ b/python/sglang/srt/function_call/mistral_detector.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -67,15 +68,15 @@ class MistralDetector(BaseFormatDetector):
                 return StreamingParseResult(normal_text=normal_text, calls=[])
 
             calls: list = []
-            try:
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                json.JSONDecodeError,
+                detail=json_array_str[:80],
+            ):
                 function_call_arr = json.loads(json_array_str)
                 if not isinstance(function_call_arr, list):
                     function_call_arr = [function_call_arr]
                 calls = self.parse_base_json(function_call_arr, tools)
-            except json.JSONDecodeError as e:
-                logger.warning(
-                    f"Failed to parse JSON part: {json_array_str}, JSON parse error: {str(e)}"
-                )
             json_pos = tool_part.find(json_array_str) if json_array_str else -1
             trailing_text = (
                 tool_part[json_pos + len(json_array_str) :].strip()

--- a/python/sglang/srt/function_call/mistral_detector.py
+++ b/python/sglang/srt/function_call/mistral_detector.py
@@ -40,7 +40,7 @@ class MistralDetector(BaseFormatDetector):
         # Common marker shared by both JSON-array and compact formats.
         self._tool_calls_marker = "[TOOL_CALLS"
         self.eot_token = "]"
-        self.tool_call_separator = ", "
+        self.tool_call_separator = ","
 
     def has_tool_call(self, text: str) -> bool:
         """Return True if the text contains either supported tool-call marker."""
@@ -65,7 +65,11 @@ class MistralDetector(BaseFormatDetector):
         if self.bot_token in tool_part:
             json_array_str = self._extract_json_array(tool_part)
             if not json_array_str:
-                return StreamingParseResult(normal_text=normal_text, calls=[])
+                self.compatibility.note(
+                    CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                    detail=tool_part[:80],
+                )
+                return StreamingParseResult(normal_text=text, calls=[])
 
             calls: list = []
             with self.compatibility.absorb(
@@ -106,7 +110,11 @@ class MistralDetector(BaseFormatDetector):
             remaining = remaining[consumed:].strip()
 
         if not all_calls:
-            return StreamingParseResult(normal_text=normal_text, calls=[])
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=tool_part[:80],
+            )
+            return StreamingParseResult(normal_text=text, calls=[])
 
         combined_normal = (
             (normal_text + " " + remaining).strip() if remaining else normal_text
@@ -126,6 +134,14 @@ class MistralDetector(BaseFormatDetector):
         self._buffer += new_text
         current_text = self._buffer
 
+        # A leading separator may follow a valid or dropped entry in this sequence.
+        starts_with_sequence_separator = (
+            self._starts_with_tool_call_separator(current_text)
+            and self._has_tool_call_sequence_context()
+        )
+        if starts_with_sequence_separator:
+            return super().parse_streaming_increment(new_text="", tools=tools)
+
         # No marker: either flush as normal text or keep buffering a partial marker.
         if self._tool_calls_marker not in current_text:
             if not self._ends_with_partial_token(self._buffer, self._tool_calls_marker):
@@ -133,6 +149,7 @@ class MistralDetector(BaseFormatDetector):
                 self._buffer = ""
                 if self.eot_token in normal_text:
                     normal_text = normal_text.replace(self.eot_token, "")
+                    self._in_tool_call_sequence = False
                 return StreamingParseResult(normal_text=normal_text)
             return StreamingParseResult()
 
@@ -151,11 +168,11 @@ class MistralDetector(BaseFormatDetector):
         compact = self._try_parse_compact_args_format(current_text)
         if compact:
             func_name, args_obj, consumed = compact
-            if func_name not in self._tool_indices:
-                # Unknown tool: treat as normal text and reset state.
-                normal_text = self._buffer
-                self._buffer = ""
-                return StreamingParseResult(normal_text=normal_text)
+            if func_name not in self._tool_indices and self._skip_unknown_tool(
+                func_name
+            ):
+                self._buffer = current_text[consumed:]
+                return self._retry_streaming_tail(current_text, [], tools)
 
             # Initialize state if this is the first tool call.
             if self.current_tool_id == -1:
@@ -187,7 +204,7 @@ class MistralDetector(BaseFormatDetector):
             self._buffer = current_text[consumed:]
             self.current_tool_id += 1
             self.current_tool_name_sent = False
-            return StreamingParseResult(normal_text="", calls=calls)
+            return self._retry_streaming_tail(current_text, calls, tools)
 
         # Canonical format delegates to the BaseFormatDetector JSON streaming logic.
         if self.bot_token in current_text:

--- a/python/sglang/srt/function_call/parsing.py
+++ b/python/sglang/srt/function_call/parsing.py
@@ -223,7 +223,9 @@ class GeneratorParser(ABC):
         """Mark everything consumed or emitted so far as accounted for."""
         self._committed_offset = self._consumed_offset()
 
-    def _note(self, event: CompatibilityEvent, detail: str = "") -> Optional[CompatibilityRecord]:
+    def _note(
+        self, event: CompatibilityEvent, detail: str = ""
+    ) -> Optional[CompatibilityRecord]:
         """Record an applied tolerance at the current consume offset.
 
         Raises ``CompatibilityViolation`` in strict mode; see the ``compatibility`` package.
@@ -685,7 +687,7 @@ class TagToolCallParser(GeneratorParser, ABC):
         detail: str = "",
         consume_suffix: bool = False,
     ) -> Generator:
-        """Compatibility scope 1: drop unparseable text up to a recognizable marker.
+        """Compatibility scope 1: drop unparsable text up to a recognizable marker.
 
         Records ``SKIPPED_GARBAGE`` only when non-whitespace text was actually
         dropped (in strict mode that record raises ``CompatibilityViolation``); the
@@ -743,9 +745,7 @@ class TagToolCallParser(GeneratorParser, ABC):
             or envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
         ):
             return False
-        self._note(
-            CompatibilityEvent.UNKNOWN_TOOL_DROPPED, detail=repr(function_name)
-        )
+        self._note(CompatibilityEvent.UNKNOWN_TOOL_DROPPED, detail=repr(function_name))
         yield from self._take_any(until=end_marker)
         self._commit()
         return True

--- a/python/sglang/srt/function_call/parsing.py
+++ b/python/sglang/srt/function_call/parsing.py
@@ -1,0 +1,801 @@
+"""Incremental parsing engine for tag-style tool-call wire formats.
+
+Most tag formats are variations of one shape::
+
+    [content] BLOCK_OPEN [per-call: name tag, parameter tags] BLOCK_CLOSE [content] ...
+
+with the function name in a tag attribute and **each parameter in its own
+tag whose body is raw text** (not JSON). Parsing such formats needs what a
+regex + ``json.loads`` cannot do: convert tag names to JSON keys, convert raw
+text values via the tool schema (``compatibility/param_types.py``), stream string values as
+escaped JSON fragments, and keep state when a tag is split across streaming
+chunks. Formats that wrap a complete JSON object (Qwen2.5, Hermes, ...) should
+use ``BaseFormatDetector`` directly instead.
+
+This module is the format-agnostic half of the tag machinery and an
+implementation detail of the detectors that use it; nothing here is a public
+extension point. It contains:
+
+- ``PatternMismatched``: the engine's parse-failure signal.
+- ``GeneratorParser``: the coroutine engine. Subclasses write their format as
+  a generator ``_process()`` using primitives like ``_literal`` and
+  ``_take_any``; ``update(text)`` advances the coroutine, which suspends
+  automatically when it needs more input.
+- ``TagToolCallParser``: shared helpers for tag formats (content/skip/emit/
+  parameter-value pieces), so each format's ``_process()`` stays a short
+  transcription of its grammar.
+
+The SGLang-facing adapter lives in ``tag_format_detector.py``. Dependency rule
+for this package: detectors -> ``tag_format_detector`` -> ``parsing`` ->
+{``compatibility``, ``param_types``}; this module must not import serving types.
+
+The delta contract between a parser and the adapter is the dict shape built
+by ``default_tool_call_output_key``::
+
+    {
+        "content": str,                  # optional normal text
+        "tool_calls": [
+            {
+                "index": int,            # 0-based ordinal of the call
+                "function": {
+                    "name": str,         # exactly once, on the first delta
+                    "arguments": str,    # JSON fragments; concatenate to a
+                                         # valid JSON object
+                },
+            }
+        ],
+    }
+
+Parsers emit only ``content`` and ``tool_calls`` (reasoning is handled by
+SGLang's separate ``--reasoning-parser`` stage).
+
+Tolerances applied while parsing are recorded on the parser's
+:class:`CompatibilityMode` (injected at construction — the detector's policy, so
+all tolerances for a request share one audit trail); coroutine code cannot
+wrap ``yield`` in ``CompatibilityMode.absorb``, so the generator helpers here call
+``note()`` directly. Errors the grammar cannot absorb propagate as
+``PatternMismatched`` to ``FunctionCallParser``, which fails open to text.
+
+TODO: accept token-level inputs (match special-token markers by token id
+instead of by string) to remove partial-marker holdback.
+"""
+
+import functools
+import json
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from enum import Enum, auto
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+from typing_extensions import Self
+
+from sglang.srt.environ import envs
+from sglang.srt.function_call.compatibility.mode import (
+    CompatibilityEvent,
+    CompatibilityMode,
+    CompatibilityRecord,
+)
+from sglang.srt.function_call.compatibility.param_types import (
+    NULL_STRINGS,
+    FunctionCallParameterDataType,
+)
+
+OutputKey = Union[str, Callable[[Any], Dict]]
+
+
+class PatternMismatched(Exception):
+    def __init__(
+        self,
+        *,
+        offset: int,
+        expected: Any,
+        actual: Any,
+        reason: str,
+        context_fn: Optional[Callable[[], str]] = None,
+    ):
+        self.offset = offset
+        self.expected = expected
+        self.actual = actual
+        self.reason = reason
+        self.context_fn = context_fn
+
+    def __str__(self):
+        main_message = f"at offset {self.offset}, {self.reason}, expected {self.expected!r} but got {self.actual!r}"
+        if self.context_fn is None:
+            return main_message
+        else:
+            return f"around context:\n{self.context_fn()}\n\n{main_message}"
+
+
+class GeneratorParser(ABC):
+    """Coroutine-based incremental text parser; see the module docstring."""
+
+    @abstractmethod
+    def _process(self) -> Generator[Dict[str, Any], None, None]:
+        pass
+
+    def __init__(self, *, compatibility: CompatibilityMode):
+        # The policy is required by construction so a request's tolerances
+        # cannot silently fork onto a second audit trail. Must be set before
+        # `_process()` starts: the grammar may consult it from its first step.
+        self.compatibility = compatibility
+        self._full_text: List[str] = []
+        self._input_length = 0
+        # The unconsumed window is ``self._buf[self._pos:]``; ``update()``
+        # compacts the consumed prefix away on each call.
+        self._buf = ""
+        self._pos = 0
+        # Raw-text offset up to which everything is *accounted for* — either
+        # emitted (content) or structure of a successfully completed
+        # construct. Grammars advance it via ``_commit()``; the error path
+        # re-surfaces ``uncommitted_text()`` so no raw text is lost.
+        self._committed_offset = 0
+        self._delta: Optional[Dict[str, Any]] = None
+        self._final: Optional[Dict[str, Any]] = None
+        self._generator = self._process()
+        next(self._generator)
+
+    def __del__(self):
+        # Necessary when GC is disabled (gc.disable()),
+        # otherwise the cyclic reference will never be collected.
+        if hasattr(self, "_generator"):
+            self._generator.close()
+            del self._generator
+
+    def update(self, input: str):
+        self._full_text.append(input)
+        self._input_length += len(input)
+        self._buf = self._buf[self._pos :] + input
+        self._pos = 0
+        # Resume the coroutine until it stops making progress (it is starved,
+        # holding back a possible partial marker) or the grammar ends.
+        while self._pos < len(self._buf):
+            before = self._pos
+            try:
+                next(self._generator)
+            except StopIteration:
+                if self._pos < len(self._buf):
+                    raise self._error(
+                        expected=None,
+                        actual=self._buf[self._pos],
+                        reason="pattern exhausted",
+                    )
+                break
+            if self._pos == before:
+                break
+
+    def get_delta(self) -> Optional[Dict[str, Any]]:
+        if self._delta:
+            delta = _get_dict_with_joint_strings(self._delta)
+            self._delta = None
+            return delta
+
+    def get_final(self) -> Optional[Dict[str, Any]]:
+        return _get_dict_with_joint_strings(self._final)
+
+    def restash_delta(self, delta: Optional[Dict[str, Any]]):
+        """Put a delta taken by ``get_delta()`` back, ahead of newer output.
+
+        Used by the adapter when post-parse processing of a drained delta
+        raises (e.g. a strict-mode gate): the delta must stay available for
+        the recovery drain or its content would be lost.
+        """
+        if delta:
+            self._delta = _merge_dicts(delta, self._delta)
+
+    def unconsumed_text(self) -> str:
+        """Text received so far that the grammar has not yet consumed.
+
+        Read-only; does not advance the generator. Used by TagToolCallDetector
+        on the error path to recover the raw tail as normal content.
+        """
+        return self._buf[self._pos :]
+
+    def uncommitted_text(self) -> str:
+        """Raw text after the last ``_commit()`` point (see ``__init__``).
+
+        On the error path this is the entire failing construct — consumed
+        markers, silently buffered names, skipped garbage — plus the
+        unconsumed tail; everything before it was either emitted as content
+        or belongs to a successfully completed construct.
+        """
+        return "".join(self._full_text)[self._committed_offset :]
+
+    def full_text_received(self) -> str:
+        """All text passed to ``update()`` so far (consumed and not)."""
+        return "".join(self._full_text)
+
+    def _consumed_offset(self) -> int:
+        return self._input_length - (len(self._buf) - self._pos)
+
+    def _commit(self):
+        """Mark everything consumed or emitted so far as accounted for."""
+        self._committed_offset = self._consumed_offset()
+
+    def _note(self, event: CompatibilityEvent, detail: str = "") -> Optional[CompatibilityRecord]:
+        """Record an applied tolerance at the current consume offset.
+
+        Raises ``CompatibilityViolation`` in strict mode; see the ``compatibility`` package.
+        """
+        return self.compatibility.note(event, detail, offset=self._consumed_offset())
+
+    def _peek(self, index: int) -> Generator[None, None, str]:
+        while self._pos + index >= len(self._buf):
+            yield
+        return self._buf[self._pos + index]
+
+    def _read_one(self) -> str:
+        # intentionally unchecked, will raise IndexError if the input buffer is empty.
+        ch = self._buf[self._pos]
+        self._pos += 1
+        return ch
+
+    def _consume(self, length: int):
+        self._pos += length
+
+    def _append(self, key: OutputKey, value: Any):
+        if isinstance(key, str):
+            delta = {key: value}
+        else:
+            delta = key(value)
+        self._append_delta(delta)
+
+    def _append_delta(self, delta: Dict[str, Any]):
+        self._delta = _merge_dicts(delta, self._delta)
+        self._final = _merge_dicts(delta, self._final)
+
+    def _error(self, *, expected: Any, actual: Any, reason: str) -> PatternMismatched:
+        offset = self._consumed_offset()
+        # _full_text is a plain list; capturing it directly (instead of self)
+        # keeps the context_fn closure free of a reference cycle.
+        full_text_ref = self._full_text
+        return PatternMismatched(
+            offset=offset,
+            expected=expected,
+            actual=actual,
+            reason=reason,
+            context_fn=functools.partial(
+                _get_context_standalone, full_text_ref, offset
+            ),
+        )
+
+    def _take_any(
+        self,
+        *,
+        until: Optional[Union[str, Tuple[str, ...]]] = None,
+        key: Optional[OutputKey] = None,
+        should_consume_suffix: bool = True,
+        commit_each: bool = False,
+    ) -> Generator[str, None, None]:
+        """``commit_each`` commits after every emitted run; pass it when the
+        output is surfaced live (content), so the error path never
+        re-surfaces it (see ``uncommitted_text``)."""
+        if until is None:
+            # Never ends without `until`, thus no need to collect the values.
+            while True:
+                yield from self._peek(0)
+                run = self._buf[self._pos :]
+                self._pos = len(self._buf)
+                self._append(key, run)
+                if commit_each:
+                    self._commit()
+        else:
+            firsts = _target_first_chars(until)
+            values = []
+            while True:
+                tried = yield from self._literal(
+                    until,
+                    should_consume=should_consume_suffix,
+                    should_raise=False,
+                )
+                if tried is not None:
+                    break
+                run = self._take_run(firsts)
+                values.append(run)
+                if key is not None:
+                    self._append(key, run)
+                if commit_each:
+                    self._commit()
+            return "".join(values)
+
+    def _take_run(self, firsts: Tuple[str, ...]) -> str:
+        """Consume the char at the current position (it starts no target —
+        ``_literal`` just said so) plus, in bulk with C-speed ``str.find``,
+        every following char that provably cannot start any target either."""
+        start = self._pos
+        self._pos += 1
+        nxt = len(self._buf)
+        for c in firsts:
+            i = self._buf.find(c, self._pos)
+            if i != -1 and i < nxt:
+                nxt = i
+        self._pos = nxt
+        return self._buf[start:nxt]
+
+    def _take_data_type_as_json(
+        self,
+        *,
+        until: Union[str, Tuple[str, ...]],
+        key: OutputKey,
+        data_type: FunctionCallParameterDataType,
+        always_nullable: bool = False,
+        should_consume_suffix: bool = True,
+    ):
+        """
+        Unlike `.take_any`, `until` and `key` is required here, because
+        - it is unnecessary and a little bit annoying to maintain the streaming state
+          for most data types other than `str`.
+        - if you don't need the output, just use `.take_any`.
+
+        NOTE: if there are various acceptable data types, we choose the FIRST convertible
+        one, indicating, if the first choice is `str`, the following choices will be
+        IGNORED, as everything could be a string.
+
+        TODO: if there are acceptable data types before `str`, we should peek until they
+        are excluded and then choose `str`, instead of choosing at the end.
+        """
+        if not data_type.streaming:
+            value = yield from self._take_any(
+                until=until, should_consume_suffix=should_consume_suffix
+            )
+            value = data_type.convert(
+                value, always_nullable=always_nullable, compatibility=self.compatibility
+            )
+            self._append(key, json_dumps(value))
+            return value
+        else:
+            if always_nullable:
+                # very tricky.
+                # even if the data type is string, we still need to check if it's null.
+                tried = yield from self._literal(
+                    _string_cartesian_product(NULL_STRINGS, until),
+                    should_consume=should_consume_suffix,
+                    should_raise=False,
+                )
+                if tried is not None:
+                    if not should_consume_suffix:
+                        null = next(n for n in NULL_STRINGS if tried.startswith(n))
+                        self._consume(len(null))
+                    self._append(key, "null")
+                    return None
+            firsts = _target_first_chars(until)
+            values = []
+            self._append(key, '"')
+            while True:
+                tried = yield from self._literal(
+                    until, should_consume=should_consume_suffix, should_raise=False
+                )
+                if tried is not None:
+                    break
+                run = self._take_run(firsts)
+                values.append(run)
+                # JSON string escaping is per-character and context-free, so
+                # escaping a run equals concatenating escaped characters;
+                # [1:-1] strips only the surrounding quotes.
+                self._append(key, json_dumps(run)[1:-1])
+            self._append(key, '"')
+            return "".join(values)
+
+    def _literal(
+        self,
+        target: Union[str, Tuple[str, ...]],
+        *,
+        should_raise: bool = True,
+        should_consume: bool = True,
+    ) -> Generator[Optional[str], None, None]:
+        """
+        NOTE: stops at the first matched target, even if it is a substring of another later target.
+        """
+        if isinstance(target, str):
+            target = (target,)
+        char_index = 0
+        target_index = 0
+        target_index_max = len(target) - 1
+        while True:
+            ith = yield from self._peek(char_index)
+            if ith != target[target_index][char_index]:
+                already_matched_and_ith = target[target_index][:char_index] + ith
+                prefix_matching_result = PrefixMatchingResult.mismatch
+                target_index += 1
+                while target_index <= target_index_max:
+                    prefix_matching_result = PrefixMatchingResult.check(
+                        target[target_index], already_matched_and_ith
+                    )
+                    if prefix_matching_result != PrefixMatchingResult.mismatch:
+                        break
+                    target_index += 1
+                if prefix_matching_result == PrefixMatchingResult.substring_of_prefix:
+                    break
+                elif prefix_matching_result == PrefixMatchingResult.mismatch:
+                    if should_raise:
+                        if len(target) == 1:
+                            raise self._error(
+                                expected=target[0][char_index:],
+                                actual=ith,
+                                reason=f"matching {target[0]!r}",
+                            )
+                        else:
+                            raise self._error(
+                                expected=target,
+                                actual=ith,
+                                reason="matching any of the list",
+                            )
+                    else:
+                        return
+            char_index += 1
+            if char_index == len(target[target_index]):
+                break
+        if should_consume:
+            self._consume(len(target[target_index]))
+        return target[target_index]
+
+    def _whitespace(self) -> Iterator[None]:
+        total = 0
+        while True:
+            peek = yield from self._peek(total)
+            if peek.isspace():
+                total += 1
+            else:
+                self._consume(total)
+                break
+
+
+def default_tool_call_output_key(tool_call_index: int, function: Dict) -> Dict:
+    return {
+        "tool_calls": [
+            {
+                "index": tool_call_index,
+                "function": function,
+            }
+        ]
+    }
+
+
+def _get_context_standalone(full_text_parts: List[str], offset: int) -> str:
+    """Standalone version of the error context that doesn't capture self."""
+    full_text = "".join(full_text_parts)
+    return f"{full_text[:offset]}💥{full_text[offset:]}"
+
+
+def _merge_dicts(
+    src: Dict[str, Any],
+    dst: Optional[Dict[str, Any]],
+    whitelist: Optional[Set[str]] = None,
+) -> Dict[str, Any]:
+    if dst is None:
+        return deepcopy(src)
+    for key, val_src in src.items():
+        if whitelist is not None and key in whitelist:
+            continue
+        val_dst = dst.get(key)
+        if val_dst is None:
+            dst[key] = deepcopy(val_src)
+        elif isinstance(val_src, dict):
+            dst[key] = _merge_dicts(val_src, val_dst)
+        elif isinstance(val_src, list):
+            # NOTE: don't just `val_dst.extend(val_src)` here, as we need a carefully constructed delta object.
+            # Assume that all elements have `index: int`, indicating its position in the final merged list.
+            if len(val_src) == len(val_dst) and all(
+                val_src[i]["index"] == val_dst[i]["index"] for i in range(len(val_src))
+            ):
+                for i in range(len(val_src)):
+                    _merge_dicts(val_src[i], val_dst[i], whitelist={"index"})
+            elif len(val_src):
+                index_to_item = {item["index"]: item for item in val_dst}
+                for item_src in val_src:
+                    idx = item_src["index"]
+                    item_dst = index_to_item.get(idx)
+                    if item_dst is None:
+                        index_to_item[idx] = deepcopy(item_src)
+                    else:
+                        _merge_dicts(item_src, item_dst, whitelist={"index"})
+                dst[key] = sorted(
+                    index_to_item.values(), key=lambda item: item["index"]
+                )
+        elif isinstance(val_src, str):
+            if isinstance(val_dst, list):
+                dst[key].append(val_src)
+            else:
+                # NOTE: to avoid O(n²) string concatenation, we store one string as a list of substrings.
+                # Later, join the substrings back by `_get_dict_with_joint_strings`.
+                dst[key] = [val_dst, val_src]
+        else:
+            raise TypeError(
+                f"key {key} has unsupported type {type(val_src)} of {val_src!r} against {val_dst!r}"
+            )
+    return dst
+
+
+def _get_dict_with_joint_strings(
+    data: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    if data is None:
+        return
+    updated = {}
+    for key, val in data.items():
+        if isinstance(val, list):
+            if val:
+                if isinstance(val[0], str):
+                    updated[key] = "".join(val)
+                elif isinstance(val[0], dict):
+                    updated[key] = [_get_dict_with_joint_strings(_) for _ in val]
+                else:
+                    updated[key] = val
+            else:
+                updated[key] = val
+        elif isinstance(val, dict):
+            updated[key] = _get_dict_with_joint_strings(val)
+        else:
+            updated[key] = val
+    return updated
+
+
+def json_dumps(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False)
+
+
+class PrefixMatchingResult(int, Enum):
+    startswith = auto()
+    substring_of_prefix = auto()
+    mismatch = auto()
+
+    @classmethod
+    def check(cls, string: str, prefix: str) -> Self:
+        if not prefix:
+            return cls.startswith
+        for i in range(len(prefix)):
+            if i >= len(string):
+                return cls.substring_of_prefix
+            if string[i] != prefix[i]:
+                return cls.mismatch
+        return cls.startswith
+
+
+@functools.cache
+def _target_first_chars(until: Union[str, Tuple[str, ...]]) -> Tuple[str, ...]:
+    targets = (until,) if isinstance(until, str) else until
+    return tuple({t[0] for t in targets})
+
+
+@functools.cache
+def _string_cartesian_product(
+    prefix: Tuple[str, ...], suffix: Union[str, Tuple[str, ...]]
+) -> Tuple[str, ...]:
+    if isinstance(suffix, str):
+        return tuple(_ + suffix for _ in prefix)
+    else:
+        return tuple(_prefix + _suffix for _prefix in prefix for _suffix in suffix)
+
+
+class TagToolCallParser(GeneratorParser, ABC):
+    """Shared building blocks for tag-format grammars; see module docstring."""
+
+    def __init__(
+        self,
+        *,
+        compatibility: CompatibilityMode,
+        functions: Optional[Dict] = None,
+        content_field: str = "content",
+        tool_call_output_key: Callable[
+            [int, Dict], Dict
+        ] = default_tool_call_output_key,
+        gate_unknown_tools: bool = True,
+    ):
+        self._functions = functions
+        self._content_field = content_field
+        self._tool_call_output_key = tool_call_output_key
+        # Whether _drop_unknown_invoke applies. Detectors whose historical
+        # contract forwards unknown names (Qwen3-Coder) pass False.
+        self._gate_unknown_tools = gate_unknown_tools
+        super().__init__(compatibility=compatibility)
+
+    # ------------------------------------------------------------------
+    # Schema helpers
+    # ------------------------------------------------------------------
+
+    def _get_function(self, function_name: str) -> Optional[Dict]:
+        if isinstance(self._functions, dict):
+            return self._functions.get(function_name)
+
+    def _param_data_type(
+        self, function: Optional[Dict], parameter_name: str
+    ) -> FunctionCallParameterDataType:
+        return FunctionCallParameterDataType.get_schema_of_parameter(
+            function, parameter_name
+        )
+
+    # ------------------------------------------------------------------
+    # Emit helpers (deltas in the adapter contract shape)
+    # ------------------------------------------------------------------
+
+    def _emit_args(self, tool_call_index: int, fragment: str) -> None:
+        self._append_delta(
+            self._tool_call_output_key(tool_call_index, {"arguments": fragment})
+        )
+
+    def _emit_name(self, tool_call_index: int, function_name: str) -> None:
+        """Emit the function name plus the opening ``{`` of its arguments."""
+        self._append_delta(
+            self._tool_call_output_key(
+                tool_call_index, {"name": function_name, "arguments": "{"}
+            )
+        )
+
+    def _emit_call_close(self, tool_call_index: int) -> None:
+        """Close the call's argument object and commit it as one step.
+
+        Closing and committing are fused so a grammar cannot complete a call
+        without also marking its raw text as accounted for — a later
+        failure's ``uncommitted_text()`` must never re-surface a call that
+        was already delivered as tool-call deltas.
+        """
+        self._emit_args(tool_call_index, "}")
+        self._commit()
+
+    def _emit_param_key(
+        self, tool_call_index: int, parameter_name: str, is_first_parameter: bool
+    ) -> None:
+        self._emit_args(
+            tool_call_index,
+            "{}{}: ".format(
+                "" if is_first_parameter else ", ", json_dumps(parameter_name)
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Parsing helpers (generators; use with ``yield from``)
+    # ------------------------------------------------------------------
+
+    def _content_until(self, marker: str) -> Generator:
+        """Stream content up to ``marker``, then consume the marker.
+
+        Partial-marker holdback at chunk boundaries is inherent: text is only
+        emitted as content once it provably is not a prefix of ``marker``.
+
+        Content is committed as it is emitted, and once more when the marker
+        matches, so the committed offset sits exactly at the marker: if the
+        construct it opens later fails, ``uncommitted_text()`` re-surfaces
+        the whole construct including this marker.
+        """
+        self._commit()
+        yield from self._take_any(
+            until=marker,
+            key=self._content_field,
+            should_consume_suffix=False,
+            commit_each=True,
+        )
+        self._commit()
+        yield from self._literal(marker)
+
+    def _skip_garbage(
+        self,
+        *,
+        until: Union[str, Tuple[str, ...]],
+        detail: str = "",
+        consume_suffix: bool = False,
+    ) -> Generator:
+        """Compatibility scope 1: drop unparseable text up to a recognizable marker.
+
+        Records ``SKIPPED_GARBAGE`` only when non-whitespace text was actually
+        dropped (in strict mode that record raises ``CompatibilityViolation``); the
+        recorded offset points at the start of the dropped text.
+        """
+        offset = self._consumed_offset()
+        skipped = yield from self._take_any(
+            until=until, should_consume_suffix=consume_suffix
+        )
+        if skipped.strip():
+            self.compatibility.note(
+                CompatibilityEvent.SKIPPED_GARBAGE,
+                detail=f"{detail}: {skipped[:80]!r}" if detail else repr(skipped[:80]),
+                offset=offset,
+            )
+        return skipped
+
+    def _recover_invoke(self, tool_call_index: int, end_marker: str) -> Generator:
+        """Compatibility scope 1, last resort inside a call: drop the rest of it.
+
+        Consume (and drop) everything up to ``end_marker`` and close the
+        argument object so the streamed fragments stay valid JSON, hoping the
+        format recovers after this call ends. Records ``DROPPED_INVOKE_TAIL``
+        (raises in strict mode, before the synthesized close is emitted).
+        """
+        offset = self._consumed_offset()
+        dropped = yield from self._take_any(until=end_marker)
+        self.compatibility.note(
+            CompatibilityEvent.DROPPED_INVOKE_TAIL,
+            detail=repr(dropped[:80]),
+            offset=offset,
+        )
+        self._emit_call_close(tool_call_index)
+
+    def _drop_unknown_invoke(self, function_name: str, end_marker: str) -> Generator:
+        """Compatibility scope 1: gate a call to a tool absent from the request.
+
+        Runs the moment the grammar has parsed the function name — before
+        anything for the call has been emitted — so in strict mode the
+        ``note`` raises with the whole call still uncommitted and the
+        fail-open path re-surfaces its raw text exactly, independent of
+        chunking. In compatibility mode the invoke is consumed (through
+        ``end_marker``), audited as ``UNKNOWN_TOOL_DROPPED``, and committed;
+        surviving calls keep dense ordinals because the caller skips its
+        index bookkeeping entirely. Honors ``SGLANG_FORWARD_UNKNOWN_TOOLS``
+        and the detector's ``gate_unknown_tools`` contract.
+
+        Returns True when the invoke was dropped (the caller continues with
+        the next construct).
+        """
+        if (
+            not self._gate_unknown_tools
+            or self._functions is None
+            or function_name in self._functions
+            or envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+        ):
+            return False
+        self._note(
+            CompatibilityEvent.UNKNOWN_TOOL_DROPPED, detail=repr(function_name)
+        )
+        yield from self._take_any(until=end_marker)
+        self._commit()
+        return True
+
+    def _param_value(
+        self,
+        *,
+        tool_call_index: int,
+        until: Union[str, Tuple[str, ...]],
+        data_type: FunctionCallParameterDataType,
+        always_nullable: bool = False,
+        strip: Optional[str] = None,
+        should_consume_suffix: bool = True,
+    ) -> Generator:
+        """Read one parameter value and emit it as a JSON argument fragment.
+
+        With ``strip=None``, delegates to ``_take_data_type_as_json``:
+        string-typed parameters stream character by character, other types are
+        buffered until ``until`` and converted via the schema. To exclude a
+        single newline before ``until`` from the value, pass it as an
+        alternative (e.g. ``until=("\\n</parameter>", "</parameter>")``).
+
+        ``strip`` (``"one_newline"`` or ``"all"``) buffers the whole value
+        first — required when the format strips more than an ``until``
+        alternative can express.
+        """
+        if strip is None:
+            value = yield from self._take_data_type_as_json(
+                until=until,
+                key=lambda fragment: self._tool_call_output_key(
+                    tool_call_index, {"arguments": fragment}
+                ),
+                data_type=data_type,
+                always_nullable=always_nullable,
+                should_consume_suffix=should_consume_suffix,
+            )
+            return value
+
+        raw = yield from self._take_any(
+            until=until, should_consume_suffix=should_consume_suffix
+        )
+        if strip == "one_newline":
+            if raw.startswith("\n"):
+                raw = raw[1:]
+            if raw.endswith("\n"):
+                raw = raw[:-1]
+        elif strip == "all":
+            raw = raw.strip()
+        value = data_type.convert(
+            raw, always_nullable=always_nullable, compatibility=self.compatibility
+        )
+        self._emit_args(tool_call_index, json_dumps(value))
+        return value

--- a/python/sglang/srt/function_call/parsing.py
+++ b/python/sglang/srt/function_call/parsing.py
@@ -50,10 +50,10 @@ Parsers emit only ``content`` and ``tool_calls`` (reasoning is handled by
 SGLang's separate ``--reasoning-parser`` stage).
 
 Tolerances applied while parsing are recorded on the parser's
-:class:`CompatibilityMode` (injected at construction — the detector's policy, so
-all tolerances for a request share one audit trail); coroutine code cannot
-wrap ``yield`` in ``CompatibilityMode.absorb``, so the generator helpers here call
-``note()`` directly. Errors the grammar cannot absorb propagate as
+:class:`CompatibilityContext` (injected at construction so helper parsers share
+the detector's request context); coroutine code cannot wrap ``yield`` in
+``CompatibilityContext.absorb``, so the generator helpers here call ``note()``
+directly. Errors the grammar cannot absorb propagate as
 ``PatternMismatched`` to ``FunctionCallParser``, which fails open to text.
 
 TODO: accept token-level inputs (match special-token markers by token id
@@ -81,9 +81,9 @@ from typing import (
 from typing_extensions import Self
 
 from sglang.srt.environ import envs
-from sglang.srt.function_call.compatibility.mode import (
+from sglang.srt.function_call.compatibility.context import (
+    CompatibilityContext,
     CompatibilityEvent,
-    CompatibilityMode,
     CompatibilityRecord,
 )
 from sglang.srt.function_call.compatibility.param_types import (
@@ -125,7 +125,7 @@ class GeneratorParser(ABC):
     def _process(self) -> Generator[Dict[str, Any], None, None]:
         pass
 
-    def __init__(self, *, compatibility: CompatibilityMode):
+    def __init__(self, *, compatibility: CompatibilityContext):
         # The policy is required by construction so a request's tolerances
         # cannot silently fork onto a second audit trail. Must be set before
         # `_process()` starts: the grammar may consult it from its first step.
@@ -586,7 +586,7 @@ class TagToolCallParser(GeneratorParser, ABC):
     def __init__(
         self,
         *,
-        compatibility: CompatibilityMode,
+        compatibility: CompatibilityContext,
         functions: Optional[Dict] = None,
         content_field: str = "content",
         tool_call_output_key: Callable[

--- a/python/sglang/srt/function_call/poolside_v1_detector.py
+++ b/python/sglang/srt/function_call/poolside_v1_detector.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -157,8 +158,7 @@ class PoolsideV1Detector(BaseFormatDetector):
 
     _STRING_TYPES = frozenset({"string", "str", "text", "enum"})
 
-    @staticmethod
-    def _convert_param_value(raw: str, schema: dict, key: str) -> Any:
+    def _convert_param_value(self, raw: str, schema: dict, key: str) -> Any:
         """Coerce a raw arg_value string per schema; fall back to raw on failure.
 
         Decoder selection by schema type:
@@ -190,6 +190,11 @@ class PoolsideV1Detector(BaseFormatDetector):
                 return result
             except (ValueError, SyntaxError, TypeError):
                 continue
+        if param_type:
+            self.compatibility.note(
+                CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW,
+                detail=f"{key}: {raw[:80]}",
+            )
         return raw
 
     def _find_name_boundary(self, text: str) -> int:
@@ -221,7 +226,15 @@ class PoolsideV1Detector(BaseFormatDetector):
         normal_text = text[:first_idx] if first_idx > 0 else ""
 
         calls: List[ToolCallItem] = []
-        for body in self.tool_call_regex.findall(text):
+        bodies = self.tool_call_regex.findall(text)
+        if not bodies:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[first_idx : first_idx + 80],
+            )
+            return StreamingParseResult(normal_text=text)
+
+        for body in bodies:
             # _find_name_boundary searches for `\n` / `<arg_key>` /
             # `</tool_call>`, but the regex already stripped `</tool_call>`,
             # so a no-arg call without a trailing newline
@@ -229,12 +242,26 @@ class PoolsideV1Detector(BaseFormatDetector):
             # that case as "name == entire body".
             boundary = self._find_name_boundary(body)
             name = (body if boundary == -1 else body[:boundary]).strip()
-            if not name or name not in tool_indices:
+            if not name:
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=body[:80],
+                )
+                continue
+            if name not in tool_indices and self._skip_unknown_tool(name):
                 continue
 
             schema = self._get_param_schema(name, tools)
             args: dict = {}
-            for raw_key, raw_val in self.arg_pair_regex.findall(body):
+            pairs = self.arg_pair_regex.findall(body)
+            if not pairs and (
+                self.arg_key_start in body or self.arg_value_start in body
+            ):
+                self.compatibility.note(
+                    CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                    detail=body[:80],
+                )
+            for raw_key, raw_val in pairs:
                 key = raw_key.strip()
                 # Strip at most one wrapping `\n` on each side (template adds
                 # them around the value); preserve newlines that are part of
@@ -244,7 +271,7 @@ class PoolsideV1Detector(BaseFormatDetector):
 
             calls.append(
                 ToolCallItem(
-                    tool_index=tool_indices[name],
+                    tool_index=tool_indices.get(name, -1),
                     name=name,
                     parameters=json.dumps(args, ensure_ascii=False),
                 )
@@ -309,7 +336,12 @@ class PoolsideV1Detector(BaseFormatDetector):
                     consume += 1
                 self.parsed_pos += consume
 
-                if name and name in tool_indices:
+                if name:
+                    if name not in tool_indices and self._skip_unknown_tool(name):
+                        # Unknown name: drain to </tool_call> with no
+                        # client-visible emission after recording the gate.
+                        self._state = _ParseState.DRAINING
+                        continue
                     self.current_tool_id += 1
                     while len(self.streamed_args_for_tool) <= self.current_tool_id:
                         self.streamed_args_for_tool.append("")
@@ -326,8 +358,10 @@ class PoolsideV1Detector(BaseFormatDetector):
                     )
                     self._state = _ParseState.READING_KEY
                 else:
-                    # Unknown / empty name — drain to </tool_call> with no
-                    # client-visible emission.
+                    self.compatibility.note(
+                        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                        detail=slice_[:80],
+                    )
                     self._state = _ParseState.DRAINING
                 continue
 
@@ -343,13 +377,20 @@ class PoolsideV1Detector(BaseFormatDetector):
                 if slice_.startswith("<"):
                     if self._is_partial_tag(slice_):
                         break
-                    # Bare '<' that's not any known tag — discard silently
-                    # (inside a tool call, this is not normal_text).
+                    self.compatibility.note(
+                        CompatibilityEvent.SKIPPED_GARBAGE,
+                        detail="inside <tool_call>: '<'",
+                    )
                     self.parsed_pos += 1
                     continue
-                # Inter-tag whitespace / newline — discard.
                 next_lt = slice_.find("<")
-                self.parsed_pos += len(slice_) if next_lt == -1 else next_lt
+                skipped = slice_ if next_lt == -1 else slice_[:next_lt]
+                if skipped.strip():
+                    self.compatibility.note(
+                        CompatibilityEvent.SKIPPED_GARBAGE,
+                        detail=f"inside <tool_call>: {skipped[:80]!r}",
+                    )
+                self.parsed_pos += len(skipped)
                 continue
 
             if state is _ParseState.READING_VALUE:
@@ -370,6 +411,15 @@ class PoolsideV1Detector(BaseFormatDetector):
                 # Without this branch the FSM treats the second <arg_key>
                 # as bare-`<` garbage and the next <arg_value> binds to
                 # the stale K1 — wrong-argument corruption.
+                if slice_.startswith(self.tool_call_end_token):
+                    self.compatibility.note(
+                        CompatibilityEvent.MISSING_CLOSE_TAG,
+                        detail=(
+                            self.current_pending_key or self.current_func_name or ""
+                        )[:80],
+                    )
+                    self._close_current_call(calls)
+                    continue
                 if slice_.startswith(self.arg_key_start):
                     if not self._consume_arg_key(slice_):
                         break  # incomplete <arg_key>
@@ -377,6 +427,48 @@ class PoolsideV1Detector(BaseFormatDetector):
                 if slice_.startswith(self.arg_value_start):
                     end = slice_.find(self.arg_value_end)
                     if end == -1:
+                        close = slice_.find(
+                            self.tool_call_end_token, len(self.arg_value_start)
+                        )
+                        if close != -1:
+                            raw = (
+                                slice_[len(self.arg_value_start) : close]
+                                .removeprefix("\n")
+                                .removesuffix("\n")
+                            )
+                            self.compatibility.note(
+                                CompatibilityEvent.MISSING_CLOSE_TAG,
+                                detail=(
+                                    self.current_pending_key
+                                    or self.current_func_name
+                                    or ""
+                                )[:80],
+                            )
+                            schema = self._get_param_schema(
+                                self.current_func_name, tools
+                            )
+                            converted = self._convert_param_value(
+                                raw, schema, self.current_pending_key
+                            )
+                            kv = (
+                                f"{json.dumps(self.current_pending_key)}: "
+                                f"{json.dumps(converted, ensure_ascii=False)}"
+                            )
+                            fragment = "{" + kv if not self.json_started else ", " + kv
+                            self.json_started = True
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    parameters=fragment,
+                                )
+                            )
+                            self.streamed_args_for_tool[
+                                self.current_tool_id
+                            ] += fragment
+                            self.current_pending_key = None
+                            self.parsed_pos += close
+                            self._close_current_call(calls)
+                            continue
                         break  # incomplete <arg_value> — no partial emission
                     raw = (
                         slice_[len(self.arg_value_start) : end]
@@ -410,10 +502,20 @@ class PoolsideV1Detector(BaseFormatDetector):
                 if slice_.startswith("<"):
                     if self._is_partial_tag(slice_):
                         break
+                    self.compatibility.note(
+                        CompatibilityEvent.SKIPPED_GARBAGE,
+                        detail="inside <arg_value>: '<'",
+                    )
                     self.parsed_pos += 1
                     continue
                 next_lt = slice_.find("<")
-                self.parsed_pos += len(slice_) if next_lt == -1 else next_lt
+                skipped = slice_ if next_lt == -1 else slice_[:next_lt]
+                if skipped.strip():
+                    self.compatibility.note(
+                        CompatibilityEvent.SKIPPED_GARBAGE,
+                        detail=f"inside <arg_value>: {skipped[:80]!r}",
+                    )
+                self.parsed_pos += len(skipped)
                 continue
 
             if state is _ParseState.DRAINING:

--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -75,7 +75,9 @@ class PythonicDetector(BaseFormatDetector):
         # recorded on self.compatibility; unexpected failures bubble to
         # FunctionCallParser, which fails open to text (see the ``compatibility`` package).
         with self.compatibility.absorb(
-            CompatibilityEvent.MALFORMED_JSON_DROPPED, SyntaxError, detail=tool_call_text[:80]
+            CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            SyntaxError,
+            detail=tool_call_text[:80],
         ) as absorbed:
             module = ast.parse(tool_call_text)
         if absorbed.fired:

--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -5,8 +5,8 @@ import re
 from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     ToolCallItem,
@@ -71,44 +71,57 @@ class PythonicDetector(BaseFormatDetector):
         # Combine normal text
         normal_text = normal_text_before + normal_text_after
 
-        try:
+        # Expected deviations are absorbed per block / per call below and
+        # recorded on self.compatibility; unexpected failures bubble to
+        # FunctionCallParser, which fails open to text (see the ``compatibility`` package).
+        with self.compatibility.absorb(
+            CompatibilityEvent.MALFORMED_JSON_DROPPED, SyntaxError, detail=tool_call_text[:80]
+        ) as absorbed:
             module = ast.parse(tool_call_text)
-            parsed = getattr(module.body[0], "value", None)
-            if not (
-                isinstance(parsed, ast.List)
-                and all(isinstance(e, ast.Call) for e in parsed.elts)
-            ):
-                return StreamingParseResult(normal_text=normal_text, calls=[])
-
-            calls = []
-            tool_indices = self._get_tool_indices(tools)
-            for call_index, call in enumerate(parsed.elts):
-                if not isinstance(call.func, ast.Name):
-                    continue
-                function_name = call.func.id
-                # Validate that the function exists in the tools
-                if function_name not in tool_indices:
-                    logger.warning(
-                        f"Model attempted to call undefined function: {function_name}"
-                    )
-                    if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
-                        continue  # Skip unknown tools (default legacy behavior)
-
-                arguments = {}
-                for keyword in call.keywords:
-                    arguments[keyword.arg] = self._get_parameter_value(keyword.value)
-                calls.append(
-                    ToolCallItem(
-                        tool_index=call_index,  # Use the call index in the response, not tool position
-                        name=function_name,
-                        parameters=json.dumps(arguments, ensure_ascii=False),
-                    )
-                )
-
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception:
-            logger.exception("Error in pythonic tool call parsing.")
+        if absorbed.fired:
+            # Looked like a pythonic call list but does not parse: surface
+            # the block as normal text rather than dropping it.
+            return StreamingParseResult(normal_text=text, calls=[])
+        parsed = getattr(module.body[0], "value", None)
+        if not (
+            isinstance(parsed, ast.List)
+            and all(isinstance(e, ast.Call) for e in parsed.elts)
+        ):
             return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        calls = []
+        tool_indices = self._get_tool_indices(tools)
+        for call_index, call in enumerate(parsed.elts):
+            if not isinstance(call.func, ast.Name):
+                continue
+            function_name = call.func.id
+            # Validate that the function exists in the tools
+            if function_name not in tool_indices and self._skip_unknown_tool(
+                function_name
+            ):
+                continue
+
+            # Non-literal arguments: drop this call, keep the others.
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                ValueError,
+                detail=f"{function_name}: non-literal arguments",
+            ) as absorbed:
+                arguments = {
+                    keyword.arg: self._get_parameter_value(keyword.value)
+                    for keyword in call.keywords
+                }
+            if absorbed.fired:
+                continue
+            calls.append(
+                ToolCallItem(
+                    tool_index=call_index,  # Use the call index in the response, not tool position
+                    name=function_name,
+                    parameters=json.dumps(arguments, ensure_ascii=False),
+                )
+            )
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def _find_matching_bracket(self, buffer: str, start: int) -> int:
         """

--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -89,6 +89,10 @@ class PythonicDetector(BaseFormatDetector):
             isinstance(parsed, ast.List)
             and all(isinstance(e, ast.Call) for e in parsed.elts)
         ):
+            self.compatibility.note(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                detail=tool_call_text[:80],
+            )
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
         calls = []
@@ -223,10 +227,12 @@ class PythonicDetector(BaseFormatDetector):
         if isinstance(val, ast.Constant):
             return val.value
         elif isinstance(val, ast.Dict):
-            return {
-                k.value: self._get_parameter_value(v)
-                for k, v in zip(val.keys, val.values)
-            }
+            result = {}
+            for k, v in zip(val.keys, val.values):
+                if not isinstance(k, ast.Constant):
+                    raise ValueError("Tool call dict keys must be literals")
+                result[k.value] = self._get_parameter_value(v)
+            return result
         elif isinstance(val, ast.List):
             return [self._get_parameter_value(v) for v in val.elts]
         else:

--- a/python/sglang/srt/function_call/qwen25_detector.py
+++ b/python/sglang/srt/function_call/qwen25_detector.py
@@ -5,6 +5,7 @@ from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     StructureInfo,
@@ -62,14 +63,13 @@ class Qwen25Detector(BaseFormatDetector):
         match_result_list = re.findall(pattern, text, re.DOTALL)
         calls = []
         for match_result in match_result_list:
-            try:
-                parsed_call = json.loads(match_result.strip())
-                calls.extend(self.parse_base_json(parsed_call, tools))
-            except json.JSONDecodeError as e:
-                logger.warning(
-                    f"Failed to parse JSON part: {match_result}, JSON parse error: {str(e)}"
-                )
-                continue
+            block = match_result.strip()
+            with self.compatibility.absorb(
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                json.JSONDecodeError,
+                detail=block[:80],
+            ):
+                calls.extend(self.parse_base_json(json.loads(block), tools))
         return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def parse_streaming_increment(

--- a/python/sglang/srt/function_call/qwen25_detector.py
+++ b/python/sglang/srt/function_call/qwen25_detector.py
@@ -59,18 +59,34 @@ class Qwen25Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
         # Find all <tool_call>\n...\n</tool_call> blocks
-        pattern = rf"{re.escape(self.bot_token)}(.*?){re.escape(self.eot_token)}"
-        match_result_list = re.findall(pattern, text, re.DOTALL)
+        pattern = re.compile(
+            rf"{re.escape(self.bot_token)}(.*?){re.escape(self.eot_token)}",
+            re.DOTALL,
+        )
+        match_result_list = list(pattern.finditer(text))
+        if not match_result_list:
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=text[idx : idx + 80],
+            )
+            return StreamingParseResult(normal_text=text, calls=[])
         calls = []
+        normal_parts = []
+        cursor = 0
         for match_result in match_result_list:
-            block = match_result.strip()
+            normal_parts.append(text[cursor : match_result.start()])
+            block = match_result.group(1).strip()
             with self.compatibility.absorb(
                 CompatibilityEvent.MALFORMED_JSON_DROPPED,
                 json.JSONDecodeError,
                 detail=block[:80],
             ):
                 calls.extend(self.parse_base_json(json.loads(block), tools))
-        return StreamingParseResult(normal_text=normal_text, calls=calls)
+            cursor = match_result.end()
+        normal_parts.append(text[cursor:])
+        return StreamingParseResult(
+            normal_text="".join(normal_parts).strip(), calls=calls
+        )
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -19,7 +19,7 @@ Tolerances (recorded on the detector compatibility policy, see the compatibility
 the historical parser): one newline on each side of
 a parameter value is structural and stripped; a parameter value may also be
 terminated by the next ``<parameter=`` or by ``</function>`` when the model
-omits ``</parameter>``; unparseable text inside a block is skipped up to the
+omits ``</parameter>``; unparsable text inside a block is skipped up to the
 next recognizable tag; ``null`` becomes JSON null for any parameter type;
 values are converted via the tool's JSON schema.
 """
@@ -110,6 +110,7 @@ class Qwen3CoderTextParser(TagToolCallParser):
                 consume_suffix=True,
             )
             tool_call_index += 1
+
 
 class Qwen3CoderDetector(TagToolCallDetector):
     """Detector for Qwen3-Coder models; the wire format is documented above.

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -1,25 +1,126 @@
-import ast
+"""Parser and detector for the Qwen3-Coder tool-call wire format.
+
+Example raw output::
+
+    Some content.
+    <tool_call>
+    <function=get_weather>
+    <parameter=city>
+    Beijing
+    </parameter>
+    <parameter=count>3</parameter>
+    </function>
+    </tool_call>
+
+One function per ``<tool_call>`` block; multiple blocks per message; text
+before, between, and after blocks is normal content.
+
+Tolerances (recorded on the detector compatibility policy, see the compatibility package; matching
+the historical parser): one newline on each side of
+a parameter value is structural and stripped; a parameter value may also be
+terminated by the next ``<parameter=`` or by ``</function>`` when the model
+omits ``</parameter>``; unparseable text inside a block is skipped up to the
+next recognizable tag; ``null`` becomes JSON null for any parameter type;
+values are converted via the tool's JSON schema.
+"""
+
 import json
-import logging
-import re
-from typing import Any, List, Optional
+from typing import Dict, Generator, Optional
 
-from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.core_types import (
-    StreamingParseResult,
-    ToolCallItem,
-    _GetInfoFunc,
-)
-
-logger = logging.getLogger(__name__)
+from sglang.srt.function_call.compatibility import CompatibilityEvent, CompatibilityMode
+from sglang.srt.function_call.core_types import ToolCallItem, _GetInfoFunc
+from sglang.srt.function_call.parsing import TagToolCallParser
+from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
 
 
-class Qwen3CoderDetector(BaseFormatDetector):
+class Qwen3CoderTextParser(TagToolCallParser):
+    BLOCK_OPEN = "<tool_call>"
+    BLOCK_CLOSE = "</tool_call>"
+    FUNC_PREFIX = "<function="
+    FUNC_END = "</function>"
+    PARAM_PREFIX = "<parameter="
+    PARAM_END = "</parameter>"
+
+    def _process(self) -> Generator:
+        tool_call_index = 0
+        while True:
+            # Content before / between / after blocks.
+            yield from self._content_until(self.BLOCK_OPEN)
+            yield from self._whitespace()
+            tried = yield from self._literal(self.FUNC_PREFIX, should_raise=False)
+            if tried is None:
+                # No function tag where expected: drop the block body.
+                yield from self._skip_garbage(
+                    until=self.BLOCK_CLOSE,
+                    detail="<tool_call> block without <function=>",
+                    consume_suffix=True,
+                )
+                continue
+
+            function_name = yield from self._take_any(until=">")
+            self._emit_name(tool_call_index, function_name)
+            function = self._get_function(function_name)
+
+            is_first_parameter = True
+            while True:
+                yield from self._whitespace()
+                tried = yield from self._literal(
+                    (self.FUNC_END, self.PARAM_PREFIX),
+                    should_raise=False,
+                )
+                if tried == self.FUNC_END:
+                    self._emit_call_close(tool_call_index)
+                    break
+                if tried is None:
+                    yield from self._skip_garbage(
+                        until=(self.PARAM_PREFIX, self.FUNC_END),
+                        detail="inside <function=>",
+                    )
+                    continue
+
+                parameter_name = yield from self._take_any(until=">")
+                self._emit_param_key(
+                    tool_call_index, parameter_name, is_first_parameter
+                )
+                data_type = self._param_data_type(function, parameter_name)
+                # The value normally ends at </parameter>; tolerate a missing
+                # close tag by also stopping at the next parameter or the end
+                # of the function, consuming only the real terminator.
+                yield from self._param_value(
+                    tool_call_index=tool_call_index,
+                    until=(self.PARAM_END, self.PARAM_PREFIX, self.FUNC_END),
+                    data_type=data_type,
+                    always_nullable=True,
+                    strip="one_newline",
+                    should_consume_suffix=False,
+                )
+                tried = yield from self._literal(self.PARAM_END, should_raise=False)
+                if tried is None:
+                    self._note(
+                        CompatibilityEvent.MISSING_CLOSE_TAG,
+                        detail=f"parameter {parameter_name[:40]!r}",
+                    )
+                is_first_parameter = False
+
+            yield from self._whitespace()
+            # Tolerate stray text between </function> and </tool_call>.
+            yield from self._skip_garbage(
+                until=self.BLOCK_CLOSE,
+                detail="between </function> and </tool_call>",
+                consume_suffix=True,
+            )
+            tool_call_index += 1
+
+class Qwen3CoderDetector(TagToolCallDetector):
+    """Detector for Qwen3-Coder models; the wire format is documented above.
+
+    Parsing is implemented by ``Qwen3CoderTextParser``; streaming bookkeeping
+    comes from ``TagToolCallDetector`` and error recovery from the package
+    compatibility mode (the ``compatibility`` package).
+    """
+
     def __init__(self):
         super().__init__()
-
-        # Sentinel tokens
         self.tool_call_start_token: str = "<tool_call>"
         self.tool_call_end_token: str = "</tool_call>"
         self.tool_call_prefix: str = "<function="
@@ -27,451 +128,37 @@ class Qwen3CoderDetector(BaseFormatDetector):
         self.parameter_prefix: str = "<parameter="
         self.parameter_end_token: str = "</parameter>"
 
-        # Regex for non-streaming fallback
-        self.tool_call_regex = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
-        self.tool_call_function_regex = re.compile(
-            r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL
-        )
-        self.tool_call_parameter_regex = re.compile(
-            r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
-            re.DOTALL,
-        )
-
-        # Streaming State
-        # Base class already initializes _buffer, we just use it directly
-        # No need to check with hasattr - we control the lifecycle through inheritance
-
-        # Index pointing to the next character to be processed in buffer
-        self.parsed_pos: int = 0
-        # Parameter count inside the current tool being processed, used to determine whether to add comma
-        self.current_tool_param_count: int = 0
-        # Flag indicating whether current tool has already sent '{'
-        self.json_started: bool = False
-
-        # [FIX] New state flag: mark whether inside tool_call structure block
-        self.is_inside_tool_call: bool = False
-
-        # Initialize attributes that were missing in the original PR
-        self.current_func_name: Optional[str] = None
-
     def has_tool_call(self, text: str) -> bool:
         return self.tool_call_start_token in text
 
-    def _get_arguments_config(
-        self, func_name: str, tools: Optional[list[Tool]]
-    ) -> dict:
-        """Extract argument configuration for a function."""
-        if tools is None:
-            return {}
-        for config in tools:
-            try:
-                config_type = config.type
-                config_function = config.function
-                config_function_name = config_function.name
-            except AttributeError:
-                continue
-
-            if config_type == "function" and config_function_name == func_name:
-                try:
-                    params = config_function.parameters
-                except AttributeError:
-                    return {}
-
-                if isinstance(params, dict) and "properties" in params:
-                    return params["properties"]
-                elif isinstance(params, dict):
-                    return params
-                else:
-                    return {}
-        logger.warning(f"Tool '{func_name}' is not defined in the tools list.")
-        return {}
-
-    def _convert_param_value(
-        self, param_value: str, param_name: str, param_config: dict, func_name: str
-    ) -> Any:
-        """Convert parameter value based on its type in the schema."""
-        # Handle null value for any type
-        if param_value.lower() == "null":
-            return None
-
-        if param_name not in param_config:
-            if param_config != {}:
-                logger.warning(
-                    f"Parsed parameter '{param_name}' is not defined in the tool "
-                    f"parameters for tool '{func_name}', directly returning the string value."
-                )
-            return param_value
-
-        if (
-            isinstance(param_config[param_name], dict)
-            and "type" in param_config[param_name]
-        ):
-            param_type = str(param_config[param_name]["type"]).strip().lower()
-        else:
-            param_type = "string"
-        if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
-            return param_value
-        elif (
-            param_type.startswith("int")
-            or param_type.startswith("uint")
-            or param_type.startswith("long")
-            or param_type.startswith("short")
-            or param_type.startswith("unsigned")
-        ):
-            try:
-                param_value = int(param_value)
-            except Exception:
-                logger.warning(
-                    f"Parsed value '{param_value}' of parameter '{param_name}' is not an integer in tool "
-                    f"'{func_name}', degenerating to string."
-                )
-            return param_value
-        elif param_type.startswith("num") or param_type.startswith("float"):
-            try:
-                maybe_convert = (
-                    False if "." in param_value or "e" in param_value.lower() else True
-                )
-                param_value: float = float(param_value)
-                if maybe_convert and param_value.is_integer():
-                    param_value = int(param_value)
-            except Exception:
-                logger.warning(
-                    f"Parsed value '{param_value}' of parameter '{param_name}' is not a float in tool "
-                    f"'{func_name}', degenerating to string."
-                )
-            return param_value
-        elif param_type in ["boolean", "bool", "binary"]:
-            param_value = param_value.lower()
-            if param_value not in ["true", "false"]:
-                logger.warning(
-                    f"Parsed value '{param_value}' of parameter '{param_name}' is not a boolean (`true` of `false`) in tool '{func_name}', degenerating to false."
-                )
-            return param_value == "true"
-        else:
-            if (
-                param_type in ["object", "array", "arr"]
-                or param_type.startswith("dict")
-                or param_type.startswith("list")
-            ):
-                try:
-                    param_value = json.loads(param_value)
-                    return param_value
-                except Exception:
-                    logger.warning(
-                        f"Parsed value '{param_value}' of parameter '{param_name}' cannot be parsed with json.loads in tool "
-                        f"'{func_name}', will try other methods to parse it."
-                    )
-            try:
-                param_value = ast.literal_eval(param_value)  # safer
-            except Exception:
-                logger.warning(
-                    f"Parsed value '{param_value}' of parameter '{param_name}' cannot be converted via Python `ast.literal_eval()` in tool '{func_name}', degenerating to string."
-                )
-            return param_value
-
-    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
-        """One-shot parsing for non-streaming scenarios."""
-        if self.tool_call_start_token not in text:
-            return StreamingParseResult(normal_text=text)
-
-        calls = []
-        try:
-            # Simple cleanup of the text to find tool calls
-            # Note: This is a simplified regex approach consistent with vLLM
-            raw_tool_calls = self.tool_call_regex.findall(text)
-            if not raw_tool_calls:
-                # Fallback: maybe the whole text is inside the tag or tags are stripped
-                if self.tool_call_prefix in text:
-                    raw_tool_calls = [text]
-
-            tool_idx = 0
-            for tool_content in raw_tool_calls:
-                # Find function calls
-                funcs = self.tool_call_function_regex.findall(tool_content)
-                for func_match in funcs:
-                    func_body = func_match[0] or func_match[1]
-                    if ">" not in func_body:
-                        continue
-
-                    name_end = func_body.index(">")
-                    func_name = func_body[:name_end]
-                    params_str = func_body[name_end + 1 :]
-
-                    param_config = self._get_arguments_config(func_name, tools)
-                    parsed_params = {}
-
-                    for p_match in self.tool_call_parameter_regex.findall(params_str):
-                        if ">" not in p_match:
-                            continue
-                        p_idx = p_match.index(">")
-                        p_name = p_match[:p_idx]
-                        p_val = p_match[p_idx + 1 :]
-                        # Remove prefixing and trailing \n
-                        if p_val.startswith("\n"):
-                            p_val = p_val[1:]
-                        if p_val.endswith("\n"):
-                            p_val = p_val[:-1]
-
-                        parsed_params[p_name] = self._convert_param_value(
-                            p_val, p_name, param_config, func_name
-                        )
-
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=tool_idx,
-                            name=func_name,
-                            parameters=json.dumps(parsed_params, ensure_ascii=False),
-                        )
-                    )
-                    tool_idx += 1
-
-            # Determine normal text (text before the first tool call)
-            start_idx = text.find(self.tool_call_start_token)
-            if start_idx == -1:
-                start_idx = text.find(self.tool_call_prefix)
-            normal_text = text[:start_idx] if start_idx > 0 else ""
-
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            return StreamingParseResult(normal_text=text)
-
-    def parse_streaming_increment(
-        self, new_text: str, tools: List[Tool]
-    ) -> StreamingParseResult:
-        """
-        Robust cursor-based streaming parser.
-        """
-        self._buffer += new_text
-
-        # Guard against empty buffer
-        if not self._buffer:
-            return StreamingParseResult()
-
-        calls = []
-        normal_text_chunks = []
-
-        while True:
-            # Working text slice
-            current_slice = self._buffer[self.parsed_pos :]
-
-            # Optimization: If almost empty, wait for more
-            if not current_slice:
-                break
-
-            # -------------------------------------------------------
-            # 1. Priority detection: check if it's the start of Tool Call
-            # -------------------------------------------------------
-            if current_slice.startswith(self.tool_call_start_token):
-                self.parsed_pos += len(self.tool_call_start_token)
-                self.is_inside_tool_call = True
-                continue
-
-            # -------------------------------------------------------
-            # 2. Function Name: <function=name>
-            # -------------------------------------------------------
-            if current_slice.startswith(self.tool_call_prefix):
-                end_angle = current_slice.find(">")
-                if end_angle != -1:
-                    func_name = current_slice[len(self.tool_call_prefix) : end_angle]
-
-                    self.current_tool_id += 1
-                    self.current_tool_name_sent = True
-                    self.current_tool_param_count = 0
-                    self.json_started = False
-                    self.current_func_name = func_name
-
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            name=func_name,
-                            parameters="",
-                        )
-                    )
-
-                    self.parsed_pos += end_angle + 1
-                    continue
-                else:
-                    # Incomplete tag
-                    break
-
-            # -------------------------------------------------------
-            # 3. Parameter: <parameter=name>value...
-            # -------------------------------------------------------
-            if current_slice.startswith(self.parameter_prefix):
-                name_end = current_slice.find(">")
-                if name_end != -1:
-                    value_start_idx = name_end + 1
-                    rest_of_slice = current_slice[value_start_idx:]
-
-                    # A parameter can end in multiple ways:
-                    # 1. [Normal] Encounter </parameter>
-                    # 2. [Abnormal] Encounter next <parameter=
-                    # 3. [Abnormal] Encounter </function>
-                    # So we need to find the smallest one as the parameter end position.
-                    cand_end_param = rest_of_slice.find(self.parameter_end_token)
-                    cand_next_param = rest_of_slice.find(self.parameter_prefix)
-                    cand_end_func = rest_of_slice.find(self.function_end_token)
-
-                    candidates = []
-                    if cand_end_param != -1:
-                        candidates.append(
-                            (cand_end_param, len(self.parameter_end_token))
-                        )
-                    if cand_next_param != -1:
-                        candidates.append((cand_next_param, 0))
-                    if cand_end_func != -1:
-                        candidates.append((cand_end_func, 0))
-
-                    if candidates:
-                        best_cand = min(candidates, key=lambda x: x[0])
-                        end_pos = best_cand[0]
-                        end_token_len = best_cand[1]
-
-                        param_name = current_slice[
-                            len(self.parameter_prefix) : name_end
-                        ]
-                        raw_value = rest_of_slice[:end_pos]
-
-                        # Cleanup value
-                        if raw_value.startswith("\n"):
-                            raw_value = raw_value[1:]
-                        if raw_value.endswith("\n"):
-                            raw_value = raw_value[:-1]
-
-                        # JSON Construction
-                        if not self.json_started:
-                            calls.append(
-                                ToolCallItem(
-                                    tool_index=self.current_tool_id, parameters="{"
-                                )
-                            )
-                            self.json_started = True
-
-                        param_config = self._get_arguments_config(
-                            self.current_func_name, tools
-                        )
-                        converted_val = self._convert_param_value(
-                            raw_value, param_name, param_config, self.current_func_name
-                        )
-
-                        # Construct JSON fragment: "key": value
-                        # Note: We must be careful with json.dumps to ensure valid JSON streaming
-                        json_key_val = f"{json.dumps(param_name)}: {json.dumps(converted_val, ensure_ascii=False)}"
-
-                        if self.current_tool_param_count > 0:
-                            fragment = f", {json_key_val}"
-                        else:
-                            fragment = json_key_val
-
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id, parameters=fragment
-                            )
-                        )
-                        self.current_tool_param_count += 1
-
-                        # Advance cursor
-                        total_len = (name_end + 1) + end_pos + end_token_len
-                        self.parsed_pos += total_len
-                        continue
-
-                # Incomplete parameter tag or value
-                break
-
-            # -------------------------------------------------------
-            # 4. Function End: </function>
-            # -------------------------------------------------------
-            if current_slice.startswith(self.function_end_token):
-                if not self.json_started:
-                    calls.append(
-                        ToolCallItem(tool_index=self.current_tool_id, parameters="{")
-                    )
-                    self.json_started = True
-
-                calls.append(
-                    ToolCallItem(tool_index=self.current_tool_id, parameters="}")
-                )
-                self.parsed_pos += len(self.function_end_token)
-                self.current_func_name = None
-                continue
-
-            # -------------------------------------------------------
-            # 5. Tool Call End: </tool_call>
-            # -------------------------------------------------------
-            if current_slice.startswith(self.tool_call_end_token):
-                self.parsed_pos += len(self.tool_call_end_token)
-                self.is_inside_tool_call = False  # [FIX] Exit tool call region
-                continue
-
-            # -------------------------------------------------------
-            # 6. Handling content / whitespace / normal text
-            # -------------------------------------------------------
-            # If current position is not the start of a tag (i.e., doesn't start with <), it might be plain text,
-            # or a newline between two tags.
-            # But we need to be careful not to output truncated tags like "<fun" as text.
-
-            next_open_angle = current_slice.find("<")
-
-            if next_open_angle == -1:
-                # This entire segment is plain text
-                if not self.is_inside_tool_call:
-                    normal_text_chunks.append(current_slice)
-                # [FIX] If inside tool call, discard this text (usually \n), don't append
-                self.parsed_pos += len(current_slice)
-                continue
-
-            elif next_open_angle == 0:
-                # Looks like a Tag, but doesn't match any known Tag above
-
-                possible_tags = [
-                    self.tool_call_start_token,
-                    self.tool_call_end_token,
-                    self.tool_call_prefix,
-                    self.function_end_token,
-                    self.parameter_prefix,
-                    self.parameter_end_token,
-                ]
-
-                is_potential_tag = False
-                for tag in possible_tags:
-                    if tag.startswith(current_slice):
-                        is_potential_tag = True
-                        break
-
-                if is_potential_tag:
-                    break  # Wait for more
-                else:
-                    # Just a plain '<' symbol
-                    if not self.is_inside_tool_call:
-                        normal_text_chunks.append("<")
-                    self.parsed_pos += 1
-                    continue
-
-            else:
-                # '<' is in the middle
-                text_segment = current_slice[:next_open_angle]
-                if not self.is_inside_tool_call:
-                    normal_text_chunks.append(text_segment)
-                # [FIX] If inside tool call, discard whitespace/text before Tag
-                self.parsed_pos += next_open_angle
-                continue
-
-        # Memory Cleanup: Slice the buffer
-        # Keep unparsed part, discard parsed part
-        if self.parsed_pos > 0:
-            self._buffer = self._buffer[self.parsed_pos :]
-            self.parsed_pos = 0
-
-        normal_text = "".join(normal_text_chunks) if normal_text_chunks else ""
-        return StreamingParseResult(calls=calls, normal_text=normal_text)
+    def _make_grammar(
+        self, functions: Optional[Dict], compatibility: CompatibilityMode
+    ) -> Qwen3CoderTextParser:
+        # Historical Qwen3-Coder behavior: unknown tool names are forwarded,
+        # not gated (mirrors _nonstream_call_items below).
+        return Qwen3CoderTextParser(
+            functions=functions,
+            compatibility=compatibility,
+            gate_unknown_tools=False,
+        )
 
     def supports_structural_tag(self) -> bool:
         return True
 
     def structure_info(self) -> _GetInfoFunc:
         raise NotImplementedError
+
+    def _nonstream_call_items(self, name, args_dict, index, tools):
+        # Historical Qwen3-Coder behavior: non-streaming tool_index is the
+        # call ordinal and unknown tool names are forwarded rather than
+        # filtered through parse_base_json.
+        return [
+            ToolCallItem(
+                tool_index=index,
+                name=name,
+                parameters=json.dumps(args_dict, ensure_ascii=False),
+            )
+        ]
 
     def get_structural_tag_name(self) -> str:
         return "qwen_3_coder"

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -27,7 +27,10 @@ values are converted via the tool's JSON schema.
 import json
 from typing import Dict, Generator, Optional
 
-from sglang.srt.function_call.compatibility import CompatibilityEvent, CompatibilityMode
+from sglang.srt.function_call.compatibility import (
+    CompatibilityContext,
+    CompatibilityEvent,
+)
 from sglang.srt.function_call.core_types import ToolCallItem, _GetInfoFunc
 from sglang.srt.function_call.parsing import TagToolCallParser
 from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
@@ -133,7 +136,7 @@ class Qwen3CoderDetector(TagToolCallDetector):
         return self.tool_call_start_token in text
 
     def _make_grammar(
-        self, functions: Optional[Dict], compatibility: CompatibilityMode
+        self, functions: Optional[Dict], compatibility: CompatibilityContext
     ) -> Qwen3CoderTextParser:
         # Historical Qwen3-Coder behavior: unknown tool names are forwarded,
         # not gated (mirrors _nonstream_call_items below).

--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -1,61 +1,148 @@
-import ast
-import json
-import logging
-import re
-from typing import Any, Dict, List
+"""Parser and detector for the Step3 tool-call wire format.
 
-from sglang.srt.entrypoints.openai.protocol import Tool
-from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.core_types import (
-    StreamingParseResult,
-    ToolCallItem,
-    _GetInfoFunc,
-)
+Example raw output (the ``｜`` bars are U+FF5C FULLWIDTH VERTICAL LINE)::
 
-logger = logging.getLogger(__name__)
-
-
-def get_argument_type(func_name: str, arg_key: str, defined_tools: List[Tool]) -> str:
-    """Get the expected type for a function argument from tool schema."""
-    name2tool = {tool.function.name: tool for tool in defined_tools}
-    if func_name not in name2tool:
-        return None
-    tool = name2tool[func_name]
-    parameters = tool.function.parameters or {}
-    properties = parameters.get("properties", {})
-    if arg_key not in properties:
-        return None
-    return properties[arg_key].get("type", None)
-
-
-def parse_arguments(value: str) -> tuple[Any, bool]:
-    """Parse a string value to appropriate type. Returns (parsed_value, success)."""
-    try:
-        try:
-            parsed_value = json.loads(value)
-        except:
-            parsed_value = ast.literal_eval(value)
-        return parsed_value, True
-    except:
-        return value, False
-
-
-class Step3Detector(BaseFormatDetector):
-    """
-    Detector for Step3 model function call format.
-
-    The Step3 format uses special Unicode tokens to delimit function calls
-    with steptml XML format for invocations.
-
-    Format Structure:
-    ```
+    Some content.
     <｜tool_calls_begin｜>
-    <｜tool_call_begin｜>function<｜tool_sep｜><steptml:invoke name="function_name">
-    <steptml:parameter name="param1">value1</steptml:parameter>
-    <steptml:parameter name="param2">value2</steptml:parameter>
+    <｜tool_call_begin｜>function<｜tool_sep｜><steptml:invoke name="get_weather">
+    <steptml:parameter name="city">Shanghai</steptml:parameter>
+    <steptml:parameter name="count">5</steptml:parameter>
     </steptml:invoke><｜tool_call_end｜>
     <｜tool_calls_end｜>
-    ```
+    More content.
+
+One ``<｜tool_calls_begin｜>`` block per message; multiple
+``<｜tool_call_begin｜>…<｜tool_call_end｜>`` entries inside it. Everything
+after ``<｜tool_calls_end｜>`` is normal content.
+
+Tolerances (recorded on the detector compatibility policy, see the compatibility package): entries whose type part is not ``function`` are skipped
+per-call (historical behavior); unparseable text between tags is skipped up to
+the next recognizable tag; parameter values are whitespace-stripped and
+converted via the tool's JSON schema; ``null`` becomes JSON null for any
+parameter type.
+"""
+
+from typing import Dict, Generator, Optional
+
+from sglang.srt.function_call.compatibility import CompatibilityEvent, CompatibilityMode
+from sglang.srt.function_call.core_types import _GetInfoFunc
+from sglang.srt.function_call.parsing import TagToolCallParser
+from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
+
+
+class Step3TextParser(TagToolCallParser):
+    BOT = "<｜tool_calls_begin｜>"
+    EOT = "<｜tool_calls_end｜>"
+    CALL_BEGIN = "<｜tool_call_begin｜>"
+    CALL_END = "<｜tool_call_end｜>"
+    TOOL_SEP = "<｜tool_sep｜>"
+    INVOKE_PREFIX = '<steptml:invoke name="'
+    INVOKE_SUFFIX = '">'
+    INVOKE_END = "</steptml:invoke>"
+    PARAM_PREFIX = '<steptml:parameter name="'
+    PARAM_NAME_SUFFIX = '">'
+    PARAM_END = "</steptml:parameter>"
+
+    def _process(self) -> Generator:
+        yield from self._content_until(self.BOT)
+
+        tool_call_index = 0
+        while True:
+            yield from self._whitespace()
+            tried = yield from self._literal(
+                (self.CALL_BEGIN, self.EOT), should_raise=False
+            )
+            if tried is None:
+                # Unparseable text between calls: skip to the next call or
+                # to the end of the block.
+                yield from self._skip_garbage(
+                    until=(self.CALL_BEGIN, self.EOT),
+                    detail="between tool-call entries",
+                )
+                continue
+            if tried == self.EOT:
+                break
+
+            type_part = yield from self._take_any(until=self.TOOL_SEP)
+            if type_part.strip() != "function":
+                # Historical behavior: skip non-function entries per-call.
+                self._note(
+                    CompatibilityEvent.SKIPPED_NON_FUNCTION_ENTRY,
+                    detail=f"type {type_part.strip()[:40]!r}",
+                )
+                yield from self._take_any(until=self.CALL_END)
+                continue
+
+            tried = yield from self._literal(self.INVOKE_PREFIX, should_raise=False)
+            if tried is None:
+                yield from self._skip_garbage(
+                    until=self.CALL_END,
+                    detail="function entry without <steptml:invoke>",
+                    consume_suffix=True,
+                )
+                continue
+
+            function_name = yield from self._take_any(until=self.INVOKE_SUFFIX)
+            dropped = yield from self._drop_unknown_invoke(
+                function_name, self.CALL_END
+            )
+            if dropped:
+                continue
+            self._emit_name(tool_call_index, function_name)
+            function = self._get_function(function_name)
+
+            is_first_parameter = True
+            while True:
+                yield from self._whitespace()
+                tried = yield from self._literal(
+                    (self.INVOKE_END, self.PARAM_PREFIX),
+                    should_raise=False,
+                )
+                if tried == self.INVOKE_END:
+                    self._emit_call_close(tool_call_index)
+                    # Anything between </steptml:invoke> and the call end
+                    # marker is dropped (the historical parser used .find).
+                    yield from self._skip_garbage(
+                        until=self.CALL_END,
+                        detail="between </steptml:invoke> and call end",
+                        consume_suffix=True,
+                    )
+                    break
+                if tried is None:
+                    yield from self._skip_garbage(
+                        until=(self.PARAM_PREFIX, self.INVOKE_END),
+                        detail="inside <steptml:invoke>",
+                    )
+                    continue
+
+                parameter_name = yield from self._take_any(
+                    until=self.PARAM_NAME_SUFFIX
+                )
+                self._emit_param_key(
+                    tool_call_index, parameter_name, is_first_parameter
+                )
+                data_type = self._param_data_type(function, parameter_name)
+                yield from self._param_value(
+                    tool_call_index=tool_call_index,
+                    until=self.PARAM_END,
+                    data_type=data_type,
+                    always_nullable=True,
+                    strip="all",
+                )
+                is_first_parameter = False
+
+            tool_call_index += 1
+
+        # After the closing token, everything is normal content.
+        self._commit()
+        yield from self._take_any(key=self._content_field, commit_each=True)
+
+class Step3Detector(TagToolCallDetector):
+    """Detector for the Step3 function call format documented above.
+
+    Parsing is implemented by ``Step3TextParser``; streaming bookkeeping
+    comes from ``TagToolCallDetector`` and error recovery from the package
+    compatibility mode (the ``compatibility`` package).
     """
 
     def __init__(self):
@@ -66,341 +153,16 @@ class Step3Detector(BaseFormatDetector):
         self.tool_call_end = "<｜tool_call_end｜>"
         self.tool_sep = "<｜tool_sep｜>"
 
-        # Regex for parsing steptml invocations
-        self.invoke_regex = re.compile(
-            r'<steptml:invoke name="([^"]+)">(.+?)</steptml:invoke>', re.DOTALL
-        )
-        self.param_regex = re.compile(
-            r'<steptml:parameter name="([^"]+)">([^<]*)</steptml:parameter>', re.DOTALL
-        )
-
-        # Streaming state variables
-        self._in_tool_block: bool = False
-        self._tool_block_finished: bool = False
-        self._current_function_name: str = ""
-        self._current_parameters: Dict[str, Any] = {}
-        self._in_tool_call: bool = False
-        self._function_name_sent: bool = False
-
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a Step3 format tool call."""
         return self.bot_token in text
 
-    def _parse_steptml_invoke(
-        self, text: str, tools: List[Tool] = None
-    ) -> tuple[str, dict]:
-        """Parse steptml invoke format to extract function name and parameters."""
-        invoke_match = self.invoke_regex.search(text)
-        if not invoke_match:
-            return None, {}
-
-        func_name = invoke_match.group(1)
-        params_text = invoke_match.group(2)
-
-        params = {}
-        for param_match in self.param_regex.finditer(params_text):
-            param_name = param_match.group(1)
-            param_value = param_match.group(2).strip()
-
-            # If tools provided, use schema-aware parsing
-            if tools:
-                arg_type = get_argument_type(func_name, param_name, tools)
-                if arg_type and arg_type != "string":
-                    parsed_value, _ = parse_arguments(param_value)
-                    params[param_name] = parsed_value
-                else:
-                    params[param_name] = param_value
-            else:
-                # Fallback to generic parsing if no tools provided
-                parsed_value, _ = parse_arguments(param_value)
-                params[param_name] = parsed_value
-
-        return func_name, params
-
-    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
-        """
-        One-time parsing: Detects and parses tool calls in the provided text.
-        """
-        if self.bot_token not in text:
-            return StreamingParseResult(normal_text=text, calls=[])
-
-        try:
-            pre_text, rest = text.split(self.bot_token, 1)
-
-            # If no end token, return everything as normal text
-            if self.eot_token not in rest:
-                return StreamingParseResult(normal_text=text, calls=[])
-
-            tool_section, post_text = rest.split(self.eot_token, 1)
-
-            # Find all individual tool calls using regex
-            calls = []
-            tool_call_pattern = (
-                f"{re.escape(self.tool_call_begin)}(.*?){re.escape(self.tool_call_end)}"
-            )
-
-            for match in re.finditer(tool_call_pattern, tool_section, re.DOTALL):
-                call_content = match.group(1)
-
-                # Check if it's a function call
-                if self.tool_sep not in call_content:
-                    continue
-
-                type_part, invoke_part = call_content.split(self.tool_sep, 1)
-                if type_part.strip() != "function":
-                    continue
-
-                func_name, params = self._parse_steptml_invoke(invoke_part, tools)
-                if func_name:
-                    # Use parse_base_json to create the ToolCallItem
-                    action = {"name": func_name, "arguments": params}
-                    calls.extend(self.parse_base_json(action, tools))
-
-            # Combine pre and post text
-            normal_text = pre_text + post_text
-
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            # Return the original text if parsing fails
-            return StreamingParseResult(normal_text=text)
-
-    def parse_streaming_increment(
-        self, new_text: str, tools: List[Tool]
-    ) -> StreamingParseResult:
-        """
-        Streaming incremental parsing for Step3 format.
-        """
-        self._buffer += new_text
-
-        # Build tool indices for validation
-        if not hasattr(self, "_tool_indices"):
-            self._tool_indices = self._get_tool_indices(tools)
-
-        # If we've finished the tool block, everything is normal text
-        if self._tool_block_finished:
-            normal_text = self._buffer
-            self._buffer = ""
-            return StreamingParseResult(normal_text=normal_text)
-
-        # Check if tool block hasn't started yet
-        if not self._in_tool_block:
-            if self.bot_token in self._buffer:
-                idx = self._buffer.find(self.bot_token)
-                normal_text = self._buffer[:idx]
-                self._buffer = self._buffer[idx + len(self.bot_token) :]
-                self._in_tool_block = True
-                return StreamingParseResult(normal_text=normal_text)
-            else:
-                # Check if we might have a partial bot_token
-                partial_len = self._ends_with_partial_token(
-                    self._buffer, self.bot_token
-                )
-                if partial_len:
-                    return StreamingParseResult()  # Wait for more text
-                else:
-                    normal_text = self._buffer
-                    self._buffer = ""
-                    return StreamingParseResult(normal_text=normal_text)
-
-        # We're inside the tool block
-        calls: List[ToolCallItem] = []
-
-        # Check if tool block is ending
-        if self.eot_token in self._buffer:
-            idx = self._buffer.find(self.eot_token)
-
-            # If we're in the middle of a tool call, we need to handle it
-            if self._in_tool_call:
-                # The buffer before eot_token might contain the end of the current tool call
-                before_eot = self._buffer[:idx]
-                if self.tool_call_end in before_eot:
-                    # Parse this final tool call
-                    result = self._parse_partial_tool_call(tools)
-                    calls.extend(result.calls)
-                else:
-                    # Incomplete tool call - log warning
-                    logger.warning("Tool block ended with incomplete tool call")
-
-            remaining = self._buffer[idx + len(self.eot_token) :]
-            self._buffer = ""
-            self._tool_block_finished = True
-
-            # Reset any partial tool call state
-            self._reset_streaming_state()
-
-            return StreamingParseResult(normal_text=remaining, calls=calls)
-
-        # Check if we're in a tool call or need to start one
-        if not self._in_tool_call:
-            if self.tool_call_begin in self._buffer:
-                idx = self._buffer.find(self.tool_call_begin)
-                # Remove any content before tool call begin (shouldn't happen but be safe)
-                self._buffer = self._buffer[idx + len(self.tool_call_begin) :]
-                self._in_tool_call = True
-                self._function_name_sent = False
-                self._current_function_name = ""
-                self._current_parameters = {}
-                # Fall through to parse the partial tool call
-            else:
-                # Wait for tool call to begin
-                return StreamingParseResult()
-
-        # Parse partial tool call
-        if self._in_tool_call:
-            return self._parse_partial_tool_call(tools)
-
-        return StreamingParseResult()
-
-    def _parse_partial_tool_call(self, tools: List[Tool]) -> StreamingParseResult:
-        """Parse partial tool call for streaming scenarios."""
-        calls = []
-
-        # Check if we have tool_sep (means we're past the type declaration)
-        if self.tool_sep not in self._buffer:
-            return StreamingParseResult(calls=calls)  # Wait for more text
-
-        type_part, invoke_part = self._buffer.split(self.tool_sep, 1)
-        if type_part.strip() != "function":
-            # Invalid tool type, skip this tool call
-            self._reset_streaming_state()
-            return StreamingParseResult(calls=calls)
-
-        # Try to extract function name if not sent yet
-        if not self._function_name_sent:
-            name_match = re.search(r'<steptml:invoke name="([^"]+)">', invoke_part)
-            if name_match:
-                func_name = name_match.group(1)
-
-                # Validate function name
-                if func_name in self._tool_indices:
-                    self._current_function_name = func_name
-                    self._function_name_sent = True
-
-                    # Initialize tool tracking
-                    if self.current_tool_id == -1:
-                        self.current_tool_id = 0
-
-                    # Ensure tracking arrays are large enough
-                    while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                        self.prev_tool_call_arr.append({})
-                    while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                        self.streamed_args_for_tool.append("")
-
-                    # Store tool call info
-                    self.prev_tool_call_arr[self.current_tool_id] = {
-                        "name": func_name,
-                        "arguments": {},
-                    }
-
-                    # Send tool name with empty parameters
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            name=func_name,
-                            parameters="",
-                        )
-                    )
-                else:
-                    # Invalid function name
-                    logger.warning(f"Invalid function name: {func_name}")
-                    self._reset_streaming_state()
-                    return StreamingParseResult(calls=calls)
-            else:
-                # Function name not complete yet
-                return StreamingParseResult(calls=calls)
-
-        # Parse parameters incrementally
-        if self._function_name_sent:
-            # Extract all complete parameters
-            new_params = {}
-            for param_match in self.param_regex.finditer(invoke_part):
-                param_name = param_match.group(1)
-                param_value = param_match.group(2).strip()
-
-                # Use schema-aware parsing
-                arg_type = get_argument_type(
-                    self._current_function_name, param_name, tools
-                )
-                if arg_type and arg_type != "string":
-                    parsed_value, _ = parse_arguments(param_value)
-                    new_params[param_name] = parsed_value
-                else:
-                    new_params[param_name] = param_value
-
-            # Check if we have new parameters to stream
-            if new_params != self._current_parameters:
-                # Build the JSON content without the closing brace for streaming
-                if not self._current_parameters:
-                    # First parameters - send opening brace and content
-                    params_content = json.dumps(new_params, ensure_ascii=False)
-                    if len(params_content) > 2:  # More than just "{}"
-                        # Send everything except the closing brace
-                        diff = params_content[:-1]
-                    else:
-                        diff = "{"
-                else:
-                    # Subsequent parameters - calculate the incremental diff
-                    old_json = json.dumps(self._current_parameters, ensure_ascii=False)
-                    new_json = json.dumps(new_params, ensure_ascii=False)
-
-                    # Remove closing braces for comparison
-                    old_without_brace = old_json[:-1]
-                    new_without_brace = new_json[:-1]
-
-                    # The new content should extend the old content
-                    if new_without_brace.startswith(old_without_brace):
-                        diff = new_without_brace[len(old_without_brace) :]
-                    else:
-                        # Parameters changed in unexpected way - shouldn't happen in normal streaming
-                        diff = ""
-
-                if diff:
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            parameters=diff,
-                        )
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += diff
-
-                # Update current state
-                self._current_parameters = new_params
-                self.prev_tool_call_arr[self.current_tool_id]["arguments"] = new_params
-
-            # Check if tool call is complete
-            if self.tool_call_end in self._buffer:
-                # Send closing brace if we've sent any parameters
-                if self.streamed_args_for_tool[self.current_tool_id]:
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            parameters="}",
-                        )
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += "}"
-
-                # Find the end position
-                end_idx = self._buffer.find(self.tool_call_end)
-                # Remove the processed tool call from buffer
-                self._buffer = self._buffer[end_idx + len(self.tool_call_end) :]
-
-                # Reset state for next tool call
-                self._reset_streaming_state()
-                self.current_tool_id += 1
-
-        return StreamingParseResult(calls=calls)
-
-    def _reset_streaming_state(self):
-        """Reset streaming state for the next tool call"""
-        self._in_tool_call = False
-        self._function_name_sent = False
-        self._current_function_name = ""
-        self._current_parameters = {}
+    def _make_grammar(
+        self, functions: Optional[Dict], compatibility: CompatibilityMode
+    ) -> Step3TextParser:
+        return Step3TextParser(functions=functions, compatibility=compatibility)
 
     def supports_structural_tag(self) -> bool:
-        """Return True if this detector supports structural tag format."""
         return False
 
     def structure_info(self) -> _GetInfoFunc:

--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -16,7 +16,7 @@ One ``<｜tool_calls_begin｜>`` block per message; multiple
 after ``<｜tool_calls_end｜>`` is normal content.
 
 Tolerances (recorded on the detector compatibility policy, see the compatibility package): entries whose type part is not ``function`` are skipped
-per-call (historical behavior); unparseable text between tags is skipped up to
+per-call (historical behavior); unparsable text between tags is skipped up to
 the next recognizable tag; parameter values are whitespace-stripped and
 converted via the tool's JSON schema; ``null`` becomes JSON null for any
 parameter type.
@@ -53,7 +53,7 @@ class Step3TextParser(TagToolCallParser):
                 (self.CALL_BEGIN, self.EOT), should_raise=False
             )
             if tried is None:
-                # Unparseable text between calls: skip to the next call or
+                # Unparsable text between calls: skip to the next call or
                 # to the end of the block.
                 yield from self._skip_garbage(
                     until=(self.CALL_BEGIN, self.EOT),
@@ -83,9 +83,7 @@ class Step3TextParser(TagToolCallParser):
                 continue
 
             function_name = yield from self._take_any(until=self.INVOKE_SUFFIX)
-            dropped = yield from self._drop_unknown_invoke(
-                function_name, self.CALL_END
-            )
+            dropped = yield from self._drop_unknown_invoke(function_name, self.CALL_END)
             if dropped:
                 continue
             self._emit_name(tool_call_index, function_name)
@@ -115,9 +113,7 @@ class Step3TextParser(TagToolCallParser):
                     )
                     continue
 
-                parameter_name = yield from self._take_any(
-                    until=self.PARAM_NAME_SUFFIX
-                )
+                parameter_name = yield from self._take_any(until=self.PARAM_NAME_SUFFIX)
                 self._emit_param_key(
                     tool_call_index, parameter_name, is_first_parameter
                 )
@@ -136,6 +132,7 @@ class Step3TextParser(TagToolCallParser):
         # After the closing token, everything is normal content.
         self._commit()
         yield from self._take_any(key=self._content_field, commit_each=True)
+
 
 class Step3Detector(TagToolCallDetector):
     """Detector for the Step3 function call format documented above.

--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -24,7 +24,10 @@ parameter type.
 
 from typing import Dict, Generator, Optional
 
-from sglang.srt.function_call.compatibility import CompatibilityEvent, CompatibilityMode
+from sglang.srt.function_call.compatibility import (
+    CompatibilityContext,
+    CompatibilityEvent,
+)
 from sglang.srt.function_call.core_types import _GetInfoFunc
 from sglang.srt.function_call.parsing import TagToolCallParser
 from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
@@ -155,7 +158,7 @@ class Step3Detector(TagToolCallDetector):
         return self.bot_token in text
 
     def _make_grammar(
-        self, functions: Optional[Dict], compatibility: CompatibilityMode
+        self, functions: Optional[Dict], compatibility: CompatibilityContext
     ) -> Step3TextParser:
         return Step3TextParser(functions=functions, compatibility=compatibility)
 

--- a/python/sglang/srt/function_call/tag_format_detector.py
+++ b/python/sglang/srt/function_call/tag_format_detector.py
@@ -1,0 +1,271 @@
+"""Adapter from a tag-format :class:`GeneratorParser` to the detector API.
+
+The SGLang-facing half of the tag machinery (the engine half is ``parsing.py``;
+dependency rule: detectors -> this module -> ``parsing`` -> {the
+``compatibility`` model, ``param_types``}).
+
+Per the compatibility ladder (the ``compatibility`` package), detectors are pure may-raise
+parsers: tolerances the grammar can absorb are recorded on the detector's
+policy; anything else propagates out of ``parse_streaming_increment`` /
+``detect_and_parse`` and is handled by ``FunctionCallParser`` — the single
+recovery boundary — through the ``fail_open_stream`` / ``fail_open_nonstream``
+hooks overridden here.
+"""
+
+import json
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+
+from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility.mode import (
+    CompatibilityEvent,
+    CompatibilityMode,
+)
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+from sglang.srt.function_call.parsing import GeneratorParser
+
+
+class TagToolCallDetector(BaseFormatDetector, ABC):
+    """Owns one tag parser per request and maps its deltas to ToolCallItems.
+
+    Subclasses implement :meth:`_make_grammar` (and ``has_tool_call``), and
+    keep their format-specific ``structure_info`` / structural-tag overrides.
+    Streaming bookkeeping consumed by the serving layer
+    (``prev_tool_call_arr``, ``streamed_args_for_tool``, ``current_tool_id``)
+    is maintained here.
+
+    Not picklable: holds a live generator. Detector instances are per-request
+    locals in the serving layer and never cross process boundaries.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._grammar: Optional[GeneratorParser] = None
+
+    @abstractmethod
+    def _make_grammar(
+        self, functions: Optional[Dict], compatibility: CompatibilityMode
+    ) -> GeneratorParser:
+        """Build a fresh parser for this request.
+
+        ``functions`` maps each tool name to ``{"parameters": <json schema>}``
+        (or is None when the request has no tools), for schema-driven
+        parameter conversion. ``compatibility`` is the detector's policy; passing it
+        into the parser keeps the request's tolerances on one audit trail.
+        """
+        raise NotImplementedError()
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError()
+
+    def _init_grammar(self, tools: List[Tool]) -> GeneratorParser:
+        if self._grammar is None:
+            functions = (
+                {
+                    tool.function.name: {
+                        "parameters": tool.function.parameters,
+                    }
+                    for tool in tools
+                }
+                if tools
+                else None
+            )
+            self._grammar = self._make_grammar(functions, self.compatibility)
+        return self._grammar
+
+    def parse_streaming_increment(
+        self, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        grammar = self._init_grammar(tools)
+        # May raise (input past the grammar's local tolerances, including the
+        # strict-mode unknown-tool gate, which fires before anything for the
+        # call is emitted); FunctionCallParser catches and calls
+        # fail_open_stream().
+        grammar.update(new_text)
+        return self._delta_to_result(grammar.get_delta())
+
+    def _delta_to_result(self, delta: Optional[Dict]) -> StreamingParseResult:
+        if delta is None:
+            return StreamingParseResult()
+
+        normal_text = delta.get("content", "")
+        calls: List[ToolCallItem] = []
+
+        for tc in delta.get("tool_calls", []):
+            func = tc.get("function", {})
+            idx = tc.get("index", 0)
+            name = func.get("name")
+            arguments = func.get("arguments")
+
+            if name is not None:
+                if self.current_tool_id == -1:
+                    self.current_tool_id = 0
+                while len(self.prev_tool_call_arr) <= idx:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= idx:
+                    self.streamed_args_for_tool.append("")
+                self.prev_tool_call_arr[idx] = {"name": name, "arguments": {}}
+                calls.append(ToolCallItem(tool_index=idx, name=name, parameters=""))
+
+            if arguments is not None:
+                while len(self.streamed_args_for_tool) <= idx:
+                    self.streamed_args_for_tool.append("")
+                self.streamed_args_for_tool[idx] += arguments
+                if idx < len(self.prev_tool_call_arr):
+                    try:
+                        self.prev_tool_call_arr[idx]["arguments"] = json.loads(
+                            self.streamed_args_for_tool[idx]
+                        )
+                    except json.JSONDecodeError:
+                        pass
+                self.current_tool_id = idx
+                calls.append(
+                    ToolCallItem(tool_index=idx, name=None, parameters=arguments)
+                )
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def _has_open_call(self) -> bool:
+        """True when a call's streamed argument fragments are incomplete JSON
+        (its name/arguments are on the wire and cannot be unsent)."""
+        tid = self.current_tool_id
+        if not (0 <= tid < len(self.streamed_args_for_tool)):
+            return False
+        streamed = self.streamed_args_for_tool[tid]
+        if not streamed:
+            return False
+        try:
+            json.loads(streamed)
+            return False
+        except json.JSONDecodeError:
+            return True
+
+    def fail_open_stream(
+        self, error: Exception, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        """Scope-4 recovery.
+
+        On top of the base behavior (close a mid-stream call's JSON), drain
+        output the parser produced before the error and re-surface raw
+        unconsumed text as content. ``new_text`` is ignored: the failing chunk
+        already sits in the parser's buffers.
+        """
+        grammar = self._grammar
+        if grammar is None:
+            return super().fail_open_stream(error, new_text, tools)
+
+        # Drain output parsed before the error so it is not lost.
+        result = self._delta_to_result(grammar.get_delta())
+        calls = list(result.calls)
+        normal_text = result.normal_text
+
+        if self._has_open_call():
+            # A call is mid-stream and cannot be unsent. Close its streamed
+            # arguments so they concatenate to valid JSON, and keep
+            # prev_tool_call_arr consistent so the serving layer's
+            # end-of-stream completion does not double-send.
+            calls.extend(self._close_mid_stream_call())
+            # The unconsumed tail was never surfaced anywhere; flush it as
+            # content. (Consumed markers of the failed call are dropped — its
+            # semantic content was already emitted as tool-call deltas.)
+            normal_text += grammar.unconsumed_text()
+        else:
+            # No call is on the wire: re-surface the entire failing construct
+            # (consumed markers, skipped text, the unconsumed tail) as raw
+            # text. Content already emitted — including the drain above — is
+            # committed as it is emitted, so nothing is duplicated.
+            normal_text += grammar.uncommitted_text()
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        grammar = self._init_grammar(tools)
+        # May raise; FunctionCallParser catches and calls fail_open_nonstream().
+        grammar.update(text)
+        return self._nonstream_result(grammar, text, tools, failed=False)
+
+    def fail_open_nonstream(
+        self, error: Exception, full_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        """Scope-4 recovery: salvage complete calls parsed before the error.
+
+        Calls truncated by the error are dropped; their raw text and the
+        unconsumed tail are re-surfaced as content (``uncommitted_text``).
+        When no call survived, ``FunctionCallParser.parse_non_stream`` falls
+        back to returning the full original text.
+        """
+        grammar = self._grammar
+        if grammar is None:
+            return super().fail_open_nonstream(error, full_text, tools)
+        return self._nonstream_result(grammar, full_text, tools, failed=True)
+
+    def _nonstream_result(
+        self, grammar: GeneratorParser, text: str, tools: List[Tool], *, failed: bool
+    ) -> StreamingParseResult:
+        delta = grammar.get_delta()
+        if delta is None:
+            return StreamingParseResult(normal_text=text, calls=[])
+
+        normal_text = delta.get("content", "")
+        calls: List[ToolCallItem] = []
+        try:
+            for tc in delta.get("tool_calls", []):
+                func = tc.get("function", {})
+                name = func.get("name", "")
+                arguments = func.get("arguments", "{}")
+                try:
+                    args_dict = json.loads(arguments)
+                except json.JSONDecodeError:
+                    if not failed:
+                        # Generation ended mid-call (e.g. max_tokens). Never
+                        # emit a half-specified call — an agent loop would
+                        # execute it with missing or mangled arguments. Drop
+                        # it; its raw text is re-surfaced below. In strict
+                        # mode the note raises and the parse fails open to
+                        # the same drop via the failed=True pass.
+                        self.compatibility.note(
+                            CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                            detail=f"{name[:40]!r}: arguments cut at {arguments[-40:]!r}",
+                        )
+                    # failed=True: calls truncated by the parse error are
+                    # dropped the same way.
+                    continue
+                calls.extend(
+                    self._nonstream_call_items(
+                        name, args_dict, tc.get("index", 0), tools
+                    )
+                )
+        except Exception:
+            # A strict-mode note raised mid-processing; put the delta back so
+            # the recovery pass (failed=True) still sees the whole parse.
+            grammar.restash_delta(delta)
+            raise
+
+        # Re-surface everything after the last completed construct: markers
+        # and buffered text of a dropped call, skipped garbage, or the
+        # held-back tail of trailing content. Completed calls and emitted
+        # content are committed, so nothing is duplicated.
+        normal_text += grammar.uncommitted_text()
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def _nonstream_call_items(
+        self, name: str, args_dict: Dict, index: int, tools: List[Tool]
+    ) -> List[ToolCallItem]:
+        """Map one completed call to ToolCallItems for the non-streaming path.
+
+        Default: route through ``parse_base_json`` (``tool_index`` is the
+        index into the tools list; unknown tools are dropped per
+        ``SGLANG_FORWARD_UNKNOWN_TOOLS``). Detectors that historically emitted
+        the call ordinal and forwarded unknown names (e.g. Qwen3-Coder)
+        override this.
+        """
+        return self.parse_base_json({"name": name, "arguments": args_dict}, tools)

--- a/python/sglang/srt/function_call/tag_format_detector.py
+++ b/python/sglang/srt/function_call/tag_format_detector.py
@@ -18,9 +18,9 @@ from typing import Dict, List, Optional
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.compatibility.mode import (
+from sglang.srt.function_call.compatibility.context import (
+    CompatibilityContext,
     CompatibilityEvent,
-    CompatibilityMode,
 )
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -49,7 +49,7 @@ class TagToolCallDetector(BaseFormatDetector, ABC):
 
     @abstractmethod
     def _make_grammar(
-        self, functions: Optional[Dict], compatibility: CompatibilityMode
+        self, functions: Optional[Dict], compatibility: CompatibilityContext
     ) -> GeneratorParser:
         """Build a fresh parser for this request.
 
@@ -190,6 +190,13 @@ class TagToolCallDetector(BaseFormatDetector, ABC):
         grammar = self._init_grammar(tools)
         # May raise; FunctionCallParser catches and calls fail_open_nonstream().
         grammar.update(text)
+        delta = grammar.get_delta()
+        grammar.restash_delta(delta)
+        if self._has_unclosed_nonstream_tail(text, grammar, delta):
+            self.compatibility.note(
+                CompatibilityEvent.TRUNCATED_CALL_DROPPED,
+                detail=grammar.uncommitted_text()[:80],
+            )
         return self._nonstream_result(grammar, text, tools, failed=False)
 
     def fail_open_nonstream(
@@ -199,8 +206,8 @@ class TagToolCallDetector(BaseFormatDetector, ABC):
 
         Calls truncated by the error are dropped; their raw text and the
         unconsumed tail are re-surfaced as content (``uncommitted_text``).
-        When no call survived, ``FunctionCallParser.parse_non_stream`` falls
-        back to returning the full original text.
+        When no call survived, the failed path still returns the full original
+        text.
         """
         grammar = self._grammar
         if grammar is None:
@@ -212,6 +219,10 @@ class TagToolCallDetector(BaseFormatDetector, ABC):
     ) -> StreamingParseResult:
         delta = grammar.get_delta()
         if delta is None:
+            if not failed and (
+                self.compatibility.records or self.compatibility.dropped
+            ):
+                return StreamingParseResult(calls=[])
             return StreamingParseResult(normal_text=text, calls=[])
 
         normal_text = delta.get("content", "")
@@ -256,6 +267,28 @@ class TagToolCallDetector(BaseFormatDetector, ABC):
         normal_text += grammar.uncommitted_text()
 
         return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def _has_unclosed_nonstream_tail(
+        self, text: str, grammar: GeneratorParser, delta: Optional[Dict]
+    ) -> bool:
+        """True when EOF left the grammar inside a recognized tool construct.
+
+        Partial argument JSON is handled in ``_nonstream_result`` so it can be
+        dropped consistently with strict-mode recovery. This method covers the
+        earlier truncation case where the marker has been consumed but no
+        argument object exists yet.
+        """
+        if not self.has_tool_call(text) or not grammar.uncommitted_text().strip():
+            return False
+        for tc in (delta or {}).get("tool_calls", []):
+            arguments = tc.get("function", {}).get("arguments")
+            if arguments is None:
+                continue
+            try:
+                json.loads(arguments)
+            except json.JSONDecodeError:
+                return False
+        return True
 
     def _nonstream_call_items(
         self, name: str, args_dict: Dict, index: int, tools: List[Tool]

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import orjson
 import partial_json_parser
+from partial_json_parser.core.exceptions import MalformedJSON
 from partial_json_parser.core.options import Allow
 
 from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
@@ -208,7 +209,15 @@ def _partial_json_loads(input_str: str, flags: Allow) -> Tuple[Any, int]:
             start = WHITESPACE.match(input_str, 0).end()
             obj, end = JSONDecoder().raw_decode(input_str, start)
             return obj, end
-        raise
+        if isinstance(e, JSONDecodeError):
+            raise
+        raise MalformedJSON(str(e)) from e
+    except AssertionError as e:
+        # partial_json_parser fails internal asserts on structurally broken
+        # JSON (e.g. "[{}}}]"); normalize to its malformed-input signal so
+        # callers' expected-deviation handling applies instead of treating
+        # model output as an internal error.
+        raise MalformedJSON(str(e)) from e
 
 
 def _is_complete_json(input_str: str) -> bool:

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -220,6 +220,53 @@ def _partial_json_loads(input_str: str, flags: Allow) -> Tuple[Any, int]:
         raise MalformedJSON(str(e)) from e
 
 
+def _closed_top_level_json_end(text: str) -> Optional[int]:
+    """Best-effort end offset for a closed top-level JSON fragment.
+
+    Partial JSON is expected during streaming and should keep buffering. When
+    the top-level array/object has syntactically closed outside a string, a
+    parser failure is no longer just "need more bytes"; callers can safely
+    isolate that fragment for malformed-payload recovery.
+    """
+    closers = {"[": "]", "{": "}"}
+    stack: List[str] = []
+    in_string = False
+    escape = False
+    started = False
+
+    for i, ch in enumerate(text):
+        if not started:
+            if ch.isspace():
+                continue
+            if ch in closers:
+                started = True
+                stack.append(closers[ch])
+                continue
+            return None
+
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+
+        if ch == '"':
+            in_string = True
+        elif ch in closers:
+            stack.append(closers[ch])
+        elif ch in "]}":
+            if not stack or ch != stack[-1]:
+                return i + 1
+            stack.pop()
+            if not stack:
+                return i + 1
+
+    return None
+
+
 def _is_complete_json(input_str: str) -> bool:
     try:
         orjson.loads(input_str)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -546,6 +546,7 @@ class ServerArgs:
     strip_thinking_cache: bool = False
     enable_strict_thinking: bool = False
     tool_call_parser: Optional[str] = None
+    enable_tool_call_compatibility_mode: bool = False
     tool_server: Optional[str] = None
     sampling_defaults: str = "model"
     asr_max_buffer_seconds: int = 60
@@ -5713,6 +5714,19 @@ class ServerArgs:
             help=f"Specify the parser for handling tool-call interactions. "
             f"Use 'auto' to detect from chat template. "
             f"Options include: {tool_call_parser_choices}.",
+        )
+        parser.add_argument(
+            "--enable-tool-call-compatibility-mode",
+            action="store_true",
+            default=ServerArgs.enable_tool_call_compatibility_mode,
+            help="Enable tolerant tool-call parsing for model output that "
+            "deviates from the expected wire format (see "
+            "python/sglang/srt/function_call/compatibility/). By default, "
+            "tool-call parsing is strict: deviations make the parse fail open "
+            "and return the output as normal text. When this flag is set, "
+            "known safe recoveries are applied and audited. Parsing never "
+            "crashes a request in either mode. Unrelated to "
+            "SGLANG_TOOL_STRICT_LEVEL, which constrains generation.",
         )
         parser.add_argument(
             "--tool-server",

--- a/test/registered/unit/function_call/test_function_call_compatibility.py
+++ b/test/registered/unit/function_call/test_function_call_compatibility.py
@@ -26,7 +26,7 @@ from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.hermes_detector import HermesDetector
 from sglang.srt.function_call.mimo_detector import MiMoDetector
 from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
-from sglang.srt.function_call.minimax_m3_nom import M3TextParser, MinimaxM3NomDetector
+from sglang.srt.function_call.minimax_m3 import M3TextParser, MinimaxM3Detector
 from sglang.srt.function_call.parsing import (
     GeneratorParser,
     default_tool_call_output_key,
@@ -137,7 +137,7 @@ PLAN_TRIP_TOOL = Tool(
 COMPLEX_TOOLS = TOOLS + [PLAN_TRIP_TOOL]
 
 
-def _make_parser(detector=None, name="minimax-m3-nom", enable_compatibility_mode=True):
+def _make_parser(detector=None, name="minimax-m3", enable_compatibility_mode=True):
     if detector is not None:
         return FunctionCallParser.with_detector(
             detector, TOOLS, enable_compatibility_mode=enable_compatibility_mode
@@ -273,10 +273,10 @@ class TestFailOpenLadder(CustomTestCase):
     def test_non_stream_error_falls_back_to_full_text(self):
         text = f"Hi {NS}<tool_call>\nnot a valid invoke"
         # Detectors are pure may-raise parsers; recovery is the boundary's.
-        detector = MinimaxM3NomDetector()
+        detector = MinimaxM3Detector()
         with self.assertRaises(Exception):
             detector.detect_and_parse(text, TOOLS)
-        parser = FunctionCallParser(TOOLS, "minimax-m3-nom")
+        parser = FunctionCallParser(TOOLS, "minimax-m3")
         normal_text, calls = parser.parse_non_stream(text)
         self.assertEqual(calls, [])
         self.assertEqual(normal_text, text)
@@ -292,7 +292,7 @@ class TestFailOpenLadder(CustomTestCase):
             f"{NS}</invoke>\n"
             f"{NS}</tool_call>TRAILING GARBAGE"
         )
-        parser = FunctionCallParser(TOOLS, "minimax-m3-nom")
+        parser = FunctionCallParser(TOOLS, "minimax-m3")
         normal_text, calls = parser.parse_non_stream(text)
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0].name, "get_weather")
@@ -407,7 +407,7 @@ class TestCompatibilityEvents(CustomTestCase):
         )
 
     def test_unconvertible_value_kept_raw_and_recorded(self):
-        detector = MinimaxM3NomDetector()
+        detector = MinimaxM3Detector()
         result = detector.detect_and_parse(
             f"{NS}<tool_call>\n"
             f'{NS}<invoke name="get_weather">'
@@ -619,7 +619,7 @@ class TestCompatibilityModeOption(CustomTestCase):
         text = TestCompatibilityEvents.DUPLICATE_TAG_TEXT
 
         compatible = FunctionCallParser(
-            TOOLS, "minimax-m3-nom", enable_compatibility_mode=True
+            TOOLS, "minimax-m3", enable_compatibility_mode=True
         )
         _, calls = compatible.parse_non_stream(text)
         self.assertEqual(len(calls), 1)
@@ -630,7 +630,7 @@ class TestCompatibilityModeOption(CustomTestCase):
         events = [r.event for r in compatible.detector.compatibility_records]
         self.assertEqual(events, [CompatibilityEvent.DUPLICATE_TAG_AS_LIST])
 
-        strict = FunctionCallParser(TOOLS, "minimax-m3-nom")
+        strict = FunctionCallParser(TOOLS, "minimax-m3")
         normal_text, calls = strict.parse_non_stream(text)
         self.assertEqual(calls, [])
         self.assertEqual(normal_text, text)
@@ -675,7 +675,7 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         self.assertIn(CompatibilityEvent.DROPPED_INVOKE_TAIL, self._events(parser))
 
         strict = _make_parser(
-            FunctionCallParser(TOOLS, "minimax-m3-nom").detector,
+            FunctionCallParser(TOOLS, "minimax-m3").detector,
             enable_compatibility_mode=False,
         )
         strict.detector.compatibility.strict = True
@@ -718,7 +718,7 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
             f"{NS}</invoke>\n{NS}</tool_call>"
         )
         parser = FunctionCallParser(
-            ARRAY_TOOLS, "minimax-m3-nom", enable_compatibility_mode=True
+            ARRAY_TOOLS, "minimax-m3", enable_compatibility_mode=True
         )
         _, calls = parser.parse_non_stream(text)
         self.assertEqual(len(calls), 1)
@@ -852,7 +852,7 @@ class TestComplexSchemaCompatibility(CustomTestCase):
     def _parser(self, enable_compatibility_mode=True):
         return FunctionCallParser(
             COMPLEX_TOOLS,
-            "minimax-m3-nom",
+            "minimax-m3",
             enable_compatibility_mode=enable_compatibility_mode,
         )
 

--- a/test/registered/unit/function_call/test_function_call_compatibility.py
+++ b/test/registered/unit/function_call/test_function_call_compatibility.py
@@ -9,6 +9,7 @@ import json
 import unittest
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.apertus2509_detector import Apertus2509Detector
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.compatibility import (
     CompatibilityEvent,
@@ -16,16 +17,20 @@ from sglang.srt.function_call.compatibility import (
     CompatibilityViolation,
     synthesize_json_close,
 )
-from sglang.srt.function_call.parsing import GeneratorParser, default_tool_call_output_key
+from sglang.srt.function_call.compatibility.param_types import (
+    FunctionCallParameterDataType,
+)
 from sglang.srt.function_call.core_types import StreamingParseResult, ToolCallItem
-from sglang.srt.function_call.apertus2509_detector import Apertus2509Detector
-from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.hermes_detector import HermesDetector
+from sglang.srt.function_call.mimo_detector import MiMoDetector
 from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
 from sglang.srt.function_call.minimax_m3_nom import M3TextParser, MinimaxM3NomDetector
-from sglang.srt.function_call.mimo_detector import MiMoDetector
-from sglang.srt.function_call.compatibility.param_types import FunctionCallParameterDataType
+from sglang.srt.function_call.parsing import (
+    GeneratorParser,
+    default_tool_call_output_key,
+)
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
@@ -132,9 +137,7 @@ PLAN_TRIP_TOOL = Tool(
 COMPLEX_TOOLS = TOOLS + [PLAN_TRIP_TOOL]
 
 
-def _make_parser(
-    detector=None, name="minimax-m3-nom", enable_compatibility_mode=True
-):
+def _make_parser(detector=None, name="minimax-m3-nom", enable_compatibility_mode=True):
     if detector is not None:
         return FunctionCallParser.with_detector(
             detector, TOOLS, enable_compatibility_mode=enable_compatibility_mode
@@ -150,9 +153,7 @@ def _stream(parser, text, chunk_size):
     normal_text = ""
     calls = []
     for i in range(0, len(text), chunk_size):
-        chunk_normal, chunk_calls = parser.parse_stream_chunk(
-            text[i : i + chunk_size]
-        )
+        chunk_normal, chunk_calls = parser.parse_stream_chunk(text[i : i + chunk_size])
         normal_text += chunk_normal
         calls.extend(chunk_calls)
     # Allow deferred emission, mirroring the serving loop's trailing ticks.
@@ -194,11 +195,11 @@ class _MidCallFailingGrammar(GeneratorParser):
 
     def _process(self):
         self._append_delta(
-            default_tool_call_output_key(
-                0, {"name": "get_weather", "arguments": "{"}
-            )
+            default_tool_call_output_key(0, {"name": "get_weather", "arguments": "{"})
         )
-        self._append_delta(default_tool_call_output_key(0, {"arguments": '"city": "Par'}))
+        self._append_delta(
+            default_tool_call_output_key(0, {"arguments": '"city": "Par'})
+        )
         while True:
             ch = yield from self._peek(0)
             if ch == "X":
@@ -490,9 +491,7 @@ class TestJsonDetectorCompatibility(CustomTestCase):
         )
         result = detector.detect_and_parse(text, TOOLS)
         self.assertEqual(len(result.calls), 1)
-        self.assertEqual(
-            json.loads(result.calls[0].parameters), {"city": "Paris"}
-        )
+        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "Paris"})
         events = [r.event for r in detector.compatibility_records]
         self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
 
@@ -761,7 +760,6 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         )
 
     def test_truncated_call_dropped_identical_in_both_modes(self):
-        from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 
         text = "Check.\n<tool_call>\n<function=get_weather>\n<parameter=city>\nBei"
         for enable_compatibility_mode in (True, False):
@@ -782,7 +780,6 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         )
 
     def test_skipped_non_function_entry(self):
-        from sglang.srt.function_call.step3_detector import Step3Detector
 
         text = (
             "<｜tool_calls_begin｜>\n"
@@ -793,9 +790,7 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
             "</steptml:invoke><｜tool_call_end｜>\n"
             "<｜tool_calls_end｜>"
         )
-        parser = FunctionCallParser(
-            TOOLS, "step3", enable_compatibility_mode=True
-        )
+        parser = FunctionCallParser(TOOLS, "step3", enable_compatibility_mode=True)
         _, calls = parser.parse_non_stream(text)
         self.assertEqual([c.name for c in calls], ["get_weather"])
         self.assertIn(
@@ -878,7 +873,9 @@ class TestComplexSchemaCompatibility(CustomTestCase):
         self.assertEqual(args["contact"], None)
         self.assertEqual(args["metadata"], {"season": "spring", "pace": "moderate"})
         self.assertEqual(args["transport"], {"mode": "train", "priority": 2})
-        self.assertEqual(args["travelers"][0]["preferences"]["tags"], ["museum", "ramen"])
+        self.assertEqual(
+            args["travelers"][0]["preferences"]["tags"], ["museum", "ramen"]
+        )
         self.assertEqual(args["travelers"][1]["age"], "old")
         self.assertEqual(args["itinerary"][1]["day"], 2)
 
@@ -955,7 +952,9 @@ class TestTagStreamingGates(CustomTestCase):
             # recorded; the FAIL_OPEN record carries it in its detail.
             records = parser.detector.compatibility_records
             self.assertEqual([r.event for r in records], [CompatibilityEvent.FAIL_OPEN])
-            self.assertIn(CompatibilityEvent.UNKNOWN_TOOL_DROPPED.value, records[0].detail)
+            self.assertIn(
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED.value, records[0].detail
+            )
 
     def test_strict_fail_open_after_completed_block_is_not_corrupted(self):
         # Regression: emitted content is not a contiguous prefix of the raw

--- a/test/registered/unit/function_call/test_function_call_compatibility.py
+++ b/test/registered/unit/function_call/test_function_call_compatibility.py
@@ -1,0 +1,981 @@
+"""Unit tests for the function_call compatibility mode (see the ``compatibility`` package).
+
+Covers the fail-open ladder at the FunctionCallParser boundary, the
+synthesized JSON close for mid-stream calls, compatibility-event recording, strict
+mode, and schema-driven value conversion fallbacks.
+"""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import (
+    CompatibilityEvent,
+    CompatibilityMode,
+    CompatibilityViolation,
+    synthesize_json_close,
+)
+from sglang.srt.function_call.parsing import GeneratorParser, default_tool_call_output_key
+from sglang.srt.function_call.core_types import StreamingParseResult, ToolCallItem
+from sglang.srt.function_call.apertus2509_detector import Apertus2509Detector
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.srt.function_call.hermes_detector import HermesDetector
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.srt.function_call.minimax_m3_nom import M3TextParser, MinimaxM3NomDetector
+from sglang.srt.function_call.mimo_detector import MiMoDetector
+from sglang.srt.function_call.compatibility.param_types import FunctionCallParameterDataType
+from sglang.srt.function_call.pythonic_detector import PythonicDetector
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+NS = "]<]minimax[>["
+
+TOOLS = [
+    Tool(
+        type="function",
+        function=Function(
+            name="get_weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "days": {"type": "integer"},
+                    "location": {"type": "object"},
+                },
+                "required": ["city"],
+            },
+        ),
+    ),
+]
+
+M3_FUNCTIONS = {
+    "get_weather": {"parameters": TOOLS[0].function.parameters},
+}
+
+PLAN_TRIP_TOOL = Tool(
+    type="function",
+    function=Function(
+        name="plan_trip",
+        parameters={
+            "type": "object",
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "enum": ["Paris", "Tokyo", "Shanghai"],
+                },
+                "days": {"type": "integer"},
+                "budget": {"type": "number"},
+                "travelers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "age": {"type": "integer"},
+                            "preferences": {
+                                "type": "object",
+                                "properties": {
+                                    "vegetarian": {"type": "boolean"},
+                                    "tags": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                        "required": ["name"],
+                    },
+                },
+                "itinerary": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "day": {"type": "integer"},
+                            "city": {"type": "string"},
+                            "activities": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+                "contact": {"type": ["string", "null"]},
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
+                "transport": {
+                    "oneOf": [
+                        {"type": "string", "enum": ["train", "flight"]},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "mode": {"type": "string"},
+                                "priority": {"type": "integer"},
+                            },
+                        },
+                    ]
+                },
+            },
+            "required": ["destination", "travelers"],
+        },
+    ),
+)
+
+COMPLEX_TOOLS = TOOLS + [PLAN_TRIP_TOOL]
+
+
+def _make_parser(
+    detector=None, name="minimax-m3-nom", enable_compatibility_mode=True
+):
+    if detector is not None:
+        return FunctionCallParser.with_detector(
+            detector, TOOLS, enable_compatibility_mode=enable_compatibility_mode
+        )
+    parser = FunctionCallParser(
+        TOOLS, name, enable_compatibility_mode=enable_compatibility_mode
+    )
+    return parser
+
+
+def _stream(parser, text, chunk_size):
+    """Feed text in fixed-size chunks; return (normal_text, calls)."""
+    normal_text = ""
+    calls = []
+    for i in range(0, len(text), chunk_size):
+        chunk_normal, chunk_calls = parser.parse_stream_chunk(
+            text[i : i + chunk_size]
+        )
+        normal_text += chunk_normal
+        calls.extend(chunk_calls)
+    # Allow deferred emission, mirroring the serving loop's trailing ticks.
+    for _ in range(4):
+        chunk_normal, chunk_calls = parser.parse_stream_chunk("")
+        if not chunk_normal and not chunk_calls:
+            break
+        normal_text += chunk_normal
+        calls.extend(chunk_calls)
+    return normal_text, calls
+
+
+class TestSynthesizeJsonClose(CustomTestCase):
+    def _check(self, partial, expected_value):
+        closing = synthesize_json_close(partial)
+        self.assertIsNotNone(closing, partial)
+        self.assertEqual(json.loads(partial + closing), expected_value)
+
+    def test_closes_partials(self):
+        self._check("{", {})
+        self._check('{"a": "x', {"a": "x"})
+        self._check('{"a": ', {"a": None})
+        self._check('{"a": 1, ', {"a": 1, "": None})
+        self._check('{"a": [1, ', {"a": [1, None]})
+        self._check('{"a": {"b": "c', {"a": {"b": "c"}})
+        self._check('{"a": "x\\', {"a": "x\\"})
+        self._check('{"a": "say \\"hi', {"a": 'say "hi'})
+
+    def test_already_valid_needs_nothing(self):
+        self.assertEqual(synthesize_json_close('{"a": 1}'), "")
+
+    def test_unfixable_returns_none(self):
+        # More closers than openers cannot be fixed by appending.
+        self.assertIsNone(synthesize_json_close('{"a": 1}}'))
+
+
+class _MidCallFailingGrammar(GeneratorParser):
+    """Emits a tool name and partial arguments, then fails on the char 'X'."""
+
+    def _process(self):
+        self._append_delta(
+            default_tool_call_output_key(
+                0, {"name": "get_weather", "arguments": "{"}
+            )
+        )
+        self._append_delta(default_tool_call_output_key(0, {"arguments": '"city": "Par'}))
+        while True:
+            ch = yield from self._peek(0)
+            if ch == "X":
+                raise self._error(expected="not-X", actual=ch, reason="forced failure")
+            self._read_one()
+
+
+class _MidCallFailingDetector(TagToolCallDetector):
+    def _make_grammar(self, functions, compatibility):
+        return _MidCallFailingGrammar(compatibility=compatibility)
+
+    def has_tool_call(self, text: str) -> bool:
+        return True
+
+
+class TestFailOpenLadder(CustomTestCase):
+    """Scope 4: the FunctionCallParser boundary never crashes a request."""
+
+    def test_error_before_tool_call_flushes_raw_text(self):
+        """Garbage inside the tool block: everything comes back as content."""
+        text = f"Hello {NS}<tool_call>\nGARBAGE no invoke here"
+        for chunk_size in (1, 7, len(text)):
+            parser = _make_parser()
+            normal_text, calls = _stream(parser, text, chunk_size)
+            self.assertEqual(calls, [], chunk_size)
+            self.assertEqual(normal_text, text, chunk_size)
+            # Subsequent chunks keep passing through.
+            chunk_normal, _ = parser.parse_stream_chunk(" more")
+            self.assertEqual(chunk_normal, " more")
+            # The failure is on the audit trail.
+            events = [r.event for r in parser.detector.compatibility_records]
+            self.assertIn(CompatibilityEvent.FAIL_OPEN, events)
+
+    def test_trailing_text_after_block_is_not_swallowed(self):
+        """A complete call followed by trailing text: call survives, text flows."""
+        block = (
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<city>Paris{NS}</city>"
+            f"{NS}</invoke>\n"
+            f"{NS}</tool_call>"
+        )
+        text = f"Lead. {block}\nTrailing."
+        for chunk_size in (1, 5, len(text)):
+            parser = _make_parser()
+            normal_text, calls = _stream(parser, text, chunk_size)
+            self.assertEqual(normal_text, "Lead. \nTrailing.", chunk_size)
+            names = [call.name for call in calls if call.name]
+            self.assertEqual(names, ["get_weather"], chunk_size)
+            streamed = "".join(call.parameters for call in calls if call.parameters)
+            self.assertEqual(json.loads(streamed), {"city": "Paris"})
+
+    def test_mid_call_failure_closes_streamed_arguments(self):
+        parser = _make_parser(_MidCallFailingDetector())
+        normal1, calls1 = parser.parse_stream_chunk("abc")
+        names = [call.name for call in calls1 if call.name]
+        self.assertEqual(names, ["get_weather"])
+
+        normal2, calls2 = parser.parse_stream_chunk("X")
+        streamed = "".join(
+            call.parameters for call in calls1 + calls2 if call.parameters
+        )
+        # The synthesized close makes the streamed fragments valid JSON.
+        self.assertEqual(json.loads(streamed), {"city": "Par"})
+        # The failing text is flushed as content, later text passes through.
+        self.assertEqual(normal2, "X")
+        normal3, calls3 = parser.parse_stream_chunk("after")
+        self.assertEqual(normal3, "after")
+        self.assertEqual(calls3, [])
+
+    def test_non_stream_error_falls_back_to_full_text(self):
+        text = f"Hi {NS}<tool_call>\nnot a valid invoke"
+        # Detectors are pure may-raise parsers; recovery is the boundary's.
+        detector = MinimaxM3NomDetector()
+        with self.assertRaises(Exception):
+            detector.detect_and_parse(text, TOOLS)
+        parser = FunctionCallParser(TOOLS, "minimax-m3-nom")
+        normal_text, calls = parser.parse_non_stream(text)
+        self.assertEqual(calls, [])
+        self.assertEqual(normal_text, text)
+        events = [r.event for r in parser.detector.compatibility_records]
+        self.assertIn(CompatibilityEvent.FAIL_OPEN, events)
+
+    def test_non_stream_error_salvages_complete_calls(self):
+        """Complete calls parsed before the error survive; the tail flows."""
+        text = (
+            f"Lead. {NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<city>Paris{NS}</city>"
+            f"{NS}</invoke>\n"
+            f"{NS}</tool_call>TRAILING GARBAGE"
+        )
+        parser = FunctionCallParser(TOOLS, "minimax-m3-nom")
+        normal_text, calls = parser.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "get_weather")
+        self.assertEqual(json.loads(calls[0].parameters), {"city": "Paris"})
+        self.assertIn("TRAILING GARBAGE", normal_text)
+
+
+class _RaisingDetector(BaseFormatDetector):
+    has_streamed_partial_args = False
+
+    def has_tool_call(self, text: str) -> bool:
+        return True
+
+    def detect_and_parse(self, text, tools) -> StreamingParseResult:
+        raise RuntimeError("boom")
+
+    def parse_streaming_increment(self, new_text, tools) -> StreamingParseResult:
+        if self.has_streamed_partial_args and self.current_tool_id == -1:
+            # Simulate a generic detector mid-call: name and partial JSON
+            # arguments already on the wire, tracked in base bookkeeping.
+            self.current_tool_id = 0
+            self.prev_tool_call_arr.append({"name": "get_weather", "arguments": {}})
+            self.streamed_args_for_tool.append('{"city": "Par')
+            return StreamingParseResult(
+                calls=[
+                    ToolCallItem(tool_index=0, name="get_weather", parameters=""),
+                    ToolCallItem(tool_index=0, parameters='{"city": "Par'),
+                ]
+            )
+        raise RuntimeError("boom")
+
+    def structure_info(self):
+        raise NotImplementedError()
+
+
+class TestGenericDetectorFailOpen(CustomTestCase):
+    """The fail-open ladder applies to every detector, not only tag formats."""
+
+    def test_stream_chunk_fails_open_and_latches(self):
+        parser = _make_parser(_RaisingDetector())
+        self.assertEqual(parser.parse_stream_chunk("chunk one"), ("chunk one", []))
+        # Latched: the detector is not called again.
+        self.assertEqual(parser.parse_stream_chunk("chunk two"), ("chunk two", []))
+        events = [r.event for r in parser.detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+
+    def test_non_stream_fails_open(self):
+        parser = _make_parser(_RaisingDetector())
+        self.assertEqual(parser.parse_non_stream("full text"), ("full text", []))
+        events = [r.event for r in parser.detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+
+    def test_mid_call_close_synthesis_from_base_bookkeeping(self):
+        detector = _RaisingDetector()
+        detector.has_streamed_partial_args = True
+        parser = _make_parser(detector)
+        _, calls1 = parser.parse_stream_chunk("first")
+        normal2, calls2 = parser.parse_stream_chunk("second")
+        streamed = "".join(
+            call.parameters for call in calls1 + calls2 if call.parameters
+        )
+        self.assertEqual(json.loads(streamed), {"city": "Par"})
+        self.assertEqual(detector.prev_tool_call_arr[0]["arguments"], {"city": "Par"})
+        self.assertEqual(normal2, "second")
+
+
+def _m3_parser(strict=False):
+    return M3TextParser(
+        functions=M3_FUNCTIONS,
+        compatibility=CompatibilityMode(strict=strict),
+    )
+
+
+class TestCompatibilityEvents(CustomTestCase):
+    """Tolerances are named, recorded, and (in strict mode) raise instead."""
+
+    DUPLICATE_TAG_TEXT = (
+        f"{NS}<tool_call>\n"
+        f'{NS}<invoke name="get_weather">'
+        f"{NS}<location>"
+        f"{NS}<city>a{NS}</city>{NS}<city>b{NS}</city>"
+        f"{NS}</location>"
+        f"{NS}</invoke>\n"
+        f"{NS}</tool_call>"
+    )
+
+    def test_clean_parse_records_nothing(self):
+        grammar = _m3_parser()
+        grammar.update(
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<city>Paris{NS}</city>{NS}<days>3{NS}</days>"
+            f"{NS}</invoke>\n"
+            f"{NS}</tool_call>"
+        )
+        self.assertEqual(grammar.compatibility.records, [])
+
+    def test_duplicate_tag_collapses_to_list_and_records(self):
+        grammar = _m3_parser()
+        grammar.update(self.DUPLICATE_TAG_TEXT)
+        args = grammar.get_final()["tool_calls"][0]["function"]["arguments"]
+        self.assertEqual(json.loads(args), {"location": {"city": ["a", "b"]}})
+        events = [r.event for r in grammar.compatibility.records]
+        self.assertEqual(events, [CompatibilityEvent.DUPLICATE_TAG_AS_LIST])
+
+    def test_strict_mode_raises_instead_of_recovering(self):
+        grammar = _m3_parser(strict=True)
+        with self.assertRaises(CompatibilityViolation) as ctx:
+            grammar.update(self.DUPLICATE_TAG_TEXT)
+        self.assertEqual(
+            ctx.exception.record.event, CompatibilityEvent.DUPLICATE_TAG_AS_LIST
+        )
+
+    def test_unconvertible_value_kept_raw_and_recorded(self):
+        detector = MinimaxM3NomDetector()
+        result = detector.detect_and_parse(
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<city>Paris{NS}</city>{NS}<days>tomorrow{NS}</days>"
+            f"{NS}</invoke>\n"
+            f"{NS}</tool_call>",
+            TOOLS,
+        )
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(
+            json.loads(result.calls[0].parameters),
+            {"city": "Paris", "days": "tomorrow"},
+        )
+        events = [r.event for r in detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW])
+
+    def test_skipped_garbage_inside_m2_invoke_recovers_and_records(self):
+        detector = MinimaxM2Detector()
+        result = detector.detect_and_parse(
+            "<minimax:tool_call>\n"
+            '<invoke name="get_weather">\n'
+            "JUNK that matches no tag\n"
+            '<parameter name="city">Paris</parameter>\n'
+            "</invoke>\n"
+            "</minimax:tool_call>",
+            TOOLS,
+        )
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "Paris"})
+        events = [r.event for r in detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.SKIPPED_GARBAGE])
+
+    def test_mixed_text_captured_under_text_key(self):
+        grammar = _m3_parser()
+        grammar.update(
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<location>"
+            f"{NS}<city>a{NS}</city>stray"
+            f"{NS}</location>"
+            f"{NS}</invoke>\n"
+            f"{NS}</tool_call>"
+        )
+        args = grammar.get_final()["tool_calls"][0]["function"]["arguments"]
+        self.assertEqual(
+            json.loads(args), {"location": {"city": "a", "$text": "stray"}}
+        )
+        events = [r.event for r in grammar.compatibility.records]
+        self.assertIn(CompatibilityEvent.MIXED_TEXT_CAPTURED, events)
+
+
+class _BufferedRaisingDetector(BaseFormatDetector):
+    """Buffers chunks (emitting nothing), then raises when it sees 'X'."""
+
+    def has_tool_call(self, text: str) -> bool:
+        return True
+
+    def detect_and_parse(self, text, tools) -> StreamingParseResult:
+        raise RuntimeError("boom")
+
+    def parse_streaming_increment(self, new_text, tools) -> StreamingParseResult:
+        self._buffer += new_text
+        if "X" in self._buffer:
+            raise RuntimeError("boom")
+        return StreamingParseResult()
+
+    def structure_info(self):
+        raise NotImplementedError()
+
+
+class TestJsonDetectorCompatibility(CustomTestCase):
+    """Compatibility events and fail-open for JSON-wrapper (non-tag) detectors."""
+
+    def test_malformed_json_block_dropped_and_recorded(self):
+        detector = Qwen25Detector()
+        text = (
+            "<tool_call>\n"
+            '{"name": "get_weather", "arguments": {"city": "Paris"}}\n'
+            "</tool_call>\n"
+            "<tool_call>\n{broken json\n</tool_call>"
+        )
+        result = detector.detect_and_parse(text, TOOLS)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(
+            json.loads(result.calls[0].parameters), {"city": "Paris"}
+        )
+        events = [r.event for r in detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
+
+    def test_unknown_tool_dropped_and_recorded(self):
+        detector = Qwen25Detector()
+        text = '<tool_call>\n{"name": "no_such_tool", "arguments": {}}\n</tool_call>'
+        result = detector.detect_and_parse(text, TOOLS)
+        self.assertEqual(result.calls, [])
+        events = [r.event for r in detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.UNKNOWN_TOOL_DROPPED])
+
+    def test_strict_mode_raises_on_unknown_tool(self):
+        detector = Qwen25Detector()
+        detector.compatibility = CompatibilityMode(strict=True)
+        text = '<tool_call>\n{"name": "no_such_tool", "arguments": {}}\n</tool_call>'
+        with self.assertRaises(CompatibilityViolation):
+            detector.detect_and_parse(text, TOOLS)
+
+    def test_deepseek_malformed_block_dropped_others_survive(self):
+        detector = DeepSeekV3Detector()
+        good = (
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+            '```json\n{"city": "Paris"}\n```<｜tool▁call▁end｜>'
+        )
+        bad = (
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+            "```json\n{broken\n```<｜tool▁call▁end｜>"
+        )
+        text = f"<｜tool▁calls▁begin｜>{good}{bad}<｜tool▁calls▁end｜>"
+        result = detector.detect_and_parse(text, TOOLS)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "Paris"})
+        events = [r.event for r in detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
+
+    def test_pythonic_non_literal_args_dropped_and_recorded(self):
+        detector = PythonicDetector()
+        result = detector.detect_and_parse("[get_weather(city=some_var)]", TOOLS)
+        self.assertEqual(result.calls, [])
+        events = [r.event for r in detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
+
+    def test_detector_local_malformed_fallback_is_recorded(self):
+        detector = HermesDetector()
+        text = "<tool_call>not valid json</tool_call>"
+
+        result = detector.detect_and_parse(text, TOOLS)
+
+        self.assertEqual(result.calls, [])
+        self.assertEqual(result.normal_text, text)
+        events = [r.event for r in detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
+
+    def test_detector_local_unknown_tool_drop_is_recorded(self):
+        cases = [
+            (
+                MiMoDetector(),
+                "<tool_call><function=no_such_tool>"
+                "<parameter=x>1</parameter></function></tool_call>",
+            ),
+            (
+                Apertus2509Detector(),
+                '<|tools_prefix|>[{"no_such_tool": {"x": 1}}]<|tools_suffix|>',
+            ),
+        ]
+
+        for detector, text in cases:
+            with self.subTest(detector=type(detector).__name__):
+                result = detector.detect_and_parse(text, TOOLS)
+                self.assertEqual(result.calls, [])
+                events = [r.event for r in detector.compatibility_records]
+                self.assertEqual(events, [CompatibilityEvent.UNKNOWN_TOOL_DROPPED])
+
+    def test_detector_local_unknown_tool_strict_fails_open(self):
+        text = (
+            "<tool_call><function=no_such_tool>"
+            "<parameter=x>1</parameter></function></tool_call>"
+        )
+        parser = _make_parser(MiMoDetector(), enable_compatibility_mode=False)
+
+        normal_text, calls = parser.parse_non_stream(text)
+
+        self.assertEqual(calls, [])
+        self.assertEqual(normal_text, text)
+        events = [r.event for r in parser.detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+
+    def test_streaming_exception_flushes_buffered_text(self):
+        """A raising detector loses no buffered text: fail-open flushes it."""
+        parser = _make_parser(_BufferedRaisingDetector())
+        normal1, calls1 = parser.parse_stream_chunk("hello ")
+        self.assertEqual((normal1, calls1), ("", []))
+        normal2, calls2 = parser.parse_stream_chunk("X world")
+        self.assertEqual(normal2, "hello X world")
+        self.assertEqual(calls2, [])
+        normal3, _ = parser.parse_stream_chunk(" after")
+        self.assertEqual(normal3, " after")
+        events = [r.event for r in parser.detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+
+
+class TestParamTypeConversion(CustomTestCase):
+    def _convert(self, value, schema):
+        return FunctionCallParameterDataType.from_property(schema).convert(value)
+
+    def test_float_text_is_preserved(self):
+        schema = {"type": "number"}
+        self.assertEqual(self._convert("3", schema), 3)
+        result = self._convert("3.0", schema)
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, 3.0)
+        result = self._convert("1e2", schema)
+        self.assertIsInstance(result, float)
+        self.assertEqual(result, 100.0)
+
+    def test_integer_schema_unchanged(self):
+        schema = {"type": "integer"}
+        self.assertEqual(self._convert("5", schema), 5)
+
+
+class TestCompatibilityModeOption(CustomTestCase):
+    """The serving-level switch: compatibility mode heals; default strict fails open."""
+
+    def test_compatibility_mode_heals_default_strict_fails_open(self):
+        text = TestCompatibilityEvents.DUPLICATE_TAG_TEXT
+
+        compatible = FunctionCallParser(
+            TOOLS, "minimax-m3-nom", enable_compatibility_mode=True
+        )
+        _, calls = compatible.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(
+            json.loads(calls[0].parameters), {"location": {"city": ["a", "b"]}}
+        )
+        # The healing is on the audit trail.
+        events = [r.event for r in compatible.detector.compatibility_records]
+        self.assertEqual(events, [CompatibilityEvent.DUPLICATE_TAG_AS_LIST])
+
+        strict = FunctionCallParser(TOOLS, "minimax-m3-nom")
+        normal_text, calls = strict.parse_non_stream(text)
+        self.assertEqual(calls, [])
+        self.assertEqual(normal_text, text)
+        events = [r.event for r in strict.detector.compatibility_records]
+        self.assertIn(CompatibilityEvent.FAIL_OPEN, events)
+
+
+ARRAY_TOOLS = TOOLS + [
+    Tool(
+        type="function",
+        function=Function(
+            name="set_flags",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "flags": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        ),
+    ),
+]
+
+
+class TestRemainingCompatibilityEvents(CustomTestCase):
+    """One test per compatibility event not covered elsewhere, plus the
+    strict-mode fail-open behavior at the boundary for each."""
+
+    def _events(self, parser):
+        return [r.event for r in parser.detector.compatibility_records]
+
+    def test_dropped_invoke_tail(self):
+        text = (
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">GARBAGE WITH NO TAG{NS}</invoke>\n'
+            f"{NS}</tool_call>"
+        )
+        parser = _make_parser()
+        normal_text, calls = parser.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "get_weather")
+        self.assertEqual(json.loads(calls[0].parameters), {})
+        self.assertIn(CompatibilityEvent.DROPPED_INVOKE_TAIL, self._events(parser))
+
+        strict = _make_parser(
+            FunctionCallParser(TOOLS, "minimax-m3-nom").detector,
+            enable_compatibility_mode=False,
+        )
+        strict.detector.compatibility.strict = True
+        normal_text, calls = strict.parse_non_stream(text)
+        self.assertEqual(calls, [])
+        self.assertEqual(normal_text, text)
+
+    def test_mismatched_closing_tag(self):
+        text = (
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<city>Paris{NS}</city>"
+            f"{NS}<location>{NS}<lat>1{NS}</wrong>{NS}</location>"
+            f"{NS}</invoke>\n{NS}</tool_call>"
+        )
+        parser = _make_parser()
+        _, calls = parser.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertIn(CompatibilityEvent.MISMATCHED_CLOSING_TAG, self._events(parser))
+
+    def test_unclosed_tags_at_end(self):
+        text = (
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<city>Paris{NS}</city>"
+            f"{NS}<location>{NS}<lat>1"
+            f"{NS}</location>"
+            f"{NS}</invoke>\n{NS}</tool_call>"
+        )
+        parser = _make_parser()
+        _, calls = parser.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertIn(CompatibilityEvent.UNCLOSED_TAGS_AT_END, self._events(parser))
+
+    def test_non_item_array_child(self):
+        text = (
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="set_flags">'
+            f"{NS}<flags>{NS}<item>a{NS}</item>{NS}<element>b{NS}</element>{NS}</flags>"
+            f"{NS}</invoke>\n{NS}</tool_call>"
+        )
+        parser = FunctionCallParser(
+            ARRAY_TOOLS, "minimax-m3-nom", enable_compatibility_mode=True
+        )
+        _, calls = parser.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(json.loads(calls[0].parameters), {"flags": ["a", "b"]})
+        self.assertIn(CompatibilityEvent.NON_ITEM_ARRAY_CHILD, self._events(parser))
+
+    def test_structure_overrode_schema(self):
+        # `city` is string-typed, but the namespace token asserts nesting.
+        text = (
+            f"{NS}<tool_call>\n"
+            f'{NS}<invoke name="get_weather">'
+            f"{NS}<city>{NS}<x>1{NS}</x>{NS}</city>"
+            f"{NS}</invoke>\n{NS}</tool_call>"
+        )
+        parser = _make_parser()
+        _, calls = parser.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertIn(
+            CompatibilityEvent.STRUCTURE_OVERRODE_SCHEMA, self._events(parser)
+        )
+
+    def test_invalid_schema_ignored_never_raises_in_strict(self):
+        data_type = FunctionCallParameterDataType.get_schema_of_parameter(
+            {
+                "parameters": {
+                    "type": "object",
+                    # multipleOf must be > 0: the schema itself is invalid.
+                    "properties": {"x": {"type": "integer", "multipleOf": 0}},
+                }
+            },
+            "x",
+        )
+        mode = CompatibilityMode(strict=True)
+        value = data_type.convert("5", compatibility=mode)
+        self.assertEqual(value, 5)
+        self.assertEqual(
+            [r.event for r in mode.records],
+            [CompatibilityEvent.INVALID_SCHEMA_IGNORED],
+        )
+
+    def test_truncated_call_dropped_identical_in_both_modes(self):
+        from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+
+        text = "Check.\n<tool_call>\n<function=get_weather>\n<parameter=city>\nBei"
+        for enable_compatibility_mode in (True, False):
+            parser = FunctionCallParser(
+                TOOLS,
+                "qwen3_coder",
+                enable_compatibility_mode=enable_compatibility_mode,
+            )
+            normal_text, calls = parser.parse_non_stream(text)
+            self.assertEqual(calls, [], enable_compatibility_mode)
+            self.assertEqual(normal_text, text, enable_compatibility_mode)
+        compatible = FunctionCallParser(
+            TOOLS, "qwen3_coder", enable_compatibility_mode=True
+        )
+        compatible.parse_non_stream(text)
+        self.assertIn(
+            CompatibilityEvent.TRUNCATED_CALL_DROPPED, self._events(compatible)
+        )
+
+    def test_skipped_non_function_entry(self):
+        from sglang.srt.function_call.step3_detector import Step3Detector
+
+        text = (
+            "<｜tool_calls_begin｜>\n"
+            "<｜tool_call_begin｜>thought<｜tool_sep｜>hmm<｜tool_call_end｜>\n"
+            "<｜tool_call_begin｜>function<｜tool_sep｜>"
+            '<steptml:invoke name="get_weather">\n'
+            '<steptml:parameter name="city">Paris</steptml:parameter>\n'
+            "</steptml:invoke><｜tool_call_end｜>\n"
+            "<｜tool_calls_end｜>"
+        )
+        parser = FunctionCallParser(
+            TOOLS, "step3", enable_compatibility_mode=True
+        )
+        _, calls = parser.parse_non_stream(text)
+        self.assertEqual([c.name for c in calls], ["get_weather"])
+        self.assertIn(
+            CompatibilityEvent.SKIPPED_NON_FUNCTION_ENTRY, self._events(parser)
+        )
+
+    def test_missing_close_tag(self):
+        text = (
+            "<tool_call>\n<function=get_weather>\n"
+            "<parameter=city>\nParis\n"
+            "<parameter=days>\n3\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        parser = FunctionCallParser(
+            TOOLS, "qwen3_coder", enable_compatibility_mode=True
+        )
+        _, calls = parser.parse_non_stream(text)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(json.loads(calls[0].parameters), {"city": "Paris", "days": 3})
+        self.assertIn(CompatibilityEvent.MISSING_CLOSE_TAG, self._events(parser))
+
+
+class TestComplexSchemaCompatibility(CustomTestCase):
+    """Compatibility mode over nested arrays, objects, unions, and conversions."""
+
+    COMPLEX_TEXT = (
+        f"{NS}<tool_call>\n"
+        f'{NS}<invoke name="plan_trip">'
+        f"{NS}<destination>Tokyo{NS}</destination>"
+        f"{NS}<days>5{NS}</days>"
+        f"{NS}<budget>1250.5{NS}</budget>"
+        f"{NS}<travelers>"
+        f"{NS}<item>"
+        f"{NS}<name>Ada{NS}</name>"
+        f"{NS}<age>34{NS}</age>"
+        f"{NS}<preferences>"
+        f"{NS}<vegetarian>true{NS}</vegetarian>"
+        f"{NS}<tags>{NS}<item>museum{NS}</item>{NS}<item>ramen{NS}</item>{NS}</tags>"
+        f"{NS}</preferences>"
+        f"{NS}</item>"
+        f"{NS}<item>"
+        f"{NS}<name>Lin{NS}</name>"
+        f"{NS}<age>old{NS}</age>"
+        f"{NS}</item>"
+        f"{NS}</travelers>"
+        f"{NS}<itinerary>"
+        f"{NS}<item>{NS}<day>1{NS}</day>{NS}<city>Tokyo{NS}</city>"
+        f"{NS}<activities>{NS}<item>arrival{NS}</item>{NS}</activities>{NS}</item>"
+        f"{NS}<entry>{NS}<day>2{NS}</day>{NS}<city>Tokyo{NS}</city>"
+        f"{NS}<activities>{NS}<item>museum{NS}</item>{NS}</activities>{NS}</entry>"
+        f"{NS}</itinerary>"
+        f"{NS}<contact>null{NS}</contact>"
+        f"{NS}<metadata>{NS}<season>spring{NS}</season>{NS}<pace>moderate{NS}</pace>{NS}</metadata>"
+        f"{NS}<transport>{NS}<mode>train{NS}</mode>{NS}<priority>2{NS}</priority>{NS}</transport>"
+        f"{NS}</invoke>\n"
+        f"{NS}</tool_call>"
+    )
+
+    def _parser(self, enable_compatibility_mode=True):
+        return FunctionCallParser(
+            COMPLEX_TOOLS,
+            "minimax-m3-nom",
+            enable_compatibility_mode=enable_compatibility_mode,
+        )
+
+    def _events(self, parser):
+        return [r.event for r in parser.detector.compatibility_records]
+
+    def test_complex_schema_heals_nested_deviations_and_records(self):
+        parser = self._parser(enable_compatibility_mode=True)
+        normal_text, calls = parser.parse_non_stream(self.COMPLEX_TEXT)
+        self.assertEqual(normal_text, "")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "plan_trip")
+
+        args = json.loads(calls[0].parameters)
+        self.assertEqual(args["destination"], "Tokyo")
+        self.assertEqual(args["days"], 5)
+        self.assertEqual(args["budget"], 1250.5)
+        self.assertEqual(args["contact"], None)
+        self.assertEqual(args["metadata"], {"season": "spring", "pace": "moderate"})
+        self.assertEqual(args["transport"], {"mode": "train", "priority": 2})
+        self.assertEqual(args["travelers"][0]["preferences"]["tags"], ["museum", "ramen"])
+        self.assertEqual(args["travelers"][1]["age"], "old")
+        self.assertEqual(args["itinerary"][1]["day"], 2)
+
+        events = self._events(parser)
+        self.assertIn(CompatibilityEvent.NON_ITEM_ARRAY_CHILD, events)
+        self.assertIn(CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW, events)
+
+    def test_complex_schema_strict_parser_fails_open(self):
+        parser = self._parser(enable_compatibility_mode=False)
+        normal_text, calls = parser.parse_non_stream(self.COMPLEX_TEXT)
+        self.assertEqual(calls, [])
+        self.assertEqual(normal_text, self.COMPLEX_TEXT)
+        events = self._events(parser)
+        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+        self.assertIn(
+            CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW.value,
+            parser.detector.compatibility_records[0].detail,
+        )
+
+
+class TestTagStreamingGates(CustomTestCase):
+    """Streaming-only behaviors of the tag adapter: the unknown-tool gate and
+    the fail-open raw-text accounting."""
+
+    def _stream_m2(self, text, chunk_size, enable_compatibility_mode=True):
+        parser = FunctionCallParser(
+            TOOLS,
+            "minimax-m2",
+            enable_compatibility_mode=enable_compatibility_mode,
+        )
+        return parser, _stream(parser, text, chunk_size)
+
+    def test_unknown_tool_dropped_in_streaming_with_dense_indices(self):
+        text = (
+            "<minimax:tool_call>\n"
+            '<invoke name="hack_tool">\n<parameter name="city">x</parameter>\n</invoke>\n'
+            '<invoke name="get_weather">\n<parameter name="city">Paris</parameter>\n</invoke>\n'
+            "</minimax:tool_call>"
+        )
+        for chunk_size in (1, 7, len(text)):
+            parser, (normal_text, calls) = self._stream_m2(text, chunk_size)
+            names = [c.name for c in calls if c.name]
+            self.assertEqual(names, ["get_weather"], chunk_size)
+            args = "".join(c.parameters for c in calls if c.parameters)
+            self.assertEqual(json.loads(args), {"city": "Paris"}, chunk_size)
+            # Indices stay dense: the grammar never assigns an ordinal to the
+            # dropped call in the first place.
+            self.assertEqual({c.tool_index for c in calls}, {0}, chunk_size)
+            events = [r.event for r in parser.detector.compatibility_records]
+            self.assertIn(CompatibilityEvent.UNKNOWN_TOOL_DROPPED, events)
+            # Consistent with the non-streaming path.
+            nonstream = FunctionCallParser(
+                TOOLS, "minimax-m2", enable_compatibility_mode=True
+            )
+            _, ns_calls = nonstream.parse_non_stream(text)
+            self.assertEqual([c.name for c in ns_calls], ["get_weather"])
+
+    def test_unknown_tool_fails_open_in_strict_streaming(self):
+        text = (
+            "<minimax:tool_call>\n"
+            '<invoke name="hack_tool">\n<parameter name="city">x</parameter>\n</invoke>\n'
+            "</minimax:tool_call> after"
+        )
+        for chunk_size in (1, 9, len(text)):
+            parser, (normal_text, calls) = self._stream_m2(
+                text, chunk_size, enable_compatibility_mode=False
+            )
+            self.assertEqual(calls, [], chunk_size)
+            # The gate fires at name-parse time, before anything for the call
+            # is emitted or committed, so fail-open re-surfaces the full raw
+            # text deterministically — independent of chunking.
+            self.assertEqual(normal_text, text, chunk_size)
+            # Strict-mode convention: the violation raises instead of being
+            # recorded; the FAIL_OPEN record carries it in its detail.
+            records = parser.detector.compatibility_records
+            self.assertEqual([r.event for r in records], [CompatibilityEvent.FAIL_OPEN])
+            self.assertIn(CompatibilityEvent.UNKNOWN_TOOL_DROPPED.value, records[0].detail)
+
+    def test_strict_fail_open_after_completed_block_is_not_corrupted(self):
+        # Regression: emitted content is not a contiguous prefix of the raw
+        # stream once a no-call block completes; fail-open used to duplicate
+        # text and clip markers here.
+        text = (
+            "A<minimax:tool_call> </minimax:tool_call>"
+            'B<minimax:tool_call> junk <invoke name="get_weather">'
+        )
+        for chunk_size in (1, 5, len(text)):
+            parser, (normal_text, calls) = self._stream_m2(
+                text, chunk_size, enable_compatibility_mode=False
+            )
+            self.assertEqual(calls, [], chunk_size)
+            self.assertEqual(
+                normal_text,
+                'AB<minimax:tool_call> junk <invoke name="get_weather">',
+                chunk_size,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/function_call/test_function_call_compatibility.py
+++ b/test/registered/unit/function_call/test_function_call_compatibility.py
@@ -7,13 +7,13 @@ mode, and schema-driven value conversion fallbacks.
 
 import json
 import unittest
+from dataclasses import dataclass
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
-from sglang.srt.function_call.apertus2509_detector import Apertus2509Detector
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.compatibility import (
+    CompatibilityContext,
     CompatibilityEvent,
-    CompatibilityMode,
     CompatibilityViolation,
     synthesize_json_close,
 )
@@ -22,17 +22,23 @@ from sglang.srt.function_call.compatibility.param_types import (
 )
 from sglang.srt.function_call.core_types import StreamingParseResult, ToolCallItem
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
+from sglang.srt.function_call.deepseekv31_detector import DeepSeekV31Detector
+from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
-from sglang.srt.function_call.hermes_detector import HermesDetector
-from sglang.srt.function_call.mimo_detector import MiMoDetector
+from sglang.srt.function_call.gemma4_detector import Gemma4Detector
+from sglang.srt.function_call.gigachat3_detector import GigaChat3Detector
+from sglang.srt.function_call.glm4_moe_detector import Glm4MoeDetector
+from sglang.srt.function_call.glm47_moe_detector import Glm47MoeDetector
+from sglang.srt.function_call.kimik2_detector import KimiK2Detector
 from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
 from sglang.srt.function_call.minimax_m3 import M3TextParser, MinimaxM3Detector
+from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.parsing import (
     GeneratorParser,
     default_tool_call_output_key,
 )
-from sglang.srt.function_call.pythonic_detector import PythonicDetector
-from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.srt.function_call.poolside_v1_detector import PoolsideV1Detector
 from sglang.srt.function_call.tag_format_detector import TagToolCallDetector
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -57,6 +63,20 @@ TOOLS = [
             },
         ),
     ),
+]
+
+BOOLEAN_TOOLS = TOOLS + [
+    Tool(
+        type="function",
+        function=Function(
+            name="set_enabled",
+            parameters={
+                "type": "object",
+                "properties": {"enabled": {"type": "boolean"}},
+                "required": ["enabled"],
+            },
+        ),
+    )
 ]
 
 M3_FUNCTIONS = {
@@ -156,8 +176,14 @@ def _stream(parser, text, chunk_size):
         chunk_normal, chunk_calls = parser.parse_stream_chunk(text[i : i + chunk_size])
         normal_text += chunk_normal
         calls.extend(chunk_calls)
-    # Allow deferred emission, mirroring the serving loop's trailing ticks.
-    for _ in range(4):
+    return _drain_stream(parser, normal_text, calls, ticks=4)
+
+
+def _drain_stream(parser, normal_text="", calls=None, ticks=8):
+    """Allow deferred emission, mirroring the serving loop's trailing ticks."""
+    if calls is None:
+        calls = []
+    for _ in range(ticks):
         chunk_normal, chunk_calls = parser.parse_stream_chunk("")
         if not chunk_normal and not chunk_calls:
             break
@@ -166,7 +192,188 @@ def _stream(parser, text, chunk_size):
     return normal_text, calls
 
 
-class TestSynthesizeJsonClose(CustomTestCase):
+def _stream_chunks(parser, chunks, ticks=8):
+    normal_text = ""
+    calls = []
+    for chunk in chunks:
+        chunk_normal, chunk_calls = parser.parse_stream_chunk(chunk)
+        normal_text += chunk_normal
+        calls.extend(chunk_calls)
+    return _drain_stream(parser, normal_text, calls, ticks=ticks)
+
+
+@dataclass(frozen=True)
+class ParserTextCase:
+    parser_name: str
+    text: str
+
+
+@dataclass(frozen=True)
+class ParserChunksCase:
+    parser_name: str
+    case_name: str
+    chunks: tuple
+    expected_event: CompatibilityEvent
+
+
+@dataclass(frozen=True)
+class ParserNamedTextCase:
+    parser_name: str
+    case_name: str
+    text: str
+    expected_event: CompatibilityEvent
+
+
+@dataclass(frozen=True)
+class ParserDropCase(ParserTextCase):
+    expected_event: CompatibilityEvent
+    expected_normal_text: str = ""
+
+
+@dataclass(frozen=True)
+class DetectorTextCase:
+    detector_factory: object
+    text: str
+
+
+@dataclass(frozen=True)
+class DetectorInstanceCase:
+    detector: object
+    text: str
+
+
+@dataclass(frozen=True)
+class DetectorArgsCase(DetectorInstanceCase):
+    expected_arguments: object
+
+
+NONSTREAM_DROP_CASES = (
+    ParserDropCase(
+        "qwen25",
+        '<tool_call>\n{"name": "no_such_tool", "arguments": {}}\n</tool_call>',
+        CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+        "",
+    ),
+    ParserDropCase(
+        "hermes",
+        "<tool_call>{broken}</tool_call>",
+        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+        "<tool_call>{broken}</tool_call>",
+    ),
+    ParserDropCase(
+        "minimax-m3",
+        f"{NS}<tool_call>\n"
+        f'{NS}<invoke name="no_such_tool">'
+        f"{NS}<city>Paris{NS}</city>"
+        f"{NS}</invoke>\n"
+        f"{NS}</tool_call>",
+        CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+        "",
+    ),
+    ParserDropCase(
+        "mimo",
+        "<tool_call><function=no_such_tool>"
+        "<parameter=city>Paris</parameter>"
+        "</function></tool_call>",
+        CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+        "",
+    ),
+    ParserDropCase(
+        "minicpm5",
+        '<function name="no_such_tool">'
+        '<param name="city">Paris</param>'
+        "</function>",
+        CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+        '<function name="no_such_tool">'
+        '<param name="city">Paris</param>'
+        "</function>",
+    ),
+    ParserDropCase(
+        "gigachat3",
+        'function call<|role_sep|>\n{"name":"no_such_tool",' '"arguments":{}}</s>',
+        CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+        "",
+    ),
+    ParserDropCase(
+        "kimi_k2",
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>functions.get_weather:0"
+        "<|tool_call_argument_begin|>{broken<|tool_call_end|>"
+        "<|tool_calls_section_end|>",
+        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+        "",
+    ),
+    ParserDropCase(
+        "gemma4",
+        "<|tool_call>not-a-call<tool_call|>",
+        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+        "",
+    ),
+    ParserDropCase(
+        "hunyuan",
+        "<tool_calls>not-a-call</tool_calls>",
+        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+        "",
+    ),
+)
+
+
+class CompatibilityTestCase(CustomTestCase):
+    def records_of(self, owner):
+        if hasattr(owner, "detector"):
+            return owner.detector.compatibility_records
+        if hasattr(owner, "compatibility_records"):
+            return owner.compatibility_records
+        if hasattr(owner, "compatibility"):
+            return owner.compatibility.records
+        return owner.records
+
+    def events_of(self, owner):
+        return [record.event for record in self.records_of(owner)]
+
+    def assert_events_equal(self, owner, expected):
+        self.assertEqual(self.events_of(owner), list(expected))
+
+    def assert_event_in(self, owner, event):
+        self.assertIn(event, self.events_of(owner))
+
+    def assert_fail_open_with_detail(self, owner, inner_event):
+        records = self.records_of(owner)
+        self.assertEqual(
+            [record.event for record in records], [CompatibilityEvent.FAIL_OPEN]
+        )
+        self.assertIn(inner_event.value, records[0].detail)
+
+    def call_names(self, calls):
+        return [call.name for call in calls if call.name]
+
+    def streamed_parameters(self, calls):
+        return "".join(call.parameters for call in calls if call.parameters)
+
+    def streamed_parameters_by_tool(self, calls):
+        grouped = {}
+        for call in calls:
+            if call.parameters:
+                grouped.setdefault(call.tool_index, "")
+                grouped[call.tool_index] += call.parameters
+        return {idx: json.loads(params) for idx, params in grouped.items()}
+
+    def assert_single_call(self, calls, *, name=None, arguments=None, tool_index=None):
+        self.assertEqual(len(calls), 1)
+        call = calls[0]
+        if name is not None:
+            self.assertEqual(call.name, name)
+        if tool_index is not None:
+            self.assertEqual(call.tool_index, tool_index)
+        if arguments is not None:
+            self.assertEqual(json.loads(call.parameters), arguments)
+        return call
+
+    def assert_streamed_arguments(self, calls, expected):
+        self.assertEqual(json.loads(self.streamed_parameters(calls)), expected)
+
+
+class TestSynthesizeJsonClose(CompatibilityTestCase):
     def _check(self, partial, expected_value):
         closing = synthesize_json_close(partial)
         self.assertIsNotNone(closing, partial)
@@ -215,7 +422,7 @@ class _MidCallFailingDetector(TagToolCallDetector):
         return True
 
 
-class TestFailOpenLadder(CustomTestCase):
+class TestFailOpenLadder(CompatibilityTestCase):
     """Scope 4: the FunctionCallParser boundary never crashes a request."""
 
     def test_error_before_tool_call_flushes_raw_text(self):
@@ -230,8 +437,7 @@ class TestFailOpenLadder(CustomTestCase):
             chunk_normal, _ = parser.parse_stream_chunk(" more")
             self.assertEqual(chunk_normal, " more")
             # The failure is on the audit trail.
-            events = [r.event for r in parser.detector.compatibility_records]
-            self.assertIn(CompatibilityEvent.FAIL_OPEN, events)
+            self.assert_event_in(parser, CompatibilityEvent.FAIL_OPEN)
 
     def test_trailing_text_after_block_is_not_swallowed(self):
         """A complete call followed by trailing text: call survives, text flows."""
@@ -247,23 +453,17 @@ class TestFailOpenLadder(CustomTestCase):
             parser = _make_parser()
             normal_text, calls = _stream(parser, text, chunk_size)
             self.assertEqual(normal_text, "Lead. \nTrailing.", chunk_size)
-            names = [call.name for call in calls if call.name]
-            self.assertEqual(names, ["get_weather"], chunk_size)
-            streamed = "".join(call.parameters for call in calls if call.parameters)
-            self.assertEqual(json.loads(streamed), {"city": "Paris"})
+            self.assertEqual(self.call_names(calls), ["get_weather"], chunk_size)
+            self.assert_streamed_arguments(calls, {"city": "Paris"})
 
     def test_mid_call_failure_closes_streamed_arguments(self):
         parser = _make_parser(_MidCallFailingDetector())
         normal1, calls1 = parser.parse_stream_chunk("abc")
-        names = [call.name for call in calls1 if call.name]
-        self.assertEqual(names, ["get_weather"])
+        self.assertEqual(self.call_names(calls1), ["get_weather"])
 
         normal2, calls2 = parser.parse_stream_chunk("X")
-        streamed = "".join(
-            call.parameters for call in calls1 + calls2 if call.parameters
-        )
         # The synthesized close makes the streamed fragments valid JSON.
-        self.assertEqual(json.loads(streamed), {"city": "Par"})
+        self.assert_streamed_arguments(calls1 + calls2, {"city": "Par"})
         # The failing text is flushed as content, later text passes through.
         self.assertEqual(normal2, "X")
         normal3, calls3 = parser.parse_stream_chunk("after")
@@ -280,8 +480,7 @@ class TestFailOpenLadder(CustomTestCase):
         normal_text, calls = parser.parse_non_stream(text)
         self.assertEqual(calls, [])
         self.assertEqual(normal_text, text)
-        events = [r.event for r in parser.detector.compatibility_records]
-        self.assertIn(CompatibilityEvent.FAIL_OPEN, events)
+        self.assert_event_in(parser, CompatibilityEvent.FAIL_OPEN)
 
     def test_non_stream_error_salvages_complete_calls(self):
         """Complete calls parsed before the error survive; the tail flows."""
@@ -294,9 +493,7 @@ class TestFailOpenLadder(CustomTestCase):
         )
         parser = FunctionCallParser(TOOLS, "minimax-m3")
         normal_text, calls = parser.parse_non_stream(text)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0].name, "get_weather")
-        self.assertEqual(json.loads(calls[0].parameters), {"city": "Paris"})
+        self.assert_single_call(calls, name="get_weather", arguments={"city": "Paris"})
         self.assertIn("TRAILING GARBAGE", normal_text)
 
 
@@ -328,7 +525,7 @@ class _RaisingDetector(BaseFormatDetector):
         raise NotImplementedError()
 
 
-class TestGenericDetectorFailOpen(CustomTestCase):
+class TestGenericDetectorFailOpen(CompatibilityTestCase):
     """The fail-open ladder applies to every detector, not only tag formats."""
 
     def test_stream_chunk_fails_open_and_latches(self):
@@ -336,14 +533,12 @@ class TestGenericDetectorFailOpen(CustomTestCase):
         self.assertEqual(parser.parse_stream_chunk("chunk one"), ("chunk one", []))
         # Latched: the detector is not called again.
         self.assertEqual(parser.parse_stream_chunk("chunk two"), ("chunk two", []))
-        events = [r.event for r in parser.detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+        self.assert_events_equal(parser, [CompatibilityEvent.FAIL_OPEN])
 
     def test_non_stream_fails_open(self):
         parser = _make_parser(_RaisingDetector())
         self.assertEqual(parser.parse_non_stream("full text"), ("full text", []))
-        events = [r.event for r in parser.detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+        self.assert_events_equal(parser, [CompatibilityEvent.FAIL_OPEN])
 
     def test_mid_call_close_synthesis_from_base_bookkeeping(self):
         detector = _RaisingDetector()
@@ -351,10 +546,7 @@ class TestGenericDetectorFailOpen(CustomTestCase):
         parser = _make_parser(detector)
         _, calls1 = parser.parse_stream_chunk("first")
         normal2, calls2 = parser.parse_stream_chunk("second")
-        streamed = "".join(
-            call.parameters for call in calls1 + calls2 if call.parameters
-        )
-        self.assertEqual(json.loads(streamed), {"city": "Par"})
+        self.assert_streamed_arguments(calls1 + calls2, {"city": "Par"})
         self.assertEqual(detector.prev_tool_call_arr[0]["arguments"], {"city": "Par"})
         self.assertEqual(normal2, "second")
 
@@ -362,11 +554,11 @@ class TestGenericDetectorFailOpen(CustomTestCase):
 def _m3_parser(strict=False):
     return M3TextParser(
         functions=M3_FUNCTIONS,
-        compatibility=CompatibilityMode(strict=strict),
+        compatibility=CompatibilityContext(strict=strict),
     )
 
 
-class TestCompatibilityEvents(CustomTestCase):
+class TestCompatibilityEvents(CompatibilityTestCase):
     """Tolerances are named, recorded, and (in strict mode) raise instead."""
 
     DUPLICATE_TAG_TEXT = (
@@ -395,8 +587,7 @@ class TestCompatibilityEvents(CustomTestCase):
         grammar.update(self.DUPLICATE_TAG_TEXT)
         args = grammar.get_final()["tool_calls"][0]["function"]["arguments"]
         self.assertEqual(json.loads(args), {"location": {"city": ["a", "b"]}})
-        events = [r.event for r in grammar.compatibility.records]
-        self.assertEqual(events, [CompatibilityEvent.DUPLICATE_TAG_AS_LIST])
+        self.assert_events_equal(grammar, [CompatibilityEvent.DUPLICATE_TAG_AS_LIST])
 
     def test_strict_mode_raises_instead_of_recovering(self):
         grammar = _m3_parser(strict=True)
@@ -416,13 +607,13 @@ class TestCompatibilityEvents(CustomTestCase):
             f"{NS}</tool_call>",
             TOOLS,
         )
-        self.assertEqual(len(result.calls), 1)
-        self.assertEqual(
-            json.loads(result.calls[0].parameters),
-            {"city": "Paris", "days": "tomorrow"},
+        self.assert_single_call(
+            result.calls,
+            arguments={"city": "Paris", "days": "tomorrow"},
         )
-        events = [r.event for r in detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW])
+        self.assert_events_equal(
+            detector, [CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW]
+        )
 
     def test_skipped_garbage_inside_m2_invoke_recovers_and_records(self):
         detector = MinimaxM2Detector()
@@ -435,10 +626,61 @@ class TestCompatibilityEvents(CustomTestCase):
             "</minimax:tool_call>",
             TOOLS,
         )
-        self.assertEqual(len(result.calls), 1)
-        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "Paris"})
-        events = [r.event for r in detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.SKIPPED_GARBAGE])
+        self.assert_single_call(result.calls, arguments={"city": "Paris"})
+        self.assert_events_equal(detector, [CompatibilityEvent.SKIPPED_GARBAGE])
+
+    def test_custom_streaming_fsm_skipped_garbage_records(self):
+        cases = [
+            DetectorArgsCase(
+                PoolsideV1Detector(),
+                "<tool_call>get_weather\n"
+                "junk<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+                "</tool_call>",
+                {"city": "Paris"},
+            ),
+            DetectorArgsCase(
+                Gemma4Detector(),
+                '<|tool_call>junkcall:get_weather{city:<|"|>Paris<|"|>}' "<tool_call|>",
+                {"city": "Paris"},
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(detector=type(case.detector).__name__):
+                parser = _make_parser(case.detector)
+
+                normal_text, calls = parser.parse_stream_chunk(case.text)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(calls[0].name, "get_weather")
+                self.assert_streamed_arguments(calls, case.expected_arguments)
+                self.assert_event_in(parser, CompatibilityEvent.SKIPPED_GARBAGE)
+
+    def test_custom_streaming_fsm_skipped_garbage_strict_fails_open(self):
+        cases = [
+            DetectorInstanceCase(
+                PoolsideV1Detector(),
+                "<tool_call>get_weather\n"
+                "junk<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+                "</tool_call>",
+            ),
+            DetectorInstanceCase(
+                Gemma4Detector(),
+                '<|tool_call>junkcall:get_weather{city:<|"|>Paris<|"|>}' "<tool_call|>",
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(detector=type(case.detector).__name__):
+                parser = _make_parser(case.detector, enable_compatibility_mode=False)
+
+                normal_text, calls = parser.parse_stream_chunk(case.text)
+
+                self.assertEqual(calls, [])
+                self.assertEqual(normal_text, case.text)
+                self.assert_fail_open_with_detail(
+                    parser, CompatibilityEvent.SKIPPED_GARBAGE
+                )
 
     def test_mixed_text_captured_under_text_key(self):
         grammar = _m3_parser()
@@ -455,8 +697,7 @@ class TestCompatibilityEvents(CustomTestCase):
         self.assertEqual(
             json.loads(args), {"location": {"city": "a", "$text": "stray"}}
         )
-        events = [r.event for r in grammar.compatibility.records]
-        self.assertIn(CompatibilityEvent.MIXED_TEXT_CAPTURED, events)
+        self.assert_event_in(grammar, CompatibilityEvent.MIXED_TEXT_CAPTURED)
 
 
 class _BufferedRaisingDetector(BaseFormatDetector):
@@ -478,106 +719,867 @@ class _BufferedRaisingDetector(BaseFormatDetector):
         raise NotImplementedError()
 
 
-class TestJsonDetectorCompatibility(CustomTestCase):
+class TestJsonDetectorCompatibility(CompatibilityTestCase):
     """Compatibility events and fail-open for JSON-wrapper (non-tag) detectors."""
 
-    def test_malformed_json_block_dropped_and_recorded(self):
-        detector = Qwen25Detector()
-        text = (
-            "<tool_call>\n"
-            '{"name": "get_weather", "arguments": {"city": "Paris"}}\n'
-            "</tool_call>\n"
-            "<tool_call>\n{broken json\n</tool_call>"
-        )
-        result = detector.detect_and_parse(text, TOOLS)
-        self.assertEqual(len(result.calls), 1)
-        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "Paris"})
-        events = [r.event for r in detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
+    def test_nonstream_compatibility_drop_records_parser_fallback(self):
+        for case in NONSTREAM_DROP_CASES:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
 
-    def test_unknown_tool_dropped_and_recorded(self):
-        detector = Qwen25Detector()
-        text = '<tool_call>\n{"name": "no_such_tool", "arguments": {}}\n</tool_call>'
-        result = detector.detect_and_parse(text, TOOLS)
-        self.assertEqual(result.calls, [])
-        events = [r.event for r in detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.UNKNOWN_TOOL_DROPPED])
+                normal_text, calls = parser.parse_non_stream(case.text)
 
-    def test_strict_mode_raises_on_unknown_tool(self):
-        detector = Qwen25Detector()
-        detector.compatibility = CompatibilityMode(strict=True)
-        text = '<tool_call>\n{"name": "no_such_tool", "arguments": {}}\n</tool_call>'
-        with self.assertRaises(CompatibilityViolation):
-            detector.detect_and_parse(text, TOOLS)
+                self.assertEqual(normal_text, case.expected_normal_text)
+                self.assertEqual(calls, [])
+                self.assert_events_equal(parser, [case.expected_event])
+
+    def test_nonstream_compatibility_drop_strict_fails_open(self):
+        for case in NONSTREAM_DROP_CASES:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=False
+                )
+
+                normal_text, calls = parser.parse_non_stream(case.text)
+
+                self.assertEqual(calls, [])
+                self.assertEqual(normal_text, case.text)
+                self.assert_fail_open_with_detail(parser, case.expected_event)
 
     def test_deepseek_malformed_block_dropped_others_survive(self):
-        detector = DeepSeekV3Detector()
-        good = (
-            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
-            '```json\n{"city": "Paris"}\n```<｜tool▁call▁end｜>'
-        )
-        bad = (
-            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
-            "```json\n{broken\n```<｜tool▁call▁end｜>"
-        )
-        text = f"<｜tool▁calls▁begin｜>{good}{bad}<｜tool▁calls▁end｜>"
-        result = detector.detect_and_parse(text, TOOLS)
-        self.assertEqual(len(result.calls), 1)
-        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "Paris"})
-        events = [r.event for r in detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
-
-    def test_pythonic_non_literal_args_dropped_and_recorded(self):
-        detector = PythonicDetector()
-        result = detector.detect_and_parse("[get_weather(city=some_var)]", TOOLS)
-        self.assertEqual(result.calls, [])
-        events = [r.event for r in detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
-
-    def test_detector_local_malformed_fallback_is_recorded(self):
-        detector = HermesDetector()
-        text = "<tool_call>not valid json</tool_call>"
-
-        result = detector.detect_and_parse(text, TOOLS)
-
-        self.assertEqual(result.calls, [])
-        self.assertEqual(result.normal_text, text)
-        events = [r.event for r in detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.MALFORMED_JSON_DROPPED])
-
-    def test_detector_local_unknown_tool_drop_is_recorded(self):
         cases = [
             (
-                MiMoDetector(),
-                "<tool_call><function=no_such_tool>"
-                "<parameter=x>1</parameter></function></tool_call>",
+                DeepSeekV3Detector(),
+                "<｜tool▁calls▁begin｜>",
+                "<｜tool▁calls▁end｜>",
+                "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+                '```json\n{"city": "Paris"}\n```<｜tool▁call▁end｜>',
+                "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+                "```json\n{broken\n```<｜tool▁call▁end｜>",
             ),
             (
-                Apertus2509Detector(),
-                '<|tools_prefix|>[{"no_such_tool": {"x": 1}}]<|tools_suffix|>',
+                DeepSeekV31Detector(),
+                "<｜tool▁calls▁begin｜>",
+                "<｜tool▁calls▁end｜>",
+                "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>"
+                '{"city": "Paris"}<｜tool▁call▁end｜>',
+                "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>"
+                "{broken<｜tool▁call▁end｜>",
+            ),
+            (
+                DeepSeekV32Detector(),
+                "<｜DSML｜function_calls>",
+                "</｜DSML｜function_calls>",
+                '<｜DSML｜invoke name="get_weather">'
+                '{"city": "Paris"}</｜DSML｜invoke>',
+                '<｜DSML｜invoke name="get_weather">{broken</｜DSML｜invoke>',
+            ),
+            (
+                DeepSeekV4Detector(),
+                "<｜DSML｜tool_calls>",
+                "</｜DSML｜tool_calls>",
+                '<｜DSML｜invoke name="get_weather">'
+                '{"city": "Paris"}</｜DSML｜invoke>',
+                '<｜DSML｜invoke name="get_weather">{broken</｜DSML｜invoke>',
             ),
         ]
 
-        for detector, text in cases:
+        for detector, begin, end, good, bad in cases:
             with self.subTest(detector=type(detector).__name__):
-                result = detector.detect_and_parse(text, TOOLS)
-                self.assertEqual(result.calls, [])
-                events = [r.event for r in detector.compatibility_records]
-                self.assertEqual(events, [CompatibilityEvent.UNKNOWN_TOOL_DROPPED])
+                result = detector.detect_and_parse(f"{begin}{good}{bad}{end}", TOOLS)
 
-    def test_detector_local_unknown_tool_strict_fails_open(self):
-        text = (
-            "<tool_call><function=no_such_tool>"
-            "<parameter=x>1</parameter></function></tool_call>"
-        )
-        parser = _make_parser(MiMoDetector(), enable_compatibility_mode=False)
+                self.assert_single_call(result.calls, arguments={"city": "Paris"})
+                self.assert_events_equal(
+                    detector, [CompatibilityEvent.MALFORMED_JSON_DROPPED]
+                )
 
-        normal_text, calls = parser.parse_non_stream(text)
+    def _unknown_tool_stream_cases(self):
+        return [
+            DetectorTextCase(
+                DeepSeekV3Detector,
+                "<｜tool▁calls▁begin｜>"
+                "<｜tool▁call▁begin｜>function<｜tool▁sep｜>no_such_tool\n"
+                "```json\n{}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+            ),
+            DetectorTextCase(
+                DeepSeekV31Detector,
+                "<｜tool▁calls▁begin｜>"
+                "<｜tool▁call▁begin｜>no_such_tool<｜tool▁sep｜>{}"
+                "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+            ),
+            DetectorTextCase(
+                DeepSeekV32Detector,
+                "<｜DSML｜function_calls>"
+                '<｜DSML｜invoke name="no_such_tool">{}</｜DSML｜invoke>'
+                "</｜DSML｜function_calls>",
+            ),
+            DetectorTextCase(
+                DeepSeekV4Detector,
+                "<｜DSML｜tool_calls>"
+                '<｜DSML｜invoke name="no_such_tool">{}</｜DSML｜invoke>'
+                "</｜DSML｜tool_calls>",
+            ),
+            DetectorTextCase(
+                Gemma4Detector, "<|tool_call>call:no_such_tool{}<tool_call|>"
+            ),
+            DetectorTextCase(
+                GigaChat3Detector,
+                'function call<|role_sep|>\n{"name": "no_such_tool", '
+                '"arguments": {}}</s>',
+            ),
+            DetectorTextCase(Glm4MoeDetector, "<tool_call>no_such_tool\n</tool_call>"),
+            DetectorTextCase(Glm47MoeDetector, "<tool_call>no_such_tool</tool_call>"),
+            DetectorTextCase(
+                KimiK2Detector,
+                "<|tool_calls_section_begin|>"
+                "<|tool_call_begin|>functions.no_such_tool:0"
+                "<|tool_call_argument_begin|>{}<|tool_call_end|>"
+                "<|tool_calls_section_end|>",
+            ),
+            DetectorTextCase(MistralDetector, "[TOOL_CALLS]no_such_tool[ARGS]{}"),
+            DetectorTextCase(
+                PoolsideV1Detector,
+                "<tool_call>no_such_tool\n"
+                "<arg_key>x</arg_key><arg_value>1</arg_value>"
+                "</tool_call>",
+            ),
+        ]
 
-        self.assertEqual(calls, [])
-        self.assertEqual(normal_text, text)
-        events = [r.event for r in parser.detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+    def test_unknown_tool_streaming_recorded_across_custom_parsers(self):
+        for case in self._unknown_tool_stream_cases():
+            with self.subTest(detector=case.detector_factory.__name__):
+                parser = FunctionCallParser.with_detector(
+                    case.detector_factory(),
+                    TOOLS,
+                    enable_compatibility_mode=True,
+                )
+
+                normal_text, calls = parser.parse_stream_chunk(case.text)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(calls, [])
+                self.assert_events_equal(
+                    parser, [CompatibilityEvent.UNKNOWN_TOOL_DROPPED]
+                )
+
+    def test_unknown_tool_streaming_strict_fails_open(self):
+        for case in self._unknown_tool_stream_cases():
+            with self.subTest(detector=case.detector_factory.__name__):
+                parser = FunctionCallParser.with_detector(
+                    case.detector_factory(),
+                    TOOLS,
+                    enable_compatibility_mode=False,
+                )
+
+                normal_text, calls = parser.parse_stream_chunk(case.text)
+
+                self.assertEqual(calls, [])
+                self.assertEqual(normal_text, case.text)
+                self.assert_fail_open_with_detail(
+                    parser, CompatibilityEvent.UNKNOWN_TOOL_DROPPED
+                )
+
+    def test_streaming_unknown_then_known_preserves_following_call(self):
+        cases = [
+            ParserTextCase(
+                "qwen25",
+                '<tool_call>\n{"name":"no_such_tool","arguments":{"city":"Ignored"}}\n'
+                '</tool_call><tool_call>\n{"name":"get_weather","arguments":{"city":"Paris"}}\n'
+                "</tool_call>",
+            ),
+            ParserTextCase(
+                "hermes",
+                '<tool_call>{"name":"no_such_tool","arguments":{"city":"Ignored"}}</tool_call>'
+                '<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>',
+            ),
+            ParserTextCase(
+                "llama3",
+                '<|python_tag|>{"name":"no_such_tool","arguments":{}};'
+                '{"name":"get_weather","arguments":{"city":"Paris"}}',
+            ),
+            ParserTextCase(
+                "mistral",
+                '[TOOL_CALLS] [{"name":"no_such_tool","arguments":{"city":"Ignored"}},'
+                '{"name":"get_weather","arguments":{"city":"Paris"}}]',
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, [case.text])
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather"])
+                self.assert_streamed_arguments(calls, {"city": "Paris"})
+                self.assert_events_equal(
+                    parser, [CompatibilityEvent.UNKNOWN_TOOL_DROPPED]
+                )
+
+    def test_streaming_split_separator_after_dropped_call_preserves_next_call(self):
+        cases = [
+            ParserChunksCase(
+                "mistral",
+                "unknown",
+                (
+                    '[TOOL_CALLS] [{"name":"no_such_tool","arguments":{}}',
+                    ",",
+                    '{"name":"get_weather","arguments":{"city":"Paris"}}]',
+                ),
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserChunksCase(
+                "mistral",
+                "malformed",
+                (
+                    "[TOOL_CALLS] [{broken}",
+                    ",",
+                    '{"name":"get_weather","arguments":{"city":"Paris"}}]',
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserChunksCase(
+                "llama3",
+                "unknown",
+                (
+                    '<|python_tag|>{"name":"no_such_tool","arguments":{}}',
+                    ";",
+                    '{"name":"get_weather","arguments":{"city":"Paris"}}',
+                ),
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserChunksCase(
+                "llama3",
+                "malformed",
+                (
+                    "<|python_tag|>{broken}",
+                    ";",
+                    '{"name":"get_weather","arguments":{"city":"Paris"}}',
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name, case_name=case.case_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, case.chunks)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather"])
+                self.assert_streamed_arguments(calls, {"city": "Paris"})
+                self.assert_events_equal(parser, [case.expected_event])
+
+    def test_streaming_split_eot_after_dropped_wrapped_call_preserves_next_call(self):
+        cases = [
+            ParserChunksCase(
+                "qwen25",
+                "unknown",
+                (
+                    '<tool_call>\n{"name":"no_such_tool","arguments":{}}',
+                    "\n</tool_call>",
+                    '<tool_call>\n{"name":"get_weather","arguments":{"city":"Paris"}}\n</tool_call>',
+                ),
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserChunksCase(
+                "qwen25",
+                "malformed",
+                (
+                    "<tool_call>\n{broken}",
+                    "\n</tool_call>",
+                    '<tool_call>\n{"name":"get_weather","arguments":{"city":"Paris"}}\n</tool_call>',
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserChunksCase(
+                "hermes",
+                "unknown",
+                (
+                    '<tool_call>{"name":"no_such_tool","arguments":{}}',
+                    "</tool_call>",
+                    '<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>',
+                ),
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserChunksCase(
+                "hermes",
+                "malformed",
+                (
+                    "<tool_call>{broken}",
+                    "</tool_call>",
+                    '<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>',
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name, case_name=case.case_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, case.chunks)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather"])
+                self.assert_streamed_arguments(calls, {"city": "Paris"})
+                self.assert_events_equal(parser, [case.expected_event])
+
+    def test_streaming_malformed_then_known_preserves_following_call(self):
+        cases = [
+            ParserTextCase(
+                "qwen25",
+                "<tool_call>\n{broken}\n</tool_call>"
+                '<tool_call>\n{"name":"get_weather","arguments":{"city":"Paris"}}\n'
+                "</tool_call>",
+            ),
+            ParserTextCase(
+                "hermes",
+                "<tool_call>{broken}</tool_call>"
+                '<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}'
+                "</tool_call>",
+            ),
+            ParserTextCase(
+                "llama3",
+                "<|python_tag|>{broken};"
+                '{"name":"get_weather","arguments":{"city":"Paris"}}',
+            ),
+            ParserTextCase(
+                "mistral",
+                '[TOOL_CALLS] [{broken},{"name":"get_weather",'
+                '"arguments":{"city":"Paris"}}]',
+            ),
+            ParserTextCase(
+                "apertus2509",
+                "<|tools_prefix|>[broken]<|tools_suffix|>"
+                '<|tools_prefix|>[{"get_weather":{"city":"Paris"}}]<|tools_suffix|>',
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, [case.text])
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather"])
+                self.assert_streamed_arguments(calls, {"city": "Paris"})
+                self.assert_events_equal(
+                    parser, [CompatibilityEvent.MALFORMED_JSON_DROPPED]
+                )
+
+    def test_streaming_bad_middle_call_preserves_dense_indices(self):
+        cases = [
+            ParserNamedTextCase(
+                "mistral",
+                "unknown",
+                '[TOOL_CALLS] [{"name":"get_weather","arguments":{"city":"London"}},'
+                '{"name":"no_such_tool","arguments":{}},'
+                '{"name":"get_weather","arguments":{"city":"Paris"}}]',
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserNamedTextCase(
+                "llama3",
+                "unknown",
+                '<|python_tag|>{"name":"get_weather","arguments":{"city":"London"}};'
+                '{"name":"no_such_tool","arguments":{}};'
+                '{"name":"get_weather","arguments":{"city":"Paris"}}',
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserNamedTextCase(
+                "mistral",
+                "malformed",
+                '[TOOL_CALLS] [{"name":"get_weather","arguments":{"city":"London"}},'
+                '{broken},{"name":"get_weather","arguments":{"city":"Paris"}}]',
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserNamedTextCase(
+                "llama3",
+                "malformed",
+                '<|python_tag|>{"name":"get_weather","arguments":{"city":"London"}};'
+                '{broken};{"name":"get_weather","arguments":{"city":"Paris"}}',
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name, case_name=case.case_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, [case.text])
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(
+                    [(call.tool_index, call.name) for call in calls if call.name],
+                    [(0, "get_weather"), (1, "get_weather")],
+                )
+                streamed_args = [
+                    json.loads(call.parameters) for call in calls if call.parameters
+                ]
+                self.assertEqual(streamed_args, [{"city": "London"}, {"city": "Paris"}])
+                self.assert_events_equal(parser, [case.expected_event])
+
+    def test_glm_streaming_malformed_arg_tail_closes_valid_json(self):
+        cases = [
+            ParserTextCase(
+                "glm",
+                "<tool_call>get_weather\n"
+                "<arg_key>city</arg_key></tool_call>"
+                "<tool_call>get_weather\n"
+                "<arg_key>city</arg_key>\n<arg_value>Paris</arg_value>\n"
+                "</tool_call>",
+            ),
+            ParserTextCase(
+                "glm47",
+                "<tool_call>get_weather"
+                "<arg_key>city</arg_key></tool_call>"
+                "<tool_call>get_weather"
+                "<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+                "</tool_call>",
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, [case.text])
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather", "get_weather"])
+                self.assertEqual(
+                    self.streamed_parameters_by_tool(calls),
+                    {0: {"city": None}, 1: {"city": "Paris"}},
+                )
+                self.assert_events_equal(
+                    parser, [CompatibilityEvent.MALFORMED_JSON_DROPPED]
+                )
+
+    def test_streaming_partial_malformed_arg_tail_closes_valid_json(self):
+        cases = [
+            (
+                "deepseekv31",
+                (
+                    "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather"
+                    '<｜tool▁sep｜>{"city": ',
+                    "",
+                    "<｜tool▁call▁end｜>",
+                    "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>"
+                    '{"city":"Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                {0: {"city": None}, 1: {"city": "Paris"}},
+            ),
+            (
+                "deepseekv32",
+                (
+                    '<｜DSML｜function_calls><｜DSML｜invoke name="get_weather">'
+                    '{"city": ',
+                    '"Par',
+                    "}</｜DSML｜invoke>",
+                    '<｜DSML｜invoke name="get_weather">{"city":"Paris"}'
+                    "</｜DSML｜invoke></｜DSML｜function_calls>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                {0: {"city": None}, 1: {"city": "Paris"}},
+            ),
+            (
+                "deepseekv4",
+                (
+                    '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
+                    '{"city": ',
+                    '"Par',
+                    "}</｜DSML｜invoke>",
+                    '<｜DSML｜invoke name="get_weather">{"city":"Paris"}'
+                    "</｜DSML｜invoke></｜DSML｜tool_calls>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                {0: {"city": None}, 1: {"city": "Paris"}},
+            ),
+            (
+                "kimi_k2",
+                (
+                    "<|tool_calls_section_begin|><|tool_call_begin|>"
+                    "functions.get_weather:0<|tool_call_argument_begin|>"
+                    '{"city": ',
+                    "",
+                    "<|tool_call_end|>",
+                    "<|tool_call_begin|>functions.get_weather:1"
+                    '<|tool_call_argument_begin|>{"city":"Paris"}'
+                    "<|tool_call_end|><|tool_calls_section_end|>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                {0: {"city": None}, 1: {"city": "Paris"}},
+            ),
+            (
+                "gigachat3",
+                (
+                    'function call<|role_sep|>\n{"name":"get_weather",'
+                    '"arguments":{"city": ',
+                    "}</s>",
+                    'function call<|role_sep|>\n{"name":"get_weather",'
+                    '"arguments":{"city":"Paris"}}</s>',
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                {0: {"city": None}, 1: {"city": "Paris"}},
+            ),
+            (
+                "hunyuan",
+                (
+                    "<tool_calls><tool_call>get_weather<tool_sep>"
+                    "<arg_key>city</arg_key><arg_value>Par",
+                    "</tool_call>",
+                    "<tool_call>get_weather<tool_sep><arg_key>city</arg_key>"
+                    "<arg_value>Paris</arg_value></tool_call></tool_calls>",
+                ),
+                CompatibilityEvent.MISSING_CLOSE_TAG,
+                {0: {"city": "Par"}, 1: {"city": "Paris"}},
+            ),
+            (
+                "poolside_v1",
+                (
+                    "<tool_call>get_weather\n<arg_key>city</arg_key>" "<arg_value>Par",
+                    "</tool_call>",
+                    "<tool_call>get_weather\n<arg_key>city</arg_key>"
+                    "<arg_value>Paris</arg_value></tool_call>",
+                ),
+                CompatibilityEvent.MISSING_CLOSE_TAG,
+                {0: {"city": "Par"}, 1: {"city": "Paris"}},
+            ),
+        ]
+
+        for parser_name, chunks, expected_event, expected_args in cases:
+            with self.subTest(parser_name=parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, chunks)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather", "get_weather"])
+                self.assertEqual(
+                    self.streamed_parameters_by_tool(calls),
+                    expected_args,
+                )
+                self.assert_events_equal(parser, [expected_event])
+
+    def test_streaming_complete_malformed_entries_are_consumed_and_recorded(self):
+        cases = [
+            ParserTextCase(
+                "kimi_k2",
+                "<|tool_calls_section_begin|><|tool_call_begin|>badid"
+                "<|tool_call_argument_begin|>{}<|tool_call_end|>"
+                "<|tool_calls_section_end|>TAIL",
+            ),
+            ParserTextCase(
+                "gigachat3",
+                'function call<|role_sep|>\n{"arguments":{}}</s>TAIL',
+            ),
+            ParserTextCase(
+                "gemma4",
+                "<|tool_call>call:get_weather<tool_call|>TAIL",
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, [case.text])
+
+                self.assertEqual(normal_text, "TAIL")
+                self.assertEqual(calls, [])
+                self.assert_events_equal(
+                    parser, [CompatibilityEvent.MALFORMED_JSON_DROPPED]
+                )
+
+    def test_nonstream_malformed_blocks_preserve_trailing_text(self):
+        cases = [
+            ParserTextCase(
+                "cohere_command4",
+                "pre <|START_ACTION|>[{bad}]<|END_ACTION|> post",
+            ),
+            ParserTextCase("qwen25", "pre <tool_call>\n{bad}\n</tool_call> post"),
+            ParserTextCase(
+                "deepseekv3",
+                "pre <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function"
+                "<｜tool▁sep｜>get_weather\n```json\n{bad}\n```"
+                "<｜tool▁call▁end｜><｜tool▁calls▁end｜> post",
+            ),
+            ParserTextCase(
+                "deepseekv31",
+                "pre <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather"
+                "<｜tool▁sep｜>{bad}<｜tool▁call▁end｜><｜tool▁calls▁end｜> post",
+            ),
+            ParserTextCase(
+                "deepseekv32",
+                'pre <｜DSML｜function_calls><｜DSML｜invoke name="get_weather">'
+                "{bad}</｜DSML｜invoke></｜DSML｜function_calls> post",
+            ),
+            ParserTextCase(
+                "deepseekv4",
+                'pre <｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
+                "{bad}</｜DSML｜invoke></｜DSML｜tool_calls> post",
+            ),
+            ParserTextCase(
+                "kimi_k2",
+                "pre <|tool_calls_section_begin|><|tool_call_begin|>"
+                "functions.get_weather:0<|tool_call_argument_begin|>{bad}"
+                "<|tool_call_end|><|tool_calls_section_end|> post",
+            ),
+            ParserTextCase("glm", "pre <tool_call>get_weather\n{bad}</tool_call> post"),
+            ParserTextCase(
+                "hunyuan",
+                "pre <tool_calls><tool_call>get_weather<tool_sep>{bad}"
+                "</tool_call></tool_calls> post",
+            ),
+            ParserTextCase(
+                "interns1",
+                "pre <|action_start|> <|plugin|>{bad}<|action_end|> post",
+            ),
+            ParserTextCase(
+                "lfm2",
+                "pre <|tool_call_start|>[get_weather(city=some_var)]"
+                "<|tool_call_end|> post",
+            ),
+            ParserTextCase(
+                "mimo",
+                "pre <tool_call><function=get_weather>{bad}</tool_call> post",
+            ),
+            ParserTextCase("gemma4", "pre <|tool_call>not-a-call<tool_call|> post"),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = parser.parse_non_stream(case.text)
+
+                self.assertEqual(calls, [])
+                self.assertIn("pre", normal_text)
+                self.assertIn("post", normal_text)
+                self.assert_event_in(parser, CompatibilityEvent.MALFORMED_JSON_DROPPED)
+
+    def test_streaming_started_malformed_call_closes_with_empty_arguments(self):
+        cases = [
+            ParserChunksCase(
+                "deepseekv3",
+                "started-json-codeblock",
+                (
+                    "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function"
+                    "<｜tool▁sep｜>get_weather\n```json\n{broken\n```",
+                    "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserChunksCase(
+                "deepseekv31",
+                "started-json",
+                (
+                    "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather"
+                    "<｜tool▁sep｜>{broken",
+                    "}<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserChunksCase(
+                "deepseekv32",
+                "started-dsml",
+                (
+                    '<｜DSML｜function_calls><｜DSML｜invoke name="get_weather">'
+                    "{broken",
+                    "}</｜DSML｜invoke></｜DSML｜function_calls>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserChunksCase(
+                "deepseekv4",
+                "started-dsml",
+                (
+                    '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">' "{broken",
+                    "}</｜DSML｜invoke></｜DSML｜tool_calls>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserChunksCase(
+                "kimi_k2",
+                "started-json",
+                (
+                    "<|tool_calls_section_begin|><|tool_call_begin|>"
+                    "functions.get_weather:0<|tool_call_argument_begin|>{broken",
+                    "}<|tool_call_end|><|tool_calls_section_end|>",
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserChunksCase(
+                "gigachat3",
+                "started-json",
+                (
+                    'function call<|role_sep|>\n{"name":"get_weather",',
+                    '"arguments":{"city":}}</s>',
+                ),
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name, case_name=case.case_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = _stream_chunks(parser, case.chunks)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather"])
+                self.assertEqual(self.streamed_parameters_by_tool(calls), {0: {}})
+                self.assert_events_equal(parser, [case.expected_event])
+
+    def test_streaming_drop_retries_same_chunk_tail(self):
+        cases = [
+            ParserNamedTextCase(
+                "deepseekv3",
+                "unknown-tool-before-valid",
+                "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function"
+                "<｜tool▁sep｜>bad\n```json\n{}\n```<｜tool▁call▁end｜>"
+                "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+                '```json\n{"city":"Paris"}\n```<｜tool▁call▁end｜>'
+                "<｜tool▁calls▁end｜>",
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserNamedTextCase(
+                "deepseekv31",
+                "unknown-tool-before-valid",
+                "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>bad"
+                "<｜tool▁sep｜>{}<｜tool▁call▁end｜>"
+                "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>"
+                '{"city":"Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+            ParserNamedTextCase(
+                "kimi_k2",
+                "bad-id-before-valid",
+                "<|tool_calls_section_begin|><|tool_call_begin|>badid"
+                "<|tool_call_argument_begin|>{}<|tool_call_end|>"
+                "<|tool_call_begin|>functions.get_weather:0"
+                '<|tool_call_argument_begin|>{"city":"Paris"}'
+                "<|tool_call_end|><|tool_calls_section_end|>",
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ),
+            ParserNamedTextCase(
+                "mistral",
+                "unknown-tool-before-valid",
+                '[TOOL_CALLS]bad[ARGS]{}[TOOL_CALLS]get_weather[ARGS]{"city":"Paris"}',
+                CompatibilityEvent.UNKNOWN_TOOL_DROPPED,
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(parser_name=case.parser_name, case_name=case.case_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                normal_text, calls = parser.parse_stream_chunk(case.text)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(self.call_names(calls), ["get_weather"])
+                self.assert_event_in(parser, case.expected_event)
+
+    def _streaming_malformed_complete_json_cases(self):
+        return [
+            ParserTextCase(
+                "deepseekv3",
+                "<｜tool▁calls▁begin｜>"
+                "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+                "```json\n{broken}\n```"
+                "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+            ),
+            ParserTextCase(
+                "deepseekv31",
+                "<｜tool▁calls▁begin｜>"
+                "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{broken}"
+                "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+            ),
+            ParserTextCase(
+                "deepseekv32",
+                '<｜DSML｜function_calls><｜DSML｜invoke name="get_weather">'
+                "{broken}</｜DSML｜invoke></｜DSML｜function_calls>",
+            ),
+            ParserTextCase(
+                "deepseekv4",
+                '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
+                "{broken}</｜DSML｜invoke></｜DSML｜tool_calls>",
+            ),
+            ParserTextCase(
+                "kimi_k2",
+                "<|tool_calls_section_begin|>"
+                "<|tool_call_begin|>functions.get_weather:0"
+                "<|tool_call_argument_begin|>{broken}<|tool_call_end|>"
+                "<|tool_calls_section_end|>",
+            ),
+            ParserTextCase(
+                "gigachat3",
+                'function call<|role_sep|>\n{"name":"get_weather",'
+                '"arguments": {broken}}</s>',
+            ),
+        ]
+
+    def test_streaming_complete_malformed_json_args_recorded(self):
+        for case in self._streaming_malformed_complete_json_cases():
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS,
+                    case.parser_name,
+                    enable_compatibility_mode=True,
+                )
+
+                normal_text, calls = parser.parse_stream_chunk(case.text)
+
+                self.assertEqual(normal_text, "")
+                self.assertEqual(calls, [])
+                self.assert_events_equal(
+                    parser, [CompatibilityEvent.MALFORMED_JSON_DROPPED]
+                )
+
+    def test_streaming_complete_malformed_json_args_strict_fails_open(self):
+        for case in self._streaming_malformed_complete_json_cases():
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS,
+                    case.parser_name,
+                    enable_compatibility_mode=False,
+                )
+
+                normal_text, calls = parser.parse_stream_chunk(case.text)
+
+                self.assertEqual(normal_text, case.text)
+                self.assertEqual(calls, [])
+                self.assert_fail_open_with_detail(
+                    parser, CompatibilityEvent.MALFORMED_JSON_DROPPED
+                )
 
     def test_streaming_exception_flushes_buffered_text(self):
         """A raising detector loses no buffered text: fail-open flushes it."""
@@ -589,11 +1591,10 @@ class TestJsonDetectorCompatibility(CustomTestCase):
         self.assertEqual(calls2, [])
         normal3, _ = parser.parse_stream_chunk(" after")
         self.assertEqual(normal3, " after")
-        events = [r.event for r in parser.detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
+        self.assert_events_equal(parser, [CompatibilityEvent.FAIL_OPEN])
 
 
-class TestParamTypeConversion(CustomTestCase):
+class TestParamTypeConversion(CompatibilityTestCase):
     def _convert(self, value, schema):
         return FunctionCallParameterDataType.from_property(schema).convert(value)
 
@@ -612,7 +1613,7 @@ class TestParamTypeConversion(CustomTestCase):
         self.assertEqual(self._convert("5", schema), 5)
 
 
-class TestCompatibilityModeOption(CustomTestCase):
+class TestCompatibilityContextOption(CompatibilityTestCase):
     """The serving-level switch: compatibility mode heals; default strict fails open."""
 
     def test_compatibility_mode_heals_default_strict_fails_open(self):
@@ -622,20 +1623,311 @@ class TestCompatibilityModeOption(CustomTestCase):
             TOOLS, "minimax-m3", enable_compatibility_mode=True
         )
         _, calls = compatible.parse_non_stream(text)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(
-            json.loads(calls[0].parameters), {"location": {"city": ["a", "b"]}}
-        )
+        self.assert_single_call(calls, arguments={"location": {"city": ["a", "b"]}})
         # The healing is on the audit trail.
-        events = [r.event for r in compatible.detector.compatibility_records]
-        self.assertEqual(events, [CompatibilityEvent.DUPLICATE_TAG_AS_LIST])
+        self.assert_events_equal(compatible, [CompatibilityEvent.DUPLICATE_TAG_AS_LIST])
 
         strict = FunctionCallParser(TOOLS, "minimax-m3")
         normal_text, calls = strict.parse_non_stream(text)
         self.assertEqual(calls, [])
         self.assertEqual(normal_text, text)
-        events = [r.event for r in strict.detector.compatibility_records]
-        self.assertIn(CompatibilityEvent.FAIL_OPEN, events)
+        self.assert_event_in(strict, CompatibilityEvent.FAIL_OPEN)
+
+
+DETECTOR_COMPATIBILITY_CASES = (
+    ParserTextCase("apertus2509", '<|tools_prefix|>[{"get_weather":{"city":"Paris"}}'),
+    ParserTextCase(
+        "cohere_command4",
+        '<|START_ACTION|>[{"tool_name":"get_weather",' '"parameters":{"city":"Paris"}}',
+    ),
+    ParserTextCase(
+        "deepseekv3",
+        "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function"
+        "<｜tool▁sep｜>get_weather\n```json\n{broken\n```"
+        "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+    ),
+    ParserTextCase(
+        "deepseekv31",
+        "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather"
+        "<｜tool▁sep｜>{broken<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+    ),
+    ParserTextCase(
+        "deepseekv32",
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_weather">'
+        "{broken</｜DSML｜invoke></｜DSML｜function_calls>",
+    ),
+    ParserTextCase(
+        "deepseekv4",
+        '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
+        "{broken</｜DSML｜invoke></｜DSML｜tool_calls>",
+    ),
+    ParserTextCase("glm", "<tool_call>get_weather\n<city>Paris"),
+    ParserTextCase("glm45", "<tool_call>get_weather\n<city>Paris"),
+    ParserTextCase("glm47", "<tool_call>get_weather<city>Paris"),
+    ParserTextCase(
+        "gpt-oss",
+        "<|start|>assistant<|channel|>commentary to=functions.get_weather"
+        "<|constrain|>json<|message|>{broken<|call|>",
+    ),
+    ParserTextCase(
+        "kimi_k2",
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0"
+        "<|tool_call_argument_begin|>{broken<|tool_call_end|>"
+        "<|tool_calls_section_end|>",
+    ),
+    ParserTextCase(
+        "lfm2",
+        "<|tool_call_start|>[get_weather(city=some_var)]<|tool_call_end|>",
+    ),
+    ParserTextCase(
+        "llama3",
+        '<|python_tag|>[{"name":"get_weather",'
+        '"parameters":{"city":"Paris"}}, garbage]',
+    ),
+    ParserTextCase("mimo", "<tool_call><function=get_weather>{broken}</tool_call>"),
+    ParserTextCase(
+        "minicpm5",
+        '<function name="get_weather"><param name="city">Paris</param>',
+    ),
+    ParserTextCase(
+        "mistral",
+        '[TOOL_CALLS] [{"name":"get_weather",' '"arguments":{"city":"Paris"}}',
+    ),
+    ParserTextCase(
+        "poolside_v1",
+        "<tool_call>get_weather\n<arg_key>city</arg_key><arg_value>Paris",
+    ),
+    ParserTextCase("pythonic", "[get_weather(city=some_var)]"),
+    ParserTextCase(
+        "qwen", '<tool_call>\n{"name":"get_weather","arguments":{"city":"Paris"}}'
+    ),
+    ParserTextCase(
+        "qwen25", '<tool_call>\n{"name":"get_weather","arguments":{"city":"Paris"}}'
+    ),
+    ParserTextCase(
+        "qwen3_coder", "<tool_call>\n<function=get_weather>\n<parameter=city>Paris"
+    ),
+    ParserTextCase(
+        "step3",
+        "<｜tool_calls_begin｜><｜tool_call_begin｜>function<｜tool_sep｜>"
+        '<steptml:invoke name="get_weather">'
+        '<steptml:parameter name="city">Paris',
+    ),
+    ParserTextCase(
+        "step3p5", "<tool_call>\n<function=get_weather>\n<parameter=city>Paris"
+    ),
+    ParserTextCase(
+        "minimax-m2",
+        '<minimax:tool_call><invoke name="get_weather">' '<parameter name="city">Paris',
+    ),
+    ParserTextCase(
+        "minimax-m3",
+        f'{NS}<tool_call>\n{NS}<invoke name="get_weather">{NS}<city>Paris',
+    ),
+    ParserTextCase(
+        "trinity",
+        '<think>x</think><tool_call>\n{"name":"get_weather",'
+        '"arguments":{"city":"Paris"}}',
+    ),
+    ParserTextCase(
+        "interns1",
+        '<|action_start|> <|plugin|>{"name":"get_weather",'
+        '"parameters":{"city":"Paris"}}',
+    ),
+    ParserTextCase(
+        "hermes", '<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}'
+    ),
+    ParserTextCase(
+        "hunyuan", "<tool_calls><tool_call><function=get_weather><parameter=city>Paris"
+    ),
+    ParserTextCase(
+        "gigachat3",
+        'function call<|role_sep|>\n{"name":"get_weather",' '"arguments":[]}</s>',
+    ),
+    ParserTextCase("gemma4", '<|tool_call>call:get_weather{"city":"Paris"<tool_call|>'),
+)
+
+_EXPECT_TRUNCATED = (CompatibilityEvent.TRUNCATED_CALL_DROPPED,)
+_EXPECT_MALFORMED = (CompatibilityEvent.MALFORMED_JSON_DROPPED,)
+
+DETECTOR_COMPATIBILITY_EXPECTED_EVENTS = {
+    "apertus2509": _EXPECT_TRUNCATED,
+    "cohere_command4": _EXPECT_TRUNCATED,
+    "deepseekv3": _EXPECT_MALFORMED,
+    "deepseekv31": _EXPECT_MALFORMED,
+    "deepseekv32": _EXPECT_MALFORMED,
+    "deepseekv4": _EXPECT_MALFORMED,
+    "gemma4": _EXPECT_MALFORMED,
+    "gigachat3": _EXPECT_MALFORMED,
+    "glm": _EXPECT_TRUNCATED,
+    "glm45": _EXPECT_TRUNCATED,
+    "glm47": _EXPECT_TRUNCATED,
+    "gpt-oss": _EXPECT_MALFORMED,
+    "hermes": _EXPECT_TRUNCATED,
+    "hunyuan": _EXPECT_TRUNCATED,
+    "interns1": _EXPECT_TRUNCATED,
+    "kimi_k2": _EXPECT_MALFORMED,
+    "lfm2": _EXPECT_MALFORMED,
+    "llama3": (
+        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+        CompatibilityEvent.MALFORMED_JSON_DROPPED,
+    ),
+    "mimo": _EXPECT_MALFORMED,
+    "minicpm5": _EXPECT_TRUNCATED,
+    "minimax-m2": _EXPECT_TRUNCATED,
+    "minimax-m3": _EXPECT_TRUNCATED,
+    "mistral": _EXPECT_TRUNCATED,
+    "poolside_v1": _EXPECT_TRUNCATED,
+    "pythonic": _EXPECT_MALFORMED,
+    "qwen": _EXPECT_TRUNCATED,
+    "qwen25": _EXPECT_TRUNCATED,
+    "qwen3_coder": _EXPECT_TRUNCATED,
+    "step3": _EXPECT_TRUNCATED,
+    "step3p5": _EXPECT_TRUNCATED,
+    "trinity": _EXPECT_TRUNCATED,
+}
+
+
+UNCONVERTIBLE_VALUE_CASES = (
+    ParserTextCase(
+        "glm",
+        "<tool_call>get_weather\n"
+        "<arg_key>city</arg_key>\n<arg_value>Paris</arg_value>\n"
+        "<arg_key>days</arg_key>\n<arg_value>soon</arg_value>\n"
+        "</tool_call>",
+    ),
+    ParserTextCase(
+        "glm47",
+        "<tool_call>get_weather"
+        "<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+        "<arg_key>days</arg_key><arg_value>soon</arg_value>"
+        "</tool_call>",
+    ),
+    ParserTextCase(
+        "poolside_v1",
+        "<tool_call>get_weather\n"
+        "<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+        "<arg_key>days</arg_key><arg_value>soon</arg_value>"
+        "</tool_call>",
+    ),
+    ParserTextCase(
+        "mimo",
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter>"
+        "<parameter=days>soon</parameter>"
+        "</function></tool_call>",
+    ),
+    ParserTextCase(
+        "minicpm5",
+        '<function name="get_weather">'
+        '<param name="city">Paris</param>'
+        '<param name="days">soon</param>'
+        "</function>",
+    ),
+    ParserTextCase(
+        "hunyuan",
+        "<tool_calls><tool_call>get_weather<tool_sep>"
+        "<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+        "<arg_key>days</arg_key><arg_value>soon</arg_value>"
+        "</tool_call></tool_calls>",
+    ),
+)
+
+
+class TestEveryRegisteredDetectorCompatibility(CompatibilityTestCase):
+    """Every registered detector reports local compatibility fallback events."""
+
+    def test_compatibility_mode_records_detector_local_fallbacks(self):
+        for case in DETECTOR_COMPATIBILITY_CASES:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                parser.parse_non_stream(case.text)
+
+                self.assert_events_equal(
+                    parser, DETECTOR_COMPATIBILITY_EXPECTED_EVENTS[case.parser_name]
+                )
+
+    def test_strict_mode_fails_open_for_detector_local_fallbacks(self):
+        for case in DETECTOR_COMPATIBILITY_CASES:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=False
+                )
+
+                normal_text, calls = parser.parse_non_stream(case.text)
+
+                self.assertEqual(calls, [])
+                self.assertEqual(normal_text, case.text)
+                self.assert_fail_open_with_detail(
+                    parser,
+                    DETECTOR_COMPATIBILITY_EXPECTED_EVENTS[case.parser_name][0],
+                )
+
+    def test_unconvertible_value_kept_raw_used_by_local_converters(self):
+        for case in UNCONVERTIBLE_VALUE_CASES:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=True
+                )
+
+                parser.parse_non_stream(case.text)
+
+                self.assert_event_in(
+                    parser, CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW
+                )
+
+    def test_unconvertible_value_strict_fails_open(self):
+        for case in UNCONVERTIBLE_VALUE_CASES:
+            with self.subTest(parser_name=case.parser_name):
+                parser = FunctionCallParser(
+                    TOOLS, case.parser_name, enable_compatibility_mode=False
+                )
+
+                normal_text, calls = parser.parse_non_stream(case.text)
+
+                self.assertEqual(calls, [])
+                self.assertEqual(normal_text, case.text)
+                self.assert_fail_open_with_detail(
+                    parser, CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW
+                )
+
+    def test_mimo_invalid_boolean_keeps_raw_and_records(self):
+        text = (
+            "<tool_call><function=set_enabled>"
+            "<parameter=enabled>maybe</parameter>"
+            "</function></tool_call>"
+        )
+        parser = FunctionCallParser(
+            BOOLEAN_TOOLS, "mimo", enable_compatibility_mode=True
+        )
+
+        _, calls = parser.parse_non_stream(text)
+
+        self.assert_single_call(calls, arguments={"enabled": "maybe"})
+        self.assert_events_equal(
+            parser, [CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW]
+        )
+
+    def test_mimo_invalid_boolean_strict_fails_open(self):
+        text = (
+            "<tool_call><function=set_enabled>"
+            "<parameter=enabled>maybe</parameter>"
+            "</function></tool_call>"
+        )
+        parser = FunctionCallParser(
+            BOOLEAN_TOOLS, "mimo", enable_compatibility_mode=False
+        )
+
+        normal_text, calls = parser.parse_non_stream(text)
+
+        self.assertEqual(calls, [])
+        self.assertEqual(normal_text, text)
+        self.assert_fail_open_with_detail(
+            parser, CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW
+        )
 
 
 ARRAY_TOOLS = TOOLS + [
@@ -654,12 +1946,9 @@ ARRAY_TOOLS = TOOLS + [
 ]
 
 
-class TestRemainingCompatibilityEvents(CustomTestCase):
+class TestRemainingCompatibilityEvents(CompatibilityTestCase):
     """One test per compatibility event not covered elsewhere, plus the
     strict-mode fail-open behavior at the boundary for each."""
-
-    def _events(self, parser):
-        return [r.event for r in parser.detector.compatibility_records]
 
     def test_dropped_invoke_tail(self):
         text = (
@@ -669,10 +1958,8 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         )
         parser = _make_parser()
         normal_text, calls = parser.parse_non_stream(text)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0].name, "get_weather")
-        self.assertEqual(json.loads(calls[0].parameters), {})
-        self.assertIn(CompatibilityEvent.DROPPED_INVOKE_TAIL, self._events(parser))
+        self.assert_single_call(calls, name="get_weather", arguments={})
+        self.assert_event_in(parser, CompatibilityEvent.DROPPED_INVOKE_TAIL)
 
         strict = _make_parser(
             FunctionCallParser(TOOLS, "minimax-m3").detector,
@@ -694,7 +1981,7 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         parser = _make_parser()
         _, calls = parser.parse_non_stream(text)
         self.assertEqual(len(calls), 1)
-        self.assertIn(CompatibilityEvent.MISMATCHED_CLOSING_TAG, self._events(parser))
+        self.assert_event_in(parser, CompatibilityEvent.MISMATCHED_CLOSING_TAG)
 
     def test_unclosed_tags_at_end(self):
         text = (
@@ -708,7 +1995,7 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         parser = _make_parser()
         _, calls = parser.parse_non_stream(text)
         self.assertEqual(len(calls), 1)
-        self.assertIn(CompatibilityEvent.UNCLOSED_TAGS_AT_END, self._events(parser))
+        self.assert_event_in(parser, CompatibilityEvent.UNCLOSED_TAGS_AT_END)
 
     def test_non_item_array_child(self):
         text = (
@@ -721,9 +2008,8 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
             ARRAY_TOOLS, "minimax-m3", enable_compatibility_mode=True
         )
         _, calls = parser.parse_non_stream(text)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(json.loads(calls[0].parameters), {"flags": ["a", "b"]})
-        self.assertIn(CompatibilityEvent.NON_ITEM_ARRAY_CHILD, self._events(parser))
+        self.assert_single_call(calls, arguments={"flags": ["a", "b"]})
+        self.assert_event_in(parser, CompatibilityEvent.NON_ITEM_ARRAY_CHILD)
 
     def test_structure_overrode_schema(self):
         # `city` is string-typed, but the namespace token asserts nesting.
@@ -736,9 +2022,7 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         parser = _make_parser()
         _, calls = parser.parse_non_stream(text)
         self.assertEqual(len(calls), 1)
-        self.assertIn(
-            CompatibilityEvent.STRUCTURE_OVERRODE_SCHEMA, self._events(parser)
-        )
+        self.assert_event_in(parser, CompatibilityEvent.STRUCTURE_OVERRODE_SCHEMA)
 
     def test_invalid_schema_ignored_never_raises_in_strict(self):
         data_type = FunctionCallParameterDataType.get_schema_of_parameter(
@@ -751,13 +2035,10 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
             },
             "x",
         )
-        mode = CompatibilityMode(strict=True)
-        value = data_type.convert("5", compatibility=mode)
+        context = CompatibilityContext(strict=True)
+        value = data_type.convert("5", compatibility=context)
         self.assertEqual(value, 5)
-        self.assertEqual(
-            [r.event for r in mode.records],
-            [CompatibilityEvent.INVALID_SCHEMA_IGNORED],
-        )
+        self.assert_events_equal(context, [CompatibilityEvent.INVALID_SCHEMA_IGNORED])
 
     def test_truncated_call_dropped_identical_in_both_modes(self):
 
@@ -775,9 +2056,7 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
             TOOLS, "qwen3_coder", enable_compatibility_mode=True
         )
         compatible.parse_non_stream(text)
-        self.assertIn(
-            CompatibilityEvent.TRUNCATED_CALL_DROPPED, self._events(compatible)
-        )
+        self.assert_event_in(compatible, CompatibilityEvent.TRUNCATED_CALL_DROPPED)
 
     def test_skipped_non_function_entry(self):
 
@@ -792,10 +2071,8 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
         )
         parser = FunctionCallParser(TOOLS, "step3", enable_compatibility_mode=True)
         _, calls = parser.parse_non_stream(text)
-        self.assertEqual([c.name for c in calls], ["get_weather"])
-        self.assertIn(
-            CompatibilityEvent.SKIPPED_NON_FUNCTION_ENTRY, self._events(parser)
-        )
+        self.assertEqual(self.call_names(calls), ["get_weather"])
+        self.assert_event_in(parser, CompatibilityEvent.SKIPPED_NON_FUNCTION_ENTRY)
 
     def test_missing_close_tag(self):
         text = (
@@ -808,12 +2085,11 @@ class TestRemainingCompatibilityEvents(CustomTestCase):
             TOOLS, "qwen3_coder", enable_compatibility_mode=True
         )
         _, calls = parser.parse_non_stream(text)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(json.loads(calls[0].parameters), {"city": "Paris", "days": 3})
-        self.assertIn(CompatibilityEvent.MISSING_CLOSE_TAG, self._events(parser))
+        self.assert_single_call(calls, arguments={"city": "Paris", "days": 3})
+        self.assert_event_in(parser, CompatibilityEvent.MISSING_CLOSE_TAG)
 
 
-class TestComplexSchemaCompatibility(CustomTestCase):
+class TestComplexSchemaCompatibility(CompatibilityTestCase):
     """Compatibility mode over nested arrays, objects, unions, and conversions."""
 
     COMPLEX_TEXT = (
@@ -856,9 +2132,6 @@ class TestComplexSchemaCompatibility(CustomTestCase):
             enable_compatibility_mode=enable_compatibility_mode,
         )
 
-    def _events(self, parser):
-        return [r.event for r in parser.detector.compatibility_records]
-
     def test_complex_schema_heals_nested_deviations_and_records(self):
         parser = self._parser(enable_compatibility_mode=True)
         normal_text, calls = parser.parse_non_stream(self.COMPLEX_TEXT)
@@ -879,7 +2152,7 @@ class TestComplexSchemaCompatibility(CustomTestCase):
         self.assertEqual(args["travelers"][1]["age"], "old")
         self.assertEqual(args["itinerary"][1]["day"], 2)
 
-        events = self._events(parser)
+        events = self.events_of(parser)
         self.assertIn(CompatibilityEvent.NON_ITEM_ARRAY_CHILD, events)
         self.assertIn(CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW, events)
 
@@ -888,15 +2161,12 @@ class TestComplexSchemaCompatibility(CustomTestCase):
         normal_text, calls = parser.parse_non_stream(self.COMPLEX_TEXT)
         self.assertEqual(calls, [])
         self.assertEqual(normal_text, self.COMPLEX_TEXT)
-        events = self._events(parser)
-        self.assertEqual(events, [CompatibilityEvent.FAIL_OPEN])
-        self.assertIn(
-            CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW.value,
-            parser.detector.compatibility_records[0].detail,
+        self.assert_fail_open_with_detail(
+            parser, CompatibilityEvent.UNCONVERTIBLE_VALUE_KEPT_RAW
         )
 
 
-class TestTagStreamingGates(CustomTestCase):
+class TestTagStreamingGates(CompatibilityTestCase):
     """Streaming-only behaviors of the tag adapter: the unknown-tool gate and
     the fail-open raw-text accounting."""
 
@@ -917,21 +2187,18 @@ class TestTagStreamingGates(CustomTestCase):
         )
         for chunk_size in (1, 7, len(text)):
             parser, (normal_text, calls) = self._stream_m2(text, chunk_size)
-            names = [c.name for c in calls if c.name]
-            self.assertEqual(names, ["get_weather"], chunk_size)
-            args = "".join(c.parameters for c in calls if c.parameters)
-            self.assertEqual(json.loads(args), {"city": "Paris"}, chunk_size)
+            self.assertEqual(self.call_names(calls), ["get_weather"], chunk_size)
+            self.assert_streamed_arguments(calls, {"city": "Paris"})
             # Indices stay dense: the grammar never assigns an ordinal to the
             # dropped call in the first place.
             self.assertEqual({c.tool_index for c in calls}, {0}, chunk_size)
-            events = [r.event for r in parser.detector.compatibility_records]
-            self.assertIn(CompatibilityEvent.UNKNOWN_TOOL_DROPPED, events)
+            self.assert_event_in(parser, CompatibilityEvent.UNKNOWN_TOOL_DROPPED)
             # Consistent with the non-streaming path.
             nonstream = FunctionCallParser(
                 TOOLS, "minimax-m2", enable_compatibility_mode=True
             )
             _, ns_calls = nonstream.parse_non_stream(text)
-            self.assertEqual([c.name for c in ns_calls], ["get_weather"])
+            self.assertEqual(self.call_names(ns_calls), ["get_weather"])
 
     def test_unknown_tool_fails_open_in_strict_streaming(self):
         text = (
@@ -950,29 +2217,8 @@ class TestTagStreamingGates(CustomTestCase):
             self.assertEqual(normal_text, text, chunk_size)
             # Strict-mode convention: the violation raises instead of being
             # recorded; the FAIL_OPEN record carries it in its detail.
-            records = parser.detector.compatibility_records
-            self.assertEqual([r.event for r in records], [CompatibilityEvent.FAIL_OPEN])
-            self.assertIn(
-                CompatibilityEvent.UNKNOWN_TOOL_DROPPED.value, records[0].detail
-            )
-
-    def test_strict_fail_open_after_completed_block_is_not_corrupted(self):
-        # Regression: emitted content is not a contiguous prefix of the raw
-        # stream once a no-call block completes; fail-open used to duplicate
-        # text and clip markers here.
-        text = (
-            "A<minimax:tool_call> </minimax:tool_call>"
-            'B<minimax:tool_call> junk <invoke name="get_weather">'
-        )
-        for chunk_size in (1, 5, len(text)):
-            parser, (normal_text, calls) = self._stream_m2(
-                text, chunk_size, enable_compatibility_mode=False
-            )
-            self.assertEqual(calls, [], chunk_size)
-            self.assertEqual(
-                normal_text,
-                'AB<minimax:tool_call> junk <invoke name="get_weather">',
-                chunk_size,
+            self.assert_fail_open_with_detail(
+                parser, CompatibilityEvent.UNKNOWN_TOOL_DROPPED
             )
 
 

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -8,10 +8,12 @@ from sglang.srt.entrypoints.openai.protocol import (
     ToolChoiceFuncName,
 )
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.compatibility import CompatibilityEvent
 from sglang.srt.function_call.core_types import StreamingParseResult
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
 from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
 from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.gemma4_detector import (
     Gemma4Detector,
     _parse_gemma4_args,
@@ -717,22 +719,31 @@ class TestBaseFormatDetector(unittest.TestCase):
             tourist_calls[0].tool_index, 1, "Second tool should have tool_index=1"
         )
 
-    def test_buffer_reset_on_invalid_tool(self):
-        """Test that buffer and state are reset when an invalid tool name is encountered."""
+    def test_buffer_reset_on_completed_invalid_tool(self):
+        """Test that invalid tools are dropped once their JSON object is complete."""
         # Start fresh with an invalid tool name from the beginning
         result = self.detector.parse_streaming_increment(
             '<tool_call>{"name": "invalid_tool", ', self.tools
         )
 
-        # Should return empty result and reset state
         self.assertEqual(result.calls, [], "Should return no calls for invalid tool")
         self.assertEqual(
             self.detector.current_tool_id,
             -1,
             "current_tool_id should remain -1 for invalid tool",
         )
+
+        result = self.detector.parse_streaming_increment(
+            '"arguments": {}}</tool_call>', self.tools
+        )
+
+        self.assertEqual(result.calls, [], "Should return no calls for invalid tool")
         self.assertEqual(
             self.detector._buffer, "", "Buffer should be cleared for invalid tool"
+        )
+        self.assertEqual(
+            [r.event for r in self.detector.compatibility_records],
+            [CompatibilityEvent.UNKNOWN_TOOL_DROPPED],
         )
 
     def test_chinese_characters_not_double_escaped(self):
@@ -3405,6 +3416,22 @@ class TestJsonArrayParser(unittest.TestCase):
         ]
         self.detector = JsonArrayParser()
 
+    def _collect_streaming(self, chunks, detector=None, ticks=8):
+        detector = detector or self.detector
+        normal_text = ""
+        calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
+            calls.extend(result.calls)
+        for _ in range(ticks):
+            result = detector.parse_streaming_increment("", self.tools)
+            if not result.normal_text and not result.calls:
+                break
+            normal_text += result.normal_text
+            calls.extend(result.calls)
+        return normal_text, calls
+
     def test_json_detector_has_no_ebnf(self):
         """JsonArrayParser no longer exposes EBNF generation helpers."""
         self.assertFalse(
@@ -3425,6 +3452,98 @@ class TestJsonArrayParser(unittest.TestCase):
         result = self.detector.parse_streaming_increment(text, self.tools)
 
         self.assertIsInstance(result, StreamingParseResult)
+
+    def test_streaming_drops_non_dict_and_missing_name_entries(self):
+        normal_text, calls = self._collect_streaming(
+            [
+                '[1,{"arguments":{}},'
+                '{"name":"get_weather","arguments":{"location":"Paris"}}]'
+            ]
+        )
+
+        self.assertEqual(normal_text, "")
+        self.assertEqual([call.name for call in calls if call.name], ["get_weather"])
+        self.assertEqual({call.tool_index for call in calls}, {0})
+        streamed_parameters = "".join(
+            call.parameters for call in calls if call.parameters
+        )
+        self.assertEqual(json.loads(streamed_parameters), {"location": "Paris"})
+        self.assertEqual(
+            [r.event for r in self.detector.compatibility_records],
+            [
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+                CompatibilityEvent.MALFORMED_JSON_DROPPED,
+            ],
+        )
+
+    def test_malformed_arguments_after_streamed_name_use_fresh_next_index(self):
+        normal_text, calls = self._collect_streaming(
+            [
+                '[{"name":"get_weather",',
+                '"arguments":{bad}}',
+                ',{"name":"search","arguments":{"query":"rome"}}]',
+            ]
+        )
+
+        self.assertEqual(normal_text, "")
+        self.assertEqual(
+            [(call.tool_index, call.name) for call in calls if call.name],
+            [(0, "get_weather"), (1, "search")],
+        )
+
+        parameters_by_index = {}
+        for call in calls:
+            if call.parameters:
+                parameters_by_index[call.tool_index] = (
+                    parameters_by_index.get(call.tool_index, "") + call.parameters
+                )
+
+        self.assertEqual(json.loads(parameters_by_index[0]), {})
+        self.assertEqual(json.loads(parameters_by_index[1]), {"query": "rome"})
+        self.assertEqual(
+            [r.event for r in self.detector.compatibility_records],
+            [CompatibilityEvent.MALFORMED_JSON_DROPPED],
+        )
+
+    def test_parser_wrapper_drains_tail_after_malformed_started_call(self):
+        parser = FunctionCallParser.with_detector(
+            JsonArrayParser(), self.tools, enable_compatibility_mode=True
+        )
+
+        normal_text, first_calls = parser.parse_stream_chunk('[{"name":"get_weather",')
+        self.assertEqual(normal_text, "")
+        self.assertEqual(
+            [(call.tool_index, call.name, call.parameters) for call in first_calls],
+            [(0, "get_weather", "")],
+        )
+
+        normal_text, second_calls = parser.parse_stream_chunk(
+            '"arguments":{bad}}, {"name":"search","arguments":{"query":"rome"}}]'
+        )
+
+        self.assertEqual(normal_text, "")
+        self.assertEqual(
+            [(call.tool_index, call.name, call.parameters) for call in second_calls],
+            [
+                (0, None, "{}"),
+                (1, "search", ""),
+                (1, None, '{"query": "rome"}'),
+            ],
+        )
+        self.assertEqual(parser.detector._buffer, "")
+
+    def test_trailing_comma_text_after_closed_array_is_flushed(self):
+        normal_text, calls = self._collect_streaming(
+            ['[{"name":"get_weather","arguments":{}}], trailing', " more"]
+        )
+
+        self.assertEqual(normal_text, ", trailing more")
+        self.assertEqual([call.name for call in calls if call.name], ["get_weather"])
+        streamed_parameters = "".join(
+            call.parameters for call in calls if call.parameters
+        )
+        self.assertEqual(json.loads(streamed_parameters), {})
+        self.assertEqual(self.detector.compatibility_records, [])
 
     def test_parse_streaming_increment_empty_input(self):
         """Test parsing with empty input"""
@@ -4181,9 +4300,12 @@ function call<|role_sep|>
         text = '<|message_sep|>\n\nfunction call<|role_sep|>\n{"name": "manage_user_memory", "arguments": {invalid json}}'
         result = self.detector.detect_and_parse(text, self.tools)
 
-        # Should return the full text as content when JSON parsing fails
-        self.assertIn("function call", result.normal_text)
+        self.assertEqual(result.normal_text, "")
         self.assertEqual(len(result.calls), 0)
+        self.assertEqual(
+            [r.event for r in self.detector.compatibility_records],
+            [CompatibilityEvent.MALFORMED_JSON_DROPPED],
+        )
 
     def test_detect_and_parse_missing_name(self):
         """Test parsing with missing function name."""
@@ -4584,8 +4706,12 @@ function call<|role_sep|>
         text = '<|function_call|>{"name": "manage_user_memory", "arguments": {invalid json}}'
         result = self.detector.detect_and_parse(text, self.tools)
 
-        self.assertIn("<|function_call|>", result.normal_text)
+        self.assertEqual(result.normal_text, "")
         self.assertEqual(len(result.calls), 0)
+        self.assertEqual(
+            [r.event for r in self.detector.compatibility_records],
+            [CompatibilityEvent.MALFORMED_JSON_DROPPED],
+        )
 
     def test_streaming_function_call_marker_simple_tool_call(self):
         """Test streaming parsing of the <|function_call|> marker form."""
@@ -5093,8 +5219,7 @@ class TestGemma4Detector(unittest.TestCase):
     def test_detect_and_parse_unknown_tool_index(self):
         text = '<|tool_call>call:unknown_func{arg:<|"|>val<|"|>}<tool_call|>'
         result = self.detector.detect_and_parse(text, self.tools)
-        self.assertEqual(len(result.calls), 1)
-        self.assertEqual(result.calls[0].tool_index, -1)
+        self.assertEqual(len(result.calls), 0)
 
     def test_detect_and_parse_nested_object(self):
         text = '<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>,details:{temp:25,unit:<|"|>celsius<|"|>}}<tool_call|>'

--- a/test/registered/unit/function_call/test_streaming_tool_call_fuzzer.py
+++ b/test/registered/unit/function_call/test_streaming_tool_call_fuzzer.py
@@ -19,16 +19,16 @@ from sglang.srt.function_call.core_types import (
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.hermes_detector import HermesDetector
-from sglang.srt.function_call.kimik2_detector import KimiK2Detector
 from sglang.srt.function_call.hunyuan_detector import HunyuanDetector
+from sglang.srt.function_call.kimik2_detector import KimiK2Detector
 from sglang.srt.function_call.llama32_detector import Llama32Detector
 from sglang.srt.function_call.minicpm5_detector import MiniCPM5Detector
 from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
 from sglang.srt.function_call.minimax_m3_nom import MinimaxM3NomDetector
 from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
-from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.srt.function_call.step3_detector import Step3Detector
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -344,7 +344,9 @@ def assert_stream_matches_non_stream(case: StreamingFuzzCase) -> None:
             f"got {len(collected)} from {all_calls}"
         )
         assert [call.name for call in collected] == reference_names
-        assert [_load_parameters(call.parameters) for call in collected] == reference_args
+        assert [
+            _load_parameters(call.parameters) for call in collected
+        ] == reference_args
 
         if case.check_normal_text:
             if case.exact_normal_text:
@@ -1195,7 +1197,9 @@ VALID_CASES: List[StreamingFuzzCase] = [
 def _registered_no_crash_cases() -> List[NoCrashFuzzCase]:
     cases: List[NoCrashFuzzCase] = []
     seen_classes = set()
-    for parser_name, detector_cls in sorted(FunctionCallParser.ToolCallParserEnum.items()):
+    for parser_name, detector_cls in sorted(
+        FunctionCallParser.ToolCallParserEnum.items()
+    ):
         if detector_cls in seen_classes:
             continue
         seen_classes.add(detector_cls)

--- a/test/registered/unit/function_call/test_streaming_tool_call_fuzzer.py
+++ b/test/registered/unit/function_call/test_streaming_tool_call_fuzzer.py
@@ -1,0 +1,1376 @@
+"""Deterministic fuzz-style tests for streaming tool-call parsers."""
+
+import json
+import random
+import re
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional
+
+import pytest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    StructureInfo,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.function_call.hermes_detector import HermesDetector
+from sglang.srt.function_call.kimik2_detector import KimiK2Detector
+from sglang.srt.function_call.hunyuan_detector import HunyuanDetector
+from sglang.srt.function_call.llama32_detector import Llama32Detector
+from sglang.srt.function_call.minicpm5_detector import MiniCPM5Detector
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.srt.function_call.minimax_m3_nom import MinimaxM3NomDetector
+from sglang.srt.function_call.mistral_detector import MistralDetector
+from sglang.srt.function_call.pythonic_detector import PythonicDetector
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sglang.srt.function_call.step3_detector import Step3Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(2.0, "base-a-test-cpu")
+
+
+DetectorFactory = Callable[[], BaseFormatDetector]
+
+
+@dataclass(frozen=True)
+class StreamingFuzzCase:
+    name: str
+    detector_factory: DetectorFactory
+    tools: List[Tool]
+    text: str
+    markers: List[str]
+    forbidden_normal_text_markers: Optional[List[str]] = None
+    check_normal_text: bool = True
+    exact_normal_text: bool = False
+    #: True when the text follows the wire format exactly: parsing it must
+    #: apply zero tolerances, so strict mode must behave identically to
+    #: compatibility mode (see assert_clean_input_strict_invariant).
+    clean: bool = True
+
+
+@dataclass(frozen=True)
+class NoCrashFuzzCase:
+    name: str
+    detector_factory: DetectorFactory
+    tools: List[Tool]
+    text: str
+    markers: List[str]
+
+
+@dataclass
+class CollectedCall:
+    name: str = ""
+    parameters: str = ""
+    first_name_pos: Optional[int] = None
+    first_param_pos: Optional[int] = None
+
+
+class JsonTagDetector(BaseFormatDetector):
+    """Small test detector that exercises BaseFormatDetector streaming logic."""
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = "<tool_call>"
+        self.eot_token = "</tool_call>"
+        self.tool_call_separator = ", "
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.bot_token in text
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        idx = text.find(self.bot_token)
+        if idx == -1:
+            return StreamingParseResult(normal_text=text, calls=[])
+
+        normal_text = text[:idx]
+        pattern = rf"{re.escape(self.bot_token)}(.*?){re.escape(self.eot_token)}"
+        calls = []
+        for body in re.findall(pattern, text, re.DOTALL):
+            calls.extend(self.parse_base_json(json.loads(body.strip()), tools))
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def structure_info(self) -> _GetInfoFunc:
+        return lambda name: StructureInfo(
+            begin=f'{self.bot_token}{{"name":"{name}", "arguments":',
+            end=f"}}{self.eot_token}",
+            trigger=self.bot_token,
+        )
+
+
+def _tool(name: str, properties: dict, required: Optional[List[str]] = None) -> Tool:
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            description=f"{name} test tool",
+            parameters={
+                "type": "object",
+                "properties": properties,
+                "required": required or [],
+            },
+        ),
+    )
+
+
+def make_common_tools() -> List[Tool]:
+    return [
+        _tool(
+            "get_weather",
+            {
+                "city": {"type": "string"},
+                "unit": {"type": "string"},
+                "count": {"type": "integer"},
+                "enabled": {"type": "boolean"},
+                "flags": {"type": "array", "items": {"type": "string"}},
+                "options": {
+                    "type": "object",
+                    "properties": {"detailed": {"type": "boolean"}},
+                },
+                "note": {"type": "string"},
+            },
+            ["city"],
+        ),
+        _tool(
+            "search",
+            {
+                "query": {"type": "string"},
+                "limit": {"type": "integer"},
+                "filters": {
+                    "type": "object",
+                    "properties": {"fresh": {"type": "boolean"}},
+                },
+            },
+            ["query"],
+        ),
+        _tool("get_current_date", {}, []),
+        _tool(
+            "sum_values",
+            {"nums": {"type": "array", "items": {"type": "integer"}}},
+            ["nums"],
+        ),
+        _tool(
+            "plan_trip",
+            {
+                "destination": {
+                    "type": "string",
+                    "enum": ["Paris", "Tokyo", "Shanghai"],
+                },
+                "days": {"type": "integer"},
+                "budget": {"type": "number"},
+                "travelers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "age": {"type": "integer"},
+                            "preferences": {
+                                "type": "object",
+                                "properties": {
+                                    "vegetarian": {"type": "boolean"},
+                                    "tags": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                        "required": ["name"],
+                    },
+                },
+                "itinerary": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "day": {"type": "integer"},
+                            "city": {"type": "string"},
+                            "activities": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+                "contact": {"type": ["string", "null"]},
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
+                "transport": {
+                    "oneOf": [
+                        {"type": "string", "enum": ["train", "flight"]},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "mode": {"type": "string"},
+                                "priority": {"type": "integer"},
+                            },
+                        },
+                    ]
+                },
+            },
+            ["destination", "travelers"],
+        ),
+    ]
+
+
+def collect_streamed_tool_calls(calls: Iterable[ToolCallItem]) -> List[CollectedCall]:
+    collected: dict[int, CollectedCall] = {}
+    for pos, call in enumerate(calls):
+        assert call.tool_index >= 0
+        current = collected.setdefault(call.tool_index, CollectedCall())
+        if call.name:
+            current.name += call.name
+            if current.first_name_pos is None:
+                current.first_name_pos = pos
+        if call.parameters:
+            current.parameters += call.parameters
+            if current.first_param_pos is None:
+                current.first_param_pos = pos
+    return [collected[idx] for idx in sorted(collected)]
+
+
+def chunk_strategies(text: str, markers: List[str]) -> List[tuple[str, List[str]]]:
+    strategies: List[tuple[str, List[str]]] = [
+        ("all", [text]),
+        ("char", list(text)),
+    ]
+
+    for size in (2, 3, 5, 8, 13):
+        strategies.append(
+            (f"fixed-{size}", [text[i : i + size] for i in range(0, len(text), size)])
+        )
+
+    cut_points = {0, len(text)}
+    for marker in markers + ["{", "}", "[", "]", '"', "\\", "</", "<", ">"]:
+        if not marker:
+            continue
+        start = 0
+        while True:
+            pos = text.find(marker, start)
+            if pos == -1:
+                break
+            for offset in (-1, 0, 1, len(marker) - 1, len(marker), len(marker) + 1):
+                cut = pos + offset
+                if 0 < cut < len(text):
+                    cut_points.add(cut)
+            start = pos + 1
+    cuts = sorted(cut_points)
+    strategies.append(("marker-boundary", [text[a:b] for a, b in zip(cuts, cuts[1:])]))
+
+    for seed in (0, 7, 13):
+        rng = random.Random(seed)
+        chunks = []
+        idx = 0
+        while idx < len(text):
+            size = rng.randint(1, 17)
+            chunks.append(text[idx : idx + size])
+            idx += size
+        strategies.append((f"seed-{seed}", chunks))
+
+    return strategies
+
+
+def _load_parameters(parameters: str) -> object:
+    return json.loads(parameters or "{}")
+
+
+def _drain_streaming_detector(
+    detector: BaseFormatDetector, tools: List[Tool], max_ticks: int
+) -> tuple[str, List[ToolCallItem]]:
+    normal_text = ""
+    calls: List[ToolCallItem] = []
+    for _ in range(max_ticks):
+        result = detector.parse_streaming_increment("", tools)
+        if not result.normal_text and not result.calls:
+            break
+        normal_text += result.normal_text
+        calls.extend(result.calls)
+    return normal_text, calls
+
+
+def test_base_streaming_holds_back_only_partial_bot_token() -> None:
+    detector = JsonTagDetector()
+    result = detector.parse_streaming_increment("Hello <tool_", make_common_tools())
+
+    assert result.normal_text == "Hello "
+    assert result.calls == []
+    assert detector._buffer == "<tool_"
+
+
+def _forbidden_normal_text_markers(markers: Iterable[str]) -> List[str]:
+    return [
+        marker
+        for marker in markers
+        if len(marker) > 1
+        and any(token in marker.lower() for token in ("tool", "invoke", "function"))
+    ]
+
+
+def assert_stream_matches_non_stream(case: StreamingFuzzCase) -> None:
+    reference = case.detector_factory().detect_and_parse(case.text, case.tools)
+    assert reference.calls, f"{case.name}: reference parser found no tool calls"
+    reference_names = [call.name for call in reference.calls]
+    reference_args = [_load_parameters(call.parameters) for call in reference.calls]
+
+    for strategy_name, chunks in chunk_strategies(case.text, case.markers):
+        detector = case.detector_factory()
+        all_calls: List[ToolCallItem] = []
+        normal_text = ""
+
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, case.tools)
+            normal_text += result.normal_text
+            all_calls.extend(result.calls)
+
+        # Some detectors emit the function name and argument JSON on separate
+        # parser ticks even when the model output arrived in one chunk.
+        drained_text, drained_calls = _drain_streaming_detector(
+            detector, case.tools, 2 * len(reference.calls) + 2
+        )
+        normal_text += drained_text
+        all_calls.extend(drained_calls)
+
+        collected = collect_streamed_tool_calls(all_calls)
+        assert len(collected) == len(reference.calls), (
+            f"{case.name}/{strategy_name}: expected {len(reference.calls)} calls, "
+            f"got {len(collected)} from {all_calls}"
+        )
+        assert [call.name for call in collected] == reference_names
+        assert [_load_parameters(call.parameters) for call in collected] == reference_args
+
+        if case.check_normal_text:
+            if case.exact_normal_text:
+                assert normal_text == reference.normal_text
+            else:
+                assert normal_text.strip() == reference.normal_text.strip()
+
+        forbidden_markers = (
+            case.forbidden_normal_text_markers
+            if case.forbidden_normal_text_markers is not None
+            else _forbidden_normal_text_markers(case.markers)
+        )
+        for marker in forbidden_markers:
+            assert marker not in normal_text
+
+        for call in collected:
+            if call.first_name_pos is not None and call.first_param_pos is not None:
+                assert call.first_name_pos <= call.first_param_pos
+
+
+def assert_clean_input_strict_invariant(case: StreamingFuzzCase) -> None:
+    """Clean input must apply zero tolerances, so strict == compatibility mode.
+
+    Without this invariant, accidental healing on valid input goes unnoticed
+    in compatibility mode and surfaces only as spurious strict-mode failures.
+    """
+    detector = case.detector_factory()
+    reference = detector.detect_and_parse(case.text, case.tools)
+    assert detector.compatibility_records == [], (
+        f"{case.name}: clean input applied tolerances (compatibility, non-stream): "
+        f"{detector.compatibility_records}"
+    )
+    reference_names = [call.name for call in reference.calls]
+    reference_args = [_load_parameters(call.parameters) for call in reference.calls]
+
+    strict_detector = case.detector_factory()
+    strict_detector.compatibility.strict = True
+    result = strict_detector.detect_and_parse(case.text, case.tools)
+    assert [call.name for call in result.calls] == reference_names
+    assert [
+        _load_parameters(call.parameters) for call in result.calls
+    ] == reference_args
+    assert result.normal_text == reference.normal_text
+
+    def parse_stream(detector: BaseFormatDetector) -> tuple[str, List[CollectedCall]]:
+        normal_text = ""
+        all_calls: List[ToolCallItem] = []
+        for i in range(0, len(case.text), 7):
+            result = detector.parse_streaming_increment(
+                case.text[i : i + 7], case.tools
+            )
+            normal_text += result.normal_text
+            all_calls.extend(result.calls)
+        drained_text, drained_calls = _drain_streaming_detector(
+            detector, case.tools, 2 * len(reference.calls) + 2
+        )
+        normal_text += drained_text
+        all_calls.extend(drained_calls)
+        return normal_text, collect_streamed_tool_calls(all_calls)
+
+    compatibility_stream_detector = case.detector_factory()
+    compatibility_normal_text, compatibility_collected = parse_stream(
+        compatibility_stream_detector
+    )
+    assert [call.name for call in compatibility_collected] == reference_names
+    assert [
+        _load_parameters(call.parameters) for call in compatibility_collected
+    ] == reference_args
+    assert compatibility_stream_detector.compatibility_records == [], (
+        f"{case.name}: clean input applied tolerances (compatibility, streaming): "
+        f"{compatibility_stream_detector.compatibility_records}"
+    )
+
+    strict_detector = case.detector_factory()
+    strict_detector.compatibility.strict = True
+    strict_normal_text, collected = parse_stream(strict_detector)
+    assert [call.name for call in collected] == reference_names
+    assert [_load_parameters(call.parameters) for call in collected] == reference_args
+    assert strict_normal_text == compatibility_normal_text
+    assert strict_detector.compatibility_records == [], (
+        f"{case.name}: clean input applied tolerances (strict, streaming): "
+        f"{strict_detector.compatibility_records}"
+    )
+
+
+def mutate_text(text: str, markers: List[str]) -> List[str]:
+    """Seeded, deterministic mutants: truncations at marker boundaries,
+    deleted / duplicated markers, garbage injections, random truncations."""
+    rng = random.Random(42)
+    mutants: List[str] = []
+    for marker in dict.fromkeys(m for m in markers if m):
+        start = 0
+        while True:
+            pos = text.find(marker, start)
+            if pos == -1:
+                break
+            mutants.append(text[: pos + max(1, len(marker) // 2)])
+            mutants.append(text[:pos] + text[pos + len(marker) :])
+            mutants.append(text[:pos] + marker + text[pos:])
+            start = pos + 1
+    for _ in range(4):
+        mutants.append(text[: rng.randrange(1, len(text))])
+    for _ in range(4):
+        at = rng.randrange(0, len(text))
+        mutants.append(text[:at] + " GARBAGE\U0001f92a " + text[at:])
+    return list(dict.fromkeys(mutants))
+
+
+def assert_mutants_never_crash(
+    case: StreamingFuzzCase, enable_compatibility_mode: bool
+) -> None:
+    """Mutated wire text must never escape the FunctionCallParser boundary,
+    whether compatibility mode is enabled or not, streaming or not — and the
+    streaming latch must keep passing text through after a failure."""
+
+    def make_parser() -> FunctionCallParser:
+        return FunctionCallParser.with_detector(
+            case.detector_factory(),
+            case.tools,
+            enable_compatibility_mode=enable_compatibility_mode,
+        )
+
+    for mutant in mutate_text(case.text, case.markers):
+        parser = make_parser()
+        normal_text, calls = parser.parse_non_stream(mutant)
+        for call in calls:
+            # Non-streaming calls carry complete argument JSON by contract.
+            _load_parameters(call.parameters)
+
+        parser = make_parser()
+        all_calls: List[ToolCallItem] = []
+        for i in range(0, len(mutant), 7):
+            _, calls = parser.parse_stream_chunk(mutant[i : i + 7])
+            all_calls.extend(calls)
+        for _ in range(4):
+            text, calls = parser.parse_stream_chunk("")
+            if not text and not calls:
+                break
+            all_calls.extend(calls)
+        for call in all_calls:
+            assert call.tool_index >= 0
+        # The latch: after any failure, later chunks flow through as text.
+        detector_failed = parser._detector_failed
+        text_after, calls_after = parser.parse_stream_chunk(" tail-after-mutant")
+        if detector_failed:
+            assert text_after == " tail-after-mutant"
+            assert calls_after == []
+        else:
+            assert isinstance(text_after, str)
+            assert isinstance(calls_after, list)
+
+
+def assert_stream_no_crash(case: NoCrashFuzzCase) -> None:
+    # The never-crash property belongs to the FunctionCallParser boundary:
+    # detectors are pure may-raise parsers (see the compatibility package scope 4), so the
+    # adversarial sweep drives the boundary, not the detector directly.
+    for _, chunks in chunk_strategies(case.text, case.markers):
+        parser = FunctionCallParser.with_detector(case.detector_factory(), case.tools)
+        all_calls: List[ToolCallItem] = []
+        for chunk in chunks:
+            _, calls = parser.parse_stream_chunk(chunk)
+            all_calls.extend(calls)
+
+        for call in all_calls:
+            assert call.tool_index >= 0
+
+
+def _json_tag_text(detector: BaseFormatDetector, name: str, args: dict) -> str:
+    info = detector.structure_info()(name)
+    return info.begin + json.dumps(args, ensure_ascii=False) + info.end
+
+
+def _hunyuan_text(*tool_bodies: str, leading: str = "") -> str:
+    return f"{leading}<tool_calls>{''.join(tool_bodies)}</tool_calls>"
+
+
+def _hunyuan_call(name: str, args: dict) -> str:
+    parts = [f"<tool_call>{name}<tool_sep>"]
+    for key, value in args.items():
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, ensure_ascii=False)
+        elif isinstance(value, bool):
+            value = "true" if value else "false"
+        elif value is None:
+            value = "null"
+        parts.append(f"<arg_key>{key}</arg_key><arg_value>{value}</arg_value>")
+    parts.append("</tool_call>")
+    return "".join(parts)
+
+
+def _minicpm_call(name: str, args: dict) -> str:
+    params = []
+    for key, value in args.items():
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, ensure_ascii=False)
+        params.append(f'<param name="{key}">{value}</param>')
+    return f'<function name="{name}">{"".join(params)}</function>'
+
+
+def _m2_call(name: str, args: dict) -> str:
+    params = []
+    for key, value in args.items():
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, ensure_ascii=False)
+        elif isinstance(value, bool):
+            value = "true" if value else "false"
+        elif value is None:
+            value = "null"
+        params.append(f'<parameter name="{key}">{value}</parameter>')
+    return f'<invoke name="{name}">\n' + "\n".join(params) + "\n</invoke>"
+
+
+def _m2_text(*calls: str, leading: str = "", trailing: str = "") -> str:
+    inner = "\n".join(calls)
+    return f"{leading}<minimax:tool_call>\n{inner}\n</minimax:tool_call>{trailing}"
+
+
+def _m3_call(name: str, args: dict) -> str:
+    ns = "]<]minimax[>["
+    parts = [f'{ns}<invoke name="{name}">']
+    for key, value in args.items():
+        parts.append(_m3_param(key, value))
+    parts.append(f"{ns}</invoke>")
+    return "".join(parts)
+
+
+def _m3_text(*calls: str, leading: str = "") -> str:
+    ns = "]<]minimax[>["
+    return f"{leading}{ns}<tool_call>\n" + "\n".join(calls) + f"\n{ns}</tool_call>"
+
+
+def _m3_param(key: str, value) -> str:
+    ns = "]<]minimax[>["
+    if isinstance(value, list):
+        return (
+            f"{ns}<{key}>"
+            + "".join(_m3_param("item", item) for item in value)
+            + f"{ns}</{key}>"
+        )
+    if isinstance(value, dict):
+        return (
+            f"{ns}<{key}>"
+            + "".join(
+                _m3_param(child_key, child_value)
+                for child_key, child_value in value.items()
+            )
+            + f"{ns}</{key}>"
+        )
+    if isinstance(value, bool):
+        value = "true" if value else "false"
+    elif value is None:
+        value = "null"
+    return f"{ns}<{key}>{value}{ns}</{key}>"
+
+
+def _qwen3_call(name: str, args: dict) -> str:
+    params = []
+    for key, value in args.items():
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, ensure_ascii=False)
+        elif isinstance(value, bool):
+            value = "true" if value else "false"
+        elif value is None:
+            value = "null"
+        params.append(f"<parameter={key}>\n{value}\n</parameter>")
+    return (
+        f"<tool_call>\n<function={name}>\n"
+        + "\n".join(params)
+        + "\n</function>\n</tool_call>"
+    )
+
+
+def _step3_entry(name: str, args: dict) -> str:
+    params = []
+    for key, value in args.items():
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, ensure_ascii=False)
+        elif isinstance(value, bool):
+            value = "true" if value else "false"
+        elif value is None:
+            value = "null"
+        params.append(f'<steptml:parameter name="{key}">{value}</steptml:parameter>')
+    return (
+        f'<｜tool_call_begin｜>function<｜tool_sep｜><steptml:invoke name="{name}">\n'
+        + "\n".join(params)
+        + "\n</steptml:invoke><｜tool_call_end｜>"
+    )
+
+
+def _step3_text(*entries: str, leading: str = "", trailing: str = "") -> str:
+    return (
+        f"{leading}<｜tool_calls_begin｜>\n"
+        + "\n".join(entries)
+        + f"\n<｜tool_calls_end｜>{trailing}"
+    )
+
+
+COMMON_TOOLS = make_common_tools()
+
+PLAN_TRIP_ARGS = {
+    "destination": "Tokyo",
+    "days": 5,
+    "budget": 1250.5,
+    "travelers": [
+        {
+            "name": "Ada",
+            "age": 34,
+            "preferences": {"vegetarian": True, "tags": ["museum", "ramen"]},
+        },
+        {
+            "name": "Lin",
+            "age": 8,
+            "preferences": {"vegetarian": False, "tags": ["park"]},
+        },
+    ],
+    "itinerary": [
+        {"day": 1, "city": "Tokyo", "activities": ["arrival", "ramen"]},
+        {"day": 2, "city": "Tokyo", "activities": ["museum"]},
+    ],
+    "contact": None,
+    "metadata": {"season": "spring", "pace": "moderate"},
+    "transport": {"mode": "train", "priority": 2},
+}
+
+
+def _extend_marker_candidates(markers: List[str], value) -> None:
+    if isinstance(value, str):
+        if value:
+            markers.append(value)
+        return
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            _extend_marker_candidates(markers, item)
+
+
+def _marker_candidates_for_detector(detector: BaseFormatDetector) -> List[str]:
+    markers: List[str] = []
+
+    try:
+        info = detector.structure_info()("get_weather")
+        _extend_marker_candidates(markers, (info.trigger, info.begin, info.end))
+    except Exception:
+        pass
+
+    for cls in reversed(type(detector).mro()):
+        for attr_name, value in vars(cls).items():
+            if attr_name.startswith("__"):
+                continue
+            _extend_marker_candidates(markers, value)
+
+    for value in vars(detector).values():
+        _extend_marker_candidates(markers, value)
+
+    if isinstance(detector, PythonicDetector):
+        for tool in COMMON_TOOLS:
+            if tool.function.name:
+                markers.append(f"[{tool.function.name}(")
+                markers.append(f"{tool.function.name}(")
+
+    return list(dict.fromkeys(markers))
+
+
+def _is_primary_tool_marker(marker: str) -> bool:
+    stripped = marker.strip()
+    if stripped in {"", ",", ";", "[", "]", "{", "}"}:
+        return False
+    if re.match(r"^\[?[A-Za-z_]\w*\(", stripped):
+        return True
+    lower = stripped.lower()
+    return any(
+        token in lower
+        for token in ("tool", "function", "invoke", "action", "call", "dsml")
+    )
+
+
+def _preferred_partial_marker(markers: List[str]) -> str:
+    for marker in markers:
+        if _is_primary_tool_marker(marker):
+            return marker
+    return markers[0] if markers else "<tool_call>"
+
+
+VALID_CASES: List[StreamingFuzzCase] = [
+    StreamingFuzzCase(
+        name="base-json-hard-markers-in-string",
+        detector_factory=JsonTagDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            'Lead. <tool_call>{"name": "get_weather", "arguments": '
+            '{"city": "Paris", "note": "literal <tool_call> marker"}}'
+            "</tool_call>"
+        ),
+        markers=["<tool_call>", "</tool_call>", '"arguments"'],
+        forbidden_normal_text_markers=[],
+        check_normal_text=False,
+    ),
+    StreamingFuzzCase(
+        name="hermes-json-unicode-nested",
+        detector_factory=HermesDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. "
+            + _json_tag_text(
+                HermesDetector(),
+                "get_weather",
+                {
+                    "city": "杭州",
+                    "unit": "celsius",
+                    "options": {"detailed": True},
+                    "note": 'quote " slash \\ newline\n<tool_call>',
+                },
+            )
+        ),
+        markers=["<tool_call>", "</tool_call>", '"arguments"'],
+    ),
+    StreamingFuzzCase(
+        name="qwen-two-calls",
+        detector_factory=Qwen25Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. "
+            + _json_tag_text(Qwen25Detector(), "get_weather", {"city": "北京"})
+            + "\n"
+            + _json_tag_text(
+                Qwen25Detector(), "search", {"query": "restaurants", "limit": 3}
+            )
+        ),
+        markers=["<tool_call>\n", "\n</tool_call>", '"arguments"'],
+        check_normal_text=False,
+    ),
+    StreamingFuzzCase(
+        name="qwen-complex-schema-plan-trip",
+        detector_factory=Qwen25Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. "
+            + _json_tag_text(Qwen25Detector(), "plan_trip", PLAN_TRIP_ARGS)
+            + " After."
+        ),
+        markers=["<tool_call>\n", "\n</tool_call>", '"arguments"'],
+        check_normal_text=False,
+    ),
+    StreamingFuzzCase(
+        name="llama-python-tag-array-object",
+        detector_factory=Llama32Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. "
+            + _json_tag_text(
+                Llama32Detector(),
+                "get_weather",
+                {
+                    "city": "Tokyo",
+                    "flags": ["rain", "wind"],
+                    "options": {"detailed": False},
+                },
+            )
+        ),
+        markers=["<|python_tag|>", '"arguments"', "{", "}"],
+        check_normal_text=False,
+    ),
+    StreamingFuzzCase(
+        name="pythonic-multiple-calls",
+        detector_factory=PythonicDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            'Lead. [get_weather(city="Paris", count=3, enabled=True), '
+            'search(query="hotels", limit=2)] After.'
+        ),
+        markers=["[", "]", "get_weather(", "search("],
+    ),
+    StreamingFuzzCase(
+        name="mistral-compact-hard-json",
+        detector_factory=MistralDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            'Lead. [TOOL_CALLS]get_weather[ARGS]{"city":"San Francisco",'
+            '"flags":["fog","wind"],"note":"[TOOL_CALLS] literal"}'
+        ),
+        markers=["[TOOL_CALLS]", "[ARGS]", "{", "}"],
+    ),
+    StreamingFuzzCase(
+        name="hunyuan-multiple-typed",
+        detector_factory=HunyuanDetector,
+        tools=COMMON_TOOLS,
+        text=_hunyuan_text(
+            _hunyuan_call("get_current_date", {}),
+            _hunyuan_call(
+                "get_weather",
+                {"city": "上海", "count": 7, "enabled": True},
+            ),
+            leading="Lead. ",
+        ),
+        markers=[
+            "<tool_calls>",
+            "</tool_calls>",
+            "<tool_call>",
+            "</tool_call>",
+            "<tool_sep>",
+            "<arg_key>",
+            "<arg_value>",
+        ],
+    ),
+    StreamingFuzzCase(
+        name="minicpm-multiple-complete-blocks",
+        detector_factory=MiniCPM5Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead.\n"
+            + _minicpm_call("get_weather", {"city": "北京", "note": "A & B"})
+            + _minicpm_call("sum_values", {"nums": [1, 2, 3]})
+        ),
+        markers=[
+            "<function",
+            "</function>",
+            "<param",
+            "</param>",
+            'name="get_weather"',
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="deepseekv3-two-fenced-json-calls",
+        detector_factory=DeepSeekV3Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. <｜tool▁calls▁begin｜>"
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+            '```json\n{"city": "Shanghai", "count": 3}\n```<｜tool▁call▁end｜>\n'
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n"
+            '```json\n{"query": "noodles"}\n```<｜tool▁call▁end｜>'
+            "<｜tool▁calls▁end｜>"
+        ),
+        markers=[
+            "<｜tool▁calls▁begin｜>",
+            "<｜tool▁call▁begin｜>",
+            "<｜tool▁sep｜>",
+            "```json",
+            "```",
+            "<｜tool▁call▁end｜>",
+            "<｜tool▁calls▁end｜>",
+        ],
+        check_normal_text=False,
+    ),
+    StreamingFuzzCase(
+        name="kimik2-two-calls",
+        detector_factory=KimiK2Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. <|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>"
+            '{"city": "Paris", "enabled": true}<|tool_call_end|>'
+            "<|tool_call_begin|>functions.search:1<|tool_call_argument_begin|>"
+            '{"query": "ramen", "limit": 5}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        ),
+        markers=[
+            "<|tool_calls_section_begin|>",
+            "<|tool_call_begin|>",
+            "<|tool_call_argument_begin|>",
+            "<|tool_call_end|>",
+            "<|tool_calls_section_end|>",
+        ],
+        check_normal_text=False,
+    ),
+    StreamingFuzzCase(
+        name="minimax-m3-multiple-invokes-nested",
+        detector_factory=MinimaxM3NomDetector,
+        tools=COMMON_TOOLS,
+        text=_m3_text(
+            _m3_call(
+                "get_weather",
+                {
+                    "city": "杭州",
+                    "count": 5,
+                    "enabled": True,
+                    "flags": ["rain", "wind"],
+                    "options": {"detailed": "true"},
+                },
+            ),
+            _m3_call("search", {"query": "pizza", "limit": 3}),
+            leading="Lead. ",
+        ),
+        markers=[
+            "]<]minimax[>[",
+            "]<]minimax[>[<tool_call>",
+            '<invoke name="',
+            "]<]minimax[>[</invoke>",
+            "]<]minimax[>[</tool_call>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="minimax-m3-complex-schema-plan-trip",
+        detector_factory=MinimaxM3NomDetector,
+        tools=COMMON_TOOLS,
+        text=_m3_text(_m3_call("plan_trip", PLAN_TRIP_ARGS), leading="Lead. "),
+        markers=[
+            "]<]minimax[>[",
+            "]<]minimax[>[<tool_call>",
+            '<invoke name="',
+            "]<]minimax[>[<travelers>",
+            "]<]minimax[>[<item>",
+            "]<]minimax[>[</tool_call>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="minimax-m2-two-calls-typed",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text=_m2_text(
+            _m2_call(
+                "get_weather",
+                {
+                    "city": "東京",
+                    "count": 7,
+                    "enabled": True,
+                    "flags": ["rain", "wind"],
+                    "options": {"detailed": True},
+                },
+            ),
+            _m2_call("search", {"query": "ramen", "limit": 5}),
+            leading="Let me check. ",
+        ),
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="',
+            "</parameter>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="minimax-m2-two-blocks-text-between",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            _m2_text(_m2_call("get_weather", {"city": "Paris"}), leading="Lead. ")
+            + "\nBetween blocks.\n"
+            + _m2_text(_m2_call("search", {"query": "pizza", "limit": 3}))
+            + " After."
+        ),
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="',
+            "</parameter>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="minimax-m2-junk-between-invokes",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text=_m2_text(
+            _m2_call("get_weather", {"city": "Paris"}),
+            "OOPS stray text",
+            _m2_call("search", {"query": "pizza"}),
+            leading="Lead. ",
+        ),
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="',
+            "</parameter>",
+        ],
+        check_normal_text=False,
+        clean=False,
+    ),
+    StreamingFuzzCase(
+        name="minimax-m2-null-and-empty-values",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text=_m2_text(
+            '<invoke name="get_weather">\n'
+            '<parameter name="city">null</parameter>\n'
+            '<parameter name="note"></parameter>\n'
+            "</invoke>",
+            leading="Lead. ",
+        ),
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="',
+            "</parameter>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="minimax-m2-complex-schema-plan-trip",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text=_m2_text(_m2_call("plan_trip", PLAN_TRIP_ARGS), leading="Lead. "),
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="travelers">',
+            "</parameter>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="qwen3-coder-two-blocks-typed",
+        detector_factory=Qwen3CoderDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. "
+            + _qwen3_call(
+                "get_weather",
+                {
+                    "city": "東京",
+                    "count": 7,
+                    "enabled": True,
+                    "flags": ["rain", "wind"],
+                    "options": {"detailed": True},
+                },
+            )
+            + "\nBetween.\n"
+            + _qwen3_call("search", {"query": "ramen", "limit": 5})
+            + " After."
+        ),
+        markers=[
+            "<tool_call>",
+            "</tool_call>",
+            "<function=",
+            "</function>",
+            "<parameter=",
+            "</parameter>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="qwen3-coder-missing-parameter-close",
+        detector_factory=Qwen3CoderDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. <tool_call>\n<function=get_weather>\n"
+            "<parameter=city>\nParis\n"
+            "<parameter=unit>\ncelsius\n</parameter>\n"
+            "</function>\n</tool_call>"
+        ),
+        markers=[
+            "<tool_call>",
+            "</tool_call>",
+            "<function=",
+            "</function>",
+            "<parameter=",
+            "</parameter>",
+        ],
+        clean=False,
+    ),
+    StreamingFuzzCase(
+        name="qwen3-coder-complex-schema-plan-trip",
+        detector_factory=Qwen3CoderDetector,
+        tools=COMMON_TOOLS,
+        text="Lead. " + _qwen3_call("plan_trip", PLAN_TRIP_ARGS) + " After.",
+        markers=[
+            "<tool_call>",
+            "</tool_call>",
+            "<function=",
+            "</function>",
+            "<parameter=travelers>",
+            "</parameter>",
+        ],
+        exact_normal_text=True,
+    ),
+    StreamingFuzzCase(
+        name="step3-two-entries-typed",
+        detector_factory=Step3Detector,
+        tools=COMMON_TOOLS,
+        text=_step3_text(
+            _step3_entry(
+                "get_weather",
+                {"city": "上海", "count": 5, "enabled": True},
+            ),
+            _step3_entry("search", {"query": "pizza", "limit": 3}),
+            leading="Lead. ",
+            trailing=" After.",
+        ),
+        markers=[
+            "<｜tool_calls_begin｜>",
+            "<｜tool_calls_end｜>",
+            "<｜tool_call_begin｜>",
+            "<｜tool_call_end｜>",
+            "<｜tool_sep｜>",
+            '<steptml:invoke name="',
+            "</steptml:invoke>",
+            '<steptml:parameter name="',
+            "</steptml:parameter>",
+        ],
+    ),
+    StreamingFuzzCase(
+        name="step3-complex-schema-plan-trip",
+        detector_factory=Step3Detector,
+        tools=COMMON_TOOLS,
+        text=_step3_text(
+            _step3_entry("plan_trip", PLAN_TRIP_ARGS),
+            leading="Lead. ",
+            trailing=" After.",
+        ),
+        markers=[
+            "<｜tool_calls_begin｜>",
+            "<｜tool_calls_end｜>",
+            "<｜tool_call_begin｜>",
+            "<｜tool_call_end｜>",
+            "<｜tool_sep｜>",
+            '<steptml:invoke name="',
+            '<steptml:parameter name="travelers">',
+            "</steptml:parameter>",
+        ],
+    ),
+    StreamingFuzzCase(
+        name="step3-non-function-entry-skipped",
+        detector_factory=Step3Detector,
+        tools=COMMON_TOOLS,
+        text=_step3_text(
+            "<｜tool_call_begin｜>thought<｜tool_sep｜>pondering...<｜tool_call_end｜>",
+            _step3_entry("search", {"query": "pizza"}),
+            leading="Lead. ",
+        ),
+        markers=[
+            "<｜tool_calls_begin｜>",
+            "<｜tool_calls_end｜>",
+            "<｜tool_call_begin｜>",
+            "<｜tool_call_end｜>",
+            "<｜tool_sep｜>",
+            '<steptml:invoke name="',
+            "</steptml:invoke>",
+            '<steptml:parameter name="',
+            "</steptml:parameter>",
+        ],
+        clean=False,
+    ),
+]
+
+
+def _registered_no_crash_cases() -> List[NoCrashFuzzCase]:
+    cases: List[NoCrashFuzzCase] = []
+    seen_classes = set()
+    for parser_name, detector_cls in sorted(FunctionCallParser.ToolCallParserEnum.items()):
+        if detector_cls in seen_classes:
+            continue
+        seen_classes.add(detector_cls)
+        detector = detector_cls()
+
+        markers = _marker_candidates_for_detector(detector)
+        marker = _preferred_partial_marker(markers)
+        partial_marker = marker[: max(1, len(marker) - 1)]
+        cases.append(
+            NoCrashFuzzCase(
+                name=f"{parser_name}-partial-marker",
+                detector_factory=detector_cls,
+                tools=COMMON_TOOLS,
+                text=f"normal before {partial_marker}",
+                markers=markers or [partial_marker],
+            )
+        )
+
+    return cases
+
+
+NO_CRASH_CASES: List[NoCrashFuzzCase] = [
+    NoCrashFuzzCase(
+        name="minimax-m3-truncated-namespace",
+        detector_factory=MinimaxM3NomDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. ]<]minimax[>[<tool_call>\n"
+            ']<]minimax[>[<invoke name="get_weather">]<]minimax[>[<city>Par'
+        ),
+        markers=["]<]minimax[>[", "<tool_call>", '<invoke name="', "<city>"],
+    ),
+    NoCrashFuzzCase(
+        name="hunyuan-truncated-arg-value",
+        detector_factory=HunyuanDetector,
+        tools=COMMON_TOOLS,
+        text=(
+            "<tool_calls><tool_call>get_weather<tool_sep>"
+            "<arg_key>city</arg_key><arg_value>San Fran"
+        ),
+        markers=["<tool_calls>", "<tool_call>", "<tool_sep>", "<arg_value>"],
+    ),
+    NoCrashFuzzCase(
+        name="mistral-truncated-compact-json",
+        detector_factory=MistralDetector,
+        tools=COMMON_TOOLS,
+        text='[TOOL_CALLS]get_weather[ARGS]{"city": "Paris", "flags": ["a"',
+        markers=["[TOOL_CALLS]", "[ARGS]", "{", "["],
+    ),
+    NoCrashFuzzCase(
+        name="base-truncated-json",
+        detector_factory=JsonTagDetector,
+        tools=COMMON_TOOLS,
+        text='<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"',
+        markers=["<tool_call>", '"arguments"', "{"],
+    ),
+    NoCrashFuzzCase(
+        name="qwen3-coder-truncated-mid-value",
+        detector_factory=Qwen3CoderDetector,
+        tools=COMMON_TOOLS,
+        text="Check.\n<tool_call>\n<function=get_weather>\n<parameter=city>\nBei",
+        markers=[
+            "<tool_call>",
+            "</tool_call>",
+            "<function=",
+            "</function>",
+            "<parameter=",
+            "</parameter>",
+        ],
+    ),
+    NoCrashFuzzCase(
+        name="step3-truncated-mid-entry",
+        detector_factory=Step3Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            "Lead. <｜tool_calls_begin｜>\n<｜tool_call_begin｜>function<｜tool_sep｜>"
+            '<steptml:invoke name="get_weather">\n<steptml:parameter name="city">Par'
+        ),
+        markers=[
+            "<｜tool_calls_begin｜>",
+            "<｜tool_calls_end｜>",
+            "<｜tool_call_begin｜>",
+            "<｜tool_call_end｜>",
+            "<｜tool_sep｜>",
+            '<steptml:invoke name="',
+            "</steptml:invoke>",
+            '<steptml:parameter name="',
+            "</steptml:parameter>",
+        ],
+    ),
+    NoCrashFuzzCase(
+        name="minimax-m2-truncated-mid-parameter",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            'Lead. <minimax:tool_call>\n<invoke name="get_weather">\n'
+            '<parameter name="city">Par'
+        ),
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="',
+            "</parameter>",
+        ],
+    ),
+    NoCrashFuzzCase(
+        name="minimax-m2-garbage-inside-block",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text="<minimax:tool_call>GARBAGE NO TAG HERE</minimax:tool_call> after",
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="',
+            "</parameter>",
+        ],
+    ),
+    NoCrashFuzzCase(
+        name="minimax-m2-missing-invoke-end",
+        detector_factory=MinimaxM2Detector,
+        tools=COMMON_TOOLS,
+        text=(
+            '<minimax:tool_call>\n<invoke name="get_weather">\n'
+            '<parameter name="city">Paris</parameter>\n'
+        ),
+        markers=[
+            "<minimax:tool_call>",
+            "</minimax:tool_call>",
+            '<invoke name="',
+            "</invoke>",
+            '<parameter name="',
+            "</parameter>",
+        ],
+    ),
+] + _registered_no_crash_cases()
+
+
+@pytest.mark.parametrize("case", VALID_CASES, ids=lambda case: case.name)
+def test_streaming_matches_non_stream_under_fuzzed_chunking(
+    case: StreamingFuzzCase,
+):
+    assert_stream_matches_non_stream(case)
+
+
+@pytest.mark.parametrize("case", NO_CRASH_CASES, ids=lambda case: case.name)
+def test_streaming_hard_mode_no_crash(case: NoCrashFuzzCase):
+    assert_stream_no_crash(case)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in VALID_CASES if case.clean],
+    ids=lambda case: case.name,
+)
+def test_clean_input_strict_matches_compatibility(case: StreamingFuzzCase):
+    assert_clean_input_strict_invariant(case)
+
+
+@pytest.mark.parametrize(
+    "enable_compatibility_mode",
+    [True, False],
+    ids=["compatibility-enabled", "compatibility-disabled"],
+)
+@pytest.mark.parametrize("case", VALID_CASES, ids=lambda case: case.name)
+def test_mutation_sweep_never_crashes(
+    case: StreamingFuzzCase, enable_compatibility_mode: bool
+):
+    assert_mutants_never_crash(case, enable_compatibility_mode)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/function_call/test_streaming_tool_call_fuzzer.py
+++ b/test/registered/unit/function_call/test_streaming_tool_call_fuzzer.py
@@ -24,7 +24,7 @@ from sglang.srt.function_call.kimik2_detector import KimiK2Detector
 from sglang.srt.function_call.llama32_detector import Llama32Detector
 from sglang.srt.function_call.minicpm5_detector import MiniCPM5Detector
 from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
-from sglang.srt.function_call.minimax_m3_nom import MinimaxM3NomDetector
+from sglang.srt.function_call.minimax_m3 import MinimaxM3Detector
 from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
@@ -914,7 +914,7 @@ VALID_CASES: List[StreamingFuzzCase] = [
     ),
     StreamingFuzzCase(
         name="minimax-m3-multiple-invokes-nested",
-        detector_factory=MinimaxM3NomDetector,
+        detector_factory=MinimaxM3Detector,
         tools=COMMON_TOOLS,
         text=_m3_text(
             _m3_call(
@@ -941,7 +941,7 @@ VALID_CASES: List[StreamingFuzzCase] = [
     ),
     StreamingFuzzCase(
         name="minimax-m3-complex-schema-plan-trip",
-        detector_factory=MinimaxM3NomDetector,
+        detector_factory=MinimaxM3Detector,
         tools=COMMON_TOOLS,
         text=_m3_text(_m3_call("plan_trip", PLAN_TRIP_ARGS), leading="Lead. "),
         markers=[
@@ -1224,7 +1224,7 @@ def _registered_no_crash_cases() -> List[NoCrashFuzzCase]:
 NO_CRASH_CASES: List[NoCrashFuzzCase] = [
     NoCrashFuzzCase(
         name="minimax-m3-truncated-namespace",
-        detector_factory=MinimaxM3NomDetector,
+        detector_factory=MinimaxM3Detector,
         tools=COMMON_TOOLS,
         text=(
             "Lead. ]<]minimax[>[<tool_call>\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Tool-call parsers currently handle model-side wire-format deviations in inconsistent ways. Some detectors drop malformed calls silently, some return the whole output as text, and some catch broad exceptions inside detector code. In streaming paths, a detector exception can corrupt the parser state after partial tool-call deltas have already reached the client.

This PR introduces a compatibility mode that makes those recoveries explicit, auditable, and centralized while preserving the strict default behavior.

## Design Philosophy

- Keep strict parsing as the default.
- Route detector failures through a single `FunctionCallParser` fail-open boundary.
- Preserve generated text whenever parsing cannot safely produce a tool call.
- Keep already-streamed tool-call arguments valid by synthesizing JSON closure fragments when recovery happens mid-call.
- Record every tolerated deviation through `CompatibilityEvent` records.
- Share parser machinery for tag-style formats instead of maintaining separate regex/state-machine implementations per model.
- Keep existing successful parsing behavior unchanged for valid model outputs.
- Keep existing normal-text behavior unchanged when the output contains no tool-call marker.
- Keep existing unknown-tool forwarding behavior controlled by `SGLANG_FORWARD_UNKNOWN_TOOLS`.

## High-Level Implementation

- Adds `--enable-tool-call-compatibility-mode`.
- Extends `FunctionCallParser` with:
  - `enable_compatibility_mode`
  - `with_detector(...)` for wrapping explicitly constructed detectors such as `JsonArrayParser`
  - streaming fail-open latch after detector exceptions
  - non-streaming fail-open recovery through `recover_nonstream`
- Adds `python/sglang/srt/function_call/compatibility/`:
  - `CompatibilityContext`
  - `CompatibilityEvent`
  - `CompatibilityRecord`
  - `CompatibilityViolation`
  - `recover_stream`
  - `recover_nonstream`
  - `synthesize_json_close`
  - schema-aware parameter conversion helpers
- Adds generic tag-format parsing infrastructure:
  - `parsing.py`
  - `tag_format_detector.py`
- Wires compatibility mode through:
  - OpenAI chat serving
  - streaming parser creation
  - constrained-output `JsonArrayParser`
  - native `/parse_function_call` endpoint
- Registers `minimax-m3-nom` in `FunctionCallParser`.
- Registers `minimax-m3`, `poolside_v1`, and the compatibility-tested aliases in `FunctionCallParser`.
- Extends base JSON streaming recovery so dropped malformed or unknown entries can be consumed inside an active multi-call sequence while preserving following calls and dense `tool_index` values.
- Adds `_closed_top_level_json_end` so streaming parsers can distinguish incomplete JSON from a completed malformed JSON entry that can be isolated and dropped.
- Adjusts non-streaming parser fallback so compatibility-recorded local drops can return detector-produced normal text instead of always restoring the full original text.

## Compatibility Mode Examples

Compatibility mode preserves existing behavior for valid outputs and makes recovery behavior explicit for known model-output deviations.

| Case | Example shape | Existing behavior before this PR | Compatibility mode behavior after this PR | Recorded event |
| --- | --- | --- | --- | --- |
| Normal text | `The weather looks clear.` | Returned as normal text. | Returned as normal text. | None |
| Well-formed single call | `<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>` | Parsed as one `get_weather` call. | Parsed as one `get_weather` call. | None |
| Well-formed multi-call output | Valid `get_weather({"city":"London"})`, then valid `get_weather({"city":"Paris"})` | Parsed valid calls in order for detectors that already supported the format. | Parsed valid calls in order. | None |
| Unknown tool with forwarding enabled | `no_such_tool({"x":1})` with `SGLANG_FORWARD_UNKNOWN_TOOLS=1` | Forwarded where detector-specific logic supported forwarding, often with `tool_index=-1`. | Forwarded through the shared unknown-tool gate where supported. | None |
| Unknown tool with forwarding disabled | `no_such_tool({"x":1})` | Some detectors dropped silently; some behaved differently in streaming and non-streaming paths. | Drops the call consistently and preserves following valid calls. | `UNKNOWN_TOOL_DROPPED` |
| Unknown middle call | Valid call, unknown call, valid call | Some streaming parsers lost following calls or reset state after the unknown entry. | Drops the unknown entry, parses later valid calls, keeps dense response indexes. | `UNKNOWN_TOOL_DROPPED` |
| Malformed middle JSON entry | Valid call, `{broken}`, valid call | Some detectors dropped the whole response, returned the whole output as text, or silently skipped the bad entry. | Drops only the malformed entry and preserves neighboring valid calls. | `MALFORMED_JSON_DROPPED` |
| Split separator after dropped entry | Bad complete entry in one chunk, separator in next chunk, valid call after that | Streaming state could lose the active multi-call sequence and treat the separator or following call as normal text. | Keeps sequence context across chunks and parses the following valid call. | `UNKNOWN_TOOL_DROPPED` or `MALFORMED_JSON_DROPPED` |
| Started streaming call with malformed args | Tool name already emitted, then `"arguments":{bad}` | Stream could end with invalid client-visible argument JSON or corrupted parser state. | Closes the started call with `{}` or synthesized JSON and continues after the malformed entry. | `MALFORMED_JSON_DROPPED` |
| Detector exception mid-stream | Already streamed `{"city":"Par`, then detector raises | Exception could escape the detector and break the streaming response. | Fails open at `FunctionCallParser`, synthesizes a JSON close when possible, then passes later text through. | `FAIL_OPEN` |
| Truncated generation | `<tool_call><function=get_weather><parameter=city>Par` | Behavior varied by detector; some returned raw text, some dropped without an audit trail. | Drops the incomplete call, returns the affected raw text as normal text, records the truncation. | `TRUNCATED_CALL_DROPPED` |
| Missing parameter close tag | `<parameter=city>Paris<parameter=days>3</parameter>` | Some tag parsers accepted this implicitly; others failed or swallowed content depending on chunking. | Terminates `city` at the next parameter/function boundary and parses remaining fields. | `MISSING_CLOSE_TAG` |
| Duplicate nested tags | `<city>a</city><city>b</city>` | Model-specific behavior; duplicate values could overwrite or require detector-local handling. | Preserves both values as `{"city":["a","b"]}`. | `DUPLICATE_TAG_AS_LIST` |
| Mixed text in nested object | `<location><city>a</city>stray</location>` | Model-specific behavior; stray text could be dropped or cause parsing failure. | Captures stray text under `$text`. | `MIXED_TEXT_CAPTURED` |
| Array child with non-`item` tag | `<flags><item>a</item><element>b</element></flags>` | Model-specific behavior; non-`item` children could be dropped or parsed inconsistently. | Preserves both values as `["a","b"]`. | `NON_ITEM_ARRAY_CHILD` |
| Schema conversion success | `<days>5</days><enabled>true</enabled><contact>null</contact>` | Some detectors had local conversion logic; behavior differed by format. | Converts values through shared schema-aware conversion where wired in. | None |
| Schema conversion failure | `<days>soon</days>` for an integer field | Some detectors kept the raw value silently; some failed conversion locally. | Keeps raw `"soon"` and records the fallback. | `UNCONVERTIBLE_VALUE_KEPT_RAW` |
| Step3 non-function entry | `thought<｜tool_sep｜>...`, then a function entry | Historical Step3 behavior skipped non-function entries. | Preserves the skip behavior and records it. | `SKIPPED_NON_FUNCTION_ENTRY` |
| Poolside V1 missing value close | `<arg_key>city</arg_key><arg_value>Paris</tool_call>` | Poolside parser support was limited and this malformed value boundary was not audited. | Treats `</tool_call>` as the value boundary and emits `{"city":"Paris"}`. | `MISSING_CLOSE_TAG` |
| Garbage inside tag-style call | Junk text before the next recognizable parameter/invoke tag | Some parsers skipped garbage silently; others failed. | Skips to the next recognizable tag and records the skipped region. | `SKIPPED_GARBAGE` |
| Unparseable invoke tail | Valid invoke start, then garbage until invoke end | Format-specific behavior; streamed arguments could remain unterminated. | Drops the invoke tail and closes emitted arguments. | `DROPPED_INVOKE_TAIL` |
## Per-Detector Modifications

- `BaseFormatDetector`
  - Adds per-request compatibility policy and records.
  - Adds fail-open hooks for streaming and non-streaming parsing.
  - Adds unknown-tool handling through `_skip_unknown_tool`.
  - Adds malformed-call recording through compatibility events.
  - Adds partial-token holdback for streaming markers.
  - Normalizes streaming unknown-tool behavior with `SGLANG_FORWARD_UNKNOWN_TOOLS`.
  - Adds `_drop_completed_malformed_entry`, `_close_started_malformed_call`, `_retry_streaming_tail`, and active multi-call sequence context.
  - Preserves following calls after malformed or unknown entries inside streaming multi-call sequences.
  - Records malformed non-dict JSON entries and missing-name entries in `parse_base_json`.

- `Apertus2509Detector`
  - Routes unknown-tool drops through `_skip_unknown_tool` in streaming and non-streaming paths.
  - Records malformed completed tool blocks, truncated blocks, malformed list items, and unknown-tool drops.
  - Preserves normal text around parsed blocks and continues parsing buffered content after dropped streaming blocks.

- `CohereCommand4Detector`
  - Records malformed JSON bodies before returning surrounding text.
  - Normalizes `tool_name` to `name`, removes `tool_call_id`, and records non-list, non-dict, and missing-name entries.
  - Distinguishes truncated bodies from malformed completed bodies.

- `DeepSeekV3Detector`
  - Handles malformed per-call JSON at call granularity.
  - Preserves other valid calls in the same response.
  - Holds back partial special tokens in streaming.
  - Uses non-greedy matching for complete streaming calls to avoid duplicate emission.
  - Closes started malformed streaming calls and retries same-chunk tails.
  - Drops complete unknown-tool calls and continues parsing later calls.

- `DeepSeekV31Detector`
  - Records detector-local malformed parse fallbacks in non-streaming and streaming paths.
  - Drops malformed per-call JSON while preserving neighboring valid calls.
  - Closes started malformed streaming calls and retries same-chunk tails.
  - Drops complete unknown-tool calls and continues parsing later calls.

- `DeepSeekV32Detector`
  - Records detector-local malformed parse fallbacks in non-streaming and streaming paths.
  - Supports DSML direct-JSON and XML-parameter bodies.
  - Records unconvertible XML parameter values, malformed invoke bodies, truncated invokes, and malformed completed JSON.
  - Streaming loops over consecutive invokes, drops unknown tools, closes started malformed calls, and continues after a dropped invoke.

- `DeepSeekV4Detector`
  - Reuses the DSML recovery path from `DeepSeekV32Detector`.
  - Covers the V4 `<｜DSML｜tool_calls>` wrapper and `deepseek_v4` structural-tag name.
  - Adds compatibility tests for malformed blocks, unknown tools, started malformed streaming calls, and partial malformed argument tails.

- `Gemma4Detector`
  - Records malformed parse fallbacks while preserving existing recovery behavior.
  - Records malformed missing call bodies, truncated calls, incomplete argument braces, skipped garbage, and unknown tools.
  - Streaming emits `{}` for completed malformed argument bodies so a started call remains JSON-valid.

- `GigaChat3Detector`
  - Records JSON decode failures in tool-call bodies.
  - Records missing required `name` / `arguments`, non-object arguments, and malformed completed streaming payloads.
  - Streaming closes started malformed calls and retries tail content after `</s>`.

- `GLM4MoeDetector`
  - Records parse failures in non-streaming and streaming paths.
  - Records argument parsing failures for completed streaming calls.
  - Records truncated blocks, malformed XML argument bodies, unknown tools, and schema conversion failures.
  - Streams XML arguments as JSON deltas and synthesizes closure for malformed tails.

- `GLM47MoeDetector`
  - Records parse failures in non-streaming and streaming paths.
  - Records argument parsing failures for completed streaming calls.
  - Records truncated blocks, malformed XML argument bodies, unknown tools, and schema conversion failures.
  - Factors streaming name emission, argument processing, and finalization into helper paths while preserving no-argument calls.

- `GptOssDetector`
  - Routes unknown-tool drops through `_skip_unknown_tool`.
  - Records malformed JSON argument blocks through compatibility absorb handling.
  - Records Harmony tool extraction failures.

- `HermesDetector`
  - Records detector-local malformed parse fallbacks.
  - Records truncated `<tool_call>` blocks, malformed JSON bodies, and non-dict parsed payloads.
  - Keeps truncated raw blocks in normal text.

- `HunyuanDetector`
  - Routes unknown-tool drops through `_skip_unknown_tool`.
  - Records malformed parse fallbacks.
  - In streaming, skips unknown tool blocks through the end marker while preserving stream state.
  - Adds schema-aware conversion for boolean, integer, number, object, array, and string-compatible values.
  - Records unconvertible typed values, missing function names, malformed/truncated blocks, and missing argument close tags.
  - Recovers partial string values closed by `</tool_call>` and keeps emitted argument JSON valid.

- `InternlmDetector`
  - Routes unknown-tool handling through `_skip_unknown_tool`.
  - Preserves forward-unknown behavior with `tool_index=-1`.
  - Records malformed JSON and outer parse failures.
  - Records truncated action blocks, non-dict payloads, and missing names.
  - Preserves normal text around complete action blocks.

- `KimiK2Detector`
  - Drops malformed per-call JSON without discarding other valid calls.
  - Holds back partial special tokens in streaming.
  - Refines streaming argument diff handling around end-token boundaries.
  - Handles standard `functions.name:index` IDs and bare counter IDs with schema-based tool-name inference.
  - Caches inferred names during streaming.
  - Records malformed IDs, malformed JSON arguments, truncated sections, and unknown tools.

- `Lfm2Detector`
  - Routes unknown-tool handling through `_skip_unknown_tool`.
  - Records malformed Pythonic, JSON, and argument-conversion failures.
  - Records Python syntax failures, unsupported AST shapes, non-literal arguments, unsupported `**kwargs`, malformed JSON entries, and truncated blocks.
  - Supports both Pythonic call lists and JSON tool-call arrays through the same validation path.

- `Llama32Detector`
  - Records malformed JSON/Python-dict fallback failures.
  - Narrows broad exception handling.
  - Preserves strict-mode compatibility violations during streaming fallback.
  - Preserves valid calls around malformed spans and keeps trailing malformed text as normal output.

- `MiMoDetector`
  - Routes unknown-tool handling through `_skip_unknown_tool`.
  - Emits calls directly so forward-unknown mode can preserve unknown names with `tool_index=-1`.
  - Records schema conversion failures for integer, number, boolean, object/list, and literal-eval fallbacks.
  - Records malformed tool-call bodies and truncated blocks.

- `MiniCPM5Detector`
  - Tracks XML fallback parse errors.
  - Routes unknown-tool handling through `_skip_unknown_tool`.
  - Records malformed blocks that fall back to normal text.
  - Records invalid parameters, duplicate or unknown parameters, missing required parameters, unconvertible typed values, and truncated blocks.
  - Uses XML parsing with regex fallback while preserving malformed raw blocks as normal text.

- `MiniMaxM2Detector`
  - Replaces custom regex/state-machine parsing with `TagToolCallDetector` plus `M2TextParser`.
  - Adds schema-aware parameter conversion.
  - Records skipped garbage and unknown-tool drops through compatibility mode.

- `MiniMaxM3NomDetector`
  - Adds namespace-tag parser for MiniMax M3 NOM tool-call format.
  - Supports nested XML parameters, duplicate tag capture, array/object reconstruction, mixed text capture, and schema-aware conversion.
  - Uses shared tag-format streaming and fail-open recovery.
  - Records structure overrides, mismatched closing tags, unclosed tags, mixed text capture, duplicate tags, non-`item` array children, dropped invoke tails, and unknown tools.

- `MistralDetector`
  - Records malformed JSON tool arrays through compatibility absorb handling.
  - Supports canonical JSON-array format and compact `[TOOL_CALLS]name[ARGS]{...}` format.
  - Records truncated arrays, malformed JSON arrays, and unknown tools.
  - Streaming retries tail content after compact-format drops and delegates canonical array recovery to `BaseFormatDetector`.

- `PoolsideV1Detector`
  - Adds the `poolside_v1` FSM parser.
  - Records truncated calls, malformed argument pairs, missing names, unknown tools, skipped garbage, missing value close tags, and unconvertible typed values.
  - Recovers `<arg_value>... </tool_call>` as a missing-close-tag value boundary.
  - Replaces orphan pending keys when a new `<arg_key>` appears before the previous key receives a value.

- `PythonicDetector`
  - Records syntax errors and non-literal argument failures per block/call.
  - Keeps valid calls when neighboring calls fail.
  - Records malformed AST shapes and unknown-tool drops.

- `Qwen25Detector`
  - Records malformed JSON blocks per call block.
  - Records truncated blocks.
  - Buffers partial `</tool_call>` text so end markers are removed from streamed normal text.

- `Qwen3CoderDetector`
  - Replaces custom parser with `TagToolCallDetector` plus `Qwen3CoderTextParser`.
  - Preserves historical call-index behavior.
  - Preserves historical unknown-tool forwarding behavior.
  - Adds missing-close-tag tolerance for parameters.
  - Adds schema-aware parameter conversion.
  - Records skipped garbage through shared tag-parser events.

- `Step3Detector`
  - Replaces custom parser with `TagToolCallDetector` plus `Step3TextParser`.
  - Records skipped non-function entries.
  - Adds schema-aware parameter conversion.
  - Preserves content after the tool-call block.
  - Records skipped garbage between StepML tags through shared tag-parser events.

- `utils._partial_json_loads`
  - Normalizes partial-json internal assertion failures into `MalformedJSON`, allowing detector compatibility handling to treat them as malformed model output.

- `JsonArrayParser`
  - Drops malformed non-dict entries and missing-name entries while preserving valid entries.
  - Closes started malformed streaming calls with `{}` and continues parsing later valid calls.
  - Flushes trailing normal text after a closed JSON array.

## Tests

Added coverage in:

- `test_function_call_compatibility.py`
- `test_streaming_tool_call_fuzzer.py`

Expanded coverage in:

- `test_function_call_parser.py`

Coverage includes:

- strict default versus compatibility mode
- preserved normal-text behavior when no tool call is present
- preserved parsing behavior for well-formed tool calls
- preserved unknown-tool forwarding behavior under `SGLANG_FORWARD_UNKNOWN_TOOLS`
- fail-open recovery before a tool call, mid-call, and after completed calls
- JSON close synthesis for interrupted streaming arguments
- unknown-tool dropping and strict-mode failure
- malformed JSON block dropping
- detector-local fallback audit records
- schema-aware parameter conversion
- nested tag deviations for MiniMax M3 NOM
- missing close tags
- skipped garbage
- duplicate tags
- mixed text capture
- non-item array children
- truncated-call dropping
- streaming/non-streaming equivalence under fuzzed chunking
- mutation-sweep no-crash coverage across parser formats
- compatibility context behavior through `CompatibilityContext`
- same-chunk retry after malformed/unknown streaming entries
- split separator and split end-token recovery after dropped entries
- dense `tool_index` preservation after dropped middle entries
- started malformed streaming-call closure with empty arguments
- top-level malformed JSON isolation for constrained-output `JsonArrayParser`
- Poolside V1 non-streaming and streaming compatibility events
- registered-detector fallback coverage for `deepseekv4`, `glm45`, `poolside_v1`, and `trinity`

Validation run:

```bash
PYTHONPATH=/personal/sglang/python pytest -q test/registered/unit/function_call
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27479972088](https://github.com/sgl-project/sglang/actions/runs/27479972088)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27479972038](https://github.com/sgl-project/sglang/actions/runs/27479972038)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->