### PR TITLE
[AMD] Contiguous varlen FMHA for Qwen3.5 mxfp4

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2350,7 +2350,7 @@ class AiterAttnBackend(AttentionBackend):
                 q_c = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
                 k_c = k.contiguous().view(-1, layer.tp_k_head_num, layer.head_dim)
                 v_c = v.contiguous().view(-1, layer.tp_v_head_num, layer.v_head_dim)
-                if self.kv_cache_dtype == fp8_dtype:
+                if self.kv_cache_dtype == fp8_dtype and is_gfx95_supported():
                     fp8_q_descale = (
                         layer.k_scale if layer.k_scale is not None else self.k_scale
                     )

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 try:
     from aiter import (
+        flash_attn_varlen_fp8_pertensor_func,
         flash_attn_varlen_func,
         get_mla_metadata_info_v1,
         get_mla_metadata_v1,
@@ -2333,6 +2334,55 @@ class AiterAttnBackend(AttentionBackend):
                     window_size,
                     sinks,
                 )
+
+            if (
+                get_bool_env_var("SGLANG_AITER_FP8_CONTIG_PREFILL", "false")
+                and forward_batch.forward_mode.is_extend()
+                and not forward_batch.forward_mode.is_draft_extend_v2()
+                and forward_batch.extend_prefix_lens_cpu is not None
+                and not any(forward_batch.extend_prefix_lens_cpu)
+                and window_size == (-1, -1)
+                and sinks is None
+                and self.logits_soft_cap == 0.0
+                and layer.head_dim == 256
+                and layer.v_head_dim == 256
+            ):
+                q_c = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+                k_c = k.contiguous().view(-1, layer.tp_k_head_num, layer.head_dim)
+                v_c = v.contiguous().view(-1, layer.tp_v_head_num, layer.v_head_dim)
+                if self.kv_cache_dtype == fp8_dtype:
+                    fp8_q_descale = (
+                        layer.k_scale if layer.k_scale is not None else self.k_scale
+                    )
+                    o = flash_attn_varlen_fp8_pertensor_func(
+                        q_c.to(fp8_dtype),
+                        k_c.to(fp8_dtype),
+                        v_c.to(fp8_dtype),
+                        fp8_q_descale,
+                        k_descale,
+                        v_descale,
+                        self.qo_indptr[:bs0],
+                        self.qo_indptr[:bs0],
+                        self.forward_metadata.max_q_len,
+                        self.forward_metadata.max_q_len,
+                        softmax_scale=layer.scaling,
+                        causal=True,
+                    )
+                else:
+                    o = flash_attn_varlen_func(
+                        q_c,
+                        k_c,
+                        v_c,
+                        self.qo_indptr[:bs0],
+                        self.qo_indptr[:bs0],
+                        self.forward_metadata.max_q_len,
+                        self.forward_metadata.max_q_len,
+                        softmax_scale=layer.scaling,
+                        causal=True,
+                    )
+                if o.dtype != self.input_dtype:
+                    o = o.to(self.input_dtype)
+                return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
             # NHD path — original aiter paged batch_prefill.
             # TODO kkhuang-amd need to remove it when mha_batch_prefill_func support fp8-kv


### PR DESCRIPTION
co-author: @mqhc2020
dependent on https://github.com/ROCm/aiter/pull/3732
## Motivation

For non-MLA GQA models (e.g. Qwen3.5) the aiter attention backend always runs prefill through the paged batch-prefill FMHA (`mha_batch_prefill_func` → `FmhaBatchPrefillWithPagedKVCache`), which gathers K/V from the paged KV pool via a page-table lookup. When a request has **no cached prefix** (`extend_prefix_lens` all zero — e.g. `--disable-radix-cache`, or the first chunk of a fresh prefill), the freshly-computed K/V for the current tokens are already contiguous, so the paged gather is unnecessary work.

The MLA path already exploits this by routing the no-prefix case through the contiguous varlen FMHA. This PR brings the same fast-path to the non-MLA GQA path, and extends it to **fp8 KV cache** via the new gfx950 hd256 fp8 FMHA kernel (`flash_attn_varlen_fp8_pertensor_func`).

## Modifications

- `python/sglang/srt/layers/attention/aiter_backend.py` (`AiterAttnBackend.forward_extend`): add a contiguous varlen FMHA fast-path in the non-MLA NHD branch. When the request is a plain extend with no cached prefix, run the varlen FMHA directly on the contiguous Q/K/V and skip the paged-KV gather.
  - **BF16 KV** → `flash_attn_varlen_func`
  - **fp8 KV** → `flash_attn_varlen_fp8_pertensor_func` (fmha_v3 `FmhaFwdKernel`, incl. the new gfx950 **hd256 fp8** kernel), with per-tensor q/k/v descales.
- Gated behind a new opt-in env var **`SGLANG_AITER_FP8_CONTIG_PREFILL`** (default `false`); when off, the common paged path is byte-for-byte unchanged. Additional conservative gates:
  - `forward_mode.is_extend()` and not `is_draft_extend_v2()`
  - `not any(extend_prefix_lens_cpu)` (no cached prefix — correctness guard)
  - `window_size == (-1, -1)`, `sinks is None`, `logits_soft_cap == 0.0`
  - `head_dim == 256 and v_head_dim == 256` (Qwen3.5 full-attention layers)

## Accuracy Tests

GSM8K (200 questions, 5-shot), Qwen3.5-397B-A17B-MXFP4, MI355 (gfx950), TP2, `--disable-radix-cache`:

| Config | Accuracy | Invalid |
|---|---|---|
| Baseline (BF16 KV, path off) | 0.945 | 0.000 |
| This change (fp8 KV + contiguous hd256 FMHA) | **0.940** | 0.000 |

The new fp8 hd256 contiguous kernel is numerically sound (within run-to-run noise of the BF16 baseline).

## Benchmarking and Profiling

Setup: Qwen3.5-397B-A17B-MXFP4, MI355 (gfx950), TP2, aiter backend, `--disable-radix-cache`, random dataset (range-ratio 0.8), `num_prompts = concurrency × 10`, `request-rate=inf`. **before** = BF16 KV, path off (unmodified). **after** = fp8 KV + `SGLANG_AITER_FP8_CONTIG_PREFILL=1`.

**Kernel-level — per-call prefill FMHA time** (`FmhaBatchPrefillWithPagedKVCache`, from Chrome traces, `IL8192 / OL1024`):

| concurrency | before (BF16 KV) | after (fp8 KV) | Δ |
|---|---|---|---|
| 4 | 1937.7 µs | 1601.8 µs | **−17.3%** |
| 64 | 2609.3 µs | 2196.5 µs | **−15.8%** |

**End-to-end A/B — canonical `IL8192 / OL1024`** (the shape this change targets):

| conc | tot tok/s (before → after) | Δ | TTFT med (before → after) | Δ |
|---|---|---|---|---|
| 4 | 3288.5 → 3365.5 | +2.3% | 340.1 → 331.0 ms | −2.7% |
| 8 | 5242.1 → 5281.4 | +0.7% | 341.3 → 329.1 ms | −3.6% |
| 16 | 7684.4 → 7888.4 | +2.7% | 346.0 → 337.6 ms | −2.4% |
| 32 | 10545.1 → 10633.0 | +0.8% | 366.3 → 352.8 ms | −3.7% |
| 64 | 13378.5 → 13431.3 | +0.4% | 427.9 → 420.8 ms | −1.7% |
| 128 | 16491.6 → 17044.9 | +3.4% | 559.0 → 512.1 ms | **−8.4%** |

- **TTFT improves 2–8%** on long-context prefill (the change is prefill-only). **ITL/decode is unchanged** (≤0.5% at every point). Throughput is marginally positive (+0.4…+3.4%).
- On the short `IL1024 / OL1024` shape the effect is within noise (prefill is too small a fraction of e2e to move TTFT).



The e2e TTFT gain above is this kernel win diluted by the rest of prefill (MoE / GEMM / comms / GDN) and the decode-dominated workload (Amdahl).

### FP8 model reference — `Qwen3.5-397B-A17B-FP8` (blockscale), TP4

Same change on the FP8 checkpoint (`head_dim=256`, before=BF16 KV / after=fp8 KV + contiguous path). Here the contiguous fp8 kernel **fully replaces** the paged `FmhaBatchPrefillWithPagedKVCache` with `aiter::fmha_fwd_hd256_fp8_causal_group_gfx950`.

Kernel-level — per-call prefill FMHA time (median, `IL8192 / OL1024`):

| concurrency | before (BF16, paged) | after (fp8, contiguous) | Δ |
|---|---|---|---|
| 4 | 956.7 µs | 313.2 µs | **−67.3%** |
| 64 | 1276.7 µs | 419.9 µs | **−67.1%** |

(the ~3× win here reflects both the paged-gather elimination *and* fp8; larger than the MXFP4 table above, which is paged-vs-paged. A one-time ~388 ms first-call JIT/autotune stall of the asm kernel is excluded via median.)


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29906694085](https://github.com/sgl-project/sglang/actions/runs/29906694085)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29906692699](https://github.com/sgl-project/sglang/actions/runs/29906692699)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
