### PR TITLE
Fix EagleDraftExtendInput missing kv_indptr crash with triton/DP attention

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -322,6 +322,10 @@ class EagleDraftExtendInput(SpecInput):
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = 1
 
+    # None for draft-extend's idle batch; attention backends fall back to
+    # rebuilding plain metadata from seq_lens when this is None.
+    kv_indptr: torch.Tensor = None
+
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT_EXTEND)
 


### PR DESCRIPTION
## Motivation
pr-#24860 ("[Spec] Install `EagleDraftExtendInput` as the V2 draft-extend `spec_info`") changed the draft-extend `spec_info` from `EagleDraftInput` to the new `EagleDraftExtendInput`. However, several attention backends read `spec_info.kv_indptr` directly in `init_forward_metadata` for the decode/idle path, and `EagleDraftExtendInput` does not define that attribute.
With EAGLE3 + DP attention, an idle DP rank goes through `forward_idle` -> `init_forward_metadata`, hitting:
```
    File ".../layers/attention/triton_backend.py", line 570, in init_forward_metadata
        if spec_info is None or spec_info.kv_indptr is None:
    AttributeError: 'EagleDraftExtendInput' object has no attribute 'kv_indptr'
```
This crashes the scheduler and fails `test/registered/spec/eagle/test_eagle_dp_attention.py`. It surfaces in AMD CI because that lane uses `--attention-backend triton`, while the CUDA lane uses `fa3` (the only backend that doesn't access `spec_info.kv_indptr`). The same crash would occur on any platform using the `triton`, `flashinfer`, `flashinfer_mla`, `aiter`, or `wave` backends.

PR-Test(AMD) - https://github.com/sgl-project/sglang/actions/runs/27519156273
<img width="312" height="63" alt="image" src="https://github.com/user-attachments/assets/a9fa4ae9-f256-4601-8fe5-592babdbcb49" />


## Modifications
Add a `kv_indptr: torch.Tensor = None` field to `EagleDraftExtendInput`, restoring the interface that the old `EagleDraftInput` provided. When it is `None` (the draft-extend idle batch case), the attention backends fall back to rebuilding plain metadata from `seq_lens`, matching the pre-a52ccd2 behavior. This fixes all affected backends with a single field.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27519849843](https://github.com/sgl-project/sglang/actions/runs/27519849843)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27519849712](https://github.com/sgl-project/sglang/actions/runs/27519849712)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->