### PR TITLE
[Fix] baichuan: place alibi_slopes on XPU device instead of CUDA

### DIFF
--- a/python/sglang/srt/models/baichuan.py
+++ b/python/sglang/srt/models/baichuan.py
@@ -51,10 +51,11 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.utils import add_prefix, is_npu
+from sglang.srt.utils import add_prefix, is_npu, is_xpu
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 _is_npu = is_npu()
+_is_xpu = is_xpu()
 
 
 def _get_alibi_slopes(total_num_heads: int) -> torch.Tensor:
@@ -193,7 +194,7 @@ class BaiChuanAttention(nn.Module):
             alibi_slopes = _get_alibi_slopes(self.total_num_heads)
             alibi_slopes = alibi_slopes[head_start:head_end]
             self.alibi_slopes = torch.tensor(
-                alibi_slopes, dtype=dtype, device="npu" if _is_npu else "cuda"
+                alibi_slopes, dtype=dtype, device="npu" if _is_npu else "xpu" if _is_xpu else "cuda"
             )
         else:
             self.rotary_emb = get_rope(


### PR DESCRIPTION
## Motivation

`BaichuanForCausalLM` (13B config, `hidden_size > 4096`) uses ALIBI positional encoding. The `alibi_slopes` tensor was unconditionally placed on `device="cuda"` when not on NPU, causing a crash on XPU platforms where CUDA is not compiled:

```
File "sglang/srt/models/baichuan.py", line 196, in __init__
    self.alibi_slopes = torch.tensor(
  File "torch/cuda/__init__.py", line 471, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

This crashes `baichuan-inc/Baichuan2-13B-Chat` (and `Baichuan-13B-Chat`) on XPU at model initialization, before any inference runs.

## Modifications

**`python/sglang/srt/models/baichuan.py`**

Add an XPU branch to the device selection for `alibi_slopes`, so the tensor is placed on the correct device for all three backends:

```python
# Before
device="npu" if _is_npu else "cuda"

# After
device="npu" if _is_npu else "xpu" if _is_xpu else "cuda"
```

`is_xpu()` is already exported from `sglang.srt.utils` — no new utility needed.

**Affected models:**
- `baichuan-inc/Baichuan2-13B-Chat` — crashes at init (ALIBI path, `hidden_size=5120`)
- `baichuan-inc/Baichuan-13B-Chat` — same architecture

**Not affected:**
- `baichuan-inc/Baichuan2-7B-Chat` — uses ROPE (`hidden_size=4096` branch)

## Accuracy Tests

No model output changes. Fix is in initialization only — the ALIBI slopes values and computation are unchanged.

## Speed Tests and Profiling

No performance impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27537591618](https://github.com/sgl-project/sglang/actions/runs/27537591618)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27537590895](https://github.com/sgl-project/sglang/actions/runs/27537590895)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->