### PR TITLE
[AMD] Fuse QK GemmaRMSNorm + MRoPE into single aiter op for Qwen3.5 attn-prep on HIP

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -130,6 +130,24 @@ _is_amx_available = cpu_has_amx_support()
 cached_get_processor = lru_cache(get_processor)
 
 
+def _split_qk_gate(
+    q_gate: torch.Tensor, head_dim: int, num_heads: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """De-interleave q and gate from a per-head interleaved buffer.
+
+    ``q_gate`` is ``(seq, num_heads * 2 * head_dim)`` laid out as
+    ``[q_h0, gate_h0, q_h1, gate_h1, ...]``. Returns contiguous
+    ``q`` ``(seq, num_heads, head_dim)`` and ``gate`` ``(seq * num_heads, head_dim)``.
+    Unlike ``fused_qk_gemma_rmsnorm_with_gate`` this does NOT apply RMSNorm to q;
+    normalization is handled by the downstream AITER fused kernel.
+    """
+    seq_len = q_gate.shape[0]
+    qg = q_gate.view(seq_len, num_heads, 2, head_dim)
+    q = qg[:, :, 0, :].contiguous()
+    gate = qg[:, :, 1, :].reshape(seq_len * num_heads, head_dim).contiguous()
+    return q, gate
+
+
 def _disable_shared_experts_fusion() -> bool:
     # Resolved lazily: the global server args is not set at module import time
     # (e.g. when this module is imported by unit tests).
@@ -905,6 +923,99 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         q, k = self.rotary_emb(positions, q, k)
         return q, k, v, gate
 
+    def _forward_prepare_hip_fused(self, positions, q, k, v, seq_len):
+        """AITER-fused QK GemmaRMSNorm + RoPE for the attn-output-gate path.
+
+        Fuses the GemmaRMSNorm (`_fused_qk_gemma_rmsnorm_gate_kernel` norm part)
+        and the RoPE (`_triton_mrope_forward_fused`) into a single AITER kernel
+        (``fused_qk_norm_mrope_3d_cache_pts_quant_shuffle``). KV-cache storage
+        stays on the existing ``self.attn`` path: we request ``return_kv`` and
+        feed scratch cache buffers so the op's mandatory cache write is harmless.
+
+        GemmaRMSNorm scales by ``(weight + 1.0)``; the AITER op uses a plain
+        ``weight * x`` RMSNorm, so we pre-add 1.0 to the norm weights.
+        """
+        from aiter.ops.fused_qk_norm_mrope_cache_quant import (
+            fused_qk_norm_mrope_3d_cache_pts_quant_shuffle,
+        )
+
+        rotary_emb = self.rotary_emb
+        rotary_emb._match_cos_sin_cache_dtype(q)
+        cos_sin = rotary_emb.cos_sin_cache
+
+        # MRoPE metadata. The aiter op expects mrope_section to sum to
+        # rotary_dim/2 and an explicit interleaved flag; MRotaryEmbedding has
+        # already validated/corrected these at construction time.
+        mrope_section = list(getattr(rotary_emb, "mrope_section", None) or [])
+        mrope_interleaved = bool(getattr(rotary_emb, "mrope_interleaved", False))
+        # The kernel views positions as (3, num_tokens) for the T/H/W axes. For
+        # text-only inference every axis is the token index, so broadcast a 1D
+        # positions tensor across the 3 mrope axes.
+        if positions.dim() == 1:
+            positions = positions.view(1, -1).expand(3, -1).contiguous()
+        else:
+            positions = positions.contiguous()
+
+        qkv_fused = torch.cat((q, k, v), dim=-1).contiguous()
+        # Pre-add 1.0 to the GemmaRMSNorm weights and build the unit per-tensor
+        # scales ONCE, cached on the module. Allocating these (esp. host-scalar
+        # ``torch.tensor(1.0)``) on every call is illegal inside a CUDA/HIP graph
+        # capture ("operation not permitted when stream is capturing"), which is
+        # exactly the decode path that gets graph-captured.
+        if getattr(self, "_fused_qk_norm_cache", None) is None:
+            qw = (self.q_norm.weight.data + 1.0).contiguous()
+            kw = (self.k_norm.weight.data + 1.0).contiguous()
+            unit_scale = torch.ones((), dtype=torch.float32, device=q.device)
+            self._fused_qk_norm_cache = (qw, kw, unit_scale)
+        qw, kw, unit_scale = self._fused_qk_norm_cache
+
+        q_out = torch.empty(
+            seq_len, self.num_heads, self.head_dim, dtype=q.dtype, device=q.device
+        )
+        k_out = torch.empty(
+            seq_len, self.num_kv_heads, self.head_dim, dtype=k.dtype, device=k.device
+        )
+        v_out = torch.empty(
+            seq_len, self.num_kv_heads, self.head_dim, dtype=v.dtype, device=v.device
+        )
+        # Scratch cache targets (op always writes cache); real store stays on
+        # the attention backend below via ``self.attn``.
+        k_cache = torch.empty_like(k_out)
+        v_cache = torch.empty_like(v_out)
+        slot_mapping = torch.arange(seq_len, device=q.device, dtype=torch.int64)
+
+        rotary_dim = int(self.head_dim * self.partial_rotary_factor)
+        fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(
+            qkv_fused,
+            qw,
+            kw,
+            cos_sin,
+            positions,
+            seq_len,
+            self.num_heads,
+            self.num_kv_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            rotary_emb.is_neox_style,
+            mrope_section,
+            mrope_interleaved,
+            self.q_norm.variance_epsilon,
+            q_out,
+            k_cache,
+            v_cache,
+            slot_mapping,
+            unit_scale,
+            unit_scale,
+            k_out,
+            v_out,
+            True,
+            False,
+            0,
+            0,
+            rotary_dim if rotary_dim != self.head_dim else 0,
+        )
+        return q_out.view(seq_len, -1), k_out.view(seq_len, -1), v_out.view(seq_len, -1)
+
     def forward_prepare_hip(self, positions, hidden_states):
         qkv, _ = self.qkv_proj(hidden_states)
         if self.attn_output_gate:
@@ -912,6 +1023,19 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
             )
             seq_len = q_gate.shape[0]
+            if _use_aiter:
+                # AITER-fused QK GemmaRMSNorm + RoPE. Gate is de-interleaved
+                # separately; q/k are normed+roped by the fused op.
+                q_raw, gate_flat = _split_qk_gate(q_gate, self.head_dim, self.num_heads)
+                q, k, v = self._forward_prepare_hip_fused(
+                    positions,
+                    q_raw.view(seq_len, -1),
+                    k.contiguous(),
+                    v.contiguous(),
+                    seq_len,
+                )
+                gate = gate_flat.view(seq_len, -1)
+                return q, k, v, gate
             q_flat, k_flat, gate_flat = fused_qk_gemma_rmsnorm_with_gate(
                 q_gate,
                 k,


### PR DESCRIPTION
## Maintainer Judgement (DRAFT)

This PR is opened as a **draft**: it is functionally correct but does **not** clear the kernel-time perf gate (≥ 1% improvement on the replaced region), so it is **not a merge-ready performance change** as-is.

- Accuracy is correct (GSM8K 0.935 vs 0.85 threshold) — the fused dispatch produces numerically sound q/k.
- The target aiter op intermittently fails **HIP CUDA-graph capture** (`operation not permitted when stream is capturing`), which is exactly the graph-captured decode path used in production. To get an apples-to-apples before/after, both baseline and after had to be measured in **eager mode**, where ITL regressed **+1.6%**. No speedup is demonstrated on the graphed (production) path.
- **Recommendation:** keep as a reference until the aiter op is made graph-capture-safe; the SGLang-side dispatch here is correct and can be re-benchmarked once that lands.

## Motivation

On HIP, the Qwen3.5 attention-output-gate prepare path (`forward_prepare_hip`) normalizes and rotates q/k with two separate launches per attention layer:

1. `_fused_qk_gemma_rmsnorm_gate_kernel` — GemmaRMSNorm on q/k
2. `_triton_mrope_forward_fused` — MRoPE on q/k

This PR routes the q/k norm+RoPE through a single aiter op, `fused_qk_norm_mrope_3d_cache_pts_quant_shuffle`, when `_use_aiter` is set — collapsing the two launches into one. The output gate is de-interleaved separately (no RMSNorm), and KV-cache storage is left on the existing attention backend (the op's mandatory cache write targets scratch buffers).

## Modifications

- **`python/sglang/srt/models/qwen3_5.py`**:
  - Add `_split_qk_gate()` — de-interleaves q and gate from the `[q_h0, gate_h0, …]` per-head buffer (gate only; q is normed downstream).
  - Add `_forward_prepare_hip_fused()` — calls the aiter fused QK GemmaRMSNorm + MRoPE op. GemmaRMSNorm's `(weight + 1.0)` scaling is pre-applied to the norm weights, and the per-tensor unit scales / pre-added weights are cached **once** on the module (allocating host scalars per call is illegal during HIP graph capture).
  - Dispatch to the fused path in `forward_prepare_hip` only when `_use_aiter and self.attn_output_gate`. The non-aiter (common) path is byte-identical; no top-level aiter import.

## Accuracy Tests

Model: Qwen3.5-397B-A17B-MXFP4, TP=2, MI355X

| Benchmark | Score | Threshold | Status |
|-----------|:-----:|:---------:|:------:|
| GSM8K (200 questions, parallel=2000) | 0.935 | 0.85 | PASS |

Invalid rate: 0.5%. The fused dispatch is numerically correct.

## Speed Tests and Profiling

### Profiling (decode, TP=2, MI355X) — CONFIRMED

- `aiter::fused_qk_norm_mrope_3d_cache_pts_quant_shuffle` present (135 invocations = 15 attention layers × 9 profiled iters).
- GPU kernel `fused_mrope_rms_kv_kernel<…>` measured at **10.75 µs** avg/layer.
- The two pre-fusion launches (`_fused_qk_gemma_rmsnorm_gate_kernel`, `_triton_mrope_forward_fused`) are gone from the attn-prep path.

### E2E benchmark (eager / `--disable-cuda-graph`; random 8192/1024, conc=4)

| Metric | Baseline | After | Delta |
|--------|:--------:|:-----:|:-----:|
| Total throughput (tok/s) | 436.50 | 430.90 | -1.3% |
| Output throughput (tok/s) | 49.18 | 48.55 | -1.3% |
| Median ITL (ms) | 76.27 | 77.47 | +1.6% |
| Median TPOT (ms) | 76.90 | 77.81 | +1.2% |

Measured in eager mode only (see Notes), so absolute latencies are ~8× a graphed run and the per-layer micro-change is diluted. **No measurable speedup** — this is why the PR is a draft.

## Notes

- The aiter fused op currently raises `operation not permitted when stream is capturing` intermittently during HIP graph capture; it must be made graph-capture-safe before this can run in the production (graphed) decode path.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
