### PR TITLE
Fix ScheduleBatch req pool CPU metadata

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2575,6 +2575,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
         bs = len(self.reqs)
+        if self.req_pool_indices_cpu is None and self.req_pool_indices is not None:
+            self.req_pool_indices_cpu = (
+                self.req_pool_indices.detach().cpu().to(dtype=torch.int64)
+            )
         # Decode embeds the last output token via embed_tokens; clear the stale
         # prefill-time tensor so it doesn't leak into ForwardBatch.
         self.input_embeds = None
@@ -2687,6 +2691,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if keep_indices is None or len(keep_indices) == 0:
             # Filter out all requests
             self.reqs = []
+            self.req_pool_indices = torch.empty(
+                0, dtype=torch.int64, device=self.device
+            )
+            self.req_pool_indices_cpu = torch.empty(0, dtype=torch.int64)
+            self.seq_lens = torch.empty(0, dtype=torch.int64, device=self.device)
+            self.seq_lens_cpu = torch.empty(0, dtype=torch.int64)
+            self.orig_seq_lens = torch.empty(0, dtype=torch.int32, device=self.device)
+            self.out_cache_loc = None
+            self.seq_lens_sum = 0
             return
 
         if len(keep_indices) == len(self.reqs):
@@ -2744,6 +2757,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
     def merge_batch(self, other: ScheduleBatch):
+        if self.req_pool_indices_cpu is None and self.req_pool_indices is not None:
+            self.req_pool_indices_cpu = (
+                self.req_pool_indices.detach().cpu().to(dtype=torch.int64)
+            )
+        if other.req_pool_indices_cpu is None and other.req_pool_indices is not None:
+            other.req_pool_indices_cpu = (
+                other.req_pool_indices.detach().cpu().to(dtype=torch.int64)
+            )
+
         # Penalizer orchestrator must be merged before Batch.reqs is merged. This is because
         # orchestrator.merge() depends on Batch.reqs during preparation of each penalizers, so it
         # needs to be called with pre-merged Batch.reqs.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2438,9 +2438,11 @@ class Scheduler(
             spec_algorithm=self.spec_algorithm,
         )
 
+        req_pool_indices = [r.req_pool_idx for r in reqs]
         batch.req_pool_indices = torch.tensor(
-            [r.req_pool_idx for r in reqs], dtype=torch.int64, device=device
+            req_pool_indices, dtype=torch.int64, device=device
         )
+        batch.req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
         seq_lens = [len(r.origin_input_ids) + len(r.output_ids) - 1 for r in reqs]
         batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=device)
         batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)

--- a/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
+++ b/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
@@ -1,0 +1,121 @@
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestScheduleBatchReqPoolIndices(unittest.TestCase):
+    def test_prepare_for_decode_restores_missing_req_pool_indices_cpu(self):
+        req = types.SimpleNamespace(
+            decode_batch_idx=0,
+            kv_committed_len=10,
+            kv_allocated_len=10,
+        )
+        batch = ScheduleBatch(
+            reqs=[req],
+            model_config=types.SimpleNamespace(is_encoder_decoder=False),
+            req_pool_indices=torch.tensor([4], dtype=torch.int64),
+            req_pool_indices_cpu=None,
+            seq_lens=torch.tensor([10], dtype=torch.int64),
+            seq_lens_cpu=torch.tensor([10], dtype=torch.int64),
+            orig_seq_lens=torch.tensor([10], dtype=torch.int32),
+            seq_lens_sum=10,
+            sampling_info=types.SimpleNamespace(
+                penalizer_orchestrator=types.SimpleNamespace(is_required=False)
+            ),
+            spec_algorithm=types.SimpleNamespace(is_none=lambda: True),
+            enable_overlap=False,
+            device="cpu",
+            hisparse_coordinator=MagicMock(),
+        )
+
+        with (
+            patch(
+                "sglang.srt.managers.schedule_batch.alloc_for_decode",
+                return_value=torch.tensor([42], dtype=torch.int64),
+            ),
+            patch(
+                "sglang.srt.managers.schedule_batch.get_global_server_args",
+                return_value=types.SimpleNamespace(
+                    enable_mamba_extra_buffer=lambda: False
+                ),
+            ),
+        ):
+            batch.prepare_for_decode()
+
+        self.assertTrue(torch.equal(batch.req_pool_indices_cpu, torch.tensor([4])))
+        batch.hisparse_coordinator.map_last_loc_to_buffer.assert_called_once()
+
+    def test_filter_batch_to_empty_clears_req_pool_metadata(self):
+        req = types.SimpleNamespace(finished=lambda: True)
+        batch = ScheduleBatch(
+            reqs=[req],
+            model_config=types.SimpleNamespace(is_encoder_decoder=False),
+            req_pool_indices=torch.tensor([4], dtype=torch.int64),
+            req_pool_indices_cpu=torch.tensor([4], dtype=torch.int64),
+            seq_lens=torch.tensor([10], dtype=torch.int64),
+            seq_lens_cpu=torch.tensor([10], dtype=torch.int64),
+            orig_seq_lens=torch.tensor([10], dtype=torch.int32),
+            seq_lens_sum=10,
+            device="cpu",
+        )
+
+        batch.filter_batch()
+
+        self.assertEqual(batch.req_pool_indices.numel(), 0)
+        self.assertEqual(batch.req_pool_indices_cpu.numel(), 0)
+        self.assertEqual(batch.seq_lens.numel(), 0)
+        self.assertEqual(batch.seq_lens_cpu.numel(), 0)
+        self.assertEqual(batch.seq_lens_sum, 0)
+
+    def test_merge_batch_restores_missing_req_pool_indices_cpu(self):
+        self_batch = ScheduleBatch(
+            reqs=[object(), object()],
+            model_config=types.SimpleNamespace(is_encoder_decoder=False),
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int64),
+            req_pool_indices_cpu=None,
+            seq_lens=torch.tensor([10, 20], dtype=torch.int64),
+            seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int64),
+            orig_seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_sum=30,
+            sampling_info=MagicMock(),
+            return_logprob=False,
+            has_grammar=False,
+            return_hidden_states=False,
+            is_prefill_only=False,
+        )
+        other_batch = ScheduleBatch(
+            reqs=[object()],
+            model_config=types.SimpleNamespace(is_encoder_decoder=False),
+            req_pool_indices=torch.tensor([3], dtype=torch.int64),
+            req_pool_indices_cpu=None,
+            seq_lens=torch.tensor([30], dtype=torch.int64),
+            seq_lens_cpu=torch.tensor([30], dtype=torch.int64),
+            orig_seq_lens=torch.tensor([30], dtype=torch.int32),
+            seq_lens_sum=30,
+            sampling_info=MagicMock(),
+            return_logprob=False,
+            has_grammar=False,
+            return_hidden_states=False,
+            is_prefill_only=False,
+        )
+
+        self_batch.merge_batch(other_batch)
+
+        self.assertTrue(
+            torch.equal(self_batch.req_pool_indices_cpu, torch.tensor([1, 2, 3]))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`ScheduleBatch` keeps both device-side `req_pool_indices` and a CPU mirror `req_pool_indices_cpu`. Some scheduler and bookkeeping paths, including HiSparse decode bookkeeping, consume the CPU mirror, while forward/kernel paths use the device tensor.

However, a few batch transition paths did not keep these fields consistently updated. For example, a batch could be filtered down to empty while still keeping stale request metadata, or a batch with only `req_pool_indices` populated could later enter decode/merge paths that expect `req_pool_indices_cpu` to be present. This can lead to stale request-pool metadata being observed after filtering, or crashes when merging batches with a missing CPU mirror.

This PR fixes those narrow lifecycle gaps without changing the `ScheduleBatch` data model.

## Modifications

- Populate `req_pool_indices_cpu` when constructing a HiSparse decode `ScheduleBatch` in the scheduler.
- Restore `req_pool_indices_cpu` from `req_pool_indices` before decode if the CPU mirror is missing.
- Clear request-pool and sequence-length metadata when `filter_batch()` filters all requests out of a batch.
- Restore missing CPU mirrors before `merge_batch()` concatenates request-pool indices.
- Add regression tests for:
  - restoring missing `req_pool_indices_cpu` before decode;
  - clearing stale metadata when filtering to an empty batch;
  - merging batches when either side is missing `req_pool_indices_cpu`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27677878103](https://github.com/sgl-project/sglang/actions/runs/27677878103)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27677877286](https://github.com/sgl-project/sglang/actions/runs/27677877286)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->