### PR TITLE
[Test] Add unit tests for srt/managers/scheduler_recv_skipper.py and  srt/managers/scheduler_input_blocker.py

### DIFF
--- a/test/registered/unit/managers/test_scheduler_input_blocker.py
+++ b/test/registered/unit/managers/test_scheduler_input_blocker.py
@@ -147,9 +147,9 @@ class TestInputBlockerGuardRegion(CustomTestCase):
         send_to_scheduler = MagicMock()
         with input_blocker_guard_region(send_to_scheduler):
             pass
-        send_to_scheduler.send_pyobj.assert_any_call(_block())
-        send_to_scheduler.send_pyobj.assert_any_call(_unblock())
-        self.assertEqual(send_to_scheduler.send_pyobj.call_count, 2)
+        self.assertEqual(send_to_scheduler.send_pyobj.mock_calls, [
+            unittest.mock.call(_block()), unittest.mock.call(_unblock())
+        ])
 
     def test_sends_unblock_even_on_exception(self):
         send_to_scheduler = MagicMock()

--- a/test/registered/unit/managers/test_scheduler_input_blocker.py
+++ b/test/registered/unit/managers/test_scheduler_input_blocker.py
@@ -147,17 +147,20 @@ class TestInputBlockerGuardRegion(CustomTestCase):
         send_to_scheduler = MagicMock()
         with input_blocker_guard_region(send_to_scheduler):
             pass
-        self.assertEqual(send_to_scheduler.send_pyobj.mock_calls, [
-            unittest.mock.call(_block()), unittest.mock.call(_unblock())
-        ])
+        self.assertEqual(
+            send_to_scheduler.send_pyobj.mock_calls,
+            [unittest.mock.call(_block()), unittest.mock.call(_unblock())],
+        )
 
     def test_sends_unblock_even_on_exception(self):
         send_to_scheduler = MagicMock()
         with self.assertRaises(ValueError):
             with input_blocker_guard_region(send_to_scheduler):
                 raise ValueError("boom")
-        self.assertEqual(send_to_scheduler.send_pyobj.mock_calls,
-                         [unittest.mock.call(_block()), unittest.mock.call(_unblock())])
+        self.assertEqual(
+            send_to_scheduler.send_pyobj.mock_calls,
+            [unittest.mock.call(_block()), unittest.mock.call(_unblock())],
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_input_blocker.py
+++ b/test/registered/unit/managers/test_scheduler_input_blocker.py
@@ -1,0 +1,164 @@
+"""Unit tests for managers/scheduler_input_blocker.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cpu_ci(est_time=6, suite="base-b-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.managers.io_struct import BlockReqInput, BlockReqType
+from sglang.srt.managers.scheduler_input_blocker import (
+    SchedulerInputBlocker,
+    _State,
+    input_blocker_guard_region,
+)
+from sglang.test.test_utils import CustomTestCase
+
+_BARRIER_PATH = "sglang.srt.managers.scheduler_input_blocker.PollBasedBarrier"
+
+
+def _block():
+    return BlockReqInput(type=BlockReqType.BLOCK)
+
+
+def _unblock():
+    return BlockReqInput(type=BlockReqType.UNBLOCK)
+
+
+class TestSchedulerInputBlocker(CustomTestCase):
+    def setUp(self):
+        self._barrier_patch = patch(_BARRIER_PATH)
+        self.mock_barrier_cls = self._barrier_patch.start()
+        self.addCleanup(self._barrier_patch.stop)
+
+    def _make_blocker(self, noop=False):
+        self.mock_barrier_cls.return_value.poll_global_arrived.return_value = False
+        return SchedulerInputBlocker(noop=noop)
+
+    def _arrive(self, blocker):
+        blocker._global_unblock_barrier.poll_global_arrived.return_value = True
+
+    def test_initial_state_is_unblocked(self):
+        blocker = self._make_blocker()
+        self.assertEqual(blocker._state, _State.UNBLOCKED)
+
+    def test_plain_request_passes_through_when_unblocked(self):
+        blocker = self._make_blocker()
+        result = blocker.handle([{"req": 1}])
+        self.assertEqual(result, [{"req": 1}])
+
+    def test_block_req_changes_state_to_blocked(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        self.assertEqual(blocker._state, _State.BLOCKED)
+
+    def test_requests_are_queued_when_blocked(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        result = blocker.handle([{"req": 1}, {"req": 2}])
+        self.assertEqual(result, [])
+        self.assertEqual(len(blocker._pending_reqs), 2)
+
+    def test_double_block_asserts(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        with self.assertRaises(AssertionError):
+            blocker.handle([_block()])
+
+    def test_unblock_without_block_asserts(self):
+        blocker = self._make_blocker()
+        with self.assertRaises(AssertionError):
+            blocker.handle([_unblock()])
+
+    def test_unblock_transitions_to_barrier_state(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        blocker.handle([_unblock()])
+        self.assertEqual(blocker._state, _State.GLOBAL_UNBLOCK_BARRIER)
+
+    def test_unblock_calls_local_arrive(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        blocker.handle([_unblock()])
+        self.mock_barrier_cls.return_value.local_arrive.assert_called_once()
+
+    def test_barrier_not_arrived_does_not_drain(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        blocker.handle([_unblock()])
+        blocker.handle([{"req": 1}])
+        self.assertEqual(blocker._state, _State.GLOBAL_UNBLOCK_BARRIER)
+        self.assertEqual(len(blocker._pending_reqs), 1)
+
+    def test_barrier_arrived_drains_pending_requests(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        blocker.handle([_unblock()])
+        blocker.handle([{"req": 1}])
+        self._arrive(blocker)
+        result = blocker.handle([])
+        self.assertEqual(result, [{"req": 1}])
+
+    def test_barrier_arrived_resets_state_to_unblocked(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        blocker.handle([_unblock()])
+        self._arrive(blocker)
+        blocker.handle([])
+        self.assertEqual(blocker._state, _State.UNBLOCKED)
+
+    def test_full_cycle_restores_normal_operation(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        blocker.handle([_unblock()])
+        self._arrive(blocker)
+        blocker.handle([])
+        result = blocker.handle([{"req": 99}])
+        self.assertEqual(result, [{"req": 99}])
+
+    def test_noop_accepts_none(self):
+        blocker = self._make_blocker(noop=True)
+        blocker.handle(None)
+
+    def test_noop_rejects_non_none(self):
+        blocker = self._make_blocker(noop=True)
+        with self.assertRaises(AssertionError):
+            blocker.handle([{"req": 1}])
+
+    def test_noop_still_polls_barrier(self):
+        blocker = self._make_blocker(noop=True)
+        blocker.handle(None)
+        self.mock_barrier_cls.return_value.poll_global_arrived.assert_called_once()
+
+    def test_pending_reqs_preserve_insertion_order(self):
+        blocker = self._make_blocker()
+        blocker.handle([_block()])
+        blocker.handle(["a", "b", "c"])
+        blocker.handle([_unblock()])
+        self._arrive(blocker)
+        result = blocker.handle([])
+        self.assertEqual(result, ["a", "b", "c"])
+
+
+class TestInputBlockerGuardRegion(CustomTestCase):
+    def test_sends_block_before_yield_and_unblock_after(self):
+        send_to_scheduler = MagicMock()
+        with input_blocker_guard_region(send_to_scheduler):
+            pass
+        send_to_scheduler.send_pyobj.assert_any_call(_block())
+        send_to_scheduler.send_pyobj.assert_any_call(_unblock())
+        self.assertEqual(send_to_scheduler.send_pyobj.call_count, 2)
+
+    def test_sends_unblock_even_on_exception(self):
+        send_to_scheduler = MagicMock()
+        with self.assertRaises(ValueError):
+            with input_blocker_guard_region(send_to_scheduler):
+                raise ValueError("boom")
+        last_args = send_to_scheduler.send_pyobj.call_args.args
+        self.assertEqual(last_args[0].type, BlockReqType.UNBLOCK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_input_blocker.py
+++ b/test/registered/unit/managers/test_scheduler_input_blocker.py
@@ -156,8 +156,8 @@ class TestInputBlockerGuardRegion(CustomTestCase):
         with self.assertRaises(ValueError):
             with input_blocker_guard_region(send_to_scheduler):
                 raise ValueError("boom")
-        last_args = send_to_scheduler.send_pyobj.call_args.args
-        self.assertEqual(last_args[0].type, BlockReqType.UNBLOCK)
+        self.assertEqual(send_to_scheduler.send_pyobj.mock_calls,
+                         [unittest.mock.call(_block()), unittest.mock.call(_unblock())])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_recv_skipper.py
+++ b/test/registered/unit/managers/test_scheduler_recv_skipper.py
@@ -1,0 +1,106 @@
+"""Unit tests for managers/scheduler_recv_skipper.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+register_cpu_ci(est_time=5, suite="base-b-test-cpu")
+
+import os
+import unittest
+
+from sglang.srt.managers.scheduler_recv_skipper import SchedulerRecvSkipper
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import CustomTestCase
+
+
+def _set_weights(default=1, decode=1, target_verify=1, none_weight=1):
+    return {
+        "SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_DEFAULT": str(default),
+        "SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_DECODE": str(decode),
+        "SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_TARGET_VERIFY": str(target_verify),
+        "SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_NONE": str(none_weight),
+    }
+
+
+class TestMaybeCreate(CustomTestCase):
+    def test_interval_le_1_returns_none(self):
+        self.assertIsNone(
+            SchedulerRecvSkipper.maybe_create(
+                ServerArgs(model_path="none", scheduler_recv_interval=1)
+            )
+        )
+        self.assertIsNone(
+            SchedulerRecvSkipper.maybe_create(
+                ServerArgs(model_path="none", scheduler_recv_interval=0)
+            )
+        )
+
+    def test_interval_gt_1_creates_instance(self):
+        with unittest.mock.patch.dict(os.environ, _set_weights()):
+            skipper = SchedulerRecvSkipper.maybe_create(
+                ServerArgs(model_path="none", scheduler_recv_interval=3)
+            )
+        self.assertIsInstance(skipper, SchedulerRecvSkipper)
+
+    def test_enable_dp_attention_asserts(self):
+        with self.assertRaises(AssertionError):
+            SchedulerRecvSkipper.maybe_create(
+                ServerArgs(
+                    model_path="none",
+                    scheduler_recv_interval=3,
+                    enable_dp_attention=True,
+                )
+            )
+
+
+class TestHandle(CustomTestCase):
+    def _make(self, interval=4, **weights):
+        defaults = {"default": 1, "decode": 1, "target_verify": 1, "none_weight": 1}
+        defaults.update(weights)
+        self.env_ctx = unittest.mock.patch.dict(os.environ, _set_weights(**defaults))
+        self.env_ctx.__enter__()
+        self.addCleanup(self.env_ctx.__exit__)
+        return SchedulerRecvSkipper(
+            ServerArgs(model_path="none", scheduler_recv_interval=interval)
+        )
+
+    def test_four_calls_trigger_on_threshold_4(self):
+        skipper = self._make(4)
+        self.assertFalse(skipper.handle(ForwardMode.DECODE))
+        self.assertFalse(skipper.handle(ForwardMode.DECODE))
+        self.assertFalse(skipper.handle(ForwardMode.DECODE))
+        self.assertTrue(skipper.handle(ForwardMode.DECODE))
+
+    def test_counter_resets_after_trigger(self):
+        skipper = self._make(4)
+        for _ in range(4):
+            skipper.handle(ForwardMode.DECODE)
+        self.assertFalse(skipper.handle(ForwardMode.DECODE))
+
+    def test_decode_weight_2_triggers_faster(self):
+        skipper = self._make(4, decode=2)
+        self.assertFalse(skipper.handle(ForwardMode.DECODE))
+        self.assertTrue(skipper.handle(ForwardMode.DECODE))
+
+    def test_target_verify_uses_own_weight(self):
+        skipper = self._make(4, target_verify=4)
+        self.assertTrue(skipper.handle(ForwardMode.TARGET_VERIFY))
+
+    def test_none_forward_mode_uses_own_weight(self):
+        skipper = self._make(4, none_weight=4)
+        self.assertTrue(skipper.handle(None))
+
+    def test_zero_weight_never_triggers(self):
+        skipper = self._make(4, default=0, decode=0, target_verify=0, none_weight=0)
+        for _ in range(100):
+            self.assertFalse(skipper.handle(ForwardMode.DECODE))
+
+    def test_unknown_forward_mode_falls_back_to_default(self):
+        skipper = self._make(4, default=2, decode=1)
+        self.assertFalse(skipper.handle("some_unknown_mode"))  # type: ignore
+        self.assertTrue(skipper.handle("some_unknown_mode"))  # type: ignore
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
28 test cases covering SchedulerRecvSkipper and SchedulerInputBlocker.

No server, no GPU, no model loading.
Ref: #20865

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Added two new test files: `test/registered/unit/managers/test_scheduler_recv_skipper.py` and `test_scheduler_input_blocker.py`

`managers/scheduler_recv_skipper.py` and `managers/scheduler_input_blocker.py` currently have no dedicated unit tests. The recv skipper contains a weighted-counter state machine that throttles how often the scheduler checks for new requests under different forward modes (DECODE, TARGET_VERIFY, etc.). The input blocker implements a three-state gate (UNBLOCKED → BLOCKED → GLOBAL_UNBLOCK_BARRIER → UNBLOCKED) that atomically blocks request flow while tokenizer performs large-batch packaging, coordinated across distributed ranks via a poll-based barrier. Both can regress silently. This PR adds CPU-only coverage for the current behavior.

**Coverage**

**`scheduler_recv_skipper.py`** (10 tests):
- `maybe_create` — interval ≤ 1 returns None, interval > 1 creates instance, DP attention asserts.
- `handle` — counter accumulates across calls, crosses threshold after N calls, resets after trigger, per-mode weights (DECODE=2 triggers faster, TARGET_VERIFY=4 triggers immediately, None=4 triggers immediately), zero weight never triggers (100 iterations), unknown forward mode falls back to default weight.

**`scheduler_input_blocker.py`** (18 tests):
- Core state machine — initial UNBLOCKED, plain requests pass through, BLOCK transitions, requests queue when blocked, double-block asserts, unblock-without-block asserts, unblock transitions to GLOBAL_UNBLOCK_BARRIER.
- Barrier coordination — `local_arrive()` called on unblock, barrier-not-arrived leaves pending intact, barrier-arrived drains pending + resets to UNBLOCKED, full cycle restores normal pass-through.
- Noop mode — accepts `None`, rejects non-None, still polls barrier.
- Guard region context manager — sends BLOCK before yield + UNBLOCK after, sends UNBLOCK even on exception.
- Pending requests preserve insertion order.

The tests are CPU-only and do not start a server or load a model. Mock usage is limited to `PollBasedBarrier` (requires `torch.distributed`) and `os.environ` (for env-var-driven weights). All state machine assertions operate on real `SchedulerRecvSkipper` / `SchedulerInputBlocker` instances. They are registered via:
<!-- Describe the purpose and goals of this pull request. -->

```python
# scheduler_recv_skipper
register_cpu_ci(est_time=4, suite="base-a-test-cpu")
register_cpu_ci(est_time=5, suite="base-b-test-cpu")

# scheduler_input_blocker
register_cpu_ci(est_time=5, suite="base-a-test-cpu")
register_cpu_ci(est_time=6, suite="base-b-test-cpu")
```

**Test plan:**
test_scheduler_recv_skipper.py:
```shell
pytest test/registered/unit/managers/test_scheduler_recv_skipper.py -v
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/evanderf/sglang/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/evanderf/sglang/test
configfile: pytest.ini
plugins: anyio-4.13.0, asyncio-1.4.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 10 items                                                                                                                                                                                                           

test/registered/unit/managers/test_scheduler_recv_skipper.py::TestMaybeCreate::test_enable_dp_attention_asserts PASSED                                                                                                 [ 10%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestMaybeCreate::test_interval_gt_1_creates_instance PASSED                                                                                              [ 20%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestMaybeCreate::test_interval_le_1_returns_none PASSED                                                                                                  [ 30%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestHandle::test_counter_resets_after_trigger PASSED                                                                                                     [ 40%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestHandle::test_decode_weight_2_triggers_faster PASSED                                                                                                  [ 50%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestHandle::test_four_calls_trigger_on_threshold_4 PASSED                                                                                                [ 60%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestHandle::test_none_forward_mode_uses_own_weight PASSED                                                                                                [ 70%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestHandle::test_target_verify_uses_own_weight PASSED                                                                                                    [ 80%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestHandle::test_unknown_forward_mode_falls_back_to_default PASSED                                                                                       [ 90%]
test/registered/unit/managers/test_scheduler_recv_skipper.py::TestHandle::test_zero_weight_never_triggers PASSED                                                                                                       [100%]

====================================================================================================== warnings summary ======================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================== 10 passed, 2 warnings in 4.41s ===============================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
test_scheduler_input_blocker.py:
```shell
pytest test/registered/unit/managers/test_scheduler_input_blocker.py -v
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/evanderf/sglang/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/evanderf/sglang/test
configfile: pytest.ini
plugins: anyio-4.13.0, asyncio-1.4.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 18 items                                                                                                                                                                                                           

test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_barrier_arrived_drains_pending_requests PASSED                                                                          [  5%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_barrier_arrived_resets_state_to_unblocked PASSED                                                                        [ 11%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_barrier_not_arrived_does_not_drain PASSED                                                                               [ 16%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_block_req_changes_state_to_blocked PASSED                                                                               [ 22%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_double_block_asserts PASSED                                                                                             [ 27%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_full_cycle_restores_normal_operation PASSED                                                                             [ 33%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_initial_state_is_unblocked PASSED                                                                                       [ 38%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_noop_accepts_none PASSED                                                                                                [ 44%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_noop_rejects_non_none PASSED                                                                                            [ 50%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_noop_still_polls_barrier PASSED                                                                                         [ 55%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_pending_reqs_preserve_insertion_order PASSED                                                                            [ 61%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_plain_request_passes_through_when_unblocked PASSED                                                                      [ 66%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_requests_are_queued_when_blocked PASSED                                                                                 [ 72%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_unblock_calls_local_arrive PASSED                                                                                       [ 77%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_unblock_transitions_to_barrier_state PASSED                                                                             [ 83%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestSchedulerInputBlocker::test_unblock_without_block_asserts PASSED                                                                                    [ 88%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestInputBlockerGuardRegion::test_sends_block_before_yield_and_unblock_after PASSED                                                                     [ 94%]
test/registered/unit/managers/test_scheduler_input_blocker.py::TestInputBlockerGuardRegion::test_sends_unblock_even_on_exception PASSED                                                                                [100%]

====================================================================================================== warnings summary ======================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/evanderf/sglang/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================== 18 passed, 16 warnings in 5.61s ===============================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

## Accuracy Tests
N/A — this is a test-only change. No kernel or model-forward code is touched.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
N/A — this PR only adds unit tests and does not affect the inference path.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27545923624](https://github.com/sgl-project/sglang/actions/runs/27545923624)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27545923666](https://github.com/sgl-project/sglang/actions/runs/27545923666)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->