### PR TITLE
docs(skill): fix cookbook-skill gaps

### DIFF
--- a/.claude/skills/cookbook-add-model/references/authoring-reference.md
+++ b/.claude/skills/cookbook-add-model/references/authoring-reference.md
@@ -146,6 +146,15 @@ schemas (full reference in the `_playground.jsx` header):
 - Constraints are AND across keys, OR within each key's array.
 - Bare `disabled: true` / `disable: true` is a static always-disabled form
   (used for "Coming soon" chips).
+- **Per-VALUE / per-OPTION only.** The constraint must sit on each value or
+  option object (as above). A `disable`/`disableReason` placed on the *axis /
+  select object itself* (a sibling of `values` / `options`) is **silently
+  ignored** — the engine's `evaluateChip` runs per entry, never on the axis
+  object, so every chip renders fully live despite looking disabled in source.
+  To grey a whole select on some variants/hw, repeat the constraint on every
+  value: `moe.backend.options[]` (per-option) works, but a bare
+  `ep: { values: [1, 2, 4], disable: {...} }` does NOT — wrap each value:
+  `values: [{ value: 1, disable: {...}, disableReason: "…" }, …]`.
 
 ## 2.4 Create the MDX page
 

--- a/.claude/skills/cookbook-migrate-model/SKILL.md
+++ b/.claude/skills/cookbook-migrate-model/SKILL.md
@@ -49,10 +49,16 @@ your dispatch prompt, or ask for it.
      **Day-0 support** (the enabling PR isn't merged and no release is cut
      yet) — a specific **PR (`PR #27944`) or commit** you can `gh pr checkout`
      / `git checkout <sha>`. Commit is most precise; a PR pin is fine for day-0.
+     **Only pin to a PR/commit the legacy page itself attributes the measurement
+     to** — never retroactively assign a plausible enabling PR to numbers the page
+     never tied to it (that fabricates the anchor → drop instead).
    - ❌ a moving ref — `"main branch"`, `"main (2026-06-11)"`, open-ended
      `"0.5.8+"` — is NOT reproducible: **drop the WHOLE result (speed AND
-     accuracy)**, not just speed. Keep `benchmarkCommands` so ⚡Reproduce still
-     guides re-measurement against a pinned build.
+     accuracy)**, not just speed. (The ⚡Reproduce modal renders only when a
+     `benchmarks` prop is ALSO present — see authoring-reference; with the data
+     dropped it does NOT render, so `benchmarkCommands` is documentation-only
+     then, not a working button. Keep it as a re-measurement recipe or drop it,
+     but don't claim Reproduce still works.)
    **Never inherit cross-model numbers** — measurements the legacy page
    attributes to a *different model* (e.g. a K2.6 page carrying K2.5-measured
    speed) are dropped regardless of version. When kept, `sglang_version` is the

--- a/.claude/skills/cookbook-migrate-model/references/dimension-mapping.md
+++ b/.claude/skills/cookbook-migrate-model/references/dimension-mapping.md
@@ -78,6 +78,20 @@ the page (otherwise a stripped cell's baseline can't be re-applied) — but
 benchmarked with NEXTN ships a single `eagle` preset, not both. (Pilot history:
 Qwen3.5 once shipped both; corrected to EAGLE-only.)
 
+**Drop a general axis when its shared preset can't safely express the model's
+flags** — not only when the model lacks the feature. If a preset would need a
+**per-variant** value that one shared preset string can't template (e.g.
+Gemma4's per-variant `--speculative-draft-model-path …/<variant>-it-assistant`)
+AND the axis's strip-list doesn't cover that flag (so toggling the axis OFF
+leaves a dangling flag → a broken command), drop the axis and keep the feature
+as the **strategy dimension** instead (every-control-survives still holds).
+Prefer this over emitting an untested/broken command shape. The cleaner
+long-term fix — adding the flag to the engine's strip-list so the toggle removes
+it — is an engine change, out of a migration PR's data-only scope; note it as a
+follow-up. (Contrast K2.5: a SINGLE hw-gated `--speculative-draft-model-path`
+rides inside one preset fine — the blocker is per-variant divergence, not draft
+paths as such.)
+
 **MTP `--max-running-requests` hint (engine, automatic):** when a cell's
 command turns speculative decoding on (`--speculative-algorithm` present)
 without `--max-running-requests`, the Deploy panel + Playground auto-render an
@@ -176,7 +190,7 @@ model-specific note — never toggle-/migration-centric explanations.
 
 | Family | strategies | Notes |
 |---|---|---|
-| Gemma4 | `low-latency` (MTP on — the legacy toggle's own "Lower Latency" subtitle) / `high-throughput` (MTP off); mi300x hides the toggle → its single recipe → `balanced` (trio union, Qwen3.5 Xeon pattern) | variants = e2b/e4b/12b/31b/26b-a4b; checkpoint radio Standard(BF16)/QAT(q4_0) → quant ids via `modelNames`; §3.3 prose carries AMD recipes beyond the widget's mi300x — maintainer call on cells-from-prose vs tips; vision/audio invocation prose carries over (deployment matrix is text-standard); "gemma4 branch" version → speed drops, MMLU/GSM8K accuracy keeps (mind the few-shot vs run_eval harness footnote); dedicated multi-arch dev images verbatim |
+| Gemma4 | `low-latency` (MTP on — the legacy toggle's own "Lower Latency" subtitle) / `high-throughput` (MTP off); mi300x hides the toggle → its single recipe → `balanced` (trio union, Qwen3.5 Xeon pattern) | variants = e2b/e4b/12b/31b/26b-a4b; checkpoint radio Standard(BF16)/QAT(q4_0) → quant ids via `modelNames`; §3.3 prose carries AMD recipes beyond the widget's mi300x — maintainer call on cells-from-prose vs tips; vision/audio invocation prose carries over (deployment matrix is text-standard); "gemma4 branch" version is non-reproducible → drop the WHOLE result (speed AND accuracy) unless pinnable to the support PR/commit the page attributes the numbers to (day-0 rule, §hard-rule-2); the few-shot vs run_eval harness footnote stays a benchmarks/§3 note; dedicated multi-arch dev images verbatim |
 | Nemotron3-Ultra | dpattention carries "Low latency"/"High throughput" subtitles (naming rule) but THREE perf controls stack — multi-value DP-Attention (2/4/8) × MTP × EP — design the tier mapping via the step-2 table; maintainer sign-off required | NVIDIA-only (h100→gb300) with a per-quant verified-hw SUPPORT matrix → absent cells; "Model" radio = the quant dim (BF16 / NVFP4 Blackwell-only); TP radio 8/16 — TP=16 is 2-node → `nodes` dim; **kvcache radio (None/fp8_e4m3/bf16) → `flagSelects` axis, config-only** (the generic primitive merged in #28128 — NO engine PR); `launch_server` + spec-V2 env prefix verbatim; dedicated `dev-nemotron3-ultra(+cu13)` images verbatim ("not in any stable release"); **"main branch" version is non-reproducible → drop the WHOLE measured result (speed AND accuracy)** unless it can be pinned to the support PR/commit (day-0 rule, §hard-rule-2) |
 | GLM-4.5, GLM-4.6 | `low-latency` (TP, + MTP from the legacy checkbox) / `high-throughput` (TP+DP+EP) | |
 | GLM-4.7 | `low-latency`(2 GPUs) / `balanced`(4) / `high-throughput`(8) — gpus 2/4/8 + SUPPORT matrix; confirm naming, tiers are GPU budgets | measured-best B200 TP=2 NVFP4 → the verified cell |

--- a/.claude/skills/cookbook-review-pr/SKILL.md
+++ b/.claude/skills/cookbook-review-pr/SKILL.md
@@ -74,7 +74,10 @@ than restating.
   use it. Model-specific axes only where applicable (MegaMoE backend + `megamoeQuant`
   only on Blackwell MoE, gated by `requiresHw`; `hisparse` only DSA-style). Knobs that are
   meaningless for a subset of variants/hw are `disable`d with a reason, not silently live
-  (e.g. MoE knobs greyed on dense variants). No empty/stub axes.
+  (e.g. MoE knobs greyed on dense variants) — and the `disable` must be **per-value /
+  per-option**, not on the select/axis object (an object-level `disable` is a silent
+  no-op: the chips render live despite the source looking disabled; spot-check the actual
+  greying rather than trusting the presence of `disable`+reason). No empty/stub axes.
 - **No leftover `__TOKEN__`** — the config was stamped from the template and every
   placeholder is filled (`grep -rn '__[A-Z_]*__'` on the new config/benchmarks/MDX returns
   nothing).


### PR DESCRIPTION
## What

Fixes 5 gaps in the cookbook skills surfaced while migrating + reviewing Phase A Wave 1 ([#28350](https://github.com/sgl-project/sglang/pull/28350) GLM-5.1, [#28352](https://github.com/sgl-project/sglang/pull/28352) MiniMax-M2.7, [#28353](https://github.com/sgl-project/sglang/pull/28353) Gemma4, [#28351](https://github.com/sgl-project/sglang/pull/28351) Nemotron3-Ultra). **Docs-only — no engine change.**

## Fixes

**1. Per-value disable** (`cookbook-add-model/references/authoring-reference.md` §2.3 + `cookbook-review-pr/SKILL.md` §2)
A Playground select's `disable`/`disableReason` must sit on each **value/option** object. Placed on the *axis/select object* (sibling of `values`/`options`) it is **silently ignored** — the engine's `evaluateChip` runs per entry, so the chips render fully live despite looking disabled in source. This bit Gemma4's `moe.ep` (greyed in source, live in the page). authoring-reference now documents the gotcha; the review checklist now says to spot-check the actual greying, not just the presence of `disable`+reason.

**2. Stale Gemma4 benchmark row** (`cookbook-migrate-model/references/dimension-mapping.md` §4)
The Gemma4 row still read `"gemma4 branch" → speed drops, accuracy keeps` — the **pre-sharpening** rule, contradicting hard rule 2 (`drop the WHOLE result`) and the sibling Nemotron3-Ultra row. #28340 swept the Nemotron row but missed this one. Now consistent.

**3. Day-0 anchor attribution** (`cookbook-migrate-model/SKILL.md` hard rule 2)
A day-0 PR/commit anchor is valid **only when the legacy page attributes the measurement to that build**. Never retroactively assign a plausible enabling PR to numbers the page never tied to it (that fabricates the anchor → drop instead). The Nemotron3-Ultra + Gemma4 migrations both correctly refused to fabricate; the rule now says so.

**4. `benchmarkCommands` ≠ working Reproduce** (`cookbook-migrate-model/SKILL.md` hard rule 2)
The rule said "keep `benchmarkCommands` so ⚡Reproduce still guides re-measurement" — but the ⚡Reproduce modal only renders when a `benchmarks` prop is **also** present (per authoring-reference). With the data dropped it does not render, so `benchmarkCommands` is documentation-only. Reworded to stop implying a working button.

**5. Drop a general axis when the shared preset can't express the model's flags** (`cookbook-migrate-model/references/dimension-mapping.md` §2b)
Distinct from "the model lacks the feature": if a preset needs a **per-variant** value one shared preset string can't template (Gemma4's per-variant `--speculative-draft-model-path`) **and** the axis strip-list omits that flag (toggling off → dangling flag → broken command), drop the axis and keep the feature as the strategy dimension. Notes the cleaner long-term fix (add the flag to the engine strip-list) as an out-of-scope engine follow-up.



🤖 Generated with [Claude Code](https://claude.com/claude-code)










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27658291070](https://github.com/sgl-project/sglang/actions/runs/27658291070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27658290981](https://github.com/sgl-project/sglang/actions/runs/27658290981)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->