### PR TITLE
[AMD] Register DP attention test

### DIFF
--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import requests
@@ -5,7 +6,7 @@ import requests
 from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.ebnf_constrained_kit import EBNFConstrainedMixin
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
@@ -22,6 +23,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=420, stage="base-b", runner_config="2-gpu-large")
+register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
 
 
 class TestDPAttentionDP2TP2(
@@ -221,4 +223,7 @@ class TestDPAttentionDP2TP2VLM(CustomTestCase):
 
 
 if __name__ == "__main__":
+    # run_suite.py invokes files with `python3 <file> -f`. Strip unittest
+    # fail-fast here so all DP Attention cases run and report their results.
+    sys.argv = [a for a in sys.argv if a not in ("-f", "--failfast")]
     unittest.main()

--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -25,6 +25,8 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=420, stage="base-b", runner_config="2-gpu-large")
 register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
 
+DP_GATHERV_MODEL = "Qwen/Qwen3-30B-A3B"
+
 
 class TestDPAttentionDP2TP2(
     CustomTestCase,
@@ -81,7 +83,7 @@ class TestDPAttentionGatherv(
 
     @classmethod
     def setUpClass(cls):
-        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
+        cls.model = DP_GATHERV_MODEL
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
             cls.model,

--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -24,7 +24,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=420, stage="base-b", runner_config="2-gpu-large")
-register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
+register_amd_ci(est_time=500, suite="stage-b-test-2-gpu-large-amd")
 
 
 @unittest.skipIf(is_in_amd_ci(), "This test case cannot run on ROCm.")

--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -20,6 +20,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    is_in_amd_ci,
     popen_launch_server,
 )
 
@@ -27,6 +28,7 @@ register_cuda_ci(est_time=420, stage="base-b", runner_config="2-gpu-large")
 register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
 
 
+@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
 class TestDPAttentionDP2TP2(
     CustomTestCase,
     GSM8KMixin,
@@ -106,6 +108,7 @@ class TestDPAttentionGatherv(
         kill_process_tree(cls.process.pid)
 
 
+@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
 class TestDPAttentionMixedChunk(
     CustomTestCase,
     GSM8KMixin,
@@ -138,6 +141,7 @@ class TestDPAttentionMixedChunk(
         kill_process_tree(cls.process.pid)
 
 
+@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
 class TestDPRetract(
     CustomTestCase,
     JSONConstrainedMixin,
@@ -178,6 +182,7 @@ class TestDPRetract(
             self.assertIsNone(self.process.poll())
 
 
+@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
 class TestDPAttentionDP2TP2VLM(CustomTestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -16,6 +16,7 @@ from sglang.test.test_utils import (
     DEFAULT_IMAGE_URL,
     DEFAULT_MLA_MODEL_NAME_FOR_TEST,
     DEFAULT_MODEL_NAME_FOR_TEST_MLA,
+    DEFAULT_TARGET_MODEL_EAGLE_DP_ATTN,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
@@ -24,8 +25,6 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=420, stage="base-b", runner_config="2-gpu-large")
 register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
-
-DP_GATHERV_MODEL = "Qwen/Qwen3-30B-A3B"
 
 
 class TestDPAttentionDP2TP2(
@@ -83,7 +82,7 @@ class TestDPAttentionGatherv(
 
     @classmethod
     def setUpClass(cls):
-        cls.model = DP_GATHERV_MODEL
+        cls.model = DEFAULT_TARGET_MODEL_EAGLE_DP_ATTN
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
             cls.model,

--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 import requests
@@ -28,7 +27,7 @@ register_cuda_ci(est_time=420, stage="base-b", runner_config="2-gpu-large")
 register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
 
 
-@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
+@unittest.skipIf(is_in_amd_ci(), "This test case cannot run on ROCm.")
 class TestDPAttentionDP2TP2(
     CustomTestCase,
     GSM8KMixin,
@@ -108,7 +107,7 @@ class TestDPAttentionGatherv(
         kill_process_tree(cls.process.pid)
 
 
-@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
+@unittest.skipIf(is_in_amd_ci(), "This test case cannot run on ROCm.")
 class TestDPAttentionMixedChunk(
     CustomTestCase,
     GSM8KMixin,
@@ -141,7 +140,7 @@ class TestDPAttentionMixedChunk(
         kill_process_tree(cls.process.pid)
 
 
-@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
+@unittest.skipIf(is_in_amd_ci(), "This test case cannot run on ROCm.")
 class TestDPRetract(
     CustomTestCase,
     JSONConstrainedMixin,
@@ -182,7 +181,7 @@ class TestDPRetract(
             self.assertIsNone(self.process.poll())
 
 
-@unittest.skipIf(is_in_amd_ci(), "Only run TestDPAttentionGatherv on AMD CI")
+@unittest.skipIf(is_in_amd_ci(), "This test case cannot run on ROCm.")
 class TestDPAttentionDP2TP2VLM(CustomTestCase):
     @classmethod
     def setUpClass(cls):
@@ -229,7 +228,4 @@ class TestDPAttentionDP2TP2VLM(CustomTestCase):
 
 
 if __name__ == "__main__":
-    # run_suite.py invokes files with `python3 <file> -f`. Strip unittest
-    # fail-fast here so all DP Attention cases run and report their results.
-    sys.argv = [a for a in sys.argv if a not in ("-f", "--failfast")]
     unittest.main()


### PR DESCRIPTION
## Summary
- Register `test/registered/dp_attn/test_dp_attention.py` in AMD PR CI under `stage-b-test-2-gpu-large-amd` with `est_time=500`.
- On AMD CI, only `TestDPAttentionGatherv` runs; the other DP Attention cases are skipped because they cannot run on ROCm.
- Use `DEFAULT_TARGET_MODEL_EAGLE_DP_ATTN` for the gatherv case.

## Test
AMD Test passed
<img width="1710" height="1165" alt="image" src="https://github.com/user-attachments/assets/8fbeb2c3-f4bf-49c4-be42-d11c8a45d3b6" />
<img width="1589" height="1189" alt="image" src="https://github.com/user-attachments/assets/bf983e28-44a9-44f6-a267-281da71e3081" />

NV Test Passed
<img width="1579" height="1386" alt="image" src="https://github.com/user-attachments/assets/a072e98f-1a4b-43e1-9b97-9d334f70dc8a" />https://github.com/sgl-project/sglang/actions/runs/27733749526/job/82046083382


## AMD CI
- AMD CI coverage is scoped to the gatherv DP attention path in `TestDPAttentionGatherv`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27697917159](https://github.com/sgl-project/sglang/actions/runs/27697917159)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27697919078](https://github.com/sgl-project/sglang/actions/runs/27697919078)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->