### PR TITLE
[Kimi K2.5] Fix eagle3 aux capture for tp>1 when AR fusion is enabled

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -457,6 +457,10 @@ class LayerCommunicator:
         self.is_last_layer = is_last_layer
         self.qkv_latent_func = qkv_latent_func
         self.force_layernorm_before_dp_gather = force_layernorm_before_dp_gather
+        # Per-layer opt-out of MLP all-reduce fusion, set on the layers that
+        # produce EAGLE3 (and DFLASH) aux-capture inputs so the captured residual
+        # stream is the reduced value rather than a per-rank partial sum.
+        self.disable_allreduce_fusion_for_eagle3_aux_capture = False
 
         self._context = CommunicateContext.init_new()
         self._context.force_layernorm_before_dp_gather = (
@@ -738,6 +742,9 @@ class LayerCommunicator:
     def should_fuse_mlp_allreduce_with_next_layer(
         self, forward_batch: ForwardBatch
     ) -> bool:
+        if self.disable_allreduce_fusion_for_eagle3_aux_capture:
+            return False
+
         # When MOE_FULL is active (moe_cp allgather), fusion must be disabled because
         # the fusion path skips postprocess_layer which contains the moe_cp scatter.
         # Without scatter, hidden_states remain at MOE_FULL size while residual is at

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -490,6 +490,18 @@ class LayerCommunicator:
                 context=self._context,
             )
         )
+        # prepare_mlp's post-attention RMSNorm only reads the residual read-only
+        # (writing a freshly allocated residual_out) when it routes through the
+        # all-reduce-fused gather path; every other path mutates the residual in
+        # place. Eagle3 aux capture uses this to decide whether it can keep the
+        # captured residual by reference instead of cloning it. See
+        # _post_attn_residual_is_read_only.
+        self._post_attn_norm_fused_capable = (
+            self.layer_scatter_modes.mlp_mode
+            in (ScatterMode.FULL, ScatterMode.MOE_FULL)
+            and self.layer_scatter_modes.middle_residual_mode
+            == ScatterMode.TP_ATTN_FULL
+        )
 
     def prepare_attn_and_capture_last_layer_outputs(
         self,
@@ -513,11 +525,39 @@ class LayerCommunicator:
                 forward_batch=forward_batch,
                 context=self._context,
             )
-            if gathered_last_layer_output is residual:
-                # Clone to avoid modifying the original residual by Custom RMSNorm inplace operation
+            if (
+                gathered_last_layer_output is residual
+                and not self._post_attn_residual_is_read_only(residual)
+            ):
+                # The post-attention RMSNorm (prepare_mlp) consumes this buffer in
+                # place on the non-fused path and would corrupt the captured value,
+                # so take a private copy. On the all-reduce-fusion path it reads the
+                # residual read-only and emits a fresh residual_out, so we capture by
+                # reference and avoid inserting a device-to-device copy between the
+                # all-reduce and the attention fused_a_gemm (preserving PDL overlap).
                 gathered_last_layer_output = residual.clone()
             captured_last_layer_outputs.append(gathered_last_layer_output)
         return hidden_states, residual
+
+    def _post_attn_residual_is_read_only(self, residual: torch.Tensor) -> bool:
+        """Whether the upcoming post-attention RMSNorm leaves ``residual`` intact.
+
+        Eagle3 aux capture keeps a reference to the post-attention residual, which
+        is normally consumed in place by ``prepare_mlp``'s fused add+RMSNorm. On the
+        flashinfer all-reduce-fusion path the norm instead reads the residual
+        read-only and writes a freshly allocated ``residual_out`` (see
+        ``flashinfer_allreduce_residual_rmsnorm``), so the captured reference stays
+        valid and the clone can be skipped.
+
+        Returns ``True`` only when that fused, out-of-place path is guaranteed.
+        """
+        return (
+            self._post_attn_norm_fused_capable
+            and self._context.attn_tp_size > 1
+            and not get_attn_tp_context().input_scattered
+            and residual.is_contiguous()
+            and apply_flashinfer_allreduce_fusion(residual.shape[0])
+        )
 
     def prepare_attn(
         self,

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -490,18 +490,6 @@ class LayerCommunicator:
                 context=self._context,
             )
         )
-        # prepare_mlp's post-attention RMSNorm only reads the residual read-only
-        # (writing a freshly allocated residual_out) when it routes through the
-        # all-reduce-fused gather path; every other path mutates the residual in
-        # place. Eagle3 aux capture uses this to decide whether it can keep the
-        # captured residual by reference instead of cloning it. See
-        # _post_attn_residual_is_read_only.
-        self._post_attn_norm_fused_capable = (
-            self.layer_scatter_modes.mlp_mode
-            in (ScatterMode.FULL, ScatterMode.MOE_FULL)
-            and self.layer_scatter_modes.middle_residual_mode
-            == ScatterMode.TP_ATTN_FULL
-        )
 
     def prepare_attn_and_capture_last_layer_outputs(
         self,
@@ -529,33 +517,32 @@ class LayerCommunicator:
                 gathered_last_layer_output is residual
                 and not self._post_attn_residual_is_read_only(residual)
             ):
-                # The post-attention RMSNorm (prepare_mlp) consumes this buffer in
-                # place on the non-fused path and would corrupt the captured value,
-                # so take a private copy. On the all-reduce-fusion path it reads the
-                # residual read-only and emits a fresh residual_out, so we capture by
-                # reference and avoid inserting a device-to-device copy between the
-                # all-reduce and the attention fused_a_gemm (preserving PDL overlap).
                 gathered_last_layer_output = residual.clone()
             captured_last_layer_outputs.append(gathered_last_layer_output)
         return hidden_states, residual
 
     def _post_attn_residual_is_read_only(self, residual: torch.Tensor) -> bool:
-        """Whether the upcoming post-attention RMSNorm leaves ``residual`` intact.
+        """True if ``prepare_mlp``'s post-attention RMSNorm leaves ``residual``
+        untouched, so Eagle3 aux capture can keep its reference and skip the clone.
 
-        Eagle3 aux capture keeps a reference to the post-attention residual, which
-        is normally consumed in place by ``prepare_mlp``'s fused add+RMSNorm. On the
-        flashinfer all-reduce-fusion path the norm instead reads the residual
-        read-only and writes a freshly allocated ``residual_out`` (see
-        ``flashinfer_allreduce_residual_rmsnorm``), so the captured reference stays
-        valid and the clone can be skipped.
-
-        Returns ``True`` only when that fused, out-of-place path is guaranteed.
+        Only the flashinfer all-reduce-fusion path writes a fresh ``residual_out``
+        (see ``flashinfer_allreduce_residual_rmsnorm``); the aiter fused kernel and
+        every plain norm fold into ``residual`` in place. That path is reachable
+        only from the ``_gather_*`` communicate-fns, and only when they fall past
+        their input-scattered branch.
         """
+        norm_fn = getattr(
+            self._communicate_with_all_reduce_and_layer_norm_fn,
+            "func",
+            self._communicate_with_all_reduce_and_layer_norm_fn,
+        )
+        uses_gather_norm = norm_fn in (
+            CommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual,
+            CommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual_moe,
+        )
         return (
-            self._post_attn_norm_fused_capable
-            and self._context.attn_tp_size > 1
+            uses_gather_norm
             and not get_attn_tp_context().input_scattered
-            and residual.is_contiguous()
             and apply_flashinfer_allreduce_fusion(residual.shape[0])
         )
 

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -457,10 +457,6 @@ class LayerCommunicator:
         self.is_last_layer = is_last_layer
         self.qkv_latent_func = qkv_latent_func
         self.force_layernorm_before_dp_gather = force_layernorm_before_dp_gather
-        # Per-layer opt-out of MLP all-reduce fusion, set on the layers that
-        # produce EAGLE3 (and DFLASH) aux-capture inputs so the captured residual
-        # stream is the reduced value rather than a per-rank partial sum.
-        self.disable_allreduce_fusion_for_eagle3_aux_capture = False
 
         self._context = CommunicateContext.init_new()
         self._context.force_layernorm_before_dp_gather = (
@@ -502,11 +498,13 @@ class LayerCommunicator:
         forward_batch: ForwardBatch,
         captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
+        quant_format: str = "",
     ):
         hidden_states, residual = self.prepare_attn(
             hidden_states,
             residual,
             forward_batch,
+            quant_format=quant_format,
             post_residual_addition=post_residual_addition,
         )
         if captured_last_layer_outputs is not None:
@@ -742,9 +740,6 @@ class LayerCommunicator:
     def should_fuse_mlp_allreduce_with_next_layer(
         self, forward_batch: ForwardBatch
     ) -> bool:
-        if self.disable_allreduce_fusion_for_eagle3_aux_capture:
-            return False
-
         # When MOE_FULL is active (moe_cp allgather), fusion must be disabled because
         # the fusion path skips postprocess_layer which contains the moe_cp scatter.
         # Without scatter, hidden_states remain at MOE_FULL size while residual is at

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -75,7 +75,6 @@ from sglang.srt.layers.communicator_dsa_cp import DSACPLayerCommunicator
 from sglang.srt.layers.dp_attention import (
     get_attention_cp_rank,
     get_attention_cp_size,
-    get_attention_tp_group,
     get_attention_tp_rank,
     get_attention_tp_size,
 )
@@ -2113,13 +2112,17 @@ class DeepseekV2DecoderLayer(nn.Module):
         gemm_output_zero_allocator: BumpAllocator = None,
         llama_4_scaling: Optional[torch.Tensor] = None,
         prev_topk_indices: Optional[torch.Tensor] = None,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> torch.Tensor:
         hidden_states_orig = hidden_states
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states,
-            residual,
-            forward_batch,
-            getattr(self, "_gfx95_quant_format", ""),
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+                quant_format=getattr(self, "_gfx95_quant_format", ""),
+            )
         )
 
         hidden_states = self.self_attn(
@@ -2386,12 +2389,6 @@ class DeepseekV2Model(nn.Module):
     def get_input_embeddings(self) -> torch.Tensor:
         return self.embed_tokens
 
-    def disable_allreduce_fusion_for_eagle3_aux_capture(self) -> None:
-        for capture_id in self.layers_to_capture:
-            producer_id = capture_id - 1
-            comm = self.layers[producer_id].layer_communicator
-            comm.disable_allreduce_fusion_for_eagle3_aux_capture = True
-
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -2472,14 +2469,6 @@ class DeepseekV2Model(nn.Module):
                 else get_global_expert_distribution_recorder().with_current_layer(i)
             )
             with ctx:
-                if i in self.layers_to_capture:
-                    if self.enable_a2a_moe and i > self.first_k_dense_replace:
-                        aux_hidden_state = get_attention_tp_group().all_gather(
-                            hidden_states + residual, dim=0
-                        )
-                        aux_hidden_states.append(aux_hidden_state)
-                    else:
-                        aux_hidden_states.append(hidden_states + residual)
                 layer = self.layers[i]
                 hidden_states, residual, topk_indices = layer(
                     positions,
@@ -2490,6 +2479,9 @@ class DeepseekV2Model(nn.Module):
                     gemm_output_zero_allocator,
                     llama_4_scaling,
                     prev_topk_indices=topk_indices,
+                    captured_last_layer_outputs=(
+                        aux_hidden_states if i in self.layers_to_capture else None
+                    ),
                 )
 
         if normal_end_layer != self.end_layer:
@@ -2782,7 +2774,6 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                 self.model.layers_to_capture = [val + 1 for val in layer_ids]
             else:
                 self.model.layers_to_capture = list(layer_ids)
-        self.model.disable_allreduce_fusion_for_eagle3_aux_capture()
 
     def set_dflash_layers_to_capture(self, layer_ids: List[int]):
         if not self.pp_group.is_last_rank:
@@ -2795,7 +2786,6 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
 
         self.capture_aux_hidden_states = True
         self.model.layers_to_capture = [val + 1 for val in layer_ids]
-        self.model.disable_allreduce_fusion_for_eagle3_aux_capture()
 
 
 class DeepseekV3ForCausalLM(DeepseekV2ForCausalLM):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2386,6 +2386,12 @@ class DeepseekV2Model(nn.Module):
     def get_input_embeddings(self) -> torch.Tensor:
         return self.embed_tokens
 
+    def disable_allreduce_fusion_for_eagle3_aux_capture(self) -> None:
+        for capture_id in self.layers_to_capture:
+            producer_id = capture_id - 1
+            comm = self.layers[producer_id].layer_communicator
+            comm.disable_allreduce_fusion_for_eagle3_aux_capture = True
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -2776,6 +2782,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                 self.model.layers_to_capture = [val + 1 for val in layer_ids]
             else:
                 self.model.layers_to_capture = list(layer_ids)
+        self.model.disable_allreduce_fusion_for_eagle3_aux_capture()
 
     def set_dflash_layers_to_capture(self, layer_ids: List[int]):
         if not self.pp_group.is_last_rank:
@@ -2788,6 +2795,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
 
         self.capture_aux_hidden_states = True
         self.model.layers_to_capture = [val + 1 for val in layer_ids]
+        self.model.disable_allreduce_fusion_for_eagle3_aux_capture()
 
 
 class DeepseekV3ForCausalLM(DeepseekV2ForCausalLM):


### PR DESCRIPTION
## Motivation

For TP > 1 with all-reduce (AR) fusion enabled, the MLP all-reduce is deferred and fused into the next layer's input RMSNorm. The previous Eagle3 aux capture read `hidden_states + residual` *before* that fused all-reduce ran, so it captured per-rank partial sums instead of the fully reduced activations — silently degrading draft quality.

```mermaid
flowchart TB
    subgraph NF["Path A — AR fusion OFF (explicit all-reduce)"]
        direction TB
        NF1["MoE finalize<br/>(per-rank partial)"]
        NF2["+ shared expert<br/>(per-rank partial)"]
        NF3["all-reduce<br/>(full sum)"]
        NF4["residual stream<br/>(reduced ✓)"]
        NF5["next layer: input RMSNorm"]
        NF1 --> NF2 --> NF3 --> NF4 -->|"--- layer boundary ---"| NF5
    end

    subgraph FU["Path B — AR fusion ON (all-reduce deferred)"]
        direction TB
        FU1["MoE finalize<br/>(per-rank partial)"]
        FU2["+ shared expert<br/>(per-rank partial)"]
        FU3["residual stream<br/>(per-rank partial, AR deferred)"]
        FU4["next layer:<br/>AR &oplus; RMSNorm fusion kernel<br/>→ emits residual_out (post-AR ✓)"]
        FU1 --> FU2 --> FU3 -->|"--- layer boundary ---"| FU4
    end

    capA(["capture — before & after fix<br/>(unchanged, already reduced)"]):::ok
    capBold(["capture BEFORE fix<br/>hidden_states + residual<br/>(pre-AR partial sum)"]):::bad
    capBnew(["capture AFTER fix<br/>residual_out from fusion kernel<br/>(post-AR)"]):::ok

    NF4 -.-> capA
    FU3 -.-> capBold
    FU4 -.-> capBnew

    classDef ok fill:#d4edda,stroke:#28a745,color:#155724;
    classDef bad fill:#f8d7da,stroke:#dc3545,color:#721c24;

```

## Modifications

Route aux capture through `prepare_attn_and_capture_last_layer_outputs` (the same pattern Qwen2/Qwen3 MoE use), which captures the post-all-reduce, pre-norm residual the AR+RMSNorm fusion kernel already produces. AR fusion stays enabled and the redundant capture add is dropped.

- `communicator.py`: thread `quant_format` through `prepare_attn_and_capture_last_layer_outputs` into `prepare_attn` (preserves DeepSeek's gfx95 format; other callers default to `""`).
- `deepseek_v2.py`: `DeepseekV2DecoderLayer.forward` captures via the helper, and `DeepseekV2Model.forward` passes `aux_hidden_states` only on `layers_to_capture`. Removes the naive `hidden_states + residual` capture (and manual a2a `all_gather`).

## Accuracy Tests

Measured acceptance length (mean accepted draft tokens per step) end-to-end across the full benchmark suite from the [draft model card](https://huggingface.co/lightseekorg/kimi-k2.6-eagle3-mla), since this is a correctness fix whose benefit shows up as draft quality.

**Setup:** target `nvidia/Kimi-K2.6-NVFP4` + EAGLE3 draft `lightseekorg/kimi-k2.6-eagle3-mla`, TP=8 on 8×B200, FlashInfer AR fusion enabled (the path this PR fixes), `num_steps=3 / topk=1 / num_draft_tokens=4`. Benchmarked via `sglang.bench_serving` (`--dataset-name speed-bench`, which applies the chat template), greedy (temp=0), natural EOS capped at 1024 tokens, concurrency 8, seed 1, radix cache flushed before each benchmark. Identical prompts across both configs.

| Category | Benchmark | N | SGLang prior to fix | SGLang post fix | Δ |
|---|---|---|---|---|---|
| Dialogue | MTBench | 80 | 2.44 | **2.50** | +0.06 (+2.5%) |
| Chinese | CEval | 212 | 2.46 | **2.48** | +0.02 (+0.8%) |
| Math | GSM8K | 500 | 2.97 | **2.98** | +0.01 (+0.3%) |
| Code | HumanEval | 164 | 2.94 | **3.03** | +0.09 (+3.1%) |
| Math | MATH500 | 500 | 2.97 | **2.99** | +0.02 (+0.7%) |
| Math | AIME | 30 | 2.84 | **2.86** | +0.02 (+0.7%) |
| Code | LiveCodeBench | 121\* | 2.43 | **2.46** | +0.03 (+1.2%) |
| Code | SPEED-Bench (coding) | 80 | 2.88 | **3.00** | +0.12 (+4.2%) |

**K2.5** (target `nvidia/Kimi-K2.5-NVFP4` + EAGLE3 draft `lightseekorg/kimi-k2.5-eagle3-mla`, same setup):

| Category | Benchmark | N | SGLang prior to fix | SGLang post fix | Δ |
|---|---|---|---|---|---|
| Dialogue | MTBench | 80 | 2.50 | **2.52** | +0.02 (+0.8%) |
| Chinese | CEval | 212 | 2.36 | **2.37** | +0.01 (+0.4%) |
| Math | GSM8K | 500 | 3.03 | **3.04** | +0.01 (+0.3%) |
| Code | HumanEval | 164 | 3.01 | **3.03** | +0.02 (+0.7%) |
| Math | MATH500 | 500 | 3.05 | **3.08** | +0.03 (+1.0%) |
| Math | AIME | 30 | 2.78 | **2.85** | +0.07 (+2.5%) |
| Code | LiveCodeBench | 121\* | 2.44 | **2.45** | +0.01 (+0.4%) |
| Code | SPEED-Bench (coding) | 80 | 3.01 | 2.98 | −0.02 (−1.2%) |

## Speed Tests and Profiling

With simulated acc len = 2.31, we observe no additional overhead. SGLang prior to fix mean TPOT 3.43. Post fix TPOT 3.40

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27661451277](https://github.com/sgl-project/sglang/actions/runs/27661451277)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27661451138](https://github.com/sgl-project/sglang/actions/runs/27661451138)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


