### PR TITLE
[Qwen3.5/MI355X] qk-norm+RoPE fusion, selective dense-FP8 for quark MXFP4, and mscclpp NVLS-on-HIP fix

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/pymscclpp.py
+++ b/python/sglang/srt/distributed/device_communicators/pymscclpp.py
@@ -90,8 +90,13 @@ class PyMscclppCommunicator:
             rank=self.rank,
         )
 
+        # NVLS (NVLink SHARP) algos are NVIDIA-only and raise InvalidUsage on
+        # ROCm/AMD during tuning, crashing init. Skip them on HIP — the generic
+        # `default_allreduce_packet` algo (0-2MB) covers small decode messages.
+        _is_hip = getattr(torch.version, "hip", None) is not None
+
         for algo in algos:
-            if algo.name == "default_allreduce_nvls_packet":
+            if algo.name == "default_allreduce_nvls_packet" and not _is_hip:
                 algo.set_message_size_range(0, 512 << 10)
                 navitve_algorithms_config.append(
                     (algo, [4, 8, 12, 16], [256, 512, 768, 1024])

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1487,6 +1487,26 @@ def apply_fp8_linear(
         )
     output_padding = 17 if pad_output else None
 
+    # Pre-quantized input fast path: `input` is a (fp8_qinput, x_scale) tuple
+    # produced by a fused rmsnorm/silu + per-token-quant kernel upstream. Skips
+    # the standalone activation quant entirely (the fp8-dense quant-fusion path).
+    # aiter per-token / bpreshuffle GEMM only.
+    if isinstance(input, tuple):
+        qinput, x_scale = input
+        qinput_2d = qinput.view(-1, qinput.shape[-1])
+        out_shape = [*qinput.shape[:-1], weight.shape[1]]
+        assert _use_aiter, "prequantized fp8 input requires the aiter w8a8 path"
+        output = gemm_a8w8_bpreshuffle(
+            XQ=qinput_2d,
+            WQ=weight.T,
+            x_scale=x_scale,
+            w_scale=weight_scale,
+            dtype=torch.bfloat16,
+        )
+        if bias is not None:
+            output += bias
+        return _process_scaled_mm_output(output, qinput_2d.shape, out_shape)
+
     # View input as 2D matrix for fp8 methods
     input_2d = input.view(-1, input.shape[-1])
     output_shape = [*input.shape[:-1], weight.shape[1]]

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -38,6 +38,45 @@ __all__ = ["QuarkLinearMethod", "QuarkFusedMoEMethod"]
 logger = logging.getLogger(__name__)
 
 
+def _dense_fp8_enabled() -> bool:
+    import os
+
+    return os.environ.get("SGLANG_QUARK_DENSE_FP8", "0") == "1"
+
+
+# Only fp8 the BIG dense projections where fp8 GEMM beats tuned bf16 at TP=2
+# (in_proj_qkvz N=10240, GDN out_proj N>=4096, shared_expert.down N=4096).
+# Exclude small-N where bf16 flydsl wins (shared gate_up N=1024, N=512) via the
+# min-N guard, and conv1d/router/gate/lm_head/embed always.
+_DENSE_FP8_ELIGIBLE = (
+    ".in_proj_qkvz",
+    "linear_attn.out_proj",
+    ".shared_expert.down_proj",
+)
+_DENSE_FP8_BLOCKED = (
+    "conv1d",
+    "shared_expert_gate",
+    "mlp.gate",
+    "in_proj_ba",
+    "lm_head",
+    "embed",
+)
+_DENSE_FP8_MIN_N = 2048
+
+
+def _dense_fp8_eligible(prefix: str, layer) -> bool:
+    if any(b in prefix for b in _DENSE_FP8_BLOCKED):
+        return False
+    if not any(e in prefix for e in _DENSE_FP8_ELIGIBLE):
+        return False
+    n = getattr(layer, "output_size_per_partition", None) or getattr(
+        layer, "output_size", None
+    )
+    if n is not None and n < _DENSE_FP8_MIN_N:
+        return False
+    return True
+
+
 class QuarkConfig(QuantizationConfig):
 
     def __init__(
@@ -87,6 +126,16 @@ class QuarkConfig(QuantizationConfig):
     def get_linear_method(self) -> "QuarkLinearMethod":
         return QuarkLinearMethod(self)
 
+    def _get_dense_fp8_method(self, prefix: str):
+        from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+
+        cfg = getattr(self, "_dense_fp8_config", None)
+        if cfg is None:
+            cfg = Fp8Config(is_checkpoint_fp8_serialized=False, activation_scheme="dynamic")
+            self._dense_fp8_config = cfg
+        logger.info("[quark] routing excluded dense layer to FP8: %s", prefix)
+        return Fp8LinearMethod(cfg)
+
     @classmethod
     def get_supported_act_dtypes(cls) -> list[torch.dtype]:
         return [torch.float16, torch.bfloat16]
@@ -118,6 +167,8 @@ class QuarkConfig(QuantizationConfig):
             fused_mapping=self.packed_modules_mapping,
         ):
             if isinstance(layer, LinearBase):
+                if _dense_fp8_enabled() and _dense_fp8_eligible(prefix, layer):
+                    return self._get_dense_fp8_method(prefix)
                 return UnquantizedLinearMethod()
             elif isinstance(layer, RadixAttention):
                 return QuarkKVCacheMethod(self)

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -211,6 +211,16 @@ class Qwen2MoeMLP(nn.Module):
                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."
             )
         self.act_fn = SiluAndMul()
+        # FP8 quant fusion: when down_proj runs as online w8a8 fp8 (TP=2 dense-fp8
+        # path), fuse SiluAndMul + the per-token activation quant into one aiter
+        # kernel (silu_and_mul_quant) and feed the pre-quantized (fp8, scale) tuple
+        # to down_proj, eliminating the standalone quant. Env-gated; default off.
+        self._fp8_silu_fuse = False
+        import os
+
+        if os.environ.get("SGLANG_MLP_FP8_SILU_FUSE", "0") == "1":
+            qm = type(getattr(self.down_proj, "quant_method", None)).__name__
+            self._fp8_silu_fuse = qm == "Fp8LinearMethod"
 
     def forward(
         self,
@@ -219,6 +229,20 @@ class Qwen2MoeMLP(nn.Module):
         use_reduce_scatter: bool = False,
     ):
         gate_up, _ = self.gate_up_proj(x)
+        if self._fp8_silu_fuse and gate_up.shape[0] > 0:
+            import aiter
+            from aiter import dtypes
+
+            M = gate_up.shape[0]
+            N = gate_up.shape[-1] // 2
+            out_fp8 = torch.empty((M, N), dtype=dtypes.fp8, device=gate_up.device)
+            scale = torch.empty((M, 1), dtype=torch.float32, device=gate_up.device)
+            aiter.silu_and_mul_quant(out_fp8, gate_up, scale, N)
+            x, _ = self.down_proj(
+                (out_fp8, scale),
+                skip_all_reduce=should_allreduce_fusion or use_reduce_scatter,
+            )
+            return x
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(
             x, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -75,6 +75,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
@@ -135,6 +136,29 @@ if _is_npu:
     from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import (
         split_qkvgate_gemma_rmsnorm_rope,
     )
+
+
+_aiter_fused_qkv_split_qk_norm_rope_cache = None
+if _is_hip:
+    try:
+        from aiter.ops.triton.rope.fused_qkv_split_qk_norm_rope_cache import (
+            fused_qkv_split_qk_norm_rope_cache as _aiter_fused_qkv_split_qk_norm_rope_cache,
+        )
+    except ImportError:
+        _aiter_fused_qkv_split_qk_norm_rope_cache = None
+
+
+_enable_aiter_qknorm_fusion: Optional[bool] = None
+
+
+def _use_aiter_qknorm_fusion() -> bool:
+    global _enable_aiter_qknorm_fusion
+    if _enable_aiter_qknorm_fusion is None:
+        _enable_aiter_qknorm_fusion = (
+            _aiter_fused_qkv_split_qk_norm_rope_cache is not None
+            and get_global_server_args().enable_aiter_qknorm_fusion
+        )
+    return _enable_aiter_qknorm_fusion
 
 
 class Qwen3_5GatedDeltaNet(nn.Module):
@@ -939,6 +963,57 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         )
         return q, k, v, gate
 
+    def _prepare_qkv_aiter_fused(self, positions, hidden_states, forward_batch):
+        qkv, _ = self.qkv_proj(hidden_states)
+
+        pool = get_token_to_kv_pool()
+        k_buffer = pool.get_key_buffer(self.attn.layer_id)
+        v_buffer = pool.get_value_buffer(self.attn.layer_id)
+
+        # Pool stores K/V as flat per-token NHD: [size+page_size, head_num, head_dim].
+        # The aiter kernel wants paged NHD: [num_blocks, page_size, head_num, head_dim].
+        page_size = pool.page_size
+        num_blocks = k_buffer.shape[0] // page_size
+        key_cache = k_buffer.view(
+            num_blocks, page_size, k_buffer.shape[1], k_buffer.shape[2]
+        )
+        value_cache = v_buffer.view(
+            num_blocks, page_size, v_buffer.shape[1], v_buffer.shape[2]
+        )
+
+        # SGLang stores cos|sin concatenated along last dim; aiter wants them split.
+        cos, sin = self.rotary_emb.cos_sin_cache.chunk(2, dim=-1)
+
+        result = _aiter_fused_qkv_split_qk_norm_rope_cache(
+            qkv=qkv,
+            q_weight=self.q_norm.weight,
+            k_weight=self.k_norm.weight,
+            cos=cos,
+            sin=sin,
+            positions=positions,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            slot_mapping=forward_batch.out_cache_loc,
+            qh=self.num_heads,
+            kvh=self.num_kv_heads,
+            head_dim=self.head_dim,
+            is_neox=getattr(self.rotary_emb, "is_neox_style", True),
+            attn_output_gate=self.attn_output_gate,
+            gated_qkv_layout="interleaved",
+            kv_cache_layout="NHD",
+            k_scale=self.attn.k_scale,
+            v_scale=self.attn.v_scale,
+            eps=self.q_norm.variance_epsilon,
+        )
+
+        if self.attn_output_gate:
+            q, gate, k, v = result
+            gate = gate.reshape(gate.shape[0], -1)
+        else:
+            q, k, v = result
+            gate = None
+        return q, k, v, gate
+
     def self_attention(
         self,
         positions: torch.Tensor,
@@ -946,28 +1021,55 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        if _is_hip and self.attn_output_gate:
-            q, k, v, gate = self.forward_prepare_hip(
-                positions=positions,
-                hidden_states=hidden_states,
+        # Fused QK-norm+RoPE+cache is ROCm/aiter-only; the kernel handle is None on
+        # every other platform, so _use_aiter_qknorm_fusion() short-circuits there
+        # and we fall through to the native/HIP/NPU path unchanged.
+        use_aiter_fused = False
+        if _use_aiter_qknorm_fusion():
+            # mRoPE uses 3-row positions [3, T] but the fused kernel does 1-D RoPE
+            # only; fuse on row 0 only when there are no mm inputs (rows identical).
+            if positions.dim() == 2 and positions.shape[0] == 3:
+                positions_fusable = not forward_batch.contains_mm_inputs()
+                fused_positions = positions[0]
+            else:
+                positions_fusable = positions.dim() == 1
+                fused_positions = positions
+            # The fused kernel writes the KV cache inline, so require a real
+            # out_cache_loc (it is None during warmup/idle).
+            use_aiter_fused = (
+                positions_fusable and forward_batch.out_cache_loc is not None
             )
-        elif (
-            not _is_npu
-            or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
-            or not self.attn_output_gate
-        ):
-            q, k, v, gate = self.forward_prepare_native(
-                positions=positions,
-                hidden_states=hidden_states,
-            )
-        else:
-            q, k, v, gate = self.forward_prepare_npu(
-                positions=positions,
+
+        if use_aiter_fused:
+            q, k, v, gate = self._prepare_qkv_aiter_fused(
+                positions=fused_positions,
                 hidden_states=hidden_states,
                 forward_batch=forward_batch,
             )
+            attn_output = self.attn(q, k, v, forward_batch, save_kv_cache=False)
+        else:
+            if _is_hip and self.attn_output_gate:
+                q, k, v, gate = self.forward_prepare_hip(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                )
+            elif (
+                not _is_npu
+                or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+                or not self.attn_output_gate
+            ):
+                q, k, v, gate = self.forward_prepare_native(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                )
+            else:
+                q, k, v, gate = self.forward_prepare_npu(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    forward_batch=forward_batch,
+                )
 
-        attn_output = self.attn(q, k, v, forward_batch)
+            attn_output = self.attn(q, k, v, forward_batch)
 
         if self.attn_output_gate:
             if _is_hip:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -660,6 +660,7 @@ class ServerArgs:
     enable_flashinfer_allreduce_fusion: bool = False
     enforce_disable_flashinfer_allreduce_fusion: bool = False
     enable_aiter_allreduce_fusion: bool = False
+    enable_aiter_qknorm_fusion: bool = False
     deepep_mode: Literal["auto", "normal", "low_latency"] = "auto"
     deepep_dispatcher_output_dtype: Literal["auto", "bf16", "fp8", "int8", "nvfp4"] = (
         "auto"
@@ -6300,6 +6301,12 @@ class ServerArgs:
             "--enable-aiter-allreduce-fusion",
             action="store_true",
             help="Enable Aiter AllReduce Fusion.",
+        )
+        parser.add_argument(
+            "--enable-aiter-qknorm-fusion",
+            action="store_true",
+            help="Enable the fused aiter qk-norm kernel (qk-norm + RoPE + quant + "
+            "KV-cache-write) in the Qwen3.5 attention prologue (ROCm/aiter only).",
         )
         parser.add_argument(
             "--deepep-mode",


### PR DESCRIPTION
## What

Inference optimizations validated on **Qwen3.5-397B-A17B-MXFP4** on **AMD MI355X (gfx950, ROCm 7.2)**, across TP=2/4/8. All changes are flag/env-gated and default to current upstream behavior.

### 1. Fused qk-norm + RoPE + KV-cache-write (`--enable-aiter-qknorm-fusion`)
Combines the Qwen3.5 attention prologue (qk-norm, RoPE, KV-cache write) into a single aiter kernel (`fused_qkv_split_qk_norm_rope_cache`). Falls back to the unfused path on non-ROCm builds or when the kernel is unavailable. Default off.

### 2. Selective dense-FP8 for quark MXFP4 models (`SGLANG_QUARK_DENSE_FP8=1`)
quark-quantized models keep dense linears in bf16. On MI355X the tuned aiter FP8 GEMM beats tuned bf16 for the *large* dense projections, so this optionally routes only those (`in_proj_qkvz`, `linear_attn.out_proj`, `shared_expert.down_proj`, N≥2048) to online w8a8 FP8; small-N projections, conv1d, router/gate, lm_head and embeddings stay bf16. Supporting pieces:
- `fp8_utils.py`: pre-quantized fast path in `apply_fp8_linear` accepting an `(fp8_qinput, x_scale)` tuple, skipping the standalone activation quant.
- `qwen2_moe.py`: fuse `SiluAndMul` + per-token quant via `aiter.silu_and_mul_quant` (`SGLANG_MLP_FP8_SILU_FUSE=1`), feeding the `(fp8, scale)` tuple to down_proj.

### 3. pymscclpp: skip NVIDIA-only NVLS on HIP/ROCm
`default_allreduce_nvls_packet` (NVLink-SHARP) raises `mscclpp Error(3) "NVLS is not supported"` during tuning on AMD, crashing init under `--enable-mscclpp`. Guarded with `not _is_hip`; the generic `default_allreduce_packet` (0–2MB) covers small-message all-reduce on AMD.

## Measured impact (MI355X, Qwen3.5-397B-A17B-MXFP4, ISL 8192 / OSL 1024, conc 16, GSM8K-gated)
- qk-norm fusion: kept across all TP.
- Selective dense-FP8 + silu/quant fusion: ~+3% at TP=2.
- (Tuning CSVs that pair with #2 are in the companion ROCm/aiter PR.)

## Testing
- GSM8K accuracy preserved (≤1pp) at every enabled setting (92–95%).
- All new paths default off → no change to existing behavior unless explicitly enabled.

## Notes
- mscclpp itself was evaluated on MI355X and found neutral-to-worse vs aiter's QuickReduce/Custom-AR for this small-message decode regime; the NVLS fix is included only so `--enable-mscclpp` does not crash on ROCm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27561214501](https://github.com/sgl-project/sglang/actions/runs/27561214501)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27561214328](https://github.com/sgl-project/sglang/actions/runs/27561214328)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->