### PR TITLE
[AMD] Fix AITER Scout workflow permissions

### DIFF
--- a/.github/workflows/amd-aiter-scout.yml
+++ b/.github/workflows/amd-aiter-scout.yml
@@ -22,6 +22,12 @@ on:
         type: boolean
         default: true
 
+permissions:
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
+
 concurrency:
   group: amd-aiter-scout-${{ github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add top-level token permissions to AMD AITER Scout so it can call the AMD PR test reusable workflows after their permissions were tightened.
- Fixes the Scout workflow startup failure caused by reusable workflow permission inheritance.

## Test plan
- pre-commit hooks from `git commit` passed, including workflow YAML validation and duplicate job name checks.


Made with [Cursor](https://cursor.com)









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27585912026](https://github.com/sgl-project/sglang/actions/runs/27585912026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27585911927](https://github.com/sgl-project/sglang/actions/runs/27585911927)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->