### PR TITLE
Fix SWA eviction before decode OOM retraction

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2293,6 +2293,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def check_decode_mem(self, selected_indices: Optional[List[int]] = None):
         num_tokens = self.new_tokens_required_next_decode(selected_indices)
         evict_from_tree_cache(self.tree_cache, num_tokens)
+        if self.token_to_kv_pool_allocator.available_size() >= num_tokens:
+            return True
+
+        # SWA eviction is normally done while preparing the next decode batch.
+        # When SWA is the first limiting pool, the scheduler can reach this OOM
+        # check before prepare_for_decode() releases out-of-window SWA pages.
+        if (
+            self.forward_mode is not None
+            and self.forward_mode.is_decode()
+            and self.tree_cache.supports_swa()
+        ):
+            self.maybe_evict_swa(force=True)
+            evict_from_tree_cache(self.tree_cache, num_tokens)
+
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens
 
     def retract_all(self, server_args: ServerArgs):
@@ -2674,7 +2688,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             forward_iter=self.forward_iter,
         )
 
-    def maybe_evict_swa(self):
+    def maybe_evict_swa(self, force: bool = False):
         if self.tree_cache.supports_swa():
             sliding_window_size = self.tree_cache.sliding_window_size
             server_args = get_global_server_args()
@@ -2699,7 +2713,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     # We set evict_swa condition here with two reasons:
                     # 1. In overlap scheduler, we cannot evict swa when req.decode_batch_idx == 0 since the prev extend batch is still running.
                     # 2. Evict swa every eviction_interval tokens to reduce the overhead.
-                    if req.decode_batch_idx % eviction_interval == 1:
+                    if req.decode_batch_idx > 0 and (
+                        force or req.decode_batch_idx % eviction_interval == 1
+                    ):
                         self._evict_swa(req, req.seqlen - 1)
 
                     # Once the decode position has moved past the sliding window,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`check_decode_mem()` can decide to retract or abort decode requests before SWA out-of-window pages are evicted.

For SWA models, `maybe_evict_swa()` normally runs during decode batch preparation and only evicts periodically. When the SWA pool is the first limiting pool, the scheduler may see insufficient KV space in `check_decode_mem()` even though reclaimable SWA pages already exist. This can trigger unnecessary decode retraction or OOM aborts.

## Modifications

- Add a `force` flag to `maybe_evict_swa()`.
- Keep the existing periodic SWA eviction behavior unchanged for normal calls.
- In `check_decode_mem()`, if the first capacity check fails and the batch is in decode mode with SWA support, force one SWA eviction pass before deciding memory is insufficient.
- Keep the overlap-scheduler safety guard by only evicting when `decode_batch_idx > 0`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27527776737](https://github.com/sgl-project/sglang/actions/runs/27527776737)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27527776502](https://github.com/sgl-project/sglang/actions/runs/27527776502)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->