### PR TITLE
[Fix] Reduce power of two to constant time

### DIFF
--- a/experimental/sgl-router/src/policies/power_of_two.rs
+++ b/experimental/sgl-router/src/policies/power_of_two.rs
@@ -3,7 +3,7 @@
 
 use crate::policies::{Policy, SelectionContext};
 use crate::workers::Worker;
-use rand::seq::IteratorRandom;
+use rand::Rng;
 use std::sync::Arc;
 
 #[derive(Debug, Default)]
@@ -20,11 +20,14 @@ impl Policy for PowerOfTwoChoicesPolicy {
         match workers.len() {
             0 => None,
             1 => Some(workers[0].clone()),
-            _ => {
+            len => {
                 let mut rng = rand::thread_rng();
-                let mut chosen = workers.iter().choose_multiple(&mut rng, 2);
-                chosen.sort_by_key(|w| w.active_load());
-                Some(chosen[0].clone())
+                let i = rng.gen_range(0..len);
+                let mut j = rng.gen_range(0..len - 1);
+                if j >= i {
+                    j += 1;
+                }
+                Some(std::cmp::min_by_key(&workers[i], &workers[j], |w| w.active_load()).clone())
             }
         }
     }

--- a/experimental/sgl-router/tests/component/policies/power_of_two.rs
+++ b/experimental/sgl-router/tests/component/policies/power_of_two.rs
@@ -71,3 +71,29 @@ fn single_worker_returns_it() {
     let ctx = SelectionContext::new(&model_id, None);
     assert_eq!(p.select(&ws, &ctx).unwrap().id.0, "only");
 }
+
+#[test]
+fn all_workers_reachable() {
+    // Ensure all workers are selectable under equal load to prevent an
+    // off-by-one error from skipping any worker during sampling
+    let workers = vec![
+        worker("a"),
+        worker("b"),
+        worker("c"),
+        worker("d"),
+        worker("e"),
+    ];
+    let p = PowerOfTwoChoicesPolicy::new();
+    let model_id = ModelId("m".into());
+    let ctx = SelectionContext::new(&model_id, None);
+    let mut seen = std::collections::HashSet::new();
+    for _ in 0..1000 {
+        let w = p.select(&workers, &ctx).unwrap();
+        seen.insert(w.id.0.clone());
+    }
+    assert_eq!(
+        seen.len(),
+        workers.len(),
+        "every worker should be reachable, saw {seen:?}"
+    );
+}


### PR DESCRIPTION
## Motivation

Closes https://github.com/sgl-project/sglang/issues/28227

Power-of-two-choices is meant to be O(1). However, `PowerOfTwoChoicesPolicy::select` was O(n) in worker count: `workers.iter().choose_multiple(&mut rng, 2)` is reservoir sampling. The `policy_select` bench confirmed linear scaling: 53 ns at n=4 and 2.45 µs at n=256.
  
## Modifications

- `select` draws two distinct indices directly in O(1) instead of scanning. The second index is drawn from the remaining `n - 1` slots and shifted past the first to guarantee a distinct pair.
- Add an `all_workers_reachable` test: under equal load, every worker must be picked at least once across many trials. It asserts reachability (not a distribution ratio) so it can't flake and the four existing `power_of_two` tests stay green.

### Selection Behavior Is Unchanged

Every unordered pair stays equiprobable (`1/C(n,2)`, same as `choose_multiple(2)`), the lower-load worker still wins, and ties resolve to the first index (`min_by_key` matches the old `sort_by_key` + take-first).
  
## Accuracy Tests
  
N/A. This PR changes load-balancer worker selection only; it does not affect model outputs.
  
## Speed Tests and Profiling
  
| n (workers) | before | after |
|---|---|---|
| 4   | 53 ns   | 62 ns |
| 16  | 197 ns  | 56 ns |
| 64  | 664 ns  | 55 ns |
| 256 | 2.45 µs | 54 ns |
  
`power_of_two` is now O(1). The only point that gets slightly slower is n=4 (+~9 ns), where two `gen_range` draws cost a little more than a 4-element reservoir walk. `round_robin` and `random` are unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27520398139](https://github.com/sgl-project/sglang/actions/runs/27520398139)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27522937354](https://github.com/sgl-project/sglang/actions/runs/27522937354)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->