### PR TITLE
[CPU] Fix Gemma4 CPU server support

### DIFF
--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -152,6 +152,9 @@ def update_intermediate_size(model_config, attr_name, intermediate_padding_size)
     elif hasattr(model_config, attr_name):
         attr_value = getattr(model_config, attr_name)
 
+    if attr_value is None:
+        return model_config
+
     if attr_value % intermediate_padding_size != 0:
         from sglang.srt.layers.vocab_parallel_embedding import pad_vocab_size
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4366,15 +4366,24 @@ class ServerArgs:
             "Gemma4ForCausalLM",
             "Gemma4UnifiedForConditionalGeneration",
         ):
+
             # Default attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _gemma4_overrides).
             prefill_backend, decode_backend = self._resolved_attention_backends()
-            accepted_backends = ("trtllm_mha", "triton", "ascend", "intel_xpu")
+            accepted_backends = (
+                "trtllm_mha",
+                "triton",
+                "ascend",
+                "intel_xpu",
+                "intel_amx",
+                "torch_native",
+            )
             assert (
                 prefill_backend in accepted_backends
                 and decode_backend in accepted_backends
             ), (
-                "Gemma4 only supports trtllm_mha, triton, or intel_xpu attention backend, "
+                "Gemma4 only supports trtllm_mha, triton, ascend, intel_xpu, "
+                "intel_amx, or torch_native attention backend, "
                 f"got prefill={prefill_backend}, decode={decode_backend}"
             )
 


### PR DESCRIPTION
## Summary


Fix Gemma4 startup and generation on the SGLang CPU engine.   Fixes #28427 

This PR:
- allows Gemma4 to use `intel_amx` and `torch_native` attention backends
- skips CPU TP intermediate-size padding when the config value is `None`
- uses the torch softcap fallback for final logits softcapping on CPU

## Motivation

Gemma4 currently fails on CPU in a few places:

1. Server argument validation rejects CPU attention backends for Gemma4.
2. Gemma4 E2B configs can have optional intermediate-size fields set to `None`, which causes CPU TP config padding to fail with `% None`.
3. Final logits softcapping calls a Triton kernel on CPU, which fails because there is no active Triton driver.

## Modifications

```
  python/sglang/srt/configs/update_config.py 
  python/sglang/srt/layers/logits_processor.py 
  python/sglang/srt/server_args.py
```

## usage
### server
``` bash export SGLANG_USE_CPU_ENGINE=1
python -m sglang.launch_server \
    --model-path google/gemma-4-E2B-it/ \
    --context-length 32768 \
    --host 0.0.0.0 \
    --port 20000 
```

### clint
``` python

import openai

client = openai.Client(base_url="http://0.0.0.0:20000/v1", api_key="None")
response = client.chat.completions.create(
    model="google/gemma-4-E2B-it/",
    messages=[
        {"role": "user", "content": "介绍一下三体"},
    ],
    temperature=0,
    max_tokens=640,
)

print(response.choices[0].message.content)

```


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29002723275](https://github.com/sgl-project/sglang/actions/runs/29002723275)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29002723148](https://github.com/sgl-project/sglang/actions/runs/29002723148)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->