### PR TITLE
[Mooncake] Add try/except guard to decode status thread

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1492,70 +1492,79 @@ class MooncakeKVManager(CommonKVManager):
         def decode_thread():
             while True:
                 msg = self.server_socket.recv_multipart()
-                if msg[0] == MooncakeKVManager.AUX_DATA_HEADER:
-                    self._handle_aux_data(msg)
-                    continue
+                try:
+                    if msg[0] == MooncakeKVManager.AUX_DATA_HEADER:
+                        self._handle_aux_data(msg)
+                        continue
 
-                # Staging: prefill notifies a chunk written to staging buffer
-                if msg[0] == b"CHUNK_READY":
-                    room = int(msg[1].decode("ascii"))
-                    chunk_idx = int(msg[2].decode("ascii"))
-                    page_start = int(msg[3].decode("ascii"))
-                    num_pages = int(msg[4].decode("ascii"))
-                    session_id = msg[5].decode("ascii")
-                    handler = self._staging_handler
-                    assert (
-                        handler is not None
-                    ), "CHUNK_READY received before staging handler initialized"
-                    handler.handle_chunk_arrived(
-                        room,
-                        chunk_idx,
-                        page_start,
-                        num_pages,
-                        session_id,
-                        self._chunk_writer_counts,
-                    )
-                    continue
-
-                # Staging: prefill pre-requests staging allocation before forward
-                if msg[0] == b"STAGING_REQ":
-                    self._handle_staging_req(msg)
-                    continue
-
-                # Prefill acknowledges abort notification
-                if msg[0] == b"ABORT_ACK":
-                    # TODO(shangming): use this info to implement the deferred release mechanism if needed
-                    ack_aborted_room = int(msg[1].decode("ascii"))
-                    logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
-                    continue
-
-                bootstrap_room, status, prefill_rank = msg
-                status = int(status.decode("ascii"))
-                bootstrap_room = int(bootstrap_room.decode("ascii"))
-                prefill_rank = int(prefill_rank.decode("ascii"))
-
-                if status == KVPoll.Success:
-                    if bootstrap_room in self.request_status:
-                        self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
-                        expected_response_num = (
-                            self.required_prefill_response_num_table[bootstrap_room]
+                    # Staging: prefill notifies a chunk written to staging buffer
+                    if msg[0] == b"CHUNK_READY":
+                        room = int(msg[1].decode("ascii"))
+                        chunk_idx = int(msg[2].decode("ascii"))
+                        page_start = int(msg[3].decode("ascii"))
+                        num_pages = int(msg[4].decode("ascii"))
+                        session_id = msg[5].decode("ascii")
+                        handler = self._staging_handler
+                        assert (
+                            handler is not None
+                        ), "CHUNK_READY received before staging handler initialized"
+                        handler.handle_chunk_arrived(
+                            room,
+                            chunk_idx,
+                            page_start,
+                            num_pages,
+                            session_id,
+                            self._chunk_writer_counts,
                         )
-                        arrived_response_num = len(
-                            self.prefill_response_tracker[bootstrap_room]
+                        continue
+
+                    # Staging: prefill pre-requests staging allocation before forward
+                    if msg[0] == b"STAGING_REQ":
+                        self._handle_staging_req(msg)
+                        continue
+
+                    # Prefill acknowledges abort notification
+                    if msg[0] == b"ABORT_ACK":
+                        # TODO(shangming): use this info to implement the deferred release mechanism if needed
+                        ack_aborted_room = int(msg[1].decode("ascii"))
+                        logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
+                        continue
+
+                    bootstrap_room, status, prefill_rank = msg
+                    status = int(status.decode("ascii"))
+                    bootstrap_room = int(bootstrap_room.decode("ascii"))
+                    prefill_rank = int(prefill_rank.decode("ascii"))
+
+                    if status == KVPoll.Success:
+                        if bootstrap_room in self.request_status:
+                            self.prefill_response_tracker[bootstrap_room].add(
+                                prefill_rank
+                            )
+                            expected_response_num = (
+                                self.required_prefill_response_num_table[bootstrap_room]
+                            )
+                            arrived_response_num = len(
+                                self.prefill_response_tracker[bootstrap_room]
+                            )
+                            if arrived_response_num == expected_response_num:
+                                if self.enable_staging:
+                                    handler = self._staging_handler
+                                    if handler.is_staging_room(bootstrap_room):
+                                        handler.submit_last_scatter_async(
+                                            bootstrap_room
+                                        )
+                                    self._chunk_writer_counts.pop(bootstrap_room, None)
+                                self.update_status(bootstrap_room, KVPoll.Success)
+                    elif status == KVPoll.Failed:
+                        self.record_failure(
+                            bootstrap_room,
+                            "Failed to get kvcache from prefill instance, it might be dead",
                         )
-                        if arrived_response_num == expected_response_num:
-                            if self.enable_staging:
-                                handler = self._staging_handler
-                                if handler.is_staging_room(bootstrap_room):
-                                    handler.submit_last_scatter_async(bootstrap_room)
-                                self._chunk_writer_counts.pop(bootstrap_room, None)
-                            self.update_status(bootstrap_room, KVPoll.Success)
-                elif status == KVPoll.Failed:
-                    self.record_failure(
-                        bootstrap_room,
-                        "Failed to get kvcache from prefill instance, it might be dead",
-                    )
-                    self.update_status(bootstrap_room, status)
+                        self.update_status(bootstrap_room, status)
+                except Exception:
+                    # Keep one malformed control message from terminating the
+                    # decode-side status worker.
+                    logger.exception("Mooncake decode status thread iteration failed")
 
         threading.Thread(target=decode_thread).start()
         self._start_heartbeat_checker_thread()

--- a/test/registered/unit/disaggregation/test_mooncake_decode_thread.py
+++ b/test/registered/unit/disaggregation/test_mooncake_decode_thread.py
@@ -1,0 +1,80 @@
+"""Unit tests for Mooncake decode-side status thread handling."""
+
+import unittest
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _StopDecodeThread(BaseException):
+    pass
+
+
+class TestMooncakeDecodeThread(unittest.TestCase):
+    def _make_decode_manager(self):
+        mgr = MooncakeKVManager.__new__(MooncakeKVManager)
+        mgr.server_socket = MagicMock()
+        mgr.request_status = {7: KVPoll.WaitingForInput}
+        mgr.prefill_response_tracker = defaultdict(set)
+        mgr.required_prefill_response_num_table = {7: 1}
+        mgr.enable_staging = False
+        mgr._staging_handler = None
+        mgr._chunk_writer_counts = {}
+        mgr._handle_aux_data = MagicMock()
+        mgr._handle_staging_req = MagicMock()
+        mgr.record_failure = MagicMock()
+
+        def update_status(room, status):
+            mgr.request_status[room] = status
+
+        mgr.update_status = MagicMock(side_effect=update_status)
+        return mgr
+
+    def test_decode_thread_continues_after_malformed_status_message(self):
+        mgr = self._make_decode_manager()
+        mgr.server_socket.recv_multipart.side_effect = [
+            [b"malformed"],
+            [b"7", str(KVPoll.Success).encode("ascii"), b"0"],
+            _StopDecodeThread(),
+        ]
+        captured_targets = []
+
+        def capture_thread(*args, **kwargs):
+            captured_targets.append(kwargs["target"])
+            thread = MagicMock()
+            thread.start.return_value = None
+            return thread
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.mooncake.conn.threading.Thread",
+                side_effect=capture_thread,
+            ),
+            patch.object(
+                MooncakeKVManager,
+                "_start_heartbeat_checker_thread",
+                return_value=None,
+            ),
+        ):
+            mgr.start_decode_thread()
+
+        self.assertEqual(len(captured_targets), 1)
+
+        with (
+            patch("sglang.srt.disaggregation.mooncake.conn.logger.exception") as log,
+            self.assertRaises(_StopDecodeThread),
+        ):
+            captured_targets[0]()
+
+        log.assert_called_once_with("Mooncake decode status thread iteration failed")
+        mgr.update_status.assert_called_once_with(7, KVPoll.Success)
+        self.assertEqual(mgr.request_status[7], KVPoll.Success)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`MooncakeKVManager.start_decode_thread` runs the decode-side status worker for Mooncake disaggregation. This worker consumes ZMQ control messages from prefill workers and advances decode-side KV transfer state from `WaitingForInput` to `Success` or `Failed`.

Previously, the loop body had no exception guard. A single malformed or unexpected control message could raise during message indexing, tuple unpacking, integer decoding, staging handling, or response-count lookup. That exception would terminate the status thread, while the process itself kept running. Once the thread exits, later prefill status messages are no longer processed and requests can remain waiting for KV transfer completion until timeout.

## Modifications

- Wrap each decode status thread iteration in `try/except Exception`.
- Log unexpected per-message failures with `logger.exception(...)`.
- Keep the existing message protocol and status update behavior unchanged.
- Add a CPU unit test that feeds one malformed status message followed by a valid success message and verifies the worker continues to process the valid message.

## Accuracy Tests

N/A. 

## Speed Tests and Profiling

N/A. 
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27625004190](https://github.com/sgl-project/sglang/actions/runs/27625004190)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27625004253](https://github.com/sgl-project/sglang/actions/runs/27625004253)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->