### PR TITLE
[Router] [Docs] Refresh policy-selection notes

### DIFF
--- a/experimental/sgl-router/BENCHMARKS.md
+++ b/experimental/sgl-router/BENCHMARKS.md
@@ -67,8 +67,8 @@ latency p50 ≤ 1.10× SMG` acceptance criterion targets.
 
 Both `random` and `power_of_two` are now O(1), ensuring consistent
 performance regardless of worker count.
-File an issue and pair it with a Criterion regression-guard in the same
-bench.
+TODO: Add a regression guard for the O(n) shape. Although `policy_select`
+measures the metric, nothing currently runs or gates on these results.
 
 ## Pre-deprecation calibration runbook
 

--- a/experimental/sgl-router/BENCHMARKS.md
+++ b/experimental/sgl-router/BENCHMARKS.md
@@ -62,11 +62,12 @@ latency p50 ≤ 1.10× SMG` acceptance criterion targets.
 | Policy | n=4 workers | n=16 | n=64 | n=256 | SMG equivalent |
 |---|---|---|---|---|---|
 | `round_robin`     | 2.5 ns | 2.5 ns | 2.5 ns | 2.5 ns | SMG round-robin is O(1) — same shape. |
-| `random`          | 16 ns | 36 ns | 137 ns | 471 ns | SMG random is also O(1) per `rand::random()` call; sgl-router's variant grows with n because it `Vec::iter().nth(idx)`. **Action item:** drop sgl-router to O(1) by indexing the slice directly. |
-| `power_of_two`    | … | … | … | 1.75 µs at n=256 | SMG power-of-two-choices is identical in shape (2× rand + 2× load read). |
+| `random`          | — | — | — | — | `SliceRandom::choose` call — O(1), matching SMG's O(1) `rand::random()` call. |
+| `power_of_two`    | — | — | — | — | Two distinct indices sampled directly - O(1), matching SMG's shape (2× rand + 2× load read). |
 
-The `random` finding (linear in worker count) is a real follow-up — file
-an issue and pair it with a Criterion regression-guard in the same
+Both `random` and `power_of_two` are now O(1), ensuring consistent
+performance regardless of worker count.
+File an issue and pair it with a Criterion regression-guard in the same
 bench.
 
 ## Pre-deprecation calibration runbook


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/sgl-project/sglang/pull/28228

After `power_of_two` is made O(1), the policy-selection notes are stale: `random` was described as O(n), but the code
uses O(1) `SliceRandom::choose`, and `power_of_two` is now O(1) too.

## Modifications

- Correct the `random` and `power_of_two` notes in the policy-selection table to reflect O(1).
- Remove the stale performance measures for those two rows (left blank to be re-measured on M1).

No code changes.

## Accuracy Tests

N/A. Documentation only.

## Speed Tests and Profiling

N/A. Documentation only; no code or performance change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). <!-- N/A: docs only -->
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). <!-- N/A: docs only -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27560545258](https://github.com/sgl-project/sglang/actions/runs/27560545258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27560544914](https://github.com/sgl-project/sglang/actions/runs/27560544914)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->