### PR TITLE
[bugfix] V2 MTP bug in deepseek

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1743,7 +1743,7 @@ class DeepseekV2AttentionMLA(
             attention_backend = get_global_server_args().decode_attention_backend
         elif (
             forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
+            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
         ):
             # Use the specified backend for speculative operations (both verify and draft extend)
             if get_global_server_args().speculative_attention_mode == "decode":


### PR DESCRIPTION
## Motivation

Fix DeepSeek MTP/EAGLE SpecV2 launch failures when speculative decode uses the decode attention backend, e.g. `--speculative-attention-mode decode` with `--decode-attention-backend trtllm_mla`.

In SpecV2, draft extension uses `ForwardMode.DRAFT_EXTEND_V2`. The DeepSeek attention dispatch path only checked `is_draft_extend()` without including V2, so `DRAFT_EXTEND_V2` was not treated as speculative draft extension. This could make the model select the prefill/MHA preparation path while the actual draft-extend attention backend was initialized from the decode backend.

For DeepSeek MLA + `trtllm_mla`, this produced a query/cache layout mismatch and failed during CUDA graph capture with:

```text
ValueError: Expected head dim 576 for query and kv_cache, got 192 and 576
```

## Modifications

Update DeepSeek attention backend dispatch to recognize `DRAFT_EXTEND_V2` as draft extension:

```python
forward_batch.forward_mode.is_draft_extend(include_v2=True)
```

This keeps SpecV2 draft-extend dispatch consistent with the selected speculative attention mode and allows the MLA path to prepare the query layout expected by `trtllm_mla`.

## Accuracy Tests

Manual test on a DeepSeek-V3-style MTP checkpoint with a valid nextn/MTP layer.

Before this change, launching with SpecV2 and:

```bash
--speculative-algorithm EAGLE
--speculative-attention-mode decode
--decode-attention-backend trtllm_mla
```

failed during CUDA graph capture with the `Expected head dim 576 ... got 192` error.

After this change, the server launches successfully and speculative decoding runs normally. Acceptance metrics were validated using a checkpoint that includes the MTP layer.

## Speed Tests and Profiling

No formal speed benchmark was run for this patch.

The change only fixes dispatch classification for `DRAFT_EXTEND_V2`; it should not affect non-SpecV2 paths or model outputs. It enables the intended `trtllm_mla` speculative decode path instead of failing at startup.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27674735481](https://github.com/sgl-project/sglang/actions/runs/27674735481)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27674734910](https://github.com/sgl-project/sglang/actions/runs/27674734910)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->