### PR TITLE
[Diffusion] enable cache-dit for ERNIE-Image model

### DIFF
--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -222,6 +222,39 @@ class CacheDitConfig:
     steps_computation_policy: str = "dynamic"
 
 
+# Single-stream (ForwardPattern.Pattern_3) transformer models not registered in
+# cache-dit's BlockAdapterRegister, mapped to their block-list attribute name.
+# cache-dit auto-resolves check_forward_pattern and blocks_name, so only the
+# attribute name is model-specific here.
+_SINGLE_STREAM_PATTERN3_BLOCKS_ATTR: dict[str, str] = {
+    "ErnieImageTransformer2DModel": "layers",
+}
+
+
+def _build_custom_block_adapter(
+    transformer: torch.nn.Module,
+) -> Optional[BlockAdapter]:
+    """Build a manual BlockAdapter for a single-stream model absent from
+    cache-dit's registry, or None if the class is unknown."""
+    blocks_attr = _SINGLE_STREAM_PATTERN3_BLOCKS_ATTR.get(
+        transformer.__class__.__name__
+    )
+    if blocks_attr is None:
+        return None
+    blocks = getattr(transformer, blocks_attr, None)
+    if blocks is None:
+        raise ValueError(
+            f"Transformer {transformer.__class__.__name__} has no attribute "
+            f"{blocks_attr!r} for cache-dit blocks."
+        )
+    return BlockAdapter(
+        transformer=transformer,
+        blocks=blocks,
+        forward_pattern=ForwardPattern.Pattern_3,
+        has_separate_cfg=True,
+    )
+
+
 def enable_cache_on_transformer(
     transformer: torch.nn.Module,
     config: CacheDitConfig,
@@ -249,16 +282,21 @@ def enable_cache_on_transformer(
             "Please provide it in CacheDitConfig."
         )
 
-    # Check if the transformer is pre-registered in cache-dit
+    # Prefer the standard path (transformer pre-registered in cache-dit). For
+    # single-transformer models absent from the registry, fall back to a manual
+    # BlockAdapter (see _build_custom_block_adapter).
+    custom_adapter = None
     if not BlockAdapterRegister.is_supported(transformer):
-        transformer_cls_name = transformer.__class__.__name__
-        raise ValueError(
-            f"{transformer_cls_name} is not officially supported by cache-dit. "
-            "Supported cache-dit DiT families include Flux, QwenImage, HunyuanDiT, "
-            "HunyuanVideo, Wan, CogVideoX, Mochi, and others. "
-            "Please ensure your transformer belongs to one of these families or "
-            "define a custom BlockAdapter."
-        )
+        custom_adapter = _build_custom_block_adapter(transformer)
+        if custom_adapter is None:
+            transformer_cls_name = transformer.__class__.__name__
+            raise ValueError(
+                f"{transformer_cls_name} is not officially supported by cache-dit. "
+                "Supported cache-dit DiT families include Flux, QwenImage, HunyuanDiT, "
+                "HunyuanVideo, Wan, CogVideoX, Mochi, and others. "
+                "Please ensure your transformer belongs to one of these families or "
+                "define a custom BlockAdapter."
+            )
 
     # Build cache config (including SCM fields if provided)
     cache_config = DBCacheConfig(
@@ -312,12 +350,28 @@ def enable_cache_on_transformer(
 
     _mark_transformer_parallelized(transformer, parallelism_config, sp_group, tp_group)
 
-    cache_dit.enable_cache(
-        transformer,
-        cache_config=cache_config,
-        calibrator_config=calibrator_config,
-        parallelism_config=None,
-    )
+    if custom_adapter is not None:
+        # Custom path: pass a pre-built BlockAdapter, bypassing the registry.
+        logger.info(
+            "Enabling cache-dit on %s via custom BlockAdapter (%s).",
+            model_name,
+            custom_adapter.forward_pattern,
+        )
+        cache_dit.enable_cache(
+            custom_adapter,
+            cache_config=cache_config,
+            calibrator_config=calibrator_config,
+            parallelism_config=None,
+        )
+    else:
+        # Standard path: transformer is pre-registered in cache-dit's
+        # BlockAdapterRegister; let enable_cache discover the adapter.
+        cache_dit.enable_cache(
+            transformer,
+            cache_config=cache_config,
+            calibrator_config=calibrator_config,
+            parallelism_config=None,
+        )
 
     if parallelism_config is not None:
         context_manager = getattr(transformer, "_context_manager", None)

--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -222,25 +222,26 @@ class CacheDitConfig:
     steps_computation_policy: str = "dynamic"
 
 
-# Single-stream (ForwardPattern.Pattern_3) transformer models not registered in
-# cache-dit's BlockAdapterRegister, mapped to their block-list attribute name.
-# cache-dit auto-resolves check_forward_pattern and blocks_name, so only the
-# attribute name is model-specific here.
-_SINGLE_STREAM_PATTERN3_BLOCKS_ATTR: dict[str, str] = {
-    "ErnieImageTransformer2DModel": "layers",
+# Custom BlockAdapter for DiT models absent from cache-dit's BlockAdapterRegister.
+# Value: (blocks attr, forward_pattern, has_separate_cfg). forward_pattern must
+# match the block's forward signature (see cache_dit.ForwardPattern; e.g., ERNIE
+# uses Pattern_3). has_separate_cfg=True aligns cache-dit's step counter for
+# sequential CFG (two forwards per step); cache-dit auto-resolves the remaining
+# fields.
+_CUSTOM_BLOCK_ADAPTER_SPECS: dict[str, tuple[str, ForwardPattern, bool]] = {
+    "ErnieImageTransformer2DModel": ("layers", ForwardPattern.Pattern_3, True),
 }
 
 
 def _build_custom_block_adapter(
     transformer: torch.nn.Module,
 ) -> Optional[BlockAdapter]:
-    """Build a manual BlockAdapter for a single-stream model absent from
-    cache-dit's registry, or None if the class is unknown."""
-    blocks_attr = _SINGLE_STREAM_PATTERN3_BLOCKS_ATTR.get(
-        transformer.__class__.__name__
-    )
-    if blocks_attr is None:
+    """Build a manual BlockAdapter for a model absent from cache-dit's registry,
+    or None if the class is unknown."""
+    spec = _CUSTOM_BLOCK_ADAPTER_SPECS.get(transformer.__class__.__name__)
+    if spec is None:
         return None
+    blocks_attr, forward_pattern, has_separate_cfg = spec
     blocks = getattr(transformer, blocks_attr, None)
     if blocks is None:
         raise ValueError(
@@ -250,8 +251,8 @@ def _build_custom_block_adapter(
     return BlockAdapter(
         transformer=transformer,
         blocks=blocks,
-        forward_pattern=ForwardPattern.Pattern_3,
-        has_separate_cfg=True,
+        forward_pattern=forward_pattern,
+        has_separate_cfg=has_separate_cfg,
     )
 
 
@@ -283,8 +284,8 @@ def enable_cache_on_transformer(
         )
 
     # Prefer the standard path (transformer pre-registered in cache-dit). For
-    # single-transformer models absent from the registry, fall back to a manual
-    # BlockAdapter (see _build_custom_block_adapter).
+    # models absent from the registry, fall back to a manual BlockAdapter (see
+    # _build_custom_block_adapter).
     custom_adapter = None
     if not BlockAdapterRegister.is_supported(transformer):
         custom_adapter = _build_custom_block_adapter(transformer)

--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -351,28 +351,22 @@ def enable_cache_on_transformer(
 
     _mark_transformer_parallelized(transformer, parallelism_config, sp_group, tp_group)
 
+    # Custom path: pass a pre-built BlockAdapter, bypassing the registry.
+    # Standard path: let enable_cache discover the registered adapter.
+    target = transformer
     if custom_adapter is not None:
-        # Custom path: pass a pre-built BlockAdapter, bypassing the registry.
+        target = custom_adapter
         logger.info(
             "Enabling cache-dit on %s via custom BlockAdapter (%s).",
             model_name,
             custom_adapter.forward_pattern,
         )
-        cache_dit.enable_cache(
-            custom_adapter,
-            cache_config=cache_config,
-            calibrator_config=calibrator_config,
-            parallelism_config=None,
-        )
-    else:
-        # Standard path: transformer is pre-registered in cache-dit's
-        # BlockAdapterRegister; let enable_cache discover the adapter.
-        cache_dit.enable_cache(
-            transformer,
-            cache_config=cache_config,
-            calibrator_config=calibrator_config,
-            parallelism_config=None,
-        )
+    cache_dit.enable_cache(
+        target,
+        cache_config=cache_config,
+        calibrator_config=calibrator_config,
+        parallelism_config=None,
+    )
 
     if parallelism_config is not None:
         context_manager = getattr(transformer, "_context_manager", None)

--- a/python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py
@@ -34,9 +34,9 @@ def _install_cache_dit_stub():
 
     cache_dit.refresh_context = refresh_context
     cache_dit.steps_mask = steps_mask
-    cache_dit.BlockAdapter = object
+    cache_dit.BlockAdapter = types.SimpleNamespace
     cache_dit.DBCacheConfig = _FakeDBCacheConfig
-    cache_dit.ForwardPattern = object
+    cache_dit.ForwardPattern = types.SimpleNamespace(Pattern_3="Pattern_3")
     cache_dit.ParamsModifier = object
     cache_dit.TaylorSeerCalibratorConfig = object
 
@@ -125,28 +125,29 @@ def _install_torch_stub():
     }
 
 
-class TestCacheDitRefreshContext(unittest.TestCase):
-    def _import_module_with_stub(self):
-        stub_modules = _install_cache_dit_stub()
-        stub_modules.update(_install_sglang_dependency_stubs())
-        stub_modules.update(_install_torch_stub())
-        module_path = (
-            Path(__file__).resolve().parents[2]
-            / "runtime"
-            / "cache"
-            / "cache_dit_integration.py"
+def _import_module_with_stub():
+    stub_modules = _install_cache_dit_stub()
+    stub_modules.update(_install_sglang_dependency_stubs())
+    stub_modules.update(_install_torch_stub())
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "runtime"
+        / "cache"
+        / "cache_dit_integration.py"
+    )
+    with patch.dict(sys.modules, stub_modules):
+        spec = importlib.util.spec_from_file_location(
+            "test_cache_dit_integration_target", module_path
         )
-        with patch.dict(sys.modules, stub_modules):
-            spec = importlib.util.spec_from_file_location(
-                "test_cache_dit_integration_target", module_path
-            )
-            module = importlib.util.module_from_spec(spec)
-            assert spec.loader is not None
-            spec.loader.exec_module(module)
-        return module
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+    return module
 
+
+class TestCacheDitRefreshContext(unittest.TestCase):
     def test_refresh_context_without_scm_preset_skips_steps_mask(self):
-        module = self._import_module_with_stub()
+        module = _import_module_with_stub()
         module.refresh_context_on_transformer(
             transformer="transformer",
             num_inference_steps=50,
@@ -166,7 +167,7 @@ class TestCacheDitRefreshContext(unittest.TestCase):
         )
 
     def test_refresh_context_with_scm_preset_uses_steps_mask(self):
-        module = self._import_module_with_stub()
+        module = _import_module_with_stub()
         module.refresh_context_on_transformer(
             transformer="transformer",
             num_inference_steps=8,
@@ -187,7 +188,7 @@ class TestCacheDitRefreshContext(unittest.TestCase):
         )
 
     def test_dual_refresh_without_scm_preset_skips_steps_mask(self):
-        module = self._import_module_with_stub()
+        module = _import_module_with_stub()
         module.refresh_context_on_dual_transformer(
             transformer="transformer",
             transformer_2="transformer_2",
@@ -214,6 +215,40 @@ class TestCacheDitRefreshContext(unittest.TestCase):
                 "steps_computation_policy": None,
             },
         )
+
+
+def _make_transformer(class_name, layers=None):
+    transformer = type(class_name, (), {})()
+    if layers is not None:
+        transformer.layers = layers
+    return transformer
+
+
+class TestBuildCustomBlockAdapter(unittest.TestCase):
+    def test_builds_adapter_for_registered_class(self):
+        module = _import_module_with_stub()
+        blocks = ["block_0", "block_1"]
+        transformer = _make_transformer("ErnieImageTransformer2DModel", blocks)
+
+        adapter = module._build_custom_block_adapter(transformer)
+
+        self.assertIsNotNone(adapter)
+        self.assertEqual(adapter.blocks, blocks)
+        self.assertEqual(adapter.forward_pattern, "Pattern_3")
+        self.assertTrue(adapter.has_separate_cfg)
+
+    def test_returns_none_for_unknown_class(self):
+        module = _import_module_with_stub()
+        transformer = _make_transformer("SomeUnregisteredTransformer", ["b0"])
+
+        self.assertIsNone(module._build_custom_block_adapter(transformer))
+
+    def test_raises_when_blocks_attr_missing(self):
+        module = _import_module_with_stub()
+        transformer = _make_transformer("ErnieImageTransformer2DModel")
+
+        with self.assertRaises(ValueError):
+            module._build_custom_block_adapter(transformer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The upstream cache-dit library does not officially register ERNIE-Image's transformer (`ErnieImageTransformer2DModel`) in its `BlockAdapterRegister`. `vllm-omni` fills this gap with a custom adapter of its own [#2861](https://github.com/vllm-project/vllm-omni/pull/2861), but SGLang has no equivalent adaptation — so enabling cache-dit on `PaddlePaddle/ERNIE-Image` crashes at the very first denoising step:

```
ValueError: ErnieImageTransformer2DModel is not officially supported by cache-dit. Supported cache-dit DiT families include Flux, QwenImage, HunyuanDiT, HunyuanVideo, Wan, CogVideoX, Mochi, and others.
```

This PR adds cache-dit support for ERNIE-Image (and, via the same mechanism, any DiT absent from cache-dit's registry) via a lightweight custom `BlockAdapter`.


## Modifications

<!-- Detail the changes made in this pull request. -->

**`python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py`**

- Add `_build_custom_block_adapter()` backed by a `_CUSTOM_BLOCK_ADAPTER_SPECS` registry that maps each unsupported transformer class to a `(blocks_attr, forward_pattern, has_separate_cfg)` triple. For transformers absent from cache-dit's `BlockAdapterRegister`, it builds a manual `BlockAdapter` instead of raising. `forward_pattern` is a per-model field, so the same path serves any block I/O signature (ERNIE's block uses `Pattern_3`; dual-stream patterns would work identically). Adding a new model is one line: `"ClassName": (blocks_attr, forward_pattern, has_separate_cfg)`.
- Wire it into `enable_cache_on_transformer()`: when `BlockAdapterRegister.is_supported(transformer)` is `False`, fall back to the custom adapter; only raise if the class also has no custom entry.

**`python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py`**

- Unit tests for `_build_custom_block_adapter()`: the spec values flow correctly into the `BlockAdapter`, unknown classes return `None` (the caller's contract for "not supported"), and a missing `blocks` attribute raises `ValueError`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

cmd (910B):
```
without cache-dit:
python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate \
    --model-path "/root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image" \
    --prompt "This is a photograph depicting an urban street scene. Shot at eye level, it shows a covered pedestrian or commercial street. Slightly below the center of the frame, a cyclist rides away from the camera toward the background, appearing as a dark silhouette against backlighting with indistinct details. The ground is paved with regular square tiles, bisected by a prominent tactile paving strip running through the scene, whose raised textures are clearly visible under the light. Light streams in diagonally from the right side of the frame, creating a strong backlight effect with a distinct Tyndall effect—visible light beams illuminating dust or vapor in the air and casting long shadows across the street. Several pedestrians appear on the left side and in the distance, some with their backs to the camera and others walking sideways, all rendered as silhouettes or semi-silhouettes. The overall color palette is warm, dominated by golden yellows and dark browns, evoking the atmosphere of dusk or early morning." \
    --num-gpus 1 \
    --height 1264 \
    --width 848

with cache-dit:
SGLANG_CACHE_DIT_ENABLED=true python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate \
    --model-path "/root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image" \
    --prompt "This is a photograph depicting an urban street scene. Shot at eye level, it shows a covered pedestrian or commercial street. Slightly below the center of the frame, a cyclist rides away from the camera toward the background, appearing as a dark silhouette against backlighting with indistinct details. The ground is paved with regular square tiles, bisected by a prominent tactile paving strip running through the scene, whose raised textures are clearly visible under the light. Light streams in diagonally from the right side of the frame, creating a strong backlight effect with a distinct Tyndall effect—visible light beams illuminating dust or vapor in the air and casting long shadows across the street. Several pedestrians appear on the left side and in the distance, some with their backs to the camera and others walking sideways, all rendered as silhouettes or semi-silhouettes. The overall color palette is warm, dominated by golden yellows and dark browns, evoking the atmosphere of dusk or early morning." \
    --num-gpus 1 \
    --height 1264 \
    --width 848
```

1. run ERNIE-Image without cache-dit: Pass
<img width="848" height="1264" alt="without cache-dit" src="https://github.com/user-attachments/assets/0c3b6172-3ffb-4559-95fc-71ca2ab42449" />

<details>
<summary> Full log: run ERNIE-Image without cache-dit </summary>
[06-15 07:56:09] server_args: {"model_path": "/root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "performance_mode": "auto", "base_gpu_id": 0, "gpu_ids": null, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_merge_mode": "auto", "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "component_transformer_weights_paths": {}, "quantization": null, "quantization_ignored_layers": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": false, "layerwise_offload_components": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "enable_layerwise_nvtx_marker": false, "warmup_mode": "off", "warmup": false, "server_warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5604, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "disagg_role": "monolithic", "disagg_timeout": 3600, "disagg_downstream_wait_timeout": 1800, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_instance_id": 0, "disagg_max_slots_per_instance": 8, "disagg_transfer_redundancy": 1.25, "disagg_role_device": "auto", "disagg_transfer_backend": "auto", "disagg_transfer_pool_size": 268435456, "disagg_transfer_pin_memory": "auto", "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_sp": null, "decoder_tp": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "pool_control_endpoint": null, "pool_control_advertised_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[06-15 07:56:09] Diffusers version: 0.36.0
[06-15 07:56:09] Local mode: True
[06-15 07:56:09] Starting server...
[06-15 07:56:30] Scheduler bind at endpoint: tcp://127.0.0.1:5604
[06-15 07:56:31] torch.compile cache: TORCHINDUCTOR_CACHE_DIR=/root/.cache/sgl_diffusion/torch_compile_cache/inductor TRITON_CACHE_DIR=/root/.cache/sgl_diffusion/torch_compile_cache/triton
[06-15 07:56:31] Initializing distributed environment with world_size=1, device=npu:0, timeout=3600
[06-15 07:56:31] Setting distributed timeout to 3600 seconds
[06-15 07:56:31] No pipeline_class_name specified, using model_index.json
[06-15 07:56:32] Diffusers version: 0.36.0
[06-15 07:56:32] Using pipeline from model_index.json: ErnieImagePipeline
[06-15 07:56:32] Loading pipeline modules...
[06-15 07:56:32] Diffusers version: 0.36.0
[06-15 07:56:32] PE model detected in model_index.json, will load PE module.
[06-15 07:56:32] Set text encoder model_max_length=2048 from tokenizer/tokenizer_config.json
[06-15 07:56:32] Set PE model_max_length=2048 from pe/tokenizer_config.json
[06-15 07:56:32] Model already exists locally and is complete
[06-15 07:56:32] Model path: /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image
[06-15 07:56:32] Diffusers version: 0.36.0
[06-15 07:56:32] Loading pipeline modules from config: {'_class_name': 'ErnieImagePipeline', '_diffusers_version': '0.36.0', 'scheduler': ['diffusers', 'FlowMatchEulerDiscreteScheduler'], 'pe': ['transformers', 'Ministral3ForCausalLM'], 'pe_tokenizer': ['transformers', 'TokenizersBackend'], 'text_encoder': ['transformers', 'Mistral3Model'], 'tokenizer': ['transformers', 'TokenizersBackend'], 'transformer': ['diffusers', 'ErnieImageTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderKLFlux2']}
[06-15 07:56:32] Loading required components: ['pe', 'text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
[06-15 07:56:32] Memory-aware component load order: ['transformer', 'text_encoder', 'pe', 'vae', 'tokenizer', 'scheduler']

Loading required modules:   0%|          | 0/6 [00:00<?, ?it/s][06-15 07:56:32] Loading transformer from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/transformer. avail mem: 60.57 GB
[06-15 07:56:32] Loading ErnieImageTransformer2DModel from 2 safetensors file(s) , param_dtype: torch.bfloat16
[06-15 07:56:32] Using Torch SDPA backend.


Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
[A

Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  3.71it/s]
[A

Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  4.94it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  4.70it/s]

[06-15 07:56:38] Loaded transformer: ErnieImageTransformer2DModel (sgl-diffusion version). model size: 14.96 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.56 GB
[06-15 07:56:38] Attention backends for transformer: torch_sdpa

Loading required modules:  17%|█▋        | 1/6 [00:06<00:32,  6.60s/it][06-15 07:56:38] Loading text_encoder from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/text_encoder. avail mem: 60.56 GB
[06-15 07:56:38] Component: text_encoder doesn't have a customized version yet, using native version
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!


Loading weights:   0%|          | 0/458 [00:00<?, ?it/s][A
Loading weights: 100%|██████████| 458/458 [00:00<00:00, 4962.08it/s]
[93m[06-15 07:58:45] Native component text_encoder: Mistral3Model is loaded, performance may be sub-optimal[0;0m
[06-15 07:58:45] Loaded text_encoder: Mistral3Model (native version). model size: 7.18 GB, consumed GPU mem: 7.57 GB, avail GPU mem: 52.99 GB

Loading required modules:  33%|███▎      | 2/6 [02:12<05:08, 77.02s/it][06-15 07:58:45] Loading pe from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/pe. avail mem: 52.99 GB
[06-15 07:58:45] Loading PE model from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/pe ...
[06-15 07:58:45] PE model_max_length=2048 (from tokenizer_config.json)


Loading weights:   0%|          | 0/237 [00:00<?, ?it/s][A
Loading weights: 100%|██████████| 237/237 [00:00<00:00, 5153.03it/s]
[06-15 08:00:52] PE model: using Flash Attention 2
[06-15 08:00:54] PE model loaded on npu:0: Ministral3ForCausalLM (attn=flash_attention_2)
[06-15 08:00:54] Loaded pe: PEModelWrapper (sgl-diffusion version). model size: NA GB, consumed GPU mem: 6.67 GB, avail GPU mem: 46.32 GB

Loading required modules:  50%|█████     | 3/6 [04:21<05:02, 100.70s/it][06-15 08:00:54] Loading vae from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/vae. avail mem: 46.32 GB
[06-15 08:00:54] Loaded vae: AutoencoderKLFlux2 (sgl-diffusion version). model size: 0.31 GB, consumed GPU mem: 0.34 GB, avail GPU mem: 45.98 GB

Loading required modules:  67%|██████▋   | 4/6 [04:22<02:02, 61.06s/it] [06-15 08:00:54] Loading tokenizer from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/tokenizer. avail mem: 45.98 GB
[06-15 08:00:58] Loaded tokenizer: TokenizersBackend (sgl-diffusion version). model size: NA GB, consumed GPU mem: -0.00 GB, avail GPU mem: 45.99 GB

Loading required modules:  83%|████████▎ | 5/6 [04:25<00:40, 40.38s/it][06-15 08:00:58] Loading scheduler from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/scheduler. avail mem: 45.99 GB
[06-15 08:00:58] Loaded scheduler: FlowMatchEulerDiscreteScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 45.99 GB

Loading required modules: 100%|██████████| 6/6 [04:25<00:00, 44.30s/it]
[06-15 08:00:58] Creating pipeline stages...
[06-15 08:00:58] Using Torch SDPA backend.
[06-15 08:00:58] Using torch_sdpa attention backend
[06-15 08:00:58] Pipeline instantiated
[06-15 08:00:58] Worker 0: Initialized device, model, and distributed environment.
[06-15 08:00:58] Worker 0: Scheduler loop started.
[06-15 08:00:58] Processing 1 grouped request(s)
[06-15 08:00:58] Sampling params:
                       width: 848
                      height: 1264
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=1017>
                  neg_prompt: <redacted, len=1>
                        seed: 42
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 5.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: outputs/This_is_a_photograph_depicting_an_urban_street_scene._Shot_at_eye_level_it_shows_a_covered_pedestri_20260615-080058_3c5863af.png
        
[06-15 08:00:58] Running pipeline stages: ['InputValidationStage', 'prompt_enhancement_stage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'denoising_stage', 'decoding_stage']
[06-15 08:00:58] [InputValidationStage] started...
[06-15 08:00:58] [InputValidationStage] finished in 0.0001 seconds
[06-15 08:00:58] [PromptEnhancementStage] started...
[06-15 08:01:15] PE enhanced prompt: 这是一张展现都市街景的写实风格照片，采用平视角度拍摄，呈现为一条被顶棚覆盖的通行人或商业街。画面中央略低于中心位置处，一名骑行者正向画面远方骑行，因背光形成深色轮廓，细节难以看清；地面由规整的方形石板铺成，被一条明显的盲道分隔带穿过，其凸起的纹理在光线下清晰可见。光线从画面右侧斜射入，形成强烈的逆光效果，产生明显的丁达尔现象——光束穿透空气中漂浮的尘埃或雾气，在地面投下长长的阴影。左侧和远处有数名行人走动，他们因大光圈虚化效果而呈现为模糊的轮廓或半剪影，其中左侧一人背对镜头，远处一人侧身而行。画面整体色调偏暖，呈金黄与深褐色调，营造出黄昏或清晨时分的氛围。
[06-15 08:01:15] [PromptEnhancementStage] finished in 17.6986 seconds
[06-15 08:01:15] [TextEncodingStage] started...
[06-15 08:01:15] [TextEncodingStage] finished in 0.1619 seconds
[06-15 08:01:15] [TimestepPreparationStage] started...
[06-15 08:01:15] [TimestepPreparationStage] finished in 0.0032 seconds
[06-15 08:01:15] [LatentPreparationStage] started...
[06-15 08:01:15] [LatentPreparationStage] finished in 0.0013 seconds
[06-15 08:01:15] [DenoisingStage] started...

  0%|          | 0/50 [00:00<?, ?it/s]
  2%|▏         | 1/50 [00:26<22:02, 26.99s/it]
  4%|▍         | 2/50 [00:27<08:59, 11.25s/it]
  6%|▌         | 3/50 [00:28<05:06,  6.53s/it]
  8%|▊         | 4/50 [00:29<03:18,  4.32s/it]
 10%|█         | 5/50 [00:29<02:19,  3.09s/it]
 12%|█▏        | 6/50 [00:30<01:43,  2.35s/it]
 14%|█▍        | 7/50 [00:31<01:20,  1.88s/it]
 16%|█▌        | 8/50 [00:32<01:06,  1.57s/it]
 18%|█▊        | 9/50 [00:33<00:56,  1.37s/it]
 20%|██        | 10/50 [00:34<00:49,  1.23s/it]
 22%|██▏       | 11/50 [00:35<00:44,  1.13s/it]
 24%|██▍       | 12/50 [00:36<00:40,  1.07s/it]
 26%|██▌       | 13/50 [00:37<00:37,  1.02s/it]
 28%|██▊       | 14/50 [00:38<00:35,  1.01it/s]
 30%|███       | 15/50 [00:39<00:33,  1.03it/s]
 32%|███▏      | 16/50 [00:40<00:32,  1.05it/s]
 34%|███▍      | 17/50 [00:40<00:31,  1.06it/s]
 36%|███▌      | 18/50 [00:41<00:29,  1.07it/s]
 38%|███▊      | 19/50 [00:42<00:28,  1.08it/s]
 40%|████      | 20/50 [00:43<00:27,  1.07it/s]
 42%|████▏     | 21/50 [00:44<00:26,  1.09it/s]
 44%|████▍     | 22/50 [00:45<00:25,  1.09it/s]
 46%|████▌     | 23/50 [00:46<00:24,  1.09it/s]
 48%|████▊     | 24/50 [00:47<00:23,  1.09it/s]
 50%|█████     | 25/50 [00:48<00:22,  1.09it/s]
 52%|█████▏    | 26/50 [00:49<00:22,  1.09it/s]
 54%|█████▍    | 27/50 [00:50<00:21,  1.09it/s]
 56%|█████▌    | 28/50 [00:51<00:20,  1.09it/s]
 58%|█████▊    | 29/50 [00:51<00:19,  1.09it/s]
 60%|██████    | 30/50 [00:52<00:18,  1.09it/s]
 62%|██████▏   | 31/50 [00:53<00:17,  1.09it/s]
 64%|██████▍   | 32/50 [00:54<00:16,  1.09it/s]
 66%|██████▌   | 33/50 [00:55<00:15,  1.09it/s]
 68%|██████▊   | 34/50 [00:56<00:14,  1.09it/s]
 70%|███████   | 35/50 [00:57<00:13,  1.09it/s]
 72%|███████▏  | 36/50 [00:58<00:12,  1.09it/s]
 74%|███████▍  | 37/50 [00:59<00:11,  1.09it/s]
 76%|███████▌  | 38/50 [01:00<00:11,  1.09it/s]
 78%|███████▊  | 39/50 [01:01<00:10,  1.09it/s]
 80%|████████  | 40/50 [01:02<00:09,  1.09it/s]
 82%|████████▏ | 41/50 [01:02<00:08,  1.09it/s]
 84%|████████▍ | 42/50 [01:03<00:07,  1.09it/s]
 86%|████████▌ | 43/50 [01:04<00:06,  1.09it/s]
 88%|████████▊ | 44/50 [01:05<00:05,  1.09it/s]
 90%|█████████ | 45/50 [01:06<00:04,  1.09it/s]
 92%|█████████▏| 46/50 [01:07<00:03,  1.09it/s]
 94%|█████████▍| 47/50 [01:08<00:02,  1.09it/s]
 96%|█████████▌| 48/50 [01:09<00:01,  1.09it/s]
 98%|█████████▊| 49/50 [01:10<00:00,  1.09it/s]
100%|██████████| 50/50 [01:11<00:00,  1.09it/s]
100%|██████████| 50/50 [01:11<00:00,  1.42s/it]
[06-15 08:02:27] [DenoisingStage] average time per step: 1.4249 seconds
[06-15 08:02:27] [DenoisingStage] finished in 71.2557 seconds
[06-15 08:02:27] [DecodingStage] started...
/root/ernie/sgl2/lib/python3.11/site-packages/torch/amp/autocast_mode.py:328: UserWarning: In npu autocast, but the target dtype is not supported. Disabling autocast.
 npu Autocast only supports dtypes of torch.float16, torch.bfloat16 currently.
  warnings.warn(error_message)
[06-15 08:02:27] [DecodingStage] finished in 0.2501 seconds
.[06-15 08:02:32] Output saved to [1;36moutputs/This_is_a_photograph_depicting_an_urban_street_scene._Shot_at_eye_level_it_shows_a_covered_pedestri_20260615-080058_3c5863af.png[0;0m
[06-15 08:02:32] Pixel data generated successfully in [92m94.39[0;0m seconds
[06-15 08:02:32] Memory usage - Max peak: 36930.00 MB, Avg peak: 36930.00 MB
[93m[06-15 08:02:32] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[06-15 08:02:33] Worker 0: Shutdown complete.
[93m[06-15 08:02:42] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m

</details>




2. run ERNIE-Image with cache-dit: Pass
<img width="848" height="1264" alt="with cache-dit" src="https://github.com/user-attachments/assets/7e10e20e-5e83-4ce2-bd73-bc40bb8f92a6" />

<details>
<summary> Full log: run ERNIE-Image with cache-dit </summary>
[06-15 07:33:25] server_args: {"model_path": "/root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "performance_mode": "auto", "base_gpu_id": 0, "gpu_ids": null, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_merge_mode": "auto", "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "component_transformer_weights_paths": {}, "quantization": null, "quantization_ignored_layers": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": false, "layerwise_offload_components": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "enable_layerwise_nvtx_marker": false, "warmup_mode": "off", "warmup": false, "server_warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5636, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "disagg_role": "monolithic", "disagg_timeout": 3600, "disagg_downstream_wait_timeout": 1800, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_instance_id": 0, "disagg_max_slots_per_instance": 8, "disagg_transfer_redundancy": 1.25, "disagg_role_device": "auto", "disagg_transfer_backend": "auto", "disagg_transfer_pool_size": 268435456, "disagg_transfer_pin_memory": "auto", "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_sp": null, "decoder_tp": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "pool_control_endpoint": null, "pool_control_advertised_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[06-15 07:33:25] Diffusers version: 0.36.0
[06-15 07:33:25] Local mode: True
[06-15 07:33:25] Starting server...
[06-15 07:33:49] Scheduler bind at endpoint: tcp://127.0.0.1:5636
[06-15 07:33:51] torch.compile cache: TORCHINDUCTOR_CACHE_DIR=/root/.cache/sgl_diffusion/torch_compile_cache/inductor TRITON_CACHE_DIR=/root/.cache/sgl_diffusion/torch_compile_cache/triton
[06-15 07:33:51] Initializing distributed environment with world_size=1, device=npu:0, timeout=3600
[06-15 07:33:51] Setting distributed timeout to 3600 seconds
[06-15 07:33:51] No pipeline_class_name specified, using model_index.json
[06-15 07:33:51] Diffusers version: 0.36.0
[06-15 07:33:51] Using pipeline from model_index.json: ErnieImagePipeline
[06-15 07:33:51] Loading pipeline modules...
[06-15 07:33:51] Diffusers version: 0.36.0
[06-15 07:33:51] PE model detected in model_index.json, will load PE module.
[06-15 07:33:51] Set text encoder model_max_length=2048 from tokenizer/tokenizer_config.json
[06-15 07:33:51] Set PE model_max_length=2048 from pe/tokenizer_config.json
[06-15 07:33:51] Model already exists locally and is complete
[06-15 07:33:51] Model path: /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image
[06-15 07:33:51] Diffusers version: 0.36.0
[06-15 07:33:51] Loading pipeline modules from config: {'_class_name': 'ErnieImagePipeline', '_diffusers_version': '0.36.0', 'scheduler': ['diffusers', 'FlowMatchEulerDiscreteScheduler'], 'pe': ['transformers', 'Ministral3ForCausalLM'], 'pe_tokenizer': ['transformers', 'TokenizersBackend'], 'text_encoder': ['transformers', 'Mistral3Model'], 'tokenizer': ['transformers', 'TokenizersBackend'], 'transformer': ['diffusers', 'ErnieImageTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderKLFlux2']}
[06-15 07:33:51] Loading required components: ['pe', 'text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
[06-15 07:33:51] Memory-aware component load order: ['transformer', 'text_encoder', 'pe', 'vae', 'tokenizer', 'scheduler']

Loading required modules:   0%|          | 0/6 [00:00<?, ?it/s][06-15 07:33:51] Loading transformer from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/transformer. avail mem: 60.56 GB
[06-15 07:33:51] Loading ErnieImageTransformer2DModel from 2 safetensors file(s) , param_dtype: torch.bfloat16
[06-15 07:33:51] Using Torch SDPA backend.


Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
[A

Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  3.67it/s]
[A

Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  5.18it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  4.87it/s]

[06-15 07:33:57] Loaded transformer: ErnieImageTransformer2DModel (sgl-diffusion version). model size: 14.96 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.56 GB
[06-15 07:33:57] Attention backends for transformer: torch_sdpa

Loading required modules:  17%|█▋        | 1/6 [00:06<00:30,  6.17s/it][06-15 07:33:57] Loading text_encoder from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/text_encoder. avail mem: 60.56 GB
[06-15 07:33:57] Component: text_encoder doesn't have a customized version yet, using native version
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!


Loading weights:   0%|          | 0/458 [00:00<?, ?it/s][A
Loading weights: 100%|██████████| 458/458 [00:00<00:00, 5069.14it/s]
[93m[06-15 07:35:52] Native component text_encoder: Mistral3Model is loaded, performance may be sub-optimal[0;0m
[06-15 07:35:52] Loaded text_encoder: Mistral3Model (native version). model size: 7.18 GB, consumed GPU mem: 7.57 GB, avail GPU mem: 52.99 GB

Loading required modules:  33%|███▎      | 2/6 [02:01<04:40, 70.17s/it][06-15 07:35:52] Loading pe from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/pe. avail mem: 52.99 GB
[06-15 07:35:52] Loading PE model from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/pe ...
[06-15 07:35:52] PE model_max_length=2048 (from tokenizer_config.json)


Loading weights:   0%|          | 0/237 [00:00<?, ?it/s][A
Loading weights: 100%|██████████| 237/237 [00:00<00:00, 5114.35it/s]
[06-15 07:37:48] PE model: using Flash Attention 2
[06-15 07:37:49] PE model loaded on npu:0: Ministral3ForCausalLM (attn=flash_attention_2)
[06-15 07:37:49] Loaded pe: PEModelWrapper (sgl-diffusion version). model size: NA GB, consumed GPU mem: 6.67 GB, avail GPU mem: 46.32 GB

Loading required modules:  50%|█████     | 3/6 [03:57<04:34, 91.47s/it][06-15 07:37:49] Loading vae from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/vae. avail mem: 46.32 GB
[06-15 07:37:49] Loaded vae: AutoencoderKLFlux2 (sgl-diffusion version). model size: 0.31 GB, consumed GPU mem: 0.34 GB, avail GPU mem: 45.98 GB

Loading required modules:  67%|██████▋   | 4/6 [03:58<01:50, 55.47s/it][06-15 07:37:49] Loading tokenizer from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/tokenizer. avail mem: 45.98 GB
[06-15 07:37:53] Loaded tokenizer: TokenizersBackend (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 45.98 GB

Loading required modules:  83%|████████▎ | 5/6 [04:01<00:36, 36.79s/it][06-15 07:37:53] Loading scheduler from /root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image/scheduler. avail mem: 45.98 GB
[06-15 07:37:53] Loaded scheduler: FlowMatchEulerDiscreteScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 45.98 GB

Loading required modules: 100%|██████████| 6/6 [04:01<00:00, 40.32s/it]
[06-15 07:37:53] Creating pipeline stages...
[06-15 07:37:53] Using Torch SDPA backend.
[06-15 07:37:53] Using torch_sdpa attention backend
[06-15 07:37:53] Pipeline instantiated
[06-15 07:37:53] Worker 0: Initialized device, model, and distributed environment.
[06-15 07:37:53] Worker 0: Scheduler loop started.
[06-15 07:37:53] Processing 1 grouped request(s)
[06-15 07:37:53] Sampling params:
                       width: 848
                      height: 1264
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=1017>
                  neg_prompt: <redacted, len=1>
                        seed: 42
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 5.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: outputs/This_is_a_photograph_depicting_an_urban_street_scene._Shot_at_eye_level_it_shows_a_covered_pedestri_20260615-073753_65d6dfdb.png
        
[06-15 07:37:53] Running pipeline stages: ['InputValidationStage', 'prompt_enhancement_stage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'denoising_stage', 'decoding_stage']
[06-15 07:37:53] [InputValidationStage] started...
[06-15 07:37:53] [InputValidationStage] finished in 0.0001 seconds
[06-15 07:37:53] [PromptEnhancementStage] started...
[06-15 07:38:13] PE enhanced prompt: 这是一张呈现城市街道场景的摄影作品，采用平视视角拍摄，画面主体为一条被照明条柱覆盖的步行或商业街，背景光线强烈呈放射状，形成明显的丁达尔效应，光束穿透空气中的微粒。画面中央偏下位置，一名骑行者正背对镜头，沿街道纵向向远处行进，骑行者呈现出深色剪影状态，细节因逆光而不清晰。地面铺设规整的方形地砖，中央有一条醒目的触觉铺装条带（盲道）从前景延伸至背景，其横向凸起纹理在光线照射下清晰可见。光线从画面右侧斜射入，产生强烈的背光效果，使光线在空气中形成可见的光束路径，并在地面投下长条状阴影。画面左侧及远处有几位行人，有的背对镜头，有的侧身行走，他们均呈现剪影或半剪影状态，有的背着背包，有的身着背心与短裤。整体色调以暖黄色和深棕色为主，营造出黄昏或清晨时分的光线氛围。
[06-15 07:38:13] [PromptEnhancementStage] finished in 20.0972 seconds
[06-15 07:38:13] [TextEncodingStage] started...
[06-15 07:38:13] [TextEncodingStage] finished in 0.1599 seconds
[06-15 07:38:13] [TimestepPreparationStage] started...
[06-15 07:38:13] [TimestepPreparationStage] finished in 0.0032 seconds
[06-15 07:38:13] [LatentPreparationStage] started...
[06-15 07:38:13] [LatentPreparationStage] finished in 0.0013 seconds
[06-15 07:38:13] [DenoisingStage] started...
[06-15 07:38:13] [Cache-DiT] pipe is None, use FakeDiffusionPipeline instead.
[06-15 07:38:13] [Cache-DiT] Auto fill blocks_name: layers.
[06-15 07:38:13] [Cache-DiT] Found transformer NOT from diffusers: sglang.multimodal_gen.runtime.models.dits.ernie_image disable check_forward_pattern by default.
[06-15 07:38:13] Enabling cache-dit on transformer with config: Fn=1, Bn=0, W=4, R=0.24, MC=3, TaylorSeer=False (order=1), steps=50
[06-15 07:38:13] Enabling cache-dit on transformer via custom BlockAdapter (ForwardPattern.Pattern_3).
[06-15 07:38:13] [Cache-DiT] Adapting Cache Acceleration using custom BlockAdapter!
[06-15 07:38:13] [Cache-DiT] Skipped Forward Pattern Check: ForwardPattern.Pattern_3
[06-15 07:38:13] [Cache-DiT] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
[06-15 07:38:13] [Cache-DiT] Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_N50_CFG1, Calibrator Config: None
[06-15 07:38:13] [Cache-DiT] Skipped Forward Pattern Check: ForwardPattern.Pattern_3
[06-15 07:38:13] [Cache-DiT] Match Blocks: CachedBlocks_Pattern_3_4_5, for layers, cache_context: layers_281461219821776, context_manager: FakeDiffusionPipeline_281461220459152.
[06-15 07:38:13] cache-dit enabled on transformer (steps=50, Fn=1, Bn=0, rdt=0.240)

  0%|          | 0/50 [00:00<?, ?it/s]
  2%|▏         | 1/50 [00:27<22:27, 27.49s/it]
  4%|▍         | 2/50 [00:27<09:09, 11.46s/it]
  6%|▌         | 3/50 [00:28<05:12,  6.65s/it]
  8%|▊         | 4/50 [00:29<03:21,  4.39s/it]
 10%|█         | 5/50 [00:31<02:31,  3.37s/it]
 14%|█▍        | 7/50 [00:31<01:17,  1.81s/it]
 16%|█▌        | 8/50 [00:32<01:00,  1.43s/it]
 20%|██        | 10/50 [00:32<00:34,  1.17it/s]
 22%|██▏       | 11/50 [00:33<00:32,  1.18it/s]
 28%|██▊       | 14/50 [00:33<00:16,  2.19it/s]
 30%|███       | 15/50 [00:34<00:18,  1.91it/s]
 36%|███▌      | 18/50 [00:34<00:10,  3.11it/s]
 38%|███▊      | 19/50 [00:35<00:12,  2.46it/s]
 44%|████▍     | 22/50 [00:35<00:07,  3.81it/s]
 46%|████▌     | 23/50 [00:36<00:09,  2.81it/s]
 52%|█████▏    | 26/50 [00:36<00:05,  4.23it/s]
 54%|█████▍    | 27/50 [00:37<00:07,  3.01it/s]
 60%|██████    | 30/50 [00:37<00:04,  4.47it/s]
 62%|██████▏   | 31/50 [00:38<00:06,  3.11it/s]
 68%|██████▊   | 34/50 [00:38<00:03,  4.61it/s]
 70%|███████   | 35/50 [00:39<00:04,  3.17it/s]
 76%|███████▌  | 38/50 [00:39<00:02,  4.68it/s]
 78%|███████▊  | 39/50 [00:40<00:03,  3.19it/s]
 84%|████████▍ | 42/50 [00:40<00:01,  4.71it/s]
 86%|████████▌ | 43/50 [00:41<00:02,  3.20it/s]
 92%|█████████▏| 46/50 [00:41<00:00,  4.69it/s]
 94%|█████████▍| 47/50 [00:42<00:00,  3.21it/s]
 96%|█████████▌| 48/50 [00:42<00:00,  2.78it/s]
 98%|█████████▊| 49/50 [00:43<00:00,  2.08it/s]
100%|██████████| 50/50 [00:44<00:00,  1.71it/s]
100%|██████████| 50/50 [00:44<00:00,  1.12it/s]
[06-15 07:38:58] [DenoisingStage] average time per step: 0.8957 seconds
[06-15 07:38:58] [DenoisingStage] finished in 44.7995 seconds
[06-15 07:38:58] [DecodingStage] started...
/root/ernie/sgl2/lib/python3.11/site-packages/torch/amp/autocast_mode.py:328: UserWarning: In npu autocast, but the target dtype is not supported. Disabling autocast.
 npu Autocast only supports dtypes of torch.float16, torch.bfloat16 currently.
  warnings.warn(error_message)
[06-15 07:38:58] [DecodingStage] finished in 0.2261 seconds
.[06-15 07:39:02] Output saved to [1;36moutputs/This_is_a_photograph_depicting_an_urban_street_scene._Shot_at_eye_level_it_shows_a_covered_pedestri_20260615-073753_65d6dfdb.png[0;0m
[06-15 07:39:02] Pixel data generated successfully in [92m68.95[0;0m seconds
[06-15 07:39:02] Memory usage - Max peak: 37056.00 MB, Avg peak: 37056.00 MB
[93m[06-15 07:39:02] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[06-15 07:39:03] Worker 0: Shutdown complete.
[93m[06-15 07:39:12] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m

</details>

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

1. run ERNIE-Image **without** cache-dit (e2e: 90052ms):
```
{
  "timestamp": "2026-06-15T08:10:11.556024+00:00",
  "request_id": "15d772e2-fc91-4fe5-8276-7de688a0effc",
  "commit_hash": "a6e876a20dd3253b9ba87c58508091399e817bd1",
  "tag": "cli_generate",
  "total_duration_ms": 90051.97176896036,
  "steps": [
    {
      "name": "InputValidationStage",
      "duration_ms": 0.11809100396931171
    },
    {
      "name": "PromptEnhancementStage",
      "duration_ms": 17869.078928022645
    },
    {
      "name": "TextEncodingStage",
      "duration_ms": 163.19261293392628
    },
    {
      "name": "TimestepPreparationStage",
      "duration_ms": 3.432043013162911
    },
    {
      "name": "LatentPreparationStage",
      "duration_ms": 1.3744529569521546
    },
    {
      "name": "DenoisingStage",
      "duration_ms": 71771.27823396586
    },
    {
      "name": "DecodingStage",
      "duration_ms": 226.96541796904057
    },
    {
      "name": "Scheduler.return_result.spill_arrays",
      "duration_ms": 0.07148098666220903
    },
    {
      "name": "SchedulerClient.materialize_file_refs",
      "duration_ms": 0.008109956979751587
    }
  ],
  "denoise_steps_ms": [
    {
      "step": 0,
      "duration_ms": 27480.602366966195
    },
    {
      "step": 1,
      "duration_ms": 196.71636598650366
    },
    {
      "step": 2,
      "duration_ms": 920.0674180174246
    },
    {
      "step": 3,
      "duration_ms": 920.2333900611848
    },
    {
      "step": 4,
      "duration_ms": 919.2673399811611
    },
    {
      "step": 5,
      "duration_ms": 917.8307360270992
    },
    {
      "step": 6,
      "duration_ms": 916.7767659528181
    },
    {
      "step": 7,
      "duration_ms": 917.1431300928816
    },
    {
      "step": 8,
      "duration_ms": 917.5956549588591
    },
    {
      "step": 9,
      "duration_ms": 917.817925917916
    },
    {
      "step": 10,
      "duration_ms": 918.2719900272787
    },
    {
      "step": 11,
      "duration_ms": 919.748043990694
    },
    {
      "step": 12,
      "duration_ms": 919.9636169942096
    },
    {
      "step": 13,
      "duration_ms": 919.7819050168619
    },
    {
      "step": 14,
      "duration_ms": 918.8769060419872
    },
    {
      "step": 15,
      "duration_ms": 917.7129550371319
    },
    {
      "step": 16,
      "duration_ms": 916.6565750492737
    },
    {
      "step": 17,
      "duration_ms": 916.541054029949
    },
    {
      "step": 18,
      "duration_ms": 918.14098902978
    },
    {
      "step": 19,
      "duration_ms": 918.4706920059398
    },
    {
      "step": 20,
      "duration_ms": 917.6839550491422
    },
    {
      "step": 21,
      "duration_ms": 919.2572600441054
    },
    {
      "step": 22,
      "duration_ms": 919.7468949714676
    },
    {
      "step": 23,
      "duration_ms": 918.8925370108336
    },
    {
      "step": 24,
      "duration_ms": 919.2321099108085
    },
    {
      "step": 25,
      "duration_ms": 917.989837937057
    },
    {
      "step": 26,
      "duration_ms": 916.6803560219705
    },
    {
      "step": 27,
      "duration_ms": 916.5499239461496
    },
    {
      "step": 28,
      "duration_ms": 918.4773620218039
    },
    {
      "step": 29,
      "duration_ms": 917.3519720789045
    },
    {
      "step": 30,
      "duration_ms": 919.2116600461304
    },
    {
      "step": 31,
      "duration_ms": 918.6875550076365
    },
    {
      "step": 32,
      "duration_ms": 919.7193949948996
    },
    {
      "step": 33,
      "duration_ms": 919.247698970139
    },
    {
      "step": 34,
      "duration_ms": 918.81146596279
    },
    {
      "step": 35,
      "duration_ms": 918.3299720752984
    },
    {
      "step": 36,
      "duration_ms": 916.2442309316248
    },
    {
      "step": 37,
      "duration_ms": 916.7916759615764
    },
    {
      "step": 38,
      "duration_ms": 918.1722999783233
    },
    {
      "step": 39,
      "duration_ms": 917.9003370227292
    },
    {
      "step": 40,
      "duration_ms": 918.0753290420398
    },
    {
      "step": 41,
      "duration_ms": 919.1580689512193
    },
    {
      "step": 42,
      "duration_ms": 920.0673380400985
    },
    {
      "step": 43,
      "duration_ms": 919.6611139923334
    },
    {
      "step": 44,
      "duration_ms": 918.8697159988806
    },
    {
      "step": 45,
      "duration_ms": 918.0706680053845
    },
    {
      "step": 46,
      "duration_ms": 916.8063460383564
    },
    {
      "step": 47,
      "duration_ms": 917.0691089238971
    },
    {
      "step": 48,
      "duration_ms": 918.5150429839268
    },
    {
      "step": 49,
      "duration_ms": 917.8122560260817
    }
  ],
  "memory_checkpoints": {
    "before_forward": {
      "allocated_mb": 14219.04,
      "reserved_mb": 14930.0,
      "peak_allocated_mb": 14219.04,
      "peak_reserved_mb": 14930.0
    },
    "after_forward": {
      "allocated_mb": 29564.14,
      "reserved_mb": 36930.0,
      "peak_allocated_mb": 32698.22,
      "peak_reserved_mb": 36930.0
    }
  },
  "meta": {
    "prompt": [
      "This is a photograph depicting an urban street scene. Shot at eye level, it shows a covered pedestrian or commercial street. Slightly below the center of the frame, a cyclist rides away from the camera toward the background, appearing as a dark silhouette against backlighting with indistinct details. The ground is paved with regular square tiles, bisected by a prominent tactile paving strip running through the scene, whose raised textures are clearly visible under the light. Light streams in diagonally from the right side of the frame, creating a strong backlight effect with a distinct Tyndall effect\u2014visible light beams illuminating dust or vapor in the air and casting long shadows across the street. Several pedestrians appear on the left side and in the distance, some with their backs to the camera and others walking sideways, all rendered as silhouettes or semi-silhouettes. The overall color palette is warm, dominated by golden yellows and dark browns, evoking the atmosphere of dusk or early morning."
    ],
    "model": "/root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image"
  }
}
```




2. run ERNIE-Image **with** cache-dit (e2e: 70186ms):
```
{
  "timestamp": "2026-06-15T07:55:21.585316+00:00",
  "request_id": "53255dca-b2e8-4224-b92d-d169af650e44",
  "commit_hash": "a6e876a20dd3253b9ba87c58508091399e817bd1",
  "tag": "cli_generate",
  "total_duration_ms": 70186.01890699938,
  "steps": [
    {
      "name": "InputValidationStage",
      "duration_ms": 0.12492097448557615
    },
    {
      "name": "PromptEnhancementStage",
      "duration_ms": 17754.25879994873
    },
    {
      "name": "TextEncodingStage",
      "duration_ms": 165.5720070702955
    },
    {
      "name": "TimestepPreparationStage",
      "duration_ms": 3.3597330329939723
    },
    {
      "name": "LatentPreparationStage",
      "duration_ms": 1.2778519885614514
    },
    {
      "name": "DenoisingStage",
      "duration_ms": 52010.58198988903
    },
    {
      "name": "DecodingStage",
      "duration_ms": 233.0783490324393
    },
    {
      "name": "Scheduler.return_result.spill_arrays",
      "duration_ms": 0.10992097668349743
    },
    {
      "name": "SchedulerClient.materialize_file_refs",
      "duration_ms": 0.016050064004957676
    }
  ],
  "denoise_steps_ms": [
    {
      "step": 0,
      "duration_ms": 34700.31495101284
    },
    {
      "step": 1,
      "duration_ms": 197.43141904473305
    },
    {
      "step": 2,
      "duration_ms": 727.548565948382
    },
    {
      "step": 3,
      "duration_ms": 922.1668880200014
    },
    {
      "step": 4,
      "duration_ms": 1598.3177489833906
    },
    {
      "step": 5,
      "duration_ms": 38.21825596969575
    },
    {
      "step": 6,
      "duration_ms": 577.2801210405305
    },
    {
      "step": 7,
      "duration_ms": 383.68323899339885
    },
    {
      "step": 8,
      "duration_ms": 36.801822017878294
    },
    {
      "step": 9,
      "duration_ms": 171.95627908222377
    },
    {
      "step": 10,
      "duration_ms": 895.3885750379413
    },
    {
      "step": 11,
      "duration_ms": 50.25989399291575
    },
    {
      "step": 12,
      "duration_ms": 42.31119598262012
    },
    {
      "step": 13,
      "duration_ms": 437.59074807167053
    },
    {
      "step": 14,
      "duration_ms": 529.6912230551243
    },
    {
      "step": 15,
      "duration_ms": 43.75302908010781
    },
    {
      "step": 16,
      "duration_ms": 36.896053003147244
    },
    {
      "step": 17,
      "duration_ms": 174.54592499416322
    },
    {
      "step": 18,
      "duration_ms": 785.2389230392873
    },
    {
      "step": 19,
      "duration_ms": 37.61853894684464
    },
    {
      "step": 20,
      "duration_ms": 38.19267498329282
    },
    {
      "step": 21,
      "duration_ms": 169.5722748991102
    },
    {
      "step": 22,
      "duration_ms": 800.9971580468118
    },
    {
      "step": 23,
      "duration_ms": 36.04124393314123
    },
    {
      "step": 24,
      "duration_ms": 35.618080059066415
    },
    {
      "step": 25,
      "duration_ms": 148.3710379106924
    },
    {
      "step": 26,
      "duration_ms": 808.9829969685525
    },
    {
      "step": 27,
      "duration_ms": 35.903482930734754
    },
    {
      "step": 28,
      "duration_ms": 35.925263073295355
    },
    {
      "step": 29,
      "duration_ms": 154.0094920201227
    },
    {
      "step": 30,
      "duration_ms": 804.221179918386
    },
    {
      "step": 31,
      "duration_ms": 36.38523805420846
    },
    {
      "step": 32,
      "duration_ms": 38.490767939947546
    },
    {
      "step": 33,
      "duration_ms": 155.21166392136365
    },
    {
      "step": 34,
      "duration_ms": 804.2130389949307
    },
    {
      "step": 35,
      "duration_ms": 35.155385034158826
    },
    {
      "step": 36,
      "duration_ms": 35.43882898520678
    },
    {
      "step": 37,
      "duration_ms": 154.54923803918064
    },
    {
      "step": 38,
      "duration_ms": 801.4319820795208
    },
    {
      "step": 39,
      "duration_ms": 35.80740198958665
    },
    {
      "step": 40,
      "duration_ms": 35.46438901685178
    },
    {
      "step": 41,
      "duration_ms": 147.04646507743746
    },
    {
      "step": 42,
      "duration_ms": 810.8322840416804
    },
    {
      "step": 43,
      "duration_ms": 35.55563907139003
    },
    {
      "step": 44,
      "duration_ms": 35.66342999693006
    },
    {
      "step": 45,
      "duration_ms": 149.65654001571238
    },
    {
      "step": 46,
      "duration_ms": 808.3817900624126
    },
    {
      "step": 47,
      "duration_ms": 567.7834369707853
    },
    {
      "step": 48,
      "duration_ms": 918.8532659318298
    },
    {
      "step": 49,
      "duration_ms": 923.4762310516089
    }
  ],
  "memory_checkpoints": {
    "before_forward": {
      "allocated_mb": 14219.04,
      "reserved_mb": 14930.0,
      "peak_allocated_mb": 14219.04,
      "peak_reserved_mb": 14930.0
    },
    "after_forward": {
      "allocated_mb": 29701.6,
      "reserved_mb": 37036.0,
      "peak_allocated_mb": 32835.68,
      "peak_reserved_mb": 37036.0
    }
  },
  "meta": {
    "prompt": [
      "This is a photograph depicting an urban street scene. Shot at eye level, it shows a covered pedestrian or commercial street. Slightly below the center of the frame, a cyclist rides away from the camera toward the background, appearing as a dark silhouette against backlighting with indistinct details. The ground is paved with regular square tiles, bisected by a prominent tactile paving strip running through the scene, whose raised textures are clearly visible under the light. Light streams in diagonally from the right side of the frame, creating a strong backlight effect with a distinct Tyndall effect\u2014visible light beams illuminating dust or vapor in the air and casting long shadows across the street. Several pedestrians appear on the left side and in the distance, some with their backs to the camera and others walking sideways, all rendered as silhouettes or semi-silhouettes. The overall color palette is warm, dominated by golden yellows and dark browns, evoking the atmosphere of dusk or early morning."
    ],
    "model": "/root/.cache/modelscope/hub/models/PaddlePaddle/ERNIE-Image"
  }
}
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28010045932](https://github.com/sgl-project/sglang/actions/runs/28010045932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28010045928](https://github.com/sgl-project/sglang/actions/runs/28010045928)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->