### PR TITLE
[HiCache] Add NIXL tenant startup cleanup

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -376,6 +376,8 @@ class Envs:
     SGLANG_HICACHE_FILE_BACKEND_EVICTION_RATIO = EnvFloat(0.9)
     SGLANG_HICACHE_FILE_BACKEND_MIN_FREE_SPACE = EnvStr("0")
     SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR = EnvStr(None)
+    SGLANG_HICACHE_NIXL_STORAGE_TENANT = EnvStr(None)
+    SGLANG_HICACHE_NIXL_FORCE_CLEAN_ON_START = EnvBool(False)
     # Enable O_DIRECT when opening NIXL POSIX backend files (bypasses OS page cache).
     # Disable with SGLANG_HICACHE_NIXL_USE_DIRECT_IO=0 or via the
     # "use_direct_io": false key in --hicache-storage-backend-extra-config.

--- a/python/sglang/srt/mem_cache/storage/nixl/README.md
+++ b/python/sglang/srt/mem_cache/storage/nixl/README.md
@@ -88,6 +88,24 @@ export SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR=/path/to/storage/dir1,/path/to/st
 
 These directories are used only for **FILE-backed** plugins. **OBJ-backed** plugins use object keys instead of local files.
 
+For FILE-backed plugins, SGLang creates a tenant subdirectory below each configured
+storage directory. By default, the tenant key is derived from model name, TP size,
+number of storage directories, and the on-disk layout version. To pin an explicit
+deployment/app tenant, set:
+
+```bash
+export SGLANG_HICACHE_NIXL_STORAGE_TENANT=my-serving-app
+```
+
+At startup, TP rank 0 best-effort deletes stale sibling tenant directories created
+by previous tenant layout versions or other tenants. It does not delete arbitrary
+directories under the storage base. To force-clean all NIXL tenant directories,
+including the current tenant, before the current tenant directories are recreated:
+
+```bash
+export SGLANG_HICACHE_NIXL_FORCE_CLEAN_ON_START=1
+```
+
 ### 3. How to Provide Configuration for Backends
 
 There are three ways to specify configurations for the backends: default config, file based config, and command-line (JSON string based) config.
@@ -302,7 +320,7 @@ python/sglang/srt/mem_cache/storage/nixl/
 
 ### HiCache / NIXL Data Model
 
-- **FILE backends** use local file paths under `SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR`. When multiple comma-separated directories are configured, each logical cache key is routed to one base directory with a stable hash and stored as `base_dir/<bucket>/<key>`.
+- **FILE backends** use local file paths under `SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR`. When multiple comma-separated directories are configured, each logical cache key is routed to one base directory with a stable hash and stored as `base_dir/<tenant>/<bucket>/<key>`.
 - **OBJ backends** use object keys directly
 - **MHA naming** includes TP rank and TP size, so each rank stores its own KV data
 - **MLA naming** omits TP rank, so all ranks refer to one shared logical KV object / file

--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -15,6 +15,10 @@ from sglang.srt.mem_cache.hicache_storage import (
 )
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
 from sglang.srt.mem_cache.mmap_allocator import alloc_mmap
+from sglang.srt.mem_cache.storage.nixl.nixl_tenant import (
+    prepare_tenant_storage_dirs,
+    resolve_tenant_key,
+)
 
 from .nixl_registry import NixlRegistry
 from .nixl_utils import NixlBackendConfig, NixlBackendSelection, NixlFileManager
@@ -66,23 +70,41 @@ class HiCacheNixl(HiCacheStorage):
 
         # select the NIXL backend plugin from extra_config or environment variable
         plugin = nixlconfig.get_specified_plugin()
+        uses_file_backend = plugin not in NixlBackendSelection.OBJ_PLUGINS
 
         use_direct_io = nixlconfig.get_use_direct_io()
-
-        # Might be better to be unified across HiCache backends and moved to HiCacheController
-        storage_dirs = _parse_storage_dirs(
-            envs.SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR.get() or file_path
-        )
-        self.file_manager = (
-            NixlFileManager(storage_dirs, use_direct_io=use_direct_io)
-            if plugin not in NixlBackendSelection.OBJ_PLUGINS
-            else None
-        )
 
         tp_rank, tp_size, model_name = (
             storage_config.tp_rank,
             storage_config.tp_size,
             storage_config.model_name,
+        )
+
+        # Might be better to be unified across HiCache backends and moved to HiCacheController
+        storage_dirs = _parse_storage_dirs(
+            envs.SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR.get() or file_path
+        )
+        self._tenant_key: Optional[str] = None
+        if uses_file_backend and storage_dirs:
+            tenant_key = resolve_tenant_key(
+                model_name,
+                tp_size,
+                num_disks=len(storage_dirs),
+                explicit_tenant=envs.SGLANG_HICACHE_NIXL_STORAGE_TENANT.get(),
+            )
+            storage_dirs, _ = prepare_tenant_storage_dirs(
+                storage_dirs,
+                tenant_key,
+                tp_rank=tp_rank,
+                force_clean_all=envs.SGLANG_HICACHE_NIXL_FORCE_CLEAN_ON_START.get(),
+                run_id=os.environ.get("SGLANG_RUN_ID"),
+            )
+            self._tenant_key = tenant_key
+
+        self.file_manager = (
+            NixlFileManager(storage_dirs, use_direct_io=use_direct_io)
+            if uses_file_backend
+            else None
         )
 
         self.is_mla_model = storage_config.is_mla_model

--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -99,6 +99,8 @@ class HiCacheNixl(HiCacheStorage):
                 force_clean_all=envs.SGLANG_HICACHE_NIXL_FORCE_CLEAN_ON_START.get(),
                 run_id=os.environ.get("SGLANG_RUN_ID"),
             )
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                torch.distributed.barrier()
             self._tenant_key = tenant_key
 
         self.file_manager = (

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_tenant.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_tenant.py
@@ -1,0 +1,162 @@
+"""Tenant directory helpers for NIXL FILE HiCache storage."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import threading
+import time
+from hashlib import sha1
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+STORAGE_LAYOUT_VERSION = "v1"
+_TENANT_DIR_RE = re.compile(r".+-v[0-9]+$")
+_UNSAFE_COMPONENT_RE = re.compile(r"[^A-Za-z0-9._=-]+")
+_MAX_COMPONENT_LEN = 128
+
+
+def resolve_tenant_key(
+    model_name: Optional[str],
+    tp_size: int,
+    num_disks: int = 1,
+    explicit_tenant: Optional[str] = None,
+) -> str:
+    """Return a stable directory key for one NIXL FILE cache tenant."""
+    name = _safe_component(explicit_tenant or model_name or "unnamed")
+    return f"{name}-tp{tp_size}-n{num_disks}-{STORAGE_LAYOUT_VERSION}"
+
+
+def prepare_tenant_storage_dirs(
+    base_dirs: list[str],
+    tenant_key: str,
+    *,
+    tp_rank: int,
+    force_clean_all: bool,
+    run_id: Optional[str] = None,
+) -> tuple[list[str], Optional[threading.Thread]]:
+    """Create tenant storage dirs and start best-effort cleanup on rank 0."""
+    tenant_dirs = [os.path.join(base_dir, tenant_key) for base_dir in base_dirs]
+    cleanup_thread = None
+
+    if tp_rank == 0:
+        cleanup_thread = start_tenant_cleanup(
+            base_dirs,
+            tenant_key,
+            force_clean_all=force_clean_all,
+        )
+        if force_clean_all and cleanup_thread is not None:
+            cleanup_thread.join()
+
+        for tenant_dir in tenant_dirs:
+            os.makedirs(tenant_dir, exist_ok=True)
+        _write_tenant_markers(tenant_dirs, tenant_key, run_id)
+
+    return tenant_dirs, cleanup_thread
+
+
+def start_tenant_cleanup(
+    base_dirs: list[str],
+    tenant_key: str,
+    *,
+    force_clean_all: bool = False,
+) -> Optional[threading.Thread]:
+    """Async-delete stale NIXL tenant dirs below configured storage bases."""
+    targets = _collect_cleanup_targets(base_dirs, tenant_key, force_clean_all)
+    if not targets:
+        return None
+
+    thread = threading.Thread(
+        target=_run_cleanup,
+        args=(targets,),
+        name="hicache-nixl-tenant-cleanup",
+        daemon=True,
+    )
+    thread.start()
+    logger.info(
+        "NIXL tenant cleanup started: %d dir(s), tenant=%s, force_clean_all=%s",
+        len(targets),
+        tenant_key,
+        force_clean_all,
+    )
+    return thread
+
+
+def _safe_component(value: str) -> str:
+    value = value.strip().strip("/")
+    value = _UNSAFE_COMPONENT_RE.sub("-", value).strip("-")
+    if not value:
+        value = "unnamed"
+    if len(value) <= _MAX_COMPONENT_LEN:
+        return value
+    digest = sha1(value.encode("utf-8")).hexdigest()[:12]
+    return f"{value[: _MAX_COMPONENT_LEN - len(digest) - 1]}-{digest}"
+
+
+def _collect_cleanup_targets(
+    base_dirs: list[str], tenant_key: str, force_clean_all: bool
+) -> list[str]:
+    targets: list[str] = []
+    for base_dir in base_dirs:
+        try:
+            entries = list(os.scandir(base_dir))
+        except FileNotFoundError:
+            continue
+        except OSError:
+            logger.warning(
+                "NIXL tenant cleanup failed to scan %s", base_dir, exc_info=True
+            )
+            continue
+
+        for entry in entries:
+            try:
+                is_dir = entry.is_dir(follow_symlinks=False)
+            except OSError:
+                continue
+            if not is_dir or _TENANT_DIR_RE.fullmatch(entry.name) is None:
+                continue
+            if not force_clean_all and entry.name == tenant_key:
+                continue
+            targets.append(entry.path)
+    return targets
+
+
+def _run_cleanup(targets: list[str]) -> None:
+    start = time.perf_counter()
+    deleted = 0
+    for target in targets:
+        try:
+            shutil.rmtree(target)
+            deleted += 1
+        except FileNotFoundError:
+            continue
+        except OSError:
+            logger.warning(
+                "NIXL tenant cleanup failed to delete %s", target, exc_info=True
+            )
+    logger.info(
+        "NIXL tenant cleanup done: deleted %d/%d dir(s) in %.1fs",
+        deleted,
+        len(targets),
+        time.perf_counter() - start,
+    )
+
+
+def _write_tenant_markers(
+    tenant_dirs: list[str], tenant_key: str, run_id: Optional[str]
+) -> None:
+    marker = f"tenant={tenant_key}\n"
+    if run_id:
+        marker += f"run_id={run_id}\n"
+
+    for tenant_dir in tenant_dirs:
+        try:
+            with open(os.path.join(tenant_dir, ".sglang-nixl-tenant"), "w") as f:
+                f.write(marker)
+        except OSError:
+            logger.warning(
+                "Failed to write NIXL tenant marker in %s", tenant_dir, exc_info=True
+            )

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_tenant.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_tenant.py
@@ -118,6 +118,8 @@ def _collect_cleanup_targets(
                 continue
             if not is_dir or _TENANT_DIR_RE.fullmatch(entry.name) is None:
                 continue
+            if not os.path.exists(os.path.join(entry.path, ".sglang-nixl-tenant")):
+                continue
             if not force_clean_all and entry.name == tenant_key:
                 continue
             targets.append(entry.path)

--- a/test/registered/unit/mem_cache/test_hicache_nixl_tenant.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_tenant.py
@@ -49,9 +49,12 @@ class TestNixlTenantStorage(CustomTestCase):
         """Startup cleanup deletes tenant siblings, not arbitrary base-dir content."""
         current = resolve_tenant_key("model-a", tp_size=8, num_disks=2)
         foreign = resolve_tenant_key("model-b", tp_size=8, num_disks=2)
+        unmarked = resolve_tenant_key("manual-data", tp_size=8, num_disks=2)
 
         for base_dir in self.base_dirs:
             self._write_file(os.path.join(base_dir, foreign, "00", "old"))
+            self._write_file(os.path.join(base_dir, foreign, ".sglang-nixl-tenant"))
+            self._write_file(os.path.join(base_dir, unmarked, "00", "keep"))
             self._write_file(os.path.join(base_dir, "not-a-tenant", "keep"))
 
         tenant_dirs, thread = prepare_tenant_storage_dirs(
@@ -67,6 +70,7 @@ class TestNixlTenantStorage(CustomTestCase):
         self.assertTrue(all(os.path.isdir(path) for path in tenant_dirs))
         for base_dir, tenant_dir in zip(self.base_dirs, tenant_dirs):
             self.assertFalse(os.path.exists(os.path.join(base_dir, foreign)))
+            self.assertTrue(os.path.exists(os.path.join(base_dir, unmarked)))
             self.assertTrue(os.path.exists(os.path.join(base_dir, "not-a-tenant")))
             marker = os.path.join(tenant_dir, ".sglang-nixl-tenant")
             with open(marker) as f:
@@ -77,6 +81,7 @@ class TestNixlTenantStorage(CustomTestCase):
         tenant = resolve_tenant_key("model-a", tp_size=8, num_disks=2)
         for base_dir in self.base_dirs:
             self._write_file(os.path.join(base_dir, tenant, "00", "old"))
+            self._write_file(os.path.join(base_dir, tenant, ".sglang-nixl-tenant"))
 
         tenant_dirs, thread = prepare_tenant_storage_dirs(
             self.base_dirs,

--- a/test/registered/unit/mem_cache/test_hicache_nixl_tenant.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_tenant.py
@@ -1,0 +1,106 @@
+"""Unit tests for NIXL FILE tenant directory helpers."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from sglang.srt.mem_cache.storage.nixl.nixl_tenant import (
+    STORAGE_LAYOUT_VERSION,
+    prepare_tenant_storage_dirs,
+    resolve_tenant_key,
+    start_tenant_cleanup,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestNixlTenantStorage(CustomTestCase):
+    """Tests for tenant-scoped NIXL FILE storage directories."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="test_nixl_tenant_")
+        self.base_dirs = [os.path.join(self.test_dir, f"disk{i}") for i in range(2)]
+        for base_dir in self.base_dirs:
+            os.makedirs(base_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _write_file(self, path: str) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(b"x")
+
+    def test_resolve_tenant_key_is_stable_and_safe(self):
+        """Tenant keys include model, TP, disk count, and layout version."""
+        key = resolve_tenant_key("/models/foo/bar", tp_size=8, num_disks=2)
+        self.assertEqual(key, f"models-foo-bar-tp8-n2-{STORAGE_LAYOUT_VERSION}")
+
+        explicit = resolve_tenant_key(
+            "ignored", tp_size=4, num_disks=1, explicit_tenant="prod/app@1"
+        )
+        self.assertEqual(explicit, f"prod-app-1-tp4-n1-{STORAGE_LAYOUT_VERSION}")
+
+    def test_prepare_cleans_only_foreign_tenant_dirs(self):
+        """Startup cleanup deletes tenant siblings, not arbitrary base-dir content."""
+        current = resolve_tenant_key("model-a", tp_size=8, num_disks=2)
+        foreign = resolve_tenant_key("model-b", tp_size=8, num_disks=2)
+
+        for base_dir in self.base_dirs:
+            self._write_file(os.path.join(base_dir, foreign, "00", "old"))
+            self._write_file(os.path.join(base_dir, "not-a-tenant", "keep"))
+
+        tenant_dirs, thread = prepare_tenant_storage_dirs(
+            self.base_dirs,
+            current,
+            tp_rank=0,
+            force_clean_all=False,
+            run_id="run-1",
+        )
+        if thread is not None:
+            thread.join()
+
+        self.assertTrue(all(os.path.isdir(path) for path in tenant_dirs))
+        for base_dir, tenant_dir in zip(self.base_dirs, tenant_dirs):
+            self.assertFalse(os.path.exists(os.path.join(base_dir, foreign)))
+            self.assertTrue(os.path.exists(os.path.join(base_dir, "not-a-tenant")))
+            marker = os.path.join(tenant_dir, ".sglang-nixl-tenant")
+            with open(marker) as f:
+                self.assertIn("run_id=run-1", f.read())
+
+    def test_force_clean_removes_current_tenant_before_recreate(self):
+        """Force cleanup waits for old current-tenant contents to be removed."""
+        tenant = resolve_tenant_key("model-a", tp_size=8, num_disks=2)
+        for base_dir in self.base_dirs:
+            self._write_file(os.path.join(base_dir, tenant, "00", "old"))
+
+        tenant_dirs, thread = prepare_tenant_storage_dirs(
+            self.base_dirs,
+            tenant,
+            tp_rank=0,
+            force_clean_all=True,
+            run_id="run-2",
+        )
+
+        self.assertTrue(thread is None or not thread.is_alive())
+        for tenant_dir in tenant_dirs:
+            self.assertTrue(os.path.isdir(tenant_dir))
+            self.assertFalse(os.path.exists(os.path.join(tenant_dir, "00", "old")))
+            self.assertTrue(
+                os.path.exists(os.path.join(tenant_dir, ".sglang-nixl-tenant"))
+            )
+
+    def test_missing_base_dir_is_tolerated(self):
+        """Missing storage bases should not make startup cleanup fail."""
+        missing = os.path.join(self.test_dir, "missing")
+        tenant = resolve_tenant_key("model-a", tp_size=1)
+        thread = start_tenant_cleanup([missing], tenant, force_clean_all=False)
+        self.assertIsNone(thread)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

FILE-backed NIXL HiCache storage keeps cache files below the configured storage directories. When deployments reuse the same storage base, stale cache files from older tenants or layout versions can survive process restarts and make startup cleanup risky: deleting the whole base directory is too broad, while doing nothing leaves old cache data behind.

This PR adds a tenant-scoped directory layer for NIXL FILE storage so each deployment/model layout can own a bounded namespace. It also adds a conservative startup cleanup path that only deletes recognized tenant directories.

## Modifications

- Add `nixl_tenant.py` for resolving and preparing tenant-scoped FILE storage directories.
  - Default tenant key includes model name, TP size, storage-dir count, and layout version `v1`.
  - `SGLANG_HICACHE_NIXL_STORAGE_TENANT` can pin an explicit deployment/app tenant.
  - Tenant components are sanitized before being used as path names.
- Change FILE-backed NIXL storage paths from `base_dir/<bucket>/<key>` to `base_dir/<tenant>/<bucket>/<key>`.
  - OBJ-backed plugins are unchanged.
  - Existing bucket routing stays inside the tenant directory.
- Add rank-0 startup cleanup for stale sibling tenant directories matching the NIXL tenant layout pattern.
  - Normal mode keeps the current tenant and deletes stale siblings only.
  - `SGLANG_HICACHE_NIXL_FORCE_CLEAN_ON_START=1` also removes the current tenant, waits for cleanup, then recreates it.
  - Arbitrary non-tenant directories under the storage base are not deleted.
- Write a `.sglang-nixl-tenant` marker in each tenant directory with the tenant key and optional `SGLANG_RUN_ID` for diagnostics.
- Document the new NIXL FILE tenant behavior and env vars.
- Add unit coverage for tenant key resolution, safe sibling cleanup, force cleanup, missing base dirs, and marker writing.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Validation:

- `git diff --check upstream/main..HEAD`
- `python3 -m py_compile python/sglang/srt/mem_cache/storage/nixl/nixl_tenant.py python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py python/sglang/srt/environ.py test/registered/unit/mem_cache/test_hicache_nixl_tenant.py`
- Module-level tenant smoke test covering `base_dir/<tenant>` creation, `v1` layout key generation, stale sibling cleanup, marker writing, and preservation of non-tenant base-dir contents











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27541546758](https://github.com/sgl-project/sglang/actions/runs/27541546758)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27541546325](https://github.com/sgl-project/sglang/actions/runs/27541546325)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->