### PR TITLE
[FA3] Fix only_qv signature placement to match pinned sgl-attn

### DIFF
--- a/python/sglang/jit_kernel/flash_attention.py
+++ b/python/sglang/jit_kernel/flash_attention.py
@@ -35,6 +35,7 @@ def flash_attn_with_kvcache(
     scheduler_metadata=None,
     num_splits=0,  # Can be tuned for speed
     pack_gqa=None,  # Can be tuned for speed
+    only_qv=False,  # ver=3 only: skip K matmul when qk rope dim is 0
     sm_margin=0,  # Can be tuned if some SMs are used for communication
     return_softmax_lse=False,
     sinks=None,
@@ -162,6 +163,7 @@ def flash_attn_with_kvcache(
             scheduler_metadata=scheduler_metadata,
             num_splits=num_splits,
             pack_gqa=pack_gqa,
+            only_qv=only_qv,
             sm_margin=sm_margin,
             return_softmax_lse=return_softmax_lse,
             sinks=sinks,

--- a/python/sglang/jit_kernel/flash_attention_v3.py
+++ b/python/sglang/jit_kernel/flash_attention_v3.py
@@ -128,6 +128,7 @@ def flash_attn_with_kvcache(
     scheduler_metadata=None,
     num_splits=0,  # Can be tuned for speed
     pack_gqa=None,  # Can be tuned for speed
+    only_qv=False,  # Skip K matmul when qk rope dim is 0 (requires qv)
     sm_margin=0,  # Can be tuned if some SMs are used for communication
     return_softmax_lse=False,
     sinks=None,
@@ -138,7 +139,11 @@ def flash_attn_with_kvcache(
             "flash_attn at sgl-kernel is only supported on sm90 and above"
         )
 
-    assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
+    # When only_qv=True the caller may pass k_cache=None (synthetic K is
+    # allocated inside the sgl-kernel wrapper). Skip the stride check in that
+    # case so the rope=0 path doesn't trip the assertion.
+    if k_cache is not None:
+        assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
     assert v_cache.stride(-1) == 1, "v_cache must have contiguous last dimension"
 
     return _call_fa3_kernel(
@@ -171,9 +176,10 @@ def flash_attn_with_kvcache(
         scheduler_metadata,
         num_splits,
         pack_gqa,
-        sm_margin,
-        return_softmax_lse,
-        sinks,
+        sm_margin=sm_margin,
+        only_qv=only_qv,
+        return_softmax_lse=return_softmax_lse,
+        sinks=sinks,
         out=out,
     )
 
@@ -201,6 +207,7 @@ def flash_attn_varlen_func(
     softcap=0.0,
     num_splits=1,
     pack_gqa=None,
+    only_qv=False,
     sm_margin=0,
     return_softmax_lse=False,
     sinks=None,
@@ -265,6 +272,7 @@ def flash_attn_varlen_func(
         softcap=softcap,
         num_splits=num_splits,
         pack_gqa=pack_gqa,
+        only_qv=only_qv,
         sm_margin=sm_margin,
         return_softmax_lse=return_softmax_lse,
         sinks=sinks,

--- a/sgl-kernel/csrc/flash_extension.cc
+++ b/sgl-kernel/csrc/flash_extension.cc
@@ -57,7 +57,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "    int      num_splits,"
       "    bool?    pack_gqa,"
       "    int      sm_margin,"
-      "    Tensor?  sinks"
+      "    Tensor?  sinks,"
+      "    Tensor?  sparse_mask_fine,"  // [total_q, max_k_blocks, num_int32_per_block]
+      "    bool     only_qv"
       ") -> (Tensor(a!), Tensor, Tensor, Tensor)");  // first return aliases out
 
   m.impl("fwd", torch::kCUDA, make_pytorch_shim(&mha_fwd));

--- a/sgl-kernel/include/sgl_flash_kernel_ops.h
+++ b/sgl-kernel/include/sgl_flash_kernel_ops.h
@@ -82,7 +82,9 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_fwd(
     int64_t num_splits,
     std::optional<bool> pack_gqa_,
     int64_t sm_margin,
-    std::optional<const at::Tensor>& sinks_);  // (h)
+    std::optional<const at::Tensor>& sinks_,    // (h)
+    std::optional<at::Tensor> sparse_mask_fine_,  // [total_q, max_k_blocks, num_int32_per_block]
+    bool only_qv);
 
 /*
  * From flash-attention: get_scheduler_metadata

--- a/sgl-kernel/python/sgl_kernel/flash_attn.py
+++ b/sgl-kernel/python/sgl_kernel/flash_attn.py
@@ -62,6 +62,7 @@ def flash_attn_with_kvcache(
     scheduler_metadata=None,
     num_splits=0,  # Can be tuned for speed
     pack_gqa=None,  # Can be tuned for speed
+    only_qv=False,  # Only use QV (skip K matmul); requires qv. Used when qk rope dim is 0.
     sm_margin=0,  # Can be tuned if some SMs are used for communication
     return_softmax_lse=False,
     sinks=None,
@@ -159,15 +160,54 @@ def flash_attn_with_kvcache(
             normalization factor).
     """
 
-    assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
+    if v_cache is None:
+        raise ValueError("v_cache must be provided")
     assert v_cache.stride(-1) == 1, "v_cache must have contiguous last dimension"
+
+    if k_cache is None:
+        if not only_qv:
+            raise ValueError("k_cache can only be None when only_qv=True")
+        if q is not None:
+            k_head_size = q.shape[-1]
+            k_dtype = q.dtype
+            k_device = q.device
+        elif k is not None:
+            k_head_size = k.shape[-1]
+            k_dtype = k.dtype
+            k_device = k.device
+        else:
+            # Fallback: only_qv kernel ignores K values, so a tiny placeholder works.
+            k_head_size = 64
+            k_dtype = v_cache.dtype
+            k_device = v_cache.device
+        k_shape = (*v_cache.shape[:-1], k_head_size)
+        # The kernel path for only_qv ignores K values, but backend API still requires k tensor.
+        k_cache = torch.empty(k_shape, dtype=k_dtype, device=k_device)
+    assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
+
+    if q is None:
+        if not only_qv:
+            raise ValueError("q can only be None when only_qv=True")
+        if qv is None:
+            raise ValueError(
+                "q must be provided unless qv is provided with only_qv=True"
+            )
+        q_shape = (*qv.shape[:-1], k_cache.shape[-1])
+        # The kernel path for only_qv ignores q values, but backend API still requires q tensor.
+        q = torch.empty(q_shape, dtype=qv.dtype, device=qv.device)
+
     if softmax_scale is None:
-        softmax_scale = (q.shape[-1] + (qv.shape[-1] if qv is not None else 0)) ** (
-            -0.5
-        )
+        if only_qv:
+            if qv is None:
+                raise ValueError("only_qv=True requires qv to be provided")
+            softmax_scale = (qv.shape[-1]) ** (-0.5)
+        else:
+            softmax_scale = (q.shape[-1] + (qv.shape[-1] if qv is not None else 0)) ** (
+                -0.5
+            )
     if cache_seqlens is not None and isinstance(cache_seqlens, int):
         cache_seqlens = torch.full(
-            (k_cache.shape[0],), cache_seqlens, dtype=torch.int32, device=k_cache.device
+            (q.shape[0],), cache_seqlens, dtype=torch.int32, device=v_cache.device
         )
         cache_seqlens = maybe_contiguous(cache_seqlens)
 
@@ -223,6 +263,8 @@ def flash_attn_with_kvcache(
         pack_gqa,
         sm_margin,
         sinks,
+        None,  # sparse_mask_fine
+        only_qv,
     )
     # return (out, softmax_lse) if return_softmax_lse else out
     return (out, softmax_lse, *rest) if return_softmax_lse else out
@@ -251,6 +293,7 @@ def flash_attn_varlen_func(
     softcap=0.0,
     num_splits=1,
     pack_gqa=None,
+    only_qv=False,
     sm_margin=0,
     return_softmax_lse=False,
     sinks=None,
@@ -311,6 +354,8 @@ def flash_attn_varlen_func(
         pack_gqa=pack_gqa,
         sm_margin=sm_margin,
         sinks=sinks,
+        sparse_mask_fine=None,
+        only_qv=only_qv,
     )
 
     return (out, softmax_lse, *rest) if return_softmax_lse else out


### PR DESCRIPTION
## Fix `only_qv` signature placement to match the pinned sgl-flash-attn

  ### Context
  Follow-up to the sgl-flash-attn upgrade in [sgl-project/sglang#28394](https://github.com/sgl-project/sglang/pull/28394), which bumps the pinned `sgl-project/sgl-attn` [commit](https://github.com/sgl-project/sgl-flash-attn/pull/45) that introduces the FA3 `only_qv` (NoPE) decode path.

  ### Problem
  This mismatch breaks op dispatch (wrong ABI), and `sparse_mask_fine` was missing from the wrapper entirely.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27611365335](https://github.com/sgl-project/sglang/actions/runs/27611365335)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27611364956](https://github.com/sgl-project/sglang/actions/runs/27611364956)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->