### PR TITLE
[diffusion] Use regional torch.compile (compile_repeated_blocks) for DiT

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -647,12 +647,7 @@ class DiffusersPipeline(ComposedPipelineBase):
                         # Regional compilation: compile a single instance of each
                         # repeated transformer block and let inductor's cache reuse
                         # it for all repeats, instead of compiling the whole DiT as
-                        # one graph. This cuts cold-start compile from O(num_blocks)
-                        # to O(1) -- e.g. on H200, FLUX.1-dev full-model compile
-                        # ~50s -> ~8s and Qwen-Image warmup compile ~163s -> ~8s --
-                        # with the same steady-state speedup (verified no per-image
-                        # latency regression). See the PyTorch regional-compilation
-                        # recipe and diffusers' ModelMixin.compile_repeated_blocks.
+                        # one graph
                         component.compile_repeated_blocks()
                     elif isinstance(component, torch.nn.Module) and hasattr(
                         component, "compile"

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -638,10 +638,23 @@ class DiffusersPipeline(ComposedPipelineBase):
             if hasattr(pipe, comp):
                 try:
                     component = getattr(pipe, comp)
-                    # TODO(DefTruth): Add support for 'compile_repeated_blocks' for 'transformer'
-                    # modules which can significantly reduce compilation time for large models
-                    # with repeated blocks.
-                    if isinstance(component, torch.nn.Module) and hasattr(
+                    repeated_blocks = getattr(component, "_repeated_blocks", None)
+                    if (
+                        isinstance(component, torch.nn.Module)
+                        and repeated_blocks
+                        and hasattr(component, "compile_repeated_blocks")
+                    ):
+                        # Regional compilation: compile a single instance of each
+                        # repeated transformer block and let inductor's cache reuse
+                        # it for all repeats, instead of compiling the whole DiT as
+                        # one graph. This cuts cold-start compile from O(num_blocks)
+                        # to O(1) -- e.g. on H200, FLUX.1-dev full-model compile
+                        # ~50s -> ~8s and Qwen-Image warmup compile ~163s -> ~8s --
+                        # with the same steady-state speedup (verified no per-image
+                        # latency regression). See the PyTorch regional-compilation
+                        # recipe and diffusers' ModelMixin.compile_repeated_blocks.
+                        component.compile_repeated_blocks()
+                    elif isinstance(component, torch.nn.Module) and hasattr(
                         component, "compile"
                     ):
                         # Prefer in-place compilation if supported. According to PyTorch documentation:


### PR DESCRIPTION
## Scope (important)

This patches **`DiffusersPipeline._apply_torch_compile`** — the path used by the **`--backend diffusers` fallback** (and `--backend auto` when a model has no native SGLang pipeline). It does **not** change the native pipeline path (`denoising.py:_maybe_enable_torch_compile`), which is a separate finding (see below).

## Change

That fallback path compiled the entire transformer/unet as one graph (`component.compile()`), so default-mode cold compile scaled with block count. Prefer diffusers' regional compilation (`compile_repeated_blocks`) when `_repeated_blocks` is defined: compile one instance of each repeated block, reuse for the rest. Falls back to the previous full compile otherwise.

## Verified (H200, 1 GPU, cache-free, diffusers backend, default compile mode)

| | cold compile | steady-state/image |
|---|---|---|
| full `component.compile()` | 50.7s | 7.6s |
| **regional** | **8.1s** (6.3×) | 7.7s (unchanged) |

Steady-state latency is unchanged; only cold-start compile drops.

## What this does NOT fix (separate issue)

The **native** pipeline (FluxPipeline/QwenImagePipeline via `denoising.py`) compiles with `SGLANG_TORCH_COMPILE_MODE=max-autotune-no-cudagraphs`, whose cold-start (~151s on FLUX.1) is dominated by **kernel autotuning**, not graph size — regional compile does **not** help there (measured 151.5s → 147.9s). For that path the levers are the compile **mode** (plain `default` compiles in ~10.7s with identical runtime on FLUX.1) and/or autotune-cache persistence (warm ≈ 11s). That's a default-mode/caching discussion, tracked separately.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27502982949](https://github.com/sgl-project/sglang/actions/runs/27502982949)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27502982883](https://github.com/sgl-project/sglang/actions/runs/27502982883)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->