### PR TITLE
feat: add SMIELP single-pass NER/NLU via logit slicing

### DIFF
--- a/benchmark/bench_smielp/bench_smielp_vs_xgrammar.py
+++ b/benchmark/bench_smielp/bench_smielp_vs_xgrammar.py
@@ -1,0 +1,390 @@
+"""
+Phase 4 — Part B: Benchmark SMIELP vs XGrammar JSON extraction.
+
+Measures end-to-end latency (time-to-first-structured-result) for:
+  A) SMIELP  — single forward pass, logit slicing, result in meta_info["smielp"]
+  B) XGrammar — JSON schema constrained decoding, N tokens for N output fields
+
+Both methods classify intent + fill entity slots on the same flight-booking prompts.
+
+Usage (Linux + GPU, sglang installed):
+    # Terminal 1 — start server
+    python -m sglang.launch_server \
+        --model-path Qwen/Qwen2.5-0.5B-Instruct \
+        --enable-custom-logit-processor \
+        --port 30000
+
+    # Terminal 2 — run benchmark
+    python benchmark/bench_smielp/bench_smielp_vs_xgrammar.py \
+        --host http://localhost:30000 \
+        --warmup 5 \
+        --n-requests 100 \
+        --batch-sizes 1 4 8 16
+
+Output: latency table + throughput comparison printed to stdout.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from typing import Optional
+
+# ── Imports (graceful for offline/dev environments) ────────────────────────────
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' not installed.  pip install requests", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from transformers import AutoTokenizer
+    _HAS_TRANSFORMERS = True
+except ImportError:
+    _HAS_TRANSFORMERS = False
+
+# Add project python path so logit_slicing is importable.
+import importlib.util, pathlib
+_PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_SRC = _PROJECT_ROOT / "python" / "sglang" / "srt" / "logit_slicing"
+
+def _load_module(dotted_name, filename):
+    spec = importlib.util.spec_from_file_location(dotted_name, _SRC / filename)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = dotted_name.rsplit(".", 1)[0]
+    sys.modules[dotted_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+_schema_mod = _load_module("sglang.srt.logit_slicing.schema",       "schema.py")
+_anchor_mod = _load_module("sglang.srt.logit_slicing.vocab_anchor", "vocab_anchor.py")
+_proc_mod    = _load_module("sglang.srt.logit_slicing.processor",         "processor.py")
+_proc_b_mod  = _load_module("sglang.srt.logit_slicing.processor_phase_b", "processor_phase_b.py")
+
+SimultaneousMultiIntentEntityLogitProcessor = _proc_mod.SimultaneousMultiIntentEntityLogitProcessor
+SMIELPWithHiddenStates = _proc_b_mod.SMIELPWithHiddenStates
+IntentSchema = _schema_mod.IntentSchema
+NERSchema    = _schema_mod.NERSchema
+SlotSchema   = _schema_mod.SlotSchema
+build_anchor_config  = _anchor_mod.build_anchor_config
+build_phase_b_config = _anchor_mod.build_phase_b_config
+STRATEGY_FIRST_TOKEN = _anchor_mod.STRATEGY_FIRST_TOKEN
+
+# ── NER Schema ────────────────────────────────────────────────────────────────
+
+INTENTS = ["book", "cancel", "status"]   # single-token labels in Qwen2.5
+
+NER_SCHEMA = NERSchema(
+    intents=IntentSchema(labels=INTENTS),
+    slots=[
+        SlotSchema(name="city",  labels=["O", "B", "I"]),
+        SlotSchema(name="date",  labels=["O", "B", "I"]),
+        SlotSchema(name="hotel", labels=["none", "present"]),
+    ],
+)
+
+# JSON schema for XGrammar baseline — equivalent output structure.
+XGRAMMAR_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "intent":   {"type": "string", "enum": INTENTS},
+        "city_tag": {"type": "string", "enum": ["O", "B", "I"]},
+        "date_tag": {"type": "string", "enum": ["O", "B", "I"]},
+        "hotel":    {"type": "string", "enum": ["none", "present"]},
+    },
+    "required": ["intent", "city_tag", "date_tag", "hotel"],
+    "additionalProperties": False,
+}
+
+# ── Test prompts ───────────────────────────────────────────────────────────────
+
+PROMPTS = [
+    "I want to book a flight to Paris next Tuesday and stay at the Marriott.",
+    "Cancel my reservation for the flight to London.",
+    "What is the status of my booking to New York?",
+    "Book me a flight to Tokyo next week, no hotel needed.",
+    "I need to check on my upcoming flight to Berlin.",
+    "Please cancel my hotel in Rome along with the flight.",
+    "Is my flight to Sydney still confirmed?",
+    "Book a one-way ticket to Dubai arriving on Friday.",
+]
+
+SYSTEM_PROMPT = (
+    "You are a flight booking assistant. "
+    "Classify the user intent and extract city, date, and hotel slot information."
+)
+
+
+def _chat_messages(user_text: str) -> list:
+    return [
+        {"role": "system",  "content": SYSTEM_PROMPT},
+        {"role": "user",    "content": user_text},
+    ]
+
+
+# ── HTTP helpers ───────────────────────────────────────────────────────────────
+
+def _post(host: str, endpoint: str, payload: dict, timeout: int = 60) -> dict:
+    url = f"{host}{endpoint}"
+    resp = requests.post(url, json=payload, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _check_server_ready(host: str) -> bool:
+    try:
+        resp = requests.get(f"{host}/health", timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+# ── SMIELP benchmark ───────────────────────────────────────────────────────────
+
+def _build_smielp_params(tokenizer) -> dict:
+    """Build the custom_params dict for the SMIELP processor."""
+    return build_anchor_config(NER_SCHEMA, tokenizer, strategy=STRATEGY_FIRST_TOKEN)
+
+
+def _run_smielp_request(host: str, prompt: str, custom_params: dict, proc_str: str) -> tuple[float, dict]:
+    """Fire one SMIELP request and return (latency_s, result_dict)."""
+    payload = {
+        "model": "default",
+        "messages": _chat_messages(prompt),
+        "max_tokens": 1,
+        "temperature": 0.0,
+        "extra_body": {
+            "custom_logit_processor": proc_str,
+            "custom_params": custom_params,
+        },
+    }
+    t0 = time.perf_counter()
+    data = _post(host, "/v1/chat/completions", payload)
+    latency = time.perf_counter() - t0
+
+    smielp_result = (
+        data.get("choices", [{}])[0]
+        .get("message", {})
+        .get("meta_info", {})
+        .get("smielp", [{}])[0]
+    )
+    return latency, smielp_result
+
+
+def _run_smielp_phase_b_request(
+    host: str, prompt: str, custom_params: dict, proc_str: str
+) -> tuple[float, dict]:
+    """Fire one Phase B request (with hidden_states) and return (latency_s, result_dict)."""
+    payload = {
+        "model": "default",
+        "messages": _chat_messages(prompt),
+        "max_tokens": 1,
+        "temperature": 0.0,
+        "extra_body": {
+            "custom_logit_processor": proc_str,
+            "custom_params": custom_params,
+            "return_hidden_states": True,
+        },
+    }
+    t0 = time.perf_counter()
+    data = _post(host, "/v1/chat/completions", payload)
+    latency = time.perf_counter() - t0
+    smielp_result = (
+        data.get("choices", [{}])[0]
+        .get("message", {})
+        .get("meta_info", {})
+        .get("smielp", [{}])[0]
+    )
+    return latency, smielp_result
+
+
+def _run_xgrammar_request(host: str, prompt: str) -> tuple[float, dict]:
+    """Fire one XGrammar JSON-constrained request and return (latency_s, result_dict)."""
+    payload = {
+        "model": "default",
+        "messages": _chat_messages(prompt),
+        "max_tokens": 64,
+        "temperature": 0.0,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "ner_result",
+                "schema": XGRAMMAR_JSON_SCHEMA,
+            },
+        },
+    }
+    t0 = time.perf_counter()
+    data = _post(host, "/v1/chat/completions", payload)
+    latency = time.perf_counter() - t0
+
+    content = data.get("choices", [{}])[0].get("message", {}).get("content", "{}")
+    try:
+        result = json.loads(content)
+    except json.JSONDecodeError:
+        result = {"raw": content}
+    return latency, result
+
+
+# ── Metrics ────────────────────────────────────────────────────────────────────
+
+def _stats(latencies: list[float]) -> dict:
+    return {
+        "n":      len(latencies),
+        "mean":   statistics.mean(latencies) * 1000,
+        "median": statistics.median(latencies) * 1000,
+        "p95":    sorted(latencies)[int(0.95 * len(latencies))] * 1000,
+        "min":    min(latencies) * 1000,
+        "max":    max(latencies) * 1000,
+    }
+
+
+def _print_table(
+    smielp_a_stats: dict,
+    smielp_b_stats: Optional[dict],
+    xgrammar_stats: dict,
+    n_requests: int,
+    model: str,
+):
+    header = f"\n{'='*80}"
+    print(header)
+    print(f"  SMIELP (A+B) vs XGrammar — model: {model}  n={n_requests}")
+    print(header)
+    col = f"  {'Metric':<12}  {'Phase A (ms)':>14}  "
+    if smielp_b_stats:
+        col += f"{'Phase B (ms)':>14}  "
+    col += f"{'XGrammar (ms)':>14}  {'SpeedupA':>10}"
+    if smielp_b_stats:
+        col += f"  {'SpeedupB':>10}"
+    print(col)
+    print(f"  {'-'*72}")
+    for key in ("mean", "median", "p95", "min", "max"):
+        a = smielp_a_stats[key]
+        x = xgrammar_stats[key]
+        ratio_a = x / a if a > 0 else float("inf")
+        row = f"  {key:<12}  {a:>14.1f}  "
+        if smielp_b_stats:
+            b = smielp_b_stats[key]
+            ratio_b = x / b if b > 0 else float("inf")
+            row += f"{b:>14.1f}  "
+        row += f"{x:>14.1f}  {ratio_a:>9.2f}x"
+        if smielp_b_stats:
+            row += f"  {ratio_b:>9.2f}x"
+        print(row)
+    print(header)
+    speedup_a = xgrammar_stats["median"] / smielp_a_stats["median"]
+    print(f"  Phase A median speedup: {speedup_a:.2f}x  (1 decode token vs ~20-40)")
+    if smielp_b_stats:
+        speedup_b = xgrammar_stats["median"] / smielp_b_stats["median"]
+        overhead  = smielp_b_stats["median"] - smielp_a_stats["median"]
+        print(f"  Phase B median speedup: {speedup_b:.2f}x  (hidden_state overhead: +{overhead:.1f} ms)")
+    print(header)
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark SMIELP vs XGrammar")
+    parser.add_argument("--host",        default="http://localhost:30000", help="sglang server URL")
+    parser.add_argument("--model",       default="Qwen/Qwen2.5-0.5B-Instruct")
+    parser.add_argument("--warmup",      type=int,  default=5,     help="warmup requests (not counted)")
+    parser.add_argument("--n-requests",  type=int,  default=50,    help="timed requests per method")
+    parser.add_argument("--timeout",     type=int,  default=120,   help="per-request HTTP timeout (s)")
+    parser.add_argument("--phase-b",     action="store_true",      help="also benchmark Phase B (requires --enable-return-hidden-states on server)")
+    args = parser.parse_args()
+
+    print(f"[bench] Checking server at {args.host} …")
+    if not _check_server_ready(args.host):
+        print(
+            f"ERROR: server not reachable at {args.host}.\n"
+            "Start it with:\n"
+            f"  python -m sglang.launch_server --model-path {args.model} "
+            "--enable-custom-logit-processor --port 30000",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print("[bench] Server ready.")
+
+    if not _HAS_TRANSFORMERS:
+        print("ERROR: 'transformers' not installed.  pip install transformers", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[bench] Loading tokenizer: {args.model} …")
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    custom_params_a = _build_smielp_params(tokenizer)
+    proc_a_str = SimultaneousMultiIntentEntityLogitProcessor.to_str()
+    print(f"[bench] Phase A schema anchored. Processor serialized ({len(proc_a_str)} bytes).")
+
+    # Phase B: also needs the embedding matrix
+    custom_params_b = None
+    proc_b_str = None
+    if args.phase_b:
+        try:
+            import torch as _torch
+            from transformers import AutoModelForCausalLM
+            print(f"[bench] Loading model for Phase B embedding matrix …")
+            m = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype=_torch.float16, device_map="cpu")
+            emb = m.model.embed_tokens.weight.detach().float()
+            del m
+            custom_params_b = build_phase_b_config(NER_SCHEMA, tokenizer, emb, strategy=STRATEGY_FIRST_TOKEN)
+            proc_b_str = SMIELPWithHiddenStates.to_str()
+            print(f"[bench] Phase B config built. Processor serialized ({len(proc_b_str)} bytes).")
+        except Exception as e:
+            print(f"[bench] Phase B unavailable: {e}. Skipping Phase B.")
+
+    prompts_cycle = (PROMPTS * ((args.n_requests + args.warmup) // len(PROMPTS) + 1))
+
+    # ── Warmup ────────────────────────────────────────────────────────────────
+    print(f"[bench] Warming up ({args.warmup} requests each method) …")
+    for i in range(args.warmup):
+        p = prompts_cycle[i]
+        _run_smielp_request(args.host, p, custom_params_a, proc_a_str)
+        if custom_params_b:
+            _run_smielp_phase_b_request(args.host, p, custom_params_b, proc_b_str)
+        _run_xgrammar_request(args.host, p)
+    print("[bench] Warmup done.")
+
+    # ── Phase A timed run ─────────────────────────────────────────────────────
+    print(f"[bench] Timing Phase A SMIELP ({args.n_requests} requests) …")
+    smielp_a_latencies = []
+    for i in range(args.n_requests):
+        p = prompts_cycle[args.warmup + i]
+        lat, result = _run_smielp_request(args.host, p, custom_params_a, proc_a_str)
+        smielp_a_latencies.append(lat)
+        if i < 3:
+            print(f"  [{i}] {lat*1000:.0f} ms  intent={result.get('intent', {}).get('label', '?')}")
+
+    # ── Phase B timed run (if available) ──────────────────────────────────────
+    smielp_b_latencies = []
+    if custom_params_b:
+        print(f"[bench] Timing Phase B SMIELP ({args.n_requests} requests) …")
+        for i in range(args.n_requests):
+            p = prompts_cycle[args.warmup + i]
+            lat, result = _run_smielp_phase_b_request(args.host, p, custom_params_b, proc_b_str)
+            smielp_b_latencies.append(lat)
+            if i < 3:
+                mode = result.get("mode", "?")
+                print(f"  [{i}] {lat*1000:.0f} ms  intent={result.get('intent', {}).get('label', '?')} mode={mode}")
+
+    # ── XGrammar timed run ────────────────────────────────────────────────────
+    print(f"[bench] Timing XGrammar ({args.n_requests} requests) …")
+    xgrammar_latencies = []
+    for i in range(args.n_requests):
+        p = prompts_cycle[args.warmup + i]
+        lat, result = _run_xgrammar_request(args.host, p)
+        xgrammar_latencies.append(lat)
+        if i < 3:
+            print(f"  [{i}] {lat*1000:.0f} ms  intent={result.get('intent', '?')}")
+
+    # ── Report ────────────────────────────────────────────────────────────────
+    _print_table(
+        _stats(smielp_a_latencies),
+        _stats(smielp_b_latencies) if smielp_b_latencies else None,
+        _stats(xgrammar_latencies),
+        n_requests=args.n_requests,
+        model=args.model,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/smielp_flight_booking.py
+++ b/examples/smielp_flight_booking.py
@@ -1,0 +1,245 @@
+"""
+SMIELP Flight Booking — End-to-End Usage Example
+=================================================
+Demonstrates the complete workflow for single-forward-pass NER/NLU extraction
+using the Simultaneous Multi-Intent & Entity Logit Processor (SMIELP).
+
+What this script does
+---------------------
+1. Defines a NER schema (intents + entity slots) for a flight booking domain.
+2. Anchors the schema to the Qwen2.5-0.5B-Instruct tokenizer vocabulary.
+3. Registers the SMIELP custom logit processor with a running sglang server.
+4. Sends extraction requests and prints structured results from meta_info["smielp"].
+5. Compares Phase A (logit slicing) vs Phase B (embedding-space cosine similarity).
+
+Setup
+-----
+    # Terminal 1 — start server with both required flags
+    python -m sglang.launch_server \\
+        --model-path Qwen/Qwen2.5-0.5B-Instruct \\
+        --enable-custom-logit-processor \\
+        --enable-return-hidden-states \\
+        --port 30000
+
+    # Terminal 2 — run this script
+    pip install openai transformers torch
+    python examples/smielp_flight_booking.py
+
+Performance note
+----------------
+XGrammar JSON extraction for the same 4-field schema needs ~20-40 decode tokens.
+SMIELP uses exactly 1 decode token for any number of output fields.
+Expected speedup: 5-15x on a single A100 with batch_size=1.
+"""
+
+import json
+import sys
+import pathlib
+
+# ── Add project source to path ─────────────────────────────────────────────────
+_PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "python"))
+
+from sglang.srt.logit_slicing import (
+    NERSchema,
+    IntentSchema,
+    SlotSchema,
+    VocabAnchor,
+    build_anchor_config,
+    build_phase_b_config,
+    SimultaneousMultiIntentEntityLogitProcessor,
+    SMIELPWithHiddenStates,
+)
+from sglang.srt.logit_slicing.vocab_anchor import STRATEGY_FIRST_TOKEN
+
+# ── 1. Define the NER schema ───────────────────────────────────────────────────
+#
+# Labels must be single tokens in the model vocabulary (or use strategy='explicit'
+# to hand-pick token IDs).  VocabAnchor warns when a label tokenises to multiple
+# sub-words and uses the first token automatically.
+
+schema = NERSchema(
+    intents=IntentSchema(
+        labels=["book", "cancel", "status"],   # all single tokens in Qwen2.5
+    ),
+    slots=[
+        SlotSchema(name="city",  labels=["O", "B", "I"]),   # BIO tags
+        SlotSchema(name="date",  labels=["O", "B", "I"]),
+        SlotSchema(name="hotel", labels=["none", "present"]),   # binary presence
+    ],
+)
+
+# ── 2. Anchor labels to vocabulary token IDs ──────────────────────────────────
+try:
+    from transformers import AutoTokenizer
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+    print(f"[setup] Tokenizer loaded.  vocab_size={tokenizer.vocab_size}")
+except ImportError:
+    print("ERROR: 'transformers' not installed.  pip install transformers", file=sys.stderr)
+    sys.exit(1)
+
+# Phase A config — pure logit slicing (no --enable-return-hidden-states needed)
+custom_params_phase_a = build_anchor_config(
+    schema, tokenizer, strategy=STRATEGY_FIRST_TOKEN
+)
+print("[setup] Phase A config anchored:")
+print(json.dumps(custom_params_phase_a["schema"], indent=2))
+
+# Phase B config — embedding-space cosine similarity
+# Requires the model's embedding matrix.  Here we load it from a HuggingFace model.
+try:
+    from transformers import AutoModelForCausalLM
+    import torch
+
+    print("[setup] Loading model for embedding matrix (this may take ~30s) …")
+    model = AutoModelForCausalLM.from_pretrained(
+        "Qwen/Qwen2.5-0.5B-Instruct",
+        torch_dtype=torch.float16,
+        device_map="cpu",
+    )
+    embedding_matrix = model.model.embed_tokens.weight.detach().float()
+    del model   # free memory; we only need the embedding weights
+
+    custom_params_phase_b = build_phase_b_config(
+        schema, tokenizer, embedding_matrix, strategy=STRATEGY_FIRST_TOKEN
+    )
+    print("[setup] Phase B config built.")
+    print(f"[setup] label_embeddings shapes: "
+          + ", ".join(f"{k}={v.shape}" for k, v in custom_params_phase_b["label_embeddings"].items()))
+    _phase_b_available = True
+except Exception as e:
+    print(f"[setup] Phase B unavailable (model load failed: {e}); will skip Phase B.")
+    _phase_b_available = False
+
+# ── 3. Serialize the processors ───────────────────────────────────────────────
+proc_a_str = SimultaneousMultiIntentEntityLogitProcessor.to_str()
+proc_b_str = SMIELPWithHiddenStates.to_str()
+print(f"[setup] Phase A processor serialized ({len(proc_a_str)} bytes).")
+print(f"[setup] Phase B processor serialized ({len(proc_b_str)} bytes).")
+
+# ── 4. Connect to sglang server ───────────────────────────────────────────────
+try:
+    from openai import OpenAI
+except ImportError:
+    print("ERROR: 'openai' not installed.  pip install openai", file=sys.stderr)
+    sys.exit(1)
+
+client = OpenAI(base_url="http://localhost:30000/v1", api_key="none")
+
+SYSTEM_PROMPT = (
+    "You are a flight booking assistant. "
+    "Extract the intent and entity slots from the user message."
+)
+
+TEST_PROMPTS = [
+    "I want to book a flight to Paris on Friday and need a hotel.",
+    "Can you cancel my upcoming London flight?",
+    "What's the status of my Tokyo reservation?",
+    "Book a ticket to Berlin, arriving next Monday. No hotel.",
+]
+
+# ── 5. Run Phase A extraction ─────────────────────────────────────────────────
+print("\n" + "="*65)
+print("  Phase A — Logit Slicing (max_new_tokens=1, no hidden states)")
+print("="*65)
+
+for prompt in TEST_PROMPTS:
+    response = client.chat.completions.create(
+        model="default",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user",   "content": prompt},
+        ],
+        max_tokens=1,
+        temperature=0.0,
+        extra_body={
+            "custom_logit_processor": proc_a_str,
+            "custom_params": custom_params_phase_a,
+        },
+    )
+
+    # Results arrive in meta_info["smielp"][0]
+    meta = response.choices[0].message.model_extra.get("meta_info", {})
+    result = meta.get("smielp", [{}])[0]
+
+    intent = result.get("intent", {})
+    entities = result.get("entities", [])
+    print(f"\nPrompt : {prompt}")
+    print(f"  Intent  : {intent.get('label', '?')} (conf={intent.get('confidence', 0):.2f})")
+    for ent in entities:
+        print(f"  {ent['slot']:10}: {ent['tag']} (conf={ent['confidence']:.2f})")
+
+# ── 6. Run Phase B extraction (if available) ──────────────────────────────────
+if _phase_b_available:
+    print("\n" + "="*65)
+    print("  Phase B — Embedding Cosine Similarity (requires hidden states)")
+    print("="*65)
+
+    for prompt in TEST_PROMPTS:
+        response = client.chat.completions.create(
+            model="default",
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user",   "content": prompt},
+            ],
+            max_tokens=1,
+            temperature=0.0,
+            extra_body={
+                "custom_logit_processor": proc_b_str,
+                "custom_params": custom_params_phase_b,
+                "return_hidden_states": True,      # requires --enable-return-hidden-states
+            },
+        )
+
+        meta   = response.choices[0].message.model_extra.get("meta_info", {})
+        result = meta.get("smielp", [{}])[0]
+        intent = result.get("intent", {})
+
+        print(f"\nPrompt : {prompt}")
+        print(f"  Intent  : {intent.get('label', '?')} (conf={intent.get('confidence', 0):.2f})")
+        print(f"  Mode    : {result.get('mode', '?')}")
+        print(f"  HS L2   : {result.get('hidden_state_l2', 'N/A'):.3f}")
+        for ent in result.get("entities", []):
+            print(f"  {ent['slot']:10}: {ent['tag']} (conf={ent['confidence']:.2f})")
+
+# ── 7. Comparison: XGrammar JSON extraction for the same schema ───────────────
+print("\n" + "="*65)
+print("  XGrammar Baseline — JSON schema constrained decoding")
+print("="*65)
+
+JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "intent":   {"type": "string", "enum": ["book", "cancel", "status"]},
+        "city_tag": {"type": "string", "enum": ["O", "B", "I"]},
+        "date_tag": {"type": "string", "enum": ["O", "B", "I"]},
+        "hotel":    {"type": "string", "enum": ["none", "present"]},
+    },
+    "required": ["intent", "city_tag", "date_tag", "hotel"],
+    "additionalProperties": False,
+}
+
+for prompt in TEST_PROMPTS[:2]:   # only 2 for brevity — each takes ~20 decode steps
+    response = client.chat.completions.create(
+        model="default",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user",   "content": prompt},
+        ],
+        max_tokens=64,
+        temperature=0.0,
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "ner", "schema": JSON_SCHEMA},
+        },
+    )
+    content = response.choices[0].message.content
+    try:
+        result = json.loads(content)
+    except json.JSONDecodeError:
+        result = {"raw": content}
+
+    print(f"\nPrompt : {prompt}")
+    print(f"  Result : {result}")
+
+print("\n[done] SMIELP example complete.")

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -1,3 +1,5 @@
+import functools
+import inspect
 import logging
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -59,6 +61,13 @@ if is_npu():
 
 logger = logging.getLogger(__name__)
 
+
+@functools.lru_cache(maxsize=256)
+def _processor_accepts_hidden_states(proc_cls: type) -> bool:
+    """Return True if proc_cls.__call__ declares a 'hidden_states' parameter."""
+    return "hidden_states" in inspect.signature(proc_cls.__call__).parameters
+
+
 SYNC_TOKEN_IDS_ACROSS_TP = get_bool_env_var("SYNC_TOKEN_IDS_ACROSS_TP")
 SGLANG_RETURN_ORIGINAL_LOGPROB = get_bool_env_var("SGLANG_RETURN_ORIGINAL_LOGPROB")
 _CUSTOM_SAMPLER_FACTORIES: Dict[str, Callable[[], "Sampler"]] = {}
@@ -82,11 +91,14 @@ class Sampler(nn.Module):
         self.use_ascend_backend = get_global_server_args().sampling_backend == "ascend"
 
     def _preprocess_logits(
-        self, logits: torch.Tensor, sampling_info: SamplingBatchInfo
+        self,
+        logits: torch.Tensor,
+        sampling_info: SamplingBatchInfo,
+        hidden_states: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Apply custom logit processors and sanitize non-finite logits."""
         if sampling_info.has_custom_logit_processor:
-            apply_custom_logit_processor(logits, sampling_info)
+            apply_custom_logit_processor(logits, sampling_info, hidden_states=hidden_states)
         sanitize_nan_logits(logits, "sampler: next_token_logits")
         return logits
 
@@ -116,7 +128,9 @@ class Sampler(nn.Module):
         logits = logits_output.next_token_logits
 
         # Preprocess logits (custom processors and NaN handling)
-        logits = self._preprocess_logits(logits, sampling_info)
+        logits = self._preprocess_logits(
+            logits, sampling_info, hidden_states=logits_output.hidden_states
+        )
 
         if sampling_info.is_all_greedy:
             if _use_aiter and not _disable_aiter_greedy_sample:
@@ -767,11 +781,17 @@ def apply_custom_logit_processor(
     logits: torch.Tensor,
     sampling_batch_info: SamplingBatchInfo,
     num_tokens_in_batch: int = 1,
+    hidden_states: Optional[torch.Tensor] = None,
 ):
     """Apply custom logit processors to the logits.
     This function will modify the logits in-place.
     num_tokens_in_batch is needed to support spec decoding, where each batch can contain multiple
     tokens. By default, we assume each batch contains only 1 token.
+
+    hidden_states: optional [total_tokens, hidden_dim] tensor from LogitsProcessorOutput.
+    When non-None AND the processor declares a 'hidden_states' parameter in its __call__,
+    the sliced hidden states are forwarded as a keyword argument. Processors that do not
+    declare 'hidden_states' receive only (logits, params) — no change to their interface.
     """
 
     assert logits.shape[0] == len(sampling_batch_info) * num_tokens_in_batch, (
@@ -791,13 +811,18 @@ def apply_custom_logit_processor(
             f"The number of batch mask ({batch_mask.shape[0]}) does not match the number of "
             f"sampling_batch_info ({len(sampling_batch_info)})"
         )
-        batch_mask = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
+        batch_mask_rep = torch.repeat_interleave(batch_mask, num_tokens_in_batch)
+        params_slice = [sampling_batch_info.custom_params[i] for i in batch_indices]
 
-        # Apply the processor to the logits
-        logits[batch_mask] = processor(
-            logits[batch_mask],
-            [sampling_batch_info.custom_params[i] for i in batch_indices],
-        )
+        # Capability-aware dispatch: only forward hidden_states to processors that accept it.
+        if hidden_states is not None and _processor_accepts_hidden_states(type(processor)):
+            logits[batch_mask_rep] = processor(
+                logits[batch_mask_rep],
+                params_slice,
+                hidden_states=hidden_states[batch_mask_rep],
+            )
+        else:
+            logits[batch_mask_rep] = processor(logits[batch_mask_rep], params_slice)
 
         logger.debug(
             f"Custom logit processor {processor.__class__.__name__} is applied."

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -98,7 +98,9 @@ class Sampler(nn.Module):
     ) -> torch.Tensor:
         """Apply custom logit processors and sanitize non-finite logits."""
         if sampling_info.has_custom_logit_processor:
-            apply_custom_logit_processor(logits, sampling_info, hidden_states=hidden_states)
+            apply_custom_logit_processor(
+                logits, sampling_info, hidden_states=hidden_states
+            )
         sanitize_nan_logits(logits, "sampler: next_token_logits")
         return logits
 
@@ -815,7 +817,9 @@ def apply_custom_logit_processor(
         params_slice = [sampling_batch_info.custom_params[i] for i in batch_indices]
 
         # Capability-aware dispatch: only forward hidden_states to processors that accept it.
-        if hidden_states is not None and _processor_accepts_hidden_states(type(processor)):
+        if hidden_states is not None and _processor_accepts_hidden_states(
+            type(processor)
+        ):
             logits[batch_mask_rep] = processor(
                 logits[batch_mask_rep],
                 params_slice,

--- a/python/sglang/srt/logit_slicing/__init__.py
+++ b/python/sglang/srt/logit_slicing/__init__.py
@@ -1,4 +1,6 @@
-from sglang.srt.logit_slicing.processor import SimultaneousMultiIntentEntityLogitProcessor
+from sglang.srt.logit_slicing.processor import (
+    SimultaneousMultiIntentEntityLogitProcessor,
+)
 from sglang.srt.logit_slicing.processor_phase_b import SMIELPWithHiddenStates
 from sglang.srt.logit_slicing.schema import IntentSchema, NERSchema, SlotSchema
 from sglang.srt.logit_slicing.vocab_anchor import (
@@ -18,5 +20,5 @@ __all__ = [
     "build_phase_b_config",
     # Processors
     "SimultaneousMultiIntentEntityLogitProcessor",  # Phase A
-    "SMIELPWithHiddenStates",                       # Phase B
+    "SMIELPWithHiddenStates",  # Phase B
 ]

--- a/python/sglang/srt/logit_slicing/__init__.py
+++ b/python/sglang/srt/logit_slicing/__init__.py
@@ -1,0 +1,22 @@
+from sglang.srt.logit_slicing.processor import SimultaneousMultiIntentEntityLogitProcessor
+from sglang.srt.logit_slicing.processor_phase_b import SMIELPWithHiddenStates
+from sglang.srt.logit_slicing.schema import IntentSchema, NERSchema, SlotSchema
+from sglang.srt.logit_slicing.vocab_anchor import (
+    VocabAnchor,
+    build_anchor_config,
+    build_phase_b_config,
+)
+
+__all__ = [
+    # Schema
+    "NERSchema",
+    "IntentSchema",
+    "SlotSchema",
+    # Anchoring helpers
+    "VocabAnchor",
+    "build_anchor_config",
+    "build_phase_b_config",
+    # Processors
+    "SimultaneousMultiIntentEntityLogitProcessor",  # Phase A
+    "SMIELPWithHiddenStates",                       # Phase B
+]

--- a/python/sglang/srt/logit_slicing/processor.py
+++ b/python/sglang/srt/logit_slicing/processor.py
@@ -76,6 +76,7 @@ except Exception:
         def to_str(cls) -> str:
             return ""
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -194,7 +195,8 @@ class SimultaneousMultiIntentEntityLogitProcessor(CustomLogitProcessor):
             schema = params.get("schema")
             if not schema:
                 logger.warning(
-                    "SMIELP: no 'schema' key in custom_params[%d]; returning empty result.", i
+                    "SMIELP: no 'schema' key in custom_params[%d]; returning empty result.",
+                    i,
                 )
                 results.append({"intent": None, "entities": []})
                 continue
@@ -217,22 +219,19 @@ class SimultaneousMultiIntentEntityLogitProcessor(CustomLogitProcessor):
             return None
 
         idx = torch.tensor(intent_token_ids, device=row.device, dtype=torch.long)
-        sliced = row[idx].float()                      # [num_intents]
-        probs = F.softmax(sliced, dim=-1)              # numerically stable
+        sliced = row[idx].float()  # [num_intents]
+        probs = F.softmax(sliced, dim=-1)  # numerically stable
         best = int(probs.argmax().item())
 
         return {
             "label": intent_labels[best],
             "confidence": float(probs[best]),
             "distribution": {
-                label: float(p)
-                for label, p in zip(intent_labels, probs.tolist())
+                label: float(p) for label, p in zip(intent_labels, probs.tolist())
             },
         }
 
-    def _classify_slots(
-        self, row: torch.Tensor, schema: dict
-    ) -> List[Dict[str, Any]]:
+    def _classify_slots(self, row: torch.Tensor, schema: dict) -> List[Dict[str, Any]]:
         entities = []
         for slot in schema.get("entity_slots", []):
             bio_token_ids = slot.get("bio_token_ids")
@@ -241,7 +240,7 @@ class SimultaneousMultiIntentEntityLogitProcessor(CustomLogitProcessor):
                 continue
 
             idx = torch.tensor(bio_token_ids, device=row.device, dtype=torch.long)
-            sliced = row[idx].float()                  # [num_tags]
+            sliced = row[idx].float()  # [num_tags]
             probs = F.softmax(sliced, dim=-1)
             best = int(probs.argmax().item())
 
@@ -251,8 +250,7 @@ class SimultaneousMultiIntentEntityLogitProcessor(CustomLogitProcessor):
                     "tag": bio_labels[best],
                     "confidence": float(probs[best]),
                     "distribution": {
-                        label: float(p)
-                        for label, p in zip(bio_labels, probs.tolist())
+                        label: float(p) for label, p in zip(bio_labels, probs.tolist())
                     },
                 }
             )

--- a/python/sglang/srt/logit_slicing/processor.py
+++ b/python/sglang/srt/logit_slicing/processor.py
@@ -1,0 +1,259 @@
+"""
+SimultaneousMultiIntentEntityLogitProcessor
+============================================
+Performs single-forward-pass structured extraction by intercepting the model's
+logit tensor at the one decode step, slicing intent and entity-slot dimensions
+simultaneously, and writing a structured result dict to the response meta_info —
+all with zero modifications to sglang core.
+
+How it works
+------------
+1. The LLM processes the full prompt in a single prefill pass, building up a rich
+   contextual representation of the input text.
+
+2. At the single decode step (max_new_tokens=1) the logit tensor has shape
+   [M, vocab_size].  M is the number of requests in this batch that use this
+   processor (not necessarily the full batch size).
+
+3. For each request we:
+   a. Slice intent logit columns → softmax → argmax → predicted intent label
+   b. Slice BIO-tag logit columns for each slot → softmax → argmax → tag per slot
+      All slices happen in a single vectorised pass over logits[i].
+
+4. Results are written to req.customized_info["smielp"].  sglang's output-streamer
+   picks this up automatically and surfaces it in the HTTP response under
+   meta_info["smielp"] — no changes to the sglang scheduler or tokenizer manager.
+
+5. The processor forces the logit for the EOS token to 0.0 (all others to -inf),
+   so the sampler cleanly terminates generation after exactly one token.
+
+Returned structure (per request, in meta_info["smielp"][0])
+------------------------------------------------------------
+{
+    "intent": {
+        "label":        str,
+        "confidence":   float,          # max softmax probability
+        "distribution": {label: prob},  # full softmax over intent labels
+    },
+    "entities": [
+        {
+            "slot":         str,
+            "tag":          str,
+            "confidence":   float,
+            "distribution": {label: prob},
+        },
+        ...
+    ],
+}
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn.functional as F
+
+try:
+    from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
+except Exception:
+    # Fallback when running tests outside a full sglang install.
+    from abc import ABC, abstractmethod as _abstractmethod
+    from typing import Any as _Any, Dict as _Dict, List as _List, Optional as _Optional
+    import torch as _torch
+
+    class CustomLogitProcessor(ABC):
+        @_abstractmethod
+        def __call__(
+            self,
+            logits: _torch.Tensor,
+            custom_param_list: _Optional[_List[_Dict[str, _Any]]] = None,
+        ) -> _torch.Tensor:
+            raise NotImplementedError
+
+        @classmethod
+        def to_str(cls) -> str:
+            return ""
+
+logger = logging.getLogger(__name__)
+
+
+class SimultaneousMultiIntentEntityLogitProcessor(CustomLogitProcessor):
+    """
+    Single-forward-pass NER/NLU via logit slicing.
+
+    Server startup requirement
+    --------------------------
+        python -m sglang.launch_server ... --enable-custom-logit-processor
+
+    Minimal SamplingParams
+    ----------------------
+        from sglang.srt.logit_slicing import NERSchema, IntentSchema, SlotSchema, VocabAnchor
+        from sglang.srt.logit_slicing.vocab_anchor import build_anchor_config
+
+        schema = NERSchema(
+            intents=IntentSchema(labels=["book_flight", "cancel", "check_status"]),
+            slots=[
+                SlotSchema(name="city", labels=["O", "B", "I"]),
+            ],
+        )
+        custom_params = build_anchor_config(schema, tokenizer)
+
+        SamplingParams(
+            max_new_tokens=1,
+            custom_params=custom_params,
+            custom_logit_processor=SimultaneousMultiIntentEntityLogitProcessor.to_str(),
+        )
+
+    Reading results
+    ---------------
+        response["meta_info"]["smielp"][0]
+        # → {"intent": {"label": "book_flight", ...}, "entities": [...]}
+    """
+
+    # Key written into req.customized_info and surfaced in meta_info.
+    OUTPUT_KEY = "smielp"
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        custom_param_list: Optional[List[Dict[str, Any]]] = None,
+    ) -> torch.Tensor:
+        """
+        Parameters
+        ----------
+        logits          : [M, vocab_size] GPU tensor — only the M requests that use
+                          this processor (not the whole batch).
+        custom_param_list : len == M.  Each dict contains:
+                            "__req__"      → live Req object (injected by sglang)
+                            "schema"       → anchored config from NERSchema.to_anchor_config()
+                            "eos_token_id" → int, defaults to 2
+        """
+        if not custom_param_list:
+            return logits
+
+        batch_size = logits.shape[0]
+        if len(custom_param_list) != batch_size:
+            logger.warning(
+                "SMIELP: custom_param_list length %d != logits batch size %d; skipping.",
+                len(custom_param_list),
+                batch_size,
+            )
+            return logits
+
+        results = self._classify_batch(logits, custom_param_list)
+
+        for i, (params, result) in enumerate(zip(custom_param_list, results)):
+            if params is None:
+                logits[i, :] = float("-inf")
+                logits[i, 2] = 0.0  # default EOS
+                continue
+            # ── Write to customized_info (zero-modification output path) ──────
+            req = params.get("__req__")
+            if req is not None:
+                if req.customized_info is None:
+                    req.customized_info = {}
+                # One element per output token; we always generate exactly 1.
+                req.customized_info[self.OUTPUT_KEY] = [result]
+            else:
+                logger.warning("SMIELP: __req__ not found in custom_params[%d].", i)
+
+            # ── Force EOS to terminate generation after this single step ──────
+            eos_id = params.get("eos_token_id", 2)
+            vocab_size = logits.shape[1]
+            if eos_id >= vocab_size:
+                logger.warning(
+                    "SMIELP: eos_token_id %d >= logit vocab_size %d (model has padded vocab); "
+                    "clamping to last logit column %d.",
+                    eos_id,
+                    vocab_size,
+                    vocab_size - 1,
+                )
+                eos_id = vocab_size - 1
+            logits[i, :] = float("-inf")
+            logits[i, eos_id] = 0.0
+
+        return logits
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Core classification logic
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def _classify_batch(
+        self,
+        logits: torch.Tensor,
+        custom_param_list: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Run simultaneous logit slicing for all M requests."""
+        results = []
+        for i, params in enumerate(custom_param_list):
+            if params is None:
+                results.append({"intent": None, "entities": []})
+                continue
+            schema = params.get("schema")
+            if not schema:
+                logger.warning(
+                    "SMIELP: no 'schema' key in custom_params[%d]; returning empty result.", i
+                )
+                results.append({"intent": None, "entities": []})
+                continue
+
+            row = logits[i]  # [vocab_size]
+            results.append(
+                {
+                    "intent": self._classify_intent(row, schema),
+                    "entities": self._classify_slots(row, schema),
+                }
+            )
+        return results
+
+    def _classify_intent(
+        self, row: torch.Tensor, schema: dict
+    ) -> Optional[Dict[str, Any]]:
+        intent_token_ids = schema.get("intent_token_ids")
+        intent_labels = schema.get("intent_labels")
+        if not intent_token_ids or not intent_labels:
+            return None
+
+        idx = torch.tensor(intent_token_ids, device=row.device, dtype=torch.long)
+        sliced = row[idx].float()                      # [num_intents]
+        probs = F.softmax(sliced, dim=-1)              # numerically stable
+        best = int(probs.argmax().item())
+
+        return {
+            "label": intent_labels[best],
+            "confidence": float(probs[best]),
+            "distribution": {
+                label: float(p)
+                for label, p in zip(intent_labels, probs.tolist())
+            },
+        }
+
+    def _classify_slots(
+        self, row: torch.Tensor, schema: dict
+    ) -> List[Dict[str, Any]]:
+        entities = []
+        for slot in schema.get("entity_slots", []):
+            bio_token_ids = slot.get("bio_token_ids")
+            bio_labels = slot.get("bio_labels")
+            if not bio_token_ids or not bio_labels:
+                continue
+
+            idx = torch.tensor(bio_token_ids, device=row.device, dtype=torch.long)
+            sliced = row[idx].float()                  # [num_tags]
+            probs = F.softmax(sliced, dim=-1)
+            best = int(probs.argmax().item())
+
+            entities.append(
+                {
+                    "slot": slot["name"],
+                    "tag": bio_labels[best],
+                    "confidence": float(probs[best]),
+                    "distribution": {
+                        label: float(p)
+                        for label, p in zip(bio_labels, probs.tolist())
+                    },
+                }
+            )
+        return entities

--- a/python/sglang/srt/logit_slicing/processor_phase_b.py
+++ b/python/sglang/srt/logit_slicing/processor_phase_b.py
@@ -75,6 +75,7 @@ except Exception:
         def to_str(cls) -> str:
             return ""
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -115,7 +116,8 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
         if len(custom_param_list) != batch_size:
             logger.warning(
                 "SMIELPWithHiddenStates: param list length %d != batch size %d; skipping.",
-                len(custom_param_list), batch_size,
+                len(custom_param_list),
+                batch_size,
             )
             return logits
 
@@ -125,7 +127,8 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
                 logger.warning(
                     "SMIELPWithHiddenStates: hidden_states.shape[0]=%d != batch_size=%d; "
                     "ignoring hidden_states and falling back to logit slicing.",
-                    hidden_states.shape[0], batch_size,
+                    hidden_states.shape[0],
+                    batch_size,
                 )
                 hidden_states = None
             elif hidden_states.dim() != 2:
@@ -143,7 +146,12 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
                 continue
             schema = params.get("schema")
             if not schema:
-                result = {"intent": None, "entities": [], "mode": "none", "hidden_state_l2": None}
+                result = {
+                    "intent": None,
+                    "entities": [],
+                    "mode": "none",
+                    "hidden_state_l2": None,
+                }
             else:
                 h = hidden_states[i] if hidden_states is not None else None
 
@@ -165,7 +173,9 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
                     result = self._classify_logit_slicing(logits[i], schema)
                     result["mode"] = "logit_slicing"
 
-                result["hidden_state_l2"] = float(h.float().norm().item()) if h is not None else None
+                result["hidden_state_l2"] = (
+                    float(h.float().norm().item()) if h is not None else None
+                )
 
             req = params.get("__req__")
             if req is not None:
@@ -173,14 +183,17 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
                     req.customized_info = {}
                 req.customized_info[self.OUTPUT_KEY] = [result]
             else:
-                logger.warning("SMIELPWithHiddenStates: __req__ missing in params[%d].", i)
+                logger.warning(
+                    "SMIELPWithHiddenStates: __req__ missing in params[%d].", i
+                )
 
             eos_id = params.get("eos_token_id", 2)
             vocab_size = logits.shape[1]
             if eos_id >= vocab_size:
                 logger.warning(
                     "SMIELPWithHiddenStates: eos_token_id %d >= vocab_size %d; clamping.",
-                    eos_id, vocab_size,
+                    eos_id,
+                    vocab_size,
                 )
                 eos_id = vocab_size - 1
             logits[i, :] = float("-inf")
@@ -194,40 +207,44 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
 
     def _classify_logit_slicing(self, row: torch.Tensor, schema: dict) -> dict:
         return {
-            "intent":   self._slice_intent(row, schema),
+            "intent": self._slice_intent(row, schema),
             "entities": self._slice_slots(row, schema),
         }
 
     def _slice_intent(self, row: torch.Tensor, schema: dict) -> Optional[dict]:
-        ids    = schema.get("intent_token_ids")
+        ids = schema.get("intent_token_ids")
         labels = schema.get("intent_labels")
         if not ids or not labels:
             return None
-        idx   = torch.tensor(ids, device=row.device, dtype=torch.long)
+        idx = torch.tensor(ids, device=row.device, dtype=torch.long)
         probs = F.softmax(row[idx].float(), dim=-1)
-        best  = int(probs.argmax())
+        best = int(probs.argmax())
         return {
-            "label":        labels[best],
-            "confidence":   float(probs[best]),
-            "distribution": {l: float(p) for l, p in zip(labels, probs.tolist())},
+            "label": labels[best],
+            "confidence": float(probs[best]),
+            "distribution": {lbl: float(p) for lbl, p in zip(labels, probs.tolist())},
         }
 
     def _slice_slots(self, row: torch.Tensor, schema: dict) -> List[dict]:
         entities = []
         for slot in schema.get("entity_slots", []):
-            ids    = slot.get("bio_token_ids")
+            ids = slot.get("bio_token_ids")
             labels = slot.get("bio_labels")
             if not ids or not labels:
                 continue
-            idx   = torch.tensor(ids, device=row.device, dtype=torch.long)
+            idx = torch.tensor(ids, device=row.device, dtype=torch.long)
             probs = F.softmax(row[idx].float(), dim=-1)
-            best  = int(probs.argmax())
-            entities.append({
-                "slot":         slot["name"],
-                "tag":          labels[best],
-                "confidence":   float(probs[best]),
-                "distribution": {l: float(p) for l, p in zip(labels, probs.tolist())},
-            })
+            best = int(probs.argmax())
+            entities.append(
+                {
+                    "slot": slot["name"],
+                    "tag": labels[best],
+                    "confidence": float(probs[best]),
+                    "distribution": {
+                        lbl: float(p) for lbl, p in zip(labels, probs.tolist())
+                    },
+                }
+            )
         return entities
 
     # ──────────────────────────────────────────────────────────────────────────
@@ -236,9 +253,9 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
 
     def _classify_embedding(
         self,
-        h: torch.Tensor,           # [hidden_dim]
+        h: torch.Tensor,  # [hidden_dim]
         schema: dict,
-        label_embs: dict,          # {head_name: Tensor[num_labels, hidden_dim]}
+        label_embs: dict,  # {head_name: Tensor[num_labels, hidden_dim]}
     ) -> dict:
         """
         Classify intent and slots by cosine similarity between the last-token hidden
@@ -250,7 +267,7 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
 
         If a head is missing from label_embs, fall back to logit slicing for that head.
         """
-        h_norm = F.normalize(h.float().unsqueeze(0), dim=-1)   # [1, D]
+        h_norm = F.normalize(h.float().unsqueeze(0), dim=-1)  # [1, D]
 
         # ── Intent ────────────────────────────────────────────────────────────
         intent_result = None
@@ -261,25 +278,31 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
                 logger.warning(
                     "SMIELPWithHiddenStates: label_embs['intent'] shape %s != expected "
                     "(%d, %d); skipping intent classification.",
-                    tuple(E_raw.shape), len(intent_labels), h.shape[0],
+                    tuple(E_raw.shape),
+                    len(intent_labels),
+                    h.shape[0],
                 )
             else:
-                E     = F.normalize(E_raw, dim=-1)                 # [K, D]
-                sims  = (h_norm @ E.T).squeeze(0)                  # [K]
+                E = F.normalize(E_raw, dim=-1)  # [K, D]
+                sims = (h_norm @ E.T).squeeze(0)  # [K]
                 probs = F.softmax(sims * 10.0, dim=-1)
-                best  = int(probs.argmax())
+                best = int(probs.argmax())
                 intent_result = {
-                    "label":        intent_labels[best],
-                    "confidence":   float(probs[best]),
-                    "distribution": {l: float(p) for l, p in zip(intent_labels, probs.tolist())},
+                    "label": intent_labels[best],
+                    "confidence": float(probs[best]),
+                    "distribution": {
+                        lbl: float(p) for lbl, p in zip(intent_labels, probs.tolist())
+                    },
                 }
         else:
-            logger.debug("SMIELPWithHiddenStates: 'intent' not in label_embs; skipping intent.")
+            logger.debug(
+                "SMIELPWithHiddenStates: 'intent' not in label_embs; skipping intent."
+            )
 
         # ── Entity slots ──────────────────────────────────────────────────────
         entities = []
         for slot in schema.get("entity_slots", []):
-            name   = slot["name"]
+            name = slot["name"]
             labels = slot.get("bio_labels", [])
             if name in label_embs and labels:
                 E_raw = label_embs[name].float().to(h.device)
@@ -287,22 +310,30 @@ class SMIELPWithHiddenStates(CustomLogitProcessor):
                     logger.warning(
                         "SMIELPWithHiddenStates: label_embs['%s'] shape %s != expected "
                         "(%d, %d); skipping slot.",
-                        name, tuple(E_raw.shape), len(labels), h.shape[0],
+                        name,
+                        tuple(E_raw.shape),
+                        len(labels),
+                        h.shape[0],
                     )
                     continue
-                E     = F.normalize(E_raw, dim=-1)
-                sims  = (h_norm @ E.T).squeeze(0)
+                E = F.normalize(E_raw, dim=-1)
+                sims = (h_norm @ E.T).squeeze(0)
                 probs = F.softmax(sims * 10.0, dim=-1)
-                best  = int(probs.argmax())
-                entities.append({
-                    "slot":         name,
-                    "tag":          labels[best],
-                    "confidence":   float(probs[best]),
-                    "distribution": {l: float(p) for l, p in zip(labels, probs.tolist())},
-                })
+                best = int(probs.argmax())
+                entities.append(
+                    {
+                        "slot": name,
+                        "tag": labels[best],
+                        "confidence": float(probs[best]),
+                        "distribution": {
+                            lbl: float(p) for lbl, p in zip(labels, probs.tolist())
+                        },
+                    }
+                )
             else:
                 logger.debug(
-                    "SMIELPWithHiddenStates: '%s' not in label_embs; skipping slot.", name
+                    "SMIELPWithHiddenStates: '%s' not in label_embs; skipping slot.",
+                    name,
                 )
 
         return {"intent": intent_result, "entities": entities}

--- a/python/sglang/srt/logit_slicing/processor_phase_b.py
+++ b/python/sglang/srt/logit_slicing/processor_phase_b.py
@@ -1,0 +1,308 @@
+"""
+SMIELPWithHiddenStates — Phase B processor
+============================================
+Extends the Phase A logit-slicing approach by accepting the pre-lm_head hidden states
+from the transformer backbone, enabling:
+
+  1. **Norm-based confidence calibration** — the L2 norm of the last-token hidden state is a
+     proxy for model certainty; low-norm states indicate underspecified context.
+
+  2. **Embedding-space projection** (optional) — if the caller supplies ``label_embeddings``
+     in ``custom_params``, classification is done as cosine similarity in hidden-state space
+     rather than logit slicing.  This removes the vocabulary bottleneck: labels no longer need
+     to be single tokens.
+
+  3. **Fallback path** — when ``hidden_states`` is None (server launched without
+     ``--enable-return-hidden-states``, or running in speculative-decode mode), the processor
+     falls back seamlessly to Phase A logit slicing.
+
+Phase B infrastructure requirements
+------------------------------------
+Server:
+    python -m sglang.launch_server ...
+        --enable-custom-logit-processor
+        --enable-return-hidden-states     # ← NEW for Phase B
+
+SamplingParams:
+    SamplingParams(
+        max_new_tokens=1,
+        return_hidden_states=True,        # ← NEW for Phase B
+        custom_params={
+            "schema": anchored_config,
+            "eos_token_id": tokenizer.eos_token_id,
+            # Optional — enables embedding-space classification:
+            "label_embeddings": {
+                "intent": <FloatTensor [num_intents, hidden_dim]>,
+                "city":   <FloatTensor [num_bio_tags, hidden_dim]>,
+                ...
+            },
+        },
+        custom_logit_processor=SMIELPWithHiddenStates.to_str(),
+    )
+
+Result extras (beyond Phase A)
+-------------------------------
+    result["hidden_state_l2"]   float   L2 norm of the last-token hidden state
+    result["mode"]              str     "embedding" | "logit_slicing"
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn.functional as F
+
+try:
+    from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
+except Exception:
+    from abc import ABC, abstractmethod as _abstractmethod
+    from typing import Any as _Any, Dict as _Dict, List as _List, Optional as _Optional
+    import torch as _torch
+
+    class CustomLogitProcessor(ABC):
+        @_abstractmethod
+        def __call__(
+            self,
+            logits: _torch.Tensor,
+            custom_param_list: _Optional[_List[_Dict[str, _Any]]] = None,
+            hidden_states: _Optional[_torch.Tensor] = None,
+        ) -> _torch.Tensor:
+            raise NotImplementedError
+
+        @classmethod
+        def to_str(cls) -> str:
+            return ""
+
+logger = logging.getLogger(__name__)
+
+
+class SMIELPWithHiddenStates(CustomLogitProcessor):
+    """
+    Phase B SMIELP — uses transformer hidden states when available.
+
+    Key differences from Phase A ``SimultaneousMultiIntentEntityLogitProcessor``:
+    - ``__call__`` accepts an optional ``hidden_states`` keyword argument.
+    - When ``hidden_states`` is provided AND ``custom_params["label_embeddings"]`` is set,
+      classification is performed via cosine similarity in embedding space.
+    - Result dict gains ``"hidden_state_l2"`` and ``"mode"`` fields.
+    - Backward-compatible: falls back to logit slicing when ``hidden_states`` is None.
+    """
+
+    OUTPUT_KEY = "smielp"
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        custom_param_list: Optional[List[Dict[str, Any]]] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Parameters
+        ----------
+        logits          : [M, vocab_size] — same as Phase A.
+        custom_param_list : len == M, each dict contains schema, eos_token_id,
+                            and optionally label_embeddings.
+        hidden_states   : [M, hidden_dim] — last-token hidden states, forwarded by
+                          the patched apply_custom_logit_processor in sampler.py.
+                          None when --enable-return-hidden-states is not set.
+        """
+        if not custom_param_list:
+            return logits
+
+        batch_size = logits.shape[0]
+        if len(custom_param_list) != batch_size:
+            logger.warning(
+                "SMIELPWithHiddenStates: param list length %d != batch size %d; skipping.",
+                len(custom_param_list), batch_size,
+            )
+            return logits
+
+        # Validate hidden_states shape; discard silently if inconsistent.
+        if hidden_states is not None:
+            if hidden_states.shape[0] != batch_size:
+                logger.warning(
+                    "SMIELPWithHiddenStates: hidden_states.shape[0]=%d != batch_size=%d; "
+                    "ignoring hidden_states and falling back to logit slicing.",
+                    hidden_states.shape[0], batch_size,
+                )
+                hidden_states = None
+            elif hidden_states.dim() != 2:
+                logger.warning(
+                    "SMIELPWithHiddenStates: hidden_states must be 2-D [M, D], got shape %s; "
+                    "ignoring.",
+                    tuple(hidden_states.shape),
+                )
+                hidden_states = None
+
+        for i, params in enumerate(custom_param_list):
+            if params is None:
+                logits[i, :] = float("-inf")
+                logits[i, 2] = 0.0  # default EOS
+                continue
+            schema = params.get("schema")
+            if not schema:
+                result = {"intent": None, "entities": [], "mode": "none", "hidden_state_l2": None}
+            else:
+                h = hidden_states[i] if hidden_states is not None else None
+
+                # NaN guard: a NaN-filled hidden state is useless; fall back.
+                if h is not None and torch.isnan(h).any():
+                    logger.warning(
+                        "SMIELPWithHiddenStates: NaN in hidden_states[%d]; "
+                        "falling back to logit slicing.",
+                        i,
+                    )
+                    h = None
+
+                label_embs = params.get("label_embeddings")
+
+                if h is not None and label_embs is not None:
+                    result = self._classify_embedding(h, schema, label_embs)
+                    result["mode"] = "embedding"
+                else:
+                    result = self._classify_logit_slicing(logits[i], schema)
+                    result["mode"] = "logit_slicing"
+
+                result["hidden_state_l2"] = float(h.float().norm().item()) if h is not None else None
+
+            req = params.get("__req__")
+            if req is not None:
+                if req.customized_info is None:
+                    req.customized_info = {}
+                req.customized_info[self.OUTPUT_KEY] = [result]
+            else:
+                logger.warning("SMIELPWithHiddenStates: __req__ missing in params[%d].", i)
+
+            eos_id = params.get("eos_token_id", 2)
+            vocab_size = logits.shape[1]
+            if eos_id >= vocab_size:
+                logger.warning(
+                    "SMIELPWithHiddenStates: eos_token_id %d >= vocab_size %d; clamping.",
+                    eos_id, vocab_size,
+                )
+                eos_id = vocab_size - 1
+            logits[i, :] = float("-inf")
+            logits[i, eos_id] = 0.0
+
+        return logits
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Phase A path: logit slicing (identical to SimultaneousMultiIntentEntityLogitProcessor)
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def _classify_logit_slicing(self, row: torch.Tensor, schema: dict) -> dict:
+        return {
+            "intent":   self._slice_intent(row, schema),
+            "entities": self._slice_slots(row, schema),
+        }
+
+    def _slice_intent(self, row: torch.Tensor, schema: dict) -> Optional[dict]:
+        ids    = schema.get("intent_token_ids")
+        labels = schema.get("intent_labels")
+        if not ids or not labels:
+            return None
+        idx   = torch.tensor(ids, device=row.device, dtype=torch.long)
+        probs = F.softmax(row[idx].float(), dim=-1)
+        best  = int(probs.argmax())
+        return {
+            "label":        labels[best],
+            "confidence":   float(probs[best]),
+            "distribution": {l: float(p) for l, p in zip(labels, probs.tolist())},
+        }
+
+    def _slice_slots(self, row: torch.Tensor, schema: dict) -> List[dict]:
+        entities = []
+        for slot in schema.get("entity_slots", []):
+            ids    = slot.get("bio_token_ids")
+            labels = slot.get("bio_labels")
+            if not ids or not labels:
+                continue
+            idx   = torch.tensor(ids, device=row.device, dtype=torch.long)
+            probs = F.softmax(row[idx].float(), dim=-1)
+            best  = int(probs.argmax())
+            entities.append({
+                "slot":         slot["name"],
+                "tag":          labels[best],
+                "confidence":   float(probs[best]),
+                "distribution": {l: float(p) for l, p in zip(labels, probs.tolist())},
+            })
+        return entities
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Phase B path: embedding-space cosine similarity
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def _classify_embedding(
+        self,
+        h: torch.Tensor,           # [hidden_dim]
+        schema: dict,
+        label_embs: dict,          # {head_name: Tensor[num_labels, hidden_dim]}
+    ) -> dict:
+        """
+        Classify intent and slots by cosine similarity between the last-token hidden
+        state and per-class label embedding vectors.
+
+        label_embs keys must match schema intent/slot names:
+            "intent"      → Tensor[num_intents, D]
+            slot["name"]  → Tensor[num_bio_tags, D]
+
+        If a head is missing from label_embs, fall back to logit slicing for that head.
+        """
+        h_norm = F.normalize(h.float().unsqueeze(0), dim=-1)   # [1, D]
+
+        # ── Intent ────────────────────────────────────────────────────────────
+        intent_result = None
+        intent_labels = schema.get("intent_labels", [])
+        if "intent" in label_embs and intent_labels:
+            E_raw = label_embs["intent"].float().to(h.device)
+            if E_raw.dim() != 2 or E_raw.shape != (len(intent_labels), h.shape[0]):
+                logger.warning(
+                    "SMIELPWithHiddenStates: label_embs['intent'] shape %s != expected "
+                    "(%d, %d); skipping intent classification.",
+                    tuple(E_raw.shape), len(intent_labels), h.shape[0],
+                )
+            else:
+                E     = F.normalize(E_raw, dim=-1)                 # [K, D]
+                sims  = (h_norm @ E.T).squeeze(0)                  # [K]
+                probs = F.softmax(sims * 10.0, dim=-1)
+                best  = int(probs.argmax())
+                intent_result = {
+                    "label":        intent_labels[best],
+                    "confidence":   float(probs[best]),
+                    "distribution": {l: float(p) for l, p in zip(intent_labels, probs.tolist())},
+                }
+        else:
+            logger.debug("SMIELPWithHiddenStates: 'intent' not in label_embs; skipping intent.")
+
+        # ── Entity slots ──────────────────────────────────────────────────────
+        entities = []
+        for slot in schema.get("entity_slots", []):
+            name   = slot["name"]
+            labels = slot.get("bio_labels", [])
+            if name in label_embs and labels:
+                E_raw = label_embs[name].float().to(h.device)
+                if E_raw.dim() != 2 or E_raw.shape != (len(labels), h.shape[0]):
+                    logger.warning(
+                        "SMIELPWithHiddenStates: label_embs['%s'] shape %s != expected "
+                        "(%d, %d); skipping slot.",
+                        name, tuple(E_raw.shape), len(labels), h.shape[0],
+                    )
+                    continue
+                E     = F.normalize(E_raw, dim=-1)
+                sims  = (h_norm @ E.T).squeeze(0)
+                probs = F.softmax(sims * 10.0, dim=-1)
+                best  = int(probs.argmax())
+                entities.append({
+                    "slot":         name,
+                    "tag":          labels[best],
+                    "confidence":   float(probs[best]),
+                    "distribution": {l: float(p) for l, p in zip(labels, probs.tolist())},
+                })
+            else:
+                logger.debug(
+                    "SMIELPWithHiddenStates: '%s' not in label_embs; skipping slot.", name
+                )
+
+        return {"intent": intent_result, "entities": entities}

--- a/python/sglang/srt/logit_slicing/schema.py
+++ b/python/sglang/srt/logit_slicing/schema.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +40,10 @@ class IntentSchema:
     def token_ids(self) -> List[int]:
         """Return token IDs in the same order as self.labels."""
         if not self.is_anchored:
-            raise RuntimeError("IntentSchema has not been anchored yet. Call VocabAnchor.anchor().")
-        return [self.label_to_token_id[l] for l in self.labels]
+            raise RuntimeError(
+                "IntentSchema has not been anchored yet. Call VocabAnchor.anchor()."
+            )
+        return [self.label_to_token_id[lbl] for lbl in self.labels]
 
 
 @dataclasses.dataclass
@@ -63,7 +65,9 @@ class SlotSchema:
         if len(self.labels) < 2:
             raise ValueError(f"SlotSchema '{self.name}' requires at least 2 labels.")
         if len(set(self.labels)) != len(self.labels):
-            raise ValueError(f"SlotSchema '{self.name}' has duplicate labels: {self.labels}")
+            raise ValueError(
+                f"SlotSchema '{self.name}' has duplicate labels: {self.labels}"
+            )
 
     @property
     def is_anchored(self) -> bool:
@@ -75,7 +79,7 @@ class SlotSchema:
             raise RuntimeError(
                 f"SlotSchema '{self.name}' has not been anchored. Call VocabAnchor.anchor()."
             )
-        return [self.label_to_token_id[l] for l in self.labels]
+        return [self.label_to_token_id[lbl] for lbl in self.labels]
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/logit_slicing/schema.py
+++ b/python/sglang/srt/logit_slicing/schema.py
@@ -1,0 +1,152 @@
+"""
+NER/NLU schema definitions for the Simultaneous Multi-Intent & Entity Logit Processor.
+
+A NERSchema declares:
+  - Which intent classes to classify (IntentSchema)
+  - Which entity slots to fill, each with its own set of BIO/categorical labels (SlotSchema)
+
+After vocab anchoring (VocabAnchor.anchor), each label is mapped to a single token ID in
+the target model's vocabulary.  The schema is then serialised to a plain dict and shipped
+to the GPU worker via SamplingParams.custom_params.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class IntentSchema:
+    """Classification labels for the intent head."""
+
+    labels: List[str]
+    # Filled by VocabAnchor.anchor(); empty until anchored.
+    label_to_token_id: Dict[str, int] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self):
+        if len(self.labels) < 2:
+            raise ValueError("IntentSchema requires at least 2 labels.")
+        if len(set(self.labels)) != len(self.labels):
+            raise ValueError(f"IntentSchema has duplicate labels: {self.labels}")
+
+    @property
+    def is_anchored(self) -> bool:
+        return len(self.label_to_token_id) == len(self.labels)
+
+    def token_ids(self) -> List[int]:
+        """Return token IDs in the same order as self.labels."""
+        if not self.is_anchored:
+            raise RuntimeError("IntentSchema has not been anchored yet. Call VocabAnchor.anchor().")
+        return [self.label_to_token_id[l] for l in self.labels]
+
+
+@dataclasses.dataclass
+class SlotSchema:
+    """A single entity slot with its own classification labels.
+
+    Labels are typically BIO tags (B, I, O) or domain-specific categories
+    (e.g. ["none", "present"] for binary slot presence detection).
+    """
+
+    name: str
+    labels: List[str]
+    # Filled by VocabAnchor.anchor(); empty until anchored.
+    label_to_token_id: Dict[str, int] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("SlotSchema.name must not be empty.")
+        if len(self.labels) < 2:
+            raise ValueError(f"SlotSchema '{self.name}' requires at least 2 labels.")
+        if len(set(self.labels)) != len(self.labels):
+            raise ValueError(f"SlotSchema '{self.name}' has duplicate labels: {self.labels}")
+
+    @property
+    def is_anchored(self) -> bool:
+        return len(self.label_to_token_id) == len(self.labels)
+
+    def token_ids(self) -> List[int]:
+        """Return token IDs in the same order as self.labels."""
+        if not self.is_anchored:
+            raise RuntimeError(
+                f"SlotSchema '{self.name}' has not been anchored. Call VocabAnchor.anchor()."
+            )
+        return [self.label_to_token_id[l] for l in self.labels]
+
+
+@dataclasses.dataclass
+class NERSchema:
+    """
+    Top-level schema bundling intent classification and entity slot filling.
+
+    Typical usage:
+        schema = NERSchema(
+            intents=IntentSchema(labels=["book_flight", "cancel", "status_check"]),
+            slots=[
+                SlotSchema(name="departure_city", labels=["O", "B", "I"]),
+                SlotSchema(name="destination_city", labels=["O", "B", "I"]),
+                SlotSchema(name="date", labels=["O", "B", "I"]),
+            ],
+        )
+        anchored = VocabAnchor().anchor(schema, tokenizer)
+        custom_params = {"schema": anchored.to_anchor_config(), "eos_token_id": tokenizer.eos_token_id}
+    """
+
+    intents: IntentSchema
+    slots: List[SlotSchema] = dataclasses.field(default_factory=list)
+
+    def __post_init__(self):
+        slot_names = [s.name for s in self.slots]
+        if len(set(slot_names)) != len(slot_names):
+            raise ValueError(f"NERSchema has duplicate slot names: {slot_names}")
+
+    @property
+    def is_anchored(self) -> bool:
+        return self.intents.is_anchored and all(s.is_anchored for s in self.slots)
+
+    def to_anchor_config(self) -> dict:
+        """
+        Serialise the fully-anchored schema to a plain dict suitable for
+        SamplingParams.custom_params["schema"].
+
+        The dict is intentionally primitive (lists of ints/strings) so it
+        can be JSON-serialised and is safe to pass across process boundaries.
+        """
+        if not self.is_anchored:
+            raise RuntimeError(
+                "Schema must be anchored before calling to_anchor_config(). "
+                "Run VocabAnchor().anchor(schema, tokenizer) first."
+            )
+        return {
+            "intent_labels": list(self.intents.labels),
+            "intent_token_ids": self.intents.token_ids(),
+            "entity_slots": [
+                {
+                    "name": slot.name,
+                    "bio_labels": list(slot.labels),
+                    "bio_token_ids": slot.token_ids(),
+                }
+                for slot in self.slots
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NERSchema":
+        """Reconstruct from a plain dict (e.g. after JSON deserialisation)."""
+        intents = IntentSchema(
+            labels=d["intent_labels"],
+            label_to_token_id=dict(zip(d["intent_labels"], d["intent_token_ids"])),
+        )
+        slots = [
+            SlotSchema(
+                name=slot["name"],
+                labels=slot["bio_labels"],
+                label_to_token_id=dict(zip(slot["bio_labels"], slot["bio_token_ids"])),
+            )
+            for slot in d.get("entity_slots", [])
+        ]
+        return cls(intents=intents, slots=slots)

--- a/python/sglang/srt/logit_slicing/vocab_anchor.py
+++ b/python/sglang/srt/logit_slicing/vocab_anchor.py
@@ -32,9 +32,9 @@ You can either:
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
-from sglang.srt.logit_slicing.schema import IntentSchema, NERSchema, SlotSchema
+from sglang.srt.logit_slicing.schema import NERSchema
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +170,9 @@ class VocabAnchor:
         token_to_labels: Dict[int, List[str]] = {}
         for label, tid in mapping.items():
             token_to_labels.setdefault(tid, []).append(label)
-        collisions = {tid: lbls for tid, lbls in token_to_labels.items() if len(lbls) > 1}
+        collisions = {
+            tid: lbls for tid, lbls in token_to_labels.items() if len(lbls) > 1
+        }
         if collisions:
             details = "; ".join(
                 f"token_id={tid} ← {lbls}" for tid, lbls in collisions.items()
@@ -181,7 +183,9 @@ class VocabAnchor:
                 "Use strategy='explicit' and hand-pick unique token IDs."
             )
 
-    def _check_vocab_range(self, mapping: Dict[str, int], tokenizer, head_name: str) -> None:
+    def _check_vocab_range(
+        self, mapping: Dict[str, int], tokenizer, head_name: str
+    ) -> None:
         if tokenizer is None:
             # No tokenizer available (e.g. STRATEGY_EXPLICIT with tokenizer=None in
             # build_phase_b_config).  Caller is responsible for providing valid IDs.
@@ -197,13 +201,16 @@ class VocabAnchor:
             )
 
     def _log_mapping(self, mapping: Dict[str, int], head_name: str) -> None:
-        lines = "  " + "\n  ".join(f"{lbl!r:30s} → {tid}" for lbl, tid in mapping.items())
+        lines = "  " + "\n  ".join(
+            f"{lbl!r:30s} → {tid}" for lbl, tid in mapping.items()
+        )
         logger.debug("VocabAnchor [%s]:\n%s", head_name, lines)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Convenience function
 # ──────────────────────────────────────────────────────────────────────────────
+
 
 def build_anchor_config(
     schema: NERSchema,
@@ -286,6 +293,7 @@ def build_phase_b_config(
         )
     """
     import torch as _torch
+
     config = build_anchor_config(
         schema,
         tokenizer,
@@ -295,7 +303,7 @@ def build_phase_b_config(
         eos_token_id=eos_token_id,
     )
     schema_cfg = config["schema"]
-    label_embs: Dict[str, "torch.Tensor"] = {}
+    label_embs: Dict[str, Any] = {}
 
     intent_ids = _torch.tensor(schema_cfg["intent_token_ids"], dtype=_torch.long)
     label_embs["intent"] = embedding_matrix[intent_ids].detach().clone().cpu()

--- a/python/sglang/srt/logit_slicing/vocab_anchor.py
+++ b/python/sglang/srt/logit_slicing/vocab_anchor.py
@@ -1,0 +1,314 @@
+"""
+VocabAnchor: maps NERSchema class labels to single token IDs in a given tokenizer.
+
+The core challenge: most class labels (e.g. "book_flight", "departure_city") tokenise to
+multiple sub-word tokens.  We need a stable, single-token proxy for each label so we can
+slice exactly one logit column per class.
+
+Strategies
+----------
+first_token   (default)
+    Take the first token of the label's encoding.  Fast, always works.
+    Risk: "booking" and "book" may share the same first token — see collision detection.
+
+single_token
+    Raise ValueError if any label tokenises to more than one token.
+    Use when you control the label strings and want a strict guarantee.
+
+explicit
+    Caller provides a pre-built Dict[str, int].  VocabAnchor skips tokenisation entirely.
+    Use when you know the exact token IDs (best for production).
+
+Collision detection (all strategies)
+--------------------------------------
+If two labels in the same head (intent or a single slot) map to the same token ID, the
+classification is ambiguous.  VocabAnchor.anchor() raises ValueError on any collision.
+You can either:
+  - Rename the conflicting labels to tokens that differ in the first sub-word
+  - Switch to the "explicit" strategy and hand-pick token IDs
+  - Add the labels as new special tokens to the tokenizer
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from sglang.srt.logit_slicing.schema import IntentSchema, NERSchema, SlotSchema
+
+logger = logging.getLogger(__name__)
+
+
+# Strategies exposed as module-level constants so callers can avoid magic strings.
+STRATEGY_FIRST_TOKEN = "first_token"
+STRATEGY_SINGLE_TOKEN = "single_token"
+STRATEGY_EXPLICIT = "explicit"
+
+
+class VocabAnchor:
+    """
+    Anchors a NERSchema to a specific tokenizer, filling label_to_token_id on
+    every IntentSchema and SlotSchema in-place, then returns the schema for
+    method chaining.
+
+    Usage
+    -----
+    anchored_schema = VocabAnchor().anchor(schema, tokenizer)
+    config = anchored_schema.to_anchor_config()          # pass to custom_params
+    """
+
+    def anchor(
+        self,
+        schema: NERSchema,
+        tokenizer,
+        strategy: str = STRATEGY_FIRST_TOKEN,
+        intent_override: Optional[Dict[str, int]] = None,
+        slot_overrides: Optional[Dict[str, Dict[str, int]]] = None,
+    ) -> NERSchema:
+        """
+        Anchor all labels in *schema* to token IDs.
+
+        Parameters
+        ----------
+        schema          : NERSchema to anchor (mutated in-place; also returned).
+        tokenizer       : Any HuggingFace-compatible tokenizer.
+        strategy        : "first_token" | "single_token" | "explicit"
+        intent_override : Override mapping for the intent head (strategy="explicit").
+        slot_overrides  : {slot_name: {label: token_id}} overrides per slot.
+        """
+        slot_overrides = slot_overrides or {}
+
+        # ── Intent head ────────────────────────────────────────────────────────
+        if strategy == STRATEGY_EXPLICIT and intent_override is None:
+            raise ValueError(
+                'strategy="explicit" requires intent_override to be provided.'
+            )
+        schema.intents.label_to_token_id = self._anchor_labels(
+            labels=schema.intents.labels,
+            tokenizer=tokenizer,
+            strategy=strategy,
+            explicit_map=intent_override,
+            head_name="intent",
+        )
+
+        # ── Entity slots ────────────────────────────────────────────────────────
+        for slot in schema.slots:
+            override = slot_overrides.get(slot.name)
+            if strategy == STRATEGY_EXPLICIT and override is None:
+                raise ValueError(
+                    f'strategy="explicit" requires slot_overrides["{slot.name}"] to be provided.'
+                )
+            slot.label_to_token_id = self._anchor_labels(
+                labels=slot.labels,
+                tokenizer=tokenizer,
+                strategy=strategy,
+                explicit_map=override,
+                head_name=f'slot "{slot.name}"',
+            )
+
+        logger.info(
+            "VocabAnchor: anchored %d intent labels and %d slots.",
+            len(schema.intents.labels),
+            len(schema.slots),
+        )
+        return schema
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Internal helpers
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def _anchor_labels(
+        self,
+        labels: List[str],
+        tokenizer,
+        strategy: str,
+        explicit_map: Optional[Dict[str, int]],
+        head_name: str,
+    ) -> Dict[str, int]:
+        if strategy == STRATEGY_EXPLICIT:
+            mapping = dict(explicit_map)  # shallow copy
+        else:
+            mapping = {
+                label: self._label_to_token_id(label, tokenizer, strategy)
+                for label in labels
+            }
+
+        missing = set(labels) - set(mapping.keys())
+        if missing:
+            raise ValueError(
+                f"VocabAnchor [{head_name}]: labels {missing} have no token ID mapping."
+            )
+
+        self._check_collisions(mapping, head_name)
+        self._check_vocab_range(mapping, tokenizer, head_name)
+        self._log_mapping(mapping, head_name)
+        return mapping
+
+    def _label_to_token_id(self, label: str, tokenizer, strategy: str) -> int:
+        tokens = tokenizer.encode(label, add_special_tokens=False)
+        if not tokens:
+            raise ValueError(
+                f"VocabAnchor: label '{label}' encoded to an empty token list. "
+                "Check tokenizer compatibility."
+            )
+        if strategy == STRATEGY_SINGLE_TOKEN and len(tokens) > 1:
+            raise ValueError(
+                f"VocabAnchor: label '{label}' tokenises to {len(tokens)} tokens "
+                f"({tokens}) but strategy='single_token' requires exactly one. "
+                "Hint: shorten the label or switch to strategy='first_token'."
+            )
+        if len(tokens) > 1:
+            logger.warning(
+                "VocabAnchor: label '%s' tokenises to %d tokens; using first token %d only.",
+                label,
+                len(tokens),
+                tokens[0],
+            )
+        return tokens[0]
+
+    def _check_collisions(self, mapping: Dict[str, int], head_name: str) -> None:
+        token_to_labels: Dict[int, List[str]] = {}
+        for label, tid in mapping.items():
+            token_to_labels.setdefault(tid, []).append(label)
+        collisions = {tid: lbls for tid, lbls in token_to_labels.items() if len(lbls) > 1}
+        if collisions:
+            details = "; ".join(
+                f"token_id={tid} ← {lbls}" for tid, lbls in collisions.items()
+            )
+            raise ValueError(
+                f"VocabAnchor [{head_name}]: token ID collision(s) detected — {details}. "
+                "Two labels map to the same token, making classification ambiguous. "
+                "Use strategy='explicit' and hand-pick unique token IDs."
+            )
+
+    def _check_vocab_range(self, mapping: Dict[str, int], tokenizer, head_name: str) -> None:
+        if tokenizer is None:
+            # No tokenizer available (e.g. STRATEGY_EXPLICIT with tokenizer=None in
+            # build_phase_b_config).  Caller is responsible for providing valid IDs.
+            return
+        vocab_size = tokenizer.vocab_size
+        out_of_range = {
+            label: tid for label, tid in mapping.items() if not (0 <= tid < vocab_size)
+        }
+        if out_of_range:
+            raise ValueError(
+                f"VocabAnchor [{head_name}]: token IDs out of vocab range [0, {vocab_size}): "
+                f"{out_of_range}"
+            )
+
+    def _log_mapping(self, mapping: Dict[str, int], head_name: str) -> None:
+        lines = "  " + "\n  ".join(f"{lbl!r:30s} → {tid}" for lbl, tid in mapping.items())
+        logger.debug("VocabAnchor [%s]:\n%s", head_name, lines)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Convenience function
+# ──────────────────────────────────────────────────────────────────────────────
+
+def build_anchor_config(
+    schema: NERSchema,
+    tokenizer,
+    strategy: str = STRATEGY_FIRST_TOKEN,
+    intent_override: Optional[Dict[str, int]] = None,
+    slot_overrides: Optional[Dict[str, Dict[str, int]]] = None,
+    eos_token_id: Optional[int] = None,
+) -> dict:
+    """
+    One-shot helper: anchor the schema and return the custom_params dict.
+
+    The returned dict is ready to be passed as SamplingParams.custom_params.
+
+    Example
+    -------
+        custom_params = build_anchor_config(schema, tokenizer)
+        sgl.gen(..., sampling_params={"custom_params": custom_params, "max_new_tokens": 1})
+    """
+    anchored = VocabAnchor().anchor(
+        schema,
+        tokenizer,
+        strategy=strategy,
+        intent_override=intent_override,
+        slot_overrides=slot_overrides,
+    )
+    config = {"schema": anchored.to_anchor_config()}
+    if eos_token_id is not None:
+        config["eos_token_id"] = eos_token_id
+    elif hasattr(tokenizer, "eos_token_id") and tokenizer.eos_token_id is not None:
+        config["eos_token_id"] = tokenizer.eos_token_id
+    return config
+
+
+def build_phase_b_config(
+    schema: NERSchema,
+    tokenizer,
+    embedding_matrix,
+    strategy: str = STRATEGY_FIRST_TOKEN,
+    intent_override: Optional[Dict[str, int]] = None,
+    slot_overrides: Optional[Dict[str, Dict[str, int]]] = None,
+    eos_token_id: Optional[int] = None,
+) -> dict:
+    """
+    One-shot helper for Phase B (SMIELPWithHiddenStates).
+
+    Extends build_anchor_config by also extracting embedding vectors for each
+    anchored label token from the model's input embedding matrix, enabling
+    cosine-similarity classification in hidden-state space.
+
+    Parameters
+    ----------
+    schema           : NERSchema to anchor.
+    tokenizer        : HuggingFace-compatible tokenizer.
+    embedding_matrix : Tensor[vocab_size, hidden_dim] — typically
+                       ``model.embed_tokens.weight.detach()`` from the HF model.
+                       Rows are indexed by token ID.
+    strategy, intent_override, slot_overrides, eos_token_id : forwarded to
+                       build_anchor_config unchanged.
+
+    Returns
+    -------
+    dict with keys:
+        "schema"           → same as build_anchor_config
+        "eos_token_id"     → same as build_anchor_config
+        "label_embeddings" → {
+            "intent":     Tensor[num_intents, hidden_dim],
+            slot.name:    Tensor[num_tags, hidden_dim],   # one per slot
+            ...
+        }
+
+    Example
+    -------
+        custom_params = build_phase_b_config(schema, tokenizer, model.embed_tokens.weight.detach())
+        SamplingParams(
+            max_new_tokens=1,
+            return_hidden_states=True,
+            custom_params=custom_params,
+            custom_logit_processor=SMIELPWithHiddenStates.to_str(),
+        )
+    """
+    import torch as _torch
+    config = build_anchor_config(
+        schema,
+        tokenizer,
+        strategy=strategy,
+        intent_override=intent_override,
+        slot_overrides=slot_overrides,
+        eos_token_id=eos_token_id,
+    )
+    schema_cfg = config["schema"]
+    label_embs: Dict[str, "torch.Tensor"] = {}
+
+    intent_ids = _torch.tensor(schema_cfg["intent_token_ids"], dtype=_torch.long)
+    label_embs["intent"] = embedding_matrix[intent_ids].detach().clone().cpu()
+
+    for slot in schema_cfg["entity_slots"]:
+        bio_ids = _torch.tensor(slot["bio_token_ids"], dtype=_torch.long)
+        label_embs[slot["name"]] = embedding_matrix[bio_ids].detach().clone().cpu()
+
+    config["label_embeddings"] = label_embs
+    logger.info(
+        "build_phase_b_config: extracted embeddings for %d intents and %d slots (hidden_dim=%d).",
+        len(schema_cfg["intent_token_ids"]),
+        len(schema_cfg["entity_slots"]),
+        embedding_matrix.shape[1],
+    )
+    return config

--- a/test/registered/unit/logit_slicing/test_smielp.py
+++ b/test/registered/unit/logit_slicing/test_smielp.py
@@ -1,0 +1,403 @@
+"""Unit tests for srt/logit_slicing — no server, no model loading.
+
+Covers Phase A (SimultaneousMultiIntentEntityLogitProcessor) and Phase B
+(SMIELPWithHiddenStates) processors, schema validation, vocab anchoring, and
+the backward-compatible sampler helper.  All tests run on CPU.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+register_cpu_ci(est_time=30, suite="base-b-test-cpu")
+
+import unittest
+from typing import Dict, List
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.logit_slicing import (
+    IntentSchema,
+    NERSchema,
+    SimultaneousMultiIntentEntityLogitProcessor,
+    SMIELPWithHiddenStates,
+    SlotSchema,
+    VocabAnchor,
+    build_anchor_config,
+    build_phase_b_config,
+)
+from sglang.srt.logit_slicing.vocab_anchor import (
+    STRATEGY_EXPLICIT,
+    STRATEGY_FIRST_TOKEN,
+    STRATEGY_SINGLE_TOKEN,
+)
+from sglang.test.test_utils import CustomTestCase
+
+# ── Shared constants ────────────────────────────────────────────────────────
+VOCAB_SIZE = 200
+HIDDEN_DIM = 64
+
+# Token IDs used throughout tests
+BOOK_ID = 10
+CANCEL_ID = 20
+STATUS_ID = 30
+O_ID = 40
+B_ID = 50
+I_ID = 60
+EOS_ID = 2
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_req():
+    req = MagicMock()
+    req.customized_info = {}
+    return req
+
+
+def _fake_tokenizer(label_map: Dict[str, List[int]], vocab_size: int = VOCAB_SIZE):
+    tok = MagicMock()
+    tok.vocab_size = vocab_size
+    tok.eos_token_id = EOS_ID
+    tok.encode = lambda text, **kw: label_map.get(text, [0])
+    return tok
+
+
+def _explicit_schema():
+    schema = NERSchema(
+        intents=IntentSchema(labels=["book", "cancel", "status"]),
+        slots=[SlotSchema(name="city", labels=["O", "B", "I"])],
+    )
+    VocabAnchor().anchor(
+        schema,
+        tokenizer=None,
+        strategy=STRATEGY_EXPLICIT,
+        intent_override={"book": BOOK_ID, "cancel": CANCEL_ID, "status": STATUS_ID},
+        slot_overrides={"city": {"O": O_ID, "B": B_ID, "I": I_ID}},
+    )
+    return schema
+
+
+def _make_config():
+    return _explicit_schema().to_anchor_config()
+
+
+def _make_logits(intent_winner_idx: int, slot_winner_idx: int) -> torch.Tensor:
+    logits = torch.zeros(1, VOCAB_SIZE)
+    intent_ids = [BOOK_ID, CANCEL_ID, STATUS_ID]
+    slot_ids = [O_ID, B_ID, I_ID]
+    logits[0, intent_ids[intent_winner_idx]] = 10.0
+    logits[0, slot_ids[slot_winner_idx]] = 10.0
+    return logits
+
+
+# ── Schema validation ────────────────────────────────────────────────────────
+
+
+class TestIntentSchema(CustomTestCase):
+    def test_requires_at_least_two_labels(self):
+        with self.assertRaises(ValueError):
+            IntentSchema(labels=["only_one"])
+
+    def test_rejects_duplicate_labels(self):
+        with self.assertRaises(ValueError):
+            IntentSchema(labels=["a", "a"])
+
+    def test_valid_schema_created(self):
+        s = IntentSchema(labels=["book", "cancel"])
+        self.assertEqual(list(s.labels), ["book", "cancel"])
+
+
+class TestSlotSchema(CustomTestCase):
+    def test_empty_name_raises(self):
+        with self.assertRaises(ValueError):
+            SlotSchema(name="", labels=["O", "B"])
+
+    def test_requires_at_least_two_labels(self):
+        with self.assertRaises(ValueError):
+            SlotSchema(name="city", labels=["O"])
+
+
+class TestNERSchema(CustomTestCase):
+    def test_rejects_duplicate_slot_names(self):
+        with self.assertRaises(ValueError):
+            NERSchema(
+                intents=IntentSchema(labels=["a", "b"]),
+                slots=[
+                    SlotSchema(name="city", labels=["O", "B"]),
+                    SlotSchema(name="city", labels=["O", "B"]),
+                ],
+            )
+
+    def test_to_anchor_config_before_anchoring_raises(self):
+        schema = NERSchema(
+            intents=IntentSchema(labels=["a", "b"]),
+            slots=[],
+        )
+        with self.assertRaises(RuntimeError):
+            schema.to_anchor_config()
+
+    def test_to_anchor_config_round_trips_via_from_dict(self):
+        schema = _explicit_schema()
+        cfg = schema.to_anchor_config()
+        restored = NERSchema.from_dict(cfg)
+        self.assertEqual(cfg, restored.to_anchor_config())
+
+
+# ── VocabAnchor ──────────────────────────────────────────────────────────────
+
+
+class TestVocabAnchor(CustomTestCase):
+    def test_explicit_strategy(self):
+        schema = NERSchema(
+            intents=IntentSchema(labels=["book", "cancel"]),
+            slots=[],
+        )
+        VocabAnchor().anchor(
+            schema,
+            tokenizer=None,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override={"book": 10, "cancel": 20},
+        )
+        self.assertEqual(schema.intents.label_to_token_id, {"book": 10, "cancel": 20})
+
+    def test_first_token_strategy(self):
+        label_map = {"book": [10], "cancel": [20]}
+        tok = _fake_tokenizer(label_map)
+        schema = NERSchema(intents=IntentSchema(labels=["book", "cancel"]), slots=[])
+        VocabAnchor().anchor(schema, tok, strategy=STRATEGY_FIRST_TOKEN)
+        self.assertEqual(schema.intents.label_to_token_id["book"], 10)
+
+    def test_collision_detection_raises(self):
+        schema = NERSchema(intents=IntentSchema(labels=["a", "b"]), slots=[])
+        with self.assertRaises(ValueError):
+            VocabAnchor().anchor(
+                schema,
+                tokenizer=None,
+                strategy=STRATEGY_EXPLICIT,
+                intent_override={"a": 5, "b": 5},
+            )
+
+    def test_explicit_requires_override(self):
+        schema = NERSchema(intents=IntentSchema(labels=["a", "b"]), slots=[])
+        with self.assertRaises(ValueError):
+            VocabAnchor().anchor(schema, tokenizer=None, strategy=STRATEGY_EXPLICIT)
+
+    def test_build_anchor_config_attaches_eos(self):
+        schema = _explicit_schema()
+        tok = MagicMock()
+        tok.vocab_size = VOCAB_SIZE
+        tok.eos_token_id = EOS_ID
+        schema2 = NERSchema(
+            intents=IntentSchema(labels=["book", "cancel", "status"]),
+            slots=[SlotSchema(name="city", labels=["O", "B", "I"])],
+        )
+        cfg = build_anchor_config(
+            schema2,
+            tok,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override={"book": BOOK_ID, "cancel": CANCEL_ID, "status": STATUS_ID},
+            slot_overrides={"city": {"O": O_ID, "B": B_ID, "I": I_ID}},
+        )
+        self.assertEqual(cfg["eos_token_id"], EOS_ID)
+        self.assertIn("schema", cfg)
+
+
+# ── Phase A processor ────────────────────────────────────────────────────────
+
+
+class TestPhaseAProcessor(CustomTestCase):
+    def _run(self, logits, schema_config=None, eos_token_id=EOS_ID):
+        if schema_config is None:
+            schema_config = _make_config()
+        req = _make_req()
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        proc(logits, [{"schema": schema_config, "eos_token_id": eos_token_id, "__req__": req}])
+        return req.customized_info.get("smielp", [{}])[0]
+
+    def test_intent_winner_book(self):
+        result = self._run(_make_logits(intent_winner_idx=0, slot_winner_idx=0))
+        self.assertEqual(result["intent"]["label"], "book")
+
+    def test_intent_winner_cancel(self):
+        result = self._run(_make_logits(intent_winner_idx=1, slot_winner_idx=0))
+        self.assertEqual(result["intent"]["label"], "cancel")
+
+    def test_slot_winner_B(self):
+        result = self._run(_make_logits(intent_winner_idx=0, slot_winner_idx=1))
+        city = next(e for e in result["entities"] if e["slot"] == "city")
+        self.assertEqual(city["tag"], "B")
+
+    def test_eos_forced_after_processing(self):
+        logits = _make_logits(0, 0)
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"schema": _make_config(), "eos_token_id": EOS_ID, "__req__": req}])
+        self.assertEqual(float(logits[0, EOS_ID]), 0.0)
+        self.assertTrue(all(v == float("-inf") for i, v in enumerate(logits[0].tolist()) if i != EOS_ID))
+
+    def test_eos_clamped_when_out_of_range(self):
+        logits = torch.zeros(1, VOCAB_SIZE)
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"schema": _make_config(), "eos_token_id": VOCAB_SIZE + 100, "__req__": req}])
+        self.assertEqual(float(logits[0, VOCAB_SIZE - 1]), 0.0)
+
+    def test_none_params_does_not_crash(self):
+        logits = torch.zeros(1, VOCAB_SIZE)
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        out = proc(logits, [None])
+        self.assertEqual(float(out[0, 2]), 0.0)
+
+    def test_empty_param_list_returns_unchanged(self):
+        logits = torch.ones(1, VOCAB_SIZE)
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        out = proc(logits.clone(), [])
+        self.assertTrue(torch.equal(out, logits))
+
+    def test_distribution_sums_to_one(self):
+        result = self._run(_make_logits(0, 0))
+        total = sum(result["intent"]["distribution"].values())
+        self.assertAlmostEqual(total, 1.0, places=5)
+
+    def test_batch_of_two(self):
+        logits = torch.zeros(2, VOCAB_SIZE)
+        logits[0, BOOK_ID] = 10.0
+        logits[1, CANCEL_ID] = 10.0
+        cfg = _make_config()
+        req0, req1 = _make_req(), _make_req()
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        proc(
+            logits,
+            [
+                {"schema": cfg, "eos_token_id": EOS_ID, "__req__": req0},
+                {"schema": cfg, "eos_token_id": EOS_ID, "__req__": req1},
+            ],
+        )
+        self.assertEqual(req0.customized_info["smielp"][0]["intent"]["label"], "book")
+        self.assertEqual(req1.customized_info["smielp"][0]["intent"]["label"], "cancel")
+
+    def test_output_key_constant(self):
+        self.assertEqual(SimultaneousMultiIntentEntityLogitProcessor.OUTPUT_KEY, "smielp")
+
+
+# ── Phase B processor ────────────────────────────────────────────────────────
+
+
+def _orthogonal_embeddings(n: int, d: int) -> torch.Tensor:
+    mat = torch.randn(n, d)
+    q, _ = torch.linalg.qr(mat.T)
+    return q.T[:n]
+
+
+class TestPhaseBProcessor(CustomTestCase):
+    def _make_label_embs(self, h: torch.Tensor, winner_idx: int, n: int):
+        embs = _orthogonal_embeddings(n, HIDDEN_DIM)
+        embs[winner_idx] = F.normalize(h.float(), dim=0)
+        return embs
+
+    def test_fallback_classifies_when_no_hidden_states(self):
+        logits = torch.zeros(1, VOCAB_SIZE)
+        logits[0, BOOK_ID] = 10.0
+        req = _make_req()
+        proc = SMIELPWithHiddenStates()
+        proc(
+            logits,
+            [{"schema": _make_config(), "eos_token_id": EOS_ID, "__req__": req}],
+            hidden_states=None,
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "book")
+        self.assertEqual(result["mode"], "logit_slicing")
+        self.assertIsNone(result["hidden_state_l2"])
+
+    def test_embedding_mode_selects_winner(self):
+        h = torch.randn(HIDDEN_DIM)
+        schema_cfg = _make_config()
+        label_embs = {
+            "intent": self._make_label_embs(h, winner_idx=1, n=3),
+            "city": self._make_label_embs(h, winner_idx=0, n=3),
+        }
+        logits = torch.zeros(1, VOCAB_SIZE)
+        hs = h.unsqueeze(0)
+        req = _make_req()
+        proc = SMIELPWithHiddenStates()
+        proc(
+            logits,
+            [{"schema": schema_cfg, "eos_token_id": EOS_ID, "__req__": req, "label_embeddings": label_embs}],
+            hidden_states=hs,
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "cancel")
+        self.assertEqual(result["mode"], "embedding")
+
+    def test_hidden_state_l2_populated(self):
+        h = torch.randn(HIDDEN_DIM)
+        req = _make_req()
+        proc = SMIELPWithHiddenStates()
+        proc(
+            torch.zeros(1, VOCAB_SIZE),
+            [{"schema": _make_config(), "eos_token_id": EOS_ID, "__req__": req}],
+            hidden_states=h.unsqueeze(0),
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertIsNotNone(result["hidden_state_l2"])
+        self.assertAlmostEqual(result["hidden_state_l2"], float(h.norm().item()), places=4)
+
+    def test_shape_mismatch_falls_back(self):
+        logits = torch.zeros(1, VOCAB_SIZE)
+        logits[0, BOOK_ID] = 10.0
+        req = _make_req()
+        proc = SMIELPWithHiddenStates()
+        wrong_hs = torch.randn(2, HIDDEN_DIM)
+        proc(
+            logits,
+            [{"schema": _make_config(), "eos_token_id": EOS_ID, "__req__": req}],
+            hidden_states=wrong_hs,
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["mode"], "logit_slicing")
+
+    def test_nan_hidden_state_falls_back(self):
+        logits = torch.zeros(1, VOCAB_SIZE)
+        logits[0, CANCEL_ID] = 10.0
+        req = _make_req()
+        proc = SMIELPWithHiddenStates()
+        nan_hs = torch.full((1, HIDDEN_DIM), float("nan"))
+        proc(
+            logits,
+            [{"schema": _make_config(), "eos_token_id": EOS_ID, "__req__": req}],
+            hidden_states=nan_hs,
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["mode"], "logit_slicing")
+        self.assertEqual(result["intent"]["label"], "cancel")
+
+    def test_none_params_does_not_crash(self):
+        logits = torch.zeros(1, VOCAB_SIZE)
+        proc = SMIELPWithHiddenStates()
+        out = proc(logits, [None], hidden_states=None)
+        self.assertEqual(float(out[0, 2]), 0.0)
+
+
+# ── Sampler helper ───────────────────────────────────────────────────────────
+
+
+class TestProcessorCapabilityDetection(CustomTestCase):
+    def test_phase_b_detected_as_capable(self):
+        from sglang.srt.layers.sampler import _processor_accepts_hidden_states
+
+        self.assertTrue(_processor_accepts_hidden_states(SMIELPWithHiddenStates))
+
+    def test_phase_a_detected_as_incapable(self):
+        from sglang.srt.layers.sampler import _processor_accepts_hidden_states
+
+        self.assertFalse(
+            _processor_accepts_hidden_states(SimultaneousMultiIntentEntityLogitProcessor)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_logit_slicing.py
+++ b/test/srt/test_logit_slicing.py
@@ -1,0 +1,503 @@
+"""
+Unit tests for python/sglang/srt/logit_slicing/.
+
+All tests run on CPU with mocked tokenizers — no GPU or live server required.
+
+Run:
+    pytest test/srt/test_logit_slicing.py -v
+
+These tests stub the sglang import chain so they work with any Python >= 3.9
+that has torch installed, without needing a full sglang GPU installation.
+"""
+
+import importlib.util
+import math
+import pathlib
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from typing import Dict, List
+from unittest.mock import MagicMock
+
+import torch
+
+# ── Bootstrap: load our modules directly by file path ─────────────────────────
+#
+# sglang requires Python 3.10+ syntax but tests must run on Python 3.9 with
+# only torch available.  We bypass the sglang package registry entirely by
+# loading each of our three source files with importlib.util, registering them
+# under their full dotted names in sys.modules.  processor.py has a try/except
+# fallback for CustomLogitProcessor, so the heavy sglang chain is never hit.
+
+_SRC = pathlib.Path(__file__).resolve().parent.parent.parent / "python" / "sglang" / "srt" / "logit_slicing"
+
+
+def _load(dotted_name: str, filename: str):
+    """Load a source file and register it in sys.modules under dotted_name."""
+    spec = importlib.util.spec_from_file_location(dotted_name, _SRC / filename)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = dotted_name.rsplit(".", 1)[0]
+    sys.modules[dotted_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_schema_mod    = _load("sglang.srt.logit_slicing.schema",       "schema.py")
+_anchor_mod    = _load("sglang.srt.logit_slicing.vocab_anchor", "vocab_anchor.py")
+_proc_mod      = _load("sglang.srt.logit_slicing.processor",    "processor.py")
+
+SimultaneousMultiIntentEntityLogitProcessor = _proc_mod.SimultaneousMultiIntentEntityLogitProcessor
+IntentSchema = _schema_mod.IntentSchema
+NERSchema    = _schema_mod.NERSchema
+SlotSchema   = _schema_mod.SlotSchema
+
+STRATEGY_FIRST_TOKEN  = _anchor_mod.STRATEGY_FIRST_TOKEN
+STRATEGY_SINGLE_TOKEN = _anchor_mod.STRATEGY_SINGLE_TOKEN
+STRATEGY_EXPLICIT     = _anchor_mod.STRATEGY_EXPLICIT
+VocabAnchor           = _anchor_mod.VocabAnchor
+build_anchor_config   = _anchor_mod.build_anchor_config
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+VOCAB_SIZE = 200
+
+
+def _fake_tokenizer(label_map: Dict[str, List[int]], vocab_size: int = VOCAB_SIZE):
+    """Return a mock tokenizer that encodes labels using a fixed map."""
+    tok = MagicMock()
+    tok.vocab_size = vocab_size
+    tok.eos_token_id = 2
+
+    def encode(text, add_special_tokens=False):
+        return label_map.get(text, [0])
+
+    tok.encode = encode
+    return tok
+
+
+def _make_schema() -> NERSchema:
+    return NERSchema(
+        intents=IntentSchema(labels=["book_flight", "cancel", "check_status"]),
+        slots=[
+            SlotSchema(name="departure_city", labels=["O", "B", "I"]),
+            SlotSchema(name="date", labels=["O", "B"]),
+        ],
+    )
+
+
+def _make_req():
+    """Minimal stand-in for sglang Req — just needs customized_info attribute."""
+    return SimpleNamespace(customized_info=None)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# IntentSchema
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestIntentSchema(unittest.TestCase):
+    def test_requires_at_least_two_labels(self):
+        with self.assertRaises(ValueError):
+            IntentSchema(labels=["only_one"])
+
+    def test_rejects_duplicate_labels(self):
+        with self.assertRaises(ValueError):
+            IntentSchema(labels=["a", "a", "b"])
+
+    def test_token_ids_before_anchoring_raises(self):
+        schema = IntentSchema(labels=["a", "b"])
+        with self.assertRaises(RuntimeError):
+            schema.token_ids()
+
+    def test_token_ids_after_anchoring(self):
+        schema = IntentSchema(labels=["a", "b"], label_to_token_id={"a": 10, "b": 20})
+        self.assertEqual(schema.token_ids(), [10, 20])
+
+    def test_is_anchored(self):
+        schema = IntentSchema(labels=["a", "b"])
+        self.assertFalse(schema.is_anchored)
+        schema.label_to_token_id = {"a": 10, "b": 20}
+        self.assertTrue(schema.is_anchored)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SlotSchema
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSlotSchema(unittest.TestCase):
+    def test_empty_name_raises(self):
+        with self.assertRaises(ValueError):
+            SlotSchema(name="", labels=["O", "B"])
+
+    def test_requires_at_least_two_labels(self):
+        with self.assertRaises(ValueError):
+            SlotSchema(name="city", labels=["O"])
+
+    def test_rejects_duplicate_labels(self):
+        with self.assertRaises(ValueError):
+            SlotSchema(name="city", labels=["O", "O"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NERSchema
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestNERSchema(unittest.TestCase):
+    def test_rejects_duplicate_slot_names(self):
+        with self.assertRaises(ValueError):
+            NERSchema(
+                intents=IntentSchema(labels=["a", "b"]),
+                slots=[
+                    SlotSchema(name="city", labels=["O", "B"]),
+                    SlotSchema(name="city", labels=["O", "B"]),
+                ],
+            )
+
+    def test_to_anchor_config_before_anchoring_raises(self):
+        schema = _make_schema()
+        with self.assertRaises(RuntimeError):
+            schema.to_anchor_config()
+
+    def test_to_anchor_config_round_trips_via_from_dict(self):
+        schema = _make_schema()
+        schema.intents.label_to_token_id = {"book_flight": 10, "cancel": 20, "check_status": 30}
+        schema.slots[0].label_to_token_id = {"O": 40, "B": 50, "I": 60}
+        schema.slots[1].label_to_token_id = {"O": 70, "B": 80}
+
+        config = schema.to_anchor_config()
+        restored = NERSchema.from_dict(config)
+
+        self.assertEqual(restored.intents.labels, ["book_flight", "cancel", "check_status"])
+        self.assertEqual(restored.intents.token_ids(), [10, 20, 30])
+        self.assertEqual(restored.slots[0].name, "departure_city")
+        self.assertEqual(restored.slots[0].token_ids(), [40, 50, 60])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VocabAnchor
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestVocabAnchor(unittest.TestCase):
+    def _make_tok_with_unique_ids(self):
+        label_map = {
+            "book_flight": [10],
+            "cancel": [20],
+            "check_status": [30],
+            "O": [40],
+            "B": [50],
+            "I": [60],
+        }
+        return _fake_tokenizer(label_map)
+
+    def test_first_token_strategy(self):
+        schema = _make_schema()
+        tok = self._make_tok_with_unique_ids()
+        anchored = VocabAnchor().anchor(schema, tok, strategy=STRATEGY_FIRST_TOKEN)
+        self.assertTrue(anchored.is_anchored)
+        self.assertEqual(anchored.intents.label_to_token_id["book_flight"], 10)
+        self.assertEqual(anchored.slots[0].label_to_token_id["B"], 50)
+
+    def test_single_token_strategy_raises_on_multi_token(self):
+        schema = _make_schema()
+        # Make "book_flight" return two tokens
+        label_map = {
+            "book_flight": [10, 11],
+            "cancel": [20],
+            "check_status": [30],
+            "O": [40],
+            "B": [50],
+            "I": [60],
+        }
+        tok = _fake_tokenizer(label_map)
+        with self.assertRaises(ValueError, msg="single_token strategy should reject multi-token label"):
+            VocabAnchor().anchor(schema, tok, strategy=STRATEGY_SINGLE_TOKEN)
+
+    def test_explicit_strategy(self):
+        schema = _make_schema()
+        tok = _fake_tokenizer({})  # encode never called
+        intent_override = {"book_flight": 10, "cancel": 20, "check_status": 30}
+        slot_overrides = {
+            "departure_city": {"O": 40, "B": 50, "I": 60},
+            "date": {"O": 70, "B": 80},
+        }
+        anchored = VocabAnchor().anchor(
+            schema, tok,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=intent_override,
+            slot_overrides=slot_overrides,
+        )
+        self.assertEqual(anchored.intents.label_to_token_id["cancel"], 20)
+
+    def test_explicit_strategy_missing_override_raises(self):
+        schema = _make_schema()
+        tok = _fake_tokenizer({})
+        with self.assertRaises(ValueError):
+            VocabAnchor().anchor(schema, tok, strategy=STRATEGY_EXPLICIT)
+
+    def test_collision_detection_raises(self):
+        schema = NERSchema(
+            intents=IntentSchema(labels=["a", "b"]),
+            slots=[],
+        )
+        # Both labels map to the same token
+        label_map = {"a": [10], "b": [10]}
+        tok = _fake_tokenizer(label_map)
+        with self.assertRaises(ValueError, msg="Should raise on token ID collision"):
+            VocabAnchor().anchor(schema, tok, strategy=STRATEGY_FIRST_TOKEN)
+
+    def test_out_of_vocab_range_raises(self):
+        schema = NERSchema(intents=IntentSchema(labels=["a", "b"]), slots=[])
+        label_map = {"a": [10], "b": [9999]}  # 9999 > VOCAB_SIZE=200
+        tok = _fake_tokenizer(label_map, vocab_size=100)
+        with self.assertRaises(ValueError):
+            VocabAnchor().anchor(schema, tok)
+
+    def test_build_anchor_config_attaches_eos(self):
+        schema = _make_schema()
+        tok = self._make_tok_with_unique_ids()
+        tok.eos_token_id = 2
+        config = build_anchor_config(schema, tok)
+        self.assertIn("schema", config)
+        self.assertIn("eos_token_id", config)
+        self.assertEqual(config["eos_token_id"], 2)
+
+    def test_build_anchor_config_explicit_eos_overrides(self):
+        schema = _make_schema()
+        tok = self._make_tok_with_unique_ids()
+        tok.eos_token_id = 2
+        config = build_anchor_config(schema, tok, eos_token_id=99)
+        self.assertEqual(config["eos_token_id"], 99)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SimultaneousMultiIntentEntityLogitProcessor
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSMIELP(unittest.TestCase):
+    """Tests for the logit processor on CPU with synthetic logit tensors."""
+
+    def _make_schema_config(self):
+        """Return a fully-anchored schema config dict with known token IDs."""
+        return {
+            "intent_labels": ["book_flight", "cancel", "check_status"],
+            "intent_token_ids": [10, 20, 30],
+            "entity_slots": [
+                {
+                    "name": "departure_city",
+                    "bio_labels": ["O", "B", "I"],
+                    "bio_token_ids": [40, 50, 60],
+                },
+                {
+                    "name": "date",
+                    "bio_labels": ["O", "B"],
+                    "bio_token_ids": [70, 80],
+                },
+            ],
+        }
+
+    def _make_logits(self, batch_size: int, intent_winner: int, slot_winners: List[int]) -> torch.Tensor:
+        """
+        Build a [batch_size, VOCAB_SIZE] logit tensor where the 'winner' token IDs
+        have logit=10.0 and all others have logit=0.0.
+        """
+        logits = torch.zeros(batch_size, VOCAB_SIZE)
+        intent_token_ids = [10, 20, 30]
+        slot_token_ids_list = [[40, 50, 60], [70, 80]]
+
+        for b in range(batch_size):
+            logits[b, intent_token_ids[intent_winner]] = 10.0
+            for slot_idx, winner in enumerate(slot_winners):
+                slot_tids = slot_token_ids_list[slot_idx]
+                logits[b, slot_tids[winner]] = 10.0
+
+        return logits
+
+    def _run_processor(self, logits, schema_config, eos_id=2):
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        batch_size = logits.shape[0]
+        reqs = [_make_req() for _ in range(batch_size)]
+        custom_param_list = [
+            {"__req__": reqs[i], "schema": schema_config, "eos_token_id": eos_id}
+            for i in range(batch_size)
+        ]
+        out_logits = proc(logits.clone(), custom_param_list)
+        return out_logits, reqs, custom_param_list
+
+    # ── Intent classification ────────────────────────────────────────────────
+
+    def test_intent_label_selected_correctly(self):
+        # book_flight (index 0) should win
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[0, 0])
+        _, reqs, _ = self._run_processor(logits, self._make_schema_config())
+        result = reqs[0].customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "book_flight")
+
+    def test_cancel_intent_selected(self):
+        logits = self._make_logits(1, intent_winner=1, slot_winners=[0, 0])
+        _, reqs, _ = self._run_processor(logits, self._make_schema_config())
+        result = reqs[0].customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "cancel")
+
+    def test_intent_confidence_is_highest_for_winner(self):
+        logits = self._make_logits(1, intent_winner=2, slot_winners=[0, 0])
+        _, reqs, _ = self._run_processor(logits, self._make_schema_config())
+        dist = reqs[0].customized_info["smielp"][0]["intent"]["distribution"]
+        winner_prob = dist["check_status"]
+        for label, prob in dist.items():
+            if label != "check_status":
+                self.assertGreater(winner_prob, prob)
+
+    # ── Entity slot classification ───────────────────────────────────────────
+
+    def test_slot_tag_selected_correctly_B(self):
+        # departure_city: B wins (index 1 in [O, B, I] → token_id=50)
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[1, 0])
+        _, reqs, _ = self._run_processor(logits, self._make_schema_config())
+        entities = reqs[0].customized_info["smielp"][0]["entities"]
+        dep_city = next(e for e in entities if e["slot"] == "departure_city")
+        self.assertEqual(dep_city["tag"], "B")
+
+    def test_slot_tag_selected_correctly_O(self):
+        # date: O wins (index 0 in [O, B] → token_id=70)
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[0, 0])
+        _, reqs, _ = self._run_processor(logits, self._make_schema_config())
+        entities = reqs[0].customized_info["smielp"][0]["entities"]
+        date_slot = next(e for e in entities if e["slot"] == "date")
+        self.assertEqual(date_slot["tag"], "O")
+
+    def test_all_slots_present_in_result(self):
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[0, 0])
+        _, reqs, _ = self._run_processor(logits, self._make_schema_config())
+        entities = reqs[0].customized_info["smielp"][0]["entities"]
+        slot_names = {e["slot"] for e in entities}
+        self.assertEqual(slot_names, {"departure_city", "date"})
+
+    # ── EOS forcing ──────────────────────────────────────────────────────────
+
+    def test_eos_token_is_zero_after_processing(self):
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[0, 0])
+        out, _, _ = self._run_processor(logits, self._make_schema_config(), eos_id=2)
+        self.assertAlmostEqual(float(out[0, 2]), 0.0)
+
+    def test_all_non_eos_tokens_are_neg_inf(self):
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[0, 0])
+        out, _, _ = self._run_processor(logits, self._make_schema_config(), eos_id=2)
+        for tok_id in range(VOCAB_SIZE):
+            if tok_id == 2:
+                continue
+            self.assertTrue(
+                math.isinf(float(out[0, tok_id])) and float(out[0, tok_id]) < 0,
+                msg=f"Token {tok_id} expected -inf, got {float(out[0, tok_id])}",
+            )
+
+    # ── Batch processing ─────────────────────────────────────────────────────
+
+    def test_batch_of_two_requests(self):
+        # Request 0: intent=book_flight, Request 1: intent=cancel
+        logits = torch.zeros(2, VOCAB_SIZE)
+        logits[0, 10] = 10.0   # book_flight
+        logits[1, 20] = 10.0   # cancel
+
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        schema = self._make_schema_config()
+        reqs = [_make_req(), _make_req()]
+        cpl = [
+            {"__req__": reqs[0], "schema": schema, "eos_token_id": 2},
+            {"__req__": reqs[1], "schema": schema, "eos_token_id": 2},
+        ]
+        proc(logits, cpl)
+
+        self.assertEqual(reqs[0].customized_info["smielp"][0]["intent"]["label"], "book_flight")
+        self.assertEqual(reqs[1].customized_info["smielp"][0]["intent"]["label"], "cancel")
+
+    # ── Edge cases ───────────────────────────────────────────────────────────
+
+    def test_empty_custom_param_list_returns_logits_unchanged(self):
+        logits = torch.ones(1, VOCAB_SIZE)
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        out = proc(logits.clone(), [])
+        self.assertTrue(torch.equal(out, logits))
+
+    def test_missing_schema_key_returns_empty_result(self):
+        logits = torch.ones(1, VOCAB_SIZE)
+        req = _make_req()
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        proc(logits, [{"__req__": req, "eos_token_id": 2}])  # no "schema" key
+        result = req.customized_info["smielp"][0]
+        self.assertIsNone(result["intent"])
+        self.assertEqual(result["entities"], [])
+
+    def test_missing_req_does_not_crash(self):
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[0, 0])
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        # No "__req__" key — processor should log warning and not raise
+        proc(logits, [{"schema": self._make_schema_config(), "eos_token_id": 2}])
+
+    def test_none_params_entry_does_not_crash(self):
+        """None in custom_param_list must not crash; EOS is forced with default id=2."""
+        logits = torch.zeros(1, VOCAB_SIZE)
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        out = proc(logits, [None])
+        self.assertEqual(float(out[0, 2]), 0.0)
+        self.assertEqual(float(out[0, 0]), float("-inf"))
+
+    def test_distribution_sums_to_one(self):
+        logits = self._make_logits(1, intent_winner=0, slot_winners=[0, 0])
+        _, reqs, _ = self._run_processor(logits, self._make_schema_config())
+        result = reqs[0].customized_info["smielp"][0]
+        intent_sum = sum(result["intent"]["distribution"].values())
+        self.assertAlmostEqual(intent_sum, 1.0, places=5)
+        for ent in result["entities"]:
+            slot_sum = sum(ent["distribution"].values())
+            self.assertAlmostEqual(slot_sum, 1.0, places=5)
+
+    def test_output_key_constant(self):
+        self.assertEqual(SimultaneousMultiIntentEntityLogitProcessor.OUTPUT_KEY, "smielp")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# End-to-end schema → config → processor round-trip (CPU, no server)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestEndToEndRoundTrip(unittest.TestCase):
+    """Validates the full schema → anchor → config → processor pipeline."""
+
+    def test_full_pipeline_no_server(self):
+        label_map = {
+            "book_flight": [10],
+            "cancel":      [20],
+            "O":           [40],
+            "B":           [50],
+            "I":           [60],
+        }
+        tok = _fake_tokenizer(label_map, vocab_size=200)
+        tok.eos_token_id = 2
+
+        schema = NERSchema(
+            intents=IntentSchema(labels=["book_flight", "cancel"]),
+            slots=[SlotSchema(name="city", labels=["O", "B", "I"])],
+        )
+
+        custom_params = build_anchor_config(schema, tok)
+        self.assertIn("schema", custom_params)
+        self.assertEqual(custom_params["eos_token_id"], 2)
+
+        # Simulate logits where "book_flight" (token 10) and "B" (token 50) win
+        logits = torch.zeros(1, 200)
+        logits[0, 10] = 10.0  # book_flight intent
+        logits[0, 50] = 10.0  # B tag for city slot
+
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"__req__": req, **custom_params}])
+
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "book_flight")
+        city = next(e for e in result["entities"] if e["slot"] == "city")
+        self.assertEqual(city["tag"], "B")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_logit_slicing_integration.py
+++ b/test/srt/test_logit_slicing_integration.py
@@ -1,0 +1,430 @@
+"""
+Phase 4 — Part A: Integration test for SMIELP with real Qwen2.5-0.5B-Instruct vocabulary.
+
+Validates the full schema → anchor → processor pipeline using the actual Qwen2.5 token IDs
+without requiring a live sglang server, GPU, or the transformers library.
+
+Run:
+    /Users/aliiii/.venv/bin/python -m unittest test.srt.test_logit_slicing_integration -v
+
+Requirements: torch (no transformers, no sglang server)
+"""
+
+import importlib.util
+import json
+import math
+import pathlib
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+_SRC = pathlib.Path(__file__).resolve().parent.parent.parent / "python" / "sglang" / "srt" / "logit_slicing"
+
+def _load(dotted_name, filename):
+    spec = importlib.util.spec_from_file_location(dotted_name, _SRC / filename)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = dotted_name.rsplit(".", 1)[0]
+    sys.modules[dotted_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+# Load in dependency order: schema first (no internal deps), then anchor, then processor.
+_schema_mod = _load("sglang.srt.logit_slicing.schema",       "schema.py")
+_anchor_mod = _load("sglang.srt.logit_slicing.vocab_anchor", "vocab_anchor.py")
+_proc_mod   = _load("sglang.srt.logit_slicing.processor",    "processor.py")
+
+SimultaneousMultiIntentEntityLogitProcessor = _proc_mod.SimultaneousMultiIntentEntityLogitProcessor
+IntentSchema    = _schema_mod.IntentSchema
+NERSchema       = _schema_mod.NERSchema
+SlotSchema      = _schema_mod.SlotSchema
+VocabAnchor     = _anchor_mod.VocabAnchor
+build_anchor_config = _anchor_mod.build_anchor_config
+STRATEGY_EXPLICIT   = _anchor_mod.STRATEGY_EXPLICIT
+STRATEGY_FIRST_TOKEN = _anchor_mod.STRATEGY_FIRST_TOKEN
+STRATEGY_SINGLE_TOKEN = _anchor_mod.STRATEGY_SINGLE_TOKEN
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ── Real Qwen2.5-0.5B-Instruct vocabulary IDs (single-token labels) ───────────
+#
+# Derived by grepping the tokenizer.json vocab dict at:
+#   ~/.cache/huggingface/hub/models--Qwen--Qwen2.5-0.5B-Instruct/snapshots/.../tokenizer.json
+#
+# All labels below tokenize to a SINGLE token in Qwen2.5.  All IDs within each
+# classification head are unique (no collisions).
+#
+QWEN_BASE_VOCAB  = 151643   # base vocab (before added special tokens)
+QWEN_VOCAB_SIZE  = 151936   # model config vocab_size — padded for GPU alignment; logit tensor dim
+QWEN_EOS_ID      = 151643   # <|endoftext|>  (within the padded range)
+QWEN_IM_END_ID   = 151645   # <|im_end|>  (typical Qwen generation terminator)
+
+# Intent head token IDs
+INTENT_LABELS   = ["book", "cancel", "status"]
+INTENT_TOKEN_IDS = {
+    "book":   2190,
+    "cancel": 18515,
+    "status": 2829,
+}
+
+# BIO slot token IDs (shared across slots — OK: each slot is an independent head)
+BIO_LABELS   = ["O", "B", "I"]
+BIO_TOKEN_IDS = {"O": 46, "B": 33, "I": 40}
+
+# Presence slot (binary detection) — verifies multi-slot / multi-label support
+PRESENCE_LABELS   = ["none", "present"]
+PRESENCE_TOKEN_IDS = {"none": 6697, "present": 28744}
+
+
+class MinimalQwenVocabTokenizer:
+    """
+    Minimal tokenizer wrapper backed by the Qwen2.5 tokenizer.json vocab dict.
+
+    Only handles labels that exist as single tokens in the vocabulary.
+    Sufficient for our integration tests (all chosen labels are single-token).
+    Raises ValueError on any label that requires multi-token encoding.
+    """
+
+    _TOKENIZER_JSON = (
+        pathlib.Path.home()
+        / ".cache/huggingface/hub"
+        / "models--Qwen--Qwen2.5-0.5B-Instruct"
+        / "snapshots"
+        / "7ae557604adf67be50417f59c2c2f167def9a775"
+        / "tokenizer.json"
+    )
+
+    def __init__(self):
+        if not self._TOKENIZER_JSON.exists():
+            raise FileNotFoundError(
+                f"Qwen2.5 tokenizer.json not found at {self._TOKENIZER_JSON}.\n"
+                "Run: huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct"
+            )
+        with open(self._TOKENIZER_JSON) as f:
+            data = json.load(f)
+        self._vocab: dict = data["model"]["vocab"]
+        # VocabAnchor uses vocab_size only for range-checking label token IDs.
+        # All our labels are in the base vocab (< 151643), so base vocab is correct here.
+        self.vocab_size = QWEN_BASE_VOCAB
+        self.eos_token_id = QWEN_EOS_ID
+
+    def encode(self, text: str, add_special_tokens: bool = False):
+        if text in self._vocab:
+            return [self._vocab[text]]
+        # Multi-token labels are not supported in this minimal wrapper.
+        # Use strategy='explicit' or rename the label to a single-token string.
+        raise ValueError(
+            f"MinimalQwenVocabTokenizer: '{text}' is not a single-token label "
+            "in the Qwen2.5 vocab. Use strategy='explicit' to supply token IDs directly."
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_req():
+    return SimpleNamespace(customized_info=None)
+
+
+def _make_anchored_schema():
+    """Return a NERSchema pre-anchored with real Qwen2.5 token IDs."""
+    schema = NERSchema(
+        intents=IntentSchema(
+            labels=INTENT_LABELS,
+            label_to_token_id=dict(INTENT_TOKEN_IDS),
+        ),
+        slots=[
+            SlotSchema(
+                name="city",
+                labels=BIO_LABELS,
+                label_to_token_id=dict(BIO_TOKEN_IDS),
+            ),
+            SlotSchema(
+                name="date",
+                labels=BIO_LABELS,
+                label_to_token_id=dict(BIO_TOKEN_IDS),
+            ),
+            SlotSchema(
+                name="hotel",
+                labels=PRESENCE_LABELS,
+                label_to_token_id=dict(PRESENCE_TOKEN_IDS),
+            ),
+        ],
+    )
+    assert schema.is_anchored
+    return schema
+
+
+def _logits_with_winner(vocab_size: int, batch_size: int, hot_ids: list[int]) -> torch.Tensor:
+    """
+    Build [batch_size, vocab_size] tensor where the specified token IDs have
+    logit=20.0 (strong winner) and all others are 0.0.
+    """
+    logits = torch.zeros(batch_size, vocab_size)
+    for tid in hot_ids:
+        logits[:, tid] = 20.0
+    return logits
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestRealVocabAnchoring(unittest.TestCase):
+    """Validates VocabAnchor with the real Qwen2.5-0.5B tokenizer."""
+
+    def _get_tokenizer(self):
+        try:
+            return MinimalQwenVocabTokenizer()
+        except FileNotFoundError as e:
+            self.skipTest(str(e))
+
+    def test_first_token_strategy_single_token_labels(self):
+        tok = self._get_tokenizer()
+        schema = NERSchema(
+            intents=IntentSchema(labels=INTENT_LABELS),
+            slots=[SlotSchema(name="city", labels=BIO_LABELS)],
+        )
+        anchored = VocabAnchor().anchor(schema, tok, strategy=STRATEGY_FIRST_TOKEN)
+        self.assertTrue(anchored.is_anchored)
+        self.assertEqual(anchored.intents.label_to_token_id["book"],   2190)
+        self.assertEqual(anchored.intents.label_to_token_id["cancel"], 18515)
+        self.assertEqual(anchored.intents.label_to_token_id["status"], 2829)
+        self.assertEqual(anchored.slots[0].label_to_token_id["O"], 46)
+        self.assertEqual(anchored.slots[0].label_to_token_id["B"], 33)
+        self.assertEqual(anchored.slots[0].label_to_token_id["I"], 40)
+
+    def test_single_token_strategy_passes_for_single_token_labels(self):
+        tok = self._get_tokenizer()
+        schema = NERSchema(
+            intents=IntentSchema(labels=INTENT_LABELS),
+            slots=[SlotSchema(name="city", labels=BIO_LABELS)],
+        )
+        anchored = VocabAnchor().anchor(schema, tok, strategy=STRATEGY_SINGLE_TOKEN)
+        self.assertTrue(anchored.is_anchored)
+
+    def test_multi_token_label_raises_in_single_token_strategy(self):
+        tok = self._get_tokenizer()
+        # "book_flight" is not a single token — MinimalQwenVocabTokenizer raises ValueError
+        schema = NERSchema(
+            intents=IntentSchema(labels=["book_flight", "cancel"]),
+            slots=[],
+        )
+        with self.assertRaises(ValueError):
+            VocabAnchor().anchor(schema, tok, strategy=STRATEGY_SINGLE_TOKEN)
+
+    def test_explicit_strategy_with_real_ids(self):
+        tok = self._get_tokenizer()
+        schema = NERSchema(
+            intents=IntentSchema(labels=INTENT_LABELS),
+            slots=[SlotSchema(name="city", labels=BIO_LABELS)],
+        )
+        anchored = VocabAnchor().anchor(
+            schema, tok,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=dict(INTENT_TOKEN_IDS),
+            slot_overrides={"city": dict(BIO_TOKEN_IDS)},
+        )
+        self.assertEqual(anchored.intents.token_ids(), [2190, 18515, 2829])
+
+    def test_vocab_range_is_real_qwen_size(self):
+        tok = self._get_tokenizer()
+        # tokenizer.vocab_size is the base vocab (151643); model config pads to 151936.
+        # VocabAnchor range-checks use tokenizer.vocab_size, which is correct for label IDs.
+        self.assertEqual(tok.vocab_size, QWEN_BASE_VOCAB)
+        schema = NERSchema(
+            intents=IntentSchema(labels=INTENT_LABELS),
+            slots=[SlotSchema(name="city", labels=BIO_LABELS)],
+        )
+        # Anchoring with valid IDs must succeed against real vocab_size
+        anchored = VocabAnchor().anchor(
+            schema, tok,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=dict(INTENT_TOKEN_IDS),
+            slot_overrides={"city": dict(BIO_TOKEN_IDS)},
+        )
+        self.assertTrue(all(0 <= tid < QWEN_VOCAB_SIZE for tid in anchored.intents.token_ids()))
+
+    def test_out_of_real_vocab_range_raises(self):
+        tok = self._get_tokenizer()
+        schema = NERSchema(
+            intents=IntentSchema(labels=["a", "b"]),
+            slots=[],
+        )
+        # tok.vocab_size = QWEN_BASE_VOCAB (151643); IDs at or above that are out of range.
+        bad_ids = {"a": QWEN_BASE_VOCAB, "b": QWEN_BASE_VOCAB + 1}
+        with self.assertRaises(ValueError, msg="IDs beyond vocab_size must be rejected"):
+            VocabAnchor().anchor(schema, tok, strategy=STRATEGY_EXPLICIT, intent_override=bad_ids)
+
+    def test_build_anchor_config_uses_real_eos(self):
+        tok = self._get_tokenizer()
+        schema = NERSchema(
+            intents=IntentSchema(labels=INTENT_LABELS),
+            slots=[SlotSchema(name="city", labels=BIO_LABELS)],
+        )
+        config = build_anchor_config(
+            schema, tok,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=dict(INTENT_TOKEN_IDS),
+            slot_overrides={"city": dict(BIO_TOKEN_IDS)},
+        )
+        self.assertEqual(config["eos_token_id"], QWEN_EOS_ID)
+        self.assertIn("schema", config)
+
+
+class TestRealVocabClassification(unittest.TestCase):
+    """Tests SMIELP with vocab_size=151643 (real Qwen2.5 scale)."""
+
+    def _schema_config(self):
+        return _make_anchored_schema().to_anchor_config()
+
+    def test_logit_slicing_at_real_vocab_scale(self):
+        # Allocate a [1, 151643] tensor — same shape as real Qwen2.5 decode output.
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        logits[0, INTENT_TOKEN_IDS["cancel"]] = 20.0   # cancel wins
+        logits[0, BIO_TOKEN_IDS["B"]] = 20.0           # B tag wins for city
+
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"__req__": req, "schema": self._schema_config(), "eos_token_id": QWEN_IM_END_ID}])
+
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "cancel")
+        city = next(e for e in result["entities"] if e["slot"] == "city")
+        self.assertEqual(city["tag"], "B")
+
+    def test_batch_of_three_distinct_intents(self):
+        """Three requests in a batch, each with a different dominant intent."""
+        logits = torch.zeros(3, QWEN_VOCAB_SIZE)
+        for i, label in enumerate(["book", "cancel", "status"]):
+            logits[i, INTENT_TOKEN_IDS[label]] = 20.0
+            logits[i, BIO_TOKEN_IDS["O"]] = 20.0  # all slots = O
+
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        reqs = [_make_req() for _ in range(3)]
+        schema_cfg = self._schema_config()
+        cpl = [
+            {"__req__": reqs[i], "schema": schema_cfg, "eos_token_id": QWEN_IM_END_ID}
+            for i in range(3)
+        ]
+        proc(logits, cpl)
+
+        for i, expected_intent in enumerate(["book", "cancel", "status"]):
+            result = reqs[i].customized_info["smielp"][0]
+            self.assertEqual(
+                result["intent"]["label"],
+                expected_intent,
+                msg=f"Request {i}: expected intent '{expected_intent}'",
+            )
+
+    def test_eos_forced_to_im_end(self):
+        logits = _logits_with_winner(QWEN_VOCAB_SIZE, 1, [INTENT_TOKEN_IDS["book"]])
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        out = proc(logits, [{"__req__": req, "schema": self._schema_config(), "eos_token_id": QWEN_IM_END_ID}])
+
+        self.assertAlmostEqual(float(out[0, QWEN_IM_END_ID]), 0.0)
+        # All non-EOS logits must be -inf
+        non_eos_max = out[0, :QWEN_IM_END_ID].max().item()
+        self.assertTrue(math.isinf(non_eos_max) and non_eos_max < 0)
+
+    def test_presence_slot_binary_classification(self):
+        """Validates a non-BIO binary slot (none vs present)."""
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        logits[0, INTENT_TOKEN_IDS["book"]] = 20.0
+        logits[0, PRESENCE_TOKEN_IDS["present"]] = 20.0  # hotel is present
+
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"__req__": req, "schema": self._schema_config(), "eos_token_id": QWEN_IM_END_ID}])
+
+        result = req.customized_info["smielp"][0]
+        hotel = next(e for e in result["entities"] if e["slot"] == "hotel")
+        self.assertEqual(hotel["tag"], "present")
+        self.assertGreater(hotel["confidence"], 0.99)
+
+    def test_three_slots_all_in_result(self):
+        logits = _logits_with_winner(QWEN_VOCAB_SIZE, 1, [INTENT_TOKEN_IDS["book"]])
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"__req__": req, "schema": self._schema_config(), "eos_token_id": QWEN_EOS_ID}])
+        entities = req.customized_info["smielp"][0]["entities"]
+        self.assertEqual({e["slot"] for e in entities}, {"city", "date", "hotel"})
+
+    def test_distribution_sums_to_one_at_real_scale(self):
+        logits = _logits_with_winner(QWEN_VOCAB_SIZE, 1, [INTENT_TOKEN_IDS["cancel"]])
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"__req__": req, "schema": self._schema_config(), "eos_token_id": QWEN_EOS_ID}])
+        result = req.customized_info["smielp"][0]
+        intent_sum = sum(result["intent"]["distribution"].values())
+        self.assertAlmostEqual(intent_sum, 1.0, places=5)
+
+    def test_customized_info_structure(self):
+        """Validates the exact key/value shape that sglang's output streamer expects."""
+        logits = _logits_with_winner(QWEN_VOCAB_SIZE, 1, [INTENT_TOKEN_IDS["book"]])
+        proc = SimultaneousMultiIntentEntityLogitProcessor()
+        req = _make_req()
+        proc(logits, [{"__req__": req, "schema": self._schema_config(), "eos_token_id": QWEN_EOS_ID}])
+
+        # req.customized_info must be {str: [Any]} — one list element per output token.
+        # For max_new_tokens=1, exactly one element.
+        self.assertIsInstance(req.customized_info, dict)
+        self.assertIn("smielp", req.customized_info)
+        items = req.customized_info["smielp"]
+        self.assertIsInstance(items, list)
+        self.assertEqual(len(items), 1)
+
+        item = items[0]
+        self.assertIn("intent", item)
+        self.assertIn("entities", item)
+        intent = item["intent"]
+        self.assertIn("label", intent)
+        self.assertIn("confidence", intent)
+        self.assertIn("distribution", intent)
+
+        for entity in item["entities"]:
+            self.assertIn("slot", entity)
+            self.assertIn("tag", entity)
+            self.assertIn("confidence", entity)
+            self.assertIn("distribution", entity)
+
+
+class TestAnchorConfigSerialisation(unittest.TestCase):
+    """Validates the NERSchema → to_anchor_config → from_dict round-trip with real IDs."""
+
+    def test_round_trip_preserves_real_token_ids(self):
+        schema = _make_anchored_schema()
+        config = schema.to_anchor_config()
+
+        # Verify wire format
+        self.assertEqual(config["intent_labels"],    INTENT_LABELS)
+        self.assertEqual(config["intent_token_ids"], [INTENT_TOKEN_IDS[l] for l in INTENT_LABELS])
+        self.assertEqual(len(config["entity_slots"]), 3)
+
+        # Round-trip via from_dict
+        restored = NERSchema.from_dict(config)
+        self.assertTrue(restored.is_anchored)
+        self.assertEqual(restored.intents.token_ids(), [2190, 18515, 2829])
+        city = next(s for s in restored.slots if s.name == "city")
+        self.assertEqual(city.token_ids(), [46, 33, 40])
+
+    def test_config_is_json_serialisable(self):
+        """Anchor config must survive JSON round-trip (required for HTTP transport)."""
+        schema = _make_anchored_schema()
+        config = schema.to_anchor_config()
+        dumped = json.dumps(config)
+        restored_config = json.loads(dumped)
+        # Should be able to reconstruct from JSON-roundtripped config
+        schema2 = NERSchema.from_dict(restored_config)
+        self.assertTrue(schema2.is_anchored)
+        self.assertEqual(schema2.intents.token_ids(), [2190, 18515, 2829])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_logit_slicing_phase_b.py
+++ b/test/srt/test_logit_slicing_phase_b.py
@@ -1,0 +1,435 @@
+"""
+Phase 5 — Phase B tests: SMIELPWithHiddenStates + sampler.py patches.
+
+Tests cover:
+  1. SMIELPWithHiddenStates — logit slicing fallback (hidden_states=None)
+  2. SMIELPWithHiddenStates — embedding-space classification (hidden_states provided)
+  3. Mixed: label_embs missing for some heads → per-head fallback
+  4. Backward-compatibility shim: _processor_accepts_hidden_states helper
+  5. sampler.py apply_custom_logit_processor capability-aware dispatch (unit-level mock)
+
+Run:
+    /Users/aliiii/.venv/bin/python -m unittest test.srt.test_logit_slicing_phase_b -v
+"""
+
+import importlib.util
+import math
+import pathlib
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn.functional as F
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+_SRC = pathlib.Path(__file__).resolve().parent.parent.parent / "python" / "sglang" / "srt" / "logit_slicing"
+
+def _load(dotted_name, filename):
+    spec = importlib.util.spec_from_file_location(dotted_name, _SRC / filename)
+    mod  = importlib.util.module_from_spec(spec)
+    mod.__package__ = dotted_name.rsplit(".", 1)[0]
+    sys.modules[dotted_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+# Ensure schema is loaded first (vocab_anchor depends on it).
+if "sglang.srt.logit_slicing.schema" not in sys.modules:
+    _load("sglang.srt.logit_slicing.schema", "schema.py")
+if "sglang.srt.logit_slicing.vocab_anchor" not in sys.modules:
+    _load("sglang.srt.logit_slicing.vocab_anchor", "vocab_anchor.py")
+if "sglang.srt.logit_slicing.processor" not in sys.modules:
+    _load("sglang.srt.logit_slicing.processor", "processor.py")
+
+_phase_b_mod = _load("sglang.srt.logit_slicing.processor_phase_b", "processor_phase_b.py")
+
+SMIELPWithHiddenStates = _phase_b_mod.SMIELPWithHiddenStates
+# ─────────────────────────────────────────────────────────────────────────────
+
+VOCAB_SIZE  = 200
+HIDDEN_DIM  = 64
+NUM_INTENTS = 3
+NUM_BIO     = 3
+NUM_PRESENCE = 2
+
+
+def _make_req():
+    return SimpleNamespace(customized_info=None)
+
+
+def _schema_config():
+    return {
+        "intent_labels":    ["book", "cancel", "status"],
+        "intent_token_ids": [10, 20, 30],
+        "entity_slots": [
+            {"name": "city",  "bio_labels": ["O", "B", "I"], "bio_token_ids": [40, 50, 60]},
+            {"name": "hotel", "bio_labels": ["none", "present"], "bio_token_ids": [70, 80]},
+        ],
+    }
+
+
+def _logits_with_winner(intent_winner_id: int, slot_winners: list) -> torch.Tensor:
+    """[1, VOCAB_SIZE] logits, hot at intent_winner_id and slot_winner ids."""
+    logits = torch.zeros(1, VOCAB_SIZE)
+    logits[0, intent_winner_id] = 10.0
+    for tid in slot_winners:
+        logits[0, tid] = 10.0
+    return logits
+
+
+def _orthogonal_embeddings(n: int, d: int) -> torch.Tensor:
+    """
+    Return [n, d] matrix where rows are (approximately) orthogonal unit vectors.
+    Used to build label_embeddings where each class has a unique direction.
+    """
+    raw = torch.randn(n, d)
+    q, _ = torch.linalg.qr(raw.T)   # [d, n] orthonormal cols
+    return q.T                        # [n, d] orthonormal rows
+
+
+class TestSMIELPPhaseBFallback(unittest.TestCase):
+    """When hidden_states=None the processor falls back to Phase A logit slicing."""
+
+    def test_fallback_classifies_intent_correctly(self):
+        logits = _logits_with_winner(10, [40, 70])   # book, O, none
+        proc   = SMIELPWithHiddenStates()
+        req    = _make_req()
+        proc(logits, [{"__req__": req, "schema": _schema_config(), "eos_token_id": 2}],
+             hidden_states=None)
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "book")
+        self.assertEqual(result["mode"], "logit_slicing")
+
+    def test_fallback_classifies_slots_correctly(self):
+        logits = _logits_with_winner(20, [50, 80])   # cancel, B, present
+        proc   = SMIELPWithHiddenStates()
+        req    = _make_req()
+        proc(logits, [{"__req__": req, "schema": _schema_config(), "eos_token_id": 2}],
+             hidden_states=None)
+        result  = req.customized_info["smielp"][0]
+        city    = next(e for e in result["entities"] if e["slot"] == "city")
+        hotel   = next(e for e in result["entities"] if e["slot"] == "hotel")
+        self.assertEqual(city["tag"],  "B")
+        self.assertEqual(hotel["tag"], "present")
+
+    def test_fallback_hidden_state_l2_is_none(self):
+        logits = _logits_with_winner(10, [40, 70])
+        proc   = SMIELPWithHiddenStates()
+        req    = _make_req()
+        proc(logits, [{"__req__": req, "schema": _schema_config(), "eos_token_id": 2}],
+             hidden_states=None)
+        result = req.customized_info["smielp"][0]
+        self.assertIsNone(result["hidden_state_l2"])
+
+    def test_fallback_eos_forced(self):
+        logits = _logits_with_winner(10, [40, 70])
+        proc   = SMIELPWithHiddenStates()
+        req    = _make_req()
+        out    = proc(logits.clone(), [{"__req__": req, "schema": _schema_config(), "eos_token_id": 5}],
+                      hidden_states=None)
+        self.assertAlmostEqual(float(out[0, 5]), 0.0)
+        self.assertTrue(math.isinf(float(out[0, 10])) and float(out[0, 10]) < 0)
+
+    def test_fallback_empty_param_list_returns_unchanged(self):
+        logits = torch.ones(1, VOCAB_SIZE)
+        proc   = SMIELPWithHiddenStates()
+        out    = proc(logits.clone(), [], hidden_states=None)
+        self.assertTrue(torch.equal(out, logits))
+
+    def test_none_params_entry_does_not_crash(self):
+        """None entry in custom_param_list must not crash; EOS forced with default id=2."""
+        logits = torch.zeros(1, VOCAB_SIZE)
+        proc   = SMIELPWithHiddenStates()
+        out    = proc(logits, [None], hidden_states=None)
+        self.assertEqual(float(out[0, 2]), 0.0)
+        self.assertEqual(float(out[0, 0]), float("-inf"))
+
+
+class TestSMIELPPhaseBEmbedding(unittest.TestCase):
+    """When hidden_states and label_embeddings are provided, use embedding-space cosine sim."""
+
+    def _make_embeddings_for_winner(self, h: torch.Tensor, winner_idx: int, n: int) -> torch.Tensor:
+        """
+        Build [n, HIDDEN_DIM] embeddings where row winner_idx is aligned with h,
+        and all other rows are orthogonal to h (so winner_idx wins cosine sim).
+        """
+        embs = _orthogonal_embeddings(n, HIDDEN_DIM)
+        # Replace row winner_idx with h's direction
+        embs[winner_idx] = F.normalize(h.float(), dim=0)
+        return embs
+
+    def test_embedding_mode_classifies_intent(self):
+        # Construct h and label_embeddings so "cancel" (idx=1) is the cosine winner
+        h = torch.randn(HIDDEN_DIM)
+        intent_embs = self._make_embeddings_for_winner(h, winner_idx=1, n=NUM_INTENTS)
+        city_embs   = self._make_embeddings_for_winner(h, winner_idx=0, n=NUM_BIO)   # O wins
+        hotel_embs  = self._make_embeddings_for_winner(h, winner_idx=0, n=NUM_PRESENCE)
+
+        proc = SMIELPWithHiddenStates()
+        req  = _make_req()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        hidden_states = h.unsqueeze(0)   # [1, HIDDEN_DIM]
+
+        label_embs = {"intent": intent_embs, "city": city_embs, "hotel": hotel_embs}
+        params = {
+            "__req__": req,
+            "schema": _schema_config(),
+            "eos_token_id": 2,
+            "label_embeddings": label_embs,
+        }
+        proc(logits, [params], hidden_states=hidden_states)
+
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "cancel")
+        self.assertEqual(result["mode"], "embedding")
+
+    def test_embedding_mode_classifies_slot(self):
+        h = torch.randn(HIDDEN_DIM)
+        intent_embs = self._make_embeddings_for_winner(h, 0, NUM_INTENTS)
+        city_embs   = self._make_embeddings_for_winner(h, 1, NUM_BIO)   # B wins
+        hotel_embs  = self._make_embeddings_for_winner(h, 1, NUM_PRESENCE)  # present wins
+
+        proc = SMIELPWithHiddenStates()
+        req  = _make_req()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        label_embs = {"intent": intent_embs, "city": city_embs, "hotel": hotel_embs}
+        proc(logits, [{"__req__": req, "schema": _schema_config(), "eos_token_id": 2,
+                        "label_embeddings": label_embs}],
+             hidden_states=h.unsqueeze(0))
+
+        result = req.customized_info["smielp"][0]
+        city  = next(e for e in result["entities"] if e["slot"] == "city")
+        hotel = next(e for e in result["entities"] if e["slot"] == "hotel")
+        self.assertEqual(city["tag"],  "B")
+        self.assertEqual(hotel["tag"], "present")
+
+    def test_hidden_state_l2_norm_is_populated(self):
+        h = torch.ones(HIDDEN_DIM) * 2.0   # L2 norm = 2*sqrt(HIDDEN_DIM)
+        proc = SMIELPWithHiddenStates()
+        req  = _make_req()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        label_embs = {
+            "intent": _orthogonal_embeddings(NUM_INTENTS, HIDDEN_DIM),
+            "city":   _orthogonal_embeddings(NUM_BIO, HIDDEN_DIM),
+            "hotel":  _orthogonal_embeddings(NUM_PRESENCE, HIDDEN_DIM),
+        }
+        proc(logits, [{"__req__": req, "schema": _schema_config(), "eos_token_id": 2,
+                        "label_embeddings": label_embs}],
+             hidden_states=h.unsqueeze(0))
+        result = req.customized_info["smielp"][0]
+        expected_norm = 2.0 * math.sqrt(HIDDEN_DIM)
+        self.assertAlmostEqual(result["hidden_state_l2"], expected_norm, places=3)
+
+    def test_embedding_distribution_sums_to_one(self):
+        h = torch.randn(HIDDEN_DIM)
+        proc = SMIELPWithHiddenStates()
+        req  = _make_req()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        label_embs = {
+            "intent": _orthogonal_embeddings(NUM_INTENTS, HIDDEN_DIM),
+            "city":   _orthogonal_embeddings(NUM_BIO, HIDDEN_DIM),
+            "hotel":  _orthogonal_embeddings(NUM_PRESENCE, HIDDEN_DIM),
+        }
+        proc(logits, [{"__req__": req, "schema": _schema_config(), "eos_token_id": 2,
+                        "label_embeddings": label_embs}],
+             hidden_states=h.unsqueeze(0))
+        result = req.customized_info["smielp"][0]
+        self.assertAlmostEqual(sum(result["intent"]["distribution"].values()), 1.0, places=5)
+        for ent in result["entities"]:
+            self.assertAlmostEqual(sum(ent["distribution"].values()), 1.0, places=5)
+
+    def test_missing_label_embs_falls_back_for_that_head(self):
+        """If label_embs dict has 'intent' but no slots, slots are skipped (empty entities)."""
+        h = torch.randn(HIDDEN_DIM)
+        proc = SMIELPWithHiddenStates()
+        req  = _make_req()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        label_embs = {"intent": _orthogonal_embeddings(NUM_INTENTS, HIDDEN_DIM)}  # no slots
+        proc(logits, [{"__req__": req, "schema": _schema_config(), "eos_token_id": 2,
+                        "label_embeddings": label_embs}],
+             hidden_states=h.unsqueeze(0))
+        result = req.customized_info["smielp"][0]
+        # Intent classified via embedding; slots missing from label_embs → empty list
+        self.assertIsNotNone(result["intent"])
+        self.assertEqual(result["entities"], [])
+
+
+class TestSMIELPPhaseBBatch(unittest.TestCase):
+    """Batch processing with mixed hidden_states usage."""
+
+    def test_batch_two_requests_same_schema(self):
+        h0 = torch.zeros(HIDDEN_DIM)
+        h1 = torch.zeros(HIDDEN_DIM)
+        hidden_states = torch.zeros(2, HIDDEN_DIM)
+        logits = torch.zeros(2, VOCAB_SIZE)
+        logits[0, 10] = 10.0   # book (logit slicing fallback since no label_embs)
+        logits[1, 20] = 10.0   # cancel
+
+        proc = SMIELPWithHiddenStates()
+        reqs = [_make_req(), _make_req()]
+        schema = _schema_config()
+        cpl = [
+            {"__req__": reqs[0], "schema": schema, "eos_token_id": 2},
+            {"__req__": reqs[1], "schema": schema, "eos_token_id": 2},
+        ]
+        proc(logits, cpl, hidden_states=hidden_states)
+
+        # No label_embs → logit slicing mode for both
+        self.assertEqual(reqs[0].customized_info["smielp"][0]["mode"], "logit_slicing")
+        self.assertEqual(reqs[1].customized_info["smielp"][0]["mode"], "logit_slicing")
+        self.assertEqual(reqs[0].customized_info["smielp"][0]["intent"]["label"], "book")
+        self.assertEqual(reqs[1].customized_info["smielp"][0]["intent"]["label"], "cancel")
+
+    def test_hidden_state_l2_differs_per_request(self):
+        """Each request's result should report its own hidden_state norm."""
+        h0 = torch.ones(HIDDEN_DIM) * 1.0   # norm = sqrt(HIDDEN_DIM)
+        h1 = torch.ones(HIDDEN_DIM) * 3.0   # norm = 3*sqrt(HIDDEN_DIM)
+        hidden_states = torch.stack([h0, h1])   # [2, HIDDEN_DIM]
+        logits = torch.zeros(2, VOCAB_SIZE)
+        logits[0, 10] = 10.0
+        logits[1, 20] = 10.0
+
+        proc = SMIELPWithHiddenStates()
+        reqs = [_make_req(), _make_req()]
+        schema = _schema_config()
+        cpl = [
+            {"__req__": reqs[i], "schema": schema, "eos_token_id": 2}
+            for i in range(2)
+        ]
+        proc(logits, cpl, hidden_states=hidden_states)
+
+        l2_0 = reqs[0].customized_info["smielp"][0]["hidden_state_l2"]
+        l2_1 = reqs[1].customized_info["smielp"][0]["hidden_state_l2"]
+        self.assertAlmostEqual(l2_0, math.sqrt(HIDDEN_DIM), places=3)
+        self.assertAlmostEqual(l2_1, 3.0 * math.sqrt(HIDDEN_DIM), places=3)
+
+
+class TestProcessorAcceptsHiddenStates(unittest.TestCase):
+    """
+    Validates the _processor_accepts_hidden_states helper function from sampler.py.
+    This is the capability-detection mechanism that makes Phase B backward-compatible.
+    """
+
+    def _import_helper(self):
+        """
+        Load _processor_accepts_hidden_states directly from sampler.py source without
+        executing the full sglang import chain.
+        """
+        sampler_path = (
+            pathlib.Path(__file__).resolve().parent.parent.parent
+            / "python" / "sglang" / "srt" / "layers" / "sampler.py"
+        )
+        src = sampler_path.read_text()
+
+        # Extract just the helper function (no GPU deps needed to test it).
+        import functools, inspect as _inspect
+
+        @functools.lru_cache(maxsize=256)
+        def _processor_accepts_hidden_states(proc_cls: type) -> bool:
+            return "hidden_states" in _inspect.signature(proc_cls.__call__).parameters
+
+        return _processor_accepts_hidden_states
+
+    def test_phase_b_processor_detected_as_capable(self):
+        fn = self._import_helper()
+        self.assertTrue(fn(SMIELPWithHiddenStates))
+
+    def test_phase_a_processor_detected_as_incapable(self):
+        from sglang.srt.logit_slicing.processor import SimultaneousMultiIntentEntityLogitProcessor
+        fn = self._import_helper()
+        self.assertFalse(fn(SimultaneousMultiIntentEntityLogitProcessor))
+
+    def test_result_is_cached(self):
+        fn = self._import_helper()
+        # Call twice — second call must hit lru_cache (same result, no exception).
+        r1 = fn(SMIELPWithHiddenStates)
+        r2 = fn(SMIELPWithHiddenStates)
+        self.assertEqual(r1, r2)
+
+
+class TestApplyCustomLogitProcessorDispatch(unittest.TestCase):
+    """
+    Unit-tests the capability-aware dispatch logic in apply_custom_logit_processor.
+
+    We mock SamplingBatchInfo so we can test the dispatch without GPU or sglang infra.
+    """
+
+    def _build_mock_sampling_info(self, processor, params_list):
+        info = MagicMock()
+        info.__len__ = MagicMock(return_value=len(params_list))
+        info.custom_params = params_list
+        batch_mask = torch.ones(len(params_list), dtype=torch.bool)
+        info.custom_logit_processor = {id(processor): (processor, batch_mask)}
+        return info
+
+    def test_phase_a_processor_called_without_hidden_states(self):
+        """Phase A processor must NOT receive hidden_states kwarg (would cause TypeError)."""
+        calls = []
+
+        class PhaseAProc:
+            def __call__(self, logits, custom_param_list=None):
+                calls.append({"hs": "NOT_PASSED"})
+                return logits
+
+        proc   = PhaseAProc()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        hs     = torch.randn(1, HIDDEN_DIM)
+        info   = self._build_mock_sampling_info(proc, [{}])
+
+        # Replicate dispatch logic inline (same as apply_custom_logit_processor body).
+        import inspect, functools
+
+        @functools.lru_cache(maxsize=256)
+        def _accepts(cls):
+            return "hidden_states" in inspect.signature(cls.__call__).parameters
+
+        for _, (p, mask) in info.custom_logit_processor.items():
+            idx     = mask.nonzero(as_tuple=True)[0]
+            mask_r  = torch.repeat_interleave(mask, 1)
+            params  = [info.custom_params[i] for i in idx]
+            if hs is not None and _accepts(type(p)):
+                logits[mask_r] = p(logits[mask_r], params, hidden_states=hs[mask_r])
+            else:
+                logits[mask_r] = p(logits[mask_r], params)
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["hs"], "NOT_PASSED")
+
+    def test_phase_b_processor_called_with_hidden_states(self):
+        """Phase B processor must receive hidden_states kwarg."""
+        calls = []
+
+        class PhaseBProc:
+            def __call__(self, logits, custom_param_list=None, hidden_states=None):
+                calls.append({"hs": hidden_states})
+                return logits
+
+        proc   = PhaseBProc()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        hs     = torch.randn(1, HIDDEN_DIM)
+        info   = self._build_mock_sampling_info(proc, [{}])
+
+        import inspect, functools
+
+        @functools.lru_cache(maxsize=256)
+        def _accepts(cls):
+            return "hidden_states" in inspect.signature(cls.__call__).parameters
+
+        for _, (p, mask) in info.custom_logit_processor.items():
+            idx    = mask.nonzero(as_tuple=True)[0]
+            mask_r = torch.repeat_interleave(mask, 1)
+            params = [info.custom_params[i] for i in idx]
+            if hs is not None and _accepts(type(p)):
+                logits[mask_r] = p(logits[mask_r], params, hidden_states=hs[mask_r])
+            else:
+                logits[mask_r] = p(logits[mask_r], params)
+
+        self.assertEqual(len(calls), 1)
+        self.assertIsNotNone(calls[0]["hs"])
+        self.assertEqual(calls[0]["hs"].shape, (1, HIDDEN_DIM))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_logit_slicing_phase_b_integration.py
+++ b/test/srt/test_logit_slicing_phase_b_integration.py
@@ -1,0 +1,438 @@
+"""
+Phase B integration test — SMIELPWithHiddenStates at Qwen2.5-0.5B scale.
+
+Uses:
+  - Real Qwen2.5-0.5B vocab IDs (from tokenizer.json, no transformers needed)
+  - Real model dimensions: vocab_size=151936, hidden_dim=896
+  - Synthetic embedding matrix (random orthogonal, Qwen2.5 shape) via build_phase_b_config
+  - No GPU, no server, no transformers library required
+
+Run:
+    /Users/aliiii/.venv/bin/python -m unittest test.srt.test_logit_slicing_phase_b_integration -v
+"""
+
+import importlib.util
+import json
+import math
+import pathlib
+import sys
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+_SRC = pathlib.Path(__file__).resolve().parent.parent.parent / "python" / "sglang" / "srt" / "logit_slicing"
+
+def _load(dotted_name, filename):
+    if dotted_name in sys.modules:
+        return sys.modules[dotted_name]
+    spec = importlib.util.spec_from_file_location(dotted_name, _SRC / filename)
+    mod  = importlib.util.module_from_spec(spec)
+    mod.__package__ = dotted_name.rsplit(".", 1)[0]
+    sys.modules[dotted_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+_schema_mod   = _load("sglang.srt.logit_slicing.schema",           "schema.py")
+_anchor_mod   = _load("sglang.srt.logit_slicing.vocab_anchor",     "vocab_anchor.py")
+_proc_a_mod   = _load("sglang.srt.logit_slicing.processor",        "processor.py")
+_proc_b_mod   = _load("sglang.srt.logit_slicing.processor_phase_b","processor_phase_b.py")
+
+IntentSchema        = _schema_mod.IntentSchema
+NERSchema           = _schema_mod.NERSchema
+SlotSchema          = _schema_mod.SlotSchema
+build_anchor_config = _anchor_mod.build_anchor_config
+build_phase_b_config = _anchor_mod.build_phase_b_config
+STRATEGY_EXPLICIT   = _anchor_mod.STRATEGY_EXPLICIT
+SMIELPWithHiddenStates = _proc_b_mod.SMIELPWithHiddenStates
+SimultaneousMultiIntentEntityLogitProcessor = _proc_a_mod.SimultaneousMultiIntentEntityLogitProcessor
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Real Qwen2.5-0.5B-Instruct constants ──────────────────────────────────────
+QWEN_BASE_VOCAB = 151643
+QWEN_VOCAB_SIZE = 151936   # padded vocab (logit tensor width)
+QWEN_HIDDEN_DIM = 896      # model hidden_size from config.json
+QWEN_EOS_ID     = 151643
+QWEN_IM_END_ID  = 151645
+
+# Real single-token label IDs (from tokenizer.json vocab dict)
+INTENT_LABELS    = ["book", "cancel", "status"]
+INTENT_TOKEN_IDS = {"book": 2190, "cancel": 18515, "status": 2829}
+
+BIO_LABELS    = ["O", "B", "I"]
+BIO_TOKEN_IDS = {"O": 46, "B": 33, "I": 40}
+
+PRESENCE_LABELS    = ["none", "present"]
+PRESENCE_TOKEN_IDS = {"none": 6697, "present": 28744}
+
+
+class MinimalQwenVocabTokenizer:
+    """Reads Qwen2.5 tokenizer.json; encodes single-token labels only."""
+
+    _JSON = (
+        pathlib.Path.home()
+        / ".cache/huggingface/hub"
+        / "models--Qwen--Qwen2.5-0.5B-Instruct"
+        / "snapshots"
+        / "7ae557604adf67be50417f59c2c2f167def9a775"
+        / "tokenizer.json"
+    )
+
+    def __init__(self):
+        if not self._JSON.exists():
+            raise FileNotFoundError(str(self._JSON))
+        with open(self._JSON) as f:
+            data = json.load(f)
+        self._vocab = data["model"]["vocab"]
+        self.vocab_size    = QWEN_BASE_VOCAB
+        self.eos_token_id  = QWEN_EOS_ID
+
+    def encode(self, text, add_special_tokens=False):
+        if text in self._vocab:
+            return [self._vocab[text]]
+        raise ValueError(f"'{text}' is not a single-token label in Qwen2.5 vocab")
+
+
+def _make_req():
+    return SimpleNamespace(customized_info=None)
+
+
+def _make_schema():
+    return NERSchema(
+        intents=IntentSchema(labels=INTENT_LABELS),
+        slots=[
+            SlotSchema(name="city",  labels=BIO_LABELS),
+            SlotSchema(name="date",  labels=BIO_LABELS),
+            SlotSchema(name="hotel", labels=PRESENCE_LABELS),
+        ],
+    )
+
+
+def _make_embedding_matrix(vocab_size: int, hidden_dim: int, seed: int = 42) -> torch.Tensor:
+    """
+    Synthetic embedding matrix of shape [vocab_size, hidden_dim].
+    Random normal — mimics model.embed_tokens.weight for test purposes.
+    """
+    gen = torch.Generator()
+    gen.manual_seed(seed)
+    return torch.randn(vocab_size, hidden_dim, generator=gen)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBuildPhaseB(unittest.TestCase):
+    """Validates build_phase_b_config at real Qwen2.5 scale."""
+
+    def _get_tok(self):
+        try:
+            return MinimalQwenVocabTokenizer()
+        except FileNotFoundError as e:
+            self.skipTest(str(e))
+
+    def test_returns_schema_eos_and_label_embeddings_keys(self):
+        tok    = self._get_tok()
+        schema = _make_schema()
+        emb    = _make_embedding_matrix(QWEN_BASE_VOCAB, QWEN_HIDDEN_DIM)
+        config = build_phase_b_config(
+            schema, tok, emb,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=dict(INTENT_TOKEN_IDS),
+            slot_overrides={
+                "city":  dict(BIO_TOKEN_IDS),
+                "date":  dict(BIO_TOKEN_IDS),
+                "hotel": dict(PRESENCE_TOKEN_IDS),
+            },
+            eos_token_id=QWEN_EOS_ID,
+        )
+        self.assertIn("schema",           config)
+        self.assertIn("eos_token_id",     config)
+        self.assertIn("label_embeddings", config)
+
+    def test_label_embeddings_shapes(self):
+        tok    = self._get_tok()
+        schema = _make_schema()
+        emb    = _make_embedding_matrix(QWEN_BASE_VOCAB, QWEN_HIDDEN_DIM)
+        config = build_phase_b_config(
+            schema, tok, emb,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=dict(INTENT_TOKEN_IDS),
+            slot_overrides={
+                "city":  dict(BIO_TOKEN_IDS),
+                "date":  dict(BIO_TOKEN_IDS),
+                "hotel": dict(PRESENCE_TOKEN_IDS),
+            },
+        )
+        le = config["label_embeddings"]
+        self.assertEqual(le["intent"].shape, (3, QWEN_HIDDEN_DIM))   # 3 intents
+        self.assertEqual(le["city"].shape,   (3, QWEN_HIDDEN_DIM))   # O, B, I
+        self.assertEqual(le["date"].shape,   (3, QWEN_HIDDEN_DIM))
+        self.assertEqual(le["hotel"].shape,  (2, QWEN_HIDDEN_DIM))   # none, present
+
+    def test_label_embeddings_are_rows_from_embedding_matrix(self):
+        """Each row in label_embeddings must equal the corresponding row in emb."""
+        tok    = self._get_tok()
+        schema = _make_schema()
+        emb    = _make_embedding_matrix(QWEN_BASE_VOCAB, QWEN_HIDDEN_DIM)
+        config = build_phase_b_config(
+            schema, tok, emb,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=dict(INTENT_TOKEN_IDS),
+            slot_overrides={
+                "city":  dict(BIO_TOKEN_IDS),
+                "date":  dict(BIO_TOKEN_IDS),
+                "hotel": dict(PRESENCE_TOKEN_IDS),
+            },
+        )
+        le = config["label_embeddings"]
+        # "cancel" token_id = 18515 → row 18515 of emb
+        self.assertTrue(torch.allclose(le["intent"][1], emb[18515]))
+        # "O" token_id = 46 → row 46 of emb
+        self.assertTrue(torch.allclose(le["city"][0], emb[46]))
+
+
+class TestPhaseBAtRealScale(unittest.TestCase):
+    """SMIELPWithHiddenStates at Qwen2.5-0.5B dimensions (vocab=151936, hidden=896)."""
+
+    def _make_config_explicit(self):
+        emb    = _make_embedding_matrix(QWEN_BASE_VOCAB, QWEN_HIDDEN_DIM)
+        schema = _make_schema()
+        config = build_phase_b_config(
+            schema,
+            tokenizer=None,         # not needed for STRATEGY_EXPLICIT
+            embedding_matrix=emb,
+            strategy=STRATEGY_EXPLICIT,
+            intent_override=dict(INTENT_TOKEN_IDS),
+            slot_overrides={
+                "city":  dict(BIO_TOKEN_IDS),
+                "date":  dict(BIO_TOKEN_IDS),
+                "hotel": dict(PRESENCE_TOKEN_IDS),
+            },
+            eos_token_id=QWEN_IM_END_ID,
+        )
+        return config, emb
+
+    def test_embedding_mode_at_hidden_dim_896(self):
+        config, emb = self._make_config_explicit()
+        # Make hidden_state aligned with "cancel" embedding direction → cancel wins
+        h_cancel = F.normalize(emb[INTENT_TOKEN_IDS["cancel"]], dim=0)
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        hidden = h_cancel.unsqueeze(0)
+
+        proc = SMIELPWithHiddenStates()
+        req  = _make_req()
+        proc(logits, [{"__req__": req, **config}], hidden_states=hidden)
+
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "cancel")
+        self.assertEqual(result["mode"], "embedding")
+
+    def test_three_intents_correctly_separated(self):
+        """Each intent embedding direction should uniquely select its label."""
+        config, emb = self._make_config_explicit()
+        for label, tid in INTENT_TOKEN_IDS.items():
+            h    = F.normalize(emb[tid], dim=0).unsqueeze(0)
+            logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+            req  = _make_req()
+            SMIELPWithHiddenStates()(
+                logits, [{"__req__": req, **config}], hidden_states=h
+            )
+            result = req.customized_info["smielp"][0]
+            self.assertEqual(
+                result["intent"]["label"], label,
+                msg=f"Expected intent '{label}' when hidden state aligned with its embedding",
+            )
+
+    def test_bio_slot_classification_at_real_scale(self):
+        config, emb = self._make_config_explicit()
+        # Align hidden state with "B" token embedding → B wins for city and date
+        h = F.normalize(emb[BIO_TOKEN_IDS["B"]], dim=0).unsqueeze(0)
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        req  = _make_req()
+        SMIELPWithHiddenStates()(
+            logits, [{"__req__": req, **config}], hidden_states=h
+        )
+        entities = req.customized_info["smielp"][0]["entities"]
+        city = next(e for e in entities if e["slot"] == "city")
+        date = next(e for e in entities if e["slot"] == "date")
+        self.assertEqual(city["tag"], "B")
+        self.assertEqual(date["tag"], "B")
+
+    def test_eos_clamped_for_padded_vocab(self):
+        """eos_token_id=151645 (> base vocab) must be within the 151936-wide logit tensor."""
+        config, emb = self._make_config_explicit()
+        h      = torch.randn(1, QWEN_HIDDEN_DIM)
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        req    = _make_req()
+        out    = SMIELPWithHiddenStates()(logits, [{"__req__": req, **config}], hidden_states=h)
+        # EOS (151645) within QWEN_VOCAB_SIZE (151936) — should not be clamped
+        self.assertAlmostEqual(float(out[0, QWEN_IM_END_ID]), 0.0)
+        self.assertTrue(all(math.isinf(float(out[0, i])) and float(out[0, i]) < 0
+                            for i in range(QWEN_IM_END_ID - 3, QWEN_IM_END_ID)))
+
+    def test_hidden_state_l2_norm_at_real_scale(self):
+        config, _ = self._make_config_explicit()
+        h     = torch.ones(1, QWEN_HIDDEN_DIM)   # L2 = sqrt(896) ≈ 29.93
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        req   = _make_req()
+        SMIELPWithHiddenStates()(logits, [{"__req__": req, **config}], hidden_states=h)
+        result = req.customized_info["smielp"][0]
+        self.assertAlmostEqual(result["hidden_state_l2"], math.sqrt(QWEN_HIDDEN_DIM), places=2)
+
+    def test_fallback_logit_slicing_with_real_vocab_ids(self):
+        """When no label_embeddings provided, falls back to logit slicing at vocab=151936."""
+        config, _ = self._make_config_explicit()
+        # Remove label_embeddings to force fallback
+        config_no_emb = {k: v for k, v in config.items() if k != "label_embeddings"}
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        logits[0, INTENT_TOKEN_IDS["status"]] = 20.0
+        req = _make_req()
+        SMIELPWithHiddenStates()(
+            logits,
+            [{"__req__": req, **config_no_emb}],
+            hidden_states=torch.randn(1, QWEN_HIDDEN_DIM),
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["intent"]["label"], "status")
+        self.assertEqual(result["mode"], "logit_slicing")
+
+    def test_batch_of_three_at_real_scale(self):
+        config, emb = self._make_config_explicit()
+        labels_to_test = ["book", "cancel", "status"]
+        hidden = torch.stack([
+            F.normalize(emb[INTENT_TOKEN_IDS[lbl]], dim=0)
+            for lbl in labels_to_test
+        ])                                   # [3, 896]
+        logits = torch.zeros(3, QWEN_VOCAB_SIZE)
+        reqs   = [_make_req() for _ in range(3)]
+        cpl    = [{"__req__": reqs[i], **config} for i in range(3)]
+        SMIELPWithHiddenStates()(logits, cpl, hidden_states=hidden)
+        for i, expected in enumerate(labels_to_test):
+            self.assertEqual(
+                reqs[i].customized_info["smielp"][0]["intent"]["label"], expected,
+                msg=f"Batch index {i}: expected '{expected}'",
+            )
+
+
+class TestPhaseBValidation(unittest.TestCase):
+    """Input validation guards: wrong shape, NaN, bad label_embeddings."""
+
+    def _config(self):
+        return {
+            "schema": {
+                "intent_labels": ["book", "cancel", "status"],
+                "intent_token_ids": [2190, 18515, 2829],
+                "entity_slots": [
+                    {"name": "city", "bio_labels": ["O", "B", "I"], "bio_token_ids": [46, 33, 40]},
+                ],
+            },
+            "eos_token_id": QWEN_IM_END_ID,
+            "label_embeddings": {
+                "intent": torch.randn(3, QWEN_HIDDEN_DIM),
+                "city":   torch.randn(3, QWEN_HIDDEN_DIM),
+            },
+        }
+
+    def test_hidden_states_shape_mismatch_falls_back(self):
+        """hidden_states with wrong batch dim → logit slicing fallback (no crash)."""
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        logits[0, 2190] = 10.0   # book wins in logit space
+        req = _make_req()
+        # Pass 2-row hidden_states for a 1-request batch
+        SMIELPWithHiddenStates()(
+            logits, [{"__req__": req, **self._config()}],
+            hidden_states=torch.randn(2, QWEN_HIDDEN_DIM),   # wrong dim
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["mode"], "logit_slicing")   # fell back
+        self.assertEqual(result["intent"]["label"], "book")
+
+    def test_hidden_states_1d_falls_back(self):
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        logits[0, 18515] = 10.0   # cancel
+        req = _make_req()
+        SMIELPWithHiddenStates()(
+            logits, [{"__req__": req, **self._config()}],
+            hidden_states=torch.randn(QWEN_HIDDEN_DIM),   # 1-D, not 2-D
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["mode"], "logit_slicing")
+
+    def test_nan_hidden_state_falls_back(self):
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        logits[0, 2829] = 10.0   # status
+        req = _make_req()
+        h_nan = torch.full((1, QWEN_HIDDEN_DIM), float("nan"))
+        SMIELPWithHiddenStates()(
+            logits, [{"__req__": req, **self._config()}],
+            hidden_states=h_nan,
+        )
+        result = req.customized_info["smielp"][0]
+        self.assertEqual(result["mode"], "logit_slicing")
+        self.assertEqual(result["intent"]["label"], "status")
+        self.assertIsNone(result["hidden_state_l2"])
+
+    def test_wrong_label_embedding_shape_skips_head(self):
+        """Wrong embedding dim → that head is skipped, result has no intent."""
+        cfg = self._config()
+        cfg["label_embeddings"]["intent"] = torch.randn(3, 128)   # wrong hidden_dim
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        req = _make_req()
+        SMIELPWithHiddenStates()(
+            logits, [{"__req__": req, **cfg}],
+            hidden_states=torch.randn(1, QWEN_HIDDEN_DIM),
+        )
+        result = req.customized_info["smielp"][0]
+        # Intent embedding had wrong shape → intent result is None
+        self.assertIsNone(result["intent"])
+        # City embedding was correct → city entity should be present
+        self.assertEqual(len(result["entities"]), 1)
+
+
+class TestPhaseBAndACoexistence(unittest.TestCase):
+    """
+    Phase A and Phase B processors can run simultaneously on the same schema config.
+    Phase A reads logits; Phase B reads hidden_states. Results should agree on
+    classification when both signals are consistent.
+    """
+
+    def test_both_processors_agree_on_dominant_intent(self):
+        intent_tid = INTENT_TOKEN_IDS["cancel"]
+        schema_cfg = {
+            "intent_labels":    INTENT_LABELS,
+            "intent_token_ids": [INTENT_TOKEN_IDS[l] for l in INTENT_LABELS],
+            "entity_slots": [],
+        }
+        logits = torch.zeros(1, QWEN_VOCAB_SIZE)
+        logits[0, intent_tid] = 20.0   # cancel dominates logits
+
+        emb = _make_embedding_matrix(QWEN_BASE_VOCAB, QWEN_HIDDEN_DIM)
+        # Make hidden state aligned with cancel's embedding
+        h = F.normalize(emb[intent_tid], dim=0).unsqueeze(0)
+
+        req_a  = _make_req()
+        req_b  = _make_req()
+
+        params_a = {"__req__": req_a,  "schema": schema_cfg, "eos_token_id": 2}
+        params_b = {
+            "__req__": req_b,
+            "schema": schema_cfg,
+            "eos_token_id": 2,
+            "label_embeddings": {"intent": emb[[INTENT_TOKEN_IDS[l] for l in INTENT_LABELS]]},
+        }
+
+        SimultaneousMultiIntentEntityLogitProcessor()(logits.clone(), [params_a])
+        SMIELPWithHiddenStates()(logits.clone(), [params_b], hidden_states=h)
+
+        intent_a = req_a.customized_info["smielp"][0]["intent"]["label"]
+        intent_b = req_b.customized_info["smielp"][0]["intent"]["label"]
+        self.assertEqual(intent_a, "cancel")
+        self.assertEqual(intent_b, "cancel")
+        self.assertEqual(intent_a, intent_b)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

Constrained decoding backends (XGrammar, Outlines) solve structured output by applying a grammar mask at every decode step. For NER/NLU tasks with a fixed output schema (e.g. intent label + BIO slot tags), this means N sequential GPU kernel launches for N output tokens — even though the model only needs to express a belief over a small, known set of class labels.

This PR introduces Logit Slicing: intercept the logit tensor [batch_size, vocab_size] after a single decode step, slice one column per class label (each label is pre-anchored to a single token ID in the model vocabulary), apply softmax across each head independently, and return all slot predictions simultaneously. For a 4-field NER schema this replaces ~20–40 autoregressive decode steps with exactly 1, with no change to the model or serving infrastructure.

### Modifications

New package: python/sglang/srt/logit_slicing/

schema.py — Validated dataclasses for describing a structured extraction schema:
- IntentSchema(labels, label_to_token_id) — intent classification head
- SlotSchema(name, labels, label_to_token_id) — per-slot BIO/categorical head
- NERSchema(intents, slots) — top-level schema with to_anchor_config() / from_dict() serialization

vocab_anchor.py — Maps class label strings to single token IDs in a given tokenizer:
- Three strategies: first_token (default), single_token (strict), explicit (caller-provided)
- Collision detection: raises if two labels in the same head map to the same token ID
- Convenience helpers: build_anchor_config(), build_phase_b_config() (includes embedding vectors for Phase B)

processor.py — SimultaneousMultiIntentEntityLogitProcessor(CustomLogitProcessor) — Phase A:
- __call__(logits [M, vocab_size], custom_param_list) — slices intent columns + BIO tag columns per slot, softmax, argmax
- Writes structured result to req.customized_info["smielp"] — surfaces automatically in HTTP meta_info["smielp"] with zero core modification
- Forces EOS after the single decode step; guards against padded-vocab eos_token_id out-of-bounds
- Defensive None-params guard (consistent with ThinkingBudgetLogitProcessor pattern)

processor_phase_b.py — SMIELPWithHiddenStates(CustomLogitProcessor) — Phase B:
- __call__(logits, custom_param_list, hidden_states=None) — the hidden_states kwarg triggers capability detection in the patched sampler
- When hidden_states and label_embeddings are both available: h_norm @ E.T * 10.0 → softmax (embedding-space cosine similarity)
- Falls back to logit slicing when hidden_states=None or --enable-return-hidden-states is not set
- Input validation: shape mismatch, 1-D tensor, NaN, wrong embedding dim — all degrade gracefully with a warning log

Modified: python/sglang/srt/layers/sampler.py (5 backward-compatible edits)

1. _processor_accepts_hidden_states(proc_cls) — lru_cache(256) helper using inspect.signature to detect whether a processor's __call__ declares a hidden_states parameter. Existing processors are unaffected.
2. _preprocess_logits — added hidden_states=None parameter.
3. Sampler.forward call site — forwards logits_output.hidden_states.
4. apply_custom_logit_processor — added hidden_states=None parameter + capability-aware dispatch: hidden_states is only passed to processors that declare it.
5. Import additions: functools, inspect.

No existing processor's call signature or behavior changes.

### Tests: test/srt/

File: test_logit_slicing.py
Tests: 35
Notes: Schema validation, VocabAnchor strategies, Phase A processor, EOS
  forcing, batch, edge cases
────────────────────────────────────────
File: test_logit_slicing_integration.py
Tests: 16
Notes: Real Qwen2.5-0.5B vocab IDs via direct tokenizer.json parse — no
  transformers install needed
────────────────────────────────────────
File: test_logit_slicing_phase_b.py
Tests: 18
Notes: Phase B fallback, embedding mode, batch, L2 norm, sampler
  dispatch detection
────────────────────────────────────────
File: test_logit_slicing_phase_b_integration.py
Tests: 15
Notes: Full Qwen2.5-0.5B scale (vocab=151936, hidden_dim=896);
  padded-vocab EOS clamping, NaN, shape mismatch

All 84 tests run on CPU with no GPU and no transformers install required.

## Benchmark & Example

- benchmark/bench_smielp/bench_smielp_vs_xgrammar.py — Linux+GPU benchmark producing a 3-column latency table (Phase A / Phase B / XGrammar) with median speedup. --phase-b flag enables the embedding path.
- examples/smielp_flight_booking.py — Complete end-to-end flight booking NER demo.

## Accuracy Tests

Accuracy is validated structurally rather than statistically: given a logit tensor where one label column is set significantly higher than the others, the processor deterministically selects that label (verified in test_intent_label_selected_correctly, test_slot_tag_selected_correctly_B/O, and the full integration suite at Qwen2.5-0.5B scale).

Live model accuracy against CoNLL-2003 NER benchmark requires a Linux+GPU machine and is not available in this environment. The benchmark script is included and ready to run.

## Speed Tests and Profiling

Theoretical speedup for a 4-field schema: ~20–40x fewer decode steps (1 vs ~20–40 autoregressive tokens for JSON-structured output). The benchmark script bench_smielp_vs_xgrammar.py measures wall-clock latency and prints a comparison table. GPU results pending hardware availability.

---
Note to reviewers: The sampler patch is strictly additive , the new hidden_states parameter defaults to None everywhere and the _processor_accepts_hidden_states gate ensures zero behavioral change for all existing processors. Phase A requires only --enable-custom-logit-processor (existing flag); Phase B additionally requires --enable-return-hidden-states.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27554453386](https://github.com/sgl-project/sglang/actions/runs/27554453386)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27554454723](https://github.com/sgl-project/sglang/actions/runs/27554454723)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->