### PR TITLE
[AMD][Perf] Fuse QK-norm + 3D mRoPE + KV cache store into single aiter op for Qwen3.5-397B-A17B-MXFP4 on HIP

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -68,6 +68,7 @@ from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.rotary_embedding.mrope import MRotaryEmbedding
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -76,6 +77,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
@@ -119,6 +121,16 @@ _is_gfx95 = is_gfx95_supported()
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _hip_use_alt_stream = get_bool_env_var("SGLANG_ALT_STREAM") and _is_hip
+
+_has_fused_qk_norm_mrope = False
+if _use_aiter:
+    try:
+        from aiter import fused_qk_norm_mrope_3d_cache_pts_quant_shuffle
+
+        _has_fused_qk_norm_mrope = True
+        logger.info("aiter fused_qk_norm_mrope_3d kernel available (qwen3_5)")
+    except ImportError:
+        pass
 _gdn_use_alt_stream = _is_cuda or (
     get_bool_env_var("SGLANG_GDN_QKVZ_BA_ALT_STREAM", "False") and _hip_use_alt_stream
 )
@@ -851,6 +863,129 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
         self.alt_stream = alt_stream
 
+        # Fused QK-norm + 3D mRoPE + KV cache store (ROCm/aiter, decode-only).
+        # The fused HIP kernel consumes a standard [q | k | v] head layout. When
+        # this model uses an attention output gate, qkv_proj emits a per-head
+        # [q | gate] interleave for the query slice, so we de-interleave the gate
+        # before calling the kernel and re-apply it after attention.
+        self.use_fused_qk_norm_mrope = (
+            _has_fused_qk_norm_mrope
+            and isinstance(self.rotary_emb, MRotaryEmbedding)
+            and getattr(self.rotary_emb, "mrope_section", None) is not None
+        )
+        if self.use_fused_qk_norm_mrope:
+            # Scale tensors MUST stay on CPU: the C++ kernel uses .item<float>()
+            # which triggers hipMemcpy D2H + sync on CUDA tensors, breaking graph
+            # capture. Explicit device='cpu' is required because SGLang builds
+            # models inside a `with torch.device('cuda'):` context.
+            self._fused_k_scale = torch.tensor(1.0, dtype=torch.float32, device="cpu")
+            self._fused_v_scale = torch.tensor(1.0, dtype=torch.float32, device="cpu")
+
+    def forward_prepare_aiter_fused_mrope(
+        self, positions, hidden_states, forward_batch
+    ):
+        """Fused QK-norm + 3D mRoPE + KV cache write for decode (ROCm/aiter).
+
+        The fused HIP kernel replaces split -> QK norm -> mRoPE -> cache write,
+        so KV is already in the paged cache when this returns.
+
+        When ``attn_output_gate`` is set, qkv_proj emits a per-head
+        ``[q_head | gate_head]`` interleave for the query slice. The fused
+        kernel expects a contiguous ``[q | k | v]`` layout, so we split off the
+        gate, pack a contiguous qkv buffer, and return the de-interleaved gate
+        for the post-attention sigmoid-mul.
+
+        Returns ``(q, None, None, gate)``; caller must pass save_kv_cache=False.
+        """
+        qkv, _ = self.qkv_proj(hidden_states)
+        num_tokens = qkv.shape[0]
+
+        if self.attn_output_gate:
+            # qkv layout: [q_size*2 | kv_size | kv_size], where the query slice
+            # interleaves q and gate per head: [..., num_heads, 2*head_dim].
+            q_gate, k, v = qkv.split(
+                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
+            )
+            q_gate = q_gate.view(num_tokens, self.num_heads, 2 * self.head_dim)
+            q_part = q_gate[..., : self.head_dim]
+            gate = q_gate[..., self.head_dim :].reshape(num_tokens, -1)
+            # Pack a contiguous [q | k | v] buffer for the fused kernel.
+            qkv_3d = torch.empty(
+                num_tokens,
+                self.num_heads + 2 * self.num_kv_heads,
+                self.head_dim,
+                dtype=qkv.dtype,
+                device=qkv.device,
+            )
+            qkv_3d[:, : self.num_heads].copy_(q_part)
+            qkv_3d[:, self.num_heads : self.num_heads + self.num_kv_heads].copy_(
+                k.view(num_tokens, self.num_kv_heads, self.head_dim)
+            )
+            qkv_3d[:, self.num_heads + self.num_kv_heads :].copy_(
+                v.view(num_tokens, self.num_kv_heads, self.head_dim)
+            )
+        else:
+            gate = None
+            qkv_3d = qkv.view(num_tokens, -1, self.head_dim)
+
+        token_to_kv_pool = get_token_to_kv_pool()
+        k_cache, v_cache = token_to_kv_pool.get_kv_buffer(self.attn.layer_id)
+        slot_mapping = forward_batch.out_cache_loc
+
+        cos_sin = self.rotary_emb.cos_sin_cache
+        if cos_sin.dtype != qkv.dtype:
+            cos_sin = cos_sin.to(dtype=qkv.dtype)
+
+        q_out = torch.empty(
+            num_tokens,
+            self.num_heads,
+            self.head_dim,
+            dtype=qkv.dtype,
+            device=qkv.device,
+        )
+
+        # Partial rotary: Qwen3.5 rotates only the first `rotary_dim` channels
+        # (rotary_dim = head_dim * partial_rotary_factor). Pass the rotary_emb's
+        # own rotary_dim so the fused kernel rotates exactly the channels the
+        # native path does; passing 0 would (incorrectly) rotate the full head.
+        rotary_dim = self.rotary_emb.rotary_dim
+
+        # GemmaRMSNorm uses (1 + weight) semantics; the fused kernel applies a
+        # standard RMSNorm (weight * x). Pass the precomputed gemma_weight buffer
+        # (== weight + 1) so the fused norm matches GemmaRMSNorm numerically.
+        fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(
+            qkv_3d,
+            self.q_norm.gemma_weight,
+            self.k_norm.gemma_weight,
+            cos_sin,
+            positions,
+            num_tokens,
+            self.num_heads,
+            self.num_kv_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            self.rotary_emb.is_neox_style,
+            self.rotary_emb.mrope_section,
+            self.rotary_emb.mrope_interleaved,
+            self.q_norm.variance_epsilon,
+            q_out,
+            k_cache,
+            v_cache,
+            slot_mapping,
+            self._fused_k_scale,
+            self._fused_v_scale,
+            None,
+            None,
+            False,
+            False,
+            0,
+            0,
+            rotary_dim,
+        )
+
+        q = q_out.reshape(num_tokens, -1)
+        return q, None, None, gate
+
     def _apply_qk_norm(
         self, q: torch.Tensor, k: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -959,7 +1094,21 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        if _is_hip and self.attn_output_gate:
+        save_kv_cache = True
+        gate = None
+        use_aiter_fused = (
+            self.use_fused_qk_norm_mrope and forward_batch.forward_mode.is_decode()
+        )
+
+        if use_aiter_fused:
+            # Fused QK-norm + 3D mRoPE + KV cache store; KV already written.
+            q, k, v, gate = self.forward_prepare_aiter_fused_mrope(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+            )
+            save_kv_cache = False
+        elif _is_hip and self.attn_output_gate:
             q, k, v, gate = self.forward_prepare_hip(
                 positions=positions,
                 hidden_states=hidden_states,
@@ -980,7 +1129,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 forward_batch=forward_batch,
             )
 
-        attn_output = self.attn(q, k, v, forward_batch)
+        attn_output = self.attn(q, k, v, forward_batch, save_kv_cache=save_kv_cache)
 
         if self.attn_output_gate:
             attn_output = fused_sigmoid_mul(attn_output, gate, inplace=True)


### PR DESCRIPTION
cuda-graph failed

## Motivation

In Qwen3.5's full-attention layers on HIP, the decode attention-prep path runs three separate kernels back-to-back before the attention core:

1. `_fused_qk_gemma_rmsnorm_gate_kernel` — QK GemmaRMSNorm + gate extraction (5.34 us)
2. `_triton_mrope_forward_fused` — 3D mRoPE, re-reading and re-writing q and k (5.68 us)
3. `store_kvcache` — bf16 KV cache write (4.28 us)

Together these cost ~15.30 us per full-attention layer and issue three kernel launches that each round-trip q/k/KV through HBM. aiter already ships a single op, `fused_qk_norm_mrope_3d_cache_pts_quant_shuffle`, that performs QK-norm, 3D mRoPE, and the paged KV cache store in one pass. This PR dispatches the decode full-attention path to that fused op, collapsing the three launches into one and removing the redundant q/k round-trips. The fused kernel measures 8.31 us, a 45.7% reduction on the replaced region (~6.99 us/layer), and eliminates two launches per full-attention layer per decode step.

## Modifications

- **python/sglang/srt/models/qwen3_5.py**: Add `forward_prepare_aiter_fused_mrope()` on `Qwen3_5AttentionDecoderLayer`, which packs a contiguous `[q | k | v]` head buffer and calls aiter's `fused_qk_norm_mrope_3d_cache_pts_quant_shuffle` to do QK-norm + 3D mRoPE + paged KV store in a single kernel (KV is already written on return, so the caller passes `save_kv_cache=False`). Because this model uses an attention output gate, `qkv_proj` emits a per-head `[q_head | gate_head]` interleave for the query slice; the new path de-interleaves the gate, repacks contiguous qkv for the kernel, and returns the gate for the post-attention sigmoid-mul. Partial rotary is honored by passing the layer's own `rotary_dim` (64). GemmaRMSNorm `(1 + weight)` semantics are preserved by passing the precomputed `gemma_weight` buffer. The dispatch is gated on `self.use_fused_qk_norm_mrope and forward_batch.forward_mode.is_decode()`, where `use_fused_qk_norm_mrope` is only set when `_use_aiter` is on, the aiter op imported successfully, and the layer uses `MRotaryEmbedding` with an mrope section. When the gate is off the kernel receives `qkv` reshaped directly with no extra copies.

The common (non-aiter) path is byte-identical: when `_use_aiter` is false or the fused op is unavailable, the existing `forward_prepare_hip` / native branches and `save_kv_cache=True` behavior are unchanged. The fusion is decode-only; prefill/extend continues to use the native kernels.

## Accuracy Tests

Model: Qwen3.5-397B-A17B-MXFP4, TP=2, MI300X, aiter backend, page-size 16

| Benchmark | Score | Threshold | Status |
|-----------|:-----:|:---------:|:------:|
| GSM8K (200 questions, parallel=2000) | 0.905 | 0.850 | PASS |

Invalid rate: 0.000.

## Speed Tests and Profiling

### Kernel-level (per full-attention layer, decode)

| Kernel | Before (us) | After (us) | Notes |
|--------|:-:|:-:|-------|
| `_fused_qk_gemma_rmsnorm_gate_kernel` | 5.34 | -- | eliminated |
| `_triton_mrope_forward_fused` | 5.68 | -- | eliminated |
| `store_kvcache` | 4.28 | -- | eliminated |
| `fused_mrope_rms_kv_kernel` (aiter) | -- | 8.31 | new fused kernel |
| **Replaced region total** | **15.30** | **8.31** | **-6.99 us (-45.7%)** |

Per-iteration savings: the fusion fires on the 15 full-attention layers (the 45 linear/GDN attention layers are unaffected).

| Layer type | Layers | Savings/layer | Total savings |
|------------|:------:|:-------------:|:-------------:|
| Full-attention (qk-norm + mrope + KV store) | 15 | 6.99 us | 104.85 us |
| Linear/GDN attention | 45 | 0 us | 0 us |
| **Total per decode iteration** | | | **104.85 us** |

Profiling confirms the fused kernel `fused_mrope_rms_kv_kernel` is present in decode (9684 launches @ 8.31 us), while the three replaced kernels drop from ~9908 decode launches to 30 prefill-only launches in the after trace.

### E2E benchmark

random, in=8192 out=1024, concurrency=4, num_prompts=8.

| Metric | Before | After | Delta |
|--------|:-:|:-:|:-:|
| Total throughput (tok/s) | 3176.79 | 3164.48 | -0.4% |
| Output throughput (tok/s) | 357.94 | 356.55 | -0.4% |
| Median TTFT (ms) | 393.43 | 391.28 | -0.6% |
| Median ITL (ms) | 9.43 | 9.60 | +1.8% |
| Median TPOT (ms) | 9.99 | 10.16 | +1.7% |
| Median E2E latency (ms) | 9921.56 | 9951.16 | +0.3% |

Honest read of the e2e numbers: the kernel-level win (45.7% on the replaced region, measured against a matched baseline decode trace) is real and well above the 1% gate. The expected ITL improvement from the per-iteration savings is ~104.85 us / 9430 us ≈ 1.1%, but this 8-prompt run is dominated by run-to-run variance (Max ITL ~575 ms; total/output throughput flat within -0.4%), so the macro ITL/TPOT/E2E deltas land within noise and the observed median ITL even moved the opposite direction. The change should be read primarily as a kernel-launch reduction (3 launches → 1) and a removed q/k HBM round-trip per full-attention layer, with CUDA-path parity preserved for all non-aiter configurations. TTFT is unaffected by design (decode-only fusion; prefill is dominated by large GEMMs).

- Notes: the fused op pre-validated numerically against a torch reference for this exact config (head_dim=256, rotary_dim=64, mrope_section=[11,11,10], interleaved), with differences at the bf16-rounding level. Scale tensors are kept on CPU so the kernel's `.item<float>()` does not force a D2H sync that would break graph capture.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27661084058](https://github.com/sgl-project/sglang/actions/runs/27661084058)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27661083919](https://github.com/sgl-project/sglang/actions/runs/27661083919)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #27661084052](https://github.com/sgl-project/sglang/actions/runs/27661084052)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->