### PR TITLE
[DONOTMERGE]Fix FP8 wo_a GEMM precision on Blackwell: quantize with UE8M0 scale

### DIFF
--- a/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
@@ -214,7 +214,7 @@ template <
     bool SCALE_UE8M0,
     bool FUSE_SILU_AND_MUL,
     bool kUsePDL,
-    typename scale_packed_t = std::conditional_t<SCALE_UE8M0, uint32_t, float>>
+    typename scale_packed_t = std::conditional_t<SCALE_UE8M0 && IS_COLUMN_MAJOR, uint32_t, float>>
 __global__ void per_token_group_quant_8bit_v2_kernel(
     const T* __restrict__ input,
     DST_DTYPE* __restrict__ output_q,
@@ -226,7 +226,7 @@ __global__ void per_token_group_quant_8bit_v2_kernel(
     const int scale_hidden_stride,
     const int num_tokens_per_expert) {
   using dst_dtype_info = DtypeInfo<DST_DTYPE>;
-  using scale_element_t = std::conditional_t<SCALE_UE8M0, uint8_t, float>;
+  using scale_element_t = std::conditional_t<SCALE_UE8M0 && IS_COLUMN_MAJOR, uint8_t, float>;
   static_assert(sizeof(scale_packed_t) % sizeof(scale_element_t) == 0);
 
   device::PDLWaitPrimary<kUsePDL>();
@@ -279,8 +279,8 @@ __global__ void per_token_group_quant_8bit_v2_kernel(
                           hidden_idx_packed * scale_hidden_stride * num_elems_per_pack +
                           token_idx * scale_token_stride * num_elems_per_pack + pack_idx);
         } else {
-          static_assert(!SCALE_UE8M0);
-          scale_output = output_s + offset_num_groups;
+          static_assert(!SCALE_UE8M0 || std::is_same_v<scale_packed_t, float>);
+          scale_output = reinterpret_cast<scale_element_t*>(output_s) + offset_num_groups;
         }
 
         if constexpr (IS_COLUMN_MAJOR and SCALE_UE8M0) {
@@ -309,12 +309,23 @@ __global__ void per_token_group_quant_8bit_v2_kernel(
         local_absmax = GroupReduceMax<THREADS_PER_SUBWARP>(local_absmax);
 
         float y_scale, y_scale_inv;
-        calculate_fp8_scales<SCALE_UE8M0, dst_dtype_info>(local_absmax, y_scale, y_scale_inv);
-        float2 y_scale_repeated = {y_scale, y_scale};
-
-        if (lane_id == 0) {
-          *scale_output = extract_required_scale_format<SCALE_UE8M0>(y_scale_inv);
+        if constexpr (SCALE_UE8M0 && !IS_COLUMN_MAJOR) {
+          // For row-major + UE8M0: quantize with exact scale, but output rounded scale_inv.
+          // This is equivalent to the original two-step approach (quant then ceil_to_ue8m0).
+          // local_absmax starts from LOCAL_ABSMAX_ABS, so the division is safe.
+          constexpr float MAX_8BIT_INV = 1.0f / dst_dtype_info::MAX;
+          y_scale_inv = local_absmax * MAX_8BIT_INV;
+          y_scale = dst_dtype_info::MAX / local_absmax;
+          if (lane_id == 0) {
+            *scale_output = fast_pow2(fast_log2_ceil(y_scale_inv));
+          }
+        } else {
+          calculate_fp8_scales<SCALE_UE8M0, dst_dtype_info>(local_absmax, y_scale, y_scale_inv);
+          if (lane_id == 0) {
+            *scale_output = extract_required_scale_format < SCALE_UE8M0 && IS_COLUMN_MAJOR > (y_scale_inv);
+          }
         }
+        float2 y_scale_repeated = {y_scale, y_scale};
 
         int4 output_buf;
         if constexpr (std::is_same_v<DST_DTYPE, fp8_e4m3_t>) {
@@ -378,7 +389,7 @@ struct PerTokenGroupQuant8bitV2Kernel {
       void* output_q,
       void* output_s,
       const int32_t* masked_m) {
-    using scale_packed_t = std::conditional_t<SCALE_UE8M0, uint32_t, float>;
+    using scale_packed_t = std::conditional_t<SCALE_UE8M0 && IS_COLUMN_MAJOR, uint32_t, float>;
     auto kernel = per_token_group_quant_8bit_v2_kernel<
         SCHEDULER,
         GROUP_SIZE,
@@ -463,7 +474,11 @@ struct PerTokenGroupQuant8bitV2Kernel {
         launch_with_config(TypeTag<NaiveScheduler>{}, std::true_type{}, std::false_type{}, std::false_type{});
       }
     } else {
-      launch_with_config(TypeTag<NaiveScheduler>{}, std::false_type{}, std::false_type{}, std::false_type{});
+      if (scale_ue8m0) {
+        launch_with_config(TypeTag<NaiveScheduler>{}, std::false_type{}, std::true_type{}, std::false_type{});
+      } else {
+        launch_with_config(TypeTag<NaiveScheduler>{}, std::false_type{}, std::false_type{}, std::false_type{});
+      }
     }
   }
 

--- a/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
@@ -309,21 +309,14 @@ __global__ void per_token_group_quant_8bit_v2_kernel(
         local_absmax = GroupReduceMax<THREADS_PER_SUBWARP>(local_absmax);
 
         float y_scale, y_scale_inv;
-        if constexpr (SCALE_UE8M0 && !IS_COLUMN_MAJOR) {
-          // For row-major + UE8M0: quantize with exact scale, but output rounded scale_inv.
-          // This is equivalent to the original two-step approach (quant then ceil_to_ue8m0).
-          // local_absmax starts from LOCAL_ABSMAX_ABS, so the division is safe.
-          constexpr float MAX_8BIT_INV = 1.0f / dst_dtype_info::MAX;
-          y_scale_inv = local_absmax * MAX_8BIT_INV;
-          y_scale = dst_dtype_info::MAX / local_absmax;
-          if (lane_id == 0) {
-            *scale_output = fast_pow2(fast_log2_ceil(y_scale_inv));
-          }
-        } else {
-          calculate_fp8_scales<SCALE_UE8M0, dst_dtype_info>(local_absmax, y_scale, y_scale_inv);
-          if (lane_id == 0) {
-            *scale_output = extract_required_scale_format < SCALE_UE8M0 && IS_COLUMN_MAJOR > (y_scale_inv);
-          }
+        // When SCALE_UE8M0, always quantize with the rounded (power-of-2) scale
+        // — not with the exact scale followed by post-hoc rounding.
+        // This matches the official DeepSeek-V4 kernel.py act_quant(scale_fmt="ue8m0")
+        // and avoids a scale mismatch between quantization and downstream GEMM dequant,
+        // which otherwise amplifies error ~14x and degrades EAGLE accept rate on Blackwell.
+        calculate_fp8_scales<SCALE_UE8M0, dst_dtype_info>(local_absmax, y_scale, y_scale_inv);
+        if (lane_id == 0) {
+          *scale_output = extract_required_scale_format < SCALE_UE8M0 && IS_COLUMN_MAJOR > (y_scale_inv);
         }
         float2 y_scale_repeated = {y_scale, y_scale};
 

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -463,17 +463,29 @@ def create_per_token_group_quant_fp8_output_scale(
     scale_ue8m0: bool,
 ):
     if scale_ue8m0:
-        assert column_major_scales and scale_tma_aligned
-        *x_batch, x_q_mn, x_q_k = x_shape
-        x_s_mn, x_s_k = x_q_mn, x_q_k // 128
-        aligned_mn = ceil_align(x_s_mn, 4)
-        aligned_k = ceil_align(x_s_k, 4)
-        # TODO(FIXME): Fix cuda kernel and recover here to empty.
-        return torch.empty(
-            (*x_batch, aligned_k // 4, aligned_mn),
-            device=device,
-            dtype=torch.int,
-        ).transpose(-1, -2)[..., :x_s_mn, :]
+        if column_major_scales and scale_tma_aligned:
+            *x_batch, x_q_mn, x_q_k = x_shape
+            x_s_mn, x_s_k = x_q_mn, x_q_k // 128
+            aligned_mn = ceil_align(x_s_mn, 4)
+            aligned_k = ceil_align(x_s_k, 4)
+            # TODO(FIXME): Fix cuda kernel and recover here to empty.
+            return torch.empty(
+                (*x_batch, aligned_k // 4, aligned_mn),
+                device=device,
+                dtype=torch.int,
+            ).transpose(-1, -2)[..., :x_s_mn, :]
+        else:
+            assert not column_major_scales, (
+                "column_major_scales requires scale_tma_aligned=True "
+                "when scale_ue8m0 is enabled"
+            )
+            # Row-major UE8M0 keeps the scale as float32 power-of-two values,
+            # matching deep_gemm.ceil_to_ue8m0 and deep_gemm.fp8_einsum.
+            return torch.empty(
+                x_shape[:-1] + (x_shape[-1] // group_size,),
+                device=device,
+                dtype=torch.float32,
+            )
     elif column_major_scales:
         if scale_tma_aligned:
             # TODO extract "align" function

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -993,8 +993,8 @@ class MQALayer(nn.Module):
             o_fp8, o_s = sglang_per_token_group_quant_fp8(
                 o.reshape(T * G, D).contiguous(),
                 group_size=128,
+                scale_ue8m0=True,
             )
-            o_s = deep_gemm.ceil_to_ue8m0(o_s)
             output = torch.empty(T, G, R, device=o.device, dtype=torch.bfloat16)
             deep_gemm.fp8_einsum(
                 "bhr,hdr->bhd",

--- a/test/registered/jit/test_per_token_group_quant_8bit_v2.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit_v2.py
@@ -1,3 +1,4 @@
+import deep_gemm
 import pytest
 import torch
 from sgl_kernel import sgl_per_token_group_quant_8bit  # AOT v2 reference op
@@ -10,6 +11,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     fp8_dtype,
     fp8_max,
     fp8_min,
+    sglang_per_token_group_quant_fp8,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -80,6 +82,24 @@ def test_v2_jit_matches_aot(dtype, num_tokens, hidden, fuse_silu_and_mul, scale_
 
     assert torch.equal(x_q.view(torch.int8), q_ref.view(torch.int8)), "fp8 codes differ"
     assert torch.equal(x_s, s_ref), "scales differ"
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("num_tokens", [1, 33, 128])
+@pytest.mark.parametrize("hidden", [128, 512, 4096, 7168])
+def test_sglang_per_token_group_quant_fp8_row_major_ue8m0_matches_ceil(
+    dtype, num_tokens, hidden
+):
+    torch.manual_seed(num_tokens * 1000 + hidden)
+    x = torch.randn(num_tokens, hidden, device="cuda", dtype=dtype)
+
+    q_ref, s_ref = sglang_per_token_group_quant_fp8(x, G, scale_ue8m0=False)
+    s_ref = deep_gemm.ceil_to_ue8m0(s_ref)
+    x_q, x_s = sglang_per_token_group_quant_fp8(x, G, scale_ue8m0=True)
+    torch.cuda.synchronize()
+
+    assert torch.equal(x_q.view(torch.int8), q_ref.view(torch.int8)), "fp8 codes differ"
+    assert torch.equal(x_s, s_ref), "row-major ue8m0 scales differ"
 
 
 # Masked (EP-MoE) path: the v2 op only has a masked scheduler for the

--- a/test/registered/jit/test_per_token_group_quant_8bit_v2.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit_v2.py
@@ -1,4 +1,3 @@
-import deep_gemm
 import pytest
 import torch
 from sgl_kernel import sgl_per_token_group_quant_8bit  # AOT v2 reference op
@@ -87,19 +86,26 @@ def test_v2_jit_matches_aot(dtype, num_tokens, hidden, fuse_silu_and_mul, scale_
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("num_tokens", [1, 33, 128])
 @pytest.mark.parametrize("hidden", [128, 512, 4096, 7168])
-def test_sglang_per_token_group_quant_fp8_row_major_ue8m0_matches_ceil(
+def test_sglang_per_token_group_quant_fp8_row_major_ue8m0(
     dtype, num_tokens, hidden
 ):
+    """Row-major scale_ue8m0=True quantizes WITH the rounded (power-of-2) scale.
+    Verify: (1) scales are exact powers of 2, (2) dequant ≈ original within FP8 tolerance."""
     torch.manual_seed(num_tokens * 1000 + hidden)
     x = torch.randn(num_tokens, hidden, device="cuda", dtype=dtype)
 
-    q_ref, s_ref = sglang_per_token_group_quant_fp8(x, G, scale_ue8m0=False)
-    s_ref = deep_gemm.ceil_to_ue8m0(s_ref)
     x_q, x_s = sglang_per_token_group_quant_fp8(x, G, scale_ue8m0=True)
     torch.cuda.synchronize()
 
-    assert torch.equal(x_q.view(torch.int8), q_ref.view(torch.int8)), "fp8 codes differ"
-    assert torch.equal(x_s, s_ref), "row-major ue8m0 scales differ"
+    # Scales must be exact powers of 2
+    log2_s = torch.log2(x_s.abs())
+    assert torch.equal(log2_s, log2_s.round()), "scales are not power-of-2"
+
+    # Dequant should approximate original within FP8 precision
+    x_deq = x_q.float().view(num_tokens, -1, G) * x_s.unsqueeze(-1)
+    x_deq = x_deq.view(num_tokens, hidden)
+    rel_err = (x.float() - x_deq).abs() / (x.float().abs() + 1e-6)
+    assert rel_err.mean() < 0.05, f"mean relative dequant error too large: {rel_err.mean():.4f}"
 
 
 # Masked (EP-MoE) path: the v2 op only has a masked scheduler for the


### PR DESCRIPTION
## Summary

Fix a precision issue in DeepSeek-V4's `wo_a` FP8 GEMM path that caused EAGLE speculative decoding accept_length to drop from 2.76 (H200) to 2.69 (B300/B200).

This PR includes #26766 (fuse UE8M0 rounding into quant kernel) as the first commit, and adds a precision fix on top.

## Root Cause

The `wo_a` FP8 path quantized activations with an exact FP32 scale, then rounded the scale to UE8M0 (power-of-2) *after* quantization:

```python
# Before (wrong order):
o_fp8, o_s = quant_fp8(o, group_size=128)   # quantize with FP32 scale
o_s = ceil_to_ue8m0(o_s)                     # round scale AFTER quantization
fp8_einsum(o_fp8, o_s, weight)               # GEMM uses rounded scale
# -> FP8 values quantized with one scale, GEMM dequants with a different scale
```

Measured impact of the scale mismatch:
- Scale inflation ratio (ceil/original): **mean=1.31, max=1.99**
- Quantization error amplification: **14.1x** vs using consistent scale
- Average relative error from rounding: **31%**

### Why Blackwell is affected more than Hopper

On **Hopper (SM90)**, `DEEPGEMM_SCALE_UE8M0=False` -- DeepGEMM processes scales as FP32 post-GEMM corrections, partially masking the mismatch.

On **Blackwell (SM100)**, `DEEPGEMM_SCALE_UE8M0=True` -- DeepGEMM packs scales into native UE8M0 format for hardware tensor-core scaling, **fully exposing the mismatch**. The `wo_a` GEMM runs in every attention layer (62 layers for DSV4-Flash), and the error accumulates through residual connections.

### The correct approach (matches official DeepSeek-V4 kernel.py)

The [official DeepSeek-V4 inference kernel](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/inference/kernel.py) computes the UE8M0 scale *first*, then quantizes with it:

```python
# Official kernel.py act_quant(scale_fmt="ue8m0"):
scale = fast_round_scale(amax / fp8_max)    # round to power-of-2 FIRST
o_fp8 = round_to_fp8(o / scale)              # quantize WITH rounded scale
# -> quantization and dequantization use the SAME scale
```

## Minimal fix (without fused kernel)

For anyone who wants to apply just the precision fix without the fused kernel from #26766, the following pure-PyTorch patch on `deepseek_v4.py` is sufficient:

```diff
         if _FP8_WO_A_GEMM:
             import deep_gemm

             T, G, D = o.shape
             R = self.o_lora_rank
-            o_fp8, o_s = sglang_per_token_group_quant_fp8(
-                o.reshape(T * G, D).contiguous(),
-                group_size=128,
-            )
-            o_s = deep_gemm.ceil_to_ue8m0(o_s)
+            # Compute UE8M0 scale first, then quantize with it
+            o_flat = o.reshape(T * G, D).contiguous()
+            _group_size = 128
+            o_groups = o_flat.float().view(-1, D // _group_size, _group_size)
+            amax = o_groups.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)
+            _fp8_max = torch.finfo(torch.float8_e4m3fn).max
+            o_s = torch.pow(2.0, torch.ceil(torch.log2(amax / _fp8_max)))
+            o_fp8 = (o_groups / o_s).clamp(-_fp8_max, _fp8_max).to(torch.float8_e4m3fn)
+            o_fp8 = o_fp8.view(T * G, D)
+            o_s = o_s.view(T * G, D // _group_size)
```

This PyTorch version was tested and produces the same accept_len improvement (B300: 2.69 -> 2.76), but launches multiple small kernels instead of one fused kernel.

## Fix in this PR (fused kernel)

The fused CUDA kernel in `per_token_group_quant_8bit_v2.cuh` had a special `SCALE_UE8M0 && !IS_COLUMN_MAJOR` branch that quantized with the exact scale and only rounded the output scale. This PR removes that branch and unifies all UE8M0 paths to use `calculate_fp8_scales<SCALE_UE8M0=true>`, which computes the rounded scale first and then quantizes with it -- single fused kernel, correct precision.

## Results

**Pure PyTorch fix (no fused kernel):**
| Platform | Before | After | Delta |
|----------|--------|-------|-------|
| B300 (SM100, trtllm, CI default config) | 2.69 | **2.76** | +0.07 |
| B300 (SM100, MegaMoE + marlin dense) | 2.71 | **2.79** | +0.08 |

**Fused CUDA kernel (this PR):**
| Platform | Before | After | Delta |
|----------|--------|-------|-------|
| H200 (SM90, marlin) | 2.76 | **2.76** | unchanged |
| B300 (SM100, trtllm, CI default config) | 2.69 | **2.77** | **+0.08** |

All 9 CI tests pass on both H200 and B300.
