### PR TITLE
[Spec][test] fix(kv_canary): assert draft-extend-v2 oracle tokens in token_oracle test

### DIFF
--- a/python/sglang/srt/kv_canary/token_oracle/oracle_manager.py
+++ b/python/sglang/srt/kv_canary/token_oracle/oracle_manager.py
@@ -36,7 +36,7 @@ class TokenOracleManager:
                 bootstrap_room_ids_int=forward_batch.bootstrap_room_ids_int,
             ),
         )
-        if forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
+        if forward_batch.forward_mode.is_extend():
             expected_tokens = input_ids
         else:
             expected_tokens = self.oracle.expected_tokens(

--- a/python/sglang/srt/kv_canary/token_oracle/oracle_manager.py
+++ b/python/sglang/srt/kv_canary/token_oracle/oracle_manager.py
@@ -36,7 +36,7 @@ class TokenOracleManager:
                 bootstrap_room_ids_int=forward_batch.bootstrap_room_ids_int,
             ),
         )
-        if forward_batch.forward_mode.is_extend():
+        if forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
             expected_tokens = input_ids
         else:
             expected_tokens = self.oracle.expected_tokens(

--- a/test/registered/kv_canary/test_self_unit_token_oracle.py
+++ b/test/registered/kv_canary/test_self_unit_token_oracle.py
@@ -46,8 +46,18 @@ class TestTokenOracleManager(CustomTestCase):
             expected_inputs_out=expected_inputs,
         )
 
+        # draft-extend-v2 is not an extend mode, so fill_expected_inputs records
+        # deterministic oracle tokens (not input_ids). The req row [3, 7] expands
+        # to num_tokens_per_req=4 draft tokens each -> one row per draft token.
+        expected_generalized_req_ids = torch.tensor(
+            [3, 3, 3, 3, 7, 7, 7, 7], dtype=torch.int64, device=self.device
+        )
+        expected_tokens = manager.oracle.expected_tokens(
+            generalized_req_ids=expected_generalized_req_ids,
+            positions=forward_batch.positions.to(torch.int64),
+        )
         self.assertTrue(
-            torch.equal(expected_inputs.tokens[:8], forward_batch.input_ids)
+            torch.equal(expected_inputs.tokens[:8], expected_tokens.to(torch.int64))
         )
         self.assertTrue(
             torch.equal(expected_inputs.positions[:8], forward_batch.positions)


### PR DESCRIPTION
## Summary
`test/registered/kv_canary/test_self_unit_token_oracle.py::test_fill_expected_inputs_expands_draft_extend_generalized_req_ids_per_token` fails with `AssertionError: False is not true`, turning the `extra-a` suite red on **both AMD and NV**.

Failing runs:
- AMD: [extra-a-test-1-gpu-small-amd, job 81319082017](https://github.com/sgl-project/sglang/actions/runs/27513944095/job/81319082017)
- NV/CUDA: [extra-a-test-1-gpu-small (1), job 81427429583](https://github.com/sgl-project/sglang/actions/runs/27548280728/job/81427429583)

### Root cause (test-only)
Regression from #28129 ("Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode", by @ch-wan). The **production** behavior was unchanged by that PR — in `TokenOracleManager.fill_expected_inputs`, the token-source check has always been a bare `is_extend()`, which historically included v1 `DRAFT_EXTEND` (→ `input_ids`) but has always **excluded** `DRAFT_EXTEND_V2` (→ deterministic oracle tokens via the `else` branch).

The only breaking change was in the **test** (line 29): #28129 flipped `ForwardMode.DRAFT_EXTEND` → `ForwardMode.DRAFT_EXTEND_V2` but kept the v1 assertion `tokens == input_ids`. Since v2 takes the oracle branch (not the extend branch), that assertion is now wrong.

### Fix
Keep production untouched and fix the test to assert v2's actual output: the req rows `[3, 7]` expand to `num_tokens_per_req=4` draft tokens each (`[3,3,3,3,7,7,7,7]`), and `fill_expected_inputs` writes the deterministic `HashOracle` tokens for those generalized req ids. The position check is unchanged.

(An earlier revision of this PR tried to change production `is_extend(include_draft_extend_v2=True)`; that was reverted because it would have altered real v2 behavior to satisfy a mis-migrated test. Net diff is now the test file only.)

### NV/CUDA impact
None on production (no production change). The test is registered for both CUDA (`register_cuda_ci`) and AMD, so it now passes on both.

cc @ch-wan (author of #28129) for review.

## Test plan
- [ ] `test_self_unit_token_oracle.py` passes (extra-a suite, AMD + CUDA).

**Verification:** MI325 dispatch of the `extra-a` suite on the corrected commit (028b2133) — [run 27586010133](https://github.com/sgl-project/sglang/actions/runs/27586010133).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27585880329](https://github.com/sgl-project/sglang/actions/runs/27585880329)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27585880220](https://github.com/sgl-project/sglang/actions/runs/27585880220)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->