### PR TITLE
[WIP][DSA] Blackwell (sm100) prefill context-parallel — round-robin global RoPE positions

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -69,6 +69,18 @@ def validate_deepseek_v4_cp(server_args: "ServerArgs") -> None:
     assert (
         server_args.tp_size <= 8
     ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
+
+    # The trtllm DSA-prefill path applies RoPE inside the backend (fp8 fused
+    # rope). Under round-robin CP it now re-splits forward_batch.positions to the
+    # rank's global token positions, so CP is allowed on Blackwell for trtllm
+    # prefill — but only for the fp8_e4m3 KV path the rope split assumes.
+    if server_args.dsa_prefill_backend == "trtllm":
+        assert server_args.kv_cache_dtype == "fp8_e4m3", (
+            "trtllm DSA-prefill context parallel requires kv_cache_dtype=fp8_e4m3 "
+            f"(got {server_args.kv_cache_dtype}); the round-robin RoPE split is only "
+            "wired for the fp8 fused-rope path."
+        )
+
     logger.warning(
         f"Enable Context Parallel for DeepSeekV4, "
         f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -126,6 +126,19 @@ def dsa_cp_round_robin_split_data(input_: Union[torch.Tensor, List]):
     return input_.view(-1, cp_size, *input_.shape[1:])[:, cp_rank].contiguous()
 
 
+def dsa_cp_round_robin_rope_positions(forward_batch: "ForwardBatch") -> torch.Tensor:
+    """Global RoPE positions for this rank's round-robin token subset.
+
+    The Hopper flashmla_sparse path applies RoPE in the model with the already
+    CP-split ``positions`` (see ``cp_split_and_rebuild_position``), but the
+    Blackwell trtllm fp8 path defers RoPE into the backend and would otherwise
+    read the full, unsplit ``forward_batch.positions``. Re-split those positions
+    with the SAME ordering as the q/k rows so token ``i`` keeps its true
+    sequence index ``i`` even though it lives at local slot ``i // cp_size``.
+    """
+    return dsa_cp_round_robin_split_data(forward_batch.positions)
+
+
 def cal_padded_tokens(forward_batch: "ForwardBatch"):
     # Consistent with the padding calculation logic in ForwardBatch.prepare_mlp_sync_batch,
     # calculate the actual token length after padding when attn_tp_size > 1 or in the MAX_LEN padding mode.

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -38,6 +38,7 @@ from sglang.srt.layers.attention.dsa.transform_index import (
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
+    dsa_cp_round_robin_rope_positions,
     dsa_cp_round_robin_split_data,
     dsa_cp_round_robin_split_q_seqs,
     is_dsa_enable_prefill_cp,
@@ -2110,12 +2111,21 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache is not None
             ), "For FP8 path cos_sin_cache should not be None."
 
+            # Under round-robin CP the q/k rows are a strided 1/cp_size subset,
+            # so RoPE must use the matching global positions, not the full
+            # forward_batch.positions (mirrors the Hopper flashmla_sparse path).
+            rope_positions = (
+                dsa_cp_round_robin_rope_positions(forward_batch)
+                if is_prefill and can_dsa_prefill_cp_round_robin_split(forward_batch)
+                else forward_batch.positions
+            )
+
             q, k, k_rope = mla_quantize_and_rope_for_fp8(
                 q,
                 q_rope,
                 k.squeeze(1),
                 k_rope.squeeze(1),
-                forward_batch.positions,
+                rope_positions,
                 cos_sin_cache,
                 is_neox,
                 self.kv_lora_rank,

--- a/test/registered/unit/layers/attention/test_dsa_cp_round_robin_positions.py
+++ b/test/registered/unit/layers/attention/test_dsa_cp_round_robin_positions.py
@@ -1,0 +1,86 @@
+"""CPU regression for the round-robin DSA prefill-CP RoPE positions.
+
+The Blackwell trtllm DSA-prefill path applies RoPE inside the backend and must
+use the rank's *global* token positions, not the full forward_batch.positions.
+This guards the inverse-map invariant the fix relies on (token i keeps its true
+sequence index i even though it lives at local slot i // cp_size), independent
+of any GPU kernel.
+"""
+
+import types
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, stage="base-b")
+
+from sglang.srt.layers.attention.dsa import utils as dsa_utils
+
+
+def _make_forward_batch(num_tokens: int) -> types.SimpleNamespace:
+    return types.SimpleNamespace(positions=torch.arange(num_tokens, dtype=torch.int64))
+
+
+class TestDSACPRoundRobinPositions(CustomTestCase):
+    def _rope_positions_for_rank(self, num_tokens: int, cp_rank: int, cp_size: int):
+        fb = _make_forward_batch(num_tokens)
+        with mock.patch.object(
+            dsa_utils, "get_attention_cp_rank", return_value=cp_rank
+        ), mock.patch.object(
+            dsa_utils, "get_attention_cp_size", return_value=cp_size
+        ):
+            return dsa_utils.dsa_cp_round_robin_rope_positions(fb)
+
+    def test_each_rank_gets_its_global_positions(self):
+        # token i -> rank i % cp_size; the positions returned for that rank must
+        # be exactly [r, r + cp_size, r + 2*cp_size, ...] (the true global ids).
+        for cp_size in (2, 4, 8):
+            for num_tokens in (cp_size, cp_size * 3, cp_size * 7):
+                for cp_rank in range(cp_size):
+                    out = self._rope_positions_for_rank(num_tokens, cp_rank, cp_size)
+                    expected = torch.arange(cp_rank, num_tokens, cp_size)
+                    self.assertTrue(
+                        torch.equal(out, expected),
+                        f"cp_size={cp_size} rank={cp_rank} tokens={num_tokens}: "
+                        f"{out.tolist()} != {expected.tolist()}",
+                    )
+
+    def test_ranks_partition_full_sequence(self):
+        # The concatenation of all ranks' positions must be a permutation of the
+        # full position range (no token dropped, none duplicated).
+        for cp_size in (2, 4, 8):
+            num_tokens = cp_size * 5
+            gathered = torch.cat(
+                [
+                    self._rope_positions_for_rank(num_tokens, r, cp_size)
+                    for r in range(cp_size)
+                ]
+            )
+            self.assertEqual(
+                sorted(gathered.tolist()), list(range(num_tokens))
+            )
+
+    def test_matches_qk_split_ordering(self):
+        # Positions must split with the SAME ordering as the q/k rows
+        # (dsa_cp_round_robin_split_data), or RoPE misaligns and produces garbage.
+        cp_size = 4
+        num_tokens = cp_size * 6
+        fb = _make_forward_batch(num_tokens)
+        fake_qk = torch.arange(num_tokens, dtype=torch.int64).view(num_tokens, 1)
+        for cp_rank in range(cp_size):
+            with mock.patch.object(
+                dsa_utils, "get_attention_cp_rank", return_value=cp_rank
+            ), mock.patch.object(
+                dsa_utils, "get_attention_cp_size", return_value=cp_size
+            ):
+                pos = dsa_utils.dsa_cp_round_robin_rope_positions(fb)
+                qk = dsa_utils.dsa_cp_round_robin_split_data(fake_qk)
+            self.assertTrue(torch.equal(pos, qk.view(-1)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> [!WARNING]
> **DRAFT / WIP / RFC — NOT YET VALIDATED ON B300 HARDWARE.**
> This is a reviewable scaffold. The author has no GPU and has **not** run the
> CP-vs-noCP 64K correctness check. Do not merge before the validation
> checklist below passes on 8×B300 (sm103). Treat the numbers/claims as the
> intended behavior, not measured results.

## Motivation

`--enable-dsa-prefill-context-parallel --dsa-prefill-cp-mode round-robin-split`
gives a large long-prefill TTFT win on DeepSeek-DSA / `GlmMoeDsa` models, but
is verified **Hopper-only**. On Blackwell (sm100/sm103) with fp8_e4m3 KV, the
trtllm DSA-prefill path produces wrong output under CP because RoPE is fed the
wrong token positions, so CP has to stay off there.

## The gap (Hopper flashmla vs Blackwell trtllm position plumbing)

Round-robin-split assigns token `i` to CP rank `i % cp_size`, so each rank
holds a **non-contiguous, strided** 1/cp_size subset of the sequence. RoPE
depends on each token's **global** sequence position.

- **Hopper (`flashmla_sparse`)**: RoPE is applied in the model
  (`forward_absorb_prepare`) using the already CP-split `positions` produced by
  `cp_split_and_rebuild_position`. Correct under CP.
- **Blackwell (`trtllm`, fp8_e4m3 KV)**: RoPE is deferred into the backend.
  `DeepseekSparseAttnBackend._forward_trtllm` calls
  `mla_quantize_and_rope_for_fp8(..., forward_batch.positions, ...)` with the
  **full, unsplit** `forward_batch.positions`, while `q`/`k`/`k_rope` are the
  rank's strided subset. Positions and rows are misaligned → garbage (same
  failure class as the AMD round-robin garbage bug #20360).

The indexer already receives the CP-split `positions` arg in the model, so only
the trtllm fused-rope step was reading the unsplit positions.

## Approach (Option A — Python-level, no new kernel)

Re-split `forward_batch.positions` with the **same ordering** as the q/k rows,
right before the fp8 fused rope, on the round-robin prefill-CP branch.

- `layers/attention/dsa/utils.py`: add `dsa_cp_round_robin_rope_positions()`,
  the inverse map of `dsa_cp_round_robin_split_data` (token `i` keeps global
  index `i` even though it lives at local slot `i // cp_size`).
- `layers/attention/dsa_backend.py`: `_forward_trtllm` uses those global
  positions in `mla_quantize_and_rope_for_fp8` when
  `is_prefill and can_dsa_prefill_cp_round_robin_split(forward_batch)`; the
  non-CP path is unchanged.
- `arg_groups/deepseek_v4_hook.py`: relax/guard the gate — trtllm prefill-CP is
  allowed, asserting `kv_cache_dtype == fp8_e4m3` (the only path the rope split
  is wired for).

This reuses the existing RoPE + trtllm kernel; only the position bookkeeping
changes. It mirrors the Hopper handling in #27276 and the structure of the
non-flashmla CP port in #27928, and hooks the CP server-arg surface introduced
by #27312 / #27313.

## Files changed

| File | Why |
| --- | --- |
| `python/sglang/srt/layers/attention/dsa/utils.py` | add `dsa_cp_round_robin_rope_positions()` global-position helper |
| `python/sglang/srt/layers/attention/dsa_backend.py` | `_forward_trtllm` feeds global CP positions to the fp8 fused rope |
| `python/sglang/srt/arg_groups/deepseek_v4_hook.py` | guard trtllm prefill-CP to the fp8_e4m3 path |
| `test/registered/unit/layers/attention/test_dsa_cp_round_robin_positions.py` | CPU regression on the global-position invariant |

## Validation checklist (REQUIRED before un-drafting)

- [ ] **Correctness (critical):** GLM-5.2-FP8 or DeepSeek-V3.2-FP8 on 8×B300,
      greedy (temp 0), `--dsa-prefill-backend trtllm`. 64K-token prompt **with**
      `--tp 8 --attn-cp-size 8 --enable-dsa-prefill-context-parallel
      --dsa-prefill-cp-mode round-robin-split` vs **without** CP — output token
      IDs identical (or within fp8 tolerance on logprobs). Rules out the
      round-robin-garbage mode (#20360).
- [ ] **Accuracy:** long-context retrieval / GSM8K, CP-on vs CP-off, no regression.
- [ ] **Perf:** 64K-in / 1K-out TTFT, CP-on vs CP-off — expect a large TTFT
      reduction (Hopper saw ~2.5–2.8×). Record decode-side KV-pool / max-context
      trade-off.
- [ ] **cuda-graph:** confirm graph capture works with CP enabled (prefill is
      eager; verify decode graphs intact).
- [ ] Promote the CPU test to a GPU CP-vs-noCP parity test mirroring #27276.

## Notes for reviewers (focus here)

- **Padding / ragged tail.** When the global token count isn't a multiple of
  `cp_size`, the batch is ceil-aligned with trailing padding rows. This PR
  splits `forward_batch.positions` with `dsa_cp_round_robin_split_data`, which
  matches how q/k/seqlens are split elsewhere in `init_forward_metadata`, but
  please confirm the padded-tail positions on the trtllm path don't poison the
  fp8 K quant / topk selection the way #27276 calls out for the sparse path.
- **`forward_batch.positions` semantics.** This assumes `forward_batch.positions`
  is still the *full, unsplit* sequence positions at the backend (the model's
  CP-split positions are a separate local var). Verify that holds for every CP
  prefill entry into `_forward_trtllm` (including chunked prefill).
- **Decode path untouched.** The split is gated on `is_prefill`; decode keeps
  `forward_batch.positions`. Confirm there's no CP-decode path that also needs it.
- **Gate scope.** I added the fp8 guard in `validate_deepseek_v4_cp`; if there's
  a better single chokepoint for "trtllm prefill-CP on Blackwell" please point me
  at it.

References: #27276 (Hopper flashmla sparse prefill CP — the position-handling
reference) · #27928 (AMD unified-KV CP port — closest non-flashmla analog) ·
#27312 / #27313 (CP strategy abstraction + simplified CP server args) ·
#20360 (the round-robin garbage failure mode this must rule out).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27648301095](https://github.com/sgl-project/sglang/actions/runs/27648301095)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27648300903](https://github.com/sgl-project/sglang/actions/runs/27648300903)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->