### PR TITLE
[Fix] Suppress Gemma4 missing-weight logs for partial updates

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2078,7 +2078,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             for handle in handles:
                 handle.wait()
 
-            self.model.load_weights(weights)
+            _model_load_weights(self.model, weights, is_full_load=False)
             return True, "Succeeded to update parameter online."
 
         except Exception as e:
@@ -2110,7 +2110,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 group=self._model_update_group[group_name],
             )
             reconstructed_tensors = bucket.reconstruct_tensors()
-            self.model.load_weights(reconstructed_tensors)
+            _model_load_weights(self.model, reconstructed_tensors, is_full_load=False)
             return True, f"Succeeded to update parameter online."
         except Exception as e:
             error_msg = (
@@ -2147,7 +2147,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             custom_loader = dynamic_import(load_format)
             custom_loader(self.model, named_tensors)
         elif load_format is None:
-            self.model.load_weights(named_tensors)
+            _model_load_weights(self.model, named_tensors, is_full_load=False)
         else:
             raise NotImplementedError(f"Unknown load_format={load_format}")
         return True, "Success"
@@ -2180,7 +2180,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         reconstructed_tensors = bucket.reconstruct_tensors()
 
         # Load the reconstructed tensors using the standard method
-        self.model.load_weights(reconstructed_tensors)
+        _model_load_weights(self.model, reconstructed_tensors, is_full_load=False)
 
         return True, "Success"
 
@@ -3313,6 +3313,24 @@ def _model_load_weights_direct(model, named_tensors: List[Tuple[str, torch.Tenso
     params_dict = dict(model.named_parameters())
     for name, tensor in named_tensors:
         default_weight_loader(params_dict[name], tensor)
+
+
+def _model_load_weights(model, weights, *, is_full_load: bool = True):
+    """Call ``model.load_weights``, forwarding ``is_full_load`` only when the model
+    accepts it. Online update paths pass ``is_full_load=False`` so loaders can skip
+    full-checkpoint diagnostics; most models don't take the kwarg, so it is forwarded
+    based on the actual signature rather than assumed."""
+    load_weights = model.load_weights
+    try:
+        supports_is_full_load = (
+            "is_full_load" in inspect.signature(load_weights).parameters
+        )
+    except (TypeError, ValueError):
+        supports_is_full_load = False
+
+    if supports_is_full_load:
+        return load_weights(weights, is_full_load=is_full_load)
+    return load_weights(weights)
 
 
 def _unwrap_tensor(tensor, tp_rank, device):

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -128,6 +128,37 @@ def pp_filter_load_weight(
     return False
 
 
+def log_unloaded_params(
+    load_logger,
+    params_dict,
+    loaded_params: Set[str],
+    param_names: Set[str],
+    non_persistent_buffers: Set[str],
+):
+    unloaded_params = params_dict.keys() - loaded_params
+    if not unloaded_params:
+        return
+
+    buckets = {
+        logging.WARNING: (
+            "Some weights are not initialized from checkpoints",
+            lambda p: p in param_names,
+        ),
+        logging.INFO: (
+            "Persistent buffers not in checkpoint (using default init)",
+            lambda p: p not in param_names and p not in non_persistent_buffers,
+        ),
+        logging.DEBUG: (
+            "Non-persistent buffers not in checkpoint (expected)",
+            lambda p: p in non_persistent_buffers,
+        ),
+    }
+    for level, (msg, pred) in buckets.items():
+        names = sorted(p for p in unloaded_params if pred(p))
+        if names:
+            load_logger.log(level, "%s: %s", msg, names)
+
+
 class Gemma4Router(nn.Module):
     """Router for Gemma4 MoE that preprocesses input before projection.
 
@@ -1176,7 +1207,12 @@ class Gemma4ForCausalLM(PreTrainedModel):
             i for i, lt in enumerate(self.config.layer_types) if lt == "full_attention"
         }
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+    def load_weights(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+        *,
+        is_full_load: bool = True,
+    ):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -1348,27 +1384,14 @@ class Gemma4ForCausalLM(PreTrainedModel):
                         )
                         weight_loader(param, loaded_weight)
                         loaded_params.add(name)
-        unloaded_params = params_dict.keys() - loaded_params
-        if unloaded_params:
-            param_names = set(dict(self.named_parameters()).keys())
-            buckets = {
-                logging.WARNING: (
-                    "Some weights are not initialized from checkpoints",
-                    lambda p: p in param_names,
-                ),
-                logging.INFO: (
-                    "Persistent buffers not in checkpoint (using default init)",
-                    lambda p: p not in param_names and p not in non_persistent_buffers,
-                ),
-                logging.DEBUG: (
-                    "Non-persistent buffers not in checkpoint (expected)",
-                    lambda p: p in non_persistent_buffers,
-                ),
-            }
-            for level, (msg, pred) in buckets.items():
-                names = sorted(p for p in unloaded_params if pred(p))
-                if names:
-                    logger.log(level, "%s: %s", msg, names)
+        if is_full_load:
+            log_unloaded_params(
+                logger,
+                params_dict,
+                loaded_params,
+                {name for name, _ in self.named_parameters()},
+                non_persistent_buffers,
+            )
         return loaded_params
 
     def _shard_weight(self, weight: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -59,7 +59,11 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.models.gemma4_audio import Gemma4AudioEncoder
-from sglang.srt.models.gemma4_causal import Gemma4TextModel, pp_filter_load_weight
+from sglang.srt.models.gemma4_causal import (
+    Gemma4TextModel,
+    log_unloaded_params,
+    pp_filter_load_weight,
+)
 from sglang.srt.models.gemma4_vision import Gemma4VisionEncoder
 from sglang.srt.utils import add_prefix
 from sglang.srt.utils.hf_transformers_utils import get_processor
@@ -826,7 +830,12 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             i for i, lt in enumerate(text_config.layer_types) if lt == "full_attention"
         }
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+    def load_weights(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+        *,
+        is_full_load: bool = True,
+    ):
         k_eq_v_layers = self._get_k_eq_v_layers()
 
         num_experts = getattr(self.config.text_config, "num_experts", 0) or 0
@@ -1017,27 +1026,14 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                         )
                         weight_loader(param, loaded_weight)
                         loaded_params.add(name)
-        unloaded_params = params_dict.keys() - loaded_params
-        if unloaded_params:
-            param_names = set(dict(self.named_parameters()).keys())
-            buckets = {
-                logging.WARNING: (
-                    "Some weights are not initialized from checkpoints",
-                    lambda p: p in param_names,
-                ),
-                logging.INFO: (
-                    "Persistent buffers not in checkpoint (using default init)",
-                    lambda p: p not in param_names and p not in non_persistent_buffers,
-                ),
-                logging.DEBUG: (
-                    "Non-persistent buffers not in checkpoint (expected)",
-                    lambda p: p in non_persistent_buffers,
-                ),
-            }
-            for level, (msg, pred) in buckets.items():
-                names = sorted(p for p in unloaded_params if pred(p))
-                if names:
-                    logger.log(level, "%s: %s", msg, names)
+        if is_full_load:
+            log_unloaded_params(
+                logger,
+                params_dict,
+                loaded_params,
+                {name for name, _ in self.named_parameters()},
+                non_persistent_buffers,
+            )
         return loaded_params
 
     lora_pattern = re.compile(

--- a/python/sglang/srt/models/gemma4_mtp.py
+++ b/python/sglang/srt/models/gemma4_mtp.py
@@ -369,14 +369,21 @@ class Gemma4AssistantForCausalLM(Gemma4ForCausalLM):
             mm_input_embeds=logits_metadata.mm_input_embeds,
         )
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+    def load_weights(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+        *,
+        is_full_load: bool = True,
+    ):
         def remap_assistant_weights():
             for name, weight in weights:
                 if name.startswith("masked_embedding."):
                     name = name.removeprefix("masked_embedding.")
                 yield name, weight
 
-        result = super().load_weights(remap_assistant_weights())
+        result = super().load_weights(
+            remap_assistant_weights(), is_full_load=is_full_load
+        )
         if self.use_ordered_embeddings:
             self._reorder_embedding_to_centroid_order()
         return result

--- a/python/sglang/srt/models/gemma4_unified.py
+++ b/python/sglang/srt/models/gemma4_unified.py
@@ -51,7 +51,11 @@ from sglang.srt.managers.schedule_batch import (
     flatten_nested_list,
 )
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.models.gemma4_causal import Gemma4TextModel, pp_filter_load_weight
+from sglang.srt.models.gemma4_causal import (
+    Gemma4TextModel,
+    log_unloaded_params,
+    pp_filter_load_weight,
+)
 from sglang.srt.models.gemma4_mm import Gemma4ForConditionalGeneration
 from sglang.srt.utils import add_prefix
 
@@ -337,7 +341,12 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
     # ------------------------------------------------------------------
     # Weight loading
     # ------------------------------------------------------------------
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:
+    def load_weights(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+        *,
+        is_full_load: bool = True,
+    ) -> Set[str]:
         k_eq_v_layers = self._get_k_eq_v_layers()
 
         params_dict = dict(self.named_parameters())
@@ -411,27 +420,14 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
                 weight_loader(param, loaded_weight)
                 loaded_params.add(name)
 
-        unloaded_params = params_dict.keys() - loaded_params
-        if unloaded_params:
-            param_names = set(dict(self.named_parameters()).keys())
-            buckets = {
-                logging.WARNING: (
-                    "Some weights are not initialized from checkpoints",
-                    lambda p: p in param_names,
-                ),
-                logging.INFO: (
-                    "Persistent buffers not in checkpoint (using default init)",
-                    lambda p: p not in param_names and p not in non_persistent_buffers,
-                ),
-                logging.DEBUG: (
-                    "Non-persistent buffers not in checkpoint (expected)",
-                    lambda p: p in non_persistent_buffers,
-                ),
-            }
-            for level, (msg, pred) in buckets.items():
-                names = sorted(p for p in unloaded_params if pred(p))
-                if names:
-                    logger.log(level, "%s: %s", msg, names)
+        if is_full_load:
+            log_unloaded_params(
+                logger,
+                params_dict,
+                loaded_params,
+                {name for name, _ in self.named_parameters()},
+                non_persistent_buffers,
+            )
         return loaded_params
 
 

--- a/test/registered/unit/model_executor/test_model_load_weights.py
+++ b/test/registered/unit/model_executor/test_model_load_weights.py
@@ -1,0 +1,54 @@
+"""Unit tests for ``_model_load_weights`` -- CPU only, no GPU required.
+
+Verifies the ``is_full_load`` kwarg is forwarded to loaders that accept it
+and omitted for loaders with the legacy signature.
+"""
+
+import unittest
+
+from sglang.srt.model_executor.model_runner import _model_load_weights
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _PartialAwareModel:
+    def __init__(self):
+        self.calls = []
+
+    def load_weights(self, weights, *, is_full_load=True):
+        self.calls.append((list(weights), is_full_load))
+        return "loaded"
+
+
+class _LegacyModel:
+    def __init__(self):
+        self.calls = []
+
+    def load_weights(self, weights):
+        self.calls.append(list(weights))
+        return "legacy-loaded"
+
+
+class TestModelLoadWeights(unittest.TestCase):
+    def test_passes_full_load_flag_when_supported(self):
+        model = _PartialAwareModel()
+        weights = [("weight", object())]
+
+        result = _model_load_weights(model, weights, is_full_load=False)
+
+        self.assertEqual(result, "loaded")
+        self.assertEqual(model.calls, [(weights, False)])
+
+    def test_omits_full_load_flag_for_legacy_models(self):
+        model = _LegacyModel()
+        weights = [("weight", object())]
+
+        result = _model_load_weights(model, weights, is_full_load=False)
+
+        self.assertEqual(result, "legacy-loaded")
+        self.assertEqual(model.calls, [weights])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_gemma4_weight_loading.py
+++ b/test/registered/unit/models/test_gemma4_weight_loading.py
@@ -1,0 +1,45 @@
+"""Unit tests for Gemma4 weight loading -- CPU only, no GPU required.
+
+Verifies that the unloaded-parameter diagnostics fire on a full checkpoint
+load but are skipped during partial (online) weight updates.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.models.gemma4_causal import Gemma4ForCausalLM
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestGemma4WeightLoading(unittest.TestCase):
+    def _make_minimal_causal_model(self):
+        model = object.__new__(Gemma4ForCausalLM)
+        model.config = SimpleNamespace(attention_k_eq_v=False)
+        model.named_parameters = lambda: iter([("missing.weight", torch.empty(1))])
+        model.named_buffers = lambda: iter([])
+        model.named_modules = lambda: iter([])
+        return model
+
+    def test_full_load_logs_unloaded_parameters(self):
+        model = self._make_minimal_causal_model()
+
+        with self.assertLogs("sglang.srt.models.gemma4_causal", level="INFO") as logs:
+            Gemma4ForCausalLM.load_weights(model, [], is_full_load=True)
+
+        output = "\n".join(logs.output)
+        self.assertIn("Some weights are not initialized from checkpoints", output)
+        self.assertIn("missing.weight", output)
+
+    def test_partial_load_skips_unloaded_parameter_logs(self):
+        model = self._make_minimal_causal_model()
+
+        with self.assertNoLogs("sglang.srt.models.gemma4_causal", level="INFO"):
+            Gemma4ForCausalLM.load_weights(model, [], is_full_load=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Gemma4 loaders log missing weights after every `load_weights` call. That is useful after a full checkpoint load, but noisy for online/RL partial updates that intentionally pass only a subset of tensors.

## Changes

- Add `is_full_load=True` to Gemma4 `load_weights` methods.
- Pass `is_full_load=False` from online weight updates when the loader accepts it.
- Keep full checkpoint load diagnostics unchanged.

This is a narrow interim stopgap. The long-term loader-side contract is RFC #28585; #28560 is the broader interim stopgap.

## Verification

No model outputs change; only missing-weight diagnostics during partial updates are suppressed.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->