### PR TITLE
[Spec v2] Use decode kernel for TRT-LLM MHA draft extend

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -517,6 +517,8 @@ class Envs:
     # Flashinfer
     SGLANG_IS_FLASHINFER_AVAILABLE = EnvBool(True)
     SGLANG_FLASHINFER_USE_PAGED = EnvBool(False)
+    # Temporary: route draft_extend_v2 through the TRT-LLM MHA decode kernel path.
+    SGLANG_TRTLLM_MHA_DRAFT_EXTEND_V2_DECODE = EnvBool(False)
     # Default to the pick from flashinfer
     SGLANG_FLASHINFER_WORKSPACE_SIZE = EnvInt(384 * 1024 * 1024)
     # Enable NVFP4 per-token activation scaling path for FlashInfer TRT-LLM MoE.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -517,8 +517,6 @@ class Envs:
     # Flashinfer
     SGLANG_IS_FLASHINFER_AVAILABLE = EnvBool(True)
     SGLANG_FLASHINFER_USE_PAGED = EnvBool(False)
-    # Temporary: route draft_extend_v2 through the TRT-LLM MHA decode kernel path.
-    SGLANG_TRTLLM_MHA_DRAFT_EXTEND_V2_DECODE = EnvBool(False)
     # Default to the pick from flashinfer
     SGLANG_FLASHINFER_WORKSPACE_SIZE = EnvInt(384 * 1024 * 1024)
     # Enable NVFP4 per-token activation scaling path for FlashInfer TRT-LLM MoE.

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -925,7 +925,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        if forward_batch.forward_mode.is_target_verify():
+        if forward_batch.forward_mode.is_target_verify() or (
+            envs.SGLANG_TRTLLM_MHA_DRAFT_EXTEND_V2_DECODE.get()
+            and forward_batch.forward_mode.is_draft_extend_v2()
+        ):
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -925,9 +925,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        if forward_batch.forward_mode.is_target_verify() or (
-            envs.SGLANG_TRTLLM_MHA_DRAFT_EXTEND_V2_DECODE.get()
-            and forward_batch.forward_mode.is_draft_extend_v2()
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
         ):
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,


### PR DESCRIPTION
## Summary
- Route TRT-LLM MHA draft_extend_v2 through the decode kernel path.
- Remove the temporary `SGLANG_TRTLLM_MHA_DRAFT_EXTEND_V2_DECODE` env guard/env var.

## Testing
- `python3 -m py_compile python/sglang/srt/layers/attention/trtllm_mha_backend.py python/sglang/srt/environ.py`
- `git diff --check -- python/sglang/srt/environ.py python/sglang/srt/layers/attention/trtllm_mha_backend.py`

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27534519414](https://github.com/sgl-project/sglang/actions/runs/27534519414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27534519328](https://github.com/sgl-project/sglang/actions/runs/27534519328)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->