### PR TITLE
[AMD] Use aiter fused topk_gating for Qwen3.5 MoE routing on HIP

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -183,7 +183,7 @@ if _is_cuda or _is_hip or _is_xpu:
 if _use_aiter:
     try:
         from aiter import biased_grouped_topk as aiter_biased_grouped_topk
-        from aiter.fused_moe import fused_topk as aiter_fused_topk
+        from aiter.ops.topk import topk_gating as aiter_topk_gating
     except ImportError:
         raise ImportError("aiter is required when SGLANG_USE_AITER is set to True")
 if _is_musa:
@@ -729,15 +729,29 @@ def fused_topk(
     if scoring_func == "softmax":
         if _use_aiter:
 
-            # Use fused_topk instead of topk_softmax to auto dispatch to the correct kernel
-            topk_weights, topk_ids = aiter_fused_topk(
-                hidden_states,
+            # Fused topk gating softmax: a single aiter kernel fuses the gating
+            # softmax (topkGatingSoftmax) with the top-k selection/sorting
+            # (opus_moe_sorting_entry), writing topk_weights/topk_ids in one
+            # launch instead of the separate softmax + topk of aiter_fused_topk.
+            #
+            # NOTE: topk_gating forces need_renorm=False for score_func="softmax"
+            # (it assumes the full softmax is already normalized). That is only
+            # true *before* top-k selection -- after selecting the top-k experts
+            # the selected weights no longer sum to 1, so we must renormalize
+            # them here when renormalize=True. Skipping this corrupts MoE routing
+            # (correct expert ids but wrong, sub-unity weights) and collapses
+            # accuracy. The renorm runs on the tiny (M x topk) weight tensor and
+            # does not negate the kernel-fusion benefit of the gating launch.
+            aiter_topk_gating(
+                topk_weights,
+                topk_ids,
                 gating_output,
-                topk,
-                renormalize,
-                topk_ids=topk_ids,
-                topk_weights=topk_weights,
+                correction_bias=None,
+                need_renorm=renormalize,
+                score_func="softmax",
             )
+            if renormalize:
+                topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
         # ===== TO BE REFACTORED ====
         elif packed_out is not None:
             # Fused gating + routed pack (SGLANG_OPT_LORA_FUSED_TOPK_PACK): one JIT kernel


### PR DESCRIPTION
## Maintainer Judgement (DRAFT)

This PR is opened as a **draft**: it is functionally correct but does **not** clear the kernel-time perf gate (≥ 1% improvement on the replaced region), so it is **not a merge-ready performance change** as-is.

- Accuracy is correct (GSM8K 0.925 vs 0.85 threshold) after the renormalization fix described below.
- There is **no perf gain**: the fused `topk_softplus` (7.4 µs) + `opus_moe_sorting_entry` (29.5 µs) pair, plus the small added renorm op, is on-par-to-slower than the baseline single `topk_softmax`; observed ITL **+3.7%**.
- **Recommendation:** the decisive outcome here is correctness, not speed. Keep only if a genuinely faster fused gating path is available; otherwise the existing `aiter.fused_moe.fused_topk` baseline is preferable.

## Motivation

On HIP, Qwen3.5 MoE routing (`fused_topk`, softmax scoring) dispatches to `aiter.fused_moe.fused_topk`, which runs the gating softmax and the top-k selection as separate steps. aiter exposes `aiter.ops.topk.topk_gating`, which fuses the gating softmax (`topkGatingSoftmax`) with the top-k select/sort (`opus_moe_sorting_entry`) into a single launch. This PR switches the `_use_aiter` softmax branch to that fused op.

## Modifications

- **`python/sglang/srt/layers/moe/topk.py`**:
  - Swap the `_use_aiter` import from `aiter.fused_moe.fused_topk` to `aiter.ops.topk.topk_gating`.
  - In the `scoring_func == "softmax"` / `_use_aiter` branch, call `topk_gating` (writing `topk_weights`/`topk_ids` in one launch).
  - **Renormalization (required for correctness):** `topk_gating` forces `need_renorm=False` for softmax scoring (it assumes a full, already-normalized softmax). That holds only *before* top-k selection — the selected top-k weights no longer sum to 1, so when `renormalize=True` we renormalize the `(M × topk)` weight tensor after the fused call. The renorm runs on a tiny tensor and does not negate the gating fusion.
  - The non-aiter (common) path is unchanged.

## Accuracy Tests

Model: Qwen3.5-397B-A17B-MXFP4

| Benchmark | Score | Threshold | Status |
|-----------|:-----:|:---------:|:------:|
| GSM8K (200 questions, parallel=2000) | 0.925 | 0.85 | PASS |

Invalid rate: 0.5%. Numerically verified against the baseline `fused_topk` path: identical expert IDs, weights matched to float32 epsilon after renormalization.

## Speed Tests and Profiling

### Profiling (decode, TP=2) — CONFIRMED

- Fused path active: `aiter::topk_softplus_kernel` (avg 7.43 µs) + `aiter::opus_moe_sorting_entry` (avg 29.53 µs).
- Baseline `aiter::topk_softmax` path fully removed (0 events) — swap confirmed.

### Kernel-region time

| Region | Before | After | Delta |
|--------|:------:|:-----:|:-----:|
| Routing gating + select | `topk_softmax` (single kernel) | `topk_softplus` + `opus_moe_sorting` + renorm | ~flat / slightly worse |

The fused pair does not beat the baseline single kernel — **the ≥1% kernel-time improvement is not met**.

### E2E benchmark (random 8192/1024, conc=4, TP=2)

| Metric | Baseline | After | Delta |
|--------|:--------:|:-----:|:-----:|
| Total throughput (tok/s) | 411.63 | 403.65 | -1.9% |
| Output throughput (tok/s) | 46.38 | 45.48 | -1.9% |
| Median ITL (ms) | 10.48 | 10.87 | +3.7% |
| Median TPOT (ms) | 11.05 | 11.43 | +3.4% |

Gating is a sub-1% slice of the ~11 ms iteration, so the e2e deltas sit within run-to-run noise — but the direction is **not** an improvement. This is **not a speedup**.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
