### PR TITLE
[Misc] feat(docker): add `SGL_COMMIT` build arg to `rocm.Dockerfile`

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -8,7 +8,7 @@
 # correctly invalidates the clone layer when the branch HEAD moves.
 # (Official release builds use --no-cache and don't need this.)
 #   docker build --build-arg SGL_BRANCH=main \
-#     --build-arg SGL_COMMIT=$(git ls-remote https://github.com/sgl-project/sglang.git main | cut -f1) \
+#     --build-arg SGL_COMMIT=$(git ls-remote https://github.com/sgl-project/sglang.git refs/heads/main | cut -f1) \
 #     --build-arg GPU_ARCH=gfx942 -t sglang-rocm-pinned -f rocm.Dockerfile .
 # Note: passing SGL_COMMIT pins to a detached HEAD; this is expected for reproducible builds.
 

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -3,6 +3,14 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm720 -t v0.5.10.post1-rocm720-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
+#
+# For local/fork builds: pin to a specific commit so Docker layer caching
+# correctly invalidates the clone layer when the branch HEAD moves.
+# (Official release builds use --no-cache and don't need this.)
+#   docker build --build-arg SGL_BRANCH=main \
+#     --build-arg SGL_COMMIT=$(git ls-remote https://github.com/sgl-project/sglang.git main | cut -f1) \
+#     --build-arg GPU_ARCH=gfx942 -t sglang-rocm-pinned -f rocm.Dockerfile .
+# Note: passing SGL_COMMIT pins to a detached HEAD; this is expected for reproducible builds.
 
 # Usage (to build SGLang ROCm + Mori docker image):
 # remove --build-arg NIC_BACKEND=ainic since new MoRI JIT will do NIC auto detection on target
@@ -81,6 +89,9 @@ ENV PYTORCH_ROCM_ARCH=gfx942;gfx950
 ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
 ARG SGL_DEFAULT="main"
 ARG SGL_BRANCH=${SGL_DEFAULT}
+# Optional: pin to an exact commit SHA to invalidate Docker cache when a
+# branch's HEAD moves.  When empty (default), only SGL_BRANCH is checked out.
+ARG SGL_COMMIT=""
 
 # Version override for setuptools_scm (used in nightly builds)
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
@@ -291,6 +302,10 @@ RUN git clone ${SGL_REPO} \
        else \
          echo "Using ${SGL_BRANCH} branch."; \
          git checkout ${SGL_BRANCH}; \
+       fi \
+    && if [ -n "${SGL_COMMIT}" ]; then \
+         echo "Pinning to commit ${SGL_COMMIT}."; \
+         git checkout ${SGL_COMMIT}; \
        fi \
     && cd sgl-kernel \
     && rm -f pyproject.toml \


### PR DESCRIPTION
## Motivation

Docker layer caching keys off the resolved command string, not the remote git state.
When building `rocm.Dockerfile` with a moving ref like `SGL_BRANCH=main` or a feature
branch, the `RUN git clone ... && git checkout <branch>` layer is cached indefinitely —
even after new commits land on that branch. Subsequent builds silently use stale code.

This is especially painful for **local and fork builds** that iterate on a branch: the
branch name stays the same, but Docker never re-clones to pick up new commits.

> Official release workflows (`release-docker-amd.yml`) sidestep the issue by passing
> `--no-cache`, which rebuilds every layer unconditionally. This change targets the
> complementary use case — builds that *want* layer caching for speed but still need
> correctness when the branch HEAD moves.

## Modifications

Add an optional `SGL_COMMIT` build arg (empty by default) that lets callers pass the
resolved commit SHA. Because the SHA appears in the command string, Docker correctly
invalidates the clone layer when the commit changes.

- Add `ARG SGL_COMMIT=""` next to the existing `SGL_BRANCH` / `SGL_REPO` args
- After the branch checkout, run `git checkout ${SGL_COMMIT}` when the arg is non-empty
- Document a `git ls-remote` one-liner in the usage header
- Note in the header that passing `SGL_COMMIT` leads to a detached HEAD (expected for reproducible builds)

**Backward-compatible:** when `SGL_COMMIT` is not passed, the default empty string
makes the conditional a no-op — behavior is identical to before.

Usage example:

```bash
docker build --build-arg SGL_BRANCH=main \
  --build-arg SGL_COMMIT=$(git ls-remote https://github.com/sgl-project/sglang.git main | cut -f1) \
  --build-arg GPU_ARCH=gfx942 -t sglang-rocm-pinned -f rocm.Dockerfile .
```

## Accuracy Tests

N/A — build-time only change, no effect on model outputs.

## Speed Tests and Profiling

N/A — no effect on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28425808488](https://github.com/sgl-project/sglang/actions/runs/28425808488)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28425808318](https://github.com/sgl-project/sglang/actions/runs/28425808318)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->