### PR TITLE
[Docs] Add fp8 kv cache for tokenspeed mla docs

### DIFF
--- a/docs_new/src/snippets/autoregressive/kimi-k25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/kimi-k25-deployment.jsx
@@ -196,13 +196,15 @@ export const KimiK25Deployment = () => {
       cmd += ' \\\n  --speculative-algorithm EAGLE3 \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4 \\\n  --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3-mla';
     }
 
+    const usesTokenspeedMla = hardware === 'b300' || hardware === 'gb300';
+
     // Blackwell (B300/GB300): tokenspeed MLA attention backend
-    if (hardware === 'b300' || hardware === 'gb300') {
+    if (usesTokenspeedMla) {
       cmd += ' \\\n  --attention-backend tokenspeed_mla';
     }
 
-    // AMD: FP8 KV cache for memory efficiency
-    if (isAMD) {
+    // FP8 KV cache for AMD memory efficiency and tokenspeed MLA compatibility
+    if (isAMD || usesTokenspeedMla) {
       cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
     }
 

--- a/docs_new/src/snippets/autoregressive/kimi-k26-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/kimi-k26-deployment.jsx
@@ -194,11 +194,13 @@ export const KimiK26Deployment = () => {
       cmd += ' \\\n  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3.1-mla';
     }
 
-    if (hardware === 'b300' || hardware === 'gb300') {
+    const usesTokenspeedMla = hardware === 'b300' || hardware === 'gb300';
+
+    if (usesTokenspeedMla) {
       cmd += ' \\\n  --attention-backend tokenspeed_mla';
     }
 
-    if (isAMD) {
+    if (isAMD || usesTokenspeedMla) {
       cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
     }
 

--- a/docs_new/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
@@ -144,11 +144,13 @@ export const KimiK27CodeDeployment = () => {
       cmd += ' \\\n  --tool-call-parser kimi_k2';
     }
 
-    if (hardware === 'b300' || hardware === 'gb300') {
+    const usesTokenspeedMla = hardware === 'b300' || hardware === 'gb300';
+
+    if (usesTokenspeedMla) {
       cmd += ' \\\n  --attention-backend tokenspeed_mla';
     }
 
-    if (isAMD) {
+    if (isAMD || usesTokenspeedMla) {
       cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
     }
 


### PR DESCRIPTION
## Summary

Fixes Kimi cookbook commands that enable `tokenspeed_mla` by also setting `--kv-cache-dtype fp8_e4m3`, preventing the backend from failing with the default `auto` KV cache dtype:

https://github.com/sgl-project/sglang/blob/582bd23f71be92337776fb99e4c9c6784a146f60/python/sglang/srt/server_args.py#L3090-L3094











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27501855842](https://github.com/sgl-project/sglang/actions/runs/27501855842)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27501855780](https://github.com/sgl-project/sglang/actions/runs/27501855780)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->