### PR TITLE
[AMD]: Enable NIXL PD disaggregation for ROCm(1/n) 

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -1086,6 +1086,23 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
+      - name: Verify NIXL in Container
+        run: |
+          docker exec ci_sglang bash -lc '
+            set -euxo pipefail
+            export LD_LIBRARY_PATH=/opt/ucx/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}
+            python -c "import nixl; print(\"nixl OK:\", nixl.__file__)"
+            test -d /opt/ucx/lib
+            UCX_INFO=$(command -v ucx_info || true)
+            if [ -z "$UCX_INFO" ]; then
+              UCX_INFO=/opt/ucx/bin/ucx_info
+            fi
+            test -x "$UCX_INFO"
+            "$UCX_INFO" -v
+            "$UCX_INFO" -d | grep -iq rocm
+            python -c "from nixl._api import nixl_agent, nixl_agent_config; nixl_agent(\"ci-smoke\", nixl_agent_config(backends=[\"UCX\"])); print(\"nixl UCX backend init OK\")"
+          '
+
       - name: Verify RDMA in Container
         run: |
           docker exec -u root ci_sglang bash -c '

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -1089,7 +1089,7 @@ jobs:
       - name: Verify NIXL in Container
         run: |
           docker exec ci_sglang bash -lc '
-            set -euxo pipefail
+            set -eux
             export LD_LIBRARY_PATH=/opt/ucx/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}
             python -c "import nixl; print(\"nixl OK:\", nixl.__file__)"
             test -d /opt/ucx/lib

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1138,7 +1138,7 @@ jobs:
       - name: Verify NIXL in Container
         run: |
           docker exec ci_sglang bash -lc '
-            set -euxo pipefail
+            set -eux
             export LD_LIBRARY_PATH=/opt/ucx/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}
             python -c "import nixl; print(\"nixl OK:\", nixl.__file__)"
             test -d /opt/ucx/lib

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1135,6 +1135,23 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
+      - name: Verify NIXL in Container
+        run: |
+          docker exec ci_sglang bash -lc '
+            set -euxo pipefail
+            export LD_LIBRARY_PATH=/opt/ucx/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}
+            python -c "import nixl; print(\"nixl OK:\", nixl.__file__)"
+            test -d /opt/ucx/lib
+            UCX_INFO=$(command -v ucx_info || true)
+            if [ -z "$UCX_INFO" ]; then
+              UCX_INFO=/opt/ucx/bin/ucx_info
+            fi
+            test -x "$UCX_INFO"
+            "$UCX_INFO" -v
+            "$UCX_INFO" -d | grep -iq rocm
+            python -c "from nixl._api import nixl_agent, nixl_agent_config; nixl_agent(\"ci-smoke\", nixl_agent_config(backends=[\"UCX\"])); print(\"nixl UCX backend init OK\")"
+          '
+
       - name: Verify RDMA in Container
         run: |
           docker exec -u root ci_sglang bash -c '

--- a/.github/workflows/release-docker-amd-nightly.yml
+++ b/.github/workflows/release-docker-amd-nightly.yml
@@ -87,7 +87,7 @@ jobs:
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg ENABLE_NIXL=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local

--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -96,7 +96,7 @@ jobs:
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg ENABLE_NIXL=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -15,9 +15,10 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
 
 # Usage (to build SGLang ROCm + NIXL docker image, for prefill/decode disaggregation):
-# Builds UCX (--with-rocm) and upstream ai-dynamo/nixl from source; enable with ENABLE_NIXL=1.
+# Builds UCX (--with-rocm) and upstream ai-dynamo/nixl from source by default.
+# Set ENABLE_NIXL=0 to skip NIXL.
 # At runtime use --disaggregation-transfer-backend nixl (env is wired via /etc/bash.bashrc).
-#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_NIXL=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
 
 # Default base images
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
@@ -112,9 +113,9 @@ ARG MORI_REPO="https://github.com/ROCm/mori.git"
 ARG MORI_COMMIT="bf99bdf18fc69887a346913ca01c315c2aa9bd4c"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
-# Built from source for ROCm; needs UCX built --with-rocm (built here from openucx). Disabled
-# by default; enable with --build-arg ENABLE_NIXL=1.
-ARG ENABLE_NIXL=0
+# Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).
+# Enabled by default; disable with --build-arg ENABLE_NIXL=0.
+ARG ENABLE_NIXL=1
 ARG UCX_REPO="https://github.com/openucx/ucx.git"
 ARG UCX_BRANCH="v1.19.x"
 ARG NIXL_REPO="https://github.com/ai-dynamo/nixl.git"
@@ -503,8 +504,8 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   echo "[MORI] Done."'
 
 # -----------------------
-# NIXL (optional) — upstream ai-dynamo/nixl KV transfer backend for PD disaggregation on ROCm.
-# Builds UCX (--with-rocm) + nixl from source; enable with --build-arg ENABLE_NIXL=1.
+# NIXL — upstream ai-dynamo/nixl KV transfer backend for PD disaggregation on ROCm.
+# Builds UCX (--with-rocm) + nixl from source by default; skip with ENABLE_NIXL=0.
 # --no-build-isolation reuses the image's ROCm torch (nixl pins torch==2.11.* as a build dep,
 # which would otherwise pull a multi-GB CUDA torch); --no-deps keeps CUDA runtime deps out.
 # wheel_variant=rocm names the pkg nixl_rocm, so symlink `nixl` since SGLang imports plain nixl.

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -14,6 +14,11 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
 
+# Usage (to build SGLang ROCm + NIXL docker image, for prefill/decode disaggregation):
+# Builds UCX (--with-rocm) and upstream ai-dynamo/nixl from source; enable with ENABLE_NIXL=1.
+# At runtime use --disaggregation-transfer-backend nixl (env is wired via /etc/bash.bashrc).
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_NIXL=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
+
 # Default base images
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
@@ -105,6 +110,15 @@ ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
 ARG MORI_COMMIT="bf99bdf18fc69887a346913ca01c315c2aa9bd4c"
+
+# NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
+# Built from source for ROCm; needs UCX built --with-rocm (built here from openucx). Disabled
+# by default; enable with --build-arg ENABLE_NIXL=1.
+ARG ENABLE_NIXL=0
+ARG UCX_REPO="https://github.com/openucx/ucx.git"
+ARG UCX_BRANCH="v1.19.x"
+ARG NIXL_REPO="https://github.com/ai-dynamo/nixl.git"
+ARG NIXL_COMMIT="c28061f9782e099f975bcc79198b7b5a1a36cc40"
 
 # AMD AINIC apt repo settings
 ARG AINIC_VERSION=1.117.5-a-38
@@ -487,6 +501,40 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   ldconfig; \
   echo "export PYTHONPATH=/sgl-workspace/mori:\${PYTHONPATH}" >> /etc/bash.bashrc; \
   echo "[MORI] Done."'
+
+# -----------------------
+# NIXL (optional) — upstream ai-dynamo/nixl KV transfer backend for PD disaggregation on ROCm.
+# Builds UCX (--with-rocm) + nixl from source; enable with --build-arg ENABLE_NIXL=1.
+# --no-build-isolation reuses the image's ROCm torch (nixl pins torch==2.11.* as a build dep,
+# which would otherwise pull a multi-GB CUDA torch); --no-deps keeps CUDA runtime deps out.
+# wheel_variant=rocm names the pkg nixl_rocm, so symlink `nixl` since SGLang imports plain nixl.
+# taskflow (header-only) is provided via pkg-config so meson skips its broken upstream wrap
+# download (GitHub regenerated the v3.10.0 tarball, breaking the pinned source_hash).
+RUN /bin/bash -lc 'set -euo pipefail; \
+  [ "${ENABLE_NIXL}" = "1" ] || { echo "[NIXL] skip (ENABLE_NIXL=${ENABLE_NIXL})"; exit 0; }; \
+  apt-get update && apt-get install -y --no-install-recommends \
+      build-essential autoconf automake libtool pkg-config git \
+      libibverbs-dev librdmacm-dev rdma-core && rm -rf /var/lib/apt/lists/*; \
+  pip install --no-cache-dir meson ninja pybind11 meson-python patchelf pyyaml; \
+  git clone --depth=1 -b "${UCX_BRANCH}" "${UCX_REPO}" /sgl-workspace/ucx; \
+  cd /sgl-workspace/ucx && ./autogen.sh && mkdir build && cd build && \
+  ../configure --prefix=/opt/ucx --enable-shared --disable-static --disable-doxygen-doc \
+      --enable-optimizations --enable-devel-headers \
+      --with-rocm=/opt/rocm --with-verbs --with-dm --enable-mt && \
+  make -j"$(nproc)" && make install; \
+  git clone --depth=1 -b v3.10.0 https://github.com/taskflow/taskflow.git /sgl-workspace/taskflow; \
+  cp -r /sgl-workspace/taskflow/taskflow /usr/local/include/; \
+  mkdir -p /usr/local/lib/pkgconfig; \
+  printf "Name: taskflow\nDescription: Taskflow\nVersion: 3.10.0\nCflags: -I/usr/local/include\n" > /usr/local/lib/pkgconfig/taskflow.pc; \
+  git clone "${NIXL_REPO}" /sgl-workspace/nixl && cd /sgl-workspace/nixl && git checkout -f "${NIXL_COMMIT}"; \
+  CXXFLAGS="-Wno-error" LD_LIBRARY_PATH="/opt/ucx/lib:/opt/rocm/lib" PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" \
+  pip install . --no-deps --no-build-isolation \
+      --config-settings=setup-args="-Ducx_path=/opt/ucx" \
+      --config-settings=setup-args="-Dwheel_variant=rocm" \
+      --config-settings=setup-args="-Denable_plugins=UCX,POSIX"; \
+  SITE=$(python3 -c "import sysconfig; print(sysconfig.get_paths()[\"purelib\"])"); \
+  ln -sfn nixl_rocm "$SITE/nixl"; \
+  echo "export LD_LIBRARY_PATH=/opt/ucx/lib:\${LD_LIBRARY_PATH}" >> /etc/bash.bashrc'
 
 # -----------------------
 # Hot patch: torch-ROCm

--- a/test/registered/amd/disaggregation/test_nixl_transfer_engine_e2e.py
+++ b/test/registered/amd/disaggregation/test_nixl_transfer_engine_e2e.py
@@ -1,0 +1,210 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+    try_cached_model,
+)
+
+register_amd_ci(est_time=900, suite="stage-b-test-large-8-gpu-mi35x-disaggregation-amd")
+
+
+class NixlTransferEngineBase(PDDisaggregationServerBase):
+    """PD-over-NIXL e2e on ROCm. NIXL (upstream ai-dynamo/nixl + UCX --with-rocm)
+    is enabled by default in the ROCm image; when the image was built with
+    `--build-arg ENABLE_NIXL=0`, `import nixl` fails and the test skips rather
+    than failing the suite."""
+
+    port_delta = 0
+    prefill_tp = 1
+    decode_tp = 1
+    decode_base_gpu_id = 1
+    required_gpus = 2
+
+    model_default = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+    model_env_var = "SGLANG_NIXL_E2E_TEST_MODEL"
+    extra_prefill_args: list = []
+    extra_decode_args: list = []
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import torch
+
+            if not torch.cuda.is_available():
+                raise unittest.SkipTest("torch.cuda is not available.")
+            if torch.cuda.device_count() < cls.required_gpus:
+                raise unittest.SkipTest(
+                    f"NIXL PD smoke test requires >= {cls.required_gpus} visible GPUs."
+                )
+        except unittest.SkipTest:
+            raise
+        except Exception as e:
+            raise unittest.SkipTest(f"torch is not available/usable: {e}")
+
+        try:
+            import nixl  # noqa: F401
+        except Exception as e:
+            raise unittest.SkipTest(
+                "nixl not importable; image may have been built with "
+                "--build-arg ENABLE_NIXL=0 "
+                f"({e})."
+            )
+
+        super().setUpClass()
+
+        cls._old_use_aiter = os.environ.get("SGLANG_USE_AITER")
+        os.environ["SGLANG_USE_AITER"] = "1"
+
+        # The shared fixture defaults to Mooncake in CI; pin NIXL explicitly here.
+        cls.transfer_backend = ["--disaggregation-transfer-backend", "nixl"]
+
+        rdma_env = os.environ.get("SGLANG_TEST_RDMA_DEVICE")
+        if rdma_env:
+            cls.rdma_devices = ["--disaggregation-ib-device", rdma_env]
+            print(f"Found RDMA devices in env: {rdma_env}")
+        else:
+            print("SGLANG_TEST_RDMA_DEVICE is not set! Running without RDMA.")
+            cls.rdma_devices = []
+
+        cls._shift_ports()
+        cls.model = try_cached_model(
+            os.environ.get(cls.model_env_var, cls.model_default)
+        )
+
+        cls.start_prefill()
+        cls.start_decode()
+
+        cls.wait_server_ready(
+            cls.prefill_url + "/health",
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            process=cls.process_prefill,
+        )
+        cls.wait_server_ready(
+            cls.decode_url + "/health",
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            process=cls.process_decode,
+        )
+        cls.launch_lb()
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "_old_use_aiter", None) is None:
+            os.environ.pop("SGLANG_USE_AITER", None)
+        else:
+            os.environ["SGLANG_USE_AITER"] = cls._old_use_aiter
+        super().tearDownClass()
+
+    @classmethod
+    def _shift_ports(cls):
+        if cls.port_delta == 0:
+            return
+
+        cls.lb_port = str(int(cls.lb_port) + cls.port_delta)
+        cls.prefill_port = str(int(cls.prefill_port) + cls.port_delta)
+        cls.decode_port = str(int(cls.decode_port) + cls.port_delta)
+        cls.bootstrap_port = str(int(cls.bootstrap_port) + cls.port_delta)
+        cls.prefill_url = f"http://{cls.base_host}:{cls.prefill_port}"
+        cls.decode_url = f"http://{cls.base_host}:{cls.decode_port}"
+        cls.lb_url = f"http://{cls.base_host}:{cls.lb_port}"
+        cls.base_url = cls.lb_url
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            str(cls.prefill_tp),
+            "--attention-backend",
+            "aiter",
+        ] + list(cls.extra_prefill_args)
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            str(cls.decode_tp),
+            "--base-gpu-id",
+            str(cls.decode_base_gpu_id),
+            "--attention-backend",
+            "aiter",
+            "--mem-fraction-static",
+            "0.8",
+        ] + list(cls.extra_decode_args)
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def _assert_generate_smoke(self):
+        resp = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+            },
+            timeout=120,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        out = resp.json()
+        self.assertIn("text", out)
+        self.assertIsInstance(out["text"], str)
+        self.assertGreater(len(out["text"]), 0)
+
+
+class TestNixlTransferEngineE2E(NixlTransferEngineBase):
+    def test_generate_smoke(self):
+        self._assert_generate_smoke()
+
+
+class TestNixlTransferEngineAccuracy(NixlTransferEngineBase):
+    port_delta = 10
+    model_default = DEFAULT_MODEL_NAME_FOR_TEST
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host=f"http://{self.base_host}",
+            port=int(self.lb_port),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"Evaluation metrics: {metrics}")
+        self.assertGreater(metrics["accuracy"], 0.70)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  Build UCX (--with-rocm) and upstream ai-dynamo/nixl from source so SGLang prefill/decode disaggregation can use --disaggregation-transfer-backend nixl on ROCm. Disabled by default; enable with --build-arg
  ENABLE_NIXL=1.

  Validated end-to-end on MI35x/ROCm 7.2: clean-image build, import resolves with plugins [POSIX, UCX], and a real 1P1D GSM8K run (accuracy 0.970, invalid 0.000) with all ranks reporting NIXL KVManager
  backend UCX.

  Motivation

  PD (prefill/decode) disaggregation can move KV cache over https://github.com/ai-dynamo/nixl, but the ROCm image ships no NIXL build, so --disaggregation-transfer-backend nixl is unusable on AMD GPUs. This
  adds an optional, reproducible NIXL build to docker/rocm.Dockerfile using the same upstream ai-dynamo/nixl that the CUDA path uses — no SGLang code changes, fully backward compatible (off by default).

  Modifications

  - docker/rocm.Dockerfile (+48): optional stage gated by --build-arg ENABLE_NIXL=1 (default 0, no change to existing builds). When enabled it:
    - Installs build deps (autoconf/automake/libtool, pkg-config, rdma-core, libibverbs/librdmacm-dev) + python build tooling (meson, ninja, pybind11, meson-python, patchelf, pyyaml).
    - Builds UCX from source (openucx v1.19.x) --with-rocm=/opt/rocm --with-verbs --with-dm --enable-mt → /opt/ucx.
    - Builds nixl from source (ai-dynamo/nixl @ c28061f) with meson -Ducx_path=/opt/ucx -Dwheel_variant=rocm -Denable_plugins=UCX,POSIX.
    - Symlinks nixl → nixl_rocm in site-packages and wires LD_LIBRARY_PATH=/opt/ucx/lib into /etc/bash.bashrc.
  - Three build fixes vs a naive build of this commit:
    a. --no-build-isolation --no-deps — nixl's build-system.requires pins torch==2.11.*, which under PEP 517 isolation pulls a multi-GB CUDA torch into a throwaway env and hangs the build. Reuses the image's
  ROCm torch instead.
    b. taskflow provided via a hand-written pkgconfig/taskflow.pc — the pinned taskflow.wrap source_hash no longer matches the regenerated GitHub archive, and meson's lowercase taskflow lookup is
  case-sensitive so the cmake-installed Taskflow config won't resolve.
    c. -Dwheel_variant=rocm names the import package nixl_rocm; SGLang imports plain nixl, hence the symlink.
  - No runtime overrides required beyond LD_LIBRARY_PATH (plugins auto-discover via $ORIGIN RPATH; backend defaults to UCX).

  Accuracy Tests

  Real 1P1D PD disaggregation on DeepSeek-R1-MXFP4, MI35x / ROCm 7.2, using the Dockerfile-built nixl:

  - Topology: prefill TP4 (GPU 0–3), decode TP4 (GPU 4–7), router front-end.
  - All 8 ranks logged NIXL KVManager initialized with backend: UCX; both warmups returned 200.
  - GSM8K: accuracy 0.970, invalid 0.000.

  Reference: deprecated AMD RIXL fork 0.950–0.955; manually-built upstream nixl 0.975. The Dockerfile-built nixl (0.970) is on par, confirming upstream nixl carries KV correctly on ROCm with zero SGLang code
  changes.

  Speed Tests and Profiling

  No inference-path code is changed (Docker build only). For reference, the same 1P1D setup over this backend sustains ~6.4 req/s / ~1.6k output tok/s, TPOT median ~17 ms (random ISL1024/OSL512, conc 32) —
  consistent across RIXL and upstream-nixl backends, i.e. no transfer-path penalty.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28382202290](https://github.com/sgl-project/sglang/actions/runs/28382202290)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28382201881](https://github.com/sgl-project/sglang/actions/runs/28382201881)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->