### PR TITLE
Fix ModelOpt quantized layers startup log

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1508,13 +1508,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             getattr(self.model, "quant_config", None), "quantized_layers", None
         )
         if (
-            hasattr(self.model, "quant_config")
-            and hasattr(self.model.quant_config, "quantized_layers")
-            and self.server_args.quantization is not None
+            self.server_args.quantization is not None
+            and isinstance(quantized_layers, tuple)
+            and len(quantized_layers) == 2
         ):
-            type_counts, quantized_layers_count = (
-                self.model.quant_config.quantized_layers
-            )
+            type_counts, quantized_layers_count = quantized_layers
             type_summary = ", ".join(f"{t}: {c}" for t, c in type_counts.items())
             logger.info(
                 f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers in total ({type_summary})."


### PR DESCRIPTION
## Summary

Put back the `quantized_layers` tuple check that #18182 removed. Without it, ModelOpt mixed-precision checkpoints hit this online-quantization log, try to unpack a dict, and crash at startup. #27284 fixed the same problem once before after the AMD MXFP4 logging was added in #18005.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27499037722](https://github.com/sgl-project/sglang/actions/runs/27499037722)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27499037617](https://github.com/sgl-project/sglang/actions/runs/27499037617)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->