### PR TITLE
[HiCache] Make HiRadixCache.writing_check all_reduce unconditional (TP-deadlock fix, sibling of #27489)

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -916,10 +916,13 @@ class HiRadixCache(RadixCache):
                 assert len(self.ongoing_write_through) == 0
             return
 
-        # NOTE: all ranks has the same ongoing_write_through, can skip sync if empty
-        if len(self.ongoing_write_through) == 0:
-            return
-
+        # Enter the all_reduce unconditionally -- do NOT early-return on an empty
+        # ongoing_write_through. write_backup() enqueues only on the ranks whose
+        # host-pool alloc succeeds, so the dict can diverge across TP ranks; an
+        # empty rank that skipped this collective while a peer entered it would
+        # desync the NCCL op sequence -> permanent deadlock. An empty rank now
+        # contributes finish_count=0 and MIN(0, ...) keeps the drain loop a no-op.
+        # Mirrors loading_check() and the UnifiedRadixCache fix in #27489.
         finish_count = 0
         if self.pp_rank == 0:
             for _, finish_event, ack_list in self.cache_controller.ack_write_queue:

--- a/test/registered/unit/mem_cache/test_hiradix_writing_check_tp_consistency.py
+++ b/test/registered/unit/mem_cache/test_hiradix_writing_check_tp_consistency.py
@@ -1,0 +1,148 @@
+"""Regression test: HiRadixCache.writing_check must enter its all_reduce barrier
+on every TP rank, even when the local ongoing_write_through dict is empty.
+
+writing_check() previously short-circuited with `if len(ongoing_write_through) ==
+0: return` before the all_reduce, on the assumption that all ranks hold an
+identical ongoing_write_through. That assumption does not hold: write_backup()
+enqueues a node into ongoing_write_through only on the ranks whose host-pool alloc
+succeeds (hiradix_cache.py: `if host_indices is not None: ... else: return 0`).
+Host-pool occupancy is per-rank physical state (driven by load_back / eviction /
+DMA-ack timing, which loading_check drains per rank), so the dict can diverge.
+Once one rank's dict empties while a peer's does not, the empty rank takes the
+early return and skips the collective while the peer enters it -> the NCCL op
+sequence desyncs -> permanent TP deadlock (NCCL has no timeout; the watchdog
+eventually SIGQUITs the process).
+
+The fix removes the early return so the all_reduce(MIN) runs unconditionally; an
+empty rank contributes finish_count=0 and MIN(0, ...) makes the drain loop a
+no-op -- behaviourally identical to the old early return, minus the desync. This
+mirrors loading_check() (already unconditional) and the UnifiedRadixCache fix in
+PR #27489 (this is the sibling fix for HiRadixCache, the cache used by the MLA
+prefix path). These tests pin the "every rank enters the collective" invariant
+WITHOUT real GPUs by driving writing_check() over stubbed ranks and modelling the
+all_reduce.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+GROUP_SIZE = 8
+
+
+def _ready_ack(ack_id):
+    """An ack-queue entry whose write-through DMA event has already completed."""
+    finish_event = SimpleNamespace(query=lambda: True, synchronize=lambda: None)
+    return (None, finish_event, [ack_id])
+
+
+def _rank(*, ongoing, ack_queue, all_reduce, pp_rank=0):
+    """A HiRadixCache shell carrying only the attributes writing_check() touches.
+
+    Built with __new__ so no pools / CUDA / process group are constructed; the
+    real, unbound HiRadixCache.writing_check is then driven over it.
+    """
+    s = HiRadixCache.__new__(HiRadixCache)
+    s.ongoing_write_through = dict(ongoing)
+    s.pp_rank = pp_rank
+    s.cache_controller = SimpleNamespace(ack_write_queue=list(ack_queue))
+    s._all_reduce = all_reduce
+    s._finish_write_through_ack = MagicMock()
+    return s
+
+
+class TestWritingCheckTPConsistency(CustomTestCase):
+    def test_empty_rank_still_enters_all_reduce(self):
+        # The core invariant the fix establishes: an empty ongoing_write_through
+        # must NOT skip the collective.
+        all_reduce = MagicMock()
+        s = _rank(ongoing={}, ack_queue=[], all_reduce=all_reduce)
+
+        HiRadixCache.writing_check(s, write_back=False)
+
+        self.assertEqual(all_reduce.call_count, 1)
+        tensor, op = all_reduce.call_args.args
+        self.assertEqual(tensor.item(), 0)  # empty rank contributes 0
+        self.assertIs(op, torch.distributed.ReduceOp.MIN)
+        s._finish_write_through_ack.assert_not_called()
+
+    def test_empty_and_nonempty_ranks_both_participate(self):
+        # Anti-deadlock property: with the dicts diverged across ranks (one empty,
+        # one with a pending write-through), every rank still enters the collective
+        # exactly once -> the NCCL op sequence stays aligned.
+        all_reduce = MagicMock()
+        empty = _rank(ongoing={}, ack_queue=[], all_reduce=all_reduce)
+        nonempty = _rank(
+            ongoing={7: object()}, ack_queue=[_ready_ack(7)], all_reduce=all_reduce
+        )
+
+        HiRadixCache.writing_check(empty, write_back=False)
+        HiRadixCache.writing_check(nonempty, write_back=False)
+
+        self.assertEqual(all_reduce.call_count, 2)
+
+    def test_min_consensus_blocks_nonempty_rank_from_draining_ahead(self):
+        # The barrier is a MIN-reduce: a rank that locally has a finished ack must
+        # not drain it while a peer rank reports 0. Model the collective returning
+        # the group minimum (0, because a peer was empty) and assert the non-empty
+        # rank leaves its ack queued instead of racing ahead.
+        def all_reduce_to_group_min(tensor, op):
+            tensor.fill_(0)  # group MIN across {local=1, peer=0}
+
+        nonempty = _rank(
+            ongoing={7: object()},
+            ack_queue=[_ready_ack(7)],
+            all_reduce=all_reduce_to_group_min,
+        )
+
+        HiRadixCache.writing_check(nonempty, write_back=False)
+
+        # Drain loop must not run: ack stays queued, no ack finalized.
+        self.assertEqual(len(nonempty.cache_controller.ack_write_queue), 1)
+        nonempty._finish_write_through_ack.assert_not_called()
+
+    def test_negative_control_old_early_return_would_desync(self):
+        # Proves the scenario actually exercises the fix: under the OLD logic the
+        # empty rank skips the collective while the non-empty rank enters it, so the
+        # ranks disagree on whether the collective ran -> the desync that deadlocks.
+        def old_rank_participates(ongoing_write_through):
+            if len(ongoing_write_through) == 0:  # the removed early return
+                return False
+            return True
+
+        participation = [
+            old_rank_participates({}),  # empty rank
+            old_rank_participates({7: object()}),  # rank with a pending write
+        ]
+        self.assertEqual(participation, [False, True])
+        self.assertEqual(
+            len(set(participation)),
+            2,
+            "ranks must disagree on entering the collective for this to be a real "
+            "desync; otherwise the fix would be untested",
+        )
+
+    def test_write_back_path_does_not_all_reduce(self):
+        # No regression on the blocking write_back=True drain: it synchronizes events
+        # directly and must not issue the scalar all_reduce barrier at all.
+        all_reduce = MagicMock()
+        s = _rank(ongoing={}, ack_queue=[], all_reduce=all_reduce)
+
+        HiRadixCache.writing_check(s, write_back=True)
+
+        all_reduce.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Root-cause analysis and proposed enqueue-consensus follow-up: #28429

## Motivation

`HiRadixCache.writing_check()` short-circuits before its `all_reduce` when the local `ongoing_write_through` is empty:

```python
# NOTE: all ranks has the same ongoing_write_through, can skip sync if empty
if len(self.ongoing_write_through) == 0:
    return
```

The same early return was fixed for `UnifiedRadixCache` in #27489 and reported for `HiMambaRadixCache` in #26921 / #26923, but `HiRadixCache` — the default hierarchical-cache implementation for non-hybrid models (`--enable-hierarchical-cache`, unless `SGLANG_ENABLE_UNIFIED_RADIX_TREE` or the experimental C++ tree is set) — was never patched. `loading_check()` in the same file is already unconditional; only `writing_check()` keeps the early return.

`ongoing_write_through` is **not** identical across ranks. `write_backup()` enqueues a node only on the ranks whose host-pool alloc succeeds (`if host_indices is not None: ... else: return 0`), and host-pool occupancy is per-rank physical state (driven by `load_back` / `evict_host` / DMA-ack timing). Once one rank's `ongoing_write_through` empties while a peer's does not, the empty rank takes the early return and skips the collective while the peer enters it → NCCL op-sequence desync → permanent TP deadlock (NCCL has no timeout) → watchdog SIGQUIT. Full root-cause analysis and the proposed enqueue-consensus follow-up are in the linked issue.

## Modification

Remove the early return so `writing_check()` always enters the `all_reduce(MIN)`, mirroring `loading_check()` and #27489. An empty rank contributes `finish_count=0`; `MIN(0, ...)` keeps the drain loop a no-op — behaviourally identical to the old early return, minus the desync.

This stops the hard deadlock. It does **not** fix the underlying content divergence of `ongoing_write_through` (the `write_backup` / `load_back` enqueue decisions are not yet collective-consistent — see the linked issue for the proposed follow-up). Same necessary-but-not-sufficient tradeoff #27489 documents.

## Accuracy

No impact on model outputs. The change only affects cache-management synchronization timing, not computation or data flow.

## Speed

One extra scalar `all_reduce` per `writing_check` call when `ongoing_write_through` is empty (a CPU int32 `MIN`), matching the cost #27489 / #26923 measured (~tens of µs on H20, < 0.4% of forward latency). `loading_check()` already pays this unconditionally.

## Test

`test/registered/unit/mem_cache/test_hiradix_writing_check_tp_consistency.py` (CPU-only, `base-a-test-cpu`) pins the invariant without GPUs:

- an empty `ongoing_write_through` still enters the collective (contributes 0);
- an empty rank and a non-empty rank both enter the collective exactly once (anti-deadlock);
- a `MIN`-reduce to the group minimum keeps a non-empty rank from draining ahead of an empty peer;
- negative control: the old early-return makes ranks disagree on entering the collective (the desync);
- the `write_back=True` blocking path issues no `all_reduce` (no regression).

I could not run the full multi-GPU repro of the hard deadlock (it manifests over hours under production memory pressure); the unit test pins the collective-participation invariant on CPU.

## Checklist

- [x] Format your code according to the pre-commit hooks.
- [x] Add unit tests.
- [x] Provide accuracy/speed reasoning.
- [x] Follow the SGLang code style guidance.

## Credit

Sibling of #27489 (@ispobock) and #26923 (@jeremyzhang866), which fix the same pattern in `UnifiedRadixCache` / `HiMambaRadixCache`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27616147749](https://github.com/sgl-project/sglang/actions/runs/27616147749)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27616147480](https://github.com/sgl-project/sglang/actions/runs/27616147480)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->