### PR TITLE
[trtllm_mla] opt-in cuteDSL grouped-Q fold kernel for the EAGLE spec-verify

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -162,6 +162,23 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         # Runtime parameters
         self.backend = backend
+        # Opt-in: route the EAGLE spec-verify through the cuteDSL grouped-Q fold kernel.
+        # The cute-dsl mla_decode kernel packs all ndt verify tokens of a request into one
+        # CTA (grouped-Q / fold_sq) and reads the KV once, vs trtllm-gen's one-CTA-per-token
+        # (KV read x ndt). Default keeps the existing trtllm-gen verify.
+        self._spec_verify_backend = getattr(
+            model_runner.server_args, "speculative_mla_verify_backend", "trtllm-gen"
+        )
+        if self._spec_verify_backend == "cute-dsl":
+            _spec_topk = (
+                getattr(model_runner.server_args, "speculative_eagle_topk", None) or 1
+            )
+            if _spec_topk > 1:
+                logger.warning(
+                    "speculative_mla_verify_backend=cute-dsl is validated for "
+                    "speculative_eagle_topk=1 only; using trtllm-gen for the verify."
+                )
+                self._spec_verify_backend = "trtllm-gen"
         self.scaling = config.scaling
         self.data_type = model_runner.kv_cache_dtype
         self.q_data_type = model_runner.dtype
@@ -190,6 +207,17 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     device=model_runner.device,
                 )
             self.workspace_buffer = global_zero_init_workspace_buffer
+
+        # The spec-verify can dispatch the cute-dsl kernel from a non-cute instance (the
+        # verify runs on the prefill/extend backend); ensure its int8 workspace exists.
+        # (global_cute_dsl_workspace_buffer is already declared global above in this fn.)
+        if self._spec_verify_backend == "cute-dsl" and self.backend != "cute-dsl":
+            if global_cute_dsl_workspace_buffer is None:
+                global_cute_dsl_workspace_buffer = torch.zeros(
+                    self.workspace_size,
+                    dtype=torch.int8,
+                    device=model_runner.device,
+                )
 
         # CUDA graph state
         self.decode_cuda_graph_metadata = {}
@@ -632,8 +660,13 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         seq_lens: torch.Tensor,
         max_seq_len: int,
         layer: RadixAttention,
+        backend_override: Optional[str] = None,
     ) -> torch.Tensor:
-        """Hook for subclasses to swap the decode/spec-verify kernel."""
+        """Hook for subclasses to swap the decode/spec-verify kernel.
+
+        ``backend_override`` lets a caller (e.g. the spec-verify) pick a different
+        flashinfer MLA backend than this instance's default ``self.backend``.
+        """
 
         # Scale computation for TRTLLM MLA kernel BMM1 operation:
         # The final BMM1 scale is computed as: q_scale * k_scale * softmax_scale
@@ -647,11 +680,16 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         seq_lens_i32 = (
             seq_lens if seq_lens.dtype == torch.int32 else seq_lens.to(torch.int32)
         )
-        extra_kwargs = {"backend": self.backend} if self.backend != "trtllm-gen" else {}
+        backend = backend_override or self.backend
+        extra_kwargs = {"backend": backend} if backend != "trtllm-gen" else {}
+        workspace_buffer = self.workspace_buffer
+        if backend == "cute-dsl" and self.backend != "cute-dsl":
+            # spec-verify dispatching the cute fold from the prefill/extend instance
+            workspace_buffer = global_cute_dsl_workspace_buffer
         return flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
             query=query,
             kv_cache=kv_cache,
-            workspace_buffer=self.workspace_buffer,
+            workspace_buffer=workspace_buffer,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
@@ -966,6 +1004,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 seq_lens=metadata.seq_lens_k,
                 max_seq_len=max_seq_len,
                 layer=layer,
+                backend_override=(
+                    self._spec_verify_backend
+                    if forward_batch.forward_mode.is_target_verify()
+                    else None
+                ),
             )
 
             if needs_unpad:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -621,6 +621,7 @@ class ServerArgs:
     speculative_accept_threshold_acc: float = 1.0
     speculative_token_map: Optional[str] = None
     speculative_attention_mode: str = "prefill"
+    speculative_mla_verify_backend: str = "trtllm-gen"
     speculative_draft_attention_backend: Optional[str] = None
     speculative_draft_window_size: Optional[int] = None
     speculative_moe_runner_backend: Optional[str] = None
@@ -6142,6 +6143,17 @@ class ServerArgs:
             choices=["prefill", "decode"],
             help="Attention backend for speculative decoding operations (both target verify and draft extend). Can be one of 'prefill' (default) or 'decode'.",
             default=ServerArgs.speculative_attention_mode,
+        )
+        parser.add_argument(
+            "--speculative-mla-verify-backend",
+            type=str,
+            choices=["trtllm-gen", "cute-dsl"],
+            default=ServerArgs.speculative_mla_verify_backend,
+            help="flashinfer MLA kernel for the EAGLE spec-verify on the trtllm_mla backend. "
+            "'cute-dsl' uses the grouped-Q fold (groupsTokensHeadsQ) kernel that packs all "
+            "draft tokens of a request into one CTA and reads the KV once (vs trtllm-gen's "
+            "one-CTA-per-token / KV read x num_draft_tokens). Requires a flashinfer build with "
+            "the cute-dsl fold kernel and speculative_eagle_topk=1; otherwise falls back to trtllm-gen.",
         )
         parser.add_argument(
             "--speculative-draft-attention-backend",


### PR DESCRIPTION
## Motivation

For EAGLE speculative decoding on the `trtllm_mla` attention backend, the target **verify** forward processes `num_draft_tokens` (`ndt`) query tokens per request over a long cached context.

**Why the kernel choice matters.** The trtllm-gen MLA decode kernel (`fmhaSm100…HQk576HV512…ForGen`) maps **one query token per CTA**, so for a verify of `ndt` tokens it launches `ndt` CTAs per request and **re-reads that request's KV cache `ndt` times**. The cuteDSL monolithic `mla_decode_fp8` kernel is already optimized for exactly this shape: its grouped-Q fold (`groupsTokensHeadsQ` / `fold_sq`) packs all `ndt` query tokens of a request into **one CTA's MMA M-tile**, so the KV is read **once per request** instead of `×ndt`. The verify attention then becomes ~flat in `ndt` (a single memory-bound KV pass) instead of scaling with it.

The cute-dsl kernel is already reachable through `flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(backend="cute-dsl")` with a 4-D `[bs, ndt, h, d]` query (the q-length is inferred from the shape). The only missing piece is **routing**: the verify is an *extend*-class forward, so it runs on the **prefill** attention backend instance (`TRTLLMMLABackend(backend="trtllm-gen")`), whose `_run_decode_kernel` passes no `backend` and therefore always dispatches trtllm-gen. Setting `--decode-attention-backend cutedsl_mla` only affects pure decode (the draft), never the verify.

This PR adds an opt-in to route the spec-verify MLA attention through the cute-dsl fold kernel.

## Change

- New server arg `--speculative-mla-verify-backend {trtllm-gen, cute-dsl}` (default `trtllm-gen`, i.e. **no behavior change** unless set).
- `TRTLLMMLABackend._run_decode_kernel` gains a `backend_override` argument; `forward_extend` passes it **only** for `is_target_verify()`, using the int8 cute-dsl workspace. Pure decode and real prefill (the separate `_run_prefill_kernel` / ragged path) are untouched.
- Guards: requires `speculative_eagle_topk == 1` (linear chain — falls back to trtllm-gen with a warning otherwise, since the tree mask under the fold is unvalidated), and a flashinfer build whose cute-dsl `mla_decode_fp8` carries the grouped-Q fold (otherwise the cute path simply behaves as today).

## Results

Kimi-K2.5-NVFP4, 8×B200 TP8, EAGLE3 `num_steps=3` (`ndt=4`), `eagle_topk=1`, FP8 KV. aiperf 50K-prefix workload, `--prompt-prefix-pool-size = concurrency`. Output Token Throughput Per User (mean, tok/s/user):

| concurrency | EAGLE ns3 trtllm-gen verify | EAGLE ns3 cute-dsl verify | Δ |
|---:|---:|---:|---:|
| 1  | 269.0 | 292.5 | +8.7% |
| 2  | 233.2 | 252.8 | +8.4% |
| 4  | 169.3 | 196.1 | +15.8% |
| 8  | 121.5 | 152.0 | +25.1% |
| 16 | 74.4  | 99.2  | +33.8% |

- **GSM8K parity**: 0.950 (cute) vs 0.970 (trtllm-gen); **accept-length matched** (2.49 vs 2.49), so the gain is kernel speed, not acceptance.
- **nsys**: the verify attention flips from trtllm-gen `fmhaSm100…HQk576` to cuteDSL `mla_decode_fp8 split_kv` (~1.86×/call at cc16; verify-attention GPU share roughly halved). The win grows with `num_steps` and concurrency (the `×ndt` KV re-read it removes grows with both).

## Test plan

GSM8K + throughput cc-sweep on an MLA model (e.g. Kimi-K2.5 / DeepSeek) with `--attention-backend trtllm_mla --speculative-algorithm EAGLE3 --speculative-eagle-topk 1 --speculative-mla-verify-backend cute-dsl`; confirm via nsys that the verify dispatches the cute-dsl kernel. Default (`trtllm-gen`) path is unchanged.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27547629406](https://github.com/sgl-project/sglang/actions/runs/27547629406)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27547628806](https://github.com/sgl-project/sglang/actions/runs/27547628806)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->