### PR TITLE
docs(ci): AMD extra-a tier + ROCm/sglang-ci coverage dashboard (skill + Cursor rule)

### DIFF
--- a/.claude/skills/ci-workflow-guide/SKILL.md
+++ b/.claude/skills/ci-workflow-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-workflow-guide
-description: Guide to SGLang CI workflow orchestration — stage ordering, fast-fail, gating, partitioning, execution modes, and debugging CI failures. Use when modifying CI workflows, adding stages, debugging CI pipeline issues, or understanding how tests are dispatched and gated across stages.
+description: Guide to SGLang CI workflow orchestration — stage ordering, fast-fail, gating, partitioning, execution modes, the base/extra label-gated tiers, AMD/ROCm CI (incl. ROCm 7.2 and the extra-a tier), and debugging CI failures. Use when modifying CI workflows, adding stages or suites (CUDA or AMD), debugging CI pipeline issues, or understanding how tests are dispatched and gated across stages.
 ---
 
 # SGLang CI Workflow Orchestration Guide
@@ -21,9 +21,12 @@ This skill covers the CI **infrastructure** layer — how tests are dispatched, 
 
 | File | Role |
 |------|------|
-| `.github/workflows/pr-test.yml` | Main workflow — all stages, jobs, conditions, matrix definitions |
-| `.github/workflows/pr-test-extra.yml` | Extra workflow — gated by BOTH `run-ci` and `run-ci-extra` labels |
-| `.github/workflows/pr-gate.yml` | PR gating: draft check, `run-ci` label, per-user rate limiting |
+| `.github/workflows/pr-test.yml` | Main CUDA workflow — all stages, jobs, conditions, matrix definitions; cron chains `pr-test-extra.yml` |
+| `.github/workflows/pr-test-extra.yml` | CUDA extra workflow — gated by BOTH `run-ci` and `run-ci-extra` labels |
+| `.github/workflows/pr-test-amd.yml` | Main AMD workflow (ROCm default) — 6-hourly cron; chains `pr-test-amd-extra.yml` |
+| `.github/workflows/pr-test-amd-rocm720.yml` | AMD ROCm 7.2 workflow — daily cron; chains `pr-test-amd-extra.yml` with `rocm_version=rocm720` |
+| `.github/workflows/pr-test-amd-extra.yml` | AMD extra workflow — gated by BOTH `run-ci` and `run-ci-extra` labels (AMD mirror of `pr-test-extra.yml`) |
+| `.github/workflows/pr-gate.yml` | Reusable PR gate: draft check, `run-ci` (+ optional `run-ci-extra`) label, per-user rate limiting |
 | `.github/actions/check-pr-test-health/action.yml` | Cross-job fast-fail: queries API for any failed job |
 | `.github/actions/wait-for-jobs/action.yml` | Stage gating: polls API until stage jobs complete |
 | `.github/actions/check-maintenance/action.yml` | Maintenance mode check |
@@ -329,6 +332,32 @@ Determines which test suites to run based on file changes.
 
 ---
 
+## AMD CI (ROCm)
+
+AMD CI mirrors the CUDA base/extra split but runs on self-hosted ROCm runners (`linux-mi325-{1,2,4,8}gpu-sglang`) inside a ROCm container. Suites are registered with `register_amd_ci(...)` in `test/run_suite.py`'s `PER_COMMIT_SUITES[HWBackend.AMD]` / `NIGHTLY_SUITES`, and jobs bring up the container via `scripts/ci/amd/amd_ci_start_container.sh` → `amd_ci_install_dependency.sh` → `amd_ci_exec.sh`.
+
+| Workflow | ROCm | Trigger | Gate |
+|----------|------|---------|------|
+| `pr-test-amd.yml` | default | PR (paths), 6-hourly cron, dispatch | `run-ci` (PR only) |
+| `pr-test-amd-rocm720.yml` | 7.2 | daily cron, dispatch | none on schedule |
+| `pr-test-amd-extra.yml` | default or 7.2 | PR `labeled`, dispatch, workflow_call | `run-ci` + `run-ci-extra` (PR only) |
+
+### Extra-a tier (`pr-test-amd-extra.yml`)
+
+AMD mirror of the CUDA `extra-a` opt-in tier. Key properties:
+
+- **Label-gated** per PR via the reusable `call-gate` → `pr-gate.yml` (`require-run-ci: true`, `require-run-ci-extra: true`). On non-`pull_request` events (schedule / workflow_call / dispatch) the label checks are skipped, so the gate passes.
+- **Single unpartitioned job** `extra-a-test-1-gpu-small-amd`: the onboarded unit tests total ~minutes, so per-job container/kernel-build setup dominates — partitioning would just multiply that setup across scarce AMD GPUs. Run the whole suite sequentially on one GPU instead.
+- **`rocm_version` input**: empty = Dockerfile default; `rocm720` = ROCm 7.2 container (passes `--rocm-version` to the container start and suffixes the job name `…-rocm720`).
+- **Dual scheduled cadence** (mirrors NV's `pr-test.yml` → `call-pr-test-extra`): chained into both AMD base schedules via `workflow_call` —
+  - `pr-test-amd.yml` → `call-pr-test-amd-extra` (6-hourly, default ROCm)
+  - `pr-test-amd-rocm720.yml` → `call-pr-test-amd-extra-rocm720` (daily, `rocm_version=rocm720`)
+  Both chain jobs are gated `github.event_name == 'schedule' || inputs.run_all_tests`, exclude targeted `target_stage` dispatches, pass `continue_on_error: true`, and are intentionally **not** part of any `*-finish` aggregator so the base AMD gate never depends on the opt-in tier.
+
+> AMD-able vs NV-only: in-process / mock-model / unit tests generally run on ROCm (`torch.cuda` maps to HIP). Tests that JIT-build CUDA kernels (e.g. the kv_canary `e2e` suites) may fail under `hipcc` and stay CUDA-only until ported — register AMD only for the subset verified green on mi325.
+
+---
+
 ## Concurrency Control
 
 ```
@@ -392,13 +421,15 @@ group: pr-test-{event_name}-{branch}-{pr_sha}-{stage}
 
 Handled by `scripts/ci/utils/slash_command_handler.py` → `.github/workflows/slash-command-handler.yml`.
 
-### Label-gated workflow dispatch (pr-test, pr-test-extra)
+### Label-gated workflow dispatch (extra workflows)
 
-`pr-test.yml` and `pr-test-extra.yml` both listen for `pull_request.labeled` (in addition to `opened`/`synchronize`/`reopened`). The `check-changes.if` gate has two clauses:
+The **extra** workflows — `pr-test-extra.yml` (CUDA) and `pr-test-amd-extra.yml` (AMD) — listen for `pull_request.labeled` (in addition to `opened`/`synchronize`/`reopened`). Their gate `if` (on `check-changes` for CUDA, `call-gate` for AMD) has two effective clauses:
 
-1. **For `labeled` events**: the just-added label must be one of the gating labels (`run-ci` for pr-test, `run-ci` or `run-ci-extra` for pr-test-extra) — otherwise every unrelated label addition would dispatch a full CI run.
-2. **All events**: the PR must currently carry the required labels.
+1. **For `labeled` events**: the just-added label must be a gating label (`run-ci` or `run-ci-extra`) — otherwise every unrelated label addition would dispatch a full extra run.
+2. **All events**: the PR must currently carry the required labels (enforced at runtime by `pr-gate.yml`'s live label fetch — see below).
 
-This is what lets `/tag-run-ci-label` (and the `extra` variant) trigger a fresh CI run without an extra push.
+This is what lets `/tag-run-ci-label extra` (and `/tag-and-rerun-ci extra`) trigger a fresh extra run without an extra push.
+
+> **Note**: `pr-test.yml` (base CUDA) and `pr-test-amd.yml` (base AMD) do **not** listen for `labeled` — they use only the default `pull_request` types. Adding `run-ci` alone therefore fires the extra workflows (if `run-ci-extra` is also present) but does **not** re-fire base CI; recover base CI with `/tag-and-rerun-ci` or a new push.
 
 **Caveat — skipped runs cannot be un-skipped by `run.rerun()`:** GitHub's rerun API reuses the original event payload, so rerunning a `pull_request`-event run that was skipped because of missing labels will skip again (label set in the frozen payload doesn't update). The only way to recover a label-skipped run is to add the missing label, which fires a fresh `labeled` event with the current label set. `handle_rerun_failed_ci` in the slash handler is for rerunning failed/non-label-skipped runs; it cannot revive label-skipped ones.

--- a/.claude/skills/ci-workflow-guide/SKILL.md
+++ b/.claude/skills/ci-workflow-guide/SKILL.md
@@ -356,6 +356,15 @@ AMD mirror of the CUDA `extra-a` opt-in tier. Key properties:
 
 > AMD-able vs NV-only: in-process / mock-model / unit tests generally run on ROCm (`torch.cuda` maps to HIP). Tests that JIT-build CUDA kernels (e.g. the kv_canary `e2e` suites) may fail under `hipcc` and stay CUDA-only until ported — register AMD only for the subset verified green on mi325.
 
+### Coverage dashboard ([ROCm/sglang-ci](https://github.com/ROCm/sglang-ci))
+
+AMD-vs-NVIDIA registration coverage is tracked by the [ROCm/sglang-ci](https://github.com/ROCm/sglang-ci) dashboard (published at <https://rocm.github.io/sglang-ci/>):
+
+- **[`/coverage`](https://rocm.github.io/sglang-ci/coverage/)** — current AMD vs NV registered-test coverage (the headline % that drops when NV adds tests AMD hasn't registered).
+- **`/upstream-ci`** — AMD / NV registration-count trends over time and the per-PR change log.
+
+Coverage is computed from `register_*_ci(...)` markers collected by `collect_tests()` (`test/run_suite.py` / `ci_register.py`), so a coverage "regression" is usually **registration lag** (NV-first tests not yet onboarded for AMD), not a model regression. When the dashboard dips, check whether NV-only additions landed in `test/registered/**` and onboard the AMD-able subset (see "AMD-able vs NV-only" above). Note that opt-in / benchmark / NV-only-hardware tiers can be over-counted as if they were core gating coverage.
+
 ---
 
 ## Concurrency Control

--- a/.cursor/rules/amd-ci-coverage.mdc
+++ b/.cursor/rules/amd-ci-coverage.mdc
@@ -1,0 +1,40 @@
+---
+description: AMD-vs-NV CI coverage dashboard (ROCm/sglang-ci) and how test registration drives it
+globs: .github/workflows/**,test/run_suite.py,test/registered/**,python/sglang/test/ci/**
+alwaysApply: false
+---
+
+# AMD CI Coverage (ROCm/sglang-ci)
+
+AMD-vs-NVIDIA test coverage is tracked by the [ROCm/sglang-ci](https://github.com/ROCm/sglang-ci)
+dashboard, published at <https://rocm.github.io/sglang-ci/>:
+
+- [`/coverage`](https://rocm.github.io/sglang-ci/coverage/) — current AMD vs NV registered-test coverage.
+- `/upstream-ci` — AMD / NV registration-count trends and the per-PR change log.
+
+## How coverage is computed
+
+Coverage comes from `register_cuda_ci(...)` / `register_amd_ci(...)` markers in
+`test/registered/**`, collected by `collect_tests()` (`test/run_suite.py`,
+`python/sglang/test/ci/ci_register.py`). A coverage drop is almost always
+**registration lag** — NV-first tests not yet registered for AMD — not a model
+regression.
+
+## When editing CI / registering tests
+
+- Adding NV tests under `test/registered/**`? Register the **AMD-able** subset too
+  (`register_amd_ci(...)` beside `register_cuda_ci(...)`). In-process / mock-model /
+  unit tests usually run on ROCm (`torch.cuda` maps to HIP); tests that JIT-build
+  CUDA kernels (e.g. kv_canary `e2e`) may fail under `hipcc` — keep those CUDA-only
+  until ported, and register AMD only for tests verified green on mi325.
+- Opt-in (`extra-*`), benchmark, and NV-only-hardware tiers should not be counted as
+  core gating coverage — check the tier before treating a dip as a regression.
+- For tier/gating/schedule mechanics, see the `ci-workflow-guide` skill
+  (`.claude/skills/ci-workflow-guide/SKILL.md`).
+
+## Onboarding workflow (Cursor)
+
+This AMD onboarding is typically done with Cursor agents: open a worktree off latest
+`origin/main`, add `register_amd_ci(...)`, validate with `collect_tests(...)`, then
+open a PR and dispatch the AMD extra workflow (label-gated or `workflow_dispatch`) to
+verify green on mi325 before merge.


### PR DESCRIPTION
## Summary

Documents the AMD `extra-a` tier (landed in #27822), references the [ROCm/sglang-ci](https://github.com/ROCm/sglang-ci) coverage dashboard, fixes an inaccurate trigger claim, and mirrors the coverage guidance into a Cursor rule.

### `ci-workflow-guide` skill (`.claude/skills/ci-workflow-guide/SKILL.md`)
- **AMD CI (ROCm)** section: base/extra split on mi325 ROCm runners, the **single-job** label-gated `extra-a` tier, the `rocm_version` input (default vs `rocm720`), and the **dual scheduled cadence** (6-hourly default ROCm + daily ROCm 7.2) chained via `call-pr-test-amd-extra{,-rocm720}`. Added the AMD workflows to the Key Files table.
- **Coverage dashboard** subsection → [ROCm/sglang-ci](https://github.com/ROCm/sglang-ci) ([`/coverage`](https://rocm.github.io/sglang-ci/coverage/), `/upstream-ci`): coverage is derived from `register_*_ci(...)` markers, so a dip is usually **registration lag** (NV-first tests not yet onboarded for AMD), not a model regression.
- **Fixed an inaccurate claim**: `pr-test.yml` / `pr-test-amd.yml` do **not** listen for `pull_request.labeled` (only the *extra* workflows do); reworded the label-gated-dispatch section + base-CI recovery path.
- Broadened the frontmatter description to surface for AMD/ROCm CI questions.

### New Cursor rule (`.cursor/rules/amd-ci-coverage.mdc`)
- Mirrors the coverage guidance so **Cursor agents** pick it up when editing CI workflows or registering tests (scoped via `globs` to `.github/workflows/**`, `test/run_suite.py`, `test/registered/**`, `python/sglang/test/ci/**`). Points back to the `ci-workflow-guide` skill for tier/gating mechanics.

Doc-only change; no workflow or code behavior is modified.

## Test plan

- [x] Verified against `origin/main`: `pr-test.yml` / `pr-test-amd.yml` have no `labeled` trigger; `pr-test-amd-extra.yml` exists and is chained from both AMD base schedules.
- [x] Cursor rule is valid `.mdc` with frontmatter (`description`, `globs`, `alwaysApply: false`); concise and scoped to CI/registration files.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27641977618](https://github.com/sgl-project/sglang/actions/runs/27641977618)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27641979282](https://github.com/sgl-project/sglang/actions/runs/27641979282)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->