### PR TITLE
[Test] Add unit tests for srt/entrypoints/openai/tool_server.py

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_tool_server.py
+++ b/test/registered/unit/entrypoints/openai/test_tool_server.py
@@ -1,0 +1,203 @@
+"""Unit tests for sglang.srt.entrypoints.openai.tool_server."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.entrypoints.openai.tool_server import (
+    MCPToolServer,
+    post_process_tools_description,
+    trim_schema,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(2.0, "base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="base-b-test-cpu")
+
+
+class TestTrimSchema(unittest.TestCase):
+    def test_removes_title(self):
+        result = trim_schema({"title": "X", "type": "string"})
+        self.assertNotIn("title", result)
+        self.assertEqual(result["type"], "string")
+
+    def test_keeps_non_none_default(self):
+        result = trim_schema({"default": "abc", "type": "string"})
+        self.assertEqual(result["default"], "abc")
+
+    def test_drops_none_default(self):
+        result = trim_schema({"default": None, "type": "string"})
+        self.assertNotIn("default", result)
+
+    def test_collapses_anyof_into_type_list(self):
+        result = trim_schema({"anyOf": [{"type": "string"}, {"type": "integer"}]})
+        self.assertNotIn("anyOf", result)
+        self.assertEqual(set(result["type"]), {"string", "integer"})
+
+    def test_anyof_filters_out_null_type(self):
+        result = trim_schema({"anyOf": [{"type": "string"}, {"type": "null"}]})
+        self.assertEqual(result["type"], ["string"])
+        self.assertNotIn("anyOf", result)
+
+    def test_recurses_into_properties(self):
+        result = trim_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"title": "Name", "type": "string"},
+                    "age": {"default": None, "type": "integer"},
+                },
+            }
+        )
+        self.assertNotIn("title", result["properties"]["name"])
+        self.assertNotIn("default", result["properties"]["age"])
+
+
+def _fake_tool(input_schema, **annotation_kwargs):
+    return SimpleNamespace(
+        name="t",
+        description="d",
+        inputSchema=input_schema,
+        annotations=SimpleNamespace(**annotation_kwargs),
+    )
+
+
+class TestPostProcessToolsDescription(unittest.TestCase):
+    def test_trims_each_tools_input_schema(self):
+        tools = [
+            _fake_tool({"title": "A", "type": "string"}),
+            _fake_tool({"default": None, "type": "string"}),
+        ]
+        result = post_process_tools_description(SimpleNamespace(tools=tools))
+        self.assertNotIn("title", result.tools[0].inputSchema)
+        self.assertNotIn("default", result.tools[1].inputSchema)
+
+    def test_excludes_tools_with_include_in_prompt_false(self):
+        keep = _fake_tool({}, include_in_prompt=True)
+        drop = _fake_tool({}, include_in_prompt=False)
+        result = post_process_tools_description(SimpleNamespace(tools=[keep, drop]))
+        self.assertEqual([t for t in result.tools], [keep])
+
+    def test_keeps_tool_when_include_in_prompt_attribute_missing(self):
+        tools = [_fake_tool({})]
+        result = post_process_tools_description(SimpleNamespace(tools=tools))
+        self.assertEqual(len(result.tools), 1)
+
+
+class TestMCPToolServerLookup(unittest.TestCase):
+    def test_lookup_round_trip_against_harmony_tool_descriptions(self):
+        server = MCPToolServer()
+        self.assertFalse(server.has_tool("missing"))
+        self.assertIsNone(server.get_tool_description("missing"))
+
+        sentinel = object()
+        server.harmony_tool_descriptions = {"foo": sentinel}
+        self.assertTrue(server.has_tool("foo"))
+        self.assertFalse(server.has_tool("bar"))
+        self.assertIs(server.get_tool_description("foo"), sentinel)
+        self.assertIsNone(server.get_tool_description("bar"))
+
+
+def _mcp_tool(name, description, input_schema, **annotation_kwargs):
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        inputSchema=input_schema,
+        annotations=SimpleNamespace(**annotation_kwargs),
+    )
+
+
+def _mcp_response(server_name, instructions, tools):
+    initialize_response = SimpleNamespace(
+        serverInfo=SimpleNamespace(name=server_name),
+        instructions=instructions,
+    )
+    list_tools_response = SimpleNamespace(tools=tools)
+    return initialize_response, list_tools_response
+
+
+class TestMCPToolServerAddToolServer(unittest.TestCase):
+    def test_processes_mcp_servers_into_harmony_with_dedup(self):
+        # Two URLs sharing harmony namespace "browser": urls dict keeps the
+        # first, harmony_tool_descriptions silently overwrites (asymmetric
+        # by design), and a warning fires for the second.
+        responses = {
+            "http://host-a:8001/sse": _mcp_response(
+                "browser",
+                "first",
+                [
+                    _mcp_tool(
+                        "search",
+                        "search the web",
+                        {
+                            "title": "SearchInput",
+                            "type": "object",
+                            "properties": {
+                                "q": {"title": "Q", "type": "string"},
+                            },
+                        },
+                    ),
+                    _mcp_tool(
+                        "internal",
+                        "hidden",
+                        {"type": "object"},
+                        include_in_prompt=False,
+                    ),
+                ],
+            ),
+            "http://host-b:8002/sse": _mcp_response(
+                "browser",
+                "second",
+                [_mcp_tool("open", "open url", {"type": "object"})],
+            ),
+        }
+
+        async def fake_list_server_and_tools(url):
+            return responses[url]
+
+        server = MCPToolServer()
+        with (
+            patch(
+                "sglang.srt.entrypoints.openai.tool_server.list_server_and_tools",
+                side_effect=fake_list_server_and_tools,
+            ),
+            self.assertLogs(
+                "sglang.srt.entrypoints.openai.tool_server", level="WARNING"
+            ) as captured_logs,
+        ):
+            asyncio.run(server.add_tool_server("host-a:8001,host-b:8002"))
+
+        self.assertEqual(server.urls, {"browser": "http://host-a:8001/sse"})
+        self.assertTrue(
+            any(
+                "already exists" in record and "host-b:8002" in record
+                for record in captured_logs.output
+            ),
+            captured_logs.output,
+        )
+
+        ns = server.harmony_tool_descriptions["browser"]
+        self.assertEqual(ns.description, "second")
+        self.assertEqual([t.name for t in ns.tools], ["open"])
+
+        # Second pass with only host-a so trim/filter assertions aren't
+        # clobbered by the dup overwrite above.
+        server2 = MCPToolServer()
+        with patch(
+            "sglang.srt.entrypoints.openai.tool_server.list_server_and_tools",
+            side_effect=fake_list_server_and_tools,
+        ):
+            asyncio.run(server2.add_tool_server("host-a:8001"))
+
+        ns_a = server2.harmony_tool_descriptions["browser"]
+        self.assertEqual([t.name for t in ns_a.tools], ["search"])
+        search = ns_a.tools[0]
+        self.assertNotIn("title", search.parameters)
+        self.assertNotIn("title", search.parameters["properties"]["q"])
+        self.assertEqual(ns_a.name, "browser")
+        self.assertEqual(ns_a.description, "first")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fill a unit-test gap on `srt/entrypoints/openai/tool_server.py`
Part of #20865
## Modifications

Adds `test/registered/unit/entrypoints/openai/test_tool_server.py` — 11 CPU-only tests, no server / GPU / model. No source changes.

| Class | # | Covers |
|---|---|---|
| `TestTrimSchema` | 6 | `title` removal, `default: null` drop vs preservation, `anyOf` → `type` list, `null`-type filtering, recursion through `properties` |
| `TestPostProcessToolsDescription` | 3 | per-tool schema trim, `include_in_prompt=False` filtering, default-true when the annotation is absent |
| `TestMCPToolServerLookup` | 1 | `has_tool` / `get_tool_description` round-trip against the documented `harmony_tool_descriptions` attribute |
| `TestMCPToolServerAddToolServer` | 1 | full `add_tool_server` pipeline with `list_server_and_tools` mocked at the network boundary: comma-split, `http://.../sse` URL prefix, schema trim, `include_in_prompt` filter, harmony-namespace keying, duplicate-name `urls` dedup + warning |

Registered via:

```python
register_cpu_ci(2.0, "base-a-test-cpu")
register_cpu_ci(est_time=7, suite="base-b-test-cpu")
```

## Test Plan

Local run on macOS / CPython 3.12, no GPU:

```
$ PYTHONPATH=python .venv/bin/python -m pytest \
    test/registered/unit/entrypoints/openai/test_tool_server.py -v

collected 11 items
... (all PASSED) ...
======================== 11 passed in 3.02s =========================
```

Sanity-checked the suite against the source by introducing three mutations into `tool_server.py` locally (then reverting) — every mutation was caught:

| Mutation | Caught by |
|---|---|
| Drop `is None` from the `default` guard (would delete all defaults) | `test_keeps_non_none_default` |
| `getattr(..., True)` → `False` (would drop every annotation-less tool) | 3 tests, incl. `test_processes_mcp_servers_into_harmony_with_dedup` |
| Silent last-write-wins on a duplicate URL (no warning) | `test_processes_mcp_servers_into_harmony_with_dedup` |

`pre-commit run` clean (ruff check + ruff format).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] ~~Update documentation~~ — N/A (no public API changes).
- [ ] ~~Provide accuracy and speed benchmark results~~ — N/A (tests-only PR).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27489062082](https://github.com/sgl-project/sglang/actions/runs/27489062082)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27489062067](https://github.com/sgl-project/sglang/actions/runs/27489062067)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->