### PR TITLE
[NPU] Use use_dsa to dispatch Ascend DSA attention

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -153,6 +153,7 @@ def forward_mla_prepare_npu(
     forward_batch: "ForwardBatch",
     zero_allocator: "BumpAllocator",
     layer_scatter_modes,
+    prev_topk_indices: torch.Tensor = None,
 ):
     if is_mla_preprocess_enabled():
         if not hasattr(m, "mla_preprocess"):
@@ -232,13 +233,16 @@ def forward_mla_prepare_npu(
             )
         topk_indices = None
         if q_lora is not None:
-            topk_indices = m.indexer(
-                x=hidden_states,
-                q_lora=q_lora,
-                positions=positions,
-                forward_batch=forward_batch,
-                layer_id=m.layer_id,
-            )
+            if hasattr(q_lora, "indexer"):
+                topk_indices = m.indexer(
+                    x=hidden_states,
+                    q_lora=q_lora,
+                    positions=positions,
+                    forward_batch=forward_batch,
+                    layer_id=m.layer_id,
+                )
+            else:
+                topk_indices = prev_topk_indices
 
     return (
         q_pe,

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -153,7 +153,6 @@ def forward_mla_prepare_npu(
     forward_batch: "ForwardBatch",
     zero_allocator: "BumpAllocator",
     layer_scatter_modes,
-    prev_topk_indices: torch.Tensor = None,
 ):
     if is_mla_preprocess_enabled():
         if not hasattr(m, "mla_preprocess"):
@@ -233,16 +232,13 @@ def forward_mla_prepare_npu(
             )
         topk_indices = None
         if q_lora is not None:
-            if hasattr(q_lora, "indexer"):
-                topk_indices = m.indexer(
-                    x=hidden_states,
-                    q_lora=q_lora,
-                    positions=positions,
-                    forward_batch=forward_batch,
-                    layer_id=m.layer_id,
-                )
-            else:
-                topk_indices = prev_topk_indices
+            topk_indices = m.indexer(
+                x=hidden_states,
+                q_lora=q_lora,
+                positions=positions,
+                forward_batch=forward_batch,
+                layer_id=m.layer_id,
+            )
 
     return (
         q_pe,

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -45,12 +45,12 @@ def handle_attention_ascend(attn, forward_batch):
         and not forward_batch.forward_mode.is_target_verify()
         and not forward_batch.forward_mode.is_draft_extend_v2()
     ):
-        if hasattr(attn, "indexer"):
+        if hasattr(attn, "use_dsa") and attn.use_dsa:
             return AttnForwardMethod.DSA_NPU
         else:
             return AttnForwardMethod.MHA_NPU
     else:
-        if hasattr(attn, "indexer"):
+        if hasattr(attn, "use_dsa") and attn.use_dsa:
             return AttnForwardMethod.DSA_NPU
         else:
             return AttnForwardMethod.MLA_NPU


### PR DESCRIPTION

## Motivation

This PR fixes the Ascend NPU attention dispatch condition for DSA models.

Previously, the Ascend attention backend used `hasattr(attn, "indexer")` to decide whether an attention module should run through `DSA_NPU`. However, `indexer` is an implementation detail of the attention module, not the semantic indicator of whether the model is a DSA model. This can make the dispatch fragile when the module layout changes or when debugging GLM DSA models.

`use_dsa` is already set from the model config and directly represents whether the current attention module should use DSA. Therefore, the dispatch should use `attn.use_dsa` instead of checking for the existence of `indexer`.

## Modifications

- Updated `python/sglang/srt/models/deepseek_common/attention_backend_handler.py`.
- Changed the Ascend attention dispatch condition from:

```python
hasattr(attn, "indexer")
```
to
```python
hasattr(attn, "use_dsa") and attn.use_dsa
```

## Accuracy Tests

Not run. This PR only changes the Ascend attention dispatch condition and does not modify kernels or numerical computation.

## Speed Tests and Profiling

No speed benchmark is included.
This PR does not change any kernel or computation logic. The expected performance impact is neutral; it only makes the dispatch condition more robust.

## Checklist

- [x ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27621240364](https://github.com/sgl-project/sglang/actions/runs/27621240364)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27621237469](https://github.com/sgl-project/sglang/actions/runs/27621237469)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->