### PR TITLE
[Fix] Demote OpenAIServingResponses init failure log to one-line WARNING

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -380,9 +380,17 @@ async def lifespan(fast_api_app: FastAPI):
             enable_prompt_tokens_details=True,
             tool_server=tool_server,
         )
-    except Exception:
-        traceback = get_exception_traceback()
-        logger.warning(f"Can not initialize OpenAIServingResponses, error: {traceback}")
+    except Exception as e:
+        # Optional endpoint; a load failure (e.g. the gpt-oss harmony vocab
+        # download) must not look like a fatal error. One-line WARNING, full
+        # traceback at DEBUG.
+        logger.warning(
+            f"OpenAI Responses API (/v1/responses) disabled: "
+            f"OpenAIServingResponses init failed ({type(e).__name__}: {e})"
+        )
+        logger.debug(
+            f"OpenAIServingResponses init traceback:\n{get_exception_traceback()}"
+        )
 
     # Execute custom warmups
     if server_args.warmups is not None:


### PR DESCRIPTION
## Motivation

When `OpenAIServingResponses` fails to initialize (e.g. the gpt-oss harmony vocab download fails), the failure is caught and non-fatal: the server still starts and only `/v1/responses` becomes unavailable. However, the handler logged the full traceback at `WARNING`, making a recoverable condition look exactly like a fatal startup error.

## Modifications

- Reduce the failure log to a one-line `WARNING` stating the endpoint is disabled plus a short exception summary (`type: message`).
- Move the full traceback to `DEBUG`.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27583859465](https://github.com/sgl-project/sglang/actions/runs/27583859465)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27583859323](https://github.com/sgl-project/sglang/actions/runs/27583859323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
