### PR TITLE
fix(router): make power-of-two-choices O(1) instead of O(n) (#28227)

### DIFF
--- a/experimental/sgl-router/src/policies/power_of_two.rs
+++ b/experimental/sgl-router/src/policies/power_of_two.rs
@@ -3,7 +3,7 @@
 
 use crate::policies::{Policy, SelectionContext};
 use crate::workers::Worker;
-use rand::seq::IteratorRandom;
+use rand::Rng;
 use std::sync::Arc;
 
 #[derive(Debug, Default)]
@@ -20,11 +20,23 @@ impl Policy for PowerOfTwoChoicesPolicy {
         match workers.len() {
             0 => None,
             1 => Some(workers[0].clone()),
-            _ => {
+            n => {
+                // Select two random workers - use offset to guarantee different selection in O(1)
+                // (`IteratorRandom::choose_multiple` is reservoir sampling and walks every worker).
                 let mut rng = rand::thread_rng();
-                let mut chosen = workers.iter().choose_multiple(&mut rng, 2);
-                chosen.sort_by_key(|w| w.active_load());
-                Some(chosen[0].clone())
+                let idx1 = rng.gen_range(0..n);
+                // Pick idx2 from remaining indices: offset by 1 + random from (len-1) to guarantee different
+                let idx2 = (idx1 + 1 + rng.gen_range(0..n - 1)) % n;
+
+                let worker1 = &workers[idx1];
+                let worker2 = &workers[idx2];
+
+                // Select worker with lower load
+                if worker1.active_load() <= worker2.active_load() {
+                    Some(worker1.clone())
+                } else {
+                    Some(worker2.clone())
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #28227.

`PowerOfTwoChoicesPolicy::select` used `workers.iter().choose_multiple(&mut rng, 2)`. `IteratorRandom::choose_multiple` is reservoir sampling — it walks the entire worker iterator (O(n)), so the policy scales linearly with worker count, defeating the whole point of power-of-two-choices (the issue measures ~600× slower than `round_robin` at n=256, growing with worker count).

## Fix

Draw two **distinct** worker indices directly in O(1), then route to the lighter-loaded of the two. This is the **same approach the sibling `PowerOfTwoPolicy` in `sgl-model-gateway` already uses** (`sgl-model-gateway/src/policies/power_of_two.rs`) — same `idx1` / `(idx1 + 1 + rand(0..n-1)) % n` offset trick and comments — so the two routers stay consistent. (Adapted to this crate's `rand 0.8` API and `Worker::active_load()`.)

The output distribution is unchanged: still the lighter-loaded of two uniformly-random distinct workers.

## Test

The existing component tests in `tests/component/policies/power_of_two.rs` all pass:

```
test policies::power_of_two::empty_returns_none ... ok
test policies::power_of_two::single_worker_returns_it ... ok
test policies::power_of_two::selects_lower_load ... ok
test policies::power_of_two::distribution_skews_to_lower_load ... ok
```

`cargo check` + `cargo fmt` clean. The O(1) flattening is measurable via `benches/policy_select.rs`.

Co-developed with an AI assistant (Claude); reviewed and validated by me.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27522209151](https://github.com/sgl-project/sglang/actions/runs/27522209151)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27522209024](https://github.com/sgl-project/sglang/actions/runs/27522209024)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->