### PR TITLE
[diffusion] UX: suppress noisy diffusers torchao warning

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
+++ b/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
@@ -562,6 +562,8 @@ def globally_suppress_loggers():
         "urllib3",
         "httpx",
         "httpcore",
+        "diffusers.quantizers.torchao.torchao_quantizer",
+        "transformers.processing_utils",
         "flash_attn.cute.cache_utils",
     ]
 


### PR DESCRIPTION
## Summary
- filter the non-actionable diffusers torchao safe-globals warning during SGLang import-time compatibility patching
- keep the filter scoped to the exact warning message so other torchao/diffusers logs still surface

## Context
Regular server startup can emit this warning even when no torchao-serialized checkpoint is being loaded, which makes logs noisier without indicating a runtime issue.





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27558384744](https://github.com/sgl-project/sglang/actions/runs/27558384744)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27558384106](https://github.com/sgl-project/sglang/actions/runs/27558384106)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->