### PR TITLE
[Fix] Improve Transformers backend compatibility for trust_remote_code models

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -595,12 +595,12 @@ class ModelConfig:
 
     def _derive_model_shapes(self):
         # Unify the config keys for hf_text_config
+        # Mamba/SSM configs have no attention heads; use 1 as safe default so
+        # head_dim falls back to hidden_size without crashing.
+        _n_heads = getattr(self.hf_text_config, "num_attention_heads", None) or 1
         self.head_dim = getattr(self.hf_text_config, "head_dim", None)
         if self.head_dim is None:
-            self.head_dim = (
-                self.hf_text_config.hidden_size
-                // self.hf_text_config.num_attention_heads
-            )
+            self.head_dim = self.hf_text_config.hidden_size // _n_heads
             setattr(self.hf_text_config, "head_dim", self.head_dim)
 
         self.v_head_dim = getattr(self.hf_text_config, "v_head_dim", None)
@@ -776,7 +776,7 @@ class ModelConfig:
 
             self.attention_arch = AttentionArch.MHA
 
-        self.num_attention_heads = self.hf_text_config.num_attention_heads
+        self.num_attention_heads = getattr(self.hf_text_config, "num_attention_heads", 1)
         self.num_key_value_heads = getattr(
             self.hf_text_config, "num_key_value_heads", None
         )

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -139,22 +139,32 @@ def resolve_transformers_arch(model_config: ModelConfig, architectures: list[str
             )
         model_module = getattr(transformers, arch, None)
         if model_module is None:
-            has_auto_model = "AutoModel" in auto_modules
+            # Accept "AutoModel" or any task-specific "AutoModelFor*" key
+            # (e.g. "AutoModelForImageTextToText" used by Molmo2).
+            _auto_model_key = next(
+                (k for k in auto_modules if k == "AutoModel" or k.startswith("AutoModelFor")),
+                None,
+            )
+            has_auto_model = _auto_model_key is not None
+            _auto_map_model_key = next(
+                (k for k in auto_map if k == "AutoModel" or k.startswith("AutoModelFor")),
+                None,
+            )
             if not has_auto_model and model_config.model_impl == ModelImpl.TRANSFORMERS:
                 logger.warning(
-                    "Cannot resolve model class for '%s' and no auto_map.AutoModel "
+                    "Cannot resolve model class for '%s' and no auto_map.AutoModel* "
                     "is present. Skipping compatibility gate because "
                     "--model-impl=transformers is explicitly requested.",
                     arch,
                 )
                 continue
-            if not has_auto_model and "AutoModel" not in auto_map:
+            if not has_auto_model and _auto_map_model_key is None:
                 raise ValueError(
                     f"Cannot find model module. '{arch}' is not a registered "
                     "model in the Transformers library (only relevant if the "
-                    "model is meant to be in Transformers) and 'AutoModel' is "
-                    "not present in the model config's 'auto_map' (relevant "
-                    "if the model is custom)."
+                    "model is meant to be in Transformers) and no 'AutoModel' or "
+                    "'AutoModelFor*' key is present in the model config's 'auto_map' "
+                    "(relevant if the model is custom)."
                 )
             if not has_auto_model:
                 raise ValueError(
@@ -163,7 +173,7 @@ def resolve_transformers_arch(model_config: ModelConfig, architectures: list[str
                     f"model from auto_map failed. The remote model code may be "
                     f"incompatible with the installed transformers version."
                 )
-            model_module = auto_modules["AutoModel"]
+            model_module = auto_modules[_auto_model_key]
         if model_config.model_impl == ModelImpl.TRANSFORMERS:
             if hasattr(model_module, "is_backend_compatible") and (
                 not model_module.is_backend_compatible()

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -72,6 +72,33 @@ from sglang.srt.utils import get_device
 from sglang.srt.utils.common import direct_register_custom_op
 from sglang.srt.utils.hf_transformers_utils import get_hf_text_config
 
+# Newer Transformers dropped the 'default' key from ROPE_INIT_FUNCTIONS but some
+# trust_remote_code model implementations still reference it.  Inject a standard
+# no-scaling implementation so those models can initialize without a KeyError.
+try:
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS as _ROPE_FUNCS
+
+    if "default" not in _ROPE_FUNCS:
+        import torch as _torch
+
+        def _default_rope_init(config=None, device=None, **kwargs):
+            head_dim = getattr(config, "head_dim", None) or (
+                config.hidden_size // config.num_attention_heads
+            )
+            base = getattr(config, "rope_theta", 10000.0)
+            inv_freq = 1.0 / (
+                base
+                ** (
+                    _torch.arange(0, head_dim, 2, dtype=_torch.float32, device=device)
+                    / head_dim
+                )
+            )
+            return inv_freq, 1.0
+
+        _ROPE_FUNCS["default"] = _default_rope_init
+except Exception:
+    pass
+
 
 def can_enable_torch_compile(config: PretrainedConfig) -> bool:
     """Check whether the model config is compatible with torch.compile.
@@ -609,15 +636,47 @@ class TransformersBase(nn.Module):
             else True
         )
 
+        # Some model configs (e.g. OuroConfig, Step3TextConfig) omit pad_token_id
+        # entirely — their remote __init__ accesses it directly and raises
+        # AttributeError.  Fall back to bos_token_id (Transformers convention).
+        for _cfg in (self.config, self.text_config):
+            if not hasattr(_cfg, "pad_token_id"):
+                _cfg.pad_token_id = getattr(_cfg, "bos_token_id", None)
+
         # Initialize on meta device to avoid premature GPU allocation
         self.text_config._attn_implementation = "sglang"
         if supports_backend:
             with _init_on_device_without_buffers(torch.device("meta")):
-                self.model: PreTrainedModel = AutoModel.from_config(
-                    self.config,
-                    torch_dtype=torch.get_default_dtype(),
-                    trust_remote_code=True,
-                )
+                try:
+                    self.model: PreTrainedModel = AutoModel.from_config(
+                        self.config,
+                        torch_dtype=torch.get_default_dtype(),
+                        trust_remote_code=True,
+                    )
+                except ValueError as _e:
+                    if "Unrecognized configuration class" not in str(_e):
+                        raise
+                    # Some VLM configs (e.g. Molmo2Config) are only registered
+                    # under a task-specific auto class ("AutoModelForImageTextToText")
+                    # rather than the base AutoModel.  Try the first matching class.
+                    _auto_map = getattr(self.config, "auto_map", {})
+                    _auto_cls_name = next(
+                        (k for k in _auto_map if k.startswith("AutoModelFor")), None
+                    )
+                    if _auto_cls_name is None:
+                        raise
+                    import importlib as _imp
+
+                    _auto_cls = getattr(
+                        _imp.import_module("transformers"), _auto_cls_name, None
+                    )
+                    if _auto_cls is None:
+                        raise
+                    self.model = _auto_cls.from_config(
+                        self.config,
+                        torch_dtype=torch.get_default_dtype(),
+                        trust_remote_code=True,
+                    )
         else:
             raise ValueError(
                 f"Model {model_cls} does not support custom attention backends "
@@ -625,11 +684,18 @@ class TransformersBase(nn.Module):
                 "requires custom attention support."
             )
 
-        self.vocab_size = getattr(
-            self.text_config,
-            "vocab_size",
-            self.model.get_input_embeddings().num_embeddings,
-        )
+        # Lazy vocab_size: avoid calling .num_embeddings directly since some VLMs
+        # (e.g. Molmo2) use custom embedding classes without that attribute.
+        _tc_vocab = getattr(self.text_config, "vocab_size", None)
+        if _tc_vocab is not None:
+            self.vocab_size = _tc_vocab
+        else:
+            _embed = self.model.get_input_embeddings()
+            self.vocab_size = (
+                getattr(_embed, "num_embeddings", None)
+                or getattr(getattr(_embed, "new_embedding", None), "num_embeddings", None)
+                or getattr(self.config, "vocab_size", None)
+            )
         self.unpadded_vocab_size = self.vocab_size
 
         # Embedding scale (e.g. Whisper)

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -252,6 +252,44 @@ def get_processor(
             )
         else:
             raise
+    except TypeError as e:
+        if "Unexpected keyword argument" not in str(e):
+            raise
+        # Some trust_remote_code processor implementations (e.g. Molmo2Processor)
+        # pass custom kwargs to ProcessorMixin.__init__ that newer Transformers no
+        # longer accepts.  Patch the validator to store them as instance attributes.
+        from transformers.processing_utils import ProcessorMixin
+
+        _orig_processor_init = ProcessorMixin.__init__
+
+        def _permissive_processor_init(self_p, *p_args, **p_kwargs):
+            valid = set(getattr(self_p.__class__, "attributes", [])) | {
+                "chat_template",
+                "audio_tokenizer",
+            }
+            extra = {k: p_kwargs.pop(k) for k in list(p_kwargs) if k not in valid}
+            _orig_processor_init(self_p, *p_args, **p_kwargs)
+            for k, v in extra.items():
+                setattr(self_p, k, v)
+
+        ProcessorMixin.__init__ = _permissive_processor_init
+        try:
+            processor = AutoProcessor.from_pretrained(
+                tokenizer_name,
+                *args,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                **kwargs,
+            )
+            logger.info(
+                "Processor for %s loaded after relaxing ProcessorMixin.__init__ "
+                "kwarg validation (model's processor passes non-standard kwargs). "
+                "Consider updating the model's processor code.",
+                tokenizer_name,
+            )
+        finally:
+            ProcessorMixin.__init__ = _orig_processor_init
+
     if (
         isinstance(processor, PreTrainedTokenizerBase)
         and getattr(config, "model_type", None) == "pixtral"


### PR DESCRIPTION
## Summary

Four targeted fixes in the SGLang Transformers backend (`--model-impl=auto` fallback path) that unblock several `trust_remote_code` models failing in broad-model accuracy CI.

### Fix 1 — `model_config.py`: Guard `num_attention_heads` with `getattr`

Pure SSM models (`MambaConfig`, `FalconMambaConfig`, `Mamba2Config`) have no attention heads. `_derive_model_shapes` crashed with `AttributeError` before even reaching the `is_backend_compatible()` check, producing a misleading error message.

```python
# Before
self.head_dim = ... // self.hf_text_config.num_attention_heads  # AttributeError for Mamba

# After
_n_heads = getattr(self.hf_text_config, "num_attention_heads", None) or 1
self.head_dim = ... // _n_heads
```

### Fix 2 — `transformers.py`: Inject `ROPE_INIT_FUNCTIONS["default"]` if missing

Older `trust_remote_code` models reference `rope_type="default"` which was removed in Transformers v5. Registers a standard no-scaling fallback at import time.

### Fix 3 — `transformers.py`: Set `pad_token_id` from `bos_token_id` when missing

Models like `OuroConfig` and `Step3TextConfig` omit `pad_token_id` entirely. Their own remote `__init__` accesses it directly, raising `AttributeError`. Applied to both top-level config and nested text config before `from_config` is called.

### Fix 4 — Molmo2 / VLM trust_remote_code compatibility

**`processor.py`**: `Molmo2Processor.__init__` passes `image_use_col_tokens` to `ProcessorMixin.__init__`, which newer Transformers rejects. Catch the `TypeError` and store unknown kwargs as instance attributes instead (with a warning to update the model code).

**`utils.py`**: `resolve_transformers_arch` only looked for `"AutoModel"` in `auto_map`. Molmo2 registers under `"AutoModelForImageTextToText"`. Now accepts any `AutoModelFor*` key.

**`transformers.py`**: Fall back to the task-specific auto class when `AutoModel.from_config` raises "Unrecognized configuration class".

**`transformers.py`**: Lazy `vocab_size` lookup — `Molmo2Embedding` uses `new_embedding` instead of `num_embeddings`. Avoid the `AttributeError` with a safe fallback chain.

## Test plan

- [x] `state-spaces/mamba-130m-hf`: `ModelConfig` loads; `num_attention_heads=1, head_dim=768`
- [x] `tiiuae/falcon-mamba-7b`: `ModelConfig` loads; `num_attention_heads=1, head_dim=4096`
- [x] `ByteDance/Ouro-1.4B`: `pad_token_id` injected from `bos_token_id=0` on both configs
- [x] `stepfun-ai/step3`: `Step3VLConfig` and `Step3TextConfig` both receive `pad_token_id`
- [x] `allenai/Molmo2-4B`: processor loads with `image_use_col_tokens` stored as attr; server reaches weight-loading stage
- [x] `allenai/Molmo2-8B`: processor loads cleanly







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27562645403](https://github.com/sgl-project/sglang/actions/runs/27562645403)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27562645088](https://github.com/sgl-project/sglang/actions/runs/27562645088)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->