### PR TITLE
Fix(sgl-kernel/rocm): enable RDNA3.5 (gfx1151) and cap TopK LDS

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1687,17 +1687,25 @@ def get_amdgpu_memory_capacity():
             shell=True,
             text=True,
         )
-        if result.returncode != 0:
-            raise RuntimeError(f"rocm-smi error: {result.stderr.strip()}")
+        # On some stacks (e.g. TheRock ROCm on Strix Halo/gfx1151) rocminfo can
+        # segfault or emit no parseable pool sizes -> fall back to torch.
+        if result.returncode != 0 or not result.stdout.strip():
+            return _cuda_mem_fallback(
+                f"rocminfo returned no memory info (rc={result.returncode})"
+            )
 
-        # Parse the output to extract memory values in MiB
-        memory_values = [
-            float(mem.split("(")[0].strip()) / 1024
-            for mem in result.stdout.strip().split("\n")
-        ]
+        # Parse the output to extract memory values in MiB. Some ROCm stacks
+        try:
+            memory_values = [
+                float(mem.split("(")[0].strip()) / 1024
+                for mem in result.stdout.strip().split("\n")
+                if mem.split("(")[0].strip()
+            ]
+        except ValueError as e:
+            return _cuda_mem_fallback(f"failed to parse rocminfo output: {e}")
 
         if not memory_values:
-            raise ValueError("No GPU memory values found.")
+            return _cuda_mem_fallback("no GPU memory values parsed from rocminfo")
 
         # Return the minimum memory value
         return min(memory_values)

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -64,31 +64,54 @@ libraries = ["hiprtc", "amdhip64", "c10", "torch", "torch_python"]
 extra_link_args = ["-Wl,-rpath,$ORIGIN/../../torch/lib", f"-L/usr/lib/{arch}-linux-gnu"]
 
 default_target = "gfx942"
-amdgpu_target = os.environ.get("AMDGPU_TARGET", default_target)
+# An explicit AMDGPU_TARGET always wins over auto-detection. This is the
+# documented escape hatch for cross-compilation and for building on
+# experimental/unsupported architectures; previously it was read here but then
+# silently overwritten by the torch.cuda detection below whenever a GPU was
+# visible, so the override never took effect on a build host with a GPU.
+explicit_target = os.environ.get("AMDGPU_TARGET")
+amdgpu_target = explicit_target or default_target
 
-if torch.cuda.is_available():
-    try:
-        amdgpu_target = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
-    except Exception as e:
-        print(f"Warning: Failed to detect GPU properties: {e}")
-else:
-    print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
+if explicit_target is None:
+    if torch.cuda.is_available():
+        try:
+            props = torch.cuda.get_device_properties(0)
+            amdgpu_target = props.gcnArchName.split(":")[0]
+        except Exception as e:
+            print(f"Warning: Failed to detect GPU properties: {e}")
+    else:
+        print(
+            f"Warning: torch.cuda not available. Using default target: {amdgpu_target}"
+        )
 
 if amdgpu_target not in ["gfx942", "gfx950"]:
     print(
         f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
     )
-    sys.exit(1)
+    # Only abort for an auto-detected architecture. If the user explicitly set
+    # AMDGPU_TARGET they have opted in to building for an unsupported arch
+    # (e.g. RDNA3 gfx1101), so honor it with a warning instead of aborting.
+    if explicit_target is None:
+        sys.exit(1)
+    print(
+        f"Warning: AMDGPU_TARGET='{explicit_target}' was set explicitly; "
+        "continuing with an unsupported architecture. This configuration is "
+        "untested upstream — use at your own risk."
+    )
 
 fp8_macro = (
     "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"
 )
 
 # Dynamic shared-memory budget for the TopK kernels.
-# - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
-#   (leaves room for static shared allocations in the kernel).
-# - gfx95x (MI350): LDS is larger (e.g. 160KB per CU) -> allow the original 128KB dynamic smem.
-topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
+# Only archs with a large LDS budget can take the 128KB path:
+# - gfx95x (MI350): LDS is large (e.g. 160KB per CU) -> allow 128KB dynamic smem.
+# Everything else (gfx942/MI300 at 64KB, and all RDNA2/RDNA3/3.5 gfx10xx/gfx11xx
+# at 64KB, plus any unknown/future arch) caps at 48KB to stay within LDS limits.
+_large_lds_targets = ["gfx950"]
+topk_dynamic_smem_bytes = (
+    32 * 1024 * 4 if amdgpu_target in _large_lds_targets else 48 * 1024
+)
 
 hipcc_flags = [
     "-DNDEBUG",


### PR DESCRIPTION
## Motivation

Closes the RDNA gap behind #27519. AMD RDNA3.5 GPUs (gfx1151 — Strix Halo "Ryzen AI MAX") could not build or run `sgl-kernel` on ROCm, even though the kernels themselves are compatible.

#27535 already improved this by **honoring an explicit `AMDGPU_TARGET`** so the build no longer hard aborts at the `gfx942`/`gfx950` whitelist. That is the right first step, but it only opens the gate *subtly* — it's an opt-in escape hatch ("continue with an unsupported arch") that does **not** make RDNA actually runnable: the build still emits a TopK kernel sized for CDNA shared memory, which crashes at launch on RDNA. This PR completes the enablement.

## What this PR changes

**1. `sgl-kernel/setup_rocm.py` — honor explicit `AMDGPU_TARGET` + correct the TopK LDS budget**
- Keeps the explicit-`AMDGPU_TARGET`-wins behavior (consistent with / superseding #27535) so RDNA targets build without removing the upstream whitelist guard.
- Fixes the dynamic-shared-memory budget for the TopK kernels. Previously:
  ```python
  topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4  # 128KB for everything else
  ```
  The 128KB branch only fits CDNA3 (gfx950/MI350, ~160KB LDS). gfx942 and **RDNA3.5 have only 64KB LDS per workgroup**, so 128KB is rejected at kernel launch. Changed to whitelist the large-LDS arch instead of assuming "not gfx942 ⇒ large":
  ```python
  large_lds_targets = ["gfx950"]
  topk_dynamic_smem_bytes = 32 * 1024 * 4 if amdgpu_target in large_lds_targets else 48 * 1024
  ```
  Behavior-preserving for gfx942 (48KB) and gfx950 (128KB); RDNA and any unknown future arch default to the safe 48KB.

**2. `python/sglang/srt/utils/common.py` — robust AMD memory detection**
- `get_amdgpu_memory_capacity()` shells out to `rocminfo`; on some ROCm stacks (observed with TheRock on Strix Halo) `rocminfo` returns no parseable pool size or segfaults, which raised and prevented server startup. Added a fallback to torch's `mem_get_info()` (the helper already used elsewhere in this file) when `rocminfo` yields nothing.

## Why #27535 alone is not enough (the subtle part)

With only #27535, `AMDGPU_TARGET=gfx1151 python setup_rocm.py` builds and the wheel imports — so it *looks* supported — but the first call into the TopK kernel fails:

```
RuntimeError: set_up_kernel_once failed: invalid argument
```

This is `hipFuncSetAttribute(hipFuncAttributeMaxDynamicSharedMemorySize, 131072)` being rejected because 128KB > the 64KB LDS limit on RDNA. Normal dense / standard-MoE serving never reaches this kernel, so a smoke test passes and the regression stays hidden; it only surfaces on the DeepSeek-V3.2 sparse-attention TopK path (`fast_topk_v2`, `topk=2048`) and `deepseek_v4_topk`.

## Testing

Hardware: **AMD Ryzen AI MAX+ 395 / Radeon 8060S (gfx1151, RDNA3.5)**, PyTorch 2.10+rocm7.13.
Device LDS confirmed: `torch.cuda.get_device_properties(0).shared_memory_per_block == 65536` (64KB).

Validated three configurations on the same hardware:

| Config | Build (`AMDGPU_TARGET=gfx1151`) | `SGL_TOPK_DYNAMIC_SMEM_BYTES` | TopK kernel (`fast_topk_v2`, topk=2048) |
|---|---|---|---|
| Upstream (pristine) | **aborts** at gfx942/950 gate | — | — |
| #27535 only | builds, wheel loads | `131072` (128KB) | **CRASH** — `set_up_kernel_once failed: invalid argument` |
| This PR | builds, wheel loads | `49152` (48KB) | **OK** — returns valid indices |

- **Build:** all 16 HIP translation units compile cleanly for gfx1151; wheel imports and loads on the GPU.
- **TopK kernel:** reproduced the crash deterministically by calling the exact op the DeepSeek sparse-attention path uses (`from sgl_kernel import fast_topk_v2; fast_topk_v2(score, lengths, 2048)`); with this PR's 48KB cap the identical call succeeds.
- **End-to-end serving:** `sglang.launch_server` with `Qwen/Qwen2.5-0.5B-Instruct` (triton attention backend) starts and serves correct `/v1/chat/completions` responses on gfx1151.
- **No CDNA regression:** gfx942 stays at 48KB and gfx950 stays at 128KB (logic is behavior-preserving for both).

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27680257272](https://github.com/sgl-project/sglang/actions/runs/27680257272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27680257105](https://github.com/sgl-project/sglang/actions/runs/27680257105)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->