### PR TITLE
Fix reasoning parser crash when force_nonempty_content is set for unsupported detectors

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Dict, List, Optional, Tuple, Type
 
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
@@ -1128,7 +1129,12 @@ class ReasoningParser:
 
         chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
         if chat_template_kwargs.get("force_nonempty_content") is True:
-            kwargs["force_nonempty_content"] = True
+            # Only a subset of detectors (e.g. Nemotron3, Apertus2509) accept
+            # ``force_nonempty_content``. Forwarding it unconditionally would
+            # raise ``TypeError`` for every other detector, so only pass it
+            # when the selected detector actually declares the parameter.
+            if "force_nonempty_content" in inspect.signature(detector_class).parameters:
+                kwargs["force_nonempty_content"] = True
 
         self.detector = detector_class(**kwargs)
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.parser.reasoning_parser import (
     BaseReasoningFormatDetector,
     DeepSeekR1Detector,
@@ -15,7 +16,6 @@ from sglang.srt.parser.reasoning_parser import (
     ReasoningParser,
     StreamingParseResult,
 )
-from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -15,6 +15,7 @@ from sglang.srt.parser.reasoning_parser import (
     ReasoningParser,
     StreamingParseResult,
 )
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -1544,6 +1545,30 @@ class TestPoolsideV1Registered(CustomTestCase):
         rp = ReasoningParser("poolside_v1", stream_reasoning=True)
         self.assertEqual(rp.detector.reasoning_default, "explicit_enable_thinking")
         self.assertTrue(rp.detector.thinks_internally)
+
+
+class TestReasoningParserForceNonemptyContent(CustomTestCase):
+    """`force_nonempty_content` is only accepted by a subset of detectors
+    (Nemotron3, Apertus2509). When it is supplied via ``chat_template_kwargs``
+    for a model whose detector does not accept it, building the parser must not
+    raise ``TypeError`` from an unexpected keyword argument."""
+
+    def _request(self):
+        return ChatCompletionRequest(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"force_nonempty_content": True},
+        )
+
+    def test_unsupported_detector_does_not_crash(self):
+        # DeepSeekR1Detector does not accept force_nonempty_content.
+        parser = ReasoningParser("deepseek-r1", request=self._request())
+        self.assertFalse(getattr(parser.detector, "_force_nonempty_content", False))
+
+    def test_supported_detector_still_receives_flag(self):
+        # Nemotron3Detector accepts force_nonempty_content and must honor it.
+        parser = ReasoningParser("nemotron_3", request=self._request())
+        self.assertTrue(parser.detector._force_nonempty_content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`ReasoningParser.__init__` forwards the `force_nonempty_content` value from a request's `chat_template_kwargs` to the selected detector. However, only `Nemotron3Detector` and `Apertus2509Detector` declare a `force_nonempty_content` parameter — every other detector (DeepSeek-R1, Qwen3, GLM-4.5, Kimi, GPT-OSS, Mistral, etc.) does not.

As a result, sending a request for any non-supporting model with `chat_template_kwargs={"force_nonempty_content": True}` crashes the parser:

```
TypeError: DeepSeekR1Detector.__init__() got an unexpected keyword argument 'force_nonempty_content'
```

`chat_template_kwargs` is user-controllable, so this turns a benign/unknown kwarg into a hard failure when constructing the reasoning parser.

## Modifications

- `python/sglang/srt/parser/reasoning_parser.py`: only forward `force_nonempty_content` to the detector when the selected detector actually declares the parameter (checked via `inspect.signature`). It is still honored for `Nemotron3Detector`/`Apertus2509Detector` and silently ignored for detectors that do not support it, instead of raising `TypeError`.
- `test/registered/unit/parser/test_reasoning_parser.py`: add `TestReasoningParserForceNonemptyContent` covering both an unsupported detector (must not crash) and a supporting detector (flag still applied).

## Accuracy Tests

Not applicable — this is a control-flow bug fix in the parser dispatch; it does not change model outputs.

## Speed Tests and Profiling

Not applicable — no performance-sensitive paths are touched.

## Verification

Ran the reasoning-parser unit tests (offline, CPU only — no GPU/torch model load required for this module):

```
python -m pytest test/registered/unit/parser/test_reasoning_parser.py -q
126 passed
```

The new `test_unsupported_detector_does_not_crash` fails on `main` with the `TypeError` above and passes with this change; `test_supported_detector_still_receives_flag` confirms Nemotron3 still receives the flag.

## Checklist

- [x] Add unit tests according to the contribution guide.

> This PR was drafted with AI assistance and manually reviewed and verified by the author before submission.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27606736175](https://github.com/sgl-project/sglang/actions/runs/27606736175)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27606735351](https://github.com/sgl-project/sglang/actions/runs/27606735351)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->