### PR TITLE
[JIT] Track angle-bracket includes in source hash

### DIFF
--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -67,7 +67,8 @@ def _make_wrapper(tup: Tuple[str, str]) -> str:
     return f"TVM_FFI_DLL_EXPORT_TYPED_FUNC({export_name}, ({kernel_name}));"
 
 
-_LOCAL_INCLUDE_RE = re.compile(r'^\s*#\s*include\s+"([^"]+)"', re.MULTILINE)
+_QUOTED_INCLUDE_RE = re.compile(r'^\s*#\s*include\s+"([^"]+)"', re.MULTILINE)
+_ANGLE_INCLUDE_RE = re.compile(r"^\s*#\s*include\s+<(sgl_kernel/[^>]+)>", re.MULTILINE)
 
 
 def _local_jit_source_hash(source_files: List[str]) -> str:
@@ -75,6 +76,7 @@ def _local_jit_source_hash(source_files: List[str]) -> str:
     digest = hashlib.sha256()
     seen: set[pathlib.Path] = set()
     stack = [pathlib.Path(path).resolve() for path in source_files]
+    include_dir = KERNEL_PATH / "include"
 
     while stack:
         path = stack.pop()
@@ -95,8 +97,12 @@ def _local_jit_source_hash(source_files: List[str]) -> str:
         digest.update(b"\0")
 
         text = data.decode("utf-8", errors="ignore")
-        for include in _LOCAL_INCLUDE_RE.findall(text):
+        for include in _QUOTED_INCLUDE_RE.findall(text):
             include_path = (path.parent / include).resolve()
+            if include_path.is_file():
+                stack.append(include_path)
+        for include in _ANGLE_INCLUDE_RE.findall(text):
+            include_path = (include_dir / include).resolve()
             if include_path.is_file():
                 stack.append(include_path)
 

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -67,8 +67,8 @@ def _make_wrapper(tup: Tuple[str, str]) -> str:
     return f"TVM_FFI_DLL_EXPORT_TYPED_FUNC({export_name}, ({kernel_name}));"
 
 
-_QUOTED_INCLUDE_RE = re.compile(r'^\s*#\s*include\s+"([^"]+)"', re.MULTILINE)
-_ANGLE_INCLUDE_RE = re.compile(r"^\s*#\s*include\s+<(sgl_kernel/[^>]+)>", re.MULTILINE)
+_QUOTED_INCLUDE_RE = re.compile(r'^\s*#\s*include\s*"([^"]+)"', re.MULTILINE)
+_ANGLE_INCLUDE_RE = re.compile(r"^\s*#\s*include\s*<(sgl_kernel/[^>]+)>", re.MULTILINE)
 
 
 def _local_jit_source_hash(source_files: List[str]) -> str:


### PR DESCRIPTION
## Summary
- Track `#include <sgl_kernel/...>` headers in the local JIT source hash.
- Keeps cached JIT shared objects invalidated when shared angle-bracket headers change.

Original commit context: `0b1dc8960aa55230197d56300a511e1176762a33`.

## Test Plan
- `with-proxy uv run python3 -m py_compile python/sglang/jit_kernel/utils.py`



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27537434719](https://github.com/sgl-project/sglang/actions/runs/27537434719)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27537432636](https://github.com/sgl-project/sglang/actions/runs/27537432636)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->