### PR TITLE
[AMD][bugfix] Place TBO cuda-graph num_token_non_padded buffer on model devices

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -316,7 +316,9 @@ def compute_split_indices_for_cuda_graph_replay(
 
 class TboCudaGraphRunnerPlugin:
     def __init__(self):
-        self._tbo_children_num_token_non_padded = torch.zeros((2,), dtype=torch.int32)
+        self._tbo_children_num_token_non_padded = torch.zeros(
+            (2,), dtype=torch.int32, device=get_global_server_args().device
+        )
 
     def capture_one_batch_size(self, batch: ForwardBatch, num_tokens: int):
         if not is_tbo_enabled():

--- a/test/registered/unit/batch_overlap/test_tbo_cuda_graph_num_token_device.py
+++ b/test/registered/unit/batch_overlap/test_tbo_cuda_graph_num_token_device.py
@@ -52,8 +52,10 @@ class TestTboCudaGraphNumTokenDevice(CustomTestCase):
         # land on the same (model) device, matching ForwardBatch's contract.
         fake_args = SimpleNamespace(device="meta")
         with patch.object(tbo, "get_global_server_args", lambda: fake_args):
-            eager = TboForwardBatchPreparer.compute_tbo_children_num_token_non_padded_raw(
-                tbo_split_token_index=3, num_token_non_padded=8
+            eager = (
+                TboForwardBatchPreparer.compute_tbo_children_num_token_non_padded_raw(
+                    tbo_split_token_index=3, num_token_non_padded=8
+                )
             )
             plugin = TboCudaGraphRunnerPlugin()
 
@@ -67,8 +69,10 @@ class TestTboCudaGraphNumTokenDevice(CustomTestCase):
         # so the values are materializable.
         fake_args = SimpleNamespace(device="cpu")
         with patch.object(tbo, "get_global_server_args", lambda: fake_args):
-            eager = TboForwardBatchPreparer.compute_tbo_children_num_token_non_padded_raw(
-                tbo_split_token_index=3, num_token_non_padded=8
+            eager = (
+                TboForwardBatchPreparer.compute_tbo_children_num_token_non_padded_raw(
+                    tbo_split_token_index=3, num_token_non_padded=8
+                )
             )
         self.assertEqual(eager.dtype, torch.int32)
         self.assertEqual(eager.tolist(), [3, 5])

--- a/test/registered/unit/batch_overlap/test_tbo_cuda_graph_num_token_device.py
+++ b/test/registered/unit/batch_overlap/test_tbo_cuda_graph_num_token_device.py
@@ -1,0 +1,78 @@
+"""Regression: the TBO cuda-graph plugin must allocate its children
+``num_token_non_padded`` buffer on the model device, not CPU.
+
+``ForwardBatch.num_token_non_padded`` is a scalar tensor on the model device
+(see ``ForwardBatch.compute``, which does ``.to(device, ...)``). The eager TBO
+split path already honors this -- ``compute_tbo_children_num_token_non_padded_raw``
+moves the tensor to ``get_global_server_args().device`` -- but
+``TboCudaGraphRunnerPlugin`` preallocated its persistent buffer with a bare
+``torch.zeros((2,), dtype=torch.int32)``, leaving it on CPU.
+
+During TBO cuda-graph replay that CPU buffer becomes the child's
+``num_token_non_padded`` and is compared against a device ``arange`` in the
+padded-region mask (``_mask_topk_ids_padded_region`` /
+``_zero_topk_weights_padded_region``), raising a device-mismatch error
+(an illegal memory access on HIP/aiter MoE).
+
+CPU-only: a ``meta`` device makes the buffer placement observable without a GPU.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.batch_overlap.two_batch_overlap as tbo
+from sglang.srt.batch_overlap.two_batch_overlap import (
+    TboCudaGraphRunnerPlugin,
+    TboForwardBatchPreparer,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestTboCudaGraphNumTokenDevice(CustomTestCase):
+    def test_plugin_buffer_on_model_device(self):
+        # Use 'meta' so the configured device differs from the implicit CPU
+        # default; a bare torch.zeros() would leave the buffer on CPU and fail.
+        fake_args = SimpleNamespace(device="meta")
+        with patch.object(tbo, "get_global_server_args", lambda: fake_args):
+            plugin = TboCudaGraphRunnerPlugin()
+
+        buf = plugin._tbo_children_num_token_non_padded
+        self.assertEqual(tuple(buf.shape), (2,))
+        self.assertEqual(buf.dtype, torch.int32)
+        self.assertEqual(buf.device.type, "meta")
+
+    def test_graph_and_eager_paths_agree_on_device(self):
+        # Both the preallocated cuda-graph buffer and the eager split tensor must
+        # land on the same (model) device, matching ForwardBatch's contract.
+        fake_args = SimpleNamespace(device="meta")
+        with patch.object(tbo, "get_global_server_args", lambda: fake_args):
+            eager = TboForwardBatchPreparer.compute_tbo_children_num_token_non_padded_raw(
+                tbo_split_token_index=3, num_token_non_padded=8
+            )
+            plugin = TboCudaGraphRunnerPlugin()
+
+        self.assertEqual(
+            eager.device.type,
+            plugin._tbo_children_num_token_non_padded.device.type,
+        )
+
+    def test_eager_split_values(self):
+        # value_a = min(split, n); value_b = max(0, n - split). Computed on CPU
+        # so the values are materializable.
+        fake_args = SimpleNamespace(device="cpu")
+        with patch.object(tbo, "get_global_server_args", lambda: fake_args):
+            eager = TboForwardBatchPreparer.compute_tbo_children_num_token_non_padded_raw(
+                tbo_split_token_index=3, num_token_non_padded=8
+            )
+        self.assertEqual(eager.dtype, torch.int32)
+        self.assertEqual(eager.tolist(), [3, 5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation
`TboCudaGraphRunnerPlugin` preallocates a persistent `_tbo_children_num_token_non_padded` buffer with a bare `torch.zeros((2,), dtype=torch.int32)`, which leaves it on **CPU**.
`ForwardBatch.num_token_non_padded` is contractually a tensor on the **model device** (`ForwardBatch.compute` does `.to(device, ...)`), and the eager TBO split path already honors this — `compute_tbo_children_num_token_non_padded_raw` moves its result to `get_global_server_args().device`. Only the cuda-graph plugin's preallocated buffer was left on CPU.
During TBO cuda-graph replay, that CPU buffer becomes the child's `num_token_non_padded` and is compared against 

## Modifications

- `python/sglang/srt/batch_overlap/two_batch_overlap.py`: allocate `_tbo_children_num_token_non_padded` on `get_global_server_args().device` so the cuda-graph buffer matches the eager split path and the `ForwardBatch` device contract. (`get_global_server_args` is already imported and used in this module.)
- `test/registered/unit/batch_overlap/test_tbo_cuda_graph_num_token_device.py`: new CPU-only regression test (registered via `register_cpu_ci`, `suite="base-a-test-cpu"`). It uses a `meta` device to make buffer placement observable without a GPU and asserts that (a) the plugin buffer lands on the model device, (b) the cuda-graph and eager paths agree on device, and (c) the eager split values are correct (`[min(split, n), max(0, n-split)]`).

## Accuracy Tests

export PYTHONPATH=/sgl-pr/python:${PYTHONPATH:-}
for r in 1 2 3; do
  python3 -m sglang.test.few_shot_gsm8k \
    --num-questions 1319 --num-shots 5 --parallel 32 \
    --host 127.0.0.1 --port 30000
done

<img width="548" height="133" alt="image" src="https://github.com/user-attachments/assets/8dc49ec2-6b5c-4b83-ba95-dc3f7261638d" />


## Speed Tests and Profiling

export PYTHONPATH=/sgl-pr/python:${PYTHONPATH:-}

# MoRI + aiter env
export SGLANG_AITER_MOE=1 TORCH_NCCL_BLOCKING_WAIT=1 TRITON_ENABLE_PRELOAD_KERNELS=0
export SGLANG_ROCM_FUSED_DECODE_MLA=1 SGLANG_AITER_AR=1
export ROCM_QUICK_REDUCE_QUANTIZATION=INT4 ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB=512
export SGLANG_AITER_MLA_PERSIST=1 SGLANG_USE_AITER=1 TORCH_BLAS_PREFER_HIPBLASLT=1
export PYTORCH_ALLOC_CONF=expandable_segments:True
export MORI_SHMEM_MODE=ISOLATION MORI_SHMEM_HEAP_SIZE=16G
export SGLANG_MORI_DISPATCH_DTYPE=fp4 SGLANG_MORI_COMBINE_DTYPE=fp8
export SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK=2048

python3 -m sglang.launch_server \
  --model-path /models/DeepSeek-R1-0528-MXFP4 \
  --trust-remote-code \
  --tp-size 8 --ep-size 8 \
  --moe-a2a-backend mori --deepep-mode normal --moe-dense-tp-size 1 \
  --enable-dp-attention --dp-size 8 --enable-dp-lm-head \
  --enable-two-batch-overlap \
  --mem-fraction-static 0.55 \
  --max-running-requests 256 \
  --kv-cache-dtype fp8_e4m3 \
  --triton-attention-num-kv-splits 2 \
  --disable-radix-cache --disable-chunked-prefix-cache \
  --cuda-graph-bs 1 2 4 8 16 32 64 128 256 512 \
  --cuda-graph-max-bs 512 \
  --watchdog-timeout 1200 \
  --host 0.0.0.0 --port 30000

<img width="548" height="161" alt="image" src="https://github.com/user-attachments/assets/9a9870b7-6368-478c-afd2-42b830db9bf1" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27770502181](https://github.com/sgl-project/sglang/actions/runs/27770502181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27770501591](https://github.com/sgl-project/sglang/actions/runs/27770501591)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->