### PR TITLE
[diffusion] Fuse tanh-GELU into shared MLP FFN up-proj GEMM epilogue

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/mlp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/mlp.py
@@ -15,6 +15,7 @@ from diffusers.models.activations import (
 )
 
 from sglang.multimodal_gen.runtime.layers.activation import get_act_fn
+from sglang.multimodal_gen.runtime.layers.fused_linear_act import linear_gelu_tanh
 from sglang.multimodal_gen.runtime.layers.linear import (
     ColumnParallelLinear,
     RowParallelLinear,
@@ -50,6 +51,9 @@ class MLP(nn.Module):
         )
 
         self.act = get_act_fn(act_type)
+        # Fuse the tanh-GELU into the fc_in GEMM epilogue (cublasLt) when the
+        # activation is the tanh-approx GELU; other activations are untouched.
+        self._fuse_gelu_tanh = act_type == "gelu_pytorch_tanh"
         if output_dim is None:
             output_dim = input_dim
         self.fc_out = RowParallelLinear(
@@ -62,8 +66,11 @@ class MLP(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x, _ = self.fc_in(x)
-        x = self.act(x)
+        if self._fuse_gelu_tanh:
+            x = linear_gelu_tanh(self.fc_in, x)
+        else:
+            x, _ = self.fc_in(x)
+            x = self.act(x)
         x, _ = self.fc_out(x)
         return x
 


### PR DESCRIPTION
## Summary

The shared diffusion FFN `MLP` (`python/sglang/multimodal_gen/runtime/layers/mlp.py`) — used by Wan2.2 (T2V / TI2V / causal), HunyuanVideo, Hunyuan3D, Helios, JoyImage and MOVA — computed `gelu_pytorch_tanh(fc_in(x))` as a standalone GEMM followed by a **separate, bandwidth-bound GELU kernel** over the `[tokens, mlp_hidden]` intermediate.

This routes the tanh-GELU FFN through the existing cublasLt GELU-epilogue helper `linear_gelu_tanh` (`runtime/layers/fused_linear_act/gelu.py`, already used by `flux.py`), folding the bias-add + tanh-GELU into the `fc_in` GEMM epilogue (`torch._addmm_activation(..., use_gelu=True)`). This removes the extra kernel launch and the HBM round-trip of the MLP intermediate.

- Only the tanh-approx GELU path (`act_type == "gelu_pytorch_tanh"`) is fused; every other activation keeps the exact reference path.
- The helper's guards (unquantized, fp16/bf16, has-bias, CUDA, no multi-rank gather) keep correctness under TP / quantization; otherwise it falls back to `fc_in(x)` + `F.gelu(approximate="tanh")`.
- cublasLt's GELU matches tanh-approximate GELU within fp16/bf16 rounding, so the fused path is numerically equivalent for half-precision inference.

This is the same mechanism already shipped for FLUX; this PR extends it to the shared `MLP` FFN so every model that uses it benefits.

## Benchmark

Wan2.2-TI2V-5B, 1280×720, 81 frames, 50 steps, **B200**, `--enable-torch-compile --warmup`, isolated HF cache. Denoise latency reported as steady-state per-step (steps 5–49; step 0 excluded as the one-time compile spike).

Command shape:
```
PYTHONPATH=python python3 \
  python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/scripts/bench_diffusion_denoise.py \
  --model wan-ti2v --label <main|pr>
```

| Metric | Latest main | PR | Speedup |
|---|---|---|---|
| Denoise steady-state median (ms/step) | 504.9 | 489.9 | **1.031×** |
| Denoise steady-state min (ms/step) | 494.6 | 482.7 | 1.025× |

Per-run steady-state median (ms/step):

| Run | main | PR |
|---|---|---|
| generate (save-output) | 504.8 | 489.9 |
| r1 | 505.0 | 489.8 |
| r2 | 504.9 | 489.3 |

(steady-state per-step variance is < 0.3 ms within each side; the speedup is consistent run-to-run.)

Mechanism: the fused path removes the standalone `triton_poi_fused_gelu` kernel, which is **3.9%** of denoise GPU time in the baseline torch.profiler trace; at Wan's FFN shape the MLP forward itself is **1.10–1.13×** faster in isolation (compiled microbench).

## Generated Video Check

Same prompt / input image / seed (42), main vs PR.

![main vs PR vs 10x diff](https://raw.githubusercontent.com/BBuf/sglang/kda/diffusion-gelu-artifacts/mlp-fused-gelu/wan_ti2v_contact_sheet.png)

Columns: **main | PR | 10× absolute diff**. Side-by-side video: https://github.com/BBuf/sglang/raw/kda/diffusion-gelu-artifacts/mlp-fused-gelu/wan_ti2v_side_by_side.mp4

Per-frame difference over all 81 frames:

| Metric | Value | CI gate (`publish_diffusion_gt.py`) |
|---|---|---|
| mean_abs_diff (0–255) | 2.71 (max 4.54) | ≤ 45.0 ✓ |
| RMS diff (0–255) | 6.24 (max 10.47) | — |
| luminance SSIM (CI formula) | 0.984 (min 0.959) | ≥ 0.20 ✓ |
| windowed SSIM (skimage) | 0.937 (min 0.890) | — |

The output is a **perceptually-equivalent sample, not bit-identical**: the bf16-level epilogue difference propagates through the 50-step denoise trajectory, so the residual differences concentrate on high-frequency edges (only visible at 10× amplification). Both diffusion-CI quality thresholds (SSIM ≥ 0.20, mean_abs_diff ≤ 45) pass by a wide margin.

## Validation

- MLP fused-vs-unfused parity at the Wan FFN shape (bf16): max relative diff 0.67% (rounding level).
- Forward smoke test on the patched module: correct shapes, finite output.
- Fallback verified: non-tanh-GELU activations and guard-failing layers (quantized / no-bias / multi-rank gather / non-CUDA) take the exact reference path.

## Checklist

- [x] Format the code, ran pre-commit on changed files.
- [x] Verified numerical parity and end-to-end output quality on a real model run.
- [x] No new dependencies; reuses the existing `fused_linear_act` helper.
- [ ] (reviewer) confirm desired on multi-GPU TP configs.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27602521664](https://github.com/sgl-project/sglang/actions/runs/27602521664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27602534758](https://github.com/sgl-project/sglang/actions/runs/27602534758)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->