### PR TITLE
[AMD] fix(jit): port kv_canary write/verify/plan kernels to ROCm

### DIFF
--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
@@ -98,7 +98,11 @@ __global__ void plan_entries_persistent_kernel(
           static_cast<long long>(total_verify),
           static_cast<long long>(params.verify_capacity));
     }
+#ifndef USE_ROCM
     __trap();
+#else
+    __builtin_trap();  // HIP/clang device-side trap; __trap() is CUDA-only.
+#endif
   }
 
   const int64_t tid_start = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;

--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
@@ -10,7 +10,9 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
@@ -195,31 +195,31 @@ struct PlanEntriesKernel {
     SymbolicSize Npool_rows = {"req_to_verify_expected_tokens_rows"};
     SymbolicSize Npool_cols = {"req_to_verify_expected_tokens_cols"};
     SymbolicDevice device_;
-    device_.set_options<kDLCUDA>();
+    device_.set_options<kDLGPU>();
 
     TensorMatcher({Nbs})  //
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(req_pool_indices)
         .verify(prefix_lens);
     TensorMatcher({Nscratch})  //
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(verify_offsets_scratch);
     TensorMatcher({1})  //
         .with_dtype<int32_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(verify_enable);
     TensorMatcher({Ncap})  //
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(out_verify_slot_indices)
         .verify(out_verify_expected_tokens)
         .verify(out_verify_expected_positions)
         .verify(out_verify_prev_slot_indices);
     TensorMatcher({Nmax_reqs, Nmax_seq_len})  //
         .with_dtype<int32_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(req_to_token);
     RuntimeCheck(
         full_to_swa_index_mapping.has_value() == HAS_SWA_LUT,
@@ -235,17 +235,17 @@ struct PlanEntriesKernel {
     if constexpr (HAS_SWA_LUT) {
       TensorMatcher({Nlut})  //
           .with_dtype<int64_t>()
-          .with_device<kDLCUDA>(device_)
+          .with_device<kDLGPU>(device_)
           .verify(full_to_swa_index_mapping.value());
     }
     if constexpr (HAS_VERIFY_EXPECTED_TOKEN_POOL) {
       TensorMatcher({Npool_rows, Npool_cols})  //
           .with_dtype<int32_t>()
-          .with_device<kDLCUDA>(device_)
+          .with_device<kDLGPU>(device_)
           .verify(req_to_verify_expected_tokens.value());
       TensorMatcher({Nbs})  //
           .with_dtype<int64_t>()
-          .with_device<kDLCUDA>(device_)
+          .with_device<kDLGPU>(device_)
           .verify(req_to_verify_expected_tokens_valid_lens.value());
     }
     RuntimeCheck(Nscratch.unwrap() >= Nbs.unwrap() + 1, "verify_offsets_scratch length must be >= bs_padded + 1");

--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_plan_entries.cuh
@@ -10,9 +10,6 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <cstdint>
-#ifndef USE_ROCM
-#include <cuda_runtime.h>
-#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_verify.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_verify.cuh
@@ -4,7 +4,9 @@
 #include <sgl_kernel/utils.h>   // For div_ceil, RuntimeCheck
 
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel, SGL_DEVICE
-#include <sgl_kernel/warp.cuh>   // For device::warp::reduce_sum (warp-size-agnostic)
+#ifdef USE_ROCM
+#include <sgl_kernel/warp.cuh>  // For device::warp::reduce_sum (ROCm wave64-safe reduction)
+#endif
 
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
@@ -125,12 +127,21 @@ __global__ void canary_verify_kernel(const VerifyKernelParams __grid_constant__ 
     }
   }
 
-  // Warp-size-agnostic reduction: device::warp::reduce_sum performs a width-kWarpThreads (32) xor
-  // all-reduce, so each 32-lane sub-group gets its own total. This is correct on both CUDA (warp=32)
-  // and ROCm wave64 (two 32-lane sub-groups per wavefront, each with its own lane-0 leader below).
-  // A hand-rolled __shfl_down over the full wavefront would cross the 32-lane boundary on wave64.
+#ifndef USE_ROCM
+  // CUDA path: unchanged 32-lane warp down-reduction (preserves the original NV codegen exactly).
+  uint32_t warp_active_count = local_active_count;
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    warp_active_count += __shfl_down_sync(0xFFFFFFFFu, warp_active_count, offset);
+  }
+  const bool is_subgroup_leader = (threadIdx.x & 31u) == 0u;
+#else
+  // ROCm wave64: a hand-rolled __shfl_down over the full 64-lane wavefront would cross the 32-lane
+  // boundary and miscount. device::warp::reduce_sum performs a width-kWarpThreads (32) xor all-reduce,
+  // so each 32-lane sub-group gets its own total with its own lane-0 leader.
   const uint32_t warp_active_count = device::warp::reduce_sum<device::kWarpThreads>(local_active_count);
-  if ((threadIdx.x % device::kWarpThreads) == 0u && warp_active_count != 0u) {
+  const bool is_subgroup_leader = (threadIdx.x % device::kWarpThreads) == 0u;
+#endif
+  if (is_subgroup_leader && warp_active_count != 0u) {
     atomicAdd(
         reinterpret_cast<unsigned long long*>(p.slot_run_counter), static_cast<unsigned long long>(warp_active_count));
   }

--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_verify.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_verify.cuh
@@ -4,6 +4,7 @@
 #include <sgl_kernel/utils.h>   // For div_ceil, RuntimeCheck
 
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel, SGL_DEVICE
+#include <sgl_kernel/warp.cuh>   // For device::warp::reduce_sum (warp-size-agnostic)
 
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
@@ -124,11 +125,12 @@ __global__ void canary_verify_kernel(const VerifyKernelParams __grid_constant__ 
     }
   }
 
-  uint32_t warp_active_count = local_active_count;
-  for (int offset = 16; offset > 0; offset >>= 1) {
-    warp_active_count += __shfl_down_sync(0xFFFFFFFFu, warp_active_count, offset);
-  }
-  if ((threadIdx.x & 31u) == 0u && warp_active_count != 0u) {
+  // Warp-size-agnostic reduction: device::warp::reduce_sum performs a width-kWarpThreads (32) xor
+  // all-reduce, so each 32-lane sub-group gets its own total. This is correct on both CUDA (warp=32)
+  // and ROCm wave64 (two 32-lane sub-groups per wavefront, each with its own lane-0 leader below).
+  // A hand-rolled __shfl_down over the full wavefront would cross the 32-lane boundary on wave64.
+  const uint32_t warp_active_count = device::warp::reduce_sum<device::kWarpThreads>(local_active_count);
+  if ((threadIdx.x % device::kWarpThreads) == 0u && warp_active_count != 0u) {
     atomicAdd(
         reinterpret_cast<unsigned long long*>(p.slot_run_counter), static_cast<unsigned long long>(warp_active_count));
   }
@@ -173,29 +175,29 @@ struct CanaryVerifyKernel {
     SymbolicSize N_stride = {"slot_stride_bytes"};
     SymbolicSize N_verify = {"verify_capacity"};
     SymbolicDevice device_;
-    device_.set_options<kDLCUDA>();
+    device_.set_options<kDLGPU>();
 
-    TensorMatcher({N_slots, N_stride}).with_dtype<uint8_t>().with_device<kDLCUDA>(device_).verify(canary_buf);
+    TensorMatcher({N_slots, N_stride}).with_dtype<uint8_t>().with_device<kDLGPU>(device_).verify(canary_buf);
 
     TensorMatcher({N_verify})
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(verify_slot_indices)
         .verify(verify_expected_tokens)
         .verify(verify_expected_positions)
         .verify(verify_prev_slot_indices);
-    TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device_).verify(verify_num_valid);
-    TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device_).verify(verify_enable);
+    TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLGPU>(device_).verify(verify_num_valid);
+    TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLGPU>(device_).verify(verify_enable);
 
-    TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device_).verify(violation_write_index);
+    TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLGPU>(device_).verify(violation_write_index);
     SymbolicSize N_ring = {"ring_capacity"};
     TensorMatcher({N_ring, static_cast<int64_t>(kViolationFields)})
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(violation_ring);
     TensorMatcher({1})
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(slot_run_counter)
         .verify(kernel_run_counter);
 
@@ -205,25 +207,25 @@ struct CanaryVerifyKernel {
     SymbolicSize N_real_kv_cols_0 = {"real_kv_cols_0"};
     TensorMatcher({N_real_kv_rows_0, N_real_kv_cols_0})
         .with_dtype<uint8_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_0);
     SymbolicSize N_real_kv_rows_1 = {"real_kv_rows_1"};
     SymbolicSize N_real_kv_cols_1 = {"real_kv_cols_1"};
     TensorMatcher({N_real_kv_rows_1, N_real_kv_cols_1})
         .with_dtype<uint8_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_1);
     SymbolicSize N_real_kv_rows_2 = {"real_kv_rows_2"};
     SymbolicSize N_real_kv_cols_2 = {"real_kv_cols_2"};
     TensorMatcher({N_real_kv_rows_2, N_real_kv_cols_2})
         .with_dtype<uint8_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_2);
     SymbolicSize N_real_kv_rows_3 = {"real_kv_rows_3"};
     SymbolicSize N_real_kv_cols_3 = {"real_kv_cols_3"};
     TensorMatcher({N_real_kv_rows_3, N_real_kv_cols_3})
         .with_dtype<uint8_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_3);
     TensorMatcher({static_cast<int64_t>(kMaxRealKvSources), static_cast<int64_t>(kRealKvSourceFieldsPerEntry)})
         .with_dtype<int32_t>()

--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_verify.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_verify.cuh
@@ -4,9 +4,7 @@
 #include <sgl_kernel/utils.h>   // For div_ceil, RuntimeCheck
 
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel, SGL_DEVICE
-#ifdef USE_ROCM
-#include <sgl_kernel/warp.cuh>  // For device::warp::reduce_sum (ROCm wave64-safe reduction)
-#endif
+#include <sgl_kernel/warp.cuh>   // For device::warp::reduce_sum
 
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
@@ -127,20 +125,12 @@ __global__ void canary_verify_kernel(const VerifyKernelParams __grid_constant__ 
     }
   }
 
-#ifndef USE_ROCM
-  // CUDA path: unchanged 32-lane warp down-reduction (preserves the original NV codegen exactly).
-  uint32_t warp_active_count = local_active_count;
-  for (int offset = 16; offset > 0; offset >>= 1) {
-    warp_active_count += __shfl_down_sync(0xFFFFFFFFu, warp_active_count, offset);
-  }
-  const bool is_subgroup_leader = (threadIdx.x & 31u) == 0u;
-#else
-  // ROCm wave64: a hand-rolled __shfl_down over the full 64-lane wavefront would cross the 32-lane
-  // boundary and miscount. device::warp::reduce_sum performs a width-kWarpThreads (32) xor all-reduce,
-  // so each 32-lane sub-group gets its own total with its own lane-0 leader.
+  // Warp-size-agnostic reduction: device::warp::reduce_sum performs a width-kWarpThreads (32) xor
+  // all-reduce, so each 32-lane sub-group gets its own total with its own lane-0 leader. Correct on
+  // both CUDA (warp=32) and ROCm wave64 (two 32-lane sub-groups per wavefront); a hand-rolled
+  // __shfl_down over the full wavefront would cross the 32-lane boundary on wave64.
   const uint32_t warp_active_count = device::warp::reduce_sum<device::kWarpThreads>(local_active_count);
   const bool is_subgroup_leader = (threadIdx.x % device::kWarpThreads) == 0u;
-#endif
   if (is_subgroup_leader && warp_active_count != 0u) {
     atomicAdd(
         reinterpret_cast<unsigned long long*>(p.slot_run_counter), static_cast<unsigned long long>(warp_active_count));

--- a/python/sglang/jit_kernel/csrc/kv_canary/canary_write.cuh
+++ b/python/sglang/jit_kernel/csrc/kv_canary/canary_write.cuh
@@ -205,20 +205,20 @@ inline void canary_write_step_cuda(
   SymbolicSize N_write_reqs = {"write_req_capacity"};
   SymbolicSize N_tokens = {"num_tokens_padded"};
   SymbolicDevice device_;
-  device_.set_options<kDLCUDA>();
+  device_.set_options<kDLGPU>();
 
-  TensorMatcher({N_slots, N_stride}).with_dtype<uint8_t>().with_device<kDLCUDA>(device_).verify(canary_buf);
+  TensorMatcher({N_slots, N_stride}).with_dtype<uint8_t>().with_device<kDLGPU>(device_).verify(canary_buf);
 
   // write_offsets has shape [write_req_capacity + 1]; the length relationship is pinned by the
   // RuntimeCheck below, this matcher pins dtype + device.
   SymbolicSize N_write_offsets = {"write_offsets_len"};
-  TensorMatcher({N_write_offsets}).with_dtype<int64_t>().with_device<kDLCUDA>(device_).verify(write_offsets);
-  TensorMatcher({N_write_reqs}).with_dtype<int64_t>().with_device<kDLCUDA>(device_).verify(write_seed_slot_indices);
-  TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device_).verify(write_num_valid_reqs);
+  TensorMatcher({N_write_offsets}).with_dtype<int64_t>().with_device<kDLGPU>(device_).verify(write_offsets);
+  TensorMatcher({N_write_reqs}).with_dtype<int64_t>().with_device<kDLGPU>(device_).verify(write_seed_slot_indices);
+  TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLGPU>(device_).verify(write_num_valid_reqs);
 
   TensorMatcher({N_tokens})
       .with_dtype<int64_t>()
-      .with_device<kDLCUDA>(device_)
+      .with_device<kDLGPU>(device_)
       .verify(input_ids)
       .verify(positions)
       .verify(out_cache_loc);
@@ -232,47 +232,47 @@ inline void canary_write_step_cuda(
   if (enable_write_input_assert_bool) {
     TensorMatcher({N_tokens})
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(expected_input_tokens.value())
         .verify(expected_input_positions.value());
   }
 
-  TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device_).verify(violation_write_index);
+  TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLGPU>(device_).verify(violation_write_index);
   SymbolicSize N_ring = {"ring_capacity"};
   TensorMatcher({N_ring, static_cast<int64_t>(kViolationFields)})
       .with_dtype<int64_t>()
-      .with_device<kDLCUDA>(device_)
+      .with_device<kDLGPU>(device_)
       .verify(violation_ring);
   TensorMatcher({1})
       .with_dtype<int64_t>()
-      .with_device<kDLCUDA>(device_)
+      .with_device<kDLGPU>(device_)
       .verify(slot_run_counter)
       .verify(kernel_run_counter);
-  TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device_).verify(enable_chain_position_assert);
+  TensorMatcher({1}).with_dtype<int32_t>().with_device<kDLGPU>(device_).verify(enable_chain_position_assert);
 
   SymbolicSize N_real_kv_rows_0 = {"real_kv_rows_0"};
   SymbolicSize N_real_kv_cols_0 = {"real_kv_cols_0"};
   TensorMatcher({N_real_kv_rows_0, N_real_kv_cols_0})
       .with_dtype<uint8_t>()
-      .with_device<kDLCUDA>(device_)
+      .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_0);
   SymbolicSize N_real_kv_rows_1 = {"real_kv_rows_1"};
   SymbolicSize N_real_kv_cols_1 = {"real_kv_cols_1"};
   TensorMatcher({N_real_kv_rows_1, N_real_kv_cols_1})
       .with_dtype<uint8_t>()
-      .with_device<kDLCUDA>(device_)
+      .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_1);
   SymbolicSize N_real_kv_rows_2 = {"real_kv_rows_2"};
   SymbolicSize N_real_kv_cols_2 = {"real_kv_cols_2"};
   TensorMatcher({N_real_kv_rows_2, N_real_kv_cols_2})
       .with_dtype<uint8_t>()
-      .with_device<kDLCUDA>(device_)
+      .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_2);
   SymbolicSize N_real_kv_rows_3 = {"real_kv_rows_3"};
   SymbolicSize N_real_kv_cols_3 = {"real_kv_cols_3"};
   TensorMatcher({N_real_kv_rows_3, N_real_kv_cols_3})
       .with_dtype<uint8_t>()
-      .with_device<kDLCUDA>(device_)
+      .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_3);
   TensorMatcher({static_cast<int64_t>(kMaxRealKvSources), static_cast<int64_t>(kRealKvSourceFieldsPerEntry)})
       .with_dtype<int32_t>()

--- a/test/registered/jit/kv_canary/test_const_sync.py
+++ b/test/registered/jit/kv_canary/test_const_sync.py
@@ -5,9 +5,10 @@ from pathlib import Path
 
 import sglang.jit_kernel
 from sglang.jit_kernel.kv_canary import consts
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=5, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=5, suite="jit-kernel-unit-test-amd")
 
 
 # Resolve the kernel source against the installed jit_kernel package rather

--- a/test/registered/jit/kv_canary/test_kernel_config.py
+++ b/test/registered/jit/kv_canary/test_kernel_config.py
@@ -33,9 +33,10 @@ from sglang.jit_kernel.tests.kv_canary._fixtures import (
     dummy_pseudo_tensors,
     empty_extras,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=60, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=60, suite="jit-kernel-unit-test-amd")
 
 _DEVICE = torch.device("cuda")
 

--- a/test/registered/jit/kv_canary/test_pipeline_e2e.py
+++ b/test/registered/jit/kv_canary/test_pipeline_e2e.py
@@ -38,9 +38,10 @@ from sglang.jit_kernel.tests.kv_canary._fixtures import (
     empty_extras,
     make_req_to_token,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")

--- a/test/registered/jit/kv_canary/test_plan_fuzz.py
+++ b/test/registered/jit/kv_canary/test_plan_fuzz.py
@@ -20,9 +20,10 @@ from sglang.jit_kernel.tests.kv_canary._fuzz_driver import (
     run_fuzz_combo,
 )
 from sglang.jit_kernel.tests.kv_canary._invariants import PlanInvariants
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")

--- a/test/registered/jit/kv_canary/test_plan_hand.py
+++ b/test/registered/jit/kv_canary/test_plan_hand.py
@@ -20,9 +20,10 @@ from sglang.jit_kernel.tests.kv_canary._fixtures import (
     make_req_to_token,
 )
 from sglang.jit_kernel.tests.kv_canary._invariants import PlanInvariants
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")

--- a/test/registered/jit/kv_canary/test_scatter_req_token_ids.py
+++ b/test/registered/jit/kv_canary/test_scatter_req_token_ids.py
@@ -10,10 +10,11 @@ from sglang.jit_kernel.kv_canary.scatter_req_token_ids import (
     launch_scatter_req_token_ids_kernel,
     scatter_req_token_ids_torch_reference,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=10, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=10, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")

--- a/test/registered/jit/kv_canary/test_verify_fuzz.py
+++ b/test/registered/jit/kv_canary/test_verify_fuzz.py
@@ -29,9 +29,10 @@ from sglang.jit_kernel.tests.kv_canary._fuzz_driver import (
     run_fuzz_combo,
 )
 from sglang.jit_kernel.tests.kv_canary._invariants import VerifyInvariants
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")

--- a/test/registered/jit/kv_canary/test_verify_hand.py
+++ b/test/registered/jit/kv_canary/test_verify_hand.py
@@ -51,9 +51,10 @@ from sglang.jit_kernel.tests.kv_canary._hand_oracle import (
     _hand_fold_all,
     _hand_fold_partial,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")

--- a/test/registered/jit/kv_canary/test_write_fuzz.py
+++ b/test/registered/jit/kv_canary/test_write_fuzz.py
@@ -29,9 +29,10 @@ from sglang.jit_kernel.tests.kv_canary._fuzz_driver import (
     run_fuzz_combo,
 )
 from sglang.jit_kernel.tests.kv_canary._invariants import WriteInvariants
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")

--- a/test/registered/jit/kv_canary/test_write_hand.py
+++ b/test/registered/jit/kv_canary/test_write_hand.py
@@ -49,9 +49,10 @@ from sglang.jit_kernel.tests.kv_canary._hand_oracle import (
     _hand_fold_all,
     _hand_fold_partial,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 _DEVICE = torch.device("cuda")


### PR DESCRIPTION
## Summary

Make the **kv_canary JIT kernels** (`write`, `verify`, `plan_entries`) compile and run correctly under hipcc/ROCm, and onboard their JIT unit tests to the `jit-kernel-unit-test-amd` suite. All ROCm-specific behavior is gated behind `USE_ROCM` so the **CUDA/NV path is unchanged**. This unblocks the kv_canary e2e tests on AMD (stacked follow-up).

Builds on the activation ROCm fix from #27947 (already merged to `main`), which is what lets `jit-kernel-unit-test-amd` compile end-to-end.

## Changes

**Kernel port (`python/sglang/jit_kernel/csrc/kv_canary/*.cuh`):**

1. **Device matching** — replace hardcoded `kDLCUDA` with the platform-agnostic `kDLGPU` alias in all `TensorMatcher` `set_options`/`with_device` calls. The previous `kDLCUDA` constraint raises a runtime `Device mismatch` on ROCm, where torch tensors export as `kDLROCM`. `kDLGPU` is `kDLCUDA` on CUDA and `kDLROCM` on ROCm (defined in `sgl_kernel/utils.cuh`), so this is a **compile-time no-op on NV**. CPU-side params (`kDLCPU`) are unchanged.

2. **Verify-kernel `slot_run_counter` reduction (ROCm-only)** — the hand-rolled `__shfl_down_sync(0xFFFFFFFFu, …)` loop assumes a 32-lane warp and crosses the 32-lane boundary on AMD wave64, miscounting. Gated behind `#ifndef USE_ROCM`/`#else`:
   - **CUDA**: keeps the original `__shfl_down_sync` down-reduction and `threadIdx.x & 31u` leader, byte-for-byte (codegen unchanged).
   - **ROCm**: uses the warp-size-agnostic `device::warp::reduce_sum<kWarpThreads>` (width-32 xor all-reduce), keeping the reduction within 32-lane sub-groups on wave64. The `warp.cuh` include is likewise `#ifdef USE_ROCM`.

3. **Plan-kernel ROCm build fixes (ROCm-only, NV untouched):**
   - Guard the CUDA-only `#include <cuda_runtime.h>` behind `#ifndef USE_ROCM` (hipcc has no such header; the write/verify kernels compile without it).
   - Replace the CUDA-only `__trap()` device builtin with `__builtin_trap()` on ROCm (clang builtin; `__trap()` is undeclared under hipcc). Same contract-break device abort.

**Test onboarding:**

- Register the 10 `test/registered/jit/kv_canary/` unit tests (write/verify/plan `hand`+`fuzz`, `scatter_req_token_ids`, `pipeline_e2e`, `kernel_config`, `const_sync`) for `jit-kernel-unit-test-amd`. These pin the kernel byte-for-byte against the torch reference. CUDA registrations (`base-b-kernel-unit-1-gpu-large`) are unchanged.

## Test plan — verified green on all three GPU lanes (head `ddb0e77b`)

- [x] **NV** `jit-kernel-unit-test` (`base-b-kernel-unit-1-gpu-large`, H100) — no regression on CUDA: https://github.com/sgl-project/sglang/actions/runs/27710196293
- [x] **AMD mi3xx** (gfx942) `jit-kernel-unit-test-amd` — 18/18, all 10 kv_canary files pass: https://github.com/sgl-project/sglang/actions/runs/27710195695
- [x] **AMD rocm720** `jit-kernel-unit-test-amd-rocm720` (stricter HIP asserts) — full canary suite green: https://github.com/sgl-project/sglang/actions/runs/27710200046
- [x] Registrations parse via `ut_parse_one_file` (amd=1/cuda=1 each, suite `jit-kernel-unit-test-amd`)
- [x] NV codegen unchanged: device alias is a no-op on CUDA; the warp-reduction rewrite, `warp.cuh` include, `cuda_runtime.h` include, and `__trap()` are all `USE_ROCM`-gated

> Note: the AMD/NV PR runs show a run-level "failure", but only from **unrelated** jobs (`stage-b-test-1-gpu-small-amd`, `multimodal-gen-*`, `base-b-test-*`/b200 model suites). None exercise the kv_canary kernels — the `jit-kernel-unit-test*` jobs themselves are green on all three lanes.

## Notes

This is the prerequisite ("port") half of the kv_canary AMD coverage work. Onboarding the kv_canary **e2e** tests (`test_self_e2e_*`) to the 1-/2-gpu-large AMD suites is a stacked follow-up now unblocked by this PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27808929660](https://github.com/sgl-project/sglang/actions/runs/27808929660)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27808929563](https://github.com/sgl-project/sglang/actions/runs/27808929563)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->