### PR TITLE
fix(multimodal_gen): disable proxy env in warmup health probe (#28493)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -61,7 +61,11 @@ SERVER_WARMUP_BYPASS_PATHS = (
 async def _wait_until_http_ready(server_args: ServerArgs) -> None:
     """for server warmup"""
     health_url = f"{server_args.url()}/health"
-    async with httpx.AsyncClient() as client:
+    # Probe the local server directly: a loopback readiness check must never be
+    # routed through an HTTP proxy. trust_env=False also avoids crashing startup
+    # on a malformed proxy env var, since httpx parses *_PROXY/NO_PROXY when the
+    # client is constructed (raising httpx.InvalidURL before any request). See #28493.
+    async with httpx.AsyncClient(trust_env=False) as client:
         for _ in range(120):
             try:
                 response = await client.get(health_url, timeout=5.0)


### PR DESCRIPTION
## Summary

Fixes #28493 — the `multimodal_gen` (diffusion) server crashes during warmup with:

```
Server warmup failed; aborting startup: Invalid port: ':'
httpx.InvalidURL: Invalid port: ':'
```

## Root cause

The warmup readiness probe in `_wait_until_http_ready()` builds the client as:

```python
async with httpx.AsyncClient() as client:
```

`httpx.AsyncClient()` defaults to `trust_env=True`, so httpx reads `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY` from the environment and turns them into proxy `mounts` **at client construction time** (`_client.py` → `URLPattern(...)`). When one of those env vars is malformed, httpx raises `httpx.InvalidURL` *before any request is sent* — which is why the traceback in the issue terminates inside `httpx.AsyncClient.__init__`, not inside `.get()`. This warmup path was added in #26247, which is why the failure is a regression in `v0.5.13`.

## Fix

Construct the warmup client with `trust_env=False`:

```python
async with httpx.AsyncClient(trust_env=False) as client:
```

This is correct independent of the crash: `_wait_until_http_ready()` polls the server's *own* loopback `/health` endpoint, and a local readiness probe should never be routed through an HTTP proxy. Disabling `trust_env` both bypasses the proxy for the loopback check and prevents a malformed ambient proxy env var from aborting startup.

Scope is limited to the warmup health-probe client; request-handling clients are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27672357180](https://github.com/sgl-project/sglang/actions/runs/27672357180)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27672356923](https://github.com/sgl-project/sglang/actions/runs/27672356923)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->