### PR TITLE
[Fix] Handle list-typed matched values in trim_matched_stop

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -176,7 +176,28 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
         if not matched:
             return output
 
-        # TODO(lmzheng): handle the case where multiple stop strs are hit
+        # Handle multiple stop strs or tokens
+        if isinstance(matched, list):
+            if matched and isinstance(matched[0], str) and isinstance(output, str):
+                # Multiple stop strings: trim at the earliest occurrence
+                earliest = len(output)
+                for m in matched:
+                    pos = output.find(m)
+                    if pos != -1:
+                        earliest = min(earliest, pos)
+                return output[:earliest] if earliest < len(output) else output
+            elif matched and isinstance(matched[0], int) and isinstance(output, list):
+                # 200012 <|call|> is the tool call token and one of eos tokens for gpt-oss model
+                if (
+                    output[-1] == 200012
+                    and self.is_tool_call_parser_gpt_oss
+                    and matched[-1] == 200012
+                ):
+                    return output
+                # Multiple stop tokens: remove from the end
+                n = min(len(matched), len(output))
+                return output[:-n] if n > 0 else output
+            return output
 
         # Trim stop str.
         if isinstance(matched, str) and isinstance(output, str):

--- a/test/registered/unit/managers/test_detokenizer_manager.py
+++ b/test/registered/unit/managers/test_detokenizer_manager.py
@@ -1,0 +1,97 @@
+"""Unit tests for DetokenizerManager.trim_matched_stop."""
+
+import unittest
+
+from sglang.srt.managers.detokenizer_manager import DetokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestTrimMatchedStop(CustomTestCase):
+    def setUp(self):
+        self.mgr = DetokenizerManager.__new__(DetokenizerManager)
+        self.mgr.is_tool_call_parser_gpt_oss = False
+
+    # --- Single match (original paths, must remain unchanged) ---
+
+    def test_single_str(self):
+        result = self.mgr.trim_matched_stop("hello world", {"matched": "world"}, False)
+        self.assertEqual(result, "hello ")
+
+    def test_single_int(self):
+        result = self.mgr.trim_matched_stop([1, 2, 3], {"matched": 3}, False)
+        self.assertEqual(result, [1, 2])
+
+    # --- Multiple stop strings (new path) ---
+
+    def test_multi_strs_trim_at_earliest(self):
+        result = self.mgr.trim_matched_stop(
+            "hello world foo", {"matched": ["world", "foo"]}, False
+        )
+        self.assertEqual(result, "hello ")
+
+    def test_multi_strs_none_match(self):
+        result = self.mgr.trim_matched_stop(
+            "hello", {"matched": ["world", "foo"]}, False
+        )
+        self.assertEqual(result, "hello")
+
+    # --- Multiple stop tokens (new path) ---
+
+    def test_multi_ints(self):
+        result = self.mgr.trim_matched_stop([1, 2, 3, 4], {"matched": [3, 4]}, False)
+        self.assertEqual(result, [1, 2])
+
+    def test_multi_ints_overflow(self):
+        result = self.mgr.trim_matched_stop([1], {"matched": [1, 2, 3]}, False)
+        self.assertEqual(result, [])
+
+    def test_multi_ints_empty_output(self):
+        result = self.mgr.trim_matched_stop([], {"matched": [1, 2]}, False)
+        self.assertEqual(result, [])
+
+    # --- Edge cases ---
+
+    def test_no_stop_trim(self):
+        result = self.mgr.trim_matched_stop("hello world", {"matched": "world"}, True)
+        self.assertEqual(result, "hello world")
+
+    def test_empty_finished_reason(self):
+        result = self.mgr.trim_matched_stop("hello world", {}, False)
+        self.assertEqual(result, "hello world")
+
+    def test_matched_none(self):
+        result = self.mgr.trim_matched_stop("hello world", {"matched": None}, False)
+        self.assertEqual(result, "hello world")
+
+    def test_empty_matched_list(self):
+        result = self.mgr.trim_matched_stop("hello", {"matched": []}, False)
+        self.assertEqual(result, "hello")
+
+    # --- gpt-oss tool call token ---
+
+    def test_gpt_oss_single_token_kept(self):
+        mgr = DetokenizerManager.__new__(DetokenizerManager)
+        mgr.is_tool_call_parser_gpt_oss = True
+        result = mgr.trim_matched_stop([100, 200012], {"matched": 200012}, False)
+        self.assertEqual(result, [100, 200012])
+
+    def test_gpt_oss_multi_token_kept(self):
+        mgr = DetokenizerManager.__new__(DetokenizerManager)
+        mgr.is_tool_call_parser_gpt_oss = True
+        result = mgr.trim_matched_stop([100, 200012], {"matched": [99, 200012]}, False)
+        self.assertEqual(result, [100, 200012])
+
+    def test_gpt_oss_multi_token_not_last(self):
+        mgr = DetokenizerManager.__new__(DetokenizerManager)
+        mgr.is_tool_call_parser_gpt_oss = True
+        result = mgr.trim_matched_stop(
+            [100, 200012, 50], {"matched": [50, 200012]}, False
+        )
+        self.assertEqual(result, [100, 200012, 50])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
FINISH_MATCHED_TOKEN.matched is typed as `Union[int, List[int]]` but `trim_matched_stop` only handled single `int` / `str` values. When `matched` is a list, the stop was silently not trimmed.

- Handle `List[str]` by trimming at the earliest occurrence
- Handle `List[int]` by removing matched tokens from the end
- Use `min()` guard instead of `assert` for overflow safety
- Added unit tests in `test/registered/unit/managers/test_detokenizer_manager.py`







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27542245259](https://github.com/sgl-project/sglang/actions/runs/27542245259)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27542245174](https://github.com/sgl-project/sglang/actions/runs/27542245174)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->