### PR TITLE
[mem_cache][12/N] refactor: stop allocators round-tripping through the KV pool

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1428,7 +1428,7 @@ class Req(ReqDllmMixin):
             self.req_pool_idx, : self.seqlen - 1
         ]
         # Copies over both the kv cache and mamba state if available
-        self.kv_cache_cpu = token_to_kv_pool_allocator.get_cpu_copy(
+        self.kv_cache_cpu = token_to_kv_pool_allocator.get_kvcache().get_cpu_copy(
             token_indices, mamba_indices=self.mamba_pool_idx
         )
 
@@ -1437,7 +1437,7 @@ class Req(ReqDllmMixin):
             self.req_pool_idx, : self.seqlen - 1
         ]
         # Loads both the kv cache and mamba state if exists
-        token_to_kv_pool_allocator.load_cpu_copy(
+        token_to_kv_pool_allocator.get_kvcache().load_cpu_copy(
             self.kv_cache_cpu, token_indices, mamba_indices=self.mamba_pool_idx
         )
         del self.kv_cache_cpu

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1824,7 +1824,7 @@ class Req(ReqDllmMixin):
             req_to_token_pool, token_to_kv_pool_allocator
         )
         self.kv.retraction_backup = RetractionBackup(
-            cpu_tensors=token_to_kv_pool_allocator.get_cpu_copy(
+            cpu_tensors=token_to_kv_pool_allocator.get_kvcache().get_cpu_copy(
                 token_indices, mamba_indices=self.kv.mamba_pool_idx
             ),
             mamba_cpu=(
@@ -1845,7 +1845,7 @@ class Req(ReqDllmMixin):
             req_to_token_pool.mamba_pool.load_cpu_copy(
                 mamba_cpu, self.kv.mamba_pool_idx.unsqueeze(0)
             )
-        token_to_kv_pool_allocator.load_cpu_copy(
+        token_to_kv_pool_allocator.get_kvcache().load_cpu_copy(
             self.kv.retraction_backup.cpu_tensors,
             token_indices,
             mamba_indices=self.kv.mamba_pool_idx,

--- a/python/sglang/srt/mem_cache/allocator/base.py
+++ b/python/sglang/srt/mem_cache/allocator/base.py
@@ -83,14 +83,6 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
                 (0,), dtype=self.release_pages.dtype, device=self.device
             )
 
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        # FIXME: reuse the get_cpu_copy after paged allocator is implemented
-        raise NotImplementedError()
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        # FIXME: reuse the load_cpu_copy after paged allocator is implemented
-        raise NotImplementedError()
-
     def alloc_extend(self, *args, **kwargs):
         raise NotImplementedError("alloc_extend is only for paged allocator")
 

--- a/python/sglang/srt/mem_cache/allocator/base.py
+++ b/python/sglang/srt/mem_cache/allocator/base.py
@@ -125,14 +125,6 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         """
         return kv_indices
 
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        # FIXME: reuse the get_cpu_copy after paged allocator is implemented
-        raise NotImplementedError()
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        # FIXME: reuse the load_cpu_copy after paged allocator is implemented
-        raise NotImplementedError()
-
     def alloc_extend(self, *args, **kwargs):
         raise NotImplementedError("alloc_extend is only for paged allocator")
 

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -161,7 +161,9 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return last_locs
 
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
-        return self._kvcache._translate_loc_to_hisparse_device(last_locs)
+        # full_to_hisparse_device_index_mapping is owned and written by this
+        # allocator; index it directly rather than round-tripping through the pool.
+        return self.full_to_hisparse_device_index_mapping[last_locs]
 
     def alloc_extend(
         self,
@@ -225,7 +227,7 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
     def free_hisparse(self, free_indices: torch.Tensor):
-        hisparse_indices = self._kvcache._translate_loc_to_hisparse_device(free_indices)
+        hisparse_indices = self.full_to_hisparse_device_index_mapping[free_indices]
         hisparse_indices = hisparse_indices[hisparse_indices > 0]
         self.free_hisparse_indices(hisparse_indices)
         self.full_to_hisparse_device_index_mapping[free_indices] = 0
@@ -450,9 +452,11 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return (last_locs - 3) // self.compress_ratio
 
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
-        return self.hisparse_kvcache._translate_loc_to_hisparse_device(
+        # Index the allocator-owned mapping directly (mirrors the pool's
+        # _translate_loc_to_hisparse_device, which reads this same tensor).
+        return self.full_to_hisparse_device_index_mapping[
             self.get_last_loc_compressed(last_locs)
-        )
+        ]
 
     def alloc_extend(
         self,
@@ -494,6 +498,9 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         assert logical_indices is not None, "Logical allocation failed in alloc_extend"
 
+        # Kept as a pool call on purpose: full->compressed is genuine C4-layout
+        # arithmetic ((i+1) % compress_ratio), a pool responsibility, not the
+        # pointless owned-mapping round-trips removed elsewhere in this allocator.
         compressed_logical_indices = (
             self.hisparse_kvcache.translate_loc_from_full_to_compressed(logical_indices)
         )
@@ -526,14 +533,18 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
     def free_compressed(self, compressed_indices: torch.Tensor):
-        hisparse_indices = self.hisparse_kvcache.translate_loc_to_hisparse_device(
+        # Index the allocator-owned mapping directly; the .to(int32) matches the
+        # pool's translate_loc_to_hisparse_device, which reads this same tensor.
+        hisparse_indices = self.full_to_hisparse_device_index_mapping[
             compressed_indices
-        )
+        ].to(torch.int32)
         hisparse_indices = hisparse_indices[hisparse_indices > 0]
         self.free_hisparse_indices(hisparse_indices)
         self.full_to_hisparse_device_index_mapping[compressed_indices] = 0
 
     def free_hisparse(self, free_indices: torch.Tensor):
+        # full->compressed is genuine C4-layout arithmetic; kept as a pool call
+        # (see alloc_extend) rather than an owned-mapping round-trip.
         compressed_indices = (
             self.hisparse_kvcache.translate_loc_from_full_to_compressed(free_indices)
         )

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -171,7 +171,9 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return last_locs
 
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
-        return self._kvcache._translate_loc_to_hisparse_device(last_locs)
+        # full_to_hisparse_device_index_mapping is owned and written by this
+        # allocator; index it directly rather than round-tripping through the pool.
+        return self.full_to_hisparse_device_index_mapping[last_locs]
 
     def alloc_extend(
         self,
@@ -233,7 +235,7 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
     def free_hisparse(self, free_indices: torch.Tensor):
-        hisparse_indices = self._kvcache._translate_loc_to_hisparse_device(free_indices)
+        hisparse_indices = self.full_to_hisparse_device_index_mapping[free_indices]
         hisparse_indices = hisparse_indices[hisparse_indices > 0]
         self.free_hisparse_indices(hisparse_indices)
         self.full_to_hisparse_device_index_mapping[free_indices] = 0
@@ -482,9 +484,11 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return (last_locs - 3) // self.compress_ratio
 
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
-        return self.hisparse_kvcache._translate_loc_to_hisparse_device(
+        # Index the allocator-owned mapping directly (mirrors the pool's
+        # _translate_loc_to_hisparse_device, which reads this same tensor).
+        return self.full_to_hisparse_device_index_mapping[
             self.get_last_loc_compressed(last_locs)
-        )
+        ]
 
     def alloc_extend(
         self,
@@ -526,6 +530,9 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         assert logical_indices is not None, "Logical allocation failed in alloc_extend"
 
+        # Kept as a pool call on purpose: full->compressed is genuine C4-layout
+        # arithmetic ((i+1) % compress_ratio), a pool responsibility, not the
+        # pointless owned-mapping round-trips removed elsewhere in this allocator.
         compressed_logical_indices = (
             self.hisparse_kvcache.translate_loc_from_full_to_compressed(logical_indices)
         )
@@ -558,14 +565,18 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
     def free_compressed(self, compressed_indices: torch.Tensor):
-        hisparse_indices = self.hisparse_kvcache.translate_loc_to_hisparse_device(
+        # Index the allocator-owned mapping directly; the .to(int32) matches the
+        # pool's translate_loc_to_hisparse_device, which reads this same tensor.
+        hisparse_indices = self.full_to_hisparse_device_index_mapping[
             compressed_indices
-        )
+        ].to(torch.int32)
         hisparse_indices = hisparse_indices[hisparse_indices > 0]
         self.free_hisparse_indices(hisparse_indices)
         self.full_to_hisparse_device_index_mapping[compressed_indices] = 0
 
     def free_hisparse(self, free_indices: torch.Tensor):
+        # full->compressed is genuine C4-layout arithmetic; kept as a pool call
+        # (see alloc_extend) rather than an owned-mapping round-trip.
         compressed_indices = (
             self.hisparse_kvcache.translate_loc_from_full_to_compressed(free_indices)
         )

--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -255,11 +255,3 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.is_not_in_free_group = True
         self.free_group = []
         self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        return self._kvcache.load_cpu_copy(
-            kv_cache_cpu, indices, mamba_indices=mamba_indices
-        )

--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -336,11 +336,3 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.free_group = None
         self.free_page_reps_group = []
         self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        return self._kvcache.load_cpu_copy(
-            kv_cache_cpu, indices, mamba_indices=mamba_indices
-        )

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -136,8 +136,10 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return self._kvcache
 
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
-        assert self._kvcache.full_to_swa_index_mapping is not None
-        return self._kvcache.translate_loc_from_full_to_swa(kv_indices)
+        # The allocator owns full_to_swa_index_mapping (it writes it on every
+        # alloc/free), so index it directly instead of round-tripping through the
+        # pool, which would only index this very same tensor.
+        return self.full_to_swa_index_mapping[kv_indices]
 
     def alloc(self, need_size: int):
         assert self.page_size == 1
@@ -381,11 +383,3 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_swa_index_mapping[:-1].fill_(0)
         self.is_not_in_free_group = True
         self.free_group = []
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        return self._kvcache.load_cpu_copy(
-            kv_cache_cpu, indices, mamba_indices=mamba_indices
-        )

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -146,8 +146,10 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return self._kvcache
 
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
-        assert self._kvcache.full_to_swa_index_mapping is not None
-        return self._kvcache.translate_loc_from_full_to_swa(kv_indices)
+        # The allocator owns full_to_swa_index_mapping (it writes it on every
+        # alloc/free), so index it directly instead of round-tripping through the
+        # pool, which would only index this very same tensor.
+        return self.full_to_swa_index_mapping[kv_indices]
 
     def alloc(self, need_size: int):
         assert self.page_size == 1
@@ -449,14 +451,6 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.free_group = None
         self.swa_free_group = []
         self.full_free_group = []
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        return self._kvcache.load_cpu_copy(
-            kv_cache_cpu, indices, mamba_indices=mamba_indices
-        )
 
 
 class PureSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):

--- a/python/sglang/srt/mem_cache/allocator/token.py
+++ b/python/sglang/srt/mem_cache/allocator/token.py
@@ -74,11 +74,3 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 self.free_pages = torch.cat((self.free_pages, free_index))
         else:
             self.free_group.append(free_index)
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        return self._kvcache.load_cpu_copy(
-            kv_cache_cpu, indices, mamba_indices=mamba_indices
-        )

--- a/python/sglang/srt/mem_cache/allocator/token.py
+++ b/python/sglang/srt/mem_cache/allocator/token.py
@@ -73,11 +73,3 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 self.free_pages = torch.cat((self.free_pages, free_index))
         else:
             self.free_group.append(self._copy_for_free_group(free_index))
-
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        return self._kvcache.load_cpu_copy(
-            kv_cache_cpu, indices, mamba_indices=mamba_indices
-        )

--- a/test/registered/unit/mem_cache/test_mamba_unittest.py
+++ b/test/registered/unit/mem_cache/test_mamba_unittest.py
@@ -629,7 +629,9 @@ class TestMamba(unittest.TestCase):
         mamba_pool.mamba_cache.temporal[:, mamba_indices] = 6.0
 
         # --- Round-trip with Mamba indices provided ---
-        cpu_copy = allocator.get_cpu_copy(kv_indices, mamba_indices=mamba_indices)
+        cpu_copy = allocator.get_kvcache().get_cpu_copy(
+            kv_indices, mamba_indices=mamba_indices
+        )
         kv_cpu, mamba_cpu = cpu_copy
         self.assertIsNotNone(
             mamba_cpu, "mamba_cpu should be saved when mamba_indices given"
@@ -643,7 +645,9 @@ class TestMamba(unittest.TestCase):
             conv[:, mamba_indices] = 0.0
         mamba_pool.mamba_cache.temporal[:, mamba_indices] = 0.0
 
-        allocator.load_cpu_copy(cpu_copy, kv_indices, mamba_indices=mamba_indices)
+        allocator.get_kvcache().load_cpu_copy(
+            cpu_copy, kv_indices, mamba_indices=mamba_indices
+        )
 
         # Verify KV restored.
         for layer_id in range(hybrid_pool.full_kv_pool.layer_num):
@@ -672,7 +676,9 @@ class TestMamba(unittest.TestCase):
         )
 
         # --- Without mamba_indices: mamba_cpu must be None ---
-        cpu_copy_no_mamba = allocator.get_cpu_copy(kv_indices, mamba_indices=None)
+        cpu_copy_no_mamba = allocator.get_kvcache().get_cpu_copy(
+            kv_indices, mamba_indices=None
+        )
         _, mamba_cpu_none = cpu_copy_no_mamba
         self.assertIsNone(
             mamba_cpu_none, "mamba_cpu should be None when mamba_indices=None"

--- a/test/registered/unit/mem_cache/test_mamba_unittest.py
+++ b/test/registered/unit/mem_cache/test_mamba_unittest.py
@@ -705,7 +705,9 @@ class TestMamba(unittest.TestCase):
         mamba_pool.mamba_cache.temporal[:, mamba_indices] = 6.0
 
         # --- Round-trip with Mamba indices provided ---
-        cpu_copy = allocator.get_cpu_copy(kv_indices, mamba_indices=mamba_indices)
+        cpu_copy = allocator.get_kvcache().get_cpu_copy(
+            kv_indices, mamba_indices=mamba_indices
+        )
         kv_cpu, mamba_cpu = cpu_copy
         self.assertIsNotNone(
             mamba_cpu, "mamba_cpu should be saved when mamba_indices given"
@@ -719,7 +721,9 @@ class TestMamba(unittest.TestCase):
             conv[:, mamba_indices] = 0.0
         mamba_pool.mamba_cache.temporal[:, mamba_indices] = 0.0
 
-        allocator.load_cpu_copy(cpu_copy, kv_indices, mamba_indices=mamba_indices)
+        allocator.get_kvcache().load_cpu_copy(
+            cpu_copy, kv_indices, mamba_indices=mamba_indices
+        )
 
         # Verify KV restored.
         for layer_id in range(hybrid_pool.full_kv_pool.layer_num):
@@ -748,7 +752,9 @@ class TestMamba(unittest.TestCase):
         )
 
         # --- Without mamba_indices: mamba_cpu must be None ---
-        cpu_copy_no_mamba = allocator.get_cpu_copy(kv_indices, mamba_indices=None)
+        cpu_copy_no_mamba = allocator.get_kvcache().get_cpu_copy(
+            kv_indices, mamba_indices=None
+        )
         _, mamba_cpu_none = cpu_copy_no_mamba
         self.assertIsNone(
             mamba_cpu_none, "mamba_cpu should be None when mamba_indices=None"

--- a/test/registered/unit/mem_cache/test_retraction_mamba_backup.py
+++ b/test/registered/unit/mem_cache/test_retraction_mamba_backup.py
@@ -22,19 +22,24 @@ class _MambaPool:
         self.loaded = state
 
 
-class _Allocator:
+class _KVPool:
     def __init__(self, carries_mamba: bool):
-        self._kv = type("_KV", (), {"cpu_copy_carries_mamba": carries_mamba})()
+        self.cpu_copy_carries_mamba = carries_mamba
         self.loaded_kv = None
-
-    def get_kvcache(self):
-        return self._kv
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         return "kv"
 
     def load_cpu_copy(self, cpu_tensors, indices, mamba_indices=None):
         self.loaded_kv = cpu_tensors
+
+
+class _Allocator:
+    def __init__(self, carries_mamba: bool):
+        self._kv = _KVPool(carries_mamba)
+
+    def get_kvcache(self):
+        return self._kv
 
 
 def _req_and_pool():


### PR DESCRIPTION
## Motivation

Part of #25371. Rebased onto current `main` and renumbered -- the branch had been sitting
since June and `[6/N]` had meanwhile been taken by #30249.

Allocators reach through the KV pool for two things they do not need it for:

1. **`get_cpu_copy` / `load_cpu_copy` pass-throughs.** `TokenToKVPoolAllocator` and
   `SWATokenToKVPoolAllocator` each define these purely to forward to `self._kvcache`,
   and `BaseTokenToKVPoolAllocator` declares them only to raise `NotImplementedError`.
   Retraction backup is a pool operation; routing it through the allocator adds a layer
   that carries no decision.
2. **Round-trips through the pool to read a tensor the allocator itself owns.** The
   allocator allocates `full_to_swa_index_mapping` / `full_to_hisparse_device_index_mapping`
   in `__init__`, hands the *same object* to the pool via `register_mapping`, and writes
   it on every alloc and free. `self._kvcache.translate_loc_from_full_to_swa(x)` is then
   literally `self.full_to_swa_index_mapping[x]` with an extra call frame.

## Modifications

- Drop `get_cpu_copy` / `load_cpu_copy` from `allocator/base.py`, `allocator/token.py`,
  `allocator/paged.py`, `allocator/swa.py`. The two call sites in `Req.save_kv_cache` /
  `Req.load_kv_cache` go through `token_to_kv_pool_allocator.get_kvcache()` instead.
- `SWATokenToKVPoolAllocator.translate_loc_from_full_to_swa` and the HiSparse allocators'
  `get_last_loc_hisparse_device` / `free_hisparse` / `free_compressed` index the
  allocator-owned mapping directly.
- `full -> compressed` is deliberately **left** as a pool call: it is genuine C4-layout
  arithmetic (`(i + 1) % compress_ratio`), a pool responsibility, not a mapping lookup.
  Comments at both sites say so, to keep the next reader from "simplifying" it too.

No behavior change: every removed indirection resolved to the same tensor index or the
same pool method.

## Accuracy Test

Rebase resolution, verified on an H200 devbox against a pristine `main` baseline on the
same box:

```
      rebased branch:   1746 passed, 1074 skipped, 201 subtests passed
  pristine main:        1746 passed, 1074 skipped, 201 subtests passed
```

(`test/registered/unit/mem_cache/` plus `spec/test_resolve_swa_kv_pool.py`; `--ignore` on
`test_umbp_store.py`, which needs the `mori` package that is absent from the image.) Zero
delta, so the 1074 skips are pre-existing.

The rebase kept the original diff shape exactly (+32/-45 across 7 files). Three of the
four conflicts were context drift around the deleted methods -- `main` had added
`translate_kv_indices_for_transfer` to `allocator/base.py`, `_copy_for_free_group` to
`allocator/token.py`, and `PureSWATokenToKVPoolAllocator` plus `swa_free_group` to
`allocator/swa.py`. All are preserved; `PureSWATokenToKVPoolAllocator` is byte-identical
to `main`, and it overrides `translate_loc_from_full_to_swa` with an identity, so it is
unaffected by the change here. The fourth conflict was real: `main` had reworked
retraction backup onto `RetractionBackup(cpu_tensors=...)`, so the resolution keeps that
structure and only reroutes the call through `get_kvcache()`.

The ownership assumption was re-checked against current `main` rather than trusting the
June-era diff: `allocator/swa.py` builds the tensor, `register_mapping` hands the same
object to the pool, and the pool's `translate_loc_from_full_to_swa` indexes that very
tensor -- so the direct index is identical, including the `-1` sentinel row. A repo-wide
grep confirms no allocator-level `get_cpu_copy` / `load_cpu_copy` caller or override
survives; every remaining one is on a pool.

## Benchmark and Profiling Results

Not applicable -- removes call frames, changes no kernel or memory layout.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33622539535](https://github.com/sgl-project/sglang/actions/runs/33622539535)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33622539519](https://github.com/sgl-project/sglang/actions/runs/33622539519)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33622539405](https://github.com/sgl-project/sglang/actions/runs/33622539405)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->