### PR TITLE
[diffusion] Qwen-Image: fuse tanh-GELU into FFN up-proj GEMM (cublasLt epilogue)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -24,6 +24,7 @@ from sglang.multimodal_gen.runtime.layers.attention import (
     build_varlen_mask_meta,
 )
 from sglang.multimodal_gen.runtime.layers.elementwise import MulAdd
+from sglang.multimodal_gen.runtime.layers.fused_linear_act import linear_gelu_tanh
 from sglang.multimodal_gen.runtime.layers.fused_scale_shift_gate import (
     FusedLayerNormScaleShiftGateSelect01,
     FusedResidualLayerNormScaleShiftGateSelect01,
@@ -779,8 +780,9 @@ class QwenImageGELU(nn.Module):
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        hidden_states, _ = self.proj(hidden_states)
-        return F.gelu(hidden_states, approximate="tanh")
+        # Fuse the up-projection GEMM with the tanh-GELU via the cublasLt
+        # epilogue (falls back to proj + F.gelu when guards fail, e.g. quantized).
+        return linear_gelu_tanh(self.proj, hidden_states)
 
 
 class QwenImageFeedForward(nn.Module):


### PR DESCRIPTION
## Summary

`QwenImageGELU` (the up-projection + activation in `QwenImageFeedForward`,
`python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py`) computed
`proj(x)` followed by a **standalone, bandwidth-bound `F.gelu(approximate="tanh")`**
over the `[tokens, 4·dim]` FFN intermediate.

Route it through the existing cublasLt GELU-epilogue helper `linear_gelu_tanh`
(added in #28166, already used by `flux.py`), folding the bias-add + tanh-GELU
into the `proj` GEMM epilogue (`torch._addmm_activation(..., use_gelu=True)`).
This removes the extra kernel launch and the HBM round-trip of the FFN
intermediate. cublasLt's GELU matches tanh-approximate GELU within fp16/bf16
rounding, so the fused path is numerically equivalent for half-precision
inference; quantized checkpoints fall back to the reference path via the
helper guards.

The win is bandwidth-bound (it eliminates a read+write of the `[tokens, 4·dim]`
intermediate), so it scales with sequence length.

## Benchmark

Qwen-Image-2512, 1024×1024, **B200**, `--enable-torch-compile --warmup`, isolated
HF cache. Steady-state per-step denoise (step 0 excluded as the one-time compile spike).

Command shape:
```
sglang generate --model-path Qwen/Qwen-Image-2512 --prompt "..." \
  --width 1024 --height 1024 --seed 42 --enable-torch-compile --warmup
```

| Metric | Latest main | PR | Speedup |
|---|---|---|---|
| Denoise steady-state median (ms/step) | 193.2 | 182.2 | **1.061×** |

Op-level microbench (QwenImageGELU up-proj + GELU, dim 3072 → 12288, B200, compiled):
1.31× at seq 4096, 1.37× at seq 8192 (neutral at seq 1024 — launch-bound).

## Generated Image Check

Same prompt + seed (42), main vs PR.

![main vs PR vs 10x diff](https://raw.githubusercontent.com/BBuf/sglang/kda/diffusion-gelu-artifacts/qwen-fused-gelu/qwen_contact_sheet.png)

Columns: **main | PR | 10× absolute diff**.

| Metric | Value | CI gate (`publish_diffusion_gt.py`) |
|---|---|---|
| mean_abs_diff (0–255) | 3.77 (max pixel 234) | ≤ 45.0 |
| RMS diff (0–255) | 8.59 | — |
| luminance SSIM (CI formula) | 0.9837 | ≥ 0.20 |
| windowed SSIM (skimage) | 0.9609 | — |

## Validation

- QwenImageGELU fused vs reference (`proj` + `F.gelu(tanh)`) parity at the FFN shape (bf16): max relative diff ~0.5% (rounding level).
- End-to-end run stays on the native path (bf16 fuses; no fallback log).
- Same mechanism already shipped for FLUX (#28166) and the shared `MLP` (#28366).

## Checklist

- [x] Format the code, ran pre-commit on changed files.
- [x] Verified numerical parity and end-to-end output quality on a real model run.
- [x] No new dependencies; reuses the existing `fused_linear_act` helper.
- [ ] (reviewer) confirm on multi-GPU TP configs.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27607697295](https://github.com/sgl-project/sglang/actions/runs/27607697295)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27607709299](https://github.com/sgl-project/sglang/actions/runs/27607709299)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->