### PR TITLE
Fix fused qkv_a_proj concat dim for mixed-quant DeepSeek/GLM checkpoints (AWQ + modules_to_not_convert)

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -303,6 +303,17 @@ class DeepseekV2WeightLoaderMixin:
                                 ) and kv_a_proj_weight.shape == torch.Size([]):
                                     fused_weight = q_a_proj_weight
                                 else:
+                                    # Pick the dim to concatenate q_a_proj and
+                                    # kv_a_proj_with_mqa along. Unquantized weights are
+                                    # stored [out_features, in_features] and fuse along
+                                    # dim 0; AWQ/GPTQ-packed weights are stored
+                                    # [in_features, out_features(/pack)] and fuse along
+                                    # dim 1. The model-level quant method alone is not a
+                                    # reliable signal: a checkpoint can be AWQ overall yet
+                                    # leave the attention a_proj layers unquantized via
+                                    # `modules_to_not_convert` (e.g. QuantTrio/GLM-5.1-AWQ),
+                                    # so the cached tensors are plain [out, in] even though
+                                    # quant_config.get_name() == "awq".
                                     cat_dim = 0
                                     if self.quant_config is not None and (
                                         self.quant_config.get_name() == "awq"
@@ -310,6 +321,18 @@ class DeepseekV2WeightLoaderMixin:
                                         or self.quant_config.get_name() == "moe_wna16"
                                     ):
                                         cat_dim = 1
+
+                                    # q_a_proj and kv_a_proj_with_mqa share the
+                                    # input-feature dim and differ on the output-feature
+                                    # dim. If the chosen cat_dim would concatenate along the
+                                    # shared (matching) dim instead, the layout assumption
+                                    # was wrong for this layer -- flip it.
+                                    if (
+                                        q_a_proj_weight.dim() == 2
+                                        and q_a_proj_weight.shape[1 - cat_dim]
+                                        != kv_a_proj_weight.shape[1 - cat_dim]
+                                    ):
+                                        cat_dim = 1 - cat_dim
 
                                     fused_weight = torch.cat(
                                         [q_a_proj_weight, kv_a_proj_weight], dim=cat_dim


### PR DESCRIPTION
## Motivation

Loading an AWQ checkpoint that leaves the attention `a_proj` layers **unquantized** via AWQ's `modules_to_not_convert` crashes at weight load when `fuse_qkv_a_proj` is active (DeepSeek-V2/V3 MLA and GLM-MoE-DSA models). Concretely, `QuantTrio/GLM-5.1-AWQ` (TP4, served as GLM-5.1) fails with:

```
File ".../models/deepseek_common/deepseek_weight_loader.py", line 314, in do_load_weights
    fused_weight = torch.cat([q_a_proj_weight, kv_a_proj_weight], dim=cat_dim)
RuntimeError: Sizes of tensors must match except in dimension 1.
Expected size 2048 but got size 576 for tensor number 1 in the list.
```

(`2048` = `q_lora_rank`, `576` = `kv_lora_rank + qk_rope_head_dim`.)

**Root cause.** When fusing `q_a_proj` + `kv_a_proj_with_mqa` into `fused_qkv_a_proj_with_mqa`, the concat dim is chosen **only** from the model-level quant method:

```python
cat_dim = 0
if self.quant_config is not None and self.quant_config.get_name() in (
    "awq", "awq_marlin", "moe_wna16"
):
    cat_dim = 1
```

This assumes every fused `a_proj` follows that one layout: unquantized weights are stored `[out_features, in_features]` (fuse on dim 0), AWQ/GPTQ-packed weights are stored `[in_features, out_features/pack]` (fuse on dim 1). But a checkpoint can be AWQ *overall* while leaving the attention `a_proj` layers in bf16 via `modules_to_not_convert`. Then `quant_config.get_name() == "awq"` sets `cat_dim = 1`, yet the cached tensors are plain `[out, in]` (`[2048, 7168]` and `[576, 7168]`) — concatenating on dim 1 requires dim 0 to match, so it raises. They should fuse on dim 0.

## Modifications

`python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`: after the existing quant-method heuristic picks `cat_dim`, derive the correct dim from the **actual tensor layout**. `q_a_proj` and `kv_a_proj_with_mqa` share the input-feature dim and differ on the output-feature dim, so if the chosen `cat_dim` would concatenate along the shared (matching) dim, the layout assumption was wrong for this layer — flip it:

```python
if (
    q_a_proj_weight.dim() == 2
    and q_a_proj_weight.shape[1 - cat_dim] != kv_a_proj_weight.shape[1 - cat_dim]
):
    cat_dim = 1 - cat_dim
```

**No behavior change for fully-quantized or fully-unquantized checkpoints** — for those the non-concat dims already match, so the flip never triggers. It only corrects the mixed case (AWQ model + unquantized attention `a_proj`, or the converse).

## Accuracy Tests

Verified on 8×H200 (TP4, `--kv-cache-dtype fp8_e4m3`), serving `QuantTrio/GLM-5.1-AWQ`:
- **Without the fix:** crashes at load (`torch.cat` error above).
- **With the fix:** loads cleanly — `Load weight end ... type=GlmMoeDsaForCausalLM, quant=awq, bits=4`, `max_total_num_tokens` allocated, server serves.
- **Output quality (same fix):** a 15-item screen passed 15/15 — 8/8 exact-match arithmetic, 3/3 format-following, 4/4 tool-call — and a full 1→256 concurrency benchmark ran clean with coherent output.

Fully-quantized AWQ and fully-unquantized checkpoints are unaffected by construction: their `q_a_proj`/`kv_a_proj_with_mqa` non-concat dims already match, so the flip condition is never true and `cat_dim` is unchanged.

## Speed Tests and Profiling

N/A — change is in the weight-load fusion path only; no inference-path/kernel change.

## Checklist

- [x] Code style consistent with surrounding loader code.
- [ ] Unit test: the natural test needs a mixed-quant checkpoint (AWQ + `modules_to_not_convert` on `a_proj`); happy to add a small shape-level unit test for the cat-dim selection if maintainers prefer.

## Related

Related to #22855 (umbrella *"GLM-5.1 AWQ fails to load"*). That thread actually covers **two distinct checkpoint variants** with different failure points:

- **`compressed_tensors`-packed** (e.g. `cyankiwi/GLM-5.1-AWQ-4bit`): fails later, in `DeepseekV2AttentionMLA` init / weight absorption, with `'ReplicatedLinear' object has no attribute 'weight'` and `KeyError: '...gate_up_proj.weight'` (the fused module is built quantized, so it has `weight_packed`/`qweight` not `.weight`). Attempted in #23195, which the author **closed as incorrect** — so this variant is still unfixed in `main` (the `is_packed_weight` allowlist still omits `compressed_tensors`).
- **true `awq`** (e.g. `QuantTrio/GLM-5.1-AWQ`, attention `a_proj` left unquantized via `modules_to_not_convert`): fails *earlier*, at the `torch.cat` fusion in the weight loader — **this is what this PR fixes.**

This PR makes `QuantTrio/GLM-5.1-AWQ` load and serve. It is intentionally scoped to the loader-fusion cat-dim and does **not** attempt the `compressed_tensors` `.weight`-guard variant (separate code path); I've left `#22855` open-referenced rather than `Fixes` so that variant isn't auto-closed.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27559797739](https://github.com/sgl-project/sglang/actions/runs/27559797739)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27559797446](https://github.com/sgl-project/sglang/actions/runs/27559797446)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->