### PR TITLE
fix(disaggregation): pass model_name to get_processor in encode_receiver

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -1512,6 +1512,7 @@ class MMReceiverBase(ABC):
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
                 use_fast=not server_args.disable_fast_image_processor,
+                model_name=server_args.model_path,
                 **extra_kwargs,
             )
         except ValueError as e:
@@ -1526,6 +1527,7 @@ class MMReceiverBase(ABC):
                     trust_remote_code=server_args.trust_remote_code,
                     revision=server_args.revision,
                     use_fast=True,
+                    model_name=server_args.model_path,
                     **extra_kwargs,
                 )
             else:


### PR DESCRIPTION
## Motivation

#25643 added a `model_name` fallback to `get_processor` so the processor config can be loaded from `model_path` when `tokenizer_path` has no `config.json` of its own. It threaded `model_name=server_args.model_path` through the tokenizer manager, scheduler and TP worker call sites, but the two `get_processor` calls in the encode receiver were missed.

As a result, the encode-side disaggregation path still hits the original failure when `tokenizer_path` lacks a `config.json`, even though the fix is already in place everywhere else.

## Modifications

Pass `model_name=server_args.model_path` to both `get_processor` calls in `encode_receiver.py` — the primary call and the slow-version fallback — matching the call sites updated in #25643.

## Accuracy Tests

No model-output changes. This only forwards an extra keyword to `get_processor`; the value mirrors the call sites already merged in #25643, so behavior on the encode receiver path now matches the rest of the codebase.

I don't have an encode/decode disaggregation setup with a config-less `tokenizer_path` to exercise locally, so I've kept the change byte-for-byte identical to the already-merged call sites and am relying on CI for the full run.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27637874435](https://github.com/sgl-project/sglang/actions/runs/27637874435)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27637873267](https://github.com/sgl-project/sglang/actions/runs/27637873267)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->