### PR TITLE
[AMD] Skip eplb bookkeeping and topk remap when EPLB is not in use on mori-ep / HIP (#22985)

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -54,6 +54,11 @@ if _use_aiter:
 logger = logging.getLogger(__name__)
 
 
+def _should_record_expert_distribution() -> bool:
+    recorder = get_global_expert_distribution_recorder()
+    return recorder.recording or torch.get_device_module().is_current_stream_capturing()
+
+
 class MoriEPPDispatchHooks(DeepEPPDispatchHooks):
 
     def __call__(self, dispatcher: BaseDispatcher):
@@ -634,6 +639,8 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
     ):
         done_event: Optional[torch.cuda.Event] = None
 
+        record = _should_record_expert_distribution()
+
         if self._comm_stream:
             compute_stream = torch.cuda.current_stream()
             comm_stream = self._comm_stream  # comm stream
@@ -668,7 +675,7 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
                     topk_weights,
                     scale,
                     topk_ids,
-                    call_local_expert_count=True,
+                    call_local_expert_count=record,
                 )
                 if self.enable_sdma:
                     self.mori_op.dispatch_recv()
@@ -700,16 +707,15 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
                 topk_weights,
                 scale,
                 topk_ids,
-                call_local_expert_count=True,
+                call_local_expert_count=record,
             )
 
-        # Use low_latency hook instead of normal since mori local_expert_count is
-        # a GPU tensor, while the normal hook expects a Python list (CPU).  The
-        # low_latency path accumulates counts directly on GPU via
-        # _DeepepLowLatencySinglePassGatherer, which is CUDA-graph safe.
-        get_global_expert_distribution_recorder().on_deepep_dispatch_low_latency(
-            self.mori_op.local_expert_count
-        )
+        # mori local_expert_count is a GPU tensor; route it through the
+        # low_latency hook only when the recorder is actually active.
+        if record:
+            get_global_expert_distribution_recorder().on_deepep_dispatch_low_latency(
+                self.mori_op.local_expert_count
+            )
 
         return (
             packed_recv_hidden,
@@ -888,11 +894,13 @@ class _MoriEPDispatcherImplLowLatency(_MoriEPDispatcherImplBase):
             is mori.ops.EpDispatchCombineKernelType.AsyncLL
         ), "mori asyncll mismatch"
 
-        self.mori_op.dispatch_recv(call_local_expert_count=True)
+        record = _should_record_expert_distribution()
+        self.mori_op.dispatch_recv(call_local_expert_count=record)
 
-        get_global_expert_distribution_recorder().on_deepep_dispatch_low_latency(
-            self.mori_op.local_expert_count
-        )
+        if record:
+            get_global_expert_distribution_recorder().on_deepep_dispatch_low_latency(
+                self.mori_op.local_expert_count
+            )
 
         return MoriEPLLDispatchOutput(
             hidden_states=hidden_states,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1114,15 +1114,16 @@ def is_power_of_two(n):
 def _mask_topk_ids_padded_region(
     topk_ids: torch.Tensor,
     num_token_non_padded: Optional[torch.Tensor] = None,
+    fill_value: int = -1,
 ) -> None:
     if num_token_non_padded is None:
         return
     # TODO: let the kernel support other dtypes
-    if _is_cuda and topk_ids.dtype == torch.int32:
+    if _is_cuda and topk_ids.dtype == torch.int32 and fill_value == -1:
         mask_topk_ids(topk_ids, num_token_non_padded)
     else:
         indices = torch.arange(0, topk_ids.shape[0], device=topk_ids.device)
-        topk_ids[indices >= num_token_non_padded, :] = -1
+        topk_ids[indices >= num_token_non_padded, :] = fill_value
 
 
 def _zero_topk_weights_padded_region(
@@ -1506,13 +1507,15 @@ def _post_process_topk_ids(
                 topk_ids, expert_location_dispatch_info, num_token_non_padded
             )
     elif _is_hip:
-        topk_ids = _biased_grouped_topk_postprocess(
-            topk_ids, expert_location_dispatch_info, num_token_non_padded
-        )
-        # On AMD HIP, the aiter MoE kernels do not handle topk_ids=-1 safely
-        # (negative indices cause illegal memory access). Instead, zero the
-        # routing weights for padded tokens so their MoE output contributes
-        # nothing to the hidden state after the weighted sum.
+        # The DP-attention padded region of topk_ids holds garbage expert ids.
+        # Mask it to a valid in-range id (0) BEFORE the logical->physical remap;
+        # otherwise the remap gather indexes the EPLB dispatch map out of bounds
+        # (illegal memory access on ROCm), which grows with uneven per-rank token
+        # counts (variable-length, high concurrency). Do not use -1 here: the
+        # aiter MoE kernels do not handle topk_ids=-1 safely, so padded tokens
+        # are neutralized via weight-zeroing below instead.
+        _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=0)
+        topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
         _zero_topk_weights_padded_region(topk_weights, num_token_non_padded)
 
     if recorder_topk_ids is None:

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1111,6 +1111,21 @@ def is_power_of_two(n):
     return n > 0 and math.log2(n).is_integer()
 
 
+def _eplb_remap_enabled() -> bool:
+    # A real logical->physical mapping only exists when EPLB is enabled, the
+    # initial expert placement is non-trivial, or there are redundant physical
+    # experts. Otherwise the map is identity and the remap must be skipped (it is
+    # both unnecessary and not well-defined over the padded region of topk_ids).
+    from sglang.srt.server_args import get_global_server_args
+
+    server_args = get_global_server_args()
+    return (
+        server_args.enable_eplb
+        or server_args.init_expert_location != "trivial"
+        or server_args.ep_num_redundant_experts > 0
+    )
+
+
 def _mask_topk_ids_padded_region(
     topk_ids: torch.Tensor,
     num_token_non_padded: Optional[torch.Tensor] = None,
@@ -1507,15 +1522,22 @@ def _post_process_topk_ids(
                 topk_ids, expert_location_dispatch_info, num_token_non_padded
             )
     elif _is_hip:
-        # The DP-attention padded region of topk_ids holds garbage expert ids.
-        # Mask it to a valid in-range id (0) BEFORE the logical->physical remap;
-        # otherwise the remap gather indexes the EPLB dispatch map out of bounds
-        # (illegal memory access on ROCm), which grows with uneven per-rank token
-        # counts (variable-length, high concurrency). Do not use -1 here: the
-        # aiter MoE kernels do not handle topk_ids=-1 safely, so padded tokens
-        # are neutralized via weight-zeroing below instead.
-        _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=0)
-        topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
+        # The logical->physical remap is only meaningful when a real
+        # expert-location mapping exists. With a trivial placement and EPLB off
+        # the map is identity, and indexing it here is both unnecessary and not
+        # well-defined for the dp-attention padded region of topk_ids; skip it.
+        # ``--ep-dispatch-algorithm fake`` is a routing benchmark artifact and
+        # does not by itself require remapping.
+        if _eplb_remap_enabled():
+            # Mask the padded region to a valid in-range id (0) before the
+            # gather so it never indexes the dispatch map out of bounds. -1 is
+            # not used here: the aiter MoE kernels do not handle topk_ids=-1.
+            _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=0)
+            topk_ids = topk_ids_logical_to_physical(
+                topk_ids, expert_location_dispatch_info
+            )
+        # On AMD HIP the aiter MoE kernels do not handle topk_ids=-1 safely, so
+        # padded tokens are neutralized by zeroing their routing weights.
         _zero_topk_weights_padded_region(topk_weights, num_token_non_padded)
 
     if recorder_topk_ids is None:


### PR DESCRIPTION
CC @billishyahao 
## Motivation

#22985 (`[AMD] Support eplb for moriep`) added EPLB support to the mori-ep / HIP path. Two of the added paths do not account for configurations where the EPLB machinery is not actually in use.

### 1. moriep recorder bookkeeping is not gated on the recorder being active

The mori dispatch path requests the local expert count and feeds it to the expert-distribution recorder unconditionally:

```python
... = self.mori_op.dispatch(..., call_local_expert_count=True)   # unconditional
get_global_expert_distribution_recorder().on_deepep_dispatch_low_latency(
    self.mori_op.local_expert_count
)
```

`call_local_expert_count=True` is passed to the mori kernel on every dispatch even when no expert-distribution recording is taking place (`--ep-dispatch-algorithm fake`, `enable_eplb=False`, no recorder). The recorder's own hook is a no-op in that case, so the extra per-dispatch kernel work is pure overhead for the common no-eplb configuration.

### 2. HIP topk eplb remap runs even when there is no real expert-location map

#22985 added a logical→physical remap to the HIP branch of `_post_process_topk_ids` (`topk.py`):

```python
elif _is_hip:
    topk_ids = _biased_grouped_topk_postprocess(
        topk_ids, expert_location_dispatch_info, num_token_non_padded
    )
    ...
```

`topk_ids_logical_to_physical` indexes the expert-location dispatch map with `topk_ids`. That map is only a real mapping when EPLB is enabled, the initial placement is non-trivial, or there are redundant experts. With a trivial placement and EPLB off (e.g. `--ep-dispatch-algorithm fake`, which is a routing benchmark artifact), the map is identity-only and the gather is not well-defined — it is not safe to index it with arbitrary `topk_ids`, including the dp-attention padded region (which exists once `moe_expert_parallel_world_size > 1`). The original HIP path never indexed `topk_ids` at all (it kept the ids valid and zeroed the padded weights), so this case was not covered when the remap was added.

The CUDA branch is left unchanged; this PR scopes the fix to the HIP path added by #22985.

## Modifications

- `moriep.py`: add `_should_record_expert_distribution()` (`recorder.recording or is_current_stream_capturing()`); pass `call_local_expert_count=record` and only call `on_deepep_dispatch_low_latency(...)` when `record` is true (normal + low-latency paths). The bookkeeping now runs only when EPLB / the recorder actually needs it.
- `topk.py`:
  - add `_eplb_remap_enabled()` — true only when `enable_eplb`, a non-trivial `init_expert_location`, or `ep_num_redundant_experts > 0`.
  - `_mask_topk_ids_padded_region(..., fill_value=-1)` — add a configurable fill value.
  - HIP branch of `_post_process_topk_ids`: only perform the logical→physical remap when `_eplb_remap_enabled()`. In that case, mask the padded region to a valid in-range id (`0`) before the gather so it never indexes the map out of bounds (`-1` is not written into `topk_ids` because the aiter MoE kernels cannot handle it). Padded tokens are neutralized via weight-zeroing, matching the existing HIP design.

For the no-eplb / fake configuration the remap is skipped entirely, restoring the pre-#22985 HIP behavior (topk_ids untouched, padded weights zeroed). With a real expert-location map, the remap runs as intended and is well-defined.

## Accuracy Tests

The remap is skipped only when the expert-location map is identity, so routing is unchanged there. On the real-EPLB path, padded-region masking does not affect non-padded (real) tokens.

## Benchmarking and Profiling

Removing the always-on `local_expert_count` request recovers per-dispatch overhead for the no-eplb mori-ep configuration. Numbers to follow.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27499245100](https://github.com/sgl-project/sglang/actions/runs/27499245100)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27499244969](https://github.com/sgl-project/sglang/actions/runs/27499244969)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->