### PR TITLE
[diffusion] Persist torch.compile Inductor/Triton cache across restarts

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -5,6 +5,7 @@ import gc
 import logging
 import multiprocessing as mp
 import os
+import tempfile
 import time
 from contextlib import ExitStack
 from dataclasses import dataclass, field
@@ -145,6 +146,46 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 torch.cuda.empty_cache()
         return OutputBatch(output={"released": released, "session_id": session_id})
 
+    def _configure_persistent_torch_compile_cache(self) -> None:
+        """Persist torch.compile's Inductor/Triton cache across restarts.
+
+        By default Inductor caches to an ephemeral ``/tmp`` dir that is wiped on
+        every fresh container/pod, so each cold start recompiles the DiT from
+        scratch (tens of seconds to minutes for a large model). Point the cache
+        at the diffusion cache root instead; cache entries are content-hashed by
+        torch, so reuse is safe, and a warm restart -- or a copy of the dir to
+        another machine -- skips recompilation.
+
+        We override only when the var is unset or still points at torch's
+        ephemeral ``$TMPDIR/torchinductor_*`` default (torch sets it on import,
+        before this runs, so ``setdefault`` would be a no-op). An explicit
+        non-temp user path (e.g. shared storage) is left untouched.
+        """
+        compile_cache_root = os.path.join(
+            envs.SGLANG_DIFFUSION_CACHE_ROOT, "torch_compile_cache"
+        )
+        tmp_root = tempfile.gettempdir()
+        for env_name, sub in (
+            ("TORCHINDUCTOR_CACHE_DIR", "inductor"),
+            ("TRITON_CACHE_DIR", "triton"),
+        ):
+            current = os.environ.get(env_name)
+            if current and not current.startswith(tmp_root):
+                # Respect an explicit, non-ephemeral user-provided cache dir.
+                continue
+            cache_path = os.path.join(compile_cache_root, sub)
+            try:
+                os.makedirs(cache_path, exist_ok=True)
+            except OSError as e:
+                logger.warning("Could not create torch.compile cache dir %s: %s", cache_path, e)
+                continue
+            os.environ[env_name] = cache_path
+        logger.info(
+            "torch.compile cache: TORCHINDUCTOR_CACHE_DIR=%s TRITON_CACHE_DIR=%s",
+            os.environ.get("TORCHINDUCTOR_CACHE_DIR"),
+            os.environ.get("TRITON_CACHE_DIR"),
+        )
+
     def init_device_and_model(self) -> None:
         """Initialize the device and load the model."""
         torch.get_device_module().set_device(self.local_rank)
@@ -154,6 +195,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         os.environ["LOCAL_RANK"] = str(self.local_rank)
         os.environ["RANK"] = str(self.rank)
         os.environ["WORLD_SIZE"] = str(self.server_args.num_gpus)
+        self._configure_persistent_torch_compile_cache()
         # initialize the distributed environment
         maybe_init_distributed_environment_and_model_parallel(
             tp_size=self.server_args.tp_size,

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -147,20 +147,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         return OutputBatch(output={"released": released, "session_id": session_id})
 
     def _configure_persistent_torch_compile_cache(self) -> None:
-        """Persist torch.compile's Inductor/Triton cache across restarts.
-
-        By default Inductor caches to an ephemeral ``/tmp`` dir that is wiped on
-        every fresh container/pod, so each cold start recompiles the DiT from
-        scratch (tens of seconds to minutes for a large model). Point the cache
-        at the diffusion cache root instead; cache entries are content-hashed by
-        torch, so reuse is safe, and a warm restart -- or a copy of the dir to
-        another machine -- skips recompilation.
-
-        We override only when the var is unset or still points at torch's
-        ephemeral ``$TMPDIR/torchinductor_*`` default (torch sets it on import,
-        before this runs, so ``setdefault`` would be a no-op). An explicit
-        non-temp user path (e.g. shared storage) is left untouched.
-        """
+        """Persist torch.compile's Inductor/Triton cache across restarts"""
         compile_cache_root = os.path.join(
             envs.SGLANG_DIFFUSION_CACHE_ROOT, "torch_compile_cache"
         )
@@ -177,7 +164,9 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             try:
                 os.makedirs(cache_path, exist_ok=True)
             except OSError as e:
-                logger.warning("Could not create torch.compile cache dir %s: %s", cache_path, e)
+                logger.warning(
+                    "Could not create torch.compile cache dir %s: %s", cache_path, e
+                )
                 continue
             os.environ[env_name] = cache_path
         logger.info(


### PR DESCRIPTION
## Problem

The diffusion runtime never configured a torch.compile cache dir, so Inductor used its ephemeral `$TMPDIR/torchinductor_*` default — **wiped on every fresh container/pod**, making each cold start recompile the DiT from scratch. The LLM runtime (`srt`) already persists its cache under `SGLANG_CACHE_DIR` (`srt/compilation/compiler_interface.py`); this brings the diffusion worker to parity.

## Change

In the GPU worker (`init_device_and_model`, before model load/compile), point `TORCHINDUCTOR_CACHE_DIR` / `TRITON_CACHE_DIR` at `SGLANG_DIFFUSION_CACHE_ROOT/torch_compile_cache`. torch sets the var to its `/tmp` default on import (before the worker runs), so `setdefault` would be a no-op — we **override only when unset or still pointing at `$TMPDIR`**; an explicit non-temp user path (e.g. shared storage) is respected. Entries are content-hashed by torch, so reuse is safe; copying the dir to another machine also warms it.

## Verified (H200, FLUX.1-dev, 1 GPU, cache-free, `default` compile mode)

Measured first-request (includes compile) vs second-request (steady-state); the warm run **wiped `/tmp` and kept only the persistent dir** (simulating a fresh container):

| | compile cost | steady-state/image |
|---|---|---|
| cold (persistent cache cleared) | 10.4s | 6.6s |
| **warm (persistent cache kept, /tmp wiped)** | **5.3s** | 6.6s |

Compile drops ~2× and lands in TensorRT-LLM VisualGen's 2–6s range; runtime unchanged. The win is larger for `max-autotune` (cold ~151s → warm ~11s). Without this, every fresh pod paid the full cold compile.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27504096234](https://github.com/sgl-project/sglang/actions/runs/27504096234)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27504096115](https://github.com/sgl-project/sglang/actions/runs/27504096115)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->