### PR TITLE
Skip empty non-idle output batches

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -157,7 +157,6 @@ class SchedulerOutputStreamer:
         payload = acc.to_payload(
             dp_rank=self.ps.dp_rank,
             is_idle_batch=is_idle_batch,
-            has_reqs=bool(reqs),
         )
         if payload is not None:
             self.send_to_detokenizer.send_output(payload)
@@ -498,9 +497,9 @@ class _GenerationStreamAccumulator:
                 self.customized_info[k].append(v[send_token_offset : len(output_ids_)])
 
     def to_payload(
-        self, *, dp_rank: int, is_idle_batch: bool, has_reqs: bool
+        self, *, dp_rank: int, is_idle_batch: bool
     ) -> Optional[BatchTokenIDOutput]:
-        if not (has_reqs or is_idle_batch):
+        if not (self.rids or is_idle_batch):
             return None
         dp_ranks = [dp_rank] * len(self.rids) if self.rids else None
         return BatchTokenIDOutput(


### PR DESCRIPTION
## Summary
- Avoid emitting `BatchTokenIDOutput` when generation output accumulation is empty and the batch is not an idle batch.
- Preserve idle empty batches so idle signaling behavior stays unchanged.

## Motivation
With `stream_interval > 1`, output streaming is still invoked every decode step. On steps where no request reaches its output interval, the previous `has_reqs` gate still emitted an empty `BatchTokenIDOutput(rids=[])`, adding scheduler-to-detokenizer/tokenizer work on the decode hot path.

## Validation
Passed:
- 12P/32D GLM-5-FP4 disaggregated serving run with SA-Bench random ISL/OSL 1024/1024 and `stream_interval=60`.
- `python3 -m compileall -q python/sglang/srt/managers/scheduler_components/output_streamer.py`
- `uvx ruff check --select F401,F821 python/sglang/srt/managers/scheduler_components/output_streamer.py`













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28077379710](https://github.com/sgl-project/sglang/actions/runs/28077379710)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28077379572](https://github.com/sgl-project/sglang/actions/runs/28077379572)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
