### PR TITLE
[Spec][LoRA] Support single-adapter LoRA with NEXTN/EAGLE speculative decoding

### DIFF
--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -266,16 +266,27 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             adapter_enabled = None
             token_lora_mapping = None
 
-        num_tokens = (
-            sum(forward_batch.extend_seq_lens_cpu)
-            if forward_batch.forward_mode.is_extend()
-            else forward_batch.batch_size
-        )
-        max_len = (
-            max(forward_batch.extend_seq_lens_cpu)
-            if forward_batch.forward_mode.is_extend()
-            else 1
-        )
+        fb = forward_batch
+        if fb.forward_mode.is_target_verify():
+            # Target-verify reports is_extend() but leaves extend_seq_lens_cpu=None
+            # (including during CUDA-graph capture). Every request verifies a uniform
+            # spec_info.draft_token_num tokens -- the same source
+            # generate_sequence_lengths() uses -- so derive the scalar counts directly
+            # (no GPU sync, unlike materializing a seg_lens tensor).
+            num_tokens_per_bs = fb.spec_info.draft_token_num
+            num_tokens = fb.batch_size * num_tokens_per_bs
+            max_len = num_tokens_per_bs
+            assert num_tokens <= fb.input_ids.shape[0], (
+                f"target-verify token count {num_tokens} exceeds input buffer "
+                f"{fb.input_ids.shape[0]}"
+            )
+        elif fb.forward_mode.is_extend():
+            extend_lens = fb.extend_seq_lens_cpu
+            num_tokens = sum(extend_lens)
+            max_len = max(extend_lens)
+        else:
+            num_tokens = fb.batch_size
+            max_len = 1
 
         if (
             batch_info.req_seg_indptr is not None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7981,12 +7981,6 @@ class ServerArgs:
                     f"so --max-loaded-loras must be less than or equal to double --max-loras-per-batch: {max_loaded_loras_limit}"
                 )
 
-            # Validate compatibility with speculative decoding
-            if self.speculative_algorithm not in ["NGRAM", None]:
-                raise ValueError(
-                    "Currently LoRA is only compatible with NGRAM speculative decoding."
-                )
-
             # Parse lora_paths
             if isinstance(self.lora_paths, list):
                 lora_paths = self.lora_paths
@@ -8044,6 +8038,8 @@ class ServerArgs:
                     "Expected a list or a dictionary."
                 )
 
+            self._check_lora_speculative_compatibility()
+
             # Normalize target modules to a set; keep {"all"} as a sentinel
             # that gets resolved model-awarely in lora_manager.init_lora_shapes().
             if self.lora_target_modules:
@@ -8081,6 +8077,55 @@ class ServerArgs:
             assert (
                 self.lora_drain_wait_threshold >= 0.0
             ), "--lora-drain-wait-threshold must be non-negative."
+
+    def _check_lora_speculative_compatibility(self):
+        """Validate LoRA + speculative decoding combinations.
+
+        LoRA is fully compatible with NGRAM speculative decoding. For NEXTN/EAGLE
+        (e.g. a model's built-in MTP head) LoRA is supported only in a fixed
+        single-adapter configuration: the adapter applies to the target model
+        while the draft worker runs unadapted (see make_draft_server_args).
+        """
+        if self.speculative_algorithm in ["NGRAM", None]:
+            return
+
+        if self.speculative_algorithm not in ["EAGLE", "NEXTN"]:
+            raise ValueError(
+                "Currently LoRA is only compatible with NGRAM speculative decoding, "
+                "or fixed single-adapter LoRA with NEXTN/EAGLE speculative decoding."
+            )
+
+        # Adaptive speculative decoding mutates speculative_num_steps (and related
+        # fields) at runtime. The draft worker is built from a static snapshot of
+        # ServerArgs (see make_draft_server_args), so adaptive updates would not be
+        # reflected in the draft -- desynchronizing target and draft. This combo is
+        # unvalidated, so reject it explicitly rather than silently diverge.
+        if self.speculative_adaptive:
+            raise ValueError(
+                "LoRA with NEXTN/EAGLE speculative decoding does not support "
+                "--speculative-adaptive (the draft worker uses a static ServerArgs "
+                "snapshot, which adaptive runtime updates would desynchronize)."
+            )
+
+        if (
+            len(self.lora_paths) == 1
+            and self.max_loras_per_batch == 1
+            and not self.enable_lora_overlap_loading
+            and not self.enable_multi_layer_eagle
+        ):
+            logger.warning(
+                "LoRA with NEXTN/EAGLE speculative decoding is enabled in "
+                "fixed single-adapter mode. This path is experimental and does "
+                "not support multi-LoRA batching."
+            )
+            return
+
+        raise ValueError(
+            "LoRA with NEXTN/EAGLE speculative decoding currently requires "
+            "fixed single-adapter mode: provide exactly one --lora-paths entry, "
+            "set --max-loras-per-batch=1, disable --enable-lora-overlap-loading, "
+            "and do not enable multi-layer EAGLE."
+        )
 
     def validate_buckets_rule(self, arg_name: str, buckets_rule: List[str]):
         if not buckets_rule:

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,9 +1,29 @@
 import logging
+from copy import copy
 
 from sglang.srt.server_args import ServerArgs, get_global_server_args
 from sglang.srt.utils.common import is_blackwell, is_hip, is_musa
 
 logger = logging.getLogger(__name__)
+
+
+def make_draft_server_args(server_args: ServerArgs) -> ServerArgs:
+    """Build the ServerArgs used to initialize a speculative draft worker.
+
+    LoRA adapters apply to the target model only. Draft/MTP weights are loaded
+    from their own checkpoint and must not initialize a second (target) LoRA
+    manager, so LoRA is stripped from the draft worker's server args.
+
+    Note: this is a static snapshot (shallow copy). It is correct for static
+    speculative configs; LoRA + adaptive speculative decoding is rejected up
+    front in ServerArgs._check_lora_speculative_compatibility() precisely
+    because adaptive runtime updates to the target args would not propagate here.
+    """
+    draft_server_args = copy(server_args)
+    draft_server_args.enable_lora = False
+    draft_server_args.enable_lora_overlap_loading = False
+    draft_server_args.lora_paths = []
+    return draft_server_args
 
 
 class DraftBackendFactory:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -48,7 +48,10 @@ from sglang.srt.speculative.adaptive_runtime_state import (
     SpecRuntimeState,
 )
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
-from sglang.srt.speculative.draft_utils import DraftBackendFactory
+from sglang.srt.speculative.draft_utils import (
+    DraftBackendFactory,
+    make_draft_server_args,
+)
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
 )
@@ -158,6 +161,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self._rebuild_topk1_chain_buffers()
 
         # Load draft model weights only.
+        # LoRA applies to the target model; the draft worker runs unadapted.
+        draft_server_args = make_draft_server_args(server_args)
         if server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
             ctx = draft_tp_context(get_attention_tp_group())
         else:
@@ -166,7 +171,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             ctx
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
             self.draft_worker = TpModelWorker(
-                server_args=server_args,
+                server_args=draft_server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
                 pp_rank=0,  # spec workers don't support pipeline parallelism

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -70,6 +70,112 @@ class TestPrepareServerArgs(CustomTestCase):
             os.unlink(config_file)
 
 
+class TestLoRASpeculativeArgs(unittest.TestCase):
+    def test_single_lora_allows_eagle_speculative_decoding(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_lora=True,
+            lora_paths=["adapter=/tmp/adapter"],
+            max_loras_per_batch=1,
+            speculative_algorithm="EAGLE",
+        )
+
+        server_args.check_lora_server_args()
+
+        self.assertEqual(len(server_args.lora_paths), 1)
+        self.assertEqual(server_args.lora_paths[0].lora_name, "adapter")
+
+    def test_single_lora_allows_nextn_before_normalization(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_lora=True,
+            lora_paths=["adapter=/tmp/adapter"],
+            max_loras_per_batch=1,
+            speculative_algorithm="NEXTN",
+        )
+
+        server_args.check_lora_server_args()
+
+        self.assertEqual(len(server_args.lora_paths), 1)
+
+    def test_multi_lora_rejects_eagle_speculative_decoding(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_lora=True,
+            lora_paths=["a=/tmp/a", "b=/tmp/b"],
+            max_loras_per_batch=2,
+            speculative_algorithm="EAGLE",
+        )
+
+        with self.assertRaisesRegex(ValueError, "fixed single-adapter mode"):
+            server_args.check_lora_server_args()
+
+    def test_lora_still_allows_ngram_speculative_decoding(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_lora=True,
+            lora_paths=["a=/tmp/a", "b=/tmp/b"],
+            max_loras_per_batch=2,
+            speculative_algorithm="NGRAM",
+        )
+
+        server_args.check_lora_server_args()
+
+        self.assertEqual(len(server_args.lora_paths), 2)
+
+    def test_lora_rejects_multi_layer_eagle_speculative_decoding(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_lora=True,
+            lora_paths=["adapter=/tmp/adapter"],
+            max_loras_per_batch=1,
+            speculative_algorithm="EAGLE",
+            enable_multi_layer_eagle=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "fixed single-adapter mode"):
+            server_args.check_lora_server_args()
+
+    def test_lora_rejects_adaptive_speculative_decoding(self):
+        # The draft worker is built from a static ServerArgs snapshot, so adaptive
+        # runtime updates would desync target/draft -> reject up front.
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_lora=True,
+            lora_paths=["adapter=/tmp/adapter"],
+            max_loras_per_batch=1,
+            speculative_algorithm="EAGLE",
+            speculative_adaptive=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "speculative-adaptive"):
+            server_args.check_lora_server_args()
+
+    def test_make_draft_server_args_strips_lora_without_mutating_original(self):
+        from sglang.srt.speculative.draft_utils import make_draft_server_args
+
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_lora=True,
+            enable_lora_overlap_loading=False,
+            lora_paths=["adapter=/tmp/adapter"],
+            max_loras_per_batch=1,
+            speculative_algorithm="EAGLE",
+        )
+        server_args.check_lora_server_args()
+
+        draft = make_draft_server_args(server_args)
+
+        # Draft worker must not carry any LoRA configuration.
+        self.assertFalse(draft.enable_lora)
+        self.assertFalse(draft.enable_lora_overlap_loading)
+        self.assertEqual(draft.lora_paths, [])
+
+        # The original (target) ServerArgs must be untouched.
+        self.assertTrue(server_args.enable_lora)
+        self.assertEqual(len(server_args.lora_paths), 1)
+
+
 class TestLoadBalanceMethod(unittest.TestCase):
     def test_non_pd_defaults_to_round_robin(self):
         server_args = ServerArgs(model_path="dummy", disaggregation_mode="null")


### PR DESCRIPTION
## Motivation

#12903 enabled LoRA with speculative decoding but scoped it to NGRAM. This extends it to NEXTN/EAGLE for a fixed single adapter, one of the LoRA items in #11762. Speculative decoding is lossless w.r.t. the target, so a LoRA'd target can be accelerated by an unadapted draft.

## Modifications

- `server_args.py`: replace the "LoRA only with NGRAM" rejection with `_check_lora_speculative_compatibility()`. NGRAM is unchanged; NEXTN/EAGLE are allowed only in fixed single-adapter mode (one `--lora-paths` entry, `--max-loras-per-batch 1`, no overlap loading, no multi-layer EAGLE). `--speculative-adaptive` + LoRA is rejected since the draft worker uses a static args snapshot.
- `speculative/draft_utils.py`: add `make_draft_server_args()` to strip LoRA from the draft worker (LoRA applies to the target model only).
- `speculative/eagle_worker_v2.py`: build the draft worker from the stripped args.
- `lora/backend/base_backend.py`: fix `_add_moe_lora_info` for target-verify, where `extend_seq_lens_cpu` is `None`; derive token counts from `spec_info.draft_token_num`.
- Add unit tests for the arg matrix and `make_draft_server_args`.

Mixed base + LoRA co-batching (which needs `max_loras_per_batch >= 2`) is left for a follow-up.

## Accuracy Tests

EAGLE with a trained draft, fully reproducible: `Llama-2-7b-chat-hf` + `lmsys/sglang-EAGLE-llama2-chat-7B` + a Norwegian LoRA. The server launches in single-adapter mode, base and LoRA requests both return 200 with EAGLE decode active, and `max_loras_per_batch=2` is correctly rejected. MoE + NEXTN (built-in MTP head) additionally covers the `base_backend` fix: LoRA and base outputs each match their non-spec output, and tool calls and a 46K-token retrieval pass for both.

## Speed Tests and Profiling

MoE/NEXTN, single-stream, server-side decode throughput (accept length ~3.0 in every case):

| Config | MoE runner | decode tok/s |
| --- | --- | --- |
| base | `flashinfer_trtllm` | ~200–250 |
| base | `triton` | ~87 |
| LoRA | `triton` | ~60 |

MoE-LoRA requires the `triton` runner, which is ~2.5x slower than the `flashinfer_trtllm` default; the LoRA kernels then add ~30% more. So the LoRA-serving cost here is dominated by the runner requirement, not by speculation — accept length is unchanged at ~3.0 and holds at 46K context. The Llama EAGLE accept length is lower (~1.5) because that draft is unadapted to the LoRA, which is expected and still lossless.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [x] Provide accuracy and speed results
