### PR TITLE
Fix Stage B CUDA CI

### DIFF
--- a/test/registered/kernels/test_mhc_kernels.py
+++ b/test/registered/kernels/test_mhc_kernels.py
@@ -18,6 +18,7 @@ def test_mhc_fused_post_pre_matches_unfused(
         pytest.skip("CUDA is required for TileLang mHC kernels")
 
     monkeypatch.setattr(mhc, "is_dsa_prefill_cp_round_robin_split", lambda: False)
+    monkeypatch.setattr(mhc, "_mhc_pre_warmed", True)
     torch.manual_seed(0)
     device = torch.device("cuda")
     hc_mult = 4


### PR DESCRIPTION
I think it's caused by https://github.com/sgl-project/sglang/pull/27986

It only tests the accuracy (and pre-warm with dummy input) will not cause accuracy issues, so it's fine.

```
python test/registered/kernels/test_mhc_kernels.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /sgl-workspace/sglang/test
configfile: pytest.ini
plugins: anyio-4.13.0, typeguard-4.5.2
collected 24 items                                                                                                                                                                                                                        

test/registered/kernels/test_mhc_kernels.py ........................                                                                                                                                                                [100%]

============================================================================================================ warnings summary =============================================================================================================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1309
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1309: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; anyio
    self._mark_plugins_for_rewrite(hook, disable_autoload)

../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1434
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================== 24 passed, 2 warnings in 1.50s ======================================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27588772195](https://github.com/sgl-project/sglang/actions/runs/27588772195)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27605121735](https://github.com/sgl-project/sglang/actions/runs/27605121735)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->