### PR TITLE
[AMD] Test DeepSeek V4 FlashMLA backend variants nightly

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1250,19 +1250,28 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
-      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4)
-        timeout-minutes: 600
+      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4, unified_kv_triton)
+        timeout-minutes: 300
         run: |
           > github_summary.md  # Clear summary file
-          for flashmla_backend in unified_kv_triton triton; do
-            echo "## SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend}" >> github_summary.md
-            bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-              -e SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend} \
-              -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-              python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-flash --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
-          done
+          echo "## SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-flash --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
-          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4, triton)
+        if: ${{ !cancelled() }}
+        timeout-minutes: 300
+        run: |
+          > github_summary.md  # Clear summary file
+          echo "## SGLANG_HACK_FLASHMLA_BACKEND=triton" >> github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_HACK_FLASHMLA_BACKEND=triton \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-flash --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
 
   nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720,'))
@@ -1289,19 +1298,28 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
-      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Pro FP8 + FP4)
-        timeout-minutes: 960
+      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Pro FP8 + FP4, unified_kv_triton)
+        timeout-minutes: 480
         run: |
           > github_summary.md  # Clear summary file
-          for flashmla_backend in unified_kv_triton triton; do
-            echo "## SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend}" >> github_summary.md
-            bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-              -e SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend} \
-              -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-              python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
-          done
+          echo "## SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
-          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Pro FP8 + FP4, triton)
+        if: ${{ !cancelled() }}
+        timeout-minutes: 480
+        run: |
+          > github_summary.md  # Clear summary file
+          echo "## SGLANG_HACK_FLASHMLA_BACKEND=triton" >> github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_HACK_FLASHMLA_BACKEND=triton \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
 
   # ==============================================================================
   # 8-GPU Kimi-K2.6 (MI30x + MI35x)

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1251,12 +1251,16 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
       - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4)
-        timeout-minutes: 300
+        timeout-minutes: 600
         run: |
           > github_summary.md  # Clear summary file
-          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-flash --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          for flashmla_backend in unified_kv_triton triton; do
+            echo "## SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend}" >> github_summary.md
+            bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+              -e SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend} \
+              -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+              python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-flash --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          done
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
@@ -1286,12 +1290,16 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
       - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Pro FP8 + FP4)
-        timeout-minutes: 480
+        timeout-minutes: 960
         run: |
           > github_summary.md  # Clear summary file
-          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          for flashmla_backend in unified_kv_triton triton; do
+            echo "## SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend}" >> github_summary.md
+            bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+              -e SGLANG_HACK_FLASHMLA_BACKEND=${flashmla_backend} \
+              -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+              python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          done
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 

--- a/test/registered/amd/test_deepseek_v4_flash_fp4.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp4.py
@@ -34,6 +34,7 @@ DEEPSEEK_V4_FP4_MODEL_PATH = os.environ.get(
     "DEEPSEEK_V4_FP4_MODEL_PATH", "deepseek-ai/DeepSeek-V4-Flash"
 )
 SERVER_LAUNCH_TIMEOUT = 3600
+FLASHMLA_BACKEND = os.environ.get("SGLANG_HACK_FLASHMLA_BACKEND", "unified_kv_triton")
 
 # Common DeepSeek-V4 env vars (AMD ROCm 7.2 path: AITER indexer + triton attn + ROCm700A).
 COMMON_ENV_VARS = {
@@ -44,7 +45,7 @@ COMMON_ENV_VARS = {
     "SGLANG_USE_ROCM700A": "1",
     "SGLANG_OPT_USE_FUSED_COMPRESS": "true",
     "SGLANG_OPT_USE_FUSED_COMPRESS_TRITON": "true",
-    "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
+    "SGLANG_HACK_FLASHMLA_BACKEND": FLASHMLA_BACKEND,
     "SGLANG_OPT_FP8_WO_A_GEMM": "false",
     "SGLANG_OPT_USE_JIT_INDEXER_METADATA": "false",
     "SGLANG_OPT_USE_TOPK_V2": "false",
@@ -126,7 +127,7 @@ class TestDeepseekV4Fp4(CustomTestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"### test_gsm8k (deepseek-v4-flash-fp4)\n"
+                f"### test_gsm8k (deepseek-v4-flash-fp4, {FLASHMLA_BACKEND})\n"
                 f'{metrics["accuracy"]=:.3f}\n'
             )
             self.assertGreater(metrics["accuracy"], 0.91)
@@ -185,7 +186,7 @@ class TestDeepseekV4Fp4(CustomTestCase):
             report_results = results_data
 
         summary_lines = [
-            "### test_perf_8k_1k (deepseek-v4-flash-fp4)",
+            f"### test_perf_8k_1k (deepseek-v4-flash-fp4, {FLASHMLA_BACKEND})",
             "input_len=8192 output_len=1024",
             "",
             "| batch size | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |",

--- a/test/registered/amd/test_deepseek_v4_flash_fp8.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8.py
@@ -34,6 +34,7 @@ DEEPSEEK_V4_FP8_MODEL_PATH = os.environ.get(
     "DEEPSEEK_V4_FP8_MODEL_PATH", "sgl-project/DeepSeek-V4-Flash-FP8"
 )
 SERVER_LAUNCH_TIMEOUT = 3600
+FLASHMLA_BACKEND = os.environ.get("SGLANG_HACK_FLASHMLA_BACKEND", "unified_kv_triton")
 
 # Common DeepSeek-V4 env vars (AMD ROCm 7.2 path: AITER indexer + triton attn + ROCm700A).
 COMMON_ENV_VARS = {
@@ -44,7 +45,7 @@ COMMON_ENV_VARS = {
     "SGLANG_USE_ROCM700A": "1",
     "SGLANG_OPT_USE_FUSED_COMPRESS": "true",
     "SGLANG_OPT_USE_FUSED_COMPRESS_TRITON": "true",
-    "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
+    "SGLANG_HACK_FLASHMLA_BACKEND": FLASHMLA_BACKEND,
     "SGLANG_OPT_FP8_WO_A_GEMM": "false",
     "SGLANG_OPT_USE_JIT_INDEXER_METADATA": "false",
     "SGLANG_OPT_USE_TOPK_V2": "false",
@@ -126,7 +127,7 @@ class TestDeepseekV4Fp8(CustomTestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"### test_gsm8k (deepseek-v4-flash-fp8)\n"
+                f"### test_gsm8k (deepseek-v4-flash-fp8, {FLASHMLA_BACKEND})\n"
                 f'{metrics["accuracy"]=:.3f}\n'
             )
             self.assertGreater(metrics["accuracy"], 0.91)
@@ -185,7 +186,7 @@ class TestDeepseekV4Fp8(CustomTestCase):
             report_results = results_data
 
         summary_lines = [
-            "### test_perf_8k_1k (deepseek-v4-flash-fp8)",
+            f"### test_perf_8k_1k (deepseek-v4-flash-fp8, {FLASHMLA_BACKEND})",
             "input_len=8192 output_len=1024",
             "",
             "| batch size | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |",

--- a/test/registered/amd/test_deepseek_v4_pro_fp4.py
+++ b/test/registered/amd/test_deepseek_v4_pro_fp4.py
@@ -36,6 +36,7 @@ DEEPSEEK_V4_PRO_FP4_MODEL_PATH = os.environ.get(
 )
 # Pro is 1.6T; weight load + warmup is much longer than Flash 285B.
 SERVER_LAUNCH_TIMEOUT = 5400
+FLASHMLA_BACKEND = os.environ.get("SGLANG_HACK_FLASHMLA_BACKEND", "unified_kv_triton")
 
 # Common DeepSeek-V4 env vars (AMD ROCm 7.2 path: AITER indexer + triton attn + ROCm700A).
 COMMON_ENV_VARS = {
@@ -46,7 +47,7 @@ COMMON_ENV_VARS = {
     "SGLANG_USE_ROCM700A": "1",
     "SGLANG_OPT_USE_FUSED_COMPRESS": "true",
     "SGLANG_OPT_USE_FUSED_COMPRESS_TRITON": "true",
-    "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
+    "SGLANG_HACK_FLASHMLA_BACKEND": FLASHMLA_BACKEND,
     "SGLANG_OPT_FP8_WO_A_GEMM": "false",
     "SGLANG_OPT_USE_JIT_INDEXER_METADATA": "false",
     "SGLANG_OPT_USE_TOPK_V2": "false",
@@ -128,7 +129,7 @@ class TestDeepseekV4ProFp4(CustomTestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"### test_gsm8k (deepseek-v4-pro-fp4)\n"
+                f"### test_gsm8k (deepseek-v4-pro-fp4, {FLASHMLA_BACKEND})\n"
                 f'{metrics["accuracy"]=:.3f}\n'
             )
             self.assertGreater(metrics["accuracy"], 0.92)
@@ -187,7 +188,7 @@ class TestDeepseekV4ProFp4(CustomTestCase):
             report_results = results_data
 
         summary_lines = [
-            "### test_perf_8k_1k (deepseek-v4-pro-fp4)",
+            f"### test_perf_8k_1k (deepseek-v4-pro-fp4, {FLASHMLA_BACKEND})",
             "input_len=8192 output_len=1024",
             "",
             "| batch size | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |",

--- a/test/registered/amd/test_deepseek_v4_pro_fp8.py
+++ b/test/registered/amd/test_deepseek_v4_pro_fp8.py
@@ -36,6 +36,7 @@ DEEPSEEK_V4_PRO_FP8_MODEL_PATH = os.environ.get(
 )
 # Pro is 1.6T; weight load + warmup is much longer than Flash 285B.
 SERVER_LAUNCH_TIMEOUT = 5400
+FLASHMLA_BACKEND = os.environ.get("SGLANG_HACK_FLASHMLA_BACKEND", "unified_kv_triton")
 
 # Common DeepSeek-V4 env vars (AMD ROCm 7.2 path: AITER indexer + triton attn + ROCm700A).
 COMMON_ENV_VARS = {
@@ -46,7 +47,7 @@ COMMON_ENV_VARS = {
     "SGLANG_USE_ROCM700A": "1",
     "SGLANG_OPT_USE_FUSED_COMPRESS": "true",
     "SGLANG_OPT_USE_FUSED_COMPRESS_TRITON": "true",
-    "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
+    "SGLANG_HACK_FLASHMLA_BACKEND": FLASHMLA_BACKEND,
     "SGLANG_OPT_FP8_WO_A_GEMM": "false",
     "SGLANG_OPT_USE_JIT_INDEXER_METADATA": "false",
     "SGLANG_OPT_USE_TOPK_V2": "false",
@@ -128,7 +129,7 @@ class TestDeepseekV4ProFp8(CustomTestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"### test_gsm8k (deepseek-v4-pro-fp8)\n"
+                f"### test_gsm8k (deepseek-v4-pro-fp8, {FLASHMLA_BACKEND})\n"
                 f'{metrics["accuracy"]=:.3f}\n'
             )
             self.assertGreater(metrics["accuracy"], 0.91)
@@ -187,7 +188,7 @@ class TestDeepseekV4ProFp8(CustomTestCase):
             report_results = results_data
 
         summary_lines = [
-            "### test_perf_8k_1k (deepseek-v4-pro-fp8)",
+            f"### test_perf_8k_1k (deepseek-v4-pro-fp8, {FLASHMLA_BACKEND})",
             "input_len=8192 output_len=1024",
             "",
             "| batch size | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |",


### PR DESCRIPTION
## Summary
- Run DeepSeek-V4 Flash and Pro ROCm 7.2 nightly suites with both `unified_kv_triton` and `triton` FlashMLA backends.
- Keep both backend variants inside the same job to reuse the existing job/container model cache.
- Surface the selected FlashMLA backend in CI summaries for easier result comparison.


## Test
https://github.com/sgl-project/sglang/actions/runs/27559151201/job/81466152641






















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27555477855](https://github.com/sgl-project/sglang/actions/runs/27555477855)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27555475313](https://github.com/sgl-project/sglang/actions/runs/27555475313)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->