### PR TITLE
refactor(runner): unify pp_proxy_tensors forward kwarg into one helper

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3268,6 +3268,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             forward_batch_template=forward_batch,
         )
 
+    def _pp_kwargs(self, pp_proxy_tensors) -> dict:
+        """Build the pp_proxy_tensors forward kwarg, in one place.
+
+        Pipeline-parallel proxy tensors are threaded into model.forward only
+        when the model accepts them (``support_pp``).
+        """
+        return {"pp_proxy_tensors": pp_proxy_tensors} if self.support_pp else {}
+
     def forward_decode(
         self,
         forward_batch: ForwardBatch,
@@ -3291,9 +3299,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             else:
                 self.attn_backend.init_forward_metadata(forward_batch)
         # FIXME: add pp_proxy_tensors arg to all models
-        kwargs = {}
-        if self.support_pp:
-            kwargs["pp_proxy_tensors"] = pp_proxy_tensors
+        kwargs = self._pp_kwargs(pp_proxy_tensors)
 
         # Launch forward
         ctx = (
@@ -3326,9 +3332,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput], bool
     ]:
         # Setup extra arguments
-        kwargs = {}
-        if self.support_pp:
-            kwargs["pp_proxy_tensors"] = pp_proxy_tensors
+        kwargs = self._pp_kwargs(pp_proxy_tensors)
         if forward_batch.input_embeds is not None:
             kwargs["input_embeds"] = forward_batch.input_embeds.bfloat16()
         if (
@@ -3430,9 +3434,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             self.attn_backend.forward_metadata = None
 
-        kwargs = {}
-        if self.support_pp:
-            kwargs["pp_proxy_tensors"] = pp_proxy_tensors
+        kwargs = self._pp_kwargs(pp_proxy_tensors)
         ctx = (
             self.device_timer.wrap(metadata={"category": "idle"})
             if self.device_timer


### PR DESCRIPTION
## Motivation

`forward_decode` / `forward_extend` / `forward_idle` each repeated the same idiom for threading pipeline-parallel proxy tensors into `model.forward`: `kwargs = {}; if support_pp: kwargs["pp_proxy_tensors"] = ...`. Centralize it.

## Modifications

- Extract the idiom into `_pp_kwargs(pp_proxy_tensors)` (same `support_pp` gate).
- The `_dummy_run` pp path (pp_size>1 + signature check + clone of a fresh `PPProxyTensors`) is intentionally left as-is — it has a different contract.

Pure helper extraction.

## Accuracy Tests

N/A — behavior-preserving refactor (no change to model outputs).

## Speed Tests and Profiling

N/A — no inference-speed impact.

## Checklist

- [x] Format your code with pre-commit.
- [x] Behavior-preserving; covered by the existing runner-mode attention unit tests (`test/registered/attention/unittests/dense`).
- [x] Follow the SGLang code style guidance.

> Builds on #28381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27647790450](https://github.com/sgl-project/sglang/actions/runs/27647790450)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27647790017](https://github.com/sgl-project/sglang/actions/runs/27647790017)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->