### PR TITLE
[RL] Fix FlashInfer TRTLLM MXFP8 dense weight layout

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -597,32 +597,27 @@ class Fp8LinearMethod(LinearMethodBase):
                 epilogue_tile_m
             )
 
-            weight_u8 = weight.contiguous().view(torch.uint8)
             scale_matrix = scale_u8.contiguous().view(torch.uint8).reshape(n, k // 32)
 
             if padded_n != n:
                 logger.debug(
-                    "Padding dense MXFP8 FlashInfer TRTLLM weight rows from %d to %d "
+                    "Padding dense MXFP8 FlashInfer TRTLLM scale rows from %d to %d "
                     "for weight shape (%d, %d).",
                     n,
                     padded_n,
                     n,
                     k,
                 )
-                padded_weight_u8 = weight_u8.new_zeros((padded_n, k))
-                padded_weight_u8[:n] = weight_u8
-                weight_u8 = padded_weight_u8
-
                 padded_scale_matrix = scale_matrix.new_zeros((padded_n, k // 32))
                 padded_scale_matrix[:n] = scale_matrix
                 scale_matrix = padded_scale_matrix
 
-            layer._mxfp8_logical_output_size = n if padded_n != n else None
-
             copy_or_rebind_param(
                 layer,
-                "weight_shuffled",
-                shuffle_matrix_a(weight_u8, epilogue_tile_m).view(torch.float8_e4m3fn),
+                "weight",
+                shuffle_matrix_a(
+                    weight.contiguous().view(torch.uint8), epilogue_tile_m
+                ).view(torch.float8_e4m3fn),
             )
             copy_or_rebind_param(
                 layer,
@@ -799,37 +794,26 @@ class Fp8LinearMethod(LinearMethodBase):
 
         if self.use_mxfp8:
             if get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
-                weight = layer.weight
                 weight_scale = layer.weight_scale_inv_swizzled
             elif get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
-                weight = layer.weight_shuffled
                 weight_scale = layer.weight_scale_inv_shuffled
             else:
-                weight = layer.weight
                 weight_scale = layer.weight_scale_inv
-            logical_output_size = getattr(layer, "_mxfp8_logical_output_size", None)
-            gemm_bias = bias if logical_output_size is None else None
             if isinstance(x, tuple):
-                output = self.w8a8_mxfp8_linear(
+                return self.w8a8_mxfp8_linear(
                     input=x[0],
-                    weight=weight,
+                    weight=layer.weight,
                     weight_scale=weight_scale,
                     input_scale=x[1],
-                    bias=gemm_bias,
+                    bias=bias,
                 )
-            else:
-                output = self.w8a8_mxfp8_linear(
-                    input=x,
-                    weight=weight,
-                    weight_scale=weight_scale,
-                    input_scale=None,
-                    bias=gemm_bias,
-                )
-            if logical_output_size is not None:
-                output = output[..., :logical_output_size]
-                if bias is not None:
-                    output += bias
-            return output
+            return self.w8a8_mxfp8_linear(
+                input=x,
+                weight=layer.weight,
+                weight_scale=weight_scale,
+                input_scale=None,
+                bias=bias,
+            )
 
         if self.block_quant:
             if use_intel_amx_backend(layer):

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -602,14 +602,6 @@ class Fp8LinearMethod(LinearMethodBase):
             pad_rows = padded_n - n
 
             if pad_rows:
-                logger.debug(
-                    "Padding dense MXFP8 FlashInfer TRTLLM scale rows from %d to %d "
-                    "for weight shape (%d, %d).",
-                    n,
-                    padded_n,
-                    n,
-                    k,
-                )
                 scale_u8 = F.pad(
                     scale_u8,
                     (0, 0, 0, pad_rows),

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -593,13 +593,15 @@ class Fp8LinearMethod(LinearMethodBase):
             scale_u8 = layer.weight_scale_inv.data
             n, k = weight.shape
             epilogue_tile_m = 128
+            sf_cols = k // 32
+
+            scale_u8 = scale_u8.contiguous().view(torch.uint8).reshape(n, sf_cols)
             padded_n = ((n + epilogue_tile_m - 1) // epilogue_tile_m) * (
                 epilogue_tile_m
             )
+            pad_rows = padded_n - n
 
-            scale_matrix = scale_u8.contiguous().view(torch.uint8).reshape(n, k // 32)
-
-            if padded_n != n:
+            if pad_rows:
                 logger.debug(
                     "Padding dense MXFP8 FlashInfer TRTLLM scale rows from %d to %d "
                     "for weight shape (%d, %d).",
@@ -608,9 +610,12 @@ class Fp8LinearMethod(LinearMethodBase):
                     n,
                     k,
                 )
-                padded_scale_matrix = scale_matrix.new_zeros((padded_n, k // 32))
-                padded_scale_matrix[:n] = scale_matrix
-                scale_matrix = padded_scale_matrix
+                scale_u8 = F.pad(
+                    scale_u8,
+                    (0, 0, 0, pad_rows),
+                    mode="constant",
+                    value=0,
+                )
 
             copy_or_rebind_param(
                 layer,
@@ -623,11 +628,11 @@ class Fp8LinearMethod(LinearMethodBase):
                 layer,
                 "weight_scale_inv_shuffled",
                 shuffle_matrix_sf_a(
-                    scale_matrix,
+                    scale_u8,
                     epilogue_tile_m,
                     num_elts_per_sf=32,
                 )
-                .reshape_as(scale_matrix)
+                .reshape_as(scale_u8)
                 .contiguous(),
             )
         elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
@@ -793,9 +798,10 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
-            if get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
-                weight_scale = layer.weight_scale_inv_swizzled
-            elif get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
+            if (
+                get_fp8_gemm_runner_backend().is_flashinfer_cutlass()
+                or get_fp8_gemm_runner_backend().is_flashinfer_trtllm()
+            ):
                 weight_scale = layer.weight_scale_inv_shuffled
             else:
                 weight_scale = layer.weight_scale_inv

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -593,23 +593,46 @@ class Fp8LinearMethod(LinearMethodBase):
             scale_u8 = layer.weight_scale_inv.data
             n, k = weight.shape
             epilogue_tile_m = 128
+            padded_n = ((n + epilogue_tile_m - 1) // epilogue_tile_m) * (
+                epilogue_tile_m
+            )
+
+            weight_u8 = weight.contiguous().view(torch.uint8)
+            scale_matrix = scale_u8.contiguous().view(torch.uint8).reshape(n, k // 32)
+
+            if padded_n != n:
+                logger.debug(
+                    "Padding dense MXFP8 FlashInfer TRTLLM weight rows from %d to %d "
+                    "for weight shape (%d, %d).",
+                    n,
+                    padded_n,
+                    n,
+                    k,
+                )
+                padded_weight_u8 = weight_u8.new_zeros((padded_n, k))
+                padded_weight_u8[:n] = weight_u8
+                weight_u8 = padded_weight_u8
+
+                padded_scale_matrix = scale_matrix.new_zeros((padded_n, k // 32))
+                padded_scale_matrix[:n] = scale_matrix
+                scale_matrix = padded_scale_matrix
+
+            layer._mxfp8_logical_output_size = n if padded_n != n else None
 
             copy_or_rebind_param(
                 layer,
-                "weight",
-                shuffle_matrix_a(
-                    weight.contiguous().view(torch.uint8), epilogue_tile_m
-                ).view(torch.float8_e4m3fn),
+                "weight_shuffled",
+                shuffle_matrix_a(weight_u8, epilogue_tile_m).view(torch.float8_e4m3fn),
             )
             copy_or_rebind_param(
                 layer,
-                "weight_scale_inv",
+                "weight_scale_inv_shuffled",
                 shuffle_matrix_sf_a(
-                    scale_u8.contiguous().view(torch.uint8).reshape(n, k // 32),
+                    scale_matrix,
                     epilogue_tile_m,
                     num_elts_per_sf=32,
                 )
-                .reshape_as(scale_u8)
+                .reshape_as(scale_matrix)
                 .contiguous(),
             )
         elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
@@ -776,24 +799,37 @@ class Fp8LinearMethod(LinearMethodBase):
 
         if self.use_mxfp8:
             if get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
+                weight = layer.weight
                 weight_scale = layer.weight_scale_inv_swizzled
+            elif get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
+                weight = layer.weight_shuffled
+                weight_scale = layer.weight_scale_inv_shuffled
             else:
+                weight = layer.weight
                 weight_scale = layer.weight_scale_inv
+            logical_output_size = getattr(layer, "_mxfp8_logical_output_size", None)
+            gemm_bias = bias if logical_output_size is None else None
             if isinstance(x, tuple):
-                return self.w8a8_mxfp8_linear(
+                output = self.w8a8_mxfp8_linear(
                     input=x[0],
-                    weight=layer.weight,
+                    weight=weight,
                     weight_scale=weight_scale,
                     input_scale=x[1],
-                    bias=bias,
+                    bias=gemm_bias,
                 )
-            return self.w8a8_mxfp8_linear(
-                input=x,
-                weight=layer.weight,
-                weight_scale=weight_scale,
-                input_scale=None,
-                bias=bias,
-            )
+            else:
+                output = self.w8a8_mxfp8_linear(
+                    input=x,
+                    weight=weight,
+                    weight_scale=weight_scale,
+                    input_scale=None,
+                    bias=gemm_bias,
+                )
+            if logical_output_size is not None:
+                output = output[..., :logical_output_size]
+                if bias is not None:
+                    output += bias
+            return output
 
         if self.block_quant:
             if use_intel_amx_backend(layer):

--- a/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py
+++ b/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py
@@ -171,7 +171,7 @@ class FlashinferTrtllmGenMoeBackendMXFP8MixedBF16Base:
                 "--kv-cache-dtype",
                 "bf16",
                 "--fp8-gemm-backend",
-                "flashinfer_cutlass",
+                "flashinfer_trtllm",
                 "--moe-runner-backend",
                 cls.backend,
                 "--tp-size",

--- a/test/registered/rl/test_update_weights_from_disk_blackwell.py
+++ b/test/registered/rl/test_update_weights_from_disk_blackwell.py
@@ -2,6 +2,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=320, stage="extra-b", runner_config="4-gpu-b200")
 
+import time
 import unittest
 
 import requests
@@ -20,6 +21,7 @@ class UpdateWeightsFromDiskBase:
     base_url = DEFAULT_URL_FOR_TEST
     request_timeout = 120
     update_timeout = 240
+    idle_timeout = 30
     launch_env = None
     decode_payload = {
         "text": "The capital of France is",
@@ -73,6 +75,19 @@ class UpdateWeightsFromDiskBase:
 
     def _run_decode(self):
         return self._post_json("/generate", self.decode_payload)["text"]
+
+    def _wait_until_idle(self):
+        deadline = time.monotonic() + self.idle_timeout
+        last_loads = None
+        while time.monotonic() < deadline:
+            last_loads = self._get_json("/v1/loads?include=core")["loads"]
+            if last_loads and all(
+                load["num_running_reqs"] == 0 and load["num_waiting_reqs"] == 0
+                for load in last_loads
+            ):
+                return
+            time.sleep(0.1)
+        self.fail(f"Server did not become idle before weight update: {last_loads=}")
 
     def _assert_non_empty_decode(self):
         self.assertTrue(len(self._run_decode()) > 0)
@@ -138,6 +153,7 @@ class UpdateWeightsFromDiskBase:
 
                     for update_test_suite in self.update_test_suites:
                         with self.subTest(case_name=case_name, **update_test_suite):
+                            self._wait_until_idle()
                             ret = self._run_update_weights(
                                 self.model,
                                 flush_cache=update_test_suite["flush_cache"],
@@ -158,6 +174,7 @@ class UpdateWeightsFromDiskBase:
 
 class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTestCase):
     model = "zianglih/JoyAI-LLM-Flash-MXFP8-last-6-BF16"
+    decode_payload = {**UpdateWeightsFromDiskBase.decode_payload, "routed_dp_rank": 0}
     backend_test_suites = (
         {
             "name": "flashinfer_trtllm_routed_mxfp8",
@@ -166,6 +183,9 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
                 "0",
                 "--tp-size",
                 "4",
+                "--dp-size",
+                "4",
+                "--enable-dp-attention",
                 "--fp8-gemm-backend",
                 "flashinfer_trtllm",
                 "--moe-runner-backend",

--- a/test/registered/rl/test_update_weights_from_disk_blackwell.py
+++ b/test/registered/rl/test_update_weights_from_disk_blackwell.py
@@ -157,7 +157,7 @@ class UpdateWeightsFromDiskBase:
 
 
 class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTestCase):
-    model = "zianglih/Qwen3-30B-A3B-Instruct-2507-MXFP8-last-8-BF16"
+    model = "zianglih/JoyAI-LLM-Flash-MXFP8-last-6-BF16"
     backend_test_suites = (
         {
             "name": "flashinfer_trtllm_routed_mxfp8",
@@ -170,6 +170,7 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
                 "flashinfer_trtllm",
                 "--moe-runner-backend",
                 "flashinfer_trtllm_routed",
+                "--trust-remote-code",
             ),
         },
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
@humansand

FlashInfer TRTLLM MXFP8 dense GEMM expects FlashInfer-shuffled B weights and 128x4-swizzled scaling factors. The non-multiple-of-128 dense output shape covered here comes from the fused MLA QKV projection, so checkpoint-shaped scaling factors can fail the FlashInfer `M % 128 == 0` scale-layout requirement.

FlashInfer's `shuffle_matrix_sf_a` applies the TRTLLM scale row shuffle and then `block_scale_interleave`, but it does not add row padding. SGLang therefore needs to pad dense MXFP8 scale rows before calling the helper.

This mirrors the existing `flashinfer_cutlass` MXFP8 structure from [sgl-project/sglang#22484](https://github.com/sgl-project/sglang/pull/22484): keep checkpoint-shaped tensors for loading and `/update_weights_from_disk`, and store the backend-ready swizzled/shuffled scale buffer separately because the FlashInfer scale transformation can pad or reshape scales.

## Modifications

- For the FlashInfer TRTLLM MXFP8 dense linear path, shuffle loaded weights with FlashInfer `shuffle_matrix_a`.
- Convert loaded MXFP8 weight scales to the linear uint8 scale matrix, pad only the scale rows to a multiple of 128 with `F.pad` when needed, then call `shuffle_matrix_sf_a(..., num_elts_per_sf=32)`.
- Keep canonical checkpoint-shaped `weight` and `weight_scale_inv` parameters for weight loading and `/update_weights_from_disk`, while storing the FlashInfer-ready scale buffer separately as `weight_scale_inv_shuffled`.
- Switch `TestFlashinferTrtllmRoutedMxfp8MixedBF16` to exercise `--fp8-gemm-backend flashinfer_trtllm`.
- Update the MXFP8 update-from-disk registered test to use `zianglih/JoyAI-LLM-Flash-MXFP8-last-6-BF16`, which is already used by the existing `TestFlashinferTrtllmRoutedMxfp8MixedBF16` registered test on `main`.
- Enable DP attention and `--trust-remote-code` for the MXFP8 update-from-disk test so it matches the checkpoint/runtime requirements.

## Accuracy Tests

Latest validation after the scale-padding cleanup:

- `FLASHINFER_DISABLE_VERSION_CHECK=1 python3 -m pytest -s test/registered/rl/test_update_weights_from_disk_blackwell.py::TestServerUpdateWeightsFromDiskMXFP8::test_parameterized_update_weights_from_disk`
  - Passed: `1 passed, 7 warnings in 91.67s`.
- `python3 -m py_compile python/sglang/srt/layers/quantization/fp8.py`
  - Passed.
- `pre-commit run --all-files`
  - Passed.

Earlier branch validation:

- `python3 -m pytest -s test/registered/rl/test_update_weights_from_disk_blackwell.py::TestServerUpdateWeightsFromDiskMXFP8`
  - Passed, including both reload modes.
- `python3 -m pytest -s test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py::TestFlashinferTrtllmRoutedMxfp8MixedBF16`
  - Passed.
  - GSM8K score: `0.940`.

## Speed Tests and Profiling

The mixed BF16 registered test reported GSM8K output throughput `3544.248 token/s`.

No additional profiling was run for the scale-padding cleanup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27652459503](https://github.com/sgl-project/sglang/actions/runs/27652459503)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27652459329](https://github.com/sgl-project/sglang/actions/runs/27652459329)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
