### PR TITLE
[Test] Add unit tests for srt/managers/scheduler_components/new_token_ratio_tracker.py

### DIFF
--- a/test/registered/unit/managers/test_new_token_ratio_tracker.py
+++ b/test/registered/unit/managers/test_new_token_ratio_tracker.py
@@ -1,0 +1,102 @@
+import unittest
+from contextlib import ExitStack
+from types import SimpleNamespace
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
+    NewTokenRatioTracker,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _override_new_token_ratio_envs(
+    *,
+    init: float,
+    min_factor: float,
+    decay_steps: int,
+):
+    stack = ExitStack()
+    stack.enter_context(envs.SGLANG_INIT_NEW_TOKEN_RATIO.override(init))
+    stack.enter_context(envs.SGLANG_MIN_NEW_TOKEN_RATIO_FACTOR.override(min_factor))
+    stack.enter_context(envs.SGLANG_NEW_TOKEN_RATIO_DECAY_STEPS.override(decay_steps))
+    return stack
+
+
+class TestNewTokenRatioTracker(CustomTestCase):
+    def test_from_server_args_computes_initial_min_and_decay(self):
+        server_args = SimpleNamespace(schedule_conservativeness=0.5)
+
+        with _override_new_token_ratio_envs(init=0.8, min_factor=0.25, decay_steps=3):
+            tracker = NewTokenRatioTracker.from_server_args(server_args)
+
+        self.assertEqual(tracker.init, 0.4)
+        self.assertEqual(tracker.min, 0.1)
+        self.assertAlmostEqual(tracker.decay, 0.1)
+        self.assertEqual(tracker.current, tracker.init)
+
+    def test_from_server_args_clamps_init_and_min_to_one(self):
+        server_args = SimpleNamespace(schedule_conservativeness=2.0)
+
+        with _override_new_token_ratio_envs(init=0.8, min_factor=2.0, decay_steps=10):
+            tracker = NewTokenRatioTracker.from_server_args(server_args)
+
+        self.assertEqual(tracker.init, 1.0)
+        self.assertEqual(tracker.min, 1.0)
+        self.assertEqual(tracker.decay, 0.0)
+        self.assertEqual(tracker.current, 1.0)
+
+    def test_decay_step_does_not_go_below_min_and_reset_restores_init(self):
+        tracker = NewTokenRatioTracker(init=0.6, min=0.2, decay=0.15, current=0.6)
+
+        tracker.decay_step()
+        tracker.decay_step()
+        tracker.decay_step()
+        tracker.decay_step()
+
+        self.assertEqual(tracker.current, 0.2)
+
+        tracker.reset()
+
+        self.assertEqual(tracker.current, 0.6)
+
+    def test_estimate_new_token_ratio_after_retract_uses_decode_steps(self):
+        reqs = [
+            SimpleNamespace(
+                output_ids=[1, 2],
+                sampling_params=SimpleNamespace(max_new_tokens=10),
+            ),
+            SimpleNamespace(
+                output_ids=[3, 4, 5],
+                sampling_params=SimpleNamespace(max_new_tokens=20),
+            ),
+        ]
+
+        with envs.SGLANG_RETRACT_DECODE_STEPS.override(4):
+            ratio = NewTokenRatioTracker.estimate_new_token_ratio_after_retract(reqs)
+
+        self.assertAlmostEqual(ratio, 13 / 31)
+
+    def test_estimate_new_token_ratio_after_retract_is_capped_at_one(self):
+        reqs = [
+            SimpleNamespace(
+                output_ids=[1, 2, 3, 4, 5],
+                sampling_params=SimpleNamespace(max_new_tokens=1),
+            )
+        ]
+
+        with envs.SGLANG_RETRACT_DECODE_STEPS.override(20):
+            ratio = NewTokenRatioTracker.estimate_new_token_ratio_after_retract(reqs)
+
+        self.assertEqual(ratio, 1.0)
+
+    def test_estimate_new_token_ratio_after_retract_handles_empty_reqs(self):
+        ratio = NewTokenRatioTracker.estimate_new_token_ratio_after_retract([])
+
+        self.assertEqual(ratio, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add CPU-only unit coverage for `NewTokenRatioTracker`, a scheduler component under `srt/managers/`.

This helps cover core manager logic without launching a server or loading model weights.
Ref: https://github.com/sgl-project/sglang/issues/20865

## Modifications

Added `test/registered/unit/managers/test_new_token_ratio_tracker.py`.

The tests cover:
- initialization from server args
- init/min ratio clamping
- decay floor behavior
- reset behavior
- retract ratio estimation
- ratio capping at 1.0
- empty request list handling

The tests are CPU-only and do not start a server or load a model. They are registered via:
```python
register_cpu_ci(est_time=5, suite="base-a-test-cpu")
```
## Accuracy Tests

Not applicable. This PR only adds unit tests and does not change model output logic.

## Speed Tests and Profiling

Not applicable. This PR only adds unit tests and does not affect inference performance.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Test

```bash
pytest test/registered/unit/managers/test_new_token_ratio_tracker.py -v
========================================================= test session starts =========================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/evanderf/sglang/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/evanderf/sglang/test
configfile: pytest.ini
plugins: anyio-4.13.0, asyncio-1.4.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 6 items                                                                                                                     

test/registered/unit/managers/test_new_token_ratio_tracker.py::TestNewTokenRatioTracker::test_decay_step_does_not_go_below_min_and_reset_restores_init PASSED [ 16%]
test/registered/unit/managers/test_new_token_ratio_tracker.py::TestNewTokenRatioTracker::test_estimate_new_token_ratio_after_retract_handles_empty_reqs PASSED [ 33%]
test/registered/unit/managers/test_new_token_ratio_tracker.py::TestNewTokenRatioTracker::test_estimate_new_token_ratio_after_retract_is_capped_at_one PASSED [ 50%]
test/registered/unit/managers/test_new_token_ratio_tracker.py::TestNewTokenRatioTracker::test_estimate_new_token_ratio_after_retract_uses_decode_steps PASSED [ 66%]
test/registered/unit/managers/test_new_token_ratio_tracker.py::TestNewTokenRatioTracker::test_from_server_args_clamps_init_and_min_to_one PASSED [ 83%]
test/registered/unit/managers/test_new_token_ratio_tracker.py::TestNewTokenRatioTracker::test_from_server_args_computes_initial_min_and_decay PASSED [100%]

========================================================== warnings summary ===========================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 6 passed, 2 warnings in 4.54s ====================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27590878880](https://github.com/sgl-project/sglang/actions/runs/27590878880)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27590878807](https://github.com/sgl-project/sglang/actions/runs/27590878807)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->