### PR TITLE
[Feature] add --language-model-only flag to skip multimodal encoder loading and serve in text-only mode

### DIFF
--- a/docs_new/docs/advanced_features/server_arguments.mdx
+++ b/docs_new/docs/advanced_features/server_arguments.mdx
@@ -3037,7 +3037,13 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
-        <tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--language-model-only`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Strip multimodal vision/audio encoders and load only the language backbone. Multimodal inputs are rejected. Frees GPU memory for additional KV cache.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--encoder-transfer-backend`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The backend for encoder disaggregation transfer. Default is zmq_to_scheduler.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`zmq_to_scheduler`</td>

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -246,6 +246,7 @@ class ModelConfig:
         is_multi_layer_eagle: bool = False,
         encoder_only: bool = False,
         language_only: bool = False,
+        language_model_only: bool = False,
         disable_hybrid_swa_memory: bool = False,
         model_config_parser: str = "auto",
         speculative_algorithm: Optional[str] = None,
@@ -479,6 +480,7 @@ class ModelConfig:
 
         self.hf_config.encoder_only = encoder_only
         self.hf_config.language_only = language_only
+        self.hf_config.language_model_only = language_model_only
 
         # matryoshka embeddings
         self.matryoshka_dimensions = getattr(
@@ -527,6 +529,7 @@ class ModelConfig:
             override_config_file=override_config_file,
             is_multi_layer_eagle=server_args.enable_multi_layer_eagle,
             language_only=server_args.language_only,
+            language_model_only=server_args.language_model_only,
             encoder_only=server_args.encoder_only,
             is_draft_model=is_draft_model,
             disable_hybrid_swa_memory=server_args.disable_hybrid_swa_memory,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -689,7 +689,11 @@ class Scheduler(
 
         # Load multimodal processor for M-RoPE fallback computation.
         self._mm_processor = None
-        if self.model_config.is_multimodal and self.processor is not None:
+        if (
+            self.model_config.is_multimodal
+            and self.processor is not None
+            and not server_args.language_model_only
+        ):
             try:
                 import_processors("sglang.srt.multimodal.processors")
                 self._mm_processor = get_mm_processor(
@@ -2195,6 +2199,17 @@ class Scheduler(
                 return
         # Handle multimodal inputs
         if recv_req.mm_inputs is not None:
+            if self.server_args.language_model_only:
+                logger.error(
+                    "Unexpected multimodal inputs received in language_model_only "
+                    "mode. This should have been rejected upstream by the tokenizer "
+                    "manager."
+                )
+                req.set_finish_with_abort("Multimodal inputs not supported")
+                self.init_req_max_new_tokens(req)
+                self._add_request_to_queue(req)
+                return
+
             image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs)
 
             SessionController.adjust_mm_offsets(recv_req, req, image_inputs)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -347,7 +347,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         server_args = self.server_args
 
         # Initialize tokenizer and processor
-        if self.model_config.is_multimodal:
+        if self.model_config.is_multimodal and not server_args.language_model_only:
             import_processors("sglang.srt.multimodal.processors")
             if mm_process_pkg := envs.SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE.get():
                 import_processors(mm_process_pkg, overwrite=True)
@@ -851,6 +851,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 )
 
         contains_mm_input = obj.contains_mm_input()
+
+        # Reject multimodal inputs when --language-model-only is set.
+        # The vision/audio encoders are not loaded, so multimodal processing
+        # is impossible. Return a clear error to the client.
+        if contains_mm_input and self.server_args.language_model_only:
+            raise ValueError(
+                "Multimodal inputs (images, video, audio) are not supported when "
+                "--language-model-only is set. This server only accepts text inputs. "
+                "To serve multimodal inputs, restart without --language-model-only."
+            )
+
         is_mossvl = (
             "MossVLForConditionalGeneration"
             in self.model_config.hf_config.architectures

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -326,6 +326,91 @@ def _post_load_weights(model: nn.Module) -> None:
     # `is_nextn=True`, so the loader doesn't need to know.
     if hasattr(model, "post_load_weights"):
         model.post_load_weights()
+    # Strip multimodal components after weight loading for loaders that bypass
+    # the DefaultModelLoader path (dummy, sharded state, remote, etc.).
+    if hasattr(model, "config") and getattr(
+        model.config, "language_model_only", False
+    ):
+        _strip_multimodal_components(model)
+
+
+# Known multimodal component attribute names across all model architectures.
+# When language_model_only=True, these are set to None after model construction
+# to free GPU memory consumed by vision/audio encoders and their projectors.
+_MM_COMPONENT_NAMES: set[str] = {
+    # Vision encoders
+    "vision_tower",
+    "vision_model",
+    "vision_encoder",
+    "visual",
+    # Vision projectors / adapters
+    "multi_modal_projector",
+    "mm_projector",
+    "vision_language_adapter",
+    "pre_mm_projector_norm",
+    "patch_merger",
+    # MiniCPM-V
+    "vpm",
+    # Audio encoders
+    "audio_tower",
+    "audio_encoder",
+    "audio_model",
+}
+
+
+def _strip_multimodal_components(model: nn.Module) -> None:
+    """Set known multimodal encoder/projector attributes to None.
+
+    After this call, PyTorch will no longer track their parameters as part of
+    the model, GPU memory is freed, and the language model forward path
+    proceeds unimpeded as long as no multimodal inputs are received (which are
+    rejected at the server level).
+    """
+    for attr_name in sorted(_MM_COMPONENT_NAMES):
+        if hasattr(model, attr_name):
+            component = getattr(model, attr_name)
+            if not isinstance(component, nn.Module):
+                continue
+            try:
+                component.cpu()
+            except Exception:
+                pass  # some modules may not support .cpu()
+            setattr(model, attr_name, None)
+            logger.info(
+                "Stripped multimodal component %r from model (language-model-only mode).",
+                attr_name,
+            )
+
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+
+# Weight name prefixes that identify multimodal encoder/projector parameters.
+# When language_model_only=True, weights matching any of these are skipped
+# during loading to save GPU memory and bandwidth.
+_MM_WEIGHT_PREFIXES: tuple[str, ...] = (
+    "vision_tower.",
+    "vision_model.",
+    "vision_encoder.",
+    "visual.",
+    "multi_modal_projector.",
+    "mm_projector.",
+    "vision_language_adapter.",
+    "pre_mm_projector_norm.",
+    "patch_merger.",
+    "vpm.",
+    "audio_tower.",
+    "audio_encoder.",
+    "audio_model.",
+    # Some models (InternVL, Llava, Qwen) prefix with "model."
+    "model.vision_tower.",
+    "model.vision_model.",
+    "model.vision_encoder.",
+    "model.visual.",
+    "model.mm_projector.",
+    "model.multi_modal_projector.",
+)
 
 
 class BaseModelLoader(ABC):
@@ -668,6 +753,21 @@ class DefaultModelLoader(BaseModelLoader):
                 new_name = name
             yield (prefix + new_name, tensor)
 
+    @staticmethod
+    def _filter_mm_weights(
+        weights_iter: Generator[Tuple[str, torch.Tensor], None, None],
+    ) -> Generator[Tuple[str, torch.Tensor], None, None]:
+        """Filter out multimodal encoder/projector weights from the iterator.
+
+        When language_model_only is set, weights belonging to vision/audio
+        encoders or their projectors are skipped, saving GPU memory and
+        avoiding unused parameter loading.
+        """
+        for name, tensor in weights_iter:
+            if name.startswith(_MM_WEIGHT_PREFIXES):
+                continue
+            yield name, tensor
+
     def _get_all_weights(
         self,
         model_config: ModelConfig,
@@ -675,13 +775,20 @@ class DefaultModelLoader(BaseModelLoader):
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
 
         primary_weights = DefaultModelLoader.Source.init_new(model_config, model)
-        yield from self._get_weights_iterator(primary_weights)
+        weights_iter = self._get_weights_iterator(primary_weights)
+
+        if getattr(model_config.hf_config, "language_model_only", False):
+            weights_iter = self._filter_mm_weights(weights_iter)
+        yield from weights_iter
 
         secondary_weights = cast(
             Iterable[DefaultModelLoader.Source], getattr(model, "secondary_weights", ())
         )
         for source in secondary_weights:
-            yield from self._get_weights_iterator(source)
+            s_iter = self._get_weights_iterator(source)
+            if getattr(model_config.hf_config, "language_model_only", False):
+                s_iter = self._filter_mm_weights(s_iter)
+            yield from s_iter
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(
@@ -790,6 +897,12 @@ class DefaultModelLoader(BaseModelLoader):
                     self.load_config,
                     quant_config,
                 )
+
+            # Strip multimodal components (vision/audio encoders, projectors)
+            # before loading weights, so their GPU memory is freed early and
+            # their weights are never loaded.
+            if getattr(model_config.hf_config, "language_model_only", False):
+                _strip_multimodal_components(model)
 
             self.load_weights_and_postprocess(
                 model, self._get_all_weights(model_config, model), target_device

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -328,9 +328,7 @@ def _post_load_weights(model: nn.Module) -> None:
         model.post_load_weights()
     # Strip multimodal components after weight loading for loaders that bypass
     # the DefaultModelLoader path (dummy, sharded state, remote, etc.).
-    if hasattr(model, "config") and getattr(
-        model.config, "language_model_only", False
-    ):
+    if hasattr(model, "config") and getattr(model.config, "language_model_only", False):
         _strip_multimodal_components(model)
 
 

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -847,7 +847,9 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
                     continue
                 # Skip loading visual/language model weights
                 if (
-                    self.config.encoder_only or self.config.language_only
+                    self.config.encoder_only
+                    or self.config.language_only
+                    or getattr(self.config, "language_model_only", False)
                 ) and name not in params_dict:
                     continue
                 param = params_dict[name]

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1250,6 +1250,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             self.config = config.text_config  # for qwen3-omni / qwen3-vl-moe
             self.config.encoder_only = getattr(config, "encoder_only", False)
             self.config.language_only = getattr(config, "language_only", False)
+            self.config.language_model_only = getattr(
+                config, "language_model_only", False
+            )
             # Propagate tie_word_embeddings from parent config. In transformers
             # v5.5.3+, Qwen3VLMoeTextConfig sets tie_word_embeddings=True by
             # default but the actual model checkpoint has a separate lm_head.
@@ -1500,7 +1503,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                     continue
                 # Skip loading visual/language model weights
                 if (
-                    self.config.encoder_only or self.config.language_only
+                    self.config.encoder_only
+                    or self.config.language_only
+                    or getattr(self.config, "language_model_only", False)
                 ) and name not in params_dict:
                     continue
                 param = params_dict[name]

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -354,7 +354,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
                     # Skip loading mm/language parameters
                     if (
-                        self.config.encoder_only or self.config.language_only
+                        self.config.encoder_only
+                        or self.config.language_only
+                        or getattr(self.config, "language_model_only", False)
                     ) and name not in params_dict:
                         continue
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5974,9 +5974,24 @@ class ServerArgs:
                     "--language-model-only cannot be combined with "
                     "--mm-enable-dp-encoder"
                 )
-            # Skip the encoder disaggregation validation (architecture whitelist,
-            # IB device checks, etc.) -- language-model-only works with any
-            # multimodal model and does not need encoder infrastructure.
+            # Validate model architecture. Currently only Qwen2-VL and Qwen3-VL
+            # family models are supported for --language-model-only.
+            hf_config = self.get_model_config().hf_config
+            model_arch = hf_config.architectures[0]
+            if model_arch not in [
+                "Qwen2VLForConditionalGeneration",
+                "Qwen2_5_VLForConditionalGeneration",
+                "Qwen3VLForConditionalGeneration",
+                "Qwen3VLMoeForConditionalGeneration",
+                "Qwen3_5ForConditionalGeneration",
+                "Qwen3_5MoeForConditionalGeneration",
+            ]:
+                raise ValueError(
+                    f"Model architecture {model_arch} is not currently supported "
+                    f"for --language-model-only. Supported architectures: "
+                    f"Qwen2VL, Qwen2_5_VL, Qwen3VL, Qwen3VLMoe, Qwen3_5, "
+                    f"Qwen3_5Moe."
+                )
             return
 
         if self.encoder_only and self.language_only:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3922,7 +3922,11 @@ class ServerArgs:
             # Multimodal models need more memory for the image processing,
             # so we adjust the mem_fraction_static accordingly.
             model_config = self.get_model_config()
-            if model_config.is_multimodal and not self.language_only and not self.language_model_only:
+            if (
+                model_config.is_multimodal
+                and not self.language_only
+                and not self.language_model_only
+            ):
                 self.adjust_mem_fraction_for_vlm(model_config)
 
         # If symm mem is enabled and prealloc size is not set, set it to 4GB

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2753,6 +2753,11 @@ class ServerArgs:
         "Enable Multi-Item Scoring optimization. Combines query and multiple items into a single sequence for efficient batch processing. Requires --attention-backend flashinfer; auto-disables CUDA graph, radix cache, and chunked prefill.",
     ] = False
 
+    language_model_only: A[
+        bool,
+        "Enable strip multimodal vision/audio encoders and load only the language backbone..",
+    ] = False
+
     # -------------------------------------------------------------------------
     # Custom hooks, probe, and plugins
     # -------------------------------------------------------------------------
@@ -3917,7 +3922,7 @@ class ServerArgs:
             # Multimodal models need more memory for the image processing,
             # so we adjust the mem_fraction_static accordingly.
             model_config = self.get_model_config()
-            if model_config.is_multimodal and not self.language_only:
+            if model_config.is_multimodal and not self.language_only and not self.language_model_only:
                 self.adjust_mem_fraction_for_vlm(model_config)
 
         # If symm mem is enabled and prealloc size is not set, set it to 4GB
@@ -5936,6 +5941,44 @@ class ServerArgs:
             raise ValueError(
                 "--enable-prefix-mm-cache requires --encoder-only to be enabled"
             )
+
+        # --language-model-only is a standalone mode that strips multimodal
+        # components without EPD disaggregation. It is incompatible with
+        # encoder-related flags.
+        if self.language_model_only:
+            if self.encoder_only:
+                raise ValueError(
+                    "--language-model-only cannot be combined with --encoder-only"
+                )
+            if self.language_only:
+                raise ValueError(
+                    "--language-model-only cannot be combined with --language-only"
+                )
+            if self.disaggregation_mode != "null":
+                raise ValueError(
+                    "--language-model-only is incompatible with "
+                    "--disaggregation-mode prefill/decode"
+                )
+            if self.enable_prefix_mm_cache:
+                raise ValueError(
+                    "--language-model-only cannot be combined with "
+                    "--enable-prefix-mm-cache"
+                )
+            if self.enable_broadcast_mm_inputs_process:
+                raise ValueError(
+                    "--language-model-only cannot be combined with "
+                    "--enable-broadcast-mm-inputs-process"
+                )
+            if self.mm_enable_dp_encoder:
+                raise ValueError(
+                    "--language-model-only cannot be combined with "
+                    "--mm-enable-dp-encoder"
+                )
+            # Skip the encoder disaggregation validation (architecture whitelist,
+            # IB device checks, etc.) -- language-model-only works with any
+            # multimodal model and does not need encoder infrastructure.
+            return
+
         if self.encoder_only and self.language_only:
             raise ValueError("Cannot set --encoder-only and --language-only together")
         if self.encoder_only and not self.disaggregation_mode == "null":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1481,5 +1481,173 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestLanguageModelOnlyArgs(CustomTestCase):
+    """Tests for --language-model-only flag validation."""
+
+    @staticmethod
+    def _mock_model_config(architectures: list[str]):
+        """Create a mock ModelConfig with the given architectures."""
+        mock_config = MagicMock()
+        mock_config.hf_config = SimpleNamespace(architectures=architectures)
+        return mock_config
+
+    def _make_server_args(self, **kwargs) -> ServerArgs:
+        """Create ServerArgs with a model path that avoids the dummy short-circuit."""
+        return ServerArgs(
+            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN, **kwargs
+        )
+
+    # --- Mutual exclusion with encoder-related flags ---
+
+    def test_language_model_only_rejects_encoder_only(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(language_model_only=True, encoder_only=True)
+        self.assertIn("cannot be combined with --encoder-only", str(ctx.exception))
+
+    def test_language_model_only_rejects_language_only(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(language_model_only=True, language_only=True)
+        self.assertIn("cannot be combined with --language-only", str(ctx.exception))
+
+    def test_language_model_only_rejects_prefill_disaggregation(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(
+                language_model_only=True, disaggregation_mode="prefill"
+            )
+        self.assertIn("incompatible with --disaggregation-mode", str(ctx.exception))
+
+    def test_language_model_only_rejects_decode_disaggregation(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(
+                language_model_only=True, disaggregation_mode="decode"
+            )
+        self.assertIn("incompatible with --disaggregation-mode", str(ctx.exception))
+
+    def test_language_model_only_rejects_enable_prefix_mm_cache(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(
+                language_model_only=True, enable_prefix_mm_cache=True
+            )
+        self.assertIn(
+            "cannot be combined with --enable-prefix-mm-cache", str(ctx.exception)
+        )
+
+    def test_language_model_only_rejects_enable_broadcast_mm_inputs_process(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(
+                language_model_only=True, enable_broadcast_mm_inputs_process=True
+            )
+        self.assertIn(
+            "cannot be combined with --enable-broadcast-mm-inputs-process",
+            str(ctx.exception),
+        )
+
+    def test_language_model_only_rejects_mm_enable_dp_encoder(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(
+                language_model_only=True, mm_enable_dp_encoder=True
+            )
+        self.assertIn(
+            "cannot be combined with --mm-enable-dp-encoder", str(ctx.exception)
+        )
+
+    # --- Architecture whitelist validation ---
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_rejects_non_vlm_architecture(
+        self, mock_get_config
+    ):
+        """A text-only model (Qwen2ForCausalLM) should be rejected."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["Qwen2ForCausalLM"]
+        )
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(language_model_only=True)
+        self.assertIn("not currently supported", str(ctx.exception))
+        self.assertIn("Qwen2ForCausalLM", str(ctx.exception))
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_rejects_llava_architecture(
+        self, mock_get_config
+    ):
+        """Llava models are not yet in the whitelist."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["LlavaForConditionalGeneration"]
+        )
+        with self.assertRaises(ValueError) as ctx:
+            self._make_server_args(language_model_only=True)
+        self.assertIn("not currently supported", str(ctx.exception))
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_accepts_qwen2_vl(self, mock_get_config):
+        """Qwen2-VL family should be accepted."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["Qwen2VLForConditionalGeneration"]
+        )
+        args = self._make_server_args(language_model_only=True)
+        self.assertTrue(args.language_model_only)
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_accepts_qwen2_5_vl(self, mock_get_config):
+        """Qwen2.5-VL should be accepted."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["Qwen2_5_VLForConditionalGeneration"]
+        )
+        args = self._make_server_args(language_model_only=True)
+        self.assertTrue(args.language_model_only)
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_accepts_qwen3_vl(self, mock_get_config):
+        """Qwen3-VL should be accepted."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["Qwen3VLForConditionalGeneration"]
+        )
+        args = self._make_server_args(language_model_only=True)
+        self.assertTrue(args.language_model_only)
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_accepts_qwen3_vl_moe(self, mock_get_config):
+        """Qwen3-VL-MoE should be accepted."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["Qwen3VLMoeForConditionalGeneration"]
+        )
+        args = self._make_server_args(language_model_only=True)
+        self.assertTrue(args.language_model_only)
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_accepts_qwen3_5(self, mock_get_config):
+        """Qwen3.5 should be accepted."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["Qwen3_5ForConditionalGeneration"]
+        )
+        args = self._make_server_args(language_model_only=True)
+        self.assertTrue(args.language_model_only)
+
+    @patch.object(ServerArgs, "get_model_config")
+    def test_language_model_only_accepts_qwen3_5_moe(self, mock_get_config):
+        """Qwen3.5-MoE should be accepted."""
+        mock_get_config.return_value = self._mock_model_config(
+            ["Qwen3_5MoeForConditionalGeneration"]
+        )
+        args = self._make_server_args(language_model_only=True)
+        self.assertTrue(args.language_model_only)
+
+    # --- Flag defaults ---
+
+    def test_language_model_only_defaults_to_false(self):
+        args = ServerArgs(model_path="dummy")
+        self.assertFalse(args.language_model_only)
+
+    def test_language_model_only_memory_adjustment_skipped(self):
+        """VLM memory adjustment should be skipped for language_model_only."""
+        args = ServerArgs(model_path="dummy", language_model_only=True)
+        self.assertTrue(args.language_model_only)
+        # When language_model_only=False (default), this wouldn't adjust anyway
+        # for dummy models. The real test is server_args.py line 1797 which
+        # guards with: not self.language_model_only
+        args2 = ServerArgs(model_path="dummy")
+        self.assertFalse(args2.language_model_only)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Feature for https://github.com/sgl-project/sglang/issues/28194.
This PR adds a new `--language-model-only` CLI flag that strips the multimodal vision/audio encoder from VLM models and serves them as text-only language models. This frees significant GPU memory that can be used for additional KV cache.

When deploying VLMs (e.g., Qwen2.5-VL, Qwen3-VL) for text-only use cases, SGLang still loads the full vision encoder, consuming GPU memory unnecessarily. vLLM has a similar `--language-model-only` option (reference: [vllm-project/vllm#22299](https://github.com/vllm-project/vllm/pull/22299)).

## Modifications

- loader.py: _strip_multimodal_components() removes vision/audio component attributes after model init; _filter_mm_weights() skips vision/audio weight names during loading
- tokenizer_manager.py: Skips multimodal processor initialization; rejects multimodal inputs upstream
- scheduler.py: Skips _mm_processor loading for M-RoPE fallback; defensive check for unexpected MM inputs

Qwen family models:
- qwen3_vl.py: Explicit language_model_only check in load_weights weight-skip logic; config propagation in MoE branch
- qwen2_5_vl.py: Same load_weights weight-skip logic
- qwen3_vl_moe.py: Same load_weights weight-skip logic

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29241339303](https://github.com/sgl-project/sglang/actions/runs/29241339303)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29241339082](https://github.com/sgl-project/sglang/actions/runs/29241339082)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->