### PR TITLE
Support Confidential Computing (CC) for Qwen3.5-397B-A17B-FP8 on B300

### DIFF
--- a/CC_FIXES.md
+++ b/CC_FIXES.md
@@ -1,0 +1,36 @@
+# Confidential Computing (CC) perf fixes
+
+Two SGLang-side fixes that recover most of the CC inference-perf gap on B300 (Qwen3.5-397B-A17B-FP8, TP4 EP1). Both auto-enable when CC is detected (`is_confidential_compute()`, NVML `ccFeature != 0`), are **byte-identical off-CC**, and each logs once at INFO so you can confirm it's live in a normal run. There is **no env var to set** — CC detection drives both.
+
+These pair with the FlashInfer-side autotuner timing fix (`flashinfer` branch `cc-autotuner-fixed` / `CC_AUTOTUNER_FIX.md`); together the three close the CC residual from ~70% to ~98% of the cc_off throughput at conc 4.
+
+This branch (`cc-fixes`) sits on `main`, which is pinned to the container release (upstream sglang `v0.5.12`).
+
+## Fix 1 — async D2H copy worker
+
+**Problem.** Under bounce-buffer CC the per-step Device→Host token readback in `GenerationBatchResult.copy_to_cpu` becomes a *synchronous* `cudaMemcpyAsync` that blocks the scheduler thread for ~one decode step at issue (the host destination is Managed/UVM-backed). The scheduler then can't launch the next CUDA graph, so overlap is serialized — ~40–87% loss at high concurrency.
+
+**Fix.** The copy can't be made async under CC, so run the still-blocking copy on a dedicated daemon thread (TRT-LLM #8463 pattern) — non-blocking *to the scheduler thread*, restoring overlap.
+- `utils/common.py` — cached `is_confidential_compute()` via NVML `nvmlSystemGetConfComputeState`, fail-safe.
+- `managers/overlap_copy_worker.py` — `AsyncD2HCopyWorker` (daemon thread + queue), with explicit teardown.
+- `managers/scheduler.py` — gate `enable_cc_async_copy = is_confidential_compute()`; submit to the worker under CC (inline otherwise) at the 3 issue sites.
+- `managers/scheduler_output_processor_mixin.py` — wait on `copy_ready_cpu` under CC at the consume sites.
+
+**Marker (INFO).** `Confidential computing detected: offloading the per-step D2H result readback to a worker thread to preserve overlap scheduling.`
+**Ref.** sgl-project/sglang#26469.
+
+## Fix 2 — ungate the FlashInfer AR+RMSNorm fusion under CC
+
+**Problem.** cc_off uses FlashInfer's `trtllm` AllReduce+RMSNorm fusion, but under CC it disables itself: `create_allreduce_fusion_workspace` hardcodes `use_symm_dev_mem=True` (symmetric/multicast memory) and its `cuMulticast` preflight fails under CC. The *kernel* is multicast-free — a one-shot **Lamport** AllReduce (verified: zero `multimem` in `trtllm_allreduce_fusion.cuh`). Only the workspace allocator wanted multicast.
+
+**Fix.** Build the fusion on a multicast-free **IPC workspace** instead of disabling it: `trtllm_create_ipc_workspace_for_all_reduce_fusion(use_symm_dev_mem=False)`, skip the `cuMulticast` preflight, and drive `trtllm_allreduce_fusion(use_oneshot, kARResidualRMSNorm)`. Fuses the TP AllReduce + the following RMSNorm into one multicast-free pass — kernel parity with cc_off.
+- `layers/flashinfer_comm_fusion.py` — `_cc_ipc_fusion_enabled()` (now just `is_confidential_compute()`), the IPC-workspace init path, the `cc_ipc` forward branch, and IPC-aware cleanup.
+
+**Enabled by default whenever CC is detected** — no env var. (Previously opt-in via `SGLANG_CC_FLASHINFER_FUSION=1`; that gate was removed.)
+**Marker (INFO).** `FlashInfer CC IPC fusion workspace initialized (multicast-free) for rank <r>, world_size <w>`.
+
+## Scope / safety
+
+- Both fixes are gated on CC detection; **off-CC runs are unchanged** (no new threads, no fusion-path change, same logs).
+- No new required dependencies (`pynvml` is used only for detection and fails safe).
+- Experiment harnesses, probes, and analysis docs used to develop these live on the `cc-analysis` branch, intentionally excluded here.

--- a/python/sglang/jit_kernel/hadamard.py
+++ b/python/sglang/jit_kernel/hadamard.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable
 import torch
 
 from sglang.jit_kernel.utils import KERNEL_PATH, cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -56,6 +57,14 @@ def _hadamard_transform_impl(
     return out.reshape(shapes_og)
 
 
+def _hadamard_transform_fake_impl(
+    x: torch.Tensor,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+@register_custom_op(fake_impl=_hadamard_transform_fake_impl)
 def hadamard_transform(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
     module = _jit_hadamard_module(x.dtype)
     return _hadamard_transform_impl(x, scale, 8, module.hadamard_transform)

--- a/python/sglang/srt/compilation/piecewise_context_manager.py
+++ b/python/sglang/srt/compilation/piecewise_context_manager.py
@@ -71,6 +71,7 @@ class ForwardContext:
         self.quant_config = None
         self.moe_layers = None
         self.moe_fusions = None
+        self.nsa_indexers = None
 
     def set_forward_batch(self, forward_batch: ForwardBatch):
         self.forward_batch = forward_batch
@@ -86,6 +87,9 @@ class ForwardContext:
 
     def set_moe_fusions(self, fusions: List[Any]):
         self.moe_fusions = fusions
+
+    def set_nsa_indexers(self, indexers: List[Any]):
+        self.nsa_indexers = indexers
 
 
 _forward_context: Optional[ForwardContext] = None
@@ -104,6 +108,7 @@ def set_forward_context(
     quant_config: Any,
     moe_layers: List[Any],
     moe_fusions: List[Any],
+    nsa_indexers: Optional[List[Any]] = None,
 ):
     global _forward_context
     _forward_context = ForwardContext()
@@ -112,6 +117,8 @@ def set_forward_context(
     _forward_context.set_quant_config(quant_config)
     _forward_context.set_moe_layers(moe_layers)
     _forward_context.set_moe_fusions(moe_fusions)
+    if nsa_indexers is not None:
+        _forward_context.set_nsa_indexers(nsa_indexers)
     try:
         yield
     finally:

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -329,7 +329,6 @@ class ModelConfig:
         self.use_ngram_embedding = getattr(self.hf_config, "use_ngram_embedding", False)
         self.is_piecewise_cuda_graph_disabled_model = (
             is_piecewise_cuda_graph_disabled_model(self.hf_config.architectures)
-            or is_deepseek_nsa(self.hf_text_config)
         )
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
 
@@ -1556,11 +1555,9 @@ multimodal_model_archs = [
 ]
 
 piecewise_cuda_graph_disabled_model_archs = [
-    "DeepseekV32ForCausalLM",
     "DeepseekV4ForCausalLM",
     "DeepseekV4ForCausalLMNextN",
     "Qwen3NextForCausalLM",
-    "GlmMoeDsaForCausalLM",
     "BailingMoeV2_5ForCausalLM",
     "LLaDAModelLM",
 ]

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -12,6 +12,10 @@ from sglang.jit_kernel.fused_store_index_cache import (
     can_use_nsa_fused_store,
     fused_store_index_k_cache,
 )
+from sglang.srt.compilation.piecewise_context_manager import (
+    get_forward_context,
+    is_in_piecewise_cuda_graph,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.nsa.utils import (
     aiter_can_use_preshuffle_paged_mqa,
@@ -88,6 +92,82 @@ if TYPE_CHECKING:
 
 
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
+
+
+if _is_cuda:
+    from sglang.srt.compilation.compilation_config import register_split_op
+    from sglang.srt.utils.custom_op import register_custom_op
+
+    @register_custom_op(mutates_args=["topk_result"])
+    @register_split_op()
+    def k_cache_and_topk_result(
+        layer_id: int,
+        key: torch.Tensor,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+        topk_result: torch.Tensor,
+    ) -> None:
+        assert (
+            _is_cuda
+        ), "Internal error: piecewise CUDA graph is only supported on CUDA"
+        from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
+
+        forward_batch = get_forward_context().forward_batch
+        indexer = get_forward_context().nsa_indexers[layer_id]
+        metadata = forward_batch.attn_backend.get_indexer_metadata(
+            layer_id, forward_batch
+        )
+
+        # slice off padding from piecewise CUDA graph
+        extend_num_tokens = forward_batch.extend_num_tokens
+
+        indexer._store_index_k_cache(
+            forward_batch=forward_batch,
+            layer_id=layer_id,
+            key=key[:extend_num_tokens],
+            act_quant=act_quant,
+            out_cache_loc=forward_batch.out_cache_loc[:extend_num_tokens],
+        )
+        indexer._get_topk_ragged(
+            False,
+            forward_batch,
+            layer_id,
+            q_fp8[:extend_num_tokens],
+            weights,
+            metadata,
+            topk_result,
+        )
+
+    def _logits_head_gate_pcg_fake_impl(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        n_heads_inv_sqrt: float,
+        softmax_scale: float,
+        q_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.empty(
+            (x.shape[0], weight.shape[0], q_scale.shape[-1]),
+            dtype=torch.float32,
+            device=x.device,
+        )
+
+    @register_custom_op(fake_impl=_logits_head_gate_pcg_fake_impl)
+    def logits_head_gate_pcg(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        n_heads_inv_sqrt: float,
+        softmax_scale: float,
+        q_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.deep_gemm_wrapper import entrypoint as deep_gemm_wrapper
+
+        out = torch.empty(
+            (x.shape[0], weight.shape[0]), dtype=torch.float32, device=x.device
+        )
+        deep_gemm_wrapper.gemm_nt_bf16bf16f32(x, weight, out)
+        weights = out * n_heads_inv_sqrt
+        weights = weights.unsqueeze(-1) * q_scale * softmax_scale
+        return weights
 
 
 class BaseIndexerMetadata(ABC):
@@ -427,7 +507,8 @@ class Indexer(MultiPlatformOp):
     def _update_rope_guarded(dst: torch.Tensor, src: torch.Tensor) -> None:
         # On AMD with in-place RoPE kernels, self-aliasing can occur;
         # skip write-back when src/dst tensors point to a single memory.
-        if src.data_ptr() == dst.data_ptr():
+        # data_ptr() is not comparable inside torch.compile, so skip the guard there.
+        if not torch.compiler.is_compiling() and src.data_ptr() == dst.data_ptr():
             return
         dst.copy_(src)
 
@@ -579,6 +660,7 @@ class Indexer(MultiPlatformOp):
         q_fp8: torch.Tensor,
         weights: torch.Tensor,
         metadata: BaseIndexerMetadata,
+        topk_result: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if TYPE_CHECKING:
             assert isinstance(forward_batch.token_to_kv_pool, NSATokenToKVPool)
@@ -619,9 +701,10 @@ class Indexer(MultiPlatformOp):
         token_nums, _, _ = q_fp8.shape
         device = q_fp8.device
 
-        topk_result = torch.full(
-            (token_nums, self.index_topk), -1, device=device, dtype=torch.int32
-        )
+        if topk_result is None:
+            topk_result = torch.full(
+                (token_nums, self.index_topk), -1, device=device, dtype=torch.int32
+            )
         if batch_size == 0:
             return topk_result
 
@@ -806,6 +889,9 @@ class Indexer(MultiPlatformOp):
         actual_seq_q: int,
         cp_index: List[Tuple[int, int, int]] = None,
     ) -> torch.Tensor:
+        assert (
+            not is_in_piecewise_cuda_graph()
+        ), "NSA context parallel (_get_topk_ragged_with_cp) not supported under piecewise CUDA graph"
         if TYPE_CHECKING:
             assert isinstance(forward_batch.token_to_kv_pool, NSATokenToKVPool)
 
@@ -952,6 +1038,9 @@ class Indexer(MultiPlatformOp):
         topk: int,
         layer_id: int,
     ) -> Optional[torch.Tensor]:
+        assert (
+            not is_in_piecewise_cuda_graph()
+        ), "NSA forward_indexer (non-CUDA loop path) not supported under piecewise CUDA graph"
         if not _is_npu:
             from sglang.srt.layers.attention.nsa.tilelang_kernel import fp8_index
 
@@ -1034,21 +1123,26 @@ class Indexer(MultiPlatformOp):
         key: torch.Tensor,
         *,
         act_quant=None,  # fallback only
+        out_cache_loc: Optional[torch.Tensor] = None,
     ) -> None:
         """
         Store NSA indexer K cache for current step.
 
         Preferred: fused_store_index_k_cache(key, cache, out_cache_loc, page_size)
         Fallback : act_quant(key) + token_to_kv_pool.set_index_k_scale_buffer(...)
+
+        out_cache_loc will default to forward_batch.out_cache_loc if not provided.
         """
 
-        # Fast path: JIT fused store (CUDA, page_size=64, non-fnuz)
+        if out_cache_loc is None:
+            out_cache_loc = forward_batch.out_cache_loc
+
         if (
             _is_cuda
             and (not _is_fp8_fnuz)
             and can_use_nsa_fused_store(
                 key.dtype,
-                forward_batch.out_cache_loc.dtype,
+                out_cache_loc.dtype,
                 forward_batch.token_to_kv_pool.page_size,
             )
         ):
@@ -1059,7 +1153,7 @@ class Indexer(MultiPlatformOp):
             fused_store_index_k_cache(
                 key,
                 buf,
-                forward_batch.out_cache_loc,
+                out_cache_loc,
                 forward_batch.token_to_kv_pool.page_size,
             )
             return
@@ -1092,13 +1186,12 @@ class Indexer(MultiPlatformOp):
         assert act_quant is not None
         k_fp8, k_scale = act_quant(key, self.block_size, self.scale_fmt)
 
-        out_loc = forward_batch.out_cache_loc
-        if not out_loc.is_contiguous():
-            out_loc = out_loc.contiguous()
+        if not out_cache_loc.is_contiguous():
+            out_cache_loc = out_cache_loc.contiguous()
 
         forward_batch.token_to_kv_pool.set_index_k_scale_buffer(
             layer_id=layer_id,
-            loc=out_loc,
+            loc=out_cache_loc,
             index_k=k_fp8,
             index_k_scale=k_scale,
         )
@@ -1137,9 +1230,17 @@ class Indexer(MultiPlatformOp):
         # a tuple like (x_fp8, x_scale[, y]). Use `x_meta` for shape/device queries.
         x_meta = x[0] if isinstance(x, tuple) else x
 
-        metadata = forward_batch.attn_backend.get_indexer_metadata(
-            layer_id, forward_batch
-        )
+        # In piecewise CUDA graph mode, metadata is fetched inside custom ops via get_forward_context() to
+        # prevent Dynamo from guarding on forward_metadata identity (which changes each
+        # replay when init_forward_metadata creates a new ForwardMetadata object).
+        if not is_in_piecewise_cuda_graph():
+            metadata = forward_batch.attn_backend.get_indexer_metadata(
+                layer_id, forward_batch
+            )
+            if metadata is None:
+                return None
+        else:
+            metadata = None
 
         enable_dual_stream = (
             self.alt_stream is not None
@@ -1148,14 +1249,13 @@ class Indexer(MultiPlatformOp):
             and q_lora.shape[0] <= DUAL_STREAM_TOKEN_THRESHOLD
         )
 
-        # skip NSA if attention backend choose to skip this batch
-        if metadata is None:
-            return None
-
         # Determine if should skip topk based on sequence length
         # We can only skip the logits computation if cuda graph is not involved
         skip_logits_computation = False
-        if forward_batch.forward_mode.is_extend_without_speculative():
+        if (
+            not is_in_piecewise_cuda_graph()
+            and forward_batch.forward_mode.is_extend_without_speculative()
+        ):
             if forward_batch.seq_lens_cpu is not None:
                 max_kv_len = forward_batch.seq_lens_cpu.max().item()
                 skip_logits_computation = max_kv_len <= self.index_topk
@@ -1211,7 +1311,7 @@ class Indexer(MultiPlatformOp):
                         act_quant=act_quant,
                     )
                 current_stream.wait_stream(self.alt_stream)
-            else:
+            elif not is_in_piecewise_cuda_graph():
                 q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
@@ -1219,6 +1319,10 @@ class Indexer(MultiPlatformOp):
                     key=key,
                     act_quant=act_quant,
                 )
+            else:
+                # piecewise CUDA graph need to split graph on store_k_cache and mqa_logits,
+                # so delay store_k_cache after weights proj.
+                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
 
             # aiter (ROCm gfx95): the 3-tuple (fp8, scale, bf16) from
             # fused_rms_fp8_group_quant is passed directly to _get_logits_head_gate,
@@ -1261,25 +1365,37 @@ class Indexer(MultiPlatformOp):
             else:
                 x_for_gate = x
 
-            weights = self._get_logits_head_gate(x_for_gate, q_scale)
+            if is_in_piecewise_cuda_graph():
+                weights = logits_head_gate_pcg(
+                    x_for_gate,
+                    self.weights_proj.weight,
+                    self.n_heads**-0.5,
+                    self.softmax_scale,
+                    q_scale,
+                )
+            else:
+                weights = self._get_logits_head_gate(x_for_gate, q_scale)
 
         if _is_cuda or _is_hip:
-            assert forward_batch.seq_lens_cpu is not None
-            if len(forward_batch.seq_lens_cpu) == 0:
-                # this seems b/c max-pad, no worries?
-                # if x.shape[0] != 0:
-                #     print(
-                #         "HACK: seq_lens empty but x not empty, hackily return all-invalid topk_result"
-                #     )
-                return maybe_capture_indexer_topk(
-                    layer_id,
-                    torch.full(
-                        (x_meta.shape[0], self.index_topk),
-                        -1,
-                        dtype=torch.int,
-                        device=x_meta.device,
-                    ),
-                )
+            # In piecewise CUDA graph, any access to seq_lens_cpu creates a Dynamo shape guard.
+            # Piecewise CUDA graph never has empty batches.
+            if not is_in_piecewise_cuda_graph():
+                assert forward_batch.seq_lens_cpu is not None
+                if len(forward_batch.seq_lens_cpu) == 0:
+                    # this seems b/c max-pad, no worries?
+                    # if x.shape[0] != 0:
+                    #     print(
+                    #         "HACK: seq_lens empty but x not empty, hackily return all-invalid topk_result"
+                    #     )
+                    return maybe_capture_indexer_topk(
+                        layer_id,
+                        torch.full(
+                            (x_meta.shape[0], self.index_topk),
+                            -1,
+                            dtype=torch.int,
+                            device=x_meta.device,
+                        ),
+                    )
 
             if (
                 forward_batch.forward_mode.is_decode_or_idle()
@@ -1331,6 +1447,24 @@ class Indexer(MultiPlatformOp):
                     return maybe_capture_indexer_topk(
                         layer_id,
                         torch.cat([topk_result_prev, topk_result_next], dim=0),
+                    )
+                elif is_in_piecewise_cuda_graph():
+                    assert (
+                        not enable_dual_stream
+                    ), "Internal error: piecewise CUDA graph should not be enabled with dual stream"
+
+                    topk_result = torch.full(
+                        (q_fp8.shape[0], self.index_topk),
+                        -1,
+                        device=q_fp8.device,
+                        dtype=torch.int32,
+                    )
+                    k_cache_and_topk_result(
+                        layer_id=layer_id,
+                        key=key,
+                        q_fp8=q_fp8,
+                        weights=weights,
+                        topk_result=topk_result,
                     )
                 else:
                     topk_result = self._get_topk_ragged(

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeAlias
@@ -7,6 +8,8 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeAlia
 import torch
 
 from sglang.srt.configs.model_config import get_nsa_index_topk, is_deepseek_nsa
+
+logger = logging.getLogger(__name__)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.nsa.dequant_k_cache import dequantize_k_cache_paged
@@ -2172,8 +2175,8 @@ class NativeSparseAttnBackend(
             backend="trtllm-gen",
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
         )
-        # Output: [batch, q_len=1, heads, v_dim] -> [batch, heads, v_dim]
-        return out.squeeze(1)
+
+        return out
 
     def _pad_topk_indices(
         self, topk_indices: torch.Tensor, num_tokens: int
@@ -2204,10 +2207,18 @@ class NativeSparseAttnBackend(
         """
         Decide all attention prefill dispatch strategies for this batch.
         """
+        from sglang.srt.compilation.piecewise_context_manager import (
+            is_in_piecewise_cuda_graph,
+        )
         from sglang.srt.utils import get_device_sm, is_blackwell
 
         # Decide MHA vs MLA
-        if forward_batch and forward_batch.forward_mode.is_extend_without_speculative():
+        if is_in_piecewise_cuda_graph():
+            # Can't branch on seq_lens_cpu in PCG, force mha off to guarantee correctness.
+            self.use_mha = False
+        elif (
+            forward_batch and forward_batch.forward_mode.is_extend_without_speculative()
+        ):
             # Check if sequence meets criteria for MHA_ONE_SHOT
             assert forward_batch.seq_lens_cpu is not None
             max_kv_len = forward_batch.seq_lens_cpu.max().item()

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -161,6 +161,42 @@ def is_flashinfer_allreduce_unavailable() -> bool:
     return _flashinfer_allreduce_unavailable
 
 
+def _cc_ipc_fusion_enabled() -> bool:
+    """Run FlashInfer's trtllm AR+RMSNorm fusion on a multicast-free IPC
+    workspace under Confidential Computing, so the SAME kernel is used CC-on and
+    CC-off (kernel parity). Auto-enabled whenever CC is detected.
+
+    The trtllm one-shot Lamport fusion kernel is multicast-free (verified: 0
+    `multimem` in trtllm_allreduce_fusion.cuh); the only multicast dependency is
+    the workspace allocator. `create_allreduce_fusion_workspace` hardcodes
+    `use_symm_dev_mem=True` (→ multicast, which fails under CC), but the
+    low-level `trtllm_create_ipc_workspace_for_all_reduce_fusion(
+    use_symm_dev_mem=False)` gives an IPC-only workspace the same kernel runs on.
+
+    Off-CC this returns False, so non-CC behavior is unchanged.
+    """
+    try:
+        from sglang.srt.utils.common import is_confidential_compute
+
+        return is_confidential_compute()
+    except Exception:
+        return False
+
+
+def _resolve_flashinfer_comm_fn(name: str):
+    """Resolve a FlashInfer comm fn from the top-level module or the trtllm_ar
+    submodule (export location varies by FlashInfer version)."""
+    fn = getattr(_flashinfer_comm, name, None)
+    if fn is None:
+        try:
+            import flashinfer.comm.trtllm_ar as _tar
+
+            fn = getattr(_tar, name, None)
+        except Exception:
+            fn = None
+    return fn
+
+
 def _make_flashinfer_workspace_allocation_prop(cuda_driver):
     if _should_force_posix_fd_transport():
         handle_type = (
@@ -340,6 +376,10 @@ class FlashInferWorkspaceManager:
         self.hidden_dim = None
         self.dtype = None
         self.initialized = False
+        # CC IPC fusion: multicast-free workspace state.
+        self.cc_ipc = False
+        self.workspace_tensor = None
+        self.workspace_metadata = None
 
     def initialize(
         self,
@@ -362,6 +402,80 @@ class FlashInferWorkspaceManager:
         self.cleanup()
 
         global _flashinfer_allreduce_unavailable
+
+        # Under CC, build a multicast-free IPC workspace so FlashInfer's own
+        # trtllm fusion kernel runs (cc_off parity). Skips the cuMulticast
+        # preflight — that probe is exactly what disables fusion under CC.
+        if _cc_ipc_fusion_enabled():
+            make_ws = _resolve_flashinfer_comm_fn(
+                "trtllm_create_ipc_workspace_for_all_reduce_fusion"
+            )
+            if make_ws is None:
+                logger.warning(
+                    "CC IPC fusion requested but "
+                    "trtllm_create_ipc_workspace_for_all_reduce_fusion is "
+                    "unavailable; leaving fusion disabled."
+                )
+                _flashinfer_allreduce_unavailable = True
+                self.workspace = None
+                self.initialized = False
+                return
+            ipc_kwargs = dict(
+                use_fp32_lamport=(dtype == torch.float32),
+                # Pin the IPC handle-exchange to the actual TP/EP subgroup.
+                group=device_group,
+                create_metadata=True,
+                use_symm_dev_mem=False,  # <-- no multicast (CC/NVLE-safe)
+            )
+            # CRITICAL: pass the same comm_backend the symm path uses. The IPC
+            # workspace creation does a collective handle exchange; without the
+            # correct backend/group it addresses the wrong peers and HANGS across
+            # ranks (the skipped cuMulticast preflight also voted ranks together).
+            if (
+                _TorchDistBackend is not None
+                and device_group is not None
+                and cpu_group is not None
+            ):
+                ipc_kwargs["comm_backend"] = _TorchDistBackend(
+                    device_group=device_group, cpu_group=cpu_group
+                )
+            try:
+                with _flashinfer_posix_fd_transport_override_if_needed():
+                    ws = make_ws(
+                        rank,
+                        world_size,
+                        max_token_num,
+                        hidden_dim,
+                        **ipc_kwargs,
+                    )
+                # (ipc_handles, workspace_tensor, metadata)
+                self.workspace = ws
+                self.workspace_tensor = ws[1]
+                self.workspace_metadata = ws[2] if len(ws) > 2 else None
+                self.cc_ipc = True
+            except Exception as e:
+                _flashinfer_allreduce_unavailable = True
+                logger.warning(
+                    f"Failed to init CC IPC fusion workspace: {e}. "
+                    "Disabling flashinfer allreduce fusion."
+                )
+                self.workspace = None
+                self.initialized = False
+                return
+
+            self.world_size = world_size
+            self.rank = rank
+            self.group = (device_group, cpu_group)
+            self.max_token_num = max_token_num
+            self.hidden_dim = hidden_dim
+            self.dtype = dtype
+            self.initialized = True
+            logger.info(
+                "FlashInfer CC IPC fusion workspace initialized (multicast-free) "
+                f"for rank {rank}, world_size {world_size}"
+            )
+            return
+
         if not _preflight_check_workspace_memory(
             world_size=world_size,
             max_token_num=max_token_num,
@@ -434,6 +548,14 @@ class FlashInferWorkspaceManager:
     ) -> bool:
         if not self.initialized or self.workspace is None:
             return False
+        if self.cc_ipc:
+            # IPC workspace is a raw tuple (no helper). Manual size check:
+            # workspace holds max_token_num*hidden_dim*dtype; reuse if it fits.
+            return (
+                token_num <= self.max_token_num
+                and hidden_dim == self.hidden_dim
+                and dtype == self.dtype
+            )
         try:
             return self.workspace.is_buffer_size_sufficient(
                 tp_size=self.world_size,
@@ -450,11 +572,26 @@ class FlashInferWorkspaceManager:
         """Clean up workspace"""
         if self.workspace is not None:
             try:
-                self.workspace.destroy()
+                if self.cc_ipc:
+                    # IPC workspace is a raw tuple; free via the destroy helper.
+                    destroy = _resolve_flashinfer_comm_fn(
+                        "trtllm_destroy_ipc_workspace_for_all_reduce_fusion"
+                    )
+                    if destroy is not None:
+                        grp = self.group[0] if self.group else None
+                        try:
+                            destroy(self.workspace, group=grp)
+                        except TypeError:
+                            destroy(self.workspace)
+                else:
+                    self.workspace.destroy()
             except Exception as e:
                 logger.warning(f"Failed to cleanup FlashInfer workspace: {e}")
             finally:
                 self.workspace = None
+                self.workspace_tensor = None
+                self.workspace_metadata = None
+                self.cc_ipc = False
                 self.initialized = False
                 self.world_size = None
                 self.rank = None
@@ -669,20 +806,49 @@ def flashinfer_allreduce_residual_rmsnorm(
     norm_out = torch.empty_like(input_tensor)
 
     workspace_manager = _get_workspace_manager(use_attn_tp_group)
-    _flashinfer_comm.allreduce_fusion(
-        input=input_tensor,
-        workspace=workspace_manager.workspace,
-        pattern=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
-        launch_with_pdl=True,
-        trigger_completion_at_end=trigger_completion_at_end,
-        residual_out=residual_out,
-        norm_out=norm_out,
-        residual_in=residual,
-        rms_gamma=weight,
-        rms_eps=eps,
-        use_oneshot=use_oneshot,
-        fp32_acc=fp32_acc,
-    )
+    if getattr(workspace_manager, "cc_ipc", False):
+        # CC: same FlashInfer kernel on the multicast-free IPC workspace, driven
+        # via the low-level op. We force oneshot (correct for decode-sized
+        # messages); the high-level heuristic is bypassed here.
+        ar_fuse = _resolve_flashinfer_comm_fn("trtllm_allreduce_fusion")
+        ar_fuse(
+            allreduce_in=input_tensor,
+            world_size=workspace_manager.world_size,
+            world_rank=workspace_manager.rank,
+            token_num=input_tensor.shape[0],
+            hidden_dim=input_tensor.shape[-1],
+            workspace_ptrs=workspace_manager.workspace_tensor,
+            launch_with_pdl=True,
+            use_oneshot=True if use_oneshot is None else bool(use_oneshot),
+            trigger_completion_at_end=trigger_completion_at_end,
+            fp32_acc=fp32_acc,
+            pattern_code=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
+            allreduce_out=None,
+            residual_in=residual,
+            residual_out=residual_out,
+            norm_out=norm_out,
+            quant_out=None,
+            scale_out=None,
+            rms_gamma=weight,
+            rms_eps=eps,
+            scale_factor=None,
+            layout_code=None,
+        )
+    else:
+        _flashinfer_comm.allreduce_fusion(
+            input=input_tensor,
+            workspace=workspace_manager.workspace,
+            pattern=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
+            launch_with_pdl=True,
+            trigger_completion_at_end=trigger_completion_at_end,
+            residual_out=residual_out,
+            norm_out=norm_out,
+            residual_in=residual,
+            rms_gamma=weight,
+            rms_eps=eps,
+            use_oneshot=use_oneshot,
+            fp32_acc=fp32_acc,
+        )
 
     return norm_out, residual_out
 

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -53,7 +53,26 @@ _flashinfer_layernorm_available = False
 if _is_cuda or _is_xpu or _is_musa:
     if _is_flashinfer_available:
         try:
-            from flashinfer.norm import layernorm
+            import flashinfer.norm
+
+            from sglang.srt.utils.custom_op import register_custom_op
+
+            def _layernorm_fake_impl(
+                input: torch.Tensor,
+                gamma: torch.Tensor,
+                beta: torch.Tensor,
+                eps: float = 1e-6,
+            ) -> torch.Tensor:
+                return torch.empty_like(input)
+
+            @register_custom_op(fake_impl=_layernorm_fake_impl)
+            def layernorm(
+                input: torch.Tensor,
+                gamma: torch.Tensor,
+                beta: torch.Tensor,
+                eps: float = 1e-6,
+            ) -> torch.Tensor:
+                return flashinfer.norm.layernorm(input, gamma, beta, eps)
 
             _flashinfer_layernorm_available = True
         except (ImportError, AttributeError):

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -159,6 +159,12 @@ def unified_attention_with_output(
     q_rope: Optional[torch.Tensor] = None,
     k_rope: Optional[torch.Tensor] = None,
     sinks: Optional[torch.Tensor] = None,
+    # MLA / TRT-LLM / NSA paths pass these through RadixAttention.forward(**kwargs);
+    # they must appear in the schema when --enforce-piecewise-cuda-graph is on.
+    cos_sin_cache: Optional[torch.Tensor] = None,
+    is_neox: Optional[bool] = None,
+    llama_4_scaling: Optional[torch.Tensor] = None,
+    topk_indices: Optional[torch.Tensor] = None,
 ) -> None:
     context = get_forward_context()
     forward_batch = context.forward_batch
@@ -177,6 +183,14 @@ def unified_attention_with_output(
         kwargs["k_rope"] = k_rope[:real_num_tokens]
     if sinks is not None:
         kwargs["sinks"] = sinks
+    if cos_sin_cache is not None:
+        kwargs["cos_sin_cache"] = cos_sin_cache
+    if is_neox is not None:
+        kwargs["is_neox"] = is_neox
+    if llama_4_scaling is not None:
+        kwargs["llama_4_scaling"] = llama_4_scaling
+    if topk_indices is not None:
+        kwargs["topk_indices"] = topk_indices[:real_num_tokens]
 
     original_out_cache_loc = forward_batch.out_cache_loc
     original_out_cache_loc_swa = forward_batch.out_cache_loc_swa

--- a/python/sglang/srt/managers/overlap_copy_worker.py
+++ b/python/sglang/srt/managers/overlap_copy_worker.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncD2HCopyWorker:
+    """Runs the per-step result Device->Host readback on a dedicated daemon thread.
+
+    Under NVIDIA Confidential Computing (bounce-buffer CC), a device-to-host
+    ``cudaMemcpyAsync`` is forced synchronous and blocks AT ISSUE (the host
+    destination is staged through an encrypted bounce buffer). Issuing it inline
+    on the scheduler thread stalls the overlap pipeline: the scheduler cannot
+    launch the next step's CUDA graph until the copy returns (~one decode step).
+
+    This worker performs the (still-blocking) copy off the scheduler thread so
+    the scheduler keeps issuing work. It mirrors TensorRT-LLM PR #8463:
+      - the scheduler thread records a CUDA event after the producing work and
+        hands (event, copy_fn, done) here, then returns immediately;
+      - this worker ``cudaEventSynchronize``-s on that event (event-sync, NOT
+        stream-wait, so the blocking copy does not stall the scheduler's CUDA
+        API calls), runs the copy on the dedicated copy stream, blocks until it
+        completes, and sets ``done``;
+      - the scheduler later waits on ``done`` (worker-done => copy-done).
+
+    The copy itself stays synchronous under CC; it is merely non-blocking *to the
+    scheduler thread*, restoring overlap.
+    """
+
+    def __init__(self, device_module, copy_stream):
+        self.device_module = device_module
+        self.copy_stream = copy_stream
+        self._queue: "queue.Queue" = queue.Queue()
+        self._thread = threading.Thread(
+            target=self._loop, name="sglang-d2h-copy-worker", daemon=True
+        )
+        self._thread.start()
+
+    def submit(
+        self,
+        src_ready: "torch.cuda.Event",  # noqa: F821 - annotation only
+        copy_fn: Callable[[], None],
+        done: threading.Event,
+    ):
+        """Enqueue a readback. ``src_ready`` must already be recorded on the
+        stream that produces the copy sources; ``copy_fn`` performs the actual
+        ``.to("cpu", ...)`` copies; ``done`` is set when they have completed."""
+        self._queue.put((src_ready, copy_fn, done))
+
+    def _loop(self):
+        while True:
+            item = self._queue.get()
+            if item is None:
+                return
+            src_ready, copy_fn, done = item
+            try:
+                # Wait until the producing forward+sample has materialized the
+                # source tensors. Event-sync (cudaEventSynchronize), not a
+                # stream wait — see class docstring / TRT-LLM #8463.
+                src_ready.synchronize()
+                # Issue the copies on a dedicated stream owned by this thread.
+                # PyTorch's current stream is thread-local, so this does not
+                # affect the scheduler thread's stream.
+                with self.device_module.stream(self.copy_stream):
+                    copy_fn()
+                self.copy_stream.synchronize()
+            except Exception:
+                logger.exception("AsyncD2HCopyWorker readback failed")
+            finally:
+                done.set()
+
+    def shutdown(self, timeout: float = 2.0):
+        """Signal the worker to stop and join it (best-effort, bounded wait)."""
+        if not self._thread.is_alive():
+            return
+        self._queue.put(None)
+        self._thread.join(timeout=timeout)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -14,10 +14,12 @@
 """A scheduler that manages a tensor parallel GPU worker."""
 
 import faulthandler
+import functools
 import logging
 import os
 import signal
 import sys
+import threading
 import time
 from collections import deque
 from contextlib import nullcontext
@@ -227,7 +229,7 @@ from sglang.srt.utils import (
     set_random_seed,
     suppress_other_loggers,
 )
-from sglang.srt.utils.common import is_npu
+from sglang.srt.utils.common import is_confidential_compute, is_npu
 from sglang.srt.utils.hf_transformers_utils import (
     get_processor,
     get_tokenizer,
@@ -274,6 +276,9 @@ class EmbeddingBatchResult:
     embeddings: torch.Tensor
     pooled_hidden_states: Optional[torch.Tensor] = None
     copy_done: Optional[torch.cuda.Event] = None
+    # Set instead of copy_done when the D2H readback is offloaded to the async
+    # copy worker (confidential-compute path). worker-done => copy-done.
+    copy_ready_cpu: Optional[threading.Event] = None
 
     def copy_to_cpu(self):
         """Copy embeddings and pooled hidden states to CPU for overlap scheduling."""
@@ -1321,6 +1326,9 @@ class Scheduler(
 
     def init_overlap(self):
         self.device_module = torch.get_device_module(self.device)
+        # Confidential-compute async D2H readback (set below once streams exist).
+        self.enable_cc_async_copy = False
+        self.d2h_worker = None
 
         if use_mlx():
             # MLX overlap scheduling uses mx.async_eval / mx.eval for
@@ -1343,6 +1351,19 @@ class Scheduler(
             self.future_map = None
             return
 
+        # Under confidential computing the per-step D2H result readback is forced
+        # synchronous and blocks the scheduler thread at issue, serializing the
+        # overlap pipeline. Offload it to a worker thread (TRT-LLM #8463 pattern).
+        self.enable_cc_async_copy = is_confidential_compute()
+        if self.enable_cc_async_copy:
+            from sglang.srt.managers.overlap_copy_worker import AsyncD2HCopyWorker
+
+            self.d2h_worker = AsyncD2HCopyWorker(self.device_module, self.copy_stream)
+            logger.info(
+                "Confidential computing detected: offloading the per-step D2H "
+                "result readback to a worker thread to preserve overlap scheduling."
+            )
+
         self.future_map = FutureMap(
             self.max_running_requests,
             self.chunked_prefill_size,
@@ -1352,6 +1373,31 @@ class Scheduler(
         )
         self.batch_record_buf = [None] * 2
         self.batch_record_ct = 0
+
+    def _issue_result_copy_to_cpu(self, result, copy_fn):
+        """Issue the result's D2H readback.
+
+        Default path: run ``copy_fn`` inline (async copies recorded into
+        ``result.copy_done``). Under confidential computing, the copy blocks at
+        issue, so instead record a ``src_ready`` event on the current (forward)
+        stream and hand the still-blocking copy to the worker thread; the
+        scheduler thread returns immediately and keeps launching work. The
+        deferred consume waits on ``result.copy_ready_cpu`` instead of
+        ``copy_done`` (see ``_wait_result_copy``).
+        """
+        if self.enable_cc_async_copy:
+            src_ready = self.device_module.Event()
+            src_ready.record()
+            result.copy_ready_cpu = threading.Event()
+            self.d2h_worker.submit(src_ready, copy_fn, result.copy_ready_cpu)
+        else:
+            copy_fn()
+
+    def _shutdown_d2h_worker(self):
+        """Stop the confidential-compute async D2H copy worker thread, if any."""
+        if getattr(self, "d2h_worker", None) is not None:
+            self.d2h_worker.shutdown()
+            self.d2h_worker = None
 
     def maybe_init_ngram_embedding(self):
         self.use_ngram_embedding = self.tp_worker.model_config.use_ngram_embedding
@@ -3044,9 +3090,13 @@ class Scheduler(
                     batch_result.copy_done = self.device_module.Event()
                     if batch_result.delay_sample_func is None:
                         self.future_map.store_to_map(future_indices, batch_result)
-                        batch_result.copy_to_cpu(
-                            return_logprob=batch.return_logprob,
-                            return_hidden_states=batch.return_hidden_states,
+                        self._issue_result_copy_to_cpu(
+                            batch_result,
+                            functools.partial(
+                                batch_result.copy_to_cpu,
+                                return_logprob=batch.return_logprob,
+                                return_hidden_states=batch.return_hidden_states,
+                            ),
                         )
                     else:
                         batch_result.future_indices = future_indices
@@ -3114,7 +3164,7 @@ class Scheduler(
                         embeddings=pooler_output.embeddings,
                         pooled_hidden_states=pooler_output.pooled_hidden_states,
                     )
-                    ret.copy_to_cpu()
+                    self._issue_result_copy_to_cpu(ret, ret.copy_to_cpu)
             else:
                 pooler_output = self.tp_worker.forward_batch_embedding(
                     model_worker_batch
@@ -3152,9 +3202,13 @@ class Scheduler(
             _batch_result = batch_result.delay_sample_func()
             assert _batch_result is batch_result
             self.future_map.store_to_map(batch_result.future_indices, batch_result)
-            batch_result.copy_to_cpu(
-                return_logprob=self.cur_batch.return_logprob,
-                return_hidden_states=self.cur_batch.return_hidden_states,
+            self._issue_result_copy_to_cpu(
+                batch_result,
+                functools.partial(
+                    batch_result.copy_to_cpu,
+                    return_logprob=self.cur_batch.return_logprob,
+                    return_hidden_states=self.cur_batch.return_hidden_states,
+                ),
             )
 
         # Release the closure and large GPU tensors that are no longer needed.
@@ -4049,3 +4103,5 @@ def run_scheduler_process(
             # FPM has a background ZMQ publisher thread that needs explicit
             # teardown to flush queued metrics and close the socket cleanly.
             scheduler._shutdown_fpm()
+            # Stop the confidential-compute async D2H copy worker thread.
+            scheduler._shutdown_d2h_worker()

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -186,8 +186,7 @@ class SchedulerOutputProcessorMixin:
         skip_stream_req = None
 
         if self.is_generation:
-            if result.copy_done is not None:
-                result.copy_done.synchronize()
+            self._wait_result_copy(result)
             if result.routed_experts_output is not None:
                 result.routed_experts_output.finalize()
                 result.routed_experts_output = None
@@ -343,8 +342,7 @@ class SchedulerOutputProcessorMixin:
                     req.time_stats.set_last_chunked_prefill_finish_time()
 
         else:  # embedding or reward model
-            if result.copy_done is not None:
-                result.copy_done.synchronize()
+            self._wait_result_copy(result)
 
             is_sparse = envs.SGLANG_EMBEDDINGS_SPARSE_HEAD.is_set()
 
@@ -453,13 +451,24 @@ class SchedulerOutputProcessorMixin:
 
         return predict_tokens
 
+    def _wait_result_copy(self: Scheduler, result):
+        """Block until the result's D2H readback is complete.
+
+        Under confidential computing the copy was offloaded to the worker thread
+        (``copy_ready_cpu`` set); wait on that. Otherwise wait on the inline
+        CUDA event (``copy_done``).
+        """
+        if getattr(result, "copy_ready_cpu", None) is not None:
+            result.copy_ready_cpu.wait()
+        elif result.copy_done is not None:
+            result.copy_done.synchronize()
+
     def process_batch_result_idle(
         self: Scheduler,
         batch: ScheduleBatch,
         result: GenerationBatchResult,
     ):
-        if result.copy_done is not None:
-            result.copy_done.synchronize()
+        self._wait_result_copy(result)
 
         self.stream_output_generation(
             batch.reqs, batch.return_logprob, is_idle_batch=True
@@ -470,8 +479,7 @@ class SchedulerOutputProcessorMixin:
         batch: ScheduleBatch,
         result: GenerationBatchResult,
     ):
-        if result.copy_done is not None:
-            result.copy_done.synchronize()
+        self._wait_result_copy(result)
         if result.routed_experts_output is not None:
             result.routed_experts_output.finalize()
             result.routed_experts_output = None

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import threading
 from typing import TYPE_CHECKING, List, Optional, Union
 
 import torch
@@ -37,6 +38,9 @@ class GenerationBatchResult:
 
     # For overlap scheduling
     copy_done: Optional[torch.cuda.Event] = None
+    # Set instead of copy_done when the D2H readback is offloaded to the async
+    # copy worker (confidential-compute path). worker-done => copy-done.
+    copy_ready_cpu: Optional["threading.Event"] = None
     delay_sample_func: Optional[callable] = None
     future_indices: Optional[FutureIndices] = None
     speculative_num_draft_tokens: Optional[int] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3017,6 +3017,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.attention_layers = []
         self.moe_layers = []
         self.moe_fusions = []
+        self.nsa_indexers = []
         for layer in layer_model.layers:
             attn_layer = None
             if hasattr(layer, "self_attn"):
@@ -3069,6 +3070,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 moe_fusion = layer.mixer
             self.moe_layers.append(moe_block)
             self.moe_fusions.append(moe_fusion)
+            # NSA indexers (None for layers without NSA)
+            nsa_indexer = None
+            if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "indexer"):
+                nsa_indexer = layer.self_attn.indexer
+            self.nsa_indexers.append(nsa_indexer)
 
         if len(self.attention_layers) < self.model_config.num_hidden_layers:
             # TODO(yuwei): support Non-Standard GQA

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -304,6 +304,7 @@ class PiecewiseCudaGraphRunner:
         self.attention_layers = self.model_runner.attention_layers
         self.moe_layers = self.model_runner.moe_layers
         self.moe_fusions = self.model_runner.moe_fusions
+        self.nsa_indexers = getattr(self.model_runner, "nsa_indexers", None)
 
         if get_global_graph_memory_pool() is None:
             set_global_graph_memory_pool(self.device_module.graph_pool_handle())
@@ -444,6 +445,7 @@ class PiecewiseCudaGraphRunner:
             self.quant_config,
             self.moe_layers,
             self.moe_fusions,
+            nsa_indexers=self.nsa_indexers,
         ):
             _ = self.model_runner.model.forward(
                 forward_batch.input_ids,
@@ -632,6 +634,7 @@ class PiecewiseCudaGraphRunner:
                 self.quant_config,
                 self.moe_layers,
                 self.moe_fusions,
+                nsa_indexers=self.nsa_indexers,
             ):
                 self.model_runner.model.forward(
                     forward_batch.input_ids,
@@ -826,6 +829,7 @@ class PiecewiseCudaGraphRunner:
                 self.quant_config,
                 self.moe_layers,
                 self.moe_fusions,
+                nsa_indexers=self.nsa_indexers,
             ):
                 # Due to the dispatch kernel for MLA model, we init the metadata with original forward_batch
                 self.model_runner.attn_backend.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1366,6 +1366,10 @@ class ServerArgs:
         # 18. CUDA Graph debug mode
         if self.debug_cuda_graph:
             self.disable_piecewise_cuda_graph = True
+        # 19. NSA prefill context parallelism (attn_cp_size is set later in
+        # _handle_model_specific_adjustments, so check the flag directly here)
+        if self.enable_nsa_prefill_context_parallel:
+            self.disable_piecewise_cuda_graph = True
 
     def _handle_multi_item_scoring(self):
         """Setup and validate multi-item scoring constraints.
@@ -3168,22 +3172,6 @@ class ServerArgs:
             assert (
                 self.ep_size == 1
             ), "FP8/MXFP8 Cutlass MoE is only supported with ep_size == 1"
-
-        # TODO(yuwei): Fix piecewise cuda graph support for bypassed topk MoE backends.
-        # Exception: GptOssForCausalLM wraps the entire MoE block in its own
-        # custom op (moe_impl), so bypassed topk is handled inside the op body.
-        if (
-            not self.enforce_piecewise_cuda_graph
-            and self.moe_runner_backend in ("flashinfer_trtllm", "flashinfer_mxfp4")
-            and self.get_model_config().hf_config.architectures[0]
-            != "GptOssForCausalLM"
-        ):
-            self.disable_piecewise_cuda_graph = True
-            logger.info(
-                f"Piecewise cuda graph is disabled for MoE runner backend "
-                f"'{self.moe_runner_backend}' (bypassed topk is incompatible "
-                f"with torch.compile)."
-            )
 
     def _handle_a2a_moe(self):
         if self.enable_deepep_waterfill and self.moe_a2a_backend != "deepep":

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -661,6 +661,37 @@ def is_pin_memory_available(device=None) -> bool:
     return True
 
 
+@lru_cache(maxsize=1)
+def is_confidential_compute() -> bool:
+    """Whether the GPU is running in NVIDIA Confidential Computing (CC) mode.
+
+    Under bounce-buffer CC, device<->host copies are forced synchronous even
+    with ``non_blocking=True`` (the host destination is staged through an
+    encrypted bounce buffer). That breaks the overlap scheduler's per-step D2H
+    token readback. Detected once via NVML and cached. Overridable with
+    ``SGLANG_CONFIDENTIAL_COMPUTE=1/0`` (lets non-CC CI exercise the CC path,
+    and lets the NVML query be bypassed where pynvml is unavailable).
+    """
+    forced = os.environ.get("SGLANG_CONFIDENTIAL_COMPUTE")
+    if forced is not None:
+        return forced == "1"
+    if not torch.cuda.is_available():
+        return False
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        try:
+            state = pynvml.nvmlSystemGetConfComputeState()
+            # ccFeature != 0 means CC is enabled (ON or devtools).
+            return int(getattr(state, "ccFeature", 0)) != 0
+        finally:
+            pynvml.nvmlShutdown()
+    except Exception as e:
+        logger.debug("Confidential-compute detection failed: %r", e)
+        return False
+
+
 class LayerFn(Protocol):
 
     def __call__(self, idx: int, prefix: str) -> torch.nn.Module: ...

--- a/test/registered/core/test_overlap_copy_worker.py
+++ b/test/registered/core/test_overlap_copy_worker.py
@@ -1,0 +1,108 @@
+"""Unit tests for the confidential-compute async D2H copy worker.
+
+These validate that ``AsyncD2HCopyWorker`` performs the device->host readback
+correctly off the calling thread, and that the CC detection env override works.
+
+They need a GPU but NO model and NO actual confidential-compute hardware: the
+worker logic is identical regardless of CC (CC only changes whether the
+scheduler routes the readback through the worker). To exercise the worker on an
+ordinary GPU, run inside the sglang container:
+
+    python -m pytest test/registered/core/test_overlap_copy_worker.py -v
+"""
+
+import os
+import threading
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.managers.overlap_copy_worker import AsyncD2HCopyWorker
+from sglang.srt.utils.common import is_confidential_compute
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "AsyncD2HCopyWorker requires CUDA")
+class TestAsyncD2HCopyWorker(CustomTestCase):
+    def setUp(self):
+        self.copy_stream = torch.cuda.Stream()
+        self.worker = AsyncD2HCopyWorker(torch.cuda, self.copy_stream)
+
+    def tearDown(self):
+        # Idempotent: a no-op if a test already shut the worker down.
+        self.worker.shutdown()
+
+    def _run_one(self, numel: int):
+        src = torch.randn(numel, device="cuda")
+        expected = src.detach().to("cpu")  # synchronous reference copy
+
+        # Source is produced on the current (default) stream; record readiness
+        # exactly as the scheduler does before handing work to the worker.
+        src_ready = torch.cuda.Event()
+        src_ready.record()
+
+        out = {}
+
+        def copy_fn():
+            out["cpu"] = src.to("cpu", non_blocking=True)
+
+        done = threading.Event()
+        self.worker.submit(src_ready, copy_fn, done)
+
+        self.assertTrue(done.wait(timeout=30), "worker did not signal completion")
+        self.assertIn("cpu", out)
+        torch.testing.assert_close(out["cpu"], expected)
+
+    def test_single_readback_matches_synchronous(self):
+        self._run_one(4)  # tiny, like next_token_ids at small batch
+        self._run_one(151936)  # vocab-sized, like a logprob row
+
+    def test_many_sequential_readbacks(self):
+        # Mimics steady-state decode: one readback per "step".
+        for _ in range(64):
+            self._run_one(8)
+
+    def test_shutdown_is_idempotent_and_joins(self):
+        self.worker.shutdown()
+        self.worker.shutdown()  # second call must be a safe no-op
+        self.assertFalse(self.worker._thread.is_alive())
+
+    def test_copy_fn_exception_still_sets_done(self):
+        # A failing copy must not hang the scheduler: ``done`` is set in finally.
+        src_ready = torch.cuda.Event()
+        src_ready.record()
+        done = threading.Event()
+
+        def boom():
+            raise RuntimeError("injected copy failure")
+
+        self.worker.submit(src_ready, boom, done)
+        self.assertTrue(
+            done.wait(timeout=30), "done must be set even when the copy fails"
+        )
+
+
+class TestConfidentialComputeDetection(CustomTestCase):
+    """CC detection env override. Does not require CUDA (override short-circuits)."""
+
+    def test_env_override_true(self):
+        is_confidential_compute.cache_clear()
+        with mock.patch.dict(os.environ, {"SGLANG_CONFIDENTIAL_COMPUTE": "1"}):
+            is_confidential_compute.cache_clear()
+            self.assertTrue(is_confidential_compute())
+        is_confidential_compute.cache_clear()
+
+    def test_env_override_false(self):
+        is_confidential_compute.cache_clear()
+        with mock.patch.dict(os.environ, {"SGLANG_CONFIDENTIAL_COMPUTE": "0"}):
+            is_confidential_compute.cache_clear()
+            self.assertFalse(is_confidential_compute())
+        is_confidential_compute.cache_clear()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/piecewise_cuda_graph/test_pcg_glm5_fp4.py
+++ b/test/registered/piecewise_cuda_graph/test_pcg_glm5_fp4.py
@@ -1,0 +1,71 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=900, stage="base-c", runner_config="4-gpu-b200")
+
+GLM5_FP4_MODEL = "nvidia/GLM-5-NVFP4"
+
+
+class TestPCGGlm5Fp4(CustomTestCase):
+    """PCG prefill on GLM-5-NVFP4 (DSA model, TP=4, B200).
+
+    GLM-5 uses GlmMoeDsaForCausalLM (DSA attention). This test verifies that
+    piecewise CUDA graph works correctly after the DSA indexer was updated to
+    cache k_fp8/k_scale for PCG-compatible prefill.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = GLM5_FP4_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "4",
+                "--trust-remote-code",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--quantization",
+                "modelopt_fp4",
+                "--disable-flashinfer-autotune",
+                "--enforce-piecewise-cuda-graph",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true, "num_threads": 64}',
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            num_examples=200,
+            num_threads=200,
+            max_tokens=4096,
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.92)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Superseded by #31447.

---

Targets `release/v0.5.12`. Enables Confidential Computing (CC) inference on B300 (validated with Qwen3.5-397B-A17B-FP8, TP4).

**CC perf fixes** — auto-enabled when NVIDIA CC is detected (`is_confidential_compute()`), byte-identical off-CC:
- **Async D2H copy worker** — run the per-step D→H token readback on a dedicated daemon thread, so the forced-synchronous copy under bounce-buffer CC no longer blocks the scheduler and serializes overlap.
- **Ungate the FlashInfer AllReduce+RMSNorm fusion under CC** — build it on a multicast-free IPC workspace instead of disabling it (kernel parity with cc_off).

**Also included:** port of #23351 (piecewise CUDA graph with NSA) for DSA/NSA models.

See `CC_FIXES.md` for details.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
