### PR TITLE
[AMD] ci: fix scheduled AMD runs startup failure when calling extra-a suite

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -99,6 +99,17 @@ on:
         type: boolean
         default: true
 
+# Mirror pr-test.yml: the chained extra suite (call-pr-test-amd-extra-rocm720
+# -> pr-test-amd-extra.yml) declares actions: write / issues: read /
+# pull-requests: read. A called reusable workflow can only use scopes the
+# caller already holds, so without this block the call fails workflow
+# validation ("requesting actions: write... but only allowed ...none").
+permissions:
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
+
 env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -95,6 +95,17 @@ on:
         type: boolean
         default: false
 
+# Mirror pr-test.yml: the chained extra suite (call-pr-test-amd-extra ->
+# pr-test-amd-extra.yml) declares actions: write / issues: read /
+# pull-requests: read. A called reusable workflow can only use scopes the
+# caller already holds, so without this block the call fails workflow
+# validation ("requesting actions: write... but only allowed ...none").
+permissions:
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
+
 env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}


### PR DESCRIPTION
## Summary
Both scheduled AMD workflows currently fail with a *Startup failure* / "Invalid workflow file" before any job runs:
- **PR Test (AMD)** — [run 27508204707](https://github.com/sgl-project/sglang/actions/runs/27508204707), `pr-test-amd.yml#L198`
- **PR Test ROCm 7.2 (AMD)** — [run 27508062091](https://github.com/sgl-project/sglang/actions/runs/27508062091), `pr-test-amd-rocm720.yml#L214`

Root cause: both workflows chain `call-pr-test-amd-extra*` → `pr-test-amd-extra.yml`, which declares `actions: write` / `issues: read` / `pull-requests: read`. A called reusable workflow can only use token scopes the **caller** already holds. Neither caller has a top-level `permissions:` block, so they fall back to the restrictive repo defaults (`...none`) and GitHub rejects the file at validation:
> The workflow is requesting `actions: write, issues: read, pull-requests: read`, but is only allowed `actions: none, issues: none, pull-requests: none`.

Fix: add a top-level `permissions:` block granting exactly those scopes to both `pr-test-amd.yml` and `pr-test-amd-rocm720.yml`, mirroring how `pr-test.yml` already grants them before calling `pr-test-extra.yml`. These are the only two callers of `pr-test-amd-extra.yml`.

## Test plan
- [ ] Next scheduled `PR Test (AMD)` run no longer shows the "Invalid workflow file" annotation at `pr-test-amd.yml#L198`.
- [ ] Next scheduled `PR Test ROCm 7.2 (AMD)` run no longer shows it at `pr-test-amd-rocm720.yml#L214`.
- [ ] The `call-pr-test-amd-extra*` jobs are queued instead of the whole workflow failing at startup.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27513404561](https://github.com/sgl-project/sglang/actions/runs/27513404561)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27513404507](https://github.com/sgl-project/sglang/actions/runs/27513404507)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->