### PR TITLE
Eliminate D2H sync in trtllm_mha_backend for full overlap

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/trtllm_mha_page_table.py
+++ b/python/sglang/srt/layers/attention/triton_ops/trtllm_mha_page_table.py
@@ -1,0 +1,85 @@
+"""Device-side page-table builder for the trtllm_mha attention backend.
+
+trtllm_mha builds its block (page) table from the global ``req_to_token`` pool.
+Doing it with a host-max PyTorch gather forces a ``seq_lens.max().item()`` D2H
+sync (the CPU must know the page-table width before launching). This kernel
+instead derives the per-request page count from the device-side ``seq_lens``
+tensor, so the build is sync-free: the grid/buffer use the static
+``max_num_pages`` upper bound, while each program self-guards on the real length.
+
+The kernel is MHA-owned (no dependency on the MLA kv-index kernels) and also
+emits the SWA-translated block table in the same pass via the full->SWA lookup
+table, so SWA hybrid models stay sync-free too.
+"""
+
+import triton
+import triton.language as tl
+
+# Tokens covered per CTA along the page-block (grid axis-1) dimension.
+_MHA_KV_INDEX_BLOCK_TOKENS = 4096
+# Triton kernels can only read module globals that are tl.constexpr instances.
+_MHA_KV_INDEX_BLOCK_TOKENS_TL = tl.constexpr(_MHA_KV_INDEX_BLOCK_TOKENS)
+
+
+def get_num_mha_kv_index_blocks(num_pages: int, page_size: int) -> int:
+    """Grid axis-1 size: number of page-block CTAs spanning the widest sequence.
+
+    ``num_pages`` is the per-row width of the page-table buffer (the static
+    ``max_num_pages`` upper bound). One CTA handles ``_MHA_KV_INDEX_BLOCK_TOKENS
+    // page_size`` pages.
+    """
+    pages_per_block = _MHA_KV_INDEX_BLOCK_TOKENS // page_size
+    return (num_pages + pages_per_block - 1) // pages_per_block
+
+
+@triton.jit
+def create_trtllm_mha_kv_indices_triton(
+    req_to_token_ptr,  # [max_reqs, max_context_len], int32
+    req_pool_indices_ptr,  # [bs]
+    seq_lens_ptr,  # [bs], per-request KV length in tokens
+    full_to_swa_ptr,  # full->SWA token-slot lookup table, or dummy when not SWA
+    page_table_ptr,  # [bs, num_pages] int32 block ids (output)
+    swa_page_table_ptr,  # [bs, num_pages] int32 SWA block ids (output), or dummy
+    req_to_token_stride: tl.constexpr,
+    page_table_stride: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    HAS_SWA: tl.constexpr,
+):
+    """Fill ``page_table_ptr`` (and ``swa_page_table_ptr`` when ``HAS_SWA``).
+
+    Program ``(pid_req, pid_blk)`` writes the block ids of request ``pid_req`` for
+    the page-block ``pid_blk``. It reads the KV token slot at each page boundary
+    from ``req_to_token`` and converts it to a block id (``slot // PAGE_SIZE``).
+    Programs past the request's page count are guarded out, so the work (and the
+    DRAM traffic) is bounded by the device-side ``seq_lens`` — no host max needed.
+    """
+    PAGES_PER_BLOCK: tl.constexpr = _MHA_KV_INDEX_BLOCK_TOKENS_TL // PAGE_SIZE
+    pid_req = tl.program_id(0)
+    pid_blk = tl.program_id(1)
+
+    seq_len = tl.load(seq_lens_ptr + pid_req)
+    num_pages = tl.cdiv(seq_len, PAGE_SIZE)
+    num_page_blocks = tl.cdiv(seq_len, _MHA_KV_INDEX_BLOCK_TOKENS_TL)
+    if pid_blk >= num_page_blocks:
+        return
+
+    req_pool_index = tl.load(req_pool_indices_ptr + pid_req)
+    page_idx = tl.arange(0, PAGES_PER_BLOCK) + pid_blk * PAGES_PER_BLOCK
+    token_pos = page_idx.to(tl.int64) * PAGE_SIZE
+    mask = page_idx < num_pages
+
+    slot = tl.load(
+        req_to_token_ptr
+        + req_pool_index.to(tl.int64) * req_to_token_stride
+        + token_pos,
+        mask=mask,
+    )
+    out_off = pid_req * page_table_stride + page_idx
+    tl.store(page_table_ptr + out_off, (slot // PAGE_SIZE).to(tl.int32), mask=mask)
+    if HAS_SWA:
+        swa_slot = tl.load(full_to_swa_ptr + slot.to(tl.int64), mask=mask)
+        tl.store(
+            swa_page_table_ptr + out_off,
+            (swa_slot // PAGE_SIZE).to(tl.int32),
+            mask=mask,
+        )

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -460,19 +460,23 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32.copy_(
                     seq_lens + self.speculative_step_id + 1
                 )
+                metadata.max_seq_len_k = self.max_context_len
+
+                max_seq_pages = (
+                    metadata.max_seq_len_k + self.page_size - 1
+                ) // self.page_size
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
+                metadata.max_seq_len_k = self.max_context_len
+                max_seq_pages = (
+                    self.max_context_len + self.page_size - 1
+                ) // self.page_size
+
                 metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-            # Compute max_seq_pages from actual seq_lens on GPU (no D2H sync)
-            max_seq_pages = int(
-                (metadata.cache_seqlens_int32.max() + self.page_size - 1)
-                // self.page_size
             )
             page_indices = self.req_to_token[
                 req_pool_indices[:, None],
@@ -486,14 +490,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
+
             metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
-            max_seq_pages = int(
-                (metadata.cache_seqlens_int32.max() + self.page_size - 1)
-                // self.page_size
-            )
+            max_seq_pages = (
+                metadata.max_seq_len_k + self.page_size - 1
+            ) // self.page_size
             page_indices = self.req_to_token[
                 req_pool_indices[:, None],
                 self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
@@ -503,6 +507,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
+
             metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
@@ -510,6 +515,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             if forward_mode.is_draft_extend_v2():
                 num_tokens_per_bs = spec_info.num_tokens_per_req
                 if num_tokens_per_bs <= 0:
+                    # Capture uses a synthetic EagleDraftExtendInput; infer the
+                    # fixed V2 stride from the capture buffer when it is unset.
                     num_tokens_per_bs = int(
                         spec_info.num_accept_tokens[:bs].max().item()
                     )
@@ -534,10 +541,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     torch.cumsum(extend_lens, dim=0, dtype=torch.int32)
                 )
 
-            max_seq_pages = int(
-                (metadata.cache_seqlens_int32.max() + self.page_size - 1)
-                // self.page_size
-            )
+            max_seq_pages = (
+                metadata.max_seq_len_k + self.page_size - 1
+            ) // self.page_size
             page_indices = self.req_to_token[
                 req_pool_indices[:, None],
                 self.draft_extend_metadata["strided_indices"][:max_seq_pages],
@@ -630,12 +636,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         batch_size = forward_batch.batch_size
         device = seqlens_in_batch.device
 
-        def _seq_max() -> int:
-            """Prefer seq_lens_cpu if present, otherwise fall back to GPU max."""
-            if forward_batch.seq_lens_cpu is not None:
-                return int(forward_batch.seq_lens_cpu.max().item())
-            return int(forward_batch.seq_lens.max())
-
         if forward_batch.forward_mode.is_decode_or_idle():
             if forward_batch.spec_info is not None:
                 # Draft Decode
@@ -643,7 +643,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32 = (
                     seqlens_in_batch + (self.speculative_step_id + 1)
                 ).to(torch.int32)
-                metadata.max_seq_len_k = _seq_max() + (self.speculative_step_id + 1)
+                metadata.max_seq_len_k = self.max_context_len
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -659,7 +659,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 # Normal Decode
                 metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = _seq_max()
+                metadata.max_seq_len_k = self.max_context_len
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -676,7 +676,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 torch.int32
             )
             metadata.max_seq_len_q = tokens_per_req
-            metadata.max_seq_len_k = _seq_max() + tokens_per_req
+            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_q = torch.arange(
                 0,
                 batch_size * tokens_per_req + 1,
@@ -694,7 +694,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         else:
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-            metadata.max_seq_len_k = _seq_max()
+            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
             )

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -68,6 +68,8 @@ class TRTLLMMHAMetadata:
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     """TRTLLM MHA attention kernel from flashinfer."""
 
+    needs_cpu_seq_lens: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -439,14 +441,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
     ):
         """Shared capture+replay body for the cuda-graph init path.
 
         Public entry: :py:meth:`init_forward_metadata_out_graph`.
         """
         seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
         req_pool_indices = req_pool_indices[:bs]
         metadata = None
         if forward_mode.is_decode_or_idle():
@@ -460,9 +460,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32.copy_(
                     seq_lens + self.speculative_step_id + 1
                 )
-                metadata.max_seq_len_k = seq_lens.max().item() + (
-                    self.speculative_step_id + 1
-                )
+                metadata.max_seq_len_k = self.max_context_len
 
                 max_seq_pages = (
                     metadata.max_seq_len_k + self.page_size - 1
@@ -470,9 +468,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
-                max_seq_pages = (max_len + self.page_size - 1) // self.page_size
-                metadata.max_seq_len_k = max_len
+                metadata.max_seq_len_k = self.max_context_len
+                max_seq_pages = (
+                    self.max_context_len + self.page_size - 1
+                ) // self.page_size
 
                 metadata.cache_seqlens_int32.copy_(seq_lens)
 
@@ -492,8 +491,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata = self.target_verify_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
 
-            metadata.max_seq_len_k = seq_lens_cpu.max().item() + metadata.max_seq_len_q
-            max_len = seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -510,8 +508,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
-            max_len = seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -608,27 +605,17 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         if in_capture:
             num_tokens = forward_batch.positions.numel()
-            seq_lens_cpu = seq_lens.cpu()
             self._build_cuda_graph_metadata(
                 bs, num_tokens, forward_mode, spec_info, seq_lens.device
             )
-            self._apply_cuda_graph_metadata(
-                bs=bs,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                forward_mode=forward_mode,
-                spec_info=spec_info,
-                seq_lens_cpu=seq_lens_cpu,
-            )
-        else:
-            self._apply_cuda_graph_metadata(
-                bs=bs,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                forward_mode=forward_mode,
-                spec_info=spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-            )
+
+        self._apply_cuda_graph_metadata(
+            bs=bs,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            forward_mode=forward_mode,
+            spec_info=spec_info,
+        )
 
         # Refill the SWA write-target buffer from the live out_cache_loc before
         # replay (the per-bs metadata holds a view bound in _build).
@@ -656,9 +643,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32 = (
                     seqlens_in_batch + (self.speculative_step_id + 1)
                 ).to(torch.int32)
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
-                    self.speculative_step_id + 1
-                )
+                metadata.max_seq_len_k = self.max_context_len
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -674,7 +659,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 # Normal Decode
                 metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = self.max_context_len
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -691,9 +676,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 torch.int32
             )
             metadata.max_seq_len_q = tokens_per_req
-            metadata.max_seq_len_k = (
-                forward_batch.seq_lens_cpu.max().item() + tokens_per_req
-            )
+            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_q = torch.arange(
                 0,
                 batch_size * tokens_per_req + 1,
@@ -711,7 +694,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         else:
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
             )
@@ -969,6 +952,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
 class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
     """Multi-step TRTLLM MHA attention kernel used by EAGLE."""
+
+    needs_cpu_seq_lens: bool = False
 
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -19,6 +19,10 @@ from sglang.srt.layers.attention.flashinfer_backend import (
 from sglang.srt.layers.attention.triton_ops.trtllm_fp8_kv_kernel import (
     fused_fp8_set_kv_buffer,
 )
+from sglang.srt.layers.attention.triton_ops.trtllm_mha_page_table import (
+    create_trtllm_mha_kv_indices_triton,
+    get_num_mha_kv_index_blocks,
+)
 from sglang.srt.layers.attention.utils import canonicalize_stride
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
@@ -133,6 +137,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # separate index spaces; SWA layers need a translated page_table.
         self._swa_kv_pool: Optional[SWAKVPool] = self._resolve_swa_kv_pool(model_runner)
 
+        self.max_num_pages = (
+            self.max_context_len + self.page_size - 1
+        ) // self.page_size
+
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
 
@@ -190,17 +198,30 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             return None
         return torch.zeros(max_bs, max_num_pages, dtype=torch.int32, device=self.device)
 
-    def _copy_swa_page_table(
+    def _fill_page_table_device(
         self,
         metadata: TRTLLMMHAMetadata,
-        page_indices: torch.Tensor,
-        num_pages: int,
+        req_pool_indices: torch.Tensor,
+        cache_seqlens: torch.Tensor,
     ):
-        """Translate and copy SWA page indices into metadata. No-op for non-SWA."""
-        if metadata.swa_page_table is None:
-            return
-        swa_indices = self._maybe_translate_swa(page_indices)
-        metadata.swa_page_table[:, :num_pages].copy_(swa_indices // self.page_size)
+        """Build the page table on-device from per-request KV lengths (no sync)."""
+        page_table = metadata.page_table
+        bs = page_table.shape[0]
+        has_swa = self._swa_kv_pool is not None
+        create_trtllm_mha_kv_indices_triton[
+            (bs, get_num_mha_kv_index_blocks(page_table.shape[1], self.page_size))
+        ](
+            self.req_to_token,
+            req_pool_indices,
+            cache_seqlens,
+            self._swa_kv_pool.full_to_swa_index_mapping if has_swa else None,
+            page_table,
+            metadata.swa_page_table if has_swa else None,
+            self.req_to_token.stride(0),
+            page_table.stride(0),
+            PAGE_SIZE=self.page_size,
+            HAS_SWA=has_swa,
+        )
 
     def _get_layer_cache_loc(
         self,
@@ -252,9 +273,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 device=self.device,
             ),
             "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
-            "strided_indices": torch.arange(
-                0, self.max_context_len, self.page_size, device=self.device
-            ),
         }
 
         # SWA write-target buffer; bound as a [:num_tokens] view in
@@ -307,9 +325,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     device=self.device,
                 ),
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
-                "strided_indices": torch.arange(
-                    0, self.max_context_len, self.page_size, device=self.device
-                ),
             }
 
             self.draft_extend_metadata = {
@@ -331,9 +346,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     device=self.device,
                 ),
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
-                "strided_indices": torch.arange(
-                    0, self.max_context_len, self.page_size, device=self.device
-                ),
             }
 
     def _build_cuda_graph_metadata(
@@ -460,54 +472,32 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32.copy_(
                     seq_lens + self.speculative_step_id + 1
                 )
-                metadata.max_seq_len_k = self.max_context_len
-
-                max_seq_pages = (
-                    metadata.max_seq_len_k + self.page_size - 1
-                ) // self.page_size
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
-                metadata.max_seq_len_k = self.max_context_len
-                max_seq_pages = (
-                    self.max_context_len + self.page_size - 1
-                ) // self.page_size
-
                 metadata.cache_seqlens_int32.copy_(seq_lens)
-
-            metadata.cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages][
-                    None, :
-                ],
-            ]
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
-        elif forward_mode.is_target_verify():
-            # Here we only support topk = 1 for now.
-            metadata = self.target_verify_metadata[bs]
-            metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
 
             metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
-            ]
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
+            self._fill_page_table_device(
+                metadata, req_pool_indices, metadata.cache_seqlens_int32
+            )
+        elif forward_mode.is_target_verify():
+            # Here we only support topk = 1 for now.
+            metadata = self.target_verify_metadata[bs]
+            metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
+            metadata.max_seq_len_k = self.max_context_len
+            metadata.cu_seqlens_k[1:].copy_(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
+            )
+            self._fill_page_table_device(
+                metadata, req_pool_indices, metadata.cache_seqlens_int32
+            )
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
-
             metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
@@ -541,15 +531,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     torch.cumsum(extend_lens, dim=0, dtype=torch.int32)
                 )
 
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
-            ]
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
+            self._fill_page_table_device(
+                metadata, req_pool_indices, metadata.cache_seqlens_int32
+            )
         self.forward_metadata = metadata
 
     def update_verify_buffers_to_fill_after_draft(
@@ -636,6 +620,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         batch_size = forward_batch.batch_size
         device = seqlens_in_batch.device
 
+        def _seq_max() -> int:
+            if forward_batch.seq_lens_cpu is not None:
+                return int(forward_batch.seq_lens_cpu.max().item())
+            return int(forward_batch.seq_lens.max())
+
         if forward_batch.forward_mode.is_decode_or_idle():
             if forward_batch.spec_info is not None:
                 # Draft Decode
@@ -643,7 +632,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32 = (
                     seqlens_in_batch + (self.speculative_step_id + 1)
                 ).to(torch.int32)
-                metadata.max_seq_len_k = self.max_context_len
+                metadata.max_seq_len_k = _seq_max() + (self.speculative_step_id + 1)
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -659,7 +648,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 # Normal Decode
                 metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = self.max_context_len
+                metadata.max_seq_len_k = _seq_max()
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -676,7 +665,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 torch.int32
             )
             metadata.max_seq_len_q = tokens_per_req
-            metadata.max_seq_len_k = self.max_context_len
+            metadata.max_seq_len_k = _seq_max() + tokens_per_req
             metadata.cu_seqlens_q = torch.arange(
                 0,
                 batch_size * tokens_per_req + 1,
@@ -694,7 +683,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         else:
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-            metadata.max_seq_len_k = self.max_context_len
+            metadata.max_seq_len_k = _seq_max()
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
             )

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -460,23 +460,19 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32.copy_(
                     seq_lens + self.speculative_step_id + 1
                 )
-                metadata.max_seq_len_k = self.max_context_len
-
-                max_seq_pages = (
-                    metadata.max_seq_len_k + self.page_size - 1
-                ) // self.page_size
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
-                metadata.max_seq_len_k = self.max_context_len
-                max_seq_pages = (
-                    self.max_context_len + self.page_size - 1
-                ) // self.page_size
-
                 metadata.cache_seqlens_int32.copy_(seq_lens)
 
+            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
+            )
+            # Compute max_seq_pages from actual seq_lens on GPU (no D2H sync)
+            max_seq_pages = int(
+                (metadata.cache_seqlens_int32.max() + self.page_size - 1)
+                // self.page_size
             )
             page_indices = self.req_to_token[
                 req_pool_indices[:, None],
@@ -490,14 +486,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
-
             metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
+            max_seq_pages = int(
+                (metadata.cache_seqlens_int32.max() + self.page_size - 1)
+                // self.page_size
+            )
             page_indices = self.req_to_token[
                 req_pool_indices[:, None],
                 self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
@@ -507,7 +503,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
-
             metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
@@ -515,8 +510,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             if forward_mode.is_draft_extend_v2():
                 num_tokens_per_bs = spec_info.num_tokens_per_req
                 if num_tokens_per_bs <= 0:
-                    # Capture uses a synthetic EagleDraftExtendInput; infer the
-                    # fixed V2 stride from the capture buffer when it is unset.
                     num_tokens_per_bs = int(
                         spec_info.num_accept_tokens[:bs].max().item()
                     )
@@ -541,9 +534,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     torch.cumsum(extend_lens, dim=0, dtype=torch.int32)
                 )
 
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
+            max_seq_pages = int(
+                (metadata.cache_seqlens_int32.max() + self.page_size - 1)
+                // self.page_size
+            )
             page_indices = self.req_to_token[
                 req_pool_indices[:, None],
                 self.draft_extend_metadata["strided_indices"][:max_seq_pages],
@@ -636,6 +630,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         batch_size = forward_batch.batch_size
         device = seqlens_in_batch.device
 
+        def _seq_max() -> int:
+            """Prefer seq_lens_cpu if present, otherwise fall back to GPU max."""
+            if forward_batch.seq_lens_cpu is not None:
+                return int(forward_batch.seq_lens_cpu.max().item())
+            return int(forward_batch.seq_lens.max())
+
         if forward_batch.forward_mode.is_decode_or_idle():
             if forward_batch.spec_info is not None:
                 # Draft Decode
@@ -643,7 +643,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32 = (
                     seqlens_in_batch + (self.speculative_step_id + 1)
                 ).to(torch.int32)
-                metadata.max_seq_len_k = self.max_context_len
+                metadata.max_seq_len_k = _seq_max() + (self.speculative_step_id + 1)
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -659,7 +659,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 # Normal Decode
                 metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = self.max_context_len
+                metadata.max_seq_len_k = _seq_max()
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -676,7 +676,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 torch.int32
             )
             metadata.max_seq_len_q = tokens_per_req
-            metadata.max_seq_len_k = self.max_context_len
+            metadata.max_seq_len_k = _seq_max() + tokens_per_req
             metadata.cu_seqlens_q = torch.arange(
                 0,
                 batch_size * tokens_per_req + 1,
@@ -694,7 +694,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         else:
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-            metadata.max_seq_len_k = self.max_context_len
+            metadata.max_seq_len_k = _seq_max()
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
             )


### PR DESCRIPTION
## Summary
- Set `needs_cpu_seq_lens = False` on `TRTLLMHAAttnBackend` and `TRTLLMHAAttnMultiStepDraftBackend`, matching `trtllm_mla_backend`
- Replace all `seq_lens_cpu.max().item()` with `self.max_context_len` to eliminate D2H synchronization points
- Remove the now-unnecessary `seq_lens_cpu` parameter from `_apply_cuda_graph_metadata` and the explicit `seq_lens.cpu()` call in the capture path

Benchmarked on B300 4xTP with Qwen3.5-397B-A17B-NVFP4 + EAGLE spec decoding (bs=1, input=50000, output=1000):
- Decode throughput: 458 → 521 tok/s (+13.8%)
- Per-iteration D2H 8-byte copies: 2 → 1 (eliminated the `seq_lens_cpu.max().item()` pair)
- Sync events per verify cycle: 4 → 3



BEFORE:
[perfetto-compatible-TP-0-DECODE-baseline.trace.json.gz](https://github.com/user-attachments/files/29028890/perfetto-compatible-TP-0-DECODE-baseline.trace.json.gz)


AFTER:
[perfetto-compatible-TP-0-DECODE.trace.json.gz](https://github.com/user-attachments/files/29028892/perfetto-compatible-TP-0-DECODE.trace.json.gz)



Before:
<img width="876" height="812" alt="image" src="https://github.com/user-attachments/assets/111f1e84-631e-4ff2-b985-9c1c13ca0652" />

After:
<img width="892" height="952" alt="image" src="https://github.com/user-attachments/assets/4f270388-aaa8-4865-8ea3-1d75e581cad1" />





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27669928747](https://github.com/sgl-project/sglang/actions/runs/27669928747)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27669928683](https://github.com/sgl-project/sglang/actions/runs/27669928683)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->