### PR TITLE
[Diffusion] Restrict fused GELU to Hopper

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/fused_linear_act/gelu.py
+++ b/python/sglang/multimodal_gen/runtime/layers/fused_linear_act/gelu.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from sglang.multimodal_gen.runtime.layers.linear import UnquantizedLinearMethod
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.srt.utils.custom_op import register_custom_op
 
 # ``torch._addmm_activation`` is the (private but stable) entry point to the
@@ -56,7 +57,7 @@ def fused_linear_gelu_tanh(
 def can_fuse_linear_gelu(linear: Any, x: torch.Tensor) -> bool:
     """Whether ``gelu(linear(x))`` can use the fused cublasLt epilogue.
 
-    Requires the fused API to exist, a CUDA half-precision input, and an
+    Requires the fused API to exist, a Hopper CUDA half-precision input, and an
     unquantized, bias'd, non-output-gathering linear layer (so the local weight
     shard is exactly what the reference forward multiplies -- correct under TP).
     A column-parallel layer that gathers across multiple ranks is excluded
@@ -64,6 +65,11 @@ def can_fuse_linear_gelu(linear: Any, x: torch.Tensor) -> bool:
     no-op gather is fine.
     """
     if not (_HAS_ADDMM_ACTIVATION and x.is_cuda):
+        return False
+    # TODO(BBuf): Re-enable SM100 after B200 SGLang diffusion gets a full
+    # #28050-style mode-selection sweep across diffusion models. For now only
+    # Hopper has a verified fused-GELU speedup.
+    if not current_platform.is_hopper():
         return False
     if x.dtype not in (torch.bfloat16, torch.float16):
         return False


### PR DESCRIPTION
## Summary

Restrict the shared diffusion fused linear + tanh-GELU cublasLt epilogue path to Hopper GPUs by using the existing `current_platform.is_hopper()` architecture guard. Non-Hopper CUDA, including B200/SM100, now falls back to the reference `linear(x)` + `F.gelu(approximate="tanh")` path.

A TODO is left beside the guard to revisit SM100 after a full B200 SGLang diffusion mode-selection sweep similar to #28050.

## Validation

- `git diff --check`
- `python3 -m py_compile python/sglang/multimodal_gen/runtime/layers/fused_linear_act/gelu.py`

Context: B200 Qwen compile default mode was measured as a win, but current evidence is only broadly verified on Hopper across these fused-GELU PRs, so this follow-up keeps Blackwell conservative until the mode sweep is complete.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27539782332](https://github.com/sgl-project/sglang/actions/runs/27539782332)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27539782089](https://github.com/sgl-project/sglang/actions/runs/27539782089)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->