### PR TITLE
Account for draft model KV cache in hybrid SWA memory pool sizing

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -265,6 +265,26 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 * self._swa_layers_num
             )
 
+        # EAGLE/STANDALONE: scale cell_size to account for the draft model KV
+        # cache, mirroring DefaultPoolConfigurator. The draft worker allocates
+        # its own KV pool sized by the target's max_total_num_tokens, so the
+        # target profile must reserve for it or the draft pool overruns the
+        # budget. Approximates the draft's per-layer KV with the target's
+        # blended (full + swa) per-token cost, matching the Default/DSV4 path.
+        if (
+            mr.spec_algorithm.is_eagle() or mr.spec_algorithm.is_standalone()
+        ) and not mr.is_draft_worker:
+            eagle_draft_num_layers = getattr(mr, "eagle_draft_num_layers", None)
+            total_layers = self._full_layers_num + self._swa_layers_num
+            if (
+                eagle_draft_num_layers is not None
+                and int(eagle_draft_num_layers) > 0
+                and total_layers > 0
+            ):
+                self._cell_size = int(
+                    self._cell_size * (1 + int(eagle_draft_num_layers) / total_layers)
+                )
+
     def _solve_pool_sizes(
         self, max_total_num_tokens: int, page_size: int
     ) -> MemoryPoolConfig:

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -334,6 +334,46 @@ class TestEagleConfigurator(unittest.TestCase):
         self.assertLessEqual(used, available)
 
 
+class TestHybridSWAEagleConfigurator(unittest.TestCase):
+    """Hybrid SWA + EAGLE/STANDALONE: draft KV cache must be budgeted too,
+    mirroring TestEagleConfigurator for the Default path."""
+
+    def _budget_holds(self, full_layers, swa_layers, eagle_draft_num_layers):
+        available = 10_000_000
+        mr = _make_model_runner(
+            is_hybrid_swa=True,
+            full_attention_layer_ids=list(range(full_layers)),
+            swa_attention_layer_ids=list(range(full_layers, full_layers + swa_layers)),
+            swa_full_tokens_ratio=1.0,
+        )
+        mr.spec_algorithm.is_eagle.return_value = True
+        mr.spec_algorithm.is_standalone.return_value = False
+        mr.spec_algorithm.is_none.return_value = False
+        mr.eagle_draft_num_layers = eagle_draft_num_layers
+
+        with mock_cpu_env():
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+            config = cfg.calculate_pool_sizes(available, 1)
+
+        # Target pool usage plus the draft worker's own pool (sized over the
+        # same token budget, modeled as eagle_draft_num_layers extra layers at
+        # the target's per-layer cost) must fit in the budget.
+        target_used = _actual_memory_used(mr, config)
+        total_layers = full_layers + swa_layers
+        total_used = target_used * (1 + eagle_draft_num_layers / total_layers)
+        self.assertLessEqual(total_used, available)
+
+    def test_hybrid_does_not_exceed_budget(self):
+        self._budget_holds(full_layers=16, swa_layers=16, eagle_draft_num_layers=4)
+
+    def test_all_swa_does_not_exceed_budget(self):
+        self._budget_holds(full_layers=0, swa_layers=32, eagle_draft_num_layers=4)
+
+
 class TestFactory(unittest.TestCase):
     def test_default_for_non_swa(self):
         mr = _make_model_runner(is_hybrid_swa=False)


### PR DESCRIPTION
`HybridSWAPoolConfigurator` does not reserve for the draft worker's KV pool, unlike `DefaultPoolConfigurator` and `DSV4PoolConfigurator` which both scale `cell_size` by the draft layer ratio. So a hybrid-SWA target (gpt-oss, Llama4, Gemma, MiMo-V2, Step3.5, ...) + EAGLE/STANDALONE sizes its KV pool to consume the full budget, then the draft worker allocates its own pool on top -> overruns `--mem-fraction-static` and OOMs at launch. The old flat 4GB/6GB spec reservation that used to mask this was removed in #23862, but the replacement (cell_size scaling) only landed on the Default/DSV4 paths.

Fix: mirror the Default path's draft-KV scaling in `HybridSWAPoolConfigurator`, covering both the hybrid and all-SWA branches. Adds a budget-invariant regression test.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27518846317](https://github.com/sgl-project/sglang/actions/runs/27518846317)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27518846211](https://github.com/sgl-project/sglang/actions/runs/27518846211)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->