### PR TITLE
Add Qwen2.5-Omni thinker multimodal support

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1567,6 +1567,8 @@ multimodal_model_archs = [
     "PixtralForConditionalGeneration",
     "Qwen2AudioForConditionalGeneration",
     "Qwen2VLForConditionalGeneration",
+    "Qwen2_5OmniForConditionalGeneration",
+    "Qwen2_5OmniModel",
     "Qwen2_5_VLForConditionalGeneration",
     "Qwen3VLForConditionalGeneration",
     "Qwen3VLMoeForConditionalGeneration",

--- a/python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py
@@ -57,6 +57,19 @@ def get_rope_index(
     second_per_grid_ts: Optional[torch.Tensor] = None,
     **kwargs,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    if model_type == "qwen2_5_omni":
+        return get_rope_index_qwen2_5_omni(
+            spatial_merge_size,
+            image_token_id,
+            video_token_id,
+            vision_start_token_id,
+            tokens_per_second,
+            input_ids,
+            image_grid_thw,
+            video_grid_thw,
+            second_per_grid_ts,
+            **kwargs,
+        )
     if model_type == "qwen3_omni_moe":
         return get_rope_index_qwen3_omni(
             spatial_merge_size,
@@ -209,6 +222,282 @@ def get_rope_index(
         max_position_ids = position_ids.amax(dim=0, keepdim=False)
         mrope_position_deltas = max_position_ids.amax(-1, keepdim=True) + 1 - s
         return position_ids, mrope_position_deltas
+
+
+def _get_qwen2_5_omni_audio_output_lengths(input_lengths):
+    return ((input_lengths - 1) // 2 + 1 - 2) // 2 + 1
+
+
+def get_rope_index_qwen2_5_omni(
+    spatial_merge_size: int,
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+    tokens_per_second: Optional[int] = None,
+    input_ids: Optional[torch.LongTensor] = None,
+    image_grid_thw: Optional[torch.LongTensor] = None,
+    video_grid_thw: Optional[torch.LongTensor] = None,
+    second_per_grid_ts: Optional[torch.Tensor] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    audio_token_id = kwargs["audio_token_id"]
+    audio_start_token_id = kwargs["audio_start_token_id"]
+    position_id_per_seconds = kwargs.get("position_id_per_seconds", None) or 1
+    use_audio_in_video = kwargs.get("use_audio_in_video", False)
+    audio_seqlens = kwargs.get("audio_seqlens", None)
+
+    if use_audio_in_video:
+        raise NotImplementedError(
+            "Qwen2.5-Omni SGLang mrope currently supports separate video/audio "
+            "inputs only. Set use_audio_in_video=False."
+        )
+
+    def _find_from(tokens, token_id, start, remain):
+        if token_id is None or remain <= 0:
+            return len(tokens) + 1
+        try:
+            return tokens.index(token_id, start)
+        except ValueError:
+            return len(tokens) + 1
+
+    has_audio_tokens = bool(
+        input_ids is not None
+        and audio_start_token_id is not None
+        and torch.any(input_ids == audio_start_token_id).item()
+    )
+    if input_ids is not None and (
+        image_grid_thw is not None
+        or video_grid_thw is not None
+        or audio_seqlens is not None
+        or has_audio_tokens
+    ):
+        total_input_ids = input_ids
+        position_ids = torch.ones(
+            3,
+            input_ids.shape[0],
+            input_ids.shape[1],
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        mrope_position_deltas = []
+        image_idx, video_idx, audio_idx = 0, 0, 0
+        for i, current_input_ids in enumerate(total_input_ids):
+            vision_start_indices = torch.argwhere(
+                current_input_ids == vision_start_token_id
+            ).squeeze(1)
+            if vision_start_indices.numel() > 0:
+                vision_tokens = current_input_ids[vision_start_indices + 1]
+                image_nums = int((vision_tokens == image_token_id).sum().item())
+                video_nums = int((vision_tokens == video_token_id).sum().item())
+            else:
+                image_nums = 0
+                video_nums = 0
+            audio_nums = int(torch.sum(current_input_ids == audio_start_token_id).item())
+
+            if audio_nums > 0:
+                if audio_seqlens is None:
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope received audio tokens but "
+                        "`audio_seqlens` is None."
+                    )
+                if audio_idx + audio_nums > int(audio_seqlens.shape[0]):
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope audio count mismatch: "
+                        f"tokens need {audio_idx + audio_nums} lengths, "
+                        f"but audio_seqlens has {int(audio_seqlens.shape[0])}."
+                    )
+            if image_nums > 0:
+                if image_grid_thw is None:
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope received image tokens but "
+                        "`image_grid_thw` is None."
+                    )
+                if image_idx + image_nums > int(image_grid_thw.shape[0]):
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope image count mismatch: "
+                        f"tokens need {image_idx + image_nums} grids, "
+                        f"but image_grid_thw has {int(image_grid_thw.shape[0])}."
+                    )
+            if video_nums > 0:
+                if video_grid_thw is None:
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope received video tokens but "
+                        "`video_grid_thw` is None."
+                    )
+                if second_per_grid_ts is None:
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope received video tokens but "
+                        "`second_per_grid_ts` is None."
+                    )
+                if video_idx + video_nums > int(video_grid_thw.shape[0]):
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope video count mismatch: "
+                        f"tokens need {video_idx + video_nums} grids, "
+                        f"but video_grid_thw has {int(video_grid_thw.shape[0])}."
+                    )
+                if video_idx + video_nums > int(second_per_grid_ts.shape[0]):
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope video timing mismatch: "
+                        f"tokens need {video_idx + video_nums} timings, "
+                        f"but second_per_grid_ts has {int(second_per_grid_ts.shape[0])}."
+                    )
+
+            input_tokens = current_input_ids.tolist()
+            llm_pos_ids_list = []
+            st = 0
+            remain_images, remain_videos, remain_audios = (
+                image_nums,
+                video_nums,
+                audio_nums,
+            )
+            for _ in range(image_nums + video_nums + audio_nums):
+                ed_image = _find_from(input_tokens, image_token_id, st, remain_images)
+                ed_video = _find_from(input_tokens, video_token_id, st, remain_videos)
+                ed_audio = _find_from(input_tokens, audio_token_id, st, remain_audios)
+
+                min_ed = min(ed_image, ed_video, ed_audio)
+                if min_ed > len(input_tokens):
+                    raise ValueError(
+                        "Qwen2.5-Omni mrope could not locate the next "
+                        "multimodal placeholder token."
+                    )
+                text_len = min_ed - st - 1
+                if text_len != 0:
+                    st_idx = (
+                        llm_pos_ids_list[-1].max() + 1
+                        if len(llm_pos_ids_list) > 0
+                        else 0
+                    )
+                    llm_pos_ids_list.append(
+                        torch.arange(text_len, device=input_ids.device)
+                        .view(1, -1)
+                        .expand(3, -1)
+                        + st_idx
+                    )
+
+                st_idx = (
+                    llm_pos_ids_list[-1].max() + 1
+                    if len(llm_pos_ids_list) > 0
+                    else 0
+                )
+                bos_len = 1
+                llm_pos_ids_list.append(
+                    torch.arange(bos_len, device=input_ids.device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + st_idx
+                )
+                st_idx = llm_pos_ids_list[-1].max() + 1
+
+                if min_ed == ed_audio:
+                    audio_len = _get_qwen2_5_omni_audio_output_lengths(
+                        audio_seqlens[audio_idx]
+                    )
+                    llm_pos_ids_list.append(
+                        torch.arange(audio_len, device=input_ids.device)
+                        .view(1, -1)
+                        .expand(3, -1)
+                        + st_idx
+                    )
+                    data_len = audio_len
+                    audio_idx += 1
+                    remain_audios -= 1
+                elif min_ed == ed_image:
+                    grid_t = image_grid_thw[image_idx][0]
+                    grid_hs = image_grid_thw[:, 1]
+                    grid_ws = image_grid_thw[:, 2]
+                    t_index = (
+                        torch.arange(grid_t, device=input_ids.device)
+                        * position_id_per_seconds
+                    ).long()
+                    llm_pos_ids = _get_llm_pos_ids_for_vision(
+                        st_idx,
+                        image_idx,
+                        spatial_merge_size,
+                        t_index,
+                        grid_hs,
+                        grid_ws,
+                        input_ids.device,
+                    )
+                    llm_pos_ids_list.append(llm_pos_ids)
+                    data_len = image_grid_thw[image_idx].prod() // (
+                        spatial_merge_size**2
+                    )
+                    image_idx += 1
+                    remain_images -= 1
+                else:
+                    grid_t = video_grid_thw[video_idx][0]
+                    grid_hs = video_grid_thw[:, 1]
+                    grid_ws = video_grid_thw[:, 2]
+                    t_index = (
+                        torch.arange(grid_t, device=input_ids.device)
+                        * second_per_grid_ts[video_idx].cpu().float()
+                        * position_id_per_seconds
+                    ).long()
+                    llm_pos_ids = _get_llm_pos_ids_for_vision(
+                        st_idx,
+                        video_idx,
+                        spatial_merge_size,
+                        t_index,
+                        grid_hs,
+                        grid_ws,
+                        input_ids.device,
+                    )
+                    llm_pos_ids_list.append(llm_pos_ids)
+                    data_len = video_grid_thw[video_idx].prod() // (
+                        spatial_merge_size**2
+                    )
+                    video_idx += 1
+                    remain_videos -= 1
+
+                st_idx = llm_pos_ids_list[-1].max() + 1
+                eos_len = 1
+                llm_pos_ids_list.append(
+                    torch.arange(eos_len, device=input_ids.device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + st_idx
+                )
+                st += int(text_len + bos_len + data_len + eos_len)
+
+            if st < len(input_tokens):
+                st_idx = (
+                    llm_pos_ids_list[-1].max() + 1
+                    if len(llm_pos_ids_list) > 0
+                    else 0
+                )
+                text_len = len(input_tokens) - st
+                llm_pos_ids_list.append(
+                    torch.arange(text_len, device=input_ids.device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + st_idx
+                )
+
+            llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+            if llm_positions.shape[1] != len(current_input_ids):
+                raise ValueError(
+                    "Qwen2.5-Omni mrope position length mismatch: "
+                    f"positions={llm_positions.shape[1]}, "
+                    f"input_ids={len(current_input_ids)}."
+                )
+            position_ids[..., i, :] = llm_positions.to(position_ids.device)
+            mrope_position_deltas.append(
+                llm_positions.max() + 1 - len(current_input_ids)
+            )
+
+        mrope_position_deltas = torch.tensor(
+            mrope_position_deltas, device=input_ids.device
+        ).unsqueeze(1)
+        return position_ids, mrope_position_deltas
+
+    s = input_ids.shape[1]
+    position_ids = torch.arange(s, device=input_ids.device)
+    position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+    mrope_position_deltas = torch.zeros(
+        [input_ids.shape[0], 1], device=input_ids.device, dtype=input_ids.dtype
+    )
+    return position_ids, mrope_position_deltas
 
 
 def get_rope_index_qwen3_omni(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -323,7 +323,11 @@ _UNSET: Any = object()
 
 def resolve_language_model(model: nn.Module) -> nn.Module:
     model_cls_name = model.__class__.__name__
-    if model_cls_name == "Qwen3OmniMoeForConditionalGeneration":
+    if model_cls_name in (
+        "Qwen2_5OmniForConditionalGeneration",
+        "Qwen2_5OmniModel",
+        "Qwen3OmniMoeForConditionalGeneration",
+    ):
         return model.thinker.model
     if hasattr(model, "model"):
         return model.model

--- a/python/sglang/srt/models/qwen2_5_omni.py
+++ b/python/sglang/srt/models/qwen2_5_omni.py
@@ -1,0 +1,346 @@
+# coding=utf-8
+"""Inference-only Qwen2.5-Omni thinker model for text generation.
+
+This implementation serves text generation only.  It loads the Qwen2.5-Omni
+``thinker`` submodule and intentionally skips the speech ``talker`` and
+``token2wav`` modules.
+"""
+
+import logging
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import (
+    Qwen2_5OmniConfig,
+    Qwen2_5OmniThinkerConfig,
+)
+from transformers.models.qwen2_5_omni.modeling_qwen2_5_omni import (
+    Qwen2_5OmniAudioEncoder,
+)
+
+from sglang.srt.distributed.parallel_state import get_pp_group
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.pooler import Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen2 import Qwen2Model
+from sglang.srt.models.qwen2_5_vl import Qwen2_5_VisionTransformer
+from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
+from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen2_5OmniThinkerForConditionalGeneration(nn.Module):
+    default_bitsandbytes_target_modules = [
+        ".gate_up_proj.",
+        ".down_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+    packed_modules_mapping = {
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(
+        self,
+        config: Qwen2_5OmniThinkerConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+        self.config = config
+        self.text_config = config.text_config
+        self.use_data_parallel = get_global_server_args().mm_enable_dp_encoder
+
+        self.model = Qwen2Model(
+            self.text_config,
+            quant_config,
+            prefix=add_prefix("model", prefix),
+        )
+
+        if self.pp_group.is_last_rank:
+            if self.pp_group.world_size == 1 and self.text_config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    self.text_config.vocab_size,
+                    self.text_config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=add_prefix("lm_head", prefix),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.audio_tower = Qwen2_5OmniAudioEncoder(config.audio_config)
+        self.visual = Qwen2_5_VisionTransformer(
+            config.vision_config,
+            norm_eps=getattr(self.text_config, "rms_norm_eps", 1e-6),
+            quant_config=quant_config,
+            prefix=add_prefix("visual", prefix),
+            use_data_parallel=self.use_data_parallel,
+            max_context_len=self.text_config.max_position_embeddings,
+        )
+
+        rope_scaling = getattr(self.text_config, "rope_scaling", None) or {}
+        self.is_mrope_enabled = "mrope_section" in rope_scaling
+        self.logits_processor = LogitsProcessor(self.text_config)
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+        self.capture_aux_hidden_states = False
+        self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
+            self.visual.dtype
+        )
+        image_grid_thw = torch.concat([item.image_grid_thw for item in items], dim=0)
+
+        if self.use_data_parallel:
+            return run_dp_sharded_mrope_vision_model(
+                self.visual, pixel_values, image_grid_thw.tolist(), rope_type="rope_3d"
+            )
+        return self.visual(pixel_values, grid_thw=image_grid_thw)
+
+    def get_video_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
+            self.visual.dtype
+        )
+        video_grid_thw = torch.concat([item.video_grid_thw for item in items], dim=0)
+
+        if self.use_data_parallel:
+            return run_dp_sharded_mrope_vision_model(
+                self.visual, pixel_values, video_grid_thw.tolist(), rope_type="rope_3d"
+            )
+        return self.visual(pixel_values, grid_thw=video_grid_thw)
+
+    def get_audio_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        feature_attention_mask = torch.cat(
+            [item.feature_attention_mask for item in items], dim=0
+        ).type(torch.long)
+        audio_device = next(self.audio_tower.parameters()).device
+        feature_attention_mask = feature_attention_mask.to(audio_device)
+
+        input_features = torch.cat([item.feature for item in items], dim=0).type(
+            self.audio_tower.dtype
+        )
+        input_features = input_features.to(audio_device)
+
+        audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
+        input_features = input_features.permute(0, 2, 1)[
+            feature_attention_mask.bool()
+        ].permute(1, 0)
+
+        audio_feat_lengths, audio_output_lengths = (
+            self.audio_tower._get_feat_extract_output_lengths(audio_feature_lengths)
+        )
+        audio_outputs = self.audio_tower(
+            input_features,
+            feature_lens=audio_feature_lengths,
+            aftercnn_lens=audio_feat_lengths,
+            return_dict=True,
+        )
+        audio_features = audio_outputs.last_hidden_state
+        if audio_features.shape[0] != int(audio_output_lengths.sum().item()):
+            raise ValueError(
+                "Length of Qwen2.5-Omni audio features does not match "
+                "audio output lengths."
+            )
+        return audio_features
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds=None,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ):
+        if self.is_mrope_enabled:
+            positions = forward_batch.mrope_positions
+
+        hidden_states = general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.model,
+            multimodal_model=self,
+            positions=positions,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+
+        if self.pp_group.is_last_rank:
+            if not get_embedding:
+                return self.logits_processor(
+                    input_ids,
+                    hidden_states,
+                    self.lm_head,
+                    forward_batch,
+                    aux_hidden_states,
+                )
+            return self.pooler(hidden_states, forward_batch)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".attn.qkv_proj", ".attn.q", "q"),
+            (".attn.qkv_proj", ".attn.k", "k"),
+            (".attn.qkv_proj", ".attn.v", "v"),
+            ("gate_up_proj", "up_proj", 1),
+            ("gate_up_proj", "gate_proj", 0),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if name.startswith("thinker."):
+                name = name[len("thinker.") :]
+            if name.startswith(("talker.", "token2wav.")):
+                continue
+
+            if (
+                self.text_config.tie_word_embeddings
+                and self.pp_group.is_last_rank
+                and name == "model.embed_tokens.weight"
+                and "lm_head.weight" in params_dict
+            ):
+                lm_head_param = params_dict["lm_head.weight"]
+                weight_loader = getattr(
+                    lm_head_param, "weight_loader", default_weight_loader
+                )
+                weight_loader(lm_head_param, loaded_weight)
+
+            loaded = False
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if "audio_tower" in name:
+                    continue
+                if (
+                    "visual" in name
+                    and weight_name in (".q_proj", ".k_proj", ".v_proj")
+                ):
+                    continue
+                if "visual" not in name and weight_name in (
+                    ".attn.q",
+                    ".attn.k",
+                    ".attn.v",
+                ):
+                    continue
+
+                mapped_name = name.replace(weight_name, param_name)
+                layer_id = get_layer_id(mapped_name)
+                if (
+                    layer_id is not None
+                    and hasattr(self.model, "start_layer")
+                    and (
+                        layer_id < self.model.start_layer
+                        or layer_id >= self.model.end_layer
+                    )
+                ):
+                    loaded = True
+                    break
+
+                if mapped_name.endswith(".bias") and mapped_name not in params_dict:
+                    loaded = True
+                    break
+                if mapped_name not in params_dict:
+                    continue
+
+                param = params_dict[mapped_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight, shard_id)
+                loaded = True
+                break
+
+            if loaded:
+                continue
+
+            if "visual" in name:
+                name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            if name not in params_dict:
+                logger.warning("Loaded weight %s not found in Qwen2.5-Omni", name)
+                continue
+
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+
+    def get_embed_and_head(self):
+        return self.model.embed_tokens.weight, self.lm_head.weight
+
+    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
+        self.capture_aux_hidden_states = True
+        self.model.capture_aux_hidden_states = True
+        if layer_ids is None:
+            num_layers = self.text_config.num_hidden_layers
+            self.model.layers_to_capture = [2, num_layers // 2, num_layers - 3]
+        else:
+            self.model.layers_to_capture = [val + 1 for val in layer_ids]
+
+
+class Qwen2_5OmniForConditionalGeneration(nn.Module):
+    def __init__(
+        self,
+        config: Qwen2_5OmniConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.thinker = Qwen2_5OmniThinkerForConditionalGeneration(
+            config.thinker_config, quant_config=quant_config, prefix=prefix
+        )
+        self.enable_talker = False
+        self.pad_input_ids = self.thinker.pad_input_ids
+        self.forward = self.thinker.forward
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        return self.thinker.load_weights(weights)
+
+    def get_embed_and_head(self):
+        return self.thinker.get_embed_and_head()
+
+
+class Qwen2_5OmniModel(Qwen2_5OmniForConditionalGeneration):
+    """Alias for checkpoints whose config.architectures is Qwen2_5OmniModel."""
+
+
+EntryClass = [Qwen2_5OmniForConditionalGeneration, Qwen2_5OmniModel]

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -419,6 +419,7 @@ class BaseMultimodalProcessor(ABC):
                 "Gemma4UnifiedProcessor",
                 "GlmAsrProcessor",
                 "Qwen2AudioProcessor",
+                "Qwen2_5OmniProcessor",
                 "Qwen3ASRProcessor",
                 "Qwen3OmniMoeProcessor",
             }:

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -18,6 +18,10 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalProcessorOutput,
 )
 from sglang.srt.models.interns2preview import InternS2PreviewForConditionalGeneration
+from sglang.srt.models.qwen2_5_omni import (
+    Qwen2_5OmniForConditionalGeneration,
+    Qwen2_5OmniModel,
+)
 from sglang.srt.models.qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
 from sglang.srt.models.qwen2_vl import Qwen2VLForConditionalGeneration
 from sglang.srt.models.qwen3_5 import (
@@ -262,6 +266,8 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
     models = [
         Qwen2VLForConditionalGeneration,
         Qwen2_5_VLForConditionalGeneration,
+        Qwen2_5OmniForConditionalGeneration,
+        Qwen2_5OmniModel,
         Qwen3VLForConditionalGeneration,
         Qwen3VLMoeForConditionalGeneration,
         Qwen3_5ForConditionalGeneration,
@@ -273,8 +279,19 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         self.model_type = hf_config.model_type
-        if hf_config.model_type == "qwen3_omni_moe":
+        if hf_config.model_type in ("qwen2_5_omni", "qwen3_omni_moe"):
             hf_config = hf_config.thinker_config
+
+        if self.model_type == "qwen2_5_omni":
+            hf_config.image_token_id = getattr(
+                hf_config, "image_token_id", hf_config.image_token_index
+            )
+            hf_config.video_token_id = getattr(
+                hf_config, "video_token_id", hf_config.video_token_index
+            )
+            hf_config.audio_token_id = getattr(
+                hf_config, "audio_token_id", hf_config.audio_token_index
+            )
 
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)
 
@@ -289,16 +306,42 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         self.audio_start_token_id = getattr(hf_config, "audio_start_token_id", None)
         self.audio_token_id = getattr(hf_config, "audio_token_id", None)
 
-        self.mm_tokens = MultimodalSpecialTokens(
-            image_token="<|vision_start|><|image_pad|><|vision_end|>",
-            image_token_id=hf_config.image_token_id,
-            # The regex that matches expanded image tokens.
-            image_token_regex=re.compile(
-                r"<\|vision_start\|>(?:<\|image_pad\|>)+<\|vision_end\|>"
-            ),
-            video_token_id=self.VIDEO_TOKEN_ID,
-            audio_token_id=self.audio_token_id,
-        ).build(_processor)
+        if self.model_type == "qwen2_5_omni":
+            vision_bos = getattr(_processor, "vision_bos_token", "<|vision_bos|>")
+            vision_eos = getattr(_processor, "vision_eos_token", "<|vision_eos|>")
+            audio_bos = getattr(_processor, "audio_bos_token", "<|audio_bos|>")
+            audio_eos = getattr(_processor, "audio_eos_token", "<|audio_eos|>")
+            image_token = getattr(_processor, "image_token", "<|IMAGE|>")
+            video_token = getattr(_processor, "video_token", "<|VIDEO|>")
+            audio_token = getattr(_processor, "audio_token", "<|AUDIO|>")
+            self.mm_tokens = MultimodalSpecialTokens(
+                image_token=f"{vision_bos}{image_token}{vision_eos}",
+                image_token_id=hf_config.image_token_id,
+                image_token_regex=re.compile(
+                    rf"{re.escape(vision_bos)}(?:{re.escape(image_token)})+{re.escape(vision_eos)}"
+                ),
+                video_token=f"{vision_bos}{video_token}{vision_eos}",
+                video_token_id=self.VIDEO_TOKEN_ID,
+                video_token_regex=re.compile(
+                    rf"{re.escape(vision_bos)}(?:{re.escape(video_token)})+{re.escape(vision_eos)}"
+                ),
+                audio_token=f"{audio_bos}{audio_token}{audio_eos}",
+                audio_token_id=self.audio_token_id,
+                audio_token_regex=re.compile(
+                    rf"{re.escape(audio_bos)}(?:{re.escape(audio_token)})+{re.escape(audio_eos)}"
+                ),
+            ).build(_processor)
+        else:
+            self.mm_tokens = MultimodalSpecialTokens(
+                image_token="<|vision_start|><|image_pad|><|vision_end|>",
+                image_token_id=hf_config.image_token_id,
+                # The regex that matches expanded image tokens.
+                image_token_regex=re.compile(
+                    r"<\|vision_start\|>(?:<\|image_pad\|>)+<\|vision_end\|>"
+                ),
+                video_token_id=self.VIDEO_TOKEN_ID,
+                audio_token_id=self.audio_token_id,
+            ).build(_processor)
 
     def build_input_ids_with_timestamps(
         self, prompt, embeddings, img_grid_thw, video_grid_thw, video_timestamps
@@ -626,7 +669,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             second_per_grid_ts=second_per_grid_ts,
             use_audio_in_video=False,
             audio_seqlens=(
-                audio_feature_lens if self.model_type == "qwen3_omni_moe" else None
+                audio_feature_lens
+                if self.model_type in ("qwen2_5_omni", "qwen3_omni_moe")
+                else None
             ),
             audio_token_id=getattr(self.hf_config, "audio_token_id", None),
             audio_start_token_id=self.audio_start_token_id,
@@ -719,11 +764,15 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         audio_feature_lengths = None
 
-        if self.model_type == "qwen3_omni_moe":
-            audio_item = next((mm for mm in mm_items if mm.is_audio()), None)
-            if audio_item:
-                audio_feature_lengths = torch.sum(
-                    audio_item.feature_attention_mask, dim=1
+        if self.model_type in ("qwen2_5_omni", "qwen3_omni_moe"):
+            audio_items = [mm for mm in mm_items if mm.is_audio()]
+            if audio_items:
+                audio_feature_lengths = torch.cat(
+                    [
+                        torch.sum(audio_item.feature_attention_mask, dim=1)
+                        for audio_item in audio_items
+                    ],
+                    dim=0,
                 )
 
         second_per_grid_ts = self._get_processor_output_value(ret, "second_per_grid_ts")

--- a/test/registered/unit/layers/test_mrope_qwen25_omni.py
+++ b/test/registered/unit/layers/test_mrope_qwen25_omni.py
@@ -1,0 +1,122 @@
+import pytest
+import torch
+
+from sglang.srt.layers.rotary_embedding.mrope_rope_index import get_rope_index
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+VISION_START = 10
+VISION_END = 11
+IMAGE = 12
+VIDEO = 20
+AUDIO_START = 30
+AUDIO_END = 31
+AUDIO = 32
+
+
+def _get_rope_index(input_ids, **kwargs):
+    return get_rope_index(
+        spatial_merge_size=2,
+        image_token_id=IMAGE,
+        video_token_id=VIDEO,
+        vision_start_token_id=VISION_START,
+        model_type="qwen2_5_omni",
+        input_ids=torch.tensor([input_ids], dtype=torch.long),
+        position_id_per_seconds=25,
+        audio_token_id=AUDIO,
+        audio_start_token_id=AUDIO_START,
+        use_audio_in_video=False,
+        **kwargs,
+    )
+
+
+def test_qwen25_omni_mrope_supports_interleaved_video_and_two_audios():
+    positions, deltas = _get_rope_index(
+        [
+            100,
+            VISION_START,
+            VIDEO,
+            VIDEO,
+            VIDEO,
+            VIDEO,
+            VISION_END,
+            101,
+            AUDIO_START,
+            AUDIO,
+            AUDIO,
+            AUDIO_END,
+            102,
+            AUDIO_START,
+            AUDIO,
+            AUDIO,
+            AUDIO,
+            AUDIO_END,
+            103,
+        ],
+        video_grid_thw=torch.tensor([[1, 4, 4]], dtype=torch.long),
+        second_per_grid_ts=torch.tensor([0.5]),
+        audio_seqlens=torch.tensor([7, 11], dtype=torch.long),
+    )
+
+    assert positions.shape == (3, 1, 19)
+    assert deltas.shape == (1, 1)
+
+
+def test_qwen25_omni_mrope_supports_audio_only():
+    positions, deltas = _get_rope_index(
+        [
+            100,
+            AUDIO_START,
+            AUDIO,
+            AUDIO,
+            AUDIO_END,
+            101,
+            AUDIO_START,
+            AUDIO,
+            AUDIO,
+            AUDIO,
+            AUDIO_END,
+            102,
+        ],
+        audio_seqlens=torch.tensor([7, 11], dtype=torch.long),
+    )
+
+    assert positions.shape == (3, 1, 12)
+    assert deltas.shape == (1, 1)
+
+
+def test_qwen25_omni_mrope_reports_audio_count_mismatch():
+    with pytest.raises(ValueError, match="audio count mismatch"):
+        _get_rope_index(
+            [
+                AUDIO_START,
+                AUDIO,
+                AUDIO,
+                AUDIO_END,
+                1,
+                AUDIO_START,
+                AUDIO,
+                AUDIO,
+                AUDIO_END,
+            ],
+            audio_seqlens=torch.tensor([7], dtype=torch.long),
+        )
+
+
+def test_qwen25_omni_mrope_rejects_audio_in_video_mode():
+    with pytest.raises(NotImplementedError, match="separate video/audio"):
+        get_rope_index(
+            spatial_merge_size=2,
+            image_token_id=IMAGE,
+            video_token_id=VIDEO,
+            vision_start_token_id=VISION_START,
+            model_type="qwen2_5_omni",
+            input_ids=torch.tensor([[AUDIO_START, AUDIO, AUDIO_END]], dtype=torch.long),
+            audio_seqlens=torch.tensor([3], dtype=torch.long),
+            audio_token_id=AUDIO,
+            audio_start_token_id=AUDIO_START,
+            use_audio_in_video=True,
+            position_id_per_seconds=25,
+        )


### PR DESCRIPTION
## Motivation

Add thinker-only inference support for Qwen2.5-Omni in SGLang and support Qwen2.5-Omni interleaved multimodal inputs, including multiple audio/video observations in one request. This is useful for agentic omni workflows where the model receives an initial context and then appends additional audio/video segments as observations.

## Modifications

- Add `Qwen2_5OmniForConditionalGeneration` / `Qwen2_5OmniModel` as inference-only thinker models.
- Register Qwen2.5-Omni as a multimodal architecture and resolve its underlying language model via `thinker.model`.
- Extend the Qwen VL multimodal processor path for Qwen2.5-Omni special tokens and audio feature lengths.
- Add Qwen2.5-Omni mrope indexing for separate image/video/audio inputs, including audio-only and interleaved video + multiple audio segments.
- Add a CPU unit test for Qwen2.5-Omni mrope behavior and CI registry metadata.

## Accuracy Tests

- `python scripts/ci/check_registered_tests.py`: passed
- `git diff --check HEAD`: passed
- `python -m py_compile python/sglang/srt/models/qwen2_5_omni.py python/sglang/srt/multimodal/processors/qwen_vl.py python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py test/registered/unit/layers/test_mrope_qwen25_omni.py`: passed
- `python -m ruff check python/sglang/srt/models/qwen2_5_omni.py python/sglang/srt/multimodal/processors/qwen_vl.py python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py test/registered/unit/layers/test_mrope_qwen25_omni.py`: passed
- `PYTHONPATH=python CUDA_VISIBLE_DEVICES= /mnt/tidalfs-bdsz01/usr/tusen/shaoshuai/envs/sglang-pr-py310/bin/python -m pytest test/registered/unit/layers/test_mrope_qwen25_omni.py -q`: 4 passed

GPU/server smoke was not run locally because this machine has NVIDIA driver 12060, which is too old for `torch==2.11.0+cu130`. Full CUDA validation should be covered by SGLang CI.

## Speed Tests and Profiling

Not run locally. The core runtime impact is limited to Qwen2.5-Omni model/processor dispatch and mrope preprocessing. No common text-only model path is expected to change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27573289236](https://github.com/sgl-project/sglang/actions/runs/27573289236)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27573289108](https://github.com/sgl-project/sglang/actions/runs/27573289108)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->