### PR TITLE
[AMD][Fix] Skip EPLB topk remap when global server args are unset

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1118,7 +1118,13 @@ def _eplb_remap_enabled() -> bool:
     # both unnecessary and not well-defined over the padded region of topk_ids).
     from sglang.srt.server_args import get_global_server_args
 
-    server_args = get_global_server_args()
+    try:
+        server_args = get_global_server_args()
+    except ValueError:
+        # Global server args are not initialized outside the server runtime
+        # (e.g. in unit tests that call select_experts directly). In that case
+        # there is no EPLB mapping, so the remap must be skipped.
+        return False
     return (
         server_args.enable_eplb
         or server_args.init_expert_location != "trivial"


### PR DESCRIPTION


## Motivation

PR 28188 added _eplb_remap_enabled() to the HIP branch of _post_process_topk_ids, which calls get_global_server_args() unconditionally. This breaks unit tests that call select_experts directly without a running server runtime: get_global_server_args() raises ValueError("Global server args is not set yet!").

This regression only affects the AMD/HIP path. The CUDA branch does not probe server args, and the NPU/CPU paths do not enter this branch at all, so only AMD CI was affected.

Failing test on AMD CI:
```
ERROR: test_w8a8_block_int8_fused_moe (test/registered/quant/test_block_int8.py) ... File "python/sglang/srt/layers/moe/topk.py", line 1531, in _post_process_topk_ids if _eplb_remap_enabled(): File "python/sglang/srt/layers/moe/topk.py", line 1121, in _eplb_remap_enabled server_args = get_global_server_args() File "python/sglang/srt/server_args.py", line 8342, in get_global_server_args raise ValueError("Global server args is not set yet!") ValueError: Global server args is not set yet!
```

## Modification

Guard _eplb_remap_enabled() against missing global server args. When they are not initialized (i.e. outside the server runtime, such as in unit tests), there is no EPLB mapping, so the logical->physical remap is correctly skipped by returning False.

This has zero effect on the production / server runtime, where global server args are always set; only the no-server code path is made to degrade gracefully instead of crashing.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27600430197](https://github.com/sgl-project/sglang/actions/runs/27600430197)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27600442013](https://github.com/sgl-project/sglang/actions/runs/27600442013)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->