### PR TITLE
Fix DSA topk propagation across PP stages

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -741,7 +741,7 @@ def build_decode_registry(
             def _pp_source(key):
                 def _fn(_fb, ctx):
                     ppx = ctx.pp_proxy_tensors
-                    return None if ppx is None else ppx.tensors[key]
+                    return None if ppx is None else ppx.tensors.get(key)
 
                 return _fn
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -61,7 +61,9 @@ from sglang.srt.configs.model_config import (
     AttentionArch,
     ModelConfig,
     ModelImpl,
+    get_dsa_index_topk,
     get_num_indexer_layers,
+    is_deepseek_dsa,
 )
 from sglang.srt.configs.update_config import adjust_config_with_unaligned_cpu_tp
 from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
@@ -2744,6 +2746,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             cache_loc_dtype=torch.int64,
             enable_mamba_track=False,
             hc_hidden_size=getattr(self.model_config, "hc_hidden_size", None),
+            pp_proxy_topk=(
+                get_dsa_index_topk(self.model_config.hf_config)
+                if self.server_args.pp_size > 1
+                and is_deepseek_dsa(self.model_config.hf_config)
+                else None
+            ),
         )
         buffers.num_token_non_padded[...] = num_tokens
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -37,6 +37,7 @@ from torch.profiler import ProfilerActivity, profile
 
 from sglang.srt.compilation import torch_compile_decoration
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
+from sglang.srt.configs.model_config import get_dsa_index_topk, is_deepseek_dsa
 from sglang.srt.distributed import get_tensor_model_parallel_rank
 from sglang.srt.distributed.parallel_state import (
     graph_capture,
@@ -179,6 +180,7 @@ def _allocate_decode_buffers(
     enable_mamba_track: bool,
     ne_token_table: Optional[torch.Tensor] = None,
     hc_hidden_size: Optional[int] = None,
+    pp_proxy_topk: Optional[int] = None,
 ) -> SimpleNamespace:
     """Allocate the FB-shared decode buffers as a namespace adopted by
     ``build_decode_registry(source=...)``."""
@@ -216,6 +218,10 @@ def _allocate_decode_buffers(
             if not is_mhc:
                 pp_proxy_tensors["residual"] = torch.zeros(
                     (max_bs, hidden_size), dtype=dtype
+                )
+            if pp_proxy_topk is not None:
+                pp_proxy_tensors["topk_indices"] = torch.zeros(
+                    (max_bs, pp_proxy_topk), dtype=torch.int32
                 )
         else:
             pp_proxy_tensors = None
@@ -446,6 +452,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             ),
             hc_hidden_size=getattr(
                 self.model_runner.model_config, "hc_hidden_size", None
+            ),
+            pp_proxy_topk=(
+                get_dsa_index_topk(self.model_runner.model_config.hf_config)
+                if self.pp_size > 1
+                and is_deepseek_dsa(self.model_runner.model_config.hf_config)
+                else None
             ),
         )
         self.buffers.share_buffers()

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -107,6 +107,7 @@ class DecodeInputBuffers(ForwardInputBuffers):
         ne_token_table: Optional[torch.Tensor] = None,
         is_hybrid_swa: bool = False,
         hc_hidden_size: Optional[int] = None,
+        pp_proxy_topk: Optional[int] = None,
     ) -> DecodeInputBuffers:
         with torch.device(device):
             input_ids = torch.zeros((max_num_token,), dtype=torch.int64)
@@ -148,6 +149,10 @@ class DecodeInputBuffers(ForwardInputBuffers):
                 if not is_mhc:
                     pp_proxy_tensors["residual"] = torch.zeros(
                         (max_bs, hidden_size), dtype=dtype
+                    )
+                if pp_proxy_topk is not None:
+                    pp_proxy_tensors["topk_indices"] = torch.zeros(
+                        (max_bs, pp_proxy_topk), dtype=torch.int32
                     )
             else:
                 pp_proxy_tensors = None
@@ -316,7 +321,9 @@ class DecodeInputBuffers(ForwardInputBuffers):
         # Pipeline-parallel proxy tensors.
         if pp_proxy_tensors is not None and self.pp_proxy_tensors is not None:
             for key, buf in self.pp_proxy_tensors.items():
-                src = pp_proxy_tensors.tensors[key]
+                src = pp_proxy_tensors.tensors.get(key)
+                if src is None:
+                    continue
                 dim = src.shape[0]
                 dsts.append(buf[:dim])
                 srcs.append(src)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2422,6 +2422,11 @@ class DeepseekV2Model(nn.Module):
             assert pp_proxy_tensors is not None
             hidden_states = pp_proxy_tensors["hidden_states"]
             residual = pp_proxy_tensors["residual"]
+        prev_topk_indices = (
+            None
+            if pp_proxy_tensors is None
+            else pp_proxy_tensors.tensors.get("topk_indices")
+        )
         device = hidden_states.device
         zero_allocator = BumpAllocator(
             buffer_size=total_num_layers * 2 * (2 if forward_batch.can_run_tbo else 1),
@@ -2474,7 +2479,7 @@ class DeepseekV2Model(nn.Module):
             elif self.first_k_dense_replace < normal_start_layer:
                 normal_end_layer = normal_start_layer = 0
         aux_hidden_states = []
-        topk_indices = None
+        topk_indices = prev_topk_indices
         for i in range(normal_start_layer, normal_end_layer):
             # NOTE: torch dynamo does not support graph break in context manager
             ctx = (
@@ -2518,12 +2523,13 @@ class DeepseekV2Model(nn.Module):
             )
 
         if not self.pp_group.is_last_rank:
-            return PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
+            proxy_tensors = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if topk_indices is not None:
+                proxy_tensors["topk_indices"] = topk_indices
+            return PPProxyTensors(proxy_tensors)
         else:
             if not forward_batch.forward_mode.is_idle():
                 if residual is None:


### PR DESCRIPTION
  ## Motivation

  DSA models with shared indexer layers can reuse `topk_indices` from earlier full-indexer layers. When pipeline parallelism splits the model before a shared-indexer
  layer, the downstream PP stage needs the `topk_indices` produced by the previous stage.

  The previous PP proxy path only propagated `hidden_states` and `residual`. As a result, DSA attention could receive missing `topk_indices`, causing failures in PP +
  CUDA graph execution, such as `NoneType` errors or `KeyError: 'topk_indices'`.

  ## Modifications

  This PR fixes DSA `topk_indices` propagation across pipeline-parallel stages.

  Changes include:

  - Propagate `topk_indices` through `PPProxyTensors` in `DeepseekV2Model`.
  - Initialize downstream PP stages with incoming `topk_indices` when present.
  - Allocate `topk_indices` PP proxy buffers for DSA models during decode CUDA graph capture/replay.
  - Make CUDA graph PP proxy buffer filling tolerate optional/missing proxy keys, because not every PP boundary necessarily carries `topk_indices`.
  ## Speed Tests and Profiling

  GLM5.2 4pp*4tp compare with TP16 in H100*16
<img width="1342" height="992" alt="2beda43c-f4d3-4c81-bb36-99d8cd7589a0" src="https://github.com/user-attachments/assets/c9f0dcd0-8066-44de-b69d-753ba0d98b93" />




  The change adds one optional PP proxy tensor for DSA models under PP. It should not affect non-DSA models or non-PP execution paths. The runtime overhead is expected
  to be minimal because it reuses the existing PP proxy/CUDA graph buffer mechanism.

  ## Accuracy Tests

  This change only forwards existing DSA `topk_indices` across PP stage boundaries. It does not change the topk computation itself or model math.

  Local validation:

  ```bash
  python3 -m py_compile \
    python/sglang/srt/models/deepseek_v2.py \
    python/sglang/srt/model_executor/runner_utils/buffers.py \
    python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py \
    python/sglang/srt/model_executor/model_runner.py \
    python/sglang/srt/model_executor/cuda_graph_buffer_registry.py

  The fix was validated against the reported PP + CUDA graph failure patte​​rn on a DSA model with shared indexer layers.



  ## Checklist

  - [x] Format your code according to the Format code with pre-commit (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the Run and add unit tests (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [x] Update documentation according to Write documentations (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to Test the accuracy (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)
    and Benchmark the speed (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).

  - [x] Follow the SGLang code style guidance (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27675012410](https://github.com/sgl-project/sglang/actions/runs/27675012410)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27675012328](https://github.com/sgl-project/sglang/actions/runs/27675012328)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->