### PR TITLE
[router] Multi-arch experimental sgl-router image + fix distroless libpcre2 startup crash

### DIFF
--- a/.github/workflows/nightly-experimental-sgl-router-docker.yml
+++ b/.github/workflows/nightly-experimental-sgl-router-docker.yml
@@ -9,10 +9,27 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+env:
+  IMAGE_REPO: lmsysorg/sglang-staging
+  IMAGE_TAG: experimental-router-dev
+
 jobs:
-  publish:
+  # Build each arch natively (no QEMU emulation) and push the image by digest.
+  # The manifest job then stitches the per-arch digests into one multi-arch
+  # tag, so `docker pull` resolves the right arch automatically.
+  build:
     if: github.repository == 'sgl-project/sglang'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,9 +43,53 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and Push
+      - name: Build and push by digest
         run: |
           docker buildx build . -f docker/sgl-router.Dockerfile \
-            --platform linux/amd64 \
-            -t lmsysorg/sglang-staging:experimental-router-dev \
-            --push
+            --platform ${{ matrix.platform }} \
+            --output "type=image,name=${IMAGE_REPO},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file /tmp/metadata.json
+          DIGEST=$(python3 -c "import json; print(json.load(open('/tmp/metadata.json'))['containerimage.digest'])")
+          echo "Pushed ${{ matrix.platform }} digest: ${DIGEST}"
+          mkdir -p /tmp/digests
+          echo "${DIGEST}" > "/tmp/digests/${{ matrix.arch }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/${{ matrix.arch }}
+          retention-days: 1
+
+  create-manifest:
+    if: github.repository == 'sgl-project/sglang'
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          AMD64_DIGEST=$(cat /tmp/digests/amd64)
+          ARM64_DIGEST=$(cat /tmp/digests/arm64)
+          docker buildx imagetools create \
+            -t "${IMAGE_REPO}:${IMAGE_TAG}" \
+            "${IMAGE_REPO}@${AMD64_DIGEST}" \
+            "${IMAGE_REPO}@${ARM64_DIGEST}"
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect "${IMAGE_REPO}:${IMAGE_TAG}"

--- a/docker/sgl-router.Dockerfile
+++ b/docker/sgl-router.Dockerfile
@@ -49,6 +49,15 @@ RUN mkdir -p src && echo "fn main() {}" > src/main.rs \
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS builder
 RUN cargo install cargo-chef --locked --version ^0.1
 WORKDIR /work
+
+# `dynamo-tokenizers` pulls in `pcre2-sys`, whose build.rs links the SYSTEM
+# libpcre2-8 whenever pkg-config finds it (it does here — the rust:bookworm
+# base ships libpcre2-dev). That dynamic dep is absent from the distroless
+# runtime, so the binary fails at startup with "libpcre2-8.so.0: cannot open
+# shared object file". Force pcre2-sys to compile its vendored PCRE2 and link
+# it statically, keeping the runtime self-contained.
+ENV PCRE2_SYS_STATIC=1
+
 COPY --from=chef /work/recipe.json ./recipe.json
 COPY --from=chef /work/Cargo.lock ./Cargo.lock
 COPY experimental/sgl-router/rust-toolchain.toml ./


### PR DESCRIPTION
## Motivation

Two fixes to make the experimental `sgl-router` docker image
(`lmsysorg/sglang-staging:experimental-router-dev`) actually usable:

1. **Multi-arch.** The nightly workflow built `linux/amd64` only, so the
   image couldn't be pulled on ARM hosts (Grace, GB200/GB300 head nodes,
   Apple Silicon dev machines).
2. **Distroless runtime crash.** The published image failed at startup with
   `error while loading shared libraries: libpcre2-8.so.0: cannot open
   shared object file`. `dynamo-tokenizers` → `pcre2-sys` dynamic-links the
   system `libpcre2-8` (the `rust:bookworm` builder ships `libpcre2-dev`, so
   pkg-config finds it), and `distroless/cc-debian12` doesn't provide that
   library. This affected the existing amd64 image too — not arch-specific.

## Modifications

**`.github/workflows/nightly-experimental-sgl-router-docker.yml` — multi-arch**

- `build` (matrix) builds `docker/sgl-router.Dockerfile` **natively per
  arch**: amd64 on `ubuntu-24.04`, arm64 on `ubuntu-24.04-arm` (no QEMU
  emulation). Each pushes by digest and uploads the digest as an artifact.
- `create-manifest` stitches the per-arch digests into the single
  `lmsysorg/sglang-staging:experimental-router-dev` tag via
  `docker buildx imagetools create`, then inspects it. `docker pull` resolves
  the correct arch automatically.

**`docker/sgl-router.Dockerfile` — static PCRE2**

- Set `PCRE2_SYS_STATIC=1` in the builder stage so `pcre2-sys` compiles its
  vendored PCRE2 and links it statically. The runtime binary then needs only
  `libstdc++ / libgcc_s / libm / libc`, all present in distroless. The
  distroless runtime stage is unchanged.

## Verification

- Built the arm64 image locally: `sgl-router --help` starts cleanly (no
  `libpcre2` error), and `readelf -d` on the runtime binary shows no
  `libpcre2` NEEDED entry — only `libstdc++.so.6`, `libgcc_s.so.1`,
  `libm.so.6`, `libc.so.6`.
- `actionlint` (incl. shellcheck) and `pre-commit` pass on the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27662297507](https://github.com/sgl-project/sglang/actions/runs/27662297507)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27662297346](https://github.com/sgl-project/sglang/actions/runs/27662297346)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->