### PR TITLE
[XPU] fix(deps): upgrade diffusers to fix fresh installs

### DIFF
--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -23,6 +23,7 @@ dependencies = [
   "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
   "IPython",
   "aiohttp",
+  "apache-tvm-ffi==0.1.9",
   "anthropic>=0.20.0",
   "blobfile==3.0.0",
   "build",
@@ -74,7 +75,7 @@ dependencies = [
 diffusion = [
   "PyYAML==6.0.1",
   "cloudpickle==3.1.2",
-  "diffusers==0.36.0",
+  "diffusers==0.38.0",
   "imageio==2.36.0",
   "imageio-ffmpeg==0.5.1",
   "moviepy>=2.0.0",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -23,7 +23,6 @@ dependencies = [
   "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
   "IPython",
   "aiohttp",
-  "apache-tvm-ffi==0.1.9",
   "anthropic>=0.20.0",
   "blobfile==3.0.0",
   "build",


### PR DESCRIPTION
## Motivation

Two dependency issues prevent fresh SGLang installs from running diffusion models on XPU:

1. **Missing `apache-tvm-ffi` dependency**: Commit 063ab89ac1 ("DeepSeek-V4 Online Compress support MTP", 2026-06-15) added `from tvm_ffi.module import Module` to `python/sglang/jit_kernel/dsv4/compress.py`.
  However, `apache-tvm-ffi` was not added to `pyproject_xpu.toml`, causing import failures when running `sglang generate` with diffusion models on fresh installs.
  
`UPDATE`: the change got reverted in this PR: https://github.com/sgl-project/sglang/pull/28426, and now we do not need to install apache-tvm-ffi

2. **Incompatible `diffusers==0.36.0`**: The pinned diffusers version has a bug in `torchao_quantizer.py` where it imports `Float8AQTTensorImpl` from `torchao.dtypes.floatx.float8_layout`, which doesn't
  exist in XPU/non-CUDA builds of torchao. Additionally, the exception handler references an undefined `logger` variable (defined after the handler runs at module load time). This is fixed in
  `diffusers>=0.38.0`.

  Error Traces

  - Missing `apache-tvm-ffi`:
  File "~/frameworks.ai.pytorch.sglang/python/sglang/cli/generate.py", line 21, in generate
    from sglang.multimodal_gen.runtime.entrypoints.cli.generate import (
  ...
  KeyError: 'sglang.multimodal_gen'

  - Incompatible diffusers:
  File "/home/user/miniforge3/envs/.../site-packages/diffusers/quantizers/torchao/torchao_quantizer.py", line 86
    from torchao.dtypes.floatx.float8_layout import Float8AQTTensorImpl
  ModuleNotFoundError: No module named 'torchao.dtypes.floatx.float8_layout'

## Modifications

  ### `python/pyproject.toml`

  ~1. **Add `apache-tvm-ffi==0.1.9`** to core dependencies:~  fixed using PR: https://github.com/sgl-project/sglang/pull/28426
   ~- Required by JIT kernel compilation infrastructure (`sglang/jit_kernel/utils.py`, `compress.py`, and 20+ other kernel modules)~
     ~- Already implicitly used throughout the codebase but not declared~

  2. **Upgrade `diffusers` from `0.36.0` to `0.38.0`** in the `[project.optional-dependencies]` `diffusion` section:
     - Fixes XPU/non-CUDA torchao compatibility
     - Fixes undefined `logger` bug in exception handler
     - No breaking changes for SGLang usage

## Accuracy Tests

  Verified the fix resolves both issues:
  ```bash
  # pip install apache-tvm-ffi==0.1.9  #Not required anymore
  pip install --upgrade diffusers==0.38.0

  sglang generate \
    --model-path Tongyi-MAI/Z-Image-Turbo \
    --prompt "A cat on table" \
    --save-output \
    --dit-precision bf16 \
    --vae-precision bf16 \
    --text-encoder-precisions bf16 \
    --pin-cpu-memory \
    --vae-cpu-offload false \
    --dit-cpu-offload false
  ```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27672879067](https://github.com/sgl-project/sglang/actions/runs/27672879067)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27672878927](https://github.com/sgl-project/sglang/actions/runs/27672878927)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->