### PR TITLE
[Spec] Add NGRAM hidden_states regression test (stacked on #28496)

### DIFF
--- a/test/registered/spec/test_spec_ngram_hidden_states.py
+++ b/test/registered/spec/test_spec_ngram_hidden_states.py
@@ -1,0 +1,55 @@
+"""Regression test for NGRAM speculative decoding + return_hidden_states (issue #26163).
+
+Complements the EAGLE coverage in test/registered/spec/eagle/. NGRAM is corpus-based
+and lands long verbatim n-gram matches, so it lights up high-accept-rate verify
+windows that exercise the strided spec-V2 hidden_states slicing.
+"""
+
+import unittest
+
+import sglang as sgl
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    CustomTestCase,
+)
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestNgramReturnHiddenStates(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = sgl.Engine(
+            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            enable_return_hidden_states=True,
+            speculative_algorithm="NGRAM",
+            speculative_num_draft_tokens=16,
+            mem_fraction_static=0.7,
+            cuda_graph_max_bs_decode=8,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "engine") and cls.engine is not None:
+            cls.engine.shutdown()
+
+    def test_ngram_with_return_hidden_states(self):
+        prompts = [
+            "Repeat the phrase the quick brown fox five times: the quick brown fox",
+            "Eeny meeny miny moe, eeny meeny miny moe, eeny meeny miny moe",
+        ]
+        outputs = self.engine.generate(
+            prompts,
+            sampling_params={"temperature": 0, "max_new_tokens": 32},
+            return_hidden_states=True,
+        )
+
+        for out in outputs:
+            hs = out["meta_info"]["hidden_states"]
+            self.assertEqual(len(hs), out["meta_info"]["completion_tokens"])
+            self.assertGreater(len(hs[0]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on top of #28496. Salvages the regression test from #26150 onto current main.

## Why most of #26150 is no longer needed

#26150 had three pieces. Two became dead code with the V1 deprecation + spec rework:

- **`ngram_info.py` truthiness fix (`if logits_output.hidden_states:` → `is not None`)** — `_fill_requests` no longer exists. NGRAM was migrated to \`EagleDraftInputV2Mixin\` and the V1-era boolean-tensor crash (#26131) can't happen on this path anymore.
- **`batch_result_processor.py` NGRAM-V1 branch** — the V1 decode path is gone. The V2 hidden_states slicing fix on the parent PR (#28496) handles NGRAM uniformly via the \`not spec_algorithm.is_none()\` arm.

The remaining piece is the **regression test**, which exercises NGRAM + \`return_hidden_states=True\` end to end and asserts the issue #26163 invariant.

## Changes vs #26150's original test

- `cuda_graph_max_bs` → `cuda_graph_max_bs_decode` (`ServerArgs` rename).
- Defensive `tearDownClass` (skill-prescribed: guard against `setUpClass` partial-init).
- Docstring rewritten — issue #26131 / `_fill_requests` references are stale.

## Test plan

- [x] `python test/registered/spec/test_spec_ngram_hidden_states.py` → `OK` (~34s on H200, Llama-3.2-1B + NGRAM).
- [x] Asserts `len(meta_info["hidden_states"]) == completion_tokens` per req with corpus-favorable prompts that land long NGRAM accept streaks.
- [ ] CI: `register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")` — same suite as `test_hidden_states.py`.

Closes #26150 in spirit (NGRAM hidden_states coverage now lives on top of the proper V2 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27671632697](https://github.com/sgl-project/sglang/actions/runs/27671632697)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27671632299](https://github.com/sgl-project/sglang/actions/runs/27671632299)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->