### PR TITLE
[CI] Extend AMD JIT kernel timeout

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -393,7 +393,7 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run JIT kernel unit tests
-        timeout-minutes: 10
+        timeout-minutes: 30
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -386,7 +386,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run JIT kernel unit tests
-        timeout-minutes: 10
+        timeout-minutes: 30
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 


### PR DESCRIPTION
## Summary
- Increase AMD ROCm 7 JIT kernel unit test timeout from 10 to 30 minutes.
- Increase AMD ROCm 7.2 JIT kernel unit test timeout from 10 to 30 minutes.

## Test plan
- Pre-commit checks passed, including YAML validation and duplicate workflow job name check.


Made with [Cursor](https://cursor.com)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27603168036](https://github.com/sgl-project/sglang/actions/runs/27603168036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27603167874](https://github.com/sgl-project/sglang/actions/runs/27603167874)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->