### PR TITLE
Fix scheduler crash on None mamba_next_track_idx for finished reqs in speculative verify

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1584,7 +1584,18 @@ def set_mamba_track_indices_from_reqs(batch):
     ]  # (bs, ping_pong_size), int64, on device
     idx = (
         torch.tensor(
-            [req.mamba_next_track_idx for req in batch.reqs],
+            [
+                # A request that finished during a speculative TARGET_VERIFY step
+                # can still be present here after its mamba resources were
+                # released (mamba_next_track_idx is reset to None on free). Its
+                # track index is unused, so guard the None to avoid
+                # "TypeError: 'NoneType' object cannot be interpreted as an
+                # integer" when building the int64 tensor. Reliably triggered by
+                # structured-output (grammar) requests, which finish
+                # deterministically at grammar completion. See #28407.
+                req.mamba_next_track_idx if req.mamba_next_track_idx is not None else 0
+                for req in batch.reqs
+            ],
             dtype=torch.int64,
             pin_memory=True,
         )


### PR DESCRIPTION
## Summary
Fixes #28407 — `set_mamba_track_indices_from_reqs` crashes all TP schedulers with `TypeError: 'NoneType' object cannot be interpreted as an integer` when a request finishes during a speculative `TARGET_VERIFY` step.

## Root cause
`prepare_mamba_track_for_verify` (active under `--mamba-scheduler-strategy extra_buffer`) calls `set_mamba_track_indices_from_reqs`, which builds:
```python
torch.tensor([req.mamba_next_track_idx for req in batch.reqs], dtype=torch.int64, ...)
```
A request that finished during the verify step can still be present in `batch.reqs` after its mamba resources were released — `mamba_next_track_idx` is reset to `None` on free. The `None` in the int64 list raises the `TypeError`, killing every TP scheduler.

Captured runtime state of the offending req (via diagnostic logging): `finished=True, mamba_pool_idx=None, mamba_ping_pong_track_buffer=None, is_retracted=False, has_grammar=True`.

Reliably triggered by structured-output (grammar) requests under NEXTN/MTP on hybrid (mamba) models such as Qwen3.5, because grammar requests finish deterministically at schema completion, so the finish lands on a verify step.

## Fix
Guard the `None` in the list comprehension — a finished req's track index is unused.

## Reproduction
```bash
python -m sglang.launch_server --model-path Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 \
  --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 --mamba-scheduler-strategy extra_buffer \
  --reasoning-parser qwen3 --tool-call-parser qwen3_coder --mem-fraction-static 0.8
```
Then send a `response_format` `json_schema` request → returns valid JSON once, then the scheduler dies.

## Verification (8x B200, sm_100)
With this fix:
- structured-output (`json_schema`) request with thinking on/off → returns valid JSON and the server stays up (was: crash).
- the diagnosed `None` condition still occurs (finished/freed reqs in batch) but is now handled — no crash.
- normal chat and 8-way concurrency unaffected (no regression).

## Note for maintainers
This is a minimal guard. An alternative would be to ensure finished requests are filtered from the batch before `prepare_mamba_track_for_verify`; happy to adjust to the preferred approach.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27603774185](https://github.com/sgl-project/sglang/actions/runs/27603774185)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27603773662](https://github.com/sgl-project/sglang/actions/runs/27603773662)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->