### PR TITLE
fix: require smg-grpc-servicer 0.5.5 for grpc metrics

### DIFF
--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-04-nvidia-run-nemotron-3-ultra/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/nemotron-3-ultra/image1.png"
+          alt="SGLang and Miles Add Day-0 Support for NVIDIA Nemotron 3 Ultra for Long-Running Autonomous Agents"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"SGLang and Miles Add Day-0 Support for NVIDIA Nemotron 3 Ultra for Long-Running Autonomous Agents"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 4, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-01-hetero-epd/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"April 10, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-25-gtc2026/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/gtc2026/happyhour-crowd.jpg"
-          alt="Highlights of SGLang at NVIDIA GTC 2026"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Highlights of SGLang at NVIDIA GTC 2026"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 31, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-08-lmsys-phd-fellowship/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/fellowship_apply/fellowship_program.png"
+          alt="Announcing the Recipient of the 2026 LMSYS PhD Fellowship"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Announcing the Recipient of the 2026 LMSYS PhD Fellowship"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 08, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-04-nvidia-run-nemotron-3-ultra/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"April 29, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-04-25-deepseek-v4/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/deepseek_v4/benchmark_vs_oss.png"
-          alt="DeepSeek-V4 on Day 0: From Fast Inference to Verified RL with SGLang and Miles"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"DeepSeek-V4 on Day 0: From Fast Inference to Verified RL with SGLang and Miles"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"April 25, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-01-hetero-epd/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/hetero-epd/1.png"
+          alt="Heterogeneous CPU + GPU EPD Disaggregation to Boost VLM Serving"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Heterogeneous CPU + GPU EPD Disaggregation to Boost VLM Serving"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"May 29, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-05-28-mori/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"March 31, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-25-eep-partial-failure-tolerance/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/eep-partial-failure-tolerance/figure.png"
-          alt="Elastic EP in SGLang: Achieving Partial Failure Tolerance for DeepSeek MoE Deployments"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Elastic EP in SGLang: Achieving Partial Failure Tolerance for DeepSeek MoE Deployments"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 25, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-05-28-mori/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/mori/tco1-new.png"
+          alt="Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Win on TCO: How AMD Instinct\u2122 MI355X Achieves Cost-Competitive Distributed Inference Through SGLang with MoRI"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"May 28, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-04-29-p2p-update/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"March 25, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-03-17-rocm-miles-rl-amd/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/rocm_miles_rl/fig_1.png"
-          alt="ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"ROCm Support for Miles: Large-Scale RL Post-Training on AMD Instinct\u2122 GPUs"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"March 17, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -138,6 +138,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
       </div>
     </a>
     <a
+      href="https://lmsys.org/blog/2026-06-04-higgs-audio-v3-tts/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://sgl-project.github.io/sglang-omni/_images/higgs-architecture.png"
+          alt="Higgs Audio v3 TTS on SGLang-Omni: Real-Time, Controllable Speech for Voice Agents"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"Higgs Audio v3 TTS on SGLang-Omni: Real-Time, Controllable Speech for Voice Agents"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 4, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-01-hetero-epd/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"April 25, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-04-10-sglang-hisparse/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/hisparse/hisparse_overview.png"
-          alt="HiSparse: Turbocharging Sparse Attention with Hierarchical Memory"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"HiSparse: Turbocharging Sparse Attention with Hierarchical Memory"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"April 10, 2026"}
         </p>
       </div>
     </a>

--- a/docs_new/index.mdx
+++ b/docs_new/index.mdx
@@ -83,6 +83,61 @@ It is designed to deliver low-latency and high-throughput inference across a wid
     }}
   >
     <a
+      href="https://lmsys.org/blog/2026-06-15-next-generation-speculative-decoding-dflash-v2/"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "block",
+        border: "1px solid rgba(128, 128, 128, 0.3)",
+        borderRadius: "0.75rem",
+        overflow: "hidden",
+        textDecoration: "none",
+        color: "inherit",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: "16 / 9",
+          overflow: "hidden",
+          background: "rgba(128, 128, 128, 0.15)",
+        }}
+      >
+        <img
+          src="https://lmsys.org/images/blog/dflash-v2/dflash-arch-diagram.webp"
+          alt="The next generation of speculative decoding: DFlash and Spec V2"
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            display: "block",
+          }}
+        />
+      </div>
+      <div style={{ padding: "0.9rem 1rem 1rem" }}>
+        <p
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            lineHeight: 1.35,
+            fontSize: "0.98rem",
+          }}
+        >
+          {"The next generation of speculative decoding: DFlash and Spec V2"}
+        </p>
+        <p
+          style={{
+            margin: "0.55rem 0 0",
+            fontSize: "0.85rem",
+            opacity: 0.75,
+          }}
+        >
+          {"June 15, 2026"}
+        </p>
+      </div>
+    </a>
+    <a
       href="https://lmsys.org/blog/2026-06-08-lmsys-phd-fellowship/"
       target="_blank"
       rel="noopener noreferrer"
@@ -354,61 +409,6 @@ It is designed to deliver low-latency and high-throughput inference across a wid
           }}
         >
           {"May 28, 2026"}
-        </p>
-      </div>
-    </a>
-    <a
-      href="https://lmsys.org/blog/2026-04-29-p2p-update/"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        display: "block",
-        border: "1px solid rgba(128, 128, 128, 0.3)",
-        borderRadius: "0.75rem",
-        overflow: "hidden",
-        textDecoration: "none",
-        color: "inherit",
-        height: "100%",
-      }}
-    >
-      <div
-        style={{
-          aspectRatio: "16 / 9",
-          overflow: "hidden",
-          background: "rgba(128, 128, 128, 0.15)",
-        }}
-      >
-        <img
-          src="https://lmsys.org/images/blog/p2p-update/p2p-overview.png"
-          alt="Updating 1T parameters in seconds \u2014 P2P weight transfer in Large Scale Distributed RL"
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            objectPosition: "center",
-            display: "block",
-          }}
-        />
-      </div>
-      <div style={{ padding: "0.9rem 1rem 1rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontWeight: 600,
-            lineHeight: 1.35,
-            fontSize: "0.98rem",
-          }}
-        >
-          {"Updating 1T parameters in seconds \u2014 P2P weight transfer in Large Scale Distributed RL"}
-        </p>
-        <p
-          style={{
-            margin: "0.55rem 0 0",
-            fontSize: "0.85rem",
-            opacity: 0.75,
-          }}
-        >
-          {"April 29, 2026"}
         </p>
       </div>
     </a>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
   "uvloop",
   "watchfiles",
   "xgrammar==0.2.0",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "kernels",
 ]
 

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -67,7 +67,7 @@ dependencies = [
   "uvicorn",
   "uvloop",
   "xgrammar==0.2.0",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -63,7 +63,7 @@ dependencies = [
   "uvicorn",
   "uvloop",
   "xgrammar==0.2.0",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -63,7 +63,7 @@ runtime_common = [
   "uvicorn",
   "uvloop",
   "xgrammar==0.2.0",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
 ]
 
 diffusion_common = [

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -67,7 +67,7 @@ dependencies = [
   "uvicorn",
   "uvloop",
   # "xgrammar==0.2.0", xgrammar depends on CUDA PyTorch and Triton only
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
 ]
 
 [project.optional-dependencies]

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -221,7 +221,7 @@ async def serve_grpc(server_args, model_info=None):
                 exc_info=True,
             )
 
-    # Older smg-grpc-servicer releases (≤ 0.5.2) accept only (server_args,
+    # Older smg-grpc-servicer releases (≤ 0.5.4) accept only (server_args,
     # model_info) and reject the on_request_manager_ready hook. The hook is
     # what calls _start_sidecar_server, so dropping the kwarg disables the
     # entire HTTP sidecar (Prometheus /metrics and /start_profile +
@@ -237,7 +237,7 @@ async def serve_grpc(server_args, model_info=None):
         # start the sidecar that serves them — fail loud rather than silently
         # produce a server with no /metrics endpoint.
         raise RuntimeError(
-            "--enable-metrics requires smg-grpc-servicer ≥ 0.5.3 (the version "
+            "--enable-metrics requires smg-grpc-servicer ≥ 0.5.5 (the version "
             "that accepts 'on_request_manager_ready'); installed version "
             "lacks the hook so the HTTP sidecar would never start. Upgrade "
             "smg-grpc-servicer or remove --enable-metrics."
@@ -247,7 +247,7 @@ async def serve_grpc(server_args, model_info=None):
             "Installed smg-grpc-servicer does not accept "
             "'on_request_manager_ready'; HTTP sidecar disabled "
             "(no /metrics, /start_profile, /stop_profile). "
-            "Upgrade smg-grpc-servicer to ≥ 0.5.3 to enable it."
+            "Upgrade smg-grpc-servicer to ≥ 0.5.5 to enable it."
         )
 
     try:


### PR DESCRIPTION
## Summary

- update gRPC metrics messaging to require `smg-grpc-servicer>=0.5.5`
- bump `smg-grpc-servicer` lower bound across pyproject variants

Fixes #28298

## Testing

- `git diff --check`
- verified no stale `smg-grpc-servicer>=0.5.0`, `>=0.5.3`, or `<=0.5.2` references remain in the touched files

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->