### PR TITLE
fix(loader): load all shards of a sharded GGUF checkpoint

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2115,24 +2115,31 @@ class GGUFModelLoader(BaseModelLoader):
         return gguf_to_hf_name_map
 
     def _get_gguf_files(self, first_shard_path: str) -> List[str]:
-        # A sharded GGUF checkpoint is split into `<name>-00001-of-000NN.gguf`
-        # files kept side by side; given any single shard, discover the full,
-        # sorted set so every tensor gets loaded. An unsharded file is returned
-        # unchanged.
-        match = re.fullmatch(
-            r"(?P<prefix>.+)-\d{5}-of-(?P<total>\d{5})\.gguf",
-            os.path.basename(first_shard_path),
-        )
+        # A sharded GGUF checkpoint is split into sibling files like
+        # `<name>-00001-of-000NN.gguf`. Given any one shard, rebuild the full
+        # set by shard index (1..total) rather than globbing, so a sibling
+        # model with a similar prefix is never pulled in. Padding width comes
+        # from the matched name; a non-sharded path is returned unchanged.
+        match = re.search(r"-(\d+)-of-(\d+)\.gguf$", os.path.basename(first_shard_path))
         if match is None:
             return [first_shard_path]
+        total = int(match.group(2))
+        num_digits = len(match.group(1))
         directory = os.path.dirname(first_shard_path)
-        pattern = f"{match.group('prefix')}-*-of-{match.group('total')}.gguf"
-        files = sorted(glob.glob(os.path.join(directory, pattern)))
-        expected = int(match.group("total"))
-        if len(files) != expected:
+        base = os.path.basename(first_shard_path)
+        prefix, suffix = base[: match.start(1)], base[match.end(2) :]
+        files = [
+            os.path.join(
+                directory,
+                f"{prefix}{i:0{num_digits}d}-of-{total:0{num_digits}d}{suffix}",
+            )
+            for i in range(1, total + 1)
+        ]
+        missing = [f for f in files if not os.path.isfile(f)]
+        if missing:
             raise ValueError(
-                f"Expected {expected} GGUF shards for {first_shard_path} "
-                f"but found {len(files)}: {files}"
+                f"Incomplete sharded GGUF for {first_shard_path}: missing "
+                f"{len(missing)} of {total} shards: {missing}"
             )
         return files
 
@@ -2157,11 +2164,10 @@ class GGUFModelLoader(BaseModelLoader):
         gguf_weights_map = self._get_gguf_weights_map(model_config)
         # we can only know about tied word embeddings after mapping weights;
         # treat a tensor as absent only if it is missing from every shard.
-        extra_tensor_names = None
+        extra_tensor_names = set(gguf_weights_map.values())
         for gguf_file in gguf_files:
-            names = set(get_gguf_extra_tensor_names(gguf_file, gguf_weights_map))
-            extra_tensor_names = (
-                names if extra_tensor_names is None else extra_tensor_names & names
+            extra_tensor_names &= set(
+                get_gguf_extra_tensor_names(gguf_file, gguf_weights_map)
             )
         if "lm_head.weight" in extra_tensor_names:
             model_config.hf_config.update({"tie_word_embeddings": True})

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2114,10 +2114,33 @@ class GGUFModelLoader(BaseModelLoader):
             gguf_to_hf_name_map[f"{gguf_name}.{suffix}"] = hf_name
         return gguf_to_hf_name_map
 
+    def _get_gguf_files(self, first_shard_path: str) -> List[str]:
+        # A sharded GGUF checkpoint is split into `<name>-00001-of-000NN.gguf`
+        # files kept side by side; given any single shard, discover the full,
+        # sorted set so every tensor gets loaded. An unsharded file is returned
+        # unchanged.
+        match = re.fullmatch(
+            r"(?P<prefix>.+)-\d{5}-of-(?P<total>\d{5})\.gguf",
+            os.path.basename(first_shard_path),
+        )
+        if match is None:
+            return [first_shard_path]
+        directory = os.path.dirname(first_shard_path)
+        pattern = f"{match.group('prefix')}-*-of-{match.group('total')}.gguf"
+        files = sorted(glob.glob(os.path.join(directory, pattern)))
+        expected = int(match.group("total"))
+        if len(files) != expected:
+            raise ValueError(
+                f"Expected {expected} GGUF shards for {first_shard_path} "
+                f"but found {len(files)}: {files}"
+            )
+        return files
+
     def _get_weights_iterator(
-        self, model_name_or_path: str, gguf_to_hf_name_map: Dict[str, str]
+        self, gguf_files: List[str], gguf_to_hf_name_map: Dict[str, str]
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
-        return gguf_quant_weights_iterator(model_name_or_path, gguf_to_hf_name_map)
+        for gguf_file in gguf_files:
+            yield from gguf_quant_weights_iterator(gguf_file, gguf_to_hf_name_map)
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config.model_path)
@@ -2130,11 +2153,17 @@ class GGUFModelLoader(BaseModelLoader):
     ) -> nn.Module:
 
         local_model_path = self._prepare_weights(model_config.model_path)
+        gguf_files = self._get_gguf_files(local_model_path)
         gguf_weights_map = self._get_gguf_weights_map(model_config)
-        # we can only know if tie word embeddings after mapping weights
-        if "lm_head.weight" in get_gguf_extra_tensor_names(
-            local_model_path, gguf_weights_map
-        ):
+        # we can only know about tied word embeddings after mapping weights;
+        # treat a tensor as absent only if it is missing from every shard.
+        extra_tensor_names = None
+        for gguf_file in gguf_files:
+            names = set(get_gguf_extra_tensor_names(gguf_file, gguf_weights_map))
+            extra_tensor_names = (
+                names if extra_tensor_names is None else extra_tensor_names & names
+            )
+        if "lm_head.weight" in extra_tensor_names:
             model_config.hf_config.update({"tie_word_embeddings": True})
 
         target_device = torch.device(device_config.device)
@@ -2142,9 +2171,7 @@ class GGUFModelLoader(BaseModelLoader):
         with set_default_torch_dtype(model_config.dtype):
             with target_device:
                 model = _initialize_model(model_config, self.load_config, quant_config)
-            model.load_weights(
-                self._get_weights_iterator(local_model_path, gguf_weights_map)
-            )
+            model.load_weights(self._get_weights_iterator(gguf_files, gguf_weights_map))
 
             for _, module in model.named_modules():
                 quant_method = getattr(module, "quant_method", None)

--- a/test/registered/unit/model_loader/test_gguf_sharded_loader.py
+++ b/test/registered/unit/model_loader/test_gguf_sharded_loader.py
@@ -1,0 +1,55 @@
+"""Unit tests for sharded GGUF discovery in GGUFModelLoader._get_gguf_files.
+
+A sharded GGUF checkpoint is split into ``<name>-00001-of-000NN.gguf`` files
+kept side by side. Given any single shard, the loader must discover the full,
+sorted set; an unsharded file must be returned unchanged.
+"""
+
+import os
+import tempfile
+import unittest
+
+from sglang.srt.configs.load_config import LoadConfig
+from sglang.srt.model_loader.loader import GGUFModelLoader
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestGGUFShardedDiscovery(CustomTestCase):
+    def setUp(self):
+        self.loader = GGUFModelLoader(LoadConfig(load_format="gguf"))
+
+    def _touch(self, path):
+        open(path, "w").close()
+        return path
+
+    def test_discovers_full_shard_set_from_any_shard(self):
+        with tempfile.TemporaryDirectory() as d:
+            # An unsharded path is returned unchanged.
+            single = self._touch(os.path.join(d, "model.gguf"))
+            self.assertEqual(self.loader._get_gguf_files(single), [single])
+
+            shards = [
+                self._touch(os.path.join(d, f"model-{i:05d}-of-00003.gguf"))
+                for i in range(1, 4)
+            ]
+            # A shard set with a different total must not be mixed in.
+            self._touch(os.path.join(d, "model-00001-of-00005.gguf"))
+
+            # Given any shard, the full matching set is discovered, sorted.
+            self.assertEqual(self.loader._get_gguf_files(shards[0]), sorted(shards))
+            self.assertEqual(self.loader._get_gguf_files(shards[2]), sorted(shards))
+
+    def test_rejects_incomplete_shard_set(self):
+        with tempfile.TemporaryDirectory() as d:
+            first = self._touch(os.path.join(d, "model-00001-of-00003.gguf"))
+            self._touch(os.path.join(d, "model-00002-of-00003.gguf"))
+            # third shard absent -> declared count does not match
+            with self.assertRaises(ValueError):
+                self.loader._get_gguf_files(first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_loader/test_gguf_sharded_loader.py
+++ b/test/registered/unit/model_loader/test_gguf_sharded_loader.py
@@ -1,8 +1,9 @@
 """Unit tests for sharded GGUF discovery in GGUFModelLoader._get_gguf_files.
 
 A sharded GGUF checkpoint is split into ``<name>-00001-of-000NN.gguf`` files
-kept side by side. Given any single shard, the loader must discover the full,
-sorted set; an unsharded file must be returned unchanged.
+kept side by side. Given any single shard, the loader must rebuild the full,
+ordered set so that every tensor gets loaded; an unsharded file must be
+returned unchanged.
 """
 
 import os
@@ -35,18 +36,28 @@ class TestGGUFShardedDiscovery(CustomTestCase):
                 self._touch(os.path.join(d, f"model-{i:05d}-of-00003.gguf"))
                 for i in range(1, 4)
             ]
-            # A shard set with a different total must not be mixed in.
+            # A sibling set with a different total, or one that merely shares a
+            # prefix, must not be pulled in.
             self._touch(os.path.join(d, "model-00001-of-00005.gguf"))
+            self._touch(os.path.join(d, "model-2-00001-of-00003.gguf"))
 
-            # Given any shard, the full matching set is discovered, sorted.
-            self.assertEqual(self.loader._get_gguf_files(shards[0]), sorted(shards))
-            self.assertEqual(self.loader._get_gguf_files(shards[2]), sorted(shards))
+            # Any shard rebuilds exactly its own ordered set.
+            self.assertEqual(self.loader._get_gguf_files(shards[0]), shards)
+            self.assertEqual(self.loader._get_gguf_files(shards[2]), shards)
+
+    def test_discovers_variable_width_padding(self):
+        with tempfile.TemporaryDirectory() as d:
+            shards = [
+                self._touch(os.path.join(d, f"model-{i:02d}-of-03.gguf"))
+                for i in range(1, 4)
+            ]
+            self.assertEqual(self.loader._get_gguf_files(shards[1]), shards)
 
     def test_rejects_incomplete_shard_set(self):
         with tempfile.TemporaryDirectory() as d:
             first = self._touch(os.path.join(d, "model-00001-of-00003.gguf"))
             self._touch(os.path.join(d, "model-00002-of-00003.gguf"))
-            # third shard absent -> declared count does not match
+            # third shard absent
             with self.assertRaises(ValueError):
                 self.loader._get_gguf_files(first)
 


### PR DESCRIPTION

## Motivation

`GGUFModelLoader` documents that it "supports loading both full models and sharded models", but the implementation only ever reads a single `.gguf`:

- `_prepare_weights` returns the one path it is given (and raises on anything that is not a file).
- `_get_weights_iterator` calls `gguf_quant_weights_iterator(<single file>, ...)`.
- `load_model` runs `get_gguf_extra_tensor_names(<single file>, ...)` for the tie-word-embeddings check.

Large GGUF checkpoints on the Hub are published as shards named `<name>-00001-of-000NN.gguf` kept next to each other (e.g. `unsloth/MiniMax-M2.1-GGUF`). Pointing SGLang at the first shard loads only that shard's tensors; the rest of the model stays uninitialized and the server crashes on the first forward pass with `Can't access the shape of an uninitialized parameter or buffer` from `fused_mul_mat_gguf`.

This PR adds generic multi-shard discovery so a sharded GGUF loads correctly from any one of its shards. It is architecture-agnostic and does not change single-file behaviour.

## Modifications

`python/sglang/srt/model_loader/loader.py` (`GGUFModelLoader`):

- Add `_get_gguf_files(first_shard_path)`: when the path matches `<prefix>-NNNNN-of-NNNNN.gguf`, reconstruct the expected sibling shard paths from the declared total and shard-number padding, return them sorted, and raise if any expected shard is missing; an unsharded path is returned unchanged. This avoids pulling in unrelated files that merely share a prefix.
- `_get_weights_iterator` now takes the list of shard files and chains `gguf_quant_weights_iterator` across all of them.
- `load_model` computes the shard list once and uses it for both weight loading and the tie-word-embeddings check; a tensor is treated as absent only when it is missing from *every* shard (per-shard "extra" sets are intersected), so a head/embedding that lives in a later shard is no longer mistaken for a tied weight.

Scope note: this is the generic sharded-GGUF loading path. The MiniMax-M2.1-specific GGUF expert-name mapping and `embed_tokens`/`lm_head` quant_config wiring (the rest of what a full MiniMax-M2.1 GGUF needs) are intentionally left for a follow-up, since they require the large MoE checkpoint to validate end to end.

## Testing

Built a real sharded GGUF from `Qwen/Qwen2.5-0.5B-Instruct-GGUF` (q4_0) by re-splitting it with `gguf`'s `GGUFWriter(split_max_tensors=...)` (291 tensors → `qwen2.5-0-00001-of-00002.gguf` + `qwen2.5-0-00002-of-00002.gguf`), then served it from the first shard on a single A800:

```
python -m sglang.launch_server \
  --model-path qwen2.5-0.5b-gguf-sharded/qwen2.5-0-00001-of-00002.gguf \
  --load-format gguf \
  --attention-backend triton --disable-cuda-graph --disable-piecewise-cuda-graph \
  --sampling-backend pytorch --mem-fraction-static 0.5 --port 30014

curl -s http://127.0.0.1:30014/generate -H 'Content-Type: application/json' \
  -d '{"text": "The capital of France is", "sampling_params": {"temperature": 0, "max_new_tokens": 8}}'
```

Before this PR: only the first shard is loaded, the remaining weights stay uninitialized, and the request crashes the scheduler during the forward pass:

```
RuntimeError: Can't access the shape of an uninitialized parameter or buffer.
  ... in fused_mul_mat_gguf (sglang/srt/layers/quantization/gguf.py)
```

With this PR: both shards are discovered from the first one and the same request returns

```
{"text": " Paris, and it is the largest city",
 "output_ids": [12095, 11, 323, 432, 374, 279, 7772, 3283], ...}
```

byte-identical to serving the same model as a single unsharded `.gguf`, confirming every weight is loaded.

CPU unit test `test/registered/unit/model_loader/test_gguf_sharded_loader.py` (`3 passed`): one case covers discovery (unsharded path returned unchanged; any shard resolves to the full sorted set while ignoring sibling sets with different totals or prefixes), one covers variable-width shard padding, and one verifies that an incomplete shard set raises `ValueError`. `ruff` / `black` / `isort` clean on both changed files.

This is a load-path-only change (shard discovery + weight iteration); the forward path and single-file loading are unaffected, so there is no accuracy or performance regression to benchmark.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests.
- [x] Update documentation / docstrings as needed.










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35522118889](https://github.com/sgl-project/sglang/actions/runs/35522118889)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35522118606](https://github.com/sgl-project/sglang/actions/runs/35522118606)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35522118763](https://github.com/sgl-project/sglang/actions/runs/35522118763)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->