### PR TITLE
[Diffusion] Use SRT custom allreduce for TP groups

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
@@ -158,6 +158,7 @@ class GroupCoordinator:
         local_rank: int,
         torch_distributed_backend: Union[str, Backend],
         use_device_communicator: bool = True,
+        use_srt_custom_allreduce: bool = False,
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
     ):
@@ -213,10 +214,28 @@ class GroupCoordinator:
                 )
 
         self.mq_broadcaster = None
+        self.srt_custom_allreduce = None
+        if (
+            use_srt_custom_allreduce
+            and current_platform.is_cuda_alike()
+            and self.world_size > 1
+        ):
+            # srt owns topology, dtype, contiguity, and size dispatch for custom ar
+            self._init_srt_custom_allreduce()
 
         # TODO(will): check if this is needed
         # self.use_custom_op_call = current_platform.is_cuda_alike()
         self.use_custom_op_call = False
+
+    def _init_srt_custom_allreduce(self) -> None:
+        from sglang.srt.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce,
+        )
+
+        self.srt_custom_allreduce = CustomAllreduce(
+            group=self.cpu_group,
+            device=self.device,
+        )
 
     @property
     def first_rank(self):
@@ -326,6 +345,18 @@ class GroupCoordinator:
         if self.world_size == 1:
             return input_
         else:
+            custom_ar = self.srt_custom_allreduce
+            if (
+                not async_op
+                and custom_ar is not None
+                and op == torch.distributed.ReduceOp.SUM
+                and not input_.is_cpu
+                and not custom_ar.disabled
+                and custom_ar.should_custom_ar(input_)
+            ):
+                if custom_ar._IS_CAPTURING:
+                    return custom_ar.custom_all_reduce(input_)
+                return custom_ar._all_reduce_impl(input_, registered=False)
             if (
                 current_platform.is_cpu()
                 and is_shm_available(input_.dtype, self.world_size, len(self.ranks))
@@ -769,6 +800,9 @@ class GroupCoordinator:
             self.cpu_group = None
         if self.device_communicator is not None:
             self.device_communicator.destroy()
+        if self.srt_custom_allreduce is not None:
+            self.srt_custom_allreduce.close()
+            self.srt_custom_allreduce = None
         if self.mq_broadcaster is not None:
             self.mq_broadcaster = None
 

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -139,6 +139,20 @@ def init_world_group(
     )
 
 
+def _sync_srt_world_group() -> None:
+    import sglang.srt.distributed.parallel_state as srt_parallel_state
+
+    if srt_parallel_state._WORLD is None:
+        srt_parallel_state._WORLD = _WORLD
+
+
+def _clear_srt_world_group() -> None:
+    import sglang.srt.distributed.parallel_state as srt_parallel_state
+
+    if srt_parallel_state._WORLD is _WORLD:
+        srt_parallel_state._WORLD = None
+
+
 def init_parallel_group_coordinator(
     group_ranks: List[List[int]],
     local_rank: int,
@@ -175,8 +189,14 @@ def init_parallel_group_coordinator(
             group_ranks=group_ranks,
             local_rank=local_rank,
             torch_distributed_backend=backend,
+            use_device_communicator=parallel_mode != "tensor",
+            use_srt_custom_allreduce=parallel_mode == "tensor",
             group_name=(
-                "vae_decode_group" if parallel_mode == "vae_decode" else "cfg_group"
+                "tp_group"
+                if parallel_mode == "tensor"
+                else (
+                    "vae_decode_group" if parallel_mode == "vae_decode" else "cfg_group"
+                )
             ),
         )
 
@@ -264,6 +284,7 @@ def init_distributed_environment(
         assert (
             _WORLD.world_size == torch.distributed.get_world_size()
         ), "world group already initialized with a different world size"
+    _sync_srt_world_group()
 
 
 def get_sp_group() -> SequenceParallelGroupCoordinator:
@@ -591,6 +612,7 @@ def get_tp_rank() -> int:
 
 def destroy_distributed_environment() -> None:
     global _WORLD
+    _clear_srt_world_group()
     if _WORLD:
         _WORLD.destroy()
     _WORLD = None


### PR DESCRIPTION
## Summary

Reuse SRT's legacy `CustomAllreduce` fast path for SGLang-Diffusion tensor-parallel all-reduce.

Changes:
- Add an optional SRT custom all-reduce backend to diffusion `GroupCoordinator`.
- Enable it only for tensor-parallel groups.
- Keep data/CFG/SP/VAE groups on the existing diffusion communication path.
- Share diffusion's world coordinator with SRT parallel state so SRT topology/NVLink checks can reuse the existing distributed setup.
- Fall back to the existing torch distributed all-reduce whenever SRT's shape/platform guard does not allow custom all-reduce.

This PR intentionally does not include the Ulysses all-to-all experiments. Those need separate validation on workloads where SP/Ulysses is end-to-end beneficial.

## Validation

Remote 8x H100 validation:

- Z-Image-Turbo TP2 clean rerun:
  - 207 denoising TP all-reduces all hit SRT legacy `CustomAllreduce`.
  - `tensor_model_parallel_all_reduce` profiler time: `21.57 ms -> 8.94 ms` (`2.41x`).
  - Steady profiled step1/2 average: `49.98 ms -> 45.21 ms` (`1.11x`).
  - Full denoise wall time was noisy due to first/last step and profiler overhead, so the steady profiled steps are the performance signal.

- Ideogram-4-fp8 TP2:
  - No denoising `tensor_model_parallel_all_reduce` events.
  - This is expected because the current Ideogram TP path is all-gather based, not row-parallel all-reduce based.
  - Result is effectively no-op for this PR.

- Isolated diffusion `get_tp_group().all_reduce()` microbench via the same `GroupCoordinator` path:
  - TP4 median speedups up to 4MB:
    - bf16: `1.18x-3.25x`
    - fp16: `1.10x-2.51x`
  - TP8 median speedups up to 4MB:
    - bf16: `1.03x-1.68x`
    - fp16: `1.05x-1.73x`
  - 16MB falls back through the SRT shape guard and stays approximately flat.

Pre-submit:

- `pre-commit run --files python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py python/sglang/multimodal_gen/runtime/distributed/parallel_state.py`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27560587081](https://github.com/sgl-project/sglang/actions/runs/27560587081)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27560586801](https://github.com/sgl-project/sglang/actions/runs/27560586801)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->