### PR TITLE
[Spec] Fix return_hidden_states under spec V2 (issue #26163)

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -668,9 +668,22 @@ class SchedulerBatchResultProcessor:
                 )
 
             if req.return_hidden_states and logits_output.hidden_states is not None:
-                req.hidden_states.append(
-                    logits_output.hidden_states[i].cpu().clone().tolist()
-                )
+                if batch.spec_algorithm.is_none():
+                    req.hidden_states.append(
+                        logits_output.hidden_states[i].cpu().clone().tolist()
+                    )
+                else:
+                    # Spec V2 hidden_states is strided [bs * speculative_num_draft_tokens, hidden_dim].
+                    # Req i's accepted-plus-bonus rows live at [i*stride : i*stride + accept_len].
+                    stride = result.speculative_num_draft_tokens
+                    accept_len = result.num_correct_drafts_per_req_cpu[i] + 1
+                    start = i * stride
+                    req.hidden_states.extend(
+                        logits_output.hidden_states[start : start + accept_len]
+                        .cpu()
+                        .clone()
+                        .tolist()
+                    )
 
             if req.grammar is not None:
                 self._apply_decode_grammar(

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -673,8 +673,7 @@ class SchedulerBatchResultProcessor:
                         logits_output.hidden_states[i].cpu().clone().tolist()
                     )
                 else:
-                    # Spec V2 hidden_states is strided [bs * speculative_num_draft_tokens, hidden_dim].
-                    # Req i's accepted-plus-bonus rows live at [i*stride : i*stride + accept_len].
+                    # Spec V2: hidden_states is [bs * speculative_num_draft_tokens, hidden_dim].
                     stride = result.speculative_num_draft_tokens
                     accept_len = result.num_correct_drafts_per_req_cpu[i] + 1
                     start = i * stride

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -480,10 +480,7 @@ class _GenerationStreamAccumulator:
 
         if self.return_hidden_states:
             if req.return_hidden_states:
-                # Mirror output_ids_through_stop: drop rows past finished_len
-                # so len(hidden_states) tracks completion_tokens. Spec V2 verify
-                # steps can overshoot when the final accepted run crosses
-                # max_new_tokens; this trims that tail.
+                # Mirror output_ids_through_stop: spec verify steps can overshoot finished_len.
                 hs = req.hidden_states
                 if req.finished_len is not None:
                     hs = hs[: req.finished_len]

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -479,9 +479,17 @@ class _GenerationStreamAccumulator:
                 self.output_token_ids_logprobs_idx.append([])
 
         if self.return_hidden_states:
-            self.output_hidden_states.append(
-                req.hidden_states if req.return_hidden_states else None
-            )
+            if req.return_hidden_states:
+                # Mirror output_ids_through_stop: drop rows past finished_len
+                # so len(hidden_states) tracks completion_tokens. Spec V2 verify
+                # steps can overshoot when the final accepted run crosses
+                # max_new_tokens; this trims that tail.
+                hs = req.hidden_states
+                if req.finished_len is not None:
+                    hs = hs[: req.finished_len]
+                self.output_hidden_states.append(hs)
+            else:
+                self.output_hidden_states.append(None)
         if self.return_routed_experts:
             self.routed_experts.append(
                 req.routed_experts if req.return_routed_experts else None

--- a/test/registered/spec/eagle/test_eagle_hidden_states.py
+++ b/test/registered/spec/eagle/test_eagle_hidden_states.py
@@ -1,0 +1,79 @@
+"""Regression test for issue #26163: return_hidden_states under EAGLE spec V2
+must yield len(hidden_states) == completion_tokens. The spec-V2 path used to
+.append a single row per verify step from a strided
+[bs * speculative_num_draft_tokens, hidden_dim] tensor, silently truncating
+output and potentially aliasing onto a neighbor request's rows.
+"""
+
+import unittest
+
+import sglang as sgl
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE,
+    DEFAULT_TARGET_MODEL_EAGLE,
+    CustomTestCase,
+)
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestEagleReturnHiddenStates(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = sgl.Engine(
+            model_path=DEFAULT_TARGET_MODEL_EAGLE,
+            speculative_algorithm="EAGLE",
+            speculative_draft_model_path=DEFAULT_DRAFT_MODEL_EAGLE,
+            speculative_num_steps=3,
+            speculative_eagle_topk=4,
+            speculative_num_draft_tokens=8,
+            enable_return_hidden_states=True,
+            mem_fraction_static=0.7,
+            attention_backend="triton",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "engine") and cls.engine is not None:
+            cls.engine.shutdown()
+
+    def test_hidden_states_length_matches_completion(self):
+        # Two prompts of different lengths catch the i*stride+accept_lens[i]
+        # slicing: with the old code, req 1's accepted-rows are partly stolen
+        # from req 0's window and vice versa.
+        prompts = [
+            "Repeat: the quick brown fox the quick brown fox the quick brown fox",
+            "Count down from ten: ten nine eight",
+        ]
+        max_new_tokens = 32
+        outputs = self.engine.generate(
+            prompts,
+            sampling_params={"temperature": 0, "max_new_tokens": max_new_tokens},
+            return_hidden_states=True,
+        )
+
+        for out in outputs:
+            meta = out["meta_info"]
+            hs = meta["hidden_states"]
+            ct = meta["completion_tokens"]
+            self.assertEqual(
+                len(hs),
+                ct,
+                f"len(hidden_states)={len(hs)} but completion_tokens={ct}",
+            )
+            # hs[0] is the prefill block (List[List[float]]); hs[1:] are
+            # per-decode-token rows (List[float]). All decode rows must share
+            # the same hidden_dim — a collapsed/promoted shape would indicate
+            # strided-tensor misindexing in the spec-V2 path.
+            decode_rows = hs[1:]
+            self.assertGreater(len(decode_rows), 0)
+            hidden_dim = len(decode_rows[0])
+            self.assertGreater(hidden_dim, 0)
+            for row in decode_rows:
+                self.assertIsInstance(row, list)
+                self.assertEqual(len(row), hidden_dim)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/eagle/test_eagle_hidden_states.py
+++ b/test/registered/spec/eagle/test_eagle_hidden_states.py
@@ -1,9 +1,4 @@
-"""Regression test for issue #26163: return_hidden_states under EAGLE spec V2
-must yield len(hidden_states) == completion_tokens. The spec-V2 path used to
-.append a single row per verify step from a strided
-[bs * speculative_num_draft_tokens, hidden_dim] tensor, silently truncating
-output and potentially aliasing onto a neighbor request's rows.
-"""
+"""Regression test for issue #26163: return_hidden_states under EAGLE spec V2."""
 
 import unittest
 
@@ -39,9 +34,7 @@ class TestEagleReturnHiddenStates(CustomTestCase):
             cls.engine.shutdown()
 
     def test_hidden_states_length_matches_completion(self):
-        # Two prompts of different lengths catch the i*stride+accept_lens[i]
-        # slicing: with the old code, req 1's accepted-rows are partly stolen
-        # from req 0's window and vice versa.
+        # Two prompts to exercise cross-request stride aliasing.
         prompts = [
             "Repeat: the quick brown fox the quick brown fox the quick brown fox",
             "Count down from ten: ten nine eight",
@@ -62,10 +55,7 @@ class TestEagleReturnHiddenStates(CustomTestCase):
                 ct,
                 f"len(hidden_states)={len(hs)} but completion_tokens={ct}",
             )
-            # hs[0] is the prefill block (List[List[float]]); hs[1:] are
-            # per-decode-token rows (List[float]). All decode rows must share
-            # the same hidden_dim — a collapsed/promoted shape would indicate
-            # strided-tensor misindexing in the spec-V2 path.
+            # hs[0] is the prefill block (List[List[float]]); hs[1:] are decode rows.
             decode_rows = hs[1:]
             self.assertGreater(len(decode_rows), 0)
             hidden_dim = len(decode_rows[0])


### PR DESCRIPTION
## Summary

Fixes #26163.

The decode-path append in `process_batch_result_decode` treats `logits_output.hidden_states` as `[bs, hidden_dim]`, but in spec V2 it is strided `[bs * speculative_num_draft_tokens, hidden_dim]`. Row `i` is the bonus position of req `i`, not its accepted-tokens slice — so `meta_info["hidden_states"]` is silently truncated (one row per verify step instead of `accept_len`), and with batch > 1 it can pick up rows belonging to a neighbor request's stride window.

Affected paths: EAGLE V2, EAGLE3, STANDALONE, FROZEN_KV_MTP, DFLASH. (Spec V1 paths in the original issue were already removed in #28129 / #28133, so this PR is the V2-only follow-up.)

- `batch_result_processor.process_batch_result_decode`: when `spec_algorithm` is active, `extend` `req.hidden_states` with `logits_output.hidden_states[i*stride : i*stride + num_correct_drafts_per_req_cpu[i] + 1]`. Non-spec keeps the existing single-row `.append`.
- `output_streamer.stream_output`: when emitting hidden states, slice to `req.finished_len` (parallel to `output_ids_through_stop`). The last verify step's `accept_len` can overrun `max_new_tokens`; without trimming, `len(meta_info["hidden_states"]) > completion_tokens`.

## Test plan

- [x] New regression test `test/registered/spec/eagle/test_eagle_hidden_states.py` — boots an EAGLE V2 Engine (`DEFAULT_TARGET_MODEL_EAGLE` / `DEFAULT_DRAFT_MODEL_EAGLE`) with `enable_return_hidden_states=True`, runs two prompts of different lengths to exercise the stride/slice, and asserts:
  - `len(meta_info["hidden_states"]) == completion_tokens` per request
  - every decode row is a list of `hidden_dim` floats (catches collapsed/misindexed shapes)
- [x] Locally green: `python test/registered/spec/eagle/test_eagle_hidden_states.py` → `OK` on H200.
- [x] Existing non-spec invariant test still green: `test/registered/core/test_hidden_states.py::TestHiddenState::test_repeatedly_changes_hidden_states` → `OK`.
- [ ] CI registration: `register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-large")` — same suite as the rest of `test/registered/spec/eagle/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27671166882](https://github.com/sgl-project/sglang/actions/runs/27671166882)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27671166829](https://github.com/sgl-project/sglang/actions/runs/27671166829)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->