### PR TITLE
Simplify fill_ids handling with a TokenArray and readonly memoryview

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -77,6 +77,7 @@ from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.scheduler_components.dp_attn import prepare_mlp_sync_batch_raw
 from sglang.srt.mem_cache.base_prefix_cache import EvictParams
+from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.model_executor.cuda_graph_config import Phase
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -377,7 +378,7 @@ def prepare_inputs_for_correctness_test(bench_args, tokenizer, custom_prompts):
             origin_input_ids=array("q", tmp_input_ids),
             sampling_params=sampling_params,
         )
-        req.full_untruncated_fill_ids = req.origin_input_ids
+        req.full_untruncated_fill_ids = TokenArray(req.origin_input_ids[:])
         req.fill_len = len(req.full_untruncated_fill_ids)
         req.logprob_start_len = -1
         req.set_extend_input_len(req.fill_len - len(req.prefix_indices))
@@ -424,7 +425,7 @@ def prepare_synthetic_inputs_for_latency_test(
             origin_input_ids=array("q", input_ids[i]),
             sampling_params=sampling_params,
         )
-        req.full_untruncated_fill_ids = req.origin_input_ids
+        req.full_untruncated_fill_ids = TokenArray(req.origin_input_ids[:])
         req.fill_len = len(req.full_untruncated_fill_ids)
         req.logprob_start_len = -1
         req.set_extend_input_len(req.fill_len - len(req.prefix_indices))

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -63,7 +63,6 @@ from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     EvictParams,
@@ -80,6 +79,7 @@ from sglang.srt.mem_cache.memory_pool import (
     ReqToTokenPool,
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -63,6 +63,7 @@ from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     EvictParams,
@@ -1413,7 +1414,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         # Truncate fill_len to kv_committed_len so cache_unfinished_req only
         # inserts committed KV into the radix tree. The last output token
         # hasn't had KV committed yet (output_ids is 1 ahead).
-        req.full_untruncated_fill_ids = req.origin_input_ids + req.output_ids
+        req.full_untruncated_fill_ids = TokenArray(
+            req.origin_input_ids + req.output_ids
+        )
         req.fill_len = req.kv_committed_len
         # Set prefix_indices so downstream consumers (init_next_round_input,
         # prepare_for_extend) see the correct prefix length. In the agg path

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -5,6 +5,7 @@ from array import array
 from typing import TYPE_CHECKING, Optional
 
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.mem_cache.token_array import TokenArray
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -60,7 +61,7 @@ class ReqDllmMixin:
             if self.fill_len == 0
             else self.dllm_block_offset + self.dllm_config.block_size
         )
-        self.full_untruncated_fill_ids = (
+        self.full_untruncated_fill_ids = TokenArray(
             self.origin_input_ids
             + self.output_ids
             + array("q", [self.dllm_config.mask_id] * self.dllm_config.block_size)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -89,6 +89,7 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -722,7 +723,7 @@ class Req(ReqDllmMixin):
         # Full untruncated sequence: origin + output (+ DLLM mask block).
         # Kept in sync by _refresh_fill_ids; admission only updates fill_len,
         # never mutates this array's length.
-        self.full_untruncated_fill_ids = array("q")
+        self.full_untruncated_fill_ids = TokenArray()
         self.fill_len: int = 0
 
         self.session = session
@@ -1100,22 +1101,18 @@ class Req(ReqDllmMixin):
         """Keep full_untruncated_fill_ids == origin_input_ids + output_ids by
         appending only the new output tokens.
 
-        Falls back to a full rebuild when the in-place append is invalid:
-        - aliasing: scheduler_pp_mixin assigns full_untruncated_fill_ids =
-          origin_input_ids directly, so extending in place would write output
-          tokens into the origin;
-        - lengths disagree: fresh req (array still empty), retraction
-          (output_ids reset to empty), or set_finish_with_abort (origin
-          replaced by a 1-token stub).
+        Falls back to a full rebuild when the in-place append is invalid because
+        lengths disagree: fresh req (array still empty), retraction (output_ids
+        reset to empty), or set_finish_with_abort (origin replaced by a 1-token
+        stub).
         """
         n_have_output = len(self.full_untruncated_fill_ids) - len(self.origin_input_ids)
-        if (
-            self.full_untruncated_fill_ids is not self.origin_input_ids
-            and 0 <= n_have_output <= len(self.output_ids)
-        ):
+        if 0 <= n_have_output <= len(self.output_ids):
             self.full_untruncated_fill_ids.extend(self.output_ids[n_have_output:])
         else:
-            self.full_untruncated_fill_ids = self.origin_input_ids + self.output_ids
+            self.full_untruncated_fill_ids = TokenArray(
+                self.origin_input_ids + self.output_ids
+            )
 
     def init_next_round_input(
         self,
@@ -1146,16 +1143,18 @@ class Req(ReqDllmMixin):
             )
             self.logprob_start_len = -1
 
-        # Pass the full array with a raw-token cap (limit) instead of slicing,
-        # avoiding an O(context) copy per prefill-batch build.
-        token_ids_to_match = self.full_untruncated_fill_ids
+        # Pass a non-copying readonly prefix view (capped to the matchable
+        # length) instead of slicing, avoiding an O(context) copy per
+        # prefill-batch build.
         key_limit: Optional[int] = self._compute_max_prefix_len(input_len)
+        token_ids_to_match = self.full_untruncated_fill_ids.readonly_prefix_view(
+            key_limit
+        )
 
         # Disable prefix caching when embed overrides are present: same token IDs
         # with different override vectors must not share cached KV values.
         if self.positional_embed_overrides is not None:
             token_ids_to_match = array("q")
-            key_limit = None
 
         if tree_cache is not None:
             if cow_mamba is None:
@@ -1165,7 +1164,6 @@ class Req(ReqDllmMixin):
                     key=RadixKey(
                         token_ids=token_ids_to_match,
                         extra_key=self.extra_key,
-                        limit=key_limit,
                     ),
                     req=self,
                     cow_mamba=cow_mamba,

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -24,12 +24,12 @@ from sglang.srt.layers.dp_attention import (
     set_is_extend_in_batch,
 )
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
-from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.managers.utils import (
     GenerationBatchResult,
     get_logprob_dict_from_result,
     get_logprob_from_pp_outputs,
 )
+from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -24,6 +24,7 @@ from sglang.srt.layers.dp_attention import (
     set_is_extend_in_batch,
 )
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.mem_cache.token_array import TokenArray
 from sglang.srt.managers.utils import (
     GenerationBatchResult,
     get_logprob_dict_from_result,
@@ -606,7 +607,7 @@ class SchedulerPPMixin:
                     origin_input_ids=input_ids,
                     sampling_params=sampling_params,
                 )
-                req.full_untruncated_fill_ids = req.origin_input_ids
+                req.full_untruncated_fill_ids = TokenArray(req.origin_input_ids[:])
                 req.fill_len = len(req.full_untruncated_fill_ids)
                 req.logprob_start_len = -1
                 req.set_extend_input_len(req.fill_len - len(req.prefix_indices))

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -507,7 +507,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         prev_prefix_len = params.prev_prefix_len
 
         if value is None:
-            value = torch.tensor([x for x in key.raw_token_ids()], dtype=torch.int64)
+            value = torch.tensor([x for x in key.token_ids], dtype=torch.int64)
         prefix_len, mamba_exist = self._insert_helper(
             self.root_node, key, value, mamba_value, params.chunked, prev_prefix_len
         )

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -56,55 +56,36 @@ if TYPE_CHECKING:
 class RadixKey:
     """is_bigram=True: token_ids holds raw tokens (N+1 for N bigrams); slices share one boundary token."""
 
-    __slots__ = ("token_ids", "extra_key", "is_bigram", "limit")
+    __slots__ = ("token_ids", "extra_key", "is_bigram")
 
     def __init__(
         self,
-        token_ids: array[int],
+        token_ids: Union[array[int], memoryview],
         extra_key: Optional[str] = None,
         is_bigram: bool = False,
-        limit: Optional[int] = None,
     ):
-        # token ids sequence (raw ints in both modes)
+        # token ids sequence (raw ints in both modes); a readonly memoryview lets
+        # the match path pass a non-copying prefix of a growing buffer.
         self.token_ids = token_ids
         # extra key (e.g. lora_id, cache_salt)
         self.extra_key = extra_key
         # bigram view over token_ids: length = max(0, len(token_ids) - 1)
         self.is_bigram = is_bigram
-        # Optional cap on raw tokens: behave as if token_ids were sliced to
-        # token_ids[:limit], without the O(n) copy. None = use all tokens.
-        self.limit = limit
-
-    def _raw_len(self) -> int:
-        n = len(self.token_ids)
-        if self.limit is not None and self.limit < n:
-            return self.limit
-        return n
-
-    def raw_token_ids(self) -> array:
-        """token_ids honoring `limit` (copies only when capped)."""
-        n = self._raw_len()
-        t = self.token_ids
-        return t if n == len(t) else t[:n]
 
     def __len__(self) -> int:
-        n = self._raw_len()
         if self.is_bigram:
+            n = len(self.token_ids)
             return n - 1 if n > 0 else 0
-        return n
+        return len(self.token_ids)
 
     # TODO(Jialin): vectorize with numpy without PyLong boxing
     def __iter__(self) -> Iterator:
-        t = self.token_ids
-        n = self._raw_len()
         if self.is_bigram:
-            for i in range(n - 1 if n > 0 else 0):
+            t = self.token_ids
+            for i in range(len(t) - 1):
                 yield (t[i], t[i + 1])
-        elif n == len(t):
-            yield from t
         else:
-            for i in range(n):
-                yield t[i]
+            yield from self.token_ids
 
     def __getitem__(self, idx: Union[int, slice]) -> RadixKey:
         # Normalize int -> 1-element slice so the rest handles one shape.
@@ -159,7 +140,6 @@ class RadixKey:
         """Logical-unit prefix length shared with ``other``. Result is rounded down to ``page_size``."""
         self._check_compatible(other)
         t0, t1 = self.token_ids, other.token_ids
-        assert type(t0) is type(t1), (type(t0), type(t1))
         n = min(len(t0), len(t1))
 
         # Exponential search for the first diverging token: gallop in doubling
@@ -186,7 +166,6 @@ class RadixKey:
             matched = max(0, min(matched_tokens - 1, len(self), len(other)))
             return (matched // page_size) * page_size if page_size > 1 else matched
 
-        matched_tokens = min(matched_tokens, len(self), len(other))
         if page_size == 1:
             return matched_tokens
         return (matched_tokens // page_size) * page_size

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -101,7 +101,7 @@ class RadixCacheCpp(BasePrefixCache):
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         key = params.key
         device_indices_vec, host_indices_length, node_gpu, node_cpu = (
-            self.tree.match_prefix(key.raw_token_ids())
+            self.tree.match_prefix(key.token_ids)
         )
         return MatchResult(
             device_indices=self._merge_tensor(device_indices_vec),
@@ -226,9 +226,7 @@ class RadixCacheCpp(BasePrefixCache):
 
         # TODO(dark): optimize the `insert` and `match` (e.g. merge into 1 function)
         # The prefix indices need to updated to reuse the kv indices in the pool
-        new_indices_vec, _, new_last_node, _ = self.tree.match_prefix(
-            RadixKey(token_ids, req.extra_key).token_ids
-        )
+        new_indices_vec, _, new_last_node, _ = self.tree.match_prefix(token_ids)
         new_indices = self._merge_tensor(new_indices_vec)
         assert new_prefix_len <= len(new_indices)
 

--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import logging
 import threading
+from array import array
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple
 
@@ -217,15 +218,16 @@ class LMCRadixCache(RadixCache):
         LMCache has tokens beyond radix. Otherwise releases
         the held read locks and returns the radix-only result.
         """
-        token_ids = key.raw_token_ids()
+        # key.token_ids may be a readonly memoryview over the request's growing
+        # fill buffer; snapshot it into an owned array before retaining it in the
+        # marker, which outlives this match.
+        token_ids = array("q", key.token_ids)
         matched = self.lmcache_connector.lookup_kv(token_ids, req.rid)
         if matched <= value.numel():
             # Release the read locks; keep the pending session for end_session.
             self.lmcache_connector.release_pending(req.rid)
             return base_res
 
-        if token_ids is key.token_ids:
-            token_ids = token_ids[:]
         self._mp_load_back_markers[req.rid] = _LMCacheLoadBackMarker(
             key=RadixKey(token_ids, key.extra_key, key.is_bigram),
             value_numel=int(value.numel()),
@@ -258,7 +260,9 @@ class LMCRadixCache(RadixCache):
         if uncached_len == 0:
             return base_res
 
-        token_ids = key.raw_token_ids()
+        # Snapshot a possibly-readonly memoryview into an owned array: the
+        # load_fn closure runs after this match, when the fill buffer may grow.
+        token_ids = array("q", key.token_ids)
         result = self._load_back(
             key=key,
             value_numel=int(value.numel()),

--- a/python/sglang/srt/mem_cache/token_array.py
+++ b/python/sglang/srt/mem_cache/token_array.py
@@ -1,0 +1,49 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from array import array
+from typing import Iterable, Iterator, Optional, Union
+
+
+class TokenArray:
+    __slots__ = ("_data",)
+
+    def __init__(self, data: Optional[array] = None) -> None:
+        self._data: array = data if data is not None else array("q")
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __getitem__(self, idx: Union[int, slice]) -> Union[int, array]:
+        return self._data[idx]
+
+    def __setitem__(self, idx: Union[int, slice], values: Union[int, Iterable[int]]) -> None:
+        self._data[idx] = values
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self._data)
+
+    def extend(self, values: Iterable[int]) -> None:
+        self._data.extend(values)
+
+    def __iadd__(self, values: Iterable[int]) -> TokenArray:
+        self._data.extend(values)
+        return self
+
+    def truncate(self, length: int) -> None:
+        del self._data[length:]
+
+    def readonly_prefix_view(self, length: Optional[int]) -> memoryview:
+        capped = len(self._data) if length is None else min(length, len(self._data))
+        return memoryview(self._data).toreadonly()[:capped]

--- a/python/sglang/srt/mem_cache/token_array.py
+++ b/python/sglang/srt/mem_cache/token_array.py
@@ -28,7 +28,9 @@ class TokenArray:
     def __getitem__(self, idx: Union[int, slice]) -> Union[int, array]:
         return self._data[idx]
 
-    def __setitem__(self, idx: Union[int, slice], values: Union[int, Iterable[int]]) -> None:
+    def __setitem__(
+        self, idx: Union[int, slice], values: Union[int, Iterable[int]]
+    ) -> None:
         self._data[idx] = values
 
     def __iter__(self) -> Iterator[int]:

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from array import array
 from typing import TYPE_CHECKING, Dict, Optional
 
 from sglang.srt.managers.io_struct import (
@@ -150,22 +149,13 @@ class Session:
             del input_ids_unpadded[self.committed_unpadded_len :]
 
         carry_fill = last_req.full_untruncated_fill_ids
-        if (
-            not isinstance(carry_fill, array)
-            or carry_fill is input_ids
-            or carry_fill is input_ids_unpadded
-        ):
-            # Unexpected type or aliased with an origin array (extending it
-            # below would double-append): let _refresh_fill_ids rebuild.
-            carry_fill = None
+        carry_fill.truncate(self.committed_fill_len)
+        baked = len(carry_fill) - len(input_ids)
+        if 0 <= baked <= len(out_tail):
+            carry_fill.extend(out_tail[baked:])
+            carry_fill.extend(new_input_ids)
         else:
-            del carry_fill[self.committed_fill_len :]
-            baked = len(carry_fill) - len(input_ids)
-            if 0 <= baked <= len(out_tail):
-                carry_fill.extend(out_tail[baked:])
-                carry_fill.extend(new_input_ids)
-            else:
-                carry_fill = None
+            carry_fill = None
 
         input_ids.extend(out_tail)
         input_ids.extend(new_input_ids)


### PR DESCRIPTION
## What

PR #27965 reduced fill_ids CPU overhead by adding `RadixKey.limit` / `_raw_len` / `raw_token_ids` and an append-only `_refresh_fill_ids`. This recovers the same speedups with less code, restoring the pre-#27965 cleanliness:

- `Req.full_untruncated_fill_ids` becomes a small `TokenArray` (append-only growth). `_refresh_fill_ids` no longer needs the origin-aliasing fallback, since `TokenArray` is a distinct type from the origin `array`.
- The prefix-match path passes a non-copying readonly `memoryview` (`TokenArray.readonly_prefix_view`) instead of a capped `RadixKey`.
- `RadixKey` returns to its pre-#27965 shape: no `limit` / `_raw_len` / `raw_token_ids`. `token_ids` (now an `array` **or** a readonly `memoryview`) is used directly by every backend.
- `lmc_radix_cache` snapshots the (possibly `memoryview`) match key into an owned `array` before retaining it in a load-back marker, since `memoryview[:]` is a view, not a copy.

Net: ~25 fewer lines across the touched files, plus one small `TokenArray` class.

## Why this is safe to memoryview

The match-path memoryview is **transient**: it is built inside `init_next_round_input`, used only for the `match_prefix` traversal, and dropped before the buffer is next extended — so the fill buffer can still grow (no `BufferError`). The only retainer (lmc's load-back marker) snapshots into an owned array.

## Perf

Recovers #27965's two wins — no per-round fill_ids concat (append-only `TokenArray`) and no O(context) match-slice copy (readonly memoryview) — and keeps the streaming-session token-array reuse. The goal is parity with #27965, not a further speedup.

## Review focus

- `RadixKey.match` now compares a `memoryview` prefix against `array` node keys (`t0[lo:hi] != t1[lo:hi]`); the `type(t0) is type(t1)` assert is dropped accordingly.
- `RadixCacheCpp.match_prefix` now passes a `memoryview` to the C++ tree.

> Draft: opened for CI; not yet locally tested.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27549143529](https://github.com/sgl-project/sglang/actions/runs/27549143529)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27549142595](https://github.com/sgl-project/sglang/actions/runs/27549142595)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->