### PR TITLE
Keep Mooncake embedding cache I/O thread alive on backend errors

### DIFF
--- a/python/sglang/srt/mem_cache/storage/mooncake_store/embedding_cache_controller.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/embedding_cache_controller.py
@@ -463,35 +463,56 @@ class EmbeddingCacheController:
 
             try:
                 op = self.prefetch_queue.get_nowait()
-                results = self.mooncake_store.batch_get(op.keys, op.ptrs, op.sizes)
-                success_count = sum(results)
-                logger.info(
-                    f"Mooncake GET Finished: Req {op.req_id}, Successfully fetched {success_count}/{len(op.keys)} images."
-                )
-                op.mark_done(all(results))
-                # Release ref counts now that RDMA GET is complete
-                with self.lock:
-                    for h in op.keys:
-                        self._release_hash(h)
-                self.prefetch_queue.task_done()
-                processed_any = True
             except Empty:
-                pass
+                op = None
+            if op is not None:
+                try:
+                    results = self.mooncake_store.batch_get(
+                        op.keys, op.ptrs, op.sizes
+                    )
+                    success_count = sum(results)
+                    logger.info(
+                        f"Mooncake GET Finished: Req {op.req_id}, Successfully fetched {success_count}/{len(op.keys)} images."
+                    )
+                    op.mark_done(all(results))
+                except Exception:
+                    logger.exception(
+                        f"Mooncake GET failed for req {op.req_id}; marking prefetch as failed."
+                    )
+                    # Signal failure so the consumer fails fast instead of
+                    # spinning until its 60s timeout.
+                    op.mark_done(False)
+                finally:
+                    # Release ref counts once the RDMA attempt has finished,
+                    # regardless of whether the backend call succeeded.
+                    with self.lock:
+                        for h in op.keys:
+                            self._release_hash(h)
+                    self.prefetch_queue.task_done()
+                processed_any = True
 
             try:
                 op = self.insert_queue.get_nowait()
-                self.mooncake_store.batch_put(op.keys, op.ptrs, op.sizes)
-                logger.info(
-                    f"Mooncake PUT Finished: Successfully stored {len(op.keys)} keys in cluster."
-                )
-                # Release ref counts now that RDMA PUT is complete
-                with self.lock:
-                    for h in op.keys:
-                        self._release_hash(h)
-                self.insert_queue.task_done()
-                processed_any = True
             except Empty:
-                pass
+                op = None
+            if op is not None:
+                try:
+                    self.mooncake_store.batch_put(op.keys, op.ptrs, op.sizes)
+                    logger.info(
+                        f"Mooncake PUT Finished: Successfully stored {len(op.keys)} keys in cluster."
+                    )
+                except Exception:
+                    logger.exception(
+                        "Mooncake PUT failed; embeddings not stored in cluster."
+                    )
+                finally:
+                    # Release ref counts once the RDMA attempt has finished,
+                    # regardless of whether the backend call succeeded.
+                    with self.lock:
+                        for h in op.keys:
+                            self._release_hash(h)
+                    self.insert_queue.task_done()
+                processed_any = True
 
             if not processed_any:
                 time.sleep(0.001)

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/embedding_cache_controller.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/embedding_cache_controller.py
@@ -467,16 +467,14 @@ class EmbeddingCacheController:
                 op = None
             if op is not None:
                 try:
-                    results = self.mooncake_store.batch_get(
-                        op.keys, op.ptrs, op.sizes
-                    )
+                    results = self.mooncake_store.batch_get(op.keys, op.ptrs, op.sizes)
                     success_count = sum(results)
                     logger.info(
                         f"Mooncake GET Finished: Req {op.req_id}, Successfully fetched {success_count}/{len(op.keys)} images."
                     )
                     op.mark_done(all(results))
                 except Exception:
-                    logger.exception(
+                    logger.error(
                         f"Mooncake GET failed for req {op.req_id}; marking prefetch as failed."
                     )
                     # Signal failure so the consumer fails fast instead of
@@ -502,7 +500,7 @@ class EmbeddingCacheController:
                         f"Mooncake PUT Finished: Successfully stored {len(op.keys)} keys in cluster."
                     )
                 except Exception:
-                    logger.exception(
+                    logger.error(
                         "Mooncake PUT failed; embeddings not stored in cluster."
                     )
                 finally:

--- a/test/registered/unit/mem_cache/test_embedding_cache_controller.py
+++ b/test/registered/unit/mem_cache/test_embedding_cache_controller.py
@@ -7,6 +7,7 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 import threading
 import time
 import unittest
+from queue import Queue
 from unittest.mock import MagicMock
 
 import torch
@@ -15,6 +16,7 @@ from sglang.srt.mem_cache.storage.mooncake_store.embedding_cache_controller impo
     ContiguousMemoryAllocator,
     EmbeddingCacheController,
     EmbeddingInsertOperation,
+    EmbeddingPrefetchOperation,
 )
 
 # ---------------------------------------------------------------------------
@@ -138,6 +140,15 @@ def _make_controller(
 
 def _embedding_bytes(num_tokens, dim):
     return num_tokens * dim * torch.float32.itemsize
+
+
+def _wait_until(predicate, timeout=1.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
 
 
 # ---------------------------------------------------------------------------
@@ -454,6 +465,81 @@ class TestRefCounting(unittest.TestCase):
 
         with ctrl.lock:
             self.assertNotIn(h, ctrl.ref_counts)
+
+
+class TestIOLoopBackendErrors(unittest.TestCase):
+    def _make_threaded_controller(self):
+        ctrl = _make_controller()
+        ctrl.prefetch_queue = Queue()
+        ctrl.insert_queue = Queue()
+        ctrl.stop_event = threading.Event()
+        ctrl.io_thread = threading.Thread(target=ctrl._io_loop, daemon=True)
+        ctrl.io_thread.start()
+        return ctrl
+
+    def tearDown(self):
+        ctrl = getattr(self, "ctrl", None)
+        if ctrl is not None:
+            ctrl.stop_event.set()
+            ctrl.io_thread.join(timeout=1)
+
+    def test_prefetch_backend_error_marks_failed_and_thread_continues(self):
+        self.ctrl = self._make_threaded_controller()
+        failing_op = EmbeddingPrefetchOperation("req_fail", ["h1"], [1], [4])
+        retry_op = EmbeddingPrefetchOperation("req_ok", ["h2"], [2], [4])
+
+        with self.ctrl.lock:
+            self.ctrl._protect_hash("h1")
+            self.ctrl._protect_hash("h2")
+
+        self.ctrl.mooncake_store.batch_get.side_effect = [
+            RuntimeError("temporary mooncake failure"),
+            [True],
+        ]
+
+        self.ctrl.prefetch_queue.put(failing_op)
+        self.assertTrue(_wait_until(lambda: failing_op.is_finished))
+        self.assertFalse(failing_op.success)
+        self.assertTrue(self.ctrl.io_thread.is_alive())
+        with self.ctrl.lock:
+            self.assertNotIn("h1", self.ctrl.ref_counts)
+
+        self.ctrl.prefetch_queue.put(retry_op)
+        self.assertTrue(_wait_until(lambda: retry_op.is_finished))
+        self.assertTrue(retry_op.success)
+        self.assertTrue(self.ctrl.io_thread.is_alive())
+        with self.ctrl.lock:
+            self.assertNotIn("h2", self.ctrl.ref_counts)
+
+    def test_insert_backend_error_releases_ref_and_thread_continues(self):
+        self.ctrl = self._make_threaded_controller()
+        failing_op = EmbeddingInsertOperation(["h1"], [1], [4])
+        retry_op = EmbeddingInsertOperation(["h2"], [2], [4])
+
+        with self.ctrl.lock:
+            self.ctrl._protect_hash("h1")
+            self.ctrl._protect_hash("h2")
+
+        self.ctrl.mooncake_store.batch_put.side_effect = [
+            RuntimeError("temporary mooncake failure"),
+            None,
+        ]
+
+        self.ctrl.insert_queue.put(failing_op)
+        self.assertTrue(
+            _wait_until(lambda: self.ctrl.mooncake_store.batch_put.call_count >= 1)
+        )
+        self.assertTrue(self.ctrl.io_thread.is_alive())
+        with self.ctrl.lock:
+            self.assertNotIn("h1", self.ctrl.ref_counts)
+
+        self.ctrl.insert_queue.put(retry_op)
+        self.assertTrue(
+            _wait_until(lambda: self.ctrl.mooncake_store.batch_put.call_count >= 2)
+        )
+        self.assertTrue(self.ctrl.io_thread.is_alive())
+        with self.ctrl.lock:
+            self.assertNotIn("h2", self.ctrl.ref_counts)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation
`EmbeddingCacheController._io_loop` is the single background worker that consumes Mooncake embedding cache prefetch and insert queues.
﻿
Previously, queue polling and backend I/O were handled in one `try` block that only caught `queue.Empty`. If `batch_get` or `batch_put` raised any other exception, the exception escaped `_io_loop` and permanently terminated the daemon thread. After that, prefetch requests could wait until timeout and later inserts would no longer be written to the distributed store until the process restarted.
## Modifications
- Separate queue-empty handling from backend I/O handling.
- Catch and log exceptions from `batch_get` and `batch_put` so the I/O thread keeps running.
- Mark failed prefetch operations as `success=False` so callers fail fast instead of waiting for timeout.
- Release RDMA ref counts in `finally`, even when backend I/O fails.
- Add unit tests covering mocked `batch_get` / `batch_put` failures and verifying the I/O thread continues processing later work.
## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27596172976](https://github.com/sgl-project/sglang/actions/runs/27596172976)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27596172887](https://github.com/sgl-project/sglang/actions/runs/27596172887)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->