### PR TITLE
[AMD] Fall back to layer_first layout for kernel write-back on ROCm

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4026,18 +4026,17 @@ class ServerArgs:
             )
 
         # The page_first kernel write-back relies on the CUDA-only JIT staged
-        # kernel. On non-CUDA platforms (e.g. ROCm) it falls back to a kernel
-        # that requires CUDA index tensors and crashes on host write-back, so
-        # use layer_first there instead.
+        # kernel. On ROCm it falls back to a kernel that requires CUDA index
+        # tensors and crashes on host write-back, so use layer_first there.
         if (
             self.hicache_mem_layout == "page_first"
             and self.hicache_io_backend == "kernel"
-            and not is_cuda()
+            and is_hip()
         ):
             self.hicache_mem_layout = "layer_first"
             logger.warning(
                 "page_first kernel write-back requires the CUDA JIT kernel; "
-                "falling back to layer_first layout on this platform."
+                "falling back to layer_first layout on ROCm."
             )
 
     def _resolve_storage_layout_compatibility(self):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4025,6 +4025,21 @@ class ServerArgs:
                 "Page first layout is not supported with direct IO backend, switching to page first direct layout"
             )
 
+        # The page_first kernel write-back relies on the CUDA-only JIT staged
+        # kernel. On non-CUDA platforms (e.g. ROCm) it falls back to a kernel
+        # that requires CUDA index tensors and crashes on host write-back, so
+        # use layer_first there instead.
+        if (
+            self.hicache_mem_layout == "page_first"
+            and self.hicache_io_backend == "kernel"
+            and not is_cuda()
+        ):
+            self.hicache_mem_layout = "layer_first"
+            logger.warning(
+                "page_first kernel write-back requires the CUDA JIT kernel; "
+                "falling back to layer_first layout on this platform."
+            )
+
     def _resolve_storage_layout_compatibility(self):
         if (
             self.hicache_storage_backend != "mooncake"


### PR DESCRIPTION
## Motivation
After #21631 changed the default `hicache_mem_layout` from `layer_first` to `page_first`, AMD/ROCm HiCache CI started failing.
On non-CUDA platforms the JIT staged write-back kernel is disabled, because it is gated by `can_use_jit = _is_cuda and ...` in `memory_pool_host.py`. With the new `page_first` default, the kernel write-back therefore falls into the non-JIT fallback path:
- MHA: `transfer_kv_all_layer_lf_pf`
- MLA: `transfer_kv_all_layer_mla_lf_pf`
These fallback kernels require the index tensors to live on CUDA:
```
TORCH_CHECK(src_indices.is_cuda(), "Source indices must be a CUDA tensor"); TORCH_CHECK(dst_indices.is_cuda(), "Destination indices must be a CUDA tensor");
```
but write-back passes `host_indices` (a CPU tensor), so the scheduler crashes:
```
RuntimeError: Destination indices must be a CUDA tensor
```
This manifests in two ways in CI:
1. `test_hicache_variants.py` (DeepSeek-Coder-V2-Lite, MLA): scheduler hits the exception, server exits with code -9 → `setUpClass` fails.
2. `test_hicache_storage.py` (Llama-3.1-8B, MHA): the server crashes on the first write-back, so the MMLU eval gets only connection errors and scores `0.0` → `AssertionError: 0.0 not greater than or equal to 0.65`.
The `page_first` + non-JIT write-back path was effectively never supported (the load direction passes host indices to the same CUDA-only kernels too); it was simply never exercised before, since the old default was `layer_first` and CUDA always takes the JIT path.
## Modification
In `ServerArgs._resolve_layout_io_compatibility()`, when `hicache_mem_layout == "page_first"` and `hicache_io_backend == "kernel"` on a non-CUDA platform, fall back to `layer_first` (the layout that AMD CI used before #21631). NVIDIA is unaffected and keeps `page_first` + JIT staged write-back.


## Accuracy Tests
<img width="1390" height="175" alt="image" src="https://github.com/user-attachments/assets/2b04d203-4d08-4e25-aa47-49905075f66e" />
<img width="1382" height="118" alt="image" src="https://github.com/user-attachments/assets/e1c128fb-9240-4e72-a882-cda0fdb1ce3f" />

<img width="1542" height="200" alt="image" src="https://github.com/user-attachments/assets/07a75eb8-e114-4493-a11b-6c2e6978303f" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27661851649](https://github.com/sgl-project/sglang/actions/runs/27661851649)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27680010263](https://github.com/sgl-project/sglang/actions/runs/27680010263)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->