### PR TITLE
fix(responses): keep special tokens when tools present so gemma4 tool calls parse under tool_choice=auto

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -266,6 +266,17 @@ class OpenAIServingResponses(OpenAIServingChat):
                         default_max_tokens, self.default_sampling_params
                     )
 
+                    # Keep special tokens when tools are present so native
+                    # tool-call markers (e.g. gemma4 <|tool_call>) survive into
+                    # `content` for FunctionCallParser; otherwise tool calls under
+                    # tool_choice="auto" leak as plain text. Mirrors serving_chat.py.
+                    if (
+                        isinstance(sampling_params, dict)
+                        and getattr(request, "tools", None)
+                        and request.tool_choice != "none"
+                    ):
+                        sampling_params["skip_special_tokens"] = False
+
                     context: ConversationContext
                     if self.use_harmony:
                         if request.stream:


### PR DESCRIPTION
## Summary

On `/v1/responses`, a Gemma 4 tool call is only parsed into a structured `function_call` item when `tool_choice="required"`. Under `tool_choice="auto"` (the OpenAI default, used when the field is omitted), the model still emits the tool call but it is returned as plain text in an `output_text` message instead of a `function_call` item. The same model + tools parse correctly on `/v1/chat/completions`, so the bug is specific to the Responses serving path.

Fixes #28475.

## Root cause

`serving_chat.py` disables special-token stripping when tools are present, so the gemma4 `<|tool_call>` markers survive into the text handed to `FunctionCallParser`. The Responses path (`serving_responses.py`) never does this — it generates with the default `skip_special_tokens=True`, so the markers are stripped before `Gemma4Detector.has_tool_call()` runs. `has_tool_call` checks `TOOL_CALL_START in text`, which is now `False`, so native parsing is skipped and the raw text passes through. `required` still works because it goes through the structural-tag / JSON fallback path that does not depend on those markers.

`ResponsesRequest` has no `skip_special_tokens` field and `to_sampling_params(...)` does not emit that key, so the fix is applied to the constructed `sampling_params` dict.

## Fix

Mirror the chat behavior: after building `sampling_params`, keep special tokens when tools are in play and `tool_choice != "none"`. The `isinstance(..., dict)` guard keeps this a no-op on any non-dict sampling-params path.

## Test plan

- [ ] `tool_choice="auto"` (and omitted) on `/v1/responses` returns a structured `function_call` for the `gemma4` parser
- [ ] `tool_choice="required"` behavior unchanged
- [ ] `tool_choice="none"` still strips special tokens (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27665143382](https://github.com/sgl-project/sglang/actions/runs/27665143382)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27665143290](https://github.com/sgl-project/sglang/actions/runs/27665143290)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->