### PR TITLE
[Perf] Make latest_output_ids H2D non-blocking in prepare_for_decode

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2595,22 +2595,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # real token is relayed via future_map and resolved at forward
             # entry. So take the last output token from Req directly
             # (origin_input_ids[-1] on the first decode, before any output).
-            # Non-blocking H2D (matches the other per-step copies in this path):
-            # a blocking device= construction here issues a cudaStreamSynchronize
-            # every decode step, which under the overlap scheduler stalls the CPU
-            # behind the in-flight forward. forward_stream waits on schedule_stream,
-            # so the async copy is still ordered before the forward consumes it.
-            latest_output_ids = torch.tensor(
-                [
-                    (
-                        req.output_ids[-1]
-                        if len(req.output_ids)
-                        else req.origin_input_ids[-1]
-                    )
-                    for req in self.reqs
-                ],
-                dtype=torch.int64,
-            ).to(self.device, non_blocking=True)
+            last_tokens = [
+                req.output_ids[-1] if len(req.output_ids) else req.origin_input_ids[-1]
+                for req in self.reqs
+            ]
+            # Non-blocking H2D so this per-step copy doesn't sync behind the forward.
+            latest_output_ids = torch.tensor(last_tokens, dtype=torch.int64).to(
+                self.device, non_blocking=True
+            )
             self.sampling_info.penalizer_orchestrator.cumulate_output_tokens(
                 latest_output_ids
             )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2595,6 +2595,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # real token is relayed via future_map and resolved at forward
             # entry. So take the last output token from Req directly
             # (origin_input_ids[-1] on the first decode, before any output).
+            # Non-blocking H2D (matches the other per-step copies in this path):
+            # a blocking device= construction here issues a cudaStreamSynchronize
+            # every decode step, which under the overlap scheduler stalls the CPU
+            # behind the in-flight forward. forward_stream waits on schedule_stream,
+            # so the async copy is still ordered before the forward consumes it.
             latest_output_ids = torch.tensor(
                 [
                     (
@@ -2605,8 +2610,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     for req in self.reqs
                 ],
                 dtype=torch.int64,
-                device=self.device,
-            )
+            ).to(self.device, non_blocking=True)
             self.sampling_info.penalizer_orchestrator.cumulate_output_tokens(
                 latest_output_ids
             )


### PR DESCRIPTION
`prepare_for_decode` builds `latest_output_ids` with a blocking `torch.tensor(..., device=...)`, unlike the other per-step H2D copies in this path which all use `non_blocking=True`. Under the overlap scheduler this forces a `cudaStreamSynchronize` every decode step that stalls the CPU behind the in-flight forward — most visible at small batch / low latency.

`forward_stream` already waits on `schedule_stream`, so the async copy stays ordered before the forward consumes it. For penalties that don't read the tensor (e.g. `min_new_tokens`, which only counts) it was pure overhead.

## Benchmark

`openai/gpt-oss-120b`, TP=4 (GB300), overlap scheduler. Workload is `aiperf` 1k-in / 1k-out at concurrency 1 (bs=1 decode), with `min_tokens` set so the penalizer path that builds `latest_output_ids` is active. `fwd occupancy` = median of `sglang:fwd_occupancy` from `/metrics` while the bench runs.

Launch:

```
SGLANG_ENABLE_METRICS_DEVICE_TIMER=1 python -m sglang.launch_server \
  --model openai/gpt-oss-120b --tp 4 --enable-metrics \
  --cuda-graph-bs-decode 1 2 4 8
```

Bench:

```
aiperf profile \
  --model openai/gpt-oss-120b --url http://127.0.0.1:30000 \
  --endpoint-type chat --streaming \
  --isl 1024 --osl 1024 --concurrency 1 \
  --extra-inputs min_tokens:1024 --extra-inputs ignore_eos:true \
  --benchmark-duration 85
```

|                          | fwd occupancy | decode throughput | inter-token latency |
| ------------------------ | ------------- | ----------------- | ------------------- |
| before (blocking H2D)    | 71.4%         | 255 tok/s         | 3.91 ms             |
| after (non-blocking H2D) | 86.9%         | 330 tok/s         | 2.96 ms             |

When no penalizer is active the copy is skipped entirely, so that path is unchanged (~90% occupancy either way).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27666195284](https://github.com/sgl-project/sglang/actions/runs/27666195284)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27666195213](https://github.com/sgl-project/sglang/actions/runs/27666195213)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
