### PR TITLE
[AMD] fix(jit): make activation unary kernel compile on ROCm (fix jit-kernel-unit-test-amd)

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
@@ -203,11 +203,12 @@ struct ActivationKernel {
     launch(input, out, type, static_cast<const int32_t*>(expert_ids.data_ptr()), static_cast<uint32_t>(expert_step));
   }
 
-  template <ActivationKind kAct>
-  static constexpr auto unary_kernel = act_kernel<T, kAct, kUsePDL>;
+  using unary_kernel_fn_t = decltype(&act_kernel<T, ActivationKind::kReLU2, kUsePDL>);
 
-  static auto select_unary_kernel(const std::string& type)
-      -> decltype(ActivationKernel::template unary_kernel<ActivationKind::kReLU2>) {
+  template <ActivationKind kAct>
+  static constexpr unary_kernel_fn_t unary_kernel = act_kernel<T, kAct, kUsePDL>;
+
+  static unary_kernel_fn_t select_unary_kernel(const std::string& type) {
     using namespace host;
     if (type == "relu2") {
       return ActivationKernel::template unary_kernel<ActivationKind::kReLU2>;


### PR DESCRIPTION
## Summary
`jit-kernel-unit-test-amd` fails because the **activation JIT kernel does not compile under ROCm/hipcc** — every test in `test/registered/jit/test_activation.py` errors with `RuntimeError: ninja exited with status 1`.

Failing run: [jit-kernel-unit-test-amd in scheduled run 27517929362](https://github.com/sgl-project/sglang/actions/runs/27517929362/job/81330028461).

### Root cause
The relu2 **unary** path (added in #26733 by @b8zhong) declared the kernel as `static constexpr auto unary_kernel = ...` and had `select_unary_kernel` return `decltype(ActivationKernel::unary_kernel<kReLU2>)`. hipcc's clang can't use a deduced `const auto` variable-template type as a function return type, producing 3 compile errors on `gfx942`:
```
error: cannot initialize return object of type 'decltype(...unary_kernel<kReLU2>)' (aka 'const auto') with an lvalue of type 'void (*const)(const UnaryActivationParams)'
error: cannot initialize return object ... with an rvalue of type 'std::nullptr_t'
error: function 'forward<const auto &>' with deduced return type cannot be used before it is defined
```
The sibling **binary** path compiles fine because it uses a concrete typedef `kernel_fn_t = decltype(&act_and_mul_kernel<...>)` and `select_kernel` returns it.

### Fix
Mirror the working binary path for the unary path: add a concrete `unary_kernel_fn_t = decltype(&act_kernel<...>)` typedef and use it for both the `unary_kernel` variable template and the `select_unary_kernel` return type.

### NV/CUDA impact
None. This is a pure type-declaration refactor with identical codegen — `unary_kernel` is still the same function pointer and `select_unary_kernel` returns the same pointer. The binary path already uses this exact pattern unconditionally (no `USE_ROCM` guard), and CUDA `test_activation.py` (which includes `relu2`) already compiled/passed with the old spelling.

cc @b8zhong (author of #26733) for awareness.

## Test plan
- [ ] `jit-kernel-unit-test-amd` (`test_activation.py`) compiles and passes on `gfx942` / MI325.
- [ ] CUDA `jit-kernel` activation tests remain green.

**Verification:** targeted MI325 dispatch of `jit-kernel-unit-test-amd` on this branch — [run 27577333019](https://github.com/sgl-project/sglang/actions/runs/27577333019).