### PR TITLE
ci: run AMD and NPU PR tests on PRs not targeting main

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -17,7 +17,6 @@ on:
   #     - ".github/workflows/pr-test-amd-rocm720.yml"
   #     - "docker/rocm.Dockerfile"
   pull_request:
-    branches: [ main ]
     paths:
       - "python/**"
       - "scripts/ci/**"

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -7,7 +7,6 @@ on:
   schedule:
     - cron: '0 */6 * * *' # Run every 6 hours (UTC)
   pull_request:
-    branches: [ main ]
     paths:
       - "python/**"
       - "scripts/ci/**"

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Motivation

For PRs that do **not** target `main` (e.g. PRs into release branches), only the NV test suite runs — AMD and NPU CI is silently skipped.

## Root cause

The NV PR-test workflow (`pr-test.yml`) triggers on `pull_request:` with **no `branches:` filter**, so it fires for PRs against any base branch. The AMD (`pr-test-amd.yml`, `pr-test-amd-rocm720.yml`) and NPU (`pr-test-npu.yml`) workflows restricted `pull_request` to `branches: [ main ]`, so PRs not targeting `main` never launched them.

## Change

Drop the `branches: [ main ]` restriction from the `pull_request` trigger in the AMD and NPU workflows so they fire for PRs against any base branch, matching NV behavior. The `paths:` filters (AMD) and NPU's `push: branches: [ main ]` post-merge trigger are left untouched.

```diff
   pull_request:
-    branches: [ main ]
     paths:
       - "python/**"
       ...
```

## Note

AMD/NPU CI will now also fire on release-branch PRs (and any non-main-targeting PRs), consistent with how NV already behaves. This increases runner load on those PRs by design.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27589207563](https://github.com/sgl-project/sglang/actions/runs/27589207563)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27589207506](https://github.com/sgl-project/sglang/actions/runs/27589207506)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->