### PR TITLE
fix: return bad request (400) for invalid multimodal data (instead of 500)

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -559,7 +559,7 @@ class BaseMultimodalProcessor(ABC):
             data_str = str(data)
             if len(data_str) > 100:
                 data_str = data_str[:100] + "..."
-            raise RuntimeError(f"Error while loading data {data_str}: {e}") from e
+            raise ValueError(f"Error while loading data {data_str}: {e}") from e
 
     @staticmethod
     def _get_preprocessed_input_format(data):
@@ -922,9 +922,9 @@ class BaseMultimodalProcessor(ABC):
                     modality.name,
                     idx,
                 )
-                raise RuntimeError(
+                raise ValueError(
                     f"An exception occurred while loading {modality.name} data at index {idx}: {e}"
-                )
+                ) from e
 
             if modality == Modality.IMAGE:
                 images[idx] = result
@@ -1054,13 +1054,13 @@ class BaseMultimodalProcessor(ABC):
                 if has_precomputed_input:
                     new_text_parts += [text_part]
                     continue
-                raise RuntimeError(
+                raise ValueError(
                     f"An exception occurred while loading multimodal data: {e}"
-                )
+                ) from e
             except Exception as e:
-                raise RuntimeError(
+                raise ValueError(
                     f"An exception occurred while loading multimodal data: {e}"
-                )
+                ) from e
         return BaseMultiModalProcessorOutput(
             images=images,
             audios=audios,

--- a/python/sglang/srt/multimodal/processors/llava.py
+++ b/python/sglang/srt/multimodal/processors/llava.py
@@ -90,6 +90,9 @@ class LlavaImageProcessor(BaseMultimodalProcessor):
                     pixel_values = pixel_values.astype(np.float16)
 
                 return pixel_values, image_hash, image.size
+        except ValueError:
+            logger.error("Exception in TokenizerManager:\n" + get_exception_traceback())
+            raise
         except Exception:
             logger.error("Exception in TokenizerManager:\n" + get_exception_traceback())
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -84,7 +84,7 @@ import torch
 import torch.distributed as dist
 import triton
 from packaging import version as pkg_version
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from starlette.routing import Mount
 from torch import nn
 from torch.library import Library
@@ -925,7 +925,12 @@ def _load_image(
             logger.warning(
                 f"Failed to decode JPEG on GPU, falling back to CPU. Error: {e}"
             )
-    return Image.open(BytesIO(image_bytes))
+    try:
+        image = Image.open(BytesIO(image_bytes))
+        image.load()
+        return image
+    except (UnidentifiedImageError, OSError) as e:
+        raise ValueError(f"Invalid image data: {e}") from e
 
 
 def load_image(

--- a/test/registered/unit/managers/test_multimodal_load_errors.py
+++ b/test/registered/unit/managers/test_multimodal_load_errors.py
@@ -1,0 +1,169 @@
+import asyncio
+import json
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede imports that may pull in sgl_kernel
+
+from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+from sglang.srt.utils import ImageData, load_image
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+BAD_IMAGE_DATA_URI = (
+    "data:image/jpeg;base64,"
+    "R0lGODlhEAAQAPZAAI6Ojp2dnampqaysrLW1tbW1tre3t7i4uLm5ubi4vbq6v7+/v8PDw8fHysvLy8zMzM3Nzc/Pz8/P19LS0tTU1NXV1dXV1tfX19fX2NbW2tfX2tDQ3NfX3dnZ2dvb29vb3tzc3N3d3d/f39nZ4Nra4dvb59ra6t7e6d3d7N/f7d7e7+Dg4ODg4ePj4+Pj5OTk5OXl5eTk5+bm5unp6e3t7e/v7/Dw8PHx8fLy8vPz8/T09Pj4+Pr6+vz8/P39/f7+/v///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAAAAAAALAAAAAAQABAAAAeLgECCg4SFhDstFRAQDhAULTuFNBEVNj1APTs4FBE0gzidPKKjojQQOIIUKzk2ra04ryIUggw2M7cxJB4ZFL0iDIILNDEtHxnHyMcLgg4UuR8kJNDSJA0OgjQIHCgl3d4lEgSogi0EDQoo6CYmGwkELoU6AigC9AMIEzmGQAEBHvqGAPz9G0iwoEF9gQAAOw=="
+)
+
+
+class _TestMultimodalProcessor(BaseMultimodalProcessor):
+    gpu_image_decode = False
+
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class _FakeServing(OpenAIServingBase):
+    def __init__(self, exc):
+        tokenizer_manager = SimpleNamespace(
+            server_args=SimpleNamespace(),
+            request_logger=SimpleNamespace(log_requests=False, log_requests_level=0),
+        )
+        super().__init__(tokenizer_manager)
+        self.exc = exc
+
+    def _request_id_prefix(self):
+        return "chatcmpl-"
+
+    def _convert_to_internal_request(self, request, raw_request=None):
+        return object(), request
+
+    async def _handle_non_streaming_request(
+        self, adapted_request, request, raw_request
+    ):
+        raise self.exc
+
+
+class MultimodalLoadErrorTestCase(unittest.TestCase):
+    def _make_processor(self, *, skip_tokenizer_init):
+        return _TestMultimodalProcessor(
+            hf_config=None,
+            server_args=SimpleNamespace(
+                mm_process_config={},
+                keep_mm_feature_on_device=False,
+                skip_tokenizer_init=skip_tokenizer_init,
+            ),
+            _processor=SimpleNamespace(),
+            transport_mode=None,
+        )
+
+    async def _load_bad_media(self, *, skip_tokenizer_init, prompt, tokens, **mm_data):
+        processor = self._make_processor(skip_tokenizer_init=skip_tokenizer_init)
+        try:
+            await processor.load_mm_data(
+                prompt=prompt,
+                multimodal_tokens=tokens,
+                **mm_data,
+            )
+        finally:
+            processor.io_executor.shutdown(wait=True)
+            processor.cpu_executor.shutdown(wait=True)
+
+    async def _load_bad_image(self, *, skip_tokenizer_init):
+        tokens = MultimodalSpecialTokens(image_token="<image>").build(SimpleNamespace())
+        await self._load_bad_media(
+            skip_tokenizer_init=skip_tokenizer_init,
+            prompt="<image>",
+            tokens=tokens,
+            image_data=[ImageData(url=BAD_IMAGE_DATA_URI)],
+        )
+
+    async def _load_bad_audio(self, *, skip_tokenizer_init):
+        tokens = MultimodalSpecialTokens(audio_token="<audio>").build(SimpleNamespace())
+        await self._load_bad_media(
+            skip_tokenizer_init=skip_tokenizer_init,
+            prompt="<audio>",
+            tokens=tokens,
+            audio_data=[b"not audio"],
+        )
+
+    async def _load_bad_video(self, *, skip_tokenizer_init):
+        tokens = MultimodalSpecialTokens(video_token="<video>").build(SimpleNamespace())
+        await self._load_bad_media(
+            skip_tokenizer_init=skip_tokenizer_init,
+            prompt="<video>",
+            tokens=tokens,
+            video_data=[b"not video"],
+        )
+
+    def _assert_maps_to_http_400(self, exc):
+        response = asyncio.run(
+            _FakeServing(exc).handle_request(
+                SimpleNamespace(stream=False),
+                raw_request=None,
+            )
+        )
+
+        body = json.loads(response.body)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(body["code"], 400)
+        self.assertEqual(body["type"], "BadRequest")
+
+    def test_bad_image_fast_loader_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "broken data stream"):
+            asyncio.run(self._load_bad_image(skip_tokenizer_init=False))
+
+    def test_bad_image_legacy_loader_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "broken data stream"):
+            asyncio.run(self._load_bad_image(skip_tokenizer_init=True))
+
+    def test_bad_audio_fast_loader_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            asyncio.run(self._load_bad_audio(skip_tokenizer_init=False))
+
+    def test_bad_audio_legacy_loader_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            asyncio.run(self._load_bad_audio(skip_tokenizer_init=True))
+
+    def test_bad_video_fast_loader_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            asyncio.run(self._load_bad_video(skip_tokenizer_init=False))
+
+    def test_bad_video_legacy_loader_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            asyncio.run(self._load_bad_video(skip_tokenizer_init=True))
+
+    def test_cpu_image_decode_unidentified_image_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "Invalid image data"):
+            load_image(b"not an image", gpu_image_decode=False)
+
+    def test_cpu_image_decode_broken_stream_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "broken data stream"):
+            load_image(ImageData(url=BAD_IMAGE_DATA_URI), gpu_image_decode=False)
+
+    def test_bad_media_value_errors_map_to_http_400(self):
+        loaders = [
+            self._load_bad_image,
+            self._load_bad_audio,
+            self._load_bad_video,
+        ]
+        for loader in loaders:
+            with self.subTest(loader=loader.__name__):
+                try:
+                    asyncio.run(loader(skip_tokenizer_init=False))
+                except ValueError as exc:
+                    self._assert_maps_to_http_400(exc)
+                else:
+                    self.fail(f"{loader.__name__} did not raise ValueError")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
- Currently when a bad image/video/audio is supplied, either by error or corrupted during transit, the container throws a 500 error causing oncall engagement.
```
[load_mm_data(simple)] error loading IMAGE data at index=0
Traceback (most recent call last):
  File ".../base_processor.py", line 545, in _load_single_item
    img = img.convert("RGB")
  File ".../PIL/Image.py", line 1070, in convert
    self.load()
  File ".../PIL/ImageFile.py", line 431, in load
    raise _get_oserror(err_code, encoder=False)
OSError: broken data stream when reading image file

The above exception was the direct cause of the following exception:

RuntimeError: Error while loading data ImageData(url='data:image/jpeg;base64,R0lGODlhEAAQAPZAAI6Ojp2d...'):
broken data stream when reading image file

Error in request: An exception occurred while loading IMAGE data at index 0: Error while loading data ImageData(...): broken data stream when reading image file

```

- The fix is to throw a 400 instead of 500 error.

```
{
  "object": "error",
  "message": "An exception occurred while loading IMAGE data at index 0: Error while loading data ImageData(...): Invalid image data: broken data stream when reading image file",
  "type": "BadRequest",
  "param": null,
  "code": 400
}

```



## Modifications
- Return HTTP 400 BadRequest for invalid multimodal media inputs instead of surfacing them as internal server errors.
- Force CPU PIL image decoding to happen inside `load_image` and wrap `PIL.UnidentifiedImageError` / `OSError` as `ValueError`.
- Add regression coverage for bad image, audio, and video inputs through both fast and legacy multimodal loading paths.

## Accuracy Tests
- N/A

## Speed Tests and Profiling
- N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27644363649](https://github.com/sgl-project/sglang/actions/runs/27644363649)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27644363412](https://github.com/sgl-project/sglang/actions/runs/27644363412)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->