### PR TITLE
[Perf] Avoid per-decode-step host sync in min_new_tokens penalty

### DIFF
--- a/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
+++ b/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
@@ -67,8 +67,11 @@ class BatchedMinNewTokensPenalizer(_BatchedPenalizer):
         self.len_output_tokens += 1
 
     def _apply(self, logits: torch.Tensor):
-        mask = (self.len_output_tokens < self.min_new_tokens).expand_as(logits)
-        logits[mask] += self.stop_token_penalties[mask]
+        # Boolean-mask indexing (logits[mask]) is data-dependent and forces a
+        # device-to-host sync every decode step; torch.where is a plain
+        # elementwise select with no sync (and no -inf*0=nan).
+        mask = self.len_output_tokens < self.min_new_tokens
+        logits.add_(torch.where(mask, self.stop_token_penalties, 0.0))
 
     def _filter(self, keep_indices: torch.Tensor):
         self.min_new_tokens = self.min_new_tokens[keep_indices]


### PR DESCRIPTION
`BatchedMinNewTokensPenalizer._apply` used boolean-mask indexing (`logits[mask]`), which is data-dependent and forces a device-to-host sync on every decode step whenever the penalty is active (any request with `min_tokens > 0`). Replace it with a `torch.where` elementwise select: no sync, numerically equivalent, and avoids `-inf * 0 = nan`.

This per-step host sync is part of the reason for the decode throughput regression reported in #28218 — it lands on the per-token critical path for `min_tokens` workloads. This PR addresses that one contributing factor and is not a full fix on its own.