### PR TITLE
fix: zero uninitialized FA3 padding output in DP attention SUM_LEN mode

### DIFF
--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -232,24 +232,21 @@ def unified_attention_with_output(
     if ret.data_ptr() != output.data_ptr():
         output[:real_num_tokens].view(ret.shape).copy_(ret)
 
-    if _is_hip:
-        # During PCG replay on AMD, varlen attention kernels only fill positions
-        # 0..actual_tokens-1 and leave padded positions with uninitialized
-        # garbage from torch.empty.  Zero these so garbage (NaN/Inf) does not
-        # propagate through residual connections, MoE routing, and allreduce.
-        # Use context.raw_num_tokens (pre-padding count from PCG runner)
-        # instead of forward_batch.extend_num_tokens, because
-        # extend_num_tokens is None for TARGET_VERIFY (EAGLE) batches.
-        pcg_static_tokens = context.num_tokens
-        actual_tokens = context.raw_num_tokens
-        if (
-            pcg_static_tokens is not None
-            and actual_tokens is not None
-            and pcg_static_tokens > actual_tokens
-        ):
-            first_dim = output.shape[0]
-            elems_per_token = output.numel() // first_dim
-            output.view(first_dim, elems_per_token)[actual_tokens:].zero_()
+    # During PCG replay the attention backend writes only the narrowed
+    # real-token slice (output[:real_num_tokens]) and leaves padded positions
+    # as uninitialized torch.empty garbage. Zero them so garbage (NaN/Inf) does
+    # not propagate through residual connections, MoE routing, and allreduce.
+    # This affects every backend that varlen-writes under PCG, not just ROCm.
+    pcg_static_tokens = context.num_tokens
+    actual_tokens = context.raw_num_tokens
+    if (
+        pcg_static_tokens is not None
+        and actual_tokens is not None
+        and pcg_static_tokens > actual_tokens
+    ):
+        first_dim = output.shape[0]
+        elems_per_token = output.numel() // first_dim
+        output.view(first_dim, elems_per_token)[actual_tokens:].zero_()
     return
 
 

--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -35,6 +35,23 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
+def _zero_linear_attn_padding(
+    attn_output: torch.Tensor, forward_batch: "ForwardBatch", seq_dim: int = 0
+) -> torch.Tensor:
+    real_num_tokens = forward_batch.get_num_non_padded_tokens(
+        attn_output.shape[seq_dim],
+    )
+    if real_num_tokens is None:
+        return attn_output
+
+    if real_num_tokens < attn_output.shape[seq_dim]:
+        zero_slice = [slice(None)] * attn_output.dim()
+        zero_slice[seq_dim] = slice(real_num_tokens, None)
+        attn_output[tuple(zero_slice)] = 0
+
+    return attn_output
+
+
 class RadixLinearAttention(nn.Module):
     """
     The Linear Attention Layer Implementation.
@@ -109,15 +126,18 @@ class RadixLinearAttention(nn.Module):
                     output,
                     self.layer_id,
                 )
-            return output
+            # fall through to zeroing
         else:
-            return get_attn_backend().forward(
+            output = get_attn_backend().forward(
                 layer=self,
                 forward_batch=forward_batch,
                 mixed_qkv=mixed_qkv,
                 a=a,
                 b=b,
             )
+
+        seq_dim = 1 if output.dim() == 4 and output.shape[0] == 1 else 0
+        return _zero_linear_attn_padding(output, forward_batch, seq_dim=seq_dim)
 
 
 @register_custom_op(mutates_args=["output"])
@@ -136,7 +156,7 @@ def unified_linear_attention_with_output(
     forward_batch = context.forward_batch
     attention_layers = context.attention_layers
     attention_layer = attention_layers[layer_id]
-    real_num_tokens = forward_batch.num_token_non_padded_cpu
+    real_num_tokens = forward_batch.get_num_non_padded_tokens(output.shape[1])
 
     original_out_cache_loc = forward_batch.out_cache_loc
     # Keep the original ForwardBatch object and only narrow cache locations for

--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 
 def _zero_linear_attn_padding(
-    attn_output: torch.Tensor, forward_batch: "ForwardBatch", seq_dim: int = 0
+    attn_output: torch.Tensor, forward_batch: ForwardBatch, seq_dim: int = 0
 ) -> torch.Tensor:
     real_num_tokens = forward_batch.get_num_non_padded_tokens(
         attn_output.shape[seq_dim],

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -855,6 +855,30 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             num_tokens_per_dp=num_tokens_per_dp,
         )
 
+    def get_num_non_padded_tokens(
+        self, max_tokens: Optional[int] = None
+    ) -> Optional[int]:
+        """Return the DP-local valid-token count before DP/MLP-sync padding.
+
+        In extend/prefill, ``extend_seq_lens_cpu`` remains the local request
+        lengths before ``prepare_mlp_sync_batch`` pads tensors and mutates
+        ``extend_num_tokens`` to the communication-aligned length.
+        """
+        if self.forward_mode.is_extend() and self.extend_seq_lens_cpu is not None:
+            if isinstance(self.extend_seq_lens_cpu, torch.Tensor):
+                num_tokens = int(self.extend_seq_lens_cpu.sum().item())
+            else:
+                num_tokens = int(sum(self.extend_seq_lens_cpu))
+            if max_tokens is None or 0 <= num_tokens <= max_tokens:
+                return num_tokens
+
+        if self.num_token_non_padded_cpu is not None:
+            num_tokens = int(self.num_token_non_padded_cpu)
+            if max_tokens is None or 0 <= num_tokens <= max_tokens:
+                return num_tokens
+
+        return None
+
     def merge_mm_inputs(self) -> Optional[MultimodalInputs]:
         """
         Merge all multimodal inputs in the batch into a single MultiModalInputs object.

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -21,6 +21,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_npu,
     _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
+    zero_dp_attention_padding,
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import BumpAllocator, get_bool_env_var, next_power_of_2
@@ -311,6 +312,7 @@ class DeepseekMHAForwardMixin:
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         attn_output = self.attn_mha(q, k, v, forward_batch, save_kv_cache=False)
+        attn_output = zero_dp_attention_padding(attn_output, forward_batch)
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
         output, _ = self.o_proj(attn_output)
         return output
@@ -365,6 +367,7 @@ class DeepseekMHAForwardMixin:
                 forward_batch=forward_batch,
             )
 
+        attn_output = zero_dp_attention_padding(attn_output, forward_batch)
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -42,6 +42,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _use_aiter,
     _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
+    zero_dp_attention_padding,
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.state_capturer.indexer_topk import (
@@ -582,6 +583,7 @@ class DeepseekMLAForwardMixin:
                 save_kv_cache=save_kv_cache,
                 **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
             )
+        attn_output = zero_dp_attention_padding(attn_output, forward_batch)
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
 
         _kvb_v = None

--- a/python/sglang/srt/models/deepseek_common/utils.py
+++ b/python/sglang/srt/models/deepseek_common/utils.py
@@ -13,7 +13,7 @@
 # ==============================================================================
 import logging
 import math
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -69,6 +69,30 @@ FORWARD_ABSORB_CORE_ATTENTION_BACKENDS = [
     "ascend",
     "intel_xpu",
 ]
+
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+def zero_dp_attention_padding(
+    attn_output: torch.Tensor, forward_batch: "ForwardBatch"
+) -> torch.Tensor:
+    """Zero padding rows that FA3 kernel leaves uninitialized in DP attention.
+
+    When DP attention uses SUM_LEN mode and ranks have different sequence
+    lengths, shorter ranks pad their Q tensor. FA3 kernel only computes
+    valid tokens and leaves padding output as uninitialized garbage (NaN/Inf).
+    This garbage propagates through residual connections and corrupts the model.
+    """
+    num_valid = forward_batch.get_num_non_padded_tokens(attn_output.shape[0])
+    if num_valid is None:
+        return attn_output
+
+    if num_valid < attn_output.shape[0]:
+        attn_output[num_valid:] = 0
+
+    return attn_output
 
 
 def awq_dequantize_func():


### PR DESCRIPTION
## Motivation

When DP attention uses SUM_LEN mode and ranks have different sequence lengths, shorter ranks pad their Q tensor. FA3 kernel only computes valid tokens and leaves padding output uninitialized (NaN/Inf). This garbage propagates through residual connections and eventually triggers CUDA assert crashes (IndexKernel.cu:111).   

Reproduced with BailingMoeV2.5 Flash (hybrid MoE with full_attn + linear_attn layers) under DP=2 RL training.

## Modifications  

- Add `ForwardBatch.get_num_non_padded_tokens()` — returns DP-local valid-token count 
- Add `zero_dp_attention_padding()` helper in `deepseek_common/utils.py`
- Insert zeroing in `forward_mla.py` and `forward_mha.py` before reshape 
- Add `_zero_linear_attn_padding` in `radix_linear_attention.py` with unified exit
- Remove `_is_hip` gate on PCG padding zeroing in `radix_attention.py` (garbage is backend-independent)    

The fix is a no-op when there is no padding (`get_num_non_padded_tokens` returns `None`), so normal non-DP paths have zero overhead.   







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27664693386](https://github.com/sgl-project/sglang/actions/runs/27664693386)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27664693251](https://github.com/sgl-project/sglang/actions/runs/27664693251)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->