### PR TITLE
[Fix] Forward clamped SwiGLU params in NVFP4 flashinfer-cutlass MoE

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2444,6 +2444,36 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                         device=x.device,
                     )
 
+            # Forward parameterized/clamped SwiGLU (e.g. GPT-OSS-style gemm1_alpha / clamp_limit)
+            # to the kernel; otherwise it computes vanilla SwiGLU and such models generate garbage.
+            # Mirrors the trtllm path (moe_runner/flashinfer_trtllm.py), which already forwards
+            # gemm1_clamp_limit. swiglu_beta=1.0 is the +1 shift on the linear branch (mxfp4 path).
+            # No-op for models that leave gemm1_alpha/gemm1_clamp_limit unset (vanilla SwiGLU).
+            swiglu_kwargs = {}
+            _gemm1_alpha = moe_runner_config.gemm1_alpha
+            _gemm1_limit = moe_runner_config.gemm1_clamp_limit
+            if _gemm1_alpha is not None or _gemm1_limit is not None:
+                _num_local_experts = layer.w13_weight.shape[0]
+                swiglu_kwargs["swiglu_alpha"] = torch.full(
+                    (_num_local_experts,),
+                    _gemm1_alpha if _gemm1_alpha is not None else 1.0,
+                    dtype=torch.float32,
+                    device=x.device,
+                )
+                swiglu_kwargs["swiglu_beta"] = torch.full(
+                    (_num_local_experts,),
+                    1.0,
+                    dtype=torch.float32,
+                    device=x.device,
+                )
+                if _gemm1_limit is not None:
+                    swiglu_kwargs["swiglu_limit"] = torch.full(
+                        (_num_local_experts,),
+                        _gemm1_limit,
+                        dtype=torch.float32,
+                        device=x.device,
+                    )
+
             output = flashinfer_cutlass_fused_moe(
                 output=symm_output,
                 input=x,
@@ -2469,6 +2499,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 tune_max_num_tokens=next_power_of_2(x.shape[0]),
                 activation_type=fi_activation,
                 enable_alltoall=get_moe_a2a_backend().is_flashinfer(),
+                **swiglu_kwargs,
             )[0]
 
             return StandardCombineInput(hidden_states=output)


### PR DESCRIPTION
## Motivation

`ModelOptNvFp4FusedMoEMethod.apply()` (the NVFP4 `flashinfer_cutlass_fused_moe` path in `srt/layers/quantization/modelopt_quant.py`) forwards `activation_type` but **not** the parameterized/clamped-SwiGLU parameters (`gemm1_alpha` / `gemm1_clamp_limit`) from `MoeRunnerConfig`.

For models that use clamped SwiGLU — e.g. **GPT-OSS** (`srt/models/gpt_oss.py` sets `gemm1_alpha` / `gemm1_clamp_limit`) — the NVFP4 cutlass MoE then computes **vanilla** SwiGLU (default `alpha=1.0`, no clamp) and the model produces garbage when served with `--quantization modelopt_fp4 --moe-runner-backend flashinfer_cutlass`.

The other MoE backends already consume these from `MoeRunnerConfig`:
- native — `srt/layers/moe/fused_moe_native.py`
- triton — `srt/layers/moe/fused_moe_triton/triton_kernels_moe.py`
- trtllm — `srt/layers/moe/moe_runner/flashinfer_trtllm.py` (builds the per-expert `gemm1_clamp_limit` tensor)

Only the NVFP4 flashinfer-cutlass path dropped them.

## Modification

In the NVFP4 cutlass `apply()`, build per-expert `swiglu_alpha` / `swiglu_beta` / `swiglu_limit` tensors from `moe_runner_config.gemm1_alpha` / `gemm1_clamp_limit` and forward them to `flashinfer_cutlass_fused_moe` (`flashinfer.fused_moe.cutlass_fused_moe` accepts these kwargs). `swiglu_beta=1.0` is the `+1` shift on the linear branch, matching the mxfp4 path.

- **Backward compatible / no-op** when `gemm1_alpha` and `gemm1_clamp_limit` are both unset (vanilla-SwiGLU models such as Llama4 / Qwen3-MoE are unaffected — `swiglu_kwargs` stays empty).
- The FP8 cutlass path is untouched.

## Validation

Surfaced while serving an NVFP4 MiniMax-M3 checkpoint on the flashinfer-cutlass MoE backend: without this, the MoE output is garbage; with it, generations are correct (e.g. arithmetic/reasoning prompts answer correctly, MiniMax-Provider-Verifier tool-call match ≈0.96 — on par with the MXFP8 baseline). The same code path is exercised by GPT-OSS NVFP4 on this backend.

> Filed as a **draft** for maintainer review/reconciliation — the parameterized-SwiGLU handling overlaps prior work in the trtllm path, and there may be related in-flight changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27561165577](https://github.com/sgl-project/sglang/actions/runs/27561165577)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27561164823](https://github.com/sgl-project/sglang/actions/runs/27561164823)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->