### PR TITLE
Unify NVTX annotation helpers and split the enable gate per subsystem

### DIFF
--- a/python/sglang/srt/batch_overlap/operations.py
+++ b/python/sglang/srt/batch_overlap/operations.py
@@ -19,7 +19,7 @@ from sglang.srt.model_executor.forward_context import (
     forward_context,
     get_forward_context,
 )
-from sglang.srt.utils.nvtx_utils import NVTX_OPERATIONS_ENABLED, nvtx_range
+from sglang.srt.utils.nvtx_utils import operations_nvtx_range
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -150,17 +150,15 @@ class _StageExecutor:
             if self._child_ctx is not None
             else nullcontext()
         )
-        stage_range = nvtx_range(
+        stage_range = operations_nvtx_range(
             debug_name=f"{self._debug_name}{self._index}",
             color="orange",
-            enabled=NVTX_OPERATIONS_ENABLED,
         )
         with ctx_mgr, stage_range:
             for op in stage:
-                with nvtx_range(
+                with operations_nvtx_range(
                     debug_name=op.debug_name,
                     color="yellow",
-                    enabled=NVTX_OPERATIONS_ENABLED,
                 ):
                     self._stage_output = op.fn(
                         state=self._stage_state,

--- a/python/sglang/srt/batch_overlap/operations.py
+++ b/python/sglang/srt/batch_overlap/operations.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import os
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import (
     TYPE_CHECKING,
@@ -15,22 +14,16 @@ from typing import (
     Union,
 )
 
-import torch
-
 from sglang.srt.layers.dp_attention import set_dp_buffer_len
 from sglang.srt.model_executor.forward_context import (
     forward_context,
     get_forward_context,
 )
+from sglang.srt.utils.nvtx_utils import NVTX_OPERATIONS_ENABLED, nvtx_range
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
     from sglang.srt.model_executor.forward_context import ForwardContext
-
-_ENABLE_PROFILE = bool(int(os.environ.get("SGLANG_OPERATIONS_ENABLE_PROFILE", "0")))
-
-if _ENABLE_PROFILE:
-    import nvtx
 
 
 def execute_operations(inputs, operations):
@@ -157,9 +150,18 @@ class _StageExecutor:
             if self._child_ctx is not None
             else nullcontext()
         )
-        with ctx_mgr, _annotate_region(debug_name=f"{self._debug_name}{self._index}"):
+        stage_range = nvtx_range(
+            debug_name=f"{self._debug_name}{self._index}",
+            color="orange",
+            enabled=NVTX_OPERATIONS_ENABLED,
+        )
+        with ctx_mgr, stage_range:
             for op in stage:
-                with _annotate_region(debug_name=op.debug_name):
+                with nvtx_range(
+                    debug_name=op.debug_name,
+                    color="yellow",
+                    enabled=NVTX_OPERATIONS_ENABLED,
+                ):
                     self._stage_output = op.fn(
                         state=self._stage_state,
                         **(
@@ -181,16 +183,6 @@ class _StageExecutor:
     @property
     def num_stages(self):
         return len(self._stages)
-
-
-@contextmanager
-def _annotate_region(debug_name):
-    if _ENABLE_PROFILE:
-        with torch.autograd.profiler.record_function(debug_name):
-            with nvtx.annotate(debug_name):
-                yield
-    else:
-        yield
 
 
 class _StateDict:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -85,10 +85,7 @@ from sglang.srt.observability.req_time_stats import (
 )
 from sglang.srt.utils import get_num_new_pages
 from sglang.srt.utils.network import NetworkAddress
-from sglang.srt.utils.nvtx_utils import (
-    NVTX_SCHEDULER_ENABLED,
-    nvtx_annotated_method,
-)
+from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = logging.getLogger(__name__)
@@ -1828,9 +1825,7 @@ class SchedulerDisaggregationDecodeMixin:
 
         return GenerationBatchResult()
 
-    @nvtx_annotated_method(
-        "scheduler.get_next_batch_to_run", enabled=NVTX_SCHEDULER_ENABLED
-    )
+    @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_disagg_decode_batch_to_run(
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -85,7 +85,10 @@ from sglang.srt.observability.req_time_stats import (
 )
 from sglang.srt.utils import get_num_new_pages
 from sglang.srt.utils.network import NetworkAddress
-from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
+from sglang.srt.utils.nvtx_utils import (
+    NVTX_SCHEDULER_ENABLED,
+    nvtx_annotated_method,
+)
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = logging.getLogger(__name__)
@@ -1825,7 +1828,9 @@ class SchedulerDisaggregationDecodeMixin:
 
         return GenerationBatchResult()
 
-    @nvtx_annotated_method("scheduler.get_next_batch_to_run")
+    @nvtx_annotated_method(
+        "scheduler.get_next_batch_to_run", enabled=NVTX_SCHEDULER_ENABLED
+    )
     def get_next_disagg_decode_batch_to_run(
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -61,10 +61,7 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
-from sglang.srt.utils.nvtx_utils import (
-    NVTX_SCHEDULER_ENABLED,
-    nvtx_annotated_method,
-)
+from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
@@ -409,9 +406,7 @@ class SchedulerDisaggregationPrefillMixin:
             if room is not None and room in kv_mgr.transfer_infos:
                 prefetch(room)
 
-    @nvtx_annotated_method(
-        "scheduler.get_next_batch_to_run", enabled=NVTX_SCHEDULER_ENABLED
-    )
+    @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_disagg_prefill_batch_to_run(
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -61,7 +61,10 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
-from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
+from sglang.srt.utils.nvtx_utils import (
+    NVTX_SCHEDULER_ENABLED,
+    nvtx_annotated_method,
+)
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
@@ -406,7 +409,9 @@ class SchedulerDisaggregationPrefillMixin:
             if room is not None and room in kv_mgr.transfer_infos:
                 prefetch(room)
 
-    @nvtx_annotated_method("scheduler.get_next_batch_to_run")
+    @nvtx_annotated_method(
+        "scheduler.get_next_batch_to_run", enabled=NVTX_SCHEDULER_ENABLED
+    )
     def get_next_disagg_prefill_batch_to_run(
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -243,7 +243,12 @@ class Envs:
     SGLANG_PROFILE_WITH_STACK = EnvBool(True)
     SGLANG_PROFILE_RECORD_SHAPES = EnvBool(True)
     SGLANG_PROFILE_V2 = EnvBool(False)
-    SGLANG_ENABLE_NVTX = EnvBool(False)
+    SGLANG_ENABLE_NVTX_SCHEDULER = EnvBoolWithAlias(
+        False, deprecated_name="SGLANG_ENABLE_NVTX"
+    )
+    SGLANG_ENABLE_NVTX_OPERATIONS = EnvBoolWithAlias(
+        False, deprecated_name="SGLANG_OPERATIONS_ENABLE_PROFILE"
+    )
     SGLANG_RECORD_STEP_TIME = EnvBool(False)
     SGLANG_FORCE_SHUTDOWN = EnvBool(False)
     SGLANG_DEBUG_MEMORY_POOL = EnvBool(False)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -263,10 +263,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_tokenizer_from_processor,
 )
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
-from sglang.srt.utils.nvtx_utils import (
-    NVTX_SCHEDULER_ENABLED,
-    nvtx_annotated_method,
-)
+from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
@@ -1589,9 +1586,7 @@ class Scheduler(
 
         return disable_overlap_for_batch or need_grammar_sync
 
-    @nvtx_annotated_method(
-        "scheduler.process_input_requests", enabled=NVTX_SCHEDULER_ENABLED
-    )
+    @scheduler_nvtx_method("scheduler.process_input_requests")
     def process_input_requests(self, recv_reqs: List):
         now = time.monotonic()
         self.session_controller.maybe_reap(now)
@@ -2468,9 +2463,7 @@ class Scheduler(
         # todo hisparse, maybe other info to contain for the new batch
         return batch
 
-    @nvtx_annotated_method(
-        "scheduler.get_next_batch_to_run", enabled=NVTX_SCHEDULER_ENABLED
-    )
+    @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:
         if self.enable_fpm:
             self._fpm_batch_t0 = time.monotonic()
@@ -3058,7 +3051,7 @@ class Scheduler(
             else:
                 batch.sampling_info = sched_sampling_info
 
-    @nvtx_annotated_method("scheduler.run_batch", enabled=NVTX_SCHEDULER_ENABLED)
+    @scheduler_nvtx_method("scheduler.run_batch")
     def run_batch(
         self,
         batch: ScheduleBatch,
@@ -3280,9 +3273,7 @@ class Scheduler(
         if batch_result.logits_output is not None:
             batch_result.logits_output.next_token_logits = None
 
-    @nvtx_annotated_method(
-        "scheduler.process_batch_result", enabled=NVTX_SCHEDULER_ENABLED
-    )
+    @scheduler_nvtx_method("scheduler.process_batch_result")
     def process_batch_result(
         self,
         batch: ScheduleBatch,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -263,7 +263,10 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_tokenizer_from_processor,
 )
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
-from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
+from sglang.srt.utils.nvtx_utils import (
+    NVTX_SCHEDULER_ENABLED,
+    nvtx_annotated_method,
+)
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
@@ -1586,7 +1589,9 @@ class Scheduler(
 
         return disable_overlap_for_batch or need_grammar_sync
 
-    @nvtx_annotated_method("scheduler.process_input_requests")
+    @nvtx_annotated_method(
+        "scheduler.process_input_requests", enabled=NVTX_SCHEDULER_ENABLED
+    )
     def process_input_requests(self, recv_reqs: List):
         now = time.monotonic()
         self.session_controller.maybe_reap(now)
@@ -2463,7 +2468,9 @@ class Scheduler(
         # todo hisparse, maybe other info to contain for the new batch
         return batch
 
-    @nvtx_annotated_method("scheduler.get_next_batch_to_run")
+    @nvtx_annotated_method(
+        "scheduler.get_next_batch_to_run", enabled=NVTX_SCHEDULER_ENABLED
+    )
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:
         if self.enable_fpm:
             self._fpm_batch_t0 = time.monotonic()
@@ -3051,7 +3058,7 @@ class Scheduler(
             else:
                 batch.sampling_info = sched_sampling_info
 
-    @nvtx_annotated_method("scheduler.run_batch")
+    @nvtx_annotated_method("scheduler.run_batch", enabled=NVTX_SCHEDULER_ENABLED)
     def run_batch(
         self,
         batch: ScheduleBatch,
@@ -3273,7 +3280,9 @@ class Scheduler(
         if batch_result.logits_output is not None:
             batch_result.logits_output.next_token_logits = None
 
-    @nvtx_annotated_method("scheduler.process_batch_result")
+    @nvtx_annotated_method(
+        "scheduler.process_batch_result", enabled=NVTX_SCHEDULER_ENABLED
+    )
     def process_batch_result(
         self,
         batch: ScheduleBatch,

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -29,7 +29,10 @@ from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
 )
-from sglang.srt.utils.nvtx_utils import nvtx_annotated_method
+from sglang.srt.utils.nvtx_utils import (
+    NVTX_SCHEDULER_ENABLED,
+    nvtx_annotated_method,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -68,7 +71,7 @@ class SchedulerRequestReceiver:
             return False
         return num_recv_reqs >= self.max_recv_per_poll
 
-    @nvtx_annotated_method("scheduler.recv_requests")
+    @nvtx_annotated_method("scheduler.recv_requests", enabled=NVTX_SCHEDULER_ENABLED)
     def recv_requests(
         self,
     ) -> List[Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput, Any]]:

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -29,10 +29,7 @@ from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
 )
-from sglang.srt.utils.nvtx_utils import (
-    NVTX_SCHEDULER_ENABLED,
-    nvtx_annotated_method,
-)
+from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -71,7 +68,7 @@ class SchedulerRequestReceiver:
             return False
         return num_recv_reqs >= self.max_recv_per_poll
 
-    @nvtx_annotated_method("scheduler.recv_requests", enabled=NVTX_SCHEDULER_ENABLED)
+    @scheduler_nvtx_method("scheduler.recv_requests")
     def recv_requests(
         self,
     ) -> List[Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput, Any]]:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -232,6 +232,7 @@ from sglang.srt.utils import (
 from sglang.srt.utils.common import ceil_align, next_power_of_2, require_mlp_sync
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
+from sglang.srt.utils.nvtx_utils import profile_range
 from sglang.srt.utils.offloader import (
     create_offloader_from_server_args,
     get_offloader,
@@ -3454,11 +3455,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.msprobe_debugger.start(model=self.model, rank_id=rank_id)
 
         # Step span
-        step_span_ctx = (
-            torch.profiler.record_function(_build_step_span_name(forward_batch))
-            if torch.autograd._profiler_enabled()
-            else contextlib.nullcontext()
-        )
+        step_span_ctx = profile_range(_build_step_span_name(forward_batch))
 
         canary_ctx = (
             context_tuple(

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
@@ -45,6 +45,7 @@ from sglang.srt.speculative.triton_ops.eagle import (
 )
 from sglang.srt.utils import is_cuda, is_hip, is_musa, is_npu, next_power_of_2
 from sglang.srt.utils.async_probe import maybe_detect_oob
+from sglang.srt.utils.nvtx_utils import profile_range
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
@@ -477,9 +478,7 @@ def spec_stage_span(name: str):
     """Profiler span for a coarse speculative-decoding stage (``draft`` /
     ``draft_extend`` / ``verify``).
     """
-    if torch.autograd._profiler_enabled():
-        return torch.profiler.record_function(name)
-    return nullcontext()
+    return profile_range(name)
 
 
 def move_accept_tokens_to_target_kvcache(

--- a/python/sglang/srt/utils/nvtx_utils.py
+++ b/python/sglang/srt/utils/nvtx_utils.py
@@ -11,20 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Lightweight NVTX annotations for hot SGLang code paths.
-
-Two independent, opt-in gates select which spans are emitted:
-
-* ``SGLANG_ENABLE_NVTX_SCHEDULER`` -- scheduler main-loop stages
-  (receive / process inputs / pick next batch / run forward / post-process).
-* ``SGLANG_ENABLE_NVTX_OPERATIONS`` -- the batch-overlap operation pipeline
-  (per-stage and per-op spans inside the model forward).
-
-Both are off by default. When a gate is off the decorator returns the original
-function untouched and the context manager hands back a shared no-op, so
-decorated hot paths pay no runtime cost. The decision is made once at import /
-decoration time, not per call.
-"""
+"""Opt-in NVTX annotations gated by the ``SGLANG_ENABLE_NVTX_*`` env flags."""
 
 import logging
 from contextlib import contextmanager, nullcontext
@@ -37,9 +24,6 @@ from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
 
-# Per-subsystem env gates. A subsystem's spans are emitted only when its flag is
-# set AND the `nvtx` package is importable; the two checks are folded together
-# below so call sites can branch on a single boolean.
 NVTX_SCHEDULER_ENABLED = envs.SGLANG_ENABLE_NVTX_SCHEDULER.get()
 NVTX_OPERATIONS_ENABLED = envs.SGLANG_ENABLE_NVTX_OPERATIONS.get()
 
@@ -57,11 +41,7 @@ NVTX_AVAILABLE = _nvtx_module is not None
 NVTX_SCHEDULER_ENABLED = NVTX_SCHEDULER_ENABLED and NVTX_AVAILABLE
 NVTX_OPERATIONS_ENABLED = NVTX_OPERATIONS_ENABLED and NVTX_AVAILABLE
 
-# Default colors for statically-named spans, so the markers are easy to tell
-# apart in Nsight Systems. Call sites with dynamic names (e.g. the operation
-# pipeline) pass an explicit `color` instead of relying on this map.
 _NVTX_COLOR_MAP = {
-    # Scheduler main loop (pipeline order).
     "scheduler.recv_requests": "blue",
     "scheduler.process_input_requests": "purple",
     "scheduler.get_next_batch_to_run": "green",
@@ -69,23 +49,17 @@ _NVTX_COLOR_MAP = {
     "scheduler.process_batch_result": "cyan",
 }
 
-# Shared no-op handed back on disabled paths so `with nvtx_range(...)` pays no
-# per-call generator overhead.
 _NULL_CONTEXT = nullcontext()
 
 
 def _resolve_color(debug_name: str, color: Optional[str]) -> Optional[str]:
-    if color is not None:
-        return color
-    return _NVTX_COLOR_MAP.get(debug_name)
+    return color if color is not None else _NVTX_COLOR_MAP.get(debug_name)
 
 
 @contextmanager
 def _nvtx_range_impl(debug_name: str, color: Optional[str]):
-    # record_function carries a non-trivial (~microseconds) cost per call even
-    # when no PyTorch profiler is collecting, so only pay it when one is active
-    # (e.g. Chrome-trace export). For Nsight-only runs the nvtx.annotate marker
-    # alone is enough.
+    # Only pay record_function's per-call cost when a profiler is collecting;
+    # for Nsight-only runs the nvtx marker alone is enough.
     if torch.autograd._profiler_enabled():
         with torch.autograd.profiler.record_function(debug_name):
             with _nvtx_module.annotate(debug_name, color=color):
@@ -96,12 +70,6 @@ def _nvtx_range_impl(debug_name: str, color: Optional[str]):
 
 
 def nvtx_range(debug_name: str, *, color: Optional[str] = None, enabled: bool):
-    """Return a context manager emitting an NVTX range for ``debug_name``.
-
-    ``enabled`` is the caller subsystem's resolved gate (e.g.
-    ``NVTX_OPERATIONS_ENABLED``); when false a shared no-op is returned. ``color``
-    overrides the color otherwise looked up from the name->color map.
-    """
     if not enabled:
         return _NULL_CONTEXT
     return _nvtx_range_impl(debug_name, _resolve_color(debug_name, color))
@@ -110,12 +78,6 @@ def nvtx_range(debug_name: str, *, color: Optional[str] = None, enabled: bool):
 def nvtx_annotated_method(
     debug_name: str, *, color: Optional[str] = None, enabled: bool
 ):
-    """Decorate a method so each call emits an NVTX range. See ``nvtx_range``.
-
-    The enable decision is made once at decoration time: when ``enabled`` is
-    false the original function is returned untouched, so decorated methods on
-    hot paths have zero runtime cost.
-    """
     if not enabled:
         return lambda func: func
 
@@ -132,8 +94,5 @@ def nvtx_annotated_method(
     return decorator
 
 
-# Pre-bound per-subsystem helpers so call sites don't repeat the gate: each
-# binds its subsystem's resolved enable flag, leaving callers to pass only the
-# span name (and optional color).
 scheduler_nvtx_method = partial(nvtx_annotated_method, enabled=NVTX_SCHEDULER_ENABLED)
 operations_nvtx_range = partial(nvtx_range, enabled=NVTX_OPERATIONS_ENABLED)

--- a/python/sglang/srt/utils/nvtx_utils.py
+++ b/python/sglang/srt/utils/nvtx_utils.py
@@ -11,10 +11,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Opt-in NVTX annotations gated by the ``SGLANG_ENABLE_NVTX_*`` env flags."""
+"""Profiler span helpers for hot SGLang code paths.
+
+A span has two independent emitters:
+
+* ``record_function`` -- emitted whenever a torch profiler is active, so spans
+  show up in torch/Perfetto traces for free (no env, no extra package).
+* ``nvtx`` range -- emitted only when the caller opts in via ``nvtx_enabled``
+  (wired to a per-subsystem ``SGLANG_ENABLE_NVTX_*`` gate) and the ``nvtx``
+  package is importable, for Nsight Systems timelines.
+
+Decoupling the two lets every annotation site -- scheduler stages, batch-overlap
+ops, and the speculative-decoding / forward spans -- share one primitive.
+"""
 
 import logging
-from contextlib import contextmanager, nullcontext
+from contextlib import ExitStack, contextmanager, nullcontext
 from functools import partial, wraps
 from typing import Optional
 
@@ -24,23 +36,26 @@ from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
 
-NVTX_SCHEDULER_ENABLED = envs.SGLANG_ENABLE_NVTX_SCHEDULER.get()
-NVTX_OPERATIONS_ENABLED = envs.SGLANG_ENABLE_NVTX_OPERATIONS.get()
+_SCHEDULER_NVTX = envs.SGLANG_ENABLE_NVTX_SCHEDULER.get()
+_OPERATIONS_NVTX = envs.SGLANG_ENABLE_NVTX_OPERATIONS.get()
 
 _nvtx_module = None
-if NVTX_SCHEDULER_ENABLED or NVTX_OPERATIONS_ENABLED:
+if _SCHEDULER_NVTX or _OPERATIONS_NVTX:
     try:
         import nvtx as _nvtx_module  # type: ignore
     except ImportError:
         logger.warning(
             "An SGLANG_ENABLE_NVTX_* flag is set, but the `nvtx` package is "
-            "missing. NVTX annotations are disabled."
+            "missing. NVTX markers are disabled; torch profiler spans still emit."
         )
 
 NVTX_AVAILABLE = _nvtx_module is not None
-NVTX_SCHEDULER_ENABLED = NVTX_SCHEDULER_ENABLED and NVTX_AVAILABLE
-NVTX_OPERATIONS_ENABLED = NVTX_OPERATIONS_ENABLED and NVTX_AVAILABLE
+# Per-subsystem nvtx gates: emit nvtx ranges only when the flag is set AND the
+# package is importable. The record_function path is independent of both.
+NVTX_SCHEDULER_ENABLED = _SCHEDULER_NVTX and NVTX_AVAILABLE
+NVTX_OPERATIONS_ENABLED = _OPERATIONS_NVTX and NVTX_AVAILABLE
 
+# Default nvtx colors for statically-named spans (only used on the nvtx path).
 _NVTX_COLOR_MAP = {
     "scheduler.recv_requests": "blue",
     "scheduler.process_input_requests": "purple",
@@ -52,41 +67,45 @@ _NVTX_COLOR_MAP = {
 _NULL_CONTEXT = nullcontext()
 
 
-def _resolve_color(debug_name: str, color: Optional[str]) -> Optional[str]:
-    return color if color is not None else _NVTX_COLOR_MAP.get(debug_name)
-
-
 @contextmanager
-def _nvtx_range_impl(debug_name: str, color: Optional[str]):
-    # Only pay record_function's per-call cost when a profiler is collecting;
-    # for Nsight-only runs the nvtx marker alone is enough.
-    if torch.autograd._profiler_enabled():
-        with torch.autograd.profiler.record_function(debug_name):
-            with _nvtx_module.annotate(debug_name, color=color):
-                yield
-    else:
-        with _nvtx_module.annotate(debug_name, color=color):
-            yield
-
-
-def nvtx_range(debug_name: str, *, color: Optional[str] = None, enabled: bool):
-    if not enabled:
-        return _NULL_CONTEXT
-    return _nvtx_range_impl(debug_name, _resolve_color(debug_name, color))
-
-
-def nvtx_annotated_method(
-    debug_name: str, *, color: Optional[str] = None, enabled: bool
+def _profile_range_impl(
+    debug_name: str, color: Optional[str], record: bool, nvtx_enabled: bool
 ):
-    if not enabled:
-        return lambda func: func
+    with ExitStack() as stack:
+        if record:
+            stack.enter_context(torch.profiler.record_function(debug_name))
+        if nvtx_enabled:
+            if color is None:
+                color = _NVTX_COLOR_MAP.get(debug_name)
+            stack.enter_context(_nvtx_module.annotate(debug_name, color=color))
+        yield
 
-    color = _resolve_color(debug_name, color)
+
+def profile_range(
+    debug_name: str, *, color: Optional[str] = None, nvtx_enabled: bool = False
+):
+    """Context manager emitting a profiler span for ``debug_name``.
+
+    A torch ``record_function`` is emitted whenever a torch profiler is active;
+    an nvtx range is emitted additionally when ``nvtx_enabled`` is true. Returns a
+    shared no-op when neither applies, so off-profile hot paths pay only one
+    ``_profiler_enabled()`` check.
+    """
+    record = torch.autograd._profiler_enabled()
+    if not record and not nvtx_enabled:
+        return _NULL_CONTEXT
+    return _profile_range_impl(debug_name, color, record, nvtx_enabled)
+
+
+def profile_method(
+    debug_name: str, *, color: Optional[str] = None, nvtx_enabled: bool = False
+):
+    """Decorator form of ``profile_range``."""
 
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            with _nvtx_range_impl(debug_name, color):
+            with profile_range(debug_name, color=color, nvtx_enabled=nvtx_enabled):
                 return func(*args, **kwargs)
 
         return wrapper
@@ -94,5 +113,7 @@ def nvtx_annotated_method(
     return decorator
 
 
-scheduler_nvtx_method = partial(nvtx_annotated_method, enabled=NVTX_SCHEDULER_ENABLED)
-operations_nvtx_range = partial(nvtx_range, enabled=NVTX_OPERATIONS_ENABLED)
+# Pre-bound per-subsystem helpers: torch spans always (under a profiler), nvtx
+# ranges only when that subsystem's gate is on.
+scheduler_nvtx_method = partial(profile_method, nvtx_enabled=NVTX_SCHEDULER_ENABLED)
+operations_nvtx_range = partial(profile_range, nvtx_enabled=NVTX_OPERATIONS_ENABLED)

--- a/python/sglang/srt/utils/nvtx_utils.py
+++ b/python/sglang/srt/utils/nvtx_utils.py
@@ -11,16 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Lightweight NVTX annotations for the scheduler main loop.
+"""Lightweight NVTX annotations for hot SGLang code paths.
 
-Enabled via the ``SGLANG_ENABLE_NVTX`` environment variable (off by default).
-When disabled, the decorator/context manager add zero runtime overhead so they
-are safe to leave on hot scheduler paths.
+Two independent, opt-in gates select which spans are emitted:
+
+* ``SGLANG_ENABLE_NVTX_SCHEDULER`` -- scheduler main-loop stages
+  (receive / process inputs / pick next batch / run forward / post-process).
+* ``SGLANG_ENABLE_NVTX_OPERATIONS`` -- the batch-overlap operation pipeline
+  (per-stage and per-op spans inside the model forward).
+
+Both are off by default. When a gate is off the decorator returns the original
+function untouched and the context manager hands back a shared no-op, so
+decorated hot paths pay no runtime cost. The decision is made once at import /
+decoration time, not per call.
 """
 
 import logging
 from contextlib import contextmanager, nullcontext
 from functools import wraps
+from typing import Optional
 
 import torch
 
@@ -28,23 +37,31 @@ from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
 
-_NVTX_ENV_ENABLED = envs.SGLANG_ENABLE_NVTX.get()
+# Per-subsystem env gates. A subsystem's spans are emitted only when its flag is
+# set AND the `nvtx` package is importable; the two checks are folded together
+# below so call sites can branch on a single boolean.
+NVTX_SCHEDULER_ENABLED = envs.SGLANG_ENABLE_NVTX_SCHEDULER.get()
+NVTX_OPERATIONS_ENABLED = envs.SGLANG_ENABLE_NVTX_OPERATIONS.get()
+
 _nvtx_module = None
-if _NVTX_ENV_ENABLED:
+if NVTX_SCHEDULER_ENABLED or NVTX_OPERATIONS_ENABLED:
     try:
         import nvtx as _nvtx_module  # type: ignore
     except ImportError:
         logger.warning(
-            "SGLANG_ENABLE_NVTX is set, but the `nvtx` package is missing. "
-            "NVTX annotations are disabled."
+            "An SGLANG_ENABLE_NVTX_* flag is set, but the `nvtx` package is "
+            "missing. NVTX annotations are disabled."
         )
 
-NVTX_ENABLED = _nvtx_module is not None
+NVTX_AVAILABLE = _nvtx_module is not None
+NVTX_SCHEDULER_ENABLED = NVTX_SCHEDULER_ENABLED and NVTX_AVAILABLE
+NVTX_OPERATIONS_ENABLED = NVTX_OPERATIONS_ENABLED and NVTX_AVAILABLE
 
-# Colors are assigned per scheduler main-loop stage so the markers are easy to
-# distinguish in Nsight Systems.
+# Default colors for statically-named spans, so the markers are easy to tell
+# apart in Nsight Systems. Call sites with dynamic names (e.g. the operation
+# pipeline) pass an explicit `color` instead of relying on this map.
 _NVTX_COLOR_MAP = {
-    # === Scheduler main loop (pipeline order) ===
+    # Scheduler main loop (pipeline order).
     "scheduler.recv_requests": "blue",
     "scheduler.process_input_requests": "purple",
     "scheduler.get_next_batch_to_run": "green",
@@ -52,10 +69,19 @@ _NVTX_COLOR_MAP = {
     "scheduler.process_batch_result": "cyan",
 }
 
+# Shared no-op handed back on disabled paths so `with nvtx_range(...)` pays no
+# per-call generator overhead.
+_NULL_CONTEXT = nullcontext()
+
+
+def _resolve_color(debug_name: str, color: Optional[str]) -> Optional[str]:
+    if color is not None:
+        return color
+    return _NVTX_COLOR_MAP.get(debug_name)
+
 
 @contextmanager
-def _nvtx_range_enabled(debug_name: str):
-    color = _NVTX_COLOR_MAP.get(debug_name)
+def _nvtx_range_impl(debug_name: str, color: Optional[str]):
     # record_function carries a non-trivial (~microseconds) cost per call even
     # when no PyTorch profiler is collecting, so only pay it when one is active
     # (e.g. Chrome-trace export). For Nsight-only runs the nvtx.annotate marker
@@ -69,28 +95,36 @@ def _nvtx_range_enabled(debug_name: str):
             yield
 
 
-if NVTX_ENABLED:
-    nvtx_range = _nvtx_range_enabled
-else:
-    # When NVTX is disabled, hand back a shared no-op context manager so hot
-    # paths using `with nvtx_range(...)` pay no per-call generator overhead.
-    _NULL_CONTEXT = nullcontext()
+def nvtx_range(debug_name: str, *, color: Optional[str] = None, enabled: bool):
+    """Return a context manager emitting an NVTX range for ``debug_name``.
 
-    def nvtx_range(debug_name: str):
+    ``enabled`` is the caller subsystem's resolved gate (e.g.
+    ``NVTX_OPERATIONS_ENABLED``); when false a shared no-op is returned. ``color``
+    overrides the color otherwise looked up from the name->color map.
+    """
+    if not enabled:
         return _NULL_CONTEXT
+    return _nvtx_range_impl(debug_name, _resolve_color(debug_name, color))
 
 
-def nvtx_annotated_method(debug_name: str):
-    # Decide at decoration time. When NVTX is disabled this returns the
-    # original function untouched, so decorated methods on hot paths have zero
-    # runtime cost.
-    if not NVTX_ENABLED:
+def nvtx_annotated_method(
+    debug_name: str, *, color: Optional[str] = None, enabled: bool
+):
+    """Decorate a method so each call emits an NVTX range. See ``nvtx_range``.
+
+    The enable decision is made once at decoration time: when ``enabled`` is
+    false the original function is returned untouched, so decorated methods on
+    hot paths have zero runtime cost.
+    """
+    if not enabled:
         return lambda func: func
+
+    color = _resolve_color(debug_name, color)
 
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            with nvtx_range(debug_name):
+            with _nvtx_range_impl(debug_name, color):
                 return func(*args, **kwargs)
 
         return wrapper

--- a/python/sglang/srt/utils/nvtx_utils.py
+++ b/python/sglang/srt/utils/nvtx_utils.py
@@ -28,7 +28,7 @@ decoration time, not per call.
 
 import logging
 from contextlib import contextmanager, nullcontext
-from functools import wraps
+from functools import partial, wraps
 from typing import Optional
 
 import torch
@@ -130,3 +130,10 @@ def nvtx_annotated_method(
         return wrapper
 
     return decorator
+
+
+# Pre-bound per-subsystem helpers so call sites don't repeat the gate: each
+# binds its subsystem's resolved enable flag, leaving callers to pass only the
+# span name (and optional color).
+scheduler_nvtx_method = partial(nvtx_annotated_method, enabled=NVTX_SCHEDULER_ENABLED)
+operations_nvtx_range = partial(nvtx_range, enabled=NVTX_OPERATIONS_ENABLED)


### PR DESCRIPTION
## Motivation

SGLang had accumulated several ad-hoc ways to emit profiler spans:

- `nvtx_utils` — NVTX ranges **plus** `record_function`, env-gated — used by the scheduler main loop.
- `batch_overlap/operations.py` — its own near-identical `record_function` + NVTX context manager, gated by a separate `SGLANG_OPERATIONS_ENABLE_PROFILE` read straight from `os.environ`.
- `spec_stage_span` (speculative decoding) and the model-forward `step[...]` span — a third idiom that emits **only** `record_function`, gated on whether a torch profiler is active.

Two problems:

1. **`record_function` was coupled to NVTX.** The `nvtx_utils` helpers emitted a span only when the `nvtx` package was importable *and* the env flag was set. So the scheduler / batch-overlap spans were **invisible in a plain `torch.profiler` capture** unless you also `pip install nvtx` — even though `record_function` needs no such dependency.
2. **Inconsistent gating / naming.** `SGLANG_ENABLE_NVTX` (scheduler) vs `SGLANG_OPERATIONS_ENABLE_PROFILE` (batch-overlap): same purpose, different conventions, one not even registered in `environ.py`.

## Changes

- **One primitive** `profile_range` / `profile_method` (`nvtx_utils.py`) with the two emitters **decoupled**:
  - `record_function` — emitted whenever a torch profiler is active (no env, no extra package).
  - NVTX range — emitted only when the caller's per-subsystem gate is on **and** the `nvtx` package is importable.
- **All annotation sites consolidated** onto it: the duplicated context manager in `batch_overlap/operations.py` is removed; `spec_stage_span` and the model-forward `step[...]` span now delegate to the shared primitive; the scheduler decorators are unchanged at the call site.
- **Per-subsystem env gates**, registered in `environ.py` with deprecation aliases:
  - `SGLANG_ENABLE_NVTX` → `SGLANG_ENABLE_NVTX_SCHEDULER`
  - `SGLANG_OPERATIONS_ENABLE_PROFILE` → `SGLANG_ENABLE_NVTX_OPERATIONS`
- Per-call `color` override for NVTX ranges.

## Result

Any `torch.profiler` capture now shows the scheduler, speculative-decoding, and forward spans **in one timeline, with no `nvtx` package installed and no `SGLANG_ENABLE_NVTX_*` set**. NVTX / Nsight markers stay opt-in behind the per-subsystem env flags.

Single-batch EAGLE3 decode capture (plain `torch.profiler`, no nvtx): `scheduler.run_batch` and the other `scheduler.*` stages now appear alongside `draft` / `draft_extend` / `step[TARGET_VERIFY]` — all funneled through `profile_method` / `profile_range` (`nvtx_utils.py`).

<img width="683" height="587" alt="4" src="https://github.com/user-attachments/assets/3f2ff2ed-4893-4f8f-9946-5e83b004f5be" />


## Compatibility

The old env names (`SGLANG_ENABLE_NVTX`, `SGLANG_OPERATIONS_ENABLE_PROFILE`) keep working and emit a `DeprecationWarning`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27491176136](https://github.com/sgl-project/sglang/actions/runs/27491176136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27491176088](https://github.com/sgl-project/sglang/actions/runs/27491176088)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->